### PR TITLE
fix Prometheus component update order when updating an Instance config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ this platform. FreeBSD builds will return in a future release.
 - [BUGFIX] Fix issue where build information was empty when running the Agent 
   with --version. (@rfratto)
 
+- [BUGFIX] Fix issue where updating a config in the scraping service may fail to 
+  pick up new targets. (@rfratto)
+
 # v0.6.0 (2020-09-04)
 
 NOTE: FreeBSD builds will not be included for this release. There is a bug in an


### PR DESCRIPTION
Prometheus applies component updates in a specific order. In particular, the scrape manager needs to be applied before the discovery manager. 

If this order is not kept, there's a chance the discovery manager will send a target for a new job to the scrape manager before the scrape manager is aware of the job. If this happens, the scrape manager drops all targets associated with that job and will not retry.