### PR TITLE
Tempo: Use correct logger in Prom SD

### DIFF
--- a/pkg/tempo/promsdprocessor/prom_sd_processor.go
+++ b/pkg/tempo/promsdprocessor/prom_sd_processor.go
@@ -63,7 +63,7 @@ func newTraceProcessor(nextConsumer consumer.TracesConsumer, scrapeConfigs []*co
 		discoveryMgrCtx:  ctx,
 		relabelConfigs:   relabelConfigs,
 		hostLabels:       make(map[string]model.LabelSet),
-		logger:           util.Logger,
+		logger:           logger,
 	}, nil
 }
 


### PR DESCRIPTION
#### PR Description 
Noticed this while working on other changes. I believe we were using the wrong logger in our SD processor.