### PR TITLE
doc: Correct and simplify "Running the Agent with Docker" example

### DIFF
--- a/production/README.md
+++ b/production/README.md
@@ -39,9 +39,8 @@ directory on your host that you want the agent to store its WAL.
 
 ```
 docker run \
-  -v /tmp/agent:/etc/agent \
-  -v /path/to/config.yaml:/etc/agent-config/agent.yaml \
-  --entrypoint "/bin/agent -config.file=/etc/agent-config/agent.yaml -prometheus.wal-directory=/etc/agent/data"
+  -v /tmp/agent:/etc/agent/data \
+  -v /path/to/config.yaml:/etc/agent/agent.yaml \
   grafana/agent:v0.14.0
 ```
 


### PR DESCRIPTION
#### PR Description 
Fixes the example which currently fails as it tries to execute the entirety of the entrypoint string. It also simplifies the example by mounting the volumes into the places expected by the image cmd.

#### Which issue(s) this PR fixes 
fixes #614
#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
