### PR TITLE
Add storage 'middleware' to do scrape time aggregation.

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -1,0 +1,226 @@
+package aggregator
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-kit/kit/log"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+)
+
+// Aggregator implement storage.Aggregator and runs a set of PromQL queries
+// on the in-memory batch before committing to the underlying appendable.
+type Aggregator struct {
+	logger     log.Logger
+	appendable storage.Appendable
+	engine     *promql.Engine
+	rules      []Rule
+}
+
+// Rule for scrape-time aggregation.
+type Rule struct {
+	Name   string            `yaml:"name"`
+	Expr   string            `yaml:"expr"`
+	Labels map[string]string `yaml:"labels,omitempty"`
+}
+
+// New makes a fresh Aggregator.
+func New(logger log.Logger, appendable storage.Appendable, rules []Rule) *Aggregator {
+	engine := promql.NewEngine(promql.EngineOpts{
+		Logger:        logger,
+		MaxSamples:    1000000,
+		Timeout:       time.Minute,
+		LookbackDelta: 15 * time.Minute,
+	})
+
+	return &Aggregator{
+		logger:     logger,
+		appendable: appendable,
+		engine:     engine,
+		rules:      rules,
+	}
+}
+
+// Appender implements storage.Appendable.
+func (a *Aggregator) Appender(ctx context.Context) storage.Appender {
+	return &batch{
+		ctx:        ctx,
+		aggregator: a,
+		appender:   a.appendable.Appender(ctx),
+	}
+}
+
+type batch struct {
+	ctx        context.Context
+	aggregator *Aggregator
+	appender   storage.Appender
+	samples    []sample
+	ts         int64
+}
+
+func (b *batch) Add(l labels.Labels, t int64, v float64) (uint64, error) {
+	b.samples = append(b.samples, sample{l, t, v})
+	return b.appender.Add(l, t, v)
+}
+
+func (b *batch) AddFast(ref uint64, t int64, v float64) error {
+	return b.appender.AddFast(ref, t, v)
+}
+
+func (b *batch) Commit() error {
+	for _, r := range b.aggregator.rules {
+		if err := b.execute(r); err != nil {
+			return err
+		}
+	}
+
+	return b.appender.Commit()
+}
+
+func (b *batch) Rollback() error {
+	return b.appender.Commit()
+}
+
+func (b *batch) execute(rule Rule) error {
+	q, err := b.aggregator.engine.NewInstantQuery(b, rule.Expr, time.Unix(0, b.ts*int64(time.Millisecond)))
+	if err != nil {
+		return err
+	}
+	defer q.Close()
+
+	r := q.Exec(b.ctx)
+	if r.Err != nil {
+		return r.Err
+	}
+
+	v, err := r.Vector()
+	if err != nil {
+		return err
+	}
+
+	for i := range v {
+		ls := v[i].Metric.Copy()
+		ls = ls.WithoutLabels(labels.MetricName)
+		ls = append(ls, labels.Label{Name: labels.MetricName, Value: rule.Name})
+		for k, v := range rule.Labels {
+			ls = append(ls, labels.Label{Name: k, Value: v})
+		}
+
+		_, err := b.Add(ls, v[i].T, v[i].V)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (b *batch) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+	return &querier{
+		ctx:  ctx,
+		b:    b,
+		mint: mint,
+		maxt: maxt,
+	}, nil
+}
+
+type querier struct {
+	storage.LabelQuerier
+
+	ctx        context.Context
+	b          *batch
+	mint, maxt int64
+}
+
+func (q *querier) Select(sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+	return &seriesSet{
+		q:        q,
+		matchers: matchers,
+		i:        -1,
+	}
+}
+
+func (*querier) Close() error {
+	return nil
+}
+
+type seriesSet struct {
+	q        *querier
+	matchers []*labels.Matcher
+	i        int
+}
+
+func (s *seriesSet) Next() bool {
+	s.i++
+	for s.i < len(s.q.b.samples) {
+		if matchLabels(s.q.b.samples[s.i].l, s.matchers) {
+			return true
+		}
+		s.i++
+	}
+	return false
+}
+
+func matchLabels(lset labels.Labels, matchers []*labels.Matcher) bool {
+	for _, m := range matchers {
+		if !m.Matches(lset.Get(m.Name)) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *seriesSet) At() storage.Series {
+	return &s.q.b.samples[s.i]
+}
+
+func (s *seriesSet) Err() error {
+	return nil
+}
+
+func (s *seriesSet) Warnings() storage.Warnings {
+	return nil
+}
+
+type sample struct {
+	l labels.Labels
+	t int64
+	v float64
+}
+
+func (s *sample) Labels() labels.Labels {
+	return s.l
+}
+
+func (s *sample) Iterator() chunkenc.Iterator {
+	return &iter{s: s}
+}
+
+type iter struct {
+	s    *sample
+	next bool
+}
+
+func (i *iter) Next() bool {
+	if i.next {
+		return false
+	}
+	i.next = true
+	return true
+}
+
+func (*iter) Seek(t int64) bool {
+	return true
+}
+
+func (i *iter) At() (int64, float64) {
+	return i.s.t, i.s.v
+}
+
+func (*iter) Err() error {
+	return nil
+}

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -1,0 +1,64 @@
+package aggregator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAggregator(t *testing.T) {
+	m := mockAppendable{}
+	a := New(log.NewNopLogger(), &m, []Rule{
+		{
+			Name:   "node_cpu_seconds_total",
+			Expr:   "sum without(cpu) (node_cpu_seconds_total)",
+			Labels: map[string]string{},
+		},
+	})
+
+	appender := a.Appender(context.Background())
+	samples := []sample{
+		{labels.FromStrings(labels.MetricName, "node_cpu_seconds_total", "cpu", "0"), 0, 123},
+		{labels.FromStrings(labels.MetricName, "node_cpu_seconds_total", "cpu", "1"), 0, 234},
+		{labels.FromStrings(labels.MetricName, "node_cpu_seconds_total", "cpu", "2"), 0, 345},
+		{labels.FromStrings(labels.MetricName, "node_cpu_seconds_total", "cpu", "3"), 0, 456},
+	}
+	for _, s := range samples {
+		_, err := appender.Add(s.Labels(), s.t, s.v)
+		require.NoError(t, err)
+	}
+	err := appender.Commit()
+	require.NoError(t, err)
+
+	expected := append(samples, sample{labels.FromStrings(labels.MetricName, "node_cpu_seconds_total"), 0, 1158})
+	require.Equal(t, expected, m.samples)
+}
+
+type mockAppendable struct {
+	samples []sample
+}
+
+func (m *mockAppendable) Appender(context.Context) storage.Appender {
+	return m
+}
+
+func (m *mockAppendable) Add(l labels.Labels, t int64, v float64) (uint64, error) {
+	m.samples = append(m.samples, sample{l, t, v})
+	return 0, nil
+}
+
+func (m *mockAppendable) AddFast(ref uint64, t int64, v float64) error {
+	return nil
+}
+
+func (m *mockAppendable) Commit() error {
+	return nil
+}
+
+func (m *mockAppendable) Rollback() error {
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: Tom Wilkie <tom@grafana.com>

#### PR Description 

This PR adds a storage "middleware" that wraps the existing storage and allows you to run quasi-recording rules again commit batches.  
The idea here is that you can use these rules to aggregate away certain labels that lead to high cardinality.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

NB this isn't wired in anywhere, and is very much just a proof of concept of an idea - that you can reuse the PromQL engine to do these scrape-time aggregations, and don't need to invent another way of doing it.

Right now this won't work as "AddFast" isn't implemented.  We need the labels to be able to execute the PromQL, so we need some cache for these.

Also, the batch doesn't use any form of index, making select queries more expensive than they should be.

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
