### PR TITLE
Move port to load_balancing config as receiver_port

### DIFF
--- a/docs/upgrade-guide/_index.md
+++ b/docs/upgrade-guide/_index.md
@@ -30,6 +30,7 @@ Example old config:
 tail_sampling:
   policies:
     - always_sample:
+  port: 4318
   load_balancing:
     exporter:
       insecure: true
@@ -37,7 +38,6 @@ tail_sampling:
       dns:
         hostname: agent
         port: 4318
-  port: 4318
 ```
 
 Example new config:

--- a/docs/upgrade-guide/_index.md
+++ b/docs/upgrade-guide/_index.md
@@ -21,7 +21,8 @@ receiving all spans for a trace in the same agent to be processed, such as
 service graphs.
 
 As a consequence, `tail_sampling.load_balancing` has been deprecated in favor of
-a `load_balancing` block.
+a `load_balancing` block. Also, `port` has been renamed to `receiver_port` and
+moved to the new `load_balancing` block.
 
 Example old config:
 
@@ -36,6 +37,7 @@ tail_sampling:
       dns:
         hostname: agent
         port: 4318
+  port: 4318
 ```
 
 Example new config:
@@ -51,6 +53,7 @@ load_balancing:
     dns:
       hostname: agent
       port: 4318
+  receiver_port: 4318
 ```
 
 ### Operator: Rename of Prometheus to Metrics (Breaking change)

--- a/pkg/tempo/config.go
+++ b/pkg/tempo/config.go
@@ -222,8 +222,6 @@ type tailSamplingConfig struct {
 	Policies []map[string]interface{} `yaml:"policies"`
 	// DecisionWait defines the time to wait for a complete trace before making a decision
 	DecisionWait time.Duration `yaml:"decision_wait,omitempty"`
-	// Port is the port the instance will use to receive load balanced traces
-	Port string `yaml:"port"`
 }
 
 // loadBalancingConfig defines the configuration for load balancing spans between agent instances
@@ -231,6 +229,8 @@ type tailSamplingConfig struct {
 type loadBalancingConfig struct {
 	Exporter exporterConfig         `yaml:"exporter"`
 	Resolver map[string]interface{} `yaml:"resolver"`
+	// ReceiverPort is the port the instance will use to receive load balanced traces
+	ReceiverPort string `yaml:"receiver_port"`
 }
 
 // exporterConfig defined the config for a otlp exporter for load balancing
@@ -544,8 +544,8 @@ func (c *InstanceConfig) otelConfig() (*config.Config, error) {
 		exporters["loadbalancing"] = internalExporter
 
 		receiverPort := defaultLoadBalancingPort
-		if c.TailSampling.Port != "" {
-			receiverPort = c.TailSampling.Port
+		if c.LoadBalancing.ReceiverPort != "" {
+			receiverPort = c.LoadBalancing.ReceiverPort
 		}
 		c.Receivers["otlp/lb"] = map[string]interface{}{
 			"protocols": map[string]interface{}{

--- a/pkg/tempo/config.go
+++ b/pkg/tempo/config.go
@@ -557,7 +557,7 @@ func (c *InstanceConfig) otelConfig() (*config.Config, error) {
 	}
 
 	// Build Pipelines
-	splitPipeline := c.TailSampling != nil && c.LoadBalancing != nil
+	splitPipeline := c.LoadBalancing != nil
 	orderedSplitProcessors := orderProcessors(processorNames, splitPipeline)
 	if splitPipeline {
 		// load balancing pipeline
@@ -690,7 +690,8 @@ func orderProcessors(processors []string, splitPipelines bool) [][]string {
 	foundAt := len(processors)
 	for i, processor := range processors {
 		if processor == "batch" ||
-			processor == "tail_sampling" {
+			processor == "tail_sampling" ||
+			processor == "automatic_logging" {
 			foundAt = i
 			break
 		}

--- a/pkg/tempo/config_test.go
+++ b/pkg/tempo/config_test.go
@@ -607,12 +607,13 @@ tail_sampling:
           - value1
           - value2
 load_balancing:
+  receiver_port: 8080
   exporter:
     insecure: true
   resolver:
     dns:
       hostname: agent
-      port: 4318
+      port: 8080
 `,
 			expectedConfig: `
 receivers:
@@ -622,7 +623,7 @@ receivers:
   otlp/lb:
     protocols:
       grpc:
-        endpoint: "0.0.0.0:4318"
+        endpoint: "0.0.0.0:8080"
 exporters:
   otlp/0:
     endpoint: example.com:12345
@@ -639,7 +640,7 @@ exporters:
     resolver:
       dns:
         hostname: agent
-        port: 4318
+        port: 8080
 processors:
   tail_sampling:
     decision_wait: 5s


### PR DESCRIPTION
#### PR Description

When extracting load balancing from tail sampling, only the the load_balancing block was moved into its own block, but the receiver's port was left in tail_sampling.

This means that the receiver port for load_balancing could not be configured without tail_sampling.

Now it's moved to load_balancing as receiver_port.

It also includes a fix for when using load balancing where pipelines wouldn't be split if tail sampling wasn't enabled as well.

#### Notes to the Reviewer

Change is not in the CHANGELOG since the load balancing change hasn't been released yet.

#### PR Checklist

- [ ] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
