### PR TITLE
Log error message when retrieving KV configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ this platform. FreeBSD builds will return in a future release.
 - [FEATURE] New integration: [memcached_exporter](https://github.com/prometheus/memcached_exporter)
   (@rfratto).
 
+- [BUGFIX] Error messages when retrieving configs from the KV store will
+  now be logged, rather than just logging a generic message saying that
+  retrieving the config has failed. (@rfratto)
+
 # v0.7.2 (2020-10-29)
 
 NOTE: FreeBSD builds will not be included for this release. There is a bug in an

--- a/pkg/prom/ha/sharding.go
+++ b/pkg/prom/ha/sharding.go
@@ -97,7 +97,7 @@ func (s *Server) AllConfigs(ctx context.Context) (<-chan instance.Config, error)
 			// TODO(rfratto): retries might be useful here
 			v, err := s.kv.Get(ctx, key)
 			if err != nil {
-				level.Error(s.logger).Log("err", "failed to get config with key", "key", key, "err", err)
+				level.Error(s.logger).Log("msg", "failed to get config with key", "key", key, "err", err)
 				return
 			} else if v == nil {
 				level.Warn(s.logger).Log("skipping key that was deleted after list was called", "key", key)

--- a/pkg/prom/ha/sharding.go
+++ b/pkg/prom/ha/sharding.go
@@ -97,7 +97,7 @@ func (s *Server) AllConfigs(ctx context.Context) (<-chan instance.Config, error)
 			// TODO(rfratto): retries might be useful here
 			v, err := s.kv.Get(ctx, key)
 			if err != nil {
-				level.Error(s.logger).Log("failed to get config with key", "key", key)
+				level.Error(s.logger).Log("err", "failed to get config with key", "key", key, "err", err)
 				return
 			} else if v == nil {
 				level.Warn(s.logger).Log("skipping key that was deleted after list was called", "key", key)


### PR DESCRIPTION
When getting a config from the KV store failed, the underlying error was not being logged.