### PR TITLE
Add depcheck workflow

### DIFF
--- a/.github/depcheck.yml
+++ b/.github/depcheck.yml
@@ -1,0 +1,16 @@
+# List of go modules to check for outdated-ness.
+go_modules:
+  - github.com/cortexproject/cortex
+  - github.com/grafana/loki
+  - github.com/oliver006/redis_exporter
+  - github.com/weaveworks/common
+  - go.opentelemetry.io/collector
+
+# List of Github repos to check for newer tags.
+github_repos:
+  - github.com/google/dnsmasq_exporter v0.2.0
+  - github.com/ncabatoff/process-exporter v0.7.2
+  - github.com/prometheus/memcached_exporter v0.7.0
+  - github.com/prometheus/mysqld_exporter v0.12.1
+  - github.com/prometheus/prometheus v2.21.0
+  - github.com/wrouesnel/postgres_exporter v0.8.0

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -11,4 +11,5 @@ jobs:
 
     - name: Invoke action
       uses: rfratto/depcheck@master
-
+      with:
+        dry_run: 'true'

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -1,0 +1,14 @@
+name: Check Dependencies
+on:
+  workflow_dispatch: {}
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Invoke action
+      uses: rfratto/depcheck@master
+


### PR DESCRIPTION
#### PR Description 

Add a `depcheck` workflow which uses [depcheck](https://github.com/rfratto/depcheck) for checking if any Go dependencies or manually listed deps are outdated. Currently set to `dry_run` which won't actually create any issues; a follow up PR will turn that off and configure running the workflow every 24 hours.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
