### PR TITLE
fix panic when starting scraping service

### DIFF
--- a/pkg/prom/ha/server.go
+++ b/pkg/prom/ha/server.go
@@ -106,7 +106,11 @@ func New(reg prometheus.Registerer, cfg Config, globalConfig *config.GlobalConfi
 	// scraping service yet.
 	cfg.Lifecycler.RingConfig.ReplicationFactor = 1
 
-	kvClient, err := kv.NewClient(cfg.KVStore, GetCodec(), reg)
+	kvClient, err := kv.NewClient(
+		cfg.KVStore,
+		GetCodec(),
+		kv.RegistererWithKVName(reg, "agent_configs"),
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Updating the Cortex vendor for importing Loki broke the scraping service. Two KV clients get initialized: one directly for storing configs and one indirectly by creating a Cortex ring client. The Cortex ring client wraps the registerer passed to the KV client with a call to kv.RegistererWithKVName. Not doing this leads to an inconsistency on constant labels added to the KV metrics and causes a panic from the
Prometheus client_golang package.

The CHANGELOG isn't updated since this bug isn't present on any current release. 