### PR TITLE
add <integration>_build_info metrics to every integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ this platform. FreeBSD builds will return in a future release.
 - [FEATURE] New integration: [memcached_exporter](https://github.com/prometheus/memcached_exporter)
   (@rfratto).
 
+- [ENHANCEMENT] Add `<integration name>_build_info` metric to all integrations.
+  The build info displayed will match the build information of the Agent and
+  *not* the embedded exporter. This metric is used by community dashboards, so
+  adding it to the Agent increases compatibility with existing dashboards that
+  depend on it existing. (@rfratto)
+
 - [BUGFIX] Error messages when retrieving configs from the KV store will
   now be logged, rather than just logging a generic message saying that
   retrieving the config has failed. (@rfratto)

--- a/pkg/integrations/common/collector_integration.go
+++ b/pkg/integrations/common/collector_integration.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/agent/pkg/integrations/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/version"
 )
 
 // CollectorIntegration is an integration exposing metrics from a Prometheus
@@ -55,6 +56,12 @@ func (i *CollectorIntegration) RegisterRoutes(r *mux.Router) error {
 func (i *CollectorIntegration) handler() (http.Handler, error) {
 	r := prometheus.NewRegistry()
 	if err := r.Register(i.c); err != nil {
+		return nil, fmt.Errorf("couldn't register %s: %w", i.name, err)
+	}
+
+	// Register <integration name>_build_info metrics, generally useful for
+	// dashboards that depend on them for discovering targets.
+	if err := r.Register(version.NewCollector(i.name)); err != nil {
 		return nil, fmt.Errorf("couldn't register %s: %w", i.name, err)
 	}
 

--- a/pkg/integrations/node_exporter/node_exporter.go
+++ b/pkg/integrations/node_exporter/node_exporter.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/agent/pkg/integrations/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/version"
 	"github.com/prometheus/node_exporter/collector"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
@@ -97,6 +98,12 @@ func (i *Integration) handler() (http.Handler, error) {
 			Registry:            i.exporterMetricsRegistry,
 		},
 	)
+
+	// Register node_exporter_build_info metrics, generally useful for
+	// dashboards that depend on them for discovering targets.
+	if err := r.Register(version.NewCollector("node_exporter")); err != nil {
+		return nil, fmt.Errorf("couldn't register node_exporter: %w", err)
+	}
 
 	if i.c.IncludeExporterMetrics {
 		// Note that we have to use reg here to use the same promhttp metrics for

--- a/pkg/integrations/process_exporter/process-exporter_linux.go
+++ b/pkg/integrations/process_exporter/process-exporter_linux.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/agent/pkg/integrations/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/version"
 
 	"github.com/ncabatoff/process-exporter/collector"
 )
@@ -67,6 +68,12 @@ func (i *Integration) handler() (http.Handler, error) {
 	r := prometheus.NewRegistry()
 	if err := r.Register(i.collector); err != nil {
 		return nil, fmt.Errorf("couldn't register process_exporter collector: %w", err)
+	}
+
+	// Register process_exporter_build_info metrics, generally useful for
+	// dashboards that depend on them for discovering targets.
+	if err := r.Register(version.NewCollector("process_exporter")); err != nil {
+		return nil, fmt.Errorf("couldn't register process_exporter: %w", err)
 	}
 
 	return promhttp.HandlerFor(


### PR DESCRIPTION
#### PR Description 

Some existing dashboards for exporters depend on an `<exporter name>_build_info` metric existing. Dashboards might put it in a panel, but some dashboards might also use it for discovering instance labels to use. As the Agent wasn't creating this metric, it would break these existing dashboards.

This PR adds `<integration>_build_info` metrics to increase compatibility with existing exporter dashboards. Note that the build info exposed will be the build information for the Agent process and not the embedded version of the exporter. 

#### PR Checklist

- [x] CHANGELOG updated 
