### PR TITLE
Tanka Jsonnet Integrations Fixes

### DIFF
--- a/production/tanka/grafana-agent/v1/lib/integrations.libsonnet
+++ b/production/tanka/grafana-agent/v1/lib/integrations.libsonnet
@@ -9,7 +9,7 @@ local container = k.core.v1.container;
   // https://github.com/grafana/agent/blob/main/docs/configuration-reference.md#integrations_config
   withIntegrations(integrations):: {
     assert std.objectHasAll(self, '_mode') : |||
-      withLokiConfig must be merged with the result of calling new.
+      withIntegrations must be merged with the result of calling new.
     |||,
     _integrations:: integrations,
   },

--- a/production/tanka/grafana-agent/v1/lib/integrations.libsonnet
+++ b/production/tanka/grafana-agent/v1/lib/integrations.libsonnet
@@ -14,7 +14,6 @@ local container = k.core.v1.container;
     _integrations:: integrations,
   },
 
-  // TODO(rfratto): only enable this when node_exporter is used.
   integrationsMixin:: {
     container+::
       container.mixin.securityContext.withPrivileged(true) +

--- a/production/tanka/grafana-agent/v1/lib/integrations.libsonnet
+++ b/production/tanka/grafana-agent/v1/lib/integrations.libsonnet
@@ -20,14 +20,14 @@ local container = k.core.v1.container;
       container.mixin.securityContext.withPrivileged(true) +
       container.mixin.securityContext.withRunAsUser(0),
 
-    local controller = self.agent._controller,
-    agent+::
+    local controller = self._controller,
+    agent+:
       // procfs, sysfs, rotfs
       k.util.hostVolumeMount('proc', '/proc', '/host/proc', readOnly=true) +
       k.util.hostVolumeMount('sys', '/sys', '/host/sys', readOnly=true) +
       k.util.hostVolumeMount('root', '/', '/host/root', readOnly=true) +
 
-      controller.mixin.spec.template.spec.withHostPid(true) +
+      controller.mixin.spec.template.spec.withHostPID(true) +
       controller.mixin.spec.template.spec.withHostNetwork(true),
   },
 }

--- a/production/tanka/grafana-agent/v1/main.libsonnet
+++ b/production/tanka/grafana-agent/v1/main.libsonnet
@@ -124,7 +124,7 @@ local service = k.core.v1.service;
           else {},
       } + (
         if has_loki_config then $.lokiPermissionsMixin else {}
-      ) + $.integrationsMixin,
+      ),
 
     agent_etc: if std.length(etc_instances) > 0 then
       agent.newAgent(name + '-etc', namespace, self._images.agent, self.etc_config, use_daemonset=false) +

--- a/production/tanka/grafana-agent/v1/main.libsonnet
+++ b/production/tanka/grafana-agent/v1/main.libsonnet
@@ -124,7 +124,7 @@ local service = k.core.v1.service;
           else {},
       } + (
         if has_loki_config then $.lokiPermissionsMixin else {}
-      ),
+      ) + $.integrationsMixin,
 
     agent_etc: if std.length(etc_instances) > 0 then
       agent.newAgent(name + '-etc', namespace, self._images.agent, self.etc_config, use_daemonset=false) +

--- a/production/tanka/grafana-agent/v1/main.libsonnet
+++ b/production/tanka/grafana-agent/v1/main.libsonnet
@@ -124,6 +124,8 @@ local service = k.core.v1.service;
           else {},
       } + (
         if has_loki_config then $.lokiPermissionsMixin else {}
+      ) + (
+        if has_integrations && std.objectHas(this._integrations, 'node_exporter') then $.integrationsMixin else {}
       ),
 
     agent_etc: if std.length(etc_instances) > 0 then


### PR DESCRIPTION
#### PR Description 
This fixes a couple small issues with the `withIntegrations` jsonnet method for tanka deploys.

It also implements the `integrationsMixin` conditionally for the node_exporter integration, adding the necessary host volume mounts, and privileged container config.

#### Which issue(s) this PR fixes 
N/A

#### Notes to the Reviewer
Don't mind the name of my branch. I had initially committed some changes to *always* apply the integrations mixin since that was my use-case. I later realized it's not much more effort to do it "right" and contribute the fixes back.

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
