### PR TITLE
Add headers field to Tempo's remote_write  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ cross-compilation issue, but will return in v0.13.0.
 
 # Main (unreleased)
 
+- [ENHANCEMENT] Add  `headers` field in `remote_write` config for Tempo. `headers`
+  specifies HTTP headers to forward to the remote endpoint. (@alexbiehl)
+
 # v0.13.1 (2021-04-09)
 
 - [BUGFIX] Validate that incoming scraped metrics do not have an empty label

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -2017,6 +2017,12 @@ remote_write:
   # host:port to send traces to
   - endpoint: <string>
 
+    # Custom HTTP headers to be sent along with each remote write request.
+    # Be aware that 'authorization' header will be overwritten in presence
+    # of basic_auth.
+    headers:
+      [ <string>: <string> ... ]
+
     # Controls whether compression is enabled.
     [ compression: <string> | default = "gzip" | supported = "none", "gzip"]
 

--- a/pkg/tempo/config.go
+++ b/pkg/tempo/config.go
@@ -136,6 +136,7 @@ type RemoteWriteConfig struct {
 	Insecure           bool                   `yaml:"insecure,omitempty"`
 	InsecureSkipVerify bool                   `yaml:"insecure_skip_verify,omitempty"`
 	BasicAuth          *prom_config.BasicAuth `yaml:"basic_auth,omitempty"`
+	Headers            map[string]string      `yaml:"headers,omitempty"`
 	SendingQueue       map[string]interface{} `yaml:"sending_queue,omitempty"`    // https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/exporter/exporterhelper/queued_retry.go#L30
 	RetryOnFailure     map[string]interface{} `yaml:"retry_on_failure,omitempty"` // https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/exporter/exporterhelper/queued_retry.go#L54
 }
@@ -171,6 +172,10 @@ func exporter(remoteWriteConfig RemoteWriteConfig) (map[string]interface{}, erro
 	}
 
 	headers := map[string]string{}
+	if remoteWriteConfig.Headers != nil {
+		headers = remoteWriteConfig.Headers
+	}
+
 	if remoteWriteConfig.BasicAuth != nil {
 		password := string(remoteWriteConfig.BasicAuth.Password)
 
@@ -183,9 +188,7 @@ func exporter(remoteWriteConfig RemoteWriteConfig) (map[string]interface{}, erro
 		}
 
 		encodedAuth := base64.StdEncoding.EncodeToString([]byte(remoteWriteConfig.BasicAuth.Username + ":" + password))
-		headers = map[string]string{
-			"authorization": "Basic " + encodedAuth,
-		}
+		headers["authorization"] = "Basic " + encodedAuth
 	}
 
 	compression := remoteWriteConfig.Compression

--- a/pkg/tempo/config_test.go
+++ b/pkg/tempo/config_test.go
@@ -316,6 +316,8 @@ receivers:
       grpc:
 remote_write:
   - endpoint: example.com:12345
+    headers:
+      x-some-header: Some value!
 `,
 			expectedConfig: `
 receivers:
@@ -326,6 +328,8 @@ exporters:
   otlp/0:
     endpoint: example.com:12345
     compression: gzip
+    headers:
+      x-some-header: Some value!
     retry_on_failure:
       max_elapsed_time: 60s
 service:
@@ -461,7 +465,7 @@ exporters:
       max_elapsed_time: 60s
   prometheus:
     endpoint: "0.0.0.0:8889"
-    namespace: promexample    
+    namespace: promexample
 processors:
   spanmetrics:
     metrics_exporter: prometheus


### PR DESCRIPTION
#### PR Description 

This PR adds an optional `headers` field to `remote_write`s in Tempo. Headers specified through that field are passed on to remote writers. 

#### Which issue(s) this PR fixes 

Closes #535 

#### PR Checklist

I will update documentation and CHANGELOG in upcoming commits.

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
