### PR TITLE
Initialize biggest ref to existing ref when reading a segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - [FEATURE] Add TLS config options for tempo `remote_write`s. (@mapno)
 
+- [BUGFIX] Fix issue where replaying a WAL caused data corruption. (@rfratto)
+
 # v0.16.0 (2021-06-17)
 
 - [FEATURE] (beta) A Grafana Agent Operator is now available. (@rfratto)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 - [FEATURE] Add TLS config options for tempo `remote_write`s. (@mapno)
 
-- [BUGFIX] Fix issue where replaying a WAL caused data corruption. (@rfratto)
+- [BUGFIX] Fix issue where replaying a WAL caused incorrect metrics to be sent
+  over remote write. (@rfratto)
 
 # v0.16.0 (2021-06-17)
 

--- a/pkg/prom/wal/wal.go
+++ b/pkg/prom/wal/wal.go
@@ -294,7 +294,7 @@ func (w *Storage) loadWAL(r *wal.Reader) (err error) {
 		}
 	}()
 
-	var biggestRef uint64 = 0
+	var biggestRef uint64 = w.ref.Load()
 
 	for d := range decoded {
 		switch v := d.(type) {

--- a/pkg/prom/wal/wal_test.go
+++ b/pkg/prom/wal/wal_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/grafana/agent/pkg/util"
 	"github.com/prometheus/prometheus/pkg/exemplar"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/value"
@@ -166,6 +167,39 @@ func TestStorage_ExistingWAL(t *testing.T) {
 	actualExemplars := collector.exemplars
 	sort.Sort(byRefExemplar(actualExemplars))
 	require.Equal(t, expectedExemplars, actualExemplars)
+}
+
+func TestStorage_ExistingWAL_RefID(t *testing.T) {
+	l := util.TestLogger(t)
+
+	walDir, err := ioutil.TempDir(os.TempDir(), "wal")
+	require.NoError(t, err)
+	defer os.RemoveAll(walDir)
+
+	s, err := NewStorage(l, nil, walDir)
+	require.NoError(t, err)
+
+	app := s.Appender(context.Background())
+	payload := buildSeries([]string{"foo", "bar", "baz", "blerg"})
+
+	// Write all the samples
+	for _, metric := range payload {
+		metric.Write(t, app)
+	}
+	require.NoError(t, app.Commit())
+
+	// Truncate the WAL to force creation of a new segment.
+	require.NoError(t, s.Truncate(0))
+	require.NoError(t, s.Close())
+
+	// Create a new storage and see what the ref ID is initialized to.
+	s, err = NewStorage(l, nil, walDir)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, s.Close())
+	}()
+
+	require.Equal(t, uint64(4), s.ref.Load())
 }
 
 func TestStorage_Truncate(t *testing.T) {

--- a/pkg/prom/wal/wal_test.go
+++ b/pkg/prom/wal/wal_test.go
@@ -199,7 +199,7 @@ func TestStorage_ExistingWAL_RefID(t *testing.T) {
 		require.NoError(t, s.Close())
 	}()
 
-	require.Equal(t, uint64(4), s.ref.Load())
+	require.Equal(t, uint64(len(payload)), s.ref.Load())
 }
 
 func TestStorage_Truncate(t *testing.T) {

--- a/pkg/prom/wal/wal_test.go
+++ b/pkg/prom/wal/wal_test.go
@@ -195,11 +195,9 @@ func TestStorage_ExistingWAL_RefID(t *testing.T) {
 	// Create a new storage and see what the ref ID is initialized to.
 	s, err = NewStorage(l, nil, walDir)
 	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, s.Close())
-	}()
+	defer require.NoError(t, s.Close())
 
-	require.Equal(t, uint64(len(payload)), s.ref.Load())
+	require.Equal(t, uint64(len(payload)), s.ref.Load(), "cached ref ID should be equal to the number of series written")
 }
 
 func TestStorage_Truncate(t *testing.T) {


### PR DESCRIPTION
#### PR Description 
`biggestRef` was incorrectly initialized to 0, which only works when there's no other segments, since that code is being called per-segment. If there was a segment with no series in it (which always happened with a new WAL is opened for writing), then the series ID will always be set to 0 and will always overlap with other metrics. 

This bug depends on an instance being restarted or the process crashing and restarting to trigger.

#### Which issue(s) this PR fixes 
Fixes #675

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
