### PR TITLE
Update dashboards setup in production mixin.

### DIFF
--- a/production/grafana-agent-mixin/dashboards.libsonnet
+++ b/production/grafana-agent-mixin/dashboards.libsonnet
@@ -62,10 +62,10 @@ local template = grafana.template;
         .addPanel(
           g.panel('Scrape failures') +
           g.queryPanel([
-            'sum by (job) (rate(prometheus_target_scrapes_exceeded_sample_limit_total[1m]))',
-            'sum by (job) (rate(prometheus_target_scrapes_sample_duplicate_timestamp_total[1m]))',
-            'sum by (job) (rate(prometheus_target_scrapes_sample_out_of_bounds_total[1m]))',
-            'sum by (job) (rate(prometheus_target_scrapes_sample_out_of_order_total[1m]))',
+            'sum by (job) (rate(prometheus_target_scrapes_exceeded_sample_limit_total{cluster=~"$cluster", namespace=~"$namespace", container=~"$container"}[1m]))',
+            'sum by (job) (rate(prometheus_target_scrapes_sample_duplicate_timestamp_total{cluster=~"$cluster", namespace=~"$namespace", container=~"$container"}[1m]))',
+            'sum by (job) (rate(prometheus_target_scrapes_sample_out_of_bounds_total{cluster=~"$cluster", namespace=~"$namespace", container=~"$container"}[1m]))',
+            'sum by (job) (rate(prometheus_target_scrapes_sample_out_of_order_total{cluster=~"$cluster", namespace=~"$namespace", container=~"$container"}[1m]))',
           ], [
             'exceeded sample limit: {{job}}',
             'duplicate timestamp: {{job}}',
@@ -261,7 +261,7 @@ local template = grafana.template;
           legendFormat='{{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}',
         ));
 
-      dashboard.new('Agent Prometheus Remote Write', editable=true)
+      dashboard.new('Agent Prometheus Remote Write', tags=['grafana-agent-mixin'], editable=true)
       .addTemplate(
         {
           hide: 0,

--- a/production/grafana-agent-mixin/mixin.libsonnet
+++ b/production/grafana-agent-mixin/mixin.libsonnet
@@ -2,6 +2,6 @@ local dashboards = import 'dashboards.libsonnet';
 
 {
   grafanaDashboards+:: std.mapWithKey(function(field, obj) obj {
-    grafanaDashboardFolder: 'Agent',
+    grafanaDashboardFolder: 'Grafana Agent',
   }, dashboards.grafanaDashboards),
 }

--- a/production/grafana-agent-mixin/utils.libsonnet
+++ b/production/grafana-agent-mixin/utils.libsonnet
@@ -1,5 +1,6 @@
 {
   injectUtils(dashboard):: dashboard {
+    tags: ['grafana-agent-mixin'],
     addMultiTemplateWithAll(name, metric_name, label_name, all='.*', hide=0):: self {
       templating+: {
         list+: [{


### PR DESCRIPTION
#### PR Description 
This changes the following:
- fix `Scrape failures` queries to use the proper variables like the rest of queries
- add `grafana-agent-mixin` tag to all dashboards to allow easy link and discovery

#### Which issue(s) this PR fixes 
n.a.

#### Notes to the Reviewer
n.a.

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
