### PR TITLE
[dev.metrics-v2] Agent-wide cluster mechanism

### DIFF
--- a/cmd/agent/agent-cluster-config.yaml
+++ b/cmd/agent/agent-cluster-config.yaml
@@ -1,0 +1,3 @@
+server:
+  log_level: debug
+  http_listen_port: 12345

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/grafana/tempo v1.0.1
 	github.com/hashicorp/consul/api v1.11.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
+	github.com/hashicorp/go-discover v0.0.0-20190403160810-22221edb15cd
 	github.com/hashicorp/go-getter v1.5.3
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/infinityworks/github-exporter v0.0.0-20201016091012-831b72461034
@@ -64,6 +65,7 @@ require (
 	github.com/prometheus/procfs v0.7.3
 	github.com/prometheus/prometheus v1.8.2-0.20211102100715-d4c83da6d252
 	github.com/prometheus/statsd_exporter v0.22.2
+	github.com/rfratto/ckit v0.0.0-20210903030023-721309d48f1e
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -193,6 +193,7 @@ github.com/NYTimes/gziphandler v1.0.1/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/OneOfOne/xxhash v1.2.6 h1:U68crOE3y3MPttCMQGywZOLrTeF5HHJ3/vDBCJn9/bA=
 github.com/OneOfOne/xxhash v1.2.6/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -220,6 +221,7 @@ github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/Workiva/go-datastructures v1.0.53/go.mod h1:1yZL+zfsztete+ePzZz/Zb1/t5BnDuE2Ya2MMGhzP6A=
+github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af h1:DBNMBMuMiWYu0b+8KMJuWmfCkcxl09JwdlqwDZZ6U14=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=
 github.com/aerospike/aerospike-client-go v1.27.0/go.mod h1:zj8LBEnWBDOVEIJt8LvaRvDG5ARAoa5dBeHaB472NRc=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
@@ -581,6 +583,7 @@ github.com/denisenkom/go-mssqldb v0.10.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27
 github.com/dennwc/varint v1.0.0 h1:kGNFFSSw8ToIy3obO/kKr8U9GZYUAxQEVuix4zfDWzE=
 github.com/dennwc/varint v1.0.0/go.mod h1:hnItb35rvZvJrbTALZtY/iQfDs48JKRG1RPpgziApxA=
 github.com/denverdino/aliyungo v0.0.0-20170926055100-d3308649c661/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
+github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba h1:p6poVbjHDkKa+wtC8frBMwQtT3BmqGYBjzMwJ63tuR4=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mzjeJY=
 github.com/dgraph-io/badger/v3 v3.2103.1/go.mod h1:dULbq6ehJ5K0cGW/1TQ9iSfUk0gbSiToDWmWmTsJ53E=
@@ -1189,6 +1192,7 @@ github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-discover v0.0.0-20190403160810-22221edb15cd h1:SynRxs8h2h7lLSA5py5a3WWkYpImhREtju0CuRd97wc=
 github.com/hashicorp/go-discover v0.0.0-20190403160810-22221edb15cd/go.mod h1:ueUgD9BeIocT7QNuvxSyJyPAM9dfifBcaWmeybb67OY=
 github.com/hashicorp/go-getter v1.5.3 h1:NF5+zOlQegim+w/EUhSLh6QhXHmZMEeHLQzllkQ3ROU=
 github.com/hashicorp/go-getter v1.5.3/go.mod h1:BrrV/1clo8cCYu6mxvboYg+KutTiFnXjMEgDD8+i7ZI=
@@ -1256,6 +1260,7 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hashicorp/hil v0.0.0-20160711231837-1e86c6b523c5/go.mod h1:KHvg/R2/dPtaePb16oW4qIyzkMxXOL38xjRN64adsts=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
+github.com/hashicorp/mdns v1.0.1 h1:XFSOubp8KWB+Jd2PDyaX5xUd5bhSP/+pTDZVDMzZJM8=
 github.com/hashicorp/mdns v1.0.1/go.mod h1:4gW7WsVCke5TE7EPeYliwHlRUyBtfCwuFwuMg2DmyNY=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/memberlist v0.1.4/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
@@ -1279,6 +1284,7 @@ github.com/hashicorp/vault v0.10.3/go.mod h1:KfSyffbKxoVyspOdlaGVjIuwLobi07qD1bA
 github.com/hashicorp/vault-plugin-secrets-kv v0.0.0-20190318174639-195e0e9d07f1/go.mod h1:VJHHT2SC1tAPrfENQeBhLlb5FbZoKZM+oC/ROmEftz0=
 github.com/hashicorp/vault/api v1.0.4/go.mod h1:gDcqh3WGcR1cpF5AJz/B1UFheUEneMoIospckxBxk6Q=
 github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=
+github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443 h1:O/pT5C1Q3mVXMyuqg7yuAWUg/jMZR1/0QTzTRdNR6Uw=
 github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443/go.mod h1:bEpDU35nTu0ey1EXjwNwPjI9xErAsoOCmcMb9GKvyxo=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
@@ -1337,6 +1343,7 @@ github.com/jackc/pgx v3.2.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGk
 github.com/jackc/pgx v3.6.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGkVEFm4TeybAXq+I=
 github.com/jaegertracing/jaeger v1.27.0 h1:gcemni8e+twGuS0dUn3k/zKKalammUPK7mP+jpyM4e4=
 github.com/jaegertracing/jaeger v1.27.0/go.mod h1:2NUmMwXOSOIrx6gwCgBvnK59yVXzQiqBUfD4tGowl2E=
+github.com/jarcoal/httpmock v0.0.0-20180424175123-9c70cfe4a1da h1:FjHUJJ7oBW4G/9j1KzlHaXL09LyMVM9rupS39lncbXk=
 github.com/jarcoal/httpmock v0.0.0-20180424175123-9c70cfe4a1da/go.mod h1:ks+b9deReOc7jgqp+e7LuFiCBH6Rm5hL32cLcEAArb4=
 github.com/jcmturner/aescts/v2 v2.0.0 h1:9YKLH6ey7H4eDBXW8khjYslgyqG2xZikXP0EQFKrle8=
 github.com/jcmturner/aescts/v2 v2.0.0/go.mod h1:AiaICIRyfYg35RUkr8yESTqvSy7csK90qZ5xfvvsoNs=
@@ -1370,6 +1377,7 @@ github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/joncrlsn/dque v2.2.1-0.20200515025108-956d14155fa2+incompatible/go.mod h1:hDZb8oMj3Kp8MxtbNLg9vrtAUDHjgI1yZvqivT4O8Iw=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/joyent/triton-go v0.0.0-20180628001255-830d2b111e62 h1:JHCT6xuyPUrbbgAPE/3dqlvUKzRHMNuTBKKUb6OeR/k=
 github.com/joyent/triton-go v0.0.0-20180628001255-830d2b111e62/go.mod h1:U+RSyWxWd04xTqnuOQxnai7XGS2PrPY2cfGoDKtMHjA=
 github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7/go.mod h1:2iMrUgbbvHEiQClaW2NsSzMyGHqN+rDFqY705q49KG0=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
@@ -1667,6 +1675,7 @@ github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/
 github.com/ncw/swift v1.0.50/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/ncw/swift v1.0.52/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/newrelic/newrelic-telemetry-sdk-go v0.2.0/go.mod h1:G9MqE/cHGv3Hx3qpYhfuyFUsGx2DpVcGi1iJIqTg+JQ=
+github.com/nicolai86/scaleway-sdk v1.10.2-0.20180628010248-798f60e20bb2 h1:BQ1HW7hr4IVovMwWg0E0PYcyW8CzqDcVmaew9cujU4s=
 github.com/nicolai86/scaleway-sdk v1.10.2-0.20180628010248-798f60e20bb2/go.mod h1:TLb2Sg7HQcgGdloNxkrmtgDNR9uVYF3lfdFIN4Ro6Sk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nsqio/go-nsq v1.0.7/go.mod h1:XP5zaUs3pqf+Q71EqUJs3HYfBIqfK6G83WQMdNN+Ito=
@@ -1801,6 +1810,7 @@ github.com/openzipkin/zipkin-go v0.2.5 h1:UwtQQx2pyPIgWYHRg+epgdx1/HnBQTgN3/oIYE
 github.com/openzipkin/zipkin-go v0.2.5/go.mod h1:KpXfKdgRDnnhsxw4pNIH9Md5lyFqKUa4YDFlwRYAMyE=
 github.com/openzipkin/zipkin-go-opentracing v0.3.4/go.mod h1:js2AbwmHW0YD9DwIw2JhQWmbfFi/UnWyYwdVhqbCDOE=
 github.com/ory/dockertest v3.3.4+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
+github.com/packethost/packngo v0.1.1-0.20180711074735-b9cb5096f54c h1:vwpFWvAO8DeIZfFeqASzZfsxuWPno9ncAebBEP0N3uE=
 github.com/packethost/packngo v0.1.1-0.20180711074735-b9cb5096f54c/go.mod h1:otzZQXgoO96RTzDB/Hycg0qZcXZsWJGJRSXbmEIJ+4M=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -1965,8 +1975,11 @@ github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 h1:Wdi9nwnhFNAlseAOekn6B5G/+GMtks9UKbvRU/CMM/o=
 github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03/go.mod h1:gRAiPF5C5Nd0eyyRdqIu9qTiFSoZzpTq727b5B8fkkU=
 github.com/retailnext/hllpp v1.0.1-0.20180308014038-101a6d2f8b52/go.mod h1:RDpi1RftBQPUCDRw6SmxeaREsAaRKnOclghuzp/WRzc=
+github.com/rfratto/ckit v0.0.0-20210903030023-721309d48f1e h1:lnBT2XlgGKkJA3YSpcqmcmEZrHVNryCHj5xQZfNBk14=
+github.com/rfratto/ckit v0.0.0-20210903030023-721309d48f1e/go.mod h1:woq/KwrCx3v4/0TbrM0XpyaDT+05hrWDYMTR4Nnc97U=
 github.com/rfratto/go-yaml v0.0.0-20211119180816-77389c3526dc h1:g196Usc63pWDzWallipxVhsEjDdh/+RLc/Oz7q3ihW4=
 github.com/rfratto/go-yaml v0.0.0-20211119180816-77389c3526dc/go.mod h1:rMzeXFmWpS5JnfDANtpzbklRJY4pqZMJNN9/SJHAXPA=
 github.com/rgeyer/github-exporter v0.0.0-20210722215637-d0cec2ee0dc8 h1:wNuNGrFzFmZlhrtz1Q8EiK1Ob6yWli8lX7D2AGmSGzE=
@@ -2064,6 +2077,7 @@ github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:s
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/snowflakedb/gosnowflake v1.3.13/go.mod h1:6nfka9aTXkUNha1p1cjeeyjDvcyh7jfjp0l8kGpDBok=
+github.com/softlayer/softlayer-go v0.0.0-20180806151055-260589d94c7d h1:bVQRCxQvfjNUeRqaY/uT0tFuvuFY0ulgnczuR684Xic=
 github.com/softlayer/softlayer-go v0.0.0-20180806151055-260589d94c7d/go.mod h1:Cw4GTlQccdRGSEf6KiMju767x0NEHE0YIVPJSaXjlsw=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/soheilhy/cmux v0.1.5-0.20210205191134-5ec6847320e5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
@@ -2074,6 +2088,7 @@ github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJ
 github.com/soundcloud/go-runit v0.0.0-20150630195641-06ad41a06c4a h1:os5OBNhwOwybXZMNLqT96XqtjdTtwRFw2w08uluvNeI=
 github.com/soundcloud/go-runit v0.0.0-20150630195641-06ad41a06c4a/go.mod h1:LeFCbQYJ3KJlPs/FvPz2dy1tkpxyeNESVyCNNzRXFR0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
@@ -2222,6 +2237,7 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vjeantet/grok v1.0.0/go.mod h1:/FWYEVYekkm+2VjcFmO9PufDU5FgXHUz9oy2EGqmQBo=
 github.com/vmware/govmomi v0.18.0/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
+github.com/vmware/govmomi v0.19.0 h1:CR6tEByWCPOnRoRyhLzuHaU+6o2ybF3qufNRWS/MGrY=
 github.com/vmware/govmomi v0.19.0/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
 github.com/wavefronthq/wavefront-sdk-go v0.9.2/go.mod h1:hQI6y8M9OtTCtc0xdwh+dCER4osxXdEAeCpacjpDZEU=

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1,0 +1,256 @@
+package cluster
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	stdlog "log"
+	"net"
+	"os"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/ring"
+	"github.com/hashicorp/go-discover"
+
+	// TODO(rfratto): Uncomment once k8s.io/apimachinery is updated.
+	// "github.com/hashicorp/go-discover/provider/k8s"
+
+	"github.com/rfratto/ckit"
+	"github.com/rfratto/ckit/chash"
+)
+
+// ErrClusterDisabled is returned when performing a cluster operation when the
+// cluster is currently disabled.
+var ErrClusterDisabled = fmt.Errorf("cluster disabled")
+
+// Config controls the clustering of Agents.
+type Config struct {
+	// If true, clustering will be used.
+	Enable bool
+
+	Discoverer          ckit.DiscovererConfig
+	AdvertiseInterfaces flagext.StringSlice
+	JoinPeers           flagext.StringSlice
+	DiscoverPeers       string
+}
+
+// DefaultConfig holds default options for clustering.
+var DefaultConfig = Config{
+	Discoverer: ckit.DiscovererConfig{
+		ListenPort: 7935,
+	},
+	AdvertiseInterfaces: []string{"eth0", "en0"},
+}
+
+// RegisterFlags registers flags to the provided flagset.
+func (c *Config) RegisterFlags(fs *flag.FlagSet) {
+	*c = DefaultConfig
+
+	fs.BoolVar(&c.Enable, "cluster.enable", DefaultConfig.Enable, "Enables clustering.")
+
+	fs.StringVar(&c.Discoverer.Name, "cluster.node-name", DefaultConfig.Discoverer.Name, "Name to identify node in cluster. If empty, defaults to hostname.")
+	fs.StringVar(&c.Discoverer.ListenAddr, "cluster.listen-addr", DefaultConfig.Discoverer.ListenAddr, "IP address to listen for gossip traffic on. If not set, defaults to the first IP found from cluster.advertise-interfaces.")
+	fs.StringVar(&c.Discoverer.AdvertiseAddr, "cluster.advertise-addr", DefaultConfig.Discoverer.AdvertiseAddr, "IP address to advertise to peers. If not set, defaults to the first IP found from cluster.advertise-interfaces.")
+	fs.IntVar(&c.Discoverer.ListenPort, "cluster.listen-port", DefaultConfig.Discoverer.ListenPort, "Port to listen for TCP and UDP gossip traffic on.")
+
+	fs.Var(&c.JoinPeers, "cluster.join-peers", "List of peers to join when starting up. Peers must have port number to connect to. Mutally exclusive with cluster.discover-peers.")
+	fs.StringVar(&c.DiscoverPeers, "cluster.discover-peers", "", "Discover peers when starting up using Hashicorp cloud discover. If discovered peers do not have a port number, cluster.listen-port will be appended to each peer. Mutually exclusive with cluster.join-peers.")
+}
+
+// ApplyDefaults will validate and apply defaults to the config.
+func (c *Config) ApplyDefaults(grpcPort int) error {
+	if !c.Enable {
+		return nil
+	}
+
+	if c.Discoverer.Name == "" {
+		hn, err := os.Hostname()
+		if err != nil {
+			return fmt.Errorf("failed to generate node name: %w", err)
+		}
+		c.Discoverer.Name = hn
+	}
+
+	if c.Discoverer.ListenAddr == "" || c.Discoverer.AdvertiseAddr == "" {
+		addr, err := ring.GetInstanceAddr("", c.AdvertiseInterfaces, log.NewNopLogger())
+		if err != nil {
+			return fmt.Errorf("failed to get advertise and listen address: %w", err)
+		}
+		if c.Discoverer.ListenAddr == "" {
+			c.Discoverer.ListenAddr = addr
+		}
+		if c.Discoverer.AdvertiseAddr == "" {
+			c.Discoverer.AdvertiseAddr = addr
+		}
+	}
+
+	if len(c.JoinPeers) > 0 && c.DiscoverPeers != "" {
+		return fmt.Errorf("only one of cluster.join-peers and cluster.discover-peers may be set")
+	} else if c.DiscoverPeers != "" {
+		discoverCfg, err := discover.Parse(c.DiscoverPeers)
+		if err != nil {
+			return fmt.Errorf("failed to parse discovery string: %w", err)
+		}
+
+		providers := make(map[string]discover.Provider)
+		for k, v := range discover.Providers {
+			providers[k] = v
+		}
+
+		// TODO(rfratto): uncomment once k8s.api/apimachinery is updated.
+		// providers["k8s"] = &k8s.Provider{}
+
+		d, err := discover.New(discover.WithProviders(providers))
+		if err != nil {
+			return fmt.Errorf("failed to bootstrap peer discovery: %w", err)
+		}
+
+		addrs, err := d.Addrs(discoverCfg.String(), stdlog.New(io.Discard, "", 0))
+		if err != nil {
+			return fmt.Errorf("failed to discover peers to join: %w", err)
+		}
+		for _, addr := range addrs {
+			c.JoinPeers = append(c.JoinPeers, appendDefaultPort(addr, c.Discoverer.ListenPort))
+		}
+	}
+
+	// TODO(rfratto): this may not work if the listen address for gRPC is
+	// different. Come back to this later.
+	c.Discoverer.ApplicationAddr = fmt.Sprintf("%s:%d", c.Discoverer.AdvertiseAddr, grpcPort)
+	return nil
+}
+
+func appendDefaultPort(addr string, port int) string {
+	host, _, err := net.SplitHostPort(addr)
+	if err == nil {
+		// No error means there was a port in the string
+		return addr
+	}
+
+	return fmt.Sprintf("%s:%d", host, port)
+}
+
+// Node is a node within a cluster.
+type Node struct {
+	cfg  *Config
+	disc *ckit.Discoverer
+	node *ckit.Node
+	log  log.Logger
+
+	watcherMut sync.Mutex
+	watchers   []PeersChangedWatcher
+}
+
+// PeersChangedWatcher is a function that will be invoked whenever
+// peers change in the cluster. Returning true means the watcher
+// should be invoked again next time peers change. Return false
+// for one-shot changes.
+type PeersChangedWatcher func(ps ckit.PeerSet) (reregister bool)
+
+// NewNode creates a new Node.
+func NewNode(l log.Logger, c *Config) *Node {
+	if l == nil {
+		l = log.NewNopLogger()
+	}
+	c.Discoverer.Log = l
+	n := &Node{cfg: c, log: l}
+
+	if !c.Enable {
+		return n
+	}
+
+	n.node = ckit.NewNode(chash.Ring(256), n.handlePeersChanged)
+	return n
+}
+
+func (n *Node) handlePeersChanged(ps ckit.PeerSet) {
+	n.watcherMut.Lock()
+	defer n.watcherMut.Unlock()
+
+	newWatchers := make([]PeersChangedWatcher, 0, len(n.watchers))
+	for _, w := range n.watchers {
+		rereg := w(ps)
+		if rereg {
+			newWatchers = append(newWatchers, w)
+		}
+	}
+	n.watchers = newWatchers
+}
+
+// OnPeersChanged registers a watcher to be invoked every time the set of peers
+// changes. w should return true as long as it should continue to get invoked.
+// If w returns false, it will never be called again.
+func (n *Node) OnPeersChanged(w PeersChangedWatcher) {
+	n.watcherMut.Lock()
+	defer n.watcherMut.Unlock()
+
+	n.watchers = append(n.watchers, w)
+}
+
+// Start starts the node. If it was configured to join any peers, it will join
+// them now. This will also invoke any PeersChangedWatchers to inform them that
+// peers are joining.
+//
+// Start may not be called concurrently.
+func (n *Node) Start() error {
+	if !n.cfg.Enable {
+		return nil
+	}
+
+	// The discoverer MUST be initialized in the Start method and not NewNode.
+	// NewDiscoverer can immediately register the local node as a peer, which
+	// would cause handlePeersChanged to be called before anything was registered.
+	if n.disc == nil {
+		var err error
+		n.disc, err = ckit.NewDiscoverer(&n.cfg.Discoverer, n.node)
+		if err != nil {
+			return fmt.Errorf("failed to create node discoverer: %w", err)
+		}
+	}
+
+	return n.disc.Start(n.cfg.JoinPeers)
+}
+
+// Get retrieves the owner for a key.
+func (n *Node) Get(key string) (*ckit.Peer, error) {
+	if !n.cfg.Enable {
+		return nil, ErrClusterDisabled
+	}
+
+	ps, err := n.node.Get(key, 1)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get owner: %w", err)
+	} else if len(ps) == 0 {
+		return nil, fmt.Errorf("failed to get owner: not enough peers")
+	}
+	return &ps[0], nil
+}
+
+// Close closes the Node.
+func (n *Node) Close() error {
+	if !n.cfg.Enable {
+		return nil
+	}
+
+	var firstErr error
+
+	if n.disc != nil {
+		if err := n.disc.Close(); err != nil {
+			level.Error(n.log).Log("msg", "failed to stop node discovery", "err", err)
+			firstErr = err
+		}
+	}
+
+	err := n.node.Close()
+	if err != nil {
+		level.Error(n.log).Log("msg", "failed to stop node", "err", err)
+	}
+	if firstErr == nil && err != nil {
+		firstErr = err
+	}
+
+	return firstErr
+}

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -16,6 +16,7 @@ import (
 func TestCluster(t *testing.T) {
 	opts := func(v ...string) []string {
 		baseOptions := []string{
+			"--cluster.enable",
 			"--cluster.listen-addr=127.0.0.1",
 			"--cluster.advertise-addr=127.0.0.1",
 		}

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1,0 +1,91 @@
+package cluster
+
+import (
+	"flag"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/pkg/util"
+	"github.com/rfratto/ckit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCluster(t *testing.T) {
+	opts := func(v ...string) []string {
+		baseOptions := []string{
+			"--cluster.listen-addr=127.0.0.1",
+			"--cluster.advertise-addr=127.0.0.1",
+		}
+		return append(baseOptions, v...)
+	}
+
+	configs := []*Config{
+		buildConfig(t, opts("--cluster.node-name=a", "--cluster.listen-port=7935")),
+		buildConfig(t, opts("--cluster.node-name=b", "--cluster.listen-port=7936", "--cluster.join-peers=127.0.0.1:7935")),
+		buildConfig(t, opts("--cluster.node-name=c", "--cluster.listen-port=7937", "--cluster.join-peers=127.0.0.1:7935")),
+		buildConfig(t, opts("--cluster.node-name=d", "--cluster.listen-port=7938", "--cluster.join-peers=127.0.0.1:7935")),
+		buildConfig(t, opts("--cluster.node-name=e", "--cluster.listen-port=7939", "--cluster.join-peers=127.0.0.1:7935")),
+	}
+
+	// Start up every node
+	var (
+		nodes []*Node
+
+		peerMap sync.Map
+	)
+	for _, cfg := range configs {
+		node := NewNode(cfg.Discoverer.Log, cfg)
+
+		var (
+			log  = cfg.Discoverer.Log
+			name = cfg.Discoverer.Name
+		)
+		node.OnPeersChanged(func(ps ckit.PeerSet) (reregister bool) {
+			level.Debug(log).Log("msg", "peers changed", "peers", ps)
+			peerMap.Store(name, ps)
+			return true
+		})
+
+		require.NoError(t, node.Start())
+		nodes = append(nodes, node)
+
+		t.Cleanup(func() {
+			require.NoError(t, node.Close())
+		})
+	}
+
+	// Wait for the dust to settle before testing anything.
+	time.Sleep(1 * time.Second)
+
+	// All nodes must have 5 peers.
+	peerMap.Range(func(key, value interface{}) bool {
+		require.Len(t, value.(ckit.PeerSet), 5, "node %s does not have the appropriate amount of peers", key.(string))
+		return true
+	})
+
+	// Test a random key, ensuring that all nodes agree on an owner.
+	key := "a random key"
+	owner, err := nodes[0].Get(key)
+	require.NoError(t, err)
+
+	for _, node := range nodes[1:] {
+		actual, err := node.Get(key)
+		require.NoError(t, err)
+		require.Equal(t, owner.Name, actual.Name)
+	}
+}
+
+func buildConfig(t *testing.T, args []string) *Config {
+	fs := flag.NewFlagSet(t.Name(), flag.PanicOnError)
+
+	var cfg Config
+	cfg.RegisterFlags(fs)
+	require.NoError(t, fs.Parse(args))
+	require.NoError(t, cfg.ApplyDefaults(8080))
+
+	cfg.Discoverer.Log = log.With(util.TestLogger(t), "node", cfg.Discoverer.Name)
+	return &cfg
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -187,14 +187,11 @@ func (c *Config) ApplyDefaults() error {
 		return err
 	}
 
-<<<<<<< HEAD
-	c.Metrics.ServiceConfig.APIEnableGetConfiguration = c.EnableConfigEndpoints
-=======
 	if err := c.Cluster.ApplyDefaults(c.Server.GRPCListenPort); err != nil {
 		return err
 	}
->>>>>>> 7d9ee73e (agent-wide cluster mechanism)
 
+	c.Metrics.ServiceConfig.APIEnableGetConfiguration = c.EnableConfigEndpoints
 	return nil
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/drone/envsubst/v2"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/pkg/cluster"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/logs"
 	"github.com/grafana/agent/pkg/metrics"
@@ -38,6 +39,7 @@ var DefaultConfig = Config{
 
 // Config contains underlying configurations for the agent
 type Config struct {
+	Cluster      cluster.Config             `yaml:"-"`
 	Server       server.Config              `yaml:"server,omitempty"`
 	Metrics      metrics.Config             `yaml:"metrics,omitempty"`
 	Integrations integrations.ManagerConfig `yaml:"integrations,omitempty"`
@@ -185,7 +187,13 @@ func (c *Config) ApplyDefaults() error {
 		return err
 	}
 
+<<<<<<< HEAD
 	c.Metrics.ServiceConfig.APIEnableGetConfiguration = c.EnableConfigEndpoints
+=======
+	if err := c.Cluster.ApplyDefaults(c.Server.GRPCListenPort); err != nil {
+		return err
+	}
+>>>>>>> 7d9ee73e (agent-wide cluster mechanism)
 
 	return nil
 }
@@ -196,6 +204,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.Server.RegisterInstrumentation = true
 	c.Metrics.RegisterFlags(f)
 	c.Server.RegisterFlags(f)
+	c.Cluster.RegisterFlags(f)
 
 	f.StringVar(&c.ReloadAddress, "reload-addr", "127.0.0.1", "address to expose a secondary server for /-/reload on.")
 	f.IntVar(&c.ReloadPort, "reload-port", 0, "port to expose a secondary server for /-/reload on. 0 disables secondary server.")


### PR DESCRIPTION
#### PR Description 
Introduces an Agent-wide clustering mechanism based off of [rfratto/ckit](https://github.com/rfratto/ckit) and my previous experiments with Pastry to implement a prototype of [per-target sharding](https://github.com/rfratto/agent/tree/per-target-sharding). 

A lot is missing here. Nothing is actually using the cluster, there are no metrics, no HTTP page to investigate the state. I'll at least add support for metrics and an HTTP page into ckit and update this PR. 

#### Which issue(s) this PR fixes 
Related: #875

#### Notes to the Reviewer
See unit tests for an idea of how to run this locally.

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
