### PR TITLE
allow 0 as a valid truncation timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ can be found at [#317](https://github.com/grafana/agent/issues/317).
 - [BUGFIX] Native Darwin arm64 builds will no longer crash when writing metrics
   to the WAL. (@rfratto)
 
+- [BUGFIX] Remote write endpoints that never function across the lifetime of the
+  Agent will no longer prevent the WAL from being truncated. (@rfratto)
+
 # v0.13.0 (2021-02-25)
 
 The primary branch name has changed from `master` to `main`. You may have to

--- a/pkg/prom/instance/instance.go
+++ b/pkg/prom/instance/instance.go
@@ -649,12 +649,10 @@ func (i *Instance) truncateLoop(ctx context.Context, wal walStorage, cfg *Config
 			//
 			// Subtracting a duration from ts will delay when it will be considered
 			// inactive and scheduled for deletion.
-			ts := i.getRemoteWriteTimestamp()
-			if ts == 0 {
-				level.Debug(i.logger).Log("msg", "can't truncate the WAL yet")
-				continue
+			ts := i.getRemoteWriteTimestamp() - i.cfg.MinWALTime.Milliseconds()
+			if ts < 0 {
+				ts = 0
 			}
-			ts -= i.cfg.MinWALTime.Milliseconds()
 
 			// Network issues can prevent the result of getRemoteWriteTimestamp from
 			// changing. We don't want data in the WAL to grow forever, so we set a cap


### PR DESCRIPTION
#### PR Description 
A remote_write timestamp of 0 preventing truncations from occurring. Ignoring 0s was an unnecessary safety measure, and only caused problems when considering the min/max WAL sample lifetime.

#### Which issue(s) this PR fixes 
Closes #409.

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
