### PR TITLE
Reduce likelihood of data loss when remote endpoint has an outage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ can be found at [#317](https://github.com/grafana/agent/issues/317).
 - [BUGFIX] Fixed a bug from v0.12.0 where the Loki installation script failed
   because positions_directory was not set. (@rfratto)
 
+- [BUGFIX] (#400) Reduce the likelihood of dataloss during a remote_write-side
+  outage by increasing the default wal_truncation_frequency to 60m and preventing
+  the WAL from being truncated if the last truncation timestamp hasn't changed.
+  This change increases the size of the WAL on average, and users may configure
+  a lower wal_truncation_frequency to deliberately choose a smaller WAL over
+  write guarantees. (@rfratto)
+
 # v0.12.0 (2021-02-05)
 
 BREAKING CHANGES: This release has two breaking changes in the configuration

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -372,14 +372,6 @@ host_filter_relabel_configs:
   [ - <relabel_config> ... ]
 
 # How frequently the WAL truncation process should run. Every iteration of
-# truncation will checkpoint old series, create a new segment for new samples,
-# and remove old samples that have been succesfully sent via remote_write.
-# If there are are multiple remote_write endpoints, the endpoint with the
-# earliest timestamp is used for the cutoff period, ensuring that no data
-# gets truncated until all remote_write configurations have been able to
-# send the data.
-
-# How frequently the WAL truncation process should run. Every iteration of
 # the truncation will checkpoint old series and remove old samples. If data
 # has not been sent within this window, some of it may be lost.
 #

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -378,7 +378,16 @@ host_filter_relabel_configs:
 # earliest timestamp is used for the cutoff period, ensuring that no data
 # gets truncated until all remote_write configurations have been able to
 # send the data.
-[wal_truncate_frequency: <duration> | default = "1m"]
+
+# How frequently the WAL truncation process should run. Every iteration of
+# the truncation will checkpoint old series and remove old samples. If data
+# has not been sent within this window, some of it may be lost.
+#
+# The size of the WAL will increase with less frequent truncations. Making
+# truncations more frequent reduces the size of the WAL but increases the
+# chances of data loss when remote_write is failing for longer than the
+# specified frequency.
+[wal_truncate_frequency: <duration> | default = "60m"]
 
 # The minimum amount of time that series and samples should exist in the WAL
 # before being considered for deletion. The consumed disk space of the WAL will

--- a/pkg/prom/instance/instance.go
+++ b/pkg/prom/instance/instance.go
@@ -628,7 +628,7 @@ func (i *Instance) newDiscoveryManager(ctx context.Context, cfg *Config) (*disco
 
 func (i *Instance) truncateLoop(ctx context.Context, wal walStorage, cfg *Config) {
 	// Track the last timestamp we truncated for to prevent segments from getting
-	// deleted until at least some data has been sent.
+	// deleted until at least some new data has been sent.
 	var lastTs int64 = math.MinInt64
 
 	for {


### PR DESCRIPTION
#### PR Description 
This PR increases the WAL truncation frequency default to 60 minutes to reduce the likelihood of samples being moved to a checkpoint when remote_writes are failing. 

An extra measure has been added to the truncate loop where a WAL truncate will be skipped if the last remote_write timestamp hasn't changed. This applies after the `min_wal_time` and `max_wal_time` checks so data older than `max_wal_time` should continue to be deleted.

#### Which issue(s) this PR fixes 
Fixes #400 (kind of, it's not perfect, but it's significantly better).

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
