### PR TITLE
Rename "loki" to "logs"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - [DEPRECATION] The `loki` key at the root of the config file has been
   deprecated in favor of `logs`. `loki`-named fields in `automatic_logging`
   have been renamed accordinly: `loki_name` is now `logs_instance_name`,
-  `loki_tag` is now `logs_tag`, and `backend: loki` is now
+  `loki_tag` is now `logs_instance_tag`, and `backend: loki` is now
   `backend: logs_instance`.
 
 # v0.16.1 (2021-06-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Main (unreleased)
 
-- [ENHANCEMENT] Allow reloading configuration using `SIGHUP` signal. (@tharun208)
-
 - [FEATURE] Add TLS config options for tempo `remote_write`s. (@mapno)
 
 - [FEATURE] Add support for OTLP HTTP trace exporting. (@mapno)
@@ -9,11 +7,19 @@
 - [ENHANCEMENT] The Grafana Agent Operator will now default to deploying
   the matching release version of the Grafana Agent instead of v0.14.0.
   (@rfratto)
-  
+
 - [ENHANCEMENT] Update OTel dependency to v0.29.0 (@mapno)
+
+- [ENHANCEMENT] Allow reloading configuration using `SIGHUP` signal. (@tharun208)
 
 - [BUGFIX] Fix race condition that may occur and result in a panic when
   initializing scraping service cluster. (@rfratto)
+
+- [DEPRECATION] The `loki` key at the root of the config file has been
+  deprecated in favor of `logs`. `loki`-named fields in `automatic_logging`
+  have been renamed accordinly: `loki_name` is now `logs_instance_name`,
+  `loki_tag` is now `logs_tag`, and `backend: loki` is now
+  `backend: logs_instance`.
 
 # v0.16.1 (2021-06-22)
 

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ lint:
 # for packages that have known race detection issues
 test:
 	CGO_ENABLED=1 go test $(CGO_FLAGS) -race -cover -coverprofile=cover.out -p=4 ./...
-	CGO_ENABLED=1 go test $(CGO_FLAGS) -cover -coverprofile=cover-norace.out -p=4 ./pkg/integrations/node_exporter ./pkg/loki
+	CGO_ENABLED=1 go test $(CGO_FLAGS) -cover -coverprofile=cover-norace.out -p=4 ./pkg/integrations/node_exporter ./pkg/logs
 
 clean:
 	rm -rf cmd/agent/agent

--- a/docs/configuration/tempo-config.md
+++ b/docs/configuration/tempo-config.md
@@ -85,28 +85,30 @@ remote_write:
     [ sending_queue: <otlpexporter.sending_queue> ]
     [ retry_on_failure: <otlpexporter.retry_on_failure> ]
 
-# This processor writes a well formatted log line to a Loki instance for each span, root, or process
+# This processor writes a well formatted log line to a logs instance for each span, root, or process
 # that passes through the Agent. This allows for automatically building a mechanism for trace
 # discovery and building metrics from traces using Loki. It should be considered experimental.
 automatic_logging:
-  # indicates where the stream of log lines should go. Either supports writing to a loki instance defined in this same config or to stdout.
-  [ backend: <string> | default = "stdout" | supported "stdout", "loki" ]
-  # indicates the Loki instance to write logs to. Required if backend is set to loki.
-  [ loki_name: <string> ]
-  # log one line per span. Warning! possibly very high volume
+  # Indicates where the stream of log lines should go. Either supports writing
+  # to a logs instance defined in this same config or to stdout.
+  [ backend: <string> | default = "stdout" | supported "stdout", "logs_instance" ]
+  # Indicates the logs instance to write logs to.
+  # Required if backend is set to logs_instance.
+  [ logs_instance_name: <string> ]
+  # Log one line per span. Warning! possibly very high volume
   [ spans: <boolean> ]
-  # log one line for every root span of a trace.
+  # Log one line for every root span of a trace.
   [ roots: <boolean> ]
-  # log one line for every process
+  # Log one line for every process
   [ processes: <boolean> ]
-  # additional span attributes to log
+  # Additional span attributes to log
   [ span_attributes: <string array> ]
-  # additional process attributes to log
+  # Additional process attributes to log
   [ process_attributes: <string array> ]
-  # timeout on sending logs to Loki
+  # Timeout on writing logs to Loki when backend is "logs_instance."
   [ timeout: <duration> | default = 1ms ]
   overrides:
-    [ loki_tag: <string> | default = "tempo" ]
+    [ logs_tag: <string> | default = "tempo" ]
     [ service_key: <string> | default = "svc" ]
     [ span_name_key: <string> | default = "span" ]
     [ status_key: <string> | default = "status" ]

--- a/docs/configuration/tempo-config.md
+++ b/docs/configuration/tempo-config.md
@@ -108,7 +108,7 @@ automatic_logging:
   # Timeout on writing logs to Loki when backend is "logs_instance."
   [ timeout: <duration> | default = 1ms ]
   overrides:
-    [ logs_tag: <string> | default = "tempo" ]
+    [ logs_instance_tag: <string> | default = "tempo" ]
     [ service_key: <string> | default = "svc" ]
     [ span_name_key: <string> | default = "span" ]
     [ status_key: <string> | default = "status" ]

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -12,6 +12,91 @@ releases and how to migrate to newer versions.
 
 These changes will come in a future version.
 
+### Logs: Deprecation of "loki" in config.
+
+The term `loki` in the config has been deprecated of favor of `logs`. This
+change is to make it clearer when referring to Grafana Loki, and
+configuration of Grafana Agent to send logs to Grafana Loki.
+
+Old configs will continue to work until it is fully deprecated. To migrate your
+config, change the `loki` key to `logs`.
+
+Example old config:
+
+```yaml
+loki:
+  positions_directory: /tmp/loki-positions
+  configs:
+  - name: default
+    clients:
+      - url: http://localhost:3100/loki/api/v1/push
+    scrape_configs:
+    - job_name: system
+      static_configs:
+      - targets: ['localhost']
+        labels:
+          job: varlogs
+          __path__: /var/log/*log
+```
+
+Example new config:
+
+```yaml
+logs:
+  positions_directory: /tmp/loki-positions
+  configs:
+  - name: default
+    clients:
+      - url: http://localhost:3100/loki/api/v1/push
+    scrape_configs:
+    - job_name: system
+      static_configs:
+      - targets: ['localhost']
+        labels:
+          job: varlogs
+          __path__: /var/log/*log
+```
+
+#### Tempo: Deprecation of "loki" in config.
+
+As part of the `loki` to `logs` rename, parts of the automatic_logging component
+in Tempo have been updated to refer to `logs_instance` instead.
+
+Old configurations using `loki_name`, `loki_tag`, or `backend: loki` will
+continue to work until the `loki` terminology is fully deprecated.
+
+Example old config:
+
+```yaml
+tempo:
+  configs:
+  - name: default
+    automatic_logging:
+      backend: loki
+      loki_name: default
+      spans: true
+      processes: true
+      roots: true
+    overrides:
+      loki_tag: tempo
+```
+
+Example new config:
+
+```yaml
+tempo:
+  configs:
+  - name: default
+    automatic_logging:
+      backend: logs_instance
+      logs_instance_name: default
+      spans: true
+      processes: true
+      roots: true
+    overrides:
+      logs_tag: tempo
+```
+
 ### Tempo: Remote write TLS config
 
 Tempo `remote_write` now supports configuring TLS settings in the trace

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -94,7 +94,7 @@ tempo:
       processes: true
       roots: true
     overrides:
-      logs_tag: tempo
+      logs_instance_tag: tempo
 ```
 
 ### Tempo: Remote write TLS config

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,11 +6,13 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/weaveworks/common/server"
 
 	"github.com/drone/envsubst"
 	"github.com/grafana/agent/pkg/integrations"
-	"github.com/grafana/agent/pkg/loki"
+	"github.com/grafana/agent/pkg/logs"
 	"github.com/grafana/agent/pkg/prom"
 	"github.com/grafana/agent/pkg/tempo"
 	"github.com/grafana/agent/pkg/util"
@@ -30,9 +32,12 @@ var DefaultConfig = Config{
 type Config struct {
 	Server       server.Config              `yaml:"server,omitempty"`
 	Prometheus   prom.Config                `yaml:"prometheus,omitempty"`
-	Loki         loki.Config                `yaml:"loki,omitempty"`
 	Integrations integrations.ManagerConfig `yaml:"integrations,omitempty"`
 	Tempo        tempo.Config               `yaml:"tempo,omitempty"`
+
+	Logs               *logs.Config `yaml:"logs,omitempty"`
+	Loki               *logs.Config `yaml:"loki,omitempty"` // Deprecated: use Logs instead
+	UsedDeprecatedLoki bool         `yaml:"-"`
 
 	// We support a secondary server just for the /-/reload endpoint, since
 	// invoking /-/reload against the primary server can cause the server
@@ -52,10 +57,26 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return unmarshal((*config)(c))
 }
 
+func (c *Config) LogDeprecations(l log.Logger) {
+	if c.UsedDeprecatedLoki {
+		level.Warn(l).Log("msg", "DEPRECATION NOTICE: `loki` is deprecated in favor of `logs`")
+	}
+}
+
 // ApplyDefaults sets default values in the config
 func (c *Config) ApplyDefaults() error {
 	if err := c.Prometheus.ApplyDefaults(); err != nil {
 		return err
+	}
+
+	if c.Logs != nil && c.Loki != nil {
+		return fmt.Errorf("at most one of loki and logs should be specified.")
+	}
+
+	if c.Logs == nil && c.Loki != nil {
+		c.Logs = c.Loki
+		c.Loki = nil
+		c.UsedDeprecatedLoki = true
 	}
 
 	if err := c.Integrations.ApplyDefaults(&c.Prometheus); err != nil {
@@ -74,7 +95,7 @@ func (c *Config) ApplyDefaults() error {
 
 	// since the Tempo config might rely on an existing Loki config
 	// this check is made here to look for cross config issues before we attempt to load
-	if err := c.Tempo.Validate(&c.Loki); err != nil {
+	if err := c.Tempo.Validate(c.Logs); err != nil {
 		return err
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,6 +57,8 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return unmarshal((*config)(c))
 }
 
+// LogDeprecations will log use of any deprecated fields to l as warn-level
+// messages.
 func (c *Config) LogDeprecations(l log.Logger) {
 	if c.UsedDeprecatedLoki {
 		level.Warn(l).Log("msg", "DEPRECATION NOTICE: `loki` is deprecated in favor of `logs`")
@@ -70,7 +72,7 @@ func (c *Config) ApplyDefaults() error {
 	}
 
 	if c.Logs != nil && c.Loki != nil {
-		return fmt.Errorf("at most one of loki and logs should be specified.")
+		return fmt.Errorf("at most one of loki and logs should be specified")
 	}
 
 	if c.Logs == nil && c.Loki != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/prom"
 	"github.com/grafana/agent/pkg/prom/instance"
+	"github.com/grafana/agent/pkg/util"
 	"github.com/prometheus/common/model"
 	promCfg "github.com/prometheus/prometheus/config"
 	"github.com/stretchr/testify/require"
@@ -183,6 +184,25 @@ tempo:
 	}
 }
 
+func TestConfig_LokiNameMigration(t *testing.T) {
+	input := util.Untab(`
+loki:
+  configs:
+  - name: foo
+    positions:
+      filename: /tmp/positions.yaml
+    clients:
+    - url: http://loki:3100/loki/api/v1/push
+`)
+	var cfg Config
+	require.NoError(t, LoadBytes([]byte(input), false, &cfg))
+	require.NoError(t, cfg.ApplyDefaults())
+
+	require.Nil(t, cfg.Loki)
+	require.NotNil(t, cfg.Logs)
+	require.Equal(t, "foo", cfg.Logs.Configs[0].Name)
+}
+
 func TestConfig_TempoLokiFailsValidation(t *testing.T) {
 	tests := []struct {
 		cfg           string
@@ -201,10 +221,10 @@ tempo:
   configs:
   - name: default
     automatic_logging:
-      backend: loki
-      loki_name: default
+      backend: logs_instance
+      logs_instance_name: default
       spans: true`,
-			expectedError: "error in config file: specified loki config default not found",
+			expectedError: "error in config file: failed to validate automatic_logging for tempo config default: specified logs config default not found in agent config",
 		},
 	}
 

--- a/pkg/logs/config.go
+++ b/pkg/logs/config.go
@@ -1,4 +1,4 @@
-package loki
+package logs
 
 import (
 	"flag"

--- a/pkg/logs/config_test.go
+++ b/pkg/logs/config_test.go
@@ -1,4 +1,4 @@
-package loki
+package logs
 
 import (
 	"fmt"
@@ -21,7 +21,7 @@ func TestConfig_ApplyDefaults_Validations(t *testing.T) {
 			err:  nil,
 			cfg: untab(`
 				positions_directory: /tmp
-				configs: 
+				configs:
 				- name: config-a
 				- name: config-b
 		  `),
@@ -31,7 +31,7 @@ func TestConfig_ApplyDefaults_Validations(t *testing.T) {
 			err:  fmt.Errorf("found two Loki configs with name config-a"),
 			cfg: untab(`
 				positions_directory: /tmp
-				configs: 
+				configs:
 				- name: config-a
 				- name: config-b
 				- name: config-a
@@ -41,7 +41,7 @@ func TestConfig_ApplyDefaults_Validations(t *testing.T) {
 			name: "two configs, different positions path",
 			err:  nil,
 			cfg: untab(`
-				configs: 
+				configs:
 				- name: config-a
 				  positions:
 					  filename: /tmp/file-a.yml
@@ -54,7 +54,7 @@ func TestConfig_ApplyDefaults_Validations(t *testing.T) {
 			name: "re-used positions path",
 			err:  fmt.Errorf("Loki configs config-a and config-c must have different positions file paths"),
 			cfg: untab(`
-				configs: 
+				configs:
 				- name: config-a
 				  positions:
 					  filename: /tmp/file-a.yml
@@ -71,7 +71,7 @@ func TestConfig_ApplyDefaults_Validations(t *testing.T) {
 			err:  fmt.Errorf("Loki config index 1 must have a name"),
 			cfg: untab(`
 				positions_directory: /tmp
-				configs: 
+				configs:
 				- name: config-a
 				- name:
 				- name: config-a
@@ -81,7 +81,7 @@ func TestConfig_ApplyDefaults_Validations(t *testing.T) {
 			name: "generated positions file path without positions_directory",
 			err:  fmt.Errorf("cannot generate Loki positions file path for config-b because positions_directory is not configured"),
 			cfg: untab(`
-				configs: 
+				configs:
 				- name: config-a
 				  positions:
 					  filename: /tmp/config-a.yaml

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -53,6 +53,10 @@ func (l *Logs) ApplyConfig(c *Config) error {
 	l.mut.Lock()
 	defer l.mut.Unlock()
 
+	if c == nil {
+		c = &Config{}
+	}
+
 	if c.PositionsDirectory != "" {
 		err := os.MkdirAll(c.PositionsDirectory, 0700)
 		if err != nil {

--- a/pkg/logs/logs_test.go
+++ b/pkg/logs/logs_test.go
@@ -1,6 +1,6 @@
 //+build !race
 
-package loki
+package logs
 
 import (
 	"fmt"
@@ -21,7 +21,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func TestLoki(t *testing.T) {
+func TestLogs(t *testing.T) {
 	//
 	// Create a temporary file to tail
 	//
@@ -83,7 +83,7 @@ configs:
 	require.NoError(t, dec.Decode(&cfg))
 
 	logger := log.NewSyncLogger(log.NewNopLogger())
-	l, err := New(prometheus.NewRegistry(), cfg, logger)
+	l, err := New(prometheus.NewRegistry(), &cfg, logger)
 	require.NoError(t, err)
 	defer l.Stop()
 
@@ -123,7 +123,7 @@ configs:
 	dec.SetStrict(true)
 	require.NoError(t, dec.Decode(&newCfg))
 
-	require.NoError(t, l.ApplyConfig(newCfg))
+	require.NoError(t, l.ApplyConfig(&newCfg))
 
 	fmt.Fprintf(tmpFile, "Hello again!\n")
 	select {

--- a/pkg/logs/logs_test.go
+++ b/pkg/logs/logs_test.go
@@ -21,6 +21,14 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+func TestLogs_NilConfig(t *testing.T) {
+	l, err := New(prometheus.NewRegistry(), nil, util.TestLogger(t))
+	require.NoError(t, err)
+	require.NoError(t, l.ApplyConfig(nil))
+
+	defer l.Stop()
+}
+
 func TestLogs(t *testing.T) {
 	//
 	// Create a temporary file to tail
@@ -132,4 +140,11 @@ configs:
 	case req := <-pushes:
 		require.Equal(t, "Hello again!", req.Streams[0].Entries[0].Line)
 	}
+
+	t.Run("update to nil", func(t *testing.T) {
+		// Applying a nil config should remove all instances.
+		err := l.ApplyConfig(nil)
+		require.NoError(t, err)
+		require.Len(t, l.instances, 0)
+	})
 }

--- a/pkg/operator/config/templates/agent-logs.libsonnet
+++ b/pkg/operator/config/templates/agent-logs.libsonnet
@@ -1,0 +1,33 @@
+// agent-logs.libsonnet is the entrypoint for rendering a Grafana Agent
+// config file for logs based on the Operator custom resources.
+//
+// When writing an object, any field will null will be removed from the final
+// YAML. This is useful as we don't want to always translate unfilled values
+// from the custom resources to a field in the YAML.
+//
+// A series of helper methods to convert default values into null (so they can
+// be trimmed) are in ./ext/optionals.libsonnet.
+//
+// When writing a new function, please document the expected types of the
+// arguments.
+
+local marshal = import 'ext/marshal.libsonnet';
+local optionals = import 'ext/optionals.libsonnet';
+
+// @param {config.Deployment} ctx
+function(ctx) marshal.YAML(optionals.trim({
+  local spec = ctx.Agent.Spec,
+  local prometheus = spec.Prometheus,
+  local namespace = ctx.Agent.ObjectMeta.Namespace,
+
+  server: {
+    http_listen_port: 8080,
+    log_level: optionals.string(spec.LogLevel),
+    log_format: optionals.string(spec.LogFormat),
+  },
+
+  logs: {
+    positions_directory: '/var/lib/grafana-agent/data',
+    configs:
+  },
+}))

--- a/pkg/tempo/automaticloggingprocessor/automaticloggingprocessor_test.go
+++ b/pkg/tempo/automaticloggingprocessor/automaticloggingprocessor_test.go
@@ -4,9 +4,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/agent/pkg/logs"
+	"github.com/grafana/agent/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"gopkg.in/yaml.v3"
 )
 
 func TestSpanKeyVals(t *testing.T) {
@@ -178,6 +181,11 @@ func TestBadConfigs(t *testing.T) {
 		},
 		{
 			cfg: &AutomaticLoggingConfig{
+				Backend: "logs",
+			},
+		},
+		{
+			cfg: &AutomaticLoggingConfig{
 				Backend: "loki",
 			},
 		},
@@ -206,7 +214,7 @@ func TestLogToStdoutSet(t *testing.T) {
 	require.True(t, p.(*automaticLoggingProcessor).logToStdout)
 
 	cfg = &AutomaticLoggingConfig{
-		Backend: BackendLoki,
+		Backend: BackendLogs,
 		Spans:   true,
 	}
 
@@ -226,10 +234,37 @@ func TestDefaults(t *testing.T) {
 	require.Equal(t, defaultTimeout, p.(*automaticLoggingProcessor).cfg.Timeout)
 	require.True(t, p.(*automaticLoggingProcessor).logToStdout)
 
-	require.Equal(t, defaultLokiTag, p.(*automaticLoggingProcessor).cfg.Overrides.LokiTag)
+	require.Equal(t, defaultLogsTag, p.(*automaticLoggingProcessor).cfg.Overrides.LogsTag)
 	require.Equal(t, defaultServiceKey, p.(*automaticLoggingProcessor).cfg.Overrides.ServiceKey)
 	require.Equal(t, defaultSpanNameKey, p.(*automaticLoggingProcessor).cfg.Overrides.SpanNameKey)
 	require.Equal(t, defaultStatusKey, p.(*automaticLoggingProcessor).cfg.Overrides.StatusKey)
 	require.Equal(t, defaultDurationKey, p.(*automaticLoggingProcessor).cfg.Overrides.DurationKey)
 	require.Equal(t, defaultTraceIDKey, p.(*automaticLoggingProcessor).cfg.Overrides.TraceIDKey)
+}
+
+func TestLokiNameMigration(t *testing.T) {
+	logsConfig := &logs.Config{
+		Configs: []*logs.InstanceConfig{{Name: "default"}},
+	}
+
+	input := util.Untab(`
+		backend: loki
+		loki_name: default
+		overrides:
+			loki_tag: tempo
+	`)
+	expect := util.Untab(`
+		backend: logs_instance
+		logs_instance_name: default
+		overrides:
+			logs_tag: tempo
+	`)
+
+	var cfg AutomaticLoggingConfig
+	require.NoError(t, yaml.Unmarshal([]byte(input), &cfg))
+	require.NoError(t, cfg.Validate(logsConfig))
+
+	bb, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+	require.YAMLEq(t, expect, string(bb))
 }

--- a/pkg/tempo/automaticloggingprocessor/automaticloggingprocessor_test.go
+++ b/pkg/tempo/automaticloggingprocessor/automaticloggingprocessor_test.go
@@ -257,7 +257,7 @@ func TestLokiNameMigration(t *testing.T) {
 		backend: logs_instance
 		logs_instance_name: default
 		overrides:
-			logs_tag: tempo
+			logs_instance_tag: tempo
 	`)
 
 	var cfg AutomaticLoggingConfig

--- a/pkg/tempo/automaticloggingprocessor/factory.go
+++ b/pkg/tempo/automaticloggingprocessor/factory.go
@@ -54,7 +54,7 @@ func (c *AutomaticLoggingConfig) Validate(logsConfig *logs.Config) error {
 	}
 
 	if c.Overrides.LogsTag != "" && c.Overrides.LokiTag != "" {
-		return fmt.Errorf("must configure at most one of overrides.logs_tag and overrides.loki_tag. logs_tag is deprecated in favor of loki_tag")
+		return fmt.Errorf("must configure at most one of overrides.logs_instance_tag and overrides.loki_tag. loki_tag is deprecated in favor of logs_instance_tag")
 	}
 
 	// Migrate deprecated config to new one
@@ -81,7 +81,7 @@ func (c *AutomaticLoggingConfig) Validate(logsConfig *logs.Config) error {
 
 // OverrideConfig contains overrides for various strings
 type OverrideConfig struct {
-	LogsTag     string `mapstructure:"logs_tag" yaml:"logs_tag,omitempty"`
+	LogsTag     string `mapstructure:"logs_instance_tag" yaml:"logs_instance_tag,omitempty"`
 	ServiceKey  string `mapstructure:"service_key" yaml:"service_key,omitempty"`
 	SpanNameKey string `mapstructure:"span_name_key" yaml:"span_name_key,omitempty"`
 	StatusKey   string `mapstructure:"status_key" yaml:"status_key,omitempty"`

--- a/pkg/tempo/automaticloggingprocessor/factory.go
+++ b/pkg/tempo/automaticloggingprocessor/factory.go
@@ -2,8 +2,10 @@ package automaticloggingprocessor
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"github.com/grafana/agent/pkg/logs"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
@@ -22,29 +24,77 @@ type Config struct {
 
 // AutomaticLoggingConfig holds config information for automatic logging
 type AutomaticLoggingConfig struct {
-	Backend           string         `mapstructure:"backend" yaml:"backend"`
-	LokiName          string         `mapstructure:"loki_name" yaml:"loki_name"`
-	Spans             bool           `mapstructure:"spans" yaml:"spans"`
-	Roots             bool           `mapstructure:"roots" yaml:"roots"`
-	Processes         bool           `mapstructure:"processes" yaml:"processes"`
-	SpanAttributes    []string       `mapstructure:"span_attributes" yaml:"span_attributes"`
-	ProcessAttributes []string       `mapstructure:"process_attributes" yaml:"process_attributes"`
-	Overrides         OverrideConfig `mapstructure:"overrides" yaml:"overrides"`
-	Timeout           time.Duration  `mapstructure:"timeout" yaml:"timeout"`
+	Backend           string         `mapstructure:"backend" yaml:"backend,omitempty"`
+	LogsName          string         `mapstructure:"logs_instance_name" yaml:"logs_instance_name,omitempty"`
+	Spans             bool           `mapstructure:"spans" yaml:"spans,omitempty"`
+	Roots             bool           `mapstructure:"roots" yaml:"roots,omitempty"`
+	Processes         bool           `mapstructure:"processes" yaml:"processes,omitempty"`
+	SpanAttributes    []string       `mapstructure:"span_attributes" yaml:"span_attributes,omitempty"`
+	ProcessAttributes []string       `mapstructure:"process_attributes" yaml:"process_attributes,omitempty"`
+	Overrides         OverrideConfig `mapstructure:"overrides" yaml:"overrides,omitempty"`
+	Timeout           time.Duration  `mapstructure:"timeout" yaml:"timeout,omitempty"`
+
+	// Deprecated fields:
+	LokiName string `mapstructure:"loki_name" yaml:"loki_name,omitempty"` // Superseded by LogsName
+}
+
+func (c *AutomaticLoggingConfig) Validate(logsConfig *logs.Config) error {
+	if c.Backend == BackendLoki {
+		c.Backend = BackendLogs
+	}
+
+	if c.LogsName != "" && c.LokiName != "" {
+		return fmt.Errorf("must configure at most one of logs_instance_name and loki_name. loki_name is deprecated in favor of logs_instance_name.")
+	}
+
+	// Migrate deprecated config to new one
+	if c.LogsName == "" && c.LokiName != "" {
+		c.LogsName, c.LokiName = c.LokiName, ""
+	}
+
+	if c.Overrides.LogsTag != "" && c.Overrides.LokiTag != "" {
+		return fmt.Errorf("must configure at most one of overrides.logs_tag and overrides.loki_tag. logs_tag is deprecated in favor of loki_tag.")
+	}
+
+	// Migrate deprecated config to new one
+	if c.Overrides.LogsTag == "" && c.Overrides.LokiTag != "" {
+		c.Overrides.LogsTag, c.Overrides.LokiTag = c.Overrides.LokiTag, ""
+	}
+
+	// Ensure the logging instance exists when using it as a backend.
+	if c.Backend == BackendLogs {
+		var found bool
+		for _, inst := range logsConfig.Configs {
+			if inst.Name == c.LogsName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("specified logs config %s not found in agent config", c.LogsName)
+		}
+	}
+
+	return nil
 }
 
 // OverrideConfig contains overrides for various strings
 type OverrideConfig struct {
-	LokiTag     string `mapstructure:"loki_tag" yaml:"loki_tag"`
-	ServiceKey  string `mapstructure:"service_key" yaml:"service_key"`
-	SpanNameKey string `mapstructure:"span_name_key" yaml:"span_name_key"`
-	StatusKey   string `mapstructure:"status_key" yaml:"status_key"`
-	DurationKey string `mapstructure:"duration_key" yaml:"duration_key"`
-	TraceIDKey  string `mapstructure:"trace_id_key" yaml:"trace_id_key"`
+	LogsTag     string `mapstructure:"logs_tag" yaml:"logs_tag,omitempty"`
+	ServiceKey  string `mapstructure:"service_key" yaml:"service_key,omitempty"`
+	SpanNameKey string `mapstructure:"span_name_key" yaml:"span_name_key,omitempty"`
+	StatusKey   string `mapstructure:"status_key" yaml:"status_key,omitempty"`
+	DurationKey string `mapstructure:"duration_key" yaml:"duration_key,omitempty"`
+	TraceIDKey  string `mapstructure:"trace_id_key" yaml:"trace_id_key,omitempty"`
+
+	// Deprecated fields:
+	LokiTag string `mapstructure:"loki_tag" yaml:"loki_tag,omitempty"` // Superseded by LogsTag
 }
 
 const (
-	// BackendLoki is the backend config value for sending logs to a Loki pipeline
+	// BackendLogs is the backend config for sending logs to a Loki pipeline
+	BackendLogs = "logs_instance"
+	// BackendLoki is an alias to BackendLogs. DEPRECATED.
 	BackendLoki = "loki"
 	// BackendStdout is the backend config value for sending logs to stdout
 	BackendStdout = "stdout"

--- a/pkg/tempo/automaticloggingprocessor/factory.go
+++ b/pkg/tempo/automaticloggingprocessor/factory.go
@@ -38,13 +38,14 @@ type AutomaticLoggingConfig struct {
 	LokiName string `mapstructure:"loki_name" yaml:"loki_name,omitempty"` // Superseded by LogsName
 }
 
+// Validate ensures that the AutomaticLoggingConfig is valid.
 func (c *AutomaticLoggingConfig) Validate(logsConfig *logs.Config) error {
 	if c.Backend == BackendLoki {
 		c.Backend = BackendLogs
 	}
 
 	if c.LogsName != "" && c.LokiName != "" {
-		return fmt.Errorf("must configure at most one of logs_instance_name and loki_name. loki_name is deprecated in favor of logs_instance_name.")
+		return fmt.Errorf("must configure at most one of logs_instance_name and loki_name. loki_name is deprecated in favor of logs_instance_name")
 	}
 
 	// Migrate deprecated config to new one
@@ -53,7 +54,7 @@ func (c *AutomaticLoggingConfig) Validate(logsConfig *logs.Config) error {
 	}
 
 	if c.Overrides.LogsTag != "" && c.Overrides.LokiTag != "" {
-		return fmt.Errorf("must configure at most one of overrides.logs_tag and overrides.loki_tag. logs_tag is deprecated in favor of loki_tag.")
+		return fmt.Errorf("must configure at most one of overrides.logs_tag and overrides.loki_tag. logs_tag is deprecated in favor of loki_tag")
 	}
 
 	// Migrate deprecated config to new one

--- a/pkg/tempo/config_test.go
+++ b/pkg/tempo/config_test.go
@@ -747,7 +747,7 @@ receivers:
       grpc:
 remote_write:
   - endpoint: example.com:12345
-    protocol: http 
+    protocol: http
   - endpoint: example.com:12345
     protocol: grpc
 `,

--- a/pkg/tempo/contextkeys/keys.go
+++ b/pkg/tempo/contextkeys/keys.go
@@ -6,6 +6,6 @@ const (
 	// Logs is used to pass *logs.Logs through the context
 	Logs key = iota
 
-	// Prometheus	is used to pass instance.Manager through the context
+	// Prometheus is used to pass instance.Manager through the context
 	Prometheus
 )

--- a/pkg/tempo/contextkeys/keys.go
+++ b/pkg/tempo/contextkeys/keys.go
@@ -2,8 +2,10 @@ package contextkeys
 
 type key int
 
-// Loki is a constant used to pass *loki.Loki through the context
 const (
-	Loki key = iota
+	// Logs is used to pass *logs.Logs through the context
+	Logs key = iota
+
+	// Prometheus	is used to pass instance.Manager through the context
 	Prometheus
 )

--- a/pkg/tempo/tempo.go
+++ b/pkg/tempo/tempo.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"contrib.go.opencensus.io/exporter/prometheus"
-	"github.com/grafana/agent/pkg/loki"
+	"github.com/grafana/agent/pkg/logs"
 	"github.com/grafana/agent/pkg/prom/instance"
 	zaplogfmt "github.com/jsternberg/zap-logfmt"
 	prom_client "github.com/prometheus/client_golang/prometheus"
@@ -32,8 +32,8 @@ type Tempo struct {
 	promInstanceManager instance.Manager
 }
 
-// New creates and starts Loki log collection.
-func New(loki *loki.Loki, promInstanceManager instance.Manager, reg prom_client.Registerer, cfg Config, level logrus.Level) (*Tempo, error) {
+// New creates and starts trace collection.
+func New(logsSubsystem *logs.Logs, promInstanceManager instance.Manager, reg prom_client.Registerer, cfg Config, level logrus.Level) (*Tempo, error) {
 	var leveller logLeveller
 
 	tempo := &Tempo{
@@ -43,14 +43,14 @@ func New(loki *loki.Loki, promInstanceManager instance.Manager, reg prom_client.
 		reg:                 reg,
 		promInstanceManager: promInstanceManager,
 	}
-	if err := tempo.ApplyConfig(loki, promInstanceManager, cfg, level); err != nil {
+	if err := tempo.ApplyConfig(logsSubsystem, promInstanceManager, cfg, level); err != nil {
 		return nil, err
 	}
 	return tempo, nil
 }
 
 // ApplyConfig updates Tempo with a new Config.
-func (t *Tempo) ApplyConfig(loki *loki.Loki, promInstanceManager instance.Manager, cfg Config, level logrus.Level) error {
+func (t *Tempo) ApplyConfig(logsSubsystem *logs.Logs, promInstanceManager instance.Manager, cfg Config, level logrus.Level) error {
 	t.mut.Lock()
 	defer t.mut.Unlock()
 
@@ -62,7 +62,7 @@ func (t *Tempo) ApplyConfig(loki *loki.Loki, promInstanceManager instance.Manage
 	for _, c := range cfg.Configs {
 		// If an old instance exists, update it and move it to the new map.
 		if old, ok := t.instances[c.Name]; ok {
-			err := old.ApplyConfig(loki, promInstanceManager, c)
+			err := old.ApplyConfig(logsSubsystem, promInstanceManager, c)
 			if err != nil {
 				return err
 			}
@@ -76,7 +76,7 @@ func (t *Tempo) ApplyConfig(loki *loki.Loki, promInstanceManager instance.Manage
 			instReg    = prom_client.WrapRegistererWith(prom_client.Labels{"tempo_config": c.Name}, t.reg)
 		)
 
-		inst, err := NewInstance(loki, instReg, c, instLogger, t.promInstanceManager)
+		inst, err := NewInstance(logsSubsystem, instReg, c, instLogger, t.promInstanceManager)
 		if err != nil {
 			return fmt.Errorf("failed to create tempo instance %s: %w", c.Name, err)
 		}


### PR DESCRIPTION
#### PR Description 
Renames the `loki` subsystem to `logs`, deprecating the old name. `loki`-named fields will continue to work until a further release that fully removes them.

#### Which issue(s) this PR fixes 
Related to #722.

#### Notes to the Reviewer
@mapno does `logs_tag` make sense for the overrides in automatic_logging? Should it be `logs_instance_tag`? I'm not 100% sure what it does. 

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
