### PR TITLE
Prevent WAL from being changed after it is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ this platform. FreeBSD builds will return in a future release.
   remote_write names will be generated based on the first 6 characters of the
   group hash and the first six characters of the remote_write hash. (@rfratto)
 
+- [BUGFIX] Fix a panic that may occur during shutdown if the WAL is closed in
+  the middle of the WAL being truncated. (@rfratto)
+
 - [DEPRECATION] `use_hostname_label` is now supplanted by
   `replace_instance_label`. `use_hostname_label` will be removed in a future
   version. (@rfratto)

--- a/pkg/prom/wal/wal.go
+++ b/pkg/prom/wal/wal.go
@@ -166,6 +166,10 @@ func (w *Storage) replayWAL() error {
 	w.walMtx.Lock()
 	defer w.walMtx.Unlock()
 
+	if w.isWALClosed() {
+		return ErrWALClosed
+	}
+
 	level.Info(w.logger).Log("msg", "replaying WAL, this may take a while", "dir", w.wal.Dir())
 	dir, startFrom, err := wal.LastCheckpoint(w.wal.Dir())
 	if err != nil && err != record.ErrNotFound {

--- a/pkg/prom/wal/wal.go
+++ b/pkg/prom/wal/wal.go
@@ -94,11 +94,12 @@ type Storage struct {
 	storage.Queryable
 	storage.ChunkQueryable
 
-	// Operations against the WAL must be protected by a mutex so it doesn't get closed
-	// in the middle of an operation. If the WAL is closed, operations that change the WAL
-	// must fail.
-	walMtx    sync.Mutex
-	walClosed chan bool
+	// Operations against the WAL must be protected by a mutex so it doesn't get
+	// closed in the middle of an operation. Other operations are concurrency-safe, so we
+	// use a RWMutex to allow multiple usages of the WAL at once. If the WAL is closed, all
+	// operations that change the WAL must fail.
+	walMtx    sync.RWMutex
+	walClosed bool
 
 	path   string
 	wal    *wal.WAL
@@ -125,8 +126,6 @@ func NewStorage(logger log.Logger, registerer prometheus.Registerer, path string
 	}
 
 	storage := &Storage{
-		walClosed: make(chan bool),
-
 		path:    path,
 		wal:     w,
 		logger:  logger,
@@ -163,10 +162,10 @@ func NewStorage(logger log.Logger, registerer prometheus.Registerer, path string
 }
 
 func (w *Storage) replayWAL() error {
-	w.walMtx.Lock()
-	defer w.walMtx.Unlock()
+	w.walMtx.RLock()
+	defer w.walMtx.RUnlock()
 
-	if w.isWALClosed() {
+	if w.walClosed {
 		return ErrWALClosed
 	}
 
@@ -371,10 +370,10 @@ func (*Storage) StartTime() (int64, error) {
 // Truncate removes all data from the WAL prior to the timestamp specified by
 // mint.
 func (w *Storage) Truncate(mint int64) error {
-	w.walMtx.Lock()
-	defer w.walMtx.Unlock()
+	w.walMtx.RLock()
+	defer w.walMtx.RUnlock()
 
-	if w.isWALClosed() {
+	if w.walClosed {
 		return ErrWALClosed
 	}
 
@@ -540,24 +539,15 @@ func (w *Storage) Close() error {
 	w.walMtx.Lock()
 	defer w.walMtx.Unlock()
 
-	if w.isWALClosed() {
+	if w.walClosed {
 		return fmt.Errorf("already closed")
 	}
-	close(w.walClosed)
+	w.walClosed = true
 
 	if w.metrics != nil {
 		w.metrics.Unregister()
 	}
 	return w.wal.Close()
-}
-
-func (w *Storage) isWALClosed() bool {
-	select {
-	case <-w.walClosed:
-		return true
-	default:
-		return false
-	}
 }
 
 type appender struct {
@@ -621,10 +611,10 @@ func (a *appender) AddFast(ref uint64, t int64, v float64) error {
 
 // Commit submits the collected samples and purges the batch.
 func (a *appender) Commit() error {
-	a.w.walMtx.Lock()
-	defer a.w.walMtx.Unlock()
+	a.w.walMtx.RLock()
+	defer a.w.walMtx.RUnlock()
 
-	if a.w.isWALClosed() {
+	if a.w.walClosed {
 		return ErrWALClosed
 	}
 

--- a/pkg/prom/wal/wal_test.go
+++ b/pkg/prom/wal/wal_test.go
@@ -239,6 +239,18 @@ func TestStorage_WriteStalenessMarkers(t *testing.T) {
 	}
 }
 
+func TestStoraeg_TruncateAfterClose(t *testing.T) {
+	walDir, err := ioutil.TempDir(os.TempDir(), "wal")
+	require.NoError(t, err)
+	defer os.RemoveAll(walDir)
+
+	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
+	require.NoError(t, err)
+
+	require.NoError(t, s.Close())
+	require.Error(t, ErrWALClosed, s.Truncate(0))
+}
+
 type sample struct {
 	ts  int64
 	val float64


### PR DESCRIPTION
There was a rare scenario that the Agent may be shut down in the middle of a truncation. The WAL was able to be closed in the middle of a truncation, which caused a panic.

This change:

- disallows closing the WAL in the middle of a mutation to the WAL
- disallows mutations to the WAL following the WAL being closed

Fixes #179