### PR TITLE
ARM Docker images and release binaries

### DIFF
--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -4,20 +4,17 @@ on:
     branches:
       - master
 jobs:
-  build-container:
-    name: Build Container
+  test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
     - name: Get build dependencies
       run: sudo apt-get update && sudo apt-get install libsystemd-dev
 
-    - name: Login to Docker Hub
-      run: docker login -u '${{ secrets.DOCKER_USER }}' -p '${{ secrets.DOCKER_PASS }}'
-
-    - name: Set up Go 1.14
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.15
       id: go
 
     - name: Checkout code
@@ -25,6 +22,48 @@ jobs:
 
     - name: Test
       run: make test
+  agent-container:
+    name: Build agent Container
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+    - name: Get build dependencies
+      run: sudo apt-get update && sudo apt-get install binfmt-support qemu-user-static
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Login to Docker Hub
+      run: docker login -u '${{ secrets.DOCKER_USER }}' -p '${{ secrets.DOCKER_PASS }}'
+
+    - name: Prepare buildx
+      run: |
+        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        docker buildx create --name builder --driver docker-container --use
+        docker buildx inspect --bootstrap
 
     - name: Make Containers
-      run: CROSS_BUILD=true RELEASE_BUILD=true make agent-image agentctl-image
+      run: CROSS_BUILD=true RELEASE_BUILD=true make agent-image 
+  agentctl-container:
+    name: Build agentctl Container
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+    - name: Get build dependencies
+      run: sudo apt-get update && sudo apt-get install binfmt-support qemu-user-static
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Login to Docker Hub
+      run: docker login -u '${{ secrets.DOCKER_USER }}' -p '${{ secrets.DOCKER_PASS }}'
+
+    - name: Prepare buildx
+      run: |
+        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        docker buildx create --name builder --driver docker-container --use
+        docker buildx inspect --bootstrap
+
+    - name: Make Containers
+      run: CROSS_BUILD=true RELEASE_BUILD=true make agentctl-image
+

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -26,8 +26,5 @@ jobs:
     - name: Test
       run: make test
 
-    - name: Make Container
-      run: RELEASE_BUILD=true make agent-image agentctl-image
-
-    - name: Push Container
-      run: RELEASE_BUILD=true make push-agent-image push-agentctl-image
+    - name: Make Containers
+      run: CROSS_BUILD=true RELEASE_BUILD=true make agent-image agentctl-image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,7 @@ jobs:
         export PATH="$(go env GOPATH)/bin:$PATH"
 
         export RELEASE_TAG=${GITHUB_REF##*/}
-        make RELEASE_BUILD=true agent-image agentctl-image
-        make RELEASE_BUILD=true push-agent-image push-agentctl-image
+        make CROSS_BUILD=true RELEASE_BUILD=true agent-image agentctl-image
 
         # Warm up make publish by pulling rfratto/seego ahead of time
         docker pull rfratto/seego:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,20 +4,84 @@ on:
     tags:
       - '*'
 jobs:
-  release:
-    name: Release
+  test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
     - name: Get build dependencies
       run: sudo apt-get update && sudo apt-get install libsystemd-dev
 
+    - name: Set up Go 1.15
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.15
+      id: go
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Test
+      run: make test
+  agent-container:
+    name: Build agent Container
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+    - name: Get build dependencies
+      run: sudo apt-get update && sudo apt-get install binfmt-support qemu-user-static
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
     - name: Login to Docker Hub
       run: docker login -u '${{ secrets.DOCKER_USER }}' -p '${{ secrets.DOCKER_PASS }}'
 
-    - name: Set up Go 1.14
+    - name: Prepare buildx
+      run: |
+        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        docker buildx create --name builder --driver docker-container --use
+        docker buildx inspect --bootstrap
+
+    - name: Build container
+      run: |
+        export RELEASE_TAG=${GITHUB_REF##*/}
+        CROSS_BUILD=true RELEASE_BUILD=true make agent-image
+  agentctl-container:
+    name: Build agentctl Container
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+    - name: Get build dependencies
+      run: sudo apt-get update && sudo apt-get install binfmt-support qemu-user-static
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Login to Docker Hub
+      run: docker login -u '${{ secrets.DOCKER_USER }}' -p '${{ secrets.DOCKER_PASS }}'
+
+    - name: Prepare buildx
+      run: |
+        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        docker buildx create --name builder --driver docker-container --use
+        docker buildx inspect --bootstrap
+
+    - name: Build container
+      run: |
+        export RELEASE_TAG=${GITHUB_REF##*/}
+        CROSS_BUILD=true RELEASE_BUILD=true make agentctl-image
+  release:
+    name: Release
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get build dependencies
+      run: sudo apt-get update && sudo apt-get install libsystemd-dev
+
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.15
       id: go
 
     - name: Install gox and ghr
@@ -31,9 +95,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Test
-      run: make test
-
     - name: Make Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -42,7 +103,6 @@ jobs:
         export PATH="$(go env GOPATH)/bin:$PATH"
 
         export RELEASE_TAG=${GITHUB_REF##*/}
-        make CROSS_BUILD=true RELEASE_BUILD=true agent-image agentctl-image
 
         # Warm up make publish by pulling rfratto/seego ahead of time
         docker pull rfratto/seego:latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Get build dependencies
-      run: sudo apt-get update && sudo apt-get install qemu-user-static
+      run: sudo apt-get update && sudo apt-get install binfmt-support qemu-user-static
 
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,9 +86,15 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@v2
+
+    - name: Setup buildx driver 
+      run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
     
     - name: Setup buildx context 
-      run: docker buildx create --use
+      run: docker buildx create --name builder --driver docker-container --use 
+
+    - name: Buildx inspect 
+      run: docker buildx inspect --bootstrap
 
     - name: Make Containers
       run: CROSS_BUILD=true RELEASE_BUILD=true make agent-image agentctl-image

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,10 @@ jobs:
     - name: Get build dependencies
       run: sudo apt-get update && sudo apt-get install libsystemd-dev
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.15
       id: go
     - name: Install golangci-lint
       run: |
@@ -32,10 +32,10 @@ jobs:
       run: sudo apt-get update && sudo apt-get install libsystemd-dev
       if: matrix.platform == 'ubuntu-latest'
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.15
       id: go
     - name: Checkout code
       uses: actions/checkout@v2
@@ -53,10 +53,10 @@ jobs:
       run: sudo apt-get update && sudo apt-get install libsystemd-dev
       if: matrix.platform == 'ubuntu-latest'
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.15
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -71,30 +71,3 @@ jobs:
       uses: actions/checkout@v2
     - name: Test Packages
       run: RELEASE_TAG=v0.0.0 make test-packages
-
-  # TODO(rfratto): temporary test to make sure cross builds work in CI. Remove after 
-  # verifying.
-  build-container:
-    name: Build Container
-    strategy:
-      matrix:
-        platform: [ubuntu-latest]
-    runs-on: ${{ matrix.platform }}
-    steps:
-    - name: Get build dependencies
-      run: sudo apt-get update && sudo apt-get install binfmt-support qemu-user-static
-
-    - name: Checkout code
-      uses: actions/checkout@v2
-
-    - name: Setup buildx driver 
-      run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-    
-    - name: Setup buildx context 
-      run: docker buildx create --name builder --driver docker-container --use 
-
-    - name: Buildx inspect 
-      run: docker buildx inspect --bootstrap
-
-    - name: Make Containers
-      run: CROSS_BUILD=true RELEASE_BUILD=true make agent-image agentctl-image

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,9 @@ jobs:
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
+    - name: Get build dependencies
+      run: sudo apt-get update && sudo apt-get install qemu-user-static
+
     - name: Checkout code
       uses: actions/checkout@v2
     

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,3 +71,18 @@ jobs:
       uses: actions/checkout@v2
     - name: Test Packages
       run: RELEASE_TAG=v0.0.0 make test-packages
+
+  # TODO(rfratto): temporary test to make sure cross builds work in CI. Remove after 
+  # verifying.
+  build-container:
+    name: Build Container
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Make Containers
+      run: CROSS_BUILD=true RELEASE_BUILD=true make agent-image agentctl-image

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,9 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+    
+    - name: Setup buildx context 
+      run: docker buildx create --use
 
     - name: Make Containers
       run: CROSS_BUILD=true RELEASE_BUILD=true make agent-image agentctl-image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ upstream library preventing cross-compilation of the Grafana Cloud Agent for
 this platform. FreeBSD builds will return in a future release.
 
 - [FEATURE] Added Tracing Support. (@joe-elliott)
+
 - [FEATURE] Add RPM and deb packaging. (@jdbaldry) (@simon6372)
+
+- [FEATURE] arm64 and arm/v7 Docker containers and release builds are now
+  available for `agent` and `agentctl`. (@rfratto) 
 
 # v0.6.1 (2020-04-11)
 

--- a/Makefile
+++ b/Makefile
@@ -133,11 +133,6 @@ all: protos agent agentctl
 agent: cmd/agent/agent
 agentctl: cmd/agentctl/agentctl
 
-agent-crossbuild:
-	bash ./tools/cross_build.bash agent
-agentctl-crossbuild:
-	bash ./tools/cross_build.bash agentctl
-
 cmd/agent/agent: cmd/agent/main.go
 ifeq ($(CROSS_BUILD),false)
 	CGO_ENABLED=1 go build $(CGO_FLAGS) -o $@ ./$(@D)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,9 @@ endif
 IMAGE_PREFIX ?= grafana
 IMAGE_TAG ?= $(shell ./tools/image-tag)
 
-# Flags used for controlling cross compilation.
+# Setting CROSS_BUILD=true enables cross-compiling `agent` and `agentctl` for
+# different architectures. When true, docker buildx is used instead of docker,
+# and seego is used for building binaries instead of go.
 CROSS_BUILD ?= false
 
 # Certain aspects of the build are done in containers for consistency.
@@ -93,8 +95,7 @@ docker-build = docker build $(DOCKER_BUILD_FLAGS)
 ifeq ($(CROSS_BUILD),true)
 DOCKERFILE = Dockerfile.buildx
 
-# TODO(rfratto): replace --output=type=local,dest=output with --push
-docker-build = docker buildx build --output=type=local,dest=output --platform linux/amd64,linux/arm64,linux/arm/v7 $(DOCKER_BUILD_FLAGS)
+docker-build = docker buildx build --push --platform linux/amd64,linux/arm64,linux/arm/v7 $(DOCKER_BUILD_FLAGS)
 endif
 
 ifeq ($(BUILD_IN_CONTAINER),false)

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ VPREFIX        := github.com/grafana/agent/pkg/build
 GO_LDFLAGS     := -X $(VPREFIX).Branch=$(GIT_BRANCH) -X $(VPREFIX).Version=$(IMAGE_TAG) -X $(VPREFIX).Revision=$(GIT_REVISION) -X $(VPREFIX).BuildUser=$(shell whoami)@$(shell hostname) -X $(VPREFIX).BuildDate=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 GO_FLAGS       := -ldflags "-extldflags \"-static\" -s -w $(GO_LDFLAGS)" -tags "netgo static_build" $(MOD_FLAG)
 DEBUG_GO_FLAGS := -gcflags "all=-N -l" -ldflags "-extldflags \"-static\" $(GO_LDFLAGS)" -tags "netgo static_build" $(MOD_FLAG)
+DOCKER_BUILD_FLAGS = --build-arg RELEASE_BUILD=$(RELEASE_BUILD) --build-arg IMAGE_TAG=$(IMAGE_TAG)
 
 # We need a separate set of flags for CGO, where building with -static can
 # cause problems with some C libraries.
@@ -79,6 +80,26 @@ PROTO_GOS := $(patsubst %.proto,%.pb.go,$(PROTO_DEFS))
 PACKAGE_VERSION := $(patsubst v%,%,$(RELEASE_TAG))
 # The number of times this version of the software was released, starting with 1 for the first release.
 PACKAGE_RELEASE := 1
+
+############
+# Commands #
+############
+
+DOCKERFILE = Dockerfile
+
+seego = docker run --rm -t -v "$(CURDIR):$(CURDIR)" -w "$(CURDIR)" -e "CGO_ENABLED=$$CGO_ENABLED" -e "GOOS=$$GOOS" -e "GOARCH=$$GOARCH" -e "GOARM=$$GOARM" rfratto/seego
+docker-build = docker build $(DOCKER_BUILD_FLAGS)
+
+ifeq ($(CROSS_BUILD),true)
+DOCKERFILE = Dockerfile.buildx
+
+# TODO(rfratto): replace --output=type=local,dest=output with --push
+docker-build = docker buildx build --output=type=local,dest=output --platform linux/amd64,linux/arm64,linux/arm/v7 $(DOCKER_BUILD_FLAGS)
+endif
+
+ifeq ($(BUILD_IN_CONTAINER),false)
+seego = "/seego.sh"
+endif
 
 #############
 # Protobufs #
@@ -112,51 +133,31 @@ agent: cmd/agent/agent
 agentctl: cmd/agentctl/agentctl
 
 agent-crossbuild:
-	bash ./tools/cross_build.bash
+	bash ./tools/cross_build.bash agent
+agentctl-crossbuild:
+	bash ./tools/cross_build.bash agentctl
 
-# The logic here can be pretty confusing, but there's three cases:
-#
-# 1) CROSS_BUILD=false :: build with native go
-# 2) CROSS_BUILD=false, BUILD_IN_CONTAINER=true  :: build with docker and seego
-# 3) CROSS_BUILD=false, BUILD_IN_CONTAINER=false :: build with /seego.sh, assuming it exists
 cmd/agent/agent: cmd/agent/main.go
 ifeq ($(CROSS_BUILD),false)
 	CGO_ENABLED=1 go build $(CGO_FLAGS) -o $@ ./$(@D)
 else
-ifeq ($(BUILD_IN_CONTAINER),true)
 	@CGO_ENABLED=1 GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOARM); $(seego) build $(CGO_FLAGS) -o $@ ./$(@D)
-else
-	@CGO_ENABLED=1 GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOARM); /seego.sh build $(CGO_FLAGS) -o $@ ./$(@D)
-endif
 endif
 	$(NETGO_CHECK)
 
 cmd/agentctl/agentctl: cmd/agentctl/main.go
-	CGO_ENABLED=0 go build $(GO_FLAGS) -o $@ ./$(@D)
+ifeq ($(CROSS_BUILD),false)
+	CGO_ENABLED=1 go build $(GO_FLAGS) -o $@ ./$(@D)
+else
+	@CGO_ENABLED=1 GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOARM); $(seego) build $(CGO_FLAGS) -o $@ ./$(@D)
+endif
 	$(NETGO_CHECK)
 
-agent-x-image:
-	docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 \
-		--build-arg RELEASE_BUILD=$(RELEASE_BUILD)  --build-arg IMAGE_TAG=$(IMAGE_TAG) \
-		-t $(IMAGE_PREFIX)/agent:latest -t $(IMAGE_PREFIX)/agent:$(IMAGE_TAG) -f cmd/agent/Dockerfile.buildx --push .
-
 agent-image:
-	docker build --build-arg RELEASE_BUILD=$(RELEASE_BUILD)  --build-arg IMAGE_TAG=$(IMAGE_TAG) \
-		-t $(IMAGE_PREFIX)/agent:latest -f cmd/agent/Dockerfile .
-	docker tag $(IMAGE_PREFIX)/agent:latest $(IMAGE_PREFIX)/agent:$(IMAGE_TAG)
+	$(docker-build) -t $(IMAGE_PREFIX)/agent:latest -t $(IMAGE_PREFIX)/agent:$(IMAGE_TAG) -f cmd/agent/$(DOCKERFILE) .
 
 agentctl-image:
-	docker build --build-arg RELEASE_BUILD=$(RELEASE_BUILD)  --build-arg IMAGE_TAG=$(IMAGE_TAG) \
-		-t $(IMAGE_PREFIX)/agentctl:latest -f cmd/agentctl/Dockerfile .
-	docker tag $(IMAGE_PREFIX)/agentctl:latest $(IMAGE_PREFIX)/agentctl:$(IMAGE_TAG)
-
-push-agent-image:
-	docker push $(IMAGE_PREFIX)/agent:latest
-	docker push $(IMAGE_PREFIX)/agent:$(IMAGE_TAG)
-
-push-agentctl-image:
-	docker push $(IMAGE_PREFIX)/agentctl:latest
-	docker push $(IMAGE_PREFIX)/agentctl:$(IMAGE_TAG)
+	$(docker-build) -t $(IMAGE_PREFIX)/agentctl:latest -t $(IMAGE_PREFIX)/agentctl:$(IMAGE_TAG) -f cmd/agentctl/$(DOCKERFILE) .
 
 install:
 	CGO_ENABLED=1 go install $(CGO_FLAGS) ./cmd/agent
@@ -190,8 +191,6 @@ example-dashboards:
 # Releasing #
 #############
 
-seego = docker run --rm -t -v "$(CURDIR):$(CURDIR)" -w "$(CURDIR)" -e "CGO_ENABLED=$$CGO_ENABLED" -e "GOOS=$$GOOS" -e "GOARCH=$$GOARCH" -e "GOARM=$$GOARM" rfratto/seego
-
 # dist builds the agent and agentctl for all different supported platforms.
 # Most of these platforms need CGO_ENABLED=1, but to simplify things we'll
 # use CGO_ENABLED for all of them. We define them all as separate targets
@@ -208,6 +207,10 @@ dist: dist-agent dist-agentctl
 dist-agent: dist/agent-linux-amd64 dist/agent-darwin-amd64 dist/agent-windows-amd64.exe
 dist/agent-linux-amd64:
 	@CGO_ENABLED=1 GOOS=linux GOARCH=amd64; $(seego) build $(CGO_FLAGS) -o $@ ./cmd/agent
+dist/agent-linux-arm64:
+	@CGO_ENABLED=1 GOOS=linux GOARCH=arm64; $(seego) build $(CGO_FLAGS) -o $@ ./cmd/agent
+dist/agent-linux-armv7:
+	@CGO_ENABLED=1 GOOS=linux GOARCH=arm GOARM=7; $(seego) build $(CGO_FLAGS) -o $@ ./cmd/agent
 dist/agent-darwin-amd64:
 	@CGO_ENABLED=1 GOOS=darwin GOARCH=amd64; $(seego) build $(CGO_FLAGS) -o $@ ./cmd/agent
 dist/agent-windows-amd64.exe:
@@ -216,6 +219,10 @@ dist/agent-windows-amd64.exe:
 dist-agentctl: dist/agentctl-linux-amd64 dist/agentctl-darwin-amd64 dist/agentctl-windows-amd64.exe
 dist/agentctl-linux-amd64:
 	@CGO_ENABLED=1 GOOS=linux GOARCH=amd64; $(seego) build $(CGO_FLAGS) -o $@ ./cmd/agentctl
+dist/agentctl-linux-arm64:
+	@CGO_ENABLED=1 GOOS=linux GOARCH=arm64; $(seego) build $(CGO_FLAGS) -o $@ ./cmd/agentctl
+dist/agentctl-linux-armv7:
+	@CGO_ENABLED=1 GOOS=linux GOARCH=arm GOARM=7; $(seego) build $(CGO_FLAGS) -o $@ ./cmd/agentctl
 dist/agentctl-darwin-amd64:
 	@CGO_ENABLED=1 GOOS=darwin GOARCH=amd64; $(seego) build $(CGO_FLAGS) -o $@ ./cmd/agentctl
 dist/agentctl-windows-amd64.exe:

--- a/cmd/agent/Dockerfile.buildx
+++ b/cmd/agent/Dockerfile.buildx
@@ -1,0 +1,24 @@
+FROM --platform=$BUILDPLATFORM rfratto/seego:latest as build
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+COPY . /src/agent
+WORKDIR /src/agent
+ARG RELEASE_BUILD=true
+ARG IMAGE_TAG
+
+# Rename seego's /go_wrapper.sh to /seego.sh for readability in the
+# Makefile.
+RUN cp /go_wrapper.sh /seego.sh
+RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agent-crossbuild
+
+FROM debian:stretch-slim
+RUN apt-get update && \
+  apt-get install -qy \
+  tzdata ca-certificates libsystemd-dev && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+COPY --from=build /src/agent/cmd/agent/agent /bin/agent
+COPY cmd/agent/agent-local-config.yaml /etc/agent/agent.yaml
+
+ENTRYPOINT ["/bin/agent"]
+CMD ["--config.file=/etc/agent/agent.yaml", "--prometheus.wal-directory=/etc/agent/data"]

--- a/cmd/agent/Dockerfile.buildx
+++ b/cmd/agent/Dockerfile.buildx
@@ -10,7 +10,7 @@ ARG IMAGE_TAG
 # Rename seego's /go_wrapper.sh to /seego.sh for readability in the
 # Makefile.
 RUN cp /go_wrapper.sh /seego.sh
-RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agent-crossbuild
+RUN make clean && IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false bash ./tools/cross_build.bash agent
 
 FROM debian:stretch-slim
 RUN apt-get update && \

--- a/cmd/agentctl/Dockerfile.buildx
+++ b/cmd/agentctl/Dockerfile.buildx
@@ -1,0 +1,21 @@
+FROM --platform=$BUILDPLATFORM rfratto/seego:latest as build
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+COPY . /src/agent
+WORKDIR /src/agent
+ARG RELEASE_BUILD=true
+ARG IMAGE_TAG
+
+# Rename seego's /go_wrapper.sh to /seego.sh for readability in the
+# Makefile.
+RUN cp /go_wrapper.sh /seego.sh
+RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agentctl-crossbuild
+
+FROM debian:stretch-slim
+RUN apt-get update && \
+  apt-get install -qy tzdata ca-certificates && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+COPY --from=build /src/agent/cmd/agentctl/agentctl /bin/agentctl
+
+ENTRYPOINT ["/bin/agentctl"]

--- a/cmd/agentctl/Dockerfile.buildx
+++ b/cmd/agentctl/Dockerfile.buildx
@@ -10,7 +10,7 @@ ARG IMAGE_TAG
 # Rename seego's /go_wrapper.sh to /seego.sh for readability in the
 # Makefile.
 RUN cp /go_wrapper.sh /seego.sh
-RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agentctl-crossbuild
+RUN make clean && IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false bash ./tools/cross_build.bash agentctl
 
 FROM debian:stretch-slim
 RUN apt-get update && \

--- a/tools/cross_build.bash
+++ b/tools/cross_build.bash
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# cross_build.bash will set appropriate GOOS/GOARCH values given a TARGETPLATFORM
+# variable. TARGETPLATFORM will accept values populated by docker buildx.
+#
+# $BUILDPLATFORM must be linux/amd64.
+#
+# Only the following values for $TARGETPLATFORM are supported:
+#   linux/amd64
+#   linux/arm64
+#   linux/arm/v7
+
+main() {
+  if [[ "$BUILDPLATFORM" != "linux/amd64" ]]; then
+    echo ">>> ERROR: BUILDPLATFORM must be linux/amd64, got $BUILDPLATFORM"
+    exit 1
+  fi
+
+  case "$TARGETPLATFORM" in
+    linux/amd64)  native_build      ;;
+    linux/arm64)  seego_build arm64 ;;
+    linux/arm/v7) seego_build arm 7 ;;
+    *)
+      echo ">>> ERROR: unsupported TARGETPLATFORM value $TARGETPLATFORM"
+      exit 1
+  esac
+}
+
+native_build() {
+  make CROSS_BUILD=false agent
+}
+
+seego_build() {
+  echo ">>> building for $1"
+  CROSS_BUILD=true CGO_ENABLED=1 GOOS=linux GOARCH=$1 GOARM=$2 make agent
+}
+
+main
+

--- a/tools/cross_build.bash
+++ b/tools/cross_build.bash
@@ -11,15 +11,22 @@
 #   linux/arm/v7
 
 main() {
+  target=$1
+
+  if [[ "$target" == "" ]]; then 
+    echo ">>> usage: cross_build.bash [makefile target]"
+    exit 1
+  fi
+
   if [[ "$BUILDPLATFORM" != "linux/amd64" ]]; then
     echo ">>> ERROR: BUILDPLATFORM must be linux/amd64, got $BUILDPLATFORM"
     exit 1
   fi
 
   case "$TARGETPLATFORM" in
-    linux/amd64)  native_build      ;;
-    linux/arm64)  seego_build arm64 ;;
-    linux/arm/v7) seego_build arm 7 ;;
+    linux/amd64)  native_build $target       ;;
+    linux/arm64)  seego_build  $target arm64 ;;
+    linux/arm/v7) seego_build  $target arm 7 ;;
     *)
       echo ">>> ERROR: unsupported TARGETPLATFORM value $TARGETPLATFORM"
       exit 1
@@ -27,13 +34,12 @@ main() {
 }
 
 native_build() {
-  make CROSS_BUILD=false agent
+  CROSS_BUILD=false make $1
 }
 
 seego_build() {
-  echo ">>> building for $1"
-  CROSS_BUILD=true CGO_ENABLED=1 GOOS=linux GOARCH=$1 GOARM=$2 make agent
+  echo ">>> building $1 for $2"
+  CROSS_BUILD=true CGO_ENABLED=1 GOOS=linux GOARCH=$2 GOARM=$3 make $1
 }
 
-main
-
+main $1


### PR DESCRIPTION
This PR adds support for building arm64 and arm/v7 Docker images alongside publishing ARM binaries as part of a release. Internally uses `docker buildx` and `seego` to build the Agent with CGO_ENABLED=1. 

To test locally, setup a buildx context if one isn't already available and run `IMAGE_PREFIX=<your dockerhub username> CROSS_BUILD=true make agent-image`. The image will be pushed immediately after building, which is a limitation of buildx. 

CI has been updated to try to parallelize the efforts here as much as possible. When building a new master commit, tests will run first and then the `agent` and `agentctl` images will build in parallel. The same change has been applied for the release: test first, then bundle release assets and build the containers all in parallel.

Note that the CI was out of date and still using go 1.14 for testing while 1.15 was used for building the image. 