### PR TITLE
ApplyConfig for integrations

### DIFF
--- a/pkg/integrations/agent/agent.go
+++ b/pkg/integrations/agent/agent.go
@@ -5,9 +5,9 @@ package agent
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/go-kit/kit/log"
-	"github.com/gorilla/mux"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/config"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -48,14 +48,9 @@ func New(c *Config) *Integration {
 	return &Integration{c: c}
 }
 
-// RegisterRoutes satisfies Integration.RegisterRoutes.
-func (i *Integration) RegisterRoutes(r *mux.Router) error {
-	// Note that if the weaveworks common server is set to not register
-	// instrumentation endpoints, this lets the agent integration still be able
-	// to scrape itself, just at /integrations/agent/metrics.
-	r.Handle("/metrics", promhttp.Handler())
-
-	return nil
+// MetricsHandler satisfies Integration.RegisterRoutes.
+func (i *Integration) MetricsHandler() (http.Handler, error) {
+	return promhttp.Handler(), nil
 }
 
 // ScrapeConfigs satisfies Integration.ScrapeConfigs.

--- a/pkg/integrations/collector_integration.go
+++ b/pkg/integrations/collector_integration.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/gorilla/mux"
 	"github.com/grafana/agent/pkg/integrations/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -61,20 +60,8 @@ func WithExporterMetricsIncluded(included bool) CollectorIntegrationConfig {
 	}
 }
 
-// RegisterRoutes satisfies Integration.RegisterRoutes. The mux.Router provided
-// here is expected to be a subrouter, where all registered paths will be
-// registered within that subroute.
-func (i *CollectorIntegration) RegisterRoutes(r *mux.Router) error {
-	handler, err := i.handler()
-	if err != nil {
-		return err
-	}
-
-	r.Handle("/metrics", handler)
-	return nil
-}
-
-func (i *CollectorIntegration) handler() (http.Handler, error) {
+// MetricsHandler returns the HTTP handler for the integration.
+func (i *CollectorIntegration) MetricsHandler() (http.Handler, error) {
 	r := prometheus.NewRegistry()
 	for _, c := range i.cs {
 		if err := r.Register(c); err != nil {

--- a/pkg/integrations/integration.go
+++ b/pkg/integrations/integration.go
@@ -2,9 +2,9 @@ package integrations
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/go-kit/kit/log"
-	"github.com/gorilla/mux"
 	"github.com/grafana/agent/pkg/integrations/config"
 )
 
@@ -25,11 +25,8 @@ type Config interface {
 // An Integration is a process that integrates with some external system and
 // pulls telemetry data.
 type Integration interface {
-	// RegisterRoutes should register any HTTP handlers needed for the
-	// integrations. The mux router provided will be a subrouter for the path
-	// /integrations/<integration name>, where the integration name is retrieved
-	// by the config that created this integration.
-	RegisterRoutes(r *mux.Router) error
+	// MetricsHandler returns an http.Handler that will return metrics.
+	MetricsHandler() (http.Handler, error)
 
 	// ScrapeConfigs returns a set of scrape configs that determine where metrics
 	// can be scraped.

--- a/pkg/integrations/manager_test.go
+++ b/pkg/integrations/manager_test.go
@@ -72,14 +72,13 @@ agent:
 	cfg.ListenPort = &listenPort
 	cfg.ListenHost = &listenHost
 
-	relabels, err := cfg.DefaultRelabelConfigs()
-	require.NoError(t, err)
+	expectHostname, _ := instance.Hostname()
+	relabels := cfg.DefaultRelabelConfigs(expectHostname)
 
 	// Ensure that the relabel configs are functional
 	require.Len(t, relabels, 1)
 	result := relabel.Process(labels.FromStrings("__address__", "127.0.0.1"), relabels...)
 
-	expectHostname, _ := instance.Hostname()
 	require.Equal(t, result.Get("instance"), expectHostname+":12345")
 }
 
@@ -88,11 +87,11 @@ func TestManager_instanceConfigForIntegration(t *testing.T) {
 	icfg := mockConfig{integration: mock}
 
 	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory)
-	m, err := newManager(mockManagerConfig(), log.NewNopLogger(), im, nil, noOpValidator)
+	m, err := NewManager(mockManagerConfig(), log.NewNopLogger(), im, noOpValidator)
 	require.NoError(t, err)
 	defer m.Stop()
 
-	cfg := m.instanceConfigForIntegration(icfg, mock)
+	cfg := m.instanceConfigForIntegration(icfg, mock, mockManagerConfig())
 
 	// Validate that the generated MetricsPath is a valid URL path
 	require.Len(t, cfg.ScrapeConfigs, 1)
@@ -105,13 +104,13 @@ func TestManager_NoIntegrationsScrape(t *testing.T) {
 	mock := newMockIntegration()
 	icfg := mockConfig{integration: mock}
 
-	integrations := map[Config]Integration{icfg: mock}
 	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory)
 
 	cfg := mockManagerConfig()
 	cfg.ScrapeIntegrations = false
+	cfg.Integrations = append(cfg.Integrations, &icfg)
 
-	m, err := newManager(cfg, log.NewNopLogger(), im, integrations, noOpValidator)
+	m, err := NewManager(cfg, log.NewNopLogger(), im, noOpValidator)
 	require.NoError(t, err)
 	defer m.Stop()
 
@@ -131,10 +130,12 @@ func TestManager_NoIntegrationScrape(t *testing.T) {
 	noScrape := false
 	mock.commonCfg.ScrapeIntegration = &noScrape
 
-	integrations := map[Config]Integration{icfg: mock}
 	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory)
 
-	m, err := newManager(mockManagerConfig(), log.NewNopLogger(), im, integrations, noOpValidator)
+	cfg := mockManagerConfig()
+	cfg.Integrations = append(cfg.Integrations, icfg)
+
+	m, err := NewManager(cfg, log.NewNopLogger(), im, noOpValidator)
 	require.NoError(t, err)
 	defer m.Stop()
 
@@ -148,10 +149,11 @@ func TestManager_StartsIntegrations(t *testing.T) {
 	mock := newMockIntegration()
 	icfg := mockConfig{integration: mock}
 
-	integrations := map[Config]Integration{icfg: mock}
+	cfg := mockManagerConfig()
+	cfg.Integrations = append(cfg.Integrations, icfg)
 
 	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory)
-	m, err := newManager(mockManagerConfig(), log.NewNopLogger(), im, integrations, noOpValidator)
+	m, err := NewManager(cfg, log.NewNopLogger(), im, noOpValidator)
 	require.NoError(t, err)
 	defer m.Stop()
 
@@ -169,9 +171,11 @@ func TestManager_RestartsIntegrations(t *testing.T) {
 	mock := newMockIntegration()
 	icfg := mockConfig{integration: mock}
 
-	integrations := map[Config]Integration{icfg: mock}
+	cfg := mockManagerConfig()
+	cfg.Integrations = append(cfg.Integrations, icfg)
+
 	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory)
-	m, err := newManager(mockManagerConfig(), log.NewNopLogger(), im, integrations, noOpValidator)
+	m, err := NewManager(cfg, log.NewNopLogger(), im, noOpValidator)
 	require.NoError(t, err)
 	defer m.Stop()
 
@@ -186,9 +190,11 @@ func TestManager_GracefulStop(t *testing.T) {
 	mock := newMockIntegration()
 	icfg := mockConfig{integration: mock}
 
-	integrations := map[Config]Integration{icfg: mock}
+	cfg := mockManagerConfig()
+	cfg.Integrations = append(cfg.Integrations, icfg)
+
 	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory)
-	m, err := newManager(mockManagerConfig(), log.NewNopLogger(), im, integrations, noOpValidator)
+	m, err := NewManager(cfg, log.NewNopLogger(), im, noOpValidator)
 	require.NoError(t, err)
 
 	test.Poll(t, time.Second, 1, func() interface{} {
@@ -208,6 +214,9 @@ func TestManager_GracefulStop(t *testing.T) {
 type mockConfig struct {
 	integration *mockIntegration
 }
+
+// Equal is used for cmp.Equal, since otherwise mockConfig can't be compared to itself.
+func (c mockConfig) Equal(other mockConfig) bool { return c.integration == other.integration }
 
 func (c mockConfig) Name() string                { return "mock" }
 func (c mockConfig) CommonConfig() config.Common { return c.integration.commonCfg }

--- a/pkg/integrations/manager_test.go
+++ b/pkg/integrations/manager_test.go
@@ -3,12 +3,12 @@ package integrations
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/util/test"
 	"github.com/go-kit/kit/log"
-	"github.com/gorilla/mux"
 	"github.com/grafana/agent/pkg/integrations/config"
 	"github.com/grafana/agent/pkg/prom/instance"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -230,9 +230,8 @@ func newMockIntegration() *mockIntegration {
 	}
 }
 
-func (i *mockIntegration) RegisterRoutes(r *mux.Router) error {
-	r.Handle("/metrics", promhttp.Handler())
-	return nil
+func (i *mockIntegration) MetricsHandler() (http.Handler, error) {
+	return promhttp.Handler(), nil
 }
 
 func (i *mockIntegration) ScrapeConfigs() []config.ScrapeConfig {

--- a/pkg/integrations/node_exporter/node_exporter.go
+++ b/pkg/integrations/node_exporter/node_exporter.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/gorilla/mux"
 	"github.com/grafana/agent/pkg/integrations/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -66,20 +65,8 @@ func New(log log.Logger, c *Config) (*Integration, error) {
 	}, nil
 }
 
-// RegisterRoutes satisfies Integration.RegisterRoutes. The mux.Router provided
-// here is expected to be a subrouter, where all registered paths will be
-// registered within that subroute.
-func (i *Integration) RegisterRoutes(r *mux.Router) error {
-	handler, err := i.handler()
-	if err != nil {
-		return err
-	}
-
-	r.Handle("/metrics", handler)
-	return nil
-}
-
-func (i *Integration) handler() (http.Handler, error) {
+// MetricsHandler implements Integration.
+func (i *Integration) MetricsHandler() (http.Handler, error) {
 	r := prometheus.NewRegistry()
 	if err := r.Register(i.nc); err != nil {
 		return nil, fmt.Errorf("couldn't register node_exporter node collector: %w", err)

--- a/pkg/integrations/node_exporter/node_exporter_test.go
+++ b/pkg/integrations/node_exporter/node_exporter_test.go
@@ -43,8 +43,9 @@ func TestNodeExporter(t *testing.T) {
 	require.NoError(t, err, "failed to setup node_exporter")
 
 	r := mux.NewRouter()
-	err = integration.RegisterRoutes(r)
+	handler, err := integration.MetricsHandler()
 	require.NoError(t, err)
+	r.Handle("/metrics", handler)
 
 	// Invoke /metrics and parse the response
 	srv := httptest.NewServer(r)

--- a/pkg/integrations/process_exporter/process-exporter.go
+++ b/pkg/integrations/process_exporter/process-exporter.go
@@ -5,10 +5,10 @@ package process_exporter //nolint:golint
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/gorilla/mux"
 	"github.com/grafana/agent/pkg/integrations/config"
 )
 
@@ -25,9 +25,9 @@ func New(logger log.Logger, c *Config) (*Integration, error) {
 	return &Integration{c: c}, nil
 }
 
-// RegisterRoutes satisfies Integration.RegisterRoutes.
-func (i *Integration) RegisterRoutes(r *mux.Router) error {
-	return nil
+// MetricsHandler satisfies Integration.RegisterRoutes.
+func (i *Integration) MetricsHandler() (http.Handler, error) {
+	return http.NotFoundHandler(), nil
 }
 
 // ScrapeConfigs satisfies Integration.ScrapeConfigs.

--- a/pkg/integrations/process_exporter/process-exporter_linux.go
+++ b/pkg/integrations/process_exporter/process-exporter_linux.go
@@ -47,19 +47,8 @@ func New(logger log.Logger, c *Config) (*Integration, error) {
 	return &Integration{c: c, collector: pc}, nil
 }
 
-// RegisterRoutes satisfies Integration.RegisterRoutes.
-func (i *Integration) RegisterRoutes(r *mux.Router) error {
-	handler, err := i.handler()
-	if err != nil {
-		return err
-	}
-
-	r.Handle("/metrics", handler)
-
-	return nil
-}
-
-func (i *Integration) handler() (http.Handler, error) {
+// MetricsHandler satisfies Integration.RegisterRoutes.
+func (i *Integration) MetricsHandler(r *mux.Router) (http.Handler, error) {
 	r := prometheus.NewRegistry()
 	if err := r.Register(i.collector); err != nil {
 		return nil, fmt.Errorf("couldn't register process_exporter collector: %w", err)

--- a/pkg/integrations/process_exporter/process-exporter_linux.go
+++ b/pkg/integrations/process_exporter/process-exporter_linux.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 
 	"github.com/go-kit/kit/log"
-	"github.com/gorilla/mux"
 	"github.com/grafana/agent/pkg/integrations/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -48,7 +47,7 @@ func New(logger log.Logger, c *Config) (*Integration, error) {
 }
 
 // MetricsHandler satisfies Integration.RegisterRoutes.
-func (i *Integration) MetricsHandler(r *mux.Router) (http.Handler, error) {
+func (i *Integration) MetricsHandler() (http.Handler, error) {
 	r := prometheus.NewRegistry()
 	if err := r.Register(i.collector); err != nil {
 		return nil, fmt.Errorf("couldn't register process_exporter collector: %w", err)

--- a/pkg/integrations/redis_exporter/redis_exporter_test.go
+++ b/pkg/integrations/redis_exporter/redis_exporter_test.go
@@ -113,7 +113,9 @@ func TestRedisCases(t *testing.T) {
 			require.NoError(t, err, "failed to setup redis_exporter")
 
 			r := mux.NewRouter()
-			err = integration.RegisterRoutes(r)
+			handler, err := integration.MetricsHandler()
+			require.NoError(t, err)
+			r.Handle("/metrics", handler)
 			require.NoError(t, err)
 
 			srv := httptest.NewServer(r)

--- a/pkg/integrations/statsd_exporter/statsd_exporter.go
+++ b/pkg/integrations/statsd_exporter/statsd_exporter.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"strconv"
 	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/gorilla/mux"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/config"
 	"github.com/prometheus/client_golang/prometheus"
@@ -149,16 +149,11 @@ func New(log log.Logger, c *Config) (integrations.Integration, error) {
 	}, nil
 }
 
-// RegisterRoutes satisfies integrations.Integration. The mux.Router provided
-// here is expected to be a subrouter, where all registered paths will be
-// registered within that subroute.
-func (e *Exporter) RegisterRoutes(r *mux.Router) error {
-	handler := promhttp.HandlerFor(e.reg, promhttp.HandlerOpts{
+// MetricsHandler returns the HTTP handler for the integration.
+func (e *Exporter) MetricsHandler() (http.Handler, error) {
+	return promhttp.HandlerFor(e.reg, promhttp.HandlerOpts{
 		ErrorHandling: promhttp.ContinueOnError,
-	})
-
-	r.Handle("/metrics", handler)
-	return nil
+	}), nil
 }
 
 // ScrapeConfigs satisfies Integration.ScrapeConfigs.


### PR DESCRIPTION
#### PR Description 
Implements ApplyConfig for integrations.

This requires a change to the integration interface to no longer register routes directly to mux. This is because mux is unable to unregister routes. The new approach is to expose the HTTP handlers that expose metrics, and look up the handler at request time.

#### Which issue(s) this PR fixes 
Related to #147. 

#### Notes to the Reviewer
Everything still seems to work after local testing. The new approach here is pretty similar, but stores the goroutines in a map (kind of like the basic instance manager) so they can be stopped independently. 

One interesting detail here: when "updating" an integration (stopping the old goroutine and starting a new one), the new goroutine does not wait for the previous one to stop. I don't believe this will cause any problems, but we might have to change this behavior later. 

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
