### PR TITLE
Re-enable host_filter for the agent daemonset

### DIFF
--- a/production/kubernetes/agent.yaml
+++ b/production/kubernetes/agent.yaml
@@ -8,7 +8,7 @@ data:
   agent.yml: |
     prometheus:
         configs:
-          - host_filter: false
+          - host_filter: true
             name: agent
             remote_write:
               - basic_auth:

--- a/production/tanka/grafana-agent/config.libsonnet
+++ b/production/tanka/grafana-agent/config.libsonnet
@@ -30,7 +30,7 @@
     // as a DaemonSet (like it is here by default), then disabling this will
     // scrape all metrics multiple times, once per node, leading to
     // duplicate samples being rejected and might hit limits.
-    agent_host_filter: false,
+    agent_host_filter: true,
 
     // The directory where the WAL is stored for all instances.
     agent_wal_dir: '/var/lib/agent/data',


### PR DESCRIPTION
It was accidentally removed when the scraping service config was added. See #108 for pointing this out.