### PR TITLE
Fix build info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ NOTE: FreeBSD builds will not be included for this release. There is a bug in an
 upstream library preventing cross-compilation of the Grafana Cloud Agent for
 this platform. FreeBSD builds will return in a future release.
 
+- [BUGFIX] Fix issue where build information was empty when running the Agent 
+  with --version. (@rfratto)
+
 # v0.6.0 (2020-09-04)
 
 NOTE: FreeBSD builds will not be included for this release. There is a bug in an

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1,6 +1,13 @@
 package build
 
-import "github.com/prometheus/common/version"
+import (
+	// We do an empty import of Loki's build package to force it ahead of us on
+	// the dependency graph. This makes sure that our init function runs after it
+	// and retains the build info we set at compile time.
+	_ "github.com/grafana/loki/pkg/build"
+
+	"github.com/prometheus/common/version"
+)
 
 // Version information passed to Prometheus version package.
 // Package path as used by linker changes based on vendoring being used or not,


### PR DESCRIPTION
After Loki support was added, it was running an init function to set build information after we ran our init function for the same purpose. This caused the build information to be misreported when running the Agent with the --version flag.

This is a temporary workaround until grafana/loki#2603 is released and vendored in the Agent.