### PR TITLE
Create scrape targets API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -176,7 +176,7 @@ Response on success:
       "endpoint": <string, URL being scraped>
       "state": <string, one of up, down, unknown>,
       "labels": {
-        "label_a", "value_a",
+        "label_a": "value_a",
         ...
       },
       "last_scrape": <string, RFC 3339 timestamp of last scrape>,

--- a/docs/api.md
+++ b/docs/api.md
@@ -132,9 +132,9 @@ Response on success:
 }
 ```
 
-## Agent API 
+## Agent API
 
-### List current running instances 
+### List current running instances
 
 ```
 GET /agent/api/v1/instances
@@ -148,6 +148,42 @@ Response on success:
   "status": "success",
   "data": [
     <strings of instance names that are currently running>
+  ]
+}
+```
+
+### List current scrape targets
+
+```
+GET /agent/api/v1/targets
+```
+
+This endpoint collects all targets known to the Agent across all running
+instances. Only targets being scraped from the local Agent will be returned. If
+running in scraping service mode, this endpoint must be invoked in all Agents
+separately to get the combined set of targets across the whole Agent cluster.
+
+Status code: 200 on success.
+Response on success:
+
+```
+{
+  "status": "success",
+  "data": [
+    {
+      "instance": <string, instance config name>,
+      "target_group": <string, scrape config group name>,
+      "endpoint": <string, URL being scraped>
+      "state": <string, one of up, down, unknown>,
+      "labels": {
+        "label_a", "value_a",
+        ...
+      },
+      "last_scrape": <string, RFC 3339 timestamp of last scrape>,
+      "scrape_duration_ms": <number, last scrape duration in milliseconds>,
+      "scrape_error": <string, last error. empty if scrape succeeded>
+    },
+    ...
   ]
 }
 ```

--- a/pkg/prom/agent_test.go
+++ b/pkg/prom/agent_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/grafana/agent/pkg/prom/instance"
 	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/scrape"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"gopkg.in/yaml.v2"
@@ -266,6 +267,10 @@ func (i *mockInstance) Run(ctx context.Context) error {
 	case err := <-i.err:
 		return err
 	}
+}
+
+func (i *mockInstance) TargetsActive() map[string][]*scrape.Target {
+	return nil
 }
 
 type mockInstanceFactory struct {

--- a/pkg/prom/agent_test.go
+++ b/pkg/prom/agent_test.go
@@ -191,13 +191,6 @@ func TestAgent_NormalInstanceExits(t *testing.T) {
 				return fact.created.Load() == 2 && len(a.cm.processes) == 2
 			})
 
-			// Get the total amount of instances that started before
-			// we send errors through
-			var oldStartedCount int64
-			for _, i := range fact.Mocks() {
-				oldStartedCount += i.startedCount.Load()
-			}
-
 			for _, mi := range fact.Mocks() {
 				mi.err <- tc.simulateError
 			}
@@ -211,7 +204,9 @@ func TestAgent_NormalInstanceExits(t *testing.T) {
 				startedCount += i.startedCount.Load()
 			}
 
-			require.Equal(t, startedCount, oldStartedCount, "instances should not have restarted")
+			// There should only be two instances that started. If there's more, something
+			// restarted despite our error.
+			require.Equal(t, int64(2), startedCount, "instances should not have restarted")
 		})
 	}
 }

--- a/pkg/prom/http.go
+++ b/pkg/prom/http.go
@@ -43,7 +43,7 @@ func (a *Agent) ListTargetsHandler(w http.ResponseWriter, _ *http.Request) {
 	a.instancesMut.Lock()
 	defer a.instancesMut.Unlock()
 
-	var resp ListTargetsResponse
+	resp := ListTargetsResponse{}
 
 	for instName, inst := range a.instances {
 		tps := inst.TargetsActive()

--- a/pkg/prom/http.go
+++ b/pkg/prom/http.go
@@ -3,10 +3,13 @@ package prom
 import (
 	"net/http"
 	"sort"
+	"time"
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/gorilla/mux"
 	"github.com/grafana/agent/pkg/prom/ha/configapi"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
 )
 
 // WireAPI adds API routes to the provided mux router.
@@ -16,6 +19,7 @@ func (a *Agent) WireAPI(r *mux.Router) {
 	}
 
 	r.HandleFunc("/agent/api/v1/instances", a.ListInstancesHandler).Methods("GET")
+	r.HandleFunc("/agent/api/v1/targets", a.ListTargetsHandler).Methods("GET")
 }
 
 // ListInstances writes the set of currently running instances to the http.ResponseWriter.
@@ -31,4 +35,85 @@ func (a *Agent) ListInstancesHandler(w http.ResponseWriter, _ *http.Request) {
 	if err != nil {
 		level.Error(a.logger).Log("msg", "failed to write response", "err", err)
 	}
+}
+
+// ListTargetsHandler retrieves the full set of targets across all instances and shows
+// information on them.
+func (a *Agent) ListTargetsHandler(w http.ResponseWriter, _ *http.Request) {
+	a.instancesMut.Lock()
+	defer a.instancesMut.Unlock()
+
+	var resp ListTargetsResponse
+
+	for instName, inst := range a.instances {
+		tps := inst.TargetsActive()
+
+		for key, targets := range tps {
+			for _, tgt := range targets {
+				var lastError string
+				if scrapeError := tgt.LastError(); scrapeError != nil {
+					lastError = scrapeError.Error()
+				}
+
+				resp = append(resp, TargetInfo{
+					InstanceName: instName,
+					TargetGroup:  key,
+
+					Endpoint:       tgt.URL().String(),
+					State:          string(tgt.Health()),
+					Labels:         tgt.Labels(),
+					LastScrape:     tgt.LastScrape(),
+					ScrapeDuration: tgt.LastScrapeDuration().Milliseconds(),
+					ScrapeError:    lastError,
+				})
+			}
+		}
+	}
+
+	sort.Slice(resp, func(i, j int) bool {
+		// sort by instance, then target group, then job label, then instance label
+		var (
+			iInstance      = resp[i].InstanceName
+			iTargetGroup   = resp[i].TargetGroup
+			iJobLabel      = resp[i].Labels.Get(model.JobLabel)
+			iInstanceLabel = resp[i].Labels.Get(model.InstanceLabel)
+
+			jInstance      = resp[j].InstanceName
+			jTargetGroup   = resp[j].TargetGroup
+			jJobLabel      = resp[j].Labels.Get(model.JobLabel)
+			jInstanceLabel = resp[j].Labels.Get(model.InstanceLabel)
+		)
+
+		switch {
+		case iInstance != jInstance:
+			return iInstance < jInstance
+		case iTargetGroup != jTargetGroup:
+			return iTargetGroup < jTargetGroup
+		case iJobLabel != jJobLabel:
+			return iJobLabel < jJobLabel
+		default:
+			return iInstanceLabel < jInstanceLabel
+		}
+	})
+
+	err := configapi.WriteResponse(w, http.StatusOK, resp)
+	if err != nil {
+		level.Error(a.logger).Log("msg", "failed to write response", "err", err)
+	}
+}
+
+// ListTargetsResponse is returned by the ListTargetsHandler.
+type ListTargetsResponse []TargetInfo
+
+// TargetInfo describes a specific target.
+type TargetInfo struct {
+	InstanceName string `json:"instance"`
+	TargetGroup  string `json:"target_group"`
+
+	Endpoint       string        `json:"endpoint"`
+	State          string        `json:"state"`
+	Labels         labels.Labels `json:"labels"`
+	LastScrape     time.Time     `json:"last_scrape"`
+	ScrapeDuration int64         `json:"scrape_duration_ms"`
+	ScrapeError    string        `json:"scrape_error"`
 }

--- a/pkg/prom/http_test.go
+++ b/pkg/prom/http_test.go
@@ -1,12 +1,17 @@
 package prom
 
 import (
+	"context"
+	"fmt"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/util/test"
 	"github.com/go-kit/kit/log"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/scrape"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,4 +43,65 @@ func TestAgent_ListInstancesHandler(t *testing.T) {
 			return expect == rr.Body.String()
 		})
 	})
+}
+
+func TestAgent_ListTargetsHandler(t *testing.T) {
+	fact := newMockInstanceFactory()
+	a, err := newAgent(Config{
+		WALDir: "/tmp/agent",
+	}, log.NewNopLogger(), fact.factory)
+	require.NoError(t, err)
+
+	r := httptest.NewRequest("GET", "/agent/api/v1/targets", nil)
+
+	t.Run("scrape manager not ready", func(t *testing.T) {
+		a.instances = map[string]inst{
+			"test_instance": &mockInstanceScrape{},
+		}
+
+		rr := httptest.NewRecorder()
+		a.ListTargetsHandler(rr, r)
+		expect := `{"status":"success","data":null}`
+		require.Equal(t, expect, rr.Body.String())
+	})
+
+	t.Run("scrape manager targets", func(t *testing.T) {
+		tgt := scrape.NewTarget(labels.FromMap(map[string]string{
+			model.JobLabel:         "job",
+			model.InstanceLabel:    "instance",
+			model.SchemeLabel:      "http",
+			model.AddressLabel:     "localhost:12345",
+			model.MetricsPathLabel: "/metrics",
+			"foo":                  "bar",
+		}), nil, nil)
+
+		startTime := time.Date(1994, time.January, 12, 0, 0, 0, 0, time.UTC)
+		tgt.Report(startTime, time.Minute, fmt.Errorf("something went wrong"))
+
+		a.instances = map[string]inst{
+			"test_instance": &mockInstanceScrape{
+				tgts: map[string][]*scrape.Target{
+					"group_a": {tgt},
+				},
+			},
+		}
+
+		rr := httptest.NewRecorder()
+		a.ListTargetsHandler(rr, r)
+		expect := `{"status":"success","data":[{"instance":"test_instance","target_group":"group_a","endpoint":"http://localhost:12345/metrics","state":"down","labels":{"foo":"bar","instance":"instance","job":"job"},"last_scrape":"1994-01-12T00:00:00Z","scrape_duration_ms":60000,"scrape_error":"something went wrong"}]}`
+		require.Equal(t, expect, rr.Body.String())
+	})
+}
+
+type mockInstanceScrape struct {
+	tgts map[string][]*scrape.Target
+}
+
+func (i *mockInstanceScrape) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+func (i *mockInstanceScrape) TargetsActive() map[string][]*scrape.Target {
+	return i.tgts
 }

--- a/pkg/prom/http_test.go
+++ b/pkg/prom/http_test.go
@@ -3,6 +3,7 @@ package prom
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -61,8 +62,9 @@ func TestAgent_ListTargetsHandler(t *testing.T) {
 
 		rr := httptest.NewRecorder()
 		a.ListTargetsHandler(rr, r)
-		expect := `{"status":"success","data":[]}`
-		require.Equal(t, expect, rr.Body.String())
+		expect := `{"status": "success", "data": []}`
+		require.JSONEq(t, expect, rr.Body.String())
+		require.Equal(t, http.StatusOK, rr.Result().StatusCode)
 	})
 
 	t.Run("scrape manager targets", func(t *testing.T) {
@@ -88,8 +90,25 @@ func TestAgent_ListTargetsHandler(t *testing.T) {
 
 		rr := httptest.NewRecorder()
 		a.ListTargetsHandler(rr, r)
-		expect := `{"status":"success","data":[{"instance":"test_instance","target_group":"group_a","endpoint":"http://localhost:12345/metrics","state":"down","labels":{"foo":"bar","instance":"instance","job":"job"},"last_scrape":"1994-01-12T00:00:00Z","scrape_duration_ms":60000,"scrape_error":"something went wrong"}]}`
-		require.Equal(t, expect, rr.Body.String())
+		expect := `{
+			"status": "success",
+			"data": [{
+				"instance": "test_instance",
+				"target_group": "group_a",
+				"endpoint": "http://localhost:12345/metrics",
+				"state": "down",
+				"labels": {
+					"foo": "bar",
+					"instance": "instance",
+					"job": "job"
+				},
+				"last_scrape": "1994-01-12T00:00:00Z",
+				"scrape_duration_ms": 60000,
+				"scrape_error":"something went wrong"
+			}]
+		}`
+		require.JSONEq(t, expect, rr.Body.String())
+		require.Equal(t, http.StatusOK, rr.Result().StatusCode)
 	})
 }
 

--- a/pkg/prom/http_test.go
+++ b/pkg/prom/http_test.go
@@ -61,7 +61,7 @@ func TestAgent_ListTargetsHandler(t *testing.T) {
 
 		rr := httptest.NewRecorder()
 		a.ListTargetsHandler(rr, r)
-		expect := `{"status":"success","data":null}`
+		expect := `{"status":"success","data":[]}`
 		require.Equal(t, expect, rr.Body.String())
 	})
 


### PR DESCRIPTION
`/agent/api/v1/targets` is a new API endpoint that will return info on all scrape targets currently being scraped by the running Agent. Targets from other Agents (i.e., in scraping service mode), will not be returned.

This API exposes the same information present on the Prometheus UI page for targets.

Provides some of #6.