### PR TITLE
Apply defaults to undefined sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,17 @@ cross-compilation issue, but will return in v0.13.0.
 
 # Main (unreleased)
 
+- [BUGFIX] Ensure defaults are applied to undefined sections in config file.
+  This fixes a problem where integrations didn't work if `prometheus:` wasn't
+  configured. (@rfratto)
+
 # 0.14.0-rc.3 (2021-04-15)
 
 - [ENHANCEMENT] Add  `headers` field in `remote_write` config for Tempo. `headers`
   specifies HTTP headers to forward to the remote endpoint. (@alexbiehl)
 
 - [BUGFIX] Grafana Agent running as a Windows service should start automatically on startup
-  (@mattdurham) 
+  (@mattdurham)
 
 - [BUGFIX] Validate that incoming scraped metrics do not have an empty label
   set or a label set with duplicate labels, mirroring the behavior of

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,13 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// DefaultConfig holds default settings for all the subsystems.
+var DefaultConfig = Config{
+	// All subsystems with a DefaultConfig should be listed here.
+	Prometheus:   prom.DefaultConfig,
+	Integrations: integrations.DefaultManagerConfig,
+}
+
 // Config contains underlying configurations for the agent
 type Config struct {
 	Server       server.Config              `yaml:"server,omitempty"`
@@ -31,6 +38,13 @@ type Config struct {
 	// to restart.
 	ReloadAddress string `yaml:"-"`
 	ReloadPort    int    `yaml:"-"`
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler.
+func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultConfig
+	type config Config
+	return unmarshal((*config)(c))
 }
 
 // ApplyDefaults sets default values in the config
@@ -103,8 +117,9 @@ func Load(fs *flag.FlagSet, args []string) (*Config, error) {
 // doesn't require having a literal file on disk.
 func load(fs *flag.FlagSet, args []string, loader func(string, bool, *Config) error) (*Config, error) {
 	var (
+		cfg = DefaultConfig
+
 		printVersion    bool
-		cfg             Config
 		file            string
 		configExpandEnv bool
 	)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/agent/pkg/integrations"
+	"github.com/grafana/agent/pkg/prom"
 	"github.com/grafana/agent/pkg/prom/instance"
 	"github.com/prometheus/common/model"
 	promCfg "github.com/prometheus/prometheus/config"
@@ -119,4 +121,13 @@ prometheus:
 		err := LoadBytes([]byte(cfg), false, &c)
 		require.Error(t, err)
 	})
+}
+
+func TestConfig_Defaults(t *testing.T) {
+	var c Config
+	err := LoadBytes([]byte(`{}`), false, &c)
+	require.NoError(t, err)
+
+	require.Equal(t, prom.DefaultConfig, c.Prometheus)
+	require.Equal(t, integrations.DefaultManagerConfig, c.Integrations)
 }


### PR DESCRIPTION
#### PR Description 
#545 found that defining _just_ an `integrations` block prevented integrations from being scraped. This was found to be because the default scrape_interval and scrape_timeout weren't being applied when `prometheus` wasn't present in the config file. 

This change ensures that defaults are applied appropriately to empty files (or files without a given section). Only defaults for integrations and prometheus need to be defined, as integrations depends on prometheus (and no other subsystem has defaults).

#### Which issue(s) this PR fixes 
Fixes #545

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
