### PR TITLE
enable strict YAML parsing for uploading a new config to config API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Next (master/unreleased)
 
+- [ENHANCEMENT] agentctl and the config API will now validate that the YAML they
+  receive are valid instance configs. (@rfratto)
+
 # v0.3.0 (2020-05-13)
 
 - [FEATURE] A third operational mode called "scraping service mode" has been

--- a/pkg/agentctl/sync.go
+++ b/pkg/agentctl/sync.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/grafana/agent/pkg/client"
 	"github.com/grafana/agent/pkg/prometheus/instance"
-	"gopkg.in/yaml.v2"
 )
 
 // ConfigSync loads YAML files from a directory and syncs them to the
@@ -128,10 +127,10 @@ func configFromFile(path string) (*instance.Config, error) {
 		return nil, err
 	}
 
-	var cfg instance.Config
-	dec := yaml.NewDecoder(f)
-	dec.SetStrict(true)
-	err = dec.Decode(&cfg)
+	cfg, err := instance.UnmarshalConfig(f)
+	if err != nil {
+		return nil, err
+	}
 	cfg.Name = configName
-	return &cfg, err
+	return cfg, nil
 }

--- a/pkg/agentctl/sync_test.go
+++ b/pkg/agentctl/sync_test.go
@@ -1,20 +1,13 @@
 package agentctl
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"io"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/grafana/agent/pkg/prometheus/ha/configapi"
 	"github.com/grafana/agent/pkg/prometheus/instance"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 )
 
 func TestConfigSync_EmptyStore(t *testing.T) {
@@ -97,45 +90,6 @@ func TestConfigSync_DryRun(t *testing.T) {
 	}
 
 	err := ConfigSync(nil, cli, "./testdata", true)
-	require.NoError(t, err)
-}
-
-func TestConfigFromFile_InvalidConfig(t *testing.T) {
-	dir, err := ioutil.TempDir("", "*")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-
-	invalidConfigContent := `whyWouldAnyoneThinkThisisAValidConfig: 12345`
-	invalidConfigPath := filepath.Join(dir, "not-a-config.yaml")
-	f, err := os.Create(invalidConfigPath)
-	require.NoError(t, err)
-	defer f.Close()
-
-	_, err = io.Copy(f, strings.NewReader(invalidConfigContent))
-	require.NoError(t, err)
-
-	_, err = configFromFile(invalidConfigPath)
-	require.Error(t, err)
-}
-
-func TestConfigFile_ValidConfig(t *testing.T) {
-	dir, err := ioutil.TempDir("", "*")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-
-	validConfig := instance.DefaultConfig
-	validConfigContent, err := yaml.Marshal(validConfig)
-	require.NoError(t, err)
-
-	validConfigPath := filepath.Join(dir, "testfile.yaml")
-	f, err := os.Create(validConfigPath)
-	require.NoError(t, err)
-	defer f.Close()
-
-	_, err = io.Copy(f, bytes.NewReader(validConfigContent))
-	require.NoError(t, err)
-
-	_, err = configFromFile(validConfigPath)
 	require.NoError(t, err)
 }
 

--- a/pkg/prometheus/instance/marshal.go
+++ b/pkg/prometheus/instance/marshal.go
@@ -10,7 +10,9 @@ import (
 // provided content type.
 func UnmarshalConfig(r io.Reader) (*Config, error) {
 	var cfg Config
-	err := yaml.NewDecoder(r).Decode(&cfg)
+	dec := yaml.NewDecoder(r)
+	dec.SetStrict(true)
+	err := dec.Decode(&cfg)
 	return &cfg, err
 }
 

--- a/pkg/prometheus/instance/marshal_test.go
+++ b/pkg/prometheus/instance/marshal_test.go
@@ -1,0 +1,26 @@
+package instance
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestUnmarshalConfig_Valid(t *testing.T) {
+	validConfig := DefaultConfig
+	validConfigContent, err := yaml.Marshal(validConfig)
+	require.NoError(t, err)
+
+	_, err = UnmarshalConfig(bytes.NewReader(validConfigContent))
+	require.NoError(t, err)
+}
+
+func TestUnmarshalConfig_Invalid(t *testing.T) {
+	invalidConfigContent := `whyWouldAnyoneThinkThisisAValidConfig: 12345`
+
+	_, err := UnmarshalConfig(strings.NewReader(invalidConfigContent))
+	require.Error(t, err)
+}


### PR DESCRIPTION
The instance.UnmarshalConfig function will now do strict decoding. This commit also changes agentctl to use this function instead of reimplementing the same functionality.