### PR TITLE
Configuration file validation subcommand for agentctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ can be found at [#317](https://github.com/grafana/agent/issues/317).
   releases to expand Agent support to cover all models of Raspberry Pis.
   ARMv6 docker builds are also now available.
   (@rfratto)
+  
+- [FEATURE] Added `config-check` subcommand for `agentctl` that can be used
+  to validate Agent configuration files before attempting to load them in the
+  `agent` itself. (@56quarters)
 
 - [ENHANCEMENT] A sigv4 install script for Prometheus has been added. (@rfratto)
 

--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -12,6 +12,7 @@ import (
 	// Adds version information
 	_ "github.com/grafana/agent/pkg/build"
 	"github.com/grafana/agent/pkg/client/grafanacloud"
+	"github.com/grafana/agent/pkg/config"
 	"github.com/olekukonko/tablewriter"
 	"github.com/prometheus/common/version"
 
@@ -35,6 +36,7 @@ func main() {
 
 	cmd.AddCommand(
 		configSyncCmd(),
+		configCheckCmd(),
 		walStatsCmd(),
 		targetStatsCmd(),
 		samplesCmd(),
@@ -81,6 +83,36 @@ source-of-truth directory.`,
 	cmd.Flags().StringVarP(&agentAddr, "addr", "a", "http://localhost:12345", "address of the agent to connect to")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "use the dry run option to validate config files without attempting to upload")
 	must(cmd.MarkFlagRequired("addr"))
+	return cmd
+}
+
+func configCheckCmd() *cobra.Command {
+	var expandEnv bool
+
+	cmd := &cobra.Command{
+		Use:   "config-check [config file]",
+		Short: "Perform basic validation of the given Agent configuration file",
+		Long: `config-check performs basic syntactic validation of the given Agent configuration
+file. The file is checked to ensure the types match the expected configuration types. Optionally,
+${var} style substitutions can be expanded based on the values of the environmental variables.
+
+If the configuration file is valid the exit code will be 0. If the configuration file is invalid
+the exit code will be 1.`,
+		Args: cobra.ExactArgs(1),
+		Run: func(_ *cobra.Command, args []string) {
+			file := args[0]
+			logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
+
+			cfg := config.Config{}
+			err := config.LoadFile(file, expandEnv, &cfg)
+			if err != nil {
+				level.Error(logger).Log("msg", "failed to validate config", "err", err)
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().BoolVarP(&expandEnv, "expand-env", "e", false, "expands ${var} in config according to the values of the environment variables")
 	return cmd
 }
 

--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -101,13 +101,14 @@ the exit code will be 1.`,
 		Args: cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			file := args[0]
-			logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
 
 			cfg := config.Config{}
 			err := config.LoadFile(file, expandEnv, &cfg)
 			if err != nil {
-				level.Error(logger).Log("msg", "failed to validate config", "err", err)
+				fmt.Fprintf(os.Stderr, "failed to validate config: %s\n", err)
 				os.Exit(1)
+			} else {
+				fmt.Fprintln(os.Stdout, "config valid")
 			}
 		},
 	}


### PR DESCRIPTION
Perform basic YAML and type checking for an Agent configuration file
and exit with `1` if there are any errors loading, parsing, or validating
the file.

Fixes #329

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [ ] Tests updated
