### PR TITLE
pkg/loki: return empty loki when no configuration is present

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -44,6 +44,7 @@ func main() {
 	lokiLogs, err := loki.New(cfg.Loki, util.Logger)
 	if err != nil {
 		level.Error(util.Logger).Log("msg", "failed to create loki log collection instance", "err", err)
+		os.Exit(1)
 	}
 
 	srv, err := server.New(cfg.Server)


### PR DESCRIPTION
If Loki isn't configured, then `promtail.New` will fail since it expects at least one client config to be present. However, this means that no Loki instance is created and calling stop on it is a nil reference, throwing a panic.

This commit returns an empty Loki when Promtail isn't configured, and explicitly exits if `loki.New` returns an error.

Fixes #153.