### PR TITLE
pkg/prometheus: fix host_filter not matching `role: node` k8s SD jobs

### DIFF
--- a/pkg/prometheus/host_filter.go
+++ b/pkg/prometheus/host_filter.go
@@ -161,16 +161,11 @@ func shouldFilterTarget(target model.LabelSet, common model.LabelSet, host strin
 		return false
 	}
 
-	// Fall back to checking metalabels as long as their values are nonempty
+	// Fall back to checking metalabels as long as their values are nonempty.
 	for _, check := range labelMatchers {
-		addr := lset.Get(check)
-		if addr == "" {
-			continue
-		}
-
 		// If any of the checked labels match for not being filtered out, we can
-		// return early
-		if !shouldFilterTargetByLabelValue(addr) {
+		// return before checking any of the other matchers.
+		if addr := lset.Get(check); addr != "" && !shouldFilterTargetByLabelValue(addr) {
 			return false
 		}
 	}

--- a/pkg/prometheus/host_filter_test.go
+++ b/pkg/prometheus/host_filter_test.go
@@ -49,8 +49,8 @@ func TestFilterGroups(t *testing.T) {
 		{
 			name: "kubneretes host match",
 			group: makeGroup([]model.LabelSet{{
-				model.AddressLabel:                       "mycontainer",
-				model.LabelName(kubernetesNodeNameLabel): "myhost",
+				model.AddressLabel:                          "mycontainer",
+				model.LabelName(kubernetesPodNodeNameLabel): "myhost",
 			}}),
 			inputHost:    "myhost",
 			shouldRemove: false,
@@ -58,8 +58,8 @@ func TestFilterGroups(t *testing.T) {
 		{
 			name: "kubernetes host mismatch",
 			group: makeGroup([]model.LabelSet{{
-				model.AddressLabel:                       "mycontainer",
-				model.LabelName(kubernetesNodeNameLabel): "notmyhost",
+				model.AddressLabel:                          "mycontainer",
+				model.LabelName(kubernetesPodNodeNameLabel): "notmyhost",
 			}}),
 			inputHost:    "myhost",
 			shouldRemove: true,
@@ -67,8 +67,8 @@ func TestFilterGroups(t *testing.T) {
 		{
 			name: "kubernetes host match with port",
 			group: makeGroup([]model.LabelSet{{
-				model.AddressLabel:                       "mycontainer:12345",
-				model.LabelName(kubernetesNodeNameLabel): "myhost:12345",
+				model.AddressLabel:                          "mycontainer:12345",
+				model.LabelName(kubernetesPodNodeNameLabel): "myhost:12345",
 			}}),
 			inputHost:    "myhost",
 			shouldRemove: false,
@@ -76,8 +76,8 @@ func TestFilterGroups(t *testing.T) {
 		{
 			name: "kubernetes host mismatch with port",
 			group: makeGroup([]model.LabelSet{{
-				model.AddressLabel:                       "mycontainer:12345",
-				model.LabelName(kubernetesNodeNameLabel): "notmyhost:12345",
+				model.AddressLabel:                          "mycontainer:12345",
+				model.LabelName(kubernetesPodNodeNameLabel): "notmyhost:12345",
 			}}),
 			inputHost:    "myhost",
 			shouldRemove: true,
@@ -85,8 +85,8 @@ func TestFilterGroups(t *testing.T) {
 		{
 			name: "kubernetes host mismatch, __address__ match",
 			group: makeGroup([]model.LabelSet{{
-				model.AddressLabel:                       "mycontainer",
-				model.LabelName(kubernetesNodeNameLabel): "notmyhost",
+				model.AddressLabel:                          "mycontainer",
+				model.LabelName(kubernetesPodNodeNameLabel): "notmyhost",
 			}}),
 			inputHost:    "mycontainer",
 			shouldRemove: false,
@@ -94,8 +94,8 @@ func TestFilterGroups(t *testing.T) {
 		{
 			name: "kubernetes host mismatch, __address__ match with port",
 			group: makeGroup([]model.LabelSet{{
-				model.AddressLabel:                       "mycontainer:12345",
-				model.LabelName(kubernetesNodeNameLabel): "notmyhost:12345",
+				model.AddressLabel:                          "mycontainer:12345",
+				model.LabelName(kubernetesPodNodeNameLabel): "notmyhost:12345",
 			}}),
 			inputHost:    "mycontainer",
 			shouldRemove: false,
@@ -103,8 +103,8 @@ func TestFilterGroups(t *testing.T) {
 		{
 			name: "always allow localhost",
 			group: makeGroup([]model.LabelSet{{
-				model.AddressLabel:                       "localhost:12345",
-				model.LabelName(kubernetesNodeNameLabel): "notmyhost:12345",
+				model.AddressLabel:                          "localhost:12345",
+				model.LabelName(kubernetesPodNodeNameLabel): "notmyhost:12345",
 			}}),
 			inputHost:    "mycontainer",
 			shouldRemove: false,
@@ -112,8 +112,8 @@ func TestFilterGroups(t *testing.T) {
 		{
 			name: "always allow 127.0.0.1",
 			group: makeGroup([]model.LabelSet{{
-				model.AddressLabel:                       "127.0.0.1:12345",
-				model.LabelName(kubernetesNodeNameLabel): "notmyhost:12345",
+				model.AddressLabel:                          "127.0.0.1:12345",
+				model.LabelName(kubernetesPodNodeNameLabel): "notmyhost:12345",
 			}}),
 			inputHost:    "mycontainer",
 			shouldRemove: false,


### PR DESCRIPTION
Previously, the `host_filter` code was looking for a label called `__meta_kubernetes_pod_node_name`. This label is only available when using the `role: pod` matcher within the `kubernetes_sd_configs` config block.

When using `role: node`, which is common for the cadvisor and kubelet jobs, the metalabel for the node name is instead called `__meta_kubernetes_node_name`. `host_filter` wasn't checking for this
label and so any `role: node` job was getting filtered out.