### PR TITLE
Add harcoded namespace to spanmetrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ cross-compilation issue, but will return in v0.13.0.
 
 - [ENHANCEMENT] Add  `headers` field in `remote_write` config for Tempo. `headers`
   specifies HTTP headers to forward to the remote endpoint. (@alexbiehl)
+- [CHANGE] Add `tempo_spanmetrics` namespace in spanmetrics (@mapno)
 
 # v0.13.1 (2021-04-09)
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -2074,6 +2074,8 @@ spanmetrics:
   metrics_exporter:
     [ endpoint: <prometheusexporter.endpoint> ]
     [ const_labels: <prometheusexporter.const_labels> ]
+    # Metrics are namespaced to `tempo_spanmetrics` by default.
+    # They can be further namespaced, i.e. `{namespace}_tempo_spanmetrics`
     [ namespace: <prometheusexporter.namespace> ]
     [ send_timestamps: <prometheusexporter.send_timestamps> ]
 ```

--- a/pkg/tempo/config_test.go
+++ b/pkg/tempo/config_test.go
@@ -465,7 +465,7 @@ exporters:
       max_elapsed_time: 60s
   prometheus:
     endpoint: "0.0.0.0:8889"
-    namespace: promexample
+    namespace: promexample_tempo_spanmetrics
 processors:
   spanmetrics:
     metrics_exporter: prometheus


### PR DESCRIPTION
#### PR Description 

Add a hardcoded namespace to "brand" the metrics as tempo metrics. Metrics can still be further namespace'd.

#### Which issue(s) this PR fixes

This comment: https://github.com/grafana/deployment_tools/pull/9416#discussion_r612409931

#### Notes to the Reviewer

#### PR Checklist

- [X] CHANGELOG updated 
- [ ] Documentation added
- [X] Tests updated
