### PR TITLE
allow dynamic updating of instance scrape_configs and remote_write

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,4 +63,4 @@ linters:
 
 issues:
   exclude:
-    - Error return value of .*log\.Logger\)\.Log\x60 is not checked
+    - Error return value of .*.Log\x60 is not checked

--- a/pkg/prom/http_test.go
+++ b/pkg/prom/http_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/util/test"
 	"github.com/go-kit/kit/log"
+	"github.com/grafana/agent/pkg/prom/instance"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/scrape"
@@ -17,7 +18,7 @@ import (
 )
 
 func TestAgent_ListInstancesHandler(t *testing.T) {
-	fact := newMockInstanceFactory()
+	fact := newFakeInstanceFactory()
 	a, err := newAgent(Config{
 		WALDir: "/tmp/agent",
 	}, log.NewNopLogger(), fact.factory)
@@ -47,7 +48,7 @@ func TestAgent_ListInstancesHandler(t *testing.T) {
 }
 
 func TestAgent_ListTargetsHandler(t *testing.T) {
-	fact := newMockInstanceFactory()
+	fact := newFakeInstanceFactory()
 	a, err := newAgent(Config{
 		WALDir: "/tmp/agent",
 	}, log.NewNopLogger(), fact.factory)
@@ -120,6 +121,10 @@ type mockInstanceScrape struct {
 
 func (i *mockInstanceScrape) Run(ctx context.Context) error {
 	<-ctx.Done()
+	return nil
+}
+
+func (i *mockInstanceScrape) Update(_ instance.Config) error {
 	return nil
 }
 

--- a/pkg/prom/instance/errors.go
+++ b/pkg/prom/instance/errors.go
@@ -1,5 +1,7 @@
 package instance
 
+import "fmt"
+
 // ErrInvalidUpdate is returned whenever Update is called against an instance
 // but an invalid field is changed between configs. If ErrInvalidUpdate is
 // returned, the instance must be fully stopped and replaced with a new one
@@ -31,4 +33,12 @@ func (e ErrInvalidUpdate) As(err interface{}) bool {
 		return false
 	}
 	return true
+}
+
+// errImmutableField is the error describing a field that cannot be changed. It
+// is wrapped inside of a ErrInvalidUpdate.
+type errImmutableField struct{ Field string }
+
+func (e errImmutableField) Error() string {
+	return fmt.Sprintf("%s cannot be changed dynamically", e.Field)
 }

--- a/pkg/prom/instance/errors.go
+++ b/pkg/prom/instance/errors.go
@@ -1,0 +1,34 @@
+package instance
+
+// ErrInvalidUpdate is returned whenever Update is called against an instance
+// but an invalid field is changed between configs. If ErrInvalidUpdate is
+// returned, the instance must be fully stopped and replaced with a new one
+// with the new config.
+type ErrInvalidUpdate struct {
+	Inner error
+}
+
+// Error implements the error interface.
+func (e ErrInvalidUpdate) Error() string { return e.Inner.Error() }
+
+// Is returns true if err is an ErrInvalidUpdate.
+func (e ErrInvalidUpdate) Is(err error) bool {
+	switch err.(type) {
+	case ErrInvalidUpdate, *ErrInvalidUpdate:
+		return true
+	default:
+		return false
+	}
+}
+
+// As will set the err object to ErrInvalidUpdate provided err
+// is a pointer to ErrInvalidUpdate.
+func (e ErrInvalidUpdate) As(err interface{}) bool {
+	switch v := err.(type) {
+	case *ErrInvalidUpdate:
+		*v = e
+	default:
+		return false
+	}
+	return true
+}

--- a/pkg/prom/instance/instance.go
+++ b/pkg/prom/instance/instance.go
@@ -187,8 +187,18 @@ type walStorageFactory func(reg prometheus.Registerer) (walStorage, error)
 
 // Instance is an individual metrics collector and remote_writer.
 type Instance struct {
-	cfgMutex sync.Mutex
-	cfg      Config
+	// All fields in the following block may be accessed and modified by
+	// concurrently running goroutines.
+	//
+	// Note that all Prometheus components listed here may be nil at any
+	// given time; methods reading them should take care to do nil checks.
+	mut                sync.Mutex
+	cfg                Config
+	wal                walStorage
+	discovery          *discoveryService
+	readyScrapeManager *scrape.ReadyScrapeManager
+	remoteStore        *remote.Storage
+	storage            storage.Storage
 
 	globalCfg config.GlobalConfig
 	logger    log.Logger
@@ -197,19 +207,6 @@ type Instance struct {
 	newWal walStorageFactory
 
 	vc *MetricValueCollector
-
-	// Components are stored as struct members to allow other methods to
-	// access components from different goroutines. They're protected by a
-	// mutex to prevent concurrent reading/writing of the pointers.
-	//
-	// All components may be nil; methods using these should take care to
-	// do nil checks.
-	componentMtx       sync.Mutex
-	wal                walStorage
-	discovery          *discoveryService
-	readyScrapeManager *scrape.ReadyScrapeManager
-	remoteStore        *remote.Storage
-	storage            storage.Storage
 }
 
 // New creates a new Instance with a directory for storing the WAL. The instance
@@ -255,7 +252,15 @@ func newInstance(globalCfg config.GlobalConfig, cfg Config, reg prometheus.Regis
 // Run may be re-called after exiting, as components will be reinitialized each
 // time Run is called.
 func (i *Instance) Run(ctx context.Context) error {
-	level.Debug(i.logger).Log("msg", "initializing instance", "name", i.Config().Name)
+	// i.cfg may change at any point in the middle of this method but not in a way
+	// that affects any of the code below; rather than grabbing a mutex every time
+	// we want to read the config, we'll simplify the access and just grab a copy
+	// now.
+	i.mut.Lock()
+	cfg := i.cfg
+	i.mut.Unlock()
+
+	level.Debug(i.logger).Log("msg", "initializing instance", "name", cfg.Name)
 
 	// trackingReg wraps the register for the instance to make sure that if Run
 	// exits, any metrics Prometheus registers are removed and can be
@@ -263,7 +268,7 @@ func (i *Instance) Run(ctx context.Context) error {
 	trackingReg := unregisterAllRegisterer{wrap: i.reg}
 	defer trackingReg.UnregisterAll()
 
-	if err := i.initialize(ctx, &trackingReg); err != nil {
+	if err := i.initialize(ctx, &trackingReg, &cfg); err != nil {
 		level.Error(i.logger).Log("msg", "failed to initialize instance", "err", err)
 		return fmt.Errorf("failed to initialize instance: %w", err)
 	}
@@ -288,7 +293,7 @@ func (i *Instance) Run(ctx context.Context) error {
 		defer contextCancel()
 		rg.Add(
 			func() error {
-				i.truncateLoop(ctx, i.wal)
+				i.truncateLoop(ctx, i.wal, &cfg)
 				level.Info(i.logger).Log("msg", "truncation loop stopped")
 				return nil
 			},
@@ -320,7 +325,7 @@ func (i *Instance) Run(ctx context.Context) error {
 
 				// On a graceful shutdown, write staleness markers. If something went
 				// wrong, then the instance will be relaunched.
-				if err == nil && i.Config().WriteStaleOnShutdown {
+				if err == nil && cfg.WriteStaleOnShutdown {
 					level.Info(i.logger).Log("msg", "writing staleness markers...")
 					err := i.wal.WriteStalenessMarkers(i.getRemoteWriteTimestamp)
 					if err != nil {
@@ -336,7 +341,7 @@ func (i *Instance) Run(ctx context.Context) error {
 		)
 	}
 
-	level.Debug(i.logger).Log("msg", "running instance", "name", i.Config().Name)
+	level.Debug(i.logger).Log("msg", "running instance", "name", cfg.Name)
 	err := rg.Run()
 	if err != nil {
 		level.Error(i.logger).Log("msg", "agent instance stopped with error", "err", err)
@@ -348,9 +353,9 @@ func (i *Instance) Run(ctx context.Context) error {
 // settings. initialize will be called each time the Instance is run. Prometheus
 // components cannot be reused after they are stopped so we need to recreate them
 // each run.
-func (i *Instance) initialize(ctx context.Context, reg prometheus.Registerer) error {
-	i.componentMtx.Lock()
-	defer i.componentMtx.Unlock()
+func (i *Instance) initialize(ctx context.Context, reg prometheus.Registerer, cfg *Config) error {
+	i.mut.Lock()
+	defer i.mut.Unlock()
 
 	var err error
 
@@ -359,7 +364,7 @@ func (i *Instance) initialize(ctx context.Context, reg prometheus.Registerer) er
 		return fmt.Errorf("error creating WAL: %w", err)
 	}
 
-	i.discovery, err = i.newDiscoveryManager(ctx)
+	i.discovery, err = i.newDiscoveryManager(ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("error creating discovery manager: %w", err)
 	}
@@ -368,10 +373,10 @@ func (i *Instance) initialize(ctx context.Context, reg prometheus.Registerer) er
 
 	// Setup the remote storage
 	remoteLogger := log.With(i.logger, "component", "remote")
-	i.remoteStore = remote.NewStorage(remoteLogger, reg, i.wal.StartTime, i.wal.Directory(), i.Config().RemoteFlushDeadline, i.readyScrapeManager)
+	i.remoteStore = remote.NewStorage(remoteLogger, reg, i.wal.StartTime, i.wal.Directory(), cfg.RemoteFlushDeadline, i.readyScrapeManager)
 	err = i.remoteStore.ApplyConfig(&config.Config{
 		GlobalConfig:       i.globalCfg,
-		RemoteWriteConfigs: i.Config().RemoteWrite,
+		RemoteWriteConfigs: cfg.RemoteWrite,
 	})
 	if err != nil {
 		return fmt.Errorf("failed applying config to remote storage: %w", err)
@@ -382,7 +387,7 @@ func (i *Instance) initialize(ctx context.Context, reg prometheus.Registerer) er
 	scrapeManager := newScrapeManager(log.With(i.logger, "component", "scrape manager"), i.storage)
 	err = scrapeManager.ApplyConfig(&config.Config{
 		GlobalConfig:  i.globalCfg,
-		ScrapeConfigs: i.Config().ScrapeConfigs,
+		ScrapeConfigs: cfg.ScrapeConfigs,
 	})
 	if err != nil {
 		return fmt.Errorf("failed applying config to scrape manager: %w", err)
@@ -397,14 +402,8 @@ func (i *Instance) initialize(ctx context.Context, reg prometheus.Registerer) er
 // running Prometheus components with the new values from Config. Update will
 // return an ErrInvalidUpdate if the Update could not be applied.
 func (i *Instance) Update(c Config) error {
-	// NOTE: you must get a lock on componentMtx first, since initialize will
-	// obtain a lock on cfgMutex and will deadlock if that is already locked
-	// by Update.
-	i.componentMtx.Lock()
-	defer i.componentMtx.Unlock()
-
-	i.cfgMutex.Lock()
-	defer i.cfgMutex.Unlock()
+	i.mut.Lock()
+	defer i.mut.Unlock()
 
 	// It's only (currently) valid to update scrape_configs and remote_write, so
 	// if any other field has changed here, return the error.
@@ -413,15 +412,15 @@ func (i *Instance) Update(c Config) error {
 	// This first case should never happen in practice but it's included here for
 	// completions sake.
 	case i.cfg.Name != c.Name:
-		err = fmt.Errorf("name cannot be changed dynamically")
+		err = errImmutableField{Field: "name"}
 	case i.cfg.HostFilter != c.HostFilter:
-		err = fmt.Errorf("host_filter cannot be changed dynamically")
+		err = errImmutableField{Field: "host_filter"}
 	case i.cfg.WALTruncateFrequency != c.WALTruncateFrequency:
-		err = fmt.Errorf("wal_truncate_frequency cannot be changed dynamically")
+		err = errImmutableField{Field: "wal_truncate_frequency"}
 	case i.cfg.RemoteFlushDeadline != c.RemoteFlushDeadline:
-		err = fmt.Errorf("remote_flush_deadline cannot be changed dynamically")
+		err = errImmutableField{Field: "remote_flush_deadline"}
 	case i.cfg.WriteStaleOnShutdown != c.WriteStaleOnShutdown:
-		err = fmt.Errorf("write_stale_on_shutdown cannot be changed dynamically")
+		err = errImmutableField{Field: "write_stale_on_shutdown"}
 	}
 	if err != nil {
 		return ErrInvalidUpdate{Inner: err}
@@ -471,8 +470,8 @@ func (i *Instance) Update(c Config) error {
 // TargetsActive returns the set of active targets from the scrape manager. Returns nil
 // if the scrape manager is not ready yet.
 func (i *Instance) TargetsActive() map[string][]*scrape.Target {
-	i.componentMtx.Lock()
-	defer i.componentMtx.Unlock()
+	i.mut.Lock()
+	defer i.mut.Unlock()
 
 	if i.readyScrapeManager == nil {
 		return nil
@@ -504,7 +503,7 @@ func (s *discoveryService) SyncCh() GroupChannel { return s.SyncChFunc() }
 // that outputs discovered targets to a channel. The implementation
 // uses the Prometheus Discovery Manager. Targets will be filtered
 // if the instance is configured to perform host filtering.
-func (i *Instance) newDiscoveryManager(ctx context.Context) (*discoveryService, error) {
+func (i *Instance) newDiscoveryManager(ctx context.Context, cfg *Config) (*discoveryService, error) {
 	ctx, cancel := context.WithCancel(ctx)
 
 	logger := log.With(i.logger, "component", "discovery manager")
@@ -513,7 +512,7 @@ func (i *Instance) newDiscoveryManager(ctx context.Context) (*discoveryService, 
 	// TODO(rfratto): refactor this to a function?
 	// TODO(rfratto): ensure job name name is unique
 	c := map[string]sd_config.ServiceDiscoveryConfig{}
-	for _, v := range i.Config().ScrapeConfigs {
+	for _, v := range cfg.ScrapeConfigs {
 		c[v.JobName] = v.ServiceDiscoveryConfig
 	}
 	err := manager.ApplyConfig(c)
@@ -539,7 +538,7 @@ func (i *Instance) newDiscoveryManager(ctx context.Context) (*discoveryService, 
 
 	// If host filtering is enabled, run it and use its channel for discovered
 	// targets.
-	if i.Config().HostFilter {
+	if cfg.HostFilter {
 		hostname, err := Hostname()
 		if err != nil {
 			cancel()
@@ -570,12 +569,12 @@ func (i *Instance) newDiscoveryManager(ctx context.Context) (*discoveryService, 
 	}, nil
 }
 
-func (i *Instance) truncateLoop(ctx context.Context, wal walStorage) {
+func (i *Instance) truncateLoop(ctx context.Context, wal walStorage, cfg *Config) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(i.Config().WALTruncateFrequency):
+		case <-time.After(cfg.WALTruncateFrequency):
 			ts := i.getRemoteWriteTimestamp()
 			if ts == 0 {
 				level.Debug(i.logger).Log("msg", "can't truncate the WAL yet")
@@ -597,13 +596,16 @@ func (i *Instance) truncateLoop(ctx context.Context, wal walStorage) {
 // This is passed to wal.Storage for its truncation. If no remote write sections
 // are configured, getRemoteWriteTimestamp returns the current time.
 func (i *Instance) getRemoteWriteTimestamp() int64 {
-	if len(i.Config().RemoteWrite) == 0 {
+	i.mut.Lock()
+	defer i.mut.Unlock()
+
+	if len(i.cfg.RemoteWrite) == 0 {
 		return timestamp.FromTime(time.Now())
 	}
 
-	lbls := make([]string, len(i.Config().RemoteWrite))
+	lbls := make([]string, len(i.cfg.RemoteWrite))
 	for idx := 0; idx < len(lbls); idx++ {
-		lbls[idx] = i.Config().RemoteWrite[idx].Name
+		lbls[idx] = i.cfg.RemoteWrite[idx].Name
 	}
 
 	vals, err := i.vc.GetValues("remote_name", lbls...)
@@ -628,13 +630,6 @@ func (i *Instance) getRemoteWriteTimestamp() int64 {
 
 	// Convert to the millisecond precision which is used by the WAL
 	return ts * 1000
-}
-
-// Config returns the current Config stored by the Instance.
-func (i *Instance) Config() Config {
-	i.cfgMutex.Lock()
-	defer i.cfgMutex.Unlock()
-	return i.cfg
 }
 
 // walStorage is an interface satisfied by wal.Storage, and created for testing.

--- a/pkg/prom/instance/instance.go
+++ b/pkg/prom/instance/instance.go
@@ -428,8 +428,7 @@ func (i *Instance) Update(c Config) error {
 	}
 
 	// Check to see if the components exist yet.
-	switch {
-	case i.discovery == nil || i.remoteStore == nil || i.readyScrapeManager == nil:
+	if i.discovery == nil || i.remoteStore == nil || i.readyScrapeManager == nil {
 		return ErrInvalidUpdate{
 			Inner: fmt.Errorf("cannot dynamically update because instance is not running"),
 		}

--- a/pkg/prom/instance/instance_integration_test.go
+++ b/pkg/prom/instance/instance_integration_test.go
@@ -1,0 +1,196 @@
+package instance
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cortexproject/cortex/pkg/util/test"
+	"github.com/go-kit/kit/log"
+	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/prometheus/config"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+// TestInstance_Update performs a full integration test by doing the following:
+//
+// 1. Launching an HTTP server which can be scraped and also mocks the remote_write
+//    endpoint.
+// 2. Creating an instance config with no scrape_configs or remote_write configs.
+// 3. Updates the instance with a scrape_config and remote_write.
+// 4. Validates that after 15 seconds, the scrape endpoint and remote_write
+//    endpoint has been called.
+func TestInstance_Update(t *testing.T) {
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+
+	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+
+	walDir, err := ioutil.TempDir(os.TempDir(), "wal")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(walDir) })
+
+	var (
+		scraped = atomic.NewBool(false)
+		pushed  = atomic.NewBool(false)
+	)
+
+	r := mux.NewRouter()
+	r.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
+		scraped.Store(true)
+		promhttp.Handler().ServeHTTP(w, r)
+	})
+	r.HandleFunc("/push", func(w http.ResponseWriter, r *http.Request) {
+		pushed.Store(true)
+		// We don't particularly care what was pushed to us so we'll ignore
+		// everything here; we just want to make sure the endpoint was invoked.
+	})
+
+	// Start a server for exposing the router.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l.Close()
+	go func() {
+		_ = http.Serve(l, r)
+	}()
+
+	// Create a new instance where it's not scraping or writing anything by default.
+	initialConfig := loadConfig(t, `
+name: integration_test
+scrape_configs: []
+remote_write: []
+`)
+	inst, err := New(config.DefaultGlobalConfig, initialConfig, walDir, logger)
+	require.NoError(t, err)
+
+	instCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		err := inst.Run(instCtx)
+		require.NoError(t, err)
+	}()
+
+	// Update the config with a single scrape_config and remote_write.
+	newConfig := loadConfig(t, fmt.Sprintf(`
+name: integration_test
+scrape_configs: 
+  - job_name: test_scrape
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['%[1]s']
+remote_write:
+  - url: http://%[1]s/push
+`, l.Addr()))
+
+	// Wait minute for the instance to update (it might not be ready yet and
+	// would return an error until everything is initialized), and then wait
+	// again for the configs to apply and set the scraped and pushed atomic
+	// variables, indicating that the Prometheus components successfully updated.
+	test.Poll(t, time.Second*15, nil, func() interface{} {
+		err := inst.Update(newConfig)
+		if err != nil {
+			logger.Log("msg", "failed to update instance", "err", err)
+		}
+		return err
+	})
+
+	test.Poll(t, time.Second*15, true, func() interface{} {
+		return scraped.Load() && pushed.Load()
+	})
+}
+
+// TestInstance_Update_InvalidChanges runs an instance with a blank initial
+// config and performs various unacceptable updates that should return an
+// error.
+func TestInstance_Update_InvalidChanges(t *testing.T) {
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+
+	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+
+	walDir, err := ioutil.TempDir(os.TempDir(), "wal")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(walDir) })
+
+	// Create a new instance where it's not scraping or writing anything by default.
+	initialConfig := loadConfig(t, `
+name: integration_test
+scrape_configs: []
+remote_write: []
+`)
+	inst, err := New(config.DefaultGlobalConfig, initialConfig, walDir, logger)
+	require.NoError(t, err)
+
+	instCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		err := inst.Run(instCtx)
+		require.NoError(t, err)
+	}()
+
+	// Do a no-op update that succeeds to ensure that the instance is running.
+	test.Poll(t, time.Second*15, nil, func() interface{} {
+		err := inst.Update(initialConfig)
+		if err != nil {
+			logger.Log("msg", "failed to update instance", "err", err)
+		}
+		return err
+	})
+
+	tt := []struct {
+		name   string
+		mut    func(c *Config)
+		expect string
+	}{
+		{
+			name:   "name changed",
+			mut:    func(c *Config) { c.Name = "changed name" },
+			expect: "name cannot be changed dynamically",
+		},
+		{
+			name:   "host_filter changed",
+			mut:    func(c *Config) { c.HostFilter = true },
+			expect: "host_filter cannot be changed dynamically",
+		},
+		{
+			name:   "wal_truncate_frequency changed",
+			mut:    func(c *Config) { c.WALTruncateFrequency *= 2 },
+			expect: "wal_truncate_frequency cannot be changed dynamically",
+		},
+		{
+			name:   "remote_flush_deadline changed",
+			mut:    func(c *Config) { c.RemoteFlushDeadline *= 2 },
+			expect: "remote_flush_deadline cannot be changed dynamically",
+		},
+		{
+			name:   "write_stale_on_shutdown changed",
+			mut:    func(c *Config) { c.WriteStaleOnShutdown = true },
+			expect: "write_stale_on_shutdown cannot be changed dynamically",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			mutatedConfig := initialConfig
+			tc.mut(&mutatedConfig)
+
+			err := inst.Update(mutatedConfig)
+			require.EqualError(t, err, tc.expect)
+		})
+	}
+
+}
+
+func loadConfig(t *testing.T, s string) Config {
+	cfg, err := UnmarshalConfig(strings.NewReader(s))
+	require.NoError(t, err)
+	require.NoError(t, cfg.ApplyDefaults(&config.DefaultGlobalConfig))
+	return *cfg
+}

--- a/pkg/prom/instance/noop.go
+++ b/pkg/prom/instance/noop.go
@@ -15,6 +15,10 @@ func (NoOpInstance) Run(ctx context.Context) error {
 	return nil
 }
 
+func (NoOpInstance) Update(_ Config) error {
+	return nil
+}
+
 func (NoOpInstance) TargetsActive() map[string][]*scrape.Target {
 	return nil
 }

--- a/pkg/prom/instance_manager_test.go
+++ b/pkg/prom/instance_manager_test.go
@@ -1,6 +1,9 @@
 package prom
 
 import (
+	"context"
+	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -8,11 +11,13 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/grafana/agent/pkg/prom/instance"
 	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/scrape"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInstanceManager_ApplyConfig(t *testing.T) {
-	fact := newMockInstanceFactory()
-	spawner := mockInstanceSpawner(fact)
+	fact := newFakeInstanceFactory()
+	spawner := fakeInstanceSpawner(fact)
 
 	cm := NewInstanceManager(DefaultInstanceManagerConfig, log.NewNopLogger(), spawner, nil)
 	_ = cm.ApplyConfig(instance.Config{Name: "test"})
@@ -32,8 +37,118 @@ func TestInstanceManager_ApplyConfig(t *testing.T) {
 	})
 }
 
-func mockInstanceSpawner(fact *mockInstanceFactory) InstanceFactory {
+func TestInstanceManager_ApplyConfig_DynamicUpdates(t *testing.T) {
+	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+
+	baseMock := mockInstance{
+		RunFunc: func(ctx context.Context) error {
+			logger.Log("msg", "starting an instance")
+			<-ctx.Done()
+			return nil
+		},
+		UpdateFunc: func(c instance.Config) error {
+			return nil
+		},
+		TargetsActiveFunc: func() map[string][]*scrape.Target {
+			return nil
+		},
+	}
+
+	t.Run("dynamic update successful", func(t *testing.T) {
+		spawnedCount := 0
+		spawner := func(c instance.Config) (Instance, error) {
+			spawnedCount++
+			return baseMock, nil
+		}
+
+		cm := NewInstanceManager(DefaultInstanceManagerConfig, logger, spawner, nil)
+
+		for i := 0; i < 10; i++ {
+			err := cm.ApplyConfig(instance.Config{Name: "test"})
+			require.NoError(t, err)
+		}
+
+		require.Equal(t, 1, spawnedCount)
+	})
+
+	t.Run("dynamic update unsuccessful", func(t *testing.T) {
+		spawnedCount := 0
+		spawner := func(c instance.Config) (Instance, error) {
+			spawnedCount++
+
+			newMock := baseMock
+			newMock.UpdateFunc = func(c instance.Config) error {
+				return instance.ErrInvalidUpdate{
+					Inner: fmt.Errorf("cannot dynamically update for testing reasons"),
+				}
+			}
+			return newMock, nil
+		}
+
+		cm := NewInstanceManager(DefaultInstanceManagerConfig, logger, spawner, nil)
+
+		for i := 0; i < 10; i++ {
+			err := cm.ApplyConfig(instance.Config{Name: "test"})
+			require.NoError(t, err)
+		}
+
+		require.Equal(t, 10, spawnedCount)
+	})
+
+	t.Run("dynamic update errored", func(t *testing.T) {
+		spawnedCount := 0
+		spawner := func(c instance.Config) (Instance, error) {
+			spawnedCount++
+
+			newMock := baseMock
+			newMock.UpdateFunc = func(c instance.Config) error {
+				return fmt.Errorf("something really bad happened")
+			}
+			return newMock, nil
+		}
+
+		cm := NewInstanceManager(DefaultInstanceManagerConfig, logger, spawner, nil)
+
+		// Creation should succeed
+		err := cm.ApplyConfig(instance.Config{Name: "test"})
+		require.NoError(t, err)
+
+		// ...but the update should fail
+		err = cm.ApplyConfig(instance.Config{Name: "test"})
+		require.Error(t, err, "something really bad happened")
+		require.Equal(t, 1, spawnedCount)
+	})
+}
+
+func fakeInstanceSpawner(fact *fakeInstanceFactory) InstanceFactory {
 	return func(c instance.Config) (Instance, error) {
 		return fact.factory(config.DefaultGlobalConfig, c, "", nil)
 	}
+}
+
+type mockInstance struct {
+	RunFunc           func(ctx context.Context) error
+	UpdateFunc        func(c instance.Config) error
+	TargetsActiveFunc func() map[string][]*scrape.Target
+}
+
+func (m mockInstance) Run(ctx context.Context) error {
+	if m.RunFunc != nil {
+		return m.RunFunc(ctx)
+	}
+	panic("RunFunc not provided")
+}
+
+func (m mockInstance) Update(c instance.Config) error {
+	if m.UpdateFunc != nil {
+		return m.UpdateFunc(c)
+	}
+	panic("UpdateFunc not provided")
+}
+
+func (m mockInstance) TargetsActive() map[string][]*scrape.Target {
+	if m.TargetsActiveFunc != nil {
+		return m.TargetsActiveFunc()
+	}
+	panic("TargetsActiveFunc not provided")
 }


### PR DESCRIPTION
This PR introduces an `Update` method against the `Instance` that allows for applying new changes found on `remote_write` and `scrape_configs` sections. If any other field changes, `Update` will return `ErrInvalidUpdate`, which will cause the `InstanceManager` to do the normal "restart" (i.e., shut down old instance, bring up new one with modified config).

Future changes may loosen the restriction on what is able to be dynamically updated, but I suspect that `scrape_configs` and `remote_write` are going to be far more common than anything else. 

Some code cleanup can be found as part of this PR: fakes that have been called mocks have been updated to use their proper name.

Closes #140.