### PR TITLE
Allow overriding instance label when replace_instance_label is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ this platform. FreeBSD builds will return in a future release.
   (@rfratto).
 
 - [BUGFIX] Support URL-encoded paths in the scraping service API. (@rfratto)
+ 
+- [BUGFIX] The instance label written from replace_instance_label can now be
+  overwritten with relabel_configs. This bugfix slightly modifies the behavior
+  of what data is stored. The final instance label will now be stored in the WAL 
+  rather than computed by remote_write. This change should not negatively effect
+  existing users. (@rfratto)
 
 # v0.6.1 (2020-04-11)
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -1543,6 +1543,15 @@ redis_exporter: <redis_exporter_config>
 # rather than 127.0.0.1:<server.http_listen_port>. Useful when running multiple
 # Agents with the same integrations and uniquely identifying where metrics are
 # coming from.
+
+# When true, replaces the instance label with the hostname of the machine,
+# rather than 127.0.0.1:<server.http_listen_port>. Useful when running multiple
+# Agents with the same integrations and uniquely identifying where metrics are 
+# coming from.
+#
+# The value for the instance label can be replaced by providing custom
+# relabel_configs for an integration. The overwritten instance label will be
+# available when relabel_configs run.
 [replace_instance_label: <boolean> | default = true]
 
 # When true, adds an agent_hostname label to all samples coming from

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -1541,11 +1541,6 @@ redis_exporter: <redis_exporter_config>
 
 # When true, replaces the instance label with the hostname of the machine,
 # rather than 127.0.0.1:<server.http_listen_port>. Useful when running multiple
-# Agents with the same integrations and uniquely identifying where metrics are
-# coming from.
-
-# When true, replaces the instance label with the hostname of the machine,
-# rather than 127.0.0.1:<server.http_listen_port>. Useful when running multiple
 # Agents with the same integrations and uniquely identifying where metrics are 
 # coming from.
 #

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,12 +50,6 @@ func (c *Config) ApplyDefaults() error {
 
 	if c.Integrations.Enabled {
 		c.Integrations.ListenPort = &c.Server.HTTPListenPort
-
-		// Apply the defaults for integrations *after* manual defaults are applied
-		// (like the c.Integrations.ListenPort) above.
-		if err := c.Integrations.ApplyDefaults(); err != nil {
-			return err
-		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR changes the mechanism for which the `replace_instance_label` config option is applied; rather than being applied through `write_relabel_configs`, it is now applied as the first `relabel_config` when relabeling targets.

This allows users to replace the instance label with their own value, and even use the existing overwritten instance label for creating the final result.

This slightly changes the behavior of the integrations. Before, the final `instance` label was computed by `remote_write`. Now that it's done by `relabel_configs`, the final instance label is being stored in the WAL. I don't anticipate this causing a problem for anyone. 

Fixes #220

