### PR TITLE
Fix issue where windows logger info messages only log "\n"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 
 - [BUGFIX] Fix collecting filesystem metrics on Mac OS (darwin) in the `node_exporter` integration default config. (@eamonryan)
 
+- [BUGFIX] Fix info logging on windows. (@mattdurham)
+
 - [CHANGE] Breaking change: reduced verbosity of tracing autologging
   by not logging `STATUS_CODE_UNSET` status codes. (@mapno)
 

--- a/pkg/util/logger_windows.go
+++ b/pkg/util/logger_windows.go
@@ -94,7 +94,7 @@ func (w *winLogger) Log(keyvals ...interface{}) error {
 	case level.DebugValue():
 		return w.infoLogger.Log(keyvals...)
 	case level.InfoValue():
-		return w.infoLogger.Log(keyvals)
+		return w.infoLogger.Log(keyvals...)
 	case level.WarnValue():
 		return w.warningLogger.Log(keyvals...)
 	case level.ErrorValue():


### PR DESCRIPTION
#### PR Description 

Previously passing the array to the logger would cause only "\n" to be logged, flattening out the array allows info to be logged correctly.

#### Which issue(s) this PR fixes 

Closes #828


#### PR Checklist

- [X] CHANGELOG updated 
- [NA] Documentation added
- [NA] Tests updated
