### PR TITLE
fix default values applied to Config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/agent/pkg/loki"
 	"github.com/grafana/agent/pkg/prom"
 	"github.com/grafana/agent/pkg/tempo"
+	"github.com/grafana/agent/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/version"
 	"gopkg.in/yaml.v2"
@@ -42,7 +43,11 @@ type Config struct {
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// Apply defaults to the config from our struct and any defaults inherited
+	// from flags.
 	*c = DefaultConfig
+	util.DefaultConfigFromFlags(c)
+
 	type config Config
 	return unmarshal((*config)(c))
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -31,6 +31,7 @@ prometheus:
 	require.NotEmpty(t, c.Prometheus.ServiceConfig.Lifecycler.InfNames)
 	require.NotZero(t, c.Prometheus.ServiceConfig.Lifecycler.NumTokens)
 	require.NotZero(t, c.Prometheus.ServiceConfig.Lifecycler.HeartbeatPeriod)
+	require.True(t, c.Server.RegisterInstrumentation)
 }
 
 func TestConfig_OverrideDefaultsOnLoad(t *testing.T) {


### PR DESCRIPTION
PR #546 introduced a default value for the overall Config struct which
overwrote the defaults coming from flags. This commit ensures that
flag-level defaults take precedence.

#### PR Description 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

(Not updating changelog since the bug was introduced before a tag)

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
