### PR TITLE
Add back in instance config defaults on unmarshal

### DIFF
--- a/pkg/prom/agent.go
+++ b/pkg/prom/agent.go
@@ -35,7 +35,6 @@ var (
 
 var (
 	DefaultConfig = Config{
-		Global:                 config.DefaultGlobalConfig,
 		InstanceRestartBackoff: 5 * time.Second,
 	}
 )

--- a/pkg/prom/agent_test.go
+++ b/pkg/prom/agent_test.go
@@ -21,7 +21,7 @@ func TestConfig_Validate(t *testing.T) {
 	valid := Config{
 		WALDir: "/tmp/data",
 		Configs: []instance.Config{
-			{Name: "instance"},
+			makeInstanceConfig("instance"),
 		},
 	}
 
@@ -49,8 +49,8 @@ func TestConfig_Validate(t *testing.T) {
 			name: "duplicate config name",
 			mutator: func(c *Config) {
 				c.Configs = append(c.Configs,
-					instance.Config{Name: "newinstance"},
-					instance.Config{Name: "instance"},
+					makeInstanceConfig("newinstance"),
+					makeInstanceConfig("instance"),
 				)
 			},
 			expect: errors.New("prometheus instance names must be unique. found multiple instances with name instance"),
@@ -87,8 +87,8 @@ func TestAgent(t *testing.T) {
 	cfg := Config{
 		WALDir: "/tmp/wal",
 		Configs: []instance.Config{
-			{Name: "instance_a"},
-			{Name: "instance_b"},
+			makeInstanceConfig("instance_a"),
+			makeInstanceConfig("instance_b"),
 		},
 		InstanceRestartBackoff: time.Duration(0),
 	}
@@ -150,8 +150,8 @@ func TestAgent_Stop(t *testing.T) {
 	cfg := Config{
 		WALDir: "/tmp/wal",
 		Configs: []instance.Config{
-			{Name: "instance_a"},
-			{Name: "instance_b"},
+			makeInstanceConfig("instance_a"),
+			makeInstanceConfig("instance_b"),
 		},
 		InstanceRestartBackoff: time.Duration(0),
 	}
@@ -230,4 +230,10 @@ func (f *mockInstanceFactory) factory(_ config.GlobalConfig, cfg instance.Config
 
 	f.mocks = append(f.mocks, inst)
 	return inst, nil
+}
+
+func makeInstanceConfig(name string) instance.Config {
+	cfg := instance.DefaultConfig
+	cfg.Name = name
+	return cfg
 }

--- a/pkg/prom/instance/instance.go
+++ b/pkg/prom/instance/instance.go
@@ -74,6 +74,17 @@ type Config struct {
 	WriteStaleOnShutdown bool          `yaml:"write_stale_on_shutdown,omitempty" json:"write_stale_on_shutdown,omitempty"`
 }
 
+func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultConfig
+
+	type plain Config
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (c Config) MarshalYAML() (interface{}, error) {
 	// We want users to be able to marshal instance.Configs directly without
 	// *needing* to call instance.MarshalConfig, so we call it internally

--- a/pkg/prom/instance/instance_test.go
+++ b/pkg/prom/instance/instance_test.go
@@ -100,6 +100,11 @@ func TestConfig_ApplyDefaults_Validations(t *testing.T) {
 			fmt.Errorf("wal_truncate_frequency must be greater than 0s"),
 		},
 		{
+			"missing remote flush deadline",
+			func(c *Config) { c.RemoteFlushDeadline = 0 },
+			fmt.Errorf("remote_flush_deadline must be greater than 0s"),
+		},
+		{
 			"scrape timeout too high",
 			func(c *Config) { c.ScrapeConfigs[0].ScrapeTimeout = global.ScrapeInterval + 1 },
 			fmt.Errorf("scrape timeout greater than scrape interval for scrape config with job name \"scrape\""),


### PR DESCRIPTION
PR #92 accidentally removed unmarshaling the default config values into the instance configs, which led to a 0s `wal_truncate_frequency`, causing the WAL to get truncated every spare CPU cycle.

This PR adds them back and adds new tests and validations to make sure it won't happen again.
