### PR TITLE
Display specific error messages when cloud-config fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - [FEATURE] (beta) A Grafana Agent Operator is now available. (@rfratto)
 
+- [ENHANCEMENT] Error messages when installing the Grafana Agent for Grafana
+  Cloud will now be shown. (@rfratto)
+
 # v0.15.0 (2021-06-03)
 
 BREAKING CHANGE: Configuration of Tempo Autologging changed in this release.

--- a/pkg/client/grafanacloud/client.go
+++ b/pkg/client/grafanacloud/client.go
@@ -49,10 +49,6 @@ func (c *Client) AgentConfig(ctx context.Context, stackID string) (string, error
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("unexpected status code %d", resp.StatusCode)
-	}
-
 	// Even though the API returns json, we'll parse it as YAML here so we can
 	// re-encode it with the same order it was decoded in.
 	payload := struct {
@@ -62,7 +58,12 @@ func (c *Client) AgentConfig(ctx context.Context, stackID string) (string, error
 	}{}
 
 	dec := yaml.NewDecoder(resp.Body)
+	dec.SetStrict(true)
 	if err := dec.Decode(&payload); err != nil {
+		if resp.StatusCode != 200 {
+			return "", fmt.Errorf("unexpected status code %d", resp.StatusCode)
+		}
+
 		return "", fmt.Errorf("failed to read response: %w", err)
 	}
 

--- a/pkg/client/grafanacloud/client_test.go
+++ b/pkg/client/grafanacloud/client_test.go
@@ -69,6 +69,7 @@ func TestClient_AgentConfig_Error(t *testing.T) {
 
 func TestClient_AgentConfig_ErrorMessage(t *testing.T) {
 	httpClient := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
 		_, err := w.Write([]byte(`{
 			"status": "error",
 			"error": "Something went wrong"


### PR DESCRIPTION
#### PR Description 
Changes the cloud-config command to attempt parsing the response body before returning an error that the response code was unexpected. 

#### Which issue(s) this PR fixes 
Fixes #360 
Closes #629 (dupe of #360)

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
