### PR TITLE
Update Go and use consistent version across distributions

### DIFF
--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -39,6 +39,8 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 
+    - name: Prepare cross compilers
+      run: CROSS_BUILD=true RELEASE_BUILD=true make seego
     - name: Make Containers
       run: CROSS_BUILD=true RELEASE_BUILD=true make agent-image
   agentctl-container:
@@ -58,5 +60,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 
+    - name: Prepare cross compilers
+      run: CROSS_BUILD=true RELEASE_BUILD=true make seego
     - name: Make Containers
       run: CROSS_BUILD=true RELEASE_BUILD=true make agentctl-image

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -39,8 +39,6 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 
-    - name: Prepare cross compilers
-      run: CROSS_BUILD=true RELEASE_BUILD=true make seego
     - name: Make Containers
       run: CROSS_BUILD=true RELEASE_BUILD=true make agent-image
   agentctl-container:
@@ -60,7 +58,5 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 
-    - name: Prepare cross compilers
-      run: CROSS_BUILD=true RELEASE_BUILD=true make seego
     - name: Make Containers
       run: CROSS_BUILD=true RELEASE_BUILD=true make agentctl-image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,6 @@ jobs:
 
         export RELEASE_TAG=${GITHUB_REF##*/}
 
-        # Warm up make publish by pulling rfratto/seego ahead of time
-        docker pull rfratto/seego:latest
+        # We need to prepare the cross compilers first.
+        make seego
         make -j4 RELEASE_BUILD=true publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,4 @@ jobs:
 
         export RELEASE_TAG=${GITHUB_REF##*/}
 
-        # We need to prepare the cross compilers first.
-        make seego
         make -j4 RELEASE_BUILD=true publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ files to the new format.
 - [ENHANCEMENT] Only keep a handful of K8s API server metrics by default to reduce
   default active series usage. (@hjet)
 
+- [ENHANCEMENT] Go 1.15.7 is now used for all distributions of the Agent.
+  (@rfratto)
+
 - [BUGFIX] `agentctl config-check` will now work correctly when the supplied
   config file contains integrations. (@hoenn)
 

--- a/Makefile
+++ b/Makefile
@@ -264,20 +264,20 @@ packaging/centos-systemd/.uptodate: $(wildcard packaging/centos-systemd/*)
 ifeq ($(BUILD_IN_CONTAINER), true)
 dist-packages: enforce-release-tag dist-agent dist-agentctl build-image/.uptodate
 	docker run --rm \
-		-v  $(shell pwd):/src/agent:delegated \
+		-v $(shell pwd):/src/agent:delegated \
 		-e RELEASE_TAG=$(RELEASE_TAG) \
 		-e SRC_PATH=/src/agent \
 		-i $(BUILD_IMAGE) $@;
 .PHONY: dist-packages
 else
 dist-packages:
-	make dist/grafana-agent-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE).amd64.rpm
-	make dist/grafana-agent-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE).amd64.deb
-	make dist/grafana-agent-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE).arm64.deb
-	make dist/grafana-agent-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE).arm64.rpm
-	make dist/grafana-agent-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE).armv7.deb
-	make dist/grafana-agent-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE).armv7.rpm
-	make dist/grafana-agent-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE).armv6.deb
+	$(MAKE) dist/grafana-agent-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE).amd64.rpm
+	$(MAKE) dist/grafana-agent-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE).amd64.deb
+	$(MAKE) dist/grafana-agent-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE).arm64.deb
+	$(MAKE) dist/grafana-agent-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE).arm64.rpm
+	$(MAKE) dist/grafana-agent-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE).armv7.deb
+	$(MAKE) dist/grafana-agent-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE).armv7.rpm
+	$(MAKE) dist/grafana-agent-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE).armv6.deb
 .PHONY: dist-packages
 
 ENVIRONMENT_FILE_rpm := /etc/sysconfig/grafana-agent
@@ -312,20 +312,24 @@ RPM_DEPS := $(wildcard packaging/rpm/**/*) packaging/grafana-agent.yaml
 # agent arm64, deb arm64, rpm aarch64
 # agent armv7, deb armhf, rpm armhfp
 # agent armv6, deb armhf, (No RPM for armv6)
-$(PACKAGE_PREFIX).amd64.deb: dist/agent-linux-amd64 dist/agentctl-linux-amd64 $(DEB_DEPS)
+#
+# These targets require the agent/agentctl binaries to have already been built
+# with seego. Since this usually runs inside of a Docker Container, we can't
+# build them here.
+$(PACKAGE_PREFIX).amd64.deb: $(DEB_DEPS)
 	$(call generate_fpm,deb,amd64,amd64,$@)
-$(PACKAGE_PREFIX).arm64.deb: dist/agent-linux-arm64 dist/agentctl-linux-arm64 $(DEB_DEPS)
+$(PACKAGE_PREFIX).arm64.deb: $(DEB_DEPS)
 	$(call generate_fpm,deb,arm64,arm64,$@)
-$(PACKAGE_PREFIX).armv7.deb: dist/agent-linux-armv7 dist/agentctl-linux-armv7 $(DEB_DEPS)
+$(PACKAGE_PREFIX).armv7.deb: $(DEB_DEPS)
 	$(call generate_fpm,deb,armhf,armv7,$@)
-$(PACKAGE_PREFIX).armv6.deb: dist/agent-linux-armv6 dist/agentctl-linux-armv6 $(DEB_DEPS)
+$(PACKAGE_PREFIX).armv6.deb: $(DEB_DEPS)
 	$(call generate_fpm,deb,armhf,armv6,$@)
 
-$(PACKAGE_PREFIX).amd64.rpm: dist/agent-linux-amd64 dist/agentctl-linux-amd64 $(RPM_DEPS)
+$(PACKAGE_PREFIX).amd64.rpm: $(RPM_DEPS)
 	$(call generate_fpm,rpm,x86_64,amd64,$@)
-$(PACKAGE_PREFIX).arm64.rpm: dist/agent-linux-arm64 dist/agentctl-linux-arm64 $(RPM_DEPS)
+$(PACKAGE_PREFIX).arm64.rpm: $(RPM_DEPS)
 	$(call generate_fpm,rpm,aarch64,arm64,$@)
-$(PACKAGE_PREFIX).armv7.rpm: dist/agent-linux-armv7 dist/agentctl-linux-armv7 $(RPM_DEPS)
+$(PACKAGE_PREFIX).armv7.rpm: $(RPM_DEPS)
 	$(call generate_fpm,rpm,armhfp,armv7,$@)
 
 endif

--- a/Makefile
+++ b/Makefile
@@ -149,10 +149,10 @@ else
 endif
 	$(NETGO_CHECK)
 
-agent-image: check-seego
+agent-image:
 	$(docker-build) -t $(IMAGE_PREFIX)/agent:latest -t $(IMAGE_PREFIX)/agent:$(IMAGE_TAG) -f cmd/agent/$(DOCKERFILE) .
 
-agentctl-image: check-seego
+agentctl-image:
 	$(docker-build) -t $(IMAGE_PREFIX)/agentctl:latest -t $(IMAGE_PREFIX)/agentctl:$(IMAGE_TAG) -f cmd/agentctl/$(DOCKERFILE) .
 
 install:
@@ -236,10 +236,10 @@ seego: tools/seego/Dockerfile
 
 # Makes seego if CROSS_BUILD is true.
 check-seego:
-ifeq ($(CROSS_BUILD),false)
-	# seego not required
-else
+ifeq ($(CROSS_BUILD),true)
+ifeq ($(BUILD_IN_CONTAINER),true)
 	$(MAKE) seego
+endif
 endif
 
 build-image/.uptodate: build-image/Dockerfile

--- a/cmd/agent/Dockerfile
+++ b/cmd/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.3-buster as build
+FROM golang:1.15.7-buster as build
 COPY . /src/agent
 WORKDIR /src/agent
 ARG RELEASE_BUILD=true

--- a/cmd/agent/Dockerfile.buildx
+++ b/cmd/agent/Dockerfile.buildx
@@ -1,18 +1,7 @@
-FROM --platform=$BUILDPLATFORM rfratto/seego:latest as build
+# grafana/agent/seego must be manually built with make seego
+FROM --platform=$BUILDPLATFORM grafana/agent/seego:latest as build
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
-
-# Use custom Go version instead of one prepacked in seego
-ENV GOLANG_VERSION 1.15.7
-ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 0d142143794721bb63ce6c8a6180c4062bcf8ef4715e7d6d6609f3a8282629b3
-RUN  rm -rf /usr/local/go                                           \
-  && curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz             \
-  && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
-  && tar -C /usr/local -xzf golang.tar.gz                           \
-  && rm golang.tar.gz
-
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 
 COPY . /src/agent
 WORKDIR /src/agent

--- a/cmd/agent/Dockerfile.buildx
+++ b/cmd/agent/Dockerfile.buildx
@@ -1,7 +1,16 @@
-# grafana/agent/seego must be manually built with make seego
-FROM --platform=$BUILDPLATFORM grafana/agent/seego:latest as build
+FROM --platform=$BUILDPLATFORM rfratto/seego:latest as build
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
+
+# Use custom Go version instead of one prepacked in seego
+ENV GOLANG_VERSION 1.15.7
+ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
+ENV GOLANG_DOWNLOAD_SHA256 0d142143794721bb63ce6c8a6180c4062bcf8ef4715e7d6d6609f3a8282629b3
+RUN  rm -rf /usr/local/go                                           \
+  && curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz             \
+  && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
+  && tar -C /usr/local -xzf golang.tar.gz                           \
+  && rm golang.tar.gz
 
 COPY . /src/agent
 WORKDIR /src/agent

--- a/cmd/agent/Dockerfile.buildx
+++ b/cmd/agent/Dockerfile.buildx
@@ -2,6 +2,18 @@ FROM --platform=$BUILDPLATFORM rfratto/seego:latest as build
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
+# Use custom Go version instead of one prepacked in seego
+ENV GOLANG_VERSION 1.15.7
+ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
+ENV GOLANG_DOWNLOAD_SHA256 0d142143794721bb63ce6c8a6180c4062bcf8ef4715e7d6d6609f3a8282629b3
+RUN  rm -rf /usr/local/go                                           \
+  && curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz             \
+  && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
+  && tar -C /usr/local -xzf golang.tar.gz                           \
+  && rm golang.tar.gz
+
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+
 COPY . /src/agent
 WORKDIR /src/agent
 ARG RELEASE_BUILD=true

--- a/cmd/agentctl/Dockerfile
+++ b/cmd/agentctl/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.3-buster as build
+FROM golang:1.15.7-buster as build
 COPY . /src/agent
 WORKDIR /src/agent
 ARG RELEASE_BUILD=false

--- a/cmd/agentctl/Dockerfile.buildx
+++ b/cmd/agentctl/Dockerfile.buildx
@@ -2,6 +2,16 @@ FROM --platform=$BUILDPLATFORM rfratto/seego:latest as build
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
+# Use custom Go version instead of one prepacked in seego
+ENV GOLANG_VERSION 1.15.7
+ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
+ENV GOLANG_DOWNLOAD_SHA256 0d142143794721bb63ce6c8a6180c4062bcf8ef4715e7d6d6609f3a8282629b3
+RUN  rm -rf /usr/local/go                                           \
+  && curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz             \
+  && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
+  && tar -C /usr/local -xzf golang.tar.gz                           \
+  && rm golang.tar.gz
+
 COPY . /src/agent
 WORKDIR /src/agent
 ARG RELEASE_BUILD=true

--- a/cmd/agentctl/Dockerfile.buildx
+++ b/cmd/agentctl/Dockerfile.buildx
@@ -1,16 +1,7 @@
-FROM --platform=$BUILDPLATFORM rfratto/seego:latest as build
+# grafana/agent/seego must be manually built with make seego
+FROM --platform=$BUILDPLATFORM grafana/agent/seego:latest as build
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
-
-# Use custom Go version instead of one prepacked in seego
-ENV GOLANG_VERSION 1.15.7
-ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 0d142143794721bb63ce6c8a6180c4062bcf8ef4715e7d6d6609f3a8282629b3
-RUN  rm -rf /usr/local/go                                           \
-  && curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz             \
-  && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
-  && tar -C /usr/local -xzf golang.tar.gz                           \
-  && rm golang.tar.gz
 
 COPY . /src/agent
 WORKDIR /src/agent

--- a/cmd/agentctl/Dockerfile.buildx
+++ b/cmd/agentctl/Dockerfile.buildx
@@ -1,7 +1,16 @@
-# grafana/agent/seego must be manually built with make seego
-FROM --platform=$BUILDPLATFORM grafana/agent/seego:latest as build
+FROM --platform=$BUILDPLATFORM rfratto/seego:latest as build
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
+
+# Use custom Go version instead of one prepacked in seego
+ENV GOLANG_VERSION 1.15.7
+ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
+ENV GOLANG_DOWNLOAD_SHA256 0d142143794721bb63ce6c8a6180c4062bcf8ef4715e7d6d6609f3a8282629b3
+RUN  rm -rf /usr/local/go                                           \
+  && curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz             \
+  && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
+  && tar -C /usr/local -xzf golang.tar.gz                           \
+  && rm golang.tar.gz
 
 COPY . /src/agent
 WORKDIR /src/agent

--- a/tools/seego/Dockerfile
+++ b/tools/seego/Dockerfile
@@ -1,6 +1,4 @@
-FROM --platform=$BUILDPLATFORM rfratto/seego:latest as build
-ARG TARGETPLATFORM
-ARG BUILDPLATFORM
+FROM rfratto/seego:latest as build
 
 # Use custom Go version instead of one prepacked in seego
 ENV GOLANG_VERSION 1.15.7

--- a/tools/seego/Dockerfile
+++ b/tools/seego/Dockerfile
@@ -1,0 +1,13 @@
+FROM --platform=$BUILDPLATFORM rfratto/seego:latest as build
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+# Use custom Go version instead of one prepacked in seego
+ENV GOLANG_VERSION 1.15.7
+ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
+ENV GOLANG_DOWNLOAD_SHA256 0d142143794721bb63ce6c8a6180c4062bcf8ef4715e7d6d6609f3a8282629b3
+RUN  rm -rf /usr/local/go                                           \
+  && curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz             \
+  && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
+  && tar -C /usr/local -xzf golang.tar.gz                           \
+  && rm golang.tar.gz


### PR DESCRIPTION
#### PR Description 
The `seego` abstraction made it unclear which version of Go was being used. This PR:

1. Makes it consistently 1.15.7 
2. Overrides the base `seego` image with 1.15.7.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
