### PR TITLE
Add pkg/prom/cluster package with membership management

### DIFF
--- a/pkg/agentproto/func.go
+++ b/pkg/agentproto/func.go
@@ -1,0 +1,21 @@
+package agentproto
+
+import (
+	"context"
+
+	empty "github.com/golang/protobuf/ptypes/empty"
+)
+
+// FuncScrapingServiceServer is an implementation of ScrapingServiceServer that
+// uses function fields to implement the interface. Useful for tests.
+type FuncScrapingServiceServer struct {
+	ReshardFunc func(context.Context, *ReshardRequest) (*empty.Empty, error)
+}
+
+// Reshard implements ScrapingServiceServer.
+func (f *FuncScrapingServiceServer) Reshard(ctx context.Context, req *ReshardRequest) (*empty.Empty, error) {
+	if f.ReshardFunc != nil {
+		return f.ReshardFunc(ctx, req)
+	}
+	panic("ReshardFunc is nil")
+}

--- a/pkg/prom/cluster/config.go
+++ b/pkg/prom/cluster/config.go
@@ -45,4 +45,5 @@ func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.DurationVar(&c.ReshardTimeout, prefix+"reshard-timeout", time.Second*30, "timeout for cluster-wide reshards and local reshards. Timeout of 0s disables timeout.")
 	c.KVStore.RegisterFlagsWithPrefix(prefix+"config-store.", "configurations/", f)
 	c.Lifecycler.RegisterFlagsWithPrefix(prefix, f)
+	c.Client.GRPCClientConfig.RegisterFlagsWithPrefix(prefix, f)
 }

--- a/pkg/prom/cluster/config.go
+++ b/pkg/prom/cluster/config.go
@@ -1,0 +1,48 @@
+package cluster
+
+import (
+	"flag"
+	"time"
+
+	"github.com/cortexproject/cortex/pkg/ring"
+	"github.com/cortexproject/cortex/pkg/ring/kv"
+	"github.com/grafana/agent/pkg/prom/ha/client"
+	flagutil "github.com/grafana/agent/pkg/util"
+)
+
+// DefaultConfig provides default values for the config
+var DefaultConfig = *flagutil.DefaultConfigFromFlags(&Config{}).(*Config)
+
+// Config describes how to instantiate a scraping service Server instance.
+type Config struct {
+	Enabled         bool                  `yaml:"enabled"`
+	ReshardInterval time.Duration         `yaml:"reshard_interval"`
+	ReshardTimeout  time.Duration         `yaml:"reshard_timeout"`
+	Client          client.Config         `yaml:"client"`
+	KVStore         kv.Config             `yaml:"kvstore"`
+	Lifecycler      ring.LifecyclerConfig `yaml:"lifecycler"`
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler.
+func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultConfig
+
+	type plain Config
+	return unmarshal((*plain)(c))
+}
+
+// RegisterFlags adds the flags required to config the Server to the given
+// FlagSet.
+func (c *Config) RegisterFlags(f *flag.FlagSet) {
+	c.RegisterFlagsWithPrefix("", f)
+}
+
+// RegisterFlagsWithPrefix adds the flags required to config this to the given
+// FlagSet with a specified prefix.
+func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.BoolVar(&c.Enabled, prefix+"enabled", false, "enables the scraping service mode")
+	f.DurationVar(&c.ReshardInterval, prefix+"reshard-interval", time.Minute*1, "how often to manually reshard")
+	f.DurationVar(&c.ReshardTimeout, prefix+"reshard-timeout", time.Second*30, "timeout for cluster-wide reshards and local reshards. Timeout of 0s disables timeout.")
+	c.KVStore.RegisterFlagsWithPrefix(prefix+"config-store.", "configurations/", f)
+	c.Lifecycler.RegisterFlagsWithPrefix(prefix, f)
+}

--- a/pkg/prom/cluster/node.go
+++ b/pkg/prom/cluster/node.go
@@ -1,0 +1,286 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/cortexproject/cortex/pkg/ring"
+	"github.com/cortexproject/cortex/pkg/ring/kv"
+	cortex_util "github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/services"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/google/go-cmp/cmp"
+	pb "github.com/grafana/agent/pkg/agentproto"
+	"github.com/grafana/agent/pkg/prom/ha/client"
+	"github.com/grafana/agent/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/weaveworks/common/user"
+)
+
+var backoffConfig = cortex_util.BackoffConfig{
+	MinBackoff: time.Second,
+	MaxBackoff: 2 * time.Minute,
+	MaxRetries: 10,
+}
+
+// node manages membership within a ring. when a node joins or leaves the ring,
+// it will inform other nodes to reshard their workloads. After a node joins
+// the ring, it will inform the local service to reshard.
+type node struct {
+	log log.Logger
+	reg *util.Unregisterer
+	srv pb.ScrapingServiceServer
+
+	mut  sync.RWMutex
+	cfg  Config
+	ring *ring.Ring
+	lc   *ring.Lifecycler
+
+	exit   chan struct{}
+	reload chan struct{}
+}
+
+// newNode creates a new node and registers it to the ring.
+func newNode(reg prometheus.Registerer, log log.Logger, cfg Config, s pb.ScrapingServiceServer) (*node, error) {
+	n := &node{
+		reg: util.WrapWithUnregisterer(reg),
+		srv: s,
+
+		reload: make(chan struct{}, 1),
+		exit:   make(chan struct{}),
+	}
+	if err := n.ApplyConfig(cfg); err != nil {
+		return nil, err
+	}
+	go n.run()
+	return n, nil
+}
+
+func (n *node) ApplyConfig(cfg Config) error {
+	n.mut.Lock()
+	defer n.mut.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	// Detect if the config changed.
+	if cmp.Equal(n.cfg, cfg) {
+		return nil
+	}
+
+	select {
+	case <-n.exit:
+		return fmt.Errorf("node stopped")
+	default:
+		// Node is running, can continue.
+	}
+
+	// Shut down old components before re-creating the updated ones.
+	n.reg.UnregisterAll()
+
+	if n.ring != nil {
+		err := services.StopAndAwaitTerminated(ctx, n.ring)
+		if err != nil {
+			return fmt.Errorf("failed to stop ring: %w", err)
+		}
+		n.ring = nil
+	}
+
+	if n.lc != nil {
+		err := services.StopAndAwaitTerminated(ctx, n.lc)
+		if err != nil {
+			return fmt.Errorf("failed to stop lifecycler: %w", err)
+		}
+		n.lc = nil
+	}
+
+	if !cfg.Enabled {
+		n.cfg = cfg
+		<-n.reload
+		return nil
+	}
+
+	r, err := newRing(cfg.Lifecycler.RingConfig, "agent_viewer", "agent", n.reg)
+	if err != nil {
+		return fmt.Errorf("failed to create ring: %w", err)
+	}
+	if err := n.reg.Register(r); err != nil {
+		return fmt.Errorf("failed to register ring metrics: %w", err)
+	}
+	if err := services.StartAndAwaitRunning(ctx, r); err != nil {
+		return fmt.Errorf("failed to start ring: %w", err)
+	}
+	n.ring = r
+
+	lc, err := ring.NewLifecycler(cfg.Lifecycler, n, "agent", "agent", true, n.reg)
+	if err != nil {
+		return fmt.Errorf("failed to create lifecycler: %w", err)
+	}
+	if err := services.StartAndAwaitRunning(ctx, lc); err != nil {
+		r.StopAsync()
+		return fmt.Errorf("failed to start lifecycler: %w", err)
+	}
+	n.lc = lc
+
+	n.cfg = cfg
+
+	<-n.reload
+	return nil
+}
+
+// newRing creates a new Cortex Ring that ignores unhealthy nodes.
+func newRing(cfg ring.Config, name, key string, reg prometheus.Registerer) (*ring.Ring, error) {
+	codec := ring.GetCodec()
+	store, err := kv.NewClient(
+		cfg.KVStore,
+		codec,
+		kv.RegistererWithKVName(reg, name+"-ring"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return ring.NewWithStoreClientAndStrategy(cfg, name, key, store, ring.NewIgnoreUnhealthyInstancesReplicationStrategy())
+}
+
+// run waits for connection to the ring and kickstarts the join process.
+func (n *node) run() {
+	for range n.reload {
+		if err := n.performClusterReshard(context.Background(), true); err != nil {
+			level.Warn(n.log).Log("msg", "dynamic cluster reshard did not succeed", "err", err)
+		}
+	}
+
+	level.Info(n.log).Log("msg", "node run loop exiting")
+}
+
+// performClusterReshard informs the cluster to immediately trigger a reshard
+// of their workloads. if includeSelf is true, the server provided to newNode will
+// also be informed. includeSelf should be true when joining the cluster, and false
+// when leaving.
+func (n *node) performClusterReshard(ctx context.Context, includeSelf bool) error {
+	n.mut.RLock()
+	defer n.mut.RUnlock()
+
+	if n.cfg.ReshardTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, n.cfg.ReshardTimeout)
+		defer cancel()
+	}
+
+	level.Info(n.log).Log("msg", "informing all nodes to reshard")
+
+	var (
+		rs  ring.ReplicationSet
+		err error
+
+		firstError error
+	)
+
+	backoff := cortex_util.NewBackoff(ctx, backoffConfig)
+	for backoff.Ongoing() {
+		rs, err = n.ring.GetAllHealthy(ring.Read)
+		if err == nil {
+			break
+		}
+		backoff.Wait()
+	}
+	if err := backoff.Err(); err != nil && firstError == nil {
+		firstError = err
+	}
+
+	_, err = rs.Do(ctx, 250*time.Millisecond, func(c context.Context, id *ring.InstanceDesc) (interface{}, error) {
+		// Skip over ourselves.
+		if id.Addr == n.lc.Addr {
+			return nil, nil
+		}
+
+		ctx = user.InjectOrgID(ctx, "fake")
+		return nil, n.notifyReshard(ctx, id)
+	})
+	if err != nil && firstError == nil {
+		firstError = err
+	}
+
+	if includeSelf {
+		level.Info(n.log).Log("msg", "running local reshard")
+		if _, err := n.srv.Reshard(ctx, &pb.ReshardRequest{}); err != nil {
+			level.Warn(n.log).Log("msg", "dynamic local reshard did not succeed", "err", err)
+		}
+	}
+
+	return firstError
+}
+
+// notifyReshard informs an individual node to reshard.
+func (n *node) notifyReshard(ctx context.Context, id *ring.InstanceDesc) error {
+	cli, err := client.New(n.cfg.Client, id.Addr)
+	if err != nil {
+		return err
+	}
+	defer cli.Close()
+
+	level.Info(n.log).Log("msg", "attempting to notify remote agent to reshard", "addr", id.Addr)
+
+	backoff := cortex_util.NewBackoff(ctx, backoffConfig)
+	for backoff.Ongoing() {
+		_, err := cli.Reshard(ctx, &pb.ReshardRequest{})
+		if err == nil {
+			break
+		}
+
+		level.Warn(n.log).Log("msg", "reshard notification attempt failed", "addr", id.Addr, "err", err, "attempt", backoff.NumRetries())
+		backoff.Wait()
+	}
+
+	return backoff.Err()
+}
+
+// Stop stops the node and cancels it from running. The node cannot be used
+// again once Stop is called.
+func (n *node) Stop() error {
+	n.mut.Lock()
+	defer n.mut.Unlock()
+
+	select {
+	case <-n.exit:
+		return fmt.Errorf("node stopped")
+	default:
+		// Node is running, can continue.
+	}
+
+	close(n.reload)
+	close(n.exit)
+
+	var firstError error
+
+	if n.ring != nil {
+		err := services.StopAndAwaitTerminated(context.Background(), n.ring)
+		if err != nil && firstError == nil {
+			firstError = fmt.Errorf("failed to stop ring: %w", err)
+		}
+		n.ring = nil
+	}
+
+	if n.lc != nil {
+		err := services.StopAndAwaitTerminated(context.Background(), n.lc)
+		if err != nil {
+			firstError = fmt.Errorf("failed to stop lifecycler: %w", err)
+		}
+		n.lc = nil
+	}
+
+	return firstError
+}
+
+// Flush implements ring.FlushTransferer. It's a no-op.
+func (n *node) Flush() {}
+
+// TransferOut implements ring.FlushTransferer. It connects to all other healthy agents and
+// tells them to reshard.
+func (n *node) TransferOut(ctx context.Context) error {
+	// Only inform other nodes in the cluster to reshard since we're leaving.
+	return n.performClusterReshard(ctx, false)
+}

--- a/pkg/prom/cluster/node_test.go
+++ b/pkg/prom/cluster/node_test.go
@@ -1,0 +1,15 @@
+package cluster
+
+import "testing"
+
+func Test_node_Join(t *testing.T) {
+	// TODO(rfratto): impl
+}
+
+func Test_node_Leave(t *testing.T) {
+	// TODO(rfratto): impl
+}
+
+func Test_node_ApplyConfig(t *testing.T) {
+	// TODO(rfratto): impl
+}

--- a/pkg/prom/cluster/node_test.go
+++ b/pkg/prom/cluster/node_test.go
@@ -1,15 +1,210 @@
 package cluster
 
-import "testing"
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cortexproject/cortex/pkg/ring"
+	"github.com/cortexproject/cortex/pkg/util/services"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/grafana/agent/pkg/agentproto"
+	"github.com/grafana/agent/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"gopkg.in/yaml.v2"
+)
 
 func Test_node_Join(t *testing.T) {
-	// TODO(rfratto): impl
+	var (
+		reg    = prometheus.NewRegistry()
+		logger = log.NewSyncLogger(log.NewLogfmtLogger(os.Stderr))
+
+		localReshard  = make(chan struct{}, 1)
+		remoteReshard = make(chan struct{}, 1)
+	)
+
+	local := &agentproto.FuncScrapingServiceServer{
+		ReshardFunc: func(c context.Context, rr *agentproto.ReshardRequest) (*empty.Empty, error) {
+			localReshard <- struct{}{}
+			return &empty.Empty{}, nil
+		},
+	}
+
+	remote := &agentproto.FuncScrapingServiceServer{
+		ReshardFunc: func(c context.Context, rr *agentproto.ReshardRequest) (*empty.Empty, error) {
+			remoteReshard <- struct{}{}
+			return &empty.Empty{}, nil
+		},
+	}
+	startNode(t, remote)
+
+	nodeConfig := DefaultConfig
+	nodeConfig.Enabled = true
+	nodeConfig.Lifecycler = testLifecyclerConfig(t)
+
+	n, err := newNode(reg, logger, nodeConfig, local)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = n.Stop() })
+
+	waitAll(t, 5*time.Second, remoteReshard, localReshard)
+}
+
+// waitAll waits for a message on all channels.
+func waitAll(t *testing.T, timeout time.Duration, chs ...chan struct{}) {
+	timeoutCh := time.After(timeout)
+	for _, ch := range chs {
+		select {
+		case <-timeoutCh:
+			require.FailNow(t, "timeout exceeded")
+		case <-ch:
+		}
+	}
 }
 
 func Test_node_Leave(t *testing.T) {
-	// TODO(rfratto): impl
+	var (
+		reg    = prometheus.NewRegistry()
+		logger = log.NewSyncLogger(log.NewLogfmtLogger(os.Stderr))
+
+		remoteReshard = make(chan struct{}, 2)
+	)
+
+	local := &agentproto.FuncScrapingServiceServer{
+		ReshardFunc: func(c context.Context, rr *agentproto.ReshardRequest) (*empty.Empty, error) {
+			return &empty.Empty{}, nil
+		},
+	}
+
+	remote := &agentproto.FuncScrapingServiceServer{
+		ReshardFunc: func(c context.Context, rr *agentproto.ReshardRequest) (*empty.Empty, error) {
+			return &empty.Empty{}, nil
+		},
+	}
+	startNode(t, remote)
+
+	nodeConfig := DefaultConfig
+	nodeConfig.Enabled = true
+	nodeConfig.Lifecycler = testLifecyclerConfig(t)
+
+	n, err := newNode(reg, logger, nodeConfig, local)
+	require.NoError(t, err)
+
+	// Update the reshard function to write to remoteReshard on shutdown.
+	remote.ReshardFunc = func(c context.Context, rr *agentproto.ReshardRequest) (*empty.Empty, error) {
+		remoteReshard <- struct{}{}
+		return &empty.Empty{}, nil
+	}
+
+	// Stop the node so it transfers data outward.
+	require.NoError(t, n.Stop(), "failed to stop the node")
+
+	level.Info(logger).Log("msg", "waiting for remote reshard to occur")
+	waitAll(t, 5*time.Second, remoteReshard)
 }
 
 func Test_node_ApplyConfig(t *testing.T) {
-	// TODO(rfratto): impl
+	var (
+		reg    = prometheus.NewRegistry()
+		logger = log.NewSyncLogger(log.NewLogfmtLogger(os.Stderr))
+
+		localReshard = make(chan struct{}, 1)
+	)
+
+	local := &agentproto.FuncScrapingServiceServer{
+		ReshardFunc: func(c context.Context, rr *agentproto.ReshardRequest) (*empty.Empty, error) {
+			localReshard <- struct{}{}
+			return &empty.Empty{}, nil
+		},
+	}
+
+	nodeConfig := DefaultConfig
+	nodeConfig.Enabled = true
+	nodeConfig.Lifecycler = testLifecyclerConfig(t)
+
+	n, err := newNode(reg, logger, nodeConfig, local)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = n.Stop() })
+
+	// Wait for the initial join to trigger.
+	waitAll(t, 5*time.Second, localReshard)
+
+	// An ApplyConfig working correctly should re-join the cluster, which can be
+	// detected by local resharding applying twice.
+	nodeConfig.Lifecycler.NumTokens = 1
+	require.NoError(t, n.ApplyConfig(nodeConfig), "failed to apply new config")
+
+	waitAll(t, 5*time.Second, localReshard)
+}
+
+func testGRPCServer(t *testing.T) (*grpc.Server, net.Listener) {
+	t.Helper()
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	grpcServer := grpc.NewServer()
+
+	go func() {
+		_ = grpcServer.Serve(l)
+	}()
+	t.Cleanup(func() { grpcServer.Stop() })
+
+	return grpcServer, l
+}
+
+// startNode launches srv as a gRPC server and registers it to the ring.
+func startNode(t *testing.T, srv agentproto.ScrapingServiceServer) {
+	t.Helper()
+
+	grpcServer, l := testGRPCServer(t)
+	agentproto.RegisterScrapingServiceServer(grpcServer, srv)
+
+	lcConfig := testLifecyclerConfig(t)
+	lcConfig.Addr = l.Addr().(*net.TCPAddr).IP.String()
+	lcConfig.Port = l.Addr().(*net.TCPAddr).Port
+
+	lc, err := ring.NewLifecycler(lcConfig, ring.NewNoopFlushTransferer(), "agent", "agent", false, prometheus.NewRegistry())
+	require.NoError(t, err)
+
+	err = services.StartAndAwaitRunning(context.Background(), lc)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = services.StopAndAwaitTerminated(context.Background(), lc)
+	})
+}
+
+func testLifecyclerConfig(t *testing.T) ring.LifecyclerConfig {
+	t.Helper()
+
+	cfgText := util.Untab(fmt.Sprintf(`
+ring:
+	kvstore:
+		store: inmemory
+		prefix: tests/%s
+final_sleep: 0s
+min_ready_duration: 0s
+	`, t.Name()))
+
+	// Apply default values by registering to a fake flag set.
+	var lc ring.LifecyclerConfig
+	lc.RegisterFlagsWithPrefix("", flag.NewFlagSet("", flag.ContinueOnError))
+
+	err := yaml.Unmarshal([]byte(cfgText), &lc)
+	require.NoError(t, err)
+
+	// Add an invalid default address/port. Tests can override if they expect
+	// incoming traffic.
+	lc.Addr = "x.x.x.x"
+	lc.Port = -1
+
+	return lc
 }

--- a/pkg/util/test_logger.go
+++ b/pkg/util/test_logger.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+)
+
+// TestLogger generates a logger for a test.
+func TestLogger(t *testing.T) log.Logger {
+	t.Helper()
+
+	l := log.NewSyncLogger(log.NewLogfmtLogger(os.Stderr))
+	l = log.WithPrefix(l,
+		"test", t.Name(),
+		"ts", log.Valuer(testTimestamp),
+	)
+
+	return l
+}
+
+// testTimestamp is a log.Valuer that returns the timestamp
+// without the date or timezone, reducing the noise in the test.
+func testTimestamp() interface{} {
+	t := time.Now().UTC()
+	return t.Format("15:04:05.000")
+}


### PR DESCRIPTION
#### PR Description 
This is the first of a few PRs to migrate the `pkg/prom/ha` logic to a `pkg/prom/cluster` package.
This first PR re-implements membership within the cluster to a dedicated `node` type. The `node` type will be used for ensuring the Agent maintains appropriate membership in the proper cluster as the config changes. 

Reshards are triggered during the membership cycle:

- All Agents will be told to reshard when a node joins (including the joining Agent)
- All Agents will be told to reshard when a node leaves (excluding the leaving Agent)

#### Which issue(s) this PR fixes 
Believe it or not, still working on #147.

#### Notes to the Reviewer
This isn't hooked into anything yet, and won't be hooked up until all pieces are migrated. Tests still needed, so I'm opening this in draft. 

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
