### PR TITLE
Match tempo.libsonnet and example k3d with latest load_balancing config

### DIFF
--- a/example/k3d/environment/main.jsonnet
+++ b/example/k3d/environment/main.jsonnet
@@ -96,15 +96,15 @@ local images = {
       policies: [{
         always_sample: null,
       }],
-      load_balancing: {
-        exporter: {
-          insecure: true,
-        },
-        resolver: {
-          dns: {
-            hostname: 'grafana-agent.default.svc.cluster.local',
-            port: 4318,
-          },
+    }) +
+    grafana_agent.withTempoLoadBalancingConfig({
+      exporter: {
+        insecure: true,
+      },
+      resolver: {
+        dns: {
+          hostname: 'grafana-agent.default.svc.cluster.local',
+          port: 4318,
         },
       },
     }),

--- a/production/tanka/grafana-agent/v1/lib/tempo.libsonnet
+++ b/production/tanka/grafana-agent/v1/lib/tempo.libsonnet
@@ -122,5 +122,13 @@
       withTempoConfig.
     |||,
     _tempo_config+:: { tail_sampling: tail_sampling },
+  },
+
+  withTempoLoadBalancingConfig(load_balancing):: {
+    assert std.objectHasAll(self, '_tempo_config') : |||
+      withTempoLoadBalancingConfig must be merged with the result of calling
+      withTempoConfig.
+    |||,
+    _tempo_config+:: { load_balancing: load_balancing },
   }
 }


### PR DESCRIPTION
This applies the tempo config change defined [here](https://github.com/grafana/agent/blob/ff545a16c02bc3877de7df7b6327ef963d94401e/docs/upgrade-guide/_index.md#tempo-split-grouping-by-trace-from-tail-sampling-config) to the k3d example project + tempo.libsonnet. 