### PR TITLE
allow relying on the default value of the -addr flag in config-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ can be found at [#317](https://github.com/grafana/agent/issues/317).
 
 # Master (unreleased)
 
+- [BUGFIX] Not providing an `-addr` flag for `agentctl config-sync` will no
+  longer report an error and will instead use the pre-existing default value.
+  (@rfratto)
+
 # v0.12.0 (2021-02-05)
 
 BREAKING CHANGES: This release has two breaking changes in the configuration

--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -70,10 +70,15 @@ source-of-truth directory.`,
 		Args: cobra.ExactArgs(1),
 
 		Run: func(_ *cobra.Command, args []string) {
+			logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
+
+			if agentAddr == "" {
+				level.Error(logger).Log("msg", "-addr must not be an empty string")
+				os.Exit(1)
+			}
+
 			directory := args[0]
 			cli := client.New(agentAddr)
-
-			logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
 
 			err := agentctl.ConfigSync(logger, cli.PrometheusClient, directory, dryRun)
 			if err != nil {
@@ -85,7 +90,6 @@ source-of-truth directory.`,
 
 	cmd.Flags().StringVarP(&agentAddr, "addr", "a", "http://localhost:12345", "address of the agent to connect to")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "use the dry run option to validate config files without attempting to upload")
-	must(cmd.MarkFlagRequired("addr"))
 	return cmd
 }
 


### PR DESCRIPTION
#### PR Description 

#### Which issue(s) this PR fixes 
Closes #395

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
