### PR TITLE
Add jmx_exporter

### DIFF
--- a/cmd/agent/agent-integrations-config.yaml
+++ b/cmd/agent/agent-integrations-config.yaml
@@ -40,6 +40,18 @@ integrations:
     enabled: true
   consul_exporter:
     enabled: true
+  jmx_exporter:
+    enabled: true
+    jvm_options:
+      - -Dcom.sun.management.jmxremote.ssl=false
+      - -Dcom.sun.management.jmxremote.authenticate=false
+      - -Dcom.sun.management.jmxremote.port=5555
+    exporter_config:
+      hostport: localhost:5555
+      username: ''
+      password: ''
+      rules:
+      - pattern: '.*'
   prometheus_remote_write:
     - url: http://localhost:9009/api/prom/push
 

--- a/cmd/agent/agent-jmx-config.yaml
+++ b/cmd/agent/agent-jmx-config.yaml
@@ -1,0 +1,13 @@
+server:
+  log_level: info
+  http_listen_port: 12345
+
+prometheus:
+  wal_directory: /tmp/agent
+  global:
+    scrape_interval: 5s
+
+integrations:
+  prometheus_remote_write:
+    - url: http://localhost:9009/api/prom/push
+

--- a/pkg/integrations/downloader/downloader.go
+++ b/pkg/integrations/downloader/downloader.go
@@ -1,0 +1,137 @@
+// Package downloader implements a file downloader that can download files from
+// a URL and verify checksums of the file.
+package downloader
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sync"
+)
+
+// Global is a globally shared downloader.
+var Global = New(nil)
+
+type Downloader struct {
+	client *http.Client
+
+	// locks holds a lock for downloading a specific file.
+	lockMtx sync.Mutex
+	locks   map[string]*sync.Mutex
+}
+
+// New creates a new Downloader. If c is nil, http.DefaultClient will be used.
+func New(c *http.Client) *Downloader {
+	if c == nil {
+		c = http.DefaultClient
+	}
+	return &Downloader{
+		client: c,
+		locks:  make(map[string]*sync.Mutex),
+	}
+}
+
+// Download downloads a file from a given URL to a path on disk. The checksum
+// is used to validate that the file has the expected contents. If the file
+// already exists on disk and has the expected checksum, the existing file will
+// be kept and the download will be skipped.
+//
+// Download is safe to call concurrently with the same target file path.
+func (d *Downloader) Download(ctx context.Context, url, file, checksum string) error {
+	d.lock(file)
+	defer d.unlock(file)
+
+	if exist, err := d.exists(ctx, file, checksum); exist {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(file, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0664)
+	if err != nil {
+		return fmt.Errorf("failed to open file for writing: %w", err)
+	}
+	defer f.Close()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("could not form HTTP request: %w", err)
+	}
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to HTTP GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected response status code from %s: %s", url, resp.Status)
+	}
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return fmt.Errorf("failed to download file: %w", err)
+	}
+
+	// Seek back to beginning for checksum validation.
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("failed to seek to start of downloaded file %s: %w", file, err)
+	}
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("failed to validate checksum: %w", err)
+	}
+	if downloadedHash := hex.EncodeToString(h.Sum(nil)); downloadedHash != checksum {
+		return fmt.Errorf("checksums do not match: expected %s, got %s", checksum, downloadedHash)
+	}
+
+	return nil
+}
+
+// Exists returns true if the target file exists and has the expected checksum.
+func (d *Downloader) Exists(ctx context.Context, file, checksum string) (bool, error) {
+	d.lock(file)
+	defer d.unlock(file)
+
+	return d.exists(ctx, file, checksum)
+}
+
+// exists is Exists but doesn't grab a lock on the file.
+func (d *Downloader) exists(ctx context.Context, file, checksum string) (bool, error) {
+	f, err := os.Open(file)
+	if os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return false, err
+	}
+	return hex.EncodeToString(h.Sum(nil)) == checksum, nil
+}
+
+func (d *Downloader) lock(file string) {
+	d.lockMtx.Lock()
+	defer d.lockMtx.Unlock()
+
+	mtx := d.locks[file]
+	if mtx == nil {
+		mtx = &sync.Mutex{}
+		d.locks[file] = mtx
+	}
+	mtx.Lock()
+}
+
+func (d *Downloader) unlock(file string) {
+	d.lockMtx.Lock()
+	defer d.lockMtx.Unlock()
+
+	mtx := d.locks[file]
+	if mtx == nil {
+		panic(file + " not locked")
+	}
+	mtx.Unlock()
+}

--- a/pkg/integrations/jmx_exporter/jmx_exporter.go
+++ b/pkg/integrations/jmx_exporter/jmx_exporter.go
@@ -1,0 +1,180 @@
+// Package jmx_exporter runs https://github.com/prometheus/jmx_exporter as a child process.
+package jmx_exporter //nolint:golint
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/gorilla/mux"
+	"github.com/grafana/agent/pkg/integrations/config"
+	"github.com/grafana/agent/pkg/integrations/downloader"
+	"github.com/grafana/agent/pkg/util"
+	"gopkg.in/yaml.v2"
+)
+
+// URL and SHA256 sum of the JMX exporter JAR.
+var (
+	JMXExporterVersion  = "0.14.0"
+	JMXExporterURL      = fmt.Sprintf("https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_httpserver/%[1]s/jmx_prometheus_httpserver-%[1]s-jar-with-dependencies.jar", JMXExporterVersion)
+	JMXExporterFilename = fmt.Sprintf("jmx_prometheus_httpserver-%s-jar-with-dependencies.jar", JMXExporterVersion)
+	JMXExporterSHA256   = "c52a8f0556aa5d6a2a2180f3766abb45b7d09fff5f2ad01f8b7dba67e4ce8291"
+
+	// JMXCacheSubpath is the subpath within the configured CacheDirectory to store the downloaded JAR.
+	JMXCacheSubpath = "grafana-agent/jmx_exporter"
+)
+
+// DefaultConfig holds default values for the config.
+var DefaultConfig = Config{
+	ListenAddress:  "localhost:5556",
+	ExporterConfig: yaml.MapSlice{},
+}
+
+type Config struct {
+	CommonConfig config.Common `yaml:",inline"`
+
+	// Enabled enables the jmx_exporter integration.
+	Enabled bool `yaml:"enabled"`
+
+	// CacheDirectory holds the directory to hold the downloaded JAR.
+	// If empty, defaults to one of the following based on host OS:
+	//
+	// - Linux: $XDG_CACHE_HOME or $HOME/.cache
+	// - macOS: $HOME/Library/Caches
+	// - Windows: %LocalAppData%
+	//
+	// The JAR will be stored inside the subpath grafana-agent/jmx_exporter/jmx_prometheus_javaagent-<version>.jar.
+	CacheDirectory string `yaml:"jar_cache_directory"`
+
+	// Path to the Java binary. If empty, looks in the PATH environment variable
+	// for Java. Java must be installed for the integration to be used.
+	JavaPath string `yaml:"java_path"`
+
+	// JVMOptions like "-Dcom.sun.management.jmxremote.ssl=false"
+	JVMOptions []string `yaml:"jvm_options"`
+
+	// ListenAddress is the address to listen for http traffic on for exposing
+	// metrics. Should be in host:port form.
+	ListenAddress string `yaml:"listen_address"`
+
+	// Config of the exporter. Passed to the JAR as the config file.
+	ExporterConfig yaml.MapSlice `yaml:"exporter_config"`
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler for Config.
+func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultConfig
+
+	type plain Config
+	return unmarshal((*plain)(c))
+}
+
+// Integration is the jmx_exporter integration.
+type Integration struct {
+	c Config
+	l log.Logger
+}
+
+func New(log log.Logger, c Config) (*Integration, error) {
+	if c.CacheDirectory == "" {
+		var err error
+		c.CacheDirectory, err = os.UserCacheDir()
+		if err != nil {
+			return nil, fmt.Errorf("failed to determine cache directory: %w", err)
+		}
+	}
+	// Try to create the final cache directory to bail early if something is wrong.
+	if err := os.MkdirAll(filepath.Join(c.CacheDirectory, JMXCacheSubpath), 0775); err != nil {
+		return nil, fmt.Errorf("failed to create cache directory: %w", err)
+	}
+
+	if c.JavaPath == "" {
+		c.JavaPath = "java"
+	}
+	if _, err := exec.LookPath(c.JavaPath); err != nil {
+		return nil, fmt.Errorf("could not validate Java is installed: %w", err)
+	}
+
+	return &Integration{l: log, c: c}, nil
+}
+
+// CommonConfig satisfies Integration.CommonConfig.
+func (i *Integration) CommonConfig() config.Common { return i.c.CommonConfig }
+
+// Name satisfies Integration.Name.
+func (i *Integration) Name() string { return "jmx_exporter" }
+
+// RegisterRoutes satisfies Integration.RegisterRoutes.
+func (i *Integration) RegisterRoutes(r *mux.Router) error {
+	proxyURL, err := url.Parse(fmt.Sprintf("http://%s/metrics", i.c.ListenAddress))
+	if err != nil {
+		return err
+	}
+
+	var reverseProxy httputil.ReverseProxy
+	reverseProxy.Director = func(r *http.Request) {
+		r.URL = proxyURL
+	}
+	r.Handle("/metrics", &reverseProxy)
+
+	return nil
+}
+
+// ScrapeConfigs satisfies Integration.ScrapeConfigs.
+func (i *Integration) ScrapeConfigs() []config.ScrapeConfig {
+	return []config.ScrapeConfig{{
+		JobName:     i.Name(),
+		MetricsPath: "/metrics",
+	}}
+}
+
+// Run satisfies Integration.Run.
+func (i *Integration) Run(ctx context.Context) error {
+	// Download the JAR for running.
+	jarPath := filepath.Join(i.c.CacheDirectory, JMXCacheSubpath, JMXExporterFilename)
+	err := downloader.Global.Download(ctx, JMXExporterURL, jarPath, JMXExporterSHA256)
+	if err != nil {
+		return fmt.Errorf("failed to download jmx_exporter jar: %w", err)
+	}
+
+	// Create config file on disk so the JAR can read it.
+	configFile, err := ioutil.TempFile(os.TempDir(), "*-jmx_exporter-config.yml")
+	if err != nil {
+		return fmt.Errorf("couldn't create config file for jmx_exporter: %w", err)
+	}
+	defer func() {
+		os.Remove(configFile.Name())
+	}()
+
+	err = yaml.NewEncoder(configFile).Encode(i.c.ExporterConfig)
+	configFile.Close()
+	if err != nil {
+		return fmt.Errorf("failed to write config file for jmx_exporter: %w", err)
+	}
+
+	// Run the JAR.
+	args := append(
+		i.c.JVMOptions,
+		"-jar", jarPath,
+		i.c.ListenAddress,
+		configFile.Name(),
+	)
+
+	cmd := exec.CommandContext(ctx, i.c.JavaPath, args...)
+	cmd.Stdout = &util.LogWriter{Log: level.Debug(i.l)}
+	cmd.Stderr = &util.LogWriter{Log: level.Warn(i.l)}
+
+	err = cmd.Run()
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return err
+}

--- a/pkg/integrations/manager.go
+++ b/pkg/integrations/manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/agent/pkg/integrations/common"
 	"github.com/grafana/agent/pkg/integrations/consul_exporter"
 	"github.com/grafana/agent/pkg/integrations/dnsmasq_exporter"
+	"github.com/grafana/agent/pkg/integrations/jmx_exporter"
 	"github.com/grafana/agent/pkg/integrations/memcached_exporter"
 	"github.com/grafana/agent/pkg/integrations/mysqld_exporter"
 	"github.com/grafana/agent/pkg/integrations/node_exporter"
@@ -70,6 +71,7 @@ type Config struct {
 	PostgresExporter  postgres_exporter.Config  `yaml:"postgres_exporter"`
 	StatsdExporter    statsd_exporter.Config    `yaml:"statsd_exporter"`
 	ConsulExporter    consul_exporter.Config    `yaml:"consul_exporter"`
+	JMXExporter       jmx_exporter.Config       `yaml:"jmx_exporter"`
 
 	// Extra labels to add for all integration samples
 	Labels model.LabelSet `yaml:"labels"`
@@ -211,6 +213,14 @@ func NewManager(c Config, logger log.Logger, im instance.Manager) (*Manager, err
 	if c.ConsulExporter.Enabled {
 		l := log.With(logger, "integration", "consul_exporter")
 		i, err := consul_exporter.New(l, c.ConsulExporter)
+		if err != nil {
+			return nil, err
+		}
+		integrations = append(integrations, i)
+	}
+	if c.JMXExporter.Enabled {
+		l := log.With(logger, "integration", "jmx_exporter")
+		i, err := jmx_exporter.New(l, c.JMXExporter)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/util/logwriter.go
+++ b/pkg/util/logwriter.go
@@ -1,0 +1,15 @@
+package util
+
+import "github.com/go-kit/kit/log"
+
+// LogWriter implements io.Writer and forwards messages to an underlying
+// log.Logger.
+type LogWriter struct {
+	Log log.Logger
+}
+
+// Write writes p as a string to the underlying logger.
+func (w *LogWriter) Write(p []byte) (n int, err error) {
+	err = w.Log.Log("msg", string(p))
+	return len(p), err
+}


### PR DESCRIPTION
#### PR Description 
Adds `jmx_exporter` as a new integration. It works by doing the following:

1. Downloads the JMX exporter JAR to the user's cache directory. The checksum will be validated to ensure the file has not been tempered. If the file already exists on disk with the expected checksum, it will not be redownloaded.
2. Creates the YAML config file the jmx_exporter requires to run based on the config given to the Agent. 
3. Runs `java` (which must be installed) with the JVM options provided and the JAR. 
4. Requests to `/integrations/jmx_exporter/metrics` will be proxied to the HTTP server of the JAR. 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer
Just a prototype for now using the first approach (download JAR to directory, validate checksum after download).

Note that this has the same restriction as jmx_exporter normally does: only one JVM process can be monitored. A follow-up PR to allow multiple instances of integrations is out of scope of this PR, but should be done (and depends on #140 to be merged). 

Note that this is the first child process exporter, and there may be room for major refactoring and cleanup as we do more of these. The immediate limitation that stood out: each child process needs its own HTTP server for being scraped. Users will need to assign their own unique port numbers to guarantee that these child process integrations are able to run as expected.

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated

Aside from unit tests, we need to be careful about the following:

- [ ] What happens if an invalid config is given to JMX exporter? The integration should restart.
- [ ] What happens if we give an in-use port to JMX exporter. The error should be logged and the integration should restart. 