### PR TITLE
Allow for specifying relabel_configs and metric_relabel_configs for integrations

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -1431,6 +1431,15 @@ agent:
   # prometheus.global.scrape_timeout.
   [scrape_timeout: <duration> | default = <global_config.scrape_timeout>]
 
+  # Allows for relabeling labels on the target. 
+  relabel_configs:
+    [- <relabel_config> ... ]
+  
+  # Relabel metrics coming from the integration, allowing to drop series 
+  # from the integration that you don't care about. 
+  metric_relabel_configs:
+    [ - <relabel_config> ... ]
+
 # When true, adds an agent_hostname label to all samples coming from
 # integrations. The value of the agent_hostname label will be the
 # value of $HOSTNAME (if available) or the machine's hostname.

--- a/pkg/integrations/config/config.go
+++ b/pkg/integrations/config/config.go
@@ -5,6 +5,8 @@ package config
 import (
 	"flag"
 	"time"
+
+	"github.com/prometheus/prometheus/pkg/relabel"
 )
 
 // Common is a set of common options shared by all integrations. It should be
@@ -14,8 +16,10 @@ import (
 //   Common config.Common `yaml:",inline"`
 // }
 type Common struct {
-	ScrapeInterval time.Duration `yaml:"scrape_interval"`
-	ScrapeTimeout  time.Duration `yaml:"scrape_timeout"`
+	ScrapeInterval       time.Duration     `yaml:"scrape_interval"`
+	ScrapeTimeout        time.Duration     `yaml:"scrape_timeout"`
+	RelabelConfigs       []*relabel.Config `yaml:"relabel_configs,omitempty"`
+	MetricRelabelConfigs []*relabel.Config `yaml:"metric_relabel_configs,omitempty"`
 }
 
 func (c *Common) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {

--- a/pkg/integrations/manager.go
+++ b/pkg/integrations/manager.go
@@ -191,6 +191,8 @@ func (m *Manager) instanceConfigForIntegration(i Integration) instance.Config {
 			ScrapeInterval:         model.Duration(common.ScrapeInterval),
 			ScrapeTimeout:          model.Duration(common.ScrapeTimeout),
 			ServiceDiscoveryConfig: m.scrapeServiceDiscovery(),
+			RelabelConfigs:         common.RelabelConfigs,
+			MetricRelabelConfigs:   common.MetricRelabelConfigs,
 		}
 
 		scrapeConfigs = append(scrapeConfigs, sc)


### PR DESCRIPTION
This PR presents a temporary workaround for #113 by letting users remove series they don't want from integrations. 

The documentation for #104 will have to rebase onto this change since the common set of config options has been expanded.