### PR TITLE
Add query_path and disable_default_metrics to postgres_exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ can be found at [#317](https://github.com/grafana/agent/issues/317).
 The primary branch name has changed from `master` to `main`. You may have to
 update your local checkouts of the repository to point at the new branch name.
 
+- [FEATURE] postgres_exporter: Support query_path and disable_default_metrics. (@rfratto)
+
 - [ENHANCEMENT] Support other architectures in installation script. (@rfratto)
 
 - [ENHANCEMENT] Allow specifying custom wal_truncate_frequency per integration.

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -3187,6 +3187,14 @@ Full reference of options:
   # is true.
   exclude_databases:
   [ - <string> ]
+
+  # Path to a YAML file containing custom queries to run. Check out
+  # postgres_exporter's queries.yaml for examples of the format:
+  # https://github.com/prometheus-community/postgres_exporter/blob/master/queries.yaml
+  [query_path: <string> | default = ""]
+
+  # When true, only exposes metrics supplied from query_path.
+  [disable_default_metrics: <boolean> | default = false]
 ```
 
 ### statsd_exporter_config

--- a/pkg/integrations/postgres_exporter/postgres_exporter.go
+++ b/pkg/integrations/postgres_exporter/postgres_exporter.go
@@ -24,6 +24,8 @@ type Config struct {
 	DisableSettingsMetrics bool     `yaml:"disable_settings_metrics"`
 	AutodiscoverDatabases  bool     `yaml:"autodiscover_databases"`
 	ExcludeDatabases       []string `yaml:"exclude_databases"`
+	DisableDefaultMetrics  bool     `yaml:"disable_default_metrics"`
+	QueryPath              string   `yaml:"query_path"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler for Config.
@@ -63,7 +65,8 @@ func New(log log.Logger, c *Config) (integrations.Integration, error) {
 
 	e := exporter.NewExporter(
 		dsn,
-		exporter.DisableDefaultMetrics(false),
+		exporter.DisableDefaultMetrics(c.DisableDefaultMetrics),
+		exporter.WithUserQueriesPath(c.QueryPath),
 		exporter.DisableSettingsMetrics(c.DisableSettingsMetrics),
 		exporter.AutoDiscoverDatabases(c.AutodiscoverDatabases),
 		exporter.ExcludeDatabases(strings.Join(c.ExcludeDatabases, ",")),


### PR DESCRIPTION
#### PR Description 
Adds `query_path` and `disable_default_metrics` to postgres_exporter, which were missing from the initial implementation.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
