### PR TITLE
Support timeouts for resharding the scraping service cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ this platform. FreeBSD builds will return in a future release.
 - [FEATURE] [redis_exporter](https://github.com/oliver006/redis_exporter) is
   now embedded and available as an integration. (@dafydd-t)
 
+- [ENHANCEMENT] Resharding the cluster when using the scraping service mode now 
+  supports timeouts through `reshard_timeout`. The default value is `30s.` This
+  timeout applies to cluster-wide reshards (performed when joining and leaving
+  the cluster) and local reshards (done on the `reshard_interval`). (@rfratto)
+
 - [BUGFIX] Fix issue where integrations crashed with instance_mode was set to
   `distinct` (@rfratto)
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -155,6 +155,11 @@ agents distribute discovery and scrape load between nodes.
 # events are not sent by an agent.
 [reshard_interval: <duration> | default = "1m"]
 
+# The timeout for a reshard. Applies to a cluster-wide reshard (done when 
+# joining or leaving the cluster) and local reshards (done every
+# reshard_interval). A timeout of 0 indicates no timeout. 
+[reshard_timeout: <duration> | default = "30s"]
+
 # Configuration for the KV store to store metrics
 kvstore: <kvstore_config>
 

--- a/pkg/prom/ha/server.go
+++ b/pkg/prom/ha/server.go
@@ -221,9 +221,6 @@ func (s *Server) join(ctx context.Context) error {
 
 	level.Info(s.logger).Log("msg", "running cluster-wide reshard")
 	if err := s.waitNotifyReshard(ctx); err != nil {
-		// Even if this fails, we should continue onwards. Nodes are expected to
-		// reshard themselves on an interval, so they will eventually correct
-		// themselves if they don't reshard immediately when we asked them to.
 		level.Error(s.logger).Log("msg", "could not run cluster-wide reshard", "err", err)
 	}
 

--- a/pkg/prom/ha/server.go
+++ b/pkg/prom/ha/server.go
@@ -76,7 +76,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.BoolVar(&c.Enabled, prefix+"enabled", false, "enables the scraping service mode")
 	f.DurationVar(&c.ReshardInterval, prefix+"reshard-interval", time.Minute*1, "how often to manually reshard")
-	f.DurationVar(&c.ReshardTimeout, prefix+"reshard-timeout", time.Second*30, "timeout for cluster-wide reshards and local reshards")
+	f.DurationVar(&c.ReshardTimeout, prefix+"reshard-timeout", time.Second*30, "timeout for cluster-wide reshards and local reshards. Timeout of 0s disables timeout.")
 	c.KVStore.RegisterFlagsWithPrefix(prefix+"config-store.", "configurations/", f)
 	c.Lifecycler.RegisterFlagsWithPrefix(prefix, f)
 }


### PR DESCRIPTION
This PR adds a `reshard_timeout` configuration option that can optionally add a timeout when performing cluster-wide or local reshards. 

This PR also prevents the join process from failing and stopping the server; if an Agent encounters an error on the initial join, the reshard intervals will eventually correct the problems. 