### PR TITLE
Implement shared instances

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,4 +28,5 @@ main problems faced by users of large deployments of Prometheus:
 3. [Configuration Reference](./configuration-reference.md)
 4. [API](./api.md)
 5. [Scraping Service Mode](./scraping-service.md)
-6. [Maintainers Guide](./maintaining.md)
+6. [Operation Guide](./operation-guide.md)
+7. [Maintainers Guide](./maintaining.md)

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -124,6 +124,10 @@ configs:
 # to restart it. 0s disables the backoff period and restarts the agent
 # immediately.
 [instance_restart_backoff: <duration> | default = "5s"]
+
+# How to spawn instances based on instance configs. Supported values: shared,
+# distinct.
+[instance_mode: <string> | default = "shared"]
 ```
 
 ### scraping_service_config

--- a/docs/operation-guide.md
+++ b/docs/operation-guide.md
@@ -1,0 +1,44 @@
+# Operation Guide 
+
+## Prometheus "Instances"
+
+The Grafana Cloud Agent defines a concept of a Prometheus _Instance_, which is
+its own mini Prometheus-lite server. The Instance runs a combination of
+Prometheus service discovery, scraping, a WAL for storage, and `remote_write`.
+
+Instances allow for fine grained control of what data gets scraped and where it
+gets sent. Users can easily define two Instances that scrape different subsets 
+of metrics and send them two two completely different remote_write systems.
+
+Instances are especially relevant to the [scraping service
+mode](./scraping-service.md), where breaking up your scrape configs into
+multiple Instances is required for sharding and balancing scrape load across a
+cluster of Agents.
+
+## Instance Sharing 
+
+The v0.5.0 release of the Agent introduced the concept of _Instance sharing_,
+which combines scrape_configs from compatible Instance configs into a single,
+shared Instance. Instance configs are compatible when they have no differences
+in configuration with the exception of what they scrape. `remote_write` configs
+may also differ in the order which endpoints are declared, but the unsorted
+`remote_writes` must still be an exact match.
+
+The shared Instances mode is the new default, and the previous behavior is
+deprecated. If you wish to restore the old behavior, set `instance_mode:
+distinct` in the
+[`prometheus_config`](./configuration-reference.md#prometheus_config) block of
+your config file.
+
+Shared Instances are completely transparent to the user with the exception of
+exposed metrics. With `instance_mode: shared`, metrics for Prometheus components
+(WAL, service discovery, remote_write, etc) have a `instance_group_name` label,
+which is the hash of all settings used to determine the shared instance. When
+`instance_mode: distinct` is set, the metrics for Prometheus components will
+instead have an `instance_name` label, which matches the name set on the
+individual Instance config. It is recommended to use the default of
+`instance_mode: shared` unless you don't mind the performance hit and really
+need granular metrics.
+
+Users can use the [targets API](./api.md#list-current-scrape-targets) to see all
+scraped targets, and the name of the shared instance they were assigned to.

--- a/pkg/prom/agent.go
+++ b/pkg/prom/agent.go
@@ -186,7 +186,7 @@ func newAgent(cfg Config, logger log.Logger, fact instanceFactory) (*Agent, erro
 func (a *Agent) newInstance(c instance.Config) (instance.ManagedInstance, error) {
 	// Controls the label
 	instanceLabel := "instance_name"
-	if a.cfg.InstanceMode == InstanceModeDistinct {
+	if a.cfg.InstanceMode == InstanceModeShared {
 		instanceLabel = "instance_group_name"
 	}
 

--- a/pkg/prom/agent.go
+++ b/pkg/prom/agent.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/agent/pkg/prom/ha"
 	"github.com/grafana/agent/pkg/prom/ha/client"
 	"github.com/grafana/agent/pkg/prom/instance"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/config"
 	"google.golang.org/grpc"
 )
@@ -24,8 +25,42 @@ var (
 		InstanceRestartBackoff: instance.DefaultBasicManagerConfig.InstanceRestartBackoff,
 		ServiceConfig:          ha.DefaultConfig,
 		ServiceClientConfig:    client.DefaultConfig,
+		InstanceMode:           DefaultInstanceMode,
 	}
 )
+
+// InstanceMode controls how instances are created.
+type InstanceMode string
+
+// Types of instance modes
+var (
+	InstanceModeDistinct InstanceMode = "distinct"
+	InstanceModeShared   InstanceMode = "shared"
+
+	DefaultInstanceMode = InstanceModeShared
+)
+
+// UnmarshalYAML unmarshals a string to an InstanceMode. Fails if the string is
+// unrecognized.
+func (m *InstanceMode) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*m = DefaultInstanceMode
+
+	var plain string
+	if err := unmarshal(&plain); err != nil {
+		return err
+	}
+
+	switch plain {
+	case string(InstanceModeDistinct):
+		*m = InstanceModeDistinct
+		return nil
+	case string(InstanceModeShared):
+		*m = InstanceModeShared
+		return nil
+	default:
+		return fmt.Errorf("unsupported instance_mode '%s'. supported values 'shared', 'distinct'", plain)
+	}
+}
 
 // Config defines the configuration for the entire set of Prometheus client
 // instances, along with a global configuration.
@@ -36,6 +71,7 @@ type Config struct {
 	ServiceClientConfig    client.Config       `yaml:"scraping_service_client"`
 	Configs                []instance.Config   `yaml:"configs,omitempty"`
 	InstanceRestartBackoff time.Duration       `yaml:"instance_restart_backoff,omitempty"`
+	InstanceMode           InstanceMode        `yaml:"instance_mode"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
@@ -120,6 +156,10 @@ func newAgent(cfg Config, logger log.Logger, fact instanceFactory) (*Agent, erro
 		InstanceRestartBackoff: cfg.InstanceRestartBackoff,
 	}, a.logger, a.newInstance, a.validateInstance)
 
+	if cfg.InstanceMode == InstanceModeShared {
+		a.cm = instance.NewGroupManager(a.cm)
+	}
+
 	allConfigsValid := true
 	for _, c := range cfg.Configs {
 		if err := a.cm.ApplyConfig(c); err != nil {
@@ -144,7 +184,17 @@ func newAgent(cfg Config, logger log.Logger, fact instanceFactory) (*Agent, erro
 
 // newInstance creates a new Instance given a config.
 func (a *Agent) newInstance(c instance.Config) (instance.ManagedInstance, error) {
-	return a.instanceFactory(a.cfg.Global, c, a.cfg.WALDir, a.logger)
+	// Controls the label
+	instanceLabel := "instance_name"
+	if a.cfg.InstanceMode == InstanceModeDistinct {
+		instanceLabel = "instance_group_name"
+	}
+
+	reg := prometheus.WrapRegistererWith(prometheus.Labels{
+		instanceLabel: c.Name,
+	}, prometheus.DefaultRegisterer)
+
+	return a.instanceFactory(reg, a.cfg.Global, c, a.cfg.WALDir, a.logger)
 }
 
 func (a *Agent) validateInstance(c *instance.Config) error {
@@ -170,8 +220,8 @@ func (a *Agent) Stop() {
 	a.cm.Stop()
 }
 
-type instanceFactory = func(global config.GlobalConfig, cfg instance.Config, walDir string, logger log.Logger) (instance.ManagedInstance, error)
+type instanceFactory = func(reg prometheus.Registerer, global config.GlobalConfig, cfg instance.Config, walDir string, logger log.Logger) (instance.ManagedInstance, error)
 
-func defaultInstanceFactory(global config.GlobalConfig, cfg instance.Config, walDir string, logger log.Logger) (instance.ManagedInstance, error) {
-	return instance.New(global, cfg, walDir, logger)
+func defaultInstanceFactory(reg prometheus.Registerer, global config.GlobalConfig, cfg instance.Config, walDir string, logger log.Logger) (instance.ManagedInstance, error) {
+	return instance.New(reg, global, cfg, walDir, logger)
 }

--- a/pkg/prom/agent_test.go
+++ b/pkg/prom/agent_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/test"
 	"github.com/go-kit/kit/log"
 	"github.com/grafana/agent/pkg/prom/instance"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/stretchr/testify/require"
@@ -24,6 +25,7 @@ func TestConfig_Validate(t *testing.T) {
 		Configs: []instance.Config{
 			makeInstanceConfig("instance"),
 		},
+		InstanceMode: DefaultInstanceMode,
 	}
 
 	tt := []struct {
@@ -74,6 +76,8 @@ func TestConfig_Validate(t *testing.T) {
 }
 
 func copyConfig(t *testing.T, c Config) Config {
+	t.Helper()
+
 	bb, err := yaml.Marshal(c)
 	require.NoError(t, err)
 
@@ -291,7 +295,7 @@ func (f *fakeInstanceFactory) Mocks() []*fakeInstance {
 	return f.mocks
 }
 
-func (f *fakeInstanceFactory) factory(_ config.GlobalConfig, cfg instance.Config, _ string, _ log.Logger) (instance.ManagedInstance, error) {
+func (f *fakeInstanceFactory) factory(_ prometheus.Registerer, _ config.GlobalConfig, cfg instance.Config, _ string, _ log.Logger) (instance.ManagedInstance, error) {
 	f.created.Add(1)
 
 	f.mut.Lock()

--- a/pkg/prom/instance/group_manager.go
+++ b/pkg/prom/instance/group_manager.go
@@ -1,0 +1,335 @@
+package instance
+
+import (
+	"bytes"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/prometheus/prometheus/config"
+)
+
+// A GroupManager wraps around another Manager and groups all incoming Configs
+// into a smaller set of configs, causing less managed instances to be spawned.
+//
+// Configs are grouped by all settings for a Config *except* scrape configs.
+// Any difference found in any flag will cause a Config to be placed in another
+// group. One exception to this rule is that remote_writes are compared
+// unordered, but the sets of remote_writes should otherwise be identical.
+//
+// GroupManagers drastically improve the performance of the Agent when a
+// significant number of instances are spawned, as the overhead of each
+// instance having its own service discovery, WAL, and remote_write can be
+// significant.
+//
+// The config names of instances within the group will be represented by
+// that group's hash of settings.
+type GroupManager struct {
+	inner Manager
+
+	mtx sync.Mutex
+
+	// groups is a map of group name to the grouped configs.
+	groups map[string]groupedConfigs
+
+	// groupLookup is a map of config name to group name.
+	groupLookup map[string]string
+}
+
+// groupedConfigs holds a set of grouped configs, keyed by the config name.
+// They are stored in a map rather than a slice to make overriding an existing
+// config within the group less error prone.
+type groupedConfigs map[string]Config
+
+// Copy returns a shallow copy of the groupedConfigs.
+func (g groupedConfigs) Copy() groupedConfigs {
+	res := make(groupedConfigs, len(g))
+	for k, v := range g {
+		res[k] = v
+	}
+	return res
+}
+
+// NewGroupManager creates a new GroupManager for combining instances of the
+// same "group."
+func NewGroupManager(inner Manager) *GroupManager {
+	return &GroupManager{
+		inner:       inner,
+		groups:      make(map[string]groupedConfigs),
+		groupLookup: make(map[string]string),
+	}
+}
+
+// ListInstances returns all currently grouped managed instances. The key
+// will be the group's hash of shared settings.
+func (m *GroupManager) ListInstances() map[string]ManagedInstance {
+	return m.inner.ListInstances()
+}
+
+// ListConfigs returns the UNGROUPED instance configs with their original
+// settings. To see the grouped instances, call ListInstances instead.
+func (m *GroupManager) ListConfigs() map[string]Config {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	cfgs := make(map[string]Config)
+	for _, groupedConfigs := range m.groups {
+		for _, cfg := range groupedConfigs {
+			cfgs[cfg.Name] = cfg
+		}
+	}
+	return cfgs
+}
+
+// ApplyConfig will determine the group of the Config before applying it to
+// the group. If no group exists, one will be created. If a group already
+// exists, the group will have its settings merged with the Config and
+// will be updated.
+func (m *GroupManager) ApplyConfig(c Config) error {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	return m.applyConfig(c)
+}
+
+func (m *GroupManager) applyConfig(c Config) (err error) {
+	groupName, err := hashConfig(c)
+	if err != nil {
+		return fmt.Errorf("failed to get group name for config %s: %w", c.Name, err)
+	}
+
+	grouped := m.groups[groupName]
+	if grouped == nil {
+		grouped = make(groupedConfigs)
+	} else {
+		grouped = grouped.Copy()
+	}
+
+	// Add the config to the group. If the config already exists within this
+	// group, it'll be overwritten.
+	grouped[c.Name] = c
+	mergedConfig, err := groupConfigs(groupName, grouped)
+	if err != nil {
+		err = fmt.Errorf("failed to group configs for %s: %w", c.Name, err)
+		return
+	}
+
+	// If this config already exists in another group, we have to delete it.
+	// If we can't delete it from the old group, we also can't apply it.
+	if oldGroup, ok := m.groupLookup[c.Name]; ok && oldGroup != groupName {
+		// There's a few cases here where if something fails, it's safer to crash
+		// out and restart the Agent from scratch than it would be to continue as
+		// normal. The panics here are for truly exceptional cases, otherwise if
+		// something is recoverable, we'll return an error like normal.
+
+		// If we can't find the old config, something got messed up when applying
+		// the config. But it also means that we're not going to be able to restore
+		// the config if something fails. Preemptively we should panic, since the
+		// internal state has gotten messed up and can't be fixed.
+		oldConfig, ok := m.groups[oldGroup][c.Name]
+		if !ok {
+			panic("failed to properly move config to new group. THIS IS A BUG!")
+		}
+
+		err = m.deleteConfig(c.Name)
+		if err != nil {
+			err = fmt.Errorf("cannot apply config %s because deleting it from the old group failed: %w", c.Name, err)
+			return
+		}
+
+		// Now that the config is deleted, we need to restore it in case applying
+		// the new one happens to fail.
+		defer func() {
+			if err == nil {
+				return
+			}
+
+			// If restoring a config fails, we've left the Agent in a really bad
+			// state: the new config can't be applied and the old config can't be
+			// brought back. Just crash and let the Agent start fresh.
+			//
+			// Restoring the config _shouldn't_ fail here since applies only fail
+			// if the config is invalid. Since the config was running before, it
+			// should already be valid. If it does happen to fail, though, the
+			// internal state is left corrupted since we've completely lost a
+			// config.
+			restoreError := m.applyConfig(oldConfig)
+			if restoreError != nil {
+				panic(fmt.Sprintf("failed to properly restore config. THIS IS A BUG! error: %s", restoreError))
+			}
+		}()
+	}
+
+	err = m.inner.ApplyConfig(mergedConfig)
+	if err != nil {
+		err = fmt.Errorf("failed to apply grouped configs for config %s: %w", c.Name, err)
+		return
+	}
+
+	// If the inner apply succeeded, we can update our group and the lookup.
+	m.groups[groupName] = grouped
+	m.groupLookup[c.Name] = groupName
+	return
+}
+
+// DeleteConfig will remove a Config from its associated group. If there are
+// no more Configs within that group after this Config is deleted, the managed
+// instance will be stopped. Otherwise, the managed instance will be updated
+// with the new grouped Config that doesn't include the removed one.
+func (m *GroupManager) DeleteConfig(name string) error {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	return m.deleteConfig(name)
+}
+
+func (m *GroupManager) deleteConfig(name string) error {
+	groupName, ok := m.groupLookup[name]
+	if !ok {
+		return fmt.Errorf("config does not exist")
+	}
+
+	// Grab a copy of the stored group and delete our entry. We can
+	// persist it after we sucessfully remove the config.
+	group := m.groups[groupName].Copy()
+	delete(group, name)
+
+	if len(group) == 0 {
+		// We deleted the last remaining config in that group; we can delete it in
+		// its entirety now.
+		if err := m.inner.DeleteConfig(groupName); err != nil {
+			return fmt.Errorf("failed to delete empty group %s after removing config %s: %w", groupName, name, err)
+		}
+	} else {
+		// We deleted the config but there's still more in the group; apply the new
+		// group that holds the remainder of the configs (minus the one we just
+		// deleted).
+		mergedConfig, err := groupConfigs(groupName, group)
+		if err != nil {
+			return fmt.Errorf("failed to regroup configs without %s: %w", name, err)
+		}
+
+		err = m.inner.ApplyConfig(mergedConfig)
+		if err != nil {
+			return fmt.Errorf("failed to apply new group without %s: %w", name, err)
+		}
+	}
+
+	// Update the stored group and remove the entry from the lookup table.
+	if len(group) == 0 {
+		delete(m.groups, groupName)
+	} else {
+		m.groups[groupName] = group
+	}
+
+	delete(m.groupLookup, name)
+	return nil
+}
+
+// Stop stops the Manager and all of its managed instances.
+func (m *GroupManager) Stop() { m.inner.Stop() }
+
+// hashConfig determines the hash of a Config used for grouping. It ignores
+// the name and scrape_configs and also orders remote_writes by name prior to
+// hashing.
+func hashConfig(c Config) (string, error) {
+	// We need a deep copy since we're going to mutate the remote_write
+	// pointers.
+	groupable, err := copyConfig(c)
+	if err != nil {
+		return "", err
+	}
+
+	// Ignore name and scrape configs when hashing
+	groupable.Name = ""
+	groupable.ScrapeConfigs = nil
+
+	// Assign names to remote_write configs if they're not present already.
+	// This is also done in AssignDefaults but is duplicated here for the sake
+	// of simplifying responsibility of GroupManager.
+	for _, cfg := range groupable.RemoteWrite {
+		if cfg != nil {
+			hash, err := getHash(cfg)
+			if err != nil {
+				return "", err
+			}
+			cfg.Name = groupable.Name + "-" + hash[:6]
+		}
+	}
+
+	// Now sort remote_writes by name and nil-ness.
+	sort.Slice(groupable.RemoteWrite, func(i, j int) bool {
+		switch {
+		case groupable.RemoteWrite[i] == nil:
+			return true
+		case groupable.RemoteWrite[j] == nil:
+			return false
+		default:
+			return groupable.RemoteWrite[i].Name < groupable.RemoteWrite[j].Name
+		}
+	})
+
+	bb, err := MarshalConfig(&groupable, false)
+	if err != nil {
+		return "", err
+	}
+	hash := md5.Sum(bb)
+	return hex.EncodeToString(hash[:]), nil
+}
+
+// copyConfig provides a deep copy of a Config that can be mutated
+// independently of c.
+func copyConfig(c Config) (Config, error) {
+	bb, err := MarshalConfig(&c, false)
+	if err != nil {
+		return Config{}, err
+	}
+	cfg, err := UnmarshalConfig(bytes.NewReader(bb))
+	if err != nil {
+		return Config{}, err
+	}
+
+	// Some tests will trip up on this; the marshal/unmarshal cycle might set
+	// an empty slice to nil. Set it back to an empty slice if we detect this
+	// happening.
+	if cfg.RemoteWrite == nil && c.RemoteWrite != nil {
+		cfg.RemoteWrite = []*config.RemoteWriteConfig{}
+	}
+	return *cfg, nil
+}
+
+// groupConfig creates a grouped Config where all fields are copied from
+// the first config except for scrape_configs, which are appended together.
+func groupConfigs(groupName string, grouped groupedConfigs) (Config, error) {
+	if len(grouped) == 0 {
+		return Config{}, fmt.Errorf("no configs")
+	}
+
+	// Move the map into a slice and sort it by name so this function
+	// consistently does the same thing.
+	cfgs := make([]Config, 0, len(grouped))
+	for _, cfg := range grouped {
+		cfgs = append(cfgs, cfg)
+	}
+	sort.Slice(cfgs, func(i, j int) bool { return cfgs[i].Name < cfgs[j].Name })
+
+	combined, err := copyConfig(cfgs[0])
+	if err != nil {
+		return Config{}, err
+	}
+	combined.Name = groupName
+	combined.ScrapeConfigs = nil
+
+	// Combine all the scrape configs. It's possible that two different ungrouped
+	// configs had a matching job name, but this will be detected and rejected
+	// (as it should be) when the underlying Manager eventually validates the
+	// combined config.
+	//
+	// TODO(rfratto): should we prepend job names with the name of the original
+	// config? (e.g., job_name = "config_name/job_name").
+	for _, cfg := range cfgs {
+		combined.ScrapeConfigs = append(combined.ScrapeConfigs, cfg.ScrapeConfigs...)
+	}
+
+	return combined, nil
+}

--- a/pkg/prom/instance/group_manager.go
+++ b/pkg/prom/instance/group_manager.go
@@ -249,11 +249,16 @@ func hashConfig(c Config) (string, error) {
 	// of simplifying responsibility of GroupManager.
 	for _, cfg := range groupable.RemoteWrite {
 		if cfg != nil {
+			// We don't care if the names are different, just that the other settings
+			// are the same. Blank out the name here before hashing the remote
+			// write config.
+			cfg.Name = ""
+
 			hash, err := getHash(cfg)
 			if err != nil {
 				return "", err
 			}
-			cfg.Name = groupable.Name + "-" + hash[:6]
+			cfg.Name = hash[:6]
 		}
 	}
 

--- a/pkg/prom/instance/group_manager.go
+++ b/pkg/prom/instance/group_manager.go
@@ -190,7 +190,7 @@ func (m *GroupManager) deleteConfig(name string) error {
 	}
 
 	// Grab a copy of the stored group and delete our entry. We can
-	// persist it after we sucessfully remove the config.
+	// persist it after we successfully remove the config.
 	group := m.groups[groupName].Copy()
 	delete(group, name)
 

--- a/pkg/prom/instance/group_manager.go
+++ b/pkg/prom/instance/group_manager.go
@@ -292,6 +292,9 @@ func copyConfig(c Config) (Config, error) {
 	// Some tests will trip up on this; the marshal/unmarshal cycle might set
 	// an empty slice to nil. Set it back to an empty slice if we detect this
 	// happening.
+	if cfg.ScrapeConfigs == nil && c.ScrapeConfigs != nil {
+		cfg.ScrapeConfigs = []*config.ScrapeConfig{}
+	}
 	if cfg.RemoteWrite == nil && c.RemoteWrite != nil {
 		cfg.RemoteWrite = []*config.RemoteWriteConfig{}
 	}
@@ -318,7 +321,7 @@ func groupConfigs(groupName string, grouped groupedConfigs) (Config, error) {
 		return Config{}, err
 	}
 	combined.Name = groupName
-	combined.ScrapeConfigs = nil
+	combined.ScrapeConfigs = []*config.ScrapeConfig{}
 
 	// Combine all the scrape configs. It's possible that two different ungrouped
 	// configs had a matching job name, but this will be detected and rejected

--- a/pkg/prom/instance/group_manager_test.go
+++ b/pkg/prom/instance/group_manager_test.go
@@ -16,29 +16,17 @@ func TestGroupManager_ListInstances_Configs(t *testing.T) {
 	configs := []string{
 		`
 name: configA
-host_filter: false
 scrape_configs: []
-remote_write: []
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false`,
+remote_write: []`,
 		`
 name: configB
-host_filter: false
 scrape_configs: []
-remote_write: []
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false`,
+remote_write: []`,
 		`
 name: configC
-host_filter: false
 scrape_configs: []
 remote_write:
-- url: http://localhost:9090
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false`,
+- url: http://localhost:9090`,
 	}
 
 	for _, cfg := range configs {
@@ -71,26 +59,18 @@ func TestGroupManager_ApplyConfig(t *testing.T) {
 		gm := NewGroupManager(inner)
 		err := gm.ApplyConfig(testUnmarshalConfig(t, `
 name: configA
-host_filter: false
 scrape_configs: []
 remote_write: []
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false
 `))
 		require.NoError(t, err)
 
 		err = gm.ApplyConfig(testUnmarshalConfig(t, `
 name: configB
-host_filter: false
 scrape_configs:
 - job_name: test_job
   static_configs:
     - targets: [127.0.0.1:12345]
 remote_write: []
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false
 `))
 		require.NoError(t, err)
 
@@ -100,15 +80,11 @@ write_stale_on_shutdown: false
 		// Check the underlying grouped config and make sure it was updated.
 		expect := testUnmarshalConfig(t, fmt.Sprintf(`
 name: %s
-host_filter: false
 scrape_configs:
 - job_name: test_job
   static_configs:
     - targets: [127.0.0.1:12345]
 remote_write: []
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false
 `, gm.groupLookup["configA"]))
 
 		innerConfigs := inner.ListConfigs()
@@ -121,12 +97,8 @@ write_stale_on_shutdown: false
 		gm := NewGroupManager(inner)
 		err := gm.ApplyConfig(testUnmarshalConfig(t, `
 name: configA
-host_filter: false
 scrape_configs: []
 remote_write: []
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false
 `))
 		require.NoError(t, err)
 		require.Equal(t, 1, len(gm.groups))
@@ -134,15 +106,11 @@ write_stale_on_shutdown: false
 
 		err = gm.ApplyConfig(testUnmarshalConfig(t, `
 name: configA
-host_filter: false
 scrape_configs:
 - job_name: test_job
   static_configs:
     - targets: [127.0.0.1:12345]
 remote_write: []
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false
 `))
 		require.NoError(t, err)
 		require.Equal(t, 1, len(gm.groups))
@@ -151,15 +119,11 @@ write_stale_on_shutdown: false
 		// Check the underlying grouped config and make sure it was updated.
 		expect := testUnmarshalConfig(t, fmt.Sprintf(`
 name: %s
-host_filter: false
 scrape_configs:
 - job_name: test_job
   static_configs:
     - targets: [127.0.0.1:12345]
 remote_write: []
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false
 `, gm.groupLookup["configA"]))
 		actual := inner.ListConfigs()[gm.groupLookup["configA"]]
 		require.Equal(t, expect, actual)
@@ -170,12 +134,8 @@ write_stale_on_shutdown: false
 		gm := NewGroupManager(inner)
 		err := gm.ApplyConfig(testUnmarshalConfig(t, `
 name: configA
-host_filter: false
 scrape_configs: []
 remote_write: []
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false
 `))
 		require.NoError(t, err)
 		require.Equal(t, 1, len(gm.groups))
@@ -190,9 +150,6 @@ name: configA
 host_filter: true
 scrape_configs: []
 remote_write: []
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false
 `))
 		require.NoError(t, err)
 		require.Equal(t, 1, len(gm.groups))
@@ -205,9 +162,6 @@ name: %s
 host_filter: true
 scrape_configs: []
 remote_write: []
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false
 `, gm.groupLookup["configA"]))
 		actual := inner.ListConfigs()[newGroup]
 		require.Equal(t, expect, actual)
@@ -227,7 +181,6 @@ func TestGroupManager_DeleteConfig(t *testing.T) {
 		// should still be active with the one config inside of it.
 		err := gm.ApplyConfig(testUnmarshalConfig(t, `
 name: configA
-host_filter: false
 scrape_configs: 
 - job_name: test_job
   static_configs:
@@ -238,7 +191,6 @@ remote_write: []
 
 		err = gm.ApplyConfig(testUnmarshalConfig(t, `
 name: configB
-host_filter: false
 scrape_configs: 
 - job_name: test_job2
   static_configs:
@@ -252,15 +204,11 @@ remote_write: []
 
 		expect := testUnmarshalConfig(t, fmt.Sprintf(`
 name: %s
-host_filter: false
 scrape_configs:
 - job_name: test_job2
   static_configs:
     - targets: [127.0.0.1:12345]
-remote_write: []
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false`, gm.groupLookup["configB"]))
+remote_write: []`, gm.groupLookup["configB"]))
 		actual := inner.ListConfigs()[gm.groupLookup["configB"]]
 		require.Equal(t, expect, actual)
 		require.Equal(t, 1, len(gm.groups))
@@ -274,7 +222,6 @@ write_stale_on_shutdown: false`, gm.groupLookup["configB"]))
 		// Apply a single config but delete the entire group.
 		err := gm.ApplyConfig(testUnmarshalConfig(t, `
 name: configA
-host_filter: false
 scrape_configs: 
 - job_name: test_job
   static_configs:
@@ -321,24 +268,16 @@ func Test_hashConfig(t *testing.T) {
 	t.Run("name and scrape configs are ignored", func(t *testing.T) {
 		configAText := `
 name: configA
-host_filter: false
 scrape_configs: []
-remote_write: []
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false`
+remote_write: []`
 
 		configBText := `
 name: configB
-host_filter: false
 scrape_configs:
 - job_name: test_job
   static_configs:
     - targets: [127.0.0.1:12345]
-remote_write: []
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false`
+remote_write: []`
 
 		hashA, hashB := getHashesFromConfigs(t, configAText, configBText)
 		require.Equal(t, hashA, hashB)
@@ -347,25 +286,17 @@ write_stale_on_shutdown: false`
 	t.Run("remote_writes are unordered", func(t *testing.T) {
 		configAText := `
 name: configA
-host_filter: false
 scrape_configs: []
 remote_write:
 - url: http://localhost:9009/api/prom/push1
-- url: http://localhost:9009/api/prom/push2
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false`
+- url: http://localhost:9009/api/prom/push2`
 
 		configBText := `
 name: configB
-host_filter: false
 scrape_configs: []
 remote_write:
 - url: http://localhost:9009/api/prom/push2
-- url: http://localhost:9009/api/prom/push1
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false`
+- url: http://localhost:9009/api/prom/push1`
 
 		hashA, hashB := getHashesFromConfigs(t, configAText, configBText)
 		require.Equal(t, hashA, hashB)
@@ -374,25 +305,17 @@ write_stale_on_shutdown: false`
 	t.Run("remote_writes must match", func(t *testing.T) {
 		configAText := `
 name: configA
-host_filter: false
 scrape_configs: []
 remote_write:
 - url: http://localhost:9009/api/prom/push1
-- url: http://localhost:9009/api/prom/push2
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false`
+- url: http://localhost:9009/api/prom/push2`
 
 		configBText := `
 name: configB
-host_filter: false
 scrape_configs: []
 remote_write:
 - url: http://localhost:9009/api/prom/push1
-- url: http://localhost:9009/api/prom/push1
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false`
+- url: http://localhost:9009/api/prom/push1`
 
 		hashA, hashB := getHashesFromConfigs(t, configAText, configBText)
 		require.NotEqual(t, hashA, hashB)
@@ -403,19 +326,13 @@ write_stale_on_shutdown: false`
 name: configA
 host_filter: true
 scrape_configs: []
-remote_write: []
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false`
+remote_write: []`
 
 		configBText := `
 name: configB
 host_filter: false
 scrape_configs: []
-remote_write: []
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false`
+remote_write: []`
 
 		hashA, hashB := getHashesFromConfigs(t, configAText, configBText)
 		require.NotEqual(t, hashA, hashB)
@@ -438,31 +355,23 @@ func getHashesFromConfigs(t *testing.T, configAText, configBText string) (string
 func Test_groupConfigs(t *testing.T) {
 	configAText := `
 name: configA
-host_filter: false
 scrape_configs:
 - job_name: test_job
   static_configs:
     - targets: [127.0.0.1:12345]
 remote_write:
 - url: http://localhost:9009/api/prom/push1
-- url: http://localhost:9009/api/prom/push2
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false`
+- url: http://localhost:9009/api/prom/push2`
 
 	configBText := `
 name: configB
-host_filter: false
 scrape_configs:
 - job_name: test_job2
   static_configs:
     - targets: [127.0.0.1:12345]
 remote_write:
 - url: http://localhost:9009/api/prom/push2
-- url: http://localhost:9009/api/prom/push1
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false`
+- url: http://localhost:9009/api/prom/push1`
 
 	configA := testUnmarshalConfig(t, configAText)
 	configB := testUnmarshalConfig(t, configBText)
@@ -472,7 +381,6 @@ write_stale_on_shutdown: false`
 
 	expectText := fmt.Sprintf(`
 name: %s
-host_filter: false
 scrape_configs:
 - job_name: test_job
   static_configs:
@@ -482,10 +390,7 @@ scrape_configs:
     - targets: [127.0.0.1:12345]
 remote_write:
 - url: http://localhost:9009/api/prom/push1
-- url: http://localhost:9009/api/prom/push2
-wal_truncate_frequency: 1m
-remote_flush_deadline: 1m
-write_stale_on_shutdown: false`, groupName)
+- url: http://localhost:9009/api/prom/push2`, groupName)
 
 	expect, err := UnmarshalConfig(strings.NewReader(expectText))
 	require.NoError(t, err)

--- a/pkg/prom/instance/group_manager_test.go
+++ b/pkg/prom/instance/group_manager_test.go
@@ -1,0 +1,334 @@
+package instance
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGroupManager_ListInstances_Configs(t *testing.T) {
+	gm := NewGroupManager(newFakeManager())
+
+	// Create two configs in the same group and one in another
+	// group.
+	configs := []string{
+		`
+name: configA
+host_filter: false
+scrape_configs: []
+remote_write: []
+wal_truncate_frequency: 1m
+remote_flush_deadline: 1m
+write_stale_on_shutdown: false`,
+		`
+name: configB
+host_filter: false
+scrape_configs: []
+remote_write: []
+wal_truncate_frequency: 1m
+remote_flush_deadline: 1m
+write_stale_on_shutdown: false`,
+		`
+name: configC
+host_filter: false
+scrape_configs: []
+remote_write: 
+- url: http://localhost:9090
+wal_truncate_frequency: 1m
+remote_flush_deadline: 1m
+write_stale_on_shutdown: false`,
+	}
+
+	for _, cfg := range configs {
+		c := testUnmarshalConfig(t, cfg)
+		err := gm.ApplyConfig(c)
+		require.NoError(t, err)
+	}
+
+	// ListInstances should return our grouped instances
+	insts := gm.ListInstances()
+	require.Equal(t, 2, len(insts))
+
+	// ...but ListConfigs should return the ungrouped configs.
+	confs := gm.ListConfigs()
+	require.Equal(t, 3, len(confs))
+	require.Containsf(t, confs, "configA", "configA not in confs")
+	require.Containsf(t, confs, "configB", "configB not in confs")
+	require.Containsf(t, confs, "configC", "configC not in confs")
+}
+
+func testUnmarshalConfig(t *testing.T, cfg string) Config {
+	c, err := UnmarshalConfig(strings.NewReader(cfg))
+	require.NoError(t, err)
+	return *c
+}
+
+func TestGroupManager_ApplyConfig(t *testing.T) {
+	t.Run("updating existing config within group", func(t *testing.T) {
+		inner := newFakeManager()
+		gm := NewGroupManager(inner)
+		err := gm.ApplyConfig(testUnmarshalConfig(t, `
+name: configA
+host_filter: false
+scrape_configs: []
+remote_write: []
+wal_truncate_frequency: 1m
+remote_flush_deadline: 1m
+write_stale_on_shutdown: false
+`))
+		require.NoError(t, err)
+		require.Equal(t, 1, len(gm.groups))
+		require.Equal(t, 1, len(gm.groupLookup))
+
+		err = gm.ApplyConfig(testUnmarshalConfig(t, `
+name: configA
+host_filter: false
+scrape_configs: 
+- job_name: test_job 
+  static_configs:
+    - targets: [127.0.0.1:12345]
+remote_write: []
+wal_truncate_frequency: 1m
+remote_flush_deadline: 1m
+write_stale_on_shutdown: false
+`))
+		require.NoError(t, err)
+		require.Equal(t, 1, len(gm.groups))
+		require.Equal(t, 1, len(gm.groupLookup))
+
+		// Check the underlying grouped config and make sure it was updated.
+		expect := testUnmarshalConfig(t, fmt.Sprintf(`
+name: %s
+host_filter: false
+scrape_configs:
+- job_name: test_job
+  static_configs:
+    - targets: [127.0.0.1:12345]
+remote_write: []
+wal_truncate_frequency: 1m
+remote_flush_deadline: 1m
+write_stale_on_shutdown: false
+`, gm.groupLookup["configA"]))
+		actual := inner.ListConfigs()[gm.groupLookup["configA"]]
+		require.Equal(t, expect, actual)
+	})
+}
+
+func newFakeManager() Manager {
+	instances := make(map[string]ManagedInstance)
+	configs := make(map[string]Config)
+
+	return &MockManager{
+		ListInstancesFunc: func() map[string]ManagedInstance {
+			return instances
+		},
+		ListConfigsFunc: func() map[string]Config {
+			return configs
+		},
+		ApplyConfigFunc: func(c Config) error {
+			instances[c.Name] = &mockInstance{}
+			configs[c.Name] = c
+			return nil
+		},
+		DeleteConfigFunc: func(name string) error {
+			delete(instances, name)
+			delete(configs, name)
+			return nil
+		},
+		StopFunc: func() {},
+	}
+}
+
+func Test_hashConfig(t *testing.T) {
+	t.Run("name and scrape configs are ignored", func(t *testing.T) {
+		configAText := `
+name: configA
+host_filter: false
+scrape_configs: []
+remote_write: []
+wal_truncate_frequency: 1m
+remote_flush_deadline: 1m
+write_stale_on_shutdown: false`
+
+		configBText := `
+name: configB
+host_filter: false
+scrape_configs: 
+- job_name: test_job 
+  static_configs:
+    - targets: [127.0.0.1:12345]
+remote_write: []
+wal_truncate_frequency: 1m
+remote_flush_deadline: 1m
+write_stale_on_shutdown: false`
+
+		hashA, hashB := getHashesFromConfigs(t, configAText, configBText)
+		require.Equal(t, hashA, hashB)
+	})
+
+	t.Run("remote_writes are unordered", func(t *testing.T) {
+		configAText := `
+name: configA
+host_filter: false
+scrape_configs: []
+remote_write: 
+- url: http://localhost:9009/api/prom/push1
+- url: http://localhost:9009/api/prom/push2
+wal_truncate_frequency: 1m
+remote_flush_deadline: 1m
+write_stale_on_shutdown: false`
+
+		configBText := `
+name: configB
+host_filter: false
+scrape_configs: []
+remote_write: 
+- url: http://localhost:9009/api/prom/push2
+- url: http://localhost:9009/api/prom/push1
+wal_truncate_frequency: 1m
+remote_flush_deadline: 1m
+write_stale_on_shutdown: false`
+
+		hashA, hashB := getHashesFromConfigs(t, configAText, configBText)
+		require.Equal(t, hashA, hashB)
+	})
+
+	t.Run("remote_writes must match", func(t *testing.T) {
+		configAText := `
+name: configA
+host_filter: false
+scrape_configs: []
+remote_write: 
+- url: http://localhost:9009/api/prom/push1
+- url: http://localhost:9009/api/prom/push2
+wal_truncate_frequency: 1m
+remote_flush_deadline: 1m
+write_stale_on_shutdown: false`
+
+		configBText := `
+name: configB
+host_filter: false
+scrape_configs: []
+remote_write: 
+- url: http://localhost:9009/api/prom/push1
+- url: http://localhost:9009/api/prom/push1
+wal_truncate_frequency: 1m
+remote_flush_deadline: 1m
+write_stale_on_shutdown: false`
+
+		hashA, hashB := getHashesFromConfigs(t, configAText, configBText)
+		require.NotEqual(t, hashA, hashB)
+	})
+
+	t.Run("other fields must match", func(t *testing.T) {
+		configAText := `
+name: configA
+host_filter: true
+scrape_configs: []
+remote_write: []
+wal_truncate_frequency: 1m
+remote_flush_deadline: 1m
+write_stale_on_shutdown: false`
+
+		configBText := `
+name: configB
+host_filter: false
+scrape_configs: []
+remote_write: []
+wal_truncate_frequency: 1m
+remote_flush_deadline: 1m
+write_stale_on_shutdown: false`
+
+		hashA, hashB := getHashesFromConfigs(t, configAText, configBText)
+		require.NotEqual(t, hashA, hashB)
+	})
+}
+
+func getHashesFromConfigs(t *testing.T, configAText, configBText string) (string, string) {
+	configA := testUnmarshalConfig(t, configAText)
+	configB := testUnmarshalConfig(t, configBText)
+
+	hashA, err := hashConfig(configA)
+	require.NoError(t, err)
+
+	hashB, err := hashConfig(configB)
+	require.NoError(t, err)
+
+	return hashA, hashB
+}
+
+func Test_groupConfigs(t *testing.T) {
+	configAText := `
+name: configA
+host_filter: false
+scrape_configs: 
+- job_name: test_job 
+  static_configs:
+    - targets: [127.0.0.1:12345]
+remote_write: 
+- url: http://localhost:9009/api/prom/push1
+- url: http://localhost:9009/api/prom/push2
+wal_truncate_frequency: 1m
+remote_flush_deadline: 1m
+write_stale_on_shutdown: false`
+
+	configBText := `
+name: configB
+host_filter: false
+scrape_configs: 
+- job_name: test_job2
+  static_configs:
+    - targets: [127.0.0.1:12345]
+remote_write: 
+- url: http://localhost:9009/api/prom/push2
+- url: http://localhost:9009/api/prom/push1
+wal_truncate_frequency: 1m
+remote_flush_deadline: 1m
+write_stale_on_shutdown: false`
+
+	configA := testUnmarshalConfig(t, configAText)
+	configB := testUnmarshalConfig(t, configBText)
+
+	groupName, err := hashConfig(configA)
+	require.NoError(t, err)
+
+	expectText := fmt.Sprintf(`
+name: %s
+host_filter: false
+scrape_configs: 
+- job_name: test_job 
+  static_configs:
+    - targets: [127.0.0.1:12345]
+- job_name: test_job2
+  static_configs:
+    - targets: [127.0.0.1:12345]
+remote_write: 
+- url: http://localhost:9009/api/prom/push1
+- url: http://localhost:9009/api/prom/push2
+wal_truncate_frequency: 1m
+remote_flush_deadline: 1m
+write_stale_on_shutdown: false`, groupName)
+
+	expect, err := UnmarshalConfig(strings.NewReader(expectText))
+	require.NoError(t, err)
+
+	group := groupedConfigs{
+		"configA": configA,
+		"configB": configB,
+	}
+	actual, err := groupConfigs(groupName, group)
+	require.NoError(t, err)
+	require.Equal(t, *expect, actual)
+
+	// Consistency check: groupedConfigs is a map and we want to always have
+	// groupConfigs return the same thing regardless of how the map
+	// is iterated over. Run through groupConfigs a bunch of times and
+	// make sure it always returns the same thing.
+	for i := 0; i < 100; i++ {
+		actual, err = groupConfigs(groupName, group)
+		require.NoError(t, err)
+		require.Equal(t, *expect, actual)
+	}
+}

--- a/pkg/prom/instance/instance.go
+++ b/pkg/prom/instance/instance.go
@@ -211,14 +211,10 @@ type Instance struct {
 
 // New creates a new Instance with a directory for storing the WAL. The instance
 // will not start until Run is called on the instance.
-func New(globalCfg config.GlobalConfig, cfg Config, walDir string, logger log.Logger) (*Instance, error) {
+func New(reg prometheus.Registerer, globalCfg config.GlobalConfig, cfg Config, walDir string, logger log.Logger) (*Instance, error) {
 	logger = log.With(logger, "instance", cfg.Name)
 
 	instWALDir := filepath.Join(walDir, cfg.Name)
-
-	reg := prometheus.WrapRegistererWith(prometheus.Labels{
-		"instance_name": cfg.Name,
-	}, prometheus.DefaultRegisterer)
 
 	newWal := func(reg prometheus.Registerer) (walStorage, error) {
 		return wal.NewStorage(logger, reg, instWALDir)

--- a/pkg/prom/instance/instance_integration_test.go
+++ b/pkg/prom/instance/instance_integration_test.go
@@ -30,8 +30,6 @@ import (
 // 4. Validates that after 15 seconds, the scrape endpoint and remote_write
 //    endpoint has been called.
 func TestInstance_Update(t *testing.T) {
-	prometheus.DefaultRegisterer = prometheus.NewRegistry()
-
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 
 	walDir, err := ioutil.TempDir(os.TempDir(), "wal")
@@ -68,7 +66,7 @@ name: integration_test
 scrape_configs: []
 remote_write: []
 `)
-	inst, err := New(config.DefaultGlobalConfig, initialConfig, walDir, logger)
+	inst, err := New(prometheus.NewRegistry(), config.DefaultGlobalConfig, initialConfig, walDir, logger)
 	require.NoError(t, err)
 
 	instCtx, cancel := context.WithCancel(context.Background())
@@ -111,8 +109,6 @@ remote_write:
 // config and performs various unacceptable updates that should return an
 // error.
 func TestInstance_Update_InvalidChanges(t *testing.T) {
-	prometheus.DefaultRegisterer = prometheus.NewRegistry()
-
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 
 	walDir, err := ioutil.TempDir(os.TempDir(), "wal")
@@ -125,7 +121,7 @@ name: integration_test
 scrape_configs: []
 remote_write: []
 `)
-	inst, err := New(config.DefaultGlobalConfig, initialConfig, walDir, logger)
+	inst, err := New(prometheus.NewRegistry(), config.DefaultGlobalConfig, initialConfig, walDir, logger)
 	require.NoError(t, err)
 
 	instCtx, cancel := context.WithCancel(context.Background())

--- a/pkg/prom/instance/instance_test.go
+++ b/pkg/prom/instance/instance_test.go
@@ -189,7 +189,7 @@ func TestInstance_Path(t *testing.T) {
 	cfg.RemoteFlushDeadline = time.Hour
 
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-	inst, err := New(globalConfig, cfg, walDir, logger)
+	inst, err := New(prometheus.NewRegistry(), globalConfig, cfg, walDir, logger)
 	require.NoError(t, err)
 	runInstance(t, inst)
 
@@ -254,7 +254,7 @@ func TestInstance_Recreate(t *testing.T) {
 	cfg.RemoteFlushDeadline = time.Hour
 
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-	inst, err := New(globalConfig, cfg, walDir, logger)
+	inst, err := New(prometheus.NewRegistry(), globalConfig, cfg, walDir, logger)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -274,7 +274,7 @@ func TestInstance_Recreate(t *testing.T) {
 
 	// Recreate the instance, no panic should happen.
 	require.NotPanics(t, func() {
-		inst, err := New(globalConfig, cfg, walDir, logger)
+		inst, err := New(prometheus.NewRegistry(), globalConfig, cfg, walDir, logger)
 		require.NoError(t, err)
 		runInstance(t, inst)
 

--- a/pkg/prom/instance/manager.go
+++ b/pkg/prom/instance/manager.go
@@ -49,7 +49,7 @@ type Manager interface {
 	// DeleteConfig deletes a given managed instance based on its Config.Name.
 	DeleteConfig(name string) error
 
-	// Stop must stop the Manager and all managed instances.
+	// Stop stops the Manager and all managed instances.
 	Stop()
 }
 


### PR DESCRIPTION
This PR adds [shared instances](https://docs.google.com/document/d/1MmQepMgdbGitt414EoeOtES1KBXu6TWYAhA0XaiF8Wc/edit?usp=sharing), which _should_ be a notable resource utilization enhancement when an Agent runs a significant number of instance configs. 

This changes default behavior of the Agent to share instances, and is a _breaking change_ for metrics; metrics around instances are now grouped by the shared instances rather than individual instance configs (when the feature is enabled). A future PR may remove support for non-shared instances. 

Early performance testing shows that this matches the utilization of having a single instance vs running multiple instances. It's hard to determine how significant that difference is in theory, but users that find their resource utilization has drastically increased after splitting their configs into multiple instances should see some kind of measurable improvement with this feature.

Closes #141. 

TODO:

- [x] Performance comparison (results indeterminate 🤷‍♂️) 
- [x] Manual testing 
- [x] Documentation