### PR TITLE
Getting started guide: correct the config file path

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -268,7 +268,7 @@ path of your Agent's YAML configuration file.
 ```
 docker run \
   -v /tmp/agent:/etc/agent \
-  -v /path/to/config.yaml:/etc/agent-config/agent.yaml \
+  -v /path/to/config.yaml:/etc/agent/agent.yaml \
   grafana/agent:v0.9.0
 ```
 


### PR DESCRIPTION
#### PR Description 

The Dockerfile's CMD statement clearly expects the config file to be present at `/etc/agent/agent.yaml` location but following instructions in Getting Started guide gets potential user nowhere with error `error loading config file /etc/agent/agent.yaml: error reading config file: open /etc/agent/agent.yaml: no such file or directory`.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [x] Documentation added
- [ ] Tests updated
