### PR TITLE
Update operator to use v0.16.1 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 - [FEATURE] Add TLS config options for tempo `remote_write`s. (@mapno)
 
-- [ENHANCEMENT] The Grafana Agent Operator will now deploy the latest release of
-  the Grafana Agent instead of v0.14.0. (@rfratto)
+- [ENHANCEMENT] The Grafana Agent Operator will now default to deploying
+  the matching release version of the Grafana Agent instead of v0.14.0.
+  (@rfratto)
 
 # v0.16.1 (2021-06-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - [FEATURE] Add TLS config options for tempo `remote_write`s. (@mapno)
 
+- [ENHANCEMENT] The Grafana Agent Operator will now deploy the latest release of
+  the Grafana Agent instead of v0.14.0. (@rfratto)
+
 # v0.16.1 (2021-06-22)
 
 - [BUGFIX] Fix issue where replaying a WAL caused incorrect metrics to be sent

--- a/pkg/operator/defaults.go
+++ b/pkg/operator/defaults.go
@@ -4,6 +4,11 @@ package operator
 var (
 	AgentCompatibilityMatrix = []string{
 		"v0.14.0",
+		"v0.15.0",
+		// "v0.16.0", // Pulled due to critical bug fixed in v0.16.1.
+		"v0.16.1",
+
+		// NOTE(rfratto): when performing an upgrade, add the newest version above instead of changing the existing reference.
 	}
 
 	DefaultAgentVersion   = AgentCompatibilityMatrix[len(AgentCompatibilityMatrix)-1]


### PR DESCRIPTION
Oops :) This wasn't being updated along with releases and was stuck at v0.14.0.