### PR TITLE
fix race condition in initializing cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   the matching release version of the Grafana Agent instead of v0.14.0.
   (@rfratto)
 
+- [BUGFIX] Fix race condition that may occur and result in a panic when
+  initializing scraping service cluster. (@rfratto)
+
 # v0.16.1 (2021-06-22)
 
 - [BUGFIX] Fix issue where replaying a WAL caused incorrect metrics to be sent

--- a/pkg/prom/cluster/cluster.go
+++ b/pkg/prom/cluster/cluster.go
@@ -107,6 +107,9 @@ func (c *Cluster) storeValidate(cfg *instance.Config) error {
 // Reshard implements agentproto.ScrapingServiceServer, and syncs the state of
 // configs with the configstore.
 func (c *Cluster) Reshard(ctx context.Context, _ *agentproto.ReshardRequest) (*empty.Empty, error) {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+
 	err := c.watcher.Refresh(ctx)
 	if err != nil {
 		level.Error(c.log).Log("msg", "failed to perform local reshard", "err", err)


### PR DESCRIPTION
#### PR Description 
Fixes a race condition while initializing the cluster. There was even a comment warning about this exact thing happening but the lock wasn't ever held when calling `Reshard`. 

#### Which issue(s) this PR fixes 
Fixes #688.

#### Notes to the Reviewer
The race checker should've caught this but it's difficult to reproduce in a test since it depends on the speed of CPUs, the work done when spinning up the cluster, and how many CPUs are available for scheduling goroutines.  

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
