### PR TITLE
update labels to current jsonnet-libs standard and fix dashboards

### DIFF
--- a/pkg/prom/wal/wal.go
+++ b/pkg/prom/wal/wal.go
@@ -22,10 +22,11 @@ import (
 type storageMetrics struct {
 	r prometheus.Registerer
 
-	numActiveSeries    prometheus.Gauge
-	numDeletedSeries   prometheus.Gauge
-	totalCreatedSeries prometheus.Counter
-	totalRemovedSeries prometheus.Counter
+	numActiveSeries      prometheus.Gauge
+	numDeletedSeries     prometheus.Gauge
+	totalCreatedSeries   prometheus.Counter
+	totalRemovedSeries   prometheus.Counter
+	totalAppendedSamples prometheus.Counter
 }
 
 func newStorageMetrics(r prometheus.Registerer) *storageMetrics {
@@ -48,6 +49,11 @@ func newStorageMetrics(r prometheus.Registerer) *storageMetrics {
 	m.totalRemovedSeries = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "agent_wal_storage_removed_series_total",
 		Help: "Total number of created series removed from the WAL",
+	})
+
+	m.totalAppendedSamples = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "agent_wal_samples_appended_total",
+		Help: "Total number of samples appended to the WAL",
 	})
 
 	if r != nil {

--- a/production/grafana-agent-mixin/mixin.libsonnet
+++ b/production/grafana-agent-mixin/mixin.libsonnet
@@ -1,7 +1,7 @@
 local dashboards = import 'dashboards.libsonnet';
 
 {
-  grafanaDashboards:: std.mapWithKey(function(field, obj) obj {
+  grafanaDashboards+:: std.mapWithKey(function(field, obj) obj {
     grafanaDashboardFolder: 'Agent',
   }, dashboards.grafanaDashboards),
 }

--- a/production/tanka/grafana-agent/config.libsonnet
+++ b/production/tanka/grafana-agent/config.libsonnet
@@ -1,6 +1,7 @@
 {
   _images+:: {
     agent: 'grafana/agent:latest',
+    agentctl: 'grafana/agentctl:latest',
   },
 
   _config+:: {
@@ -29,7 +30,7 @@
     // as a DaemonSet (like it is here by default), then disabling this will
     // scrape all metrics multiple times, once per node, leading to
     // duplicate samples being rejected and might hit limits.
-    agent_host_filter: true,
+    agent_host_filter: false,
 
     // The directory where the WAL is stored for all instances.
     agent_wal_dir: '/var/lib/agent/data',
@@ -151,11 +152,27 @@
             action: 'replace',
             target_label: 'namespace',
           },
-
-          // Rename instances to be the pod name
           {
             source_labels: ['__meta_kubernetes_pod_name'],
             action: 'replace',
+            target_label: 'pod',  // Not 'pod_name', which disappeared in K8s 1.16.
+          },
+          {
+            source_labels: ['__meta_kubernetes_pod_container_name'],
+            action: 'replace',
+            target_label: 'container',  // Not 'container_name', which disappeared in K8s 1.16.
+          },
+
+          // Rename instances to the concatenation of pod:container:port.
+          // All three components are needed to guarantee a unique instance label.
+          {
+            source_labels: [
+              '__meta_kubernetes_pod_name',
+              '__meta_kubernetes_pod_container_name',
+              '__meta_kubernetes_pod_container_port_name',
+            ],
+            action: 'replace',
+            separator: ':',
             target_label: 'instance',
           },
 
@@ -203,12 +220,16 @@
             action: 'keep',
           },
 
-          // Rename instances to be the pod name. As the scrape two
-          // ports of kube-state-metrics, include the port name in the
-          // interface name. Otherwise, alerts about scrape failures and
-          // timeouts won't work.
+          // Rename instances to the concatenation of pod:container:port.
+          // In the specific case of KSM, we could leave out the container
+          // name and still have a unique instance label, but we leave it
+          // in here for consistency with the normal pod scraping.
           {
-            source_labels: ['__meta_kubernetes_pod_name', '__meta_kubernetes_pod_container_port_name'],
+            source_labels: [
+              '__meta_kubernetes_pod_name',
+              '__meta_kubernetes_pod_container_name',
+              '__meta_kubernetes_pod_container_port_name',
+            ],
             action: 'replace',
             separator: ':',
             target_label: 'instance',


### PR DESCRIPTION
grafana/jsonnet-libs#261 updates labels to make instance labels unique. This commit sycnes with that change, but subsequently makes an overdue change by going through all the dashboards and fixing various issues with them.

The new dashboards are compatible with the new labeling scheme, but also fixes some problems:

1. Make sure the unloved Agent and Agent Prometheus Remote Write runs correct queries and account for the instance_name labels
2. Use proper graph label values in Agent Operational
3. Allow to filter Agent Operational graph by container

As part of making the Agent dashboard useful, a new metric has been added to track samples added to the WAL over time.

Closes #73.