### PR TITLE
Hoenn/agentctl register integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ can be found at [#317](https://github.com/grafana/agent/issues/317).
 
 # Master (unreleased)
 
+- [BUGFIX] `agentctl config-check` will now work correctly for when the supplied config file contains integrations.
+
 # v0.11.0 (2021-01-20)
 
 - [FEATURE] ARMv6 builds of `agent` and `agentctl` will now be included in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ can be found at [#317](https://github.com/grafana/agent/issues/317).
 
 # Master (unreleased)
 
-- [BUGFIX] `agentctl config-check` will now work correctly when the supplied config file contains integrations.
+- [BUGFIX] `agentctl config-check` will now work correctly when the supplied config file contains integrations. (@hoenn)
 
 # v0.11.0 (2021-01-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ can be found at [#317](https://github.com/grafana/agent/issues/317).
 
 # Master (unreleased)
 
-- [BUGFIX] `agentctl config-check` will now work correctly for when the supplied config file contains integrations.
+- [BUGFIX] `agentctl config-check` will now work correctly when the supplied config file contains integrations.
 
 # v0.11.0 (2021-01-20)
 

--- a/Makefile
+++ b/Makefile
@@ -143,9 +143,9 @@ endif
 
 cmd/agentctl/agentctl: cmd/agentctl/main.go
 ifeq ($(CROSS_BUILD),false)
-	CGO_ENABLED=0 go build $(GO_FLAGS) -o $@ ./$(@D)
+	CGO_ENABLED=1 go build $(CGO_FLAGS) -o $@ ./$(@D)
 else
-	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOARM) go build $(GO_FLAGS) -o $@ ./$(@D)
+	@CGO_ENABLED=1 GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOARM); $(seego) build $(CGO_FLAGS) -o $@ ./$(@D)
 endif
 	$(NETGO_CHECK)
 

--- a/cmd/agentctl/Dockerfile
+++ b/cmd/agentctl/Dockerfile
@@ -1,15 +1,23 @@
-FROM golang:1.15 as build
+FROM golang:1.15.3-buster as build
 COPY . /src/agent
 WORKDIR /src/agent
 ARG RELEASE_BUILD=false
 ARG IMAGE_TAG
+
+# Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
+RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -t buster-backports -qy libsystemd-dev
+
 RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agentctl
 
 FROM debian:buster-slim
-RUN apt-get update && \
-  apt-get install -qy \
-  tzdata ca-certificates && \
+
+# Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
+RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -t buster-backports -qy libsystemd-dev && \
+  apt-get install -qy tzdata ca-certificates && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 COPY --from=build /src/agent/cmd/agentctl/agentctl /bin/agentctl
 
 ENTRYPOINT ["/bin/agentctl"]

--- a/cmd/agentctl/Dockerfile.buildx
+++ b/cmd/agentctl/Dockerfile.buildx
@@ -13,10 +13,13 @@ RUN cp /go_wrapper.sh /seego.sh
 RUN make clean && IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false bash ./tools/cross_build.bash agentctl
 
 FROM debian:buster-slim
-RUN apt-get update && \
-  apt-get install -qy \
-  tzdata ca-certificates && \
+
+# Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
+RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -t buster-backports -qy libsystemd-dev && \
+  apt-get install -qy tzdata ca-certificates libsystemd-dev && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 COPY --from=build /src/agent/cmd/agentctl/agentctl /bin/agentctl
 
 ENTRYPOINT ["/bin/agentctl"]

--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -24,6 +24,9 @@ import (
 
 	// Register Prometheus SD components
 	_ "github.com/prometheus/prometheus/discovery/install"
+
+	// Register integrations
+	_ "github.com/grafana/agent/pkg/integrations/install"
 )
 
 func main() {


### PR DESCRIPTION
#### PR Description 
Registers integrations in agent-ctl. This allows `agentctl config-check` to function correctly when integrations are present.
 
#### PR Checklist
- [x] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
