### PR TITLE
Ignore regex capture groups when expanding environment vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
   deprecated in favor of `logs`. `loki`-named fields in `automatic_logging`
   have been renamed accordinly: `loki_name` is now `logs_instance_name`,
   `loki_tag` is now `logs_instance_tag`, and `backend: loki` is now
-  `backend: logs_instance`. (@rfratto)[]
+  `backend: logs_instance`. (@rfratto)
 
 # v0.16.1 (2021-06-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@
 
 - [BUGFIX] Fix race condition that may occur and result in a panic when
   initializing scraping service cluster. (@rfratto)
-  
+
+- [BUGFIX] Regex capture groups like `${1}` will now be kept intact when
+  using `-config.expand-env`.
+
 - [CHANGE] Breaking change: reduced verbosity of tracing autologging
   by not logging `STATUS_CODE_UNSET` status codes. (@mapno)
 
@@ -27,7 +30,7 @@
   deprecated in favor of `logs`. `loki`-named fields in `automatic_logging`
   have been renamed accordinly: `loki_name` is now `logs_instance_name`,
   `loki_tag` is now `logs_instance_tag`, and `backend: loki` is now
-  `backend: logs_instance`.
+  `backend: logs_instance`. (@rfratto)[]
 
 # v0.16.1 (2021-06-22)
 

--- a/docs/configuration/_index.md
+++ b/docs/configuration/_index.md
@@ -44,6 +44,17 @@ Where default_value is the value to use if the environment variable is
 undefined. The full list of supported syntax can be found at Drone's
 [envsubst repository](https://github.com/drone/envsubst).
 
+### Regex capture group references
+
+When using `-config.expand-env`, `VAR` must be an alphanumeric string with at
+least one non-digit character. If `VAR` is a number, the expander will assume
+you're trying to use a regex capture group reference, and will coerce the result
+to be one.
+
+This means references in your config file like `${1}` will remain
+untouched, but edge cases like `${1:-default}` will also be coerced to `${1}`,
+which may be slightly unexpected.
+
 ## Reloading (beta)
 
 The configuration file can be reloaded at runtime. Read the [API


### PR DESCRIPTION
#### PR Description 
Environment variable patterns from `-config.expand-env` (`${HOSTNAME}`) can look exactly like regex capture group references (`${1}`), causing the latter to get trimmed out from the file. This PR checks to see if the environment name is a number, and if it is, will keep the reference intact.

#### Which issue(s) this PR fixes 
Closes #692.

#### Notes to the Reviewer
This is kind of a hacky fix. Windows technically supports numeric environment variables (IIRC), and also this will replace other functions like `${1=default}` with `${1}`. But it might be good enough for now, since the latter would only be valid on Windows and I suspect would be an extremely rare use case.

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
