### PR TITLE
Use Deployment for traces quickstart

### DIFF
--- a/production/kubernetes/README.md
+++ b/production/kubernetes/README.md
@@ -15,6 +15,7 @@ For sample configurations and detailed installation instructions, please head to
 
 - [Grafana Agent Metrics Kubernetes Quickstart](https://grafana.com/docs/grafana-cloud/quickstart/agent-k8s/k8s_agent_metrics/)
 - [Grafana Agent Logs Kubernetes Quickstart](https://grafana.com/docs/grafana-cloud/quickstart/agent-k8s/k8s_agent_logs/)
+- [Grafana Agent Traces Kubernetes Quickstart](https://grafana.com/docs/grafana-cloud/quickstart/agent-k8s/k8s_agent_traces/)
 
 ## Manually Applying
 

--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -61,6 +61,11 @@ spec:
         - -config.file=/etc/agent/agent.yaml
         command:
         - /bin/agent
+        env:
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         image: grafana/agent:v0.16.1
         imagePullPolicy: IfNotPresent
         name: agent

--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -64,6 +64,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         image: grafana/agent:v0.16.1
         imagePullPolicy: IfNotPresent
         name: agent

--- a/production/kubernetes/agent-tempo.yaml
+++ b/production/kubernetes/agent-tempo.yaml
@@ -2,69 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: grafana-agent-traces
-  namespace: ${NAMESPACE}
----
-apiVersion: v1
-data:
-  agent.yaml: |
-    server:
-        http_listen_port: 8080
-        log_level: info
-    tempo:
-        configs:
-          - batch:
-                send_batch_size: 1000
-                timeout: 5s
-            name: default
-            receivers:
-                jaeger:
-                    protocols:
-                        grpc: null
-                        thrift_binary: null
-                        thrift_compact: null
-                        thrift_http: null
-                    remote_sampling:
-                        insecure: true
-                        strategy_file: /etc/agent/strategies.json
-                opencensus: null
-                otlp:
-                    protocols:
-                        grpc: null
-                        http: null
-                zipkin: null
-            remote_write:
-              - basic_auth:
-                    password: ${TEMPO_PASSWORD}
-                    username: ${TEMPO_USERNAME}
-                endpoint: ${TEMPO_ENDPOINT}
-                retry_on_failure:
-                    enabled: false
-            scrape_configs:
-              - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-                job_name: kubernetes-pods
-                kubernetes_sd_configs:
-                  - role: pod
-                relabel_configs:
-                  - action: replace
-                    source_labels:
-                      - __meta_kubernetes_namespace
-                    target_label: namespace
-                  - action: replace
-                    source_labels:
-                      - __meta_kubernetes_pod_name
-                    target_label: pod
-                  - action: replace
-                    source_labels:
-                      - __meta_kubernetes_pod_container_name
-                    target_label: container
-                tls_config:
-                    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                    insecure_skip_verify: false
-  strategies.json: '{"default_strategy": {"param": 0.001, "type": "probabilistic"}}'
-kind: ConfigMap
-metadata:
-  name: grafana-agent-traces
-  namespace: ${NAMESPACE}
+  namespace: YOUR_NAMESPACE
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -99,7 +37,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: grafana-agent-traces
-  namespace: ${NAMESPACE}
+  namespace: YOUR_NAMESPACE
 ---
 apiVersion: v1
 kind: Service
@@ -107,7 +45,7 @@ metadata:
   labels:
     name: grafana-agent-traces
   name: grafana-agent-traces
-  namespace: ${NAMESPACE}
+  namespace: YOUR_NAMESPACE
 spec:
   ports:
   - name: agent-http-metrics
@@ -145,12 +83,14 @@ spec:
     name: grafana-agent-traces
 ---
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   name: grafana-agent-traces
-  namespace: ${NAMESPACE}
+  namespace: YOUR_NAMESPACE
 spec:
   minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       name: grafana-agent-traces
@@ -200,12 +140,7 @@ spec:
         - mountPath: /etc/agent
           name: grafana-agent-traces
       serviceAccount: grafana-agent-traces
-      tolerations:
-      - effect: NoSchedule
-        operator: Exists
       volumes:
       - configMap:
           name: grafana-agent-traces
         name: grafana-agent-traces
-  updateStrategy:
-    type: RollingUpdate

--- a/production/kubernetes/build/templates/tempo/main.jsonnet
+++ b/production/kubernetes/build/templates/tempo/main.jsonnet
@@ -11,7 +11,7 @@ local newPort(name, portNumber, protocol='TCP') =
 
 {
   agent:
-    agent.new('grafana-agent-traces', '${NAMESPACE}') +
+    agent.newDeployment('grafana-agent-traces', 'YOUR_NAMESPACE') +
     agent.withConfigHash(false) +
     agent.withImages({
       agent: (import 'version.libsonnet'),
@@ -74,5 +74,10 @@ local newPort(name, portNumber, protocol='TCP') =
         param: 0.001,
       },
     }) +
-    agent.withTempoScrapeConfigs(agent.tempoScrapeKubernetes),
+    agent.withTempoScrapeConfigs(agent.tempoScrapeKubernetes) + {
+      agent+: {
+        // Remove this block to generate ConfigMap
+        config_map:: {},
+      },
+    },
 }

--- a/production/tanka/grafana-agent/v1/internal/agent.libsonnet
+++ b/production/tanka/grafana-agent/v1/internal/agent.libsonnet
@@ -45,7 +45,10 @@ local serviceAccount = k.core.v1.serviceAccount;
       container.withCommand('/bin/agent') +
       container.withArgsMixin(k.util.mapToFlags({
         'config.file': '/etc/agent/agent.yaml',
-      })),
+      })) +
+      container.withEnvMixin([
+        k.core.v1.envVar.fromFieldPath('HOSTNAME', 'spec.nodeName'),
+      ]),
 
     agent:
       (

--- a/production/tanka/grafana-agent/v1/lib/deployment.libsonnet
+++ b/production/tanka/grafana-agent/v1/lib/deployment.libsonnet
@@ -1,4 +1,9 @@
 local agent = import '../internal/agent.libsonnet';
+local k = import 'ksonnet-util/kausal.libsonnet';
+
+local configMap = k.core.v1.configMap;
+local service = k.core.v1.service;
+local container = k.core.v1.container;
 
 {
   // newDeployment creates a new single-replicaed Deployment of the
@@ -26,25 +31,61 @@ local agent = import '../internal/agent.libsonnet';
 
     local has_prometheus_config = std.objectHasAll(self, '_prometheus_config'),
     local has_prometheus_instances = std.objectHasAll(self, '_prometheus_instances'),
+    local has_tempo_config = std.objectHasAll(self, '_tempo_config'),
+    local has_sampling_strategies = std.objectHasAll(self, '_tempo_sampling_strategies'),
 
     config:: {
       server: {
         log_level: 'info',
         http_listen_port: 8080,
       },
-
-      prometheus:
-        if !has_prometheus_config then {}
-        else this._prometheus_config {
-          configs:
-            if has_prometheus_instances
-            then this._prometheus_instances
-            else [],
+    } + (
+      if has_prometheus_config 
+      then {
+        prometheus:
+          this._prometheus_config {
+            configs:
+              if has_prometheus_instances
+              then this._prometheus_instances
+              else [],
+          },
+      }
+      else {}
+    ) + (
+      if has_tempo_config then {
+        tempo: {
+          configs: [this._tempo_config {
+            name: 'default',
+          }],
         },
-    },
+      }
+      else {}
+    ),
 
     agent:
       agent.newAgent(name, namespace, self._images.agent, self.config, use_daemonset=false) +
-      agent.withConfigHash(self._config_hash),
+      agent.withConfigHash(self._config_hash) + (
+        if has_tempo_config
+        then 
+          {
+            container+:: container.withEnvMixin([
+              k.core.v1.envVar.fromFieldPath('HOSTNAME', 'spec.nodeName'),
+            ]),
+
+            // If sampling strategies were defined, we need to mount them as a JSON
+            // file.
+            config_map+:
+              if has_sampling_strategies
+              then configMap.withDataMixin({
+                'strategies.json': std.toString(this._tempo_sampling_strategies),
+              })
+              else {},
+
+            // If we're deploying for tracing, applications will want to write to
+            // a service for load balancing span delivery.
+            service:
+              k.util.serviceFor(self.agent) + service.mixin.metadata.withNamespace(namespace)
+          } else {}
+      )
   },
 }

--- a/production/tanka/grafana-agent/v1/lib/deployment.libsonnet
+++ b/production/tanka/grafana-agent/v1/lib/deployment.libsonnet
@@ -40,7 +40,7 @@ local container = k.core.v1.container;
         http_listen_port: 8080,
       },
     } + (
-      if has_prometheus_config 
+      if has_prometheus_config
       then {
         prometheus:
           this._prometheus_config {
@@ -65,23 +65,20 @@ local container = k.core.v1.container;
     agent:
       agent.newAgent(name, namespace, self._images.agent, self.config, use_daemonset=false) +
       agent.withConfigHash(self._config_hash) + {
-        container+:: container.withEnvMixin([
-          k.core.v1.envVar.fromFieldPath('HOSTNAME', 'spec.nodeName'),
-        ]),
-          // If sampling strategies were defined, we need to mount them as a JSON
-          // file.
-          config_map+:
-            if has_sampling_strategies
-            then configMap.withDataMixin({
-              'strategies.json': std.toString(this._tempo_sampling_strategies),
-            })
-            else {},
-            // If we're deploying for tracing, applications will want to write to
-            // a service for load balancing span delivery.
-            service:
-              if has_tempo_config
-              then k.util.serviceFor(self.agent) + service.mixin.metadata.withNamespace(namespace)
-              else {},
+        // If sampling strategies were defined, we need to mount them as a JSON
+        // file.
+        config_map+:
+          if has_sampling_strategies
+          then configMap.withDataMixin({
+            'strategies.json': std.toString(this._tempo_sampling_strategies),
+          })
+          else {},
+        // If we're deploying for tracing, applications will want to write to
+        // a service for load balancing span delivery.
+        service:
+          if has_tempo_config
+          then k.util.serviceFor(self.agent) + service.mixin.metadata.withNamespace(namespace)
+          else {},
       },
   },
 }


### PR DESCRIPTION
#### PR Description 

This PR moves quickstart deployment and configuration instructions into the Cloud docs. In addition, the trace collector Agent is rolled out as a Deployment instead of a DaemonSet by default. Tested with the Grafana [demo app](https://github.com/grafana/tns) and Grafana Cloud.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

Broken link pending https://github.com/grafana/website/pull/5340 

#### PR Checklist

- [ ] CHANGELOG updated 
- [x] Documentation added
- [ ] Tests updated
