### PR TITLE
Add debug log in prom-sd processor to indicate missing ip tag

### DIFF
--- a/pkg/tempo/promsdprocessor/prom_sd_processor.go
+++ b/pkg/tempo/promsdprocessor/prom_sd_processor.go
@@ -98,6 +98,7 @@ func (p *promServiceDiscoProcessor) processAttributes(attrs pdata.AttributeMap) 
 
 	// have to have an ip for labels lookup
 	if ip == "" {
+		level.Debug(p.logger).Log("msg", "unable to find ip in span attributes, skipping attribute addition")
 		return
 	}
 


### PR DESCRIPTION
Hi agent team! 👋 

This is a tiny PR to add a debug log in the prom service discovery processor. Something that will be helpful in discovering when attributes are not auto-added to spans.

Signed-off-by: Annanay <annanay.agarwal@grafana.com>
