### PR TITLE
Remove duplicate HOSTNAME env var

### DIFF
--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -64,10 +64,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: HOSTNAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
         image: grafana/agent:v0.16.1
         imagePullPolicy: IfNotPresent
         name: agent

--- a/production/tanka/grafana-agent/v1/main.libsonnet
+++ b/production/tanka/grafana-agent/v1/main.libsonnet
@@ -101,12 +101,6 @@ local service = k.core.v1.service;
     agent:
       agent.newAgent(name, namespace, self._images.agent, self.config, use_daemonset=true) +
       agent.withConfigHash(self._config_hash) + {
-        // Required for the scraping service; get the node name and store it in
-        // $HOSTNAME so host_filtering works.
-        container+:: container.withEnvMixin([
-          k.core.v1.envVar.fromFieldPath('HOSTNAME', 'spec.nodeName'),
-        ]),
-
         // If sampling strategies were defined, we need to mount them as a JSON
         // file.
         config_map+:


### PR DESCRIPTION
#### PR Description 

Cleans up small bug from https://github.com/grafana/agent/pull/772 where `HOSTNAME` is set twice
