### PR TITLE
improve memory stability and performance of WAL

### DIFF
--- a/pkg/prom/wal/series.go
+++ b/pkg/prom/wal/series.go
@@ -27,11 +27,15 @@ type memSeries struct {
 	// willDelete marks a series as to be deleted on the next garbage
 	// collection. If it receives a write, willDelete is disabled.
 	willDelete bool
+
+	// Whether this series has samples waiting to be committed to the WAL
+	pendingCommit bool
 }
 
 func (s *memSeries) updateTs(ts int64) {
 	s.lastTs = ts
 	s.willDelete = false
+	s.pendingCommit = true
 }
 
 // seriesHashmap is a simple hashmap for memSeries by their label set. It is
@@ -147,7 +151,7 @@ func (s *stripeSeries) gc(mint int64) map[uint64]struct{} {
 
 			// If the series has received a write after mint, there's still
 			// data and it's not completely gone yet.
-			if series.lastTs >= mint {
+			if series.lastTs >= mint || series.pendingCommit {
 				series.willDelete = false
 				series.Unlock()
 				continue
@@ -171,9 +175,6 @@ func (s *stripeSeries) gc(mint int64) map[uint64]struct{} {
 
 			deleted[series.ref] = struct{}{}
 			delete(s.series[i], series.ref)
-
-			// This may be a no-op: only series replayed from the WAL are
-			// present in the hashes collection and are removed over time.
 			s.hashes[j].del(series.hash, series.ref)
 
 			if i != j {

--- a/pkg/prom/wal/series.go
+++ b/pkg/prom/wal/series.go
@@ -237,14 +237,6 @@ func (s *stripeSeries) saveLabels(hash uint64, series *memSeries, lbls labels.La
 	s.locks[i].Unlock()
 }
 
-func (s *stripeSeries) delLabels(hash uint64, series *memSeries) {
-	i := hash & uint64(s.size-1)
-
-	s.locks[i].Lock()
-	s.hashes[i].del(hash, series.ref)
-	s.locks[i].Unlock()
-}
-
 func (s *stripeSeries) iterator() *stripeSeriesIterator {
 	return &stripeSeriesIterator{s}
 }

--- a/pkg/prom/wal/wal.go
+++ b/pkg/prom/wal/wal.go
@@ -62,6 +62,7 @@ func newStorageMetrics(r prometheus.Registerer) *storageMetrics {
 			m.numDeletedSeries,
 			m.totalCreatedSeries,
 			m.totalRemovedSeries,
+			m.totalAppendedSamples,
 		)
 	}
 
@@ -547,6 +548,7 @@ func (a *appender) Add(l labels.Labels, t int64, v float64) (uint64, error) {
 
 	a.w.metrics.numActiveSeries.Inc()
 	a.w.metrics.totalCreatedSeries.Inc()
+	a.w.metrics.totalAppendedSamples.Inc()
 
 	return series.ref, a.AddFast(series.ref, t, v)
 }
@@ -568,6 +570,8 @@ func (a *appender) AddFast(ref uint64, t int64, v float64) error {
 		T:   t,
 		V:   v,
 	})
+
+	a.w.metrics.totalAppendedSamples.Inc()
 	return nil
 }
 

--- a/pkg/prom/wal/wal.go
+++ b/pkg/prom/wal/wal.go
@@ -373,9 +373,9 @@ func (w *Storage) Truncate(mint int64) error {
 		return nil // no segments yet.
 	}
 
-	// The lower third of segments should contain mostly obsolete samples.
-	// If we have less than three segments, it's not worth checkpointing yet.
-	last = first + (last-first)/3
+	// The lower two thirds of segments should contain mostly obsolete samples.
+	// If we have less than two segments, it's not worth checkpointing yet.
+	last = first + (last-first)*2/3
 	if last <= first {
 		return nil
 	}
@@ -445,7 +445,7 @@ func (w *Storage) gc(mint int64) {
 		w.deleted[ref] = last
 	}
 
-	w.metrics.numDeletedSeries.Set(float64(len(deleted)))
+	w.metrics.numDeletedSeries.Set(float64(len(w.deleted)))
 }
 
 // WriteStalenessMarkers appends a staleness sample for all active series.
@@ -522,57 +522,29 @@ type appender struct {
 }
 
 func (a *appender) Add(l labels.Labels, t int64, v float64) (uint64, error) {
-	// The normal procedure here would be to see if we have any in-memory
-	// series with the same label set and return the same ref ID if such
-	// a series exists. However, storing all these labels takes up a fair
-	// amount of memory, so we take a shortcut here: return a series if its
-	// labels were already stored, but don't store labels for new series.
-	//
-	// This shortcut is utilized by the WAL replay to make sure that replayed
-	// series retain the same ref ID, but new series or existing series that go
-	// stale and come back will be assigned new ref IDs.
-	//
-	// In most cases, this won't be a problem, and both the scraping and remote
-	// write code will handle this gracefully. There is a slightly chance of samples
-	// being skipped if the following happens, in order:
-	//
-	// 1. A series goes stale and is not present in a scrape. The saved series ID
-	//    is removed from the scrape cache as a result.
-	// 2. Samples from that stale series are still pending to be sent to the
-	//    remote.
-	// 3. The series comes back and is assigned a new ref ID per the code below this
-	//    comment block.
-	// 4. Samples from the series with the new ref ID are sent before the pending
-	//    series.
-	// 5. When the samples from the previous ref ID get sent, they are rejected as
-	//    being out of order.
-
 	hash := l.Hash()
 
 	series := a.w.series.getByHash(hash, l)
 	if series != nil {
-		// Unlikely path: existing series whose labels have been saved.
-
-		// Now that the series has been read and will be cached by the scraping code,
-		// we can remove the stored labels from memory.
-		a.w.series.delLabels(hash, series)
 		return series.ref, a.AddFast(series.ref, t, v)
 	}
 
-	// More common path: we haven't saved the labels for this series,
-	// create a new ref ID for it.
 	a.w.mtx.Lock()
 	ref := a.w.nextRef
 	a.w.nextRef++
 	a.w.mtx.Unlock()
 
-	series = &memSeries{ref: ref, hash: hash, lastTs: t}
+	series = &memSeries{ref: ref, hash: hash}
+	series.updateTs(t)
+
 	a.series = append(a.series, record.RefSeries{
 		Ref:    ref,
 		Labels: l,
 	})
 
 	a.w.series.set(series)
+	a.w.series.saveLabels(series.hash, series, l)
+
 	a.w.metrics.numActiveSeries.Inc()
 	a.w.metrics.totalCreatedSeries.Inc()
 
@@ -622,6 +594,16 @@ func (a *appender) Commit() error {
 
 	//nolint:staticcheck
 	a.w.bufPool.Put(buf)
+
+	for _, sample := range a.samples {
+		series := a.w.series.getByID(sample.Ref)
+		if series != nil {
+			series.Lock()
+			series.pendingCommit = false
+			series.Unlock()
+		}
+	}
+
 	return a.Rollback()
 }
 


### PR DESCRIPTION
Overall, this PR should result in less spikey memory usage and may demonstrate a measurable decrease in memory usage overall. Active series will now be reported more accurately.

Several small issues were fixed in particular:

1. Match the upstream TSDB usage of the WAL where series are prevented from getting deleted if they were pending a commit.

2. Match the upstream TSDB usage of the WAL to only delete the lower 2/3rds of segments when truncating the WAL.

3. The deleted series metric was being incorrectly reported.

4. We revert the behavior of not tracking labels for active series. This caused many issues and only marginally improved memory usage. Not tracking labels caused series to get double-counted when they went stale. Reverting this change does make memory usage marginally worse, but the combined set of changes for this commit offset the hit here.

/cc @annanay25 