### PR TITLE
shorten agent tempo port names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ upstream library preventing cross-compilation of the Grafana Cloud Agent for
 this platform. FreeBSD builds will return in a future release.
 
 - [FEATURE] Add `sample-stats` to `agentctl` to search the WAL and return a
-  summary of samples of series matching the given label selector.
-  (@simonswine)
+  summary of samples of series matching the given label selector. (@simonswine)
+
+- [BUGFIX] Fix issue where the Tempo example manifest could not be applied
+  because the port names were too long. (@rfratto)
 
 - [FEATURE] New integration:
   [postgres_exporter](https://github.com/wrouesnel/postgres_exporter) (@rfratto)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ this platform. FreeBSD builds will return in a future release.
 - [FEATURE] Add `sample-stats` to `agentctl` to search the WAL and return a
   summary of samples of series matching the given label selector. (@simonswine)
 
-- [BUGFIX] Fix issue where the Tempo example manifest could not be applied
-  because the port names were too long. (@rfratto)
-
 - [FEATURE] New integration:
   [postgres_exporter](https://github.com/wrouesnel/postgres_exporter) (@rfratto)
 
@@ -24,6 +21,9 @@ this platform. FreeBSD builds will return in a future release.
   behavior, set `min_wal_time` to `0s`. (@rfratto)
 
 - [ENHANCEMENT] Update `redis_exporter` to v1.13.1. (@rfratto)
+
+- [BUGFIX] Fix issue where the Tempo example manifest could not be applied
+  because the port names were too long. (@rfratto)
 
 # v0.8.0 (2020-11-06)
 

--- a/production/kubernetes/agent-tempo.yaml
+++ b/production/kubernetes/agent-tempo.yaml
@@ -109,31 +109,31 @@ spec:
   - name: agent-http-metrics
     port: 8080
     targetPort: 8080
-  - name: agent-tempo-jaeger-thrift-compact
+  - name: agent-thrift-c
     port: 6831
     protocol: UDP
     targetPort: 6831
-  - name: agent-tempo-jaeger-thrift-binary
+  - name: agent-thrift-bin
     port: 6832
     protocol: UDP
     targetPort: 6832
-  - name: agent-tempo-jaeger-thrift-http
+  - name: agent-thrift-http
     port: 14268
     protocol: TCP
     targetPort: 14268
-  - name: agent-tempo-jaeger-grpc
+  - name: agent-thrift-grpc
     port: 14250
     protocol: TCP
     targetPort: 14250
-  - name: agent-tempo-zipkin
+  - name: agent-zipkin
     port: 9411
     protocol: TCP
     targetPort: 9411
-  - name: agent-tempo-otlp
+  - name: agent-otlp
     port: 55680
     protocol: TCP
     targetPort: 55680
-  - name: agent-tempo-opencensus
+  - name: agent-opencensus
     port: 55678
     protocol: TCP
     targetPort: 55678
@@ -170,25 +170,25 @@ spec:
         - containerPort: 8080
           name: http-metrics
         - containerPort: 6831
-          name: tempo-jaeger-thrift-compact
+          name: thrift-c
           protocol: UDP
         - containerPort: 6832
-          name: tempo-jaeger-thrift-binary
+          name: thrift-bin
           protocol: UDP
         - containerPort: 14268
-          name: tempo-jaeger-thrift-http
+          name: thrift-http
           protocol: TCP
         - containerPort: 14250
-          name: tempo-jaeger-grpc
+          name: thrift-grpc
           protocol: TCP
         - containerPort: 9411
-          name: tempo-zipkin
+          name: zipkin
           protocol: TCP
         - containerPort: 55680
-          name: tempo-otlp
+          name: otlp
           protocol: TCP
         - containerPort: 55678
-          name: tempo-opencensus
+          name: opencensus
           protocol: TCP
         volumeMounts:
         - mountPath: /etc/agent

--- a/production/kubernetes/agent-tempo.yaml
+++ b/production/kubernetes/agent-tempo.yaml
@@ -109,11 +109,11 @@ spec:
   - name: agent-http-metrics
     port: 8080
     targetPort: 8080
-  - name: agent-thrift-c
+  - name: agent-thrift-compact
     port: 6831
     protocol: UDP
     targetPort: 6831
-  - name: agent-thrift-bin
+  - name: agent-thrift-binary
     port: 6832
     protocol: UDP
     targetPort: 6832
@@ -170,10 +170,10 @@ spec:
         - containerPort: 8080
           name: http-metrics
         - containerPort: 6831
-          name: thrift-c
+          name: thrift-compact
           protocol: UDP
         - containerPort: 6832
-          name: thrift-bin
+          name: thrift-binary
           protocol: UDP
         - containerPort: 14268
           name: thrift-http

--- a/production/kubernetes/build/templates/tempo/main.jsonnet
+++ b/production/kubernetes/build/templates/tempo/main.jsonnet
@@ -32,19 +32,19 @@ local containerPort = k.core.v1.containerPort;
     }) +
     agent.withPortsMixin([
       // Jaeger receiver
-      containerPort.new('tempo-jaeger-thrift-compact', 6831) + containerPort.withProtocol('UDP'),
-      containerPort.new('tempo-jaeger-thrift-binary', 6832) + containerPort.withProtocol('UDP'),
-      containerPort.new('tempo-jaeger-thrift-http', 14268) + containerPort.withProtocol('TCP'),
-      containerPort.new('tempo-jaeger-grpc', 14250) + containerPort.withProtocol('TCP'),
+      containerPort.new('thrift-c', 6831) + containerPort.withProtocol('UDP'),
+      containerPort.new('thrift-bin', 6832) + containerPort.withProtocol('UDP'),
+      containerPort.new('thrift-http', 14268) + containerPort.withProtocol('TCP'),
+      containerPort.new('thrift-grpc', 14250) + containerPort.withProtocol('TCP'),
 
       // Zipkin
-      containerPort.new('tempo-zipkin', 9411) + containerPort.withProtocol('TCP'),
+      containerPort.new('zipkin', 9411) + containerPort.withProtocol('TCP'),
 
       // OTLP
-      containerPort.new('tempo-otlp', 55680) + containerPort.withProtocol('TCP'),
+      containerPort.new('otlp', 55680) + containerPort.withProtocol('TCP'),
 
       // Opencensus
-      containerPort.new('tempo-opencensus', 55678) + containerPort.withProtocol('TCP'),
+      containerPort.new('opencensus', 55678) + containerPort.withProtocol('TCP'),
     ]) +
     agent.withTempoPushConfig({
       endpoint: '${TEMPO_ENDPOINT}',

--- a/production/kubernetes/build/templates/tempo/main.jsonnet
+++ b/production/kubernetes/build/templates/tempo/main.jsonnet
@@ -31,9 +31,11 @@ local containerPort = k.core.v1.containerPort;
       },
     }) +
     agent.withPortsMixin([
+      // NOTE: none of these may surpass 15 characters.
+
       // Jaeger receiver
-      containerPort.new('thrift-c', 6831) + containerPort.withProtocol('UDP'),
-      containerPort.new('thrift-bin', 6832) + containerPort.withProtocol('UDP'),
+      containerPort.new('thrift-compact', 6831) + containerPort.withProtocol('UDP'),
+      containerPort.new('thrift-binary', 6832) + containerPort.withProtocol('UDP'),
       containerPort.new('thrift-http', 14268) + containerPort.withProtocol('TCP'),
       containerPort.new('thrift-grpc', 14250) + containerPort.withProtocol('TCP'),
 


### PR DESCRIPTION
The port name limit is 15 characters and the names given (when combined
with the generated prefix `agent-`), were too long, so the manifest was
failing to be applied.

#### PR Description 

#### Which issue(s) this PR fixes 

Closes #251 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
