### PR TITLE
Use a text-based codec for interacting with config store KV 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ can be found at [#317](https://github.com/grafana/agent/issues/317).
 - [BUGFIX] Remote write endpoints that never function across the lifetime of the
   Agent will no longer prevent the WAL from being truncated. (@rfratto)
 
+- [CHANGE] Instance configs uploaded to the Config Store API will no longer be
+  stored along with the global Prometheus defaults. This is done to allow
+  globals to be updated and re-apply the new global defaults to the configs from
+  the Config Store. (@rfratto)
+
 # v0.13.0 (2021-02-25)
 
 The primary branch name has changed from `master` to `main`. You may have to

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -99,8 +99,6 @@ func (c *prometheusClient) GetConfiguration(ctx context.Context, name string) (*
 
 	var config instance.Config
 	err = yaml.NewDecoder(strings.NewReader(data.Value)).Decode(&config)
-	config.Name = name
-
 	return &config, err
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -99,6 +99,8 @@ func (c *prometheusClient) GetConfiguration(ctx context.Context, name string) (*
 
 	var config instance.Config
 	err = yaml.NewDecoder(strings.NewReader(data.Value)).Decode(&config)
+	config.Name = name
+
 	return &config, err
 }
 

--- a/pkg/prom/ha/codec_test.go
+++ b/pkg/prom/ha/codec_test.go
@@ -3,9 +3,7 @@ package ha
 import (
 	"testing"
 
-	"github.com/grafana/agent/pkg/prom/instance"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 )
 
 func TestCodec(t *testing.T) {
@@ -19,73 +17,13 @@ scrape_configs:
           cluster: 'local'
           origin: 'agent'`
 
-	var in instance.Config
-	err := yaml.Unmarshal([]byte(exampleConfig), &in)
-	require.NoError(t, err)
-
 	c := &yamlCodec{}
-	bb, err := c.Encode(in)
+	bb, err := c.Encode(exampleConfig)
 	require.NoError(t, err)
 
 	out, err := c.Decode(bb)
 	require.NoError(t, err)
-	require.Equal(t, &in, out)
-}
-
-func TestCodec_RetainsSecrets_Password(t *testing.T) {
-	exampleConfig := `name: 'test'
-host_filter: false
-scrape_configs:
-  - job_name: process-1
-    static_configs:
-      - targets: ['process-1:80']
-        labels:
-          cluster: 'local'
-          origin: 'agent'
-remote_write:
-  - url: http://cortex:9090/api/prom/push
-    basic_auth:
-      username: test_username
-      password: test_pass`
-
-	var in instance.Config
-	err := yaml.Unmarshal([]byte(exampleConfig), &in)
-	require.NoError(t, err)
-
-	c := &yamlCodec{}
-	bb, err := c.Encode(in)
-	require.NoError(t, err)
-
-	out, err := c.Decode(bb)
-	require.NoError(t, err)
-	require.Equal(t, &in, out)
-}
-
-func TestCodec_RetainsSecrets_BearerToken(t *testing.T) {
-	exampleConfig := `name: 'test'
-host_filter: false
-scrape_configs:
-  - job_name: process-1
-    static_configs:
-      - targets: ['process-1:80']
-        labels:
-          cluster: 'local'
-          origin: 'agent'
-remote_write:
-  - url: http://cortex:9090/api/prom/push
-    bearer_token: test_bearer`
-
-	var in instance.Config
-	err := yaml.Unmarshal([]byte(exampleConfig), &in)
-	require.NoError(t, err)
-
-	c := &yamlCodec{}
-	bb, err := c.Encode(in)
-	require.NoError(t, err)
-
-	out, err := c.Decode(bb)
-	require.NoError(t, err)
-	require.Equal(t, &in, out)
+	require.Equal(t, exampleConfig, out)
 }
 
 // TestCodec_Decode_Nil makes sure that if Decode is called with an empty value,

--- a/pkg/prom/ha/http.go
+++ b/pkg/prom/ha/http.go
@@ -152,10 +152,6 @@ func (s *Server) PutConfiguration(r *http.Request) (interface{}, error) {
 		return nil, err
 	}
 
-	// We want to make sure the config is valid so we'll unmarshal it and
-	// apply defaults. However, since defaults can change at runtime, we
-	// just want to store the raw string, so inst is only used for validation
-	// here.
 	inst, err := instance.UnmarshalConfig(strings.NewReader(config.String()))
 	if err != nil {
 		return nil, err
@@ -166,7 +162,7 @@ func (s *Server) PutConfiguration(r *http.Request) (interface{}, error) {
 	}
 
 	// Remarshal the instance with static defaults applied and the name of the
-	// instance set.
+	// instance forced based on the URL.
 	configBytes, err := instance.MarshalConfig(inst, false)
 	if err != nil {
 		return nil, err

--- a/pkg/prom/ha/server.go
+++ b/pkg/prom/ha/server.go
@@ -347,13 +347,10 @@ func (s *Server) watchKV(ctx context.Context) {
 
 		// New config should be applied if we own it
 		case !isDeleted && owned:
-
-			// Unmarshal the raw string and force its name to be set to the key.
 			cfg, err := instance.UnmarshalConfig(strings.NewReader(v.(string)))
 			if err != nil {
 				level.Error(s.logger).Log("msg", "could not unmarshal stored config", "name", key, "err", err)
 			}
-			cfg.Name = key
 
 			// Applying configs should only fail if the config is invalid
 			err = s.im.ApplyConfig(*cfg)

--- a/pkg/prom/ha/server.go
+++ b/pkg/prom/ha/server.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -346,9 +347,16 @@ func (s *Server) watchKV(ctx context.Context) {
 
 		// New config should be applied if we own it
 		case !isDeleted && owned:
+
+			// Unmarshal the raw string and force its name to be set to the key.
+			cfg, err := instance.UnmarshalConfig(strings.NewReader(v.(string)))
+			if err != nil {
+				level.Error(s.logger).Log("msg", "could not unmarshal stored config", "name", key, "err", err)
+			}
+			cfg.Name = key
+
 			// Applying configs should only fail if the config is invalid
-			cfg := v.(*instance.Config)
-			err := s.im.ApplyConfig(*cfg)
+			err = s.im.ApplyConfig(*cfg)
 			if err != nil {
 				level.Error(s.logger).Log("msg", "failed to apply config, will retry on next reshard", "name", key, "err", err)
 				return true

--- a/pkg/prom/ha/sharding.go
+++ b/pkg/prom/ha/sharding.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"hash/fnv"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -114,7 +115,12 @@ func (s *Server) AllConfigs(ctx context.Context) (<-chan instance.Config, error)
 				return
 			}
 
-			cfg := v.(*instance.Config)
+			cfg, err := instance.UnmarshalConfig(strings.NewReader(v.(string)))
+			if err != nil {
+				level.Error(s.logger).Log("msg", "could not unmarshal stored config", "name", key, "err", err)
+			}
+			cfg.Name = key
+
 			ch <- *cfg
 		}(key)
 	}

--- a/pkg/prom/ha/sharding.go
+++ b/pkg/prom/ha/sharding.go
@@ -119,7 +119,6 @@ func (s *Server) AllConfigs(ctx context.Context) (<-chan instance.Config, error)
 			if err != nil {
 				level.Error(s.logger).Log("msg", "could not unmarshal stored config", "name", key, "err", err)
 			}
-			cfg.Name = key
 
 			ch <- *cfg
 		}(key)

--- a/pkg/prom/ha/sharding_test.go
+++ b/pkg/prom/ha/sharding_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring/kv/consul"
 	"github.com/go-kit/kit/log"
 	"github.com/grafana/agent/pkg/agentproto"
-	"github.com/grafana/agent/pkg/prom/instance"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,7 +21,7 @@ func TestServer_Reshard(t *testing.T) {
 	mockKv := consul.NewInMemoryClient(GetCodec())
 	for _, name := range []string{"keep_a", "keep_b", "new_a", "new_b"} {
 		err := mockKv.CAS(context.Background(), name, func(in interface{}) (out interface{}, retry bool, err error) {
-			return &instance.Config{Name: name}, true, nil
+			return testConfig(t, name), true, nil
 		})
 		require.NoError(t, err)
 	}
@@ -73,7 +72,7 @@ func TestServer_Ownership(t *testing.T) {
 	mockKv := consul.NewInMemoryClient(GetCodec())
 	for _, name := range []string{"owned", "unowned"} {
 		err := mockKv.CAS(context.Background(), name, func(in interface{}) (out interface{}, retry bool, err error) {
-			return &instance.Config{Name: name}, true, nil
+			return testConfig(t, name), true, nil
 		})
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
#### PR Description 
This PR changes the Codec used to operate on the raw config strings instead of `instance.Configs`. This is primarily to serve #147 which will need the ability to re-apply global defaults to configs retrieved from the config store. 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
