### PR TITLE
Load balance without tail sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,12 @@ for specific instructions.
 
 - [BUGFIX] Logs should contain a caller field with file and line numbers again (@kgeckhart)
 
+- [BUGFIX] In scraping service mode, the polling configuration refresh should honor timeout. (@mattdurham)
+
+- [BUGFIX] In scraping service mode, the lifecycle reshard should happen using a goroutine. (@mattdurham)
+
+- [BUGFIX] In scraping service mode, scraping service can deadlock when reloading during join. (@mattdurham)
+
 - [CHANGE] Breaking change: reduced verbosity of tracing autologging
   by not logging `STATUS_CODE_UNSET` status codes. (@mapno)
 
@@ -76,6 +82,11 @@ for specific instructions.
   have been renamed accordinly: `loki_name` is now `logs_instance_name`,
   `loki_tag` is now `logs_instance_tag`, and `backend: loki` is now
   `backend: logs_instance`. (@rfratto)
+
+- [DEPRECATION] The `prometheus` key at the root of the config file has been
+  deprecated in favor of `metrics`. Flag names starting with `prometheus.` have
+  also been deprecated in favor of the same flags with the `metrics.` prefix.
+  (@rfratto)
 
 # v0.18.2 (2021-08-12)
 

--- a/cmd/agent/entrypoint.go
+++ b/cmd/agent/entrypoint.go
@@ -75,7 +75,7 @@ func NewEntrypoint(logger *util.Logger, cfg *config.Config, reloader Reloader) (
 
 	ep.srv = server.New(prometheus.DefaultRegisterer, logger)
 
-	ep.promMetrics, err = metrics.New(prometheus.DefaultRegisterer, cfg.Prometheus, logger)
+	ep.promMetrics, err = metrics.New(prometheus.DefaultRegisterer, cfg.Metrics, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (ep *Entrypoint) ApplyConfig(cfg config.Config) error {
 	}
 
 	// Go through each component and update it.
-	if err := ep.promMetrics.ApplyConfig(cfg.Prometheus); err != nil {
+	if err := ep.promMetrics.ApplyConfig(cfg.Metrics); err != nil {
 		level.Error(ep.log).Log("msg", "failed to update prometheus", "err", err)
 		failed = true
 	}

--- a/docs/configuration/prometheus-config.md
+++ b/docs/configuration/prometheus-config.md
@@ -61,14 +61,19 @@ agents distribute discovery and scrape load between nodes.
 # cannot be used.
 [enabled: <boolean> | default = false]
 
-# How often should the agent manually reshard. Useful for if KV change
+# Note these next 3 configuration options are confusing. Due to backwards compatibility the naming
+# is less than ideal.
+
+# How often should the agent manually refresh the configuration. Useful for if KV change
 # events are not sent by an agent.
 [reshard_interval: <duration> | default = "1m"]
 
-# The timeout for a reshard. Applies to a cluster-wide reshard (done when
-# joining or leaving the cluster) and local reshards (done every
-# reshard_interval). A timeout of 0 indicates no timeout.
+# The timeout for configuration refreshes. This can occur on cluster events or 
+# on the reshard interval. A timeout of 0 indicates no timeout.
 [reshard_timeout: <duration> | default = "30s"]
+
+# The timeout for a cluster reshard events. A timeout of 0 indicates no timeout.
+[cluster_reshard_event_timeout: <duration> | default = "30s"]
 
 # Configuration for the KV store to store configurations.
 kvstore: <kvstore_config>

--- a/docs/upgrade-guide/_index.md
+++ b/docs/upgrade-guide/_index.md
@@ -118,6 +118,51 @@ rules:
   verbs: [get, list, watch]
 ```
 
+### Metrics: Deprecation of "prometheus" in config. (Deprecation)
+
+The term `prometheus` in the config has been deprecated of favor of `metrics`. This
+change is to make it clearer when referring to Prometheus or another
+Prometheus-like database, and configuration of Grafana Agent to send metrics to
+one of those systems.
+
+Old configs will continue to work until it is fully deprecated. To migrate your
+config, change the `prometheus` key to `metrics`.
+
+Example old config:
+
+```yaml
+prometheus:
+  configs:
+    - name: default
+      host_filter: false
+      scrape_configs:
+        - job_name: local_scrape
+          static_configs:
+            - targets: ['127.0.0.1:12345']
+              labels:
+                cluster: 'localhost'
+      remote_write:
+        - url: http://localhost:9009/api/prom/push
+```
+
+Example new config:
+
+```yaml
+metrics:
+  configs:
+    - name: default
+      host_filter: false
+      scrape_configs:
+        - job_name: local_scrape
+          static_configs:
+            - targets: ['127.0.0.1:12345']
+              labels:
+                cluster: 'localhost'
+      remote_write:
+        - url: http://localhost:9009/api/prom/push
+```
+
+
 ### Logs: Deprecation of "loki" in config. (Deprecation)
 
 The term `loki` in the config has been deprecated of favor of `logs`. This

--- a/docs/upgrade-guide/_index.md
+++ b/docs/upgrade-guide/_index.md
@@ -21,7 +21,8 @@ receiving all spans for a trace in the same agent to be processed, such as
 service graphs.
 
 As a consequence, `tail_sampling.load_balancing` has been deprecated in favor of
-a `load_balancing` block.
+a `load_balancing` block. Also, `port` has been renamed to `receiver_port` and
+moved to the new `load_balancing` block.
 
 Example old config:
 
@@ -36,6 +37,7 @@ tail_sampling:
       dns:
         hostname: agent
         port: 4318
+  port: 4318
 ```
 
 Example new config:
@@ -51,6 +53,7 @@ load_balancing:
     dns:
       hostname: agent
       port: 4318
+  receiver_port: 4318
 ```
 
 ### Operator: Rename of Prometheus to Metrics (Breaking change)

--- a/example/docker-compose/grafana/dashboards/agent-operational.json
+++ b/example/docker-compose/grafana/dashboards/agent-operational.json
@@ -273,7 +273,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(container_cpu_usage_seconds_total{cluster=~\"$cluster\", container=~\"$container\", pod=~\"$pod\"}[5m])",
+                     "expr": "rate(container_cpu_usage_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\", pod=~\"$pod\"}[5m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
@@ -349,7 +349,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "container_memory_working_set_bytes{cluster=~\"$cluster\", container=~\"$container\", pod=~\"$pod\"}",
+                     "expr": "container_memory_working_set_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\", pod=~\"$pod\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
@@ -1036,7 +1036,9 @@
    ],
    "schemaVersion": 14,
    "style": "dark",
-   "tags": [ ],
+   "tags": [
+      "grafana-agent-mixin"
+   ],
    "templating": {
       "list": [
          {

--- a/example/docker-compose/grafana/dashboards/agent-remote-write.json
+++ b/example/docker-compose/grafana/dashboards/agent-remote-write.json
@@ -52,7 +52,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "(\n  prometheus_remote_storage_highest_timestamp_in_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}\n  -\n  ignoring(url, instance_group_name, remote_name) group_right(pod)\n  prometheus_remote_storage_queue_highest_sent_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}\n)\n",
+                     "expr": "(\n  prometheus_remote_storage_highest_timestamp_in_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}\n  -\n  ignoring(url, remote_name) group_right(pod)\n  prometheus_remote_storage_queue_highest_sent_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}\n)\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}",
@@ -131,7 +131,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "(\n  rate(prometheus_remote_storage_highest_timestamp_in_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m])\n  -\n  ignoring(url, instance_group_name, remote_name) group_right(pod)\n  rate(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m])\n)\n",
+                     "expr": "(\n  rate(prometheus_remote_storage_highest_timestamp_in_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m])\n  -\n  ignoring(url, remote_name) group_right(pod)\n  rate(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m])\n)\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}",
@@ -218,12 +218,12 @@
                "repeat": null,
                "seriesOverrides": [ ],
                "spaceLength": 10,
-               "span": 12,
+               "span": 6,
                "stack": false,
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(\n  prometheus_remote_storage_samples_in_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m])\n-\n  ignoring(url, instance_group_name, remote_name) group_right(pod)\n  rate(prometheus_remote_storage_succeeded_samples_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m])\n-\n  rate(prometheus_remote_storage_dropped_samples_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m])\n",
+                     "expr": "prometheus_remote_storage_samples_pending{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}",
@@ -233,7 +233,244 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Rate, in vs. succeeded or dropped [5m]",
+               "title": "Pending Samples",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "fill": 1,
+               "gridPos": { },
+               "id": 5,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 6,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(prometheus_remote_storage_samples_dropped_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Dropped Samples",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "fill": 1,
+               "gridPos": { },
+               "id": 6,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 6,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(prometheus_remote_storage_samples_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Failed Samples",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "fill": 1,
+               "gridPos": { },
+               "id": 7,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 6,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(prometheus_remote_storage_samples_retried_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Retried Samples",
                "tooltip": {
                   "shared": true,
                   "sort": 0,
@@ -287,7 +524,7 @@
                "datasource": "$datasource",
                "fill": 1,
                "gridPos": { },
-               "id": 5,
+               "id": 8,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -367,7 +604,7 @@
                "datasource": "$datasource",
                "fill": 1,
                "gridPos": { },
-               "id": 6,
+               "id": 9,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -446,7 +683,7 @@
                "datasource": "$datasource",
                "fill": 1,
                "gridPos": { },
-               "id": 7,
+               "id": 10,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -525,7 +762,7 @@
                "datasource": "$datasource",
                "fill": 1,
                "gridPos": { },
-               "id": 8,
+               "id": 11,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -617,7 +854,7 @@
                "datasource": "$datasource",
                "fill": 1,
                "gridPos": { },
-               "id": 9,
+               "id": 12,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -687,85 +924,6 @@
                      "show": true
                   }
                ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "gridPos": { },
-               "id": 10,
-               "legend": {
-                  "alignAsTable": false,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "prometheus_remote_storage_pending_samples{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Pending Samples",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
             }
          ],
          "repeat": null,
@@ -788,7 +946,7 @@
                "datasource": "$datasource",
                "fill": 1,
                "gridPos": { },
-               "id": 11,
+               "id": 13,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -880,164 +1038,6 @@
                "datasource": "$datasource",
                "fill": 1,
                "gridPos": { },
-               "id": 12,
-               "legend": {
-                  "alignAsTable": false,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "rate(prometheus_remote_storage_dropped_samples_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Dropped Samples",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "gridPos": { },
-               "id": 13,
-               "legend": {
-                  "alignAsTable": false,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "rate(prometheus_remote_storage_failed_samples_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Failed Samples",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "gridPos": { },
                "id": 14,
                "legend": {
                   "alignAsTable": false,
@@ -1061,86 +1061,7 @@
                "repeat": null,
                "seriesOverrides": [ ],
                "spaceLength": 10,
-               "span": 3,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "rate(prometheus_remote_storage_retried_samples_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Retried Samples",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "gridPos": { },
-               "id": 15,
-               "legend": {
-                  "alignAsTable": false,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
+               "span": 6,
                "stack": false,
                "steppedLine": false,
                "targets": [
@@ -1200,7 +1121,9 @@
    ],
    "schemaVersion": 14,
    "style": "dark",
-   "tags": [ ],
+   "tags": [
+      "grafana-agent-mixin"
+   ],
    "templating": {
       "list": [
          {

--- a/example/docker-compose/grafana/dashboards/agent.json
+++ b/example/docker-compose/grafana/dashboards/agent.json
@@ -473,7 +473,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum by (job) (rate(prometheus_target_scrapes_exceeded_sample_limit_total[1m]))",
+                     "expr": "sum by (job) (rate(prometheus_target_scrapes_exceeded_sample_limit_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[1m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "exceeded sample limit: {{job}}",
@@ -481,7 +481,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum by (job) (rate(prometheus_target_scrapes_sample_duplicate_timestamp_total[1m]))",
+                     "expr": "sum by (job) (rate(prometheus_target_scrapes_sample_duplicate_timestamp_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[1m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "duplicate timestamp: {{job}}",
@@ -489,7 +489,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum by (job) (rate(prometheus_target_scrapes_sample_out_of_bounds_total[1m]))",
+                     "expr": "sum by (job) (rate(prometheus_target_scrapes_sample_out_of_bounds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[1m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "out of bounds: {{job}}",
@@ -497,7 +497,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum by (job) (rate(prometheus_target_scrapes_sample_out_of_order_total[1m]))",
+                     "expr": "sum by (job) (rate(prometheus_target_scrapes_sample_out_of_order_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[1m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "out of order: {{job}}",
@@ -573,7 +573,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum by (job, instance_group_name) (rate(agent_wal_storage_samples_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m]))",
+                     "expr": "sum by (job, instance_group_name) (rate(agent_wal_storage_created_series_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{job}} {{instance_group_name}}",
@@ -584,7 +584,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Appended Samples",
+               "title": "Created Series",
                "tooltip": {
                   "shared": true,
                   "sort": 0,
@@ -628,7 +628,9 @@
    ],
    "schemaVersion": 14,
    "style": "dark",
-   "tags": [ ],
+   "tags": [
+      "grafana-agent-mixin"
+   ],
    "templating": {
       "list": [
          {

--- a/pkg/metrics/agent.go
+++ b/pkg/metrics/agent.go
@@ -43,11 +43,16 @@ type Config struct {
 	Configs                []instance.Config     `yaml:"configs,omitempty,omitempty"`
 	InstanceRestartBackoff time.Duration         `yaml:"instance_restart_backoff,omitempty"`
 	InstanceMode           instance.Mode         `yaml:"instance_mode,omitempty"`
+
+	// Unmarshaled is true when the Config was unmarshaled from YAML.
+	Unmarshaled bool `yaml:"-"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	*c = DefaultConfig
+	util.DefaultConfigFromFlags(c)
+	c.Unmarshaled = true
 
 	type plain Config
 	err := unmarshal((*plain)(c))
@@ -97,13 +102,21 @@ func (c *Config) ApplyDefaults() error {
 
 // RegisterFlags defines flags corresponding to the Config.
 func (c *Config) RegisterFlags(f *flag.FlagSet) {
-	f.StringVar(&c.WALDir, "prometheus.wal-directory", "", "base directory to store the WAL in")
-	f.DurationVar(&c.WALCleanupAge, "prometheus.wal-cleanup-age", DefaultConfig.WALCleanupAge, "remove abandoned (unused) WALs older than this")
-	f.DurationVar(&c.WALCleanupPeriod, "prometheus.wal-cleanup-period", DefaultConfig.WALCleanupPeriod, "how often to check for abandoned WALs")
-	f.DurationVar(&c.InstanceRestartBackoff, "prometheus.instance-restart-backoff", DefaultConfig.InstanceRestartBackoff, "how long to wait before restarting a failed Prometheus instance")
+	c.RegisterFlagsWithPrefix("metrics.", f)
 
-	c.ServiceConfig.RegisterFlagsWithPrefix("prometheus.service.", f)
-	c.ServiceClientConfig.RegisterFlags(f)
+	// Register deprecated flag names.
+	c.RegisterFlagsWithPrefix("prometheus.", f)
+}
+
+// RegisterFlagsWithPrefix defines flags with the provided prefix.
+func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.StringVar(&c.WALDir, prefix+"wal-directory", "", "base directory to store the WAL in")
+	f.DurationVar(&c.WALCleanupAge, prefix+"wal-cleanup-age", DefaultConfig.WALCleanupAge, "remove abandoned (unused) WALs older than this")
+	f.DurationVar(&c.WALCleanupPeriod, prefix+"wal-cleanup-period", DefaultConfig.WALCleanupPeriod, "how often to check for abandoned WALs")
+	f.DurationVar(&c.InstanceRestartBackoff, prefix+"instance-restart-backoff", DefaultConfig.InstanceRestartBackoff, "how long to wait before restarting a failed Prometheus instance")
+
+	c.ServiceConfig.RegisterFlagsWithPrefix(prefix+"service.", f)
+	c.ServiceClientConfig.RegisterFlagsWithPrefix(prefix, f)
 }
 
 // Agent is an agent for collecting Prometheus metrics. It acts as a

--- a/pkg/metrics/cluster/client/client.go
+++ b/pkg/metrics/cluster/client/client.go
@@ -40,7 +40,13 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // RegisterFlags registers flags to the provided flag set.
 func (c *Config) RegisterFlags(f *flag.FlagSet) {
-	c.GRPCClientConfig.RegisterFlagsWithPrefix("prometheus.service-client", f)
+	c.RegisterFlagsWithPrefix("prometheus.", f)
+}
+
+// RegisterFlagsWithPrefix registers flags to the provided flag set with the
+// specified prefix.
+func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	c.GRPCClientConfig.RegisterFlagsWithPrefix(prefix+"service-client", f)
 }
 
 // New returns a new scraping service client.

--- a/pkg/metrics/cluster/cluster.go
+++ b/pkg/metrics/cluster/cluster.go
@@ -107,14 +107,15 @@ func (c *Cluster) storeValidate(cfg *instance.Config) error {
 // Reshard implements agentproto.ScrapingServiceServer, and syncs the state of
 // configs with the configstore.
 func (c *Cluster) Reshard(ctx context.Context, _ *agentproto.ReshardRequest) (*empty.Empty, error) {
-	c.mut.RLock()
-	defer c.mut.RUnlock()
-
-	err := c.watcher.Refresh(ctx)
-	if err != nil {
-		level.Error(c.log).Log("msg", "failed to perform local reshard", "err", err)
-	}
-	return &empty.Empty{}, err
+	go func() {
+		c.mut.RLock()
+		defer c.mut.RUnlock()
+		err := c.watcher.Refresh(context.Background())
+		if err != nil {
+			level.Error(c.log).Log("msg", "failed to perform local reshard", "err", err)
+		}
+	}()
+	return &empty.Empty{}, nil
 }
 
 // ApplyConfig applies configuration changes to Cluster.

--- a/pkg/metrics/cluster/config.go
+++ b/pkg/metrics/cluster/config.go
@@ -15,11 +15,12 @@ var DefaultConfig = *flagutil.DefaultConfigFromFlags(&Config{}).(*Config)
 
 // Config describes how to instantiate a scraping service Server instance.
 type Config struct {
-	Enabled         bool                  `yaml:"enabled"`
-	ReshardInterval time.Duration         `yaml:"reshard_interval"`
-	ReshardTimeout  time.Duration         `yaml:"reshard_timeout"`
-	KVStore         kv.Config             `yaml:"kvstore"`
-	Lifecycler      ring.LifecyclerConfig `yaml:"lifecycler"`
+	Enabled                    bool                  `yaml:"enabled"`
+	ReshardInterval            time.Duration         `yaml:"reshard_interval"`
+	ReshardTimeout             time.Duration         `yaml:"reshard_timeout"`
+	ClusterReshardEventTimeout time.Duration         `yaml:"cluster_reshard_event_timeout"`
+	KVStore                    kv.Config             `yaml:"kvstore"`
+	Lifecycler                 ring.LifecyclerConfig `yaml:"lifecycler"`
 
 	DangerousAllowReadingFiles bool `yaml:"dangerous_allow_reading_files"`
 
@@ -50,8 +51,9 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 // FlagSet with a specified prefix.
 func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.BoolVar(&c.Enabled, prefix+"enabled", false, "enables the scraping service mode")
-	f.DurationVar(&c.ReshardInterval, prefix+"reshard-interval", time.Minute*1, "how often to manually reshard")
-	f.DurationVar(&c.ReshardTimeout, prefix+"reshard-timeout", time.Second*30, "timeout for cluster-wide reshards and local reshards. Timeout of 0s disables timeout.")
+	f.DurationVar(&c.ReshardInterval, prefix+"reshard-interval", time.Minute*1, "how often to manually refresh configuration")
+	f.DurationVar(&c.ReshardTimeout, prefix+"reshard-timeout", time.Second*30, "timeout for refreshing the configuration. Timeout of 0s disables timeout.")
+	f.DurationVar(&c.ClusterReshardEventTimeout, prefix+"cluster-reshard-event-timeout", time.Second*30, "timeout for the cluster reshard. Timeout of 0s disables timeout.")
 	c.KVStore.RegisterFlagsWithPrefix(prefix+"config-store.", "configurations/", f)
 	c.Lifecycler.RegisterFlagsWithPrefix(prefix, f)
 	c.Client.GRPCClientConfig.RegisterFlagsWithPrefix(prefix, f)

--- a/pkg/tempo/config.go
+++ b/pkg/tempo/config.go
@@ -575,7 +575,7 @@ func (c *InstanceConfig) otelConfig() (*config.Config, error) {
 	}
 
 	// Build Pipelines
-	splitPipeline := c.TailSampling != nil && c.LoadBalancing != nil
+	splitPipeline := c.LoadBalancing != nil
 	orderedSplitProcessors := orderProcessors(processorNames, splitPipeline)
 	if splitPipeline {
 		// load balancing pipeline
@@ -710,7 +710,9 @@ func orderProcessors(processors []string, splitPipelines bool) [][]string {
 	foundAt := len(processors)
 	for i, processor := range processors {
 		if processor == "batch" ||
-			processor == "tail_sampling" {
+			processor == "tail_sampling" ||
+			processor == "service_graphs" ||
+			processor == "automatic_logging" {
 			foundAt = i
 			break
 		}

--- a/pkg/tempo/config.go
+++ b/pkg/tempo/config.go
@@ -226,8 +226,6 @@ type tailSamplingConfig struct {
 	Policies []map[string]interface{} `yaml:"policies"`
 	// DecisionWait defines the time to wait for a complete trace before making a decision
 	DecisionWait time.Duration `yaml:"decision_wait,omitempty"`
-	// Port is the port the instance will use to receive load balanced traces
-	Port string `yaml:"port"`
 }
 
 // loadBalancingConfig defines the configuration for load balancing spans between agent instances
@@ -235,6 +233,8 @@ type tailSamplingConfig struct {
 type loadBalancingConfig struct {
 	Exporter exporterConfig         `yaml:"exporter"`
 	Resolver map[string]interface{} `yaml:"resolver"`
+	// ReceiverPort is the port the instance will use to receive load balanced traces
+	ReceiverPort string `yaml:"receiver_port"`
 }
 
 // exporterConfig defined the config for a otlp exporter for load balancing
@@ -554,8 +554,8 @@ func (c *InstanceConfig) otelConfig() (*config.Config, error) {
 		exporters["loadbalancing"] = internalExporter
 
 		receiverPort := defaultLoadBalancingPort
-		if c.TailSampling.Port != "" {
-			receiverPort = c.TailSampling.Port
+		if c.LoadBalancing.ReceiverPort != "" {
+			receiverPort = c.LoadBalancing.ReceiverPort
 		}
 		c.Receivers["otlp/lb"] = map[string]interface{}{
 			"protocols": map[string]interface{}{

--- a/pkg/tempo/config_test.go
+++ b/pkg/tempo/config_test.go
@@ -970,10 +970,59 @@ service_graphs:
 				"traces/0": {
 					config.NewID("attributes"),
 					config.NewID("spanmetrics"),
-					config.NewID("service_graphs"),
 				},
 				"traces/1": {
+					config.NewID("service_graphs"),
 					config.NewID("tail_sampling"),
+					config.NewID("automatic_logging"),
+					config.NewID("batch"),
+				},
+				"metrics/spanmetrics": nil,
+			},
+		},
+		{
+			name: "load balancing without tail sampling",
+			cfg: `
+receivers:
+  jaeger:
+    protocols:
+      grpc:
+remote_write:
+  - endpoint: example.com:12345
+    headers:
+      x-some-header: Some value!
+attributes:
+  actions:
+  - key: montgomery
+    value: forever
+    action: update
+spanmetrics:
+  latency_histogram_buckets: [2ms, 6ms, 10ms, 100ms, 250ms]
+  dimensions:
+    - name: http.method
+      default: GET
+    - name: http.status_code
+  prom_instance: tempo
+automatic_logging:
+  spans: true
+batch:
+  timeout: 5s
+  send_batch_size: 100
+load_balancing:
+  exporter:
+    insecure: true
+  resolver:
+    dns:
+      hostname: agent
+      port: 4318
+`,
+			expectedProcessors: map[string][]config.ComponentID{
+				"traces/0": {
+					config.NewID("attributes"),
+					config.NewID("spanmetrics"),
+				},
+				"traces/1": {
+					config.NewID("service_graphs"),
 					config.NewID("automatic_logging"),
 					config.NewID("batch"),
 				},

--- a/pkg/tempo/config_test.go
+++ b/pkg/tempo/config_test.go
@@ -607,12 +607,13 @@ tail_sampling:
           - value1
           - value2
 load_balancing:
+  receiver_port: 8080
   exporter:
     insecure: true
   resolver:
     dns:
       hostname: agent
-      port: 4318
+      port: 8080
 `,
 			expectedConfig: `
 receivers:
@@ -622,7 +623,7 @@ receivers:
   otlp/lb:
     protocols:
       grpc:
-        endpoint: "0.0.0.0:4318"
+        endpoint: "0.0.0.0:8080"
 exporters:
   otlp/0:
     endpoint: example.com:12345
@@ -639,7 +640,7 @@ exporters:
     resolver:
       dns:
         hostname: agent
-        port: 4318
+        port: 8080
 processors:
   tail_sampling:
     decision_wait: 5s

--- a/production/grafana-agent-mixin/debugging.libsonnet
+++ b/production/grafana-agent-mixin/debugging.libsonnet
@@ -37,14 +37,14 @@ local utils = import './utils.libsonnet';
         .addPanel(
           g.panel('CPU') +
           g.queryPanel(
-            'rate(container_cpu_usage_seconds_total{cluster=~"$cluster", container=~"$container", pod=~"$pod"}[5m])',
+            'rate(container_cpu_usage_seconds_total{cluster=~"$cluster", namespace=~"$namespace", container=~"$container", pod=~"$pod"}[5m])',
             '{{pod}}',
           )
         )
         .addPanel(
           g.panel('WSS') +
           g.queryPanel(
-            'container_memory_working_set_bytes{cluster=~"$cluster", container=~"$container", pod=~"$pod"}',
+            'container_memory_working_set_bytes{cluster=~"$cluster", namespace=~"$namespace", container=~"$container", pod=~"$pod"}',
             '{{pod}}',
           )
         )


### PR DESCRIPTION
#### PR Description

Pipelines weren't split for load balance if tail sampling wasn't configured. Now it only need load balance to be configured to split them.

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [x] Tests updated
