### PR TITLE
Support mirror traffic pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ cross-compilation issue, but will return in v0.13.0.
   
 - [ENHANCEMENT] Upgrade `go.opentelemetry.io/collector` to v0.21.0 (@mapno)
 
+- [ENHANCEMENT] Support mirroring a trace pipeline to multiple backends (@mapno)
+
+- [DEPRECATION] `push_config` is now supplanted by `remote_block` and `batch`.
+  `push_config` will be removed in a future version (@mapno)
+
 # v0.13.0 (2021-02-25)
 
 The primary branch name has changed from `master` to `main`. You may have to

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -1989,34 +1989,35 @@ name: <string>
 #  This field allows for the general manipulation of tags on spans that pass through this agent.  A common use may be to add an environment or cluster variable.
 attributes: [attributes.config]
 
-push_config:
+# Batch options: https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/processor/batchprocessor
+#  This field allows to configure grouping spans into batches.  Batching helps better compress the data and reduce the number of outgoing connections required to transmit the data.
+batch: [batch.config]
+
+remote_write:
   # host:port to send traces to
-  endpoint: <string>
+  - endpoint: <string>
 
-  # Controls whether compression is enabled.
-  [ compression: <string> | default = "gzip" | supported = "none", "gzip"]
+    # Controls whether compression is enabled.
+    [ compression: <string> | default = "gzip" | supported = "none", "gzip"]
 
-  # Controls whether or not TLS is required.  See https://godoc.org/google.golang.org/grpc#WithInsecure
-  [ insecure: <boolean> | default = false ]
+    # Controls whether or not TLS is required.  See https://godoc.org/google.golang.org/grpc#WithInsecure
+    [ insecure: <boolean> | default = false ]
 
-  # Disable validation of the server certificate. Only used when insecure is set
-  # to false.
-  [ insecure_skip_verify: <bool> | default = false ]
+    # Disable validation of the server certificate. Only used when insecure is set
+    # to false.
+    [ insecure_skip_verify: <bool> | default = false ]
 
-  # Sets the `Authorization` header on every trace push with the
-  # configured username and password.
-  # password and password_file are mutually exclusive.
-  basic_auth:
-    [ username: <string> ]
-    [ password: <secret> ]
-    [ password_file: <string> ]
+    # Sets the `Authorization` header on every trace push with the
+    # configured username and password.
+    # password and password_file are mutually exclusive.
+    basic_auth:
+      [ username: <string> ]
+      [ password: <secret> ]
+      [ password_file: <string> ]
 
-  # Batch options are the same as: https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/processor/batchprocessor
-  [ batch: <batch.config> ]
-
-  # sending_queue and retry_on_failure are the same as: https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/exporter/otlpexporter
-  [ sending_queue: <otlpexporter.sending_queue> ]
-  [ retry_on_failure: <otlpexporter.retry_on_failure> ]
+    # sending_queue and retry_on_failure are the same as: https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/exporter/otlpexporter
+    [ sending_queue: <otlpexporter.sending_queue> ]
+    [ retry_on_failure: <otlpexporter.retry_on_failure> ]
 
 # Receiver configurations are mapped directly into the OpenTelmetry receivers block.
 #   At least one receiver is required.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -256,14 +256,14 @@ tempo:
       jaeger:
         protocols:
           grpc: # listens on the default jaeger grpc port: 14250
-    push_config:
-      endpoint: localhost:55680
-      insecure: true  # only add this if TLS is not required
-      batch:
-        timeout: 5s
-        send_batch_size: 100
-      queue:
-        retry_on_failure: true
+    remote_write:
+      - endpoint: localhost:55680
+        insecure: true  # only add this if TLS is not required
+        queue:
+          retry_on_failure: true
+    batch:
+      timeout: 5s
+      send_batch_size: 100
 ```
 
 ## Running

--- a/example/docker-compose/agent/config/agent.yaml
+++ b/example/docker-compose/agent/config/agent.yaml
@@ -73,9 +73,9 @@ tempo:
       - action: upsert
         key: env
         value: prod
-    push_config:
-      endpoint: otel-collector:55680
-      insecure: true
-      batch:
-        timeout: 5s
-        send_batch_size: 100
+    remote_write:
+      - endpoint: otel-collector:55680
+        insecure: true
+    batch:
+      timeout: 5s
+      send_batch_size: 100

--- a/pkg/tempo/config.go
+++ b/pkg/tempo/config.go
@@ -97,10 +97,9 @@ type PushConfig struct {
 	Insecure           bool                   `yaml:"insecure"`
 	InsecureSkipVerify bool                   `yaml:"insecure_skip_verify"`
 	BasicAuth          *prom_config.BasicAuth `yaml:"basic_auth,omitempty"`
+	Batch              map[string]interface{} `yaml:"batch,omitempty"`            // https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/processor/batchprocessor/config.go#L24
 	SendingQueue       map[string]interface{} `yaml:"sending_queue,omitempty"`    // https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/exporter/exporterhelper/queued_retry.go#L30
 	RetryOnFailure     map[string]interface{} `yaml:"retry_on_failure,omitempty"` // https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/exporter/exporterhelper/queued_retry.go#L54
-	// Deprecated. Configure the batch processor with InstanceConfig.Batch instead.
-	Batch map[string]interface{} `yaml:"batch,omitempty"` // https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/processor/batchprocessor/config.go#L24
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.

--- a/pkg/tempo/config.go
+++ b/pkg/tempo/config.go
@@ -61,10 +61,17 @@ func (c *Config) Validate() error {
 type InstanceConfig struct {
 	Name string `yaml:"name"`
 
+	// Deprecated in favor of RemoteWrite and Batch.
 	PushConfig PushConfig `yaml:"push_config"`
+
+	// RemoteWrite defines one or multiple backends that can receive the pipeline's traffic.
+	RemoteWrite []PushConfig `yaml:"remote_write"`
 
 	// Receivers: https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/receiver/README.md
 	Receivers map[string]interface{} `yaml:"receivers"`
+
+	// Batch: https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/processor/batchprocessor/config.go#L24
+	Batch map[string]interface{} `yaml:"batch,omitempty"`
 
 	// Attributes: https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/processor/attributesprocessor/config.go#L30
 	Attributes map[string]interface{} `yaml:"attributes"`
@@ -90,9 +97,10 @@ type PushConfig struct {
 	Insecure           bool                   `yaml:"insecure"`
 	InsecureSkipVerify bool                   `yaml:"insecure_skip_verify"`
 	BasicAuth          *prom_config.BasicAuth `yaml:"basic_auth,omitempty"`
-	Batch              map[string]interface{} `yaml:"batch,omitempty"`            // https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/processor/batchprocessor/config.go#L24
-	SendingQueue       map[string]interface{} `yaml:"sending_queue,omitempty"`    // https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/exporter/exporterhelper/queued_retry.go#L30
-	RetryOnFailure     map[string]interface{} `yaml:"retry_on_failure,omitempty"` // https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/exporter/exporterhelper/queued_retry.go#L54
+	// Deprecated. Configure the batch processor with InstanceConfig.Batch instead.
+	Batch          map[string]interface{} `yaml:"batch,omitempty"`            // https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/processor/batchprocessor/config.go#L24
+	SendingQueue   map[string]interface{} `yaml:"sending_queue,omitempty"`    // https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/exporter/exporterhelper/queued_retry.go#L30
+	RetryOnFailure map[string]interface{} `yaml:"retry_on_failure,omitempty"` // https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/exporter/exporterhelper/queued_retry.go#L54
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
@@ -110,49 +118,43 @@ func (c *PushConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
-func (c *InstanceConfig) otelConfig() (*configmodels.Config, error) {
-	otelMapStructure := map[string]interface{}{}
-
-	if len(c.Receivers) == 0 {
-		return nil, errors.New("must have at least one configured receiver")
-	}
-
-	if len(c.PushConfig.Endpoint) == 0 {
+// exporter builds an OTel exporter from PushConfig
+func (c *InstanceConfig) exporter(remoteWriteConfig PushConfig) (map[string]interface{}, error) {
+	if len(remoteWriteConfig.Endpoint) == 0 {
 		return nil, errors.New("must have a configured remote_write.endpoint")
 	}
 
-	// exporter
 	headers := map[string]string{}
-	if c.PushConfig.BasicAuth != nil {
-		password := string(c.PushConfig.BasicAuth.Password)
+	if remoteWriteConfig.BasicAuth != nil {
+		password := string(remoteWriteConfig.BasicAuth.Password)
 
-		if len(c.PushConfig.BasicAuth.PasswordFile) > 0 {
-			buff, err := ioutil.ReadFile(c.PushConfig.BasicAuth.PasswordFile)
+		if len(remoteWriteConfig.BasicAuth.PasswordFile) > 0 {
+			buff, err := ioutil.ReadFile(remoteWriteConfig.BasicAuth.PasswordFile)
 			if err != nil {
-				return nil, fmt.Errorf("unable to load password file %s: %w", c.PushConfig.BasicAuth.PasswordFile, err)
+				return nil, fmt.Errorf("unable to load password file %s: %w", remoteWriteConfig.BasicAuth.PasswordFile, err)
 			}
 			password = string(buff)
 		}
 
-		encodedAuth := base64.StdEncoding.EncodeToString([]byte(c.PushConfig.BasicAuth.Username + ":" + password))
+		encodedAuth := base64.StdEncoding.EncodeToString([]byte(remoteWriteConfig.BasicAuth.Username + ":" + password))
 		headers = map[string]string{
 			"authorization": "Basic " + encodedAuth,
 		}
 	}
 
-	compression := c.PushConfig.Compression
+	compression := remoteWriteConfig.Compression
 	if compression == compressionNone {
 		compression = ""
 	}
 
 	otlpExporter := map[string]interface{}{
-		"endpoint":             c.PushConfig.Endpoint,
+		"endpoint":             remoteWriteConfig.Endpoint,
 		"compression":          compression,
 		"headers":              headers,
-		"insecure":             c.PushConfig.Insecure,
-		"insecure_skip_verify": c.PushConfig.InsecureSkipVerify,
-		"sending_queue":        c.PushConfig.SendingQueue,
-		"retry_on_failure":     c.PushConfig.RetryOnFailure,
+		"insecure":             remoteWriteConfig.Insecure,
+		"insecure_skip_verify": remoteWriteConfig.InsecureSkipVerify,
+		"sending_queue":        remoteWriteConfig.SendingQueue,
+		"retry_on_failure":     remoteWriteConfig.RetryOnFailure,
 	}
 
 	// Apply some sane defaults to the exporter. The
@@ -167,9 +169,60 @@ func (c *InstanceConfig) otelConfig() (*configmodels.Config, error) {
 		retryConfig["max_elapsed_time"] = "60s"
 	}
 
-	otelMapStructure["exporters"] = map[string]interface{}{
-		"otlp": otlpExporter,
+	return otlpExporter, nil
+}
+
+// exporters builds one or multiple exporters from a remote_write block.
+// It also supports building an exporter from push_config.
+func (c *InstanceConfig) exporters() (map[string]interface{}, error) {
+	if len(c.RemoteWrite) == 0 {
+		otlpExporter, err := c.exporter(c.PushConfig)
+		return map[string]interface{}{
+			"otlp": otlpExporter,
+		}, err
 	}
+
+	exporters := map[string]interface{}{}
+	for i, remoteWriteConfig := range c.RemoteWrite {
+		exporter, err := c.exporter(remoteWriteConfig)
+		if err != nil {
+			return nil, err
+		}
+		exporterName := fmt.Sprintf("otlp/%d", i)
+		exporters[exporterName] = exporter
+	}
+	return exporters, nil
+}
+
+func (c *InstanceConfig) otelConfig() (*configmodels.Config, error) {
+	otelMapStructure := map[string]interface{}{}
+
+	if len(c.Receivers) == 0 {
+		return nil, errors.New("must have at least one configured receiver")
+	}
+
+	if len(c.RemoteWrite) == 0 && len(c.PushConfig.Endpoint) == 0 {
+		return nil, errors.New("must have a configured at least one remote_write or push_config.endpoint")
+	}
+
+	if len(c.RemoteWrite) != 0 && len(c.PushConfig.Endpoint) != 0 {
+		return nil, errors.New("must not configure push_config and remote_write. push_config is deprecated in favor of remote_write")
+	}
+
+	if c.Batch != nil && c.PushConfig.Batch != nil {
+		return nil, errors.New("must not configure push_config.batch and batch. push_config.batch is deprecated in favor of batch")
+	}
+
+	exporters, err := c.exporters()
+	if err != nil {
+		return nil, err
+	}
+	exportersNames := make([]string, 0, len(exporters))
+	for name := range exporters {
+		exportersNames = append(exportersNames, name)
+	}
+
+	otelMapStructure["exporters"] = exporters
 
 	// processors
 	processors := map[string]interface{}{}
@@ -186,7 +239,10 @@ func (c *InstanceConfig) otelConfig() (*configmodels.Config, error) {
 		processorNames = append(processorNames, "attributes")
 	}
 
-	if c.PushConfig.Batch != nil {
+	if c.Batch != nil {
+		processors["batch"] = c.Batch
+		processorNames = append(processorNames, "batch")
+	} else if c.PushConfig.Batch != nil {
 		processors["batch"] = c.PushConfig.Batch
 		processorNames = append(processorNames, "batch")
 	}
@@ -204,7 +260,7 @@ func (c *InstanceConfig) otelConfig() (*configmodels.Config, error) {
 	otelMapStructure["service"] = map[string]interface{}{
 		"pipelines": map[string]interface{}{
 			"traces": map[string]interface{}{
-				"exporters":  []string{"otlp"},
+				"exporters":  exportersNames,
 				"processors": processorNames,
 				"receivers":  receiverNames,
 			},
@@ -213,7 +269,7 @@ func (c *InstanceConfig) otelConfig() (*configmodels.Config, error) {
 
 	// now build the otel configmodel from the mapstructure
 	v := viper.New()
-	err := v.MergeConfigMap(otelMapStructure)
+	err = v.MergeConfigMap(otelMapStructure)
 	if err != nil {
 		return nil, fmt.Errorf("failed to merge in mapstructure config: %w", err)
 	}

--- a/pkg/tempo/instance.go
+++ b/pkg/tempo/instance.go
@@ -132,6 +132,9 @@ func (i *Instance) buildAndStartPipeline(ctx context.Context, cfg InstanceConfig
 	if err != nil {
 		return fmt.Errorf("failed to load otelConfig from agent tempo config: %w", err)
 	}
+	if cfg.PushConfig.Endpoint != "" {
+		i.logger.Warn("Configuring exporter with deprecated push_config. Use remote_write and batch instead")
+	}
 
 	factories, err := tracingFactories()
 	if err != nil {

--- a/production/kubernetes/agent-tempo.yaml
+++ b/production/kubernetes/agent-tempo.yaml
@@ -11,17 +11,10 @@ data:
         log_level: info
     tempo:
         configs:
-          - name: default
-            push_config:
-                basic_auth:
-                    password: ${TEMPO_PASSWORD}
-                    username: ${TEMPO_USERNAME}
-                batch:
-                    send_batch_size: 1000
-                    timeout: 5s
-                endpoint: ${TEMPO_ENDPOINT}
-                retry_on_failure:
-                    enabled: false
+          - batch:
+                send_batch_size: 1000
+                timeout: 5s
+            name: default
             receivers:
                 jaeger:
                     protocols:
@@ -38,6 +31,13 @@ data:
                         grpc: null
                         http: null
                 zipkin: null
+            remote_write:
+              - basic_auth:
+                    password: ${TEMPO_PASSWORD}
+                    username: ${TEMPO_USERNAME}
+                endpoint: ${TEMPO_ENDPOINT}
+                retry_on_failure:
+                    enabled: false
             scrape_configs:
               - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
                 job_name: kubernetes-pods

--- a/production/kubernetes/build/templates/tempo/main.jsonnet
+++ b/production/kubernetes/build/templates/tempo/main.jsonnet
@@ -35,6 +35,10 @@ local newPort(name, portNumber, protocol='TCP') =
         },
         opencensus: null,
       },
+      batch: {
+        timeout: '5s',
+        send_batch_size: 1000,
+      }
     }) +
     agent.withPortsMixin([
       // Jaeger receiver
@@ -52,20 +56,18 @@ local newPort(name, portNumber, protocol='TCP') =
       // Opencensus
       newPort('opencensus', 55678, 'TCP'),
     ]) +
-    agent.withTempoPushConfig({
-      endpoint: '${TEMPO_ENDPOINT}',
-      basic_auth: {
-        username: '${TEMPO_USERNAME}',
-        password: '${TEMPO_PASSWORD}',
+    agent.withTempoRemoteWrite([
+      {
+        endpoint: '${TEMPO_ENDPOINT}',
+        basic_auth: {
+          username: '${TEMPO_USERNAME}',
+          password: '${TEMPO_PASSWORD}',
+        },
+        retry_on_failure: {
+          enabled: false,
+        },
       },
-      batch: {
-        timeout: '5s',
-        send_batch_size: 1000,
-      },
-      retry_on_failure: {
-        enabled: false,
-      },
-    }) +
+    ]) +
     agent.withTempoSamplingStrategies({
       default_strategy: {
         type: 'probabilistic',

--- a/production/tanka/grafana-agent/v1/README.md
+++ b/production/tanka/grafana-agent/v1/README.md
@@ -62,7 +62,8 @@ example, you may not deploy a scraping service with Loki logs collection.
 ## Configure Tempo
 
 - `withTempoConfig(config)`: Creates a Tempo config block to pass to the Agent.
-- `withTempoPushConfig(push_config)`: Configures a location to push spans to.
+- (Deprecated) `withTempoPushConfig(push_config)`: Configures a location to push spans to.
+- `withTempoRemoteWrite(remote_write)`: Configures one or multiple locations to push spans to.
 - `withTempoSamplingStrategies(strategies)`: Configures strategies for trace collection.
 - `withTempoScrapeConfigs(scrape_configs)`: Configures scrape configs to attach
    labels to incoming spans.

--- a/production/tanka/grafana-agent/v1/lib/tempo.libsonnet
+++ b/production/tanka/grafana-agent/v1/lib/tempo.libsonnet
@@ -10,6 +10,7 @@
     _tempo_config:: config,
   },
 
+  // Deprecated in favor of withTempoRemoteWrite.
   // withTempoPushConfig configures a location to write traces to.
   //
   // Availabile options can be found in the configuration reference:
@@ -20,6 +21,18 @@
       withTempoConfig.
     |||,
     _tempo_config+:: { push_config: push_config },
+  },
+
+  // withTempoRemoteWrite configures one or multiple backends to write traces to.
+  //
+  // Availabile options can be found in the configuration reference:
+  // https://github.com/grafana/agent/blob/main/docs/configuration-reference.md#tempo_config
+  withTempoRemoteWrite(remote_write):: {
+    assert std.objectHasAll(self, '_tempo_config') : |||
+      withTempoRemoteWrite must be merged with the result of calling
+      withTempoConfig.
+    |||,
+    _tempo_config+:: { remote_write: remote_write },
   },
 
   // withTempoSamplingStrategies accepts an object for trace sampling strategies.


### PR DESCRIPTION
#### PR Description 

Adds support for multiple backends in a tracing pipeline. `push_config` is deprecated in favor of `remote_write` and `batch`, which configure the multiple exporters.

`remote_write` still uses `PushConfig`, but the idea is to rename it and remove the `Batch` field once the `push_config` is removed from the config.

#### Which issue(s) this PR fixes

Closes https://github.com/grafana/agent/issues/466

#### Notes to the Reviewer

#### PR Checklist

- [X] CHANGELOG updated 
- [x] Documentation added
- [X] Tests updated
