### PR TITLE
Resolve K8s API server IP using DNS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ can be found at [#317](https://github.com/grafana/agent/issues/317).
 
 # Master (unreleased)
 
+- [BUGFIX] The K8s API server scrape job will use the API server Service name
+  when resolving IP addresses for Prometheus service discovery using the "Endpoints" role. (@hjet)
+
 # v0.10.0 (2021-01-13)
 
 - [FEATURE] Prometheus `remote_write` now supports SigV4 authentication using 

--- a/production/kubernetes/agent.yaml
+++ b/production/kubernetes/agent.yaml
@@ -198,6 +198,7 @@ data:
                 tls_config:
                     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
                     insecure_skip_verify: false
+                    server_name: kubernetes
         global:
             scrape_interval: 15s
         wal_directory: /var/lib/agent/data

--- a/production/kubernetes/agent.yaml
+++ b/production/kubernetes/agent.yaml
@@ -242,6 +242,7 @@ data:
                 tls_config:
                     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
                     insecure_skip_verify: false
+                    server_name: kubernetes
         global:
             scrape_interval: 15s
         wal_directory: /var/lib/agent/data

--- a/production/tanka/grafana-agent/config.libsonnet
+++ b/production/tanka/grafana-agent/config.libsonnet
@@ -112,6 +112,7 @@
         tls_config: {
           ca_file: '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
           insecure_skip_verify: $._config.prometheus_insecure_skip_verify,
+          server_name: 'kubernetes',
         },
         bearer_token_file: '/var/run/secrets/kubernetes.io/serviceaccount/token',
         relabel_configs: [{

--- a/production/tanka/grafana-agent/v1/internal/kubernetes_instance.libsonnet
+++ b/production/tanka/grafana-agent/v1/internal/kubernetes_instance.libsonnet
@@ -25,6 +25,9 @@ local k8s_tls_config(config) = {
           role: if config.scrape_api_server_endpoints then 'endpoints' else 'service',
         }],
         scheme: 'https',
+        tls_config+: {
+          server_name: 'kubernetes',
+        },
 
         relabel_configs: [{
           source_labels: ['__meta_kubernetes_service_label_component'],


### PR DESCRIPTION
#### PR Description 

Agent scrapes the K8s API server using Prometheus K8s service discovery. If using the "endpoints" role (as is currently done in the manifest), the TLS `server_name` parameter must be set to the K8s API server Service name (`kubernetes` by default), which resolves to the ClusterIP address contained in the X.509 client cert used for authentication. If omitted, Prom service discovery will use the Endpoints object IP address, which is not referenced in the cert and will cause an error. Tested on DigitalOcean Kubernetes. This may be provider-specific? To investigate on GCP, etc. 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

See Slack thread.

#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated