### PR TITLE
Operator: use reflection to discover references to secrets and configsmaps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/justwatchcom/elasticsearch_exporter v1.1.0
 	github.com/klauspost/compress v1.13.1 // indirect
 	github.com/miekg/dns v1.1.41
+	github.com/mitchellh/reflectwalk v1.0.2
 	github.com/ncabatoff/process-exporter v0.7.5
 	github.com/oklog/run v1.1.0
 	github.com/olekukonko/tablewriter v0.0.2

--- a/pkg/operator/config/config_references.go
+++ b/pkg/operator/config/config_references.go
@@ -1,8 +1,10 @@
 package config
 
 import (
-	grafana "github.com/grafana/agent/pkg/operator/apis/monitoring/v1alpha1"
+	"github.com/grafana/agent/pkg/util/structwalk"
 	prom "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // AssetReference is a namespaced Secret or ConfigMap selector.
@@ -15,158 +17,61 @@ type AssetReference struct {
 // the deployment. Every used secret and configmap should then be loaded into
 // an assets.SecretStore.
 func (d *Deployment) AssetReferences() []AssetReference {
-	var res []AssetReference
-
-	// Retrieve referenences from Agent
-	if d.Agent.Spec.APIServerConfig != nil {
-		res = append(res, apiServerAssetReferences(d.Agent.Namespace, d.Agent.Spec.APIServerConfig)...)
+	var refs []AssetReference
+	w := assetReferencesWalker{
+		addReference: func(ar AssetReference) {
+			refs = append(refs, ar)
+		},
 	}
-	for _, rw := range d.Agent.Spec.Prometheus.RemoteWrite {
-		res = append(res, remoteWriteAssetReferences(d.Agent.Namespace, &rw)...)
-	}
-
-	// Retrieve references from each PrometheusInstance
-	for _, inst := range d.Prometheis {
-		// Retrieve from inner PrometheusInstance
-		res = append(res, AssetReference{
-			Namespace: inst.Instance.Namespace,
-			Reference: prom.SecretOrConfigMap{Secret: inst.Instance.Spec.AdditionalScrapeConfigs},
-		})
-		for _, rw := range inst.Instance.Spec.RemoteWrite {
-			res = append(res, remoteWriteAssetReferences(inst.Instance.Namespace, &rw)...)
-		}
-
-		// Retrieve from ServiceMonitors
-		for _, monitor := range inst.ServiceMonitors {
-			for _, endpoint := range monitor.Spec.Endpoints {
-				res = append(res, basicAuthAssetReferences(monitor.Namespace, endpoint.BasicAuth)...)
-
-				if endpoint.TLSConfig != nil {
-					res = append(res, tlsConfigReferences(monitor.Namespace, endpoint.TLSConfig)...)
-				}
-				res = append(res, AssetReference{
-					Namespace: monitor.Namespace,
-					Reference: prom.SecretOrConfigMap{Secret: &endpoint.BearerTokenSecret},
-				})
-			}
-		}
-
-		// Retrieve from PodMonitors
-		for _, monitor := range inst.PodMonitors {
-			for _, endpoint := range monitor.Spec.PodMetricsEndpoints {
-				res = append(res, basicAuthAssetReferences(monitor.Namespace, endpoint.BasicAuth)...)
-
-				if endpoint.TLSConfig != nil {
-					res = append(res, tlsConfigReferences(monitor.Namespace, &prom.TLSConfig{
-						SafeTLSConfig: endpoint.TLSConfig.SafeTLSConfig,
-					})...)
-				}
-				res = append(res, AssetReference{
-					Namespace: monitor.Namespace,
-					Reference: prom.SecretOrConfigMap{Secret: &endpoint.BearerTokenSecret},
-				})
-			}
-		}
-
-		// Retrieve from Probes
-		for _, probe := range inst.Probes {
-			res = append(res, basicAuthAssetReferences(probe.Namespace, probe.Spec.BasicAuth)...)
-
-			if probe.Spec.TLSConfig != nil {
-				res = append(res, tlsConfigReferences(probe.Namespace, &prom.TLSConfig{
-					SafeTLSConfig: probe.Spec.TLSConfig.SafeTLSConfig,
-				})...)
-			}
-			res = append(res, AssetReference{
-				Namespace: probe.Namespace,
-				Reference: prom.SecretOrConfigMap{Secret: &probe.Spec.BearerTokenSecret},
-			})
-		}
-	}
-
-	return filterEmptyReferences(res)
+	structwalk.Walk(&w, d)
+	return refs
 }
 
-func apiServerAssetReferences(namespace string, apiServer *prom.APIServerConfig) []AssetReference {
-	var res []AssetReference
-
-	res = append(res, basicAuthAssetReferences(namespace, apiServer.BasicAuth)...)
-
-	if apiServer.TLSConfig != nil {
-		res = append(res, tlsConfigReferences(namespace, apiServer.TLSConfig)...)
-	}
-
-	return filterEmptyReferences(res)
+type assetReferencesWalker struct {
+	namespace    string
+	addReference func(ar AssetReference)
 }
 
-func basicAuthAssetReferences(namespace string, ba *prom.BasicAuth) []AssetReference {
-	if ba == nil {
+func (arw *assetReferencesWalker) Visit(v interface{}) (w structwalk.Visitor) {
+	if v == nil {
 		return nil
 	}
 
-	return []AssetReference{{
-		Namespace: namespace,
-		Reference: prom.SecretOrConfigMap{Secret: &ba.Username},
-	}, {
-		Namespace: namespace,
-		Reference: prom.SecretOrConfigMap{Secret: &ba.Password},
-	}}
-}
-
-func remoteWriteAssetReferences(namespace string, rw *grafana.RemoteWriteSpec) []AssetReference {
-	var res []AssetReference
-
-	res = append(res, basicAuthAssetReferences(namespace, rw.BasicAuth)...)
-
-	if rw.SigV4 != nil {
-		res = append(res, AssetReference{
-			Namespace: namespace,
-			Reference: prom.SecretOrConfigMap{Secret: rw.SigV4.AccessKey},
-		})
-		res = append(res, AssetReference{
-			Namespace: namespace,
-			Reference: prom.SecretOrConfigMap{Secret: rw.SigV4.SecretKey},
-		})
-	}
-
-	if rw.TLSConfig != nil {
-		res = append(res, tlsConfigReferences(namespace, rw.TLSConfig)...)
-	}
-
-	return filterEmptyReferences(res)
-}
-
-func tlsConfigReferences(namespace string, cfg *prom.TLSConfig) []AssetReference {
-	return filterEmptyReferences([]AssetReference{
-		{Namespace: namespace, Reference: cfg.CA},
-		{Namespace: namespace, Reference: cfg.Cert},
-		{Namespace: namespace, Reference: prom.SecretOrConfigMap{Secret: cfg.KeySecret}},
-	})
-}
-
-// filterEmptyReferences is a post-processing step of retrieving references to
-// remove any references that are empty or nil. This makes the preceding code
-// a little cleaner, since it won't have to check if each individual reference
-// is defined.
-func filterEmptyReferences(refs []AssetReference) []AssetReference {
-	res := make([]AssetReference, 0, len(refs))
-
-Outer:
-	for _, ref := range refs {
-		var (
-			configMap = ref.Reference.ConfigMap
-			secret    = ref.Reference.Secret
-		)
-		switch {
-		case configMap == nil && secret == nil:
-			continue Outer
-		case configMap != nil && configMap.LocalObjectReference.Name == "":
-			continue Outer
-		case secret != nil && secret.LocalObjectReference.Name == "":
-			continue Outer
+	// If we've come across a namespaced object, create a new visitor for that
+	// namespace.
+	if o, ok := v.(metav1.Object); ok {
+		return &assetReferencesWalker{
+			namespace:    o.GetNamespace(),
+			addReference: arw.addReference,
 		}
-		res = append(res, ref)
 	}
 
-	return res
+	switch sel := v.(type) {
+	case corev1.SecretKeySelector:
+		if sel.Key != "" && sel.Name != "" {
+			arw.addReference(AssetReference{
+				Namespace: arw.namespace,
+				Reference: prom.SecretOrConfigMap{Secret: &sel},
+			})
+		}
+	case *corev1.SecretKeySelector:
+		arw.addReference(AssetReference{
+			Namespace: arw.namespace,
+			Reference: prom.SecretOrConfigMap{Secret: sel},
+		})
+	case corev1.ConfigMapKeySelector:
+		if sel.Key != "" && sel.Name != "" {
+			arw.addReference(AssetReference{
+				Namespace: arw.namespace,
+				Reference: prom.SecretOrConfigMap{ConfigMap: &sel},
+			})
+		}
+	case *corev1.ConfigMapKeySelector:
+		arw.addReference(AssetReference{
+			Namespace: arw.namespace,
+			Reference: prom.SecretOrConfigMap{ConfigMap: sel},
+		})
+	}
+
+	return arw
 }

--- a/pkg/operator/config/config_references_test.go
+++ b/pkg/operator/config/config_references_test.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/grafana/agent/pkg/operator/apis/monitoring/v1alpha1"
+	prom "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDeployment_AssetReferences(t *testing.T) {
+	deployment := Deployment{
+		Agent: &v1alpha1.GrafanaAgent{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: "agent",
+			},
+			Spec: v1alpha1.GrafanaAgentSpec{
+				APIServerConfig: &prom.APIServerConfig{
+					BasicAuth: &prom.BasicAuth{
+						Username: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "spec-apiserverconfig-basicauth-username",
+							},
+							Key: "key",
+						},
+					},
+				},
+			},
+		},
+		Prometheis: []PrometheusInstance{{
+			Instance: &v1alpha1.PrometheusInstance{
+				ObjectMeta: v1.ObjectMeta{Namespace: "metrics-instance"},
+			},
+			PodMonitors: []*prom.PodMonitor{{
+				ObjectMeta: v1.ObjectMeta{Namespace: "pmon"},
+			}},
+			Probes: []*prom.Probe{{
+				ObjectMeta: v1.ObjectMeta{Namespace: "probe"},
+			}},
+			ServiceMonitors: []*prom.ServiceMonitor{{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "smon",
+				},
+				Spec: prom.ServiceMonitorSpec{
+					Endpoints: []prom.Endpoint{{
+						BearerTokenSecret: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "prometheis-servicemonitors-spec-endpoints-bearertokensecret",
+							},
+							Key: "key",
+						},
+					}},
+				},
+			}},
+		}},
+	}
+
+	require.Equal(t, []AssetReference{
+		{
+			Namespace: "agent",
+			Reference: prom.SecretOrConfigMap{
+				Secret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "spec-apiserverconfig-basicauth-username",
+					},
+					Key: "key",
+				},
+			},
+		},
+		{
+			Namespace: "smon",
+			Reference: prom.SecretOrConfigMap{
+				Secret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "prometheis-servicemonitors-spec-endpoints-bearertokensecret",
+					},
+					Key: "key",
+				},
+			},
+		},
+	}, deployment.AssetReferences())
+}

--- a/pkg/util/structwalk/structwalk.go
+++ b/pkg/util/structwalk/structwalk.go
@@ -17,7 +17,7 @@ import (
 // o must be non-nil.
 func Walk(v Visitor, o interface{}) {
 	sw := structWalker{v: v}
-	reflectwalk.Walk(o, &sw)
+	_ = reflectwalk.Walk(o, &sw)
 }
 
 // Visitor will have its Visit method invoked for each struct value encountered
@@ -59,7 +59,7 @@ func (sw *structWalker) Struct(v reflect.Value) error {
 	if w == nil {
 		return reflectwalk.SkipEntry
 	}
-	reflectwalk.Walk(rawValue, &structWalker{cur: rawValue, v: w})
+	_ = reflectwalk.Walk(rawValue, &structWalker{cur: rawValue, v: w})
 	w.Visit(nil)
 
 	return reflectwalk.SkipEntry

--- a/pkg/util/structwalk/structwalk.go
+++ b/pkg/util/structwalk/structwalk.go
@@ -1,0 +1,70 @@
+// Package structwalk allows you to "walk" the hierarchy of a struct. It is
+// very similar to github.com/mitchellh/reflectwalk but allows you to change
+// the visitor mid-walk.
+package structwalk
+
+import (
+	"reflect"
+
+	"github.com/mitchellh/reflectwalk"
+)
+
+// Walk traverses the hierarchy of o in depth-first order. It starts by calling
+// v.Visit(o). If the visitor w returned by v.Visit(o) is not nil, Walk is
+// invoked recursively with visitor w for each of the structs inside of o,
+// followed by a call to w.Visit(nil).
+//
+// o must be non-nil.
+func Walk(v Visitor, o interface{}) {
+	sw := structWalker{v: v}
+	reflectwalk.Walk(o, &sw)
+}
+
+// Visitor will have its Visit method invoked for each struct value encountered
+// by Walk. If w returned from Visit is non-nil, Walk will then visit each child
+// of value with w. The final call after visiting all children will be to
+// w.Visit(nil).
+type Visitor interface {
+	Visit(value interface{}) (w Visitor)
+}
+
+type structWalker struct {
+	cur interface{}
+	v   Visitor
+}
+
+// Struct invoke the Visitor for v and its children.
+func (sw *structWalker) Struct(v reflect.Value) error {
+	// Get the interface to the value. reflectwalk will fully derefernce all
+	// structs, so if it's possible for us to get address it into a pointer,
+	// we will use that for visiting.
+	var (
+		rawValue = v.Interface()
+		ptrValue = rawValue
+	)
+	if v.Kind() != reflect.Ptr && v.CanAddr() {
+		ptrValue = v.Addr().Interface()
+	}
+
+	// Struct will recursively call reflectwalk.Walk with a new walker, which
+	// means that sw.Struct will be called twice for the same value. We want
+	// to ignore calls to Struct with the same value so we don't recurse
+	// infinitely.
+	if sw.cur != nil && reflect.DeepEqual(rawValue, sw.cur) {
+		return nil
+	}
+
+	// Visit our struct and create a new walker with the returned Visitor.
+	w := sw.v.Visit(ptrValue)
+	if w == nil {
+		return reflectwalk.SkipEntry
+	}
+	reflectwalk.Walk(rawValue, &structWalker{cur: rawValue, v: w})
+	w.Visit(nil)
+
+	return reflectwalk.SkipEntry
+}
+
+func (sw *structWalker) StructField(reflect.StructField, reflect.Value) error {
+	return nil
+}

--- a/pkg/util/structwalk/structwalk_test.go
+++ b/pkg/util/structwalk/structwalk_test.go
@@ -34,7 +34,7 @@ func TestWalk(t *testing.T) {
 	fv = func(val interface{}) Visitor {
 		iteration++
 
-		// After visiting all 3 structs, should recieve a w.Visit(nil) for each level
+		// After visiting all 3 structs, should receive a w.Visit(nil) for each level
 		if iteration >= 4 {
 			require.Nil(t, val)
 			return nil

--- a/pkg/util/structwalk/structwalk_test.go
+++ b/pkg/util/structwalk/structwalk_test.go
@@ -1,0 +1,63 @@
+package structwalk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type LevelA struct {
+	Field1 bool
+	Field2 string
+	Field3 int
+	Nested LevelB
+}
+
+type LevelB struct {
+	Level1 bool
+	Level2 string
+	Field3 int
+	Nested LevelC
+}
+
+type LevelC struct {
+	Level1 bool
+	Level2 string
+	Field3 int
+}
+
+func TestWalk(t *testing.T) {
+	var (
+		iteration int
+		fv        FuncVisitor
+	)
+	fv = func(val interface{}) Visitor {
+		iteration++
+
+		// After visiting all 3 structs, should recieve a w.Visit(nil) for each level
+		if iteration >= 4 {
+			require.Nil(t, val)
+			return nil
+		}
+
+		switch iteration {
+		case 1:
+			require.IsType(t, LevelA{}, val)
+		case 2:
+			require.IsType(t, LevelB{}, val)
+		case 3:
+			require.IsType(t, LevelC{}, val)
+		default:
+			require.FailNow(t, "unexpected iteration")
+		}
+
+		return fv
+	}
+
+	var val LevelA
+	Walk(fv, val)
+}
+
+type FuncVisitor func(v interface{}) Visitor
+
+func (fv FuncVisitor) Visit(v interface{}) Visitor { return fv(v) }


### PR DESCRIPTION
#### PR Description 
Modifies the AssetReferences code to no longer manually traverse the resource hierarchy and instead use reflection to find all secret and configmap selectors.

This allows AssetReferences to always work regardless of changes we make to the CRDs and removes the risk of forgetting to update it. 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated  (N/A)
- [x] Documentation added (N/A)
- [x] Tests updated
