### PR TITLE
scraping service: shard only on instance config name instead of contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ files to the new format.
   cortex_ring_) will now be registered for tracking the state of the hash
   ring. (@rfratto)
 
+- [ENHANCEMENT] Scraping service: instance config ownership is now determined by
+  the hash of the instance config name instead of the entire config. This means
+  that updating a config is guaranteed to always hash to the same Agent,
+  reducing the number of metrics gaps. (@rfratto)
+
 - [BUGFIX] `agentctl config-check` will now work correctly when the supplied
   config file contains integrations. (@hoenn)
 

--- a/docs/scraping-service.md
+++ b/docs/scraping-service.md
@@ -57,16 +57,17 @@ The Distributed Hash Ring is also stored in a KV store. Since a KV store is
 also needed for storing configuration files, it is encouraged to re-use
 the same KV store for the ring.
 
-When sharding, the Agent currently uses the entire contents of a config file
-stored in the KV store for load distribution. The hash of the config file is
-used as the _key_ in the ring and determines which agent (based on token)
-should be responsible for that config.  "Price is Right" rules are used for the
-Agent lookup; the Agent owning the token with the closest value to the key
-without going over is responsible for the config.
+When sharding, the Agent currently uses the name of a config file
+stored in the KV store for load distribution. Config names are guaranteed to be
+unique keys. The hash of the name is used as the _lookup key_ in the ring and
+determines which agent (based on token) should be responsible for that config.
+"Price is Right" rules are used for the Agent lookup; the Agent owning the token
+with the closest value to the key without going over is responsible for the
+config.
 
 All Agents are simultaneously watching the KV store for changes to the set of
 configuration files. When a config file is added or updated in the configuration
-store, each Agent will run the config file hash through their copy of the Hash
+store, each Agent will run the config name hash through their copy of the Hash
 Ring to determine if they are responsible for that config.
 
 When an Agent receives a new config that it is responsible for, it launches a

--- a/pkg/prom/ha/sharding.go
+++ b/pkg/prom/ha/sharding.go
@@ -194,18 +194,23 @@ func (m ShardingInstanceManager) ListConfigs() map[string]instance.Config {
 
 // ApplyConfig implements instance.Manager.ApplyConfig.
 func (m ShardingInstanceManager) ApplyConfig(c instance.Config) error {
-	hash, err := configHash(&c)
+	keyHash, err := configKeyHash(&c)
 	if err != nil {
 		return fmt.Errorf("failed to hash config: %w", err)
 	}
 
-	owned, err := m.owns(hash)
+	owned, err := m.owns(keyHash)
 	if err != nil {
 		level.Error(m.log).Log("msg", "failed to check if a config is owned, skipping config until next reshard", "err", err)
 		return nil
 	}
 
 	if owned {
+		hash, err := configHash(&c)
+		if err != nil {
+			return fmt.Errorf("failed to hash config: %w", err)
+		}
+
 		// If the config is unchanged, do nothing.
 		if m.keyToHash[c.Name] == hash {
 			return nil
@@ -254,6 +259,7 @@ func (m ShardingInstanceManager) owns(hash uint32) (bool, error) {
 	return false, nil
 }
 
+// configHash returns the hash of the entirety of an instance config.
 func configHash(c *instance.Config) (uint32, error) {
 	val, err := instance.MarshalConfig(c, false)
 	if err != nil {
@@ -261,5 +267,14 @@ func configHash(c *instance.Config) (uint32, error) {
 	}
 	h := fnv.New32()
 	_, _ = h.Write(val)
+	return h.Sum32(), nil
+}
+
+// configKeyHash gets a hash for a config that is used to determine ownership.
+// It is based on primary keys of the instance config rather than the entire
+// config.
+func configKeyHash(c *instance.Config) (uint32, error) {
+	h := fnv.New32()
+	_, _ = h.Write([]byte(c.Name))
 	return h.Sum32(), nil
 }

--- a/pkg/prom/ha/sharding.go
+++ b/pkg/prom/ha/sharding.go
@@ -194,11 +194,7 @@ func (m ShardingInstanceManager) ListConfigs() map[string]instance.Config {
 
 // ApplyConfig implements instance.Manager.ApplyConfig.
 func (m ShardingInstanceManager) ApplyConfig(c instance.Config) error {
-	keyHash, err := configKeyHash(&c)
-	if err != nil {
-		return fmt.Errorf("failed to hash config: %w", err)
-	}
-
+	keyHash := configKeyHash(&c)
 	owned, err := m.owns(keyHash)
 	if err != nil {
 		level.Error(m.log).Log("msg", "failed to check if a config is owned, skipping config until next reshard", "err", err)
@@ -273,8 +269,8 @@ func configHash(c *instance.Config) (uint32, error) {
 // configKeyHash gets a hash for a config that is used to determine ownership.
 // It is based on primary keys of the instance config rather than the entire
 // config.
-func configKeyHash(c *instance.Config) (uint32, error) {
+func configKeyHash(c *instance.Config) uint32 {
 	h := fnv.New32()
 	_, _ = h.Write([]byte(c.Name))
-	return h.Sum32(), nil
+	return h.Sum32()
 }


### PR DESCRIPTION
#### PR Description 
Sharding will now be performed based on the name of the config file instead of the contents of the config file. This guarantees that in a static ring, the same config name will always hash to the same Agent. This improves guarantees of the hashing, but also ensures that changing a config will not cause it to move to another Agent and cause gaps in metrics as the scrape responsibility moves.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
