### PR TITLE
Fix zero default scrape interval by initializing global config stanza with defaults (fixes #106)

### DIFF
--- a/pkg/prom/agent.go
+++ b/pkg/prom/agent.go
@@ -62,11 +62,10 @@ func (c *Config) ApplyDefaults() error {
 
 	usedNames := map[string]struct{}{}
 
-	for i, cfg := range c.Configs {
-		err := c.Configs[i].ApplyDefaults(&c.Global)
-		if err != nil {
+	for i := range c.Configs {
+		name := c.Configs[i].Name
+		if err := c.Configs[i].ApplyDefaults(&c.Global); err != nil {
 			// Try to show a helpful name in the error
-			name := cfg.Name
 			if name == "" {
 				name = fmt.Sprintf("at index %d", i)
 			}
@@ -74,13 +73,13 @@ func (c *Config) ApplyDefaults() error {
 			return fmt.Errorf("error validating instance %s: %w", name, err)
 		}
 
-		if _, ok := usedNames[cfg.Name]; ok {
+		if _, ok := usedNames[name]; ok {
 			return fmt.Errorf(
 				"prometheus instance names must be unique. found multiple instances with name %s",
-				cfg.Name,
+				name,
 			)
 		}
-		usedNames[cfg.Name] = struct{}{}
+		usedNames[name] = struct{}{}
 	}
 
 	for i := range c.Configs {

--- a/pkg/prom/agent.go
+++ b/pkg/prom/agent.go
@@ -35,6 +35,7 @@ var (
 
 var (
 	DefaultConfig = Config{
+		Global:                 config.DefaultGlobalConfig,
 		InstanceRestartBackoff: 5 * time.Second,
 	}
 )
@@ -48,6 +49,13 @@ type Config struct {
 	ServiceClientConfig    client.Config       `yaml:"scraping_service_client"`
 	Configs                []instance.Config   `yaml:"configs,omitempty"`
 	InstanceRestartBackoff time.Duration       `yaml:"instance_restart_backoff,omitempty"`
+}
+
+func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultConfig
+
+	type plain Config
+	return unmarshal((*plain)(c))
 }
 
 // ApplyDefaults applies default values to the Config and validates it.

--- a/pkg/prom/agent.go
+++ b/pkg/prom/agent.go
@@ -81,14 +81,6 @@ func (c *Config) ApplyDefaults() error {
 		}
 		usedNames[name] = struct{}{}
 	}
-
-	for i := range c.Configs {
-		err := c.Configs[i].ApplyDefaults(&c.Global)
-		if err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/prom/agent_test.go
+++ b/pkg/prom/agent_test.go
@@ -82,6 +82,31 @@ func copyConfig(t *testing.T, c Config) Config {
 	return cp
 }
 
+func TestConfigNonzeroDefaultScrapeInterval(t *testing.T) {
+	cfgText := `
+wal_directory: ./wal
+configs:
+  - name: testconfig
+    scrape_configs:
+      - job_name: 'node'
+        static_configs:
+          - targets: ['localhost:9100']
+`
+
+	var cfg Config
+
+	err := yaml.Unmarshal([]byte(cfgText), &cfg)
+	require.NoError(t, err)
+	err = cfg.ApplyDefaults()
+	require.NoError(t, err)
+
+	require.Equal(t, len(cfg.Configs), 1)
+	instanceConfig := cfg.Configs[0]
+	require.Equal(t, len(instanceConfig.ScrapeConfigs), 1)
+	scrapeConfig := instanceConfig.ScrapeConfigs[0]
+	require.Greater(t, int64(scrapeConfig.ScrapeInterval), int64(0))
+}
+
 func TestAgent(t *testing.T) {
 	// Lanch two instances
 	cfg := Config{

--- a/pkg/prom/instance/instance.go
+++ b/pkg/prom/instance/instance.go
@@ -79,11 +79,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	*c = DefaultConfig
 
 	type plain Config
-	if err := unmarshal((*plain)(c)); err != nil {
-		return err
-	}
-
-	return nil
+	return unmarshal((*plain)(c))
 }
 
 func (c Config) MarshalYAML() (interface{}, error) {

--- a/pkg/prom/wal/wal.go
+++ b/pkg/prom/wal/wal.go
@@ -149,7 +149,7 @@ func NewStorage(logger log.Logger, registerer prometheus.Registerer, path string
 }
 
 func (w *Storage) replayWAL() error {
-	level.Info(w.logger).Log("msg", "replaying WAL, this may take awhile", "dir", w.wal.Dir())
+	level.Info(w.logger).Log("msg", "replaying WAL, this may take a while", "dir", w.wal.Dir())
 	dir, startFrom, err := wal.LastCheckpoint(w.wal.Dir())
 	if err != nil && err != record.ErrNotFound {
 		return errors.Wrap(err, "find last checkpoint")


### PR DESCRIPTION
Couple of small clean-up commits around config parsing, and then a fix for #106.

New here, do let me know if I should be doing anything here differently!

I found the code around `ApplyDefaults` a bit confusing: Pretty sure that second loop that's removed in https://github.com/grafana/agent/commit/15659e6865fafdad0e5061084985dd61cc2f13ae was redundant, but actually there's a third call via `validateInstance` which doesn't make a whole lot of sense to me. At least it doesn't crash anymore now (for me :TM:).

Fixes #106 