### PR TITLE
add docs sync

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: publish_docs
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - 'docs/**'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync
+    - name: publish-to-git
+      uses: ./.github/actions/website-sync
+      id: publish
+      with:
+        repository: grafana/website
+        branch: master
+        host: github.com
+        github_pat: '${{ secrets.GH_BOT_ACCESS_TOKEN }}'
+        source_folder: docs
+        target_folder: content/docs/agent/latest
+    - shell: bash
+      run: |
+        test -n "${{ steps.publish.outputs.commit_hash }}"
+        test -n "${{ steps.publish.outputs.working_directory }}"


### PR DESCRIPTION
#### PR Description 

Syncs `docs` dir to the website. Fixes https://github.com/grafana/website/issues/5440.

Todo:
- [x] Add `GH_BOT_ACCESS_TOKEN` as a repository secret: https://github.com/grafana/agent/settings/secrets/actions (I don't have access for this repo). This can be obtained by logging in as grafanabot and adding a personal access token. @rfratto Are you able to do that?