### PR TITLE
infer sigv4 region from environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ update your local checkouts of the repository to point at the new branch name.
 - [ENHANCEMENT] Allow specifying custom wal_truncate_frequency per integration.
   (@rfratto)
 
+- [ENHANCEMENT] The SigV4 region can now be inferred using the shared config
+  (at `$HOME/.aws/config`) or environment variables (via `AWS_CONFIG`).
+  (@rfratto)
+
 - [BUGFIX] Not providing an `-addr` flag for `agentctl config-sync` will no
   longer report an error and will instead use the pre-existing default value.
   (@rfratto)

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -1818,19 +1818,21 @@ basic_auth:
 #
 # https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
 #
-# When enabled, region must be supplied.
+# Region must be supplied if it cannot be inferred from the shared config
+# ($HOME/.aws/config when AWS_SDK_LOAD_CONFIG is truthy) or the environment
+# (AWS_REGION).
 #
-# This feature is currently exclusive to the Grafana Cloud Agent and is only
-# currently available for remote_write of Prometheus metrics.
+# This feature is only currently available for remote_write of Prometheus
+# metrics.
 sigv4:
   # Enable SigV4 request signing. May not be enabled at the same time as
   # configuring basic auth or bearer_token/bearer_token_file.
   [ enabled: <boolean> | default = false ]
 
-  # Region to use for signing the requests. When sigv4.enabled is true,
-  # must be non-empty and must be the region of the AMP workspace specified
-  # by the remote_write URL.
-  region: <string>
+  # Region to use for signing the requests. Must be supplied if region cannot
+  # be inferred from environment. Region must match the region of the AMP
+  # workspace specified by the remote_write URL.
+  [region: <string>]
 
 # Configures the remote write request's TLS settings.
 tls_config:

--- a/pkg/prom/instance/sigv4.go
+++ b/pkg/prom/instance/sigv4.go
@@ -49,7 +49,7 @@ func NewSigV4RoundTripper(cfg SigV4Config, next http.RoundTripper) (http.RoundTr
 	if _, err := sess.Config.Credentials.Get(); err != nil {
 		return nil, fmt.Errorf("could not get sigv4 credentials: %w", err)
 	}
-	if sess.Config.Region == nil || *sess.Config.Region == "" {
+	if aws.StringValue(sess.Config.Region) == "" {
 		return nil, fmt.Errorf("region not configured in sigv4 or in default credentials chain")
 	}
 

--- a/pkg/prom/instance/sigv4_test.go
+++ b/pkg/prom/instance/sigv4_test.go
@@ -2,23 +2,39 @@ package instance
 
 import (
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
 	signer "github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/stretchr/testify/require"
 )
 
+func TestSigV4_Inferred_Region(t *testing.T) {
+	os.Setenv("AWS_ACCESS_KEY_ID", "secret")
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "token")
+	os.Setenv("AWS_REGION", "us-west-2")
+
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(""),
+	})
+	require.NoError(t, err)
+	_, err = sess.Config.Credentials.Get()
+	require.NoError(t, err)
+
+	require.NotNil(t, sess.Config.Region)
+	require.Equal(t, "us-west-2", *sess.Config.Region)
+}
+
 func TestSigV4RoundTripper(t *testing.T) {
 	var gotReq *http.Request
 
 	rt := &sigV4RoundTripper{
-		cfg: SigV4Config{
-			Enabled: true,
-			Region:  "us-east-2",
-		},
+		region: "us-east-2",
 		next: promhttp.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			gotReq = req
 			return &http.Response{StatusCode: http.StatusOK}, nil

--- a/pkg/prom/instance/sigv4_test.go
+++ b/pkg/prom/instance/sigv4_test.go
@@ -20,6 +20,8 @@ func TestSigV4_Inferred_Region(t *testing.T) {
 	os.Setenv("AWS_REGION", "us-west-2")
 
 	sess, err := session.NewSession(&aws.Config{
+		// Setting to an empty string to demostrate the default value from the yaml
+		// won't override the environment's region.
 		Region: aws.String(""),
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
#### PR Description 
Allows for inferring the sigv4 region from environment variables or the shared config file. The region specified in the Agent YAML serves as the final override. 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
