### PR TITLE
Register missing metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ for specific instructions.
 
 - [BUGFIX] Fix yaml marshalling tag for cert_file in kafka exporter agent config. (@rgeyer)
 
+- [BUGFIX] Register missing metric for configstore consul request duration.
+
 - [CHANGE] Breaking change: reduced verbosity of tracing autologging
   by not logging `STATUS_CODE_UNSET` status codes. (@mapno)
 

--- a/pkg/metrics/instance/configstore/remote.go
+++ b/pkg/metrics/instance/configstore/remote.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/agent/pkg/metrics/instance"
 	"github.com/grafana/agent/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 /***********************************************************************************************************************
@@ -28,12 +29,10 @@ consul. See issue https://github.com/grafana/agent/issues/789. The long term met
 the cortex code so other stores can also benefit from this. @mattdurham
 ***********************************************************************************************************************/
 
-// This is copied from cortex code so that stats stay the same
-var consulRequestDuration = instrument.NewHistogramCollector(prometheus.NewHistogramVec(prometheus.HistogramOpts{
-	Namespace: "cortex",
-	Name:      "consul_request_duration_seconds",
-	Help:      "Time spent on consul requests.",
-	Buckets:   prometheus.DefBuckets,
+var consulRequestDuration = instrument.NewHistogramCollector(promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "agent_configstore_consul_request_duration_seconds",
+	Help:    "Time spent on consul requests when loading configs.",
+	Buckets: prometheus.DefBuckets,
 }, []string{"operation", "status_code"}))
 
 // Remote loads instance files from a remote KV store. The KV store

--- a/pkg/metrics/instance/configstore/remote.go
+++ b/pkg/metrics/instance/configstore/remote.go
@@ -30,7 +30,7 @@ the cortex code so other stores can also benefit from this. @mattdurham
 ***********************************************************************************************************************/
 
 var consulRequestDuration = instrument.NewHistogramCollector(promauto.NewHistogramVec(prometheus.HistogramOpts{
-	Name:    "agent_configstore_consul_list_request_duration_seconds",
+	Name:    "agent_configstore_consul_request_duration_seconds",
 	Help:    "Time spent on consul requests when listing configs.",
 	Buckets: prometheus.DefBuckets,
 }, []string{"operation", "status_code"}))

--- a/pkg/metrics/instance/configstore/remote.go
+++ b/pkg/metrics/instance/configstore/remote.go
@@ -30,8 +30,8 @@ the cortex code so other stores can also benefit from this. @mattdurham
 ***********************************************************************************************************************/
 
 var consulRequestDuration = instrument.NewHistogramCollector(promauto.NewHistogramVec(prometheus.HistogramOpts{
-	Name:    "agent_configstore_consul_request_duration_seconds",
-	Help:    "Time spent on consul requests when loading configs.",
+	Name:    "agent_configstore_consul_list_request_duration_seconds",
+	Help:    "Time spent on consul requests when listing configs.",
 	Buckets: prometheus.DefBuckets,
 }, []string{"operation", "status_code"}))
 


### PR DESCRIPTION
#### PR Description 
Registers `agent_configstore_consul_request_duration_seconds` to track the time it takes to do a consul list using the optimization shortcut. 

Note that the metric must have a different name due to it being a separate histogram, and the underlying metric used by Cortex's kv store is not exposed so we have to make our own.

#### Which issue(s) this PR fixes 
Fixes #855 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
