### PR TITLE
Rename prometheus to metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,11 @@ for specific instructions.
   `loki_tag` is now `logs_instance_tag`, and `backend: loki` is now
   `backend: logs_instance`. (@rfratto)
 
+- [DEPRECATION] The `prometheus` key at the root of the config file has been
+  deprecated in favor of `metrics`. Flag names starting with `prometheus.` have
+  also been deprecated in favor of the same flags with the `metrics.` prefix.
+  (@rfratto)
+
 # v0.18.2 (2021-08-12)
 
 - [BUGFIX] Honor the prefix and remove prefix from consul list results (@mattdurham)

--- a/cmd/agent/entrypoint.go
+++ b/cmd/agent/entrypoint.go
@@ -75,7 +75,7 @@ func NewEntrypoint(logger *util.Logger, cfg *config.Config, reloader Reloader) (
 
 	ep.srv = server.New(prometheus.DefaultRegisterer, logger)
 
-	ep.promMetrics, err = metrics.New(prometheus.DefaultRegisterer, cfg.Prometheus, logger)
+	ep.promMetrics, err = metrics.New(prometheus.DefaultRegisterer, cfg.Metrics, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (ep *Entrypoint) ApplyConfig(cfg config.Config) error {
 	}
 
 	// Go through each component and update it.
-	if err := ep.promMetrics.ApplyConfig(cfg.Prometheus); err != nil {
+	if err := ep.promMetrics.ApplyConfig(cfg.Metrics); err != nil {
 		level.Error(ep.log).Log("msg", "failed to update prometheus", "err", err)
 		failed = true
 	}

--- a/docs/upgrade-guide/_index.md
+++ b/docs/upgrade-guide/_index.md
@@ -118,6 +118,51 @@ rules:
   verbs: [get, list, watch]
 ```
 
+### Metrics: Deprecation of "prometheus" in config. (Deprecation)
+
+The term `prometheus` in the config has been deprecated of favor of `metrics`. This
+change is to make it clearer when referring to Prometheus or another
+Prometheus-like database, and configuration of Grafana Agent to send metrics to
+one of those systems.
+
+Old configs will continue to work until it is fully deprecated. To migrate your
+config, change the `prometheus` key to `metrics`.
+
+Example old config:
+
+```yaml
+prometheus:
+  configs:
+    - name: default
+      host_filter: false
+      scrape_configs:
+        - job_name: local_scrape
+          static_configs:
+            - targets: ['127.0.0.1:12345']
+              labels:
+                cluster: 'localhost'
+      remote_write:
+        - url: http://localhost:9009/api/prom/push
+```
+
+Example new config:
+
+```yaml
+metrics:
+  configs:
+    - name: default
+      host_filter: false
+      scrape_configs:
+        - job_name: local_scrape
+          static_configs:
+            - targets: ['127.0.0.1:12345']
+              labels:
+                cluster: 'localhost'
+      remote_write:
+        - url: http://localhost:9009/api/prom/push
+```
+
+
 ### Logs: Deprecation of "loki" in config. (Deprecation)
 
 The term `loki` in the config has been deprecated of favor of `logs`. This

--- a/pkg/metrics/agent.go
+++ b/pkg/metrics/agent.go
@@ -51,6 +51,7 @@ type Config struct {
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	*c = DefaultConfig
+	util.DefaultConfigFromFlags(c)
 	c.Unmarshaled = true
 
 	type plain Config

--- a/pkg/metrics/cluster/client/client.go
+++ b/pkg/metrics/cluster/client/client.go
@@ -40,7 +40,13 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // RegisterFlags registers flags to the provided flag set.
 func (c *Config) RegisterFlags(f *flag.FlagSet) {
-	c.GRPCClientConfig.RegisterFlagsWithPrefix("prometheus.service-client", f)
+	c.RegisterFlagsWithPrefix("prometheus.", f)
+}
+
+// RegisterFlagsWithPrefix registers flags to the provided flag set with the
+// specified prefix.
+func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	c.GRPCClientConfig.RegisterFlagsWithPrefix(prefix+"service-client", f)
 }
 
 // New returns a new scraping service client.


### PR DESCRIPTION
#### PR Description 
Aliases `prometheus` to `metrics` and deprecates the former. 

#### Which issue(s) this PR fixes 
Related to #722. 

#### Notes to the Reviewer
Does not touch the tracing configs yet, that will be done in a follow up PR.

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
