### PR TITLE
Add install-bare.sh warning

### DIFF
--- a/production/kubernetes/README.md
+++ b/production/kubernetes/README.md
@@ -26,6 +26,11 @@ applying out of the box and you will have to manually perform the following step
 
 3. Apply the modified manifest file: `kubectl -ndefault apply -f manifest.yaml`.
 
+This directory also conains an `install-bare.sh` script that is used inside of
+Grafana Cloud instructions. If using the Grafana Agent outside of Grafana Cloud,
+it is recommended to follow the steps above instead of calling this script
+directly.
+
 ## Rebuilding the manifests
 
 The manifests provided are created using Grafana Labs' production
@@ -37,7 +42,7 @@ of software installed:
 2. [`jsonnet-bundler`](https://github.com/jsonnet-bundler/jsonnet-bundler) >= v0.2.1
 
 See the [`template` Tanka environment](./build/templates) for the current
-settings that initialize the Grafana Agent Tanka configs. 
+settings that initialize the Grafana Agent Tanka configs.
 
-To build the YAML files, execute the `./build/build.sh` script or run `make example-kubernetes` 
+To build the YAML files, execute the `./build/build.sh` script or run `make example-kubernetes`
 from the project's root directory.

--- a/production/kubernetes/README.md
+++ b/production/kubernetes/README.md
@@ -8,7 +8,8 @@ Manifests:
 - Log collection (DaemonSet): [`agent-loki.yaml`](./agent-loki.yaml)
 - Trace collection (DaemonSet): [`agent-tempo.yaml`](./agent-tempo.yaml)
 
-These manifests do not include the Agent's configuration (ConfigMaps).
+⚠️  **These manifests do not include the Agent's configuration (ConfigMaps)**,
+which are necessary to run the Agent.
 
 For sample configurations and detailed installation instructions, please head to:
 

--- a/production/kubernetes/install-bare.sh
+++ b/production/kubernetes/install-bare.sh
@@ -2,9 +2,17 @@
 # shellcheck shell=bash
 
 #
-# install-bare.sh is a installer for the Agent without the ConfigMap. It is
-# useful for being integrated into an installation process that provides a
-# ConfigMap following the installation of Kubernetes components.
+# install-bare.sh is an installer for the Agent without a ConfigMap. It is
+# used during the Grafana Cloud integrations wizard and is not recommended
+# to be used directly. Instead of calling this script directly, please
+# make a copy of ./agent-bare.yaml and modify it for your needs.
+#
+# Note that agent-bare.yaml does not have a ConfigMap, so the Grafana Agent
+# will not launch until one is created. For more information on setting up
+# a ConfigMap, please refer to:
+#
+# Metrics quickstart: https://grafana.com/docs/grafana-cloud/quickstart/agent-k8s/k8s_agent_metrics/
+# Logs quickstart: https://grafana.com/docs/grafana-cloud/quickstart/agent-k8s/k8s_agent_logs/
 #
 
 check_installed() {


### PR DESCRIPTION
#### PR Description 
Directs users away from the install-bare.sh script which is used only for Grafana Cloud and will eventually be removed in favor of Helm charts.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
