### PR TITLE
include discovered labels in /agent/api/v1/targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ can be found at [#317](https://github.com/grafana/agent/issues/317).
   been renamed to `amd64` to stay synchronized with the architecture name
   presented from other release assets. (@rfratto)
 
+- [ENHANCEMENT] The `/agent/api/v1/targets` API will now include discovered labels
+  on the target pre-relabeling in a `discovered_labels` field. (@rfratto)
+
 - [BUGFIX] `agentctl config-check` will now work correctly when the supplied
   config file contains integrations. (@hoenn)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -186,10 +186,10 @@ Response on success:
       "target_group": <string, scrape config group name>,
       "endpoint": <string, URL being scraped>
       "state": <string, one of up, down, unknown>,
-			"discovered_labels": {
-				"__address__": "<address>",
-				...
-			},
+      "discovered_labels": {
+        "__address__": "<address>",
+        ...
+      },
       "labels": {
         "label_a": "value_a",
         ...

--- a/docs/api.md
+++ b/docs/api.md
@@ -170,6 +170,10 @@ instances. Only targets being scraped from the local Agent will be returned. If
 running in scraping service mode, this endpoint must be invoked in all Agents
 separately to get the combined set of targets across the whole Agent cluster.
 
+The `labels` fields shows the labels that will be added to metrics from the
+target, while the `discovered_labels` field shows all labels found during
+service discovery.
+
 Status code: 200 on success.
 Response on success:
 
@@ -182,6 +186,10 @@ Response on success:
       "target_group": <string, scrape config group name>,
       "endpoint": <string, URL being scraped>
       "state": <string, one of up, down, unknown>,
+			"discovered_labels": {
+				"__address__": "<address>",
+				...
+			},
       "labels": {
         "label_a": "value_a",
         ...

--- a/pkg/prom/http.go
+++ b/pkg/prom/http.go
@@ -57,12 +57,13 @@ func (a *Agent) ListTargetsHandler(w http.ResponseWriter, _ *http.Request) {
 					InstanceName: instName,
 					TargetGroup:  key,
 
-					Endpoint:       tgt.URL().String(),
-					State:          string(tgt.Health()),
-					Labels:         tgt.Labels(),
-					LastScrape:     tgt.LastScrape(),
-					ScrapeDuration: tgt.LastScrapeDuration().Milliseconds(),
-					ScrapeError:    lastError,
+					Endpoint:         tgt.URL().String(),
+					State:            string(tgt.Health()),
+					DiscoveredLabels: tgt.DiscoveredLabels(),
+					Labels:           tgt.Labels(),
+					LastScrape:       tgt.LastScrape(),
+					ScrapeDuration:   tgt.LastScrapeDuration().Milliseconds(),
+					ScrapeError:      lastError,
 				})
 			}
 		}
@@ -108,10 +109,11 @@ type TargetInfo struct {
 	InstanceName string `json:"instance"`
 	TargetGroup  string `json:"target_group"`
 
-	Endpoint       string        `json:"endpoint"`
-	State          string        `json:"state"`
-	Labels         labels.Labels `json:"labels"`
-	LastScrape     time.Time     `json:"last_scrape"`
-	ScrapeDuration int64         `json:"scrape_duration_ms"`
-	ScrapeError    string        `json:"scrape_error"`
+	Endpoint         string        `json:"endpoint"`
+	State            string        `json:"state"`
+	Labels           labels.Labels `json:"labels"`
+	DiscoveredLabels labels.Labels `json:"discovered_labels"`
+	LastScrape       time.Time     `json:"last_scrape"`
+	ScrapeDuration   int64         `json:"scrape_duration_ms"`
+	ScrapeError      string        `json:"scrape_error"`
 }

--- a/pkg/prom/http_test.go
+++ b/pkg/prom/http_test.go
@@ -127,7 +127,6 @@ func TestAgent_ListTargetsHandler(t *testing.T) {
 				"scrape_error":"something went wrong"
 			}]
 		}`
-		fmt.Println(rr.Body.String())
 		require.JSONEq(t, expect, rr.Body.String())
 		require.Equal(t, http.StatusOK, rr.Result().StatusCode)
 	})

--- a/pkg/prom/http_test.go
+++ b/pkg/prom/http_test.go
@@ -84,11 +84,13 @@ func TestAgent_ListTargetsHandler(t *testing.T) {
 		tgt := scrape.NewTarget(labels.FromMap(map[string]string{
 			model.JobLabel:         "job",
 			model.InstanceLabel:    "instance",
+			"foo":                  "bar",
 			model.SchemeLabel:      "http",
 			model.AddressLabel:     "localhost:12345",
 			model.MetricsPathLabel: "/metrics",
-			"foo":                  "bar",
-		}), nil, nil)
+		}), labels.FromMap(map[string]string{
+			"__discovered__": "yes",
+		}), nil)
 
 		startTime := time.Date(1994, time.January, 12, 0, 0, 0, 0, time.UTC)
 		tgt.Report(startTime, time.Minute, fmt.Errorf("something went wrong"))
@@ -117,11 +119,15 @@ func TestAgent_ListTargetsHandler(t *testing.T) {
 					"instance": "instance",
 					"job": "job"
 				},
+				"discovered_labels": {
+					"__discovered__": "yes"
+				},
 				"last_scrape": "1994-01-12T00:00:00Z",
 				"scrape_duration_ms": 60000,
 				"scrape_error":"something went wrong"
 			}]
 		}`
+		fmt.Println(rr.Body.String())
 		require.JSONEq(t, expect, rr.Body.String())
 		require.Equal(t, http.StatusOK, rr.Result().StatusCode)
 	})


### PR DESCRIPTION
#### PR Description 
Adds discovered labels of the targets in `/agent/api/v1/targets`, making it easier to understand what labels the target had pre- and post- relabeling. 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
