### PR TITLE
Automate updates of Homebrew formula

### DIFF
--- a/tools/update_formula.bash
+++ b/tools/update_formula.bash
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# update_formula.bash will patch the Grafana Agent formula in the checked out
+# tap directory to install the specified version.
+set -eo pipefail
+
+FORMULA_PATH="grafana-cloud-agent.rb"
+TAP_DIR=""
+VERSION=""
+
+for arg in "$@"; do
+  case $arg in
+    -v|--version)
+      VERSION="$2"
+      shift; shift # Remove name and value
+      ;;
+    -t|--tap-dir)
+      TAP_DIR="$2"
+      shift; shift # Remove name and value
+      ;;
+  esac
+done
+
+if [ -z "$TAP_DIR" ] || [ -z "$VERSION" ]; then
+  echo "usage: $0 --tap-dir <path to tap> --version <new version>"
+  exit 1
+fi
+
+NEW_URL="https://github.com/grafana/agent/archive/${VERSION}.tar.gz"
+NEW_SHA=$(curl -fsSL "$NEW_URL" | sha256sum | awk '{print $1}')
+
+echo "New URL: $NEW_URL"
+echo "New SHA: $NEW_SHA"
+
+sed -E 's#url "(.*)"#url "'$NEW_URL'"#g; s#sha256 "(.*)"#sha256 "'$NEW_SHA'"#g' \
+  "$TAP_DIR/$FORMULA_PATH" > $FORMULA_PATH.tmp
+mv $FORMULA_PATH.tmp "$TAP_DIR/$FORMULA_PATH"

--- a/tools/update_formula.bash
+++ b/tools/update_formula.bash
@@ -4,7 +4,7 @@
 # tap directory to install the specified version.
 set -eo pipefail
 
-FORMULA_PATH="grafana-cloud-agent.rb"
+FORMULA_PATH="grafana-agent.rb"
 TAP_DIR=""
 VERSION=""
 


### PR DESCRIPTION
#### PR Description 
This PR will make Homebrew support first-class by automating its maintenance alongside the agent repository. 

Adds a script to update the Grafana Agent formula from the [homebrew-grafana tap](https://github.com/grafana/homebrew-grafana/blob/master/grafana-cloud-agent.rb).

#### Which issue(s) this PR fixes 
Closes #433.
Closes #193. 

#### Notes to the Reviewer
Opening in draft because there's a few things that need to be done still: 

- [x] The formula needs to be [renamed](https://docs.brew.sh/Rename-A-Formula) first to grafana-agent. (grafana/homebrew-grafana#15)
- [ ] The formula should really run `make agent` instead of `go build`. A second step can move it to the install directory. 
- [ ] Ditto with `make agentctl`. Both tools should be installed. 
- [ ] We need to hook this up into CI. It needs to be done _after_ a release is published, so it might make sense to keep this as a GitHub Action instead of Drone. cc @mattdurham for thoughts. 

For automating this with CI: 
* Clone the repo and the homebrew tap 
* Run the script 
* Create and push commit directly to tap repo   

(And then the changelog/documentation should be updated too)

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [x] Tests updated
