### PR TITLE
allow specifying installation namespace in script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 NOTE: FreeBSD builds have not been available since v0.6.0 due to a
-cross-compilation issue. The issue for tracking adding support back 
+cross-compilation issue. The issue for tracking adding support back
 can be found at [#317](https://github.com/grafana/agent/issues/317).
 
 # Master (unreleased)
@@ -11,6 +11,9 @@ can be found at [#317](https://github.com/grafana/agent/issues/317).
 
 - [ENHANCEMENT] A sigv4 install script for Prometheus has been added. (@rfratto)
 
+- [ENHANCEMENT] NAMESPACE may be passed as an environment variable to the
+  Kubernetes install scripts to specify an installation namespace. (@rfratto)
+
 - [BUGFIX] The K8s API server scrape job will use the API server Service name
   when resolving IP addresses for Prometheus service discovery using the
   "Endpoints" role. (@hjet)
@@ -20,10 +23,10 @@ can be found at [#317](https://github.com/grafana/agent/issues/317).
 
 # v0.10.0 (2021-01-13)
 
-- [FEATURE] Prometheus `remote_write` now supports SigV4 authentication using 
+- [FEATURE] Prometheus `remote_write` now supports SigV4 authentication using
   the [AWS default credentials
   chain](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html).
-  This enables the Agent to send metrics to Amazon Managed Prometheus without 
+  This enables the Agent to send metrics to Amazon Managed Prometheus without
   needing the [SigV4 Proxy](https://github.com/awslabs/aws-sigv4-proxy).
   (@rfratto)
 
@@ -44,7 +47,7 @@ can be found at [#317](https://github.com/grafana/agent/issues/317).
   work on journals that use +ZSTD compression. (@rfratto)
 
 - [BUGFIX] Integrations will now function if the HTTP listen address was set to
-  a value other than the default. ([#206](https://github.com/grafana/agent/issues/206)) (@mattdurham) 
+  a value other than the default. ([#206](https://github.com/grafana/agent/issues/206)) (@mattdurham)
 
 - [BUGFIX] The default Loki installation will now be able to write its positions
   file. This was prevented by accidentally writing to a readonly volume mount.
@@ -52,7 +55,7 @@ can be found at [#317](https://github.com/grafana/agent/issues/317).
 
 # v0.9.1 (2021-01-04)
 
-- [ENHANCEMENT] agentctl will now be installed by the rpm and deb packages as 
+- [ENHANCEMENT] agentctl will now be installed by the rpm and deb packages as
   `grafana-agentctl`. (@rfratto)
 
 # v0.9.0 (2020-12-10)

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Simply copy and paste the following lines in your terminal (requires `envsubst`
 (GNU gettext)):
 
 ```
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install.sh)" | kubectl apply -f -
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install-loki.sh)" | kubectl apply -f -
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install-tempo.sh)" | kubectl apply -f -
+NAMESPACE="default" /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install.sh)" | kubectl apply -f -
+NAMESPACE="default" /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install-loki.sh)" | kubectl apply -f -
+NAMESPACE="default" /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install-tempo.sh)" | kubectl apply -f -
 ```
 
 Other installation methods can be found in our
@@ -93,9 +93,9 @@ quickly within the Agent. We aim to always base our vendor off of a recent offic
 Prometheus release and to keep the experimental changes not available in the upstream
 repository to a minimum.
 
-Please refer to the pinned 
-[Prometheus Vendor Update Tracking](https://github.com/grafana/agent/issues/112) issue 
-for our current vendored Prometheus release. 
+Please refer to the pinned
+[Prometheus Vendor Update Tracking](https://github.com/grafana/agent/issues/112) issue
+for our current vendored Prometheus release.
 
 For more context on our vendoring strategy, read our
 [repo maintenance guide](./docs/maintaining.md#grafanaprometheus-maintenance).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,8 +60,9 @@ applied.
 > **Warning**: Always verify scripts from the internet before running them.
 
 ```
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install.sh)" | kubectl -ndefault apply -f -
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install-loki.sh)" | kubectl apply -f -
+NAMESPACE="default" /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install.sh)" | kubectl -ndefault apply -f -
+NAMESPACE="default" /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install-loki.sh)" | kubectl apply -f -
+NAMESPACE="default" /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install-tempo.sh)" | kubectl apply -f -
 ```
 
 ### Kubernetes Manifest

--- a/production/README.md
+++ b/production/README.md
@@ -12,12 +12,14 @@ easiest to hardest:
 
 ## Install Script for Kubernetes
 
-The Grafana Cloud Agent repository comes with an installation script to
-configure remote write and return a Kubernetes manifest that uses our preferred
-defaults. To run the script, copy and paste this line in your terminal:
+The Grafana Cloud Agent repository comes with installation scripts to
+configure components and return a Kubernetes manifest that uses our preferred
+defaults. To run the script, copy and paste this in your terminal:
 
 ```
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install.sh)" | kubectl -ndefault apply -f -
+NAMESPACE="default" /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install.sh)" | kubectl apply -f -
+NAMESPACE="default" /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install-loki.sh)" | kubectl apply -f -
+NAMESPACE="default" /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install-tempo.sh)" | kubectl apply -f -
 ```
 
 See the [Kubernetes README](./kubernetes/README.md) for more information.

--- a/production/kubernetes/README.md
+++ b/production/kubernetes/README.md
@@ -26,12 +26,13 @@ install script does the following:
    step 1.
 4. Prints out the final manifest to stdout without applying it.
 
-Here's a two-line script to copy and paste to install the Agent on
-Kubernetes for collecting metrics and logs (requires `envsubst` (GNU gettext)):
+Here's a script to copy and paste to install the Agent on Kubernetes for
+collecting metrics, logs, and traces (requires `envsubst` (GNU gettext)):
 
 ```
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install.sh)" | kubectl -ndefault apply -f -
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install-loki.sh)" | kubectl -ndefault apply -f -
+NAMESPACE="default" /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install.sh)" | kubectl apply -f -
+NAMESPACE="default" /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install-loki.sh)" | kubectl apply -f -
+NAMESPACE="default" /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/release/production/kubernetes/install-tempo.sh)" | kubectl apply -f -
 ```
 
 ## Manually Applying

--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -36,12 +36,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: grafana-agent
-  namespace: default
+  namespace: ${NAMESPACE}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: grafana-agent
+  namespace: ${NAMESPACE}
 spec:
   minReadySeconds: 10
   selector:

--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: grafana-agent
+  namespace: ${NAMESPACE}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole

--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -262,7 +262,7 @@ data:
 kind: ConfigMap
 metadata:
   name: grafana-agent-logs
-  namespace: default
+  namespace: ${NAMESPACE}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -297,13 +297,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: grafana-agent-logs
-  namespace: default
+  namespace: ${NAMESPACE}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: grafana-agent-logs
-  namespace: default
+  namespace: ${NAMESPACE}
 spec:
   minReadySeconds: 10
   selector:

--- a/production/kubernetes/agent-sigv4.yaml
+++ b/production/kubernetes/agent-sigv4.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     eks.amazonaws.com/role-arn: ${ROLE_ARN}
   name: grafana-agent
+  namespace: ${NAMESPACE}
 ---
 apiVersion: v1
 data:

--- a/production/kubernetes/agent-sigv4.yaml
+++ b/production/kubernetes/agent-sigv4.yaml
@@ -88,11 +88,11 @@ data:
                     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
                     insecure_skip_verify: false
               - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-                job_name: default/kube-state-metrics
+                job_name: ${NAMESPACE}/kube-state-metrics
                 kubernetes_sd_configs:
                   - namespaces:
                         names:
-                          - default
+                          - ${NAMESPACE}
                     role: pod
                 relabel_configs:
                   - action: keep
@@ -110,11 +110,11 @@ data:
                     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
                     insecure_skip_verify: false
               - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-                job_name: default/node-exporter
+                job_name: ${NAMESPACE}/node-exporter
                 kubernetes_sd_configs:
                   - namespaces:
                         names:
-                          - default
+                          - ${NAMESPACE}
                     role: pod
                 relabel_configs:
                   - action: keep
@@ -183,6 +183,7 @@ data:
 kind: ConfigMap
 metadata:
   name: grafana-agent
+  namespace: ${NAMESPACE}
 ---
 apiVersion: v1
 data:
@@ -227,6 +228,7 @@ data:
 kind: ConfigMap
 metadata:
   name: grafana-agent-deployment
+  namespace: ${NAMESPACE}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -261,12 +263,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: grafana-agent
-  namespace: default
+  namespace: ${NAMESPACE}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: grafana-agent
+  namespace: ${NAMESPACE}
 spec:
   minReadySeconds: 10
   selector:
@@ -315,6 +318,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana-agent-deployment
+  namespace: ${NAMESPACE}
 spec:
   minReadySeconds: 10
   replicas: 1

--- a/production/kubernetes/agent-sigv4.yaml
+++ b/production/kubernetes/agent-sigv4.yaml
@@ -16,6 +16,7 @@ data:
             remote_write:
               - sigv4:
                     enabled: true
+                    region: ${REGION}
                 url: ${REMOTE_WRITE_URL}
             scrape_configs:
               - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -198,6 +199,7 @@ data:
             remote_write:
               - sigv4:
                     enabled: true
+                    region: ${REGION}
                 url: ${REMOTE_WRITE_URL}
             scrape_configs:
               - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/production/kubernetes/agent-sigv4.yaml
+++ b/production/kubernetes/agent-sigv4.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    eks.amazonaws.com/role-arn: ${ROLE_ARN}
   name: grafana-agent
 ---
 apiVersion: v1

--- a/production/kubernetes/agent-tempo.yaml
+++ b/production/kubernetes/agent-tempo.yaml
@@ -61,7 +61,7 @@ data:
 kind: ConfigMap
 metadata:
   name: grafana-agent-traces
-  namespace: default
+  namespace: ${NAMESPACE}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -96,7 +96,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: grafana-agent-traces
-  namespace: default
+  namespace: ${NAMESPACE}
 ---
 apiVersion: v1
 kind: Service
@@ -104,6 +104,7 @@ metadata:
   labels:
     name: grafana-agent-traces
   name: grafana-agent-traces
+  namespace: ${NAMESPACE}
 spec:
   ports:
   - name: agent-http-metrics
@@ -144,7 +145,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: grafana-agent-traces
-  namespace: default
+  namespace: ${NAMESPACE}
 spec:
   minReadySeconds: 10
   selector:

--- a/production/kubernetes/agent.yaml
+++ b/production/kubernetes/agent.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: grafana-agent
+  namespace: ${NAMESPACE}
 ---
 apiVersion: v1
 data:

--- a/production/kubernetes/agent.yaml
+++ b/production/kubernetes/agent.yaml
@@ -89,11 +89,11 @@ data:
                     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
                     insecure_skip_verify: false
               - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-                job_name: default/kube-state-metrics
+                job_name: ${NAMESPACE}/kube-state-metrics
                 kubernetes_sd_configs:
                   - namespaces:
                         names:
-                          - default
+                          - ${NAMESPACE}
                     role: pod
                 relabel_configs:
                   - action: keep
@@ -111,11 +111,11 @@ data:
                     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
                     insecure_skip_verify: false
               - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-                job_name: default/node-exporter
+                job_name: ${NAMESPACE}/node-exporter
                 kubernetes_sd_configs:
                   - namespaces:
                         names:
-                          - default
+                          - ${NAMESPACE}
                     role: pod
                 relabel_configs:
                   - action: keep
@@ -184,6 +184,7 @@ data:
 kind: ConfigMap
 metadata:
   name: grafana-agent
+  namespace: ${NAMESPACE}
 ---
 apiVersion: v1
 data:
@@ -229,6 +230,7 @@ data:
 kind: ConfigMap
 metadata:
   name: grafana-agent-deployment
+  namespace: ${NAMESPACE}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -263,12 +265,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: grafana-agent
-  namespace: default
+  namespace: ${NAMESPACE}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: grafana-agent
+  namespace: ${NAMESPACE}
 spec:
   minReadySeconds: 10
   selector:
@@ -317,6 +320,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana-agent-deployment
+  namespace: ${NAMESPACE}
 spec:
   minReadySeconds: 10
   replicas: 1

--- a/production/kubernetes/build/templates/bare/main.jsonnet
+++ b/production/kubernetes/build/templates/bare/main.jsonnet
@@ -6,7 +6,7 @@ agent {
   },
 
   _config+:: {
-    namespace: 'default',
+    namespace: '${NAMESPACE}',
 
     // Since the config map isn't managed by Tanka, we don't want to
     // add the configmap's hash as an annotation for the Kubernetes

--- a/production/kubernetes/build/templates/base-sigv4/main.jsonnet
+++ b/production/kubernetes/build/templates/base-sigv4/main.jsonnet
@@ -6,7 +6,7 @@ agent {
   },
 
   _config+:: {
-    namespace: 'default',
+    namespace: '${NAMESPACE}',
     agent_remote_write: [{
       url: '${REMOTE_WRITE_URL}',
       sigv4: {

--- a/production/kubernetes/build/templates/base-sigv4/main.jsonnet
+++ b/production/kubernetes/build/templates/base-sigv4/main.jsonnet
@@ -1,5 +1,8 @@
 local agent = import 'grafana-agent/grafana-agent.libsonnet';
 
+local k = import 'ksonnet-util/kausal.libsonnet';
+local serviceAccount = k.core.v1.serviceAccount;
+
 agent {
   _images+:: {
     agent: (import 'version.libsonnet'),
@@ -18,5 +21,11 @@ agent {
     // add the configmap's hash as an annotation for the Kubernetes
     // YAML manifest.
     agent_config_hash_annotation: false,
+  },
+
+  agent_rbac+: {
+    service_account+: serviceAccount.mixin.metadata.withAnnotationsMixin({
+      'eks.amazonaws.com/role-arn': '${ROLE_ARN}',
+    }),
   },
 }

--- a/production/kubernetes/build/templates/base-sigv4/main.jsonnet
+++ b/production/kubernetes/build/templates/base-sigv4/main.jsonnet
@@ -14,6 +14,7 @@ agent {
       url: '${REMOTE_WRITE_URL}',
       sigv4: {
         enabled: true,
+        region: '${REGION}',
       },
     }],
 

--- a/production/kubernetes/build/templates/base/main.jsonnet
+++ b/production/kubernetes/build/templates/base/main.jsonnet
@@ -6,7 +6,7 @@ agent {
   },
 
   _config+:: {
-    namespace: 'default',
+    namespace: '${NAMESPACE}',
     agent_remote_write: [{
       url: '${REMOTE_WRITE_URL}',
       basic_auth: {

--- a/production/kubernetes/build/templates/loki/main.jsonnet
+++ b/production/kubernetes/build/templates/loki/main.jsonnet
@@ -2,7 +2,7 @@ local agent = import 'grafana-agent/v1/main.libsonnet';
 
 {
   agent:
-    agent.new('grafana-agent-logs', 'default') +
+    agent.new('grafana-agent-logs', '${NAMESPACE}') +
     agent.withConfigHash(false) +
     agent.withImages({
       agent: (import 'version.libsonnet'),

--- a/production/kubernetes/build/templates/tempo/main.jsonnet
+++ b/production/kubernetes/build/templates/tempo/main.jsonnet
@@ -11,7 +11,7 @@ local newPort(name, portNumber, protocol='TCP') =
 
 {
   agent:
-    agent.new('grafana-agent-traces', 'default') +
+    agent.new('grafana-agent-traces', '${NAMESPACE}') +
     agent.withConfigHash(false) +
     agent.withImages({
       agent: (import 'version.libsonnet'),

--- a/production/kubernetes/install-bare.sh
+++ b/production/kubernetes/install-bare.sh
@@ -18,5 +18,8 @@ check_installed envsubst
 
 MANIFEST_BRANCH=v0.10.0
 MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent-bare.yaml}
+NAMESPACE=${NAMESPACE:-default}
+
+export NAMESPACE
 
 curl -fsSL $MANIFEST_URL | envsubst

--- a/production/kubernetes/install-loki.sh
+++ b/production/kubernetes/install-loki.sh
@@ -7,9 +7,10 @@
 #
 # There are three ways to provide the inputs for installation:
 #
-# 1. Environment variables (LOKI_HOSTNAME, LOKI_USERNAME, LOKI_PASSWORD)
+# 1. Environment variables (LOKI_HOSTNAME, LOKI_USERNAME, LOKI_PASSWORD,
+#    NAMESPACE)
 #
-# 2. Flags (-h for hostname, -u for username, -p for password)
+# 2. Flags (-h for hostname, -u for username, -p for password, -n namespace)
 #
 # 3. stdin from prompts
 #
@@ -31,6 +32,7 @@ check_installed envsubst
 
 MANIFEST_BRANCH=v0.10.0
 MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent-loki.yaml}
+NAMESPACE=${NAMESPACE:-default}
 
 LOKI_USERNAME_SET=0
 LOKI_PASSWORD_SET=0
@@ -48,8 +50,11 @@ while getopts "h:u:p:" opt; do
       LOKI_PASSWORD=$OPTARG
       LOKI_PASSWORD_SET=1
       ;;
+    n)
+      NAMESPACE=$OPTARG
+      ;;
     ?)
-      echo "usage: $(basename $0) [-h Loki hostname] [-u Loki username] [-p Loki password]" >&2
+      echo "usage: $(basename $0) [-h Loki hostname] [-u Loki username] [-p Loki password] [-n namespace]" >&2
       exit 1
       ;;
   esac
@@ -78,6 +83,7 @@ if [ -z "${LOKI_PASSWORD}" ] && [ "${LOKI_PASSWORD_SET}" -eq 0 ]; then
   printf $'\n' >&2
 fi
 
+export NAMESPACE
 export LOKI_HOSTNAME
 export LOKI_USERNAME
 export LOKI_PASSWORD

--- a/production/kubernetes/install-sigv4.sh
+++ b/production/kubernetes/install-sigv4.sh
@@ -7,9 +7,9 @@
 #
 # There are three ways to provide the inputs for installation:
 #
-# 1. Environment variables (REMOTE_WRITE_URL, ROLE_ARN, NAMESPACE)
+# 1. Environment variables (REMOTE_WRITE_URL, REGION, ROLE_ARN, NAMESPACE)
 #
-# 2. Flags (-l for remote write URL, -n for namespace, -r for ARN)
+# 2. Flags (-l for remote write URL, -n for namespace, -a for ARN, -r for region)
 #
 # 3. stdin from prompts
 #
@@ -42,8 +42,11 @@ while getopts "l:u:p:" opt; do
     n)
       NAMESPACE=$OPTARG
       ;;
-    r)
+    a)
       ROLE_ARN=$OPTARG
+      ;;
+    r)
+      REGION=$OPTARG
       ;;
     ?)
       echo "usage: $(basename $0) [-l remote write url] [-n namespace]" >&2
@@ -56,17 +59,26 @@ if [ -z "${REMOTE_WRITE_URL}" ]; then
   read -sp 'Enter your remote write URL: ' REMOTE_WRITE_URL
   printf $'\n' >&2
 
-  # We require a remote write URL for the agent; we don't do this same check for
-  # the username and password as the remote write system may not have basic
-  # auth enabled.
   if [ -z "${REMOTE_WRITE_URL}" ]; then
     echo "error: REMOTE_WRITE_URL must be provided by flag, env, or stdin" >&2
     exit 1
   fi
 fi
 
+if [ -z "${REGION}" ]; then
+  read -sp 'Enter the remote write region: ' REGION
+  printf $'\n' >&2
+
+  if [ -z "${REGION}" ]; then
+    echo "error: REGION must be provided by flag, env, or stdin" >&2
+    exit 1
+  fi
+fi
+
+
 export NAMESPACE
 export REMOTE_WRITE_URL
 export ROLE_ARN
+export REGION
 
 curl -fsSL $MANIFEST_URL | envsubst

--- a/production/kubernetes/install-sigv4.sh
+++ b/production/kubernetes/install-sigv4.sh
@@ -7,9 +7,9 @@
 #
 # There are three ways to provide the inputs for installation:
 #
-# 1. Environment variables (REMOTE_WRITE_URL)
+# 1. Environment variables (REMOTE_WRITE_URL, NAMESPACE)
 #
-# 2. Flags (-l for remote write URL)
+# 2. Flags (-l for remote write URL, -n namespace)
 #
 # 3. stdin from prompts
 #
@@ -31,14 +31,18 @@ check_installed envsubst
 
 MANIFEST_BRANCH=v0.10.0
 MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent-sigv4.yaml}
+NAMESPACE=${MANIFEST_URL:-default}
 
 while getopts "l:u:p:" opt; do
   case "$opt" in
     l)
       REMOTE_WRITE_URL=$OPTARG
       ;;
+    n)
+      NAMESPACE=$OPTARG
+      ;;
     ?)
-      echo "usage: $(basename $0) [-l remote write url] [-u remote write username] [-p remote write password]" >&2
+      echo "usage: $(basename $0) [-l remote write url] [-n namespace]" >&2
       exit 1
       ;;
   esac
@@ -57,5 +61,6 @@ if [ -z "${REMOTE_WRITE_URL}" ]; then
   fi
 fi
 
+export NAMESPACE
 export REMOTE_WRITE_URL
 curl -fsSL $MANIFEST_URL | envsubst

--- a/production/kubernetes/install-sigv4.sh
+++ b/production/kubernetes/install-sigv4.sh
@@ -7,9 +7,9 @@
 #
 # There are three ways to provide the inputs for installation:
 #
-# 1. Environment variables (REMOTE_WRITE_URL, NAMESPACE)
+# 1. Environment variables (REMOTE_WRITE_URL, ROLE_ARN, NAMESPACE)
 #
-# 2. Flags (-l for remote write URL, -n namespace)
+# 2. Flags (-l for remote write URL, -n for namespace, -r for ARN)
 #
 # 3. stdin from prompts
 #
@@ -32,6 +32,7 @@ check_installed envsubst
 MANIFEST_BRANCH=v0.10.0
 MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent-sigv4.yaml}
 NAMESPACE=${MANIFEST_URL:-default}
+ROLE_ARN=${ROLE_ARN:-}
 
 while getopts "l:u:p:" opt; do
   case "$opt" in
@@ -40,6 +41,9 @@ while getopts "l:u:p:" opt; do
       ;;
     n)
       NAMESPACE=$OPTARG
+      ;;
+    r)
+      ROLE_ARN=$OPTARG
       ;;
     ?)
       echo "usage: $(basename $0) [-l remote write url] [-n namespace]" >&2
@@ -63,4 +67,6 @@ fi
 
 export NAMESPACE
 export REMOTE_WRITE_URL
+export ROLE_ARN
+
 curl -fsSL $MANIFEST_URL | envsubst

--- a/production/kubernetes/install-sigv4.sh
+++ b/production/kubernetes/install-sigv4.sh
@@ -31,7 +31,7 @@ check_installed envsubst
 
 MANIFEST_BRANCH=v0.10.0
 MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent-sigv4.yaml}
-NAMESPACE=${MANIFEST_URL:-default}
+NAMESPACE=${NAMESPACE:-default}
 ROLE_ARN=${ROLE_ARN:-}
 
 while getopts "l:u:p:" opt; do

--- a/production/kubernetes/install-tempo.sh
+++ b/production/kubernetes/install-tempo.sh
@@ -7,9 +7,10 @@
 #
 # There are three ways to provide the inputs for installation:
 #
-# 1. Environment variables (TEMPO_ENDPOINT, TEMPO_USERNAME, TEMPO_PASSWORD)
+# 1. Environment variables (TEMPO_ENDPOINT, TEMPO_USERNAME, TEMPO_PASSWORD,
+#    NAMESPACE)
 #
-# 2. Flags (-e for endpoint, -u for username, -p for password)
+# 2. Flags (-e for endpoint, -u for username, -p for password, -n for namespace)
 #
 # 3. stdin from prompts
 #
@@ -31,6 +32,7 @@ check_installed envsubst
 
 MANIFEST_BRANCH=v0.10.0
 MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent-tempo.yaml}
+NAMESPACE=${NAMESPACE:-default}
 
 TEMPO_USERNAME_SET=0
 TEMPO_PASSWORD_SET=0
@@ -48,8 +50,11 @@ while getopts "e:u:p:" opt; do
       TEMPO_PASSWORD=$OPTARG
       TEMPO_PASSWORD_SET=1
       ;;
+    n)
+      NAMESPACE=$OPTARG
+      ;;
     ?)
-      echo "usage: $(basename $0) [-e Tempo endpoint] [-u Tempo username] [-p Tempo password]" >&2
+      echo "usage: $(basename $0) [-e Tempo endpoint] [-u Tempo username] [-p Tempo password] [-n namespace]" >&2
       exit 1
       ;;
   esac
@@ -78,6 +83,7 @@ if [ -z "${TEMPO_PASSWORD}" ] && [ "${TEMPO_PASSWORD_SET}" -eq 0 ]; then
   printf $'\n' >&2
 fi
 
+export NAMESPACE
 export TEMPO_ENDPOINT
 export TEMPO_USERNAME
 export TEMPO_PASSWORD

--- a/production/kubernetes/install.sh
+++ b/production/kubernetes/install.sh
@@ -7,11 +7,11 @@
 #
 # There are three ways to provide the inputs for installation:
 #
-# 1. Environment variables (REMOTE_WRITE_URL, REMOTE_WRITE_USERNAME,
+# 1. Environment variables (NAMESPACE, REMOTE_WRITE_URL, REMOTE_WRITE_USERNAME,
 #    REMOTE_WRITE_PASSWORD)
 #
 # 2. Flags (-l for remote write URL, -u for remote write username, -p for remote
-#    write password)
+#    write password, -n for namespace)
 #
 # 3. stdin from prompts
 #
@@ -33,6 +33,7 @@ check_installed envsubst
 
 MANIFEST_BRANCH=v0.10.0
 MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent.yaml}
+NAMESPACE=${NAMESPACE:-default}
 
 REMOTE_WRITE_USERNAME_SET=0
 REMOTE_WRITE_PASSWORD_SET=0
@@ -50,8 +51,11 @@ while getopts "l:u:p:" opt; do
       REMOTE_WRITE_PASSWORD=$OPTARG
       REMOTE_WRITE_PASSWORD_SET=1
       ;;
+    n)
+      NAMESPACE=$OPTARG
+      ;;
     ?)
-      echo "usage: $(basename $0) [-l remote write url] [-u remote write username] [-p remote write password]" >&2
+      echo "usage: $(basename $0) [-l remote write url] [-u remote write username] [-p remote write password] [-n namespace]" >&2
       exit 1
       ;;
   esac
@@ -80,6 +84,7 @@ if [ -z "${REMOTE_WRITE_PASSWORD}" ] && [ "${REMOTE_WRITE_PASSWORD_SET}" -eq 0 ]
   printf $'\n' >&2
 fi
 
+export NAMESPACE
 export REMOTE_WRITE_URL
 export REMOTE_WRITE_USERNAME
 export REMOTE_WRITE_PASSWORD

--- a/production/tanka/grafana-agent/grafana-agent.libsonnet
+++ b/production/tanka/grafana-agent/grafana-agent.libsonnet
@@ -7,6 +7,7 @@ k + config {
   local daemonSet = $.apps.v1.daemonSet,
   local deployment = $.apps.v1.deployment,
   local policyRule = $.rbac.v1.policyRule,
+  local serviceAccount = $.core.v1.serviceAccount,
 
   agent_rbac:
     $.util.rbac($._config.agent_cluster_role_name, [
@@ -16,7 +17,10 @@ k + config {
 
       policyRule.withNonResourceUrls('/metrics') +
       policyRule.withVerbs(['get']),
-    ]),
+    ]) {
+      service_account+: 
+        serviceAccount.mixin.metadata.withNamespace($._config.namespace),
+    },
 
   agent_config_map:
     configMap.new($._config.agent_configmap_name) +

--- a/production/tanka/grafana-agent/grafana-agent.libsonnet
+++ b/production/tanka/grafana-agent/grafana-agent.libsonnet
@@ -20,6 +20,7 @@ k + config {
 
   agent_config_map:
     configMap.new($._config.agent_configmap_name) +
+    configMap.mixin.metadata.withNamespace($._config.namespace) +
     configMap.withData({
       'agent.yml': $.util.manifestYaml($._config.agent_config),
     }),
@@ -55,6 +56,7 @@ k + config {
   // TODO(rfratto): persistent storage for the WAL here is missing. hostVolume?
   agent_daemonset:
     daemonSet.new($._config.agent_pod_name, [$.agent_container]) +
+    daemonSet.mixin.metadata.withNamespace($._config.namespace) +
     daemonSet.mixin.spec.template.spec.withServiceAccount($._config.agent_cluster_role_name) +
     self.config_hash_mixin.daemonSet +
     $.util.configVolumeMount($._config.agent_configmap_name, '/etc/agent'),
@@ -62,6 +64,7 @@ k + config {
   agent_deployment_config_map:
     if $._config.agent_host_filter then
       configMap.new($._config.agent_deployment_configmap_name) +
+      configMap.mixin.metadata.withNamespace($._config.namespace) +
       configMap.withData({
         'agent.yml': $.util.manifestYaml($._config.deployment_agent_config),
       })
@@ -70,6 +73,7 @@ k + config {
   agent_deployment:
     if $._config.agent_host_filter then
       deployment.new($._config.agent_deployment_pod_name, 1, [$.agent_container]) +
+      deployment.mixin.metadata.withNamespace($._config.namespace) +
       deployment.mixin.spec.template.spec.withServiceAccount($._config.agent_cluster_role_name) +
       deployment.mixin.spec.withReplicas(1) +
       self.config_hash_mixin.deployment +

--- a/production/tanka/grafana-agent/v1/main.libsonnet
+++ b/production/tanka/grafana-agent/v1/main.libsonnet
@@ -4,6 +4,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
 
 local container = k.core.v1.container;
 local configMap = k.core.v1.configMap;
+local service = k.core.v1.service;
 
 // Merge all of our libraries to create the final exposed library.
 (import './lib/deployment.libsonnet') +
@@ -104,7 +105,9 @@ local configMap = k.core.v1.configMap;
         // If we're deploying for tracing, applications will want to write to
         // a service for load balancing span delivery.
         service:
-          if has_tempo_config then k.util.serviceFor(self.agent) else {},
+          if has_tempo_config 
+          then k.util.serviceFor(self.agent) + service.mixin.metadata.withNamespace(namespace)
+          else {},
       } + (
         if has_loki_config then $.lokiPermissionsMixin else {}
       ),

--- a/tools/release-note.md
+++ b/tools/release-note.md
@@ -17,9 +17,9 @@ final collects traces. You will be prompted for input for each manifest. The
 script requires curl and envsubst (GNU gettext).
 
 ```
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/${RELEASE_TAG}/production/kubernetes/install.sh)" | kubectl -ndefault apply -f -
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/${RELEASE_TAG}/production/kubernetes/install-loki.sh)" | kubectl -ndefault apply -f -
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/${RELEASE_TAG}/production/kubernetes/install-tempo.sh)" | kubectl -ndefault apply -f -
+NAMESPACE="default" /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/${RELEASE_TAG}/production/kubernetes/install.sh)" | kubectl apply -f -
+NAMESPACE="default" /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/${RELEASE_TAG}/production/kubernetes/install-loki.sh)" | kubectl apply -f -
+NAMESPACE="default" /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/${RELEASE_TAG}/production/kubernetes/install-tempo.sh)" | kubectl apply -f -
 ```
 
 #### Docker container:


### PR DESCRIPTION
#### PR Description 
Allows a custom installation namespace in the Kubernetes install scripts through replacing an environment variable. 

This also tweaks errors to the sigv4 script found when testing out #334.

#### Which issue(s) this PR fixes 
Closes #319 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
