### PR TITLE
fix issue where agent dashboards weren't properly assigned a folder

### DIFF
--- a/production/grafana-agent-mixin/mixin.libsonnet
+++ b/production/grafana-agent-mixin/mixin.libsonnet
@@ -1,3 +1,7 @@
-(import 'dashboards.libsonnet') + {
-  grafanaDashboardFolder: 'Agent',
+local dashboards = import 'dashboards.libsonnet';
+
+{
+  grafanaDashboards: std.mapWithKey(function(field, obj) obj {
+    grafanaDashboardFolder: 'Agent',
+  }, dashboards.grafanaDashboards),
 }

--- a/production/grafana-agent-mixin/mixin.libsonnet
+++ b/production/grafana-agent-mixin/mixin.libsonnet
@@ -1,7 +1,7 @@
 local dashboards = import 'dashboards.libsonnet';
 
 {
-  grafanaDashboards: std.mapWithKey(function(field, obj) obj {
+  grafanaDashboards:: std.mapWithKey(function(field, obj) obj {
     grafanaDashboardFolder: 'Agent',
   }, dashboards.grafanaDashboards),
 }


### PR DESCRIPTION
The previous Jsonnet code wasn't adding the folder to the dashboard objects. This commit maps over the dashboards and properly adds the folder key.