### PR TITLE
Make subsystems optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,10 @@
   will now be `GrafanaCloudAgent/<Version>` instead of `Prometheus/<Prometheus Version>`.
   (@rfratto)
 
-- [ENHANCEMENT] The various existing subsystems of the Agent (`prometheus`,
-  `integrations`) are now made optional. If they are not defined in the config
-  file, they will not be started. Defining integrations implicitly enables
-  Prometheus as integrations support depends on Prometheus running. This
-  optional subsystem enhancement also applies to the new `loki` subsystem.
-  (@rfratto)
+- [ENHANCEMENT] The subsystems of the Agent (`prometheus`, `loki`) are now made
+  optional. Enabling integrations also implicitly enables the associated
+  subsystem. For example, enabling the `agent` or `node_exporter` integration will
+  force the `prometheus` subsystem to be enabled.  (@rfratto)
 
 - [BUGFIX] The documentation for Tanka configs is now correct. (@amckinley)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@
   will now be `GrafanaCloudAgent/<Version>` instead of `Prometheus/<Prometheus Version>`.
   (@rfratto)
 
+- [ENHANCEMENT] The various existing subsystems of the Agent (`prometheus`,
+  `integrations`) are now made optional. If they are not defined in the config
+  file, they will not be started. Defining integrations implicitly enables
+  Prometheus as integrations support depends on Prometheus running. This
+  optional subsystem enhancement also applies to the new `loki` subsystem.
+  (@rfratto)
+
 - [BUGFIX] The documentation for Tanka configs is now correct. (@amckinley)
 
 - [BUGFIX] Minor corrections and spelling issues have been fixed in the Overview

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,6 +27,9 @@ type Config struct {
 func (c *Config) ApplyDefaults() error {
 	// The integration subsystem depends on Prometheus; so if it's enabled, force Prometheus
 	// to be enabled.
+	//
+	// TODO(rfratto): when Loki integrations are added, this line will no longer work; each
+	// integration will then have to be associated with a subsystem.
 	if c.Integrations.Enabled && !c.Prometheus.Enabled {
 		fmt.Println("NOTE: enabling Prometheus subsystem as Integrations are enabled")
 		c.Prometheus.Enabled = true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,7 +27,8 @@ type Config struct {
 func (c *Config) ApplyDefaults() error {
 	// The integration subsystem depends on Prometheus; so if it's enabled, force Prometheus
 	// to be enabled.
-	if c.Integrations.Enabled {
+	if c.Integrations.Enabled && !c.Prometheus.Enabled {
+		fmt.Println("NOTE: enabling Prometheus subsystem as Integrations are enabled")
 		c.Prometheus.Enabled = true
 	}
 

--- a/pkg/integrations/manager.go
+++ b/pkg/integrations/manager.go
@@ -41,9 +41,11 @@ var (
 
 // Config holds the configuration for all integrations.
 type Config struct {
+	// Whether the Integration subsystem should be enabled.
+	Enabled bool `yaml:"-"`
+
 	// When true, scrapes metrics from integrations.
 	ScrapeIntegrations bool `yaml:"scrape_integrations"`
-
 	// When true, replaces the instance label with the agent hostname.
 	ReplaceInstanceLabel bool `yaml:"replace_instance_label"`
 
@@ -70,6 +72,10 @@ type Config struct {
 // UnmarshalYAML implements yaml.Unmarshaler for Config.
 func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	*c = DefaultConfig
+
+	// If the Config is unmarshaled, it's present in the config and should be
+	// enabled.
+	c.Enabled = true
 
 	type plain Config
 	return unmarshal((*plain)(c))

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -17,10 +17,23 @@ import (
 
 // Config controls the configuration of the Loki log scraper.
 type Config struct {
+	// Whether the Loki subsystem should be enabled.
+	Enabled bool `yaml:"-"`
+
 	ClientConfigs   []client.Config       `yaml:"clients,omitempty"`
 	PositionsConfig positions.Config      `yaml:"positions,omitempty"`
 	ScrapeConfig    []scrapeconfig.Config `yaml:"scrape_configs,omitempty"`
 	TargetConfig    file.Config           `yaml:"target_config,omitempty"`
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler.
+func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// If the Config is unmarshaled, it's present in the config and should be
+	// enabled.
+	c.Enabled = true
+
+	type plain Config
+	return unmarshal((*plain)(c))
 }
 
 func (c *Config) RegisterFlags(f *flag.FlagSet) {

--- a/pkg/prom/agent.go
+++ b/pkg/prom/agent.go
@@ -65,6 +65,9 @@ func (m *InstanceMode) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // Config defines the configuration for the entire set of Prometheus client
 // instances, along with a global configuration.
 type Config struct {
+	// Whether the Prometheus subsystem should be enabled.
+	Enabled bool `yaml:"-"`
+
 	Global                 config.GlobalConfig `yaml:"global"`
 	WALDir                 string              `yaml:"wal_directory"`
 	ServiceConfig          ha.Config           `yaml:"scraping_service"`
@@ -77,6 +80,10 @@ type Config struct {
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	*c = DefaultConfig
+
+	// If the Config is unmarshaled, it's present in the config and should be
+	// enabled.
+	c.Enabled = true
 
 	type plain Config
 	return unmarshal((*plain)(c))


### PR DESCRIPTION
This PR makes the `prometheus`, `loki`, and `integrations` subsystems optionally loaded depending on if they are defined in the configuration file. This allows to provide a config file that only enables Loki mode without setting the WAL directory for Prometheus.

Fixes #170.