### PR TITLE
Fix Redis exporter initialization log

### DIFF
--- a/pkg/integrations/redis_exporter/redis_exporter.go
+++ b/pkg/integrations/redis_exporter/redis_exporter.go
@@ -127,7 +127,7 @@ func init() {
 // New creates a new redis_exporter integration. The integration queries
 // a redis instance's INFO and exposes the results as metrics.
 func New(log log.Logger, c *Config) (integrations.Integration, error) {
-	level.Debug(log).Log("msg", "initialising redis_exporer with config %v", c)
+	level.Debug(log).Log("msg", "initializing redis_exporter", "config", c)
 
 	exporterConfig := c.GetExporterOptions()
 


### PR DESCRIPTION
#### PR Description 
Super minor, but I was running the agent with log_level=debug and noticed that my Redis exporter config wasn't being logged correctly:
```
ts=2021-08-19T13:41:55Z level=info msg="Receiver started." component=tempo tempo_config=default kind=receiver name=jaeger
ts=2021-08-19T13:41:55.5608507Z level=debug integration=redis_exporter msg="initialising redis_exporer with config %v"
```

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [x] Documentation added
- [ ] Tests updated

(No breaking changes so I haven't updated other things)