### PR TITLE
Retry getting prom instance in Tempo start up

### DIFF
--- a/pkg/tempo/config.go
+++ b/pkg/tempo/config.go
@@ -461,8 +461,9 @@ func (c *InstanceConfig) otelConfig() (*configmodels.Config, error) {
 		if len(c.SpanMetrics.PromInstance) != 0 && len(c.SpanMetrics.HandlerEndpoint) == 0 {
 			exporterName = remotewriteexporter.TypeStr
 			exporters[remotewriteexporter.TypeStr] = map[string]interface{}{
-				"namespace":    namespace,
-				"const_labels": c.SpanMetrics.ConstLabels,
+				"namespace":     namespace,
+				"const_labels":  c.SpanMetrics.ConstLabels,
+				"prom_instance": c.SpanMetrics.PromInstance,
 			}
 		} else if len(c.SpanMetrics.PromInstance) == 0 && len(c.SpanMetrics.HandlerEndpoint) != 0 {
 			exporterName = "prometheus"

--- a/pkg/tempo/config_test.go
+++ b/pkg/tempo/config_test.go
@@ -463,6 +463,7 @@ exporters:
       max_elapsed_time: 60s
   remote_write:
     namespace: tempo_spanmetrics
+    prom_instance: tempo
 processors:
   spanmetrics:
     metrics_exporter: remote_write

--- a/pkg/tempo/remotewriteexporter/factory.go
+++ b/pkg/tempo/remotewriteexporter/factory.go
@@ -18,8 +18,9 @@ const (
 type Config struct {
 	configmodels.ProcessorSettings `mapstructure:",squash"`
 
-	ConstLabels labels.Labels `mapstructure:"const_labels"`
-	Namespace   string        `mapstructure:"namespace"`
+	ConstLabels  labels.Labels `mapstructure:"const_labels"`
+	Namespace    string        `mapstructure:"namespace"`
+	PromInstance string        `mapstructure:"prom_instance"`
 }
 
 // NewFactory returns a new factory for the Attributes processor.


### PR DESCRIPTION
#### PR Description 

Fixes a race condition where the agent will fail to boot if the prometheus
instance that it's set to use to remote write metrics in the tracing
pipeline is not ready yet.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
