### PR TITLE
Add Loki installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,18 @@ the remote system.
 - [x] Support for integrations (embedded exporters/automatic scrape configs)
 - [x] Promtail for Loki logs
 - [ ] `carbon-relay-ng` for Graphite metrics.
+- [ ] All-in-one installation script (metrics and logs)
 
 ## Getting Started
 
 The easiest way to get started with the Grafana Cloud Agent is to use the
-Kubernetes install script. Simply copy and paste the following line in your
-terminal (requires `envsubst` (GNU gettext)):
+Kubernetes install scripts. The first script installs the Agent for collecting
+metrics and the second installs the Agent for collecting logs. Simply copy and
+paste the following lines in your terminal (requires `envsubst` (GNU gettext)):
 
 ```
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install.sh)" | kubectl apply -f -
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install-loki.sh)" | kubectl apply -f -
 ```
 
 Other installation methods can be found in our

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,12 +52,16 @@ docker pull grafana/agent:v0.5.0
 ### Kubernetes Install Script
 
 Running this script will automatically download and apply our recommended
-Grafana Cloud Agent Kubernetes deployment manifest (requires `envsubst` (GNU gettext)):
+Grafana Cloud Agent Kubernetes deployment manifests (requires `envsubst` (GNU gettext)).
+Two manifests will be installed: one for collecting metrics, and the other for
+collecting logs. You will be prompted for input for each manifest that is
+applied.
 
 > **Warning**: Always verify scripts from the internet before running them.
 
 ```
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install.sh)" | kubectl -ndefault apply -f -
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install-loki.sh)" | kubectl apply -f -
 ```
 
 ### Kubernetes Manifest

--- a/example/k3d/environment/main.jsonnet
+++ b/example/k3d/environment/main.jsonnet
@@ -1,6 +1,5 @@
 local default = import 'default/main.libsonnet';
 local etcd = import 'etcd/main.libsonnet';
-//local grafana_agent = import 'grafana-agent/grafana-agent.libsonnet';
 local agent_cluster = import 'grafana-agent/scraping-svc/main.libsonnet';
 local k = import 'ksonnet-util/kausal.libsonnet';
 

--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -1,0 +1,364 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-agent-logs
+---
+apiVersion: v1
+data:
+  agent.yaml: |
+    loki:
+        clients:
+          - url: https://${LOKI_USERNAME}:${LOKI_PASSWORD}@${LOKI_HOSTNAME}/loki/api/v1/push
+        scrape_configs:
+          - job_name: kubernetes-pods-name
+            kubernetes_sd_configs:
+              - role: pod
+            pipeline_stages:
+              - docker: {}
+            relabel_configs:
+              - source_labels:
+                  - __meta_kubernetes_pod_label_name
+                target_label: __service__
+              - source_labels:
+                  - __meta_kubernetes_pod_node_name
+                target_label: __host__
+              - action: drop
+                regex: ""
+                source_labels:
+                  - __service__
+              - action: labelmap
+                regex: __meta_kubernetes_pod_label_(.+)
+              - action: replace
+                replacement: $1
+                separator: /
+                source_labels:
+                  - __meta_kubernetes_namespace
+                  - __service__
+                target_label: job
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_namespace
+                target_label: namespace
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_name
+                target_label: pod
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_container_name
+                target_label: container
+              - replacement: /var/log/pods/*$1/*.log
+                separator: /
+                source_labels:
+                  - __meta_kubernetes_pod_uid
+                  - __meta_kubernetes_pod_container_name
+                target_label: __path__
+          - job_name: kubernetes-pods-app
+            kubernetes_sd_configs:
+              - role: pod
+            pipeline_stages:
+              - docker: {}
+            relabel_configs:
+              - action: drop
+                regex: .+
+                source_labels:
+                  - __meta_kubernetes_pod_label_name
+              - source_labels:
+                  - __meta_kubernetes_pod_label_app
+                target_label: __service__
+              - source_labels:
+                  - __meta_kubernetes_pod_node_name
+                target_label: __host__
+              - action: drop
+                regex: ""
+                source_labels:
+                  - __service__
+              - action: labelmap
+                regex: __meta_kubernetes_pod_label_(.+)
+              - action: replace
+                replacement: $1
+                separator: /
+                source_labels:
+                  - __meta_kubernetes_namespace
+                  - __service__
+                target_label: job
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_namespace
+                target_label: namespace
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_name
+                target_label: pod
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_container_name
+                target_label: container
+              - replacement: /var/log/pods/*$1/*.log
+                separator: /
+                source_labels:
+                  - __meta_kubernetes_pod_uid
+                  - __meta_kubernetes_pod_container_name
+                target_label: __path__
+          - job_name: kubernetes-pods-direct-controllers
+            kubernetes_sd_configs:
+              - role: pod
+            pipeline_stages:
+              - docker: {}
+            relabel_configs:
+              - action: drop
+                regex: .+
+                separator: ""
+                source_labels:
+                  - __meta_kubernetes_pod_label_name
+                  - __meta_kubernetes_pod_label_app
+              - action: drop
+                regex: '[0-9a-z-.]+-[0-9a-f]{8,10}'
+                source_labels:
+                  - __meta_kubernetes_pod_controller_name
+              - source_labels:
+                  - __meta_kubernetes_pod_controller_name
+                target_label: __service__
+              - source_labels:
+                  - __meta_kubernetes_pod_node_name
+                target_label: __host__
+              - action: drop
+                regex: ""
+                source_labels:
+                  - __service__
+              - action: labelmap
+                regex: __meta_kubernetes_pod_label_(.+)
+              - action: replace
+                replacement: $1
+                separator: /
+                source_labels:
+                  - __meta_kubernetes_namespace
+                  - __service__
+                target_label: job
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_namespace
+                target_label: namespace
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_name
+                target_label: pod
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_container_name
+                target_label: container
+              - replacement: /var/log/pods/*$1/*.log
+                separator: /
+                source_labels:
+                  - __meta_kubernetes_pod_uid
+                  - __meta_kubernetes_pod_container_name
+                target_label: __path__
+          - job_name: kubernetes-pods-indirect-controller
+            kubernetes_sd_configs:
+              - role: pod
+            pipeline_stages:
+              - docker: {}
+            relabel_configs:
+              - action: drop
+                regex: .+
+                separator: ""
+                source_labels:
+                  - __meta_kubernetes_pod_label_name
+                  - __meta_kubernetes_pod_label_app
+              - action: keep
+                regex: '[0-9a-z-.]+-[0-9a-f]{8,10}'
+                source_labels:
+                  - __meta_kubernetes_pod_controller_name
+              - action: replace
+                regex: ([0-9a-z-.]+)-[0-9a-f]{8,10}
+                source_labels:
+                  - __meta_kubernetes_pod_controller_name
+                target_label: __service__
+              - source_labels:
+                  - __meta_kubernetes_pod_node_name
+                target_label: __host__
+              - action: drop
+                regex: ""
+                source_labels:
+                  - __service__
+              - action: labelmap
+                regex: __meta_kubernetes_pod_label_(.+)
+              - action: replace
+                replacement: $1
+                separator: /
+                source_labels:
+                  - __meta_kubernetes_namespace
+                  - __service__
+                target_label: job
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_namespace
+                target_label: namespace
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_name
+                target_label: pod
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_container_name
+                target_label: container
+              - replacement: /var/log/pods/*$1/*.log
+                separator: /
+                source_labels:
+                  - __meta_kubernetes_pod_uid
+                  - __meta_kubernetes_pod_container_name
+                target_label: __path__
+          - job_name: kubernetes-pods-static
+            kubernetes_sd_configs:
+              - role: pod
+            pipeline_stages:
+              - docker: {}
+            relabel_configs:
+              - action: drop
+                regex: ""
+                source_labels:
+                  - __meta_kubernetes_pod_annotation_kubernetes_io_config_mirror
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_label_component
+                target_label: __service__
+              - source_labels:
+                  - __meta_kubernetes_pod_node_name
+                target_label: __host__
+              - action: drop
+                regex: ""
+                source_labels:
+                  - __service__
+              - action: labelmap
+                regex: __meta_kubernetes_pod_label_(.+)
+              - action: replace
+                replacement: $1
+                separator: /
+                source_labels:
+                  - __meta_kubernetes_namespace
+                  - __service__
+                target_label: job
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_namespace
+                target_label: namespace
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_name
+                target_label: pod
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_container_name
+                target_label: container
+              - replacement: /var/log/pods/*$1/*.log
+                separator: /
+                source_labels:
+                  - __meta_kubernetes_pod_annotation_kubernetes_io_config_mirror
+                  - __meta_kubernetes_pod_container_name
+                target_label: __path__
+    server:
+        http_listen_port: 8080
+        log_level: info
+kind: ConfigMap
+metadata:
+  name: grafana-agent-logs
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: grafana-agent-logs
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - nodes/proxy
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-agent-logs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: grafana-agent-logs
+subjects:
+- kind: ServiceAccount
+  name: grafana-agent-logs
+  namespace: default
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: grafana-agent-logs
+  namespace: default
+spec:
+  minReadySeconds: 10
+  selector:
+    matchLabels:
+      name: grafana-agent-logs
+  template:
+    metadata:
+      labels:
+        name: grafana-agent-logs
+    spec:
+      containers:
+      - args:
+        - -config.file=/etc/agent/agent.yaml
+        env:
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: grafana/agent:v0.5.0
+        imagePullPolicy: IfNotPresent
+        name: agent
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /etc/agent
+          name: grafana-agent-logs
+        - mountPath: /var/log
+          name: varlog
+          readOnly: true
+        - mountPath: /var/lib/docker/containers
+          name: varlibdockercontainers
+          readOnly: true
+        - mountPath: /etc/machine-id
+          name: etcmachineid
+          readOnly: true
+      serviceAccount: grafana-agent-logs
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      volumes:
+      - configMap:
+          name: grafana-agent-logs
+        name: grafana-agent-logs
+      - hostPath:
+          path: /var/log
+        name: varlog
+      - hostPath:
+          path: /var/lib/docker/containers
+        name: varlibdockercontainers
+      - hostPath:
+          path: /etc/machine-id
+        name: etcmachineid
+  updateStrategy:
+    type: RollingUpdate

--- a/production/kubernetes/build/build.sh
+++ b/production/kubernetes/build/build.sh
@@ -8,4 +8,5 @@ pushd ${DIRNAME}
 jb install
 tk show --dangerous-allow-redirect ./templates/base > ${PWD}/../agent.yaml
 tk show --dangerous-allow-redirect ./templates/bare > ${PWD}/../agent-bare.yaml
+tk show --dangerous-allow-redirect ./templates/loki > ${PWD}/../agent-loki.yaml
 popd

--- a/production/kubernetes/build/templates/loki/main.jsonnet
+++ b/production/kubernetes/build/templates/loki/main.jsonnet
@@ -1,0 +1,19 @@
+local agent = import 'grafana-agent/v1/main.libsonnet';
+
+{
+  agent:
+    agent.new('grafana-agent-logs', 'default') +
+    agent.withConfigHash(false) +
+    agent.withImages({
+      agent: (import 'version.libsonnet'),
+    }) +
+    agent.withLokiConfig(agent.scrapeKubernetesLogs) +
+    agent.withLokiClients(
+      agent.newLokiClient({
+        scheme: 'https',
+        hostname: '${LOKI_HOSTNAME}',
+        username: '${LOKI_USERNAME}',
+        password: '${LOKI_PASSWORD}',
+      })
+    ),
+}

--- a/production/kubernetes/build/templates/loki/spec.json
+++ b/production/kubernetes/build/templates/loki/spec.json
@@ -1,0 +1,11 @@
+{
+  "apiVersion": "tanka.dev/v1alpha1",
+  "kind": "Environment",
+  "metadata": {
+    "name": "template"
+  },
+  "spec": {
+    "apiServer": "",
+    "namespace": "default"
+  }
+}

--- a/production/kubernetes/install-loki.sh
+++ b/production/kubernetes/install-loki.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+#
+# install-loki.sh is a really basic installer for the agent. It uses the existing
+# Kubernetes YAML example and envsubst to fill in the details for Loki write
+# URL, username, and password.
+#
+# There are three ways to provide the inputs for installation:
+#
+# 1. Environment variables (LOKI_HOSTNAME, LOKI_USERNAME, LOKI_PASSWORD)
+#
+# 2. Flags (-h for hostname, -u for username, -p for password)
+#
+# 3. stdin from prompts
+#
+# Flags override environment variables, and stdin is used as a fallback if a
+# value wasn't given from a flag or environment variable. An empty username
+# or password is acceptable, as it disables basic auth. However, a hostname must 
+# always be provided.
+#
+
+check_installed() {
+  if ! type $1 >/dev/null 2>&1; then
+    echo "error: $1 not installed" >&2
+    exit 1
+  fi
+}
+
+check_installed curl
+check_installed envsubst
+
+MANIFEST_BRANCH=v0.5.0
+MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent-loki.yaml}
+
+LOKI_USERNAME_SET=0
+LOKI_PASSWORD_SET=0
+
+while getopts "l:u:p:" opt; do
+  case "$opt" in
+    h)
+      LOKI_HOSTNAME=$OPTARG
+      ;;
+    u)
+      LOKI_USERNAME=$OPTARG
+      LOKI_USERNAME_SET=1
+      ;;
+    p)
+      LOKI_PASSWORD=$OPTARG
+      LOKI_PASSWORD_SET=1
+      ;;
+    ?)
+      echo "usage: $(basename $0) [-h Loki hostname] [-u Loki username] [-p Loki password]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "${LOKI_HOSTNAME}" ]; then
+  read -sp 'Enter your Loki hostname (i.e., logs-us-central1.grafana.net): ' LOKI_HOSTNAME
+  printf $'\n' >&2
+
+  # We require a hostname for the agent; we don't do this same check for
+  # the username and password as the remote Loki system may not have basic
+  # auth enabled.
+  if [ -z "${LOKI_HOSTNAME}" ]; then
+    echo "error: LOKI_HOSTNAME must be provided by flag, env, or stdin" >&2
+    exit 1
+  fi
+fi
+
+if [ -z "${LOKI_USERNAME}" ] && [ "${LOKI_USERNAME_SET}" -eq 0 ]; then
+  read -sp 'Enter your Loki username: ' LOKI_USERNAME
+  printf $'\n' >&2
+fi
+
+if [ -z "${LOKI_PASSWORD}" ] && [ "${LOKI_PASSWORD_SET}" -eq 0 ]; then
+  read -sp 'Enter your Loki password: ' LOKI_PASSWORD
+  printf $'\n' >&2
+fi
+
+export LOKI_HOSTNAME
+export LOKI_USERNAME
+export LOKI_PASSWORD
+
+curl -fsSL $MANIFEST_URL | envsubst

--- a/production/tanka/grafana-agent/v1/internal/kubernetes_logs.libsonnet
+++ b/production/tanka/grafana-agent/v1/internal/kubernetes_logs.libsonnet
@@ -1,6 +1,8 @@
 local gen_scrape_config(job_name, pod_uid) = {
   job_name: job_name,
-  pipeline_stages: $._config.promtail_config.pipeline_stages,
+  pipeline_stages: [{
+    docker: {},
+  }],
   kubernetes_sd_configs: [{
     role: 'pod',
   }],

--- a/production/tanka/grafana-agent/v1/lib/loki.libsonnet
+++ b/production/tanka/grafana-agent/v1/lib/loki.libsonnet
@@ -66,7 +66,7 @@ local container = k.core.v1.container;
       container.mixin.securityContext.withPrivileged(true) +
       container.mixin.securityContext.withRunAsUser(0),
 
-    agent+::
+    agent+:
       // For reading docker containers
       k.util.hostVolumeMount('varlog', '/var/log', '/var/log', readOnly=true) +
       k.util.hostVolumeMount('varlibdockercontainers', '/var/lib/docker/containers', '/var/lib/docker/containers', readOnly=true) +

--- a/tools/release-note.md
+++ b/tools/release-note.md
@@ -11,11 +11,14 @@ use-case best.
 
 #### Kubernetes Install Script
 
-The following script will download a Kubernetes manifest for the Agent and
-prompt for remote_write credentials. It requires curl and envsubst (GNU gettext).
+The following scripts will download and install two Kubernetes manifests for the
+Agent. The first manifest will collect metrics and the second will collect logs. 
+You will be prompted for input for each manifest. The script requires curl and
+envsubst (GNU gettext).
 
 ```
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/${RELEASE_TAG}/production/kubernetes/install.sh)" | kubectl -ndefault apply -f -
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/${RELEASE_TAG}/production/kubernetes/install-loki.sh)" | kubectl -ndefault apply -f -
 ```
 
 #### Docker container:


### PR DESCRIPTION
This acts as the counterpart to the Prometheus installation script but installs a separate deployment of the Agent for collecting logs. Right now the scripts will remain separated we can provide these instructions across an entire Grafana Cloud stack instead of per data source. 

Closes #156 as an example that the Tanka configs can generate the Agent with functional Loki support. 

