### PR TITLE
Add /-/config endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ cross-compilation issue, but will return in v0.13.0.
   `/-/reload`-only HTTP server that can be used to safely reload the Agent's
   state.  (@rfratto)
 
+- [FEATURE] Add a /-/config endpoint. This endpoint will return the current
+  configuration file with defaults applied that the Agent has loaded from disk.
+  (@rfratto)
+
 - [ENHANCEMENT] Support compression for trace export. (@mdisibio)
 
 - [ENHANCEMENT] Allow Prometheus URL configuration to propagate to instances and integrations, if not given. (@mattdurham)
@@ -43,7 +47,7 @@ cross-compilation issue, but will return in v0.13.0.
   `GrafanaAgent/<version>` (@rfratto)
 
 - [ENHANCEMENT] Upgrade `go.opentelemetry.io/collector` to v0.21.0 (@mapno)
-  
+
 - [ENHANCEMENT] Add kafka trace receiver (@mapno)
 
 - [ENHANCEMENT] Support mirroring a trace pipeline to multiple backends (@mapno)

--- a/docs/api.md
+++ b/docs/api.md
@@ -243,6 +243,19 @@ will be logged, and should be fixed before calling `/-/reload` again.
 
 Status code: 200 on success, 400 otherwise.
 
+### Show Configuration file
+
+```
+GET /-/config
+```
+
+This endpoint prints out the currently loaded configuration the Agent is using.
+The returned YAML has defaults applied, and only shows changes to the state that
+validated successfuly, so the results will not identically match the
+configuration file on disk.
+
+Status code: 200 on success.
+
 ## Ready / Health API
 
 ### Readiness Check

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,10 +20,10 @@ import (
 
 // Config contains underlying configurations for the agent
 type Config struct {
-	Server       server.Config              `yaml:"server"`
+	Server       server.Config              `yaml:"server,omitempty"`
 	Prometheus   prom.Config                `yaml:"prometheus,omitempty"`
 	Loki         loki.Config                `yaml:"loki,omitempty"`
-	Integrations integrations.ManagerConfig `yaml:"integrations"`
+	Integrations integrations.ManagerConfig `yaml:"integrations,omitempty"`
 	Tempo        tempo.Config               `yaml:"tempo,omitempty"`
 
 	// We support a secondary server just for the /-/reload endpoint, since

--- a/pkg/integrations/config/config.go
+++ b/pkg/integrations/config/config.go
@@ -15,13 +15,13 @@ import (
 //     Common config.Common `yaml:",inline"`
 //   }
 type Common struct {
-	Enabled              bool              `yaml:"enabled"`
-	ScrapeIntegration    *bool             `yaml:"scrape_integration"`
-	ScrapeInterval       time.Duration     `yaml:"scrape_interval"`
-	ScrapeTimeout        time.Duration     `yaml:"scrape_timeout"`
+	Enabled              bool              `yaml:"enabled,omitempty"`
+	ScrapeIntegration    *bool             `yaml:"scrape_integration,omitempty"`
+	ScrapeInterval       time.Duration     `yaml:"scrape_interval,omitempty"`
+	ScrapeTimeout        time.Duration     `yaml:"scrape_timeout,omitempty"`
 	RelabelConfigs       []*relabel.Config `yaml:"relabel_configs,omitempty"`
 	MetricRelabelConfigs []*relabel.Config `yaml:"metric_relabel_configs,omitempty"`
-	WALTruncateFrequency time.Duration     `yaml:"wal_truncate_frequency"`
+	WALTruncateFrequency time.Duration     `yaml:"wal_truncate_frequency,omitempty"`
 }
 
 // ScrapeConfig is a subset of options used by integrations to inform how samples

--- a/pkg/integrations/consul_exporter/consul_exporter.go
+++ b/pkg/integrations/consul_exporter/consul_exporter.go
@@ -24,20 +24,20 @@ var DefaultConfig = Config{
 type Config struct {
 	Common config.Common `yaml:",inline"`
 
-	Server             string        `yaml:"server"`
-	CAFile             string        `yaml:"ca_file"`
-	CertFile           string        `yaml:"cert_file"`
-	KeyFile            string        `yaml:"key_file"`
-	ServerName         string        `yaml:"server_name"`
-	Timeout            time.Duration `yaml:"timeout"`
-	InsecureSkipVerify bool          `yaml:"insecure_skip_verify"`
-	RequestLimit       int           `yaml:"concurrent_request_limit"`
-	AllowStale         bool          `yaml:"allow_stale"`
-	RequireConsistent  bool          `yaml:"require_consistent"`
+	Server             string        `yaml:"server,omitempty"`
+	CAFile             string        `yaml:"ca_file,omitempty"`
+	CertFile           string        `yaml:"cert_file,omitempty"`
+	KeyFile            string        `yaml:"key_file,omitempty"`
+	ServerName         string        `yaml:"server_name,omitempty"`
+	Timeout            time.Duration `yaml:"timeout,omitempty"`
+	InsecureSkipVerify bool          `yaml:"insecure_skip_verify,omitempty"`
+	RequestLimit       int           `yaml:"concurrent_request_limit,omitempty"`
+	AllowStale         bool          `yaml:"allow_stale,omitempty"`
+	RequireConsistent  bool          `yaml:"require_consistent,omitempty"`
 
-	KVPrefix      string `yaml:"kv_prefix"`
-	KVFilter      string `yaml:"kv_filter"`
-	HealthSummary bool   `yaml:"generate_health_summary"`
+	KVPrefix      string `yaml:"kv_prefix,omitempty"`
+	KVFilter      string `yaml:"kv_filter,omitempty"`
+	HealthSummary bool   `yaml:"generate_health_summary,omitempty"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler for Config.

--- a/pkg/integrations/dnsmasq_exporter/dnsmasq_exporter.go
+++ b/pkg/integrations/dnsmasq_exporter/dnsmasq_exporter.go
@@ -20,10 +20,10 @@ type Config struct {
 	Common config.Common `yaml:",inline"`
 
 	// DnsmasqAddress is the address of the dnsmasq server (host:port).
-	DnsmasqAddress string `yaml:"dnsmasq_address"`
+	DnsmasqAddress string `yaml:"dnsmasq_address,omitempty"`
 
 	// Path to the dnsmasq leases file.
-	LeasesPath string `yaml:"leases_path"`
+	LeasesPath string `yaml:"leases_path,omitempty"`
 }
 
 // Name returns the name of the integration that this config is for.

--- a/pkg/integrations/elasticsearch_exporter/elasticsearch_exporter.go
+++ b/pkg/integrations/elasticsearch_exporter/elasticsearch_exporter.go
@@ -35,33 +35,33 @@ type Config struct {
 	// Exporter configuration
 
 	// HTTP API address of an Elasticsearch node.
-	Address string `yaml:"address"`
+	Address string `yaml:"address,omitempty"`
 	// Timeout for trying to get stats from Elasticsearch.
-	Timeout time.Duration `yaml:"timeout"`
+	Timeout time.Duration `yaml:"timeout,omitempty"`
 	// Export stats for all nodes in the cluster. If used, this flag will override the flag es.node.
-	AllNodes bool `yaml:"all"`
+	AllNodes bool `yaml:"all,omitempty"`
 	// Node's name of which metrics should be exposed.
-	Node string `yaml:"node"`
+	Node string `yaml:"node,omitempty"`
 	// Export stats for indices in the cluster.
-	ExportIndices bool `yaml:"indices"`
+	ExportIndices bool `yaml:"indices,omitempty"`
 	// Export stats for settings of all indices of the cluster.
-	ExportIndicesSettings bool `yaml:"indices_settings"`
+	ExportIndicesSettings bool `yaml:"indices_settings,omitempty"`
 	// Export stats for cluster settings.
-	ExportClusterSettings bool `yaml:"cluster_settings"`
+	ExportClusterSettings bool `yaml:"cluster_settings,omitempty"`
 	// Export stats for shards in the cluster (implies indices).
-	ExportShards bool `yaml:"shards"`
+	ExportShards bool `yaml:"shards,omitempty"`
 	// Export stats for the cluster snapshots.
-	ExportSnapshots bool `yaml:"snapshots"`
+	ExportSnapshots bool `yaml:"snapshots,omitempty"`
 	// Cluster info update interval for the cluster label.
-	ExportClusterInfoInterval time.Duration `yaml:"clusterinfo_interval"`
+	ExportClusterInfoInterval time.Duration `yaml:"clusterinfo_interval,omitempty"`
 	// Path to PEM file that contains trusted Certificate Authorities for the Elasticsearch connection.
-	CA string `yaml:"ca"`
+	CA string `yaml:"ca,omitempty"`
 	// Path to PEM file that contains the private key for client auth when connecting to Elasticsearch.
-	ClientPrivateKey string `yaml:"client_private_key"`
+	ClientPrivateKey string `yaml:"client_private_key,omitempty"`
 	// Path to PEM file that contains the corresponding cert for the private key to connect to Elasticsearch.
-	ClientCert string `yaml:"client_cert"`
+	ClientCert string `yaml:"client_cert,omitempty"`
 	// Skip SSL verification when connecting to Elasticsearch.
-	InsecureSkipVerify bool `yaml:"ssl_skip_verify"`
+	InsecureSkipVerify bool `yaml:"ssl_skip_verify,omitempty"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler for Config

--- a/pkg/integrations/manager.go
+++ b/pkg/integrations/manager.go
@@ -71,7 +71,7 @@ type ManagerConfig struct {
 	// listening on for generating Prometheus instance configs
 	ListenHost string `yaml:"-"`
 
-	TLSConfig config_util.TLSConfig `yaml:"http_tls_config"`
+	TLSConfig config_util.TLSConfig `yaml:"http_tls_config,omitempty"`
 
 	// This is set to true if the Server TLSConfig Cert and Key path are set
 	ServerUsingTLS bool `yaml:"-"`

--- a/pkg/integrations/manager_test.go
+++ b/pkg/integrations/manager_test.go
@@ -21,6 +21,35 @@ import (
 
 func noOpValidator(*instance.Config) error { return nil }
 
+// TestConfig_MarshalEmptyIntegrations ensures that an empty set of integrations
+// can be marshaled correctly.
+func TestConfig_MarshalEmptyIntegrations(t *testing.T) {
+	cfgText := `
+scrape_integrations: true
+replace_instance_label: true
+integration_restart_backoff: 5s
+use_hostname_label: true
+http_tls_config:
+  insecure_skip_verify: false
+`
+	var (
+		cfg        ManagerConfig
+		listenPort int    = 12345
+		listenHost string = "127.0.0.1"
+	)
+	require.NoError(t, yaml.Unmarshal([]byte(cfgText), &cfg))
+
+	// Listen port must be set before applying defaults. Normally applied by the
+	// config package.
+	cfg.ListenPort = listenPort
+	cfg.ListenHost = listenHost
+
+	outBytes, err := yaml.Marshal(cfg)
+	require.NoError(t, err, "Failed creating integration")
+	fmt.Println(string(outBytes))
+	require.YAMLEq(t, cfgText, string(outBytes))
+}
+
 // Test that embedded integration fields in the struct can be unmarshaled and
 // remarshaled back out to text.
 func TestConfig_Remarshal(t *testing.T) {

--- a/pkg/integrations/manager_test.go
+++ b/pkg/integrations/manager_test.go
@@ -29,8 +29,6 @@ scrape_integrations: true
 replace_instance_label: true
 integration_restart_backoff: 5s
 use_hostname_label: true
-http_tls_config:
-  insecure_skip_verify: false
 `
 	var (
 		cfg        ManagerConfig
@@ -59,8 +57,6 @@ scrape_integrations: true
 replace_instance_label: true
 integration_restart_backoff: 5s
 use_hostname_label: true
-http_tls_config:
-  insecure_skip_verify: false
 test:
   text: Hello, world!
   truth: true

--- a/pkg/integrations/memcached_exporter/memcached_exporter.go
+++ b/pkg/integrations/memcached_exporter/memcached_exporter.go
@@ -21,10 +21,10 @@ type Config struct {
 	Common config.Common `yaml:",inline"`
 
 	// MemcachedAddress is the address of the memcached server (host:port).
-	MemcachedAddress string `yaml:"memcached_address"`
+	MemcachedAddress string `yaml:"memcached_address,omitempty"`
 
 	// Timeout is the connection timeout for memcached.
-	Timeout time.Duration `yaml:"timeout"`
+	Timeout time.Duration `yaml:"timeout,omitempty"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler for Config.

--- a/pkg/integrations/mysqld_exporter/mysqld-exporter.go
+++ b/pkg/integrations/mysqld_exporter/mysqld-exporter.go
@@ -36,34 +36,34 @@ type Config struct {
 	Common config.Common `yaml:",inline"`
 
 	// DataSourceName to use to connect to MySQL.
-	DataSourceName string `yaml:"data_source_name"`
+	DataSourceName string `yaml:"data_source_name,omitempty"`
 
 	// Collectors to mark as enabled in addition to the default.
-	EnableCollectors []string `yaml:"enable_collectors"`
+	EnableCollectors []string `yaml:"enable_collectors,omitempty"`
 	// Collectors to explicitly mark as disabled.
-	DisableCollectors []string `yaml:"disable_collectors"`
+	DisableCollectors []string `yaml:"disable_collectors,omitempty"`
 
 	// Overrides the default set of enabled collectors with the given list.
-	SetCollectors []string `yaml:"set_collectors"`
+	SetCollectors []string `yaml:"set_collectors,omitempty"`
 
 	// Collector-wide options
-	LockWaitTimeout int  `yaml:"lock_wait_timeout"`
-	LogSlowFilter   bool `yaml:"log_slow_filter"`
+	LockWaitTimeout int  `yaml:"lock_wait_timeout,omitempty"`
+	LogSlowFilter   bool `yaml:"log_slow_filter,omitempty"`
 
 	// Collector-specific config options
-	InfoSchemaProcessListMinTime         int    `yaml:"info_schema_processlist_min_time"`
-	InfoSchemaProcessListProcessesByUser bool   `yaml:"info_schema_processlist_processes_by_user"`
-	InfoSchemaProcessListProcessesByHost bool   `yaml:"info_schema_processlist_processes_by_host"`
-	InfoSchemaTablesDatabases            string `yaml:"info_schema_tables_databases"`
-	PerfSchemaEventsStatementsLimit      int    `yaml:"perf_schema_eventsstatements_limit"`
-	PerfSchemaEventsStatementsTimeLimit  int    `yaml:"perf_schema_eventsstatements_time_limit"`
-	PerfSchemaEventsStatementsTextLimit  int    `yaml:"perf_schema_eventsstatements_digtext_text_limit"`
-	PerfSchemaFileInstancesFilter        string `yaml:"perf_schema_file_instances_filter"`
-	PerfSchemaFileInstancesRemovePrefix  string `yaml:"perf_schema_file_instances_remove_prefix"`
-	HeartbeatDatabase                    string `yaml:"heartbeat_database"`
-	HeartbeatTable                       string `yaml:"heartbeat_table"`
-	HeartbeatUTC                         bool   `yaml:"heartbeat_utc"`
-	MySQLUserPrivileges                  bool   `yaml:"mysql_user_privileges"`
+	InfoSchemaProcessListMinTime         int    `yaml:"info_schema_processlist_min_time,omitempty"`
+	InfoSchemaProcessListProcessesByUser bool   `yaml:"info_schema_processlist_processes_by_user,omitempty"`
+	InfoSchemaProcessListProcessesByHost bool   `yaml:"info_schema_processlist_processes_by_host,omitempty"`
+	InfoSchemaTablesDatabases            string `yaml:"info_schema_tables_databases,omitempty"`
+	PerfSchemaEventsStatementsLimit      int    `yaml:"perf_schema_eventsstatements_limit,omitempty"`
+	PerfSchemaEventsStatementsTimeLimit  int    `yaml:"perf_schema_eventsstatements_time_limit,omitempty"`
+	PerfSchemaEventsStatementsTextLimit  int    `yaml:"perf_schema_eventsstatements_digtext_text_limit,omitempty"`
+	PerfSchemaFileInstancesFilter        string `yaml:"perf_schema_file_instances_filter,omitempty"`
+	PerfSchemaFileInstancesRemovePrefix  string `yaml:"perf_schema_file_instances_remove_prefix,omitempty"`
+	HeartbeatDatabase                    string `yaml:"heartbeat_database,omitempty"`
+	HeartbeatTable                       string `yaml:"heartbeat_table,omitempty"`
+	HeartbeatUTC                         bool   `yaml:"heartbeat_utc,omitempty"`
+	MySQLUserPrivileges                  bool   `yaml:"mysql_user_privileges,omitempty"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler for Config.

--- a/pkg/integrations/node_exporter/config.go
+++ b/pkg/integrations/node_exporter/config.go
@@ -65,49 +65,49 @@ func init() {
 type Config struct {
 	Common config.Common `yaml:",inline"`
 
-	IncludeExporterMetrics bool `yaml:"include_exporter_metrics"`
+	IncludeExporterMetrics bool `yaml:"include_exporter_metrics,omitempty"`
 
-	ProcFSPath string `yaml:"procfs_path"`
-	SysFSPath  string `yaml:"sysfs_path"`
-	RootFSPath string `yaml:"rootfs_path"`
+	ProcFSPath string `yaml:"procfs_path,omitempty"`
+	SysFSPath  string `yaml:"sysfs_path,omitempty"`
+	RootFSPath string `yaml:"rootfs_path,omitempty"`
 
 	// Collectors to mark as enabled
-	EnableCollectors flagext.StringSlice `yaml:"enable_collectors"`
+	EnableCollectors flagext.StringSlice `yaml:"enable_collectors,omitempty"`
 
 	// Collectors to mark as disabled
-	DisableCollectors flagext.StringSlice `yaml:"disable_collectors"`
+	DisableCollectors flagext.StringSlice `yaml:"disable_collectors,omitempty"`
 
 	// Overrides the default set of enabled collectors with the collectors
 	// listed.
-	SetCollectors flagext.StringSlice `yaml:"set_collectors"`
+	SetCollectors flagext.StringSlice `yaml:"set_collectors,omitempty"`
 
 	// Collector-specific config options
-	CPUEnableCPUInfo              bool                `yaml:"enable_cpu_info_metric"`
-	DiskStatsIgnoredDevices       string              `yaml:"diskstats_ignored_devices"`
-	FilesystemIgnoredMountPoints  string              `yaml:"filesystem_ignored_mount_points"`
-	FilesystemIgnoredFSTypes      string              `yaml:"filesystem_ignored_fs_types"`
-	NetclassIgnoredDevices        string              `yaml:"netclass_ignored_devices"`
-	NetdevDeviceBlacklist         string              `yaml:"netdev_device_blacklist"`
-	NetdevDeviceWhitelist         string              `yaml:"netdev_device_whitelist"`
-	NetstatFields                 string              `yaml:"netstat_fields"`
-	NTPServer                     string              `yaml:"ntp_server"`
-	NTPProtocolVersion            int                 `yaml:"ntp_protocol_version"`
-	NTPServerIsLocal              bool                `yaml:"ntp_server_is_local"`
-	NTPIPTTL                      int                 `yaml:"ntp_ip_ttl"`
-	NTPMaxDistance                time.Duration       `yaml:"ntp_max_distance"`
-	NTPLocalOffsetTolerance       time.Duration       `yaml:"ntp_local_offset_tolerance"`
-	PerfCPUS                      string              `yaml:"perf_cpus"`
-	PerfTracepoint                flagext.StringSlice `yaml:"perf_tracepoint"`
-	PowersupplyIgnoredSupplies    string              `yaml:"powersupply_ignored_supplies"`
-	RunitServiceDir               string              `yaml:"runit_service_dir"`
-	SupervisordURL                string              `yaml:"supervisord_url"`
-	SystemdUnitWhitelist          string              `yaml:"systemd_unit_whitelist"`
-	SystemdUnitBlacklist          string              `yaml:"systemd_unit_blacklist"`
-	SystemdEnableTaskMetrics      bool                `yaml:"systemd_enable_task_metrics"`
-	SystemdEnableRestartsMetrics  bool                `yaml:"systemd_enable_restarts_metrics"`
-	SystemdEnableStartTimeMetrics bool                `yaml:"systemd_enable_start_time_metrics"`
-	VMStatFields                  string              `yaml:"vmstat_fields"`
-	TextfileDirectory             string              `yaml:"textfile_directory"`
+	CPUEnableCPUInfo              bool                `yaml:"enable_cpu_info_metric,omitempty"`
+	DiskStatsIgnoredDevices       string              `yaml:"diskstats_ignored_devices,omitempty"`
+	FilesystemIgnoredMountPoints  string              `yaml:"filesystem_ignored_mount_points,omitempty"`
+	FilesystemIgnoredFSTypes      string              `yaml:"filesystem_ignored_fs_types,omitempty"`
+	NetclassIgnoredDevices        string              `yaml:"netclass_ignored_devices,omitempty"`
+	NetdevDeviceBlacklist         string              `yaml:"netdev_device_blacklist,omitempty"`
+	NetdevDeviceWhitelist         string              `yaml:"netdev_device_whitelist,omitempty"`
+	NetstatFields                 string              `yaml:"netstat_fields,omitempty"`
+	NTPServer                     string              `yaml:"ntp_server,omitempty"`
+	NTPProtocolVersion            int                 `yaml:"ntp_protocol_version,omitempty"`
+	NTPServerIsLocal              bool                `yaml:"ntp_server_is_local,omitempty"`
+	NTPIPTTL                      int                 `yaml:"ntp_ip_ttl,omitempty"`
+	NTPMaxDistance                time.Duration       `yaml:"ntp_max_distance,omitempty"`
+	NTPLocalOffsetTolerance       time.Duration       `yaml:"ntp_local_offset_tolerance,omitempty"`
+	PerfCPUS                      string              `yaml:"perf_cpus,omitempty"`
+	PerfTracepoint                flagext.StringSlice `yaml:"perf_tracepoint,omitempty"`
+	PowersupplyIgnoredSupplies    string              `yaml:"powersupply_ignored_supplies,omitempty"`
+	RunitServiceDir               string              `yaml:"runit_service_dir,omitempty"`
+	SupervisordURL                string              `yaml:"supervisord_url,omitempty"`
+	SystemdUnitWhitelist          string              `yaml:"systemd_unit_whitelist,omitempty"`
+	SystemdUnitBlacklist          string              `yaml:"systemd_unit_blacklist,omitempty"`
+	SystemdEnableTaskMetrics      bool                `yaml:"systemd_enable_task_metrics,omitempty"`
+	SystemdEnableRestartsMetrics  bool                `yaml:"systemd_enable_restarts_metrics,omitempty"`
+	SystemdEnableStartTimeMetrics bool                `yaml:"systemd_enable_start_time_metrics,omitempty"`
+	VMStatFields                  string              `yaml:"vmstat_fields,omitempty"`
+	TextfileDirectory             string              `yaml:"textfile_directory,omitempty"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler for Config.

--- a/pkg/integrations/postgres_exporter/postgres_exporter.go
+++ b/pkg/integrations/postgres_exporter/postgres_exporter.go
@@ -17,13 +17,13 @@ type Config struct {
 	Common config.Common `yaml:",inline"`
 
 	// DataSourceNames to use to connect to Postgres.
-	DataSourceNames []string `yaml:"data_source_names"`
+	DataSourceNames []string `yaml:"data_source_names,omitempty"`
 
-	DisableSettingsMetrics bool     `yaml:"disable_settings_metrics"`
-	AutodiscoverDatabases  bool     `yaml:"autodiscover_databases"`
-	ExcludeDatabases       []string `yaml:"exclude_databases"`
-	DisableDefaultMetrics  bool     `yaml:"disable_default_metrics"`
-	QueryPath              string   `yaml:"query_path"`
+	DisableSettingsMetrics bool     `yaml:"disable_settings_metrics,omitempty"`
+	AutodiscoverDatabases  bool     `yaml:"autodiscover_databases,omitempty"`
+	ExcludeDatabases       []string `yaml:"exclude_databases,omitempty"`
+	DisableDefaultMetrics  bool     `yaml:"disable_default_metrics,omitempty"`
+	QueryPath              string   `yaml:"query_path,omitempty"`
 }
 
 // Name returns the name of the integration this config is for.

--- a/pkg/integrations/process_exporter/config.go
+++ b/pkg/integrations/process_exporter/config.go
@@ -21,13 +21,13 @@ var DefaultConfig = Config{
 // Config controls the process_exporter integration.
 type Config struct {
 	Common          config.Common                `yaml:",inline"`
-	ProcessExporter exporter_config.MatcherRules `yaml:"process_names"`
+	ProcessExporter exporter_config.MatcherRules `yaml:"process_names,omitempty"`
 
-	ProcFSPath string `yaml:"procfs_path"`
-	Children   bool   `yaml:"track_children"`
-	Threads    bool   `yaml:"track_threads"`
-	SMaps      bool   `yaml:"gather_smaps"`
-	Recheck    bool   `yaml:"recheck_on_scrape"`
+	ProcFSPath string `yaml:"procfs_path,omitempty"`
+	Children   bool   `yaml:"track_children,omitempty"`
+	Threads    bool   `yaml:"track_threads,omitempty"`
+	SMaps      bool   `yaml:"gather_smaps,omitempty"`
+	Recheck    bool   `yaml:"recheck_on_scrape,omitempty"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.

--- a/pkg/integrations/redis_exporter/redis_exporter.go
+++ b/pkg/integrations/redis_exporter/redis_exporter.go
@@ -39,33 +39,33 @@ type Config struct {
 	//
 	// The exporter binary config differs to this, but these
 	// are the only fields that are relevant to the exporter struct.
-	RedisAddr               string        `yaml:"redis_addr"`
-	RedisUser               string        `yaml:"redis_user"`
-	RedisPassword           string        `yaml:"redis_password"`
-	RedisPasswordFile       string        `yaml:"redis_password_file"`
-	Namespace               string        `yaml:"namespace"`
-	ConfigCommand           string        `yaml:"config_command"`
-	CheckKeys               string        `yaml:"check_keys"`
-	CheckKeyGroups          string        `yaml:"check_key_groups"`
-	CheckKeyGroupsBatchSize int64         `yaml:"check_key_groups_batch_size"`
-	MaxDistinctKeyGroups    int64         `yaml:"max_distinct_key_groups"`
-	CheckSingleKeys         string        `yaml:"check_single_keys"`
-	CheckStreams            string        `yaml:"check_streams"`
-	CheckSingleStreams      string        `yaml:"check_single_streams"`
-	CountKeys               string        `yaml:"count_keys"`
-	ScriptPath              string        `yaml:"script_path"`
-	ConnectionTimeout       time.Duration `yaml:"connection_timeout"`
-	TLSClientKeyFile        string        `yaml:"tls_client_key_file"`
-	TLSClientCertFile       string        `yaml:"tls_client_cert_file"`
-	TLSCaCertFile           string        `yaml:"tls_ca_cert_file"`
-	SetClientName           bool          `yaml:"set_client_name"`
-	IsTile38                bool          `yaml:"is_tile38"`
-	ExportClientList        bool          `yaml:"export_client_list"`
-	ExportClientPort        bool          `yaml:"export_client_port"`
-	RedisMetricsOnly        bool          `yaml:"redis_metrics_only"`
-	PingOnConnect           bool          `yaml:"ping_on_connect"`
-	InclSystemMetrics       bool          `yaml:"incl_system_metrics"`
-	SkipTLSVerification     bool          `yaml:"skip_tls_verification"`
+	RedisAddr               string        `yaml:"redis_addr,omitempty"`
+	RedisUser               string        `yaml:"redis_user,omitempty"`
+	RedisPassword           string        `yaml:"redis_password,omitempty"`
+	RedisPasswordFile       string        `yaml:"redis_password_file,omitempty"`
+	Namespace               string        `yaml:"namespace,omitempty"`
+	ConfigCommand           string        `yaml:"config_command,omitempty"`
+	CheckKeys               string        `yaml:"check_keys,omitempty"`
+	CheckKeyGroups          string        `yaml:"check_key_groups,omitempty"`
+	CheckKeyGroupsBatchSize int64         `yaml:"check_key_groups_batch_size,omitempty"`
+	MaxDistinctKeyGroups    int64         `yaml:"max_distinct_key_groups,omitempty"`
+	CheckSingleKeys         string        `yaml:"check_single_keys,omitempty"`
+	CheckStreams            string        `yaml:"check_streams,omitempty"`
+	CheckSingleStreams      string        `yaml:"check_single_streams,omitempty"`
+	CountKeys               string        `yaml:"count_keys,omitempty"`
+	ScriptPath              string        `yaml:"script_path,omitempty"`
+	ConnectionTimeout       time.Duration `yaml:"connection_timeout,omitempty"`
+	TLSClientKeyFile        string        `yaml:"tls_client_key_file,omitempty"`
+	TLSClientCertFile       string        `yaml:"tls_client_cert_file,omitempty"`
+	TLSCaCertFile           string        `yaml:"tls_ca_cert_file,omitempty"`
+	SetClientName           bool          `yaml:"set_client_name,omitempty"`
+	IsTile38                bool          `yaml:"is_tile38,omitempty"`
+	ExportClientList        bool          `yaml:"export_client_list,omitempty"`
+	ExportClientPort        bool          `yaml:"export_client_port,omitempty"`
+	RedisMetricsOnly        bool          `yaml:"redis_metrics_only,omitempty"`
+	PingOnConnect           bool          `yaml:"ping_on_connect,omitempty"`
+	InclSystemMetrics       bool          `yaml:"incl_system_metrics,omitempty"`
+	SkipTLSVerification     bool          `yaml:"skip_tls_verification,omitempty"`
 }
 
 // GetExporterOptions returns relevant Config properties as a redis_exporter

--- a/pkg/integrations/register.go
+++ b/pkg/integrations/register.go
@@ -98,6 +98,9 @@ func MarshalYAML(v interface{}) (interface{}, error) {
 	for i, n := 0, inType.NumField(); i < n; i++ {
 		if inType.Field(i).Type == configsType {
 			configs = inVal.Field(i).Interface().(Configs)
+			if configs == nil {
+				configs = Configs{}
+			}
 		}
 		if cfgType.Field(i).PkgPath != "" {
 			continue // Field is unexported: ignore.
@@ -105,13 +108,13 @@ func MarshalYAML(v interface{}) (interface{}, error) {
 		cfgVal.Field(i).Set(inVal.Field(i))
 	}
 	if configs == nil {
-		return nil, fmt.Errorf("discovery: Configs field not found in type: %T", v)
+		return nil, fmt.Errorf("integrations: Configs field not found in type: %T", v)
 	}
 
 	for _, c := range configs {
 		fieldName, ok := configFieldNames[reflect.TypeOf(c)]
 		if !ok {
-			return nil, fmt.Errorf("discovery: cannot marshal unregistered Config type: %T", c)
+			return nil, fmt.Errorf("integrations: cannot marshal unregistered Config type: %T", c)
 		}
 		field := cfgVal.FieldByName("XXX_Config_" + fieldName)
 		field.Set(reflect.ValueOf(c))
@@ -222,7 +225,7 @@ func getConfigTypeForIntegrations(integrations []Config, out reflect.Type) refle
 		fieldName := "XXX_Config_" + cfg.Name()
 		fields = append(fields, reflect.StructField{
 			Name: fieldName,
-			Tag:  reflect.StructTag(fmt.Sprintf(`yaml:"%s"`, cfg.Name())),
+			Tag:  reflect.StructTag(fmt.Sprintf(`yaml:"%s,omitempty"`, cfg.Name())),
 			Type: reflect.TypeOf(cfg),
 		})
 	}

--- a/pkg/integrations/statsd_exporter/statsd_exporter.go
+++ b/pkg/integrations/statsd_exporter/statsd_exporter.go
@@ -48,23 +48,23 @@ var DefaultConfig = Config{
 type Config struct {
 	Common config.Common `yaml:",inline"`
 
-	ListenUDP      string               `yaml:"listen_udp"`
-	ListenTCP      string               `yaml:"listen_tcp"`
-	ListenUnixgram string               `yaml:"listen_unixgram"`
-	UnixSocketMode string               `yaml:"unix_socket_mode"`
-	MappingConfig  *mapper.MetricMapper `yaml:"mapping_config"`
+	ListenUDP      string               `yaml:"listen_udp,omitempty"`
+	ListenTCP      string               `yaml:"listen_tcp,omitempty"`
+	ListenUnixgram string               `yaml:"listen_unixgram,omitempty"`
+	UnixSocketMode string               `yaml:"unix_socket_mode,omitempty"`
+	MappingConfig  *mapper.MetricMapper `yaml:"mapping_config,omitempty"`
 
-	ReadBuffer          int           `yaml:"read_buffer"`
-	CacheSize           int           `yaml:"cache_size"`
-	CacheType           string        `yaml:"cache_type"`
-	EventQueueSize      int           `yaml:"event_queue_size"`
-	EventFlushThreshold int           `yaml:"event_flush_threshold"`
-	EventFlushInterval  time.Duration `yaml:"event_flush_interval"`
+	ReadBuffer          int           `yaml:"read_buffer,omitempty"`
+	CacheSize           int           `yaml:"cache_size,omitempty"`
+	CacheType           string        `yaml:"cache_type,omitempty"`
+	EventQueueSize      int           `yaml:"event_queue_size,omitempty"`
+	EventFlushThreshold int           `yaml:"event_flush_threshold,omitempty"`
+	EventFlushInterval  time.Duration `yaml:"event_flush_interval,omitempty"`
 
-	ParseDogStatsd bool `yaml:"parse_dogstatsd_tags"`
-	ParseInfluxDB  bool `yaml:"parse_influxdb_tags"`
-	ParseLibrato   bool `yaml:"parse_librato_tags"`
-	ParseSignalFX  bool `yaml:"parse_signalfx_tags"`
+	ParseDogStatsd bool `yaml:"parse_dogstatsd_tags,omitempty"`
+	ParseInfluxDB  bool `yaml:"parse_influxdb_tags,omitempty"`
+	ParseLibrato   bool `yaml:"parse_librato_tags,omitempty"`
+	ParseSignalFX  bool `yaml:"parse_signalfx_tags,omitempty"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler for Config.

--- a/pkg/integrations/windows_exporter/config.go
+++ b/pkg/integrations/windows_exporter/config.go
@@ -16,16 +16,16 @@ type Config struct {
 
 	EnabledCollectors string `yaml:"enabled_collectors"`
 
-	Exchange    ExchangeConfig    `yaml:"exchange"`
-	IIS         IISConfig         `yaml:"iis"`
-	TextFile    TextFileConfig    `yaml:"text_file"`
-	SMTP        SMTPConfig        `yaml:"smtp"`
-	Service     ServiceConfig     `yaml:"service"`
-	Process     ProcessConfig     `yaml:"process"`
-	Network     NetworkConfig     `yaml:"network"`
-	MSSQL       MSSQLConfig       `yaml:"mssql"`
-	MSMQ        MSMQConfig        `yaml:"msmq"`
-	LogicalDisk LogicalDiskConfig `yaml:"logical_disk"`
+	Exchange    ExchangeConfig    `yaml:"exchange,omitempty"`
+	IIS         IISConfig         `yaml:"iis,omitempty"`
+	TextFile    TextFileConfig    `yaml:"text_file,omitempty"`
+	SMTP        SMTPConfig        `yaml:"smtp,omitempty"`
+	Service     ServiceConfig     `yaml:"service,omitempty"`
+	Process     ProcessConfig     `yaml:"process,omitempty"`
+	Network     NetworkConfig     `yaml:"network,omitempty"`
+	MSSQL       MSSQLConfig       `yaml:"mssql,omitempty"`
+	MSMQ        MSMQConfig        `yaml:"msmq,omitempty"`
+	LogicalDisk LogicalDiskConfig `yaml:"logical_disk,omitempty"`
 }
 
 // Name returns the name used, "windows_explorer"
@@ -45,57 +45,57 @@ func (c *Config) NewIntegration(l log.Logger) (integrations.Integration, error) 
 
 // ExchangeConfig handles settings for the windows_exporter Exchange collector
 type ExchangeConfig struct {
-	EnabledList string `yaml:"enabled_list"`
+	EnabledList string `yaml:"enabled_list,omitempty"`
 }
 
 // IISConfig handles settings for the windows_exporter IIS collector
 type IISConfig struct {
-	SiteWhiteList string `yaml:"site_whitelist"`
-	SiteBlackList string `yaml:"site_blacklist"`
-	AppWhiteList  string `yaml:"app_whitelist"`
-	AppBlackList  string `yaml:"app_blacklist"`
+	SiteWhiteList string `yaml:"site_whitelist,omitempty"`
+	SiteBlackList string `yaml:"site_blacklist,omitempty"`
+	AppWhiteList  string `yaml:"app_whitelist,omitempty"`
+	AppBlackList  string `yaml:"app_blacklist,omitempty"`
 }
 
 // TextFileConfig handles settings for the windows_exporter Text File collector
 type TextFileConfig struct {
-	TextFileDirectory string `yaml:"text_file_directory"`
+	TextFileDirectory string `yaml:"text_file_directory,omitempty"`
 }
 
 // SMTPConfig handles settings for the windows_exporter SMTP collector
 type SMTPConfig struct {
-	WhiteList string `yaml:"whitelist"`
-	BlackList string `yaml:"blacklist"`
+	WhiteList string `yaml:"whitelist,omitempty"`
+	BlackList string `yaml:"blacklist,omitempty"`
 }
 
 // ServiceConfig handles settings for the windows_exporter service collector
 type ServiceConfig struct {
-	Where string `yaml:"where_clause"`
+	Where string `yaml:"where_clause,omitempty"`
 }
 
 // ProcessConfig handles settings for the windows_exporter process collector
 type ProcessConfig struct {
-	WhiteList string `yaml:"whitelist"`
-	BlackList string `yaml:"blacklist"`
+	WhiteList string `yaml:"whitelist,omitempty"`
+	BlackList string `yaml:"blacklist,omitempty"`
 }
 
 // NetworkConfig handles settings for the windows_exporter network collector
 type NetworkConfig struct {
-	WhiteList string `yaml:"whitelist"`
-	BlackList string `yaml:"blacklist"`
+	WhiteList string `yaml:"whitelist,omitempty"`
+	BlackList string `yaml:"blacklist,omitempty"`
 }
 
 // MSSQLConfig handles settings for the windows_exporter SQL server collector
 type MSSQLConfig struct {
-	EnabledClasses string `yaml:"enabled_classes"`
+	EnabledClasses string `yaml:"enabled_classes,omitempty"`
 }
 
 // MSMQConfig handles settings for the windows_exporter MSMQ collector
 type MSMQConfig struct {
-	Where string `yaml:"where_clause"`
+	Where string `yaml:"where_clause,omitempty"`
 }
 
 // LogicalDiskConfig handles settings for the windows_exporter logical disk collector
 type LogicalDiskConfig struct {
-	WhiteList string `yaml:"whitelist"`
-	BlackList string `yaml:"blacklist"`
+	WhiteList string `yaml:"whitelist,omitempty"`
+	BlackList string `yaml:"blacklist,omitempty"`
 }

--- a/pkg/loki/config.go
+++ b/pkg/loki/config.go
@@ -13,8 +13,8 @@ import (
 
 // Config controls the configuration of the Loki log scraper.
 type Config struct {
-	PositionsDirectory string            `yaml:"positions_directory"`
-	Configs            []*InstanceConfig `yaml:"configs"`
+	PositionsDirectory string            `yaml:"positions_directory,omitempty"`
+	Configs            []*InstanceConfig `yaml:"configs,omitempty"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.

--- a/pkg/prom/agent.go
+++ b/pkg/prom/agent.go
@@ -35,15 +35,15 @@ var DefaultConfig = Config{
 // Config defines the configuration for the entire set of Prometheus client
 // instances, along with a global configuration.
 type Config struct {
-	Global                 config.GlobalConfig           `yaml:"global"`
-	WALDir                 string                        `yaml:"wal_directory"`
-	WALCleanupAge          time.Duration                 `yaml:"wal_cleanup_age"`
-	WALCleanupPeriod       time.Duration                 `yaml:"wal_cleanup_period"`
-	ServiceConfig          cluster.Config                `yaml:"scraping_service"`
-	ServiceClientConfig    client.Config                 `yaml:"scraping_service_client"`
-	Configs                []instance.Config             `yaml:"configs,omitempty"`
+	Global                 config.GlobalConfig           `yaml:"global,omitempty"`
+	WALDir                 string                        `yaml:"wal_directory,omitempty"`
+	WALCleanupAge          time.Duration                 `yaml:"wal_cleanup_age,omitempty"`
+	WALCleanupPeriod       time.Duration                 `yaml:"wal_cleanup_period,omitempty"`
+	ServiceConfig          cluster.Config                `yaml:"scraping_service,omitempty"`
+	ServiceClientConfig    client.Config                 `yaml:"scraping_service_client,omitempty"`
+	Configs                []instance.Config             `yaml:"configs,omitempty,omitempty"`
 	InstanceRestartBackoff time.Duration                 `yaml:"instance_restart_backoff,omitempty"`
-	InstanceMode           instance.Mode                 `yaml:"instance_mode"`
+	InstanceMode           instance.Mode                 `yaml:"instance_mode,omitempty"`
 	RemoteWrite            []*instance.RemoteWriteConfig `yaml:"remote_write,omitempty"`
 }
 

--- a/pkg/prom/cluster/client/client.go
+++ b/pkg/prom/cluster/client/client.go
@@ -27,7 +27,7 @@ var (
 
 // Config controls how scraping service clients are created.
 type Config struct {
-	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config"`
+	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config,omitempty"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.

--- a/pkg/prom/instance/instance.go
+++ b/pkg/prom/instance/instance.go
@@ -56,21 +56,21 @@ var (
 // Config is a specific agent that runs within the overall Prometheus
 // agent. It has its own set of scrape_configs and remote_write rules.
 type Config struct {
-	Name                     string                 `yaml:"name" json:"name"`
-	HostFilter               bool                   `yaml:"host_filter" json:"host_filter"`
+	Name                     string                 `yaml:"name,omitempty"`
+	HostFilter               bool                   `yaml:"host_filter,omitempty"`
 	HostFilterRelabelConfigs []*relabel.Config      `yaml:"host_filter_relabel_configs,omitempty"`
-	ScrapeConfigs            []*config.ScrapeConfig `yaml:"scrape_configs,omitempty" json:"scrape_configs,omitempty"`
-	RemoteWrite              []*RemoteWriteConfig   `yaml:"remote_write,omitempty" json:"remote_write,omitempty"`
+	ScrapeConfigs            []*config.ScrapeConfig `yaml:"scrape_configs,omitempty"`
+	RemoteWrite              []*RemoteWriteConfig   `yaml:"remote_write,omitempty"`
 
 	// How frequently the WAL should be truncated.
-	WALTruncateFrequency time.Duration `yaml:"wal_truncate_frequency,omitempty" json:"wal_truncate_frequency,omitempty"`
+	WALTruncateFrequency time.Duration `yaml:"wal_truncate_frequency,omitempty"`
 
 	// Minimum and maximum time series should exist in the WAL for.
-	MinWALTime time.Duration `yaml:"min_wal_time,omitempty" json:"min_wal_time,omitempty"`
-	MaxWALTime time.Duration `yaml:"max_wal_time,omitempty" json:"max_wal_time,omitempty"`
+	MinWALTime time.Duration `yaml:"min_wal_time,omitempty"`
+	MaxWALTime time.Duration `yaml:"max_wal_time,omitempty"`
 
-	RemoteFlushDeadline  time.Duration `yaml:"remote_flush_deadline,omitempty" json:"remote_flush_deadline,omitempty"`
-	WriteStaleOnShutdown bool          `yaml:"write_stale_on_shutdown,omitempty" json:"write_stale_on_shutdown,omitempty"`
+	RemoteFlushDeadline  time.Duration `yaml:"remote_flush_deadline,omitempty"`
+	WriteStaleOnShutdown bool          `yaml:"write_stale_on_shutdown,omitempty"`
 }
 
 // BaseRemoteWrite returns the base remote write configs without the added

--- a/pkg/prom/instance/marshal_test.go
+++ b/pkg/prom/instance/marshal_test.go
@@ -29,7 +29,6 @@ func TestUnmarshalConfig_Invalid(t *testing.T) {
 // instance config does the same thing and retains secrets.
 func TestMarshal_UnmarshalConfig(t *testing.T) {
 	cfg := `name: test
-host_filter: false
 scrape_configs:
 - job_name: local_scrape
   honor_timestamps: true
@@ -101,7 +100,6 @@ remote_flush_deadline: 1m0s
 // instance config does the same thing and retains secrets.
 func TestMarshal_UnmarshalConfig_Sigv4(t *testing.T) {
 	cfg := `name: test
-host_filter: false
 scrape_configs:
 - job_name: local_scrape
   honor_timestamps: true

--- a/pkg/tempo/config.go
+++ b/pkg/tempo/config.go
@@ -24,7 +24,7 @@ import (
 
 // Config controls the configuration of Tempo trace pipelines.
 type Config struct {
-	Configs []InstanceConfig `yaml:"configs"`
+	Configs []InstanceConfig `yaml:"configs,omitempty"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
@@ -57,22 +57,22 @@ type InstanceConfig struct {
 	Name string `yaml:"name"`
 
 	// Deprecated in favor of RemoteWrite and Batch.
-	PushConfig PushConfig `yaml:"push_config"`
+	PushConfig PushConfig `yaml:"push_config,omitempty"`
 
 	// RemoteWrite defines one or multiple backends that can receive the pipeline's traffic.
-	RemoteWrite []RemoteWriteConfig `yaml:"remote_write"`
+	RemoteWrite []RemoteWriteConfig `yaml:"remote_write,omitempty"`
 
 	// Receivers: https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/receiver/README.md
-	Receivers map[string]interface{} `yaml:"receivers"`
+	Receivers map[string]interface{} `yaml:"receivers,omitempty"`
 
 	// Batch: https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/processor/batchprocessor/config.go#L24
 	Batch map[string]interface{} `yaml:"batch,omitempty"`
 
 	// Attributes: https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/processor/attributesprocessor/config.go#L30
-	Attributes map[string]interface{} `yaml:"attributes"`
+	Attributes map[string]interface{} `yaml:"attributes,omitempty"`
 
 	// prom service discovery
-	ScrapeConfigs []interface{} `yaml:"scrape_configs"`
+	ScrapeConfigs []interface{} `yaml:"scrape_configs,omitempty"`
 }
 
 const (
@@ -87,11 +87,11 @@ var DefaultPushConfig = PushConfig{
 
 // PushConfig controls the configuration of exporting to Grafana Cloud
 type PushConfig struct {
-	Endpoint           string                 `yaml:"endpoint"`
-	Compression        string                 `yaml:"compression"`
-	Insecure           bool                   `yaml:"insecure"`
-	InsecureSkipVerify bool                   `yaml:"insecure_skip_verify"`
-	BasicAuth          *prom_config.BasicAuth `yaml:"basic_auth,omitempty"`
+	Endpoint           string                 `yaml:"endpoint,omitempty"`
+	Compression        string                 `yaml:"compression,omitempty"`
+	Insecure           bool                   `yaml:"insecure,omitempty"`
+	InsecureSkipVerify bool                   `yaml:"insecure_skip_verify,omitempty"`
+	BasicAuth          *prom_config.BasicAuth `yaml:"basic_auth,omitempty,omitempty"`
 	Batch              map[string]interface{} `yaml:"batch,omitempty"`            // https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/processor/batchprocessor/config.go#L24
 	SendingQueue       map[string]interface{} `yaml:"sending_queue,omitempty"`    // https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/exporter/exporterhelper/queued_retry.go#L30
 	RetryOnFailure     map[string]interface{} `yaml:"retry_on_failure,omitempty"` // https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/exporter/exporterhelper/queued_retry.go#L54
@@ -119,10 +119,10 @@ var DefaultRemoteWriteConfig = RemoteWriteConfig{
 
 // RemoteWriteConfig controls the configuration of an exporter
 type RemoteWriteConfig struct {
-	Endpoint           string                 `yaml:"endpoint"`
-	Compression        string                 `yaml:"compression"`
-	Insecure           bool                   `yaml:"insecure"`
-	InsecureSkipVerify bool                   `yaml:"insecure_skip_verify"`
+	Endpoint           string                 `yaml:"endpoint,omitempty"`
+	Compression        string                 `yaml:"compression,omitempty"`
+	Insecure           bool                   `yaml:"insecure,omitempty"`
+	InsecureSkipVerify bool                   `yaml:"insecure_skip_verify,omitempty"`
 	BasicAuth          *prom_config.BasicAuth `yaml:"basic_auth,omitempty"`
 	SendingQueue       map[string]interface{} `yaml:"sending_queue,omitempty"`    // https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/exporter/exporterhelper/queued_retry.go#L30
 	RetryOnFailure     map[string]interface{} `yaml:"retry_on_failure,omitempty"` // https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/exporter/exporterhelper/queued_retry.go#L54


### PR DESCRIPTION
#### PR Description 
Marks all fields as `omitempty` and adds support for a `/-/config` endpoint that marshals out the current loaded configuration over HTTP. 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer
Some of this implementation accidentally snuck into #493, sorry!

There was a bug where an empty list of integrations was not marshaling correctly, but that has been fixed with this PR (and a new test to make sure we don't regress).

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
