### PR TITLE
Be explicit about envsubst requirement in install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ the remote system.
 
 The easiest way to get started with the Grafana Cloud Agent is to use the
 Kubernetes install script. Simply copy and paste the following line in your
-terminal:
+terminal (requires `envsubst` (GNU gettext)):
 
 ```
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install.sh)" | kubectl apply -f -

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ docker pull grafana/agent:v0.3.2
 ### Kubernetes Install Script
 
 Running this script will automatically download and apply our recommended
-Grafana Cloud Agent Kubernetes deployment manifest:
+Grafana Cloud Agent Kubernetes deployment manifest (requires `envsubst` (GNU gettext)):
 
 > **Warning**: Always verify scripts from the internet before running them.
 

--- a/production/kubernetes/README.md
+++ b/production/kubernetes/README.md
@@ -15,7 +15,7 @@ The install script does the following:
 4. Prints out the final manifest to stdout without applying it.
 
 Here's a one-line script to copy and paste to install the Agent on
-Kubernetes:
+Kubernetes (requires `envsubst` (GNU gettext)):
 
 ```
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/v0.3.2/production/kubernetes/install.sh)" | kubectl apply -f -

--- a/production/kubernetes/install.sh
+++ b/production/kubernetes/install.sh
@@ -21,6 +21,16 @@
 # URL must always be provided.
 #
 
+check_installed() {
+  if ! type $1 >/dev/null 2>&1; then
+    echo "error: $1 not installed" >&2
+    exit 1
+  fi
+}
+
+check_installed curl
+check_installed envsubst
+
 MANIFEST_BRANCH=v0.3.2
 MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent.yaml}
 

--- a/tools/release-note.md
+++ b/tools/release-note.md
@@ -11,6 +11,9 @@ use-case best.
 
 #### Kubernetes Install Script
 
+The following script will download a Kubernetes manifest for the Agent and
+prompt for remote_write credentials. It requires curl and envsubst (GNU gettext).
+
 ```
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/${RELEASE_TAG}/production/kubernetes/install.sh)" | kubectl apply -f -
 ```


### PR DESCRIPTION
So `install.sh` requires `envsubst` which isn't a standard POSIX tool, but part of GNU gettext and not installed e.g. on macOS by default.

Probably it would be a good idea to make the script more portable longer-term (I imagine macOS users in particular are a non-negligible part of the user base), but this should make it fail a bit more nicely. (I added in `curl` too, which is kind of pointless but it felt ugly to not ask for both tools.)

I also tried documenting the requirement in the various places the install script was mentioned (there's way too many of those 😅 ).