### PR TITLE
Scrape default/kubernetes in host_filter mode

### DIFF
--- a/example/docker-compose/vendor/grafana-agent-mixin
+++ b/example/docker-compose/vendor/grafana-agent-mixin
@@ -1,1 +1,1 @@
-/home/robert/dev/grafana/agent/production/grafana-agent-mixin
+../../../production/grafana-agent-mixin

--- a/production/kubernetes/agent.yaml
+++ b/production/kubernetes/agent.yaml
@@ -309,7 +309,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:latest
+        image: grafana/agent:v0.4.0
         imagePullPolicy: IfNotPresent
         name: agent
         ports:
@@ -357,7 +357,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:latest
+        image: grafana/agent:v0.4.0
         imagePullPolicy: IfNotPresent
         name: agent
         ports:

--- a/production/kubernetes/agent.yaml
+++ b/production/kubernetes/agent.yaml
@@ -207,6 +207,50 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
 ---
+apiVersion: v1
+data:
+  agent.yml: |
+    prometheus:
+        configs:
+          - host_filter: false
+            name: agent
+            remote_write:
+              - basic_auth:
+                    password: ${REMOTE_WRITE_PASSWORD}
+                    username: ${REMOTE_WRITE_USERNAME}
+                url: ${REMOTE_WRITE_URL}
+            scrape_configs:
+              - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                job_name: default/kubernetes
+                kubernetes_sd_configs:
+                  - role: endpoints
+                metric_relabel_configs:
+                  - action: drop
+                    regex: apiserver_admission_controller_admission_latencies_seconds_.*
+                    source_labels:
+                      - __name__
+                  - action: drop
+                    regex: apiserver_admission_step_admission_latencies_seconds_.*
+                    source_labels:
+                      - __name__
+                relabel_configs:
+                  - action: keep
+                    regex: apiserver
+                    source_labels:
+                      - __meta_kubernetes_service_label_component
+                scheme: https
+                tls_config:
+                    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                    insecure_skip_verify: false
+        global:
+            scrape_interval: 15s
+        wal_directory: /var/lib/agent/data
+    server:
+        log_level: info
+kind: ConfigMap
+metadata:
+  name: grafana-agent-deployment
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -287,3 +331,46 @@ spec:
         name: grafana-agent
   updateStrategy:
     type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana-agent-deployment
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: grafana-agent-deployment
+  template:
+    metadata:
+      labels:
+        name: grafana-agent-deployment
+    spec:
+      containers:
+      - args:
+        - -config.file=/etc/agent/agent.yml
+        - -prometheus.wal-directory=/tmp/agent/data
+        env:
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: grafana/agent:latest
+        imagePullPolicy: IfNotPresent
+        name: agent
+        ports:
+        - containerPort: 80
+          name: http-metrics
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /etc/agent
+          name: grafana-agent-deployment
+      serviceAccount: grafana-agent
+      volumes:
+      - configMap:
+          name: grafana-agent-deployment
+        name: grafana-agent-deployment

--- a/production/kubernetes/build/template/main.jsonnet
+++ b/production/kubernetes/build/template/main.jsonnet
@@ -1,6 +1,10 @@
 local agent = import 'grafana-agent/grafana-agent.libsonnet';
 
 agent {
+  _images+:: {
+    agent: 'grafana/agent:v0.4.0',
+  },
+
   _config+:: {
     namespace: 'default',
     agent_remote_write: [{

--- a/production/kubernetes/build/vendor/grafana-agent
+++ b/production/kubernetes/build/vendor/grafana-agent
@@ -1,1 +1,1 @@
-/home/robert/dev/grafana/agent/production/tanka/grafana-agent
+../../../tanka/grafana-agent

--- a/production/tanka/grafana-agent/config.libsonnet
+++ b/production/tanka/grafana-agent/config.libsonnet
@@ -12,6 +12,7 @@
     agent_configmap_name: 'grafana-agent',
     agent_deployment_configmap_name: self.agent_configmap_name + '-deployment',
     agent_pod_name: 'grafana-agent',
+    agent_deployment_pod_name: self.agent_pod_name + '-deployment',
 
     cluster_dns_tld: 'local',
     cluster_dns_suffix: 'cluster.' + self.cluster_dns_tld,

--- a/production/tanka/grafana-agent/config.libsonnet
+++ b/production/tanka/grafana-agent/config.libsonnet
@@ -77,9 +77,17 @@
       },
     },
     deployment_agent_config: self.agent_config {
-      configs: std.map(function(c) c {
-        host_filter: false,
-      }, super.configs),
+      prometheus+: {
+        configs: [{
+          name: 'agent',
+
+          host_filter: false,
+
+          scrape_configs: $._config.deployment_scrape_configs,
+          remote_write: $._config.agent_remote_write,
+        }],
+      },
+
     },
 
     //
@@ -105,7 +113,6 @@
           insecure_skip_verify: $._config.prometheus_insecure_skip_verify,
         },
         bearer_token_file: '/var/run/secrets/kubernetes.io/serviceaccount/token',
-
         relabel_configs: [{
           source_labels: ['__meta_kubernetes_service_label_component'],
           regex: 'apiserver',

--- a/production/tanka/grafana-agent/config.libsonnet
+++ b/production/tanka/grafana-agent/config.libsonnet
@@ -10,6 +10,7 @@
     //
     agent_cluster_role_name: 'grafana-agent',
     agent_configmap_name: 'grafana-agent',
+    agent_deployment_configmap_name: self.agent_configmap_name + '-deployment',
     agent_pod_name: 'grafana-agent',
 
     cluster_dns_tld: 'local',
@@ -46,6 +47,9 @@
     // to control the agent. A single instance is hard-coded and its
     // scrape_configs are defined below.
     //
+    // deployment_agent_config is a copy of `agent_config` that is used by the
+    // single-replica deployment to scrape jobs that don't work in host
+    // filtering mode.
     agent_config: {
       server: {
         log_level: 'info',
@@ -63,12 +67,67 @@
 
           host_filter: $._config.agent_host_filter,
 
-          scrape_configs: $._config.kubernetes_scrape_configs,
+          scrape_configs:
+            if $._config.agent_host_filter then
+              $._config.kubernetes_scrape_configs + $._config.deployment_scrape_configs
+            else
+              $._config.kubernetes_scrape_configs,
           remote_write: $._config.agent_remote_write,
         }],
       },
     },
+    deployment_agent_config: self.agent_config {
+      configs: std.map(function(c) c {
+        host_filter: false,
+      }, super.configs),
+    },
 
+    //
+    // We have two optional extension points for scrape config. One for the
+    // statefulset that holds all the agents attached to a node
+    // (kubernetes_scrape_configs) and One for the single replica deployment
+    // that is used to scrape jobs that don't work with host filtering mode
+    // (deployment_scrape_configs) the later is only used when host_filter =
+    // true.
+    deployment_scrape_configs: [
+      {
+        job_name: 'default/kubernetes',
+        kubernetes_sd_configs: [{
+          role:
+            if $._config.scrape_api_server_endpoints
+            then 'endpoints'
+            else 'service',
+        }],
+        scheme: 'https',
+
+        tls_config: {
+          ca_file: '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
+          insecure_skip_verify: $._config.prometheus_insecure_skip_verify,
+        },
+        bearer_token_file: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+
+        relabel_configs: [{
+          source_labels: ['__meta_kubernetes_service_label_component'],
+          regex: 'apiserver',
+          action: 'keep',
+        }],
+
+        // Drop some high cardinality metrics.
+        metric_relabel_configs: [
+          {
+            source_labels: ['__name__'],
+            regex: 'apiserver_admission_controller_admission_latencies_seconds_.*',
+            action: 'drop',
+          },
+          {
+            source_labels: ['__name__'],
+            regex: 'apiserver_admission_step_admission_latencies_seconds_.*',
+            action: 'drop',
+          },
+        ],
+
+      },
+    ],
     kubernetes_scrape_configs: [
       {
         job_name: 'kubernetes-pods',
@@ -351,46 +410,6 @@
           {
             source_labels: ['__name__'],
             regex: 'container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)',
-            action: 'drop',
-          },
-        ],
-      },
-
-      // If running on GKE, you cannot scrape API server pods, and must
-      // instead scrape the API server service endpoints. On AKS this doesn't
-      // work.
-      {
-        job_name: 'default/kubernetes',
-        kubernetes_sd_configs: [{
-          role:
-            if $._config.scrape_api_server_endpoints
-            then 'endpoints'
-            else 'service',
-        }],
-        scheme: 'https',
-
-        tls_config: {
-          ca_file: '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
-          insecure_skip_verify: $._config.prometheus_insecure_skip_verify,
-        },
-        bearer_token_file: '/var/run/secrets/kubernetes.io/serviceaccount/token',
-
-        relabel_configs: [{
-          source_labels: ['__meta_kubernetes_service_label_component'],
-          regex: 'apiserver',
-          action: 'keep',
-        }],
-
-        // Drop some high cardinality metrics.
-        metric_relabel_configs: [
-          {
-            source_labels: ['__name__'],
-            regex: 'apiserver_admission_controller_admission_latencies_seconds_.*',
-            action: 'drop',
-          },
-          {
-            source_labels: ['__name__'],
-            regex: 'apiserver_admission_step_admission_latencies_seconds_.*',
             action: 'drop',
           },
         ],

--- a/production/tanka/grafana-agent/grafana-agent.libsonnet
+++ b/production/tanka/grafana-agent/grafana-agent.libsonnet
@@ -5,6 +5,7 @@ k + config {
   local configMap = $.core.v1.configMap,
   local container = $.core.v1.container,
   local daemonSet = $.apps.v1.daemonSet,
+  local deployment = $.core.v1.deployment,
   local policyRule = $.rbac.v1beta1.policyRule,
 
   agent_rbac:
@@ -42,9 +43,9 @@ k + config {
 
   local config_hash_mixin =
     if $._config.agent_config_hash_annotation then
-    daemonSet.mixin.spec.template.metadata.withAnnotationsMixin({
-      config_hash: std.md5(std.toString($._config.agent_config)),
-    })
+      daemonSet.mixin.spec.template.metadata.withAnnotationsMixin({
+        config_hash: std.md5(std.toString($._config.agent_config)),
+      })
     else {},
 
   // TODO(rfratto): persistent storage for the WAL here is missing. hostVolume?
@@ -53,4 +54,67 @@ k + config {
     daemonSet.mixin.spec.template.spec.withServiceAccount($._config.agent_cluster_role_name) +
     config_hash_mixin +
     $.util.configVolumeMount($._config.agent_configmap_name, '/etc/agent'),
+
+
+  local agent_deployment_configmap_name = $._config.agent_configmap_name + '_deployment',
+  // If running on GKE, you cannot scrape API server pods, and must
+  // instead scrape the API server service endpoints. On AKS this doesn't
+  // work.
+  agent_deployment_config_map:
+    if $._config.agent_host_filter then
+      configMap.new(agent_deployment_configmap_name) +
+      configMap.withData({
+        'agent.yml': $.util.manifestYaml($._config.agent_config {
+          configs: [{
+            name: 'agent',
+            host_filter: $._config.agent_host_filter,
+            remote_write: $._config.agent_remote_write,
+            scrape_configs: [{
+              job_name: 'default/kubernetes',
+              kubernetes_sd_configs: [{
+                role:
+                  if $._config.scrape_api_server_endpoints
+                  then 'endpoints'
+                  else 'service',
+              }],
+              scheme: 'https',
+
+              tls_config: {
+                ca_file: '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
+                insecure_skip_verify: $._config.prometheus_insecure_skip_verify,
+              },
+              bearer_token_file: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+
+              relabel_configs: [{
+                source_labels: ['__meta_kubernetes_service_label_component'],
+                regex: 'apiserver',
+                action: 'keep',
+              }],
+
+              // Drop some high cardinality metrics.
+              metric_relabel_configs: [
+                {
+                  source_labels: ['__name__'],
+                  regex: 'apiserver_admission_controller_admission_latencies_seconds_.*',
+                  action: 'drop',
+                },
+                {
+                  source_labels: ['__name__'],
+                  regex: 'apiserver_admission_step_admission_latencies_seconds_.*',
+                  action: 'drop',
+                },
+              ],
+            }],
+          }],
+        }),
+      })
+    else {},
+
+  agent_deployment:
+    if $._config.agent_host_filter then
+      deployment.new($._config.agent_pod_name, 1, [$.agent_container]) +
+      deployment.mixin.spec.template.spec.withServiceAccount($._config.agent_cluster_role_name) +
+      deployment.mixin.spec.withReplicas(1) +
+      $.util.configVolumeMount(agent_deployment_configmap_name, '/etc/agent')
+    else {},
 }

--- a/production/tanka/grafana-agent/grafana-agent.libsonnet
+++ b/production/tanka/grafana-agent/grafana-agent.libsonnet
@@ -5,7 +5,7 @@ k + config {
   local configMap = $.core.v1.configMap,
   local container = $.core.v1.container,
   local daemonSet = $.apps.v1.daemonSet,
-  local deployment = $.core.v1.deployment,
+  local deployment = $.apps.v1.deployment,
   local policyRule = $.rbac.v1beta1.policyRule,
 
   agent_rbac:
@@ -70,7 +70,7 @@ k + config {
 
   agent_deployment:
     if $._config.agent_host_filter then
-      deployment.new($._config.agent_pod_name, 1, [$.agent_container]) +
+      deployment.new($._config.agent_deployment_pod_name, 1, [$.agent_container]) +
       deployment.mixin.spec.template.spec.withServiceAccount($._config.agent_cluster_role_name) +
       deployment.mixin.spec.withReplicas(1) +
       self.config_hash_mixin.deployment +


### PR DESCRIPTION
I genuinely think #124 describes the problem way better than what I would ever be able to phrase, so I won't paraphrase.

The work done here refers to the second solution mentioned in the issue where we'll deploy a single replica deployment to scrape for `default/kubernetes` explicitly. 

Closes #124.