### PR TITLE
Scraping service: stop scraping service instances on partial shutdown

### DIFF
--- a/pkg/prom/ha/server.go
+++ b/pkg/prom/ha/server.go
@@ -390,7 +390,14 @@ func (s *Server) Stop() error {
 	s.cancel()
 	<-s.exited
 
-	return s.closeDependencies()
+	err := s.closeDependencies()
+
+	// Delete all the local configs that were running.
+	s.configManagerMut.Lock()
+	defer s.configManagerMut.Unlock()
+	s.im.Stop()
+
+	return err
 }
 
 // stopServices stops services in argument-call order. Blocks until all services

--- a/pkg/prom/ha/sharding.go
+++ b/pkg/prom/ha/sharding.go
@@ -237,8 +237,16 @@ func (m ShardingInstanceManager) DeleteConfig(name string) error {
 	return err
 }
 
-// Stop implements instance.Manager.Stop.
-func (m ShardingInstanceManager) Stop() { m.inner.Stop() }
+// Stop implements instance.Manager.Stop. It only stops the configs
+// passed through to this manager and not all instances.
+func (m ShardingInstanceManager) Stop() {
+	for k := range m.keyToHash {
+		err := m.DeleteConfig(k)
+		if err != nil {
+			level.Error(m.log).Log("msg", "failed to remove config", "name", k)
+		}
+	}
+}
 
 // owns checks if the ShardingInstanceManager is responsible for
 // a given hash.

--- a/pkg/prom/ha/sharding.go
+++ b/pkg/prom/ha/sharding.go
@@ -243,7 +243,7 @@ func (m ShardingInstanceManager) Stop() {
 	for k := range m.keyToHash {
 		err := m.DeleteConfig(k)
 		if err != nil {
-			level.Error(m.log).Log("msg", "failed to remove config", "name", k, "error", err)
+			level.Error(m.log).Log("msg", "failed to remove config", "name", k, "err", err)
 		}
 	}
 }

--- a/pkg/prom/ha/sharding.go
+++ b/pkg/prom/ha/sharding.go
@@ -243,7 +243,7 @@ func (m ShardingInstanceManager) Stop() {
 	for k := range m.keyToHash {
 		err := m.DeleteConfig(k)
 		if err != nil {
-			level.Error(m.log).Log("msg", "failed to remove config", "name", k)
+			level.Error(m.log).Log("msg", "failed to remove config", "name", k, "error", err)
 		}
 	}
 }


### PR DESCRIPTION
#### PR Description 
This is needed for the config reloading, but is already handled today: when the overall Agent stop, it stops all intances, including ones retrieved via the scraping service. However, if _just_ the scraping service was stopped, then its instances would continue running in the background. This fixes that problem.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated (not needed)
- [x] Documentation added (not needed)
- [x] Tests updated (not needed)
