### PR TITLE
add min_wal_time and max_wal_time to bound WAL data lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ this platform. FreeBSD builds will return in a future release.
 - [FEATURE] New integration:
   [postgres_exporter](https://github.com/wrouesnel/postgres_exporter) (@rfratto)
 
-- [ENHANCEMENT] `min_wal_time` has been added to the instance config settings,
-  and will determine the minimum amount of time data must exist within the WAL
-  before being considered for deletion. This gives an extra buffer to ensure
-  data is sent over remote_write. The default value is 5 minutes. This change
-  will slightly increase the size of the WAL. The old behavior can be retrieved
-  by setting `min_wal_time` to `0s`. (@rfratto)
+- [ENHANCEMENT] `min_wal_time` and `max_wal_time` have been added to the
+  instance config settings, guaranteeing that data in the WAL will exist for at
+  least `min_wal_time` and will not exist for longer than `max_wal_time`. This
+  change will increase the size of the WAL slightly but will prevent certain
+  scenarios where data is deleted before it is sent. To revert back to the old
+  behavior, set `min_wal_time` to `0s`. (@rfratto)
 
 # v0.8.0 (2020-11-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ this platform. FreeBSD builds will return in a future release.
 - [FEATURE] New integration:
   [postgres_exporter](https://github.com/wrouesnel/postgres_exporter) (@rfratto)
 
+- [ENHANCEMENT] `min_wal_time` has been added to the instance config settings,
+  and will determine the minimum amount of time data must exist within the WAL
+  before being considered for deletion. This gives an extra buffer to ensure
+  data is sent over remote_write. The default value is 5 minutes. This change
+  will slightly increase the size of the WAL. The old behavior can be retrieved
+  by setting `min_wal_time` to `0s`. (@rfratto)
+
 # v0.8.0 (2020-11-06)
 
 NOTE: FreeBSD builds will not be included for this release. There is a bug in an

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -344,6 +344,15 @@ host_filter_relabel_configs:
 # send the data.
 [wal_truncate_frequency: <duration> | default = "1m"]
 
+# The minimum amount of time series and samples should exist in the WAL before
+# being considered for deletion. The consumed disk space of the WAL will
+# increase by making this value larger.
+#
+# Setting this value to 0s is valid, but may delete series before all
+# remote_write shards have been able to write all data, and may cause errors on
+# slower machines.
+[min_wal_time: <duration> | default = "5m"]
+
 # Deadline for flushing data when a Prometheus instance shuts down
 # before giving up and letting the shutdown proceed.
 [remote_flush_deadline: <duration> | default = "1m"]

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -344,14 +344,25 @@ host_filter_relabel_configs:
 # send the data.
 [wal_truncate_frequency: <duration> | default = "1m"]
 
-# The minimum amount of time series and samples should exist in the WAL before
-# being considered for deletion. The consumed disk space of the WAL will
+# The minimum amount of time that series and samples should exist in the WAL
+# before being considered for deletion. The consumed disk space of the WAL will
 # increase by making this value larger.
 #
 # Setting this value to 0s is valid, but may delete series before all
 # remote_write shards have been able to write all data, and may cause errors on
 # slower machines.
 [min_wal_time: <duration> | default = "5m"]
+
+# The maximum amount of time that series and samples may exist within the WAL
+# before being considered for deletion. Series that have not received writes
+# since this period will be removed, and all samples older than this period will
+# be removed.
+#
+# This value is useful in long-running network outages, preventing the WAL from
+# growing forever.
+#
+# Must be larger than min_wal_time.
+[max_wal_time: <duration> | default = "4h"]
 
 # Deadline for flushing data when a Prometheus instance shuts down
 # before giving up and letting the shutdown proceed.

--- a/pkg/prom/instance/instance.go
+++ b/pkg/prom/instance/instance.go
@@ -576,7 +576,15 @@ func (i *Instance) truncateLoop(ctx context.Context, wal walStorage, cfg *Config
 				continue
 			}
 
-			// Subtract the minimum amount of time we want data in the WAL to live for.
+			// The ts timestamp is used to determine which series are inactive (e.g.,
+			// not being appended to with new samples) and may be deleted from the
+			// WAL. Their most recent append timestamp is compared to ts; if their
+			// most recent append timestamp is older than ts, they are considered
+			// inactive and may be deleted.
+			//
+			// Subtracting some duration from ts makes an series considered active
+			// for a longer period of time, delaying when it gets scheduled for
+			// deletion from the WAL.
 			ts -= i.cfg.MinWALTime.Milliseconds()
 
 			level.Debug(i.logger).Log("msg", "truncating the WAL", "ts", ts)

--- a/pkg/prom/instance/instance.go
+++ b/pkg/prom/instance/instance.go
@@ -46,6 +46,7 @@ var (
 		HostFilter:           false,
 		WALTruncateFrequency: 1 * time.Minute,
 		MinWALTime:           5 * time.Minute,
+		MaxWALTime:           4 * time.Hour,
 		RemoteFlushDeadline:  1 * time.Minute,
 		WriteStaleOnShutdown: false,
 	}
@@ -63,8 +64,9 @@ type Config struct {
 	// How frequently the WAL should be truncated.
 	WALTruncateFrequency time.Duration `yaml:"wal_truncate_frequency,omitempty" json:"wal_truncate_frequency,omitempty"`
 
-	// Minimum time data in the WAL should exist for.
+	// Minimum and maximum time series should exist in the WAL for.
 	MinWALTime time.Duration `yaml:"min_wal_time,omitempty" json:"min_wal_time,omitempty"`
+	MaxWALTime time.Duration `yaml:"max_wal_time,omitempty" json:"max_wal_time,omitempty"`
 
 	RemoteFlushDeadline  time.Duration `yaml:"remote_flush_deadline,omitempty" json:"remote_flush_deadline,omitempty"`
 	WriteStaleOnShutdown bool          `yaml:"write_stale_on_shutdown,omitempty" json:"write_stale_on_shutdown,omitempty"`
@@ -106,6 +108,8 @@ func (c *Config) ApplyDefaults(global *config.GlobalConfig) error {
 		return errors.New("wal_truncate_frequency must be greater than 0s")
 	case c.RemoteFlushDeadline <= 0:
 		return errors.New("remote_flush_deadline must be greater than 0s")
+	case c.MinWALTime > c.MaxWALTime:
+		return errors.New("min_wal_time must be less than max_wal_time")
 	}
 
 	jobNames := map[string]struct{}{}
@@ -570,22 +574,27 @@ func (i *Instance) truncateLoop(ctx context.Context, wal walStorage, cfg *Config
 		case <-ctx.Done():
 			return
 		case <-time.After(cfg.WALTruncateFrequency):
+			// The timestamp ts is used to determine which series are not receiving
+			// samples and may be deleted from the WAL. Their most recent append
+			// timestamp is compared to ts, and if that timestamp is older then ts,
+			// they are considered inactive and may be deleted.
+			//
+			// Subtracting a duration from ts will delay when it will be considered
+			// inactive and scheduled for deletion.
 			ts := i.getRemoteWriteTimestamp()
 			if ts == 0 {
 				level.Debug(i.logger).Log("msg", "can't truncate the WAL yet")
 				continue
 			}
-
-			// The ts timestamp is used to determine which series are inactive (e.g.,
-			// not being appended to with new samples) and may be deleted from the
-			// WAL. Their most recent append timestamp is compared to ts; if their
-			// most recent append timestamp is older than ts, they are considered
-			// inactive and may be deleted.
-			//
-			// Subtracting some duration from ts makes an series considered active
-			// for a longer period of time, delaying when it gets scheduled for
-			// deletion from the WAL.
 			ts -= i.cfg.MinWALTime.Milliseconds()
+
+			// Network issues can prevent the result of getRemoteWriteTimestamp from
+			// changing. We don't want data in the WAL to grow forever, so we set a cap
+			// on the maximum age data can be. If our ts is older than this cutoff point,
+			// we'll shift it forward to start deleting very stale data.
+			if maxTS := timestamp.FromTime(time.Now().Add(-i.cfg.MaxWALTime)); ts < maxTS {
+				ts = maxTS
+			}
 
 			level.Debug(i.logger).Log("msg", "truncating the WAL", "ts", ts)
 			err := wal.Truncate(ts)

--- a/pkg/prom/instance/marshal_test.go
+++ b/pkg/prom/instance/marshal_test.go
@@ -62,6 +62,7 @@ remote_write:
     send: true
     send_interval: 1m
 wal_truncate_frequency: 1m0s
+min_wal_time: 5m0s
 remote_flush_deadline: 1m0s
 `
 

--- a/pkg/prom/instance/marshal_test.go
+++ b/pkg/prom/instance/marshal_test.go
@@ -63,6 +63,7 @@ remote_write:
     send_interval: 1m
 wal_truncate_frequency: 1m0s
 min_wal_time: 5m0s
+max_wal_time: 4h0m0s
 remote_flush_deadline: 1m0s
 `
 


### PR DESCRIPTION
#### PR Description 

It's suspected that immediately deleting data from the WAL as soon any sample with that given timestamp is `remote_written` is error prone, with one potential scenario described in #248. Similarly, it's possible that the 
WAL may grow forever in cases of long-running network outages, as described by #226.   

This PR adds two new options, `min_wal_time` and `max_wal_time`, to control the bounds of how long data may exist for within the WAL. 

The default setting for `min_wal_time` is 5m, which should be ample time for remote_write to give up on a failed batch. Users are free to set `min_wal_time` to anything, including 0s to retain the old behavior. 

The default setting for `max_wal_time` is 4h, and must be greater than `min_wal_time`. 

#### Which issue(s) this PR fixes 

Closes #138.
Closes #226.

#### Notes to the Reviewer

I ran a test to ensure that subtracting `time.Minute.Milliseconds()` from a Prometheus timestamp is equivalent to converting `time.Now().Add(-time.Minute)` to a Prometheus millisecond-precise timestamp.

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
