### PR TITLE
Add TLS config options for tempo remote_write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Main (unreleased)
 
+- [FEATURE] Add TLS config options for tempo `remote_write`s. (@mapno)
+
 # v0.16.0 (2021-06-17)
 
 - [FEATURE] (beta) A Grafana Agent Operator is now available. (@rfratto)
-
-- [FEATURE] Add TLS config options for tempo `remote_write`s. (@mapno)
 
 - [ENHANCEMENT] Error messages when installing the Grafana Agent for Grafana
   Cloud will now be shown. (@rfratto)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - [FEATURE] (beta) A Grafana Agent Operator is now available. (@rfratto)
 
+- [FEATURE] Add TLS config options for tempo `remote_write`s. (@mapno)
+
 - [ENHANCEMENT] Error messages when installing the Grafana Agent for Grafana
   Cloud will now be shown. (@rfratto)
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -2042,9 +2042,22 @@ remote_write:
     # Controls whether or not TLS is required.  See https://godoc.org/google.golang.org/grpc#WithInsecure
     [ insecure: <boolean> | default = false ]
 
-    # Disable validation of the server certificate. Only used when insecure is set
-    # to false.
+    # Deprecated in favor of tls_config
+    # If both `insecure_skip_verify` and `tls_config.insecure_skip_verify` are used,
+    # the latter take precedence.
     [ insecure_skip_verify: <bool> | default = false ]
+    
+    # Controls TLS settings of the exporter's client. See https://github.com/open-telemetry/opentelemetry-collector/blob/v0.21.0/config/configtls/README.md
+    # This should be used only if `insecure` is set to false
+    tls_config:
+      # Path to the CA cert. For a client this verifies the server certificate. If empty uses system root CA.
+      [ca_file: <string>]
+      # Path to the TLS cert to use for TLS required connections
+      [cert_file: <string>]
+      # Path to the TLS key to use for TLS required connections
+      [key_file: <string>]
+      # Disable validation of the server certificate.
+      [ insecure_skip_verify: <bool> | default = false ]
 
     # Sets the `Authorization` header on every trace push with the
     # configured username and password.

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -3,6 +3,43 @@
 This is a guide detailing all breaking changes that have happened in prior
 releases and how to migrate to newer versions.
 
+# Unreleased
+
+## Tempo: Remote write TLS config
+
+Tempo `remote_write` now supports configuring TLS settings in the trace
+exporter's client. `insecure_skip_verify` is moved into this setting's block.
+
+Old config's with `insecure_skip_verify` outside `tls_config` will continue
+to work until it's fully deprecated.
+If both `insecure_skip_verify` and `tls_config.insecure_skip_verify` are used,
+the latter take precedence
+
+Example old config:
+
+```
+tempo:
+  configs:
+    - name: default
+      remote_write:
+        - endpoint: otel-collector:55680
+          insecure: true
+          insecure_skip_verify: true
+```
+
+Example new config:
+
+```
+tempo:
+  configs:
+    - name: default
+      remote_write:
+        - endpoint: otel-collector:55680
+          insecure: true
+          tls_config:
+            insecure_skip_verify: true
+```
+
 # v0.15.0
 
 ## Tempo: `automatic_logging` changes

--- a/pkg/tempo/config.go
+++ b/pkg/tempo/config.go
@@ -308,10 +308,7 @@ func exporter(rwCfg RemoteWriteConfig) (map[string]interface{}, error) {
 			otlpExporter["insecure_skip_verify"] = rwCfg.InsecureSkipVerify
 		}
 	}
-
-	if !rwCfg.Insecure && rwCfg.TLSConfig != nil {
-	}
-
+g
 	// Apply some sane defaults to the exporter. The
 	// sending_queue.retry_on_failure default is 300s which prevents any
 	// sending-related errors to not be logged for 5 minutes. We'll lower that

--- a/pkg/tempo/config.go
+++ b/pkg/tempo/config.go
@@ -176,23 +176,14 @@ var DefaultRemoteWriteConfig = RemoteWriteConfig{
 	Compression: compressionGzip,
 }
 
-// TLSConfig controls the TLS config for the exporter's client.
-type TLSConfig struct {
-	CAFile             string `yaml:"ca_file,omitempty"`
-	CertFile           string `yaml:"cert_file,omitempty"`
-	KeyFile            string `yaml:"key_file,omitempty"`
-	InsecureSkipVerify bool   `yaml:"insecure_skip_verify,omitempty"`
-}
-
 // RemoteWriteConfig controls the configuration of an exporter
 type RemoteWriteConfig struct {
-	Endpoint           string                 `yaml:"endpoint,omitempty"`
-	Compression        string                 `yaml:"compression,omitempty"`
-	Insecure           bool                   `yaml:"insecure,omitempty"`
-	// TODO(@mapno): Remove InsecureSkipVerify in favor of TLSConfig
+	Endpoint    string `yaml:"endpoint,omitempty"`
+	Compression string `yaml:"compression,omitempty"`
+	Insecure    bool   `yaml:"insecure,omitempty"`
 	// Deprecated
 	InsecureSkipVerify bool                   `yaml:"insecure_skip_verify,omitempty"`
-	TLSConfig          *TLSConfig             `yaml:"tls_config,omitempty"`
+	TLSConfig          *prom_config.TLSConfig `yaml:"tls_config,omitempty"`
 	BasicAuth          *prom_config.BasicAuth `yaml:"basic_auth,omitempty"`
 	Headers            map[string]string      `yaml:"headers,omitempty"`
 	SendingQueue       map[string]interface{} `yaml:"sending_queue,omitempty"`    // https://github.com/open-telemetry/opentelemetry-collector/blob/7d7ae2eb34b5d387627875c498d7f43619f37ee3/exporter/exporterhelper/queued_retry.go#L30
@@ -308,7 +299,7 @@ func exporter(rwCfg RemoteWriteConfig) (map[string]interface{}, error) {
 			otlpExporter["insecure_skip_verify"] = rwCfg.InsecureSkipVerify
 		}
 	}
-g
+
 	// Apply some sane defaults to the exporter. The
 	// sending_queue.retry_on_failure default is 300s which prevents any
 	// sending-related errors to not be logged for 5 minutes. We'll lower that
@@ -332,7 +323,7 @@ func (c *InstanceConfig) exporters() (map[string]interface{}, error) {
 			Endpoint:    c.PushConfig.Endpoint,
 			Compression: c.PushConfig.Compression,
 			Insecure:    c.PushConfig.Insecure,
-			TLSConfig: &TLSConfig{
+			TLSConfig: &prom_config.TLSConfig{
 				InsecureSkipVerify: c.PushConfig.InsecureSkipVerify,
 			},
 			BasicAuth:      c.PushConfig.BasicAuth,
@@ -378,7 +369,7 @@ func (c *InstanceConfig) loadBalancingExporter() (map[string]interface{}, error)
 		Endpoint:    "noop",
 		Compression: c.TailSampling.LoadBalancing.Exporter.Compression,
 		Insecure:    c.TailSampling.LoadBalancing.Exporter.Insecure,
-		TLSConfig:   &TLSConfig{InsecureSkipVerify: c.TailSampling.LoadBalancing.Exporter.InsecureSkipVerify},
+		TLSConfig:   &prom_config.TLSConfig{InsecureSkipVerify: c.TailSampling.LoadBalancing.Exporter.InsecureSkipVerify},
 		BasicAuth:   c.TailSampling.LoadBalancing.Exporter.BasicAuth,
 	})
 	if err != nil {

--- a/pkg/tempo/config_test.go
+++ b/pkg/tempo/config_test.go
@@ -700,6 +700,44 @@ service:
       receivers: ["jaeger"]
       `,
 		},
+		{
+			name: "tls config",
+			cfg: `
+receivers:
+  jaeger:
+    protocols:
+      grpc:
+remote_write:
+  - insecure: false
+    tls_config:
+      ca_file: server.crt
+      cert_file: client.crt
+      key_file: client.key
+    endpoint: example.com:12345
+`,
+			expectedConfig: `
+receivers:
+  jaeger:
+    protocols:
+      grpc:
+exporters:
+  otlp/0:
+    endpoint: example.com:12345
+    insecure: false
+    ca_file: server.crt
+    cert_file: client.crt
+    key_file: client.key
+    compression: gzip
+    retry_on_failure:
+      max_elapsed_time: 60s
+service:
+  pipelines:
+    traces:
+      exporters: ["otlp/0"]
+      processors: []
+      receivers: ["jaeger"]
+`,
+		},
 	}
 
 	for _, tc := range tt {

--- a/pkg/tempo/instance.go
+++ b/pkg/tempo/instance.go
@@ -138,6 +138,14 @@ func (i *Instance) buildAndStartPipeline(ctx context.Context, cfg InstanceConfig
 	if cfg.PushConfig.Endpoint != "" {
 		i.logger.Warn("Configuring exporter with deprecated push_config. Use remote_write and batch instead")
 	}
+	for _, rw := range cfg.RemoteWrite {
+		if rw.InsecureSkipVerify {
+			i.logger.Warn("Configuring TLS with insecure_skip_verify. Use tls_config.insecure_skip_verify instead")
+		}
+		if rw.TLSConfig != nil && rw.TLSConfig.ServerName != "" {
+			i.logger.Warn("Configuring unsupported tls_config.server_name")
+		}
+	}
 
 	if cfg.SpanMetrics != nil && len(cfg.SpanMetrics.PromInstance) != 0 {
 		ctx = context.WithValue(ctx, contextkeys.Prometheus, promManager)


### PR DESCRIPTION
#### PR Description

Add TLS config options for tempo remote_write. `insecure_skip_verify` is moved to `tls_config`

#### Which issue(s) this PR fixes 

Fixes https://github.com/grafana/agent/issues/662.

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
