### PR TITLE
close WALs after calculating cardinality/sample stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ cross-compilation issue, but will return in v0.13.0.
 
 - [BUGFIX] Bring back FreeBSD support. (@rfratto)
 
+- [BUGFIX] agentctl will no longer leak WAL resources when retrieving WAL stats. (@rfratto)
+
 - [CHANGE] The Grafana Cloud Agent has been renamed to the Grafana Agent.
     (@rfratto)
 

--- a/pkg/agentctl/cardinality.go
+++ b/pkg/agentctl/cardinality.go
@@ -20,6 +20,7 @@ func FindCardinality(walDir string, job string, instance string) ([]Cardinality,
 	if err != nil {
 		return nil, err
 	}
+	defer w.Close()
 
 	cardinality := map[string]int{}
 

--- a/pkg/agentctl/samples.go
+++ b/pkg/agentctl/samples.go
@@ -29,6 +29,7 @@ func FindSamples(walDir string, selectorStr string) ([]*SampleStats, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer w.Close()
 
 	selector, err := parser.ParseMetricSelector(selectorStr)
 	if err != nil {

--- a/pkg/prom/instance/instance.go
+++ b/pkg/prom/instance/instance.go
@@ -345,6 +345,8 @@ func (i *Instance) Run(ctx context.Context) error {
 					}
 				}
 
+				// Closing the storage closes both the WAL storage and remote wrte
+				// storage.
 				level.Info(i.logger).Log("msg", "closing storage...")
 				if err := i.storage.Close(); err != nil {
 					level.Error(i.logger).Log("msg", "error stopping storage", "err", err)


### PR DESCRIPTION
#### PR Description 
Closes WALs after agentctl finishes doing analysis.

#### Which issue(s) this PR fixes 
Fixes #506 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
