### PR TITLE
Fix typo in tanka config

### DIFF
--- a/production/tanka/grafana-agent/config.libsonnet
+++ b/production/tanka/grafana-agent/config.libsonnet
@@ -361,7 +361,7 @@
         }],
 
         // Drop some high cardinality metrics.
-        metric_label_configs: [
+        metric_relabel_configs: [
           {
             source_labels: ['__name__'],
             regex: 'apiserver_admission_controller_admission_latencies_seconds_.*',


### PR DESCRIPTION
The pod was failing for me in my deployment until I changed this