### PR TITLE
don't mount /var/log as readonly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ this platform. FreeBSD builds will return in a future release.
 - [BUGFIX] Integrations will now function if the HTTP listen address was set to
   a value other than the default. ([#206](https://github.com/grafana/agent/issues/206)) (@mattdurham) 
 
-- [BUGFIX] The default Loki installation will no longer incorrectly mount
-  `/var/log` as readonly, which is used for saving the last read offset of
-  files. (@rfratto)
+- [BUGFIX] The default Loki installation will now be able to write its positions
+  file. This was prevented by accidentally writing to a readonly volume mount.
+  (@rfratto)
 
 # v0.9.1 (2021-01-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ this platform. FreeBSD builds will return in a future release.
 - [BUGFIX] Integrations will now function if the HTTP listen address was set to
   a value other than the default. ([#206](https://github.com/grafana/agent/issues/206)) (@mattdurham) 
 
+- [BUGFIX] The default Loki installation will no longer incorrectly mount
+  `/var/log` as readonly, which is used for saving the last read offset of
+  files. (@rfratto)
+
 # v0.9.1 (2021-01-04)
 
 NOTE: FreeBSD builds will not be included for this release. There is a bug in an

--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -338,7 +338,6 @@ spec:
           name: grafana-agent-logs
         - mountPath: /var/log
           name: varlog
-          readOnly: true
         - mountPath: /var/lib/docker/containers
           name: varlibdockercontainers
           readOnly: true

--- a/production/tanka/grafana-agent/v1/lib/loki.libsonnet
+++ b/production/tanka/grafana-agent/v1/lib/loki.libsonnet
@@ -67,8 +67,9 @@ local container = k.core.v1.container;
       container.mixin.securityContext.withRunAsUser(0),
 
     agent+:
-      // For reading docker containers
-      k.util.hostVolumeMount('varlog', '/var/log', '/var/log', readOnly=true) +
+      // For reading docker containers. /var/log is used for the positions file
+      // and shouldn't be set to readonly.
+      k.util.hostVolumeMount('varlog', '/var/log', '/var/log') +
       k.util.hostVolumeMount('varlibdockercontainers', '/var/lib/docker/containers', '/var/lib/docker/containers', readOnly=true) +
 
       // For reading journald


### PR DESCRIPTION
#### PR Description 
The `/var/log` folder is used by default for storing the last read file offset. We were previously mounting this path as readonly. Writing the positions.yaml to this folder helps the Agent recover from a crash and not resend logs that were already sent to Loki.

This change reflects what the official Promtail configs do.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
