### PR TITLE
Added dry run flag to agentctl config-sync cmd

### DIFF
--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -33,6 +33,7 @@ func main() {
 func configSyncCmd() *cobra.Command {
 	var (
 		agentAddr string
+		dryRun    bool
 	)
 
 	cmd := &cobra.Command{
@@ -55,7 +56,7 @@ source-of-truth directory.`,
 
 			logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
 
-			err := agentctl.ConfigSync(logger, cli.PrometheusClient, directory)
+			err := agentctl.ConfigSync(logger, cli.PrometheusClient, directory, dryRun)
 			if err != nil {
 				level.Error(logger).Log("msg", "failed to sync config", "err", err)
 				os.Exit(1)
@@ -64,6 +65,7 @@ source-of-truth directory.`,
 	}
 
 	cmd.Flags().StringVarP(&agentAddr, "addr", "a", "http://localhost:12345", "address of the agent to connect to")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "use the dry run option to validate config files without attempting to upload")
 	must(cmd.MarkFlagRequired("addr"))
 	return cmd
 }

--- a/pkg/agentctl/sync.go
+++ b/pkg/agentctl/sync.go
@@ -25,20 +25,20 @@ import (
 // ConfigSync will completely overwrite the set of active configs
 // present in the provided PrometheusClient - configs present in the
 // API but not in the directory will be deleted.
-func ConfigSync(logger log.Logger, cli client.PrometheusClient, dir string) error {
+func ConfigSync(logger log.Logger, cli client.PrometheusClient, dir string, dryRun bool) error {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
 
 	ctx := context.Background()
-	existing, err := cli.ListConfigs(ctx)
-	if err != nil {
-		return fmt.Errorf("could not list configs: %w", err)
-	}
-
 	cfgs, err := ConfigsFromDirectory(dir)
 	if err != nil {
 		return err
+	}
+
+	if dryRun {
+		fmt.Println("Dry run successful")
+		return nil
 	}
 
 	uploaded := make(map[string]struct{}, len(cfgs))
@@ -52,6 +52,11 @@ func ConfigSync(logger log.Logger, cli client.PrometheusClient, dir string) erro
 			hadErrors = true
 		}
 		uploaded[cfg.Name] = struct{}{}
+	}
+
+	existing, err := cli.ListConfigs(ctx)
+	if err != nil {
+		return fmt.Errorf("could not list configs: %w", err)
 	}
 
 	// Delete configs from the existing API list that we didn't upload.

--- a/pkg/agentctl/sync.go
+++ b/pkg/agentctl/sync.go
@@ -37,7 +37,7 @@ func ConfigSync(logger log.Logger, cli client.PrometheusClient, dir string, dryR
 	}
 
 	if dryRun {
-		fmt.Println("Dry run successful")
+		level.Info(logger).Log("msg", "config files validated successfully")
 		return nil
 	}
 

--- a/pkg/agentctl/sync_test.go
+++ b/pkg/agentctl/sync_test.go
@@ -79,23 +79,18 @@ func TestConfigSync_DryRun(t *testing.T) {
 		}, nil
 	}
 
-	var putConfigs []string
 	cli.PutConfigurationFunc = func(_ context.Context, name string, _ *instance.Config) error {
-		putConfigs = append(putConfigs, name)
+		t.FailNow()
 		return nil
 	}
 
-	var deletedConfigs []string
 	cli.DeleteConfigurationFunc = func(_ context.Context, name string) error {
-		deletedConfigs = append(deletedConfigs, name)
+		t.FailNow()
 		return nil
 	}
 
 	err := ConfigSync(nil, cli, "./testdata", true)
 	require.NoError(t, err)
-
-	require.Empty(t, putConfigs)
-	require.Empty(t, deletedConfigs)
 }
 
 type mockFuncPromClient struct {


### PR DESCRIPTION
Fixes #65 by adding a dry-run flag to the existing `agentctl config-sync`. In the dry-run path the address is never used but still a required flag. If we want we can create a separate command for dry-running config-sync that doesn't mark the addr flag as required.