### PR TITLE
disable host filterer by default

### DIFF
--- a/cmd/agent/agent-local-config.yaml
+++ b/cmd/agent/agent-local-config.yaml
@@ -7,6 +7,7 @@ prometheus:
     scrape_interval: 5s
   configs:
     - name: test
+      host_filter: false
       scrape_configs:
         - job_name: local_scrape
           static_configs:

--- a/pkg/prometheus/instance.go
+++ b/pkg/prometheus/instance.go
@@ -49,7 +49,7 @@ var (
 	}
 
 	DefaultInstanceConfig = InstanceConfig{
-		HostFilter:           true,
+		HostFilter:           false,
 		WALTruncateFrequency: 1 * time.Minute,
 		RemoteFlushDeadline:  1 * time.Minute,
 		WriteStaleOnShutdown: true,


### PR DESCRIPTION
Allows for using the agent as a drop-in replcement for Prometheus' single process. This makes more sense as the default as the host filterer, when enabled, works without friction in less environments.