### PR TITLE
fix integrations on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ this platform. FreeBSD builds will return in a future release.
 - [FEATURE] Add `wal-stats` and `target-stats` tooling to `agentctl` to discover
   WAL and cardinality issues. (@rfratto)
 
+- [BUGFIX] Fix issue where integrations crashed with instance_mode was set to
+  `distinct` (@rfratto)
+
+- [BUGFIX] Fix issue where the `agent` integration did not work on Windows
+  (@rfratto).
+
 # v0.6.1 (2020-04-11)
 
 NOTE: FreeBSD builds will not be included for this release. There is a bug in an

--- a/pkg/integrations/manager.go
+++ b/pkg/integrations/manager.go
@@ -3,7 +3,7 @@ package integrations
 import (
 	"context"
 	"fmt"
-	"path/filepath"
+	"path"
 	"sync"
 	"time"
 
@@ -251,7 +251,7 @@ func (m *Manager) instanceConfigForIntegration(i Integration) instance.Config {
 	for _, cfg := range i.ScrapeConfigs() {
 		sc := &config.ScrapeConfig{
 			JobName:                fmt.Sprintf("integrations/%s", cfg.JobName),
-			MetricsPath:            filepath.Join("/integrations", i.Name(), cfg.MetricsPath),
+			MetricsPath:            path.Join("/integrations", i.Name(), cfg.MetricsPath),
 			Scheme:                 "http",
 			HonorLabels:            false,
 			HonorTimestamps:        true,


### PR DESCRIPTION
Windows generated invalid metrics paths with \ separating URL components.

Closes #197