### PR TITLE
metrics: read global config when reloading instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ service config.
   This fixes a problem where integrations didn't work if `prometheus:` wasn't
   configured. (@rfratto)
 
+- [BUGFIX] Re-read `prometheus.global` settings when calling /-/reload.
+  (@rfratto)
+
 # 0.14.0-rc.3 (2021-04-15)
 
 - [ENHANCEMENT] Add  `headers` field in `remote_write` config for Tempo. `headers`

--- a/example/k3d/environment/main.jsonnet
+++ b/example/k3d/environment/main.jsonnet
@@ -142,6 +142,10 @@ local images = {
               cluster: cluster_label,
             },
           },
+
+          scraping_service+: {
+            dangerous_allow_reading_files: true,
+          },
         },
       },
 

--- a/pkg/prom/agent.go
+++ b/pkg/prom/agent.go
@@ -73,11 +73,8 @@ func (c *Config) ApplyDefaults() error {
 	usedNames := map[string]struct{}{}
 
 	for i := range c.Configs {
-		// Initialize the global settings.
-		c.Configs[i].Global = c.Global
-
 		name := c.Configs[i].Name
-		if err := c.Configs[i].ApplyDefaults(); err != nil {
+		if err := c.Configs[i].ApplyDefaults(c.Global); err != nil {
 			// Try to show a helpful name in the error
 			if name == "" {
 				name = fmt.Sprintf("at index %d", i)
@@ -193,9 +190,7 @@ func (a *Agent) Validate(c *instance.Config) error {
 	a.mut.RLock()
 	defer a.mut.RUnlock()
 
-	c.Global = a.cfg.Global
-
-	if err := c.ApplyDefaults(); err != nil {
+	if err := c.ApplyDefaults(a.cfg.Global); err != nil {
 		return fmt.Errorf("failed to apply defaults to %q: %w", c.Name, err)
 	}
 	return nil

--- a/pkg/prom/agent_test.go
+++ b/pkg/prom/agent_test.go
@@ -301,7 +301,7 @@ func (f *fakeInstanceFactory) Mocks() []*fakeInstance {
 	return f.mocks
 }
 
-func (f *fakeInstanceFactory) factory(_ prometheus.Registerer, _ instance.GlobalConfig, cfg instance.Config, _ string, _ log.Logger) (instance.ManagedInstance, error) {
+func (f *fakeInstanceFactory) factory(_ prometheus.Registerer, cfg instance.Config, _ string, _ log.Logger) (instance.ManagedInstance, error) {
 	f.created.Add(1)
 
 	f.mut.Lock()

--- a/pkg/prom/instance/group_manager.go
+++ b/pkg/prom/instance/group_manager.go
@@ -317,6 +317,7 @@ func copyConfig(c Config) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	cfg.Global = c.Global
 
 	// Some tests will trip up on this; the marshal/unmarshal cycle might set
 	// an empty slice to nil. Set it back to an empty slice if we detect this
@@ -327,6 +328,7 @@ func copyConfig(c Config) (Config, error) {
 	if cfg.RemoteWrite == nil && c.RemoteWrite != nil {
 		cfg.RemoteWrite = []*config.RemoteWriteConfig{}
 	}
+
 	return *cfg, nil
 }
 

--- a/pkg/prom/instance/group_manager.go
+++ b/pkg/prom/instance/group_manager.go
@@ -305,9 +305,6 @@ func hashConfig(c Config) (string, error) {
 	return hex.EncodeToString(hash[:]), nil
 }
 
-// copyConfig provides a deep copy of a Config that can be mutated
-// independently of c.
-
 // groupConfig creates a grouped Config where all fields are copied from
 // the first config except for scrape_configs, which are appended together.
 func groupConfigs(groupName string, grouped groupedConfigs) (Config, error) {

--- a/pkg/prom/instance/instance_integration_test.go
+++ b/pkg/prom/instance/instance_integration_test.go
@@ -250,6 +250,6 @@ remote_write: []
 func loadConfig(t *testing.T, s string) Config {
 	cfg, err := UnmarshalConfig(strings.NewReader(s))
 	require.NoError(t, err)
-	require.NoError(t, cfg.ApplyDefaults())
+	require.NoError(t, cfg.ApplyDefaults(DefaultGlobalConfig))
 	return *cfg
 }

--- a/pkg/prom/instance/instance_integration_test.go
+++ b/pkg/prom/instance/instance_integration_test.go
@@ -65,7 +65,7 @@ name: integration_test
 scrape_configs: []
 remote_write: []
 `)
-	inst, err := New(prometheus.NewRegistry(), DefaultGlobalConfig, initialConfig, walDir, logger)
+	inst, err := New(prometheus.NewRegistry(), initialConfig, walDir, logger)
 	require.NoError(t, err)
 
 	instCtx, cancel := context.WithCancel(context.Background())
@@ -131,7 +131,7 @@ name: integration_test
 scrape_configs: []
 remote_write: []
 `)
-	inst, err := New(prometheus.NewRegistry(), DefaultGlobalConfig, initialConfig, walDir, logger)
+	inst, err := New(prometheus.NewRegistry(), initialConfig, walDir, logger)
 	require.NoError(t, err)
 
 	instCtx, cancel := context.WithCancel(context.Background())
@@ -184,7 +184,7 @@ name: integration_test
 scrape_configs: []
 remote_write: []
 `)
-	inst, err := New(prometheus.NewRegistry(), DefaultGlobalConfig, initialConfig, walDir, logger)
+	inst, err := New(prometheus.NewRegistry(), initialConfig, walDir, logger)
 	require.NoError(t, err)
 
 	instCtx, cancel := context.WithCancel(context.Background())
@@ -250,6 +250,6 @@ remote_write: []
 func loadConfig(t *testing.T, s string) Config {
 	cfg, err := UnmarshalConfig(strings.NewReader(s))
 	require.NoError(t, err)
-	require.NoError(t, cfg.ApplyDefaults(&DefaultGlobalConfig))
+	require.NoError(t, cfg.ApplyDefaults())
 	return *cfg
 }

--- a/pkg/prom/instance/instance_test.go
+++ b/pkg/prom/instance/instance_test.go
@@ -40,7 +40,7 @@ remote_write:
 	cfg, err := UnmarshalConfig(strings.NewReader(cfgText))
 	require.NoError(t, err)
 
-	err = cfg.ApplyDefaults()
+	err = cfg.ApplyDefaults(global)
 	require.NoError(t, err)
 
 	require.Equal(t, DefaultConfig.HostFilter, cfg.HostFilter)
@@ -161,7 +161,7 @@ func TestConfig_ApplyDefaults_Validations(t *testing.T) {
 				tc.mutation(&input)
 			}
 
-			err := input.ApplyDefaults()
+			err := input.ApplyDefaults(global)
 			if tc.err == nil {
 				require.NoError(t, err)
 			} else {
@@ -181,7 +181,7 @@ remote_write:
 
 	cfg, err := UnmarshalConfig(strings.NewReader(cfgText))
 	require.NoError(t, err)
-	require.NoError(t, cfg.ApplyDefaults())
+	require.NoError(t, cfg.ApplyDefaults(DefaultGlobalConfig))
 	require.NotEmpty(t, cfg.RemoteWrite[0].Name)
 }
 
@@ -397,7 +397,7 @@ func getTestConfig(t *testing.T, global *GlobalConfig, scrapeAddr string) Config
 	cfg := DefaultConfig
 	cfg.Name = "test"
 	cfg.ScrapeConfigs = []*config.ScrapeConfig{&scrapeCfg}
-	cfg.Global = *global
+	cfg.global = *global
 
 	return cfg
 }


### PR DESCRIPTION
This PR fixes an issue where the global settings were not being read by instances when reloading. This was because the global settings were passed to the constructor of instances, but never updated when applying the new instance settings.

This could be reproduced by adding a new external_label and reloading the config. The new label will not be present on newer sent metrics. 

This PR fixes that problem by adding the global config to be a part of the instance config struct. It cannot be marshaled into the instance, and must be set manually by the code before applying the changes.

There are two code paths to consider here:

1. The scraping service will re-read the global config on the next reshard tick.
2. Non-scraping service will apply the global config as soon as the new config is read in.

This also changes the group manager to ensure the global settings are kept when creating a group.