### PR TITLE
Config API: Enforce unique job names across all configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
   the numbger of launched instances. If instance sharing is not enabled, both
   metrics will share the same value. (@rfratto)
 
-- [BUGFIX] The Configs API will now disallows two instance configs having
+- [BUGFIX] The Configs API will now disallow two instance configs having
   multiple `scrape_configs` with the same `job_name`. THIS IS A BREAKING CHANGE.
   This was needed for the instance sharing mode, where combined instances may
   have duplicate `job_names` across their `scrape_configs`. This brings the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@
   the numbger of launched instances. If instance sharing is not enabled, both
   metrics will share the same value. (@rfratto)
 
+- [BUGFIX] The Configs API will now disallows two instance configs having
+  multiple `scrape_configs` with the same `job_name`. THIS IS A BREAKING CHANGE.
+  This was needed for the instance sharing mode, where combined instances may
+  have duplicate `job_names` across their `scrape_configs`. This brings the
+  scraping service more in line with Prometheus, where `job_names` must globally
+  be unique. This change also disallows concurrent requests to the put/apply
+  config API endpoint to prevent a race condition of two conflicting configs
+  being applied at the same time. (@rfratto)
+
 - [DEPRECATION] `use_hostname_label` is now supplanted by
   `replace_instance_label`. `use_hostname_label` will be removed in a future
   version. (@rfratto)

--- a/pkg/prom/ha/http.go
+++ b/pkg/prom/ha/http.go
@@ -1,6 +1,7 @@
 package ha
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -135,6 +136,11 @@ func (s *Server) PutConfiguration(r *http.Request) (interface{}, error) {
 		return nil, err
 	}
 
+	// Validate that the job names from the incoming config are unique
+	if err := s.checkUnique(r.Context(), inst); err != nil {
+		return nil, err
+	}
+
 	var newConfig bool
 	err = s.kv.CAS(r.Context(), inst.Name, func(in interface{}) (out interface{}, retry bool, err error) {
 		// The configuration is new if there's no previous value from the CAS
@@ -154,6 +160,44 @@ func (s *Server) PutConfiguration(r *http.Request) (interface{}, error) {
 
 	totalUpdatedConfigs.Inc()
 	return &httpResponse{StatusCode: http.StatusOK}, nil
+}
+
+// checkUnique looks at all the existing configs and ensures that no other
+// config shares a job_name with the incoming config.
+func (s *Server) checkUnique(ctx context.Context, cfg *instance.Config) error {
+	cfgCh, err := s.AllConfigs(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		// Make sure we drain the channel. This will need to be done if we are
+		// returning an error.
+		for range cfgCh {
+		}
+	}()
+
+	newJobNames := make(map[string]struct{}, len(cfg.ScrapeConfigs))
+	for _, sc := range cfg.ScrapeConfigs {
+		newJobNames[sc.JobName] = struct{}{}
+	}
+
+	for otherConfig := range cfgCh {
+		// Skip over the config if it's the same one we're about to apply.
+		if otherConfig.Name == cfg.Name {
+			continue
+		}
+
+		for _, otherScrape := range otherConfig.ScrapeConfigs {
+			if _, exist := newJobNames[otherScrape.JobName]; exist {
+				return &httpError{
+					StatusCode: http.StatusBadRequest,
+					Err:        fmt.Errorf("found multiple scrape configs with job name %q", otherScrape.JobName),
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 // DeleteConfiguration deletes an existing named configuration.

--- a/pkg/prom/ha/http_test.go
+++ b/pkg/prom/ha/http_test.go
@@ -135,7 +135,7 @@ func TestServer_PutConfiguration(t *testing.T) {
 		MetricsPath: "/metrics",
 		Scheme:      "http",
 	}}
-	cfg.ApplyDefaults(&config.DefaultGlobalConfig)
+	_ = cfg.ApplyDefaults(&config.DefaultGlobalConfig)
 
 	bb, err := yaml.Marshal(cfg)
 	require.NoError(t, err)
@@ -174,7 +174,7 @@ func TestServer_PutConfiguration_NonUnique(t *testing.T) {
 		MetricsPath: "/metrics",
 		Scheme:      "http",
 	}}
-	conflictA.ApplyDefaults(&config.DefaultGlobalConfig)
+	_ = conflictA.ApplyDefaults(&config.DefaultGlobalConfig)
 
 	//
 	// Put conflict A; it should succeed

--- a/pkg/prom/ha/http_test.go
+++ b/pkg/prom/ha/http_test.go
@@ -189,7 +189,7 @@ func TestServer_PutConfiguration_NonUnique(t *testing.T) {
 
 	//
 	// Put conflict B; it should fail because conflict-a already
-	// has a job with the name test_job
+	// has a job with the name "conflicting."
 	//
 	conflictB := conflictA
 	conflictB.Name = "conflict-b"

--- a/pkg/prom/ha/http_test.go
+++ b/pkg/prom/ha/http_test.go
@@ -128,8 +128,14 @@ func TestServer_PutConfiguration(t *testing.T) {
 
 	cfg := instance.DefaultConfig
 	cfg.Name = "newconfig"
-	cfg.HostFilter = true
+	cfg.HostFilter = false
 	cfg.RemoteFlushDeadline = 10 * time.Minute
+	cfg.ScrapeConfigs = []*config.ScrapeConfig{{
+		JobName:     "test_job",
+		MetricsPath: "/metrics",
+		Scheme:      "http",
+	}}
+	cfg.ApplyDefaults(&config.DefaultGlobalConfig)
 
 	bb, err := yaml.Marshal(cfg)
 	require.NoError(t, err)
@@ -154,6 +160,50 @@ func TestServer_PutConfiguration(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, cfg, actual, "unmarshaled stored configuration did not match input")
 	}
+}
+
+func TestServer_PutConfiguration_NonUnique(t *testing.T) {
+	env := newAPITestEnvironment(t)
+
+	conflictA := instance.DefaultConfig
+	conflictA.Name = "conflict-a"
+	conflictA.HostFilter = false
+	conflictA.RemoteFlushDeadline = 10 * time.Minute
+	conflictA.ScrapeConfigs = []*config.ScrapeConfig{{
+		JobName:     "conflicting",
+		MetricsPath: "/metrics",
+		Scheme:      "http",
+	}}
+	conflictA.ApplyDefaults(&config.DefaultGlobalConfig)
+
+	//
+	// Put conflict A; it should succeed
+	//
+	bb, err := yaml.Marshal(conflictA)
+	require.NoError(t, err)
+
+	resp, err := http.Post(env.srv.URL+"/agent/api/v1/config/conflict-a", "", bytes.NewReader(bb))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	unmarshalTestResponse(t, resp.Body, nil)
+
+	//
+	// Put conflict B; it should fail because conflict-a already
+	// has a job with the name test_job
+	//
+	conflictB := conflictA
+	conflictB.Name = "conflict-b"
+
+	bb, err = yaml.Marshal(conflictB)
+	require.NoError(t, err)
+
+	resp, err = http.Post(env.srv.URL+"/agent/api/v1/config/conflict-b", "", bytes.NewReader(bb))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	var errResp configapi.ErrorResponse
+	unmarshalTestResponse(t, resp.Body, &errResp)
+	require.Equal(t, `found multiple scrape configs with job name "conflicting"`, errResp.Error)
 }
 
 func TestServer_PutConfiguration_Invalid(t *testing.T) {

--- a/pkg/prom/ha/sharding.go
+++ b/pkg/prom/ha/sharding.go
@@ -97,7 +97,7 @@ func (s *Server) AllConfigs(ctx context.Context) (<-chan instance.Config, error)
 			// TODO(rfratto): retries might be useful here
 			v, err := s.kv.Get(ctx, key)
 			if err != nil {
-				level.Error(s.logger).Log("failed to get key for resharding", "key", key)
+				level.Error(s.logger).Log("failed to get config with key", "key", key)
 				return
 			} else if v == nil {
 				level.Warn(s.logger).Log("skipping key that was deleted after list was called", "key", key)

--- a/pkg/prom/instance/instance.go
+++ b/pkg/prom/instance/instance.go
@@ -150,7 +150,9 @@ func (c *Config) ApplyDefaults(global *config.GlobalConfig) error {
 		}
 		jobNames[sc.JobName] = struct{}{}
 
-		sc.RelabelConfigs = append(sc.RelabelConfigs, DefaultRelabelConfigs...)
+		if c.HostFilter {
+			sc.RelabelConfigs = append(sc.RelabelConfigs, DefaultRelabelConfigs...)
+		}
 	}
 
 	rwNames := map[string]struct{}{}

--- a/pkg/prom/instance/instance_test.go
+++ b/pkg/prom/instance/instance_test.go
@@ -51,7 +51,6 @@ remote_write:
 	for _, sc := range cfg.ScrapeConfigs {
 		require.Equal(t, sc.ScrapeInterval, global.ScrapeInterval)
 		require.Equal(t, sc.ScrapeTimeout, global.ScrapeTimeout)
-		require.Equal(t, sc.RelabelConfigs, DefaultRelabelConfigs)
 	}
 }
 


### PR DESCRIPTION
Instance sharing broke an accidental behavior of instance configs when using the scraping service mode: job names did not have to be unique across multiple instances. This was caused by each instance config (previously) being given its own dedicated set of Prometheus components. 

Now that components are shared, `job_name`s must be globally unique. The HTTP API for storing configs will now retrieve all existing configs to validate uniqueness of the job_name. This also opens up an opportunity for a race condition of two conflicting configs being applied concurrently. To avoid the race condition, this PR also prevents concurrent requests against the PUT API. 

Note that this is a breaking change of an undocumented feature, but it brings instance configs sin line with how Prometheus handles job names, where they musts be globally unique. This change also reduces the performance of applying a config due to the validation overhead. The exact performance hit will depend on the latency of the KV store. 

One small extra change is snuck into this PR: the default relabeling configs will no longer be applied when host filtering mode is disabled. The default relabeling configs were made for host filtering mode, and are not needed otherwise. Making this change made writing tests for this bugfix easier.   
