### PR TITLE
Use buffered channel for signal.Notify

### DIFF
--- a/cmd/agent/entrypoint.go
+++ b/cmd/agent/entrypoint.go
@@ -236,7 +236,7 @@ func (ep *Entrypoint) Start() error {
 	// signal is received.
 	signalHandler := signals.NewHandler(ep.cfg.Server.Log)
 
-	notifier := make(chan os.Signal)
+	notifier := make(chan os.Signal, 1)
 	signal.Notify(notifier, syscall.SIGHUP)
 
 	defer func() {


### PR DESCRIPTION
The documentation for [`signal.Notify`](https://pkg.go.dev/os/signal#Notify) says:

> Package signal will not block sending to c: the caller must ensure that c has sufficient buffer space to keep up with the expected signal rate. For a channel used for notification of just one signal value, a buffer of size 1 is sufficient. 

This PR adds a buffer to the channel introduced in #710. 

