### PR TITLE
re-render Kubernetes manifest to include fix from #71

### DIFF
--- a/production/kubernetes/agent.yaml
+++ b/production/kubernetes/agent.yaml
@@ -168,7 +168,7 @@ data:
                 job_name: default/kubernetes
                 kubernetes_sd_configs:
                   - role: endpoints
-                metric_label_configs:
+                metric_relabel_configs:
                   - action: drop
                     regex: apiserver_admission_controller_admission_latencies_seconds_.*
                     source_labels:

--- a/production/kubernetes/build/jsonnetfile.json
+++ b/production/kubernetes/build/jsonnetfile.json
@@ -1,14 +1,6 @@
 {
+  "version": 1,
   "dependencies": [
-    {
-      "source": {
-        "git": {
-          "remote": "https://github.com/grafana/jsonnet-libs",
-          "subdir": "ksonnet-util"
-        }
-      },
-      "version": "master"
-    },
     {
       "source": {
         "git": {

--- a/production/kubernetes/build/jsonnetfile.lock.json
+++ b/production/kubernetes/build/jsonnetfile.lock.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "dependencies": [
     {
       "source": {
@@ -7,8 +8,8 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "c19a92e586a6752f11745b47f309b13f02ef7147",
-      "sum": "LKsTTBcH8TXX5ANgRUu5I7Y1tf5le4nANFV3/W53I+c="
+      "version": "811ccb022bc2bdcd0b8281ed0a0c858c63e20542",
+      "sum": "smRyjpmKy4pURM47XTv+9azXjP6L/n4gXjxzRxAvY1Q="
     },
     {
       "source": {


### PR DESCRIPTION
Reran `make example-kubernetes` to rerender the Kubernetes manifest and had to rerun `jb install`, which was required before the render would work. 

Fixes #77.