### PR TITLE
operator: add cluster label to all logs

### DIFF
--- a/pkg/operator/config/templates/agent-logs.libsonnet
+++ b/pkg/operator/config/templates/agent-logs.libsonnet
@@ -32,7 +32,7 @@ function(ctx) marshal.YAML(optionals.trim({
     positions_directory: '/var/lib/grafana-agent/data',
     configs: optionals.array(std.map(
       function(logs_inst) new_logs_instance(
-        agentNamespace=ctx.Agent.ObjectMeta.Namespace,
+        agent=ctx.Agent,
         global=logs,
         instance=logs_inst,
         apiServer=spec.APIServerConfig,

--- a/pkg/operator/config/templates/component/logs/client.libsonnet
+++ b/pkg/operator/config/templates/component/logs/client.libsonnet
@@ -1,13 +1,15 @@
 local optionals = import 'ext/optionals.libsonnet';
 local secrets = import 'ext/secrets.libsonnet';
 
+local new_external_labels = import './external_labels.libsonnet';
 local new_tls_config = import 'component/metrics/tls_config.libsonnet';
 
 // Generates the content of a client object to send logs to Loki.
 //
+// @param {GrafanaAgent} agent
 // @param {string} namespace - namespace of spec.
 // @param {LogsClientSpec} spec
-function(namespace, spec) {
+function(agent, namespace, spec) {
   url: spec.URL,
   tls_config:
     if spec.TLSConfig != null then new_tls_config(namespace, spec.TLSConfig),
@@ -33,5 +35,5 @@ function(namespace, spec) {
     max_retries: optionals.number(spec.BackoffConfig.MaxRetries),
   },
 
-  external_labels: optionals.object(spec.ExternalLabels),
+  external_labels: optionals.object(new_external_labels(agent, spec)),
 }

--- a/pkg/operator/config/templates/component/logs/external_labels.libsonnet
+++ b/pkg/operator/config/templates/component/logs/external_labels.libsonnet
@@ -1,0 +1,27 @@
+// Generates an external_label mapping. This includes the user-provided labels
+// as well as the injected cluster label.
+//
+// @param {GrafanaAgent} agent
+// @param {LogsClientSpec} client
+function(agent, client) (
+  local meta = agent.ObjectMeta;
+  local logs = agent.Spec.Logs;
+
+  // Provide the cluster label first. Doing it this way allows the user to
+  // override with a value they choose.
+  (
+    local clusterValue = '%s/%s' % [meta.Namespace, meta.Name];
+    local clusterLabel = logs.LogsExternalLabelName;
+
+    if clusterLabel == null then { cluster: clusterValue }
+    else if clusterLabel != '' then { [clusterLabel]: clusterValue }
+    else {}
+  ) +
+
+  // Finally add in any user-configured labels.
+  (
+    if client.ExternalLabels != null
+    then client.ExternalLabels
+    else {}
+  )
+)

--- a/pkg/operator/config/templates/logs.libsonnet
+++ b/pkg/operator/config/templates/logs.libsonnet
@@ -8,20 +8,21 @@ local new_pod_logs = import 'component/logs/pod_logs.libsonnet';
 
 // Generates a logs_instance.
 //
-// @param {string} agentNamespace - namespace of the GrafanaAgent
+// @param {GrafanaAgent} agent
 // @param {LogsSubsystemSpec} global - global logs settings & defaults
 // @param {LogInstance} instance
 // @param {APIServerConfig} apiServer
 // @param {boolean} ignoreNamespaceSelectors
 // @param {string} enforcedNamespaceLabel
 function(
-  agentNamespace,
+  agent,
   global,
   instance,
   apiServer,
   ignoreNamespaceSelectors,
   enforcedNamespaceLabel,
 ) {
+  local agentNamespace = agent.ObjectMeta.Namespace,
   local meta = instance.Instance.ObjectMeta,
   local spec = instance.Instance.Spec,
 
@@ -39,7 +40,7 @@ function(
     else { ns: agentNamespace, list: global.Clients },
 
   clients: optionals.array(std.map(
-    function(spec) new_client(clients.ns, spec),
+    function(spec) new_client(agent, clients.ns, spec),
     clients.list,
   )),
 


### PR DESCRIPTION
#### PR Description 
Adds the `cluster` label to all logs found by the Grafana Agent Operator deployment. This matches the behavior of the cluster label added for metrics. The replica label isn't added since there is no concept of replicas for logs.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer
Found during #748.

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
