### PR TITLE
Change configless Agent k8s install to use a deployment

### DIFF
--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -40,12 +40,14 @@ subjects:
   namespace: ${NAMESPACE}
 ---
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   name: grafana-agent
   namespace: ${NAMESPACE}
 spec:
   minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       name: grafana-agent
@@ -56,34 +58,20 @@ spec:
     spec:
       containers:
       - args:
-        - -config.file=/etc/agent/agent.yml
-        - -prometheus.wal-directory=/tmp/agent/data
+        - -config.file=/etc/agent/agent.yaml
         command:
         - /bin/agent
-        env:
-        - name: HOSTNAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
         image: grafana/agent:v0.13.0
         imagePullPolicy: IfNotPresent
         name: agent
         ports:
-        - containerPort: 80
+        - containerPort: 12345
           name: http-metrics
-        securityContext:
-          privileged: true
-          runAsUser: 0
         volumeMounts:
         - mountPath: /etc/agent
           name: grafana-agent
       serviceAccount: grafana-agent
-      tolerations:
-      - effect: NoSchedule
-        operator: Exists
       volumes:
       - configMap:
           name: grafana-agent
         name: grafana-agent
-  updateStrategy:
-    type: RollingUpdate

--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: grafana-agent-logs
+  namespace: ${NAMESPACE}
 ---
 apiVersion: v1
 data:

--- a/production/kubernetes/agent-tempo.yaml
+++ b/production/kubernetes/agent-tempo.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: grafana-agent-traces
+  namespace: ${NAMESPACE}
 ---
 apiVersion: v1
 data:

--- a/production/kubernetes/build/templates/bare/main.jsonnet
+++ b/production/kubernetes/build/templates/bare/main.jsonnet
@@ -1,22 +1,19 @@
-local agent = import 'grafana-agent/grafana-agent.libsonnet';
+local agent = import 'grafana-agent/v1/main.libsonnet';
 
-agent {
-  _images+:: {
-    agent: (import 'version.libsonnet'),
-  },
+{
+  agent:
+    agent.newDeployment('grafana-agent', '${NAMESPACE}') +
+    agent.withConfigHash(false) +
+    agent.withImages({
+      agent: (import 'version.libsonnet'),
+    }) + {
+      agent+: {
+        // The listen port from the cloud config is set to 12345.
+        listen_port:: 12345,
 
-  _config+:: {
-    namespace: '${NAMESPACE}',
-
-    // Since the config map isn't managed by Tanka, we don't want to
-    // add the configmap's hash as an annotation for the Kubernetes
-    // YAML manifest.
-    agent_config_hash_annotation: false,
-  },
-
-  // We're describing a deployment where the ConfigMap isn't available, 
-  // so remove the various config maps and components that aren't relevant.
-  agent_config_map:: {},
-  agent_deployment_config_map:: {},
-  agent_deployment:: {},
+        // The bare deployment doesn't provide a ConfigMap by default, so
+        // remove it from here.
+        config_map:: {},
+      },
+    },
 }

--- a/production/tanka/grafana-agent/v1/lib/deployment.libsonnet
+++ b/production/tanka/grafana-agent/v1/lib/deployment.libsonnet
@@ -44,7 +44,7 @@ local agent = import '../internal/agent.libsonnet';
     },
 
     agent:
-      agent.newAgent(name, namespace, self._images.agent, self.config, use_daemonset=true) +
+      agent.newAgent(name, namespace, self._images.agent, self.config, use_daemonset=false) +
       agent.withConfigHash(self._config_hash),
   },
 }


### PR DESCRIPTION
#### PR Description 
A DaemonSet deployment of the Agent is only useful when paired with a Deployment for scraping resources that don't live within the cluster. This makes the Agent more confusing to configure and manage, since two ConfigMaps have to be juggled, and even reduces performance due to the potential of overloading the Kubernetes API if the number of cluster nodes is high.

This PR changes the DaemonSet deployment of the "bare" (i.e., configmapless install) that will be used by Grafana Cloud to use a single-replica Deployment.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer
The bare install was never documented or referenced anywhere, so I don't think we need to add a changelog entry for it. 

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
