### PR TITLE
use remote_write and scrape_config validations from Prometheus

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,13 +17,16 @@ type Config struct {
 }
 
 // ApplyDefaults sets default values in the config
-func (c *Config) ApplyDefaults() {
-	c.Prometheus.ApplyDefaults()
+func (c *Config) ApplyDefaults() error {
+	if err := c.Prometheus.ApplyDefaults(); err != nil {
+		return err
+	}
 
 	// The default port exposed to the lifecycler should be the gRPC listen
 	// port since the agents will use gRPC for notifying other agents of
 	// resharding.
 	c.Prometheus.ServiceConfig.Lifecycler.ListenPort = &c.Server.GRPCListenPort
+	return nil
 }
 
 // RegisterFlags registers flags in underlying configs
@@ -51,7 +54,5 @@ func Load(buf []byte, c *Config) error {
 		return err
 	}
 
-	c.ApplyDefaults()
-
-	return nil
+	return c.ApplyDefaults()
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -12,6 +12,7 @@ import (
 func TestConfig_OverrideDefaultsOnLoad(t *testing.T) {
 	cfg := `
 prometheus:
+  wal_directory: /tmp/wal
   global:
     scrape_timeout: 33s`
 	expect := promCfg.GlobalConfig{
@@ -30,6 +31,7 @@ func TestConfig_StrictYamlParsing(t *testing.T) {
 	t.Run("duplicate key", func(t *testing.T) {
 		cfg := `
 prometheus:
+  wal_directory: /tmp/wal
   global:
     scrape_timeout: 10s
     scrape_timeout: 15s`
@@ -41,6 +43,7 @@ prometheus:
 	t.Run("non existing key", func(t *testing.T) {
 		cfg := `
 prometheus:
+  wal_directory: /tmp/wal
   global:
   scrape_timeout: 10s`
 		var c Config

--- a/pkg/prom/ha/http.go
+++ b/pkg/prom/ha/http.go
@@ -130,6 +130,11 @@ func (s *Server) PutConfiguration(r *http.Request) (interface{}, error) {
 	}
 	inst.Name = getConfigName(r)
 
+	// Validate the incoming config
+	if err := inst.ApplyDefaults(s.globalConfig); err != nil {
+		return nil, err
+	}
+
 	var newConfig bool
 	err = s.kv.CAS(r.Context(), inst.Name, func(in interface{}) (out interface{}, retry bool, err error) {
 		// The configuration is new if there's no previous value from the CAS

--- a/pkg/prom/ha/server_test.go
+++ b/pkg/prom/ha/server_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/agent/pkg/agentproto"
 	"github.com/grafana/agent/pkg/prom/ha/client"
 	"github.com/grafana/agent/pkg/prom/instance"
+	"github.com/prometheus/prometheus/config"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"google.golang.org/grpc"
@@ -223,7 +224,7 @@ func newTestServer(r readRing, kv kv.Client, cm ConfigManager, reshard time.Dura
 	logger := log.NewNopLogger()
 	closer := func() error { return nil }
 
-	return newServer(cfg, clientConfig, logger, cm, "test", r, kv, closer)
+	return newServer(cfg, &config.DefaultGlobalConfig, clientConfig, logger, cm, "test", r, kv, closer)
 }
 
 func getRunningConfigs(cm ConfigManager) []string {

--- a/pkg/prom/instance/instance.go
+++ b/pkg/prom/instance/instance.go
@@ -157,7 +157,7 @@ func (c *Config) ApplyDefaults(global *config.GlobalConfig) error {
 			if generatedName {
 				return fmt.Errorf("found two identical remote_write configs")
 			}
-			return fmt.Errorf("found duplicate remove write configs with name %q", cfg.Name)
+			return fmt.Errorf("found duplicate remote write configs with name %q", cfg.Name)
 		}
 		rwNames[cfg.Name] = struct{}{}
 	}

--- a/pkg/prom/instance/instance.go
+++ b/pkg/prom/instance/instance.go
@@ -122,7 +122,7 @@ func (c *Config) ApplyDefaults(global *config.GlobalConfig) error {
 			}
 		}
 
-		if _, ok := jobNames[sc.JobName]; ok {
+		if _, exists := jobNames[sc.JobName]; exists {
 			return fmt.Errorf("found multiple scrape configs with job name %q", sc.JobName)
 		}
 		jobNames[sc.JobName] = struct{}{}
@@ -153,7 +153,7 @@ func (c *Config) ApplyDefaults(global *config.GlobalConfig) error {
 			generatedName = true
 		}
 
-		if _, ok := rwNames[cfg.Name]; ok {
+		if _, exists := rwNames[cfg.Name]; exists {
 			if generatedName {
 				return fmt.Errorf("found two identical remote_write configs")
 			}

--- a/pkg/prom/instance/instance_test.go
+++ b/pkg/prom/instance/instance_test.go
@@ -40,7 +40,9 @@ func TestConfig_ApplyDefaults(t *testing.T) {
 		}},
 	}
 
-	cfg.ApplyDefaults(&global)
+	err := cfg.ApplyDefaults(&global)
+	require.NoError(t, err)
+
 	for _, sc := range cfg.ScrapeConfigs {
 		require.Equal(t, sc.ScrapeInterval, global.ScrapeInterval)
 		require.Equal(t, sc.ScrapeTimeout, global.ScrapeTimeout)


### PR DESCRIPTION
Prometheus was doing some validations on the `remote_write` and `scrape_config` sections per config that we weren't doing yet. To make this a little easier, ApplyDefaults and Validate have been merged.

The scraping service PutConfiguration endpoint will now apply the defaults to the config before passing it through to the KV store; invalid configs will be prevented from reaching the KV store and errors will be returned to the client.

When migrating to this change, if any invalid configs exist in the KV store, the Agent will refuse to start them and log an error. The configs in the KV store should be updated to fix the invalid settings before the Agent will be able to run it.

Fixes #80.