### PR TITLE
Enable strict yaml parse

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"io/ioutil"
 
-	prom "github.com/grafana/agent/pkg/prometheus"
+	"github.com/grafana/agent/pkg/prometheus"
 	"github.com/pkg/errors"
 	"github.com/weaveworks/common/server"
 	"gopkg.in/yaml.v2"
@@ -12,10 +12,11 @@ import (
 
 // Config contains underlying configurations for the agent
 type Config struct {
-	Server     server.Config `yaml:"server"`
-	Prometheus prom.Config   `yaml:"prometheus,omitempty"`
+	Server     server.Config     `yaml:"server"`
+	Prometheus prometheus.Config `yaml:"prometheus,omitempty"`
 }
 
+// ApplyDefaults sets default values in the config
 func (c *Config) ApplyDefaults() {
 	c.Prometheus.ApplyDefaults()
 }
@@ -28,6 +29,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.Server.RegisterFlags(f)
 }
 
+// LoadFile reads a file and passes the contents to Load
 func LoadFile(filename string, c *Config) error {
 	buf, err := ioutil.ReadFile(filename)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"flag"
+	"io/ioutil"
+
+	prom "github.com/grafana/agent/pkg/prometheus"
+	"github.com/pkg/errors"
+	"github.com/weaveworks/common/server"
+	"gopkg.in/yaml.v2"
+)
+
+// Config contains underlying configurations for the agent
+type Config struct {
+	Server     server.Config `yaml:"server"`
+	Prometheus prom.Config   `yaml:"prometheus,omitempty"`
+}
+
+func (c *Config) ApplyDefaults() {
+	c.Prometheus.ApplyDefaults()
+}
+
+// RegisterFlags registers flags in underlying configs
+func (c *Config) RegisterFlags(f *flag.FlagSet) {
+	c.Server.MetricsNamespace = "agent"
+	c.Server.RegisterInstrumentation = true
+	c.Prometheus.RegisterFlags(f)
+	c.Server.RegisterFlags(f)
+}
+
+func LoadFile(filename string, c *Config) error {
+	buf, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return errors.Wrap(err, "error reading config file")
+	}
+
+	return Load(buf, c)
+}
+
+// Load loads a config and applies defaults
+func Load(buf []byte, c *Config) error {
+	err := yaml.UnmarshalStrict(buf, c)
+	if err != nil {
+		return err
+	}
+
+	c.ApplyDefaults()
+
+	return nil
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -47,5 +47,4 @@ prometheus:
 		err := Load([]byte(cfg), &c)
 		require.Error(t, err)
 	})
-
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -32,7 +32,7 @@ func TestConfig_StrictYamlParsing(t *testing.T) {
 prometheus:
   global:
     scrape_timeout: 10s
-	scrape_timeout: 15s`
+    scrape_timeout: 15s`
 		var c Config
 		err := Load([]byte(cfg), &c)
 		require.Error(t, err)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	promCfg "github.com/prometheus/prometheus/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_OverrideDefaultsOnLoad(t *testing.T) {
+	cfg := `
+prometheus:
+  global:
+    scrape_timeout: 33s`
+	expect := promCfg.GlobalConfig{
+		ScrapeInterval:     model.Duration(1 * time.Minute),
+		ScrapeTimeout:      model.Duration(33 * time.Second),
+		EvaluationInterval: model.Duration(1 * time.Minute),
+	}
+
+	var c Config
+	err := Load([]byte(cfg), &c)
+	require.NoError(t, err)
+	require.Equal(t, expect, c.Prometheus.Global)
+}
+
+func TestConfig_StrictYamlParsing(t *testing.T) {
+	t.Run("duplicate key", func(t *testing.T) {
+		cfg := `
+prometheus:
+  global:
+    scrape_timeout: 10s
+	scrape_timeout: 15s`
+		var c Config
+		err := Load([]byte(cfg), &c)
+		require.Error(t, err)
+	})
+
+	t.Run("non existing key", func(t *testing.T) {
+		cfg := `
+prometheus:
+  global:
+  scrape_timeout: 10s`
+		var c Config
+		err := Load([]byte(cfg), &c)
+		require.Error(t, err)
+	})
+
+}


### PR DESCRIPTION
Closes https://github.com/grafana/agent/issues/49 

Added a couple of tests to show `UnmarshalStrict` catching issues. 

Also wanted to move the config structure out of `main.go`, but happy to undo leave it where it was and move tests to `cmd/` if that's preferable.