### PR TITLE
Fixing typo in the GrafanaAgents CRD

### DIFF
--- a/pkg/operator/apis/monitoring/v1alpha1/types.go
+++ b/pkg/operator/apis/monitoring/v1alpha1/types.go
@@ -86,7 +86,7 @@ type GrafanaAgentSpec struct {
 	// ConfigMaps is a liset of config maps in the same namespace as the
 	// GrafanaAgent object which will be mounted into each running Grafana Agent
 	// pod.
-	// The secrets are mounted into /etc/grafana-agent/configmaps/<configmap-name>.
+	// The ConfigMaps are mounted into /etc/grafana-agent/configmaps/<configmap-name>.
 	ConfigMaps []string `json:"configMaps,omitempty"`
 	// Affinity, if specified, controls pod scheduling constraints.
 	Affinity *v1.Affinity `json:"affinity,omitempty"`

--- a/production/operator/crds/monitoring.grafana.com_grafana-agents.yaml
+++ b/production/operator/crds/monitoring.grafana.com_grafana-agents.yaml
@@ -647,7 +647,7 @@ spec:
                 - host
                 type: object
               configMaps:
-                description: ConfigMaps is a liset of config maps in the same namespace as the GrafanaAgent object which will be mounted into each running Grafana Agent pod. The secrets are mounted into /etc/grafana-agent/configmaps/<configmap-name>.
+                description: ConfigMaps is a liset of config maps in the same namespace as the GrafanaAgent object which will be mounted into each running Grafana Agent pod. The ConfigMaps are mounted into /etc/grafana-agent/configmaps/<configmap-name>.
                 items:
                   type: string
                 type: array


### PR DESCRIPTION
#### PR Description

This PR si fixing a typo in the `GrafanaAgent` CRD which was probably introduced by copying description for `spec.secrets` to `spec.configMaps`.