### PR TITLE
Update queue_config defaults in docs to match latest Prometheus defaults

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -1912,13 +1912,13 @@ queue_config:
   # samples from the WAL. It is recommended to have enough capacity in each
   # shard to buffer several requests to keep throughput up while processing
   # occasional slow remote requests.
-  [ capacity: <int> | default = 500 ]
+  [ capacity: <int> | default = 2500 ]
   # Maximum number of shards, i.e. amount of concurrency.
-  [ max_shards: <int> | default = 1000 ]
+  [ max_shards: <int> | default = 200 ]
   # Minimum number of shards, i.e. amount of concurrency.
   [ min_shards: <int> | default = 1 ]
   # Maximum number of samples per send.
-  [ max_samples_per_send: <int> | default = 100]
+  [ max_samples_per_send: <int> | default = 500 ]
   # Maximum time a sample will wait in buffer.
   [ batch_send_deadline: <duration> | default = 5s ]
   # Initial retry delay. Gets doubled for every retry.


### PR DESCRIPTION
#### PR Description 
Prometheus 2.26 updated the queue_config defaults. The values listed in the Agent's configuration reference were for the 2.25 values, and were out of sync with the version of Prometheus being used. 

#### Notes to the Reviewer
(#120 would be nice here)
