### PR TITLE
apply defaults for the config after parsing flags 

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -58,7 +58,7 @@ func main() {
 	}
 
 	if err := cfg.ApplyDefaults(); err != nil {
-		log.Fatalln("error in config file: %w", err)
+		log.Fatalf("error in config file: %s\n", err)
 	}
 
 	// After this point we can use util.Logger and stop using the log package

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -57,6 +57,10 @@ func main() {
 		log.Fatalf("error parsing flags: %v\n", err)
 	}
 
+	if err := cfg.ApplyDefaults(); err != nil {
+		log.Fatalln("error in config file: %w", err)
+	}
+
 	// After this point we can use util.Logger and stop using the log package
 	util.InitLogger(&cfg.Server)
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -25,40 +25,10 @@ func init() {
 }
 
 func main() {
-	var (
-		printVersion bool
-
-		cfg        config.Config
-		configFile string
-	)
-
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	fs.StringVar(&configFile, "config.file", "", "configuration file to load")
-	fs.BoolVar(&printVersion, "version", false, "Print this build's version information")
-	cfg.RegisterFlags(fs)
-
-	if err := fs.Parse(os.Args[1:]); err != nil {
-		log.Fatalf("error parsing flags: %v\n", err)
-	}
-
-	if printVersion {
-		fmt.Println(version.Print("agent"))
-		return
-	}
-
-	if configFile == "" {
-		log.Fatalln("-config.file flag required")
-	} else if err := config.LoadFile(configFile, &cfg); err != nil {
-		log.Fatalf("error loading config file %s: %v\n", configFile, err)
-	}
-
-	// Parse the flags again to override any yaml values with command line flags
-	if err := fs.Parse(os.Args[1:]); err != nil {
-		log.Fatalf("error parsing flags: %v\n", err)
-	}
-
-	if err := cfg.ApplyDefaults(); err != nil {
-		log.Fatalf("error in config file: %s\n", err)
+	cfg, err := config.Load(fs, os.Args[1:])
+	if err != nil {
+		log.Fatalln(err)
 	}
 
 	// After this point we can use util.Logger and stop using the log package

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,12 +50,9 @@ func LoadFile(filename string, c *Config) error {
 	return Load(buf, c)
 }
 
-// Load loads a config and applies defaults
+// Load loads a config, but doesn't apply defaults. Defaults
+// should be deferred to a separate process to allow flags
+// to override values unmarshaled here.
 func Load(buf []byte, c *Config) error {
-	err := yaml.UnmarshalStrict(buf, c)
-	if err != nil {
-		return err
-	}
-
-	return c.ApplyDefaults()
+	return yaml.UnmarshalStrict(buf, c)
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,10 +1,53 @@
 package config
 
 import (
+	"flag"
 	"testing"
+	"time"
 
+	"github.com/prometheus/common/model"
+	promCfg "github.com/prometheus/prometheus/config"
 	"github.com/stretchr/testify/require"
 )
+
+func TestConfig_OverrideDefaultsOnLoad(t *testing.T) {
+	cfg := `
+prometheus:
+  wal_directory: /tmp/wal
+  global:
+    scrape_timeout: 33s`
+	expect := promCfg.GlobalConfig{
+		ScrapeInterval:     model.Duration(1 * time.Minute),
+		ScrapeTimeout:      model.Duration(33 * time.Second),
+		EvaluationInterval: model.Duration(1 * time.Minute),
+	}
+
+	fs := flag.NewFlagSet("test", flag.ExitOnError)
+	c, err := load(fs, []string{"-config.file", "test"}, func(_ string, c *Config) error {
+		return LoadBytes([]byte(cfg), c)
+	})
+	require.NoError(t, err)
+	require.Equal(t, expect, c.Prometheus.Global)
+}
+
+func TestConfig_FlagsAreAccepted(t *testing.T) {
+	cfg := `
+prometheus:
+  global:
+    scrape_timeout: 33s`
+
+	fs := flag.NewFlagSet("test", flag.ExitOnError)
+	args := []string{
+		"-config.file", "test",
+		"-prometheus.wal-directory", "/tmp/wal",
+	}
+
+	c, err := load(fs, args, func(_ string, c *Config) error {
+		return LoadBytes([]byte(cfg), c)
+	})
+	require.NoError(t, err)
+	require.Equal(t, "/tmp/wal", c.Prometheus.WALDir)
+}
 
 func TestConfig_StrictYamlParsing(t *testing.T) {
 	t.Run("duplicate key", func(t *testing.T) {
@@ -15,7 +58,7 @@ prometheus:
     scrape_timeout: 10s
     scrape_timeout: 15s`
 		var c Config
-		err := Load([]byte(cfg), &c)
+		err := LoadBytes([]byte(cfg), &c)
 		require.Error(t, err)
 	})
 
@@ -26,7 +69,7 @@ prometheus:
   global:
   scrape_timeout: 10s`
 		var c Config
-		err := Load([]byte(cfg), &c)
+		err := LoadBytes([]byte(cfg), &c)
 		require.Error(t, err)
 	})
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,30 +2,9 @@ package config
 
 import (
 	"testing"
-	"time"
 
-	"github.com/prometheus/common/model"
-	promCfg "github.com/prometheus/prometheus/config"
 	"github.com/stretchr/testify/require"
 )
-
-func TestConfig_OverrideDefaultsOnLoad(t *testing.T) {
-	cfg := `
-prometheus:
-  wal_directory: /tmp/wal
-  global:
-    scrape_timeout: 33s`
-	expect := promCfg.GlobalConfig{
-		ScrapeInterval:     model.Duration(1 * time.Minute),
-		ScrapeTimeout:      model.Duration(33 * time.Second),
-		EvaluationInterval: model.Duration(1 * time.Minute),
-	}
-
-	var c Config
-	err := Load([]byte(cfg), &c)
-	require.NoError(t, err)
-	require.Equal(t, expect, c.Prometheus.Global)
-}
 
 func TestConfig_StrictYamlParsing(t *testing.T) {
 	t.Run("duplicate key", func(t *testing.T) {

--- a/pkg/integrations/node_exporter/config.go
+++ b/pkg/integrations/node_exporter/config.go
@@ -49,7 +49,6 @@ var (
 )
 
 func init() {
-	fmt.Println(runtime.GOOS)
 	switch runtime.GOOS {
 	case "freebsd", "netbsd", "openbsd":
 		DefaultConfig.FilesystemIgnoredMountPoints = "^/(dev)($|/)"


### PR DESCRIPTION
Previously, ApplyDefaults was invoked immediately after the config file was loaded. This was fine prior to #107, where unmarshaling the file did not override any values specified by command line flags. However, as #107 added back UnmarshalYaml to prom.Config, the flag value was getting wiped and anything specified only by flags would fail to load.