### PR TITLE
fix crash in integrations with distinct instance mode

### DIFF
--- a/pkg/integrations/manager.go
+++ b/pkg/integrations/manager.go
@@ -97,6 +97,8 @@ func (c *Config) ApplyDefaults() error {
 				{
 					SourceLabels: model.LabelNames{model.InstanceLabel},
 					Action:       relabel.Replace,
+					Separator:    ";",
+					Regex:        relabel.MustNewRegexp("(.*)"),
 					Replacement:  replacement,
 					TargetLabel:  model.InstanceLabel,
 				},


### PR DESCRIPTION
The relabel rules being generated for the instagrations did not fill out all required fields. This works in shared instance mode, where the pre-grouped instances are "copied" by marshaling them to YAML and unmarshaling them back. The process of unmarshaling from YAML was filling out all required fields for us.

As distinct instance mode does not marshal/unmarshal configs being applied, this invalid behavior was hidden from the default config settings.

Closes #199 