### PR TITLE
lint for proper godoc-style comments

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,5 +62,13 @@ linters:
     - typecheck
 
 issues:
+  # golangci-lint excludes some stuff we want by default (i.e., proper go-style comments).
+  # We exclude the defaults and then manually exclude the subset of defaults we truly don't
+  # care about.
+  exclude-use-default: false
+
   exclude:
-    - Error return value of .*.Log\x60 is not checked
+    # EXC0001 errcheck: Almost all programs ignore errors on these functions
+    # and in most cases it's ok. This is copied from the golangci-lint defaults
+    # mut modified to include go-kit logging.
+    - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv|.*\.Log). is not checked

--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-kit/kit/log"
 )
 
+// Entrypoint is the entrypoint of the application that starts all subsystems.
 type Entrypoint struct {
 	promMetrics *prom.Agent
 	lokiLogs    *loki.Loki
@@ -24,6 +25,7 @@ type Entrypoint struct {
 	srv         *server.Server
 }
 
+// NewEntryPoint creates a new Entrypoint.
 func NewEntryPoint(logger log.Logger, cfg *config.Config) (*Entrypoint, error) {
 	var (
 		promMetrics *prom.Agent
@@ -91,9 +93,9 @@ func NewEntryPoint(logger log.Logger, cfg *config.Config) (*Entrypoint, error) {
 		manager:     manager,
 		srv:         srv,
 	}, nil
-
 }
 
+// Stop stops the Entrypoint and all subsystems.
 func (srv *Entrypoint) Stop() {
 	// Stop enabled subsystems
 	if srv.manager != nil {
@@ -110,6 +112,8 @@ func (srv *Entrypoint) Stop() {
 	}
 }
 
+// Start starts the server used by the Entrypoint, and will block until a
+// termination signal is sent to the process.
 func (srv *Entrypoint) Start() error {
 	return srv.srv.Run()
 }

--- a/cmd/agent/service.go
+++ b/cmd/agent/service.go
@@ -2,10 +2,14 @@
 
 package main
 
+// IsWindowsService returns whether the current process is running as a Windows
+// Service. On non-Windows platforms, this always returns false.
 func IsWindowsService() bool {
 	return false
 }
 
+// RunService runs the current process as a Windows servce. On non-Windows platforms,
+// this is always a no-op.
 func RunService() error {
 	return nil
 }

--- a/cmd/agent/service_windows.go
+++ b/cmd/agent/service_windows.go
@@ -17,8 +17,10 @@ import (
 const ServiceName = "Grafana Agent"
 const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
 
+// AgentService runs the Grafana Agent as a service.
 type AgentService struct{}
 
+// Execute starts the AgentService.
 func (m *AgentService) Execute(args []string, serviceRequests <-chan svc.ChangeRequest, changes chan<- svc.Status) (ssec bool, errno uint32) {
 	changes <- svc.Status{State: svc.StartPending}
 
@@ -72,6 +74,8 @@ loop:
 	return
 }
 
+// IsWindowsService returns whether the current process is running as a Windows
+// Service. On non-Windows platforms, this always returns false.
 func IsWindowsService() bool {
 	isService, err := svc.IsWindowsService()
 	if err != nil {
@@ -80,6 +84,8 @@ func IsWindowsService() bool {
 	return isService
 }
 
+// RunService runs the current process as a Windows servce. On non-Windows platforms,
+// this is always a no-op.
 func RunService() error {
 	return svc.Run(ServiceName, &AgentService{})
 }

--- a/pkg/agentctl/samples.go
+++ b/pkg/agentctl/samples.go
@@ -11,6 +11,10 @@ import (
 	"github.com/prometheus/prometheus/tsdb/wal"
 )
 
+// SampleStats are statistics for samples for a series within the WAL. Each
+// instance represents a unique series based on its labels, and holds the range
+// of timestamps found for all samples including the total number of samples
+// for that series.
 type SampleStats struct {
 	Labels  labels.Labels
 	From    time.Time

--- a/pkg/agentctl/walstats.go
+++ b/pkg/agentctl/walstats.go
@@ -46,7 +46,7 @@ type WALStats struct {
 	Targets []WALTargetStats
 }
 
-// Samples returns the number of Series across all targets.
+// Series returns the number of series across all targets.
 func (s WALStats) Series() int {
 	var series int
 	for _, t := range s.Targets {

--- a/pkg/integrations/agent/agent.go
+++ b/pkg/integrations/agent/agent.go
@@ -18,14 +18,17 @@ type Config struct {
 	Common config.Common `yaml:",inline"`
 }
 
+// Name returns the name of the integration that this config represents.
 func (c *Config) Name() string {
 	return "agent"
 }
 
+// CommonConfig returns the common settings shared across all integrations.
 func (c *Config) CommonConfig() config.Common {
 	return c.Common
 }
 
+// NewIntegration converts this config into an instance of an integration.
 func (c *Config) NewIntegration(_ log.Logger) (integrations.Integration, error) {
 	return New(c), nil
 }
@@ -40,6 +43,7 @@ type Integration struct {
 	c *Config
 }
 
+// New creates a new Agent integration.
 func New(c *Config) *Integration {
 	return &Integration{c: c}
 }

--- a/pkg/integrations/collector_integration.go
+++ b/pkg/integrations/collector_integration.go
@@ -39,7 +39,7 @@ func NewCollectorIntegration(name string, configs ...CollectorIntegrationConfig)
 // CollectorIntegrationConfig defines constructor configuration for NewCollectorIntegration
 type CollectorIntegrationConfig func(integration *CollectorIntegration)
 
-// WithCollector adds more collectors to the CollectorIntegration being created.
+// WithCollectors adds more collectors to the CollectorIntegration being created.
 func WithCollectors(cs ...prometheus.Collector) CollectorIntegrationConfig {
 	return func(i *CollectorIntegration) {
 		i.cs = append(i.cs, cs...)

--- a/pkg/integrations/consul_exporter/consul_exporter.go
+++ b/pkg/integrations/consul_exporter/consul_exporter.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/consul_exporter/pkg/exporter"
 )
 
+// DefaultConfig holds the default settings for the consul_exporter integration.
 var DefaultConfig = Config{
 	Server:        "http://localhost:8500",
 	Timeout:       500 * time.Millisecond,
@@ -47,14 +48,17 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return unmarshal((*plain)(c))
 }
 
+// Name returns the name of the integration.
 func (c *Config) Name() string {
 	return "consul_exporter"
 }
 
+// CommonConfig returns the common set of settings for this integration.
 func (c *Config) CommonConfig() config.Common {
 	return c.Common
 }
 
+// NewIntegration converts the config into an instance of an integration.
 func (c *Config) NewIntegration(l log.Logger) (integrations.Integration, error) {
 	return New(l, c)
 }

--- a/pkg/integrations/dnsmasq_exporter/dnsmasq_exporter.go
+++ b/pkg/integrations/dnsmasq_exporter/dnsmasq_exporter.go
@@ -26,14 +26,17 @@ type Config struct {
 	LeasesPath string `yaml:"leases_path"`
 }
 
+// Name returns the name of the integration that this config is for.
 func (c *Config) Name() string {
 	return "dnsmasq_exporter"
 }
 
+// CommonConfig returns the set of common settings shared across all integrations.
 func (c *Config) CommonConfig() config.Common {
 	return c.Common
 }
 
+// NewIntegration converts this config into an instance of an integration.
 func (c *Config) NewIntegration(l log.Logger) (integrations.Integration, error) {
 	return New(l, c)
 }

--- a/pkg/integrations/elasticsearch_exporter/elasticsearch_exporter.go
+++ b/pkg/integrations/elasticsearch_exporter/elasticsearch_exporter.go
@@ -19,6 +19,8 @@ import (
 	"github.com/justwatchcom/elasticsearch_exporter/pkg/clusterinfo"
 )
 
+// DefaultConfig holds the default settings for the elasticsearch_exporter
+// integration.
 var DefaultConfig = Config{
 	Address:                   "http://localhost:9200",
 	Timeout:                   5 * time.Second,
@@ -70,10 +72,13 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return unmarshal((*plain)(c))
 }
 
+// Name returns the name of the integration that this config represents.
 func (c *Config) Name() string {
 	return "elasticsearch_exporter"
 }
 
+// CommonConfig returns the common settings shared across all configs for
+// integrations.
 func (c *Config) CommonConfig() config.Common {
 	return c.Common
 }

--- a/pkg/integrations/manager.go
+++ b/pkg/integrations/manager.go
@@ -29,14 +29,13 @@ var (
 	}, []string{"integration_name"})
 )
 
-var (
-	DefaultManagerConfig = ManagerConfig{
-		ScrapeIntegrations:        true,
-		IntegrationRestartBackoff: 5 * time.Second,
-		UseHostnameLabel:          true,
-		ReplaceInstanceLabel:      true,
-	}
-)
+// DefaultManagerConfig holds the default settings for integrations.
+var DefaultManagerConfig = ManagerConfig{
+	ScrapeIntegrations:        true,
+	IntegrationRestartBackoff: 5 * time.Second,
+	UseHostnameLabel:          true,
+	ReplaceInstanceLabel:      true,
+}
 
 // ManagerConfig holds the configuration for all integrations.
 type ManagerConfig struct {
@@ -308,6 +307,7 @@ func (m *Manager) scrapeServiceDiscovery() discovery.Configs {
 	}
 }
 
+// WireAPI routes integrations to the given router.
 func (m *Manager) WireAPI(r *mux.Router) error {
 	for c, i := range m.integrations {
 		integrationsRoot := fmt.Sprintf("/integrations/%s", c.Name())

--- a/pkg/integrations/memcached_exporter/memcached_exporter.go
+++ b/pkg/integrations/memcached_exporter/memcached_exporter.go
@@ -35,14 +35,17 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return unmarshal((*plain)(c))
 }
 
+// Name returns the name of the integration that this config represents.
 func (c *Config) Name() string {
 	return "memcached_exporter"
 }
 
+// CommonConfig returns the common settings shared across all integratons.
 func (c *Config) CommonConfig() config.Common {
 	return c.Common
 }
 
+// NewIntegration converts this config into an instance of an integration.
 func (c *Config) NewIntegration(l log.Logger) (integrations.Integration, error) {
 	return New(l, c)
 }

--- a/pkg/integrations/mysqld_exporter/mysqld-exporter.go
+++ b/pkg/integrations/mysqld_exporter/mysqld-exporter.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/mysqld_exporter/collector"
 )
 
+// DefaultConfig holds the default settings for the mysqld_exporter integration.
 var DefaultConfig = Config{
 	LockWaitTimeout: 2,
 
@@ -73,14 +74,17 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return unmarshal((*plain)(c))
 }
 
+// Name returns the name of the integration that this config represents.
 func (c *Config) Name() string {
 	return "mysqld_exporter"
 }
 
+// CommonConfig returns the common settings shared across all integrations.
 func (c *Config) CommonConfig() config.Common {
 	return c.Common
 }
 
+// NewIntegration converts this config into an instance of an integration.
 func (c *Config) NewIntegration(l log.Logger) (integrations.Integration, error) {
 	return New(l, c)
 }

--- a/pkg/integrations/node_exporter/config.go
+++ b/pkg/integrations/node_exporter/config.go
@@ -118,14 +118,17 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return unmarshal((*plain)(c))
 }
 
+// Name returns the name of the integration that this config represents.
 func (c *Config) Name() string {
 	return "node_exporter"
 }
 
+// CommonConfig returns the common configs that are shared across all integrations.
 func (c *Config) CommonConfig() config.Common {
 	return c.Common
 }
 
+// NewIntegration converts this config into an instance of an integration.
 func (c *Config) NewIntegration(l log.Logger) (integrations.Integration, error) {
 	return New(l, c)
 }

--- a/pkg/integrations/postgres_exporter/postgres_exporter.go
+++ b/pkg/integrations/postgres_exporter/postgres_exporter.go
@@ -12,8 +12,6 @@ import (
 	"github.com/wrouesnel/postgres_exporter/exporter"
 )
 
-var DefaultConfig = Config{}
-
 // Config controls the postgres_exporter integration.
 type Config struct {
 	Common config.Common `yaml:",inline"`
@@ -28,22 +26,18 @@ type Config struct {
 	QueryPath              string   `yaml:"query_path"`
 }
 
-// UnmarshalYAML implements yaml.Unmarshaler for Config.
-func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	*c = DefaultConfig
-
-	type plain Config
-	return unmarshal((*plain)(c))
-}
-
+// Name returns the name of the integration this config is for.
 func (c *Config) Name() string {
 	return "postgres_exporter"
 }
 
+// CommonConfig returns the common set of options shared across all configs for
+// integrations.
 func (c *Config) CommonConfig() config.Common {
 	return c.Common
 }
 
+// NewIntegration converts this config into an instance of a configuration.
 func (c *Config) NewIntegration(l log.Logger) (integrations.Integration, error) {
 	return New(l, c)
 }

--- a/pkg/integrations/process_exporter/config.go
+++ b/pkg/integrations/process_exporter/config.go
@@ -9,15 +9,14 @@ import (
 	exporter_config "github.com/ncabatoff/process-exporter/config"
 )
 
-var (
-	DefaultConfig Config = Config{
-		ProcFSPath: "/proc",
-		Children:   true,
-		Threads:    true,
-		SMaps:      true,
-		Recheck:    false,
-	}
-)
+// DefaultConfig holds the default settings for the process_exporter integration.
+var DefaultConfig = Config{
+	ProcFSPath: "/proc",
+	Children:   true,
+	Threads:    true,
+	SMaps:      true,
+	Recheck:    false,
+}
 
 // Config controls the process_exporter integration.
 type Config struct {
@@ -31,6 +30,7 @@ type Config struct {
 	Recheck    bool   `yaml:"recheck_on_scrape"`
 }
 
+// UnmarshalYAML implements yaml.Unmarshaler.
 func (c *Config) UnmarshalYAML(unmarshal func(v interface{}) error) error {
 	*c = DefaultConfig
 
@@ -38,14 +38,17 @@ func (c *Config) UnmarshalYAML(unmarshal func(v interface{}) error) error {
 	return unmarshal((*plain)(c))
 }
 
+// Name returns the name of the integration that this config represents.
 func (c *Config) Name() string {
 	return "process_exporter"
 }
 
+// CommonConfig returns the set of common settings shared across all integrations.
 func (c *Config) CommonConfig() config.Common {
 	return c.Common
 }
 
+// NewIntegration converts this config into an instance of an integration.
 func (c *Config) NewIntegration(l log.Logger) (integrations.Integration, error) {
 	return New(l, c)
 }

--- a/pkg/integrations/process_exporter/process-exporter.go
+++ b/pkg/integrations/process_exporter/process-exporter.go
@@ -18,6 +18,8 @@ type Integration struct {
 	c *Config
 }
 
+// New creates a process_exporter integration for non-Linux platforms, which is always a
+// no-op.
 func New(logger log.Logger, c *Config) (*Integration, error) {
 	level.Warn(logger).Log("msg", "the process_exporter only works on Linux; enabling it otherwise will do nothing")
 	return &Integration{c: c}, nil

--- a/pkg/integrations/process_exporter/process-exporter_linux.go
+++ b/pkg/integrations/process_exporter/process-exporter_linux.go
@@ -24,6 +24,7 @@ type Integration struct {
 	collector *collector.NamedProcessCollector
 }
 
+// New creaets a new instance of the process_exporter integration.
 func New(logger log.Logger, c *Config) (*Integration, error) {
 	cfg, err := c.ProcessExporter.ToConfig()
 	if err != nil {

--- a/pkg/integrations/redis_exporter/redis_exporter.go
+++ b/pkg/integrations/redis_exporter/redis_exporter.go
@@ -1,4 +1,4 @@
-// package redis_exporter embeds https://github.com/oliver006/redis_exporter
+// Package redis_exporter embeds https://github.com/oliver006/redis_exporter
 package redis_exporter //nolint:golint
 
 import (
@@ -104,14 +104,18 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return unmarshal((*plain)(c))
 }
 
+// Name returns the name of the integration this config is for.
 func (c *Config) Name() string {
 	return "redis_exporter"
 }
 
+// CommonConfig returns the common set of settings shared across all configs
+// for integrations.
 func (c *Config) CommonConfig() config.Common {
 	return c.Common
 }
 
+// NewIntegration converts the config into an integration instance.
 func (c *Config) NewIntegration(l log.Logger) (integrations.Integration, error) {
 	return New(l, c)
 }

--- a/pkg/integrations/register.go
+++ b/pkg/integrations/register.go
@@ -33,6 +33,7 @@ func RegisterIntegration(cfg Config) {
 // Configs is a list of integrations.
 type Configs []Config
 
+// UnmarshalYAML implements yaml.Unmarshaler.
 func (c *Configs) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return c.unmarshalWithIntegrations(registeredIntegrations, unmarshal)
 }

--- a/pkg/integrations/statsd_exporter/statsd_exporter.go
+++ b/pkg/integrations/statsd_exporter/statsd_exporter.go
@@ -26,6 +26,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// DefaultConfig holds the default settings for the statsd_exporter integration.
 var DefaultConfig = Config{
 	ListenUDP:      ":9125",
 	ListenTCP:      ":9125",
@@ -74,14 +75,17 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return unmarshal((*plain)(c))
 }
 
+// Name returns the name of the integration that this config represents.
 func (c *Config) Name() string {
 	return "statsd_exporter"
 }
 
+// CommonConfig returns the common settings shared across all integrations.
 func (c *Config) CommonConfig() config.Common {
 	return c.Common
 }
 
+// NewIntegration converts this config into an instance of an integration.
 func (c *Config) NewIntegration(l log.Logger) (integrations.Integration, error) {
 	return New(l, c)
 }
@@ -90,7 +94,7 @@ func init() {
 	integrations.RegisterIntegration(&Config{})
 }
 
-// Exporters defines the statsd_exporter integration.
+// Exporter defines the statsd_exporter integration.
 type Exporter struct {
 	cfg      *Config
 	reg      *prometheus.Registry

--- a/pkg/loki/config.go
+++ b/pkg/loki/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	Configs            []*InstanceConfig `yaml:"configs"`
 }
 
+// UnmarshalYAML implements yaml.Unmarshaler.
 func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// If the Config is unmarshaled, it's present in the config and should be
 	// enabled.
@@ -86,6 +87,7 @@ type InstanceConfig struct {
 	TargetConfig    file.Config           `yaml:"target_config,omitempty"`
 }
 
+// UnmarshalYAML implements yaml.Unmarshaler.
 func (c *InstanceConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// Defaults for Promtail are hidden behind flags. Register flags to a fake flagset
 	// just to set the defaults in the configs.

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -22,6 +22,8 @@ func init() {
 	client.UserAgent = fmt.Sprintf("GrafanaAgent/%s", version.Version)
 }
 
+// Loki is a Loki log collection. It uses multiple distinct sets of Loki
+// Promtail agents to collect logs and send them to a Loki server.
 type Loki struct {
 	mut sync.Mutex
 
@@ -91,6 +93,7 @@ func (l *Loki) ApplyConfig(c Config) error {
 	return nil
 }
 
+// Stop stops the log collector.
 func (l *Loki) Stop() {
 	l.mut.Lock()
 	defer l.mut.Unlock()
@@ -171,6 +174,7 @@ func (i *Instance) ApplyConfig(c *InstanceConfig) error {
 	return nil
 }
 
+// Stop stops the Promtail instance.
 func (i *Instance) Stop() {
 	i.mut.Lock()
 	defer i.mut.Unlock()

--- a/pkg/prom/agent.go
+++ b/pkg/prom/agent.go
@@ -21,17 +21,16 @@ import (
 	"google.golang.org/grpc"
 )
 
-var (
-	DefaultConfig = Config{
-		Global:                 config.DefaultGlobalConfig,
-		InstanceRestartBackoff: instance.DefaultBasicManagerConfig.InstanceRestartBackoff,
-		WALCleanupAge:          DefaultCleanupAge,
-		WALCleanupPeriod:       DefaultCleanupPeriod,
-		ServiceConfig:          cluster.DefaultConfig,
-		ServiceClientConfig:    client.DefaultConfig,
-		InstanceMode:           instance.DefaultMode,
-	}
-)
+// DefaultConfig is the default settings for the Prometheus-lite client.
+var DefaultConfig = Config{
+	Global:                 config.DefaultGlobalConfig,
+	InstanceRestartBackoff: instance.DefaultBasicManagerConfig.InstanceRestartBackoff,
+	WALCleanupAge:          DefaultCleanupAge,
+	WALCleanupPeriod:       DefaultCleanupPeriod,
+	ServiceConfig:          cluster.DefaultConfig,
+	ServiceClientConfig:    client.DefaultConfig,
+	InstanceMode:           instance.DefaultMode,
+}
 
 // Config defines the configuration for the entire set of Prometheus client
 // instances, along with a global configuration.
@@ -302,11 +301,15 @@ func (a *Agent) run() {
 	}
 }
 
+// WireGRPC wires gRPC services into the provided server.
 func (a *Agent) WireGRPC(s *grpc.Server) {
 	a.cluster.WireGRPC(s)
 }
 
-func (a *Agent) Config() Config                    { return a.cfg }
+// Config returns the configuration of this Agent.
+func (a *Agent) Config() Config { return a.cfg }
+
+// InstanceManager returns the instance manager used by this Agent.
 func (a *Agent) InstanceManager() instance.Manager { return a.mm }
 
 // Stop stops the agent and all its instances.

--- a/pkg/prom/cleaner.go
+++ b/pkg/prom/cleaner.go
@@ -15,6 +15,7 @@ import (
 	promwal "github.com/prometheus/prometheus/tsdb/wal"
 )
 
+// Default settings for the WAL cleaner.
 const (
 	DefaultCleanupAge    = 12 * time.Hour
 	DefaultCleanupPeriod = 30 * time.Minute

--- a/pkg/prom/cluster/configapi/types.go
+++ b/pkg/prom/cluster/configapi/types.go
@@ -14,6 +14,8 @@ type APIResponse struct {
 	Data   interface{} `json:"data,omitempty"`
 }
 
+// WriteTo writes the response to the given ResponseWriter with the provided
+// statusCode.
 func (r *APIResponse) WriteTo(w http.ResponseWriter, statusCode int) error {
 	bb, err := json.Marshal(r)
 	if err != nil {
@@ -55,6 +57,8 @@ type GetConfigurationResponse struct {
 	Value string `json:"value"`
 }
 
+// WriteResponse writes a response object to the provided ResponseWriter w and with a
+// status code of statusCode. resp is marshaled to JSON.
 func WriteResponse(w http.ResponseWriter, statusCode int, resp interface{}) error {
 	apiResp := &APIResponse{Status: "success", Data: resp}
 	return apiResp.WriteTo(w, statusCode)

--- a/pkg/prom/http.go
+++ b/pkg/prom/http.go
@@ -20,7 +20,7 @@ func (a *Agent) WireAPI(r *mux.Router) {
 	r.HandleFunc("/agent/api/v1/targets", a.ListTargetsHandler).Methods("GET")
 }
 
-// ListInstances writes the set of currently running instances to the http.ResponseWriter.
+// ListInstancesHandler writes the set of currently running instances to the http.ResponseWriter.
 func (a *Agent) ListInstancesHandler(w http.ResponseWriter, _ *http.Request) {
 	cfgs := a.mm.ListConfigs()
 	instanceNames := make([]string, 0, len(cfgs))

--- a/pkg/prom/instance/host_filter.go
+++ b/pkg/prom/instance/host_filter.go
@@ -51,7 +51,7 @@ type HostFilter struct {
 	relabels []*relabel.Config
 }
 
-// NewHostFilter creates a new HostFilter
+// NewHostFilter creates a new HostFilter.
 func NewHostFilter(host string, relabels []*relabel.Config) *HostFilter {
 	ctx, cancel := context.WithCancel(context.Background())
 	f := &HostFilter{
@@ -65,6 +65,10 @@ func NewHostFilter(host string, relabels []*relabel.Config) *HostFilter {
 	return f
 }
 
+// Run starts the HostFilter. It only exits when the HostFilter is stopped.
+// Run will continually read from syncCh and filter groups discovered down to
+// targets that are colocated on the same node as the one the HostFilter is
+// running in.
 func (f *HostFilter) Run(syncCh GroupChannel) {
 	f.inputCh = syncCh
 

--- a/pkg/prom/instance/instance.go
+++ b/pkg/prom/instance/instance.go
@@ -86,6 +86,7 @@ func (c *Config) BaseRemoteWrite() []*config.RemoteWriteConfig {
 	return res
 }
 
+// UnmarshalYAML implements yaml.Unmarshaler.
 func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	*c = DefaultConfig
 
@@ -93,6 +94,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return unmarshal((*plain)(c))
 }
 
+// MarshalYAML implements yaml.Marshaler.
 func (c Config) MarshalYAML() (interface{}, error) {
 	// We want users to be able to marshal instance.Configs directly without
 	// *needing* to call instance.MarshalConfig, so we call it internally
@@ -546,6 +548,8 @@ func (i *Instance) TargetsActive() map[string][]*scrape.Target {
 	return mgr.TargetsActive()
 }
 
+// StorageDirectory returns the directory where this Instance is writing series
+// and samples to for the WAL.
 func (i *Instance) StorageDirectory() string {
 	return i.wal.Directory()
 }
@@ -871,6 +875,8 @@ func (rg *runGroupContext) Add(execute func() error, interrupt func(error)) {
 func (rg *runGroupContext) Run() error   { return rg.g.Run() }
 func (rg *runGroupContext) Stop(_ error) { rg.cancel() }
 
+// ErrNotReady is returned when the scrape manager is used but has not been
+// initialized yet.
 var ErrNotReady = errors.New("Scrape manager not ready")
 
 // readyScrapeManager allows a scrape manager to be retrieved. Even if it's set at a later point in time.

--- a/pkg/prom/instance/noop.go
+++ b/pkg/prom/instance/noop.go
@@ -10,19 +10,23 @@ import (
 // but does not do anything. Useful for tests.
 type NoOpInstance struct{}
 
+// Run implements Instance.
 func (NoOpInstance) Run(ctx context.Context) error {
 	<-ctx.Done()
 	return nil
 }
 
+// Update implements Instance.
 func (NoOpInstance) Update(_ Config) error {
 	return nil
 }
 
+// TargetsActive implements Instance.
 func (NoOpInstance) TargetsActive() map[string][]*scrape.Target {
 	return nil
 }
 
+// StorageDirectory implements Instance.
 func (NoOpInstance) StorageDirectory() string {
 	return ""
 }

--- a/pkg/prom/instance/remote_write.go
+++ b/pkg/prom/instance/remote_write.go
@@ -13,6 +13,7 @@ type RemoteWriteConfig struct {
 	SigV4 SigV4Config `yaml:"sigv4,omitempty"`
 }
 
+// UnmarshalYAML implements yaml.Unmarshaler.
 func (c *RemoteWriteConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	c.Base = config.DefaultRemoteWriteConfig
 

--- a/pkg/prom/wal/util.go
+++ b/pkg/prom/wal/util.go
@@ -111,7 +111,8 @@ func (c *walDataCollector) StoreSeries(series []record.RefSeries, _ int) {
 
 func (c *walDataCollector) SeriesReset(_ int) {}
 
-// Get the subdirectory within a Storage directory used for the Prometheus WAL
+// SubDirectory returns the subdirectory within a Storage directory used for
+// the Prometheus WAL.
 func SubDirectory(base string) string {
 	return filepath.Join(base, "wal")
 }

--- a/pkg/prom/wal/wal.go
+++ b/pkg/prom/wal/wal.go
@@ -19,9 +19,9 @@ import (
 	"github.com/prometheus/prometheus/tsdb/wal"
 )
 
-var (
-	ErrWALClosed = fmt.Errorf("WAL storage closed")
-)
+// ErrWALClosed is an error returned when a WAL operation can't run because the
+// storage has already been closed.
+var ErrWALClosed = fmt.Errorf("WAL storage closed")
 
 type storageMetrics struct {
 	r prometheus.Registerer

--- a/pkg/tempo/instance.go
+++ b/pkg/tempo/instance.go
@@ -46,6 +46,7 @@ func NewInstance(reg prometheus.Registerer, cfg InstanceConfig, logger *zap.Logg
 	return instance, nil
 }
 
+// ApplyConfig updates the configuration of the Instance.
 func (i *Instance) ApplyConfig(cfg InstanceConfig) error {
 	i.mut.Lock()
 	defer i.mut.Unlock()

--- a/pkg/tempo/internal/tempoutils/server.go
+++ b/pkg/tempo/internal/tempoutils/server.go
@@ -23,6 +23,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Server is a Tempo testing server that invokes a function every time a span
+// is received.
 type Server struct {
 	receivers builder.Receivers
 	pipelines builder.BuiltPipelines
@@ -47,7 +49,7 @@ func NewTestServer(t *testing.T, callback func(pdata.Traces)) string {
 	return listenAddr
 }
 
-// NewServerWithRandomAddress calls NewServer with a random port >49152 and
+// NewServerWithRandomPort calls NewServer with a random port >49152 and
 // <65535. It will try up to five times before failing.
 func NewServerWithRandomPort(callback func(pdata.Traces)) (srv *Server, addr string, err error) {
 	var lastError error
@@ -166,6 +168,7 @@ service:
 	}, nil
 }
 
+// Stop stops the testing server.
 func (s *Server) Stop() error {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/pkg/tempo/promsdprocessor/factory.go
+++ b/pkg/tempo/promsdprocessor/factory.go
@@ -12,8 +12,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// TypeStr is the unique identifier for the Prometheus SD processor.
 const TypeStr = "prom_sd_processor"
 
+// Config holds the configuration for the Prometheus SD processor.
 type Config struct {
 	configmodels.ProcessorSettings `mapstructure:",squash"`
 	ScrapeConfigs                  []interface{} `mapstructure:"scrape_configs"`


### PR DESCRIPTION
#### PR Description 
Disables default exclusions from the golint-ci config, which used to ignore a lack of godoc-style comments on exported types and methods. This caused a lot of errors, so I added comments from anything that was missing them.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer
Fully an internal change, and only comments have been updated.

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
