### PR TITLE
override remote_name when grouping configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@
   config API endpoint to prevent a race condition of two conflicting configs
   being applied at the same time. (@rfratto)
 
+- [BUGFIX] remote_write names in a group will no longer be copied from the
+  remote_write names of the first instance in the group. Rather, all
+  remote_write names will be generated based on the first 6 characters of the
+  group hash and the first six characters of the remote_write hash. (@rfratto)
+
 - [DEPRECATION] `use_hostname_label` is now supplanted by
   `replace_instance_label`. `use_hostname_label` will be removed in a future
   version. (@rfratto)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
   config API endpoint to prevent a race condition of two conflicting configs
   being applied at the same time. (@rfratto)
 
-- [BUGFIX] remote_write names in a group will no longer be copied from the
+- [BUGFIX] `remote_write` names in a group will no longer be copied from the
   remote_write names of the first instance in the group. Rather, all
   remote_write names will be generated based on the first 6 characters of the
   group hash and the first six characters of the remote_write hash. (@rfratto)

--- a/docs/operation-guide.md
+++ b/docs/operation-guide.md
@@ -1,4 +1,4 @@
-# Operation Guide 
+# Operation Guide
 
 ## Prometheus "Instances"
 
@@ -7,7 +7,7 @@ its own mini Prometheus-lite server. The Instance runs a combination of
 Prometheus service discovery, scraping, a WAL for storage, and `remote_write`.
 
 Instances allow for fine grained control of what data gets scraped and where it
-gets sent. Users can easily define two Instances that scrape different subsets 
+gets sent. Users can easily define two Instances that scrape different subsets
 of metrics and send them two two completely different remote_write systems.
 
 Instances are especially relevant to the [scraping service
@@ -15,7 +15,7 @@ mode](./scraping-service.md), where breaking up your scrape configs into
 multiple Instances is required for sharding and balancing scrape load across a
 cluster of Agents.
 
-## Instance Sharing 
+## Instance Sharing
 
 The v0.5.0 release of the Agent introduced the concept of _Instance sharing_,
 which combines scrape_configs from compatible Instance configs into a single,
@@ -23,6 +23,11 @@ shared Instance. Instance configs are compatible when they have no differences
 in configuration with the exception of what they scrape. `remote_write` configs
 may also differ in the order which endpoints are declared, but the unsorted
 `remote_writes` must still be an exact match.
+
+In the shared Instances mode, the `name` field of `remote_write` configs is
+ignored. The resulting `remote_write` configs will have a name identical to the
+first six characters of the group name and the first six characters of the hash
+from that `remote_write` config separated by a `-`.
 
 The shared Instances mode is the new default, and the previous behavior is
 deprecated. If you wish to restore the old behavior, set `instance_mode:

--- a/pkg/prom/instance/group_manager.go
+++ b/pkg/prom/instance/group_manager.go
@@ -328,6 +328,22 @@ func groupConfigs(groupName string, grouped groupedConfigs) (Config, error) {
 	combined.Name = groupName
 	combined.ScrapeConfigs = []*config.ScrapeConfig{}
 
+	// Assign all remote_write configs in the group a consistent set of remote_names.
+	// If the grouped configs are coming from the scraping service, defaults will have
+	// been applied and the remote names will be prefixed with the old instance config name.
+	for _, rwc := range combined.RemoteWrite {
+		// Blank out the existing name before getting the hash so it is doesn't take into
+		// account any existing name.
+		rwc.Name = ""
+
+		hash, err := getHash(rwc)
+		if err != nil {
+			return Config{}, err
+		}
+
+		rwc.Name = groupName[:6] + "-" + hash[:6]
+	}
+
 	// Combine all the scrape configs. It's possible that two different ungrouped
 	// configs had a matching job name, but this will be detected and rejected
 	// (as it should be) when the underlying Manager eventually validates the


### PR DESCRIPTION
In the instance sharing mode, `remote_write` configs with a custom name (`remote_names`) were being copied from the first member of the group. This causes the `remote_name` to change when the first element is removed, which is an unexpected behavior. This particularly affects scraping service users, where the stored configs already have defaults applied, including the generated `remote_name` for each instance config.

`remote_names` are now forced to be the combination of the fix six characters of the group name and `remote_write` config hash separated by a hypen. A future enhancement may wish to consider non-autogenerated names when grouping `remote_write` configs, but that change is out of scope here.