### PR TITLE
Split trace agreggation

### DIFF
--- a/docs/configuration/tempo-config.md
+++ b/docs/configuration/tempo-config.md
@@ -175,7 +175,7 @@ spanmetrics:
 #
 # In order to make a correct sampling decision it's important that the agent has
 # a complete trace. This is achieved by waiting a given time for all the spans
-# before evaluating the trace.
+# before evaluating the trace. In order to get complete traces, configure group_by_trace.
 #
 # Tail sampling also supports multiple agent deployments, allowing to group all
 # spans of a trace in the same agent by load balancing the spans by trace ID
@@ -185,11 +185,6 @@ tail_sampling:
   # can be added to the same pipeline.
   policies:
     - [<tailsamplingprocessor.policies>]
-
-  # Time that to wait before making a decision for a trace.
-  # Longer wait times reduce the probability of sampling an incomplete trace at
-  # the cost of higher memory usage.
-  decision_wait: [ <duration> | default="5s" ]
 
   # load_balancing configures load balancing of spans across multiple agents.
   # It ensures that all spans of a trace are sampled in the same instance.
@@ -226,6 +221,24 @@ tail_sampling:
         [ username: <string> ]
         [ password: <secret> ]
         [ password_file: <string> ]
+
+# Configures aggregation of spans by trace.
+# This is of particular interest for processor that benefit from having complete
+# traces, such as tail-based sampling
+#
+# A trace will be considered complete after the defined `wait` duration has
+# passed since its first span arrived to the processors.
+# If the trace is not complete by then, it'll be split into more than one trace.
+#
+# Longer waiting times will increase the number of traces that are correctly
+# grouped. However, it will also increase the memory overhead of the processor.
+group_by_trace:
+  
+  # Defines the time to wait for a complete trace before considering it complete
+  [ wait: <duration> | default="5s" ]
+    
+  # Configures the max amount of traces to keep in memory waiting for the duration
+  [ num_traces: <int> | default="1_000_000" ]
 ```
 
 > **Note:** More information on the following types can be found on the

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -12,6 +12,36 @@ releases and how to migrate to newer versions.
 
 These changes will come in a future version.
 
+### Tempo: split grouping by trace from tail sampling config
+
+Grouping spans by trace has been moved from an embedded functionality in tail
+sampling to its own configuration block. This is done due to more processor
+benefiting from receiving grouped traces, other than tail sampling.
+
+As a consequence, `tail_sampling.wait_duration` has been deprecated in favor of
+a `group_by_trace` block. Old configs will continue to work until it is fully
+deprecated.
+
+Example old config:
+
+```yaml
+tail_sampling:
+  duration_wait: 2s
+  policies:
+    - always_sample:
+```
+
+Example new config:
+
+```yaml
+tail_sampling:
+  policies:
+    - always_sample:
+group_by_trace:
+  wait: 2s
+```
+
+
 ### Logs: Deprecation of "loki" in config.
 
 The term `loki` in the config has been deprecated of favor of `logs`. This

--- a/example/docker-compose/agent/config/agent-scraping-service.yaml
+++ b/example/docker-compose/agent/config/agent-scraping-service.yaml
@@ -59,4 +59,6 @@ tempo:
         dimensions:
           - name: http.url
         handler_endpoint: 0.0.0.0:8889
+      group_by_trace:
+        wait: 4s
 

--- a/example/docker-compose/agent/config/agent.yaml
+++ b/example/docker-compose/agent/config/agent.yaml
@@ -11,7 +11,7 @@ prometheus:
       scrape_configs:
         - job_name: local_scrape
           static_configs:
-            - targets: ['127.0.0.1:12345']
+            - targets: ['127.0.0.1:12345', '127.0.0.1:8889']
               labels:
                 cluster: 'docker_compose'
                 container: 'agent'
@@ -89,4 +89,4 @@ tempo:
       processes: true
       roots: true
     spanmetrics:
-      prom_instance: tempo
+      handler_endpoint: 0.0.0.0:8889

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.2
 	github.com/oliver006/redis_exporter v1.15.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.29.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor v0.29.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor v0.29.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.29.0
 	github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e

--- a/go.sum
+++ b/go.sum
@@ -1351,6 +1351,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancing
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.29.0/go.mod h1:6XSErVryxabB3T9aT7adMGoiPV7EG+hRACn2FRxQ/R4=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.29.0 h1:zYbxW9OUwu/9W+P2bEOEqoQjn/rJfXmHxQQtYSpHLIc=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.29.0/go.mod h1:zqMjJEuS55YssiJ4EFlD/dGBpZ/ij2jrtk0D2LC46wg=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor v0.29.0 h1:ZgW0DOgUDFrRCPJ9pSUZ8iezpkUu/eQOP4RBDZINokI=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor v0.29.0/go.mod h1:mEhEo1eK37dvXB3VzZEZxvQzjnuJw7jO6jnik7PcVtA=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor v0.29.0 h1:0MwrtSxAQfk6DpktK8RK/yMADqmGZuK17F4U/zJnZTA=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor v0.29.0/go.mod h1:6mho/Bo63I7dJqWyBvgfQSMObUopYisig9OBMDb33gw=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.29.0 h1:A10YxBMf8ki9bBNSbcG4bsnhhs7GXLegQ0xzjB5G40w=

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -224,7 +224,7 @@ tempo:
       backend: logs_instance
       logs_instance_name: default
       spans: true`,
-			expectedError: "error in config file: failed to validate automatic_logging for tempo config default: specified logs config default not found in agent config",
+			expectedError: "specified logs config default not found in agent config",
 		},
 	}
 
@@ -234,6 +234,7 @@ tempo:
 			return LoadBytes([]byte(tc.cfg), false, c)
 		})
 
-		require.EqualError(t, err, tc.expectedError)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), tc.expectedError)
 	}
 }

--- a/pkg/tempo/config.go
+++ b/pkg/tempo/config.go
@@ -584,8 +584,12 @@ func (c *InstanceConfig) otelConfig() (*config.Config, error) {
 		wait := defaultWaitDuration
 		numTraces := defaultNumTraces
 		if c.GroupByTrace != nil {
-			wait = c.GroupByTrace.WaitDuration
-			numTraces = c.GroupByTrace.NumTraces
+			if c.GroupByTrace.WaitDuration > 0 {
+				wait = c.GroupByTrace.WaitDuration
+			}
+			if c.GroupByTrace.NumTraces > 0 {
+				numTraces = c.GroupByTrace.NumTraces
+			}
 		}
 
 		if c.TailSampling != nil {

--- a/pkg/tempo/config.go
+++ b/pkg/tempo/config.go
@@ -530,8 +530,8 @@ func (c *InstanceConfig) otelConfig() (*config.Config, error) {
 		processorNames = append(processorNames, "tail_sampling", "groupbytrace")
 		processors["tail_sampling"] = map[string]interface{}{
 			"policies": policies,
-			// Don't wait, groupbytrace processor does it
-			"decision_wait": 0,
+			// Wait just 1sec, groupbytrace waits the rest of the time
+			"decision_wait": time.Second,
 		}
 
 		processors["groupbytrace"] = map[string]interface{}{

--- a/pkg/tempo/config.go
+++ b/pkg/tempo/config.go
@@ -121,7 +121,9 @@ type InstanceConfig struct {
 	// TailSampling defines a sampling strategy for the pipeline
 	TailSampling *tailSamplingConfig `yaml:"tail_sampling,omitempty"`
 
-	// GroupByTrace is a config that does very impressive things
+	// GroupByTrace configures aggregation of spans by trace
+	// making processing of complete traces possible.
+	// This is useful for processing such as tail-based sampling.
 	GroupByTrace *groupByTraceConfig `yaml:"group_by_trace,omitempty"`
 }
 

--- a/pkg/tempo/config_test.go
+++ b/pkg/tempo/config_test.go
@@ -572,7 +572,7 @@ exporters:
       max_elapsed_time: 60s
 processors:
   tail_sampling:
-    decision_wait: 0s
+    decision_wait: 1s
     policies:
       - name: always_sample/0
         type: always_sample
@@ -647,7 +647,7 @@ exporters:
         port: 4318
 processors:
   tail_sampling:
-    decision_wait: 0s
+    decision_wait: 1s
     policies:
       - name: always_sample/0
         type: always_sample

--- a/pkg/tempo/config_test.go
+++ b/pkg/tempo/config_test.go
@@ -3,9 +3,7 @@ package tempo
 import (
 	"io/ioutil"
 	"os"
-	"runtime"
 	"sort"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -572,7 +570,8 @@ exporters:
       max_elapsed_time: 60s
 processors:
   tail_sampling:
-    decision_wait: 1s
+    decision_wait: 5s
+    num_traces: 1000000
     policies:
       - name: always_sample/0
         type: always_sample
@@ -583,14 +582,11 @@ processors:
           values:
             - value1
             - value2
-  groupbytrace:
-    wait_duration: 5s
-    num_workers: ` + strconv.Itoa(runtime.NumCPU()) + `
 service:
   pipelines:
     traces:
       exporters: ["otlp/0"]
-      processors: ["groupbytrace", "tail_sampling"]
+      processors: ["tail_sampling"]
       receivers: ["jaeger"]
 `,
 		},
@@ -647,7 +643,8 @@ exporters:
         port: 4318
 processors:
   tail_sampling:
-    decision_wait: 1s
+    decision_wait: 5s
+    num_traces: 1000000
     policies:
       - name: always_sample/0
         type: always_sample
@@ -658,9 +655,6 @@ processors:
           values:
             - value1
             - value2
-  groupbytrace:
-    wait_duration: 5s
-    num_workers: ` + strconv.Itoa(runtime.NumCPU()) + `
 service:
   pipelines:
     traces/0:
@@ -669,7 +663,7 @@ service:
       receivers: ["jaeger"]
     traces/1:
       exporters: ["otlp/0"]
-      processors: ["groupbytrace", "tail_sampling"]
+      processors: ["tail_sampling"]
       receivers: ["otlp/lb"]
 `,
 		},
@@ -884,7 +878,6 @@ tail_sampling:
 				"traces": {
 					config.NewID("attributes"),
 					config.NewID("spanmetrics"),
-					config.NewID("groupbytrace"),
 					config.NewID("tail_sampling"),
 					config.NewID("automatic_logging"),
 					config.NewID("batch"),
@@ -942,7 +935,6 @@ tail_sampling:
 					config.NewID("spanmetrics"),
 				},
 				"traces/1": {
-					config.NewID("groupbytrace"),
 					config.NewID("tail_sampling"),
 					config.NewID("automatic_logging"),
 					config.NewID("batch"),

--- a/pkg/tempo/config_test.go
+++ b/pkg/tempo/config_test.go
@@ -668,7 +668,7 @@ service:
 `,
 		},
 		{
-			name: "automatic logging : default",
+			name: "automatic logging: default",
 			cfg: `
 receivers:
   jaeger:
@@ -774,6 +774,47 @@ service:
     traces:
       exporters: ["otlphttp/0", "otlp/1"]
       processors: []
+      receivers: ["jaeger"]
+`,
+		},
+		{
+			name: "tail sampling config with group by trace",
+			cfg: `
+receivers:
+  jaeger:
+    protocols:
+      grpc:
+remote_write:
+  - endpoint: example.com:12345
+tail_sampling:
+  policies:
+    - always_sample:
+group_by_trace:
+  wait: 1s
+`,
+			expectedConfig: `
+receivers:
+  jaeger:
+    protocols:
+      grpc:
+exporters:
+  otlp/0:
+    endpoint: example.com:12345
+    compression: gzip
+    retry_on_failure:
+      max_elapsed_time: 60s
+processors:
+  tail_sampling:
+    decision_wait: 1s
+    num_traces: 1000000
+    policies:
+      - name: always_sample/0
+        type: always_sample
+service:
+  pipelines:
+    traces:
+      exporters: ["otlp/0"]
+      processors: ["tail_sampling"]
       receivers: ["jaeger"]
 `,
 		},

--- a/pkg/tempo/instance.go
+++ b/pkg/tempo/instance.go
@@ -147,7 +147,7 @@ func (i *Instance) buildAndStartPipeline(ctx context.Context, cfg InstanceConfig
 		}
 	}
 
-	if cfg.TailSampling.DecisionWait != 0 {
+	if cfg.TailSampling != nil && cfg.TailSampling.DecisionWait != 0 {
 		i.logger.Warn("Configuring grouping by trace with deprecated tail_sampling.duration_wait. Use group_by_trace.wait")
 	}
 

--- a/pkg/tempo/instance.go
+++ b/pkg/tempo/instance.go
@@ -147,6 +147,10 @@ func (i *Instance) buildAndStartPipeline(ctx context.Context, cfg InstanceConfig
 		}
 	}
 
+	if cfg.TailSampling.DecisionWait != 0 {
+		i.logger.Warn("Configuring grouping by trace with deprecated tail_sampling.duration_wait. Use group_by_trace.wait")
+	}
+
 	if cfg.SpanMetrics != nil && len(cfg.SpanMetrics.PromInstance) != 0 {
 		ctx = context.WithValue(ctx, contextkeys.Prometheus, promManager)
 	}


### PR DESCRIPTION
#### PR Description

Split trace aggregation from tail sampling, as it can be useful for other purposes too, such as service graphs or other processors that benefit from having complete traces.

The pipeline will use `groupbytrace` processor for aggregation, except when using tail sampling, in which case grouping will be performed by the embedded aggregator in the sampling processor. It's not possible to have the tail sampling processor only sampling and leave aggregation to `groupbytrace`. Tail sampling has to buffer traces for at least 1s, so it's just better not to use `groupbytrace` in that case for simplicity and performance.

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
