### PR TITLE
TestEnqueueRequestForSelector: only run test if -online flag is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - [FEATURE] Support autologging span attributes as log labels (@mapno)
 
+- [FEATURE] Put Tests requiring Network Access behind a -online flag (@flokli)
+
 - [ENHANCEMENT] The Grafana Agent Operator will now default to deploying
   the matching release version of the Grafana Agent instead of v0.14.0.
   (@rfratto)

--- a/Makefile
+++ b/Makefile
@@ -218,8 +218,8 @@ lint:
 # for packages that have known race detection issues
 # Run tests with -online flag set to true, to include tests requiring network connectivity in CI
 test:
-	CGO_ENABLED=1 go test $(CGO_FLAGS) -race -cover -coverprofile=cover.out -p=4 ./... -online
-	CGO_ENABLED=1 go test $(CGO_FLAGS) -cover -coverprofile=cover-norace.out -p=4 ./pkg/integrations/node_exporter ./pkg/logs -online
+	CGO_ENABLED=1 go test $(CGO_FLAGS) -race -cover -coverprofile=cover.out -p=4 ./... -- -online
+	CGO_ENABLED=1 go test $(CGO_FLAGS) -cover -coverprofile=cover-norace.out -p=4 ./pkg/integrations/node_exporter ./pkg/logs -- -online
 
 clean:
 	rm -rf cmd/agent/agent

--- a/Makefile
+++ b/Makefile
@@ -216,9 +216,10 @@ lint:
 
 # We have to run test twice: once for all packages with -race and then once more without -race
 # for packages that have known race detection issues
+# Run tests with -online flag set to true, to include tests requiring network connectivity in CI
 test:
-	CGO_ENABLED=1 go test $(CGO_FLAGS) -race -cover -coverprofile=cover.out -p=4 ./...
-	CGO_ENABLED=1 go test $(CGO_FLAGS) -cover -coverprofile=cover-norace.out -p=4 ./pkg/integrations/node_exporter ./pkg/logs
+	CGO_ENABLED=1 go test $(CGO_FLAGS) -race -cover -coverprofile=cover.out -p=4 ./... -online
+	CGO_ENABLED=1 go test $(CGO_FLAGS) -cover -coverprofile=cover-norace.out -p=4 ./pkg/integrations/node_exporter ./pkg/logs -online
 
 clean:
 	rm -rf cmd/agent/agent

--- a/pkg/operator/selector_eventhandler_test.go
+++ b/pkg/operator/selector_eventhandler_test.go
@@ -6,6 +6,7 @@ package operator
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -34,11 +35,16 @@ var (
 		runtime.GOOS,
 		runtime.GOARCH,
 	)
+
+	online = flag.Bool("online", false, "Run tests requiring network access")
 )
 
 // TestEnqueueRequestForSelector creates an example Kubenretes cluster and runs
 // EnqueueRequestForSelector to validate it works.
 func TestEnqueueRequestForSelector(t *testing.T) {
+	if !*online {
+		t.Skip("skipping test, pass -online to run tests requiring network access")
+	}
 	l := log.NewNopLogger()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)


### PR DESCRIPTION
This test does download and invoke kubebuilder-tools, to make sure there
is no extra steps needed just to run this one test.
(https://github.com/grafana/agent/issues/731#issuecomment-878255964).

However, distros usually build and run tests in a sandbox with network
access disabled, causing this test to fail.

Introduce a `online` flag, defaulting to false, and skip this test as
long as `-online` is not passed.

CI, which invokes `make test` deliberately sets this to true, to have
coverage for that test provided by CI.

Fixes #731.

#### PR Description 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added
- [x] Tests updated
