### PR TITLE
couple discovery and host filtering

### DIFF
--- a/pkg/prometheus/instance/instance.go
+++ b/pkg/prometheus/instance/instance.go
@@ -335,7 +335,7 @@ func (i *Instance) newDiscoveryManager(ctx context.Context) (*discoveryService, 
 		level.Info(i.logger).Log("msg", "service discovery manager stopped")
 		return err
 	}, func(err error) {
-		level.Info(i.logger).Log("msg", "stopping scrape discovery manager...")
+		level.Info(i.logger).Log("msg", "stopping service discovery manager...")
 		cancel()
 	})
 

--- a/pkg/prometheus/instance/instance.go
+++ b/pkg/prometheus/instance/instance.go
@@ -311,7 +311,7 @@ func (s *discoveryService) SyncCh() GroupChannel { return s.SyncChFunc() }
 func (i *Instance) newDiscoveryManager(ctx context.Context) (*discoveryService, error) {
 	ctx, cancel := context.WithCancel(ctx)
 
-	logger := log.With(i.logger, "component", "discover manager scrape")
+	logger := log.With(i.logger, "component", "discovery manager")
 	manager := discovery.NewManager(ctx, logger, discovery.Name("scrape"))
 
 	// TODO(rfratto): refactor this to a function?
@@ -332,10 +332,10 @@ func (i *Instance) newDiscoveryManager(ctx context.Context) (*discoveryService, 
 	// Run the manager
 	rg.Add(func() error {
 		err := manager.Run()
-		level.Info(i.logger).Log("msg", "service discovery manager stopped")
+		level.Info(i.logger).Log("msg", "discovery manager stopped")
 		return err
 	}, func(err error) {
-		level.Info(i.logger).Log("msg", "stopping service discovery manager...")
+		level.Info(i.logger).Log("msg", "stopping discovery manager...")
 		cancel()
 	})
 


### PR DESCRIPTION
The implementation of #83 will require the ability to replace the Prometheus discovery manager with a custom component that outputs discovered targets. The first half of this is to couple the Prometheus
discovery manager and host filtering as a single "actor" that can be swapped out with another implementation.