### PR TITLE
Adding windows/amd64 into the Docker manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Main (unreleased)
 
+- [FEATURE] windows/amd64 added into the Docker manifest. (@jtyr)
+
 - [FEATURE] (beta) A Grafana Agent Operator is now available. (@rfratto)
 
 - [ENHANCEMENT] Error messages when installing the Grafana Agent for Grafana

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ docker-build = docker build $(DOCKER_BUILD_FLAGS)
 ifeq ($(CROSS_BUILD),true)
 DOCKERFILE = Dockerfile.buildx
 
-docker-build = docker buildx build --push --platform linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7 $(DOCKER_BUILD_FLAGS)
+docker-build = docker buildx build --push --platform linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7,windows/amd64 $(DOCKER_BUILD_FLAGS)
 endif
 
 ifeq ($(BUILD_IN_CONTAINER),false)


### PR DESCRIPTION
#### PR Description 
This PR is adding `windows/amd64` into the Docker manifest so we can use images from Windows nodes.

#### Which issue(s) this PR fixes 
It should fix issue #646.

#### Notes to the Reviewer
N/A

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
