### PR TITLE
pkg/prom: implement ApplyConfig

### DIFF
--- a/pkg/prom/ha/api.go
+++ b/pkg/prom/ha/api.go
@@ -1,0 +1,187 @@
+package ha
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/gorilla/mux"
+	"github.com/grafana/agent/pkg/agentproto"
+	"github.com/grafana/agent/pkg/prom/ha/configapi"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// APIHandler is a function that returns a configapi Response type
+// and optionally an error.
+type APIHandler func(r *http.Request) (interface{}, error)
+
+// API can wire HTTP and gRPC routes.
+type API struct {
+	mut         sync.Mutex
+	server      *Server
+	logger      log.Logger
+	scrapingApi *deferredScrapingServiceServer
+}
+
+// NewAPI creates a new API for a given server s. s may be nil and updated later.
+func NewAPI(log log.Logger, s *Server) *API {
+	return &API{
+		server:      s,
+		logger:      log,
+		scrapingApi: &deferredScrapingServiceServer{server: s},
+	}
+}
+
+// SetServer updates the server used by the API.
+func (api *API) SetServer(s *Server) {
+	api.mut.Lock()
+	defer api.mut.Unlock()
+
+	api.server = s
+	api.scrapingApi.SetServer(s)
+}
+
+// WireAPI injects routes into the provided mux router for the config
+// management API.
+func (api *API) WireAPI(r *mux.Router) {
+	var (
+		listConfig   = api.wrapHandler(func(s *Server) APIHandler { return s.ListConfigurations })
+		getConfig    = api.wrapHandler(func(s *Server) APIHandler { return s.GetConfiguration })
+		deleteConfig = api.wrapHandler(func(s *Server) APIHandler { return s.DeleteConfiguration })
+
+		// putConfig doesn't support multiple concurrent requests since it acts as
+		// a non-atomic CAS.
+		putConfig = nonConcurrentHTTPHandler(
+			api.wrapHandler(func(s *Server) APIHandler { return s.PutConfiguration }),
+		)
+	)
+
+	// Support URL-encoded config names. The handlers will need to decode the
+	// name when reading the path variable.
+	r = r.UseEncodedPath()
+
+	r.HandleFunc("/agent/api/v1/configs", listConfig).Methods("GET")
+	r.HandleFunc("/agent/api/v1/configs/{name}", getConfig).Methods("GET")
+	r.HandleFunc("/agent/api/v1/config/{name}", putConfig).Methods("PUT", "POST")
+	r.HandleFunc("/agent/api/v1/config/{name}", deleteConfig).Methods("DELETE")
+
+	r.HandleFunc("/debug/ring", func(rw http.ResponseWriter, r *http.Request) {
+		api.mut.Lock()
+		defer api.mut.Unlock()
+
+		if api.server == nil {
+			err := configapi.WriteError(rw, http.StatusNotFound, fmt.Errorf("scraping service not enabled"))
+			if err != nil {
+				level.Error(api.logger).Log("msg", "failed writing error response to client", "err", err)
+			}
+			return
+		}
+
+		api.server.ring.ServeHTTP(rw, r)
+	})
+}
+
+// WireGRPC injects gRPC server handlers into the provided gRPC server.
+func (api *API) WireGRPC(srv *grpc.Server) {
+	agentproto.RegisterScrapingServiceServer(srv, api.scrapingApi)
+}
+
+// wrapHandler is responsible for turning an APIHandler into an HTTP
+// handler by wrapping responses and writing them as JSON.
+func (api *API) wrapHandler(getHandler func(s *Server) APIHandler) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		api.mut.Lock()
+		defer api.mut.Unlock()
+
+		if api.server == nil {
+			err := configapi.WriteError(w, http.StatusNotFound, fmt.Errorf("scraping service not enabled"))
+			if err != nil {
+				level.Error(api.logger).Log("msg", "failed writing error response to client", "err", err)
+			}
+			return
+		}
+
+		next := getHandler(api.server)
+		resp, err := next(r)
+		if err != nil {
+			httpErr, ok := err.(*httpError)
+
+			if ok {
+				err = configapi.WriteError(w, httpErr.StatusCode, httpErr.Err)
+			} else {
+				err = configapi.WriteError(w, http.StatusInternalServerError, err)
+			}
+
+			if err != nil {
+				level.Error(api.logger).Log("msg", "failed writing error response to client", "err", err)
+			}
+			return
+		}
+
+		// Prepare data and status code to send back to the writer: if the handler
+		// returned an *httpResponse, use the status code defined there and send the
+		// internal data. Otherwise, assume HTTP 200 OK and marshal the raw response.
+		var (
+			data       = resp
+			statusCode = http.StatusOK
+		)
+		if httpResp, ok := data.(*httpResponse); ok {
+			data = httpResp.Data
+			statusCode = httpResp.StatusCode
+		}
+
+		if err := configapi.WriteResponse(w, statusCode, data); err != nil {
+			level.Error(api.logger).Log("msg", "failed to write valid response", "err", err)
+		}
+	})
+}
+
+// nonConcurrentHTTPHandler wraps an http.HandlerFunc in a mutex.
+func nonConcurrentHTTPHandler(next http.HandlerFunc) http.HandlerFunc {
+	var mut sync.Mutex
+	return func(rw http.ResponseWriter, r *http.Request) {
+		mut.Lock()
+		defer mut.Unlock()
+		next(rw, r)
+	}
+}
+
+type deferredScrapingServiceServer struct {
+	mut    sync.Mutex
+	server *Server
+}
+
+func (s *deferredScrapingServiceServer) SetServer(server *Server) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+	s.server = server
+}
+
+func (s *deferredScrapingServiceServer) Reshard(ctx context.Context, req *agentproto.ReshardRequest) (*empty.Empty, error) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	if s.server == nil {
+		return nil, status.Errorf(codes.Unimplemented, "scraping service not running")
+	}
+
+	return s.server.Reshard(ctx, req)
+}
+
+type httpError struct {
+	StatusCode int
+	Err        error
+}
+
+func (e httpError) Error() string { return e.Err.Error() }
+
+type httpResponse struct {
+	StatusCode int
+	Data       interface{}
+}

--- a/pkg/prom/ha/http_test.go
+++ b/pkg/prom/ha/http_test.go
@@ -375,7 +375,7 @@ func newAPITestEnvironment(t *testing.T) apiTestEnvironment {
 	require.NoError(t, err)
 
 	// Wire the API
-	ha.WireAPI(router)
+	NewAPI(logger, ha).WireAPI(router)
 
 	return apiTestEnvironment{
 		ha:     ha,

--- a/pkg/prom/ha/server.go
+++ b/pkg/prom/ha/server.go
@@ -27,7 +27,6 @@ import (
 	"github.com/prometheus/prometheus/config"
 	"github.com/weaveworks/common/user"
 	"go.uber.org/atomic"
-	"google.golang.org/grpc"
 )
 
 var (
@@ -361,11 +360,6 @@ func (s *Server) localReshard(ctx context.Context) {
 	if err != nil {
 		level.Error(s.logger).Log("msg", "resharding failed", "err", err)
 	}
-}
-
-// WireGRPC injects gRPC server handlers into the provided gRPC server.
-func (s *Server) WireGRPC(srv *grpc.Server) {
-	agentproto.RegisterScrapingServiceServer(srv, s)
 }
 
 // Flush satisfies ring.FlushTransferer. It is a no-op for the Agent.

--- a/pkg/prom/http.go
+++ b/pkg/prom/http.go
@@ -14,9 +14,7 @@ import (
 
 // WireAPI adds API routes to the provided mux router.
 func (a *Agent) WireAPI(r *mux.Router) {
-	if a.cfg.ServiceConfig.Enabled {
-		a.ha.WireAPI(r)
-	}
+	a.haAPI.WireAPI(r)
 
 	r.HandleFunc("/agent/api/v1/instances", a.ListInstancesHandler).Methods("GET")
 	r.HandleFunc("/agent/api/v1/targets", a.ListTargetsHandler).Methods("GET")

--- a/pkg/prom/instance/modal_manager.go
+++ b/pkg/prom/instance/modal_manager.go
@@ -69,10 +69,6 @@ type ModalManager struct {
 
 // NewModalManager creates a new ModalManager.
 func NewModalManager(reg prometheus.Registerer, l log.Logger, next Manager, mode Mode) (*ModalManager, error) {
-	if mode == "" {
-		mode = DefaultMode
-	}
-
 	currentActiveConfigs := promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 		Name: "agent_prometheus_active_configs",
 		Help: "Current number of active configs being used by the agent.",
@@ -94,6 +90,10 @@ func NewModalManager(reg prometheus.Registerer, l log.Logger, next Manager, mode
 // an expensive operation; all underlying configs must be stopped and then
 // reapplied.
 func (m *ModalManager) SetMode(newMode Mode) error {
+	if newMode == "" {
+		newMode = DefaultMode
+	}
+
 	m.mut.Lock()
 	defer m.mut.Unlock()
 
@@ -115,7 +115,7 @@ func (m *ModalManager) SetMode(newMode Mode) error {
 	case ModeShared:
 		m.active = NewGroupManager(m.wrapped)
 	default:
-		panic("unknown mode " + m.mode)
+		panic("unknown mode " + newMode)
 	}
 	m.mode = newMode
 


### PR DESCRIPTION
#### PR Description 
This PR implements ApplyConfig for the Prometheus instance manager. 

#### Which issue(s) this PR fixes 
Partial implementation of #147.  
Similar PRs: #416, #424, #427. 

#### Notes to the Reviewer
The behavior here is easily the most drastic: changing the scraping service config can only be handled by leaving the cluster, changing the config, and rejoining. 

#### PR Checklist

- [x] CHANGELOG updated (internal change, not needed) 
- [x] Documentation added (internal change, not needed)
- [x] Tests updated
