### PR TITLE
add sigv4 install script, fix bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,14 @@ can be found at [#317](https://github.com/grafana/agent/issues/317).
   ARMv6 docker builds are also now available.
   (@rfratto)
 
+- [ENHANCEMENT] A sigv4 install script for Prometheus has been added. (@rfratto)
+
 - [BUGFIX] The K8s API server scrape job will use the API server Service name
-  when resolving IP addresses for Prometheus service discovery using the "Endpoints" role. (@hjet)
+  when resolving IP addresses for Prometheus service discovery using the
+  "Endpoints" role. (@hjet)
+
+- [BUGFIX] The K8s manifests will no longer include the `default/kubernetes` job
+  twice in both the DaemonSet and the Deployment. (@rfratto)
 
 # v0.10.0 (2021-01-13)
 

--- a/production/kubernetes/agent-sigv4.yaml
+++ b/production/kubernetes/agent-sigv4.yaml
@@ -11,9 +11,8 @@ data:
           - host_filter: true
             name: agent
             remote_write:
-              - basic_auth:
-                    password: ${REMOTE_WRITE_PASSWORD}
-                    username: ${REMOTE_WRITE_USERNAME}
+              - sigv4:
+                    enabled: true
                 url: ${REMOTE_WRITE_URL}
             scrape_configs:
               - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -193,9 +192,8 @@ data:
           - host_filter: false
             name: agent
             remote_write:
-              - basic_auth:
-                    password: ${REMOTE_WRITE_PASSWORD}
-                    username: ${REMOTE_WRITE_USERNAME}
+              - sigv4:
+                    enabled: true
                 url: ${REMOTE_WRITE_URL}
             scrape_configs:
               - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/production/kubernetes/build/build.sh
+++ b/production/kubernetes/build/build.sh
@@ -7,6 +7,7 @@ pushd ${DIRNAME}
 # Make sure dependencies are up to date
 jb install
 tk show --dangerous-allow-redirect ./templates/base > ${PWD}/../agent.yaml
+tk show --dangerous-allow-redirect ./templates/base-sigv4 > ${PWD}/../agent-sigv4.yaml
 tk show --dangerous-allow-redirect ./templates/bare > ${PWD}/../agent-bare.yaml
 tk show --dangerous-allow-redirect ./templates/loki > ${PWD}/../agent-loki.yaml
 tk show --dangerous-allow-redirect ./templates/tempo > ${PWD}/../agent-tempo.yaml

--- a/production/kubernetes/build/templates/base-sigv4/main.jsonnet
+++ b/production/kubernetes/build/templates/base-sigv4/main.jsonnet
@@ -1,0 +1,22 @@
+local agent = import 'grafana-agent/grafana-agent.libsonnet';
+
+agent {
+  _images+:: {
+    agent: (import 'version.libsonnet'),
+  },
+
+  _config+:: {
+    namespace: 'default',
+    agent_remote_write: [{
+      url: '${REMOTE_WRITE_URL}',
+      sigv4: {
+        enabled: true,
+      },
+    }],
+
+    // Since the config map isn't managed by Tanka, we don't want to
+    // add the configmap's hash as an annotation for the Kubernetes
+    // YAML manifest.
+    agent_config_hash_annotation: false,
+  },
+}

--- a/production/kubernetes/build/templates/base-sigv4/spec.json
+++ b/production/kubernetes/build/templates/base-sigv4/spec.json
@@ -1,0 +1,11 @@
+{
+  "apiVersion": "tanka.dev/v1alpha1",
+  "kind": "Environment",
+  "metadata": {
+    "name": "template"
+  },
+  "spec": {
+    "apiServer": "",
+    "namespace": ""
+  }
+}

--- a/production/kubernetes/install-sigv4.sh
+++ b/production/kubernetes/install-sigv4.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+#
+# install.sh is a really basic installer for the agent. It uses the existing
+# Kubernetes YAML example and envsubst to fill in the details for remote write
+# URL, username, and password.
+#
+# There are three ways to provide the inputs for installation:
+#
+# 1. Environment variables (REMOTE_WRITE_URL)
+#
+# 2. Flags (-l for remote write URL)
+#
+# 3. stdin from prompts
+#
+# Flags override environment variables, and stdin is used as a fallback if a
+# value wasn't given from a flag or environment variable. An empty username
+# or password is acceptable, as it disables basic auth. However, a remote write
+# URL must always be provided.
+#
+
+check_installed() {
+  if ! type $1 >/dev/null 2>&1; then
+    echo "error: $1 not installed" >&2
+    exit 1
+  fi
+}
+
+check_installed curl
+check_installed envsubst
+
+MANIFEST_BRANCH=v0.10.0
+MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent-sigv4.yaml}
+
+while getopts "l:u:p:" opt; do
+  case "$opt" in
+    l)
+      REMOTE_WRITE_URL=$OPTARG
+      ;;
+    ?)
+      echo "usage: $(basename $0) [-l remote write url] [-u remote write username] [-p remote write password]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "${REMOTE_WRITE_URL}" ]; then
+  read -sp 'Enter your remote write URL: ' REMOTE_WRITE_URL
+  printf $'\n' >&2
+
+  # We require a remote write URL for the agent; we don't do this same check for
+  # the username and password as the remote write system may not have basic
+  # auth enabled.
+  if [ -z "${REMOTE_WRITE_URL}" ]; then
+    echo "error: REMOTE_WRITE_URL must be provided by flag, env, or stdin" >&2
+    exit 1
+  fi
+fi
+
+export REMOTE_WRITE_URL
+curl -fsSL $MANIFEST_URL | envsubst

--- a/production/tanka/grafana-agent/config.libsonnet
+++ b/production/tanka/grafana-agent/config.libsonnet
@@ -70,9 +70,9 @@
 
           scrape_configs:
             if $._config.agent_host_filter then
-              $._config.kubernetes_scrape_configs + $._config.deployment_scrape_configs
+              $._config.kubernetes_scrape_configs
             else
-              $._config.kubernetes_scrape_configs,
+              $._config.kubernetes_scrape_configs + $._config.deployment_scrape_configs,
           remote_write: $._config.agent_remote_write,
         }],
       },


### PR DESCRIPTION
#### PR Description 
Adds a sigv4-specific install script. 

Also fixes bug where the deployment scrape config was included with host filtering enabled, where the inverse should've been true. (cc @hjet, this fixes the duplicate default/kubernetes job)

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
