### PR TITLE
Operator: tests and fix various small issues

### DIFF
--- a/pkg/operator/config/config_test.go
+++ b/pkg/operator/config/config_test.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/grafana/agent/pkg/operator/assets"
 	"github.com/grafana/agent/pkg/util"
+	prom_v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s_yaml "sigs.k8s.io/yaml"
 
 	grafana "github.com/grafana/agent/pkg/operator/apis/monitoring/v1alpha1"
@@ -137,3 +139,294 @@ func TestBuildConfig(t *testing.T) {
 		})
 	}
 }
+
+// TestFullConfig tests generation of a config that may be used to collect
+// metrics from Kubernetes.
+func TestFullConfig(t *testing.T) {
+	var store = make(assets.SecretStore)
+
+	input := Deployment{
+		Agent: &grafana.GrafanaAgent{
+			TypeMeta: v1.TypeMeta{
+				APIVersion: "monitoring.grafana.com/v1alpha1",
+				Kind:       "GrafanaAgent",
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "agent",
+				Namespace: "operator",
+				Labels:    map[string]string{"app": "grafana-agent"},
+			},
+			Spec: grafana.GrafanaAgentSpec{
+				Image:              strPointer("grafana/agent:latest"),
+				ServiceAccountName: "agent",
+				Prometheus: grafana.PrometheusSubsystemSpec{
+					InstanceSelector: &v1.LabelSelector{
+						MatchLabels: map[string]string{"agent": "agent"},
+					},
+				},
+			},
+		},
+		Prometheis: []PrometheusInstance{{
+			Instance: &grafana.PrometheusInstance{
+				TypeMeta: v1.TypeMeta{
+					APIVersion: "monitoring.grafana.com/v1alpha1",
+					Kind:       "PrometheusInstance",
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "primary",
+					Namespace: "operator",
+					Labels: map[string]string{
+						"agent": "agent",
+						"app":   "grafana-agent",
+					},
+				},
+				Spec: grafana.PrometheusInstanceSpec{
+					RemoteWrite: []grafana.RemoteWriteSpec{{
+						URL: "http://cortex:80/api/prom/push",
+					}},
+					ServiceMonitorSelector: &v1.LabelSelector{
+						MatchLabels: map[string]string{"instance": "primary"},
+					},
+					PodMonitorSelector: &v1.LabelSelector{
+						MatchLabels: map[string]string{"instance": "primary"},
+					},
+					ProbeSelector: &v1.LabelSelector{
+						MatchLabels: map[string]string{"instance": "primary"},
+					},
+				},
+			},
+
+			ServiceMonitors: []*prom_v1.ServiceMonitor{{
+				TypeMeta: v1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       "ServiceMonitor",
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "kubernetes",
+					Namespace: "default",
+					Labels: map[string]string{
+						"instance": "primary",
+						"app":      "grafana-agent",
+					},
+				},
+				Spec: prom_v1.ServiceMonitorSpec{
+					Selector: v1.LabelSelector{
+						MatchLabels: map[string]string{"component": "apiserver"},
+					},
+					Endpoints: []prom_v1.Endpoint{{
+						Port:   "https",
+						Scheme: "https",
+						TLSConfig: &prom_v1.TLSConfig{
+							SafeTLSConfig: prom_v1.SafeTLSConfig{
+								ServerName: "kubernetes",
+							},
+						},
+						MetricRelabelConfigs: []*prom_v1.RelabelConfig{{
+							SourceLabels: []string{"__name__"},
+							Regex:        "workqueue_queue_duration_seconds_bucket|process_cpu_seconds_total|process_resident_memory_bytes|workqueue_depth|rest_client_request_duration_seconds_bucket|workqueue_adds_total|up|rest_client_requests_total|apiserver_request_total|go_goroutines",
+							Action:       "keep",
+						}},
+					}},
+				},
+			}},
+
+			PodMonitors: []*prom_v1.PodMonitor{{
+				TypeMeta: v1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       "PodMonitor",
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "kubernetes-pods",
+					Namespace: "operator",
+					Labels: map[string]string{
+						"instance": "primary",
+						"app":      "grafana-agent",
+					},
+				},
+				Spec: prom_v1.PodMonitorSpec{
+					NamespaceSelector: prom_v1.NamespaceSelector{Any: true},
+					Selector: v1.LabelSelector{
+						MatchExpressions: []v1.LabelSelectorRequirement{{
+							Key:      "name",
+							Operator: v1.LabelSelectorOpExists,
+						}},
+					},
+					PodMetricsEndpoints: []prom_v1.PodMetricsEndpoint{{
+						Port: ".*-metrics",
+						RelabelConfigs: []*prom_v1.RelabelConfig{
+							{
+								SourceLabels: []string{
+									"__meta_kubernetes_namespace",
+									"__meta_kubernetes_pod_label_name",
+								},
+								Action:      "replace",
+								Separator:   "/",
+								TargetLabel: "job",
+								Replacement: "$1",
+							},
+							{
+								SourceLabels: []string{
+									"__meta_kubernetes_pod_name",
+									"__meta_kubernetes_pod_container_name",
+									"__meta_kubernetes_pod_container_port_name",
+								},
+								Action:      "replace",
+								Separator:   ":",
+								TargetLabel: "instance",
+							},
+						},
+					}},
+				},
+			}},
+		}},
+	}
+
+	expect := util.Untab(`
+server:
+  http_listen_port: 8080
+
+prometheus:
+  wal_directory: /var/lib/grafana-agent/data
+  global:
+    external_labels:
+      __replica__: replica-$(STATEFULSET_ORDINAL_NUMBER)
+      cluster: operator/agent
+  configs:
+  - name: operator/primary
+    remote_write:
+    - url: http://cortex:80/api/prom/push
+    scrape_configs:
+    - honor_labels: false
+      job_name: serviceMonitor/default/kubernetes/0
+      kubernetes_sd_configs:
+      - namespaces:
+          names:
+          - default
+        role: endpoints
+      metric_relabel_configs:
+      - action: keep
+        regex: workqueue_queue_duration_seconds_bucket|process_cpu_seconds_total|process_resident_memory_bytes|workqueue_depth|rest_client_request_duration_seconds_bucket|workqueue_adds_total|up|rest_client_requests_total|apiserver_request_total|go_goroutines
+        source_labels:
+        - __name__
+      relabel_configs:
+      - source_labels:
+        - job
+        target_label: __tmp_prometheus_job_name
+      - action: keep
+        regex: apiserver
+        source_labels:
+        - __meta_kubernetes_service_label_component
+      - action: keep
+        regex: https
+        source_labels:
+        - __meta_kubernetes_endpoint_port_name
+      - regex: Node;(.*)
+        replacement: $1
+        separator: ;
+        source_labels:
+        - __meta_kubernetes_endpoint_address_target_kind
+        - __meta_kubernetes_endpoint_address_target_name
+        target_label: node
+      - regex: Pod;(.*)
+        replacement: $1
+        separator: ;
+        source_labels:
+        - __meta_kubernetes_endpoint_address_target_kind
+        - __meta_kubernetes_endpoint_address_target_name
+        target_label: pod
+      - source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - source_labels:
+        - __meta_kubernetes_service_name
+        target_label: service
+      - source_labels:
+        - __meta_kubernetes_pod_name
+        target_label: pod
+      - source_labels:
+        - __meta_kubernetes_pod_container_name
+        target_label: container
+      - replacement: $1
+        source_labels:
+        - __meta_kubernetes_service_name
+        target_label: job
+      - replacement: https
+        target_label: endpoint
+      - action: hashmod
+        modulus: 1
+        source_labels:
+        - __address__
+        target_label: __tmp_hash
+      - action: keep
+        regex: $(SHARD)
+        source_labels:
+        - __tmp_hash
+      scheme: https
+      tls_config:
+        server_name: kubernetes
+    - honor_labels: false
+      job_name: podMonitor/operator/kubernetes-pods/0
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - job
+        target_label: __tmp_prometheus_job_name
+      - action: keep
+        regex: "true"
+        source_labels:
+        - __meta_kubernetes_pod_labelpresent_name
+      - action: keep
+        regex: .*-metrics
+        source_labels:
+        - __meta_kubernetes_pod_container_port_name
+      - source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - source_labels:
+        - __meta_kubernetes_service_name
+        target_label: service
+      - source_labels:
+        - __meta_kubernetes_pod_name
+        target_label: pod
+      - source_labels:
+        - __meta_kubernetes_pod_container_name
+        target_label: container
+      - replacement: operator/kubernetes-pods
+        target_label: job
+      - replacement: .*-metrics
+        target_label: endpoint
+      - action: replace
+        replacement: $1
+        separator: /
+        source_labels:
+        - __meta_kubernetes_namespace
+        - __meta_kubernetes_pod_label_name
+        target_label: job
+      - action: replace
+        separator: ':'
+        source_labels:
+        - __meta_kubernetes_pod_name
+        - __meta_kubernetes_pod_container_name
+        - __meta_kubernetes_pod_container_port_name
+        target_label: instance
+      - action: hashmod
+        modulus: 1
+        source_labels:
+        - __address__
+        target_label: __tmp_hash
+      - action: keep
+        regex: $(SHARD)
+        source_labels:
+        - __tmp_hash
+	`)
+
+	result, err := input.BuildConfig(store)
+	require.NoError(t, err)
+
+	if !assert.YAMLEq(t, expect, result) {
+		fmt.Println(result)
+	}
+}
+
+func strPointer(s string) *string { return &s }

--- a/pkg/operator/config/templates/component/pod_monitor.libsonnet
+++ b/pkg/operator/config/templates/component/pod_monitor.libsonnet
@@ -17,8 +17,8 @@ local new_safe_tls_config = import '../component/safe_tls_config.libsonnet';
 // @param {boolean} overrideHonorTimestamps
 // @param {boolean} ignoreNamespaceSelectors
 // @param {boolean} enforcedNamespaceLabel
-// @param {boolean} enforcedSampleLimit
-// @param {boolean} enforcedTargetLimit
+// @param {*number} enforcedSampleLimit
+// @param {*number} enforcedTargetLimit
 // @param {number} shards
 function(
   agentNamespace,

--- a/pkg/operator/config/templates/component/probe.libsonnet
+++ b/pkg/operator/config/templates/component/probe.libsonnet
@@ -130,7 +130,11 @@ function(
             action: 'keep',
           },
           // Keep the output consistent by sorting the keys first.
-          std.sort(std.objectFields(probe.Spec.Targets.Ingress.Selector.MatchLabels)),
+          std.sort(std.objectFields(
+            if monitor.Spec.Targets.Ingress.Selector.MatchLabels != null
+            then monitor.Spec.Targets.Ingress.Selector.MatchLabels
+            else {}
+          )),
         ) +
 
         // Set-based label matching. we have to map the valid relations

--- a/pkg/operator/config/templates/component/probe.libsonnet
+++ b/pkg/operator/config/templates/component/probe.libsonnet
@@ -11,18 +11,16 @@ local new_tls_config = import '../component/tls_config.libsonnet';
 // @param {string} agentNamespace - Namespace the GrafanaAgent CR is in.
 // @param {Probe} probe
 // @param {APIServerConfig} apiServer
-// @param {boolean} overrideHonorLabels
 // @param {boolean} overrideHonorTimestamps
 // @param {boolean} ignoreNamespaceSelectors
 // @param {boolean} enforcedNamespaceLabel
-// @param {boolean} enforcedSampleLimit
-// @param {boolean} enforcedTargetLimit
+// @param {*number} enforcedSampleLimit
+// @param {*number} enforcedTargetLimit
 // @param {number} shards
 function(
   agentNamespace,
   probe,
   apiServer,
-  overrideHonorLabels,
   overrideHonorTimestamps,
   ignoreNamespaceSelectors,
   enforcedNamespaceLabel,
@@ -52,14 +50,14 @@ function(
   },
 
   tls_config:
-    if endpoint.TLSConfig != null then new_tls_config(meta.Namespace, endpoint.TLSConfig),
+    if probe.Spec.TLSConfig != null then new_tls_config(meta.Namespace, probe.Spec.TLSConfig),
   bearer_token:
     if probe.Spec.BearerTokenSecret.LocalObjectReference.Name != ''
     then secrets.valueForSecret(meta.Namespace, probe.Spec.BearerTokenSecret),
 
-  basic_auth: if endpoint.BasicAuth != null then {
-    username: secrets.valueForSecret(meta.Namespace, endpoint.BasicAuth.Username),
-    password: secrets.valueForSecret(meta.Namespace, endpoint.BasicAuth.Password),
+  basic_auth: if probe.Spec.BasicAuth != null then {
+    username: secrets.valueForSecret(meta.Namespace, probe.Spec.BasicAuth.Username),
+    password: secrets.valueForSecret(meta.Namespace, probe.Spec.BasicAuth.Password),
   },
 
   // Generate static_configs section if StaticConfig is provided.
@@ -126,13 +124,13 @@ function(
         std.map(
           function(k) {
             source_labels: ['__meta_kubernetes_ingress_label_' + k8s.sanitize(k)],
-            regex: monitor.Spec.Selector.MatchLabels[k],
+            regex: probe.Spec.Targets.Ingress.Selector.MatchLabels[k],
             action: 'keep',
           },
           // Keep the output consistent by sorting the keys first.
           std.sort(std.objectFields(
-            if monitor.Spec.Targets.Ingress.Selector.MatchLabels != null
-            then monitor.Spec.Targets.Ingress.Selector.MatchLabels
+            if probe.Spec.Targets.Ingress.Selector.MatchLabels != null
+            then probe.Spec.Targets.Ingress.Selector.MatchLabels
             else {}
           )),
         ) +
@@ -211,23 +209,8 @@ function(
     std.filter(function(e) e != null, [
       if enforcedNamespaceLabel != '' then {
         target_label: enforcedNamespaceLabel,
-        replacement: monitor.ObjectMeta.Namespace,
+        replacement: probe.ObjectMeta.Namespace,
       },
     ])
   ),
-
-  metric_relabel_configs: if endpoint.MetricRelabelConfigs != null then optionals.array(
-    std.filterMap(
-      function(c) !(c.TargetLabel != '' && enforcedNamespaceLabel != '' && c.TargetLabel == enforcedNamespaceLabel),
-      function(c) new_relabel_config(c),
-      k8s.array(endpoint.MetricRelabelConfigs),
-    )
-  ),
-
-  sample_limit:
-    if monitor.Spec.SampleLimit > 0 || enforcedSampleLimit != null
-    then k8s.limit(monitor.Spec.SampleLimit, enforcedSampleLimit),
-  target_limit:
-    if monitor.Spec.TargetLimit > 0 || enforcedTargetLimit != null
-    then k8s.limit(monitor.Spec.TargetLimit, enforcedTargetLimit),
 }

--- a/pkg/operator/config/templates/component/remote_write.libsonnet
+++ b/pkg/operator/config/templates/component/remote_write.libsonnet
@@ -46,10 +46,10 @@ function(namespace, rw) {
 
   queue_config: (
     if rw.QueueConfig != null then {
-      capacity: optionals.string(rw.QueueConfig.Capacity),
-      max_shards: optionals.string(rw.QueueConfig.MaxShards),
-      min_shards: optionals.string(rw.QueueConfig.MinShards),
-      max_samples_per_send: optionals.string(rw.QueueConfig.MaxSamplesPerSend),
+      capacity: optionals.number(rw.QueueConfig.Capacity),
+      max_shards: optionals.number(rw.QueueConfig.MaxShards),
+      min_shards: optionals.number(rw.QueueConfig.MinShards),
+      max_samples_per_send: optionals.number(rw.QueueConfig.MaxSamplesPerSend),
       batch_send_deadline: optionals.string(rw.QueueConfig.BatchSendDeadline),
       min_backoff: optionals.string(rw.QueueConfig.MinBackoff),
       max_backoff: optionals.string(rw.QueueConfig.MaxBackoff),

--- a/pkg/operator/config/templates/component/service_monitor.libsonnet
+++ b/pkg/operator/config/templates/component/service_monitor.libsonnet
@@ -17,8 +17,8 @@ local new_tls_config = import '../component/tls_config.libsonnet';
 // @param {boolean} overrideHonorTimestamps
 // @param {boolean} ignoreNamespaceSelectors
 // @param {boolean} enforcedNamespaceLabel
-// @param {boolean} enforcedSampleLimit
-// @param {boolean} enforcedTargetLimit
+// @param {*number} enforcedSampleLimit
+// @param {*number} enforcedTargetLimit
 // @param {number} shards
 function(
   agentNamespace,

--- a/pkg/operator/config/templates/component/service_monitor.libsonnet
+++ b/pkg/operator/config/templates/component/service_monitor.libsonnet
@@ -87,7 +87,11 @@ function(
         action: 'keep',
       },
       // Keep the output consistent by sorting the keys first.
-      std.sort(std.objectFields(monitor.Spec.Selector.MatchLabels)),
+      std.sort(std.objectFields(
+        if monitor.Spec.Selector.MatchLabels != null
+        then monitor.Spec.Selector.MatchLabels
+        else {}
+      )),
     ) +
 
     // Set-based label matching. we have to map the valid relations

--- a/pkg/operator/config/templates/prometheus.libsonnet
+++ b/pkg/operator/config/templates/prometheus.libsonnet
@@ -3,7 +3,7 @@ local optionals = import './ext/optionals.libsonnet';
 local secrets = import './ext/secrets.libsonnet';
 local k8s = import './utils/k8s.libsonnet';
 
-local new_pod_monitor = import './component/pod_monitor.libsonnet.libsonnet';
+local new_pod_monitor = import './component/pod_monitor.libsonnet';
 local new_probe = import './component/probe.libsonnet';
 local new_remote_write = import './component/remote_write.libsonnet';
 local new_service_monitor = import './component/service_monitor.libsonnet';

--- a/pkg/operator/config/templates/prometheus.libsonnet
+++ b/pkg/operator/config/templates/prometheus.libsonnet
@@ -110,7 +110,6 @@ function(
         agentNamespace=agentNamespace,
         probe=probe,
         apiServer=apiServer,
-        overrideHonorLabels=overrideHonorLabels,
         overrideHonorTimestamps=overrideHonorTimestamps,
         ignoreNamespaceSelectors=ignoreNamespaceSelectors,
         enforcedNamespaceLabel=enforcedNamespaceLabel,

--- a/pkg/operator/config/templates_test.go
+++ b/pkg/operator/config/templates_test.go
@@ -1,0 +1,249 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	jsonnet "github.com/google/go-jsonnet"
+	"github.com/grafana/agent/pkg/operator/apis/monitoring/v1alpha1"
+	"github.com/grafana/agent/pkg/operator/assets"
+	"github.com/grafana/agent/pkg/util"
+	prom_v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestExternalLabels(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  interface{}
+		expect string
+	}{
+		{
+			name: "defaults",
+			input: Deployment{
+				Agent: &v1alpha1.GrafanaAgent{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Namespace: "operator",
+						Name:      "agent",
+					},
+				},
+			},
+			expect: util.Untab(`
+				cluster: operator/agent
+				__replica__: replica-$(STATEFULSET_ORDINAL_NUMBER)
+			`),
+		},
+		{
+			name: "external_labels",
+			input: Deployment{
+				Agent: &v1alpha1.GrafanaAgent{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Namespace: "operator",
+						Name:      "agent",
+					},
+					Spec: v1alpha1.GrafanaAgentSpec{
+						Prometheus: v1alpha1.PrometheusSubsystemSpec{
+							ExternalLabels: map[string]string{"foo": "bar"},
+						},
+					},
+				},
+			},
+			expect: util.Untab(`
+				cluster: operator/agent
+				foo: bar
+				__replica__: replica-$(STATEFULSET_ORDINAL_NUMBER)
+			`),
+		},
+		{
+			name: "custom labels",
+			input: Deployment{
+				Agent: &v1alpha1.GrafanaAgent{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Namespace: "operator",
+						Name:      "agent",
+					},
+					Spec: v1alpha1.GrafanaAgentSpec{
+						Prometheus: v1alpha1.PrometheusSubsystemSpec{
+							PrometheusExternalLabelName: strPointer("deployment"),
+							ReplicaExternalLabelName:    strPointer("replica"),
+							ExternalLabels:              map[string]string{"foo": "bar"},
+						},
+					},
+				},
+			},
+			expect: util.Untab(`
+				deployment: operator/agent
+				foo: bar
+				replica: replica-$(STATEFULSET_ORDINAL_NUMBER)
+			`),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			vm, err := createVM(nil)
+			require.NoError(t, err)
+			bb, err := jsonnetMarshal(tc.input)
+			require.NoError(t, err)
+
+			vm.TLACode("ctx", string(bb))
+			actual, err := runSnippet(vm, "./component/external_labels.libsonnet", "ctx")
+			require.NoError(t, err)
+			require.YAMLEq(t, tc.expect, actual)
+		})
+	}
+}
+
+func TestKubeSDConfig(t *testing.T) {
+	store := make(assets.SecretStore)
+
+	store[assets.KeyForConfigMap("operator", &v1.ConfigMapKeySelector{
+		LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+		Key:                  "key",
+	})] = "secretcm"
+
+	store[assets.KeyForSecret("operator", &v1.SecretKeySelector{
+		LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+		Key:                  "key",
+	})] = "secretkey"
+
+	tt := []struct {
+		name   string
+		input  map[string]interface{}
+		expect string
+	}{
+		{
+			name: "defaults",
+			input: map[string]interface{}{
+				"namespace": "operator",
+				"role":      "pod",
+			},
+			expect: util.Untab(`
+				role: pod
+			`),
+		},
+		{
+			name: "defaults",
+			input: map[string]interface{}{
+				"namespace":  "operator",
+				"namespaces": []string{"operator"},
+				"role":       "pod",
+			},
+			expect: util.Untab(`
+				role: pod
+				namespaces:
+					names: [operator]
+			`),
+		},
+		{
+			name: "host",
+			input: map[string]interface{}{
+				"namespace": "operator",
+				"apiServer": &prom_v1.APIServerConfig{Host: "host"},
+				"role":      "pod",
+			},
+			expect: util.Untab(`
+				role: pod
+				api_server: host
+			`),
+		},
+		{
+			name: "basic auth",
+			input: map[string]interface{}{
+				"namespace": "operator",
+				"apiServer": &prom_v1.APIServerConfig{
+					BasicAuth: &prom_v1.BasicAuth{
+						Username: v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+							Key:                  "key",
+						},
+						Password: v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+							Key:                  "key",
+						},
+					},
+				},
+				"role": "pod",
+			},
+			expect: util.Untab(`
+				role: pod
+				basic_auth:
+					username: secretkey
+					password: secretkey
+			`),
+		},
+		{
+			name: "bearer auth",
+			input: map[string]interface{}{
+				"namespace": "operator",
+				"apiServer": &prom_v1.APIServerConfig{
+					BearerToken:     "bearer",
+					BearerTokenFile: "file",
+				},
+				"role": "pod",
+			},
+			expect: util.Untab(`
+				role: pod
+				authorization:
+					type: Bearer
+					credentials: bearer
+					credentials_file: file
+			`),
+		},
+		{
+			name: "tls_config",
+			input: map[string]interface{}{
+				"namespace": "operator",
+				"apiServer": &prom_v1.APIServerConfig{
+					TLSConfig: &prom_v1.TLSConfig{
+						CAFile: "ca",
+					},
+				},
+				"role": "pod",
+			},
+			expect: util.Untab(`
+				role: pod
+				tls_config:
+					ca_file: ca
+			`),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			vm, err := createVM(store)
+			require.NoError(t, err)
+
+			args := []string{"namespace", "namespaces", "apiServer", "role"}
+			for _, arg := range args {
+				bb, err := jsonnetMarshal(tc.input[arg])
+				require.NoError(t, err)
+				vm.TLACode(arg, string(bb))
+			}
+
+			actual, err := runSnippet(vm, "./component/kube_sd_config.libsonnet", args...)
+			require.NoError(t, err)
+			require.YAMLEq(t, tc.expect, actual)
+		})
+	}
+}
+
+func runSnippet(vm *jsonnet.VM, filename string, args ...string) (string, error) {
+	boundArgs := make([]string, len(args))
+	for i := range args {
+		boundArgs[i] = fmt.Sprintf("%[1]s=%[1]s", args[i])
+	}
+
+	return vm.EvaluateAnonymousSnippet(
+		filename,
+		fmt.Sprintf(`
+			local marshal = import './ext/marshal.libsonnet';
+			local optionals = import './ext/optionals.libsonnet';
+			local eval = import '%s';
+			function(%s) marshal.YAML(optionals.trim(eval(%s)))
+		`, filename, strings.Join(args, ","), strings.Join(boundArgs, ",")),
+	)
+}

--- a/pkg/operator/config/templates_test.go
+++ b/pkg/operator/config/templates_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/grafana/agent/pkg/operator/assets"
 	"github.com/grafana/agent/pkg/util"
 	prom_v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -98,18 +100,6 @@ func TestExternalLabels(t *testing.T) {
 }
 
 func TestKubeSDConfig(t *testing.T) {
-	store := make(assets.SecretStore)
-
-	store[assets.KeyForConfigMap("operator", &v1.ConfigMapKeySelector{
-		LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
-		Key:                  "key",
-	})] = "secretcm"
-
-	store[assets.KeyForSecret("operator", &v1.SecretKeySelector{
-		LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
-		Key:                  "key",
-	})] = "secretkey"
-
 	tt := []struct {
 		name   string
 		input  map[string]interface{}
@@ -214,7 +204,7 @@ func TestKubeSDConfig(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			vm, err := createVM(store)
+			vm, err := createVM(testStore())
 			require.NoError(t, err)
 
 			args := []string{"namespace", "namespaces", "apiServer", "role"}
@@ -225,6 +215,749 @@ func TestKubeSDConfig(t *testing.T) {
 			}
 
 			actual, err := runSnippet(vm, "./component/kube_sd_config.libsonnet", args...)
+			require.NoError(t, err)
+			require.YAMLEq(t, tc.expect, actual)
+		})
+	}
+}
+
+func TestPodMonitor(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  map[string]interface{}
+		expect string
+	}{
+		{
+			name: "default",
+			input: map[string]interface{}{
+				"agentNamespace": "operator",
+				"monitor": prom_v1.PodMonitor{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Namespace: "operator",
+						Name:      "podmonitor",
+					},
+				},
+				"endpoint": prom_v1.PodMetricsEndpoint{
+					Port: "metrics",
+				},
+				"index":                    0,
+				"apiServer":                prom_v1.APIServerConfig{},
+				"overrideHonorLabels":      false,
+				"overrideHonorTimestamps":  false,
+				"ignoreNamespaceSelectors": false,
+				"enforcedNamespaceLabel":   false,
+				"enforcedSampleLimit":      nil,
+				"enforcedTargetLimit":      nil,
+				"shards":                   1,
+			},
+			expect: util.Untab(`
+				job_name: podMonitor/operator/podmonitor/0
+				honor_labels: false
+				kubernetes_sd_configs:
+				- role: pod
+				  namespaces:
+						names: [operator]
+				relabel_configs:
+				- source_labels: [job]
+					target_label: __tmp_prometheus_job_name
+				- source_labels: [__meta_kubernetes_pod_container_port_name]
+					regex: metrics
+					action: keep
+				- source_labels: [__meta_kubernetes_namespace]
+					target_label: namespace
+				- source_labels: [__meta_kubernetes_service_name]
+					target_label: service
+				- source_labels: [__meta_kubernetes_pod_name]
+					target_label: pod
+				- source_labels: [__meta_kubernetes_pod_container_name]
+					target_label: container
+				- target_label: job
+					replacement: operator/podmonitor
+				- target_label: endpoint
+					replacement: metrics
+				- target_label: false
+					replacement: operator
+				- source_labels: [__address__]
+					target_label: __tmp_hash
+					action: hashmod
+					modulus: 1
+				- source_labels: [__tmp_hash]
+					action: keep
+					regex: $(SHARD)
+			`),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			vm, err := createVM(testStore())
+			require.NoError(t, err)
+
+			args := []string{
+				"agentNamespace", "monitor", "endpoint", "index", "apiServer", "overrideHonorLabels",
+				"overrideHonorTimestamps", "ignoreNamespaceSelectors", "enforcedNamespaceLabel",
+				"enforcedSampleLimit", "enforcedTargetLimit", "shards",
+			}
+			for _, arg := range args {
+				bb, err := jsonnetMarshal(tc.input[arg])
+				require.NoError(t, err)
+				vm.TLACode(arg, string(bb))
+			}
+
+			actual, err := runSnippet(vm, "./component/pod_monitor.libsonnet", args...)
+			require.NoError(t, err)
+			if !assert.YAMLEq(t, tc.expect, actual) {
+				fmt.Fprintln(os.Stderr, actual)
+			}
+		})
+	}
+}
+
+func TestProbe(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  map[string]interface{}
+		expect string
+	}{
+		{
+			name: "default",
+			input: map[string]interface{}{
+				"agentNamespace": "operator",
+				"probe": prom_v1.Probe{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Namespace: "operator",
+						Name:      "probe",
+					},
+					Spec: prom_v1.ProbeSpec{
+						Module: "mod",
+						Targets: prom_v1.ProbeTargets{
+							Ingress: &prom_v1.ProbeTargetIngress{
+								Selector: meta_v1.LabelSelector{
+									MatchLabels: map[string]string{"foo": "bar"},
+								},
+							},
+						},
+					},
+				},
+				"apiServer":                prom_v1.APIServerConfig{},
+				"overrideHonorTimestamps":  false,
+				"ignoreNamespaceSelectors": false,
+				"enforcedNamespaceLabel":   false,
+				"enforcedSampleLimit":      nil,
+				"enforcedTargetLimit":      nil,
+				"shards":                   1,
+			},
+			expect: util.Untab(`
+				job_name: probe/operator/probe
+				honor_timestamps: true
+				kubernetes_sd_configs:
+				- role: ingress
+					namespaces:
+						names: [operator]
+				metrics_path: /probe
+				params:
+					module: ["mod"]
+				relabel_configs:
+				- source_labels: [job]
+					target_label: __tmp_prometheus_job_name
+				- action: keep
+					regex: bar
+					source_labels: [__meta_kubernetes_ingress_label_foo]
+				- action: replace
+					regex: (.+);(.+);(.+)
+					replacement: $1://$2$3
+					separator: ;
+					source_labels:
+						- __meta_kubernetes_ingress_scheme
+						- __address__
+						- __meta_kubernetes_ingress_path
+					target_label: __param_target
+				- source_labels: [__meta_kubernetes_namespace]
+					target_label: namespace
+				- source_labels: [__meta_kubernetes_ingress_name]
+					target_label: ingress
+				- source_labels: [__param_target]
+					target_label: instance
+				- replacement: ""
+					target_label: __address__
+				- replacement: operator
+					target_label: false
+			`),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			vm, err := createVM(testStore())
+			require.NoError(t, err)
+
+			args := []string{
+				"agentNamespace", "probe", "apiServer", "overrideHonorTimestamps",
+				"ignoreNamespaceSelectors", "enforcedNamespaceLabel",
+				"enforcedSampleLimit", "enforcedTargetLimit", "shards",
+			}
+			for _, arg := range args {
+				bb, err := jsonnetMarshal(tc.input[arg])
+				require.NoError(t, err)
+				vm.TLACode(arg, string(bb))
+			}
+
+			actual, err := runSnippet(vm, "./component/probe.libsonnet", args...)
+			require.NoError(t, err)
+			if !assert.YAMLEq(t, tc.expect, actual) {
+				fmt.Fprintln(os.Stderr, actual)
+			}
+		})
+	}
+}
+
+func TestRelabelConfig(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  interface{}
+		expect string
+	}{
+		{
+			name: "full",
+			input: prom_v1.RelabelConfig{
+				SourceLabels: []string{"input_a", "input_b"},
+				Separator:    ";",
+				TargetLabel:  "target_a",
+				Regex:        "regex",
+				Modulus:      1234,
+				Replacement:  "foobar",
+				Action:       "replace",
+			},
+			expect: util.Untab(`
+				source_labels: ["input_a", "input_b"]
+				separator: ";"
+				target_label: "target_a"
+				regex: regex
+				modulus: 1234
+				replacement: foobar
+				action: replace
+			`),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			vm, err := createVM(nil)
+			require.NoError(t, err)
+			bb, err := jsonnetMarshal(tc.input)
+			require.NoError(t, err)
+
+			vm.TLACode("cfg", string(bb))
+			actual, err := runSnippet(vm, "./component/relabel_config.libsonnet", "cfg")
+			require.NoError(t, err)
+			require.YAMLEq(t, tc.expect, actual)
+		})
+	}
+}
+
+func TestRemoteWrite(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  map[string]interface{}
+		expect string
+	}{
+		{
+			name: "bare",
+			input: map[string]interface{}{
+				"namespace": "operator",
+				"rw": v1alpha1.RemoteWriteSpec{
+					URL: "http://cortex/api/prom/push",
+				},
+			},
+			expect: util.Untab(`
+				url: http://cortex/api/prom/push
+			`),
+		},
+		{
+			name: "base configs",
+			input: map[string]interface{}{
+				"namespace": "operator",
+				"rw": v1alpha1.RemoteWriteSpec{
+					Name:          "cortex",
+					URL:           "http://cortex/api/prom/push",
+					RemoteTimeout: "5m",
+					Headers:       map[string]string{"foo": "bar"},
+				},
+			},
+			expect: util.Untab(`
+				name: cortex
+				url: http://cortex/api/prom/push
+				remote_timeout: 5m
+				headers:
+					foo: bar
+			`),
+		},
+		{
+			name: "write_relabel_configs",
+			input: map[string]interface{}{
+				"namespace": "operator",
+				"rw": v1alpha1.RemoteWriteSpec{
+					URL: "http://cortex/api/prom/push",
+					WriteRelabelConfigs: []prom_v1.RelabelConfig{{
+						SourceLabels: []string{"__name__"},
+						Action:       "drop",
+					}},
+				},
+			},
+			expect: util.Untab(`
+				url: http://cortex/api/prom/push
+				write_relabel_configs:
+				- source_labels: [__name__]
+					action: drop
+			`),
+		},
+		{
+			name: "tls_config",
+			input: map[string]interface{}{
+				"namespace": "operator",
+				"rw": v1alpha1.RemoteWriteSpec{
+					URL: "http://cortex/api/prom/push",
+					TLSConfig: &prom_v1.TLSConfig{
+						CAFile:   "ca",
+						CertFile: "cert",
+					},
+				},
+			},
+			expect: util.Untab(`
+				url: http://cortex/api/prom/push
+				tls_config:
+					ca_file: ca
+					cert_file: cert
+			`),
+		},
+		{
+			name: "basic_auth",
+			input: map[string]interface{}{
+				"namespace": "operator",
+				"rw": v1alpha1.RemoteWriteSpec{
+					URL: "http://cortex/api/prom/push",
+					BasicAuth: &prom_v1.BasicAuth{
+						Username: v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+							Key:                  "key",
+						},
+						Password: v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+							Key:                  "key",
+						},
+					},
+				},
+			},
+			expect: util.Untab(`
+				url: http://cortex/api/prom/push
+				basic_auth:
+					username: secretkey
+					password: secretkey
+			`),
+		},
+		{
+			name: "sigv4",
+			input: map[string]interface{}{
+				"namespace": "operator",
+				"rw": v1alpha1.RemoteWriteSpec{
+					URL: "http://cortex/api/prom/push",
+					SigV4: &v1alpha1.SigV4Config{
+						Region: "region",
+						AccessKey: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+							Key:                  "key",
+						},
+						SecretKey: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+							Key:                  "key",
+						},
+						Profile: "profile",
+						RoleARN: "arn",
+					},
+				},
+			},
+			expect: util.Untab(`
+				url: http://cortex/api/prom/push
+				sigv4:
+					region: region
+					access_key: secretkey
+					secret_key: secretkey
+					profile: profile
+					role_arn: arn
+			`),
+		},
+		{
+			name: "queue_config",
+			input: map[string]interface{}{
+				"namespace": "operator",
+				"rw": v1alpha1.RemoteWriteSpec{
+					URL: "http://cortex/api/prom/push",
+					QueueConfig: &v1alpha1.QueueConfig{
+						Capacity:          1000,
+						MinShards:         1,
+						MaxShards:         100,
+						MaxSamplesPerSend: 500,
+						BatchSendDeadline: "5m",
+						MinBackoff:        "1m",
+						MaxBackoff:        "5m",
+					},
+				},
+			},
+			expect: util.Untab(`
+				url: http://cortex/api/prom/push
+				queue_config:
+					capacity: 1000
+					min_shards: 1
+					max_shards: 100
+					max_samples_per_send: 500
+					batch_send_deadline: 5m
+					min_backoff: 1m
+					max_backoff: 5m
+			`),
+		},
+		{
+			name: "metadata_config",
+			input: map[string]interface{}{
+				"namespace": "operator",
+				"rw": v1alpha1.RemoteWriteSpec{
+					URL: "http://cortex/api/prom/push",
+					MetadataConfig: &v1alpha1.MetadataConfig{
+						Send:         true,
+						SendInterval: "5m",
+					},
+				},
+			},
+			expect: util.Untab(`
+				url: http://cortex/api/prom/push
+				metadata_config:
+					send: true
+					send_interval: 5m
+			`),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			vm, err := createVM(testStore())
+			require.NoError(t, err)
+
+			args := []string{"namespace", "rw"}
+			for _, arg := range args {
+				bb, err := jsonnetMarshal(tc.input[arg])
+				require.NoError(t, err)
+				vm.TLACode(arg, string(bb))
+			}
+
+			actual, err := runSnippet(vm, "./component/remote_write.libsonnet", args...)
+			require.NoError(t, err)
+			require.YAMLEq(t, tc.expect, actual)
+		})
+	}
+}
+
+func TestSafeTLSConfig(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  map[string]interface{}
+		expect string
+	}{
+		{
+			name: "configmap",
+			input: map[string]interface{}{
+				"namespace": "operator",
+				"config": prom_v1.SafeTLSConfig{
+					ServerName:         "server",
+					InsecureSkipVerify: true,
+					CA: prom_v1.SecretOrConfigMap{
+						ConfigMap: &v1.ConfigMapKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+							Key:                  "key",
+						},
+					},
+					Cert: prom_v1.SecretOrConfigMap{
+						ConfigMap: &v1.ConfigMapKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+							Key:                  "key",
+						},
+					},
+					KeySecret: &v1.SecretKeySelector{
+						LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+						Key:                  "key",
+					},
+				},
+			},
+			expect: util.Untab(`
+				ca_file: /var/lib/grafana-agent/secrets/_configMaps_operator_obj_key
+				cert_file: /var/lib/grafana-agent/secrets/_configMaps_operator_obj_key
+				key_file: /var/lib/grafana-agent/secrets/_secrets_operator_obj_key
+				server_name: server
+				insecure_skip_verify: true
+			`),
+		},
+		{
+			name: "secrets",
+			input: map[string]interface{}{
+				"namespace": "operator",
+				"config": prom_v1.SafeTLSConfig{
+					ServerName:         "server",
+					InsecureSkipVerify: true,
+					CA: prom_v1.SecretOrConfigMap{
+						Secret: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+							Key:                  "key",
+						},
+					},
+					Cert: prom_v1.SecretOrConfigMap{
+						Secret: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+							Key:                  "key",
+						},
+					},
+					KeySecret: &v1.SecretKeySelector{
+						LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+						Key:                  "key",
+					},
+				},
+			},
+			expect: util.Untab(`
+				ca_file: /var/lib/grafana-agent/secrets/_secrets_operator_obj_key
+				cert_file: /var/lib/grafana-agent/secrets/_secrets_operator_obj_key
+				key_file: /var/lib/grafana-agent/secrets/_secrets_operator_obj_key
+				server_name: server
+				insecure_skip_verify: true
+			`),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			vm, err := createVM(testStore())
+			require.NoError(t, err)
+
+			args := []string{"namespace", "config"}
+			for _, arg := range args {
+				bb, err := jsonnetMarshal(tc.input[arg])
+				require.NoError(t, err)
+				vm.TLACode(arg, string(bb))
+			}
+
+			actual, err := runSnippet(vm, "./component/safe_tls_config.libsonnet", args...)
+			require.NoError(t, err)
+			require.YAMLEq(t, tc.expect, actual)
+		})
+	}
+}
+
+func TestServiceMonitor(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  map[string]interface{}
+		expect string
+	}{
+		{
+			name: "default",
+			input: map[string]interface{}{
+				"agentNamespace": "operator",
+				"monitor": prom_v1.ServiceMonitor{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Namespace: "operator",
+						Name:      "servicemonitor",
+					},
+				},
+				"endpoint": prom_v1.Endpoint{
+					Port: "metrics",
+				},
+				"index":                    0,
+				"apiServer":                prom_v1.APIServerConfig{},
+				"overrideHonorLabels":      false,
+				"overrideHonorTimestamps":  false,
+				"ignoreNamespaceSelectors": false,
+				"enforcedNamespaceLabel":   false,
+				"enforcedSampleLimit":      nil,
+				"enforcedTargetLimit":      nil,
+				"shards":                   1,
+			},
+			expect: util.Untab(`
+				job_name: serviceMonitor/operator/servicemonitor/0
+				honor_labels: false
+				kubernetes_sd_configs:
+				- role: endpoints
+				  namespaces:
+						names: [operator]
+				relabel_configs:
+				- source_labels:
+					- job
+					target_label: __tmp_prometheus_job_name
+				- action: keep
+					regex: metrics
+					source_labels:
+					- __meta_kubernetes_endpoint_port_name
+				- regex: Node;(.*)
+					replacement: $1
+					separator: ;
+					source_labels:
+					- __meta_kubernetes_endpoint_address_target_kind
+					- __meta_kubernetes_endpoint_address_target_name
+					target_label: node
+				- regex: Pod;(.*)
+					replacement: $1
+					separator: ;
+					source_labels:
+					- __meta_kubernetes_endpoint_address_target_kind
+					- __meta_kubernetes_endpoint_address_target_name
+					target_label: pod
+				- source_labels:
+					- __meta_kubernetes_namespace
+					target_label: namespace
+				- source_labels:
+					- __meta_kubernetes_service_name
+					target_label: service
+				- source_labels:
+					- __meta_kubernetes_pod_name
+					target_label: pod
+				- source_labels:
+					- __meta_kubernetes_pod_container_name
+					target_label: container
+				- replacement: $1
+					source_labels:
+					- __meta_kubernetes_service_name
+					target_label: job
+				- replacement: metrics
+					target_label: endpoint
+				- replacement: operator
+					target_label: false
+				- action: hashmod
+					modulus: 1
+					source_labels:
+					- __address__
+					target_label: __tmp_hash
+				- action: keep
+					regex: $(SHARD)
+					source_labels:
+					- __tmp_hash
+			`),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			vm, err := createVM(testStore())
+			require.NoError(t, err)
+
+			args := []string{
+				"agentNamespace", "monitor", "endpoint", "index", "apiServer", "overrideHonorLabels",
+				"overrideHonorTimestamps", "ignoreNamespaceSelectors", "enforcedNamespaceLabel",
+				"enforcedSampleLimit", "enforcedTargetLimit", "shards",
+			}
+			for _, arg := range args {
+				bb, err := jsonnetMarshal(tc.input[arg])
+				require.NoError(t, err)
+				vm.TLACode(arg, string(bb))
+			}
+
+			actual, err := runSnippet(vm, "./component/service_monitor.libsonnet", args...)
+			require.NoError(t, err)
+			if !assert.YAMLEq(t, tc.expect, actual) {
+				fmt.Fprintln(os.Stderr, actual)
+			}
+		})
+	}
+}
+
+func TestTLSConfig(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  map[string]interface{}
+		expect string
+	}{
+		{
+			name: "passthrough",
+			input: map[string]interface{}{
+				"namespace": "operator",
+				"config": prom_v1.TLSConfig{
+					SafeTLSConfig: prom_v1.SafeTLSConfig{
+						ServerName:         "server",
+						InsecureSkipVerify: true,
+						CA: prom_v1.SecretOrConfigMap{
+							Secret: &v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+								Key:                  "key",
+							},
+						},
+						Cert: prom_v1.SecretOrConfigMap{
+							Secret: &v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+								Key:                  "key",
+							},
+						},
+						KeySecret: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+							Key:                  "key",
+						},
+					},
+				},
+			},
+			expect: util.Untab(`
+				ca_file: /var/lib/grafana-agent/secrets/_secrets_operator_obj_key
+				cert_file: /var/lib/grafana-agent/secrets/_secrets_operator_obj_key
+				key_file: /var/lib/grafana-agent/secrets/_secrets_operator_obj_key
+				server_name: server
+				insecure_skip_verify: true
+			`),
+		},
+		{
+			name: "overrides",
+			input: map[string]interface{}{
+				"namespace": "operator",
+				"config": prom_v1.TLSConfig{
+					SafeTLSConfig: prom_v1.SafeTLSConfig{
+						ServerName:         "server",
+						InsecureSkipVerify: true,
+						CA: prom_v1.SecretOrConfigMap{
+							Secret: &v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+								Key:                  "key",
+							},
+						},
+						Cert: prom_v1.SecretOrConfigMap{
+							Secret: &v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+								Key:                  "key",
+							},
+						},
+						KeySecret: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+							Key:                  "key",
+						},
+					},
+					CAFile:   "ca",
+					CertFile: "cert",
+					KeyFile:  "key",
+				},
+			},
+			expect: util.Untab(`
+				ca_file: ca
+				cert_file: cert
+				key_file: key
+				server_name: server
+				insecure_skip_verify: true
+			`),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			vm, err := createVM(testStore())
+			require.NoError(t, err)
+
+			args := []string{"namespace", "config"}
+			for _, arg := range args {
+				bb, err := jsonnetMarshal(tc.input[arg])
+				require.NoError(t, err)
+				vm.TLACode(arg, string(bb))
+			}
+
+			actual, err := runSnippet(vm, "./component/tls_config.libsonnet", args...)
 			require.NoError(t, err)
 			require.YAMLEq(t, tc.expect, actual)
 		})
@@ -246,4 +979,20 @@ func runSnippet(vm *jsonnet.VM, filename string, args ...string) (string, error)
 			function(%s) marshal.YAML(optionals.trim(eval(%s)))
 		`, filename, strings.Join(args, ","), strings.Join(boundArgs, ",")),
 	)
+}
+
+func testStore() assets.SecretStore {
+	store := make(assets.SecretStore)
+
+	store[assets.KeyForConfigMap("operator", &v1.ConfigMapKeySelector{
+		LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+		Key:                  "key",
+	})] = "secretcm"
+
+	store[assets.KeyForSecret("operator", &v1.SecretKeySelector{
+		LocalObjectReference: v1.LocalObjectReference{Name: "obj"},
+		Key:                  "key",
+	})] = "secretkey"
+
+	return store
 }

--- a/pkg/operator/config/utils.go
+++ b/pkg/operator/config/utils.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 
 	jsonnet "github.com/google/go-jsonnet"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func unmarshalYAML(i []interface{}) (interface{}, error) {

--- a/pkg/operator/resources.go
+++ b/pkg/operator/resources.go
@@ -191,6 +191,12 @@ func generateStatefulSetSpec(
 	d config.Deployment,
 	shard int32,
 ) (*apps_v1.StatefulSetSpec, error) {
+
+	shards := minShards
+	if reqShards := d.Agent.Spec.Prometheus.Shards; reqShards != nil && *reqShards > 1 {
+		shards = *reqShards
+	}
+
 	terminationGracePeriodSeconds := int64(4800)
 
 	imagePath := fmt.Sprintf("%s:%s", DefaultAgentBaseImage, d.Agent.Spec.Version)
@@ -343,6 +349,10 @@ func generateStatefulSetSpec(
 		{
 			Name:  "SHARD",
 			Value: fmt.Sprintf("%d", shard),
+		},
+		{
+			Name:  "SHARDS",
+			Value: fmt.Sprintf("%d", shards),
 		},
 	}
 


### PR DESCRIPTION
#### PR Description 

This PR adds tests to validate the operator and fixes various small issues:

1. BearerTokenFile doesn't exist for PodMonitors
2. MatchLabels may be null
3. Fix `pod_monitor.libsonnet` import
4. Use `yaml.v3` for Jsonnet `unmarshalYAML`, which unmarshals to
   `map[string]interface{}` instead of `map[interface{}]interface{}`
5. Define `SHARDS` as an environment variable so custom scrape jobs can
   reference it

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer
The unit tests are quite a bit longer than I'd like them to be, but I can't think of a way to break them up any more, and they were useful for finding a few extra things I missed.

Feel free to just 🙈 through the tests, I suspect the Jsonnet code might not survive very long. Cue one day?

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
