### PR TITLE
pkg/prom: refactor InstanceManager

### DIFF
--- a/pkg/integrations/manager_test.go
+++ b/pkg/integrations/manager_test.go
@@ -137,8 +137,8 @@ func (i *mockIntegration) Run(ctx context.Context) error {
 	}
 }
 
-func mockInstanceFactory(_ instance.Config) prom.Instance {
-	return instance.NoOpInstance{}
+func mockInstanceFactory(_ instance.Config) (prom.Instance, error) {
+	return instance.NoOpInstance{}, nil
 }
 
 func mockManagerConfig() Config {

--- a/pkg/integrations/manager_test.go
+++ b/pkg/integrations/manager_test.go
@@ -24,7 +24,7 @@ func TestManager_ValidInstanceConfigs(t *testing.T) {
 	mock := newMockIntegration()
 
 	integrations := []Integration{mock}
-	im := prom.NewInstanceManager(mockInstanceLauncher, func(c *instance.Config) error {
+	im := prom.NewInstanceManager(prom.DefaultInstanceManagerConfig, log.NewNopLogger(), mockInstanceFactory, func(c *instance.Config) error {
 		globalConfig := prom_config.DefaultConfig.GlobalConfig
 		return c.ApplyDefaults(&globalConfig)
 	})
@@ -44,7 +44,8 @@ func TestManager_StartsIntegrations(t *testing.T) {
 	mock := newMockIntegration()
 
 	integrations := []Integration{mock}
-	im := prom.NewInstanceManager(mockInstanceLauncher, nil)
+
+	im := prom.NewInstanceManager(prom.DefaultInstanceManagerConfig, log.NewNopLogger(), mockInstanceFactory, nil)
 	m, err := newManager(mockManagerConfig(), log.NewNopLogger(), im, integrations)
 	require.NoError(t, err)
 	defer m.Stop()
@@ -63,7 +64,7 @@ func TestManager_RestartsIntegrations(t *testing.T) {
 	mock := newMockIntegration()
 
 	integrations := []Integration{mock}
-	im := prom.NewInstanceManager(mockInstanceLauncher, nil)
+	im := prom.NewInstanceManager(prom.DefaultInstanceManagerConfig, log.NewNopLogger(), mockInstanceFactory, nil)
 	m, err := newManager(mockManagerConfig(), log.NewNopLogger(), im, integrations)
 	require.NoError(t, err)
 	defer m.Stop()
@@ -79,7 +80,7 @@ func TestManager_GracefulStop(t *testing.T) {
 	mock := newMockIntegration()
 
 	integrations := []Integration{mock}
-	im := prom.NewInstanceManager(mockInstanceLauncher, nil)
+	im := prom.NewInstanceManager(prom.DefaultInstanceManagerConfig, log.NewNopLogger(), mockInstanceFactory, nil)
 	m, err := newManager(mockManagerConfig(), log.NewNopLogger(), im, integrations)
 	require.NoError(t, err)
 
@@ -136,7 +137,9 @@ func (i *mockIntegration) Run(ctx context.Context) error {
 	}
 }
 
-func mockInstanceLauncher(ctx context.Context, _ instance.Config) { <-ctx.Done() }
+func mockInstanceFactory(_ instance.Config) prom.Instance {
+	return instance.NoOpInstance{}
+}
 
 func mockManagerConfig() Config {
 	listenPort := 0

--- a/pkg/prom/agent.go
+++ b/pkg/prom/agent.go
@@ -143,13 +143,8 @@ func newAgent(cfg Config, logger log.Logger, fact instanceFactory) (*Agent, erro
 }
 
 // newInstance creates a new Instance given a config.
-func (a *Agent) newInstance(c instance.Config) Instance {
-	inst, err := a.instanceFactory(a.cfg.Global, c, a.cfg.WALDir, a.logger)
-	if err != nil {
-		level.Error(a.logger).Log("msg", "failed to create instance", "err", err)
-		return nil
-	}
-	return inst
+func (a *Agent) newInstance(c instance.Config) (Instance, error) {
+	return a.instanceFactory(a.cfg.Global, c, a.cfg.WALDir, a.logger)
 }
 
 func (a *Agent) validateInstance(c *instance.Config) error {

--- a/pkg/prom/agent.go
+++ b/pkg/prom/agent.go
@@ -4,11 +4,9 @@
 package prom
 
 import (
-	"context"
 	"errors"
 	"flag"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -16,23 +14,8 @@ import (
 	"github.com/grafana/agent/pkg/prom/ha"
 	"github.com/grafana/agent/pkg/prom/ha/client"
 	"github.com/grafana/agent/pkg/prom/instance"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/config"
-	"github.com/prometheus/prometheus/scrape"
 	"google.golang.org/grpc"
-)
-
-var (
-	instanceAbnormalExits = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "agent_prometheus_instance_abnormal_exits_total",
-		Help: "Total number of times a Prometheus instance exited unexpectedly, causing it to be restarted.",
-	}, []string{"instance_name"})
-
-	currentActiveConfigs = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "agent_prometheus_active_configs",
-		Help: "Current number of active configs being used by the agent.",
-	})
 )
 
 var (
@@ -107,9 +90,9 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 }
 
 // Agent is an agent for collecting Prometheus metrics. It acts as a
-// Prometheus-lite; only running the service discovery, remote_write,
-// and WAL components of Prometheus. It is broken down into a series
-// of Instances, each of which perform metric collection.
+// Prometheus-lite; only running the service discovery, remote_write, and WAL
+// components of Prometheus. It is broken down into a series of Instances, each
+// of which perform metric collection.
 type Agent struct {
 	cfg    Config
 	logger log.Logger
@@ -117,9 +100,6 @@ type Agent struct {
 	cm *InstanceManager
 
 	instanceFactory instanceFactory
-
-	instancesMut sync.Mutex
-	instances    map[string]inst
 
 	ha *ha.Server
 }
@@ -134,10 +114,11 @@ func newAgent(cfg Config, logger log.Logger, fact instanceFactory) (*Agent, erro
 		cfg:             cfg,
 		logger:          log.With(logger, "agent", "prometheus"),
 		instanceFactory: fact,
-		instances:       make(map[string]inst),
 	}
 
-	a.cm = NewInstanceManager(a.spawnInstance, a.validateInstance)
+	a.cm = NewInstanceManager(InstanceManagerConfig{
+		InstanceRestartBackoff: cfg.InstanceRestartBackoff,
+	}, a.logger, a.newInstance, a.validateInstance)
 
 	allConfigsValid := true
 	for _, c := range cfg.Configs {
@@ -161,45 +142,18 @@ func newAgent(cfg Config, logger log.Logger, fact instanceFactory) (*Agent, erro
 	return a, nil
 }
 
-func (a *Agent) validateInstance(c *instance.Config) error {
-	return c.ApplyDefaults(&a.cfg.Global)
-}
-
-// spawnInstance takes an instance.Config and launches an instance, restarting
-// it if it stops unexpectedly. The instance will be stopped whenever ctx
-// is canceled. This function will not return until the launched instance
-// has fully shut down.
-func (a *Agent) spawnInstance(ctx context.Context, c instance.Config) {
+// newInstance creates a new Instance given a config.
+func (a *Agent) newInstance(c instance.Config) Instance {
 	inst, err := a.instanceFactory(a.cfg.Global, c, a.cfg.WALDir, a.logger)
 	if err != nil {
 		level.Error(a.logger).Log("msg", "failed to create instance", "err", err)
-		return
+		return nil
 	}
+	return inst
+}
 
-	// Internally keep track of the instance. This is used by the Agent API to
-	// pull metadata from the instances. When this function exits, we'll remove
-	// the in-memory reference.
-	a.instancesMut.Lock()
-	a.instances[c.Name] = inst
-	a.instancesMut.Unlock()
-
-	defer func() {
-		a.instancesMut.Lock()
-		delete(a.instances, c.Name)
-		a.instancesMut.Unlock()
-	}()
-
-	for {
-		err = inst.Run(ctx)
-		if err != nil && err != context.Canceled {
-			instanceAbnormalExits.WithLabelValues(c.Name).Inc()
-			level.Error(a.logger).Log("msg", "instance stopped abnormally, restarting after backoff period", "err", err, "backoff", a.cfg.InstanceRestartBackoff, "instance", c.Name)
-			time.Sleep(a.cfg.InstanceRestartBackoff)
-		} else {
-			level.Info(a.logger).Log("msg", "stopped instance", "instance", c.Name)
-			break
-		}
-	}
+func (a *Agent) validateInstance(c *instance.Config) error {
+	return c.ApplyDefaults(&a.cfg.Global)
 }
 
 func (a *Agent) WireGRPC(s *grpc.Server) {
@@ -208,13 +162,8 @@ func (a *Agent) WireGRPC(s *grpc.Server) {
 	}
 }
 
-func (a *Agent) Config() Config {
-	return a.cfg
-}
-
-func (a *Agent) InstanceManager() *InstanceManager {
-	return a.cm
-}
+func (a *Agent) Config() Config                    { return a.cfg }
+func (a *Agent) InstanceManager() *InstanceManager { return a.cm }
 
 // Stop stops the agent and all its instances.
 func (a *Agent) Stop() {
@@ -226,15 +175,8 @@ func (a *Agent) Stop() {
 	a.cm.Stop()
 }
 
-// inst is an interface implemented by Instance, and used by tests
-// to isolate agent from instance functionality.
-type inst interface {
-	Run(ctx context.Context) error
-	TargetsActive() map[string][]*scrape.Target
-}
+type instanceFactory = func(global config.GlobalConfig, cfg instance.Config, walDir string, logger log.Logger) (Instance, error)
 
-type instanceFactory = func(global config.GlobalConfig, cfg instance.Config, walDir string, logger log.Logger) (inst, error)
-
-func defaultInstanceFactory(global config.GlobalConfig, cfg instance.Config, walDir string, logger log.Logger) (inst, error) {
+func defaultInstanceFactory(global config.GlobalConfig, cfg instance.Config, walDir string, logger log.Logger) (Instance, error) {
 	return instance.New(global, cfg, walDir, logger)
 }

--- a/pkg/prom/agent_test.go
+++ b/pkg/prom/agent_test.go
@@ -285,7 +285,7 @@ func (f *mockInstanceFactory) Mocks() []*mockInstance {
 	return f.mocks
 }
 
-func (f *mockInstanceFactory) factory(_ config.GlobalConfig, cfg instance.Config, _ string, _ log.Logger) (inst, error) {
+func (f *mockInstanceFactory) factory(_ config.GlobalConfig, cfg instance.Config, _ string, _ log.Logger) (Instance, error) {
 	f.created.Add(1)
 
 	f.mut.Lock()

--- a/pkg/prom/http.go
+++ b/pkg/prom/http.go
@@ -40,12 +40,10 @@ func (a *Agent) ListInstancesHandler(w http.ResponseWriter, _ *http.Request) {
 // ListTargetsHandler retrieves the full set of targets across all instances and shows
 // information on them.
 func (a *Agent) ListTargetsHandler(w http.ResponseWriter, _ *http.Request) {
-	a.instancesMut.Lock()
-	defer a.instancesMut.Unlock()
-
+	instances := a.cm.ListInstances()
 	resp := ListTargetsResponse{}
 
-	for instName, inst := range a.instances {
+	for instName, inst := range instances {
 		tps := inst.TargetsActive()
 
 		for key, targets := range tps {

--- a/pkg/prom/http_test.go
+++ b/pkg/prom/http_test.go
@@ -56,8 +56,8 @@ func TestAgent_ListTargetsHandler(t *testing.T) {
 	r := httptest.NewRequest("GET", "/agent/api/v1/targets", nil)
 
 	t.Run("scrape manager not ready", func(t *testing.T) {
-		a.instances = map[string]inst{
-			"test_instance": &mockInstanceScrape{},
+		a.cm.processes = map[string]*instanceManagerProcess{
+			"test_instance": {inst: &mockInstanceScrape{}},
 		}
 
 		rr := httptest.NewRecorder()
@@ -80,10 +80,12 @@ func TestAgent_ListTargetsHandler(t *testing.T) {
 		startTime := time.Date(1994, time.January, 12, 0, 0, 0, 0, time.UTC)
 		tgt.Report(startTime, time.Minute, fmt.Errorf("something went wrong"))
 
-		a.instances = map[string]inst{
-			"test_instance": &mockInstanceScrape{
-				tgts: map[string][]*scrape.Target{
-					"group_a": {tgt},
+		a.cm.processes = map[string]*instanceManagerProcess{
+			"test_instance": {
+				inst: &mockInstanceScrape{
+					tgts: map[string][]*scrape.Target{
+						"group_a": {tgt},
+					},
 				},
 			},
 		}

--- a/pkg/prom/instance/noop.go
+++ b/pkg/prom/instance/noop.go
@@ -1,0 +1,20 @@
+package instance
+
+import (
+	"context"
+
+	"github.com/prometheus/prometheus/scrape"
+)
+
+// NoOpInstance implements the Instance interface in pkg/prom
+// but does not do anything. Useful for tests.
+type NoOpInstance struct{}
+
+func (NoOpInstance) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+func (NoOpInstance) TargetsActive() map[string][]*scrape.Target {
+	return nil
+}

--- a/pkg/prom/instance_manager.go
+++ b/pkg/prom/instance_manager.go
@@ -5,35 +5,66 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/grafana/agent/pkg/prom/instance"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/prometheus/scrape"
 )
 
-// InstanceManager manages a set of instance.Configs, calling a function whenever
-// a Config should be "started." It is detacted from the concept of actual instances
-// to allow for mocking. The New function in this package creates an Agent that
-// utilizes InstanceManager for actually launching real instances.
+var (
+	instanceAbnormalExits = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "agent_prometheus_instance_abnormal_exits_total",
+		Help: "Total number of times a Prometheus instance exited unexpectedly, causing it to be restarted.",
+	}, []string{"instance_name"})
+
+	currentActiveConfigs = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "agent_prometheus_active_configs",
+		Help: "Current number of active configs being used by the agent.",
+	})
+
+	// DefaultInstanceManagerConfig is the default config for instance managers,
+	// derived from the default Agent config.
+	DefaultInstanceManagerConfig = InstanceManagerConfig{
+		InstanceRestartBackoff: DefaultConfig.InstanceRestartBackoff,
+	}
+)
+
+type InstanceManagerConfig struct {
+	InstanceRestartBackoff time.Duration
+}
+
+// InstanceManager manages a set of Instances, calling a factory function to
+// create a new Instance whenever one should be created. Instances will be
+// kept running by the InstanceManager and restarted if they are stopped.
 type InstanceManager struct {
+	cfg    InstanceManagerConfig
+	logger log.Logger
+
 	// Take care when locking mut: if you hold onto a lock of mut while calling
 	// Stop on one of the processes below, you will deadlock.
 	mut       sync.Mutex
-	processes map[string]*configManagerProcess
+	processes map[string]*instanceManagerProcess
 
-	launch   InstanceLauncher
+	launch   InstanceFactory
 	validate ConfigValidator
 }
 
-// configManagerProcess represents a goroutine managing an instance.Config. In
+// instanceManagerProcess represents a goroutine managing an instance.Config. In
 // practice, this will be an *instance.Instance. cancel requests that the goroutine
 // should shut down. done will be closed after the goroutine exits.
-type configManagerProcess struct {
+type instanceManagerProcess struct {
 	cfg    instance.Config
+	inst   Instance
 	cancel context.CancelFunc
 	done   chan bool
 }
 
 // Stop stops the process and waits for it to exit.
-func (p configManagerProcess) Stop() {
+func (p instanceManagerProcess) Stop() {
 	p.cancel()
 	<-p.done
 }
@@ -47,24 +78,50 @@ func (p configManagerProcess) Stop() {
 //
 // The ConfigValidator will be called before launching an instance. If the config
 // is not valid, the config will not be launched.
-func NewInstanceManager(launch InstanceLauncher, validate ConfigValidator) *InstanceManager {
+func NewInstanceManager(cfg InstanceManagerConfig, logger log.Logger, launch InstanceFactory, validate ConfigValidator) *InstanceManager {
 	return &InstanceManager{
-		processes: make(map[string]*configManagerProcess),
+		cfg:       cfg,
+		logger:    logger,
+		processes: make(map[string]*instanceManagerProcess),
 		launch:    launch,
 		validate:  validate,
 	}
 }
 
-type InstanceLauncher func(ctx context.Context, c instance.Config)
+// An InstanceFactory should return an unstarted instance given some config.
+type InstanceFactory func(c instance.Config) Instance
+
+// A ConfigValidator should validate an instance.Config and return an error if
+// a problem was found.
 type ConfigValidator func(c *instance.Config) error
 
-// ListConfigs lists the current active configs managed by the InstanceManager.
-func (cm *InstanceManager) ListConfigs() map[string]instance.Config {
-	cm.mut.Lock()
-	defer cm.mut.Unlock()
+// Instance represents a running process that performance Prometheus
+// functionality. It is implemented by instance.Instance but is defined as an
+// interface here for the sake of testing.
+type Instance interface {
+	Run(ctx context.Context) error
+	TargetsActive() map[string][]*scrape.Target
+}
 
-	cfgs := make(map[string]instance.Config, len(cm.processes))
-	for name, process := range cm.processes {
+// ListInstances returns the current active instances managed by the InstanceManager.
+func (im *InstanceManager) ListInstances() map[string]Instance {
+	im.mut.Lock()
+	defer im.mut.Unlock()
+
+	insts := make(map[string]Instance, len(im.processes))
+	for name, process := range im.processes {
+		insts[name] = process.inst
+	}
+	return insts
+}
+
+// ListConfigs lists the current active configs managed by the InstanceManager.
+func (im *InstanceManager) ListConfigs() map[string]instance.Config {
+	im.mut.Lock()
+	defer im.mut.Unlock()
+
+	cfgs := make(map[string]instance.Config, len(im.processes))
+	for name, process := range im.processes {
 		cfgs[name] = process.cfg
 	}
 	return cfgs
@@ -74,90 +131,107 @@ func (cm *InstanceManager) ListConfigs() map[string]instance.Config {
 // or updates an existing track config. The value for Name in c is used to
 // uniquely identify the instance.Config and determine whether it is new
 // or existing.
-func (cm *InstanceManager) ApplyConfig(c instance.Config) error {
-	if cm.validate != nil {
-		err := cm.validate(&c)
+func (im *InstanceManager) ApplyConfig(c instance.Config) error {
+	if im.validate != nil {
+		err := im.validate(&c)
 		if err != nil {
 			return fmt.Errorf("failed to validate instance %s: %w", c.Name, err)
 		}
 	}
 
-	cm.mut.Lock()
-	defer cm.mut.Unlock()
+	im.mut.Lock()
+	defer im.mut.Unlock()
 
 	// If the config already exists, we need to "restart" it. We do this by
 	// stopping the old process and spawning a new one with the updated config.
-	if proc, ok := cm.processes[c.Name]; ok {
+	if proc, ok := im.processes[c.Name]; ok {
 		proc.Stop()
 	}
 
 	// Spawn a new process for the new config.
-	cm.spawnProcess(c)
+	im.spawnProcess(c)
 	currentActiveConfigs.Inc()
 	return nil
 }
 
-func (cm *InstanceManager) spawnProcess(c instance.Config) {
+func (im *InstanceManager) spawnProcess(c instance.Config) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan bool)
 
-	proc := &configManagerProcess{
+	proc := &instanceManagerProcess{
 		cancel: cancel,
 		done:   done,
+		cfg:    c,
+		inst:   im.launch(c),
 	}
 
-	cm.processes[c.Name] = proc
+	im.processes[c.Name] = proc
 
 	go func() {
-		cm.launch(ctx, c)
+		im.runProcess(ctx, c.Name, proc.inst)
 		close(done)
 
-		cm.mut.Lock()
+		im.mut.Lock()
 		// Now that the process is stopped, we can remove it from our tracked
 		// list. It will stop showing up in the result of ListConfigs.
 		//
 		// However, it's possible that a new config has been applied and overwrote
 		// the initial value in our map. We should only delete the process from
 		// the map if it hasn't changed from what we initially set it to.
-		if storedProc, exist := cm.processes[c.Name]; exist && storedProc == proc {
-			delete(cm.processes, c.Name)
+		if storedProc, exist := im.processes[c.Name]; exist && storedProc == proc {
+			delete(im.processes, c.Name)
 		}
-		cm.mut.Unlock()
+		im.mut.Unlock()
 
 		currentActiveConfigs.Dec()
 	}()
 }
 
+// runProcess runs an instance and keeps it alive until the context is canceled.
+func (im *InstanceManager) runProcess(ctx context.Context, name string, inst Instance) {
+	for {
+		err := inst.Run(ctx)
+		if err != nil && err != context.Canceled {
+			instanceAbnormalExits.WithLabelValues(name).Inc()
+			level.Error(im.logger).Log("msg", "instance stopped abnormally, restarting after backoff period", "err", err, "backoff", im.cfg.InstanceRestartBackoff, "instance", name)
+			time.Sleep(im.cfg.InstanceRestartBackoff)
+		} else {
+			level.Info(im.logger).Log("msg", "stopped instance", "instance", name)
+			break
+		}
+	}
+}
+
 // DeleteConfig removes an instance.Config by its name. Returns an error if
 // the instance.Config is not currently being tracked.
-func (cm *InstanceManager) DeleteConfig(name string) error {
-	cm.mut.Lock()
-	proc, ok := cm.processes[name]
+func (im *InstanceManager) DeleteConfig(name string) error {
+	im.mut.Lock()
+	proc, ok := im.processes[name]
 	if !ok {
 		return errors.New("config does not exist")
 	}
-	cm.mut.Unlock()
+	im.mut.Unlock()
 
 	// spawnProcess is responsible for removing the process from the
 	// map after it stops so we don't need to delete anything from
-	// cm.processes here.
+	// im.processes here.
 	proc.Stop()
 	return nil
 }
 
 // Stop stops the InstanceManager and stops all active processes for configs.
-func (cm *InstanceManager) Stop() {
+func (im *InstanceManager) Stop() {
 	var wg sync.WaitGroup
 
-	cm.mut.Lock()
-	wg.Add(len(cm.processes))
-	for _, proc := range cm.processes {
-		go func(proc *configManagerProcess) {
+	im.mut.Lock()
+	wg.Add(len(im.processes))
+	for _, proc := range im.processes {
+		go func(proc *instanceManagerProcess) {
 			proc.Stop()
 			wg.Done()
 		}(proc)
 	}
-	cm.mut.Unlock()
+	im.mut.Unlock()
 
 	wg.Wait()
 }

--- a/pkg/prom/instance_manager.go
+++ b/pkg/prom/instance_manager.go
@@ -158,13 +158,13 @@ func (im *InstanceManager) ApplyConfig(c instance.Config) error {
 }
 
 func (im *InstanceManager) spawnProcess(c instance.Config) error {
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan bool)
-
 	inst, err := im.launch(c)
 	if err != nil {
 		return err
 	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan bool)
 
 	proc := &instanceManagerProcess{
 		cancel: cancel,

--- a/pkg/prom/instance_manager_test.go
+++ b/pkg/prom/instance_manager_test.go
@@ -33,11 +33,7 @@ func TestInstanceManager_ApplyConfig(t *testing.T) {
 }
 
 func mockInstanceSpawner(fact *mockInstanceFactory) InstanceFactory {
-	return func(c instance.Config) Instance {
-		inst, err := fact.factory(config.DefaultGlobalConfig, c, "", nil)
-		if err != nil {
-			return nil
-		}
-		return inst
+	return func(c instance.Config) (Instance, error) {
+		return fact.factory(config.DefaultGlobalConfig, c, "", nil)
 	}
 }


### PR DESCRIPTION
This PR refactors `InstanceManager` to make it responsible for running instances, rather than deferring to a function which creates and runs them. This now makes `InstanceManager` aware of the running instance interfaces, opening the door for implementing #140. 

Note that with this PR, `pkg/prom.Agent` does very little outside of exposing an HTTP API and gluing various things together. 