### PR TITLE
Honor config refresh timeout, remove timeout for lifecycle and instead use background context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ for specific instructions.
 
 - [BUGFIX] In scraping service mode, the lifecycle reshard should happen using a goroutine. (@mattdurham)
 
+- [BUGFIX] In scraping service mode, scraping service can deadlock when reloading during join. (@mattdurham)
+
 - [CHANGE] Breaking change: reduced verbosity of tracing autologging
   by not logging `STATUS_CODE_UNSET` status codes. (@mapno)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ for specific instructions.
 
 - [BUGFIX] In scraping service mode, the polling configuration refresh should honor timeout. (@mattdurham)
 
-- [BUGFIX] In scraping service mode, the lifecycle reshard should happen using a background context. (@mattdurham)
+- [BUGFIX] In scraping service mode, the lifecycle reshard should happen using a goroutine. (@mattdurham)
 
 - [CHANGE] Breaking change: reduced verbosity of tracing autologging
   by not logging `STATUS_CODE_UNSET` status codes. (@mapno)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ for specific instructions.
 
 - [BUGFIX] Logs should contain a caller field with file and line numbers again (@kgeckhart)
 
+- [BUGFIX] In scraping service mode, the polling configuration refresh should honor timeout. (@mattdurham)
+
+- [BUGFIX] In scraping service mode, the lifecycle reshard should happen using a background context. (@mattdurham)
+
 - [CHANGE] Breaking change: reduced verbosity of tracing autologging
   by not logging `STATUS_CODE_UNSET` status codes. (@mapno)
 

--- a/docs/configuration/prometheus-config.md
+++ b/docs/configuration/prometheus-config.md
@@ -73,7 +73,7 @@ agents distribute discovery and scrape load between nodes.
 [reshard_timeout: <duration> | default = "30s"]
 
 # The timeout for a cluster reshard events. A timeout of 0 indicates no timeout.
-[refresh_timeout: <duration> | default = "30s"]
+[cluster_reshard_event_timeout: <duration> | default = "30s"]
 
 # Configuration for the KV store to store configurations.
 kvstore: <kvstore_config>

--- a/docs/configuration/prometheus-config.md
+++ b/docs/configuration/prometheus-config.md
@@ -61,14 +61,19 @@ agents distribute discovery and scrape load between nodes.
 # cannot be used.
 [enabled: <boolean> | default = false]
 
-# How often should the agent manually reshard. Useful for if KV change
+# Note these next 3 configuration options are confusing. Due to backwards compatibility the naming
+# is less than ideal.
+
+# How often should the agent manually refresh the configuration. Useful for if KV change
 # events are not sent by an agent.
 [reshard_interval: <duration> | default = "1m"]
 
-# The timeout for a reshard. Applies to a cluster-wide reshard (done when
-# joining or leaving the cluster) and local reshards (done every
-# reshard_interval). A timeout of 0 indicates no timeout.
+# The timeout for configuration refreshes. This can occur on cluster events or 
+# on the reshard interval. A timeout of 0 indicates no timeout.
 [reshard_timeout: <duration> | default = "30s"]
+
+# The timeout for a cluster reshard events. A timeout of 0 indicates no timeout.
+[refresh_timeout: <duration> | default = "30s"]
 
 # Configuration for the KV store to store configurations.
 kvstore: <kvstore_config>

--- a/pkg/metrics/cluster/cluster.go
+++ b/pkg/metrics/cluster/cluster.go
@@ -107,10 +107,9 @@ func (c *Cluster) storeValidate(cfg *instance.Config) error {
 // Reshard implements agentproto.ScrapingServiceServer, and syncs the state of
 // configs with the configstore.
 func (c *Cluster) Reshard(ctx context.Context, _ *agentproto.ReshardRequest) (*empty.Empty, error) {
-	c.mut.RLock()
-	defer c.mut.RUnlock()
-
 	go func() {
+		c.mut.RLock()
+		defer c.mut.RUnlock()
 		err := c.watcher.Refresh(context.Background())
 		if err != nil {
 			level.Error(c.log).Log("msg", "failed to perform local reshard", "err", err)

--- a/pkg/metrics/cluster/cluster.go
+++ b/pkg/metrics/cluster/cluster.go
@@ -110,11 +110,13 @@ func (c *Cluster) Reshard(ctx context.Context, _ *agentproto.ReshardRequest) (*e
 	c.mut.RLock()
 	defer c.mut.RUnlock()
 
-	err := c.watcher.Refresh(ctx)
-	if err != nil {
-		level.Error(c.log).Log("msg", "failed to perform local reshard", "err", err)
-	}
-	return &empty.Empty{}, err
+	go func() {
+		err := c.watcher.Refresh(context.Background())
+		if err != nil {
+			level.Error(c.log).Log("msg", "failed to perform local reshard", "err", err)
+		}
+	}()
+	return &empty.Empty{}, nil
 }
 
 // ApplyConfig applies configuration changes to Cluster.

--- a/pkg/metrics/cluster/config.go
+++ b/pkg/metrics/cluster/config.go
@@ -15,12 +15,12 @@ var DefaultConfig = *flagutil.DefaultConfigFromFlags(&Config{}).(*Config)
 
 // Config describes how to instantiate a scraping service Server instance.
 type Config struct {
-	Enabled         bool                  `yaml:"enabled"`
-	ReshardInterval time.Duration         `yaml:"reshard_interval"`
-	ReshardTimeout  time.Duration         `yaml:"reshard_timeout"`
-	RefreshTimeout  time.Duration         `yaml:"refresh_timeout"`
-	KVStore         kv.Config             `yaml:"kvstore"`
-	Lifecycler      ring.LifecyclerConfig `yaml:"lifecycler"`
+	Enabled                    bool                  `yaml:"enabled"`
+	ReshardInterval            time.Duration         `yaml:"reshard_interval"`
+	ReshardTimeout             time.Duration         `yaml:"reshard_timeout"`
+	ClusterReshardEventTimeout time.Duration         `yaml:"cluster_reshard_event_timeout"`
+	KVStore                    kv.Config             `yaml:"kvstore"`
+	Lifecycler                 ring.LifecyclerConfig `yaml:"lifecycler"`
 
 	DangerousAllowReadingFiles bool `yaml:"dangerous_allow_reading_files"`
 
@@ -53,8 +53,7 @@ func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.BoolVar(&c.Enabled, prefix+"enabled", false, "enables the scraping service mode")
 	f.DurationVar(&c.ReshardInterval, prefix+"reshard-interval", time.Minute*1, "how often to manually refresh configuration")
 	f.DurationVar(&c.ReshardTimeout, prefix+"reshard-timeout", time.Second*30, "timeout for refreshing the configuration. Timeout of 0s disables timeout.")
-	f.DurationVar(&c.RefreshTimeout, prefix+"refresh-timeout", time.Second*30, "timeout for the cluster reshard. Timeout of 0s disables timeout.")
-
+	f.DurationVar(&c.ClusterReshardEventTimeout, prefix+"cluster-reshard-event-timeout", time.Second*30, "timeout for the cluster reshard. Timeout of 0s disables timeout.")
 	c.KVStore.RegisterFlagsWithPrefix(prefix+"config-store.", "configurations/", f)
 	c.Lifecycler.RegisterFlagsWithPrefix(prefix, f)
 	c.Client.GRPCClientConfig.RegisterFlagsWithPrefix(prefix, f)

--- a/pkg/metrics/cluster/config.go
+++ b/pkg/metrics/cluster/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	Enabled         bool                  `yaml:"enabled"`
 	ReshardInterval time.Duration         `yaml:"reshard_interval"`
 	ReshardTimeout  time.Duration         `yaml:"reshard_timeout"`
+	RefreshTimeout  time.Duration         `yaml:"refresh_timeout"`
 	KVStore         kv.Config             `yaml:"kvstore"`
 	Lifecycler      ring.LifecyclerConfig `yaml:"lifecycler"`
 
@@ -50,8 +51,10 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 // FlagSet with a specified prefix.
 func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.BoolVar(&c.Enabled, prefix+"enabled", false, "enables the scraping service mode")
-	f.DurationVar(&c.ReshardInterval, prefix+"reshard-interval", time.Minute*1, "how often to manually reshard")
-	f.DurationVar(&c.ReshardTimeout, prefix+"reshard-timeout", time.Second*30, "timeout for cluster-wide reshards and local reshards. Timeout of 0s disables timeout.")
+	f.DurationVar(&c.ReshardInterval, prefix+"reshard-interval", time.Minute*1, "how often to manually refresh configuration")
+	f.DurationVar(&c.ReshardTimeout, prefix+"reshard-timeout", time.Second*30, "timeout for refreshing the configuration. Timeout of 0s disables timeout.")
+	f.DurationVar(&c.RefreshTimeout, prefix+"refresh-timeout", time.Second*30, "timeout for the cluster reshard. Timeout of 0s disables timeout.")
+
 	c.KVStore.RegisterFlagsWithPrefix(prefix+"config-store.", "configurations/", f)
 	c.Lifecycler.RegisterFlagsWithPrefix(prefix, f)
 	c.Client.GRPCClientConfig.RegisterFlagsWithPrefix(prefix, f)

--- a/pkg/metrics/cluster/config_watcher.go
+++ b/pkg/metrics/cluster/config_watcher.go
@@ -118,7 +118,7 @@ func (w *configWatcher) run(ctx context.Context) {
 func (w *configWatcher) Refresh(ctx context.Context) (err error) {
 	w.mut.Lock()
 	enabled := w.cfg.Enabled
-	refreshTimeout := w.cfg.RefreshTimeout
+	refreshTimeout := w.cfg.ReshardTimeout
 	w.mut.Unlock()
 
 	if !enabled {

--- a/pkg/metrics/cluster/config_watcher.go
+++ b/pkg/metrics/cluster/config_watcher.go
@@ -148,7 +148,6 @@ func (w *configWatcher) Refresh(ctx context.Context) (err error) {
 	if err = ctx.Err(); err != nil {
 		return fmt.Errorf("context deadline exceeded before calling store.all")
 	}
-	// These two checks for deadline are to be able to get fine grained information about the deadline
 	deadline, _ := ctx.Deadline()
 	level.Debug(w.log).Log("msg", "deadline before store.all", "deadline", deadline)
 	configs, err := w.store.All(ctx, func(key string) bool {

--- a/pkg/metrics/cluster/config_watcher.go
+++ b/pkg/metrics/cluster/config_watcher.go
@@ -140,7 +140,10 @@ func (w *configWatcher) Refresh(ctx context.Context) (err error) {
 	if err = ctx.Err(); err != nil {
 		return fmt.Errorf("context deadline exceeded before calling store.all")
 	}
-
+	// These two checks for deadline are to be able to get fine grained information about the deadline
+	if deadline, set := ctx.Deadline(); set {
+		level.Debug(w.log).Log("msg", "deadline before store.all", "deadline", deadline)
+	}
 	configs, err := w.store.All(ctx, func(key string) bool {
 		owns, err := w.owns(key)
 		if err != nil {
@@ -149,6 +152,10 @@ func (w *configWatcher) Refresh(ctx context.Context) (err error) {
 		}
 		return owns
 	})
+	if deadline, set := ctx.Deadline(); set {
+		level.Debug(w.log).Log("msg", "deadline after store.all", "deadline", deadline)
+	}
+
 	if err != nil {
 		return fmt.Errorf("failed to get configs from store: %w", err)
 	}

--- a/pkg/metrics/cluster/node.go
+++ b/pkg/metrics/cluster/node.go
@@ -226,6 +226,8 @@ func (n *node) performClusterReshard(ctx context.Context, joining bool) error {
 				level.Warn(n.log).Log("msg", "dynamic local reshard did not succeed", "err", err)
 			}
 		}()
+	} else {
+		defer cancel()
 	}
 
 	return err

--- a/pkg/metrics/cluster/node.go
+++ b/pkg/metrics/cluster/node.go
@@ -221,10 +221,9 @@ func (n *node) performClusterReshard(ctx context.Context, joining bool) error {
 		level.Error(n.log).Log("msg", "notifying other nodes failed", "err", err)
 	}
 
-	// This is ran in the background to help prevent unnecessary mutex locking.
 	if joining {
 		level.Info(n.log).Log("msg", "running local reshard")
-		if _, reshardErr := n.srv.Reshard(ctx, &pb.ReshardRequest{}); reshardErr != nil {
+		if _, err = n.srv.Reshard(ctx, &pb.ReshardRequest{}); err != nil {
 			level.Warn(n.log).Log("msg", "dynamic local reshard did not succeed", "err", err)
 		}
 	}

--- a/pkg/metrics/cluster/node.go
+++ b/pkg/metrics/cluster/node.go
@@ -223,7 +223,7 @@ func (n *node) performClusterReshard(ctx context.Context, joining bool) error {
 
 	if joining {
 		level.Info(n.log).Log("msg", "running local reshard")
-		if _, err = n.srv.Reshard(ctx, &pb.ReshardRequest{}); err != nil {
+		if _, err := n.srv.Reshard(ctx, &pb.ReshardRequest{}); err != nil {
 			level.Warn(n.log).Log("msg", "dynamic local reshard did not succeed", "err", err)
 		}
 	}


### PR DESCRIPTION
#### PR Description 

Config refresh timeout should honor the timeout, but the lifecycle timeout should use a background context.

#### Which issue(s) this PR fixes 

Closes #856 
Closes #857 
Closes #877 

#### Notes to the Reviewer

#### PR Checklist

- [X] CHANGELOG updated 
- [X] Documentation added
- [NA] Tests updated
