### PR TITLE
Include agent-operator as a release asset

### DIFF
--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -60,3 +60,22 @@ jobs:
 
     - name: Make Containers
       run: CROSS_BUILD=true RELEASE_BUILD=true make agentctl-image
+  agent-operator-container:
+    name: Build agent-operator Container
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Login to Docker Hub
+      run: docker login -u '${{ secrets.DOCKER_USER }}' -p '${{ secrets.DOCKER_PASS }}'
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Make Containers
+      run: CROSS_BUILD=true RELEASE_BUILD=true make agent-operator-image

--- a/.github/workflows/force_release.yml
+++ b/.github/workflows/force_release.yml
@@ -78,6 +78,32 @@ jobs:
       run: |
         export RELEASE_TAG=${{ github.event.inputs.tag }}
         CROSS_BUILD=true RELEASE_BUILD=true make agentctl-image
+  agent-operator-container:
+    name: Build agent-operator Container
+    runs-on: Linux
+    needs: test
+    steps:
+    - name: Get build dependencies
+      run: sudo apt-get update && sudo apt-get install binfmt-support qemu-user-static
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        ref: '${{ github.event.inputs.tag }}'
+
+    - name: Login to Docker Hub
+      run: docker login -u '${{ secrets.DOCKER_USER }}' -p '${{ secrets.DOCKER_PASS }}'
+
+    - name: Prepare buildx
+      run: |
+        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        docker buildx create --name builder --node builder --driver docker-container --use
+        docker buildx inspect --bootstrap
+
+    - name: Build container
+      run: |
+        export RELEASE_TAG=${{ github.event.inputs.tag }}
+        CROSS_BUILD=true RELEASE_BUILD=true make agent-operator-image
   release:
     name: Release
     needs: test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,30 @@ jobs:
       run: |
         export RELEASE_TAG=${GITHUB_REF##*/}
         CROSS_BUILD=true RELEASE_BUILD=true make agentctl-image
+  agent-operator-container:
+    name: Build agent-operator Container
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+    - name: Get build dependencies
+      run: sudo apt-get update && sudo apt-get install binfmt-support qemu-user-static
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Login to Docker Hub
+      run: docker login -u '${{ secrets.DOCKER_USER }}' -p '${{ secrets.DOCKER_PASS }}'
+
+    - name: Prepare buildx
+      run: |
+        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        docker buildx create --name builder --driver docker-container --use
+        docker buildx inspect --bootstrap
+
+    - name: Build container
+      run: |
+        export RELEASE_TAG=${GITHUB_REF##*/}
+        CROSS_BUILD=true RELEASE_BUILD=true make agent-operator-image
   release:
     name: Release
     needs: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Build
-      run: make cmd/agent/agent cmd/agentctl/agentctl
+      run: make cmd/agent/agent cmd/agentctl/agentctl cmd/agent-operator/agent-operator
     - name: Test
       run: make test
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ cover*.out
 
 cmd/agent/agent
 cmd/agentctl/agentctl
+cmd/agent-operator/agent-operator
 dist/
 
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,7 @@ endif
 all: protos agent agentctl
 agent: cmd/agent/agent
 agentctl: cmd/agentctl/agentctl
+agent-operator: cmd/agent-operator/agent-operator
 
 cmd/agent/agent: check-seego cmd/agent/main.go
 ifeq ($(CROSS_BUILD),false)
@@ -153,11 +154,22 @@ else
 endif
 	$(NETGO_CHECK)
 
+cmd/agent-operator/agent-operator: cmd/agent-operator/main.go
+ifeq ($(CROSS_BUILD),false)
+	CGO_ENABLED=0 go build $(GO_FLAGS) -o $@ ./$(@D)
+else
+	GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOARM) CGO_ENABLED=0 go build $(GO_FLAGS) -o $@ ./$(@D)
+endif
+	$(NETGO_CHECK)
+
 agent-image:
 	$(docker-build) -t $(IMAGE_PREFIX)/agent:latest -t $(IMAGE_PREFIX)/agent:$(IMAGE_TAG) -f cmd/agent/$(DOCKERFILE) .
 
 agentctl-image:
 	$(docker-build) -t $(IMAGE_PREFIX)/agentctl:latest -t $(IMAGE_PREFIX)/agentctl:$(IMAGE_TAG) -f cmd/agentctl/$(DOCKERFILE) .
+
+agent-operator-image:
+	$(docker-build) -t $(IMAGE_PREFIX)/agent-operator:latest -t $(IMAGE_PREFIX)/agent-operator:$(IMAGE_TAG) -f cmd/agent-operator/$(DOCKERFILE) .
 
 install:
 	CGO_ENABLED=1 go install $(CGO_FLAGS) ./cmd/agent

--- a/cmd/agent-operator/Dockerfile
+++ b/cmd/agent-operator/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.16-buster as build
+COPY . /src/agent
+WORKDIR /src/agent
+ARG RELEASE_BUILD=false
+ARG IMAGE_TAG
+
+RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agent-operator
+
+FROM debian:buster-slim
+
+RUN apt-get update && \
+  apt-get install -qy tzdata ca-certificates && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=build /src/agent/cmd/agent-operator/agent-operator /bin/agent-operator
+
+ENTRYPOINT ["/bin/agent-operator"]

--- a/cmd/agent-operator/Dockerfile.buildx
+++ b/cmd/agent-operator/Dockerfile.buildx
@@ -1,0 +1,20 @@
+FROM --platform=$BUILDPLATFORM golang:1.16-buster as build
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+COPY . /src/agent
+WORKDIR /src/agent
+ARG RELEASE_BUILD=true
+ARG IMAGE_TAG
+
+RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agent-operator
+
+FROM debian:buster-slim
+
+RUN apt-get update && \
+  apt-get install -qy tzdata ca-certificates && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=build /src/agent/cmd/agent-operator/agent-operator /bin/agent-operator
+
+ENTRYPOINT ["/bin/agent-operator"]

--- a/tools/release-note.md
+++ b/tools/release-note.md
@@ -1,25 +1,18 @@
 This is release `${RELEASE_TAG}` of the Grafana Agent.
 
 ### Upgrading
-Read the
-[migration guide](https://github.com/grafana/agent/blob/${RELEASE_TAG}/docs/migration-guide.md)
-for specific instructions on upgrading from older versions.
+Read the [migration guide](https://github.com/grafana/agent/blob/${RELEASE_TAG}/docs/migration-guide.md) for specific instructions on upgrading from older versions.
 
 ### Notable changes:
 :warning: **ADD RELEASE NOTES HERE** :warning:
 
 
 ### Installation:
-Grafana Agent is currently distributed in plain binary form, Docker
-container images, and a Kubernetes install script. Choose whichever fits your
-use-case best.
+Grafana Agent is currently distributed in plain binary form, Docker container images, and a Kubernetes install script. Choose whichever fits your use-case best.
 
 #### Kubernetes Install Script
 
-The following scripts will download and install two Kubernetes manifests for the
-Agent. The first manifest collects metrics, the second collects logs, and the
-final collects traces. You will be prompted for input for each manifest. The
-script requires curl and envsubst (GNU gettext).
+The following scripts will download and install two Kubernetes manifests for the Agent. The first manifest collects metrics, the second collects logs, and the final collects traces. You will be prompted for input for each manifest. The script requires curl and envsubst (GNU gettext).
 
 ```
 NAMESPACE="default" /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/agent/${RELEASE_TAG}/production/kubernetes/install.sh)" | kubectl apply -f -
@@ -37,9 +30,7 @@ docker pull "grafana/agent:${RELEASE_TAG}"
 
 #### Binary
 
-We provide precompiled binary executables for the most common operating systems.
-Choose from the assets below for your matching operating system. Example for the
-`linux` operating system on `amd64`:
+We provide precompiled binary executables for the most common operating systems. Choose from the assets below for your matching operating system. Example for the `linux` operating system on `amd64`:
 
 ```bash
 # download the binary
@@ -54,15 +45,13 @@ chmod a+x "agent-linux-amd64"
 
 #### `agentctl`
 
-`agentctl`, a tool for helping you interact with the Agent,
-is available as a Docker image:
+`agentctl`, a tool for helping you interact with the Agent, is available as a Docker image:
 
 ```bash
 docker pull "grafana/agentctl:${RELEASE_TAG}"
 ```
 
-Or as a binary. Like before, choose the assets below that matches your
-operating system. For example, with `linux` on `amd64`:
+Or as a binary. Like before, choose the assets below that matches your operating system. For example, with `linux` on `amd64`:
 
 ```bash
 # download the binary
@@ -73,4 +62,12 @@ unzip "agentctl-linux-amd64.zip"
 
 # make sure it is executable
 chmod a+x "agentctl-linux-amd64"
+```
+
+#### `agent-operator`
+
+`agent-operator`, a Kubernetes Operator for the Grafana Agent, is available only as a Docker image:
+
+```bash
+docker pull "grafana/agent-operator:${RELEASE_TAG}"
 ```

--- a/tools/release-note.md
+++ b/tools/release-note.md
@@ -8,7 +8,7 @@ Read the [migration guide](https://github.com/grafana/agent/blob/${RELEASE_TAG}/
 
 
 ### Installation:
-Grafana Agent is currently distributed in plain binary form, Docker container images, and a Kubernetes install script. Choose whichever fits your use-case best.
+Grafana Agent is currently distributed in plain binary form, Docker container images, a Windows installer, and a Kubernetes install script. Choose whichever fits your use-case best.
 
 #### Kubernetes Install Script
 
@@ -27,6 +27,10 @@ NAMESPACE="default" /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com
 ```bash
 docker pull "grafana/agent:${RELEASE_TAG}"
 ```
+
+#### Windows installer
+
+The Windows installer is provided as a [release asset](https://github.com/grafana/agent/releases/download/${RELEASE_TAG}/grafana-agent-installer.exe) for x64 machines.
 
 #### Binary
 


### PR DESCRIPTION
#### PR Description 
Adds agent-operator as a release asset. This only includes it as a Docker image, since it doesn't make much sense (IMO, at least for now) for it to also be a plain binary, given its intention to run on Kubernetes.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
