### PR TITLE
Fix k3d create script on Fedora 34

### DIFF
--- a/example/k3d/scripts/create.bash
+++ b/example/k3d/scripts/create.bash
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
 
+EXTRA_MOUNTS=""
+
+if [ -f /etc/machine-id ]; then
+  EXTRA_MOUNTS="$EXTRA_MOUNTS -v /etc/machine-id:/etc/machine-id"
+fi
+
+if [ -d /dev/mapper ]; then
+  EXTRA_MOUNTS="$EXTRA_MOUNTS -v /dev/mapper:/dev/mapper"
+fi
+
 k3d cluster create agent-k3d \
   --port 30080:80@loadbalancer \
   --api-port 50443 \
   -v /var/lib/k3d/agent-k3d/storage/:/var/lib/rancher/k3s/storage/ \
-  -v /etc/machine-id:/etc/machine-id \
+  $EXTRA_MOUNTS \
   --kubeconfig-update-default=true \
   --kubeconfig-switch-context=true \
   --wait


### PR DESCRIPTION
Fedora 34 requires mapping /dev/mapper to the k3d container: https://k3d.io/faq/faq/#issues-with-btrfs
