### PR TITLE
Allow specifying wal truncate frequencies per integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ can be found at [#317](https://github.com/grafana/agent/issues/317).
 
 - [ENHANCEMENT] Support other architectures in installation script. (@rfratto)
 
+- [ENHANCEMENT] Allow specifying custom wal_truncate_frequency per integration.
+  (@rfratto)
+
 - [BUGFIX] Not providing an `-addr` flag for `agentctl config-sync` will no
   longer report an error and will instead use the pre-existing default value.
   (@rfratto)

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -2016,6 +2016,9 @@ agent:
   # prometheus.global.scrape_timeout.
   [scrape_timeout: <duration> | default = <global_config.scrape_timeout>]
 
+  # How frequent to truncate the WAL for this integration.
+  [wal_truncate_frequency: <duration> | default = "1m"]
+
   # Allows for relabeling labels on the target.
   relabel_configs:
     [- <relabel_config> ... ]
@@ -2286,6 +2289,9 @@ the Agent is running on is a no-op.
   metric_relabel_configs:
     [ - <relabel_config> ... ]
 
+  # How frequent to truncate the WAL for this integration.
+  [wal_truncate_frequency: <duration> | default = "1m"]
+
   # Monitor the exporter itself and include those metrics in the results.
   [include_exporter_metrics: <boolean> | default = false]
 
@@ -2500,6 +2506,9 @@ Full reference of options:
   metric_relabel_configs:
     [ - <relabel_config> ... ]
 
+  # How frequent to truncate the WAL for this integration.
+  [wal_truncate_frequency: <duration> | default = "1m"]
+
   # procfs mountpoint.
   [procfs_path: <string> | default = "/proc"]
 
@@ -2622,6 +2631,9 @@ Full reference of options:
   # from the integration that you don't care about.
   metric_relabel_configs:
     [ - <relabel_config> ... ]
+
+  # How frequent to truncate the WAL for this integration.
+  [wal_truncate_frequency: <duration> | default = "1m"]
 
   # Data Source Name specifies the MySQL server to connect to. This is REQUIRED
   # but may also be specified by the MYSQLD_EXPORTER_DATA_SOURCE_NAME
@@ -2763,6 +2775,9 @@ Full reference of options:
   # from the integration that you don't care about.
   metric_relabel_configs:
     [ - <relabel_config> ... ]
+
+  # How frequent to truncate the WAL for this integration.
+  [wal_truncate_frequency: <duration> | default = "1m"]
 
   # Monitor the exporter itself and include those metrics in the results.
   [include_exporter_metrics: <bool> | default = false]
@@ -2909,6 +2924,9 @@ Full reference of options:
   metric_relabel_configs:
     [ - <relabel_config> ... ]
 
+  # How frequent to truncate the WAL for this integration.
+  [wal_truncate_frequency: <duration> | default = "1m"]
+
   # Monitor the exporter itself and include those metrics in the results.
   [include_exporter_metrics: <bool> | default = false]
 
@@ -2964,6 +2982,9 @@ Full reference of options:
   # from the integration that you don't care about.
   metric_relabel_configs:
     [ - <relabel_config> ... ]
+
+  # How frequent to truncate the WAL for this integration.
+  [wal_truncate_frequency: <duration> | default = "1m"]
 
   # Monitor the exporter itself and include those metrics in the results.
   [include_exporter_metrics: <bool> | default = false]
@@ -3068,6 +3089,9 @@ Full reference of options:
   metric_relabel_configs:
     [ - <relabel_config> ... ]
 
+  # How frequent to truncate the WAL for this integration.
+  [wal_truncate_frequency: <duration> | default = "1m"]
+
   # Monitor the exporter itself and include those metrics in the results.
   [include_exporter_metrics: <bool> | default = false]
 
@@ -3119,6 +3143,9 @@ Full reference of options:
   # from the integration that you don't care about.
   metric_relabel_configs:
     [ - <relabel_config> ... ]
+
+  # How frequent to truncate the WAL for this integration.
+  [wal_truncate_frequency: <duration> | default = "1m"]
 
   # Monitor the exporter itself and include those metrics in the results.
   [include_exporter_metrics: <bool> | default = false]
@@ -3192,6 +3219,9 @@ Full reference of options:
   # from the integration that you don't care about.
   metric_relabel_configs:
     [ - <relabel_config> ... ]
+
+  # How frequent to truncate the WAL for this integration.
+  [wal_truncate_frequency: <duration> | default = "1m"]
 
   # Monitor the exporter itself and include those metrics in the results.
   [include_exporter_metrics: <bool> | default = false]
@@ -3295,6 +3325,9 @@ Full reference of options:
   # from the integration that you don't care about.
   metric_relabel_configs:
     [ - <relabel_config> ... ]
+
+  # How frequent to truncate the WAL for this integration.
+  [wal_truncate_frequency: <duration> | default = "1m"]
 
   # Monitor the exporter itself and include those metrics in the results.
   [include_exporter_metrics: <bool> | default = false]

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -2017,7 +2017,7 @@ agent:
   [scrape_timeout: <duration> | default = <global_config.scrape_timeout>]
 
   # How frequent to truncate the WAL for this integration.
-  [wal_truncate_frequency: <duration> | default = "1m"]
+  [wal_truncate_frequency: <duration> | default = "60m"]
 
   # Allows for relabeling labels on the target.
   relabel_configs:
@@ -2290,7 +2290,7 @@ the Agent is running on is a no-op.
     [ - <relabel_config> ... ]
 
   # How frequent to truncate the WAL for this integration.
-  [wal_truncate_frequency: <duration> | default = "1m"]
+  [wal_truncate_frequency: <duration> | default = "60m"]
 
   # Monitor the exporter itself and include those metrics in the results.
   [include_exporter_metrics: <boolean> | default = false]
@@ -2507,7 +2507,7 @@ Full reference of options:
     [ - <relabel_config> ... ]
 
   # How frequent to truncate the WAL for this integration.
-  [wal_truncate_frequency: <duration> | default = "1m"]
+  [wal_truncate_frequency: <duration> | default = "60m"]
 
   # procfs mountpoint.
   [procfs_path: <string> | default = "/proc"]
@@ -2633,7 +2633,7 @@ Full reference of options:
     [ - <relabel_config> ... ]
 
   # How frequent to truncate the WAL for this integration.
-  [wal_truncate_frequency: <duration> | default = "1m"]
+  [wal_truncate_frequency: <duration> | default = "60m"]
 
   # Data Source Name specifies the MySQL server to connect to. This is REQUIRED
   # but may also be specified by the MYSQLD_EXPORTER_DATA_SOURCE_NAME
@@ -2777,7 +2777,7 @@ Full reference of options:
     [ - <relabel_config> ... ]
 
   # How frequent to truncate the WAL for this integration.
-  [wal_truncate_frequency: <duration> | default = "1m"]
+  [wal_truncate_frequency: <duration> | default = "60m"]
 
   # Monitor the exporter itself and include those metrics in the results.
   [include_exporter_metrics: <bool> | default = false]
@@ -2925,7 +2925,7 @@ Full reference of options:
     [ - <relabel_config> ... ]
 
   # How frequent to truncate the WAL for this integration.
-  [wal_truncate_frequency: <duration> | default = "1m"]
+  [wal_truncate_frequency: <duration> | default = "60m"]
 
   # Monitor the exporter itself and include those metrics in the results.
   [include_exporter_metrics: <bool> | default = false]
@@ -2984,7 +2984,7 @@ Full reference of options:
     [ - <relabel_config> ... ]
 
   # How frequent to truncate the WAL for this integration.
-  [wal_truncate_frequency: <duration> | default = "1m"]
+  [wal_truncate_frequency: <duration> | default = "60m"]
 
   # Monitor the exporter itself and include those metrics in the results.
   [include_exporter_metrics: <bool> | default = false]
@@ -3090,7 +3090,7 @@ Full reference of options:
     [ - <relabel_config> ... ]
 
   # How frequent to truncate the WAL for this integration.
-  [wal_truncate_frequency: <duration> | default = "1m"]
+  [wal_truncate_frequency: <duration> | default = "60m"]
 
   # Monitor the exporter itself and include those metrics in the results.
   [include_exporter_metrics: <bool> | default = false]
@@ -3145,7 +3145,7 @@ Full reference of options:
     [ - <relabel_config> ... ]
 
   # How frequent to truncate the WAL for this integration.
-  [wal_truncate_frequency: <duration> | default = "1m"]
+  [wal_truncate_frequency: <duration> | default = "60m"]
 
   # Monitor the exporter itself and include those metrics in the results.
   [include_exporter_metrics: <bool> | default = false]
@@ -3221,7 +3221,7 @@ Full reference of options:
     [ - <relabel_config> ... ]
 
   # How frequent to truncate the WAL for this integration.
-  [wal_truncate_frequency: <duration> | default = "1m"]
+  [wal_truncate_frequency: <duration> | default = "60m"]
 
   # Monitor the exporter itself and include those metrics in the results.
   [include_exporter_metrics: <bool> | default = false]
@@ -3327,7 +3327,7 @@ Full reference of options:
     [ - <relabel_config> ... ]
 
   # How frequent to truncate the WAL for this integration.
-  [wal_truncate_frequency: <duration> | default = "1m"]
+  [wal_truncate_frequency: <duration> | default = "60m"]
 
   # Monitor the exporter itself and include those metrics in the results.
   [include_exporter_metrics: <bool> | default = false]

--- a/pkg/integrations/config/config.go
+++ b/pkg/integrations/config/config.go
@@ -21,6 +21,7 @@ type Common struct {
 	ScrapeTimeout        time.Duration     `yaml:"scrape_timeout"`
 	RelabelConfigs       []*relabel.Config `yaml:"relabel_configs,omitempty"`
 	MetricRelabelConfigs []*relabel.Config `yaml:"metric_relabel_configs,omitempty"`
+	WALTruncateFrequency time.Duration     `yaml:"wal_truncate_frequency"`
 }
 
 // ScrapeConfig is a subset of options used by integrations to inform how samples

--- a/pkg/integrations/manager.go
+++ b/pkg/integrations/manager.go
@@ -206,7 +206,7 @@ func (m *Manager) runIntegration(ctx context.Context, cfg Config, i Integration)
 		// Apply the config so an instance is launched to scrape our integration.
 		instanceConfig := m.instanceConfigForIntegration(cfg, i)
 		if err := m.im.ApplyConfig(instanceConfig); err != nil {
-			level.Error(m.logger).Log("msg", "failed to apply integration. integration will not run. THIS IS A BUG!", "err", err, "integration", cfg.Name())
+			level.Error(m.logger).Log("msg", "failed to apply integration. integration will not run", "err", err, "integration", cfg.Name())
 			return
 		}
 	}
@@ -252,6 +252,9 @@ func (m *Manager) instanceConfigForIntegration(cfg Config, i Integration) instan
 	instanceCfg.Name = prometheusName
 	instanceCfg.ScrapeConfigs = scrapeConfigs
 	instanceCfg.RemoteWrite = m.c.PrometheusRemoteWrite
+	if common.WALTruncateFrequency > 0 {
+		instanceCfg.WALTruncateFrequency = common.WALTruncateFrequency
+	}
 	return instanceCfg
 }
 


### PR DESCRIPTION
#### PR Description 
Adds `wal_truncate_frequency` as a common integration setting, allowing to override the forced default. 

#### Which issue(s) this PR fixes
Closes #390  

#### Notes to the Reviewer
Blocked by #401.

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
