### PR TITLE
fix deadlock when one series is added while another is deleted

### DIFF
--- a/pkg/prom/wal/wal.go
+++ b/pkg/prom/wal/wal.go
@@ -294,11 +294,6 @@ func (w *Storage) loadWAL(r *wal.Reader) (err error) {
 				// the truncation is performed.
 				if w.series.getByID(s.Ref) == nil {
 					series := &memSeries{ref: s.Ref, lset: s.Labels, lastTs: 0}
-
-					// Store both the series and the labels so the appender's Add function
-					// can look up this series later. We only want to store the labels for
-					// replayed series and delete the entry for the after it's read to save
-					// on memory usage.
 					w.series.set(s.Labels.Hash(), series)
 
 					w.metrics.numActiveSeries.Inc()


### PR DESCRIPTION
This changes the `seriesHashmap` to refer directly to a `memSeries` rather than a tuple of `(refID, labels)`. This is also what Prometheus does, but was changed early in the design of the Agent before the shared interner existed to lower memory usage. 

The problem with having a `seriesHashmap` that indirectly refers to a series is the requirement of holding two separate locks simultaneously. The garbage collection goroutine _also_ needs to hold two separate locks, which can cause a deadlock if these two goroutines run at the same time. Referring directly to the memory series pointer removes the need for holding two locks when looking up a series. 

Closes #184.
