### PR TITLE
Fix filesystem collector defaults on darwin / Mac OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
   to be a member of the adm and systemd-journal groups. This will allow logs to
   read from journald and /var/log by default. (@rfratto)
 
+- [BUGFIX] Fix collecting filesystem metrics on Mac OS (darwin) in the `node_exporter` integration default config. (@eamonryan)
+
 - [CHANGE] Breaking change: reduced verbosity of tracing autologging
   by not logging `STATUS_CODE_UNSET` status codes. (@mapno)
 

--- a/pkg/integrations/node_exporter/config.go
+++ b/pkg/integrations/node_exporter/config.go
@@ -55,7 +55,7 @@ func init() {
 	case "linux":
 		DefaultConfig.FilesystemIgnoredMountPoints = "^/(dev|proc|sys|var/lib/docker/.+)($|/)"
 		DefaultConfig.FilesystemIgnoredFSTypes = "^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$"
-	case "freebsd", "netbsd", "openbsd":
+	case "freebsd", "netbsd", "openbsd", "darwin":
 		DefaultConfig.FilesystemIgnoredMountPoints = "^/(dev)($|/)"
 		DefaultConfig.FilesystemIgnoredFSTypes = "^devfs$"
 	}


### PR DESCRIPTION
#### PR Description 
This adds `darwin` to the switch statement for the `node_exporter` default config, making it so that filesystem metrics are actually collected.

#### Which issue(s) this PR fixes
Fixed #818 

#### Notes to the Reviewer

#### PR Checklist

- [X] CHANGELOG updated 
- [N/A] Documentation added
- [ ] Tests updated
