### PR TITLE
the Operator-specific documentation

### DIFF
--- a/docs/getting-started/_index.md
+++ b/docs/getting-started/_index.md
@@ -7,7 +7,7 @@ weight = 100
 
 This guide helps users get started with the Grafana Agent. For getting started
 with the Grafana Agent Operator, please refer to the Operator-specific
-[documentation](../operator/_index.md).
+[documentation](../operator/).
 
 Currently, there are six ways to install the agent:
 


### PR DESCRIPTION
The original [documentation](../operator/_index.md) makes the link broken; removing the _index.md part should fix it based on similar links in this and other pages.

#### PR Description 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
