### PR TITLE
update cortex for example/docker-compose and example/k3d to use blocks

### DIFF
--- a/example/docker-compose/cortex/config/cortex.yaml
+++ b/example/docker-compose/cortex/config/cortex.yaml
@@ -17,12 +17,12 @@ ingester_client:
   grpc_client_config:
     max_recv_msg_size: 104857600
     max_send_msg_size: 104857600
-    use_gzip_compression: true
+    grpc_compression: gzip
 
 ingester:
   lifecycler:
     join_after: 0
-    claim_on_rollout: false
+    min_ready_duration: 0s
     final_sleep: 0s
     num_tokens: 512
 
@@ -31,21 +31,35 @@ ingester:
         store: inmemory
       replication_factor: 1
 
-schema:
-  configs:
-  - from: 2020-02-07
-    store: boltdb
-    object_store: filesystem
-    schema: v10
-    index:
-      prefix: index_
-      period: 168h
-
 storage:
-  boltdb:
-    directory: /tmp/cortex/index
+  engine: blocks
+
+blocks_storage:
+  tsdb:
+    dir: /tmp/cortex/tsdb
+  bucket_store:
+    sync_dir: /tmp/cortex/tsdb-sync
+
+  backend: filesystem
   filesystem:
-    directory: /tmp/cortex/chunks
+    dir: /tmp/cortex/blocks
+
+compactor:
+  data_dir: /tmp/cortex/compactor
+  sharding_ring:
+    kvstore:
+      store: inmemory
+
+frontend_worker:
+  match_max_concurrent: true
+
+ruler:
+  enable_api: true
+  enable_sharding: false
+  storage:
+    type: local
+    local:
+      directory: /tmp/cortex/rules
 
 limits:
   ingestion_rate: 250000

--- a/example/docker-compose/docker-compose.integrations.yaml
+++ b/example/docker-compose/docker-compose.integrations.yaml
@@ -5,7 +5,7 @@
 #
 # that enable local testing of all components of the Agent.
 #
-# The agent/config/agent-local.yaml file holds a config to 
+# The agent/config/agent-local.yaml file holds a config to
 # scrape all of these services.
 version: "2"
 services:
@@ -15,7 +15,7 @@ services:
   #
 
   grafana:
-    image: grafana/grafana:6.6.1
+    image: grafana/grafana:7.5.4
     entrypoint:
       - /usr/share/grafana/bin/grafana-server
       - --homepath=/usr/share/grafana
@@ -33,7 +33,7 @@ services:
   #
 
   cortex:
-    image: cortexproject/cortex:v0.6.1
+    image: cortexproject/cortex:v1.8.1
     volumes:
       - /tmp/cortex:/tmp/cortex
       - ./cortex/config:/etc/cortex-config

--- a/example/docker-compose/docker-compose.scraping-service.yaml
+++ b/example/docker-compose/docker-compose.scraping-service.yaml
@@ -46,7 +46,7 @@ services:
       - --log-level=info
 
   cortex:
-    image: cortexproject/cortex:v0.6.1
+    image: cortexproject/cortex:v1.8.1
     volumes:
       - /tmp/cortex:/tmp/cortex
       - ./cortex/config:/etc/cortex-config
@@ -57,7 +57,7 @@ services:
       - "9009:9009"
 
   grafana:
-    image: grafana/grafana:6.6.1
+    image: grafana/grafana:7.5.4
     entrypoint:
       - /usr/share/grafana/bin/grafana-server
       - --homepath=/usr/share/grafana

--- a/example/docker-compose/docker-compose.yaml
+++ b/example/docker-compose/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
     command: -config.file=/etc/loki/local-config.yaml
 
   cortex:
-    image: cortexproject/cortex:v0.6.1
+    image: cortexproject/cortex:v1.8.1
     volumes:
       - /tmp/cortex:/tmp/cortex
       - ./cortex/config:/etc/cortex-config
@@ -46,9 +46,9 @@ services:
   # tracing backend
   tempo:
     image: grafana/tempo:df7225ae
-    command: 
+    command:
       - "-storage.trace.backend=local"                  # tell tempo where to permanently put traces
-      - "-storage.trace.local.path=/tmp/tempo/traces"   
+      - "-storage.trace.local.path=/tmp/tempo/traces"
       - "-storage.trace.wal.path=/tmp/tempo/wal"        # tell tempo where to store the wal
       - "-auth.enabled=false"                           # disables the requirement for the X-Scope-OrgID header
       - "-server.http-listen-port=3200"

--- a/example/k3d/lib/cortex/cortex-config.libsonnet
+++ b/example/k3d/lib/cortex/cortex-config.libsonnet
@@ -22,14 +22,14 @@
     grpc_client_config: {
       max_recv_msg_size: 104857600,
       max_send_msg_size: 104857600,
-      use_gzip_compression: true,
+      grpc_compression: 'gzip',
     },
   },
 
   ingester: {
     lifecycler: {
       join_after: 0,
-      claim_on_rollout: false,
+      min_ready_duration: '0s',
       final_sleep: '0s',
       num_tokens: 512,
 
@@ -42,25 +42,45 @@
     },
   },
 
-  schema: {
-    configs: [{
-      from: '2020-02-07',
-      store: 'boltdb',
-      object_store: 'filesystem',
-      schema: 'v10',
-      index: {
-        prefix: 'index_',
-        period: '168h',
-      },
-    }],
+  storage: {
+    engine: 'blocks',
   },
 
-  storage: {
-    boltdb: {
-      directory: '/tmp/cortex/index',
+  blocks_storage: {
+    tsdb: {
+      dir: '/tmp/cortex/tsdb',
     },
+    bucket_store: {
+      sync_dir: '/tmp/cortex/tsdb-sync',
+    },
+
+    backend: 'filesystem',
     filesystem: {
-      directory: '/tmp/cortex/chunks',
+      dir: '/tmp/cortex/blocks',
+    },
+  },
+
+  compactor: {
+    data_dir: '/tmp/cortex/compactor',
+    sharding_ring: {
+      kvstore: {
+        store: 'inmemory',
+      },
+    },
+  },
+
+  frontend_worker: {
+    match_max_concurrent: true,
+  },
+
+  ruler: {
+    enable_api: true,
+    enable_sharding: false,
+    storage: {
+      type: 'local',
+      'local': {
+        directory: '/tmp/cortex/rules',
+      },
     },
   },
 

--- a/example/k3d/lib/cortex/main.libsonnet
+++ b/example/k3d/lib/cortex/main.libsonnet
@@ -14,7 +14,7 @@ local volume = k.core.v1.volume;
     local this = self,
 
     _images:: {
-      cortex: 'cortexproject/cortex:v0.6.1',
+      cortex: 'cortexproject/cortex:v1.8.1',
     },
     _config:: (import './cortex-config.libsonnet'),
 


### PR DESCRIPTION
#### PR Description 
Updates from a very old Cortex to the latest one to take advantage of blocks storage. Uses the [example single-process config](https://github.com/cortexproject/cortex/blob/master/docs/configuration/single-process-config-blocks.yaml) for configuring Cortex.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist
I'd consider this an "internal change," so nothing to do here.

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
