### PR TITLE
Fix issue with global scrape_interval changes not reloading integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 
 - [BUGFIX] Remove v0.0.0 flags during build with no explicit release tag (@mattdurham)
 
+- [BUGFIX] Fix issue with global scrape_interval changes not reloading integrations (@kgeckhart)
+
 - [CHANGE] Breaking change: reduced verbosity of tracing autologging
   by not logging `STATUS_CODE_UNSET` status codes. (@mapno)
 

--- a/cmd/agent/entrypoint.go
+++ b/cmd/agent/entrypoint.go
@@ -90,7 +90,7 @@ func NewEntrypoint(logger *util.Logger, cfg *config.Config, reloader Reloader) (
 		return nil, err
 	}
 
-	ep.manager, err = integrations.NewManager(cfg.Integrations, logger, ep.promMetrics.InstanceManager(), ep.promMetrics.Validate, cfg.Prometheus.Global.Prometheus)
+	ep.manager, err = integrations.NewManager(cfg.Integrations, logger, ep.promMetrics.InstanceManager(), ep.promMetrics.Validate)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func (ep *Entrypoint) ApplyConfig(cfg config.Config) error {
 		failed = true
 	}
 
-	if err := ep.manager.ApplyConfig(cfg.Integrations, cfg.Prometheus.Global.Prometheus); err != nil {
+	if err := ep.manager.ApplyConfig(cfg.Integrations); err != nil {
 		level.Error(ep.log).Log("msg", "failed to update integrations", "err", err)
 		failed = true
 	}

--- a/cmd/agent/entrypoint.go
+++ b/cmd/agent/entrypoint.go
@@ -61,8 +61,8 @@ func NewEntrypoint(logger *util.Logger, cfg *config.Config, reloader Reloader) (
 	)
 
 	if cfg.ReloadPort != 0 {
-		reloadUrl := fmt.Sprintf("%s:%d", cfg.ReloadAddress, cfg.ReloadPort)
-		ep.reloadListener, err = net.Listen("tcp", reloadUrl)
+		reloadURL := fmt.Sprintf("%s:%d", cfg.ReloadAddress, cfg.ReloadPort)
+		ep.reloadListener, err = net.Listen("tcp", reloadURL)
 		if err != nil {
 			return nil, fmt.Errorf("failed to listen on address for secondary /-/reload server: %w", err)
 		}
@@ -70,7 +70,7 @@ func NewEntrypoint(logger *util.Logger, cfg *config.Config, reloader Reloader) (
 		reloadMux := mux.NewRouter()
 		reloadMux.HandleFunc("/-/reload", ep.reloadHandler).Methods("GET", "POST")
 		ep.reloadServer = &http.Server{Handler: reloadMux}
-		level.Info(ep.log).Log("msg", "reload server started", "url", reloadUrl)
+		level.Info(ep.log).Log("msg", "reload server started", "url", reloadURL)
 	}
 
 	ep.srv = server.New(prometheus.DefaultRegisterer, logger)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -96,6 +96,8 @@ func (c *Config) ApplyDefaults() error {
 		c.Integrations.PrometheusRemoteWrite = c.Prometheus.Global.RemoteWrite
 	}
 
+	c.Integrations.PrometheusGlobalConfig = c.Prometheus.Global.Prometheus
+
 	// since the Tempo config might rely on an existing Loki config
 	// this check is made here to look for cross config issues before we attempt to load
 	if err := c.Tempo.Validate(c.Logs); err != nil {

--- a/pkg/integrations/manager.go
+++ b/pkg/integrations/manager.go
@@ -202,10 +202,10 @@ func (m *Manager) ApplyConfig(cfg ManagerConfig) error {
 	// The global prometheus config settings don't get applied to integrations until later. This
 	// causes us to skip reload when those settings change.
 	if util.CompareYAML(m.cfg, cfg) && util.CompareYAML(m.cfg.PrometheusGlobalConfig, cfg.PrometheusGlobalConfig) {
-		level.Info(m.logger).Log("msg", "Integrations config is unchanged skipping apply")
+		level.Debug(m.logger).Log("msg", "Integrations config is unchanged skipping apply")
 		return nil
 	}
-	level.Info(m.logger).Log("msg", "Applying integrations config changes")
+	level.Debug(m.logger).Log("msg", "Applying integrations config changes")
 
 	select {
 	case <-m.ctx.Done():

--- a/pkg/integrations/manager.go
+++ b/pkg/integrations/manager.go
@@ -204,9 +204,8 @@ func (m *Manager) ApplyConfig(cfg ManagerConfig) error {
 	if util.CompareYAML(m.cfg, cfg) && util.CompareYAML(m.cfg.PrometheusGlobalConfig, cfg.PrometheusGlobalConfig) {
 		level.Info(m.logger).Log("msg", "Integrations config is unchanged skipping apply")
 		return nil
-	} else {
-		level.Info(m.logger).Log("msg", "Applying integrations config changes")
 	}
+	level.Info(m.logger).Log("msg", "Applying integrations config changes")
 
 	select {
 	case <-m.ctx.Done():

--- a/pkg/integrations/manager_test.go
+++ b/pkg/integrations/manager_test.go
@@ -196,7 +196,6 @@ func TestManager_StartsIntegrations(t *testing.T) {
 	})
 }
 
-//TODO how does this work it's looks exactly the same as above?
 func TestManager_RestartsIntegrations(t *testing.T) {
 	mock := newMockIntegration()
 	icfg := mockConfig{Integration: mock}


### PR DESCRIPTION
#### PR Description 
We are doing a yaml compare of the IntegrationsManager config on reload to see if anything changed. Prometheus settings are not applied to the Integration configs the IntegrationManager has so it looks like nothing changed and we short circuit out. 

This change adds the global Prometheus Config to the IntegrationManager config to avoid short circuiting. There's also some small logging changes I kept that made it a little easier while troubleshooting. 

#### Which issue(s) this PR fixes 
Fixes #827 

#### PR Checklist

- [x] CHANGELOG updated 
- [NA] Documentation added
- [x] Tests updated
