### PR TITLE
Fix environment variable substitution syntax

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -32,11 +32,12 @@ you specify a default value or custom error text.
 To specify a default value, use:
 
 ```
-${VAR:default_value}
+${VAR:-default_value}
 ```
 
 Where default_value is the value to use if the environment variable is
-undefined.
+undefined. The full list of supported syntax can be found at Drone's 
+[envsubst repository](https://github.com/drone/envsubst).
 
 ## File Format
 


### PR DESCRIPTION
Fix the syntax in the docs used for environment variable substitution.

#### PR Description 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
