### PR TITLE
don't return ErrNotFound on bad ref in Append

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   This fix was made to a [dependency](https://github.com/grafana/prometheus/pull/21).
   (@rfratto)
 
+- [BUGFIX] Fix issue where a target will fail to be scraped for the process lifetime
+  if that target had gone down for long enough that its series were removed from
+  the in-memory cache (2 GC cycles). (@rfratto)
+
 # v0.15.0 (2021-06-03)
 
 BREAKING CHANGE: Configuration of Tempo Autologging changed in this release.

--- a/pkg/prom/wal/wal.go
+++ b/pkg/prom/wal/wal.go
@@ -624,7 +624,7 @@ func (a *appender) getOrCreate(l labels.Labels) (series *memSeries, created bool
 func (a *appender) AppendExemplar(ref uint64, _ labels.Labels, e exemplar.Exemplar) (uint64, error) {
 	s := a.w.series.getByID(ref)
 	if s == nil {
-		return 0, errors.Wrapf(storage.ErrNotFound, "unknown series ref %d when trying to add exemplar", ref)
+		return 0, fmt.Errorf("unknown series ref. when trying to add exemplar: %d", ref)
 	}
 
 	// Ensure no empty labels have gotten through.

--- a/pkg/prom/wal/wal.go
+++ b/pkg/prom/wal/wal.go
@@ -20,6 +20,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/record"
 	"github.com/prometheus/prometheus/tsdb/wal"
+	"go.uber.org/atomic"
 )
 
 // ErrWALClosed is an error returned when a WAL operation can't run because the
@@ -120,9 +121,8 @@ type Storage struct {
 	appenderPool sync.Pool
 	bufPool      sync.Pool
 
-	mtx     sync.RWMutex
-	nextRef uint64
-	series  *stripeSeries
+	ref    *atomic.Uint64
+	series *stripeSeries
 
 	deletedMtx sync.Mutex
 	deleted    map[uint64]int // Deleted series, and what WAL segment they must be kept until.
@@ -144,10 +144,7 @@ func NewStorage(logger log.Logger, registerer prometheus.Registerer, path string
 		deleted: map[uint64]int{},
 		series:  newStripeSeries(),
 		metrics: newStorageMetrics(registerer),
-
-		// The first ref ID must be non-zero, as the scraping code treats 0 as a
-		// non-existent ID and won't cache it.
-		nextRef: 1,
+		ref:     atomic.NewUint64(0),
 	}
 
 	storage.bufPool.New = func() interface{} {
@@ -297,6 +294,8 @@ func (w *Storage) loadWAL(r *wal.Reader) (err error) {
 		}
 	}()
 
+	var biggestRef uint64 = 0
+
 	for d := range decoded {
 		switch v := d.(type) {
 		case []record.RefSeries:
@@ -312,11 +311,9 @@ func (w *Storage) loadWAL(r *wal.Reader) (err error) {
 					w.metrics.numActiveSeries.Inc()
 					w.metrics.totalCreatedSeries.Inc()
 
-					w.mtx.Lock()
-					if w.nextRef <= s.Ref {
-						w.nextRef = s.Ref + 1
+					if biggestRef <= s.Ref {
+						biggestRef = s.Ref
 					}
-					w.mtx.Unlock()
 				}
 			}
 
@@ -344,6 +341,8 @@ func (w *Storage) loadWAL(r *wal.Reader) (err error) {
 			panic(fmt.Errorf("unexpected decoded type: %T", d))
 		}
 	}
+
+	w.ref.Store(biggestRef)
 
 	select {
 	case err := <-errCh:
@@ -566,78 +565,54 @@ type appender struct {
 }
 
 func (a *appender) Append(ref uint64, l labels.Labels, t int64, v float64) (uint64, error) {
-	if ref == 0 {
-		return a.Add(l, t, v)
-	}
-	return ref, a.AddFast(ref, t, v)
-}
-
-func (a *appender) Add(l labels.Labels, t int64, v float64) (uint64, error) {
-	hash := l.Hash()
-	series := a.w.series.getByHash(hash, l)
-	if series != nil {
-		return series.ref, a.AddFast(series.ref, t, v)
-	}
-
-	// Ensure no empty or duplicate labels have gotten through. This mirrors the
-	// equivalent validation code in the TSDB's headAppender.
-	l = l.WithoutEmpty()
-	if len(l) == 0 {
-		return 0, errors.Wrap(tsdb.ErrInvalidSample, "empty labelset")
-	}
-
-	if lbl, dup := l.HasDuplicateLabelNames(); dup {
-		return 0, errors.Wrap(tsdb.ErrInvalidSample, fmt.Sprintf(`label name "%s" is not unique`, lbl))
-	}
-
-	a.w.mtx.Lock()
-	ref := a.w.nextRef
-	a.w.nextRef++
-	a.w.mtx.Unlock()
-
-	series = &memSeries{ref: ref, lset: l}
-	series.updateTs(t)
-
-	a.series = append(a.series, record.RefSeries{
-		Ref:    ref,
-		Labels: l,
-	})
-
-	a.w.series.set(hash, series)
-
-	a.w.metrics.numActiveSeries.Inc()
-	a.w.metrics.totalCreatedSeries.Inc()
-	a.w.metrics.totalAppendedSamples.Inc()
-
-	return series.ref, a.AddFast(series.ref, t, v)
-}
-
-func (a *appender) AddFast(ref uint64, t int64, v float64) error {
 	series := a.w.series.getByID(ref)
 	if series == nil {
-		return storage.ErrNotFound
+		// Ensure no empty or duplicate labels have gotten through. This mirrors the
+		// equivalent validation code in the TSDB's headAppender.
+		l = l.WithoutEmpty()
+		if len(l) == 0 {
+			return 0, errors.Wrap(tsdb.ErrInvalidSample, "empty labelset")
+		}
+
+		if lbl, dup := l.HasDuplicateLabelNames(); dup {
+			return 0, errors.Wrap(tsdb.ErrInvalidSample, fmt.Sprintf(`label name "%s" is not unique`, lbl))
+		}
+
+		ref = a.w.ref.Inc()
+		series = &memSeries{ref: ref, lset: l}
+
+		a.series = append(a.series, record.RefSeries{
+			Ref:    ref,
+			Labels: l,
+		})
+
+		a.w.series.set(l.Hash(), series)
+
+		a.w.metrics.numActiveSeries.Inc()
+		a.w.metrics.totalCreatedSeries.Inc()
 	}
+
 	series.Lock()
 	defer series.Unlock()
 
 	// Update last recorded timestamp. Used by Storage.gc to determine if a
-	// series is dead.
+	// series is stale.
 	series.updateTs(t)
 
 	a.samples = append(a.samples, record.RefSample{
-		Ref: ref,
+		Ref: series.ref,
 		T:   t,
 		V:   v,
 	})
 
 	a.w.metrics.totalAppendedSamples.Inc()
-	return nil
+	return series.ref, nil
 }
 
 func (a *appender) AppendExemplar(ref uint64, _ labels.Labels, e exemplar.Exemplar) (uint64, error) {
 	s := a.w.series.getByID(ref)
 	if s == nil {
-		return 0, fmt.Errorf("unknown series ref. when trying to add exemplar: %d", ref)
+		return 0, errors.Wrapf(storage.ErrNotFound, "unknown series ref %d when trying to add exemplar", ref)
 	}
 
 	// Ensure no empty labels have gotten through.


### PR DESCRIPTION
#### PR Description 
Prometheus 2.26 changed the storage interface, removing the `AddFast` and `Add` methods, replacing with a single `Append` method. This also changed the expectation that `Append` should _not_ return `storage.ErrNotFound` on an invalid ref ID like `AddFast` used to. 

The 2.26 scraper will fail the scrape if `storage.ErrNotFound` is returned, and failed scrapes won't clear the cache, so the target will continue to fail to be scraped for the remainder of the process lifetime. This can be triggered primarily by a target going down for 2 GC cycles, when ref IDs of stale series are purged.

#### Which issue(s) this PR fixes 
Fixes #659

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
