### PR TITLE
fix release container version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next (master/unreleased)
 
 - Fix various dashboard mixin problems from v0.1.0 (@rfratto)
+- Pass through release tag to `docker build` (@rfratto)
 
 # v0.1.0 (2020-03-16)
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ RELEASE_BUILD ?= false
 
 # Docker image info
 IMAGE_PREFIX ?= grafana
-IMAGE_TAG := $(shell ./tools/image-tag)
+IMAGE_TAG ?= $(shell ./tools/image-tag)
 
 # Version info for binaries
 GIT_REVISION := $(shell git rev-parse --short HEAD)
@@ -71,7 +71,7 @@ cmd/agent/agent: cmd/agent/main.go
 	$(NETGO_CHECK)
 
 agent-image:
-	docker build --build-arg RELEASE_BUILD=$(RELEASE_BUILD) \
+	docker build --build-arg RELEASE_BUILD=$(RELEASE_BUILD)  --build-arg IMAGE_TAG=$(IMAGE_TAG) \
 		-t $(IMAGE_PREFIX)/agent:latest -f cmd/agent/Dockerfile .
 	docker tag $(IMAGE_PREFIX)/agent:latest $(IMAGE_PREFIX)/agent:$(IMAGE_TAG)
 

--- a/cmd/agent/Dockerfile
+++ b/cmd/agent/Dockerfile
@@ -2,7 +2,8 @@ FROM golang:1.14 as build
 COPY . /src/agent
 WORKDIR /src/agent
 ARG RELEASE_BUILD=false
-RUN make clean && make RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agent
+ARG IMAGE_TAG
+RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agent
 
 FROM alpine:3.9
 RUN apk add --update --no-cache ca-certificates


### PR DESCRIPTION
v0.1.0 release image lacked the proper version in `agent -version`. This
commit fixes that problem by passing through the IMAGE_TAG override
through to the docker build process.