### PR TITLE
Override Promtail User-Agent header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ this platform. FreeBSD builds will return in a future release.
 - [BUGFIX] Fix issue where the Tempo example manifest could not be applied
   because the port names were too long. (@rfratto)
 
+- [CHANGE] The User-Agent header sent for logs will now be
+  `GrafanaCloudAgent/<version>` (@rfratto)
+
 # v0.8.0 (2020-11-06)
 
 NOTE: FreeBSD builds will not be included for this release. There is a bug in an

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1,13 +1,6 @@
 package build
 
-import (
-	// We do an empty import of Loki's build package to force it ahead of us on
-	// the dependency graph. This makes sure that our init function runs after it
-	// and retains the build info we set at compile time.
-	_ "github.com/grafana/loki/pkg/build"
-
-	"github.com/prometheus/common/version"
-)
+import "github.com/prometheus/common/version"
 
 // Version information passed to Prometheus version package.
 // Package path as used by linker changes based on vendoring being used or not,

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/grafana/agent/pkg/build"
 	"github.com/grafana/loki/pkg/promtail"
 	"github.com/grafana/loki/pkg/promtail/client"
 	"github.com/grafana/loki/pkg/promtail/config"
@@ -15,10 +14,11 @@ import (
 	"github.com/grafana/loki/pkg/promtail/scrapeconfig"
 	"github.com/grafana/loki/pkg/promtail/server"
 	"github.com/grafana/loki/pkg/promtail/targets/file"
+	"github.com/prometheus/common/version"
 )
 
 func init() {
-	client.UserAgent = fmt.Sprintf("GrafanaCloudAgent/%s", build.Version)
+	client.UserAgent = fmt.Sprintf("GrafanaCloudAgent/%s", version.Version)
 }
 
 // Config controls the configuration of the Loki log scraper.

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -3,9 +3,11 @@ package loki
 
 import (
 	"flag"
+	"fmt"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/grafana/agent/pkg/build"
 	"github.com/grafana/loki/pkg/promtail"
 	"github.com/grafana/loki/pkg/promtail/client"
 	"github.com/grafana/loki/pkg/promtail/config"
@@ -14,6 +16,10 @@ import (
 	"github.com/grafana/loki/pkg/promtail/server"
 	"github.com/grafana/loki/pkg/promtail/targets/file"
 )
+
+func init() {
+	client.UserAgent = fmt.Sprintf("GrafanaCloudAgent/%s", build.Version)
+}
 
 // Config controls the configuration of the Loki log scraper.
 type Config struct {


### PR DESCRIPTION
Fixes #188

#### PR Description 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer
The hack that forced the Agent after Loki in the dependency graph is no longer needed; my PR to Loki (which has been vendored for a while) fixed the issue that required it.  

#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
