### PR TITLE
update to go 1.15.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ files to the new format.
 - [ENHANCEMENT] Only keep a handful of K8s API server metrics by default to reduce
   default active series usage. (@hjet)
 
-- [ENHANCEMENT] Go 1.15.7 is now used for all distributions of the Agent.
+- [ENHANCEMENT] Go 1.15.8 is now used for all distributions of the Agent.
   (@rfratto)
 
 - [BUGFIX] `agentctl config-check` will now work correctly when the supplied

--- a/cmd/agent/Dockerfile
+++ b/cmd/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.7-buster as build
+FROM golang:1.15.8-buster as build
 COPY . /src/agent
 WORKDIR /src/agent
 ARG RELEASE_BUILD=true

--- a/cmd/agent/Dockerfile.buildx
+++ b/cmd/agent/Dockerfile.buildx
@@ -3,9 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
 # Use custom Go version instead of one prepacked in seego
-ENV GOLANG_VERSION 1.15.7
+ENV GOLANG_VERSION 1.15.8
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 0d142143794721bb63ce6c8a6180c4062bcf8ef4715e7d6d6609f3a8282629b3
+ENV GOLANG_DOWNLOAD_SHA256 d3379c32a90fdf9382166f8f48034c459a8cc433730bc9476d39d9082c94583b
 RUN  rm -rf /usr/local/go                                           \
   && curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz             \
   && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/cmd/agentctl/Dockerfile
+++ b/cmd/agentctl/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.7-buster as build
+FROM golang:1.15.8-buster as build
 COPY . /src/agent
 WORKDIR /src/agent
 ARG RELEASE_BUILD=false

--- a/cmd/agentctl/Dockerfile.buildx
+++ b/cmd/agentctl/Dockerfile.buildx
@@ -3,9 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
 # Use custom Go version instead of one prepacked in seego
-ENV GOLANG_VERSION 1.15.7
+ENV GOLANG_VERSION 1.15.8
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 0d142143794721bb63ce6c8a6180c4062bcf8ef4715e7d6d6609f3a8282629b3
+ENV GOLANG_DOWNLOAD_SHA256 d3379c32a90fdf9382166f8f48034c459a8cc433730bc9476d39d9082c94583b
 RUN  rm -rf /usr/local/go                                           \
   && curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz             \
   && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/go.mod
+++ b/go.mod
@@ -1,57 +1,57 @@
 module github.com/grafana/agent
 
-go 1.12
+go 1.15
 
 require (
-	contrib.go.opencensus.io/exporter/prometheus v0.2.0
-	github.com/aws/aws-sdk-go v1.36.15
-	github.com/cortexproject/cortex v1.6.1-0.20210129172402-0976147451ee
-	github.com/drone/envsubst v1.0.2
-	github.com/go-kit/kit v0.10.0
-	github.com/go-playground/validator/v10 v10.4.0 // indirect
-	github.com/gogo/protobuf v1.3.1
-	github.com/golang/protobuf v1.4.3
-	github.com/google/dnsmasq_exporter v0.0.0-00010101000000-000000000000
-	github.com/gorilla/mux v1.8.0
-	github.com/grafana/loki v1.6.2-0.20210203125540-d667dd20f287
-	github.com/hashicorp/consul/api v1.8.1
-	github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d // indirect
-	github.com/joshdk/go-junit v0.0.0-20200702055522-6efcf4050909 // indirect
-	github.com/jsternberg/zap-logfmt v1.2.0
-	github.com/justwatchcom/elasticsearch_exporter v1.1.0
-	github.com/miekg/dns v1.1.35
-	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 // indirect
-	github.com/ncabatoff/process-exporter v0.7.5
-	github.com/oklog/run v1.1.0
-	github.com/olekukonko/tablewriter v0.0.2
-	github.com/oliver006/redis_exporter v1.15.0
-	github.com/opentracing-contrib/go-grpc v0.0.0-20191001143057-db30781987df
-	github.com/opentracing/opentracing-go v1.2.0
-	github.com/pkg/errors v0.9.1
-	github.com/prometheus/client_golang v1.9.0
-	github.com/prometheus/common v0.15.0
-	github.com/prometheus/consul_exporter v0.7.2-0.20210127095228-584c6de19f23
-	github.com/prometheus/memcached_exporter v0.8.0
-	github.com/prometheus/mysqld_exporter v0.0.0-00010101000000-000000000000
-	github.com/prometheus/node_exporter v1.0.1
-	github.com/prometheus/procfs v0.2.0
-	github.com/prometheus/prometheus v1.8.2-0.20210124145330-b5dfa2414b9e
-	github.com/prometheus/statsd_exporter v0.18.1-0.20201124082027-8b2b4c1a2b49
-	github.com/sirupsen/logrus v1.7.0
-	github.com/spf13/cobra v1.1.1
-	github.com/spf13/viper v1.7.1
-	github.com/stretchr/testify v1.6.1
-	github.com/weaveworks/common v0.0.0-20210112142934-23c8d7fa6120
-	github.com/wrouesnel/postgres_exporter v0.0.0-00010101000000-000000000000
-	go.opencensus.io v0.22.5
-	go.opentelemetry.io/collector v0.16.0
-	go.uber.org/atomic v1.7.0
-	go.uber.org/zap v1.16.0
-	google.golang.org/grpc v1.33.2
-	gopkg.in/alecthomas/kingpin.v2 v2.2.6
-	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
-	gotest.tools/v3 v3.0.3 // indirect
+  contrib.go.opencensus.io/exporter/prometheus v0.2.0
+  github.com/aws/aws-sdk-go v1.36.15
+  github.com/cortexproject/cortex v1.6.1-0.20210129172402-0976147451ee
+  github.com/drone/envsubst v1.0.2
+  github.com/go-kit/kit v0.10.0
+  github.com/go-playground/validator/v10 v10.4.0 // indirect
+  github.com/gogo/protobuf v1.3.1
+  github.com/golang/protobuf v1.4.3
+  github.com/google/dnsmasq_exporter v0.0.0-00010101000000-000000000000
+  github.com/gorilla/mux v1.8.0
+  github.com/grafana/loki v1.6.2-0.20210203125540-d667dd20f287
+  github.com/hashicorp/consul/api v1.8.1
+  github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d // indirect
+  github.com/joshdk/go-junit v0.0.0-20200702055522-6efcf4050909 // indirect
+  github.com/jsternberg/zap-logfmt v1.2.0
+  github.com/justwatchcom/elasticsearch_exporter v1.1.0
+  github.com/miekg/dns v1.1.35
+  github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 // indirect
+  github.com/ncabatoff/process-exporter v0.7.5
+  github.com/oklog/run v1.1.0
+  github.com/olekukonko/tablewriter v0.0.2
+  github.com/oliver006/redis_exporter v1.15.0
+  github.com/opentracing-contrib/go-grpc v0.0.0-20191001143057-db30781987df
+  github.com/opentracing/opentracing-go v1.2.0
+  github.com/pkg/errors v0.9.1
+  github.com/prometheus/client_golang v1.9.0
+  github.com/prometheus/common v0.15.0
+  github.com/prometheus/consul_exporter v0.7.2-0.20210127095228-584c6de19f23
+  github.com/prometheus/memcached_exporter v0.8.0
+  github.com/prometheus/mysqld_exporter v0.0.0-00010101000000-000000000000
+  github.com/prometheus/node_exporter v1.0.1
+  github.com/prometheus/procfs v0.2.0
+  github.com/prometheus/prometheus v1.8.2-0.20210124145330-b5dfa2414b9e
+  github.com/prometheus/statsd_exporter v0.18.1-0.20201124082027-8b2b4c1a2b49
+  github.com/sirupsen/logrus v1.7.0
+  github.com/spf13/cobra v1.1.1
+  github.com/spf13/viper v1.7.1
+  github.com/stretchr/testify v1.6.1
+  github.com/weaveworks/common v0.0.0-20210112142934-23c8d7fa6120
+  github.com/wrouesnel/postgres_exporter v0.0.0-00010101000000-000000000000
+  go.opencensus.io v0.22.5
+  go.opentelemetry.io/collector v0.16.0
+  go.uber.org/atomic v1.7.0
+  go.uber.org/zap v1.16.0
+  google.golang.org/grpc v1.33.2
+  gopkg.in/alecthomas/kingpin.v2 v2.2.6
+  gopkg.in/yaml.v2 v2.4.0
+  gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
+  gotest.tools/v3 v3.0.3 // indirect
 )
 
 // Needed for Cortex's dependencies to work properly.
@@ -62,18 +62,18 @@ replace k8s.io/klog => github.com/simonpasquier/klog-gokit v0.1.0
 
 // Replace directives from Cortex
 replace (
-	git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
-	github.com/gocql/gocql => github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85
-	github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+  git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
+  github.com/gocql/gocql => github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85
+  github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
 )
 
 // Replace directives from Loki
 replace (
-	github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v36.2.0+incompatible
-	github.com/hashicorp/consul => github.com/hashicorp/consul v1.5.1
-	github.com/hpcloud/tail => github.com/grafana/tail v0.0.0-20201004203643-7aa4e4a91f03
-	k8s.io/api => k8s.io/api v0.19.4
-	k8s.io/client-go => k8s.io/client-go v0.19.4
+  github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v36.2.0+incompatible
+  github.com/hashicorp/consul => github.com/hashicorp/consul v1.5.1
+  github.com/hpcloud/tail => github.com/grafana/tail v0.0.0-20201004203643-7aa4e4a91f03
+  k8s.io/api => k8s.io/api v0.19.4
+  k8s.io/client-go => k8s.io/client-go v0.19.4
 )
 
 replace github.com/prometheus/prometheus => github.com/grafana/prometheus v1.8.2-0.20210111220521-c0d5de2f0ee3
@@ -82,10 +82,10 @@ replace gopkg.in/yaml.v2 => github.com/rfratto/go-yaml v0.0.0-20200521142311-984
 
 // TODO(rfratto): remove forks when changes are merged upstream
 replace (
-	github.com/google/dnsmasq_exporter => github.com/grafana/dnsmasq_exporter v0.2.1-0.20201029182940-e5169b835a23
-	github.com/ncabatoff/process-exporter => github.com/grafana/process-exporter v0.7.3-0.20210106202358-831154072e2a
-	github.com/prometheus/mysqld_exporter => github.com/grafana/mysqld_exporter v0.12.2-0.20201015182516-5ac885b2d38a
-	github.com/wrouesnel/postgres_exporter => github.com/grafana/postgres_exporter v0.8.1-0.20201106170118-5eedee00c1db
+  github.com/google/dnsmasq_exporter => github.com/grafana/dnsmasq_exporter v0.2.1-0.20201029182940-e5169b835a23
+  github.com/ncabatoff/process-exporter => github.com/grafana/process-exporter v0.7.3-0.20210106202358-831154072e2a
+  github.com/prometheus/mysqld_exporter => github.com/grafana/mysqld_exporter v0.12.2-0.20201015182516-5ac885b2d38a
+  github.com/wrouesnel/postgres_exporter => github.com/grafana/postgres_exporter v0.8.1-0.20201106170118-5eedee00c1db
 )
 
 // Required for redis_exporter, which is incompatible with v2.0.0+incompatible.

--- a/tools/seego/Dockerfile
+++ b/tools/seego/Dockerfile
@@ -1,9 +1,9 @@
 FROM rfratto/seego:latest as build
 
 # Use custom Go version instead of one prepacked in seego
-ENV GOLANG_VERSION 1.15.7
+ENV GOLANG_VERSION 1.15.8
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 0d142143794721bb63ce6c8a6180c4062bcf8ef4715e7d6d6609f3a8282629b3
+ENV GOLANG_DOWNLOAD_SHA256 d3379c32a90fdf9382166f8f48034c459a8cc433730bc9476d39d9082c94583b
 RUN  rm -rf /usr/local/go                                           \
   && curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz             \
   && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9,6 +9,7 @@ cloud.google.com/go/pubsub
 cloud.google.com/go/pubsub/apiv1
 cloud.google.com/go/pubsub/internal/distribution
 # contrib.go.opencensus.io/exporter/prometheus v0.2.0
+## explicit
 contrib.go.opencensus.io/exporter/prometheus
 # github.com/Azure/azure-sdk-for-go v45.1.0+incompatible => github.com/Azure/azure-sdk-for-go v36.2.0+incompatible
 github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute
@@ -45,6 +46,7 @@ github.com/apache/thrift/lib/go/thrift
 github.com/armon/go-metrics
 github.com/armon/go-metrics/prometheus
 # github.com/aws/aws-sdk-go v1.36.15
+## explicit
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/awserr
 github.com/aws/aws-sdk-go/aws/awsutil
@@ -121,6 +123,7 @@ github.com/coreos/go-systemd/sdjournal
 # github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 github.com/coreos/pkg/capnslog
 # github.com/cortexproject/cortex v1.6.1-0.20210129172402-0976147451ee
+## explicit
 github.com/cortexproject/cortex/pkg/distributor
 github.com/cortexproject/cortex/pkg/ingester/client
 github.com/cortexproject/cortex/pkg/prom1/storage/metric
@@ -184,6 +187,7 @@ github.com/docker/go-connections/tlsconfig
 # github.com/docker/go-units v0.4.0
 github.com/docker/go-units
 # github.com/drone/envsubst v1.0.2
+## explicit
 github.com/drone/envsubst
 github.com/drone/envsubst/parse
 github.com/drone/envsubst/path
@@ -200,12 +204,15 @@ github.com/felixge/httpsnoop
 # github.com/fsnotify/fsnotify v1.4.9
 github.com/fsnotify/fsnotify
 # github.com/go-kit/kit v0.10.0
+## explicit
 github.com/go-kit/kit/log
 github.com/go-kit/kit/log/level
 # github.com/go-logfmt/logfmt v0.5.0
 github.com/go-logfmt/logfmt
 # github.com/go-logr/logr v0.2.0
 github.com/go-logr/logr
+# github.com/go-playground/validator/v10 v10.4.0
+## explicit
 # github.com/go-sql-driver/mysql v1.5.0
 github.com/go-sql-driver/mysql
 # github.com/godbus/dbus v0.0.0-20190402143921-271e53dc4968
@@ -214,6 +221,7 @@ github.com/godbus/dbus
 github.com/gogo/googleapis/google/api
 github.com/gogo/googleapis/google/rpc
 # github.com/gogo/protobuf v1.3.1
+## explicit
 github.com/gogo/protobuf/gogoproto
 github.com/gogo/protobuf/jsonpb
 github.com/gogo/protobuf/proto
@@ -225,6 +233,7 @@ github.com/gogo/status
 # github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 github.com/golang/groupcache/lru
 # github.com/golang/protobuf v1.4.3
+## explicit
 github.com/golang/protobuf/descriptor
 github.com/golang/protobuf/internal/gengogrpc
 github.com/golang/protobuf/jsonpb
@@ -245,6 +254,7 @@ github.com/gomodule/redigo/redis
 # github.com/google/btree v1.0.0
 github.com/google/btree
 # github.com/google/dnsmasq_exporter v0.0.0-00010101000000-000000000000 => github.com/grafana/dnsmasq_exporter v0.2.1-0.20201029182940-e5169b835a23
+## explicit
 github.com/google/dnsmasq_exporter/collector
 # github.com/google/go-cmp v0.5.4
 github.com/google/go-cmp/cmp
@@ -278,10 +288,12 @@ github.com/gophercloud/gophercloud/openstack/identity/v3/tokens
 github.com/gophercloud/gophercloud/openstack/utils
 github.com/gophercloud/gophercloud/pagination
 # github.com/gorilla/mux v1.8.0
+## explicit
 github.com/gorilla/mux
 # github.com/gorilla/websocket v1.4.2
 github.com/gorilla/websocket
 # github.com/grafana/loki v1.6.2-0.20210203125540-d667dd20f287
+## explicit
 github.com/grafana/loki/pkg/distributor
 github.com/grafana/loki/pkg/helpers
 github.com/grafana/loki/pkg/ingester/client
@@ -333,6 +345,7 @@ github.com/grpc-ecosystem/grpc-gateway/utilities
 # github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
 github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc
 # github.com/hashicorp/consul/api v1.8.1
+## explicit
 github.com/hashicorp/consul/api
 # github.com/hashicorp/errwrap v1.0.0
 github.com/hashicorp/errwrap
@@ -368,6 +381,8 @@ github.com/hashicorp/hcl/json/token
 github.com/hashicorp/memberlist
 # github.com/hashicorp/serf v0.9.5
 github.com/hashicorp/serf/coordinate
+# github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d
+## explicit
 # github.com/hetznercloud/hcloud-go v1.21.1
 github.com/hetznercloud/hcloud-go/hcloud
 github.com/hetznercloud/hcloud-go/hcloud/schema
@@ -422,6 +437,8 @@ github.com/jaegertracing/jaeger/thrift-gen/zipkincore
 github.com/jmespath/go-jmespath
 # github.com/jonboulle/clockwork v0.1.0
 github.com/jonboulle/clockwork
+# github.com/joshdk/go-junit v0.0.0-20200702055522-6efcf4050909
+## explicit
 # github.com/jpillora/backoff v1.0.0
 github.com/jpillora/backoff
 # github.com/json-iterator/go v1.1.10
@@ -431,8 +448,10 @@ github.com/jstemmer/go-junit-report
 github.com/jstemmer/go-junit-report/formatter
 github.com/jstemmer/go-junit-report/parser
 # github.com/jsternberg/zap-logfmt v1.2.0
+## explicit
 github.com/jsternberg/zap-logfmt
 # github.com/justwatchcom/elasticsearch_exporter v1.1.0
+## explicit
 github.com/justwatchcom/elasticsearch_exporter/collector
 github.com/justwatchcom/elasticsearch_exporter/pkg/clusterinfo
 # github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165
@@ -465,11 +484,14 @@ github.com/mdlayher/netlink/nlenc
 github.com/mdlayher/wifi
 github.com/mdlayher/wifi/internal/nl80211
 # github.com/miekg/dns v1.1.35
+## explicit
 github.com/miekg/dns
 # github.com/mitchellh/go-homedir v1.1.0
 github.com/mitchellh/go-homedir
 # github.com/mitchellh/mapstructure v1.3.3
 github.com/mitchellh/mapstructure
+# github.com/moby/term v0.0.0-20201216013528-df9cb8a40635
+## explicit
 # github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
@@ -479,17 +501,21 @@ github.com/mwitkow/go-conntrack
 # github.com/ncabatoff/go-seq v0.0.0-20180805175032-b08ef85ed833
 github.com/ncabatoff/go-seq/seq
 # github.com/ncabatoff/process-exporter v0.7.5 => github.com/grafana/process-exporter v0.7.3-0.20210106202358-831154072e2a
+## explicit
 github.com/ncabatoff/process-exporter
 github.com/ncabatoff/process-exporter/collector
 github.com/ncabatoff/process-exporter/config
 github.com/ncabatoff/process-exporter/proc
 # github.com/oklog/run v1.1.0
+## explicit
 github.com/oklog/run
 # github.com/oklog/ulid v1.3.1
 github.com/oklog/ulid
 # github.com/olekukonko/tablewriter v0.0.2
+## explicit
 github.com/olekukonko/tablewriter
 # github.com/oliver006/redis_exporter v1.15.0
+## explicit
 github.com/oliver006/redis_exporter/exporter
 # github.com/opencontainers/go-digest v1.0.0
 github.com/opencontainers/go-digest
@@ -497,10 +523,12 @@ github.com/opencontainers/go-digest
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
 # github.com/opentracing-contrib/go-grpc v0.0.0-20191001143057-db30781987df
+## explicit
 github.com/opentracing-contrib/go-grpc
 # github.com/opentracing-contrib/go-stdlib v1.0.0
 github.com/opentracing-contrib/go-stdlib/nethttp
 # github.com/opentracing/opentracing-go v1.2.0
+## explicit
 github.com/opentracing/opentracing-go
 github.com/opentracing/opentracing-go/ext
 github.com/opentracing/opentracing-go/log
@@ -510,6 +538,7 @@ github.com/openzipkin/zipkin-go/proto/zipkin_proto3
 # github.com/pelletier/go-toml v1.8.0
 github.com/pelletier/go-toml
 # github.com/pkg/errors v0.9.1
+## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
@@ -517,6 +546,7 @@ github.com/pmezard/go-difflib/difflib
 github.com/pquerna/cachecontrol
 github.com/pquerna/cachecontrol/cacheobject
 # github.com/prometheus/client_golang v1.9.0
+## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promauto
@@ -527,6 +557,7 @@ github.com/prometheus/client_golang/prometheus/testutil/promlint
 # github.com/prometheus/client_model v0.2.0
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.15.0
+## explicit
 github.com/prometheus/common/config
 github.com/prometheus/common/expfmt
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
@@ -534,15 +565,20 @@ github.com/prometheus/common/log
 github.com/prometheus/common/model
 github.com/prometheus/common/version
 # github.com/prometheus/consul_exporter v0.7.2-0.20210127095228-584c6de19f23
+## explicit
 github.com/prometheus/consul_exporter/pkg/exporter
 # github.com/prometheus/memcached_exporter v0.8.0
+## explicit
 github.com/prometheus/memcached_exporter/pkg/exporter
 # github.com/prometheus/mysqld_exporter v0.0.0-00010101000000-000000000000 => github.com/grafana/mysqld_exporter v0.12.2-0.20201015182516-5ac885b2d38a
+## explicit
 github.com/prometheus/mysqld_exporter/collector
 # github.com/prometheus/node_exporter v1.0.1
+## explicit
 github.com/prometheus/node_exporter/collector
 github.com/prometheus/node_exporter/https
 # github.com/prometheus/procfs v0.2.0
+## explicit
 github.com/prometheus/procfs
 github.com/prometheus/procfs/bcache
 github.com/prometheus/procfs/btrfs
@@ -552,6 +588,7 @@ github.com/prometheus/procfs/nfs
 github.com/prometheus/procfs/sysfs
 github.com/prometheus/procfs/xfs
 # github.com/prometheus/prometheus v1.8.2-0.20210124145330-b5dfa2414b9e => github.com/grafana/prometheus v1.8.2-0.20210111220521-c0d5de2f0ee3
+## explicit
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
 github.com/prometheus/prometheus/discovery/azure
@@ -607,6 +644,7 @@ github.com/prometheus/prometheus/util/teststorage
 github.com/prometheus/prometheus/util/testutil
 github.com/prometheus/prometheus/util/treecache
 # github.com/prometheus/statsd_exporter v0.18.1-0.20201124082027-8b2b4c1a2b49
+## explicit
 github.com/prometheus/statsd_exporter/pkg/address
 github.com/prometheus/statsd_exporter/pkg/clock
 github.com/prometheus/statsd_exporter/pkg/event
@@ -636,6 +674,7 @@ github.com/shurcooL/vfsgen
 # github.com/siebenmann/go-kstat v0.0.0-20200303194639-4e8294f9e9d5
 github.com/siebenmann/go-kstat
 # github.com/sirupsen/logrus v1.7.0
+## explicit
 github.com/sirupsen/logrus
 # github.com/soheilhy/cmux v0.1.4
 github.com/soheilhy/cmux
@@ -647,16 +686,19 @@ github.com/spf13/afero/mem
 # github.com/spf13/cast v1.3.1
 github.com/spf13/cast
 # github.com/spf13/cobra v1.1.1
+## explicit
 github.com/spf13/cobra
 # github.com/spf13/jwalterweatherman v1.1.0
 github.com/spf13/jwalterweatherman
 # github.com/spf13/pflag v1.0.5
 github.com/spf13/pflag
 # github.com/spf13/viper v1.7.1
+## explicit
 github.com/spf13/viper
 # github.com/stretchr/objx v0.2.0
 github.com/stretchr/objx
 # github.com/stretchr/testify v1.6.1
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 github.com/stretchr/testify/require
@@ -687,6 +729,7 @@ github.com/uber/jaeger-client-go/utils
 # github.com/uber/jaeger-lib v2.4.0+incompatible
 github.com/uber/jaeger-lib/metrics
 # github.com/weaveworks/common v0.0.0-20210112142934-23c8d7fa6120
+## explicit
 github.com/weaveworks/common/errors
 github.com/weaveworks/common/grpc
 github.com/weaveworks/common/httpgrpc
@@ -701,6 +744,7 @@ github.com/weaveworks/common/user
 # github.com/weaveworks/promrus v1.2.0
 github.com/weaveworks/promrus
 # github.com/wrouesnel/postgres_exporter v0.0.0-00010101000000-000000000000 => github.com/grafana/postgres_exporter v0.8.1-0.20201106170118-5eedee00c1db
+## explicit
 github.com/wrouesnel/postgres_exporter/exporter
 # github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
 github.com/xiang90/probing
@@ -785,6 +829,7 @@ go.etcd.io/etcd/version
 go.etcd.io/etcd/wal
 go.etcd.io/etcd/wal/walpb
 # go.opencensus.io v0.22.5
+## explicit
 go.opencensus.io
 go.opencensus.io/internal
 go.opencensus.io/internal/tagencoding
@@ -805,6 +850,7 @@ go.opencensus.io/trace/internal
 go.opencensus.io/trace/propagation
 go.opencensus.io/trace/tracestate
 # go.opentelemetry.io/collector v0.16.0
+## explicit
 go.opentelemetry.io/collector/client
 go.opentelemetry.io/collector/component
 go.opentelemetry.io/collector/component/componenterror
@@ -866,6 +912,7 @@ go.opentelemetry.io/collector/translator/trace
 go.opentelemetry.io/collector/translator/trace/jaeger
 go.opentelemetry.io/collector/translator/trace/zipkin
 # go.uber.org/atomic v1.7.0
+## explicit
 go.uber.org/atomic
 # go.uber.org/goleak v1.1.10
 go.uber.org/goleak
@@ -873,6 +920,7 @@ go.uber.org/goleak/internal/stack
 # go.uber.org/multierr v1.5.0
 go.uber.org/multierr
 # go.uber.org/zap v1.16.0
+## explicit
 go.uber.org/zap
 go.uber.org/zap/buffer
 go.uber.org/zap/internal/bufferpool
@@ -994,6 +1042,7 @@ google.golang.org/genproto/googleapis/rpc/status
 google.golang.org/genproto/googleapis/type/expr
 google.golang.org/genproto/protobuf/field_mask
 # google.golang.org/grpc v1.33.2 => google.golang.org/grpc v1.29.1
+## explicit
 google.golang.org/grpc
 google.golang.org/grpc/attributes
 google.golang.org/grpc/backoff
@@ -1091,6 +1140,7 @@ google.golang.org/protobuf/types/known/timestamppb
 google.golang.org/protobuf/types/known/wrapperspb
 google.golang.org/protobuf/types/pluginpb
 # gopkg.in/alecthomas/kingpin.v2 v2.2.6
+## explicit
 gopkg.in/alecthomas/kingpin.v2
 # gopkg.in/fsnotify.v1 v1.4.7
 gopkg.in/fsnotify.v1
@@ -1107,9 +1157,13 @@ gopkg.in/square/go-jose.v2/json
 # gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
 gopkg.in/tomb.v1
 # gopkg.in/yaml.v2 v2.4.0 => github.com/rfratto/go-yaml v0.0.0-20200521142311-984fc90c8a04
+## explicit
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
+## explicit
 gopkg.in/yaml.v3
+# gotest.tools/v3 v3.0.3
+## explicit
 # k8s.io/api v0.19.4 => k8s.io/api v0.19.4
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1beta1
@@ -1265,3 +1319,20 @@ k8s.io/utils/trace
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
+# google.golang.org/grpc => google.golang.org/grpc v1.29.1
+# k8s.io/klog => github.com/simonpasquier/klog-gokit v0.1.0
+# git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
+# github.com/gocql/gocql => github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85
+# github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+# github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v36.2.0+incompatible
+# github.com/hashicorp/consul => github.com/hashicorp/consul v1.5.1
+# github.com/hpcloud/tail => github.com/grafana/tail v0.0.0-20201004203643-7aa4e4a91f03
+# k8s.io/api => k8s.io/api v0.19.4
+# k8s.io/client-go => k8s.io/client-go v0.19.4
+# github.com/prometheus/prometheus => github.com/grafana/prometheus v1.8.2-0.20210111220521-c0d5de2f0ee3
+# gopkg.in/yaml.v2 => github.com/rfratto/go-yaml v0.0.0-20200521142311-984fc90c8a04
+# github.com/google/dnsmasq_exporter => github.com/grafana/dnsmasq_exporter v0.2.1-0.20201029182940-e5169b835a23
+# github.com/ncabatoff/process-exporter => github.com/grafana/process-exporter v0.7.3-0.20210106202358-831154072e2a
+# github.com/prometheus/mysqld_exporter => github.com/grafana/mysqld_exporter v0.12.2-0.20201015182516-5ac885b2d38a
+# github.com/wrouesnel/postgres_exporter => github.com/grafana/postgres_exporter v0.8.1-0.20201106170118-5eedee00c1db
+# github.com/gomodule/redigo => github.com/gomodule/redigo v1.8.2


### PR DESCRIPTION
#### PR Description 
I noticed Go 1.15.8 got released right after I merged #383 🙃 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
