### PR TITLE
Fixes for honoring timeout and having lifecycle reshard use background context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - [BUGFIX] In scraping service mode, the polling configuration refresh should honor timeout. (@mattdurham)
 
-- [BUGFIX] In scraping service mode, the lifecycle reshard should happen on a background context asynchronously. (@mattdurham) 
+- [BUGFIX] In scraping service mode, the lifecycle reshard should happen using a background context. (@mattdurham) 
 
 - [BUGFIX] Regex capture groups like `${1}` will now be kept intact when
   using `-config.expand-env`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - [ENHANCEMENT] Allow reloading configuration using `SIGHUP` signal. (@tharun208)
 
+- [BUGFIX] In scraping service mode, the polling configuration refresh should honor timeout. (@mattdurham)
+
+- [BUGFIX] In scraping service mode, the lifecycle reshard should happen on a background context asynchronously. (@mattdurham) 
+
 - [BUGFIX] Regex capture groups like `${1}` will now be kept intact when
   using `-config.expand-env`.
 

--- a/pkg/prom/cluster/config_watcher.go
+++ b/pkg/prom/cluster/config_watcher.go
@@ -99,11 +99,12 @@ func (w *configWatcher) run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-time.After(nextPoll):
-			refreshCtx, _ := context.WithTimeout(ctx, timeout)
+			refreshCtx, cancelFunc := context.WithTimeout(ctx, timeout)
 			err := w.Refresh(refreshCtx)
 			if err != nil {
 				level.Error(w.log).Log("msg", "failed polling refresh", "err", err)
 			}
+			cancelFunc()
 		case ev := <-w.store.Watch():
 			if err := w.handleEvent(ev); err != nil {
 				level.Error(w.log).Log("msg", "failed to handle changed or deleted config", "key", ev.Key, "err", err)

--- a/pkg/prom/cluster/config_watcher.go
+++ b/pkg/prom/cluster/config_watcher.go
@@ -92,17 +92,21 @@ func (w *configWatcher) run(ctx context.Context) {
 	for {
 		w.mut.Lock()
 		nextPoll := w.cfg.ReshardInterval
+		timeout := w.cfg.ReshardTimeout
 		w.mut.Unlock()
 
 		select {
 		case <-ctx.Done():
 			return
 		case <-time.After(nextPoll):
-			// Errors are logged by w.Refresh, ignore the error here.
-			_ = w.Refresh(ctx)
+			refreshCtx, _ := context.WithTimeout(ctx, timeout)
+			err := w.Refresh(refreshCtx)
+			if err != nil {
+				level.Error(w.log).Log("msg", "failed polling refresh", "err", err)
+			}
 		case ev := <-w.store.Watch():
 			if err := w.handleEvent(ev); err != nil {
-				level.Error(w.log).Log("msg", "failed to handle changend or deleted config", "key", ev.Key, "err", err)
+				level.Error(w.log).Log("msg", "failed to handle changed or deleted config", "key", ev.Key, "err", err)
 			}
 		}
 	}
@@ -130,6 +134,11 @@ func (w *configWatcher) Refresh(ctx context.Context) (err error) {
 		}
 		reshardDuration.WithLabelValues(success).Observe(time.Since(start).Seconds())
 	}()
+
+	// This is used to determine if the context was already exceeded before calling the kv provider
+	if err = ctx.Err(); err != nil {
+		return fmt.Errorf("context deadline exceeded before calling store.all")
+	}
 
 	configs, err := w.store.All(ctx, func(key string) bool {
 		owns, err := w.owns(key)

--- a/pkg/prom/cluster/node.go
+++ b/pkg/prom/cluster/node.go
@@ -206,8 +206,8 @@ func (n *node) performClusterReshard(ctx context.Context, joining bool) error {
 			return nil, nil
 		}
 
-		c = user.InjectOrgID(c, "fake")
-		return nil, n.notifyReshard(c, id)
+		notifyCtx := user.InjectOrgID(c, "fake")
+		return nil, n.notifyReshard(notifyCtx, id)
 	})
 	if err != nil && firstError == nil {
 		firstError = err

--- a/pkg/prom/cluster/node.go
+++ b/pkg/prom/cluster/node.go
@@ -206,8 +206,8 @@ func (n *node) performClusterReshard(ctx context.Context, joining bool) error {
 			return nil, nil
 		}
 
-		notifyCtx := user.InjectOrgID(ctx, "fake")
-		return nil, n.notifyReshard(notifyCtx, id)
+		c = user.InjectOrgID(c, "fake")
+		return nil, n.notifyReshard(c, id)
 	})
 	if err != nil && firstError == nil {
 		firstError = err

--- a/pkg/prom/cluster/node.go
+++ b/pkg/prom/cluster/node.go
@@ -174,7 +174,7 @@ func (n *node) run() {
 // of their workloads. if joining is true, the server provided to newNode will
 // also be informed.
 func (n *node) performClusterReshard(ctx context.Context, joining bool) chan error {
-	errCh := make(chan error, 0)
+	errCh := make(chan error, 1)
 	if n.ring == nil || n.lc == nil {
 		level.Info(n.log).Log("msg", "node disabled, not resharding")
 		errCh <- nil


### PR DESCRIPTION

#### PR Description 

The poling refresh interval should use the timeout specified, added additional logging to distinguish between a context deadline exceeded from waiting on mutex and waiting on kv store.

Lifecycle refresh also happens in the background on a background thread. 

#### Which issue(s) this PR fixes 

Closes #856 and #857 

#### Notes to the Reviewer

#### PR Checklist

- [X] CHANGELOG updated 
- [X] Documentation added
- [X] Tests updated
