### PR TITLE
Add caller information to logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ for specific instructions.
 
 - [BUGFIX] Fix yaml marshalling tag for cert_file in kafka exporter agent config. (@rgeyer)
 
+- [BUGFIX] Logs should contain a caller field with file and line numbers again (@kgeckhart)
+
 - [CHANGE] Breaking change: reduced verbosity of tracing autologging
   by not logging `STATUS_CODE_UNSET` status codes. (@mapno)
 

--- a/pkg/tempo/tempo.go
+++ b/pkg/tempo/tempo.go
@@ -115,7 +115,7 @@ func newLogger(zapLevel zapcore.LevelEnabler) *zap.Logger {
 		zaplogfmt.NewEncoder(config),
 		os.Stdout,
 		zapLevel,
-	))
+	), zap.AddCaller())
 	logger = logger.With(zap.String("component", "tempo"))
 	logger.Info("Tempo Logger Initialized")
 

--- a/pkg/util/logger.go
+++ b/pkg/util/logger.go
@@ -59,7 +59,8 @@ func defaultLogger(cfg *server.Config) (log.Logger, error) {
 		return nil, err
 	}
 
-	return l, nil
+	// There are two wrappers on the log so skip two extra stacks vs default
+	return log.With(l, "caller", log.Caller(5)), nil
 }
 
 // Log logs a log line.
@@ -69,10 +70,7 @@ func (l *Logger) Log(kvps ...interface{}) error {
 	return l.l.Log(kvps...)
 }
 
-// GoKitLogger creates a logging.Interface from a log.Logger. A "caller" label will
-// be added.
+// GoKitLogger creates a logging.Interface from a log.Logger.
 func GoKitLogger(l log.Logger) logging.Interface {
-	// logging.GoKit wraps the log function, so we need to skip one extra stack
-	// from than the default caller to get the caller information.
-	return logging.GoKit(log.With(l, "caller", log.Caller(4)))
+	return logging.GoKit(l)
 }


### PR DESCRIPTION
#### PR Description 

This adds caller information to the logger used primarily throughout the agent. This also adds caller info to the tempo logger which uses a different library. The format for that library is slightly different though
<img width="1099" alt="image" src="https://user-images.githubusercontent.com/4571540/131397888-b9971788-2c5a-47c7-8d09-334c3832db45.png">.

#### Which issue(s) this PR fixes 
Fixes #684 

#### Notes to the Reviewer
The issue is here, https://github.com/grafana/agent/blob/1278506dcc74cd7818c436b1ad0e2d494d9bb8f1/cmd/agent/main.go#L58-L78 The call `cfgLogger = util.GoKitLogger(logger)` adds caller info via `log.With` which makes a new instance. The new instance becomes `cfgLogger` but `logger` is still used because of type differences.


#### PR Checklist

- [ x ] CHANGELOG updated 
- [ na ] Documentation added
- [ na ] Tests updated : I couldn't come up with a clean way to test this change
