### PR TITLE
Simplify sharding logic

### DIFF
--- a/pkg/prom/ha/server.go
+++ b/pkg/prom/ha/server.go
@@ -333,8 +333,8 @@ func (s *Server) watchKV(ctx context.Context) {
 
 		switch {
 		// Two deletion scenarios:
-		// 1. A config we're running got deleted
-		// 2. A config we're running got moved to a new owner
+		// 1. A config we're running got moved to a new owner
+		// 2. A config we're running got deleted
 		case (isRunning && !owned) || (v == nil && isRunning):
 			if err := s.im.DeleteConfig(key); err != nil {
 				level.Error(s.logger).Log("msg", "failed to delete config", "name", key, "err", err)

--- a/pkg/prom/ha/server.go
+++ b/pkg/prom/ha/server.go
@@ -93,6 +93,7 @@ type Server struct {
 	configManagerMut sync.Mutex
 	im               instance.Manager
 	joined           *atomic.Bool
+	configs          map[string]struct{}
 
 	kv   kv.Client
 	ring ReadRing
@@ -150,7 +151,7 @@ func New(reg prometheus.Registerer, cfg Config, globalConfig *config.GlobalConfi
 		clientConfig,
 		logger,
 
-		NewShardingInstanceManager(logger, im, r, lc.Addr),
+		im,
 
 		lc.Addr,
 		r,
@@ -192,8 +193,9 @@ func newServer(cfg Config, globalCfg *config.GlobalConfig, clientCfg client.Conf
 		logger:       log,
 		addr:         addr,
 
-		im:     im,
-		joined: atomic.NewBool(false),
+		im:      im,
+		joined:  atomic.NewBool(false),
+		configs: make(map[string]struct{}),
 
 		kv:   kv,
 		ring: r,
@@ -401,7 +403,16 @@ func (s *Server) Stop() error {
 	// Delete all the local configs that were running.
 	s.configManagerMut.Lock()
 	defer s.configManagerMut.Unlock()
-	s.im.Stop()
+
+	for cfg := range s.configs {
+		if err := s.im.DeleteConfig(cfg); err != nil {
+			level.Warn(s.logger).Log("msg", "failed to delete config on shutdown", "config", cfg, "err", err)
+		}
+
+		// Deletes only fail if the config doesn't exist, so either way we want to
+		// stop tracking it here.
+		delete(s.configs, cfg)
+	}
 
 	return err
 }

--- a/pkg/prom/ha/server_test.go
+++ b/pkg/prom/ha/server_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math"
 	"net"
+	"net/http"
 	"sort"
 	"strings"
 	"sync"
@@ -421,4 +422,25 @@ func startScrapingServiceServer(t *testing.T, srv agentproto.ScrapingServiceServ
 		State:     ring.ACTIVE,
 		Timestamp: math.MaxInt64,
 	}
+}
+
+type mockFuncReadRing struct {
+	http.Handler
+
+	GetFunc           func(key uint32, op ring.Operation, bufDescs []ring.InstanceDesc, bufHosts, bufZones []string) (ring.ReplicationSet, error)
+	GetAllHealthyFunc func(ring.Operation) (ring.ReplicationSet, error)
+}
+
+func (r *mockFuncReadRing) Get(key uint32, op ring.Operation, bufDescs []ring.InstanceDesc, bufHosts, bufZones []string) (ring.ReplicationSet, error) {
+	if r.GetFunc != nil {
+		return r.GetFunc(key, op, bufDescs, bufHosts, bufZones)
+	}
+	return ring.ReplicationSet{}, errors.New("not implemented")
+}
+
+func (r *mockFuncReadRing) GetAllHealthy(op ring.Operation) (ring.ReplicationSet, error) {
+	if r.GetAllHealthyFunc != nil {
+		return r.GetAllHealthyFunc(op)
+	}
+	return ring.ReplicationSet{}, errors.New("not implemented")
 }

--- a/pkg/prom/ha/sharding.go
+++ b/pkg/prom/ha/sharding.go
@@ -2,14 +2,12 @@ package ha
 
 import (
 	"context"
-	"fmt"
 	"hash/fnv"
 	"net/http"
 	"sync"
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/ring"
-	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/grafana/agent/pkg/agentproto"
@@ -35,9 +33,6 @@ func (s *Server) Reshard(ctx context.Context, _ *agentproto.ReshardRequest) (_ *
 	}()
 
 	var (
-		// current configs the agent is tracking
-		currentConfigs = s.im.ListConfigs()
-
 		// configs found in the KV store. currentConfigs - discoveredConfigs is the
 		// list of configs that was removed from the KV store since the last reshard.
 		discoveredConfigs = map[string]struct{}{}
@@ -49,16 +44,18 @@ func (s *Server) Reshard(ctx context.Context, _ *agentproto.ReshardRequest) (_ *
 		return nil, err
 	}
 	for ch := range configCh {
-		discoveredConfigs[ch.Name] = struct{}{}
-		if err := s.im.ApplyConfig(ch); err != nil {
+		err := s.im.ApplyConfig(ch)
+		if err != nil {
 			level.Error(s.logger).Log("msg", "failed to apply config when resharding", "err", err)
+			continue
 		}
+
+		discoveredConfigs[ch.Name] = struct{}{}
 	}
 
-	// Find the set of configs that weren't present in the KV store response but are
-	// being tracked locally. Any config that wasn't still in the KV store must be
-	// removed from our tracked list.
-	for runningConfig := range currentConfigs {
+	// Find the set of configs that disappeared from AllConfigs from the last
+	// time this ran and remove them.
+	for runningConfig := range s.configs {
 		_, keyInStore := discoveredConfigs[runningConfig]
 		if keyInStore {
 			continue
@@ -70,6 +67,9 @@ func (s *Server) Reshard(ctx context.Context, _ *agentproto.ReshardRequest) (_ *
 			level.Error(s.logger).Log("msg", "failed to delete stale config", "err", err)
 		}
 	}
+
+	// Update the set of running configs to what we last got from the server.
+	s.configs = discoveredConfigs
 
 	return &empty.Empty{}, nil
 }
@@ -94,6 +94,15 @@ func (s *Server) AllConfigs(ctx context.Context) (<-chan instance.Config, error)
 		go func(key string) {
 			defer wg.Done()
 
+			owns, err := s.owns(key)
+			if err != nil {
+				level.Error(s.logger).Log("msg", "failed to detect if key was owned", "key", key, "err", err)
+				return
+			} else if !owns {
+				// Unowned key, ignore it.
+				return
+			}
+
 			// TODO(rfratto): retries might be useful here
 			v, err := s.kv.Get(ctx, key)
 			if err != nil {
@@ -111,6 +120,23 @@ func (s *Server) AllConfigs(ctx context.Context) (<-chan instance.Config, error)
 	return ch, nil
 }
 
+// owns checks to see if a config name is owned by this Server.
+func (s *Server) owns(key string) (bool, error) {
+	h := fnv.New32()
+	_, _ = h.Write([]byte(key))
+
+	rs, err := s.ring.Get(h.Sum32(), ring.Write, nil, nil, nil)
+	if err != nil {
+		return false, err
+	}
+	for _, r := range rs.Ingesters {
+		if r.Addr == s.addr {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // ReadRing is a subset of the Cortex ring.ReadRing interface with only the
 // functionality used by the HA server.
 type ReadRing interface {
@@ -118,167 +144,4 @@ type ReadRing interface {
 
 	Get(key uint32, op ring.Operation, bufDescs []ring.InstanceDesc, bufHosts, bufZones []string) (ring.ReplicationSet, error)
 	GetAllHealthy(op ring.Operation) (ring.ReplicationSet, error)
-}
-
-// ShardingInstanceManager wraps around an existing instance.Manager and uses a
-// hash ring to determine if a config should be applied. If an applied
-// config used to be owned by the local address but no longer does, it
-// will be deleted on the next apply.
-type ShardingInstanceManager struct {
-	log   log.Logger
-	inner instance.Manager
-	ring  ReadRing
-	addr  string
-
-	keyToHash map[string]uint32
-}
-
-// NewShardingInstanceManager creates a new ShardingInstanceManager that wraps
-// around an underlying instance.Manager. ring and addr are used together to do
-// hash ring lookups; for a given applied config, it is owned by the instance of
-// ShardingInstanceManager if looking up its hash in the ring results in the
-// address specified by addr.
-func NewShardingInstanceManager(logger log.Logger, wrap instance.Manager, ring ReadRing, addr string) ShardingInstanceManager {
-	return ShardingInstanceManager{
-		log:       logger,
-		inner:     wrap,
-		ring:      ring,
-		addr:      addr,
-		keyToHash: make(map[string]uint32),
-	}
-}
-
-// ListInstances returns the list of instances that have been applied through
-// the ShardingInstanceManager. It will return a subset of the overall
-// set of configs passed to the instance.Manager as a whole.
-//
-// Returning the subset of configs that only the ShardingInstanceManager
-// applied itself allows for the underlying instance.Manager to manage
-// its own set of configs that will not be affected by the scraping
-// service resharding and deleting configs that aren't found in the KV
-// store.
-func (m ShardingInstanceManager) ListInstances() map[string]instance.ManagedInstance {
-	inner := m.inner.ListInstances()
-	sharded := make(map[string]instance.ManagedInstance, len(inner))
-
-	for k, v := range inner {
-		if _, isSharded := m.keyToHash[k]; isSharded {
-			sharded[k] = v
-		}
-	}
-
-	return sharded
-}
-
-// ListConfigs returns the list of configs that have been applied through
-// the ShardingInstanceManager. It will return a subset of the overall
-// set of configs passed to the instance.Manager as a whole.
-//
-// Returning the subset of configs that only the ShardingInstanceManager
-// applied itself allows for the underlying instance.Manager to manage
-// its own set of configs that will not be affected by the scraping
-// service resharding and deleting configs that aren't found in the KV
-// store.
-func (m ShardingInstanceManager) ListConfigs() map[string]instance.Config {
-	inner := m.inner.ListConfigs()
-	sharded := make(map[string]instance.Config, len(inner))
-
-	for k, v := range inner {
-		if _, isSharded := m.keyToHash[k]; isSharded {
-			sharded[k] = v
-		}
-	}
-
-	return sharded
-}
-
-// ApplyConfig implements instance.Manager.ApplyConfig.
-func (m ShardingInstanceManager) ApplyConfig(c instance.Config) error {
-	keyHash := configKeyHash(&c)
-	owned, err := m.owns(keyHash)
-	if err != nil {
-		level.Error(m.log).Log("msg", "failed to check if a config is owned, skipping config until next reshard", "err", err)
-		return nil
-	}
-
-	if owned {
-		hash, err := configHash(&c)
-		if err != nil {
-			return fmt.Errorf("failed to hash config: %w", err)
-		}
-
-		// If the config is unchanged, do nothing.
-		if m.keyToHash[c.Name] == hash {
-			return nil
-		}
-
-		level.Info(m.log).Log("msg", "detected new or changed config", "name", c.Name)
-		m.keyToHash[c.Name] = hash
-		return m.inner.ApplyConfig(c)
-	}
-
-	// If we don't own the config, it's possible that we owned it before
-	// and need to delete it now.
-	return m.DeleteConfig(c.Name)
-}
-
-// DeleteConfig implements instance.Manager.DeleteConfig.
-func (m ShardingInstanceManager) DeleteConfig(name string) error {
-	// Doesn't exist, ignore.
-	if _, exist := m.keyToHash[name]; !exist {
-		return nil
-	}
-
-	level.Info(m.log).Log("msg", "removing config", "name", name)
-	err := m.inner.DeleteConfig(name)
-	if err == nil {
-		delete(m.keyToHash, name)
-	}
-	return err
-}
-
-// Stop implements instance.Manager.Stop. It only stops the configs
-// passed through to this manager and not all instances.
-func (m ShardingInstanceManager) Stop() {
-	for k := range m.keyToHash {
-		err := m.DeleteConfig(k)
-		if err != nil {
-			level.Error(m.log).Log("msg", "failed to remove config", "name", k, "err", err)
-		}
-	}
-}
-
-// owns checks if the ShardingInstanceManager is responsible for
-// a given hash.
-func (m ShardingInstanceManager) owns(hash uint32) (bool, error) {
-	rs, err := m.ring.Get(hash, ring.Write, nil, nil, nil)
-	if err != nil {
-		return false, err
-	}
-	for _, r := range rs.Ingesters {
-		if r.Addr == m.addr {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-// configHash returns the hash of the entirety of an instance config.
-func configHash(c *instance.Config) (uint32, error) {
-	val, err := instance.MarshalConfig(c, false)
-	if err != nil {
-		return 0, err
-	}
-	h := fnv.New32()
-	_, _ = h.Write(val)
-	return h.Sum32(), nil
-}
-
-// configKeyHash gets a hash for a config that is used to determine ownership.
-// It is based on primary keys of the instance config rather than the entire
-// config.
-func configKeyHash(c *instance.Config) uint32 {
-	h := fnv.New32()
-	_, _ = h.Write([]byte(c.Name))
-	return h.Sum32()
 }

--- a/pkg/prom/ha/sharding.go
+++ b/pkg/prom/ha/sharding.go
@@ -122,10 +122,7 @@ func (s *Server) AllConfigs(ctx context.Context) (<-chan instance.Config, error)
 
 // owns checks to see if a config name is owned by this Server.
 func (s *Server) owns(key string) (bool, error) {
-	h := fnv.New32()
-	_, _ = h.Write([]byte(key))
-
-	rs, err := s.ring.Get(h.Sum32(), ring.Write, nil, nil, nil)
+	rs, err := s.ring.Get(keyHash(key), ring.Write, nil, nil, nil)
 	if err != nil {
 		return false, err
 	}
@@ -135,6 +132,12 @@ func (s *Server) owns(key string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func keyHash(key string) uint32 {
+	h := fnv.New32()
+	_, _ = h.Write([]byte(key))
+	return h.Sum32()
 }
 
 // ReadRing is a subset of the Cortex ring.ReadRing interface with only the

--- a/pkg/prom/ha/sharding_test.go
+++ b/pkg/prom/ha/sharding_test.go
@@ -2,9 +2,6 @@ package ha
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"net/http"
 	"sort"
 	"testing"
 
@@ -14,7 +11,6 @@ import (
 	"github.com/grafana/agent/pkg/agentproto"
 	"github.com/grafana/agent/pkg/prom/instance"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 )
 
 func TestServer_Reshard(t *testing.T) {
@@ -22,9 +18,6 @@ func TestServer_Reshard(t *testing.T) {
 	//	- All configs in the store should be applied
 	//	- All configs not in the store but in the existing InstanceManager should be deleted
 	fakeIm := newFakeInstanceManager()
-	for _, name := range []string{"keep_a", "keep_b", "remove_a", "remove_b"} {
-		_ = fakeIm.ApplyConfig(instance.Config{Name: name})
-	}
 
 	mockKv := consul.NewInMemoryClient(GetCodec())
 	for _, name := range []string{"keep_a", "keep_b", "new_a", "new_b"} {
@@ -34,282 +27,39 @@ func TestServer_Reshard(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	srv := Server{kv: mockKv, im: fakeIm, logger: log.NewNopLogger()}
+	fakeRing := mockFuncReadRing{
+		GetFunc: func(key uint32, op ring.Operation, bufDescs []ring.InstanceDesc, bufHosts, bufZones []string) (ring.ReplicationSet, error) {
+			return ring.ReplicationSet{Ingesters: []ring.InstanceDesc{{Addr: "test-server"}}}, nil
+		},
+	}
+
+	srv := Server{
+		logger: log.NewNopLogger(),
+
+		kv: mockKv,
+		im: fakeIm,
+
+		ring: &fakeRing,
+		addr: "test-server",
+
+		// Pass fake configs that were applied in a previous run. remove_a and remove_b
+		// don't exist
+		configs: map[string]struct{}{
+			"keep_a":   {},
+			"keep_b":   {},
+			"remove_a": {},
+			"remove_b": {},
+		},
+	}
+
 	_, err := srv.Reshard(context.Background(), &agentproto.ReshardRequest{})
 	require.NoError(t, err)
 
-	expect := []string{
-		"keep_a",
-		"keep_b",
-		"new_a",
-		"new_b",
-	}
+	expect := []string{"keep_a", "keep_b", "new_a", "new_b"}
 	var actual []string
 	for k := range fakeIm.ListConfigs() {
 		actual = append(actual, k)
 	}
 	sort.Strings(actual)
 	require.Equal(t, expect, actual)
-}
-
-func TestShardingInstanceManager(t *testing.T) {
-	logger := log.NewNopLogger()
-
-	t.Run("only lists configs applied through sharded instance manager", func(t *testing.T) {
-		fakeIm := newFakeInstanceManager()
-		mockRing := &mockFuncReadRing{}
-		mockRing.GetFunc = func(_ uint32, _ ring.Operation, _ []ring.InstanceDesc, _, _ []string) (ring.ReplicationSet, error) {
-			return ring.ReplicationSet{
-				Ingesters: []ring.InstanceDesc{{Addr: "same_machine"}},
-			}, nil
-		}
-
-		_ = fakeIm.ApplyConfig(instance.Config{Name: "applied_elsewhere"})
-
-		cm := NewShardingInstanceManager(logger, fakeIm, mockRing, "same_machine")
-		_ = cm.ApplyConfig(instance.Config{Name: "test"})
-
-		var keys []string
-		for k := range cm.ListConfigs() {
-			keys = append(keys, k)
-		}
-		require.Equal(t, []string{"test"}, keys)
-	})
-
-	t.Run("applies owned config", func(t *testing.T) {
-		fakeIm := newFakeInstanceManager()
-		mockRing := &mockFuncReadRing{}
-		mockRing.GetFunc = func(_ uint32, _ ring.Operation, _ []ring.InstanceDesc, _, _ []string) (ring.ReplicationSet, error) {
-			return ring.ReplicationSet{
-				Ingesters: []ring.InstanceDesc{{Addr: "same_machine"}},
-			}, nil
-		}
-
-		cm := NewShardingInstanceManager(logger, fakeIm, mockRing, "same_machine")
-		_ = cm.ApplyConfig(instance.Config{Name: "test"})
-
-		require.Equal(t, 1, len(fakeIm.ListConfigs()))
-	})
-
-	t.Run("ignores apply of unowned config", func(t *testing.T) {
-		fakeIm := newFakeInstanceManager()
-		mockRing := &mockFuncReadRing{}
-		mockRing.GetFunc = func(_ uint32, _ ring.Operation, _ []ring.InstanceDesc, _, _ []string) (ring.ReplicationSet, error) {
-			return ring.ReplicationSet{
-				Ingesters: []ring.InstanceDesc{{Addr: "remote"}},
-			}, nil
-		}
-
-		cm := NewShardingInstanceManager(logger, fakeIm, mockRing, "same_machine")
-		_ = cm.ApplyConfig(instance.Config{Name: "test"})
-
-		require.Equal(t, 0, len(fakeIm.ListConfigs()))
-	})
-
-	t.Run("properly hashes config", func(t *testing.T) {
-		var hashes []uint32
-
-		fakeIm := newFakeInstanceManager()
-		mockRing := &mockFuncReadRing{}
-		mockRing.GetFunc = func(key uint32, _ ring.Operation, _ []ring.InstanceDesc, _, _ []string) (ring.ReplicationSet, error) {
-			hashes = append(hashes, key)
-			return ring.ReplicationSet{
-				Ingesters: []ring.InstanceDesc{{Addr: "remote"}},
-			}, nil
-		}
-
-		// Each config here should be given a different hash when checked against the ring
-		cm := NewShardingInstanceManager(logger, fakeIm, mockRing, "same_machine")
-		_ = cm.ApplyConfig(instance.Config{Name: "test1"})
-		_ = cm.ApplyConfig(instance.Config{Name: "test2"})
-
-		require.Len(t, hashes, 2)
-		require.NotEqual(t, hashes[0], hashes[1])
-	})
-
-	t.Run("deletes previously owned config on apply", func(t *testing.T) {
-		returnRingAddr := "same_machine"
-
-		fakeIm := newFakeInstanceManager()
-		mockRing := &mockFuncReadRing{}
-		mockRing.GetFunc = func(_ uint32, _ ring.Operation, _ []ring.InstanceDesc, _, _ []string) (ring.ReplicationSet, error) {
-			return ring.ReplicationSet{
-				Ingesters: []ring.InstanceDesc{{Addr: returnRingAddr}},
-			}, nil
-		}
-
-		cm := NewShardingInstanceManager(logger, fakeIm, mockRing, "same_machine")
-		_ = cm.ApplyConfig(instance.Config{Name: "test"})
-		require.Equal(t, 1, len(fakeIm.ListConfigs()))
-
-		// Pretend the ring changed and that ring doesn't hash to us anymore.
-		// The next apply should delete it.
-		returnRingAddr = "not_localhost"
-
-		_ = cm.ApplyConfig(instance.Config{Name: "test"})
-		require.Equal(t, 0, len(fakeIm.ListConfigs()), "unowned config was not deleted")
-	})
-
-	t.Run("doesn't reapply unchanged config", func(t *testing.T) {
-		fakeIm := newFakeInstanceManager()
-		mockRing := &mockFuncReadRing{}
-		mockRing.GetFunc = func(_ uint32, _ ring.Operation, _ []ring.InstanceDesc, _, _ []string) (ring.ReplicationSet, error) {
-			return ring.ReplicationSet{
-				Ingesters: []ring.InstanceDesc{{Addr: "same_machine"}},
-			}, nil
-		}
-
-		cm := NewShardingInstanceManager(logger, fakeIm, mockRing, "same_machine")
-		_ = cm.ApplyConfig(instance.Config{Name: "test"})
-
-		require.Equal(t, 1, len(fakeIm.ListConfigs()))
-
-		// Internally delete the config and try to reapply; our wrapper should ignore
-		// it since the hash hasn't changed from the last time it was applied.
-		_ = fakeIm.DeleteConfig("test")
-		_ = cm.ApplyConfig(instance.Config{Name: "test"})
-		require.Equal(t, 0, len(fakeIm.ListConfigs()), "unchanged config got reapplied")
-	})
-
-	t.Run("reapplies changed config", func(t *testing.T) {
-		fakeIm := newFakeInstanceManager()
-		mockRing := &mockFuncReadRing{}
-		mockRing.GetFunc = func(_ uint32, _ ring.Operation, _ []ring.InstanceDesc, _, _ []string) (ring.ReplicationSet, error) {
-			return ring.ReplicationSet{
-				Ingesters: []ring.InstanceDesc{{Addr: "same_machine"}},
-			}, nil
-		}
-
-		cm := NewShardingInstanceManager(logger, fakeIm, mockRing, "same_machine")
-		_ = cm.ApplyConfig(instance.Config{Name: "test"})
-
-		require.Equal(t, 1, len(fakeIm.ListConfigs()))
-
-		_ = cm.ApplyConfig(instance.Config{Name: "test", HostFilter: true})
-		require.Equal(t, 1, len(fakeIm.ListConfigs()))
-
-		require.True(t, fakeIm.ListConfigs()["test"].HostFilter)
-	})
-
-	t.Run("ignores deletes of unowned config", func(t *testing.T) {
-		fakeIm := newFakeInstanceManager()
-		mockRing := &mockFuncReadRing{}
-		cm := NewShardingInstanceManager(logger, fakeIm, mockRing, "same_machine")
-
-		_ = fakeIm.ApplyConfig(instance.Config{Name: "test"})
-		err := cm.DeleteConfig("test")
-		require.NoError(t, err)
-
-		require.Equal(t, 1, len(fakeIm.ListConfigs()), "untracked config was not ignored")
-	})
-
-	t.Run("deletes owned config", func(t *testing.T) {
-		fakeIm := newFakeInstanceManager()
-		mockRing := &mockFuncReadRing{}
-		mockRing.GetFunc = func(_ uint32, _ ring.Operation, _ []ring.InstanceDesc, _, _ []string) (ring.ReplicationSet, error) {
-			return ring.ReplicationSet{
-				Ingesters: []ring.InstanceDesc{{Addr: "same_machine"}},
-			}, nil
-		}
-
-		cm := NewShardingInstanceManager(logger, fakeIm, mockRing, "same_machine")
-		_ = cm.ApplyConfig(instance.Config{Name: "test"})
-
-		err := cm.DeleteConfig("test")
-		require.NoError(t, err)
-		require.Equal(t, 0, len(fakeIm.ListConfigs()), "owned config was not deleted")
-	})
-}
-
-func TestConfigHash_Secrets_BasicAuth(t *testing.T) {
-	configTemplate := `name: 'test'
-host_filter: false
-scrape_configs:
-  - job_name: process-1
-    static_configs:
-      - targets: ['process-1:80']
-        labels:
-          cluster: 'local'
-          origin: 'agent'
-remote_write:
-  - name: test-abcdef
-    url: http://cortex:9090/api/prom/push
-    basic_auth:
-      username: test_username
-      password: %s`
-
-	configA := fmt.Sprintf(configTemplate, "password_a")
-	configB := fmt.Sprintf(configTemplate, "password_b")
-
-	var inA instance.Config
-	err := yaml.Unmarshal([]byte(configA), &inA)
-	require.NoError(t, err)
-
-	hashA, err := configHash(&inA)
-	require.NoError(t, err)
-
-	var inB instance.Config
-	err = yaml.Unmarshal([]byte(configB), &inB)
-	require.NoError(t, err)
-
-	hashB, err := configHash(&inB)
-	require.NoError(t, err)
-
-	require.NotEqual(t, hashA, hashB, "secrets were not hashed separately")
-}
-
-func TestConfigHash_Secrets_BearerToken(t *testing.T) {
-	configTemplate := `name: 'test'
-host_filter: false
-scrape_configs:
-  - job_name: process-1
-    static_configs:
-      - targets: ['process-1:80']
-        labels:
-          cluster: 'local'
-          origin: 'agent'
-remote_write:
-  - name: test-abcdef
-    url: http://cortex:9090/api/prom/push
-    bearer_token: %s`
-
-	configA := fmt.Sprintf(configTemplate, "bearer_a")
-	configB := fmt.Sprintf(configTemplate, "bearer_b")
-
-	var inA instance.Config
-	err := yaml.Unmarshal([]byte(configA), &inA)
-	require.NoError(t, err)
-
-	hashA, err := configHash(&inA)
-	require.NoError(t, err)
-
-	var inB instance.Config
-	err = yaml.Unmarshal([]byte(configB), &inB)
-	require.NoError(t, err)
-
-	hashB, err := configHash(&inB)
-	require.NoError(t, err)
-
-	require.NotEqual(t, hashA, hashB, "secrets were not hashed separately")
-}
-
-type mockFuncReadRing struct {
-	http.Handler
-
-	GetFunc           func(key uint32, op ring.Operation, bufDescs []ring.InstanceDesc, bufHosts, bufZones []string) (ring.ReplicationSet, error)
-	GetAllHealthyFunc func(ring.Operation) (ring.ReplicationSet, error)
-}
-
-func (r *mockFuncReadRing) Get(key uint32, op ring.Operation, bufDescs []ring.InstanceDesc, bufHosts, bufZones []string) (ring.ReplicationSet, error) {
-	if r.GetFunc != nil {
-		return r.GetFunc(key, op, bufDescs, bufHosts, bufZones)
-	}
-	return ring.ReplicationSet{}, errors.New("not implemented")
-}
-
-func (r *mockFuncReadRing) GetAllHealthy(op ring.Operation) (ring.ReplicationSet, error) {
-	if r.GetAllHealthyFunc != nil {
-		return r.GetAllHealthyFunc(op)
-	}
-	return ring.ReplicationSet{}, errors.New("not implemented")
 }

--- a/pkg/prom/ha/sharding_test.go
+++ b/pkg/prom/ha/sharding_test.go
@@ -63,3 +63,54 @@ func TestServer_Reshard(t *testing.T) {
 	sort.Strings(actual)
 	require.Equal(t, expect, actual)
 }
+
+func TestServer_Ownership(t *testing.T) {
+	// Resharding should do the following:
+	//	- All configs in the store should be applied
+	//	- All configs not in the store but in the existing InstanceManager should be deleted
+	fakeIm := newFakeInstanceManager()
+
+	mockKv := consul.NewInMemoryClient(GetCodec())
+	for _, name := range []string{"owned", "unowned"} {
+		err := mockKv.CAS(context.Background(), name, func(in interface{}) (out interface{}, retry bool, err error) {
+			return &instance.Config{Name: name}, true, nil
+		})
+		require.NoError(t, err)
+	}
+
+	var (
+		ownedHash = keyHash("owned")
+	)
+
+	fakeRing := mockFuncReadRing{
+		GetFunc: func(key uint32, op ring.Operation, bufDescs []ring.InstanceDesc, bufHosts, bufZones []string) (ring.ReplicationSet, error) {
+			switch key {
+			case ownedHash:
+				return ring.ReplicationSet{Ingesters: []ring.InstanceDesc{{Addr: "test-server"}}}, nil
+			default:
+				return ring.ReplicationSet{Ingesters: []ring.InstanceDesc{{Addr: "someone-else"}}}, nil
+			}
+		},
+	}
+
+	srv := Server{
+		logger: log.NewNopLogger(),
+
+		kv: mockKv,
+		im: fakeIm,
+
+		ring: &fakeRing,
+		addr: "test-server",
+	}
+
+	_, err := srv.Reshard(context.Background(), &agentproto.ReshardRequest{})
+	require.NoError(t, err)
+
+	expect := []string{"owned"}
+	var actual []string
+	for k := range fakeIm.ListConfigs() {
+		actual = append(actual, k)
+	}
+	sort.Strings(actual)
+	require.Equal(t, expect, actual)
+}


### PR DESCRIPTION
#### PR Description 
This PR simplifies the scraping service sharding mechanism by removing the scraping service manager and performing ownership checking locally directly in the shard logic. 

This removes the need for a ton of code. 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer
Previously hashing was used to cache whether an instance needed to be updated and ignoring the ApplyConfig if it didn't. This hasn't been necessary for a while; ApplyConfig for an unmodified instance is a no-op. 

#### PR Checklist
(Internal change, no changelog or documentation)

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
