### PR TITLE
simplify instance creation and lifecycle

### DIFF
--- a/pkg/prometheus/instance/instance.go
+++ b/pkg/prometheus/instance/instance.go
@@ -215,12 +215,12 @@ func (i *Instance) Run(ctx context.Context) error {
 	}
 
 	readyScrapeManager := &scrape.ReadyScrapeManager{}
-	fanoutStorage, err := i.newStorage(&trackingReg, wstore, readyScrapeManager)
+	storage, err := i.newStorage(&trackingReg, wstore, readyScrapeManager)
 	if err != nil {
 		return err
 	}
 
-	scrapeManager := scrape.NewManager(log.With(i.logger, "component", "scrape manager"), fanoutStorage)
+	scrapeManager := scrape.NewManager(log.With(i.logger, "component", "scrape manager"), storage)
 	err = scrapeManager.ApplyConfig(&config.Config{
 		GlobalConfig:  i.globalCfg,
 		ScrapeConfigs: i.cfg.ScrapeConfigs,
@@ -333,7 +333,7 @@ func (i *Instance) Run(ctx context.Context) error {
 				}
 
 				level.Info(i.logger).Log("msg", "closing storage...")
-				if err := fanoutStorage.Close(); err != nil {
+				if err := storage.Close(); err != nil {
 					level.Error(i.logger).Log("msg", "error stopping storage", "err", err)
 				}
 			},

--- a/pkg/prometheus/instance/instance.go
+++ b/pkg/prometheus/instance/instance.go
@@ -389,7 +389,7 @@ func (i *Instance) newStorage(reg prometheus.Registerer, wal walStorage, sm scra
 func (i *Instance) newHostFilter() (*HostFilter, error) {
 	hostname, err := hostname()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create host filterer: %w", err)
 	}
 
 	level.Debug(i.logger).Log("msg", "creating host filterer", "for_host", hostname, "enabled", i.cfg.HostFilter)
@@ -526,7 +526,11 @@ func hostname() (string, error) {
 		return hostname, nil
 	}
 
-	return os.Hostname()
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", fmt.Errorf("failed to get hostname: %w", err)
+	}
+	return hostname, nil
 }
 
 func getHash(data interface{}) (string, error) {

--- a/pkg/prometheus/instance/instance.go
+++ b/pkg/prometheus/instance/instance.go
@@ -147,9 +147,8 @@ type Instance struct {
 	vc *MetricValueCollector
 }
 
-// New creates and starts a new Instance. NewInstance creates a WAL in
-// a folder with the same name as the instance's name in a subdirectory of the
-// walDir parameter.
+// New creates a new Instance with a directory for storing the WAL. The instance
+// will not start until Run is called on the instance.
 func New(globalCfg config.GlobalConfig, cfg Config, walDir string, logger log.Logger) (*Instance, error) {
 	logger = log.With(logger, "instance", cfg.Name)
 

--- a/pkg/prometheus/wal/wal.go
+++ b/pkg/prometheus/wal/wal.go
@@ -82,6 +82,7 @@ type Storage struct {
 	// Embed Queryable for compatibility, but don't actually implement it.
 	storage.Queryable
 
+	path   string
 	wal    *wal.WAL
 	logger log.Logger
 
@@ -106,6 +107,7 @@ func NewStorage(logger log.Logger, registerer prometheus.Registerer, path string
 	}
 
 	storage := &Storage{
+		path:    path,
 		wal:     w,
 		logger:  logger,
 		deleted: map[uint64]int{},
@@ -321,6 +323,11 @@ func (w *Storage) loadWAL(r *wal.Reader) (err error) {
 	}
 
 	return nil
+}
+
+// Directory returns the path where the WAL storage is held.
+func (w *Storage) Directory() string {
+	return w.path
 }
 
 // Appender returns a new appender against the storage.


### PR DESCRIPTION
As part of #83, the instance package will have to be utilized in a new way for running integrations (i.e., running an instance that does not have a discovery component).

To prepare for this change, the instance package was in need of a refactoring to simplify how the instance objects are used. Now, instead of an instance immediately starting when it is created, it must be started explicitly through the `Run` function. `Run` is a blocking operation and will only exit on error or when the context is canceled. Changing to this allowed for cleaning up a lot of code callers required to watch the lifecycle of the Instance.

Note that the code for unregistering WAL metrics is no longer needed as the WAL is now created when Run is called.

Running an instance with a discovery manager is still required as of this PR; future work is still needed to make the individual components of the Instance optional.

/cc @gotjosh 