### PR TITLE
Default enable compression for trace export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ can be found at [#317](https://github.com/grafana/agent/issues/317).
 
 # Main (unreleased)
 
+- [ENHANCEMENT] Support compression for trace export. (@mdisibio)
+
 # v0.13.0 (2021-02-25)
 
 The primary branch name has changed from `master` to `main`. You may have to
@@ -21,8 +23,6 @@ update your local checkouts of the repository to point at the new branch name.
   (@rfratto)
 
 - [ENHANCEMENT] Update Prometheus dependency to v2.25.0. (@rfratto)
-
-- [ENHANCEMENT] Support compression for trace export. (@mdisibio)
 
 - [BUGFIX] Not providing an `-addr` flag for `agentctl config-sync` will no
   longer report an error and will instead use the pre-existing default value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ update your local checkouts of the repository to point at the new branch name.
 
 - [ENHANCEMENT] Update Prometheus dependency to v2.25.0. (@rfratto)
 
+- [ENHANCEMENT] Support compression for trace export. (@mdisibio)
+
 - [BUGFIX] Not providing an `-addr` flag for `agentctl config-sync` will no
   longer report an error and will instead use the pre-existing default value.
   (@rfratto)

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -1987,6 +1987,9 @@ push_config:
   # host:port to send traces to
   endpoint: <string>
 
+  # Controls whether compression is enabled.
+  [ compression: <string> | default = "" | supported = "", "gzip"]
+
   # Controls whether or not TLS is required.  See https://godoc.org/google.golang.org/grpc#WithInsecure
   [ insecure: <boolean> | default = false ]
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -1988,7 +1988,7 @@ push_config:
   endpoint: <string>
 
   # Controls whether compression is enabled.
-  [ compression: <string> | default = "" | supported = "", "gzip"]
+  [ compression: <string> | default = "gzip" | supported = "none", "gzip"]
 
   # Controls whether or not TLS is required.  See https://godoc.org/google.golang.org/grpc#WithInsecure
   [ insecure: <boolean> | default = false ]

--- a/pkg/tempo/config.go
+++ b/pkg/tempo/config.go
@@ -116,6 +116,13 @@ func (c *InstanceConfig) otelConfig() (*configmodels.Config, error) {
 		}
 	}
 
+	switch c.PushConfig.Compression {
+	case "none":
+		c.PushConfig.Compression = ""
+	case "":
+		c.PushConfig.Compression = "gzip"
+	}
+
 	otlpExporter := map[string]interface{}{
 		"endpoint":             c.PushConfig.Endpoint,
 		"compression":          c.PushConfig.Compression,

--- a/pkg/tempo/config.go
+++ b/pkg/tempo/config.go
@@ -74,8 +74,15 @@ type InstanceConfig struct {
 	ScrapeConfigs []interface{} `yaml:"scrape_configs"`
 }
 
-const compressionNone = "none"
-const compressionGzip = "gzip"
+const (
+	compressionNone = "none"
+	compressionGzip = "gzip"
+)
+
+// DefaultPushConfig holds the default settings for a PushConfig.
+var DefaultPushConfig = PushConfig{
+	Compression: compressionGzip,
+}
 
 // PushConfig controls the configuration of exporting to Grafana Cloud
 type PushConfig struct {
@@ -91,25 +98,16 @@ type PushConfig struct {
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (c *PushConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	// Default
-	c.Compression = compressionGzip
+	*c = DefaultPushConfig
 
 	type plain PushConfig
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
-	return c.Validate()
-}
 
-// Validate ensures that the Config is valid.
-func (c *PushConfig) Validate() error {
-	switch c.Compression {
-	case compressionGzip:
-	case compressionNone:
-	default:
-		return fmt.Errorf("unsupported compression '%s'", c.Compression)
+	if c.Compression != compressionGzip && c.Compression != compressionNone {
+		return fmt.Errorf("unsupported compression '%s', expected 'gzip' or 'none'", c.Compression)
 	}
-
 	return nil
 }
 

--- a/pkg/tempo/config.go
+++ b/pkg/tempo/config.go
@@ -77,6 +77,7 @@ type InstanceConfig struct {
 // PushConfig controls the configuration of exporting to Grafana Cloud
 type PushConfig struct {
 	Endpoint           string                 `yaml:"endpoint"`
+	Compression        string                 `yaml:"compression"`
 	Insecure           bool                   `yaml:"insecure"`
 	InsecureSkipVerify bool                   `yaml:"insecure_skip_verify"`
 	BasicAuth          *prom_config.BasicAuth `yaml:"basic_auth,omitempty"`
@@ -117,6 +118,7 @@ func (c *InstanceConfig) otelConfig() (*configmodels.Config, error) {
 
 	otlpExporter := map[string]interface{}{
 		"endpoint":             c.PushConfig.Endpoint,
+		"compression":          c.PushConfig.Compression,
 		"headers":              headers,
 		"insecure":             c.PushConfig.Insecure,
 		"insecure_skip_verify": c.PushConfig.InsecureSkipVerify,

--- a/pkg/tempo/config_test.go
+++ b/pkg/tempo/config_test.go
@@ -79,6 +79,7 @@ receivers:
 exporters:
   otlp:
     endpoint: example.com:12345
+    compression: gzip
     retry_on_failure:
       max_elapsed_time: 60s
 service:
@@ -111,6 +112,7 @@ receivers:
 exporters:
   otlp:
     endpoint: example.com:12345
+    compression: gzip
     insecure: true
     headers:
       authorization: Basic dGVzdDpibGVyZw==
@@ -155,6 +157,7 @@ receivers:
 exporters:
   otlp:
     endpoint: example.com:12345
+    compression: gzip
     retry_on_failure:
       initial_interval: 10s
       max_elapsed_time: 60s
@@ -198,6 +201,7 @@ receivers:
 exporters:
   otlp:
     endpoint: example.com:12345
+    compression: gzip
     insecure: true
     headers:
       authorization: Basic dGVzdDpwYXNzd29yZF9pbl9maWxl
@@ -221,6 +225,37 @@ receivers:
 push_config:
   insecure_skip_verify: true
   endpoint: example.com:12345`,
+			expectedConfig: `
+receivers:
+  jaeger:
+    protocols:
+      grpc:
+exporters:
+  otlp:
+    endpoint: example.com:12345
+    compression: gzip
+    insecure_skip_verify: true
+    retry_on_failure:
+      max_elapsed_time: 60s
+service:
+  pipelines:
+    traces:
+      exporters: ["otlp"]
+      processors: []
+      receivers: ["jaeger"]
+`,
+		},
+		{
+			name: "no compression",
+			cfg: `
+receivers:
+  jaeger:
+    protocols:
+      grpc:
+push_config:
+  insecure_skip_verify: true
+  endpoint: example.com:12345
+  compression: none`,
 			expectedConfig: `
 receivers:
   jaeger:


### PR DESCRIPTION
#### PR Description 
This PR exposes compression for the tempo trace export section, which is already supported by the vendored OTLP exporter.  Supported compressions are gzip or none.  

As discussed, it now defaults to enabling gzip, but can be disabled with "none".

#### Which issue(s) this PR fixes 
n/a

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
