### PR TITLE
Logs:  create positionsdir per config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
 - [BUGFIX] Regex capture groups like `${1}` will now be kept intact when
   using `-config.expand-env`.
 
+- [BUGFIX] The directory of the logs positions file will now properly be created
+  on startup for all instances.
+
 - [CHANGE] Breaking change: reduced verbosity of tracing autologging
   by not logging `STATUS_CODE_UNSET` status codes. (@mapno)
 

--- a/docs/configuration/loki-config.md
+++ b/docs/configuration/loki-config.md
@@ -21,6 +21,8 @@ for the supported values for these fields.
 # <positions_directory>/<loki_instance_config.name>.yml.
 #
 # Optional only if every config has a positions.filename manually provided.
+#
+# This directory will be automatically created if it doesn't exist.
 [positions_directory: <string>]
 
 # Loki Promtail instances to run for log collection.
@@ -47,6 +49,9 @@ clients:
 # Optional configuration for where to store the positions files. If
 # positions.filename is left empty, the file will be stored in
 # <loki_config.positions_directory>/<loki_instance_config.name>.yml.
+#
+# The directory of the positions file will automatically be created on start up
+# if it doesn't already exist..
 [positions: <promtail.position_config>]
 
 scrape_configs:

--- a/docs/getting-started/install-agent-on-windows.md
+++ b/docs/getting-started/install-agent-on-windows.md
@@ -5,11 +5,11 @@ weight = 120
 
 # Install Agent on Windows
 
-The installer will install Grafana Agent into the default directory `C:\Program Files\Grafana Agent`. The [windows_exporter integration](https://github.com/prometheus-community/windows_exporter) can be enabled with all default windows_exporter options. 
+The installer will install Grafana Agent into the default directory `C:\Program Files\Grafana Agent`. The [windows_exporter integration](https://github.com/prometheus-community/windows_exporter) can be enabled with all default windows_exporter options.
 
 ## Installation
 
-After installation, ensure that you can reach `http://localhost:12345/-/healthy` and `http://localhost:12345/agent/api/v1/targets`. 
+After installation, ensure that you can reach `http://localhost:12345/-/healthy` and `http://localhost:12345/agent/api/v1/targets`.
 
 After installation, you can adjust `C:\Program Files\Grafana Agent\agent-config.yaml` to meet your specific needs. After changing the configuration file, the Grafana Agent service must be restarted to load changes to the configuration.
 
@@ -21,7 +21,7 @@ Silent installation can be achieved via  `grafana-agent-installer.exe /S  /Enabl
 
 ## Security
 
-A configuration file for the Agent is provided by default at `C:\Program Files\Grafana Agent`. Depending on your configuration, you may wish to modify the default permissions of the file or move it to another directory. 
+A configuration file for the Agent is provided by default at `C:\Program Files\Grafana Agent`. Depending on your configuration, you may wish to modify the default permissions of the file or move it to another directory.
 
 When changing the location of the configuration file, you must update the Grafana Agent service to load the new path. Run the following in an elevated prompt, replacing `<new_path>` with the full path holding `agent-config.yaml`:
 
@@ -46,14 +46,15 @@ server:
   log_level: debug
   http_listen_port: 12345
 loki:
-  # This directory needs to already exist
+  # Choose a directory to save the last read position of log files at.
+  # This directory will be created if it doesn't already exist.
   positions_directory: "C:\\path\\to\\directory"
   configs:
-    - name: windows 
+    - name: windows
       # Loki endpoint to push logs to
       clients:
         - url: https://example.com
-      scrape_configs: 
+      scrape_configs:
       - job_name: windows
         windows_events:
           # Note the directory structure must already exist but the file will be created on demand

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -4,6 +4,7 @@ package logs
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -55,13 +56,6 @@ func (l *Logs) ApplyConfig(c *Config) error {
 
 	if c == nil {
 		c = &Config{}
-	}
-
-	if c.PositionsDirectory != "" {
-		err := os.MkdirAll(c.PositionsDirectory, 0700)
-		if err != nil {
-			level.Warn(l.l).Log("msg", "failed to create the positions directory. logs may be unable to save their position", "path", c.PositionsDirectory, "err", err)
-		}
 	}
 
 	newInstances := make(map[string]*Instance, len(c.Configs))
@@ -154,6 +148,12 @@ func (i *Instance) ApplyConfig(c *InstanceConfig) error {
 		return nil
 	}
 	i.cfg = c
+
+	positionsDir := filepath.Dir(c.PositionsConfig.PositionsFile)
+	err := os.MkdirAll(positionsDir, 0775)
+	if err != nil {
+		level.Warn(i.log).Log("msg", "failed to create the positions directory. logs may be unable to save their position", "path", positionsDir, "err", err)
+	}
 
 	if i.promtail != nil {
 		i.promtail.Shutdown()

--- a/pkg/logs/logs_test.go
+++ b/pkg/logs/logs_test.go
@@ -164,12 +164,14 @@ func TestLogs_PositionsDirectory(t *testing.T) {
 	// Launch Loki so it starts tailing the file and writes to our server.
 	//
 	cfgText := util.Untab(fmt.Sprintf(`
-positions_directory: %s/positions
+positions_directory: %[1]s/positions
 configs:
 - name: instance-a
   clients:
 	- url: http://127.0.0.1:80/loki/api/v1/push
 - name: instance-b
+  positions:
+	  filename: %[1]s/other-positions/instance.yml
   clients:
 	- url: http://127.0.0.1:80/loki/api/v1/push
 	`, positionsDir))
@@ -184,8 +186,8 @@ configs:
 	require.NoError(t, err)
 	defer l.Stop()
 
-	for _, inst := range cfg.Configs {
-		_, err := os.Stat(filepath.Dir(inst.PositionsConfig.PositionsFile))
-		require.NoError(t, err, "directory should have been created for instance %s", inst.Name)
-	}
+	_, err = os.Stat(filepath.Join(positionsDir, "positions"))
+	require.NoError(t, err, "default shared positions directory did not get created")
+	_, err = os.Stat(filepath.Join(positionsDir, "other-positions"))
+	require.NoError(t, err, "instance-specific positions directory did not get creatd")
 }

--- a/pkg/logs/logs_test.go
+++ b/pkg/logs/logs_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -147,4 +148,44 @@ configs:
 		require.NoError(t, err)
 		require.Len(t, l.instances, 0)
 	})
+}
+
+func TestLogs_PositionsDirectory(t *testing.T) {
+	//
+	// Create a temporary file to tail
+	//
+	positionsDir, err := ioutil.TempDir(os.TempDir(), "positions-*")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(positionsDir)
+	})
+
+	//
+	// Launch Loki so it starts tailing the file and writes to our server.
+	//
+	cfgText := util.Untab(fmt.Sprintf(`
+positions_directory: %s/positions
+configs:
+- name: instance-a
+  clients:
+	- url: http://127.0.0.1:80/loki/api/v1/push
+- name: instance-b
+  clients:
+	- url: http://127.0.0.1:80/loki/api/v1/push
+	`, positionsDir))
+
+	var cfg Config
+	dec := yaml.NewDecoder(strings.NewReader(cfgText))
+	dec.SetStrict(true)
+	require.NoError(t, dec.Decode(&cfg))
+
+	logger := util.TestLogger(t)
+	l, err := New(prometheus.NewRegistry(), &cfg, logger)
+	require.NoError(t, err)
+	defer l.Stop()
+
+	for _, inst := range cfg.Configs {
+		_, err := os.Stat(filepath.Dir(inst.PositionsConfig.PositionsFile))
+		require.NoError(t, err, "directory should have been created for instance %s", inst.Name)
+	}
 }


### PR DESCRIPTION
#### PR Description 
I noticed a problem with #748 where positions directories weren't being created properly. This PR will create the positions directory at the config level (since they can be different and we intend to automatically create them)..

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
