### PR TITLE
explicitly add command to Agent manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ this platform. FreeBSD builds will return in a future release.
 
 - [FEATURE] New integration:
   [consul_exporter](https://github.com/prometheus/consul_exporter) (@rfratto)
-  
-- [FEATURE] Add optional environment variable substitution of configuration file. (@dcseifert)  
+
+- [FEATURE] Add optional environment variable substitution of configuration
+  file. (@dcseifert)
 
 - [ENHANCEMENT] `min_wal_time` and `max_wal_time` have been added to the
   instance config settings, guaranteeing that data in the WAL will exist for at
@@ -34,6 +35,9 @@ this platform. FreeBSD builds will return in a future release.
 
 - [BUGFIX] Fix issue where the Tempo example manifest could not be applied
   because the port names were too long. (@rfratto)
+
+- [BUGFIX] Fix issue where the Agent Kubernetes manifests may not load properly
+  on AKS. (#279) (@rfratto)
 
 - [CHANGE] The User-Agent header sent for logs will now be
   `GrafanaCloudAgent/<version>` (@rfratto)

--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -56,6 +56,8 @@ spec:
       - args:
         - -config.file=/etc/agent/agent.yml
         - -prometheus.wal-directory=/tmp/agent/data
+        command:
+        - /bin/agent
         env:
         - name: HOSTNAME
           valueFrom:

--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -317,6 +317,8 @@ spec:
       containers:
       - args:
         - -config.file=/etc/agent/agent.yaml
+        command:
+        - /bin/agent
         env:
         - name: HOSTNAME
           valueFrom:

--- a/production/kubernetes/agent-tempo.yaml
+++ b/production/kubernetes/agent-tempo.yaml
@@ -158,6 +158,8 @@ spec:
       containers:
       - args:
         - -config.file=/etc/agent/agent.yaml
+        command:
+        - /bin/agent
         env:
         - name: HOSTNAME
           valueFrom:

--- a/production/kubernetes/agent.yaml
+++ b/production/kubernetes/agent.yaml
@@ -304,6 +304,8 @@ spec:
       - args:
         - -config.file=/etc/agent/agent.yml
         - -prometheus.wal-directory=/tmp/agent/data
+        command:
+        - /bin/agent
         env:
         - name: HOSTNAME
           valueFrom:
@@ -352,6 +354,8 @@ spec:
       - args:
         - -config.file=/etc/agent/agent.yml
         - -prometheus.wal-directory=/tmp/agent/data
+        command:
+        - /bin/agent
         env:
         - name: HOSTNAME
           valueFrom:

--- a/production/tanka/grafana-agent/grafana-agent.libsonnet
+++ b/production/tanka/grafana-agent/grafana-agent.libsonnet
@@ -32,6 +32,7 @@ k + config {
   agent_container::
     container.new('agent', $._images.agent) +
     container.withPorts($.core.v1.containerPort.new('http-metrics', 80)) +
+    container.withCommand('/bin/agent') +
     container.withArgsMixin($.util.mapToFlags($.agent_args)) +
     container.withEnv([
       $.core.v1.envVar.fromFieldPath('HOSTNAME', 'spec.nodeName'),

--- a/production/tanka/grafana-agent/v1/internal/agent.libsonnet
+++ b/production/tanka/grafana-agent/v1/internal/agent.libsonnet
@@ -36,6 +36,7 @@ local policyRule = k.rbac.v1.policyRule;
     container::
       container.new('agent', image) +
       container.withPorts(k.core.v1.containerPort.new('http-metrics', 8080)) +
+      container.withCommand('/bin/agent') +
       container.withArgsMixin(k.util.mapToFlags({
         'config.file': '/etc/agent/agent.yaml',
       })),


### PR DESCRIPTION
#### PR Description 
Some pod controllers on Kubernetes may require an explicit command set if args is also set. See #279 for an example of this, which seems to be Azure-based. 

#### Which issue(s) this PR fixes 
Closes #279

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
