### PR TITLE
Add HTTP api for configstore

### DIFF
--- a/pkg/prom/instance/configstore/api.go
+++ b/pkg/prom/instance/configstore/api.go
@@ -1,0 +1,245 @@
+package configstore
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/gorilla/mux"
+	"github.com/grafana/agent/pkg/prom/ha/configapi"
+	"github.com/grafana/agent/pkg/prom/instance"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// API is an HTTP API to interact with a configstore.
+type API struct {
+	log       log.Logger
+	storeMut  sync.Mutex
+	store     Store
+	validator Validator
+
+	totalCreatedConfigs prometheus.Counter
+	totalUpdatedConfigs prometheus.Counter
+	totalDeletedConfigs prometheus.Counter
+}
+
+// Validator valides a config before putting it into the store.
+// Validator is allowed to mutate the config and will only be given a copy.
+type Validator func(c *instance.Config) error
+
+// NewAPI creates a new API. Store can be applied later with SetStore.
+func NewAPI(l log.Logger, store Store, v Validator) *API {
+	return &API{
+		log:       l,
+		store:     store,
+		validator: v,
+
+		totalCreatedConfigs: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "agent_prometheus_ha_configs_created_total",
+			Help: "Total number of created scraping service configs",
+		}),
+		totalUpdatedConfigs: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "agent_prometheus_ha_configs_updated_total",
+			Help: "Total number of updated scraping service configs",
+		}),
+		totalDeletedConfigs: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "agent_prometheus_ha_configs_deleted_total",
+			Help: "Total number of deleted scraping service configs",
+		}),
+	}
+}
+
+// WireAPI injects routes into the provided mux router for the config
+// store API.
+func (api *API) WireAPI(r *mux.Router) {
+	// Support URL-encoded config names. The handlers will need to decode the
+	// name when reading the path variable.
+	r = r.UseEncodedPath()
+
+	r.HandleFunc("/agent/api/v1/configs", api.ListConfigurations).Methods("GET")
+	r.HandleFunc("/agent/api/v1/configs/{name}", api.GetConfiguration).Methods("GET")
+	r.HandleFunc("/agent/api/v1/config/{name}", api.PutConfiguration).Methods("PUT", "POST")
+	r.HandleFunc("/agent/api/v1/config/{name}", api.DeleteConfiguration).Methods("DELETE")
+}
+
+// Describe implements prometheus.Collector.
+func (api *API) Describe(ch chan<- *prometheus.Desc) {
+	ch <- api.totalCreatedConfigs.Desc()
+	ch <- api.totalUpdatedConfigs.Desc()
+	ch <- api.totalDeletedConfigs.Desc()
+}
+
+// Collect implements prometheus.Collector.
+func (api *API) Collect(mm chan<- prometheus.Metric) {
+	mm <- api.totalCreatedConfigs
+	mm <- api.totalUpdatedConfigs
+	mm <- api.totalDeletedConfigs
+}
+
+// ListConfigurations returns a list of configurations.
+func (api *API) ListConfigurations(rw http.ResponseWriter, r *http.Request) {
+	api.storeMut.Lock()
+	defer api.storeMut.Unlock()
+	if api.store == nil {
+		api.writeError(rw, http.StatusNotFound, fmt.Errorf("no config store running"))
+		return
+	}
+
+	keys, err := api.store.List(r.Context())
+	if err != nil {
+		api.writeError(rw, http.StatusInternalServerError, fmt.Errorf("failed to write config: %w", err))
+		return
+	}
+	api.writeResponse(rw, http.StatusOK, configapi.ListConfigurationsResponse{Configs: keys})
+}
+
+// GetConfiguration gets an individual configuration.
+func (api *API) GetConfiguration(rw http.ResponseWriter, r *http.Request) {
+	api.storeMut.Lock()
+	defer api.storeMut.Unlock()
+	if api.store == nil {
+		api.writeError(rw, http.StatusNotFound, fmt.Errorf("no config store running"))
+		return
+	}
+
+	configKey, err := getConfigName(r)
+	if err != nil {
+		api.writeError(rw, http.StatusBadRequest, err)
+		return
+	}
+
+	cfg, err := api.store.Get(r.Context(), configKey)
+	switch {
+	case errors.As(err, &NotExistError{}):
+		api.writeError(rw, http.StatusBadRequest, err)
+	case err != nil:
+		api.writeError(rw, http.StatusInternalServerError, err)
+	case err == nil:
+		bb, err := instance.MarshalConfig(&cfg, false)
+		if err != nil {
+			api.writeError(rw, http.StatusInternalServerError, fmt.Errorf("could not marshal config for response: %w", err))
+			return
+		}
+		api.writeResponse(rw, http.StatusOK, &configapi.GetConfigurationResponse{
+			Value: string(bb),
+		})
+	}
+}
+
+// PutConfiguration creates or updates a configuration.
+func (api *API) PutConfiguration(rw http.ResponseWriter, r *http.Request) {
+	api.storeMut.Lock()
+	defer api.storeMut.Unlock()
+	if api.store == nil {
+		api.writeError(rw, http.StatusNotFound, fmt.Errorf("no config store running"))
+		return
+	}
+
+	configName, err := getConfigName(r)
+	if err != nil {
+		api.writeError(rw, http.StatusBadRequest, err)
+		return
+	}
+
+	var config strings.Builder
+	if _, err := io.Copy(&config, r.Body); err != nil {
+		api.writeError(rw, http.StatusInternalServerError, err)
+		return
+	}
+
+	cfg, err := instance.UnmarshalConfig(strings.NewReader(config.String()))
+	if err != nil {
+		api.writeError(rw, http.StatusBadRequest, fmt.Errorf("could not unmarshal config: %w", err))
+		return
+	}
+	cfg.Name = configName
+
+	if api.validator != nil {
+		validateCfg, err := instance.UnmarshalConfig(strings.NewReader(config.String()))
+		if err != nil {
+			api.writeError(rw, http.StatusBadRequest, fmt.Errorf("could not unmarshal config: %w", err))
+			return
+		}
+		validateCfg.Name = configName
+
+		if err := api.validator(validateCfg); err != nil {
+			api.writeError(rw, http.StatusBadRequest, fmt.Errorf("failed to validate config: %w", err))
+			return
+		}
+	}
+
+	created, err := api.store.Put(r.Context(), *cfg)
+	switch {
+	case errors.As(err, &NotUniqueError{}):
+		api.writeError(rw, http.StatusBadRequest, err)
+	case err != nil:
+		api.writeError(rw, http.StatusInternalServerError, err)
+	default:
+		if created {
+			api.totalCreatedConfigs.Inc()
+			api.writeResponse(rw, http.StatusCreated, nil)
+		} else {
+			api.totalUpdatedConfigs.Inc()
+			api.writeResponse(rw, http.StatusOK, nil)
+		}
+	}
+}
+
+// DeleteConfiguration deletes a configuration.
+func (api *API) DeleteConfiguration(rw http.ResponseWriter, r *http.Request) {
+	api.storeMut.Lock()
+	defer api.storeMut.Unlock()
+	if api.store == nil {
+		api.writeError(rw, http.StatusNotFound, fmt.Errorf("no config store running"))
+		return
+	}
+
+	configKey, err := getConfigName(r)
+	if err != nil {
+		api.writeError(rw, http.StatusBadRequest, err)
+		return
+	}
+
+	err = api.store.Delete(r.Context(), configKey)
+	switch {
+	case errors.As(err, &NotExistError{}):
+		api.writeError(rw, http.StatusBadRequest, err)
+	case err != nil:
+		api.writeError(rw, http.StatusInternalServerError, err)
+	default:
+		api.totalDeletedConfigs.Inc()
+		api.writeResponse(rw, http.StatusOK, nil)
+	}
+}
+
+func (api *API) writeError(rw http.ResponseWriter, statusCode int, writeErr error) {
+	err := configapi.WriteError(rw, statusCode, writeErr)
+	if err != nil {
+		level.Error(api.log).Log("msg", "failed to write response", "err", err)
+	}
+}
+
+func (api *API) writeResponse(rw http.ResponseWriter, statusCode int, v interface{}) {
+	err := configapi.WriteResponse(rw, statusCode, v)
+	if err != nil {
+		level.Error(api.log).Log("msg", "failed to write response", "err", err)
+	}
+}
+
+// getConfigName uses gorilla/mux's route variables to extract the
+// "name" variable. If not found, getConfigName will panic.
+func getConfigName(r *http.Request) (string, error) {
+	vars := mux.Vars(r)
+	name := vars["name"]
+	name, err := url.PathUnescape(name)
+	if err != nil {
+		return "", fmt.Errorf("could not decode config name: %w", err)
+	}
+	return name, nil
+}

--- a/pkg/prom/instance/configstore/api_test.go
+++ b/pkg/prom/instance/configstore/api_test.go
@@ -267,7 +267,7 @@ type mockStore struct {
 	PutFunc    func(ctx context.Context, c instance.Config) (created bool, err error)
 	DeleteFunc func(ctx context.Context, key string) error
 	AllFunc    func(ctx context.Context, keep func(key string) bool) (<-chan instance.Config, error)
-	WatchFunc  func() <-chan []instance.Config
+	WatchFunc  func() <-chan WatchEvent
 	CloseFunc  func() error
 }
 
@@ -306,7 +306,7 @@ func (s *mockStore) All(ctx context.Context, keep func(key string) bool) (<-chan
 	panic("All not implemented")
 }
 
-func (s *mockStore) Watch() <-chan []instance.Config {
+func (s *mockStore) Watch() <-chan WatchEvent {
 	if s.WatchFunc != nil {
 		return s.WatchFunc()
 	}

--- a/pkg/prom/instance/configstore/api_test.go
+++ b/pkg/prom/instance/configstore/api_test.go
@@ -1,0 +1,338 @@
+package configstore
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/gorilla/mux"
+	"github.com/grafana/agent/pkg/client"
+	"github.com/grafana/agent/pkg/prom/ha/configapi"
+	"github.com/grafana/agent/pkg/prom/instance"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPI_ListConfigurations(t *testing.T) {
+	s := &mockStore{
+		ListFunc: func(ctx context.Context) ([]string, error) {
+			return []string{"a", "b", "c"}, nil
+		},
+	}
+
+	api := NewAPI(log.NewNopLogger(), s, nil)
+	env := newAPITestEnvironment(t, api)
+
+	resp, err := http.Get(env.srv.URL + "/agent/api/v1/configs")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	expect := `{
+		"status": "success",
+		"data": {
+			"configs": ["a", "b", "c"]
+		}
+	}`
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.JSONEq(t, expect, string(body))
+
+	t.Run("With Client", func(t *testing.T) {
+		cli := client.New(env.srv.URL)
+		apiResp, err := cli.ListConfigs(context.Background())
+		require.NoError(t, err)
+
+		expect := &configapi.ListConfigurationsResponse{Configs: []string{"a", "b", "c"}}
+		require.Equal(t, expect, apiResp)
+	})
+}
+
+func TestAPI_GetConfiguration_Invalid(t *testing.T) {
+	s := &mockStore{
+		GetFunc: func(ctx context.Context, key string) (instance.Config, error) {
+			return instance.Config{}, NotExistError{Key: key}
+		},
+	}
+
+	api := NewAPI(log.NewNopLogger(), s, nil)
+	env := newAPITestEnvironment(t, api)
+
+	resp, err := http.Get(env.srv.URL + "/agent/api/v1/configs/does-not-exist")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	expect := `{
+		"status": "error",
+		"data": {
+			"error": "configuration does-not-exist does not exist"
+		}
+	}`
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.JSONEq(t, expect, string(body))
+
+	t.Run("With Client", func(t *testing.T) {
+		cli := client.New(env.srv.URL)
+		_, err := cli.GetConfiguration(context.Background(), "does-not-exist")
+		require.NotNil(t, err)
+		require.Equal(t, "configuration does-not-exist does not exist", err.Error())
+	})
+}
+
+func TestAPI_GetConfiguration(t *testing.T) {
+	s := &mockStore{
+		GetFunc: func(ctx context.Context, key string) (instance.Config, error) {
+			return instance.Config{
+				Name:                key,
+				HostFilter:          true,
+				RemoteFlushDeadline: 10 * time.Minute,
+			}, nil
+		},
+	}
+
+	api := NewAPI(log.NewNopLogger(), s, nil)
+	env := newAPITestEnvironment(t, api)
+
+	resp, err := http.Get(env.srv.URL + "/agent/api/v1/configs/exists")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	expect := `{
+		"status": "success",
+		"data": {
+			"value": "name: exists\nhost_filter: true\nremote_flush_deadline: 10m0s\n"
+		}
+	}`
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.JSONEq(t, expect, string(body))
+
+	t.Run("With Client", func(t *testing.T) {
+		cli := client.New(env.srv.URL)
+		actual, err := cli.GetConfiguration(context.Background(), "exists")
+		require.NoError(t, err)
+
+		// The client will apply defaults, so we need to start with the DefaultConfig
+		// as a base here.
+		expect := instance.DefaultConfig
+		expect.Name = "exists"
+		expect.HostFilter = true
+		expect.RemoteFlushDeadline = 10 * time.Minute
+		require.Equal(t, &expect, actual)
+	})
+}
+
+func TestServer_PutConfiguration(t *testing.T) {
+	var s mockStore
+
+	api := NewAPI(log.NewNopLogger(), &s, nil)
+	env := newAPITestEnvironment(t, api)
+
+	cfg := instance.Config{Name: "newconfig"}
+	bb, err := instance.MarshalConfig(&cfg, false)
+	require.NoError(t, err)
+
+	t.Run("Created", func(t *testing.T) {
+		// Created configs should return http.StatusCreated
+		s.PutFunc = func(ctx context.Context, c instance.Config) (created bool, err error) {
+			return true, nil
+		}
+
+		resp, err := http.Post(env.srv.URL+"/agent/api/v1/config/newconfig", "", bytes.NewReader(bb))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+	})
+
+	t.Run("Updated", func(t *testing.T) {
+		// Updated configs should return http.StatusOK
+		s.PutFunc = func(ctx context.Context, c instance.Config) (created bool, err error) {
+			return false, nil
+		}
+
+		resp, err := http.Post(env.srv.URL+"/agent/api/v1/config/newconfig", "", bytes.NewReader(bb))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}
+
+func TestServer_PutConfiguration_Invalid(t *testing.T) {
+	var s mockStore
+
+	api := NewAPI(log.NewNopLogger(), &s, func(c *instance.Config) error {
+		return fmt.Errorf("custom validation error")
+	})
+	env := newAPITestEnvironment(t, api)
+
+	cfg := instance.Config{Name: "newconfig"}
+	bb, err := instance.MarshalConfig(&cfg, false)
+	require.NoError(t, err)
+
+	resp, err := http.Post(env.srv.URL+"/agent/api/v1/config/newconfig", "", bytes.NewReader(bb))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	expect := `{
+		"status": "error",
+		"data": {
+			"error": "failed to validate config: custom validation error"
+		}
+	}`
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.JSONEq(t, expect, string(body))
+}
+
+func TestServer_PutConfiguration_WithClient(t *testing.T) {
+	var s mockStore
+	api := NewAPI(log.NewNopLogger(), &s, nil)
+	env := newAPITestEnvironment(t, api)
+
+	cfg := instance.DefaultConfig
+	cfg.Name = "newconfig-withclient"
+	cfg.HostFilter = true
+	cfg.RemoteFlushDeadline = 10 * time.Minute
+
+	s.PutFunc = func(ctx context.Context, c instance.Config) (created bool, err error) {
+		assert.Equal(t, cfg, c)
+		return true, nil
+	}
+
+	cli := client.New(env.srv.URL)
+	err := cli.PutConfiguration(context.Background(), "newconfig-withclient", &cfg)
+	require.NoError(t, err)
+}
+
+func TestServer_DeleteConfiguration(t *testing.T) {
+	s := &mockStore{
+		DeleteFunc: func(ctx context.Context, key string) error {
+			assert.Equal(t, "deleteme", key)
+			return nil
+		},
+	}
+
+	api := NewAPI(log.NewNopLogger(), s, nil)
+	env := newAPITestEnvironment(t, api)
+
+	req, err := http.NewRequest(http.MethodDelete, env.srv.URL+"/agent/api/v1/config/deleteme", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	t.Run("With Client", func(t *testing.T) {
+		cli := client.New(env.srv.URL)
+		err := cli.DeleteConfiguration(context.Background(), "deleteme")
+		require.NoError(t, err)
+	})
+}
+
+func TestServer_URLEncoded(t *testing.T) {
+	var s mockStore
+
+	api := NewAPI(log.NewNopLogger(), &s, nil)
+	env := newAPITestEnvironment(t, api)
+
+	var cfg instance.Config
+	bb, err := instance.MarshalConfig(&cfg, false)
+	require.NoError(t, err)
+
+	s.PutFunc = func(ctx context.Context, c instance.Config) (created bool, err error) {
+		assert.Equal(t, "url/encoded", c.Name)
+		return true, nil
+	}
+
+	resp, err := http.Post(env.srv.URL+"/agent/api/v1/config/url%2Fencoded", "", bytes.NewReader(bb))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	s.GetFunc = func(ctx context.Context, key string) (instance.Config, error) {
+		assert.Equal(t, "url/encoded", key)
+		return instance.Config{Name: "url/encoded"}, nil
+	}
+
+	resp, err = http.Get(env.srv.URL + "/agent/api/v1/configs/url%2Fencoded")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+type mockStore struct {
+	ListFunc   func(ctx context.Context) ([]string, error)
+	GetFunc    func(ctx context.Context, key string) (instance.Config, error)
+	PutFunc    func(ctx context.Context, c instance.Config) (created bool, err error)
+	DeleteFunc func(ctx context.Context, key string) error
+	AllFunc    func(ctx context.Context, keep func(key string) bool) (<-chan instance.Config, error)
+	WatchFunc  func() <-chan []instance.Config
+	CloseFunc  func() error
+}
+
+func (s *mockStore) List(ctx context.Context) ([]string, error) {
+	if s.ListFunc != nil {
+		return s.ListFunc(ctx)
+	}
+	panic("List not implemented")
+}
+
+func (s *mockStore) Get(ctx context.Context, key string) (instance.Config, error) {
+	if s.GetFunc != nil {
+		return s.GetFunc(ctx, key)
+	}
+	panic("Get not implemented")
+}
+
+func (s *mockStore) Put(ctx context.Context, c instance.Config) (created bool, err error) {
+	if s.PutFunc != nil {
+		return s.PutFunc(ctx, c)
+	}
+	panic("Put not implemented")
+}
+
+func (s *mockStore) Delete(ctx context.Context, key string) error {
+	if s.DeleteFunc != nil {
+		return s.DeleteFunc(ctx, key)
+	}
+	panic("Delete not implemented")
+}
+
+func (s *mockStore) All(ctx context.Context, keep func(key string) bool) (<-chan instance.Config, error) {
+	if s.AllFunc != nil {
+		return s.AllFunc(ctx, keep)
+	}
+	panic("All not implemented")
+}
+
+func (s *mockStore) Watch() <-chan []instance.Config {
+	if s.WatchFunc != nil {
+		return s.WatchFunc()
+	}
+	panic("Watch not implemented")
+}
+
+func (s *mockStore) Close() error {
+	if s.CloseFunc != nil {
+		return s.CloseFunc()
+	}
+	panic("Close not implemented")
+}
+
+type apiTestEnvironment struct {
+	srv    *httptest.Server
+	router *mux.Router
+}
+
+func newAPITestEnvironment(t *testing.T, api *API) apiTestEnvironment {
+	t.Helper()
+
+	router := mux.NewRouter()
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+
+	api.WireAPI(router)
+
+	return apiTestEnvironment{srv: srv, router: router}
+}


### PR DESCRIPTION

#### PR Description 
Ports over the HTTP code of the scraping service to the configstore.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer
Once again, not hooked in anywhere, and the old code still exists for now.

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
