### PR TITLE
Add missing network options to node_exporter doc

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -2371,6 +2371,9 @@ spec:
     - name: procfs
       mountPath: /host/proc
       readOnly: true
+  hostPID: true
+  hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   volumes:
   - name: rootfs
     hostPath:


### PR DESCRIPTION
#### PR Description 
node_exporter integration doc is missing some parameters that enable the agent to monitor the node network instead of just the pod's

`hostPID: true` is in the upstream node_exporter [doc](https://github.com/prometheus-community/helm-charts/blob/f905bb896007b5fb63cb34e1717865d432cb6547/charts/prometheus-node-exporter/templates/daemonset.yaml#L131)
`hostNetwork: true` so we have access to node network ([doc](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#host-namespaces))
`dnsPolicy: ClusterFirstWithHostNet` so we can still resolve cluster dns names ([doc](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy))

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
