### PR TITLE
Improve performance of kubernetes_sd_configs when using host_filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ guide](./docs/migration-guide.md) for details.
 
 - [ENHANCEMENT] Add the option to log to stdout instead of a Loki instance. (@joe-elliott)
 
+- [ENHANCEMENT] Running the Agent as a DaemonSet with host_filter and role: pod
+  should no longer cause unnecessary load against the Kubernetes SD API.
+  (@rfratto)
+
+- [BUGFIX] Host filter relabeling rules should now work. (@rfratto)
+
 - [CHANGE] Intentionally order tracing processors. (@joe-elliott)
 
 # v0.14.0 (2021-05-19)

--- a/pkg/prom/instance/host_filter.go
+++ b/pkg/prom/instance/host_filter.go
@@ -91,6 +91,7 @@ func (f *HostFilter) PatchSD(scrapes []*config.ScrapeConfig) {
 
 }
 
+// SetRelabels updates the relabeling rules used by the HostFilter.
 func (f *HostFilter) SetRelabels(relabels []*relabel.Config) {
 	f.relabelMut.Lock()
 	defer f.relabelMut.Unlock()

--- a/pkg/prom/instance/host_filter.go
+++ b/pkg/prom/instance/host_filter.go
@@ -2,9 +2,13 @@ package instance
 
 import (
 	"context"
+	"fmt"
 	"net"
+	"sync"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/discovery/kubernetes"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/relabel"
@@ -48,7 +52,8 @@ type HostFilter struct {
 	inputCh  GroupChannel
 	outputCh chan map[string][]*targetgroup.Group
 
-	relabels []*relabel.Config
+	relabelMut sync.Mutex
+	relabels   []*relabel.Config
 }
 
 // NewHostFilter creates a new HostFilter.
@@ -58,11 +63,38 @@ func NewHostFilter(host string, relabels []*relabel.Config) *HostFilter {
 		ctx:    ctx,
 		cancel: cancel,
 
-		host: host,
+		host:     host,
+		relabels: relabels,
 
 		outputCh: make(chan map[string][]*targetgroup.Group),
 	}
 	return f
+}
+
+// PatchSD patches services discoveries to optimize performance for host
+// filtering. The discovered targets will be pruned to as close to the set
+// that HostFilter will output as possible.
+func (f *HostFilter) PatchSD(scrapes []*config.ScrapeConfig) {
+	for _, sc := range scrapes {
+		for _, d := range sc.ServiceDiscoveryConfigs {
+			switch d := d.(type) {
+			case *kubernetes.SDConfig:
+				if d.Role == kubernetes.RolePod {
+					d.Selectors = []kubernetes.SelectorConfig{{
+						Role:  kubernetes.RolePod,
+						Field: fmt.Sprintf("spec.nodeName=%s", f.host),
+					}}
+				}
+			}
+		}
+	}
+
+}
+
+func (f *HostFilter) SetRelabels(relabels []*relabel.Config) {
+	f.relabelMut.Lock()
+	defer f.relabelMut.Unlock()
+	f.relabels = relabels
 }
 
 // Run starts the HostFilter. It only exits when the HostFilter is stopped.
@@ -77,7 +109,11 @@ func (f *HostFilter) Run(syncCh GroupChannel) {
 		case <-f.ctx.Done():
 			return
 		case data := <-f.inputCh:
-			f.outputCh <- FilterGroups(data, f.host, f.relabels)
+			f.relabelMut.Lock()
+			relabels := f.relabels
+			f.relabelMut.Unlock()
+
+			f.outputCh <- FilterGroups(data, f.host, relabels)
 		}
 	}
 }

--- a/pkg/prom/instance/host_filter_test.go
+++ b/pkg/prom/instance/host_filter_test.go
@@ -190,5 +190,6 @@ func TestHostFilter_PatchSD(t *testing.T) {
 	NewHostFilter("myhost", nil).PatchSD(input)
 
 	output, err := yaml.Marshal(input)
+	require.NoError(t, err)
 	require.YAMLEq(t, expect, string(output))
 }


### PR DESCRIPTION
#### PR Description 
This change introduces a patching mechanism for `scrape_configs` to make performance-related tweaks for host filtering. The first performance tweak is to add a selector for `role: pod` to only look for pods on the same node as the Agent. 

This code is heavily inspired by (copied from) [Promtail](https://github.com/grafana/loki/blob/966bed72d3247a15c7f94a14ca13b536edb30f74/clients/pkg/promtail/targets/file/filetargetmanager.go#L95-L105).

#### Which issue(s) this PR fixes 
Fixes #48. 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
