### PR TITLE
Only keep certain K8s API server metrics by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@ can be found at [#317](https://github.com/grafana/agent/issues/317).
 
 # Master (unreleased)
 
-- [ENHANCEMENT] Only keep a handful of K8s API server metrics by default to reduce
-  default active series usage.
-
 BREAKING CHANGES: This release has two breaking changes in the configuration
 file. Please read the release notes carefully and our
 [migration guide](./docs/migration-guide.md) to help migrate your configuration
@@ -44,6 +41,9 @@ files to the new format.
   the hash of the instance config name instead of the entire config. This means
   that updating a config is guaranteed to always hash to the same Agent,
   reducing the number of metrics gaps. (@rfratto)
+
+- [ENHANCEMENT] Only keep a handful of K8s API server metrics by default to reduce
+  default active series usage. (@hjet)
 
 - [BUGFIX] `agentctl config-check` will now work correctly when the supplied
   config file contains integrations. (@hoenn)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ can be found at [#317](https://github.com/grafana/agent/issues/317).
 
 # Master (unreleased)
 
+- [ENHANCEMENT] Only keep a handful of K8s API server metrics by default to reduce
+  default active series usage.
+
 BREAKING CHANGES: This release has two breaking changes in the configuration
 file. Please read the release notes carefully and our
 [migration guide](./docs/migration-guide.md) to help migrate your configuration

--- a/production/kubernetes/agent-sigv4.yaml
+++ b/production/kubernetes/agent-sigv4.yaml
@@ -207,12 +207,8 @@ data:
                 kubernetes_sd_configs:
                   - role: endpoints
                 metric_relabel_configs:
-                  - action: drop
-                    regex: apiserver_admission_controller_admission_latencies_seconds_.*
-                    source_labels:
-                      - __name__
-                  - action: drop
-                    regex: apiserver_admission_step_admission_latencies_seconds_.*
+                  - action: keep
+                    regex: workqueue_queue_duration_seconds_bucket|process_cpu_seconds_total|process_resident_memory_bytes|workqueue_depth|rest_client_request_duration_seconds_bucket|workqueue_adds_total|up|rest_client_requests_total|apiserver_request_total|go_goroutines
                     source_labels:
                       - __name__
                 relabel_configs:

--- a/production/kubernetes/agent.yaml
+++ b/production/kubernetes/agent.yaml
@@ -205,12 +205,8 @@ data:
                 kubernetes_sd_configs:
                   - role: endpoints
                 metric_relabel_configs:
-                  - action: drop
-                    regex: apiserver_admission_controller_admission_latencies_seconds_.*
-                    source_labels:
-                      - __name__
-                  - action: drop
-                    regex: apiserver_admission_step_admission_latencies_seconds_.*
+                  - action: keep
+                    regex: workqueue_queue_duration_seconds_bucket|process_cpu_seconds_total|process_resident_memory_bytes|workqueue_depth|rest_client_request_duration_seconds_bucket|workqueue_adds_total|up|rest_client_requests_total|apiserver_request_total|go_goroutines
                     source_labels:
                       - __name__
                 relabel_configs:

--- a/production/tanka/grafana-agent/config.libsonnet
+++ b/production/tanka/grafana-agent/config.libsonnet
@@ -121,17 +121,12 @@
           action: 'keep',
         }],
 
-        // Drop some high cardinality metrics.
+        // Keep limited set of metrics to reduce default usage, drop all others
         metric_relabel_configs: [
           {
             source_labels: ['__name__'],
-            regex: 'apiserver_admission_controller_admission_latencies_seconds_.*',
-            action: 'drop',
-          },
-          {
-            source_labels: ['__name__'],
-            regex: 'apiserver_admission_step_admission_latencies_seconds_.*',
-            action: 'drop',
+            regex: 'workqueue_queue_duration_seconds_bucket|process_cpu_seconds_total|process_resident_memory_bytes|workqueue_depth|rest_client_request_duration_seconds_bucket|workqueue_adds_total|up|rest_client_requests_total|apiserver_request_total|go_goroutines',
+            action: 'keep',
           },
         ],
 

--- a/production/tanka/grafana-agent/v1/internal/kubernetes_instance.libsonnet
+++ b/production/tanka/grafana-agent/v1/internal/kubernetes_instance.libsonnet
@@ -35,17 +35,12 @@ local k8s_tls_config(config) = {
           action: 'keep',
         }],
 
-        // Drop some high cardinality metrics.
+        // Keep limited set of metrics to reduce default usage, drop all others
         metric_relabel_configs: [
           {
             source_labels: ['__name__'],
-            regex: 'apiserver_admission_controller_admission_latencies_seconds_.*',
-            action: 'drop',
-          },
-          {
-            source_labels: ['__name__'],
-            regex: 'apiserver_admission_step_admission_latencies_seconds_.*',
-            action: 'drop',
+            regex: 'workqueue_queue_duration_seconds_bucket|process_cpu_seconds_total|process_resident_memory_bytes|workqueue_depth|rest_client_request_duration_seconds_bucket|workqueue_adds_total|up|rest_client_requests_total|apiserver_request_total|go_goroutines',
+            action: 'keep',
           },
         ],
       },


### PR DESCRIPTION
#### PR Description 
Per https://github.com/grafana/agent/pull/352 and other user feedback, the default scrape configuration results in a large number of metrics being shipped out of the box, which can create a significant storage costs.

Using guidelines from https://grafana.com/docs/grafana-cloud/billing-and-usage/prometheus/usage-reduction-k8s/, this temporary fix only scrapes a handful of API server metrics by default instead of scraping everything (~20k active series). 

The inclusion criteria is basically "are these API server metrics referenced in a [kubernetes-mixin](https://github.com/kubernetes-monitoring/kubernetes-mixin) dashboard." If they are referenced in a recording rule, they are not included here. 

This is not a perfect solution to this problem, but a temporary patch to make the default less jarring and cost-intensive for users getting started with the agent. 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

@rfratto Please generate the relevant JSON from the Tanka... got a new laptop and still have to set up all the build stuff...Sorry!!

#### PR Checklist

- [✔️ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated