### PR TITLE
add ability to get an instance by name

### DIFF
--- a/pkg/prom/cluster/config_watcher_test.go
+++ b/pkg/prom/cluster/config_watcher_test.go
@@ -210,6 +210,11 @@ type mockConfigManager struct {
 	mock.Mock
 }
 
+func (m *mockConfigManager) GetInstance(name string) (instance.ManagedInstance, error) {
+	args := m.Mock.Called()
+	return args.Get(0).(instance.ManagedInstance), args.Error(1)
+}
+
 func (m *mockConfigManager) ListInstances() map[string]instance.ManagedInstance {
 	args := m.Mock.Called()
 	return args.Get(0).(map[string]instance.ManagedInstance)

--- a/pkg/prom/instance/group_manager.go
+++ b/pkg/prom/instance/group_manager.go
@@ -62,6 +62,23 @@ func NewGroupManager(inner Manager) *GroupManager {
 	}
 }
 
+// GetInstance gets the underlying grouped instance for a given name.
+func (m *GroupManager) GetInstance(name string) (ManagedInstance, error) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	group, ok := m.groupLookup[name]
+	if !ok {
+		return nil, fmt.Errorf("instance %s does not exist", name)
+	}
+
+	inst, err := m.inner.GetInstance(group)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get instance for %s: %w", name, err)
+	}
+	return inst, nil
+}
+
 // ListInstances returns all currently grouped managed instances. The key
 // will be the group's hash of shared settings.
 func (m *GroupManager) ListInstances() map[string]ManagedInstance {

--- a/pkg/prom/instance/manager.go
+++ b/pkg/prom/instance/manager.go
@@ -34,7 +34,7 @@ var (
 // Manager represents a set of methods for manipulating running instances at
 // runtime.
 type Manager interface {
-	// GetInstance retrieved a ManagedInstance by name.
+	// GetInstance retrieves a ManagedInstance by name.
 	GetInstance(name string) (ManagedInstance, error)
 
 	// ListInstances returns all currently managed instances running

--- a/pkg/prom/instance/modal_manager.go
+++ b/pkg/prom/instance/modal_manager.go
@@ -139,6 +139,13 @@ func (m *ModalManager) SetMode(newMode Mode) error {
 	return firstError
 }
 
+// GetInstance implements Manager.
+func (m *ModalManager) GetInstance(name string) (ManagedInstance, error) {
+	m.mut.RLock()
+	defer m.mut.RUnlock()
+	return m.active.GetInstance(name)
+}
+
 // ListInstances implements Manager.
 func (m *ModalManager) ListInstances() map[string]ManagedInstance {
 	m.mut.RLock()


### PR DESCRIPTION
#### PR Description 
An internal-only change for now that adds the ability to retrieve a managed instance by name. In the case of instances being grouped, the running group gets returned instead. 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
