### PR TITLE
Prepare for 0.14.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-NOTE: FreeBSD builds have not been available since v0.6.0 due to a
-cross-compilation issue, but will return in v0.13.0.
-
 # Main (unreleased)
 
 - [BUGFIX] Fixed issue where automatic logging double logged "svc". (@joe-elliott)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,67 +5,18 @@ cross-compilation issue, but will return in v0.13.0.
 
 - [BUGFIX] Fixed issue where automatic logging double logged "svc". (@joe-elliott)
 
-# 0.14.0-rc.4 (2021-05-03)
+# v0.14.0 (2021-05-19)
 
-BREAKING CHANGES: For security, the scraping service config API will reject
+BREAKING CHANGE: This release has a breaking change for SigV4 support. Please
+read the release notes carefully and our [migration
+guide](./docs/migration-guide.md) to help migrate your configuration files to
+the new format.
+
+BREAKING CHANGE: For security, the scraping service config API will reject
 configs that read credentials from disk to prevent malicious users from reading
 artbirary files and sending their contents over the network. The old behavior
 can be achieved by enabling `dangerous_allow_reading_files` in the scraping
 service config.
-
-- [FEATURE] Added Automatic Logging feature for Tempo (@joe-elliott)
-
-- [FEATURE] Disallow reading files from within scraping service configs by
-  default. (@rfratto)
-  
-- [FEATURE] Add remote write for span metrics (@mapno)
-
-- [ENHANCEMENT] Add silent uninstall to Windows Uninstaller. (@mattdurham)
-
-- [BUGFIX] Ensure defaults are applied to undefined sections in config file.
-  This fixes a problem where integrations didn't work if `prometheus:` wasn't
-  configured. (@rfratto)
-
-- [BUGFIX]  Use 64 bit Program Files when installing on Windows. (@mattdurham)
-
-- [BUGFIX] Re-read `prometheus.global` settings when calling /-/reload.
-  (@rfratto)
-  
-# 0.14.0-rc.3 (2021-04-15)
-
-- [ENHANCEMENT] Add  `headers` field in `remote_write` config for Tempo. `headers`
-  specifies HTTP headers to forward to the remote endpoint. (@alexbiehl)
-- [CHANGE] Add `tempo_spanmetrics` namespace in spanmetrics (@mapno)
-
-- [BUGFIX] Grafana Agent running as a Windows service should start automatically on startup
-  (@mattdurham)
-
-- [BUGFIX] Validate that incoming scraped metrics do not have an empty label
-  set or a label set with duplicate labels, mirroring the behavior of
-  Prometheus. (@rfratto)
-
-- [FEATURE] Tail-based sampling for tracing pipelines (@mapno)
-
-# v0.13.1 (2021-04-09)
-
-- [BUGFIX] Validate that incoming scraped metrics do not have an empty label
-  set or a label set with duplicate labels, mirroring the behavior of
-  Prometheus. (@rfratto)
-
-# 0.14.0-rc.2 (2021-04-08)
-
-- [BUGFIX] Include Windows Installer when building for release (@mattdurham)
-
-# 0.14.0-rc.1 (2021-04-08)
-
-(No changes from 0.14.0-rc.0)
-
-# 0.14.0-rc.0 (2021-04-07)
-
-BREAKING CHANGES: This release has a breaking change for SigV4 support. Please
-read the release notes carefully and our [migration
-guide](./docs/migration-guide.md) to help migrate your configuration files to
-the new format.
 
 As of this release, functionality that is not recommended for production use
 and is expected to change will be tagged interchangably as "experimental" or
@@ -95,6 +46,15 @@ and is expected to change will be tagged interchangably as "experimental" or
 - [FEATURE] (beta) Support generating metrics and exposing them via a Prometheus exporter
   from span data. (@yeya24)
 
+- [FEATURE] Tail-based sampling for tracing pipelines (@mapno)
+
+- [FEATURE] Added Automatic Logging feature for Tempo (@joe-elliott)
+
+- [FEATURE] Disallow reading files from within scraping service configs by
+  default. (@rfratto)
+
+- [FEATURE] Add remote write for span metrics (@mapno)
+
 - [ENHANCEMENT] Support compression for trace export. (@mdisibio)
 
 - [ENHANCEMENT] Add global remote_write configuration that is shared between all
@@ -103,6 +63,17 @@ and is expected to change will be tagged interchangably as "experimental" or
 - [ENHANCEMENT] Go 1.16 is now used for all builds of the Agent. (@rfratto)
 
 - [ENHANCEMENT] Update Prometheus dependency to v2.26.0. (@rfratto)
+
+- [ENHANCEMENT] Upgrade `go.opentelemetry.io/collector` to v0.21.0 (@mapno)
+
+- [ENHANCEMENT] Add kafka trace receiver (@mapno)
+
+- [ENHANCEMENT] Support mirroring a trace pipeline to multiple backends (@mapno)
+
+- [ENHANCEMENT] Add  `headers` field in `remote_write` config for Tempo. `headers`
+  specifies HTTP headers to forward to the remote endpoint. (@alexbiehl)
+
+- [ENHANCEMENT] Add silent uninstall to Windows Uninstaller. (@mattdurham)
 
 - [BUGFIX] Native Darwin arm64 builds will no longer crash when writing metrics
   to the WAL. (@rfratto)
@@ -113,6 +84,10 @@ and is expected to change will be tagged interchangably as "experimental" or
 - [BUGFIX] Bring back FreeBSD support. (@rfratto)
 
 - [BUGFIX] agentctl will no longer leak WAL resources when retrieving WAL stats. (@rfratto)
+
+- [BUGFIX] Ensure defaults are applied to undefined sections in config file.
+  This fixes a problem where integrations didn't work if `prometheus:` wasn't
+  configured. (@rfratto)
 
 - [CHANGE] The Grafana Cloud Agent has been renamed to the Grafana Agent.
   (@rfratto)
@@ -125,14 +100,16 @@ and is expected to change will be tagged interchangably as "experimental" or
 - [CHANGE] The User-Agent header sent for logs will now be
   `GrafanaAgent/<version>` (@rfratto)
 
-- [ENHANCEMENT] Upgrade `go.opentelemetry.io/collector` to v0.21.0 (@mapno)
-
-- [ENHANCEMENT] Add kafka trace receiver (@mapno)
-
-- [ENHANCEMENT] Support mirroring a trace pipeline to multiple backends (@mapno)
+- [CHANGE] Add `tempo_spanmetrics` namespace in spanmetrics (@mapno)
 
 - [DEPRECATION] `push_config` is now supplanted by `remote_block` and `batch`.
   `push_config` will be removed in a future version (@mapno)
+
+# v0.13.1 (2021-04-09)
+
+- [BUGFIX] Validate that incoming scraped metrics do not have an empty label
+  set or a label set with duplicate labels, mirroring the behavior of
+  Prometheus. (@rfratto)
 
 # v0.13.0 (2021-02-25)
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -2113,7 +2113,7 @@ spanmetrics:
   [ namespace: <string> ]
   # prom_instance is the prometheus used to remote write metrics.
   [ prom_instance: <string> ]
-  # handler_endpoint defines the endpoint where the OTel prometheus exporter will be exposed. 
+  # handler_endpoint defines the endpoint where the OTel prometheus exporter will be exposed.
   [ handler_endpoint: <string> ]
 
 # tail_sampling supports tail-based sampling of traces in the agent.
@@ -2310,7 +2310,7 @@ docker run \
   -v "/proc:/host/proc:ro,rslave" \
   -v /tmp/agent:/etc/agent \
   -v /path/to/config.yaml:/etc/agent-config/agent.yaml \
-  grafana/agent:v0.13.1 \
+  grafana/agent:v0.14.0 \
   --config.file=/etc/agent-config/agent.yaml
 ```
 
@@ -2350,7 +2350,7 @@ metadata:
   name: agent
 spec:
   containers:
-  - image: grafana/agent:v0.13.1
+  - image: grafana/agent:v0.14.0
     name: agent
     args:
     - --config.file=/etc/agent-config/agent.yaml
@@ -2619,7 +2619,7 @@ docker run \
   -v "/proc:/proc:ro" \
   -v /tmp/agent:/etc/agent \
   -v /path/to/config.yaml:/etc/agent-config/agent.yaml \
-  grafana/agent:v0.13.1 \
+  grafana/agent:v0.14.0 \
   --config.file=/etc/agent-config/agent.yaml
 ```
 
@@ -2636,7 +2636,7 @@ metadata:
   name: agent
 spec:
   containers:
-  - image: grafana/agent:v0.13.1
+  - image: grafana/agent:v0.14.0
     name: agent
     args:
     - --config.file=/etc/agent-config/agent.yaml

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,7 +47,7 @@ Currently, there are five ways to install the agent:
 ### Docker Container
 
 ```
-docker pull grafana/agent:v0.13.1
+docker pull grafana/agent:v0.14.0
 ```
 
 ### Kubernetes Install Script
@@ -283,7 +283,7 @@ path of your Agent's YAML configuration file.
 docker run \
   -v /tmp/agent:/etc/agent \
   -v /path/to/config.yaml:/etc/agent/agent.yaml \
-  grafana/agent:v0.13.1
+  grafana/agent:v0.14.0
 ```
 
 ### Locally

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -3,45 +3,6 @@
 This is a guide detailing all breaking changes that have happened in prior
 releases and how to migrate to newer versions.
 
-# Unreleased
-
-## Span metrics exporter changes
-
-Remote write exporting support has been added to span metrics in the tracing
-pipeline. To make configuration more clear and reduce boilerplate between
-both exporter configurations (i.e. remote write and prometheus), the config has
-been slightly modified.
-
-The `metrics_exporter` block indentation has been removed and `endpoint` has been
-changed to `handler_endpoint`. Also, `send_timestamps` has been removed.
-
-Example old config:
-
-```yaml
-tempo:
-  configs:
-    - name: default
-      spanmetrics:
-        metrics_exporter:
-          endpoint: 0.0.0.0:8889
-          namespace: example
-          const_labels:
-            key: value
-```
-
-Example new config:
-
-```yaml
-tempo:
-  configs:
-    - name: default
-      spanmetrics:
-        handler_endpoint: 0.0.0.0:8889
-        namespace: example
-        const_labels:
-          key: value
-```
-
 # v0.14.0
 
 ## Scraping Service security change

--- a/production/README.md
+++ b/production/README.md
@@ -42,7 +42,7 @@ docker run \
   -v /tmp/agent:/etc/agent \
   -v /path/to/config.yaml:/etc/agent-config/agent.yaml \
   --entrypoint "/bin/agent -config.file=/etc/agent-config/agent.yaml -prometheus.wal-directory=/etc/agent/data"
-  grafana/agent:v0.13.1
+  grafana/agent:v0.14.0
 ```
 
 ## Running the Agent locally

--- a/production/grafanacloud-install.sh
+++ b/production/grafanacloud-install.sh
@@ -47,7 +47,7 @@ PACKAGE_SYSTEM=${PACKAGE_SYSTEM:=}
 #
 # Global constants.
 #
-RELEASE_VERSION="0.13.1"
+RELEASE_VERSION="0.14.0"
 
 RELEASE_URL="https://github.com/grafana/agent/releases/download/v${RELEASE_VERSION}"
 DEB_URL="${RELEASE_URL}/grafana-agent-${RELEASE_VERSION}-1.${ARCH}.deb"

--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -61,7 +61,7 @@ spec:
         - -config.file=/etc/agent/agent.yaml
         command:
         - /bin/agent
-        image: grafana/agent:v0.13.1
+        image: grafana/agent:v0.14.0
         imagePullPolicy: IfNotPresent
         name: agent
         ports:

--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -328,7 +328,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.13.1
+        image: grafana/agent:v0.14.0
         imagePullPolicy: IfNotPresent
         name: agent
         ports:

--- a/production/kubernetes/agent-sigv4.yaml
+++ b/production/kubernetes/agent-sigv4.yaml
@@ -278,7 +278,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.13.1
+        image: grafana/agent:v0.14.0
         imagePullPolicy: IfNotPresent
         name: agent
         ports:
@@ -329,7 +329,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.13.1
+        image: grafana/agent:v0.14.0
         imagePullPolicy: IfNotPresent
         name: agent
         ports:

--- a/production/kubernetes/agent-tempo.yaml
+++ b/production/kubernetes/agent-tempo.yaml
@@ -169,7 +169,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.13.1
+        image: grafana/agent:v0.14.0
         imagePullPolicy: IfNotPresent
         name: agent
         ports:

--- a/production/kubernetes/agent.yaml
+++ b/production/kubernetes/agent.yaml
@@ -278,7 +278,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.13.1
+        image: grafana/agent:v0.14.0
         imagePullPolicy: IfNotPresent
         name: agent
         ports:
@@ -329,7 +329,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.13.1
+        image: grafana/agent:v0.14.0
         imagePullPolicy: IfNotPresent
         name: agent
         ports:

--- a/production/kubernetes/build/lib/version.libsonnet
+++ b/production/kubernetes/build/lib/version.libsonnet
@@ -1,1 +1,1 @@
-'grafana/agent:v0.13.1'
+'grafana/agent:v0.14.0'

--- a/production/kubernetes/install-bare.sh
+++ b/production/kubernetes/install-bare.sh
@@ -17,7 +17,7 @@ check_installed() {
 check_installed curl
 check_installed envsubst
 
-MANIFEST_BRANCH=v0.13.1
+MANIFEST_BRANCH=v0.14.0
 MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent-bare.yaml}
 NAMESPACE=${NAMESPACE:-default}
 

--- a/production/kubernetes/install-loki.sh
+++ b/production/kubernetes/install-loki.sh
@@ -31,7 +31,7 @@ check_installed() {
 check_installed curl
 check_installed envsubst
 
-MANIFEST_BRANCH=v0.13.1
+MANIFEST_BRANCH=v0.14.0
 MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent-loki.yaml}
 NAMESPACE=${NAMESPACE:-default}
 

--- a/production/kubernetes/install-sigv4.sh
+++ b/production/kubernetes/install-sigv4.sh
@@ -30,7 +30,7 @@ check_installed() {
 check_installed curl
 check_installed envsubst
 
-MANIFEST_BRANCH=v0.13.1
+MANIFEST_BRANCH=v0.14.0
 MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent-sigv4.yaml}
 NAMESPACE=${NAMESPACE:-default}
 ROLE_ARN=${ROLE_ARN:-}

--- a/production/kubernetes/install-tempo.sh
+++ b/production/kubernetes/install-tempo.sh
@@ -31,7 +31,7 @@ check_installed() {
 check_installed curl
 check_installed envsubst
 
-MANIFEST_BRANCH=v0.13.1
+MANIFEST_BRANCH=v0.14.0
 MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent-tempo.yaml}
 NAMESPACE=${NAMESPACE:-default}
 

--- a/production/kubernetes/install.sh
+++ b/production/kubernetes/install.sh
@@ -32,7 +32,7 @@ check_installed() {
 check_installed curl
 check_installed envsubst
 
-MANIFEST_BRANCH=v0.13.1
+MANIFEST_BRANCH=v0.14.0
 MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent.yaml}
 NAMESPACE=${NAMESPACE:-default}
 

--- a/production/tanka/grafana-agent/v1/main.libsonnet
+++ b/production/tanka/grafana-agent/v1/main.libsonnet
@@ -15,8 +15,8 @@ local service = k.core.v1.service;
 (import './lib/tempo.libsonnet') +
 {
   _images:: {
-    agent: 'grafana/agent:v0.13.1',
-    agentctl: 'grafana/agentctl:v0.13.1',
+    agent: 'grafana/agent:v0.14.0',
+    agentctl: 'grafana/agentctl:v0.14.0',
   },
 
   // new creates a new DaemonSet deployment of the grafana-agent. By default,


### PR DESCRIPTION
I squashed the changelogs from all release candidates, removing bugfixes that only applied to a changed introduced in a previous release candidate. 