### PR TITLE
Fix CI flakiness on merge jobs

### DIFF
--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -1,10 +1,8 @@
 name: Containerize
-# TODO(rfratto): move back to on push before merging
-on: [pull_request]
-# on:
-#   push:
-#     branches:
-#       - master
+on:
+  push:
+    branches:
+      - master
 jobs:
   test:
     name: Test
@@ -37,13 +35,9 @@ jobs:
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
+
     - name: Set up Docker Buildx
-      id: buildx
       uses: docker/setup-buildx-action@v1
-    - name: Builder instance name
-      run: echo ${{ steps.buildx.outputs.name }}
-    - name: Available platforms
-      run: echo ${{ steps.buildx.outputs.platforms }}
 
     - name: Make Containers
       run: CROSS_BUILD=true RELEASE_BUILD=true make agent-image
@@ -60,13 +54,9 @@ jobs:
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
+
     - name: Set up Docker Buildx
-      id: buildx
       uses: docker/setup-buildx-action@v1
-    - name: Builder instance name
-      run: echo ${{ steps.buildx.outputs.name }}
-    - name: Available platforms
-      run: echo ${{ steps.buildx.outputs.platforms }}
 
     - name: Make Containers
       run: CROSS_BUILD=true RELEASE_BUILD=true make agentctl-image

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -29,15 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-    - name: Get build dependencies
-      run: sudo apt-get update && sudo apt-get install binfmt-support qemu-user-static
-
     - name: Checkout code
       uses: actions/checkout@v2
 
     - name: Login to Docker Hub
       run: docker login -u '${{ secrets.DOCKER_USER }}' -p '${{ secrets.DOCKER_PASS }}'
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v1
@@ -53,15 +52,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-    - name: Get build dependencies
-      run: sudo apt-get update && sudo apt-get install binfmt-support qemu-user-static
-
     - name: Checkout code
       uses: actions/checkout@v2
 
     - name: Login to Docker Hub
       run: docker login -u '${{ secrets.DOCKER_USER }}' -p '${{ secrets.DOCKER_PASS }}'
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v1
@@ -70,8 +68,5 @@ jobs:
     - name: Available platforms
       run: echo ${{ steps.buildx.outputs.platforms }}
 
-
-
     - name: Make Containers
       run: CROSS_BUILD=true RELEASE_BUILD=true make agentctl-image
-

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -1,8 +1,10 @@
 name: Containerize
-on:
-  push:
-    branches:
-      - master
+# TODO(rfratto): move back to on push before merging
+on: [pull_request]
+# on:
+#   push:
+#     branches:
+#       - master
 jobs:
   test:
     name: Test
@@ -36,14 +38,16 @@ jobs:
     - name: Login to Docker Hub
       run: docker login -u '${{ secrets.DOCKER_USER }}' -p '${{ secrets.DOCKER_PASS }}'
 
-    - name: Prepare buildx
-      run: |
-        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-        docker buildx create --name builder --driver docker-container --use
-        docker buildx inspect --bootstrap
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Builder instance name
+      run: echo ${{ steps.buildx.outputs.name }}
+    - name: Available platforms
+      run: echo ${{ steps.buildx.outputs.platforms }}
 
     - name: Make Containers
-      run: CROSS_BUILD=true RELEASE_BUILD=true make agent-image 
+      run: CROSS_BUILD=true RELEASE_BUILD=true make agent-image
   agentctl-container:
     name: Build agentctl Container
     runs-on: ubuntu-latest
@@ -58,11 +62,15 @@ jobs:
     - name: Login to Docker Hub
       run: docker login -u '${{ secrets.DOCKER_USER }}' -p '${{ secrets.DOCKER_PASS }}'
 
-    - name: Prepare buildx
-      run: |
-        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-        docker buildx create --name builder --driver docker-container --use
-        docker buildx inspect --bootstrap
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Builder instance name
+      run: echo ${{ steps.buildx.outputs.name }}
+    - name: Available platforms
+      run: echo ${{ steps.buildx.outputs.platforms }}
+
+
 
     - name: Make Containers
       run: CROSS_BUILD=true RELEASE_BUILD=true make agentctl-image

--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,7 @@ docker-build = docker build $(DOCKER_BUILD_FLAGS)
 ifeq ($(CROSS_BUILD),true)
 DOCKERFILE = Dockerfile.buildx
 
-# TODO(rfratto): don't merge with --load, change back to --push
-docker-build = docker buildx build --load --platform linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7 $(DOCKER_BUILD_FLAGS)
+docker-build = docker buildx build --push --platform linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7 $(DOCKER_BUILD_FLAGS)
 endif
 
 ifeq ($(BUILD_IN_CONTAINER),false)

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,8 @@ docker-build = docker build $(DOCKER_BUILD_FLAGS)
 ifeq ($(CROSS_BUILD),true)
 DOCKERFILE = Dockerfile.buildx
 
-docker-build = docker buildx build --push --platform linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7 $(DOCKER_BUILD_FLAGS)
+# TODO(rfratto): don't merge with --load, change back to --push
+docker-build = docker buildx build --load --platform linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7 $(DOCKER_BUILD_FLAGS)
 endif
 
 ifeq ($(BUILD_IN_CONTAINER),false)


### PR DESCRIPTION
#### PR Description 
Switches the Containerize workflow to use `docker/setup-qemu-action@v1` and `docker/setup-buildx-action@v1` instead of the manual commands, which seemed to be prone to a race condition where the ARM builders weren't immediately available. 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
