### PR TITLE
Add installation script for tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,19 +53,22 @@ the remote system.
 - [x] A second clustering mode to solve sharding monitoring availability problems.
 - [x] Support for integrations (embedded exporters/automatic scrape configs)
 - [x] Promtail for Loki logs
+- [x] Tempo traces
 - [ ] `carbon-relay-ng` for Graphite metrics.
-- [ ] All-in-one installation script (metrics and logs)
+- [ ] All-in-one installation script (metrics, logs, and traces)
 
 ## Getting Started
 
 The easiest way to get started with the Grafana Cloud Agent is to use the
-Kubernetes install scripts. The first script installs the Agent for collecting
-metrics and the second installs the Agent for collecting logs. Simply copy and
-paste the following lines in your terminal (requires `envsubst` (GNU gettext)):
+Kubernetes install scripts. The first script installs an Agent for collecting
+metrics, the second for collecting logs, and the third for collecting traces.
+Simply copy and paste the following lines in your terminal (requires `envsubst`
+(GNU gettext)):
 
 ```
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install.sh)" | kubectl apply -f -
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install-loki.sh)" | kubectl apply -f -
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install-tempo.sh)" | kubectl apply -f -
 ```
 
 Other installation methods can be found in our

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -1453,7 +1453,7 @@ The `tempo_config` block configures how the Agent receives traces and sends them
 #  This field allows for the general manipulation of tags on spans that pass through this agent.  A common use may be to add an environment or cluster variable.
 attributes: [attributes.config] 
 
-remote_write:
+push_config:
   # host:port to send traces to
   endpoint: <string>
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -243,7 +243,7 @@ tempo:
     jaeger:
       protocols:
         grpc: # listens on the default jaeger grpc port: 14250
-  remote_write:
+  push_config:
     endpoint: localhost:55680
     insecure: true  # only add this if TLS is not required
     batch:

--- a/example/docker-compose/agent/config/agent.yaml
+++ b/example/docker-compose/agent/config/agent.yaml
@@ -69,7 +69,7 @@ tempo:
     - action: upsert
       key: env
       value: prod
-  remote_write:
+  push_config:
     endpoint: otel-collector:55680
     insecure: true
     batch:

--- a/production/kubernetes/README.md
+++ b/production/kubernetes/README.md
@@ -7,11 +7,13 @@ Manifests:
 
 - Metric collection: [`agent.yaml`](./agent.yaml)
 - Log collection: [`agent-loki.yaml`](./agent-loki.yaml)
+- Trace collection: [`agent-tempo.yaml`](./agent-tempo.yaml)
 
 Installation script:
 
 - Metric collection: [`install.sh`](./install.sh)
 - Log collection: [`install-loki.sh`](./install-loki.sh)
+- Tempo collection: [`install-tempo.sh`](./install-tempo.sh)
 
 ## Install Scripts
 
@@ -41,21 +43,7 @@ the installation script does:
 1. Download the manifest as `manifest.yaml`.
 
 2. Modify your copy of the manifest, replacing all variables with the
-   appropriate values:
-
-   1. For the metrics collection manifest, replace `${REMOTE_WRITE_URL}` with
-      the full endpoint of the Prometheus remote write API. For logs collection,
-      replace `${LOKI_HOSTNAME}` with the hostname of the Loki API. Unlike the
-      remote write API, `${LOKI_HOSTNAME}` should _only_ be the hostname, such
-      as `localhost` or `logs-us-central1.grafana.net`.
-
-  2. Replace `${REMOTE_WRITE_PASSWORD}` or `${LOKI_PASSWORD}` with the password
-     for authentication against the remote API. If you do not need
-     authentication, remove the entire authentication section.
-
-  3. If you did not remove the authentication section from the previous step,
-     replace `${REMOTE_WRITE_USERNAME}` or `${LOKI_USERNAME}` with the username
-     used to connect to the remote API.
+   appropriate values.
 
 3. Apply the modified manifest file: `kubectl -ndefault apply -f manifest.yaml`.
 

--- a/production/kubernetes/README.md
+++ b/production/kubernetes/README.md
@@ -13,7 +13,7 @@ Installation script:
 
 - Metric collection: [`install.sh`](./install.sh)
 - Log collection: [`install-loki.sh`](./install-loki.sh)
-- Tempo collection: [`install-tempo.sh`](./install-tempo.sh)
+- Trace collection: [`install-tempo.sh`](./install-tempo.sh)
 
 ## Install Scripts
 

--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: grafana-agent
-  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -43,7 +42,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: grafana-agent
-  namespace: default
 spec:
   minReadySeconds: 10
   selector:

--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: grafana-agent-logs
-  namespace: default
 ---
 apiVersion: v1
 data:

--- a/production/kubernetes/agent-tempo.yaml
+++ b/production/kubernetes/agent-tempo.yaml
@@ -24,10 +24,18 @@ data:
             jaeger:
                 protocols:
                     grpc: null
+                    thrift_binary: null
                     thrift_compact: null
+                    thrift_http: null
                 remote_sampling:
                     insecure: true
                     strategy_file: /etc/agent/strategies.json
+            opencensus: null
+            otlp:
+                protocols:
+                    grpc: null
+                    http: null
+            zipkin: null
         scrape_configs:
           - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
             job_name: kubernetes-pods
@@ -101,6 +109,34 @@ spec:
   - name: agent-http-metrics
     port: 8080
     targetPort: 8080
+  - name: agent-tempo-jaeger-thrift-compact
+    port: 6831
+    protocol: UDP
+    targetPort: 6831
+  - name: agent-tempo-jaeger-thrift-binary
+    port: 6832
+    protocol: UDP
+    targetPort: 6832
+  - name: agent-tempo-jaeger-thrift-http
+    port: 14268
+    protocol: TCP
+    targetPort: 14268
+  - name: agent-tempo-jaeger-grpc
+    port: 14250
+    protocol: TCP
+    targetPort: 14250
+  - name: agent-tempo-zipkin
+    port: 9411
+    protocol: TCP
+    targetPort: 9411
+  - name: agent-tempo-otlp
+    port: 55680
+    protocol: TCP
+    targetPort: 55680
+  - name: agent-tempo-opencensus
+    port: 55678
+    protocol: TCP
+    targetPort: 55678
   selector:
     name: grafana-agent-traces
 ---
@@ -133,6 +169,27 @@ spec:
         ports:
         - containerPort: 8080
           name: http-metrics
+        - containerPort: 6831
+          name: tempo-jaeger-thrift-compact
+          protocol: UDP
+        - containerPort: 6832
+          name: tempo-jaeger-thrift-binary
+          protocol: UDP
+        - containerPort: 14268
+          name: tempo-jaeger-thrift-http
+          protocol: TCP
+        - containerPort: 14250
+          name: tempo-jaeger-grpc
+          protocol: TCP
+        - containerPort: 9411
+          name: tempo-zipkin
+          protocol: TCP
+        - containerPort: 55680
+          name: tempo-otlp
+          protocol: TCP
+        - containerPort: 55678
+          name: tempo-opencensus
+          protocol: TCP
         volumeMounts:
         - mountPath: /etc/agent
           name: grafana-agent-traces

--- a/production/kubernetes/agent-tempo.yaml
+++ b/production/kubernetes/agent-tempo.yaml
@@ -1,0 +1,148 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-agent-traces
+---
+apiVersion: v1
+data:
+  agent.yaml: |
+    server:
+        http_listen_port: 8080
+        log_level: info
+    tempo:
+        push_config:
+            basic_auth:
+                password: ${TEMPO_PASSWORD}
+                username: ${TEMPO_USERNAME}
+            batch:
+                send_batch_size: 1000
+                timeout: 5s
+            endpoint: ${TEMPO_ENDPOINT}
+            queue:
+                retry_on_failure: false
+        receivers:
+            jaeger:
+                protocols:
+                    grpc: null
+                    thrift_compact: null
+                remote_sampling:
+                    insecure: true
+                    strategy_file: /etc/agent/strategies.json
+        scrape_configs:
+          - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            job_name: kubernetes-pods
+            kubernetes_sd_configs:
+              - role: pod
+            relabel_configs:
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_namespace
+                target_label: namespace
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_name
+                target_label: pod
+              - action: replace
+                source_labels:
+                  - __meta_kubernetes_pod_container_name
+                target_label: container
+            tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: false
+  strategies.json: '{"default_strategy": {"param": 0.001, "type": "probabilistic"}}'
+kind: ConfigMap
+metadata:
+  name: grafana-agent-traces
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: grafana-agent-traces
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - nodes/proxy
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-agent-traces
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: grafana-agent-traces
+subjects:
+- kind: ServiceAccount
+  name: grafana-agent-traces
+  namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: grafana-agent-traces
+  name: grafana-agent-traces
+spec:
+  ports:
+  - name: agent-http-metrics
+    port: 8080
+    targetPort: 8080
+  selector:
+    name: grafana-agent-traces
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: grafana-agent-traces
+  namespace: default
+spec:
+  minReadySeconds: 10
+  selector:
+    matchLabels:
+      name: grafana-agent-traces
+  template:
+    metadata:
+      labels:
+        name: grafana-agent-traces
+    spec:
+      containers:
+      - args:
+        - -config.file=/etc/agent/agent.yaml
+        env:
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: grafana/agent:v0.6.1
+        imagePullPolicy: IfNotPresent
+        name: agent
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        volumeMounts:
+        - mountPath: /etc/agent
+          name: grafana-agent-traces
+      serviceAccount: grafana-agent-traces
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      volumes:
+      - configMap:
+          name: grafana-agent-traces
+        name: grafana-agent-traces
+  updateStrategy:
+    type: RollingUpdate

--- a/production/kubernetes/agent.yaml
+++ b/production/kubernetes/agent.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: grafana-agent
-  namespace: default
 ---
 apiVersion: v1
 data:
@@ -207,7 +206,6 @@ data:
 kind: ConfigMap
 metadata:
   name: grafana-agent
-  namespace: default
 ---
 apiVersion: v1
 data:
@@ -252,7 +250,6 @@ data:
 kind: ConfigMap
 metadata:
   name: grafana-agent-deployment
-  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -293,7 +290,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: grafana-agent
-  namespace: default
 spec:
   minReadySeconds: 10
   selector:
@@ -340,7 +336,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana-agent-deployment
-  namespace: default
 spec:
   minReadySeconds: 10
   replicas: 1

--- a/production/kubernetes/build/build.sh
+++ b/production/kubernetes/build/build.sh
@@ -9,4 +9,5 @@ jb install
 tk show --dangerous-allow-redirect ./templates/base > ${PWD}/../agent.yaml
 tk show --dangerous-allow-redirect ./templates/bare > ${PWD}/../agent-bare.yaml
 tk show --dangerous-allow-redirect ./templates/loki > ${PWD}/../agent-loki.yaml
+tk show --dangerous-allow-redirect ./templates/tempo > ${PWD}/../agent-tempo.yaml
 popd

--- a/production/kubernetes/build/templates/bare/spec.json
+++ b/production/kubernetes/build/templates/bare/spec.json
@@ -6,6 +6,6 @@
   },
   "spec": {
     "apiServer": "",
-    "namespace": "default"
+    "namespace": ""
   }
 }

--- a/production/kubernetes/build/templates/base/spec.json
+++ b/production/kubernetes/build/templates/base/spec.json
@@ -6,6 +6,6 @@
   },
   "spec": {
     "apiServer": "",
-    "namespace": "default"
+    "namespace": ""
   }
 }

--- a/production/kubernetes/build/templates/loki/spec.json
+++ b/production/kubernetes/build/templates/loki/spec.json
@@ -6,6 +6,6 @@
   },
   "spec": {
     "apiServer": "",
-    "namespace": "default"
+    "namespace": ""
   }
 }

--- a/production/kubernetes/build/templates/tempo/main.jsonnet
+++ b/production/kubernetes/build/templates/tempo/main.jsonnet
@@ -1,5 +1,8 @@
 local agent = import 'grafana-agent/v1/main.libsonnet';
 
+local k = import 'ksonnet-util/kausal.libsonnet';
+local containerPort = k.core.v1.containerPort;
+
 {
   agent:
     agent.new('grafana-agent-traces', 'default') +
@@ -10,10 +13,39 @@ local agent = import 'grafana-agent/v1/main.libsonnet';
     agent.withTempoConfig({
       receivers: {
         jaeger: {
-          protocols: { thrift_compact: null, grpc: null },
+          protocols: {
+            thrift_http: null,
+            thrift_binary: null,
+            thrift_compact: null,
+            grpc: null,
+          },
         },
+        zipkin: null,
+        otlp: {
+          protocols: {
+            http: null,
+            grpc: null,
+          },
+        },
+        opencensus: null,
       },
     }) +
+    agent.withPortsMixin([
+      // Jaeger receiver
+      containerPort.new('tempo-jaeger-thrift-compact', 6831) + containerPort.withProtocol('UDP'),
+      containerPort.new('tempo-jaeger-thrift-binary', 6832) + containerPort.withProtocol('UDP'),
+      containerPort.new('tempo-jaeger-thrift-http', 14268) + containerPort.withProtocol('TCP'),
+      containerPort.new('tempo-jaeger-grpc', 14250) + containerPort.withProtocol('TCP'),
+
+      // Zipkin
+      containerPort.new('tempo-zipkin', 9411) + containerPort.withProtocol('TCP'),
+
+      // OTLP
+      containerPort.new('tempo-otlp', 55680) + containerPort.withProtocol('TCP'),
+
+      // Opencensus
+      containerPort.new('tempo-opencensus', 55678) + containerPort.withProtocol('TCP'),
+    ]) +
     agent.withTempoPushConfig({
       endpoint: '${TEMPO_ENDPOINT}',
       basic_auth: {

--- a/production/kubernetes/build/templates/tempo/main.jsonnet
+++ b/production/kubernetes/build/templates/tempo/main.jsonnet
@@ -1,0 +1,38 @@
+local agent = import 'grafana-agent/v1/main.libsonnet';
+
+{
+  agent:
+    agent.new('grafana-agent-traces', 'default') +
+    agent.withConfigHash(false) +
+    agent.withImages({
+      agent: (import 'version.libsonnet'),
+    }) +
+    agent.withTempoConfig({
+      receivers: {
+        jaeger: {
+          protocols: { thrift_compact: null, grpc: null },
+        },
+      },
+    }) +
+    agent.withTempoPushConfig({
+      endpoint: '${TEMPO_ENDPOINT}',
+      basic_auth: {
+        username: '${TEMPO_USERNAME}',
+        password: '${TEMPO_PASSWORD}',
+      },
+      batch: {
+        timeout: '5s',
+        send_batch_size: 1000,
+      },
+      queue: {
+        retry_on_failure: false,
+      },
+    }) +
+    agent.withTempoSamplingStrategies({
+      default_strategy: {
+        type: 'probabilistic',
+        param: 0.001,
+      },
+    }) +
+    agent.withTempoScrapeConfigs(agent.tempoScrapeKubernetes),
+}

--- a/production/kubernetes/build/templates/tempo/spec.json
+++ b/production/kubernetes/build/templates/tempo/spec.json
@@ -1,0 +1,11 @@
+{
+  "apiVersion": "tanka.dev/v1alpha1",
+  "kind": "Environment",
+  "metadata": {
+    "name": "template"
+  },
+  "spec": {
+    "apiServer": "",
+    "namespace": "default"
+  }
+}

--- a/production/kubernetes/build/templates/tempo/spec.json
+++ b/production/kubernetes/build/templates/tempo/spec.json
@@ -6,6 +6,6 @@
   },
   "spec": {
     "apiServer": "",
-    "namespace": "default"
+    "namespace": ""
   }
 }

--- a/production/kubernetes/install-loki.sh
+++ b/production/kubernetes/install-loki.sh
@@ -35,7 +35,7 @@ MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${M
 LOKI_USERNAME_SET=0
 LOKI_PASSWORD_SET=0
 
-while getopts "l:u:p:" opt; do
+while getopts "h:u:p:" opt; do
   case "$opt" in
     h)
       LOKI_HOSTNAME=$OPTARG

--- a/production/kubernetes/install-tempo.sh
+++ b/production/kubernetes/install-tempo.sh
@@ -56,7 +56,7 @@ while getopts "e:u:p:" opt; do
 done
 
 if [ -z "${TEMPO_ENDPOINT}" ]; then
-  read -sp 'Enter your Tempo endpoint (i.e., traces-us-central1.grafana.net): ' TEMPO_ENDPOINT
+  read -sp 'Enter your Tempo endpoint (i.e., tempo-us-central1.grafana.net): ' TEMPO_ENDPOINT
   printf $'\n' >&2
 
   # We require a endpoint for the agent; we don't do this same check for

--- a/production/kubernetes/install-tempo.sh
+++ b/production/kubernetes/install-tempo.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+#
+# install-tempo.sh is a really basic installer for the agent. It uses the existing
+# Kubernetes YAML example and envsubst to fill in the details for Tempo push
+# URL, username, and password.
+#
+# There are three ways to provide the inputs for installation:
+#
+# 1. Environment variables (TEMPO_ENDPOINT, TEMPO_USERNAME, TEMPO_PASSWORD)
+#
+# 2. Flags (-e for endpoint, -u for username, -p for password)
+#
+# 3. stdin from prompts
+#
+# Flags override environment variables, and stdin is used as a fallback if a
+# value wasn't given from a flag or environment variable. An empty username
+# or password is acceptable, as it disables basic auth. However, a hostname must
+# always be provided.
+#
+
+check_installed() {
+  if ! type $1 >/dev/null 2>&1; then
+    echo "error: $1 not installed" >&2
+    exit 1
+  fi
+}
+
+check_installed curl
+check_installed envsubst
+
+MANIFEST_BRANCH=v0.6.1
+MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent-tempo.yaml}
+
+TEMPO_USERNAME_SET=0
+TEMPO_PASSWORD_SET=0
+
+while getopts "e:u:p:" opt; do
+  case "$opt" in
+    e)
+      TEMPO_ENDPOINT=$OPTARG
+      ;;
+    u)
+      TEMPO_USERNAME=$OPTARG
+      TEMPO_USERNAME_SET=1
+      ;;
+    p)
+      TEMPO_PASSWORD=$OPTARG
+      TEMPO_PASSWORD_SET=1
+      ;;
+    ?)
+      echo "usage: $(basename $0) [-e Tempo endpoint] [-u Tempo username] [-p Tempo password]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "${TEMPO_ENDPOINT}" ]; then
+  read -sp 'Enter your Tempo endpoint (i.e., traces-us-central1.grafana.net): ' TEMPO_ENDPOINT
+  printf $'\n' >&2
+
+  # We require a endpoint for the agent; we don't do this same check for
+  # the username and password as the remote Tempo system may not have basic
+  # auth enabled.
+  if [ -z "${TEMPO_ENDPOINT}" ]; then
+    echo "error: TEMPO_ENDPOINT must be provided by flag, env, or stdin" >&2
+    exit 1
+  fi
+fi
+
+if [ -z "${TEMPO_USERNAME}" ] && [ "${TEMPO_USERNAME_SET}" -eq 0 ]; then
+  read -sp 'Enter your Tempo username: ' TEMPO_USERNAME
+  printf $'\n' >&2
+fi
+
+if [ -z "${TEMPO_PASSWORD}" ] && [ "${TEMPO_PASSWORD_SET}" -eq 0 ]; then
+  read -sp 'Enter your Tempo password: ' TEMPO_PASSWORD
+  printf $'\n' >&2
+fi
+
+export TEMPO_ENDPOINT
+export TEMPO_USERNAME
+export TEMPO_PASSWORD
+
+curl -fsSL $MANIFEST_URL | envsubst

--- a/production/tanka/grafana-agent/v1/README.md
+++ b/production/tanka/grafana-agent/v1/README.md
@@ -15,11 +15,11 @@ incompatible changes will be made.
 This library is significantly more flexible than its `v0` counterpart. It tries
 to allow to deploy and configure the Agent in a feature matrix:
 
-| Mechanism        | Prometheus Metrics | Loki Logs | Integrations |
-| ---------------- | ------------------ | --------- | ------------ |
-| DaemonSet        | Yes                | Yes       | Yes          |
-| Deployment       | Yes                | No        | No           |
-| Scraping Service | Yes                | No        | No           |
+| Mechanism        | Prometheus Metrics | Loki Logs | Traces | Integrations | 
+| ---------------- | ------------------ | --------- | ------ | ------------ |
+| DaemonSet        | Yes                | Yes       | Yes    | Yes          |
+| Deployment       | Yes                | No        | No     | No           |
+| Scraping Service | Yes                | No        | No     | No           |
 
 The library can be invoked multiple times to get full coverage. For example, you
 may wish to deploy a scraping service for scalable metrics collection, and a
@@ -59,4 +59,14 @@ example, you may not deploy a scraping service with Loki logs collection.
 - `scrapeKubernetesLogs`: Default Loki config that collects logs from Kubernetes
   pods.
 
+## Configure Tempo
 
+- `withTempoConfig(config)`: Creates a Tempo config block to pass to the Agent.
+- `withTempoPushConfig(push_config)`: Configures a location to push spans to. 
+- `withTempoSamplingStrategies(strategies)`: Configures strategies for trace collection. 
+- `withTempoScrapeConfigs(scrape_configs)`: Configures scrape configs to attach
+   labels to incoming spans. 
+- `tempoScrapeKubernetes`: Default scrape configs to collect meta information
+   from pods. Aligns with the labels from `scrapeInstanceKubernetes` and
+   `scrapeKubernetesLogs` so logs, metrics, and traces all use the same set of
+   labels.

--- a/production/tanka/grafana-agent/v1/README.md
+++ b/production/tanka/grafana-agent/v1/README.md
@@ -1,21 +1,21 @@
-# Tanka Configs 
+# Tanka Configs
 
 **STATUS**: Work in progress, use of these configs is not recommended for production.
 
 This directory contains the Tanka configs that we use to deploy the Grafana
 Cloud Agent. It is marked as `v1` and is incompatible with the `v0` configs
-found in the [parent directory](../). 
+found in the [parent directory](../).
 
 This library is currently a work in progress and backwards-incompatible changes
 may occur. Once the library is considered complete, no further backwards
 incompatible changes will be made.
 
-## Capabilities 
+## Capabilities
 
 This library is significantly more flexible than its `v0` counterpart. It tries
 to allow to deploy and configure the Agent in a feature matrix:
 
-| Mechanism        | Prometheus Metrics | Loki Logs | Traces | Integrations | 
+| Mechanism        | Prometheus Metrics | Loki Logs | Traces | Integrations |
 | ---------------- | ------------------ | --------- | ------ | ------------ |
 | DaemonSet        | Yes                | Yes       | Yes    | Yes          |
 | Deployment       | Yes                | No        | No     | No           |
@@ -23,12 +23,12 @@ to allow to deploy and configure the Agent in a feature matrix:
 
 The library can be invoked multiple times to get full coverage. For example, you
 may wish to deploy a scraping service for scalable metrics collection, and a
-DaemonSet with just Loki Logs for log collection. 
+DaemonSet with just Loki Logs for log collection.
 
 Trying to use the library in incompatible ways will generate errors. For
 example, you may not deploy a scraping service with Loki logs collection.
 
-## API 
+## API
 
 ## Generate Agent Deployment
 
@@ -39,7 +39,7 @@ example, you may not deploy a scraping service with Loki logs collection.
 - `newScrapingService(name, namespace, replicas)`: (Not yet available). Create a
   scalable deployment of clustered Agents. Requires being given a KV store such as Redis or ETCD.
 
-## Configure Prometheus 
+## Configure Prometheus
 
 - `withPrometheusConfig(config)`: Creates a Prometheus config block.
 - `defaultPrometheusConfig`: Default Prometheus config block.
@@ -47,13 +47,13 @@ example, you may not deploy a scraping service with Loki logs collection.
   tell the Agent what to scrape.
 - `withRemoteWrite(remote_writes)`: Configures locations to remote write metrics
    to. Controlls remote writes for all instances.
-- `scrapeInstanceKubernetes`: Default Prometheus instance config to scrape from 
+- `scrapeInstanceKubernetes`: Default Prometheus instance config to scrape from
   Kubernetes.
 
 ## Configure Loki
 
-- `withLokiConfig(config)`: Creates a Loki config block to pass to the Agent. 
-- `newLokiClient(client_config)`: Creates a new client configuration to pass 
+- `withLokiConfig(config)`: Creates a Loki config block to pass to the Agent.
+- `newLokiClient(client_config)`: Creates a new client configuration to pass
   to `withLokiClients`.
 - `withLokiClients(clients)`: Add a set of clients to a Loki config block.
 - `scrapeKubernetesLogs`: Default Loki config that collects logs from Kubernetes
@@ -62,11 +62,18 @@ example, you may not deploy a scraping service with Loki logs collection.
 ## Configure Tempo
 
 - `withTempoConfig(config)`: Creates a Tempo config block to pass to the Agent.
-- `withTempoPushConfig(push_config)`: Configures a location to push spans to. 
-- `withTempoSamplingStrategies(strategies)`: Configures strategies for trace collection. 
+- `withTempoPushConfig(push_config)`: Configures a location to push spans to.
+- `withTempoSamplingStrategies(strategies)`: Configures strategies for trace collection.
 - `withTempoScrapeConfigs(scrape_configs)`: Configures scrape configs to attach
-   labels to incoming spans. 
+   labels to incoming spans.
 - `tempoScrapeKubernetes`: Default scrape configs to collect meta information
    from pods. Aligns with the labels from `scrapeInstanceKubernetes` and
    `scrapeKubernetesLogs` so logs, metrics, and traces all use the same set of
    labels.
+
+## General
+
+- `withImages(images)`: Use custom images.
+- `withConfigHash(include=true)`: Whether to include a config hash annotation.
+- `withPortsMixin(ports)`: Mixin ports from `k.core.v1.containerPort` against
+   the container and service.

--- a/production/tanka/grafana-agent/v1/lib/tempo.libsonnet
+++ b/production/tanka/grafana-agent/v1/lib/tempo.libsonnet
@@ -1,0 +1,101 @@
+{
+  // withTempoConfig adds a Tempo config to collect traces. 
+  // 
+  // For the full list of options, refer to the configuration reference:
+  //
+  withTempoConfig(config):: {
+    assert std.objectHasAll(self, '_mode') : |||
+      withLokiConfig must be merged with the result of calling new.
+    |||,
+    _tempo_config:: config,
+  },
+
+  // withTempoPushConfig configures a location to write traces to. 
+  // 
+  // Availabile options can be found in the configuration reference:
+  // https://github.com/grafana/agent/blob/master/docs/configuration-reference.md#tempo_config
+  withTempoPushConfig(push_config):: {
+    assert std.objectHasAll(self, '_tempo_config') : |||
+      withTempoPushConfig must be merged with the result of calling
+      withTempoConfig.
+    |||,
+    _tempo_config+:: { push_config: push_config },
+  },
+
+  // withTempoSamplingStrategies accepts an object for trace sampling strategies. 
+  // 
+  // Refer to Jaeger's documentation for available fields:
+  // https://www.jaegertracing.io/docs/1.17/sampling/#collector-sampling-configuration
+  //
+  // Creating a file isn't necessary; just provide the object and a ConfigMap
+  // will be created for you and added to the tempo config.
+  withTempoSamplingStrategies(strategies):: {
+    assert std.objectHasAll(self, '_tempo_config') : |||
+      withTempoPushConfig must be merged with the result of calling
+      withTempoConfig.
+    |||,
+
+    assert 
+      std.objectHasAll(self._tempo_config, 'receivers') &&
+      std.objectHasAll(self._tempo_config.receivers, 'jaeger') : |||
+        withStrategies can only be used if the tempo config is configured for 
+        receiving Jaeger spans and traces.
+      |||,
+
+    // The main library should detect the presence of _tempo_sampling_strategies 
+    // and create a ConfigMap bound to /etc/agent/strategies.json.
+    _tempo_sampling_strategies:: strategies,
+    _tempo_config+:: {
+      receivers+: {
+        jaeger+: {
+          remote_sampling: {
+            strategy_file: '/etc/agent/strategies.json',
+            insecure: true,
+          },
+        },
+      },
+    },
+  },
+
+  // Configures scrape_configs for discovering meta labels that will be attached 
+  // to incoming metrics and spans whose IP matches the __address__ of the
+  // target.
+  withTempoScrapeConfigs(scrape_configs):: {
+    assert std.objectHasAll(self, '_tempo_config') : |||
+      withTempoScrapeConfigs must be merged with the result of calling
+      withTempoConfig.
+    |||,
+    _tempo_config+: { scrape_configs: scrape_configs },
+  },
+
+  // Provides a default set of scrape_configs to use for discovering labels from
+  // Pods. Labels will be attached to any traces sent from the discovered pods.
+  tempoScrapeKubernetes:: [
+    {
+      bearer_token_file: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+      job_name: 'kubernetes-pods',
+      kubernetes_sd_configs: [{ role: 'pod' }],
+      relabel_configs: [
+        {
+          action: 'replace',
+          source_labels: ['__meta_kubernetes_namespace'],
+          target_label: 'namespace',
+        },
+        {
+          action: 'replace',
+          source_labels: ['__meta_kubernetes_pod_name'],
+          target_label: 'pod',
+        },
+        {
+          action: 'replace',
+          source_labels: ['__meta_kubernetes_pod_container_name'],
+          target_label: 'container',
+        },
+      ],
+      tls_config: {
+        ca_file: '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
+        insecure_skip_verify: false,
+      },
+    },
+  ]
+}

--- a/production/tanka/grafana-agent/v1/main.libsonnet
+++ b/production/tanka/grafana-agent/v1/main.libsonnet
@@ -66,7 +66,7 @@ local configMap = k.core.v1.configMap;
       else {}
     ) + (
       if has_loki_config then { loki: this._loki_config } else {}
-    ) + ( 
+    ) + (
       if has_tempo_config then { tempo: this._tempo_config } else {}
     ) + (
       if has_integrations then { integrations: this._integrations } else {}
@@ -91,17 +91,17 @@ local configMap = k.core.v1.configMap;
         container+:: container.withEnvMixin([
           k.core.v1.envVar.fromFieldPath('HOSTNAME', 'spec.nodeName'),
         ]),
-  
-        // If sampling strategies were defined, we need to mount them as a JSON 
+
+        // If sampling strategies were defined, we need to mount them as a JSON
         // file.
-        config_map+: 
-          if has_sampling_strategies 
+        config_map+:
+          if has_sampling_strategies
           then configMap.withDataMixin({
             'strategies.json': std.toString(this._tempo_sampling_strategies),
-          }) 
+          })
           else {},
- 
-        // If we're deploying for tracing, applications will want to write to 
+
+        // If we're deploying for tracing, applications will want to write to
         // a service for load balancing span delivery.
         service:
           if has_tempo_config then k.util.serviceFor(self.agent) else {},
@@ -120,4 +120,11 @@ local configMap = k.core.v1.configMap;
 
   // Includes or excludes the config hash annotation.
   withConfigHash(include=true):: { _config_hash:: include },
+
+  // withPortsMixin adds extra ports to expose.
+  withPortsMixin(ports=[]):: {
+    agent+: {
+      container+:: container.withPortsMixin(ports),
+    },
+  },
 }

--- a/tools/release-note.md
+++ b/tools/release-note.md
@@ -12,13 +12,14 @@ use-case best.
 #### Kubernetes Install Script
 
 The following scripts will download and install two Kubernetes manifests for the
-Agent. The first manifest will collect metrics and the second will collect logs. 
-You will be prompted for input for each manifest. The script requires curl and
-envsubst (GNU gettext).
+Agent. The first manifest collects metrics, the second collects logs, and the
+final collects traces. You will be prompted for input for each manifest. The
+script requires curl and envsubst (GNU gettext).
 
 ```
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/${RELEASE_TAG}/production/kubernetes/install.sh)" | kubectl -ndefault apply -f -
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/${RELEASE_TAG}/production/kubernetes/install-loki.sh)" | kubectl -ndefault apply -f -
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/${RELEASE_TAG}/production/kubernetes/install-tempo.sh)" | kubectl -ndefault apply -f -
 ```
 
 #### Docker container:


### PR DESCRIPTION
This PR does a few things:

1. Add basic support for configuring the Tempo subsystem within the v1 Tanka library.
1. Utilize the tanka configs to expose a sane default config `production/kubernetes/agent-tempo.yaml`.
1. Add a bash script to render environment variables in the default config. (This is inline with the other "install" bash scripts).
1. Rename `remote_write` in the Tempo config to `push_config`. `remote_write` should be reserved for fields that act fully like the Prometheus `remote_write`; an array with the standard fields. Once the Tempo subsystem supports an array of targets to write spans to, a `remote_write` field name can return.