### PR TITLE
Clarify limitations and scaling issues, and usage of Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@
 Grafana Cloud Agent is an observability data collector optimized for sending
 metrics and log data to [Grafana Cloud](https://grafana.com/products/cloud/).
 
-Users of Prometheus cloud storage vendors can struggle sending their data at
-scale: Prometheus is sometimes called a single point of failure that generally
-requires a giant machine with a lot of resources allocated to it.
+Users of Prometheus cloud storage vendors with a single Prometheus instance can 
+struggle sending their data at massive scale (millions of active series): 
+Prometheus is sometimes called a single point of failure that generally requires 
+a giant machine with a lot of resources allocated to it.
 
-The Grafana Cloud Agent tackles these issues by stripping Prometheus down to its
-most relavant parts for interaction with hosted metrics:
+The Grafana Cloud Agent uses the same code as Prometheus, but tackles these issues 
+by only using the most relevant parts of Prometheus for interaction with hosted 
+metrics: 
 
 1. Service Discovery
 2. Scraping
@@ -37,9 +39,11 @@ trade-offs have been made:
 - When sharding the Agent, if your node has problems that interrupt metric
   availability, metrics tracking that node won't be sent for alerting on.
 
-The Agent sets the expectation that recording rules and alerts should be the
-responsibility of the remote write system rather than the responsibility of the
-metrics collector.
+While the Agent can't use recording rules and alerts, `remote_write` systems such 
+as Cortex currently support server-side rules and alerts. Note that this trade-off 
+means that reliability of alerts are tied to the reliability of the remote system 
+and alerts will be delayed at least by the time it takes for samples to reach 
+the remote system. 
 
 ## Roadmap
 


### PR DESCRIPTION
Based on feedback received. This adds more context to the scaling issues that Grafana Labs has seen with Prometheus. 

This change also adds more context to the trade-off of only having server-side alerts, and clarifies that we are vendoring Prometheus itself rather than recreating its functionalities. 