### PR TITLE
Duplicate RemoteWriteConfig without the Secret type

### DIFF
--- a/pkg/prometheus/ha/codec.go
+++ b/pkg/prometheus/ha/codec.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/ring/kv/codec"
 	"github.com/grafana/agent/pkg/prometheus/instance"
-	"github.com/prometheus/common/config"
 	"gopkg.in/yaml.v2"
 )
 
@@ -31,33 +30,26 @@ func (*yamlCodec) Decode(bb []byte) (interface{}, error) {
 		return nil, err
 	}
 
-	var codecConfig codecConfig
-	if err := yaml.NewDecoder(r).Decode(&codecConfig); err != nil {
+	var inst instance.Config
+	if err := yaml.NewDecoder(r).Decode(&inst); err != nil {
 		return nil, err
 	}
-	restoreConfig(&codecConfig)
-	return codecConfig.Config, nil
+	return &inst, nil
 }
 
 func (*yamlCodec) Encode(v interface{}) ([]byte, error) {
 	var buf bytes.Buffer
 
-	var configToWrite *instance.Config
-
-	switch val := v.(type) {
-	case instance.Config:
-		configToWrite = &val
-	case *instance.Config:
-		configToWrite = val
+	switch v.(type) {
+	case instance.Config, *instance.Config:
+		break
 	default:
 		panic(fmt.Sprintf("unexpected type %T passed to yamlCodec.Encode", v))
 	}
 
-	codecConfig := newCodecConfig(configToWrite)
-
 	w := gzip.NewWriter(&buf)
 	yamlEncoder := yaml.NewEncoder(w)
-	if err := yamlEncoder.Encode(codecConfig); err != nil {
+	if err := yamlEncoder.Encode(v); err != nil {
 		return nil, err
 	}
 
@@ -67,46 +59,4 @@ func (*yamlCodec) Encode(v interface{}) ([]byte, error) {
 
 func (*yamlCodec) CodecID() string {
 	return "agentConfig/yaml"
-}
-
-type codecConfig struct {
-	Config  *instance.Config `yaml:"config"`
-	Secrets []configSecrets  `yaml:"secrets"`
-}
-
-// newCodecConfig creates a new codecConfig that is ready for marshaling as YAML
-// and storing in a KV store. newCodecConfig must extract secrets stored in the
-// instance.Config and store them elsewhere as strings as the MarshalYAML function
-// on the Prometheus Secret type replaces the contents of the secret with
-// the text "<secret>".
-func newCodecConfig(c *instance.Config) *codecConfig {
-	var secrets []configSecrets
-	for _, rwr := range c.RemoteWrite {
-		var s configSecrets
-		if rwr.HTTPClientConfig.BasicAuth != nil {
-			s.BasicAuthPassword = string(rwr.HTTPClientConfig.BasicAuth.Password)
-		}
-		s.BearerToken = string(rwr.HTTPClientConfig.BearerToken)
-		secrets = append(secrets, s)
-	}
-	return &codecConfig{
-		Config:  c,
-		Secrets: secrets,
-	}
-}
-
-type configSecrets struct {
-	BasicAuthPassword string `yaml:"basic_auth_password"`
-	BearerToken       string `yaml:"bearer_token"`
-}
-
-// restoreConfig restores the instance config stored in a codec config by copying
-// extracted secrets to it.
-func restoreConfig(c *codecConfig) {
-	for i, rwr := range c.Config.RemoteWrite {
-		if rwr.HTTPClientConfig.BasicAuth != nil {
-			rwr.HTTPClientConfig.BasicAuth.Password = config.Secret(c.Secrets[i].BasicAuthPassword)
-		}
-		rwr.HTTPClientConfig.BearerToken = config.Secret(c.Secrets[i].BearerToken)
-	}
 }

--- a/pkg/prometheus/ha/http.go
+++ b/pkg/prometheus/ha/http.go
@@ -112,7 +112,7 @@ func (s *Server) GetConfiguration(r *http.Request) (interface{}, error) {
 		}
 	}
 
-	cfg, err := instance.MarshalConfig(v.(*instance.Config))
+	cfg, err := instance.MarshalConfig(v.(*instance.Config), true)
 	if err != nil {
 		level.Error(s.logger).Log("msg", "error marshaling configuration", "err", err)
 		return nil, err

--- a/pkg/prometheus/ha/sharding.go
+++ b/pkg/prometheus/ha/sharding.go
@@ -221,16 +221,5 @@ func configHash(c *instance.Config) (uint32, error) {
 	}
 	h := fnv.New32()
 	_, _ = h.Write(bb)
-
-	// Secrets need to be hashed separately since when marshaled they are
-	// removed by the a custom marshaler. We want changes to secrets to result in
-	// a different hash.
-	for _, rwr := range c.RemoteWrite {
-		if basic := rwr.HTTPClientConfig.BasicAuth; basic != nil {
-			_, _ = h.Write([]byte(basic.Password))
-		}
-		_, _ = h.Write([]byte(rwr.HTTPClientConfig.BearerToken))
-	}
-
 	return h.Sum32(), nil
 }

--- a/pkg/prometheus/instance/marshal.go
+++ b/pkg/prometheus/instance/marshal.go
@@ -15,7 +15,13 @@ func UnmarshalConfig(r io.Reader) (*Config, error) {
 }
 
 // MarshalConfig marshals an instance config based on a provided content type.
-func MarshalConfig(c *Config) (string, error) {
+func MarshalConfig(c *Config, sanitize bool) (string, error) {
+	if sanitize {
+		for _, rw := range c.RemoteWrite {
+			rw.Sanitize()
+		}
+	}
+
 	bb, err := yaml.Marshal(c)
 	return string(bb), err
 }

--- a/pkg/prometheus/instance/remote_write.go
+++ b/pkg/prometheus/instance/remote_write.go
@@ -1,0 +1,152 @@
+package instance
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	config_util "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/pkg/relabel"
+)
+
+var (
+	DefaultRemoteWriteConfig = RemoteWriteConfig{
+		RemoteTimeout:  model.Duration(30 * time.Second),
+		QueueConfig:    config.DefaultQueueConfig,
+		MetadataConfig: config.DefaultMetadataConfig,
+	}
+)
+
+// RemoteWriteConfig holds configuration for remote_write. It is duplicated from the
+// Prometheus RemoteWriteConfig to allow for marshaling secrets to YAML.
+type RemoteWriteConfig struct {
+	URL                 *config_util.URL  `yaml:"url"`
+	RemoteTimeout       model.Duration    `yaml:"remote_timeout,omitempty"`
+	WriteRelabelConfigs []*relabel.Config `yaml:"write_relabel_configs,omitempty"`
+	Name                string            `yaml:"name,omitempty"`
+
+	// We cannot do proper Go type embedding below as the parser will then parse
+	// values arbitrarily into the overflow maps of further-down types.
+	HTTPClientConfig HTTPClientConfig      `yaml:",inline"`
+	QueueConfig      config.QueueConfig    `yaml:"queue_config,omitempty"`
+	MetadataConfig   config.MetadataConfig `yaml:"metadata_config,omitempty"`
+}
+
+// PrometheusConfig returns the Prometheus-config equivalent of RemoteWriteConfig.
+func (c *RemoteWriteConfig) PrometheusConfig() *config.RemoteWriteConfig {
+	return &config.RemoteWriteConfig{
+		URL:                 c.URL,
+		RemoteTimeout:       c.RemoteTimeout,
+		WriteRelabelConfigs: c.WriteRelabelConfigs,
+		Name:                c.Name,
+
+		HTTPClientConfig: c.HTTPClientConfig.PrometheusConfig(),
+		QueueConfig:      c.QueueConfig,
+		MetadataConfig:   c.MetadataConfig,
+	}
+}
+
+// Sanitize finds all secrets in the RemoteWriteConfig and replaces their values
+// with <secret>.
+func (c *RemoteWriteConfig) Sanitize() {
+	if c.HTTPClientConfig.BasicAuth != nil && c.HTTPClientConfig.BasicAuth.Password != "" {
+		c.HTTPClientConfig.BasicAuth.Password = "<secret>"
+	}
+
+	if c.HTTPClientConfig.BearerToken != "" {
+		c.HTTPClientConfig.BearerToken = "<secret>"
+	}
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *RemoteWriteConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultRemoteWriteConfig
+	type plain RemoteWriteConfig
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+	if c.URL == nil {
+		return errors.New("url for remote_write is empty")
+	}
+	for _, rlcfg := range c.WriteRelabelConfigs {
+		if rlcfg == nil {
+			return errors.New("empty or null relabeling rule in remote write config")
+		}
+	}
+
+	// The UnmarshalYAML method of HTTPClientConfig is not being called because it's not a pointer.
+	// We cannot make it a pointer as the parser panics for inlined pointer structs.
+	// Thus we just do its validation here.
+	return c.HTTPClientConfig.Validate()
+}
+
+// HTTPClientConfig configures an HTTP client.
+type HTTPClientConfig struct {
+	// The HTTP basic authentication credentials for the targets.
+	BasicAuth *BasicAuth `yaml:"basic_auth,omitempty"`
+	// The bearer token for the targets.
+	BearerToken string `yaml:"bearer_token,omitempty"`
+	// The bearer token file for the targets.
+	BearerTokenFile string `yaml:"bearer_token_file,omitempty"`
+	// HTTP proxy server to use to connect to the targets.
+	ProxyURL config_util.URL `yaml:"proxy_url,omitempty"`
+	// TLSConfig to use to connect to the targets.
+	TLSConfig config_util.TLSConfig `yaml:"tls_config,omitempty"`
+}
+
+// PrometheusConfig returns the Prometheus-config equivalent of HTTPClientConfig.
+func (c *HTTPClientConfig) PrometheusConfig() config_util.HTTPClientConfig {
+	var basic *config_util.BasicAuth
+	if c.BasicAuth != nil {
+		basic = &config_util.BasicAuth{
+			Username: c.BasicAuth.Username,
+			Password: config_util.Secret(c.BasicAuth.Password),
+		}
+	}
+
+	return config_util.HTTPClientConfig{
+		BasicAuth:       basic,
+		BearerToken:     config_util.Secret(c.BearerToken),
+		BearerTokenFile: c.BearerTokenFile,
+		ProxyURL:        c.ProxyURL,
+		TLSConfig:       c.TLSConfig,
+	}
+}
+
+type BasicAuth struct {
+	Username     string `yaml:"username"`
+	Password     string `yaml:"password,omitempty"`
+	PasswordFile string `yaml:"password_file,omitempty"`
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface
+func (c *HTTPClientConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type plain HTTPClientConfig
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+	return c.Validate()
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (a *BasicAuth) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type plain BasicAuth
+	return unmarshal((*plain)(a))
+}
+
+// Validate validates the HTTPClientConfig to check only one of BearerToken,
+// BasicAuth and BearerTokenFile is configured.
+func (c *HTTPClientConfig) Validate() error {
+	if len(c.BearerToken) > 0 && len(c.BearerTokenFile) > 0 {
+		return fmt.Errorf("at most one of bearer_token & bearer_token_file must be configured")
+	}
+	if c.BasicAuth != nil && (len(c.BearerToken) > 0 || len(c.BearerTokenFile) > 0) {
+		return fmt.Errorf("at most one of basic_auth, bearer_token & bearer_token_file must be configured")
+	}
+	if c.BasicAuth != nil && (string(c.BasicAuth.Password) != "" && c.BasicAuth.PasswordFile != "") {
+		return fmt.Errorf("at most one of basic_auth password & password_file must be configured")
+	}
+	return nil
+}

--- a/pkg/prometheus/instance/remote_write.go
+++ b/pkg/prometheus/instance/remote_write.go
@@ -145,7 +145,7 @@ func (c *HTTPClientConfig) Validate() error {
 	if c.BasicAuth != nil && (len(c.BearerToken) > 0 || len(c.BearerTokenFile) > 0) {
 		return fmt.Errorf("at most one of basic_auth, bearer_token & bearer_token_file must be configured")
 	}
-	if c.BasicAuth != nil && (string(c.BasicAuth.Password) != "" && c.BasicAuth.PasswordFile != "") {
+	if c.BasicAuth != nil && (c.BasicAuth.Password != "" && c.BasicAuth.PasswordFile != "") {
 		return fmt.Errorf("at most one of basic_auth password & password_file must be configured")
 	}
 	return nil


### PR DESCRIPTION
The fix from #63 didn't fix everything: since `agentctl` also marshals the config to YAML, secrets were being removed before they even reached the config API. 

This PR completely removes the Secret type to allow RemoteWriteConfigs to be arbitrarily marshalled back and forth between YAML. Sanitization now happens on demand rather than being forced by the marshaling.

Closes #62, and reverts some of #63. 