### PR TITLE
Clean up abandoned WAL directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ this platform. FreeBSD builds will return in a future release.
   top-level Prometheus configuration section. These settings control how Write Ahead
   Logs (WALs) that are not associated with any instances are cleaned up. By default,
   WALs not associated with an instance that have not been written in the last 12 hours
-  are eligible to be cleaned up. (#304) (@56quarters)
+  are eligible to be cleaned up. This cleanup can be disabled by setting `wal_cleanup_period`
+  to `0`. (#304) (@56quarters)
 
 # v0.9.1 (2021-01-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ this platform. FreeBSD builds will return in a future release.
   file. This was prevented by accidentally writing to a readonly volume mount.
   (@rfratto)
 
+- [ENHANCEMENT] `wal_cleanup_age` and `wal_cleanup_period` have been added to the
+  top-level Prometheus configuration section. These settings control how Write Ahead
+  Logs (WALs) that are not associated with any instances are cleaned up. By default,
+  WALs not associated with an instance that have not been written in the last 12 hours
+  are eligible to be cleaned up. (#304) (@56quarters)
+
 # v0.9.1 (2021-01-04)
 
 NOTE: FreeBSD builds will not be included for this release. There is a bug in an

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -157,7 +157,8 @@ define one instance.
 # may be written to before being eligible to be deleted
 [wal_cleanup_age: <duration> | default = "12h"]
 
-# Configures how often checks for abandoned WALs to be delete are performed
+# Configures how often checks for abandoned WALs to be deleted are performed.
+# A value of 0 disables periodic cleanup of abandoned WALs
 [wal_cleanup_period: <duration> | default = "30m"]
 
 # The list of Prometheus instances to launch with the agent.

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -153,6 +153,13 @@ define one instance.
 # Configure the directory used by instances to store their WAL.
 [wal_directory: <string> | default = ""]
 
+# Configures how long ago an abandoned (not associated with an instance) WAL
+# may be written to before being eligible to be deleted
+[wal_cleanup_age: <duration> | default = "12h"]
+
+# Configures how often checks for abandoned WALs to be delete are performed
+[wal_cleanup_period: <duration> | default = "30m"]
+
 # The list of Prometheus instances to launch with the agent.
 configs:
   [- <prometheus_instance_config>]

--- a/pkg/prom/agent.go
+++ b/pkg/prom/agent.go
@@ -186,8 +186,8 @@ func newAgent(reg prometheus.Registerer, cfg Config, logger log.Logger, fact ins
 		a.logger,
 		a.cm,
 		cfg.WALDir,
-		WithCleanerMinAge(cfg.WALCleanupAge),
-		WithCleanerPeriod(cfg.WALCleanupPeriod),
+		cfg.WALCleanupAge,
+		cfg.WALCleanupPeriod,
 	)
 
 	allConfigsValid := true

--- a/pkg/prom/agent.go
+++ b/pkg/prom/agent.go
@@ -23,6 +23,8 @@ var (
 	DefaultConfig = Config{
 		Global:                 config.DefaultGlobalConfig,
 		InstanceRestartBackoff: instance.DefaultBasicManagerConfig.InstanceRestartBackoff,
+		WALCleanupAge:          DefaultCleanupAge,
+		WALCleanupPeriod:       DefaultCleanupPeriod,
 		ServiceConfig:          ha.DefaultConfig,
 		ServiceClientConfig:    client.DefaultConfig,
 		InstanceMode:           DefaultInstanceMode,
@@ -70,6 +72,8 @@ type Config struct {
 
 	Global                 config.GlobalConfig `yaml:"global"`
 	WALDir                 string              `yaml:"wal_directory"`
+	WALCleanupAge          time.Duration       `yaml:"wal_cleanup_age"`
+	WALCleanupPeriod       time.Duration       `yaml:"wal_cleanup_period"`
 	ServiceConfig          ha.Config           `yaml:"scraping_service"`
 	ServiceClientConfig    client.Config       `yaml:"scraping_service_client"`
 	Configs                []instance.Config   `yaml:"configs,omitempty"`
@@ -126,6 +130,8 @@ func (c *Config) ApplyDefaults() error {
 // RegisterFlags defines flags corresponding to the Config.
 func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&c.WALDir, "prometheus.wal-directory", "", "base directory to store the WAL in")
+	f.DurationVar(&c.WALCleanupAge, "prometheus.wal-cleanup-age", DefaultConfig.WALCleanupAge, "remove abandoned (unused) WALs older than this")
+	f.DurationVar(&c.WALCleanupPeriod, "prometheus.wal-cleanup-period", DefaultConfig.WALCleanupPeriod, "how often to check for abandoned WALs")
 	f.DurationVar(&c.InstanceRestartBackoff, "prometheus.instance-restart-backoff", DefaultConfig.InstanceRestartBackoff, "how long to wait before restarting a failed Prometheus instance")
 
 	c.ServiceConfig.RegisterFlagsWithPrefix("prometheus.service.", f)
@@ -141,7 +147,8 @@ type Agent struct {
 	logger log.Logger
 	reg    prometheus.Registerer
 
-	cm instance.Manager
+	cm      instance.Manager
+	cleaner *WALCleaner
 
 	instanceFactory instanceFactory
 
@@ -172,6 +179,16 @@ func newAgent(reg prometheus.Registerer, cfg Config, logger log.Logger, fact ins
 	// Regardless of the instance mode, wrap the manager in a CountingManager so we can
 	// collect metrics on the number of active configs.
 	a.cm = instance.NewCountingManager(reg, a.cm)
+
+	// Periodically attempt to clean up WALs from instances that aren't being run by
+	// this agent anymore.
+	a.cleaner = NewWALCleaner(
+		a.logger,
+		a.cm,
+		cfg.WALDir,
+		WithCleanerMinAge(cfg.WALCleanupAge),
+		WithCleanerPeriod(cfg.WALCleanupPeriod),
+	)
 
 	allConfigsValid := true
 	for _, c := range cfg.Configs {
@@ -230,6 +247,7 @@ func (a *Agent) Stop() {
 			level.Error(a.logger).Log("msg", "failed to stop scraping service server", "err", err)
 		}
 	}
+	a.cleaner.Stop()
 	a.cm.Stop()
 }
 

--- a/pkg/prom/agent_test.go
+++ b/pkg/prom/agent_test.go
@@ -278,6 +278,10 @@ func (i *fakeInstance) TargetsActive() map[string][]*scrape.Target {
 	return nil
 }
 
+func (i *fakeInstance) StorageDirectory() string {
+	return ""
+}
+
 type fakeInstanceFactory struct {
 	mut   sync.Mutex
 	mocks []*fakeInstance

--- a/pkg/prom/cleaner.go
+++ b/pkg/prom/cleaner.go
@@ -165,7 +165,7 @@ func (c *WALCleaner) getAllStorage() []string {
 			// The root WAL directory doesn't exist. Maybe this Agent isn't responsible for any
 			// instances yet. Log at debug since this isn't a big deal. We'll just try to crawl
 			// the direction again on the next periodic run.
-			level.Debug(c.logger).Log("msg", "WAL storage path does not exist", "path", p, err)
+			level.Debug(c.logger).Log("msg", "WAL storage path does not exist", "path", p, "err", err)
 		} else if err != nil {
 			// Just log any errors traversing the WAL directory. This will potentially result
 			// in a WAL (that has incorrect permissions or some similar problem) not being cleaned

--- a/pkg/prom/cleaner.go
+++ b/pkg/prom/cleaner.go
@@ -23,7 +23,7 @@ const (
 var (
 	discoveryError = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "agent_prometheus_cleaner_storage_discovery_error",
+			Name: "agent_prometheus_cleaner_storage_error_total",
 			Help: "Errors encountered discovering local storage paths",
 		},
 		[]string{"storage"},
@@ -31,7 +31,7 @@ var (
 
 	segmentError = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "agent_prometheus_cleaner_segment_error",
+			Name: "agent_prometheus_cleaner_segment_error_total",
 			Help: "Errors encountered finding most recent WAL segments",
 		},
 		[]string{"storage"},
@@ -50,23 +50,36 @@ var (
 			Help: "Number of storage directories not associated with any managed instance",
 		},
 	)
+
+	cleanupRunsSuccess = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "agent_prometheus_cleaner_success_total",
+			Help: "Number of successfully removed abandoned WALs",
+		},
+	)
+
+	cleanupRunsErrors = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "agent_prometheus_cleaner_errors_total",
+			Help: "Number of errors removing abandoned WALs",
+		},
+	)
+
+	cleanupTimes = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name: "agent_prometheus_cleaner_cleanup_seconds",
+			Help: "Time spent performing each periodic WAL cleanup",
+		},
+	)
 )
 
-// Operations that require interacting with the Prometheus Write Ahead Log (WAL)
-// file format. This interface exists to allow easier testing of the cleaner.
-type walOperations interface {
-	// Get the last modified time of the last segment in a WAL
-	lastModified(path string) (time.Time, error)
-}
+// lastModifiedFunc gets the last modified time of the most recent segment of a WAL
+type lastModifiedFunc func(path string) (time.Time, error)
 
-type walOperationsDefault struct{}
-
-func (w *walOperationsDefault) lastModified(path string) (time.Time, error) {
-	empty := time.Time{}
-
+func lastModified(path string) (time.Time, error) {
 	existing, err := promwal.Open(nil, path)
 	if err != nil {
-		return empty, err
+		return time.Time{}, err
 	}
 
 	// We don't care if there are errors closing the abandoned WAL
@@ -74,81 +87,65 @@ func (w *walOperationsDefault) lastModified(path string) (time.Time, error) {
 
 	_, last, err := existing.Segments()
 	if err != nil {
-		return empty, err
+		return time.Time{}, fmt.Errorf("unable to open WAL: %w", err)
 	}
 
 	if last == -1 {
-		return empty, fmt.Errorf("unable to determine most recent segment for %s", path)
+		return time.Time{}, fmt.Errorf("unable to determine most recent segment for %s", path)
 	}
 
 	// full path to the most recent segment in this WAL
 	lastSegment := promwal.SegmentName(path, last)
 	segmentFile, err := os.Stat(lastSegment)
 	if err != nil {
-		return empty, err
+		return time.Time{}, fmt.Errorf("unable to determine mtime for %s segment: %w", lastSegment, err)
 	}
 
 	return segmentFile.ModTime(), nil
 }
 
-type WALCleanerOpts func(c *WALCleaner)
-
-// Override default age after which abandoned WALs can be removed
-func WithCleanerMinAge(d time.Duration) WALCleanerOpts {
-	return func(c *WALCleaner) {
-		if d > 0 {
-			c.minAge = d
-		}
-	}
-}
-
-// Override default period for checking for abandoned WALs
-func WithCleanerPeriod(d time.Duration) WALCleanerOpts {
-	return func(c *WALCleaner) {
-		if d > 0 {
-			c.ticker = time.NewTicker(d)
-		}
-	}
-}
-
-//
+// WALCleaner periodically checks for Write Ahead Logs (WALs) that are not associated
+// with any active instance.ManagedInstance and have not been written to in some configured
+// amount of time and deletes them.
 type WALCleaner struct {
 	logger          log.Logger
 	instanceManager instance.Manager
 	walDirectory    string
-	walOperations   walOperations
+	walLastModified lastModifiedFunc
 	minAge          time.Duration
-	ticker          *time.Ticker
+	period          time.Duration
 	done            chan bool
 }
 
-// Create a new cleaner that looks for abandoned WALs in the given directory and
-// removes them if they haven't been modified in over minAge. Starts a goroutine
-// to periodically run WALCleaner.CleanupStorage in a loop
-func NewWALCleaner(logger log.Logger, manager instance.Manager, walDirectory string, opts ...WALCleanerOpts) *WALCleaner {
+// NewWALCleaner creates a new cleaner that looks for abandoned WALs in the given
+// directory and removes them if they haven't been modified in over minAge. Starts
+// a goroutine to periodically run the cleanup method in a loop
+func NewWALCleaner(logger log.Logger, manager instance.Manager, walDirectory string, minAge time.Duration, period time.Duration) *WALCleaner {
 	c := &WALCleaner{
 		logger:          log.With(logger, "component", "cleaner"),
 		instanceManager: manager,
 		walDirectory:    filepath.Clean(walDirectory),
-		walOperations:   &walOperationsDefault{},
+		walLastModified: lastModified,
 		minAge:          DefaultCleanupAge,
+		period:          DefaultCleanupPeriod,
 		done:            make(chan bool),
 	}
 
-	for _, opt := range opts {
-		opt(c)
+	if minAge > 0 {
+		c.minAge = minAge
 	}
 
-	// If the caller hasn't set a ticker, create one with the default period
-	if c.ticker == nil {
-		c.ticker = time.NewTicker(DefaultCleanupPeriod)
+	// We allow a period of 0 here because '0' means "don't run the task". This
+	// is handled by not running a ticker at all in the run method.
+	if period >= 0 {
+		c.period = period
 	}
 
 	go c.run()
 	return c
 }
 
-// Get storage directories used for each ManagedInstance
+// getManagedStorage gets storage directories used for each ManagedInstance
 func (c *WALCleaner) getManagedStorage(instances map[string]instance.ManagedInstance) map[string]bool {
 	out := make(map[string]bool)
 
@@ -159,81 +156,92 @@ func (c *WALCleaner) getManagedStorage(instances map[string]instance.ManagedInst
 	return out
 }
 
-// Get all Storage directories under walDirectory
+// getAllStorage gets all storage directories under walDirectory
 func (c *WALCleaner) getAllStorage() []string {
 	var out []string
 
 	_ = filepath.Walk(c.walDirectory, func(p string, info os.FileInfo, err error) error {
-		if err != nil {
-			if os.IsNotExist(err) {
-				// The root WAL directory doesn't exist. Maybe this Agent isn't responsible for any
-				// instances yet. Log at debug since this isn't a big deal. We'll just try to crawl
-				// the direction again on the next periodic run.
-				level.Debug(c.logger).Log("msg", "WAL storage path does not exist", "path", p, err)
-			} else {
-				// Just log any errors traversing the WAL directory. This will potentially result
-				// in a WAL (that has incorrect permissions or some similar problem) not being cleaned
-				// up. This is  better than preventing *all* other WALs from being cleaned up.
-				discoveryError.WithLabelValues(p).Inc()
-				level.Warn(c.logger).Log("msg", "unable to traverse WAL storage path", "path", p, "err", err)
-			}
+		if os.IsNotExist(err) {
+			// The root WAL directory doesn't exist. Maybe this Agent isn't responsible for any
+			// instances yet. Log at debug since this isn't a big deal. We'll just try to crawl
+			// the direction again on the next periodic run.
+			level.Debug(c.logger).Log("msg", "WAL storage path does not exist", "path", p, err)
+		} else if err != nil {
+			// Just log any errors traversing the WAL directory. This will potentially result
+			// in a WAL (that has incorrect permissions or some similar problem) not being cleaned
+			// up. This is  better than preventing *all* other WALs from being cleaned up.
+			discoveryError.WithLabelValues(p).Inc()
+			level.Warn(c.logger).Log("msg", "unable to traverse WAL storage path", "path", p, "err", err)
 		} else if info.IsDir() && filepath.Dir(p) == c.walDirectory {
 			// Single level below the root are instance storage directories (including WALs)
 			out = append(out, p)
 		}
+
 		return nil
 	})
 
 	return out
 }
 
-// Get the full path of storage directories that aren't associated with an active instance
-// and haven't been written to within a configured duration (usually several hours or more).
+// getAbandonedStorage gets the full path of storage directories that aren't associated with
+// an active instance  and haven't been written to within a configured duration (usually several
+// hours or more).
 func (c *WALCleaner) getAbandonedStorage(all []string, managed map[string]bool, now time.Time) []string {
 	var out []string
 
 	for _, dir := range all {
-		if !managed[dir] {
-			walDir := wal.SubDirectory(dir)
-			mtime, err := c.walOperations.lastModified(walDir)
-			if err != nil {
-				segmentError.WithLabelValues(dir).Inc()
-				level.Warn(c.logger).Log("msg", "unable to find segment mtime of WAL", "name", dir, "err", err)
-				continue
-			}
-
-			diff := now.Sub(mtime)
-			if diff > c.minAge {
-				// The last segment for this WAL was modified more then $minAge (positive number of hours)
-				// in the past. This makes it a candidate for deletion since it's also not associated with
-				// any Instances this agent knows about.
-				out = append(out, dir)
-			}
-
-			level.Debug(c.logger).Log("msg", "abandoned WAL", "name", dir, "mtime", mtime, "diff", diff)
-		} else {
+		if managed[dir] {
 			level.Debug(c.logger).Log("msg", "active WAL", "name", dir)
+			continue
 		}
+
+		walDir := wal.SubDirectory(dir)
+		mtime, err := c.walLastModified(walDir)
+		if err != nil {
+			segmentError.WithLabelValues(dir).Inc()
+			level.Warn(c.logger).Log("msg", "unable to find segment mtime of WAL", "name", dir, "err", err)
+			continue
+		}
+
+		diff := now.Sub(mtime)
+		if diff > c.minAge {
+			// The last segment for this WAL was modified more then $minAge (positive number of hours)
+			// in the past. This makes it a candidate for deletion since it's also not associated with
+			// any Instances this agent knows about.
+			out = append(out, dir)
+		}
+
+		level.Debug(c.logger).Log("msg", "abandoned WAL", "name", dir, "mtime", mtime, "diff", diff)
 	}
 
 	return out
 }
 
+// run cleans up abandoned WALs (if period != 0) in a loop periodically until stopped
 func (c *WALCleaner) run() {
+	// A period of 0 means don't run a cleanup task
+	if c.period == 0 {
+		return
+	}
+
+	ticker := time.NewTicker(c.period)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-c.done:
 			return
-		case <-c.ticker.C:
-			c.CleanupStorage()
+		case <-ticker.C:
+			c.cleanup()
 		}
 	}
 }
 
-// Remove any abandoned and unused WAL directories. Note that it shouldn't be
-// necessary to call this method explicitly in most cases since it will be run
-// periodically in a goroutine (started when WALCleaner is created).
-func (c *WALCleaner) CleanupStorage() {
+// cleanup removes any abandoned and unused WAL directories. Note that it shouldn't be
+// necessary to call this method explicitly in most cases since it will be run periodically
+// in a goroutine (started when WALCleaner is created).
+func (c *WALCleaner) cleanup() {
+	start := time.Now()
 	all := c.getAllStorage()
 	managed := c.getManagedStorage(c.instanceManager.ListInstances())
 	abandoned := c.getAbandonedStorage(all, managed, time.Now())
@@ -246,13 +254,17 @@ func (c *WALCleaner) CleanupStorage() {
 		err := os.RemoveAll(a)
 		if err != nil {
 			level.Error(c.logger).Log("msg", "failed to delete abandoned WAL", "name", a, "err", err)
+			cleanupRunsErrors.Inc()
+		} else {
+			cleanupRunsSuccess.Inc()
 		}
 	}
+
+	cleanupTimes.Observe(time.Since(start).Seconds())
 }
 
 // Stop the cleaner and any background tasks running
 func (c *WALCleaner) Stop() {
 	level.Debug(c.logger).Log("msg", "stopping cleaner...")
-	c.ticker.Stop()
 	close(c.done)
 }

--- a/pkg/prom/cleaner.go
+++ b/pkg/prom/cleaner.go
@@ -230,6 +230,7 @@ func (c *WALCleaner) run() {
 	for {
 		select {
 		case <-c.done:
+			level.Debug(c.logger).Log("msg", "stopping cleaner...")
 			return
 		case <-ticker.C:
 			c.cleanup()
@@ -265,6 +266,5 @@ func (c *WALCleaner) cleanup() {
 
 // Stop the cleaner and any background tasks running
 func (c *WALCleaner) Stop() {
-	level.Debug(c.logger).Log("msg", "stopping cleaner...")
 	close(c.done)
 }

--- a/pkg/prom/cleaner.go
+++ b/pkg/prom/cleaner.go
@@ -1,0 +1,258 @@
+package prom
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/grafana/agent/pkg/prom/instance"
+	"github.com/grafana/agent/pkg/prom/wal"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	promwal "github.com/prometheus/prometheus/tsdb/wal"
+)
+
+const (
+	DefaultCleanupAge    = 12 * time.Hour
+	DefaultCleanupPeriod = 30 * time.Minute
+)
+
+var (
+	discoveryError = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "agent_prometheus_cleaner_storage_discovery_error",
+			Help: "Errors encountered discovering local storage paths",
+		},
+		[]string{"storage"},
+	)
+
+	segmentError = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "agent_prometheus_cleaner_segment_error",
+			Help: "Errors encountered finding most recent WAL segments",
+		},
+		[]string{"storage"},
+	)
+
+	managedStorage = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "agent_prometheus_cleaner_managed_storage",
+			Help: "Number of storage directories associated with managed instances",
+		},
+	)
+
+	abandonedStorage = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "agent_prometheus_cleaner_abandoned_storage",
+			Help: "Number of storage directories not associated with any managed instance",
+		},
+	)
+)
+
+// Operations that require interacting with the Prometheus Write Ahead Log (WAL)
+// file format. This interface exists to allow easier testing of the cleaner.
+type walOperations interface {
+	// Get the last modified time of the last segment in a WAL
+	lastModified(path string) (time.Time, error)
+}
+
+type walOperationsDefault struct{}
+
+func (w *walOperationsDefault) lastModified(path string) (time.Time, error) {
+	empty := time.Time{}
+
+	existing, err := promwal.Open(nil, path)
+	if err != nil {
+		return empty, err
+	}
+
+	// We don't care if there are errors closing the abandoned WAL
+	defer func() { _ = existing.Close() }()
+
+	_, last, err := existing.Segments()
+	if err != nil {
+		return empty, err
+	}
+
+	if last == -1 {
+		return empty, fmt.Errorf("unable to determine most recent segment for %s", path)
+	}
+
+	// full path to the most recent segment in this WAL
+	lastSegment := promwal.SegmentName(path, last)
+	segmentFile, err := os.Stat(lastSegment)
+	if err != nil {
+		return empty, err
+	}
+
+	return segmentFile.ModTime(), nil
+}
+
+type WALCleanerOpts func(c *WALCleaner)
+
+// Override default age after which abandoned WALs can be removed
+func WithCleanerMinAge(d time.Duration) WALCleanerOpts {
+	return func(c *WALCleaner) {
+		if d > 0 {
+			c.minAge = d
+		}
+	}
+}
+
+// Override default period for checking for abandoned WALs
+func WithCleanerPeriod(d time.Duration) WALCleanerOpts {
+	return func(c *WALCleaner) {
+		if d > 0 {
+			c.ticker = time.NewTicker(d)
+		}
+	}
+}
+
+//
+type WALCleaner struct {
+	logger          log.Logger
+	instanceManager instance.Manager
+	walDirectory    string
+	walOperations   walOperations
+	minAge          time.Duration
+	ticker          *time.Ticker
+	done            chan bool
+}
+
+// Create a new cleaner that looks for abandoned WALs in the given directory and
+// removes them if they haven't been modified in over minAge. Starts a goroutine
+// to periodically run WALCleaner.CleanupStorage in a loop
+func NewWALCleaner(logger log.Logger, manager instance.Manager, walDirectory string, opts ...WALCleanerOpts) *WALCleaner {
+	c := &WALCleaner{
+		logger:          log.With(logger, "component", "cleaner"),
+		instanceManager: manager,
+		walDirectory:    filepath.Clean(walDirectory),
+		walOperations:   &walOperationsDefault{},
+		minAge:          DefaultCleanupAge,
+		done:            make(chan bool),
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	// If the caller hasn't set a ticker, create one with the default period
+	if c.ticker == nil {
+		c.ticker = time.NewTicker(DefaultCleanupPeriod)
+	}
+
+	go c.run()
+	return c
+}
+
+// Get storage directories used for each ManagedInstance
+func (c *WALCleaner) getManagedStorage(instances map[string]instance.ManagedInstance) map[string]bool {
+	out := make(map[string]bool)
+
+	for _, inst := range instances {
+		out[inst.StorageDirectory()] = true
+	}
+
+	return out
+}
+
+// Get all Storage directories under walDirectory
+func (c *WALCleaner) getAllStorage() []string {
+	var out []string
+
+	_ = filepath.Walk(c.walDirectory, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				// The root WAL directory doesn't exist. Maybe this Agent isn't responsible for any
+				// instances yet. Log at debug since this isn't a big deal. We'll just try to crawl
+				// the direction again on the next periodic run.
+				level.Debug(c.logger).Log("msg", "WAL storage path does not exist", "path", p, err)
+			} else {
+				// Just log any errors traversing the WAL directory. This will potentially result
+				// in a WAL (that has incorrect permissions or some similar problem) not being cleaned
+				// up. This is  better than preventing *all* other WALs from being cleaned up.
+				discoveryError.WithLabelValues(p).Inc()
+				level.Warn(c.logger).Log("msg", "unable to traverse WAL storage path", "path", p, "err", err)
+			}
+		} else if info.IsDir() && filepath.Dir(p) == c.walDirectory {
+			// Single level below the root are instance storage directories (including WALs)
+			out = append(out, p)
+		}
+		return nil
+	})
+
+	return out
+}
+
+// Get the full path of storage directories that aren't associated with an active instance
+// and haven't been written to within a configured duration (usually several hours or more).
+func (c *WALCleaner) getAbandonedStorage(all []string, managed map[string]bool, now time.Time) []string {
+	var out []string
+
+	for _, dir := range all {
+		if !managed[dir] {
+			walDir := wal.SubDirectory(dir)
+			mtime, err := c.walOperations.lastModified(walDir)
+			if err != nil {
+				segmentError.WithLabelValues(dir).Inc()
+				level.Warn(c.logger).Log("msg", "unable to find segment mtime of WAL", "name", dir, "err", err)
+				continue
+			}
+
+			diff := now.Sub(mtime)
+			if diff > c.minAge {
+				// The last segment for this WAL was modified more then $minAge (positive number of hours)
+				// in the past. This makes it a candidate for deletion since it's also not associated with
+				// any Instances this agent knows about.
+				out = append(out, dir)
+			}
+
+			level.Debug(c.logger).Log("msg", "abandoned WAL", "name", dir, "mtime", mtime, "diff", diff)
+		} else {
+			level.Debug(c.logger).Log("msg", "active WAL", "name", dir)
+		}
+	}
+
+	return out
+}
+
+func (c *WALCleaner) run() {
+	for {
+		select {
+		case <-c.done:
+			return
+		case <-c.ticker.C:
+			c.CleanupStorage()
+		}
+	}
+}
+
+// Remove any abandoned and unused WAL directories. Note that it shouldn't be
+// necessary to call this method explicitly in most cases since it will be run
+// periodically in a goroutine (started when WALCleaner is created).
+func (c *WALCleaner) CleanupStorage() {
+	all := c.getAllStorage()
+	managed := c.getManagedStorage(c.instanceManager.ListInstances())
+	abandoned := c.getAbandonedStorage(all, managed, time.Now())
+
+	managedStorage.Set(float64(len(managed)))
+	abandonedStorage.Set(float64(len(abandoned)))
+
+	for _, a := range abandoned {
+		level.Info(c.logger).Log("msg", "deleting abandoned WAL", "name", a)
+		err := os.RemoveAll(a)
+		if err != nil {
+			level.Error(c.logger).Log("msg", "failed to delete abandoned WAL", "name", a, "err", err)
+		}
+	}
+}
+
+// Stop the cleaner and any background tasks running
+func (c *WALCleaner) Stop() {
+	level.Debug(c.logger).Log("msg", "stopping cleaner...")
+	c.ticker.Stop()
+	close(c.done)
+}

--- a/pkg/prom/cleaner_test.go
+++ b/pkg/prom/cleaner_test.go
@@ -9,23 +9,24 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/grafana/agent/pkg/prom/instance"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// Basic logger to write to stderr to help debug test failures
-func getLogger() log.Logger {
-	return log.NewLogfmtLogger(os.Stderr)
-}
-
 func TestWALCleaner_getAllStorageNoRoot(t *testing.T) {
 	walRoot := filepath.Join(os.TempDir(), "getAllStorageNoRoot")
-	cleaner := NewWALCleaner(getLogger(), &mockManager{}, walRoot)
+	logger := log.NewLogfmtLogger(os.Stderr)
+	cleaner := NewWALCleaner(
+		logger,
+		&instance.MockManager{},
+		walRoot,
+		DefaultCleanupAge,
+		DefaultCleanupPeriod,
+	)
 
 	// Bogus WAL root that doesn't exist. Method should return no results
 	wals := cleaner.getAllStorage()
 
-	assert.Empty(t, wals)
+	require.Empty(t, wals)
 }
 
 func TestWALCleaner_getAllStorageSuccess(t *testing.T) {
@@ -37,10 +38,17 @@ func TestWALCleaner_getAllStorageSuccess(t *testing.T) {
 	err = os.MkdirAll(walDir, 0755)
 	require.NoError(t, err)
 
-	cleaner := NewWALCleaner(getLogger(), &mockManager{}, walRoot)
+	logger := log.NewLogfmtLogger(os.Stderr)
+	cleaner := NewWALCleaner(
+		logger,
+		&instance.MockManager{},
+		walRoot,
+		DefaultCleanupAge,
+		DefaultCleanupPeriod,
+	)
 	wals := cleaner.getAllStorage()
 
-	assert.Equal(t, []string{walDir}, wals)
+	require.Equal(t, []string{walDir}, wals)
 }
 
 func TestWALCleaner_getAbandonedStorageBeforeCutoff(t *testing.T) {
@@ -56,23 +64,24 @@ func TestWALCleaner_getAbandonedStorageBeforeCutoff(t *testing.T) {
 	managed := make(map[string]bool)
 	now := time.Now()
 
+	logger := log.NewLogfmtLogger(os.Stderr)
 	cleaner := NewWALCleaner(
-		getLogger(),
-		&mockManager{},
+		logger,
+		&instance.MockManager{},
 		walRoot,
-		WithCleanerMinAge(5*time.Minute),
+		5*time.Minute,
+		DefaultCleanupPeriod,
 	)
 
-	cleaner.walOperations = &mockWalOperations{
-		mtime: now,
-		err:   nil,
+	cleaner.walLastModified = func(path string) (time.Time, error) {
+		return now, nil
 	}
 
 	// Last modification time on our WAL directory is the same as "now"
 	// so there shouldn't be any results even though it's not part of the
 	// set of "managed" directories.
 	abandoned := cleaner.getAbandonedStorage(all, managed, now)
-	assert.Empty(t, abandoned)
+	require.Empty(t, abandoned)
 }
 
 func TestWALCleaner_getAbandonedStorageAfterCutoff(t *testing.T) {
@@ -88,27 +97,28 @@ func TestWALCleaner_getAbandonedStorageAfterCutoff(t *testing.T) {
 	managed := make(map[string]bool)
 	now := time.Now()
 
+	logger := log.NewLogfmtLogger(os.Stderr)
 	cleaner := NewWALCleaner(
-		getLogger(),
-		&mockManager{},
+		logger,
+		&instance.MockManager{},
 		walRoot,
-		WithCleanerMinAge(5*time.Minute),
+		5*time.Minute,
+		DefaultCleanupPeriod,
 	)
 
-	cleaner.walOperations = &mockWalOperations{
-		mtime: now.Add(-30 * time.Minute),
-		err:   nil,
+	cleaner.walLastModified = func(path string) (time.Time, error) {
+		return now.Add(-30 * time.Minute), nil
 	}
 
 	// Last modification time on our WAL directory is 30 minutes in the past
 	// compared to "now" and we've set the cutoff for our cleaner to be 5
 	// minutes: our WAL directory should show up as abandoned
 	abandoned := cleaner.getAbandonedStorage(all, managed, now)
-	assert.Equal(t, []string{walDir}, abandoned)
+	require.Equal(t, []string{walDir}, abandoned)
 }
 
-func TestWALCleaner_CleanupStorage(t *testing.T) {
-	walRoot, err := ioutil.TempDir(os.TempDir(), "CleanupStorage")
+func TestWALCleaner_cleanup(t *testing.T) {
+	walRoot, err := ioutil.TempDir(os.TempDir(), "cleanup")
 	require.NoError(t, err)
 	defer os.RemoveAll(walRoot)
 
@@ -117,54 +127,29 @@ func TestWALCleaner_CleanupStorage(t *testing.T) {
 	require.NoError(t, err)
 
 	now := time.Now()
+	logger := log.NewLogfmtLogger(os.Stderr)
+	manager := &instance.MockManager{}
+	manager.ListInstancesFunc = func() map[string]instance.ManagedInstance {
+		return make(map[string]instance.ManagedInstance)
+	}
+
 	cleaner := NewWALCleaner(
-		getLogger(),
-		&mockManager{},
+		logger,
+		manager,
 		walRoot,
-		WithCleanerMinAge(5*time.Minute),
+		5*time.Minute,
+		DefaultCleanupPeriod,
 	)
 
-	cleaner.walOperations = &mockWalOperations{
-		mtime: now.Add(-30 * time.Minute),
-		err:   nil,
+	cleaner.walLastModified = func(path string) (time.Time, error) {
+		return now.Add(-30 * time.Minute), nil
 	}
 
 	// Last modification time on our WAL directory is 30 minutes in the past
 	// compared to "now" and we've set the cutoff for our cleaner to be 5
 	// minutes: our WAL directory should be removed since it's abandoned
-	cleaner.CleanupStorage()
+	cleaner.cleanup()
 	_, err = os.Stat(walDir)
-	assert.Error(t, err)
-	assert.True(t, os.IsNotExist(err))
-}
-
-type mockManager struct{}
-
-func (m *mockManager) ListInstances() map[string]instance.ManagedInstance {
-	return make(map[string]instance.ManagedInstance)
-}
-
-func (m *mockManager) ListConfigs() map[string]instance.Config {
-	return make(map[string]instance.Config)
-}
-
-func (m *mockManager) ApplyConfig(_ instance.Config) error {
-	return nil
-}
-
-func (m *mockManager) DeleteConfig(_ string) error {
-	return nil
-}
-
-func (m *mockManager) Stop() {
-	// nop
-}
-
-type mockWalOperations struct {
-	mtime time.Time
-	err   error
-}
-
-func (m *mockWalOperations) lastModified(path string) (time.Time, error) {
-	return m.mtime, m.err
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
 }

--- a/pkg/prom/cleaner_test.go
+++ b/pkg/prom/cleaner_test.go
@@ -1,0 +1,170 @@
+package prom
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/grafana/agent/pkg/prom/instance"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Basic logger to write to stderr to help debug test failures
+func getLogger() log.Logger {
+	return log.NewLogfmtLogger(os.Stderr)
+}
+
+func TestWALCleaner_getAllStorageNoRoot(t *testing.T) {
+	walRoot := filepath.Join(os.TempDir(), "getAllStorageNoRoot")
+	cleaner := NewWALCleaner(getLogger(), &mockManager{}, walRoot)
+
+	// Bogus WAL root that doesn't exist. Method should return no results
+	wals := cleaner.getAllStorage()
+
+	assert.Empty(t, wals)
+}
+
+func TestWALCleaner_getAllStorageSuccess(t *testing.T) {
+	walRoot, err := ioutil.TempDir(os.TempDir(), "getAllStorageSuccess")
+	require.NoError(t, err)
+	defer os.RemoveAll(walRoot)
+
+	walDir := filepath.Join(walRoot, "instance-1")
+	err = os.MkdirAll(walDir, 0755)
+	require.NoError(t, err)
+
+	cleaner := NewWALCleaner(getLogger(), &mockManager{}, walRoot)
+	wals := cleaner.getAllStorage()
+
+	assert.Equal(t, []string{walDir}, wals)
+}
+
+func TestWALCleaner_getAbandonedStorageBeforeCutoff(t *testing.T) {
+	walRoot, err := ioutil.TempDir(os.TempDir(), "getAbandonedStorageBeforeCutoff")
+	require.NoError(t, err)
+	defer os.RemoveAll(walRoot)
+
+	walDir := filepath.Join(walRoot, "instance-1")
+	err = os.MkdirAll(walDir, 0755)
+	require.NoError(t, err)
+
+	all := []string{walDir}
+	managed := make(map[string]bool)
+	now := time.Now()
+
+	cleaner := NewWALCleaner(
+		getLogger(),
+		&mockManager{},
+		walRoot,
+		WithCleanerMinAge(5*time.Minute),
+	)
+
+	cleaner.walOperations = &mockWalOperations{
+		mtime: now,
+		err:   nil,
+	}
+
+	// Last modification time on our WAL directory is the same as "now"
+	// so there shouldn't be any results even though it's not part of the
+	// set of "managed" directories.
+	abandoned := cleaner.getAbandonedStorage(all, managed, now)
+	assert.Empty(t, abandoned)
+}
+
+func TestWALCleaner_getAbandonedStorageAfterCutoff(t *testing.T) {
+	walRoot, err := ioutil.TempDir(os.TempDir(), "getAbandonedStorageAfterCutoff")
+	require.NoError(t, err)
+	defer os.RemoveAll(walRoot)
+
+	walDir := filepath.Join(walRoot, "instance-1")
+	err = os.MkdirAll(walDir, 0755)
+	require.NoError(t, err)
+
+	all := []string{walDir}
+	managed := make(map[string]bool)
+	now := time.Now()
+
+	cleaner := NewWALCleaner(
+		getLogger(),
+		&mockManager{},
+		walRoot,
+		WithCleanerMinAge(5*time.Minute),
+	)
+
+	cleaner.walOperations = &mockWalOperations{
+		mtime: now.Add(-30 * time.Minute),
+		err:   nil,
+	}
+
+	// Last modification time on our WAL directory is 30 minutes in the past
+	// compared to "now" and we've set the cutoff for our cleaner to be 5
+	// minutes: our WAL directory should show up as abandoned
+	abandoned := cleaner.getAbandonedStorage(all, managed, now)
+	assert.Equal(t, []string{walDir}, abandoned)
+}
+
+func TestWALCleaner_CleanupStorage(t *testing.T) {
+	walRoot, err := ioutil.TempDir(os.TempDir(), "CleanupStorage")
+	require.NoError(t, err)
+	defer os.RemoveAll(walRoot)
+
+	walDir := filepath.Join(walRoot, "instance-1")
+	err = os.MkdirAll(walDir, 0755)
+	require.NoError(t, err)
+
+	now := time.Now()
+	cleaner := NewWALCleaner(
+		getLogger(),
+		&mockManager{},
+		walRoot,
+		WithCleanerMinAge(5*time.Minute),
+	)
+
+	cleaner.walOperations = &mockWalOperations{
+		mtime: now.Add(-30 * time.Minute),
+		err:   nil,
+	}
+
+	// Last modification time on our WAL directory is 30 minutes in the past
+	// compared to "now" and we've set the cutoff for our cleaner to be 5
+	// minutes: our WAL directory should be removed since it's abandoned
+	cleaner.CleanupStorage()
+	_, err = os.Stat(walDir)
+	assert.Error(t, err)
+	assert.True(t, os.IsNotExist(err))
+}
+
+type mockManager struct{}
+
+func (m *mockManager) ListInstances() map[string]instance.ManagedInstance {
+	return make(map[string]instance.ManagedInstance)
+}
+
+func (m *mockManager) ListConfigs() map[string]instance.Config {
+	return make(map[string]instance.Config)
+}
+
+func (m *mockManager) ApplyConfig(_ instance.Config) error {
+	return nil
+}
+
+func (m *mockManager) DeleteConfig(_ string) error {
+	return nil
+}
+
+func (m *mockManager) Stop() {
+	// nop
+}
+
+type mockWalOperations struct {
+	mtime time.Time
+	err   error
+}
+
+func (m *mockWalOperations) lastModified(path string) (time.Time, error) {
+	return m.mtime, m.err
+}

--- a/pkg/prom/http_test.go
+++ b/pkg/prom/http_test.go
@@ -143,3 +143,7 @@ func (i *mockInstanceScrape) Update(_ instance.Config) error {
 func (i *mockInstanceScrape) TargetsActive() map[string][]*scrape.Target {
 	return i.tgts
 }
+
+func (i *mockInstanceScrape) StorageDirectory() string {
+	return ""
+}

--- a/pkg/prom/instance/instance.go
+++ b/pkg/prom/instance/instance.go
@@ -486,6 +486,10 @@ func (i *Instance) TargetsActive() map[string][]*scrape.Target {
 	return mgr.TargetsActive()
 }
 
+func (i *Instance) StorageDirectory() string {
+	return i.wal.Directory()
+}
+
 type discoveryService struct {
 	Manager *discovery.Manager
 

--- a/pkg/prom/instance/manager.go
+++ b/pkg/prom/instance/manager.go
@@ -59,6 +59,7 @@ type ManagedInstance interface {
 	Run(ctx context.Context) error
 	Update(c Config) error
 	TargetsActive() map[string][]*scrape.Target
+	StorageDirectory() string
 }
 
 // BasicManagerConfig controls the operations of a BasicManager.

--- a/pkg/prom/instance/manager_test.go
+++ b/pkg/prom/instance/manager_test.go
@@ -97,9 +97,10 @@ func TestBasicManager_ApplyConfig(t *testing.T) {
 }
 
 type mockInstance struct {
-	RunFunc           func(ctx context.Context) error
-	UpdateFunc        func(c Config) error
-	TargetsActiveFunc func() map[string][]*scrape.Target
+	RunFunc              func(ctx context.Context) error
+	UpdateFunc           func(c Config) error
+	TargetsActiveFunc    func() map[string][]*scrape.Target
+	StorageDirectoryFunc func() string
 }
 
 func (m mockInstance) Run(ctx context.Context) error {
@@ -121,4 +122,11 @@ func (m mockInstance) TargetsActive() map[string][]*scrape.Target {
 		return m.TargetsActiveFunc()
 	}
 	panic("TargetsActiveFunc not provided")
+}
+
+func (m mockInstance) StorageDirectory() string {
+	if m.StorageDirectoryFunc != nil {
+		return m.StorageDirectoryFunc()
+	}
+	panic("StorageDirectoryFunc not provided")
 }

--- a/pkg/prom/instance/noop.go
+++ b/pkg/prom/instance/noop.go
@@ -22,3 +22,7 @@ func (NoOpInstance) Update(_ Config) error {
 func (NoOpInstance) TargetsActive() map[string][]*scrape.Target {
 	return nil
 }
+
+func (NoOpInstance) StorageDirectory() string {
+	return ""
+}

--- a/pkg/prom/wal/util.go
+++ b/pkg/prom/wal/util.go
@@ -1,7 +1,7 @@
 package wal
 
 import (
-	"path"
+	"path/filepath"
 	"sync"
 
 	"github.com/prometheus/prometheus/tsdb/record"
@@ -113,5 +113,5 @@ func (c *walDataCollector) SeriesReset(_ int) {}
 
 // Get the subdirectory within a Storage directory used for the Prometheus WAL
 func SubDirectory(base string) string {
-	return path.Join(base, "wal")
+	return filepath.Join(base, "wal")
 }

--- a/pkg/prom/wal/util.go
+++ b/pkg/prom/wal/util.go
@@ -1,6 +1,7 @@
 package wal
 
 import (
+	"path"
 	"sync"
 
 	"github.com/prometheus/prometheus/tsdb/record"
@@ -109,3 +110,8 @@ func (c *walDataCollector) StoreSeries(series []record.RefSeries, _ int) {
 }
 
 func (c *walDataCollector) SeriesReset(_ int) {}
+
+// Get the subdirectory within a Storage directory used for the Prometheus WAL
+func SubDirectory(base string) string {
+	return path.Join(base, "wal")
+}

--- a/pkg/prom/wal/wal.go
+++ b/pkg/prom/wal/wal.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -121,7 +120,7 @@ type Storage struct {
 
 // NewStorage makes a new Storage.
 func NewStorage(logger log.Logger, registerer prometheus.Registerer, path string) (*Storage, error) {
-	w, err := wal.NewSize(logger, registerer, filepath.Join(path, "wal"), wal.DefaultSegmentSize, true)
+	w, err := wal.NewSize(logger, registerer, SubDirectory(path), wal.DefaultSegmentSize, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Remove WAL directories that are no longer associated with a `ManagedInstance`
that this agent is responsible for. The storage directories used by active
instances are compared to all subdirectories under the `wal_directory` root.
Any that are not associated with an instance and that haven't been modified
in over a configured amount of time are removed.

How often the check is run and the cutoff for how recently a WAL must have
been modified are controlled by the `wal_cleanup_period` and
`wal_cleanup_age` settings respectively, under the top-level Prometheus
configuration. When omitted, they default to a period of 30 minutes and
recently modified threshold of 12 hours.

Fixes #132

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
