### PR TITLE
Update libsystemd version in Docker containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,19 +10,22 @@ this platform. FreeBSD builds will return in a future release.
 
 - [ENHANCEMENT] `process-exporter` has been updated to v0.7.5. (@rfratto)
 
-- [BUGFIX] Integrations will now function if the HTTP listen address was set to
-  a value other than the default. ([#206](https://github.com/grafana/agent/issues/206)) (@mattdurham) 
-
-- [BUGFIX] The default Loki installation will now be able to write its positions
-  file. This was prevented by accidentally writing to a readonly volume mount.
-  (@rfratto)
-
 - [ENHANCEMENT] `wal_cleanup_age` and `wal_cleanup_period` have been added to the
   top-level Prometheus configuration section. These settings control how Write Ahead
   Logs (WALs) that are not associated with any instances are cleaned up. By default,
   WALs not associated with an instance that have not been written in the last 12 hours
   are eligible to be cleaned up. This cleanup can be disabled by setting `wal_cleanup_period`
   to `0`. (#304) (@56quarters)
+
+- [ENHANCEMENT] Configuring logs to read from the systemd journal should now
+  work on journals that use +ZSTD compression. (@rfratto)
+
+- [BUGFIX] Integrations will now function if the HTTP listen address was set to
+  a value other than the default. ([#206](https://github.com/grafana/agent/issues/206)) (@mattdurham) 
+
+- [BUGFIX] The default Loki installation will now be able to write its positions
+  file. This was prevented by accidentally writing to a readonly volume mount.
+  (@rfratto)
 
 # v0.9.1 (2021-01-04)
 

--- a/cmd/agent/Dockerfile
+++ b/cmd/agent/Dockerfile
@@ -1,16 +1,27 @@
-FROM golang:1.15 as build
+FROM golang:1.15.3-buster as build
 COPY . /src/agent
 WORKDIR /src/agent
 ARG RELEASE_BUILD=true
 ARG IMAGE_TAG
-RUN apt-get update && apt-get install -qy libsystemd-dev
+
+# Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
+RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -t buster-backports -qy libsystemd-dev
+
 RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agent
 
 FROM debian:buster-slim
+
+# Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
+RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -t buster-backports -qy libsystemd-dev && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 RUN apt-get update && \
   apt-get install -qy \
-  tzdata ca-certificates libsystemd-dev && \
+  tzdata ca-certificates && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 COPY --from=build /src/agent/cmd/agent/agent /bin/agent
 COPY cmd/agent/agent-local-config.yaml /etc/agent/agent.yaml
 

--- a/cmd/agent/Dockerfile
+++ b/cmd/agent/Dockerfile
@@ -15,11 +15,7 @@ FROM debian:buster-slim
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
 RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -t buster-backports -qy libsystemd-dev && \
-  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-RUN apt-get update && \
-  apt-get install -qy \
-  tzdata ca-certificates && \
+  apt-get install -qy tzdata ca-certificates && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY --from=build /src/agent/cmd/agent/agent /bin/agent

--- a/cmd/agent/Dockerfile.buildx
+++ b/cmd/agent/Dockerfile.buildx
@@ -13,10 +13,17 @@ RUN cp /go_wrapper.sh /seego.sh
 RUN make clean && IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false bash ./tools/cross_build.bash agent
 
 FROM debian:buster-slim
+
+# Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
+RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -t buster-backports -qy libsystemd-dev && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 RUN apt-get update && \
   apt-get install -qy \
   tzdata ca-certificates libsystemd-dev && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 COPY --from=build /src/agent/cmd/agent/agent /bin/agent
 COPY cmd/agent/agent-local-config.yaml /etc/agent/agent.yaml
 

--- a/cmd/agent/Dockerfile.buildx
+++ b/cmd/agent/Dockerfile.buildx
@@ -17,11 +17,7 @@ FROM debian:buster-slim
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
 RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -t buster-backports -qy libsystemd-dev && \
-  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-RUN apt-get update && \
-  apt-get install -qy \
-  tzdata ca-certificates libsystemd-dev && \
+  apt-get install -qy tzdata ca-certificates libsystemd-dev && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY --from=build /src/agent/cmd/agent/agent /bin/agent


### PR DESCRIPTION
### PR Description 

Corresponds to grafana/loki#2957, needed for reading journals that have `+ZSTD` compression which is starting to become standard. 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
