### PR TITLE
Allow failed agents in ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ files to the new format.
 
 - [ENHANCEMENT] Update to Cortex v1.7.0-rc.0 (@rfratto)
 
+- [ENHANCEMENT] Scraping service: Unhealthy Agents in the ring will no longer
+  cause job distribution to fail. (@rfratto)
+
+- [ENHANCEMENT] Scraping service: Cortex ring metrics (prefixed with
+  cortex_ring_) will now be registered for tracking the state of the hash
+  ring. (@rfratto)
+
 - [BUGFIX] `agentctl config-check` will now work correctly when the supplied
   config file contains integrations. (@hoenn)
 


### PR DESCRIPTION
#### PR Description 
Changes the replication strategy used by the Agents to ignore unhealthy nodes. This allows for configs to automatically roll over to the next available Agent. 

Also adds ring metrics, which weren't being registered before. 

#### Which issue(s) this PR fixes 
Closes #130.

#### Notes to the Reviewer
Tested this in the k3d environment, appears to work. 

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
