### PR TITLE
track number of active configs vs instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,12 @@
 - [BUGFIX] Minor corrections and spelling issues have been fixed in the Overview
   documentation. (@amckinley)
 
-- [BUGFIX] The `agent_prometheus_active_configs` metric will now properly track
-  the number of unique configs applied. This behavior was broken in 0.5.0 with
-  the introduction of instance sharing. An `agent_prometheus_active_instances`
-  metric has also been added to track the number of running instances (e.g.,
-  configs post-sharing). If instance sharing is not enabled, both metrics
-  will have the same value. (@rfratto)
+- [BUGFIX] The new default of `shared` instances mode broke the metric value for
+  `agent_prometheus_active_configs`, which was tracking the number of combined
+  configs (i.e., number of launched instances). This metric has been fixed and
+  a new metric, `agent_prometheus_active_instances`, has been added to track
+  the numbger of launched instances. If instance sharing is not enabled, both
+  metrics will share the same value. (@rfratto)
 
 - [DEPRECATION] `use_hostname_label` is now supplanted by
   `replace_instance_label`. `use_hostname_label` will be removed in a future

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
   the number of unique configs applied. This behavior was broken in 0.5.0 with
   the introduction of instance sharing. An `agent_prometheus_active_instances`
   metric has also been added to track the number of running instances (e.g.,
-  configs post-sharing). If instance sharing is not enabled, these two metrics
+  configs post-sharing). If instance sharing is not enabled, both metrics
   will have the same value. (@rfratto)
 
 - [DEPRECATION] `use_hostname_label` is now supplanted by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   (@rfratto)
 
 - [ENHANCEMENT] A new config option, `replace_instance_label`, is now available
-  for use with integrations. When this is true, the instance label for all 
+  for use with integrations. When this is true, the instance label for all
   metrics coming from an integration will be replaced with the machine's
   hostname rather than 127.0.0.1. (@rfratto)
 
@@ -16,6 +16,13 @@
 
 - [BUGFIX] Minor corrections and spelling issues have been fixed in the Overview
   documentation. (@amckinley)
+
+- [BUGFIX] The `agent_prometheus_active_configs` metric will now properly track
+  the number of unique configs applied. This behavior was broken in 0.5.0 with
+  the introduction of instance sharing. An `agent_prometheus_active_instances`
+  metric has also been added to track the number of running instances (e.g.,
+  configs post-sharing). If instance sharing is not enabled, these two metrics
+  will have the same value. (@rfratto)
 
 - [DEPRECATION] `use_hostname_label` is now supplanted by
   `replace_instance_label`. `use_hostname_label` will be removed in a future

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -35,7 +35,7 @@ func main() {
 	// After this point we can use util.Logger and stop using the log package
 	util.InitLogger(&cfg.Server)
 
-	promMetrics, err := prom.New(cfg.Prometheus, util.Logger)
+	promMetrics, err := prom.New(prometheus.DefaultRegisterer, cfg.Prometheus, util.Logger)
 	if err != nil {
 		level.Error(util.Logger).Log("msg", "failed to create prometheus instance", "err", err)
 		os.Exit(1)

--- a/pkg/prom/agent.go
+++ b/pkg/prom/agent.go
@@ -132,6 +132,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 type Agent struct {
 	cfg    Config
 	logger log.Logger
+	reg    prometheus.Registerer
 
 	cm instance.Manager
 
@@ -141,11 +142,11 @@ type Agent struct {
 }
 
 // New creates and starts a new Agent.
-func New(cfg Config, logger log.Logger) (*Agent, error) {
-	return newAgent(cfg, logger, defaultInstanceFactory)
+func New(reg prometheus.Registerer, cfg Config, logger log.Logger) (*Agent, error) {
+	return newAgent(reg, cfg, logger, defaultInstanceFactory)
 }
 
-func newAgent(cfg Config, logger log.Logger, fact instanceFactory) (*Agent, error) {
+func newAgent(reg prometheus.Registerer, cfg Config, logger log.Logger, fact instanceFactory) (*Agent, error) {
 	a := &Agent{
 		cfg:             cfg,
 		logger:          log.With(logger, "agent", "prometheus"),
@@ -162,7 +163,7 @@ func newAgent(cfg Config, logger log.Logger, fact instanceFactory) (*Agent, erro
 
 	// Regardless of the instance mode, wrap the manager in a CountingManager so we can
 	// collect metrics on the number of active configs.
-	a.cm = instance.NewCountingManager(prometheus.DefaultRegisterer, a.cm)
+	a.cm = instance.NewCountingManager(reg, a.cm)
 
 	allConfigsValid := true
 	for _, c := range cfg.Configs {
@@ -177,7 +178,7 @@ func newAgent(cfg Config, logger log.Logger, fact instanceFactory) (*Agent, erro
 
 	if cfg.ServiceConfig.Enabled {
 		var err error
-		a.ha, err = ha.New(prometheus.DefaultRegisterer, cfg.ServiceConfig, &cfg.Global, cfg.ServiceClientConfig, a.logger, a.cm)
+		a.ha, err = ha.New(reg, cfg.ServiceConfig, &cfg.Global, cfg.ServiceClientConfig, a.logger, a.cm)
 		if err != nil {
 			return nil, err
 		}
@@ -196,7 +197,7 @@ func (a *Agent) newInstance(c instance.Config) (instance.ManagedInstance, error)
 
 	reg := prometheus.WrapRegistererWith(prometheus.Labels{
 		instanceLabel: c.Name,
-	}, prometheus.DefaultRegisterer)
+	}, a.reg)
 
 	return a.instanceFactory(reg, a.cfg.Global, c, a.cfg.WALDir, a.logger)
 }

--- a/pkg/prom/agent.go
+++ b/pkg/prom/agent.go
@@ -160,6 +160,10 @@ func newAgent(cfg Config, logger log.Logger, fact instanceFactory) (*Agent, erro
 		a.cm = instance.NewGroupManager(a.cm)
 	}
 
+	// Regardless of the instance mode, wrap the manager in a CountingManager so we can
+	// collect metrics on the number of active configs.
+	a.cm = instance.NewCountingManager(prometheus.DefaultRegisterer, a.cm)
+
 	allConfigsValid := true
 	for _, c := range cfg.Configs {
 		if err := a.cm.ApplyConfig(c); err != nil {

--- a/pkg/prom/agent_test.go
+++ b/pkg/prom/agent_test.go
@@ -125,7 +125,7 @@ func TestAgent(t *testing.T) {
 
 	fact := newFakeInstanceFactory()
 
-	a, err := newAgent(cfg, log.NewNopLogger(), fact.factory)
+	a, err := newAgent(prometheus.NewRegistry(), cfg, log.NewNopLogger(), fact.factory)
 	require.NoError(t, err)
 
 	test.Poll(t, time.Second*30, true, func() interface{} {
@@ -185,7 +185,7 @@ func TestAgent_NormalInstanceExits(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			fact := newFakeInstanceFactory()
 
-			a, err := newAgent(cfg, log.NewNopLogger(), fact.factory)
+			a, err := newAgent(prometheus.NewRegistry(), cfg, log.NewNopLogger(), fact.factory)
 			require.NoError(t, err)
 
 			test.Poll(t, time.Second*30, true, func() interface{} {
@@ -228,7 +228,7 @@ func TestAgent_Stop(t *testing.T) {
 
 	fact := newFakeInstanceFactory()
 
-	a, err := newAgent(cfg, log.NewNopLogger(), fact.factory)
+	a, err := newAgent(prometheus.NewRegistry(), cfg, log.NewNopLogger(), fact.factory)
 	require.NoError(t, err)
 
 	test.Poll(t, time.Second*30, true, func() interface{} {

--- a/pkg/prom/http_test.go
+++ b/pkg/prom/http_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/test"
 	"github.com/go-kit/kit/log"
 	"github.com/grafana/agent/pkg/prom/instance"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/scrape"
@@ -19,7 +20,7 @@ import (
 
 func TestAgent_ListInstancesHandler(t *testing.T) {
 	fact := newFakeInstanceFactory()
-	a, err := newAgent(Config{
+	a, err := newAgent(prometheus.NewRegistry(), Config{
 		WALDir: "/tmp/agent",
 	}, log.NewNopLogger(), fact.factory)
 	require.NoError(t, err)
@@ -49,7 +50,7 @@ func TestAgent_ListInstancesHandler(t *testing.T) {
 
 func TestAgent_ListTargetsHandler(t *testing.T) {
 	fact := newFakeInstanceFactory()
-	a, err := newAgent(Config{
+	a, err := newAgent(prometheus.NewRegistry(), Config{
 		WALDir: "/tmp/agent",
 	}, log.NewNopLogger(), fact.factory)
 	require.NoError(t, err)

--- a/pkg/prom/instance/counting_manager.go
+++ b/pkg/prom/instance/counting_manager.go
@@ -1,0 +1,80 @@
+package instance
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// CountingManager counts how many unique configs pass through a Manager.
+// It may be distinct from the set of instances depending on available
+// Managers.
+//
+// CountingManager implements Manager.
+type CountingManager struct {
+	currentActiveConfigs prometheus.Gauge
+
+	cache map[string]struct{}
+	inner Manager
+}
+
+// NewCountingManager creates a new CountingManager. The Manager provided
+// by inner will be wrapped by CountingManager and will handle requests to
+// apply configs.
+func NewCountingManager(reg prometheus.Registerer, inner Manager) *CountingManager {
+	currentActiveConfigs := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "agent_prometheus_active_configs",
+		Help: "Current number of active configs being used by the agent.",
+	})
+	if reg != nil {
+		reg.MustRegister(currentActiveConfigs)
+	}
+
+	return &CountingManager{
+		currentActiveConfigs: currentActiveConfigs,
+		cache:                make(map[string]struct{}),
+		inner:                inner,
+	}
+}
+
+// ListInstances implements Manager.
+func (cm *CountingManager) ListInstances() map[string]ManagedInstance {
+	return cm.inner.ListInstances()
+}
+
+// ListConfigs implements Manager.
+func (cm *CountingManager) ListConfigs() map[string]Config {
+	return cm.inner.ListConfigs()
+}
+
+// ApplyConfig implements Manager.
+func (cm *CountingManager) ApplyConfig(c Config) error {
+	err := cm.inner.ApplyConfig(c)
+	if err != nil {
+		return err
+	}
+
+	// If the config isn't in the cache, add it and increment the counter.
+	if _, ok := cm.cache[c.Name]; !ok {
+		cm.cache[c.Name] = struct{}{}
+		cm.currentActiveConfigs.Inc()
+	}
+
+	return nil
+}
+
+// DeleteConfig implements Manager.
+func (cm *CountingManager) DeleteConfig(name string) error {
+	err := cm.inner.DeleteConfig(name)
+	if err != nil {
+		return err
+	}
+
+	// Remove the config from the cache and decrement the counter.
+	delete(cm.cache, name)
+	cm.currentActiveConfigs.Dec()
+	return nil
+}
+
+// Stop implements Manager.
+func (cm *CountingManager) Stop() {
+	cm.inner.Stop()
+}

--- a/pkg/prom/instance/counting_manager_test.go
+++ b/pkg/prom/instance/counting_manager_test.go
@@ -1,0 +1,68 @@
+package instance
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCountingManager(t *testing.T) {
+	mockConfigs := make(map[string]Config)
+
+	mock := &MockManager{
+		ListInstancesFunc: func() map[string]ManagedInstance { return nil },
+		ListConfigsFunc: func() map[string]Config {
+			return mockConfigs
+		},
+		ApplyConfigFunc: func(c Config) error {
+			mockConfigs[c.Name] = c
+			return nil
+		},
+		DeleteConfigFunc: func(name string) error {
+			if _, ok := mockConfigs[name]; !ok {
+				return errors.New("config does not exist")
+			}
+			delete(mockConfigs, name)
+			return nil
+		},
+	}
+
+	reg := prometheus.NewRegistry()
+	cm := NewCountingManager(reg, mock)
+
+	// Pull values from the registry and assert that our gauge has the
+	// expected value.
+	requireGaugeValue := func(value int) {
+		expect := fmt.Sprintf(`
+		# HELP agent_prometheus_active_configs Current number of active configs being used by the agent.
+		# TYPE agent_prometheus_active_configs gauge
+		agent_prometheus_active_configs %d
+		`, value)
+
+		r := strings.NewReader(expect)
+		require.NoError(t, testutil.GatherAndCompare(reg, r))
+	}
+
+	requireGaugeValue(0)
+
+	// Apply two diferent configs, but each config twice. The gauge should
+	// only be set to 2.
+	_ = cm.ApplyConfig(Config{Name: "config-a"})
+	_ = cm.ApplyConfig(Config{Name: "config-a"})
+	_ = cm.ApplyConfig(Config{Name: "config-b"})
+	_ = cm.ApplyConfig(Config{Name: "config-b"})
+	requireGaugeValue(2)
+
+	// Deleting a config that doesn't exist shouldn't change the gauge.
+	_ = cm.DeleteConfig("config-nil")
+	requireGaugeValue(2)
+
+	// Deleting a config that does exist _should_ change the gauge.
+	_ = cm.DeleteConfig("config-b")
+	requireGaugeValue(1)
+}

--- a/pkg/prom/instance/counting_manager_test.go
+++ b/pkg/prom/instance/counting_manager_test.go
@@ -50,7 +50,7 @@ func TestCountingManager(t *testing.T) {
 
 	requireGaugeValue(0)
 
-	// Apply two diferent configs, but each config twice. The gauge should
+	// Apply two different configs, but each config twice. The gauge should
 	// only be set to 2.
 	_ = cm.ApplyConfig(Config{Name: "config-a"})
 	_ = cm.ApplyConfig(Config{Name: "config-a"})

--- a/pkg/prom/instance/manager.go
+++ b/pkg/prom/instance/manager.go
@@ -20,9 +20,9 @@ var (
 		Help: "Total number of times a Prometheus instance exited unexpectedly, causing it to be restarted.",
 	}, []string{"instance_name"})
 
-	currentActiveConfigs = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "agent_prometheus_active_configs",
-		Help: "Current number of active configs being used by the agent.",
+	currentActiveInstances = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "agent_prometheus_active_instances",
+		Help: "Current number of active instances being used by the agent.",
 	})
 
 	// DefaultBasicManagerConfig is the default config for the BasicManager.
@@ -194,7 +194,7 @@ func (m *BasicManager) ApplyConfig(c Config) error {
 		return err
 	}
 
-	currentActiveConfigs.Inc()
+	currentActiveInstances.Inc()
 	return nil
 }
 
@@ -236,7 +236,7 @@ func (m *BasicManager) spawnProcess(c Config) error {
 		}
 		m.mut.Unlock()
 
-		currentActiveConfigs.Dec()
+		currentActiveInstances.Dec()
 	}()
 
 	return nil

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/lint.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/lint.go
@@ -1,0 +1,46 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil/promlint"
+)
+
+// CollectAndLint registers the provided Collector with a newly created pedantic
+// Registry. It then calls GatherAndLint with that Registry and with the
+// provided metricNames.
+func CollectAndLint(c prometheus.Collector, metricNames ...string) ([]promlint.Problem, error) {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return nil, fmt.Errorf("registering collector failed: %s", err)
+	}
+	return GatherAndLint(reg, metricNames...)
+}
+
+// GatherAndLint gathers all metrics from the provided Gatherer and checks them
+// with the linter in the promlint package. If any metricNames are provided,
+// only metrics with those names are checked.
+func GatherAndLint(g prometheus.Gatherer, metricNames ...string) ([]promlint.Problem, error) {
+	got, err := g.Gather()
+	if err != nil {
+		return nil, fmt.Errorf("gathering metrics failed: %s", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+	return promlint.NewWithMetricFamilies(got).Lint()
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/promlint.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/promlint.go
@@ -1,0 +1,386 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package promlint provides a linter for Prometheus metrics.
+package promlint
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/prometheus/common/expfmt"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// A Linter is a Prometheus metrics linter.  It identifies issues with metric
+// names, types, and metadata, and reports them to the caller.
+type Linter struct {
+	// The linter will read metrics in the Prometheus text format from r and
+	// then lint it, _and_ it will lint the metrics provided directly as
+	// MetricFamily proto messages in mfs. Note, however, that the current
+	// constructor functions New and NewWithMetricFamilies only ever set one
+	// of them.
+	r   io.Reader
+	mfs []*dto.MetricFamily
+}
+
+// A Problem is an issue detected by a Linter.
+type Problem struct {
+	// The name of the metric indicated by this Problem.
+	Metric string
+
+	// A description of the issue for this Problem.
+	Text string
+}
+
+// newProblem is helper function to create a Problem.
+func newProblem(mf *dto.MetricFamily, text string) Problem {
+	return Problem{
+		Metric: mf.GetName(),
+		Text:   text,
+	}
+}
+
+// New creates a new Linter that reads an input stream of Prometheus metrics in
+// the Prometheus text exposition format.
+func New(r io.Reader) *Linter {
+	return &Linter{
+		r: r,
+	}
+}
+
+// NewWithMetricFamilies creates a new Linter that reads from a slice of
+// MetricFamily protobuf messages.
+func NewWithMetricFamilies(mfs []*dto.MetricFamily) *Linter {
+	return &Linter{
+		mfs: mfs,
+	}
+}
+
+// Lint performs a linting pass, returning a slice of Problems indicating any
+// issues found in the metrics stream. The slice is sorted by metric name
+// and issue description.
+func (l *Linter) Lint() ([]Problem, error) {
+	var problems []Problem
+
+	if l.r != nil {
+		d := expfmt.NewDecoder(l.r, expfmt.FmtText)
+
+		mf := &dto.MetricFamily{}
+		for {
+			if err := d.Decode(mf); err != nil {
+				if err == io.EOF {
+					break
+				}
+
+				return nil, err
+			}
+
+			problems = append(problems, lint(mf)...)
+		}
+	}
+	for _, mf := range l.mfs {
+		problems = append(problems, lint(mf)...)
+	}
+
+	// Ensure deterministic output.
+	sort.SliceStable(problems, func(i, j int) bool {
+		if problems[i].Metric == problems[j].Metric {
+			return problems[i].Text < problems[j].Text
+		}
+		return problems[i].Metric < problems[j].Metric
+	})
+
+	return problems, nil
+}
+
+// lint is the entry point for linting a single metric.
+func lint(mf *dto.MetricFamily) []Problem {
+	fns := []func(mf *dto.MetricFamily) []Problem{
+		lintHelp,
+		lintMetricUnits,
+		lintCounter,
+		lintHistogramSummaryReserved,
+		lintMetricTypeInName,
+		lintReservedChars,
+		lintCamelCase,
+		lintUnitAbbreviations,
+	}
+
+	var problems []Problem
+	for _, fn := range fns {
+		problems = append(problems, fn(mf)...)
+	}
+
+	// TODO(mdlayher): lint rules for specific metrics types.
+	return problems
+}
+
+// lintHelp detects issues related to the help text for a metric.
+func lintHelp(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+
+	// Expect all metrics to have help text available.
+	if mf.Help == nil {
+		problems = append(problems, newProblem(mf, "no help text"))
+	}
+
+	return problems
+}
+
+// lintMetricUnits detects issues with metric unit names.
+func lintMetricUnits(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+
+	unit, base, ok := metricUnits(*mf.Name)
+	if !ok {
+		// No known units detected.
+		return nil
+	}
+
+	// Unit is already a base unit.
+	if unit == base {
+		return nil
+	}
+
+	problems = append(problems, newProblem(mf, fmt.Sprintf("use base unit %q instead of %q", base, unit)))
+
+	return problems
+}
+
+// lintCounter detects issues specific to counters, as well as patterns that should
+// only be used with counters.
+func lintCounter(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+
+	isCounter := mf.GetType() == dto.MetricType_COUNTER
+	isUntyped := mf.GetType() == dto.MetricType_UNTYPED
+	hasTotalSuffix := strings.HasSuffix(mf.GetName(), "_total")
+
+	switch {
+	case isCounter && !hasTotalSuffix:
+		problems = append(problems, newProblem(mf, `counter metrics should have "_total" suffix`))
+	case !isUntyped && !isCounter && hasTotalSuffix:
+		problems = append(problems, newProblem(mf, `non-counter metrics should not have "_total" suffix`))
+	}
+
+	return problems
+}
+
+// lintHistogramSummaryReserved detects when other types of metrics use names or labels
+// reserved for use by histograms and/or summaries.
+func lintHistogramSummaryReserved(mf *dto.MetricFamily) []Problem {
+	// These rules do not apply to untyped metrics.
+	t := mf.GetType()
+	if t == dto.MetricType_UNTYPED {
+		return nil
+	}
+
+	var problems []Problem
+
+	isHistogram := t == dto.MetricType_HISTOGRAM
+	isSummary := t == dto.MetricType_SUMMARY
+
+	n := mf.GetName()
+
+	if !isHistogram && strings.HasSuffix(n, "_bucket") {
+		problems = append(problems, newProblem(mf, `non-histogram metrics should not have "_bucket" suffix`))
+	}
+	if !isHistogram && !isSummary && strings.HasSuffix(n, "_count") {
+		problems = append(problems, newProblem(mf, `non-histogram and non-summary metrics should not have "_count" suffix`))
+	}
+	if !isHistogram && !isSummary && strings.HasSuffix(n, "_sum") {
+		problems = append(problems, newProblem(mf, `non-histogram and non-summary metrics should not have "_sum" suffix`))
+	}
+
+	for _, m := range mf.GetMetric() {
+		for _, l := range m.GetLabel() {
+			ln := l.GetName()
+
+			if !isHistogram && ln == "le" {
+				problems = append(problems, newProblem(mf, `non-histogram metrics should not have "le" label`))
+			}
+			if !isSummary && ln == "quantile" {
+				problems = append(problems, newProblem(mf, `non-summary metrics should not have "quantile" label`))
+			}
+		}
+	}
+
+	return problems
+}
+
+// lintMetricTypeInName detects when metric types are included in the metric name.
+func lintMetricTypeInName(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+	n := strings.ToLower(mf.GetName())
+
+	for i, t := range dto.MetricType_name {
+		if i == int32(dto.MetricType_UNTYPED) {
+			continue
+		}
+
+		typename := strings.ToLower(t)
+		if strings.Contains(n, "_"+typename+"_") || strings.HasSuffix(n, "_"+typename) {
+			problems = append(problems, newProblem(mf, fmt.Sprintf(`metric name should not include type '%s'`, typename)))
+		}
+	}
+	return problems
+}
+
+// lintReservedChars detects colons in metric names.
+func lintReservedChars(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+	if strings.Contains(mf.GetName(), ":") {
+		problems = append(problems, newProblem(mf, "metric names should not contain ':'"))
+	}
+	return problems
+}
+
+var camelCase = regexp.MustCompile(`[a-z][A-Z]`)
+
+// lintCamelCase detects metric names and label names written in camelCase.
+func lintCamelCase(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+	if camelCase.FindString(mf.GetName()) != "" {
+		problems = append(problems, newProblem(mf, "metric names should be written in 'snake_case' not 'camelCase'"))
+	}
+
+	for _, m := range mf.GetMetric() {
+		for _, l := range m.GetLabel() {
+			if camelCase.FindString(l.GetName()) != "" {
+				problems = append(problems, newProblem(mf, "label names should be written in 'snake_case' not 'camelCase'"))
+			}
+		}
+	}
+	return problems
+}
+
+// lintUnitAbbreviations detects abbreviated units in the metric name.
+func lintUnitAbbreviations(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+	n := strings.ToLower(mf.GetName())
+	for _, s := range unitAbbreviations {
+		if strings.Contains(n, "_"+s+"_") || strings.HasSuffix(n, "_"+s) {
+			problems = append(problems, newProblem(mf, "metric names should not contain abbreviated units"))
+		}
+	}
+	return problems
+}
+
+// metricUnits attempts to detect known unit types used as part of a metric name,
+// e.g. "foo_bytes_total" or "bar_baz_milligrams".
+func metricUnits(m string) (unit string, base string, ok bool) {
+	ss := strings.Split(m, "_")
+
+	for unit, base := range units {
+		// Also check for "no prefix".
+		for _, p := range append(unitPrefixes, "") {
+			for _, s := range ss {
+				// Attempt to explicitly match a known unit with a known prefix,
+				// as some words may look like "units" when matching suffix.
+				//
+				// As an example, "thermometers" should not match "meters", but
+				// "kilometers" should.
+				if s == p+unit {
+					return p + unit, base, true
+				}
+			}
+		}
+	}
+
+	return "", "", false
+}
+
+// Units and their possible prefixes recognized by this library.  More can be
+// added over time as needed.
+var (
+	// map a unit to the appropriate base unit.
+	units = map[string]string{
+		// Base units.
+		"amperes": "amperes",
+		"bytes":   "bytes",
+		"celsius": "celsius", // Also allow Celsius because it is common in typical Prometheus use cases.
+		"grams":   "grams",
+		"joules":  "joules",
+		"kelvin":  "kelvin", // SI base unit, used in special cases (e.g. color temperature, scientific measurements).
+		"meters":  "meters", // Both American and international spelling permitted.
+		"metres":  "metres",
+		"seconds": "seconds",
+		"volts":   "volts",
+
+		// Non base units.
+		// Time.
+		"minutes": "seconds",
+		"hours":   "seconds",
+		"days":    "seconds",
+		"weeks":   "seconds",
+		// Temperature.
+		"kelvins":    "kelvin",
+		"fahrenheit": "celsius",
+		"rankine":    "celsius",
+		// Length.
+		"inches": "meters",
+		"yards":  "meters",
+		"miles":  "meters",
+		// Bytes.
+		"bits": "bytes",
+		// Energy.
+		"calories": "joules",
+		// Mass.
+		"pounds": "grams",
+		"ounces": "grams",
+	}
+
+	unitPrefixes = []string{
+		"pico",
+		"nano",
+		"micro",
+		"milli",
+		"centi",
+		"deci",
+		"deca",
+		"hecto",
+		"kilo",
+		"kibi",
+		"mega",
+		"mibi",
+		"giga",
+		"gibi",
+		"tera",
+		"tebi",
+		"peta",
+		"pebi",
+	}
+
+	// Common abbreviations that we'd like to discourage.
+	unitAbbreviations = []string{
+		"s",
+		"ms",
+		"us",
+		"ns",
+		"sec",
+		"b",
+		"kb",
+		"mb",
+		"gb",
+		"tb",
+		"pb",
+		"m",
+		"h",
+		"d",
+	}
+)

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
@@ -1,0 +1,230 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testutil provides helpers to test code using the prometheus package
+// of client_golang.
+//
+// While writing unit tests to verify correct instrumentation of your code, it's
+// a common mistake to mostly test the instrumentation library instead of your
+// own code. Rather than verifying that a prometheus.Counter's value has changed
+// as expected or that it shows up in the exposition after registration, it is
+// in general more robust and more faithful to the concept of unit tests to use
+// mock implementations of the prometheus.Counter and prometheus.Registerer
+// interfaces that simply assert that the Add or Register methods have been
+// called with the expected arguments. However, this might be overkill in simple
+// scenarios. The ToFloat64 function is provided for simple inspection of a
+// single-value metric, but it has to be used with caution.
+//
+// End-to-end tests to verify all or larger parts of the metrics exposition can
+// be implemented with the CollectAndCompare or GatherAndCompare functions. The
+// most appropriate use is not so much testing instrumentation of your code, but
+// testing custom prometheus.Collector implementations and in particular whole
+// exporters, i.e. programs that retrieve telemetry data from a 3rd party source
+// and convert it into Prometheus metrics.
+//
+// In a similar pattern, CollectAndLint and GatherAndLint can be used to detect
+// metrics that have issues with their name, type, or metadata without being
+// necessarily invalid, e.g. a counter with a name missing the “_total” suffix.
+package testutil
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/prometheus/common/expfmt"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/internal"
+)
+
+// ToFloat64 collects all Metrics from the provided Collector. It expects that
+// this results in exactly one Metric being collected, which must be a Gauge,
+// Counter, or Untyped. In all other cases, ToFloat64 panics. ToFloat64 returns
+// the value of the collected Metric.
+//
+// The Collector provided is typically a simple instance of Gauge or Counter, or
+// – less commonly – a GaugeVec or CounterVec with exactly one element. But any
+// Collector fulfilling the prerequisites described above will do.
+//
+// Use this function with caution. It is computationally very expensive and thus
+// not suited at all to read values from Metrics in regular code. This is really
+// only for testing purposes, and even for testing, other approaches are often
+// more appropriate (see this package's documentation).
+//
+// A clear anti-pattern would be to use a metric type from the prometheus
+// package to track values that are also needed for something else than the
+// exposition of Prometheus metrics. For example, you would like to track the
+// number of items in a queue because your code should reject queuing further
+// items if a certain limit is reached. It is tempting to track the number of
+// items in a prometheus.Gauge, as it is then easily available as a metric for
+// exposition, too. However, then you would need to call ToFloat64 in your
+// regular code, potentially quite often. The recommended way is to track the
+// number of items conventionally (in the way you would have done it without
+// considering Prometheus metrics) and then expose the number with a
+// prometheus.GaugeFunc.
+func ToFloat64(c prometheus.Collector) float64 {
+	var (
+		m      prometheus.Metric
+		mCount int
+		mChan  = make(chan prometheus.Metric)
+		done   = make(chan struct{})
+	)
+
+	go func() {
+		for m = range mChan {
+			mCount++
+		}
+		close(done)
+	}()
+
+	c.Collect(mChan)
+	close(mChan)
+	<-done
+
+	if mCount != 1 {
+		panic(fmt.Errorf("collected %d metrics instead of exactly 1", mCount))
+	}
+
+	pb := &dto.Metric{}
+	m.Write(pb)
+	if pb.Gauge != nil {
+		return pb.Gauge.GetValue()
+	}
+	if pb.Counter != nil {
+		return pb.Counter.GetValue()
+	}
+	if pb.Untyped != nil {
+		return pb.Untyped.GetValue()
+	}
+	panic(fmt.Errorf("collected a non-gauge/counter/untyped metric: %s", pb))
+}
+
+// CollectAndCount registers the provided Collector with a newly created
+// pedantic Registry. It then calls GatherAndCount with that Registry and with
+// the provided metricNames. In the unlikely case that the registration or the
+// gathering fails, this function panics. (This is inconsistent with the other
+// CollectAnd… functions in this package and has historical reasons. Changing
+// the function signature would be a breaking change and will therefore only
+// happen with the next major version bump.)
+func CollectAndCount(c prometheus.Collector, metricNames ...string) int {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		panic(fmt.Errorf("registering collector failed: %s", err))
+	}
+	result, err := GatherAndCount(reg, metricNames...)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}
+
+// GatherAndCount gathers all metrics from the provided Gatherer and counts
+// them. It returns the number of metric children in all gathered metric
+// families together. If any metricNames are provided, only metrics with those
+// names are counted.
+func GatherAndCount(g prometheus.Gatherer, metricNames ...string) (int, error) {
+	got, err := g.Gather()
+	if err != nil {
+		return 0, fmt.Errorf("gathering metrics failed: %s", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+
+	result := 0
+	for _, mf := range got {
+		result += len(mf.GetMetric())
+	}
+	return result, nil
+}
+
+// CollectAndCompare registers the provided Collector with a newly created
+// pedantic Registry. It then calls GatherAndCompare with that Registry and with
+// the provided metricNames.
+func CollectAndCompare(c prometheus.Collector, expected io.Reader, metricNames ...string) error {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return fmt.Errorf("registering collector failed: %s", err)
+	}
+	return GatherAndCompare(reg, expected, metricNames...)
+}
+
+// GatherAndCompare gathers all metrics from the provided Gatherer and compares
+// it to an expected output read from the provided Reader in the Prometheus text
+// exposition format. If any metricNames are provided, only metrics with those
+// names are compared.
+func GatherAndCompare(g prometheus.Gatherer, expected io.Reader, metricNames ...string) error {
+	got, err := g.Gather()
+	if err != nil {
+		return fmt.Errorf("gathering metrics failed: %s", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+	var tp expfmt.TextParser
+	wantRaw, err := tp.TextToMetricFamilies(expected)
+	if err != nil {
+		return fmt.Errorf("parsing expected metrics failed: %s", err)
+	}
+	want := internal.NormalizeMetricFamilies(wantRaw)
+
+	return compare(got, want)
+}
+
+// compare encodes both provided slices of metric families into the text format,
+// compares their string message, and returns an error if they do not match.
+// The error contains the encoded text of both the desired and the actual
+// result.
+func compare(got, want []*dto.MetricFamily) error {
+	var gotBuf, wantBuf bytes.Buffer
+	enc := expfmt.NewEncoder(&gotBuf, expfmt.FmtText)
+	for _, mf := range got {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding gathered metrics failed: %s", err)
+		}
+	}
+	enc = expfmt.NewEncoder(&wantBuf, expfmt.FmtText)
+	for _, mf := range want {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding expected metrics failed: %s", err)
+		}
+	}
+
+	if wantBuf.String() != gotBuf.String() {
+		return fmt.Errorf(`
+metric output does not match expectation; want:
+
+%s
+got:
+
+%s`, wantBuf.String(), gotBuf.String())
+
+	}
+	return nil
+}
+
+func filterMetrics(metrics []*dto.MetricFamily, names []string) []*dto.MetricFamily {
+	var filtered []*dto.MetricFamily
+	for _, m := range metrics {
+		for _, name := range names {
+			if m.GetName() == name {
+				filtered = append(filtered, m)
+				break
+			}
+		}
+	}
+	return filtered
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -391,6 +391,8 @@ github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promauto
 github.com/prometheus/client_golang/prometheus/promhttp
 github.com/prometheus/client_golang/prometheus/push
+github.com/prometheus/client_golang/prometheus/testutil
+github.com/prometheus/client_golang/prometheus/testutil/promlint
 # github.com/prometheus/client_model v0.2.0
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.10.0


### PR DESCRIPTION
Instance sharing broke the `active_configs` metric, which started to represent the number of instances (e.g., configs post-sharing) instead. Knowing exactly how many configs exist _pre-sharing_ is still useful, so this PR:

1. renames the old metric to `active_instances` 
2. reintroduces the `active_configs` metric to accurately track the number of configs before instance sharing is applied.
 