### PR TITLE
Set DNSPolicy correctly when host network is used in daemonset

### DIFF
--- a/production/tanka/grafana-agent/v1/lib/integrations.libsonnet
+++ b/production/tanka/grafana-agent/v1/lib/integrations.libsonnet
@@ -27,6 +27,7 @@ local container = k.core.v1.container;
       k.util.hostVolumeMount('root', '/', '/host/root', readOnly=true) +
 
       controller.mixin.spec.template.spec.withHostPID(true) +
-      controller.mixin.spec.template.spec.withHostNetwork(true),
+      controller.mixin.spec.template.spec.withHostNetwork(true) +
+      controller.mixin.spec.template.spec.withDnsPolicy('ClusterFirstWithHostNet'),
   },
 }


### PR DESCRIPTION
#### PR Description 

When an integration is applied using the tanka library, it sets the daemonset or deployment to use host networking, but it does not change the DNS policy.

In my environment, this meant it could not write to my local cortex at `cortex.cortex.svc.cluster.local` because it couldn't resolve it.

#### Which issue(s) this PR fixes 

N/A

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
