### PR TITLE
change the default application semantics of instance configs

### DIFF
--- a/pkg/integrations/manager_test.go
+++ b/pkg/integrations/manager_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana/agent/pkg/integrations/config"
 	"github.com/grafana/agent/pkg/prom/instance"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	prom_config "github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/stretchr/testify/require"
@@ -55,7 +54,7 @@ test:
 
 func TestConfig_AddressRelabels(t *testing.T) {
 	cfgText := `
-agent: 
+agent:
   enabled: true
 `
 
@@ -82,35 +81,11 @@ agent:
 	require.Equal(t, result.Get("instance"), expectHostname+":12345")
 }
 
-// TestManager_ValidInstanceConfigs ensures that the instance configs
-// applied to the instance manager are valid.
-func TestManager_ValidInstanceConfigs(t *testing.T) {
-	mock := newMockIntegration()
-	icfg := mockConfig{integration: mock}
-
-	integrations := map[Config]Integration{icfg: mock}
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory, func(c *instance.Config) error {
-		globalConfig := prom_config.DefaultConfig.GlobalConfig
-		return c.ApplyDefaults(&globalConfig, nil)
-	})
-	m, err := newManager(mockManagerConfig(), log.NewNopLogger(), im, integrations)
-	require.NoError(t, err)
-	defer m.Stop()
-
-	// If the config doesn't show up in ListConfigs, it wasn't valid.
-	test.Poll(t, time.Second, 1, func() interface{} {
-		return len(im.ListConfigs())
-	})
-}
-
 func TestManager_instanceConfigForIntegration(t *testing.T) {
 	mock := newMockIntegration()
 	icfg := mockConfig{integration: mock}
 
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory, func(c *instance.Config) error {
-		globalConfig := prom_config.DefaultConfig.GlobalConfig
-		return c.ApplyDefaults(&globalConfig, nil)
-	})
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory)
 	m, err := newManager(mockManagerConfig(), log.NewNopLogger(), im, nil)
 	require.NoError(t, err)
 	defer m.Stop()
@@ -129,10 +104,7 @@ func TestManager_NoIntegrationsScrape(t *testing.T) {
 	icfg := mockConfig{integration: mock}
 
 	integrations := map[Config]Integration{icfg: mock}
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory, func(c *instance.Config) error {
-		globalConfig := prom_config.DefaultConfig.GlobalConfig
-		return c.ApplyDefaults(&globalConfig, nil)
-	})
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory)
 
 	cfg := mockManagerConfig()
 	cfg.ScrapeIntegrations = false
@@ -158,10 +130,7 @@ func TestManager_NoIntegrationScrape(t *testing.T) {
 	mock.commonCfg.ScrapeIntegration = &noScrape
 
 	integrations := map[Config]Integration{icfg: mock}
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory, func(c *instance.Config) error {
-		globalConfig := prom_config.DefaultConfig.GlobalConfig
-		return c.ApplyDefaults(&globalConfig, nil)
-	})
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory)
 
 	m, err := newManager(mockManagerConfig(), log.NewNopLogger(), im, integrations)
 	require.NoError(t, err)
@@ -179,7 +148,7 @@ func TestManager_StartsIntegrations(t *testing.T) {
 
 	integrations := map[Config]Integration{icfg: mock}
 
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory, nil)
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory)
 	m, err := newManager(mockManagerConfig(), log.NewNopLogger(), im, integrations)
 	require.NoError(t, err)
 	defer m.Stop()
@@ -199,7 +168,7 @@ func TestManager_RestartsIntegrations(t *testing.T) {
 	icfg := mockConfig{integration: mock}
 
 	integrations := map[Config]Integration{icfg: mock}
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory, nil)
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory)
 	m, err := newManager(mockManagerConfig(), log.NewNopLogger(), im, integrations)
 	require.NoError(t, err)
 	defer m.Stop()
@@ -216,7 +185,7 @@ func TestManager_GracefulStop(t *testing.T) {
 	icfg := mockConfig{integration: mock}
 
 	integrations := map[Config]Integration{icfg: mock}
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory, nil)
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory)
 	m, err := newManager(mockManagerConfig(), log.NewNopLogger(), im, integrations)
 	require.NoError(t, err)
 

--- a/pkg/prom/agent.go
+++ b/pkg/prom/agent.go
@@ -142,7 +142,7 @@ func newAgent(reg prometheus.Registerer, cfg Config, logger log.Logger, fact ins
 
 	a.bm = instance.NewBasicManager(instance.BasicManagerConfig{
 		InstanceRestartBackoff: cfg.InstanceRestartBackoff,
-	}, a.logger, a.newInstance, a.validateInstance)
+	}, a.logger, a.newInstance)
 
 	var err error
 	a.mm, err = instance.NewModalManager(a.reg, a.logger, a.bm, cfg.InstanceMode)
@@ -195,10 +195,6 @@ func (a *Agent) newInstance(c instance.Config) (instance.ManagedInstance, error)
 	}, a.reg)
 
 	return a.instanceFactory(reg, a.cfg.Global, c, a.cfg.WALDir, a.logger)
-}
-
-func (a *Agent) validateInstance(c *instance.Config) error {
-	return c.ApplyDefaults(&a.cfg.Global, c.RemoteWrite)
 }
 
 func (a *Agent) WireGRPC(s *grpc.Server) {

--- a/pkg/prom/instance/manager_test.go
+++ b/pkg/prom/instance/manager_test.go
@@ -37,7 +37,7 @@ func TestBasicManager_ApplyConfig(t *testing.T) {
 			return &newMock, nil
 		}
 
-		cm := NewBasicManager(DefaultBasicManagerConfig, logger, spawner, nil)
+		cm := NewBasicManager(DefaultBasicManagerConfig, logger, spawner)
 
 		for i := 0; i < 10; i++ {
 			err := cm.ApplyConfig(Config{Name: "test"})
@@ -61,7 +61,7 @@ func TestBasicManager_ApplyConfig(t *testing.T) {
 			return &newMock, nil
 		}
 
-		cm := NewBasicManager(DefaultBasicManagerConfig, logger, spawner, nil)
+		cm := NewBasicManager(DefaultBasicManagerConfig, logger, spawner)
 
 		for i := 0; i < 10; i++ {
 			err := cm.ApplyConfig(Config{Name: "test"})
@@ -83,7 +83,7 @@ func TestBasicManager_ApplyConfig(t *testing.T) {
 			return &newMock, nil
 		}
 
-		cm := NewBasicManager(DefaultBasicManagerConfig, logger, spawner, nil)
+		cm := NewBasicManager(DefaultBasicManagerConfig, logger, spawner)
 
 		// Creation should succeed
 		err := cm.ApplyConfig(Config{Name: "test"})


### PR DESCRIPTION
#### PR Description 
This PR commit reduces the number of places defaults are applied to instance configs to just:

1. When the Agent YAML is unmarshaled
2. When the instance config is loaded from the KV store

This makes it easier to follow the lifetime of an instance config. 

#### Which issue(s) this PR fixes 
Done in relation to #147.

#### Notes to the Reviewer

#### PR Checklist
Internal change, nothing here needed.

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
