### PR TITLE
enable and schedule depcheck to run every day at midnight

### DIFF
--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -1,6 +1,8 @@
 name: Check Dependencies
 on:
   workflow_dispatch: {}
+  schedule:
+    - cron: '0 0 * * *'
 jobs:
   check:
     name: Check
@@ -12,5 +14,4 @@ jobs:
     - name: Invoke action
       uses: rfratto/depcheck@main
       with:
-        dry-run: 'true'
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### PR Description 

Follow up to #259 that enables depcheck to create issues and schedules it to run every 24 hours. 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

The [last dry run](https://github.com/grafana/agent/runs/1455196016?check_suite_focus=true) of the depcheck workflow was functional.

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
