### PR TITLE
agentctl: allow specifying Grafana Cloud's API url in cloud-config cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@ for specific instructions.
   also been deprecated in favor of the same flags with the `metrics.` prefix.
   (@rfratto)
 
+- [ENHANCEMENT] `agentctl cloud-config` now allows specifying an url for
+  Grafana Cloud's API. (@cristiangreco)
+
 # v0.18.2 (2021-08-12)
 
 - [BUGFIX] Honor the prefix and remove prefix from consul list results (@mattdurham)

--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -427,6 +427,7 @@ func filterAgentOwners(refs []meta_v1.OwnerReference) (filtered []meta_v1.OwnerR
 func cloudConfigCmd() *cobra.Command {
 	var (
 		stackID string
+		apiURL  string
 		apiKey  string
 	)
 
@@ -448,7 +449,7 @@ config that may be used with this agent.`,
 				return fmt.Errorf("--api-key must be provided")
 			}
 
-			cli := grafanacloud.NewClient(nil, apiKey)
+			cli := grafanacloud.NewClient(nil, apiKey, apiURL)
 
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 			defer cancel()
@@ -466,6 +467,7 @@ config that may be used with this agent.`,
 
 	cmd.Flags().StringVarP(&stackID, "stack", "u", "", "stack ID to get a config for")
 	cmd.Flags().StringVarP(&apiKey, "api-key", "p", "", "API key to authenticate against Grafana Cloud's API with")
+	cmd.Flags().StringVarP(&apiURL, "api-url", "e", "", "Grafana Cloud's API url")
 	must(cmd.MarkFlagRequired("stack"))
 	must(cmd.MarkFlagRequired("api-key"))
 

--- a/pkg/client/grafanacloud/client.go
+++ b/pkg/client/grafanacloud/client.go
@@ -10,24 +10,28 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const integrationsAPIURL = "https://integrations-api.grafana.net"
+const defaultAPIURL = "https://integrations-api.grafana.net"
 
 // Client is a grafanacloud API client.
 type Client struct {
 	c      *http.Client
 	apiKey string
+	apiURL string
 }
 
 // NewClient creates a new Grafana Cloud client. All requests made will be
 // performed using the provided http.Client c. If c is nil, the default
 // http client will be used instead.
 //
-// apiKey will be used to authenticate against the API.
-func NewClient(c *http.Client, apiKey string) *Client {
+// apiKey will be used to authenticate against the apiURL.
+func NewClient(c *http.Client, apiKey, apiURL string) *Client {
 	if c == nil {
 		c = http.DefaultClient
 	}
-	return &Client{c: c, apiKey: apiKey}
+	if apiURL == "" {
+		apiURL = defaultAPIURL
+	}
+	return &Client{c: c, apiKey: apiKey, apiURL: apiURL}
 }
 
 // AgentConfig generates a Grafana Agent config from the given stack.
@@ -35,7 +39,7 @@ func NewClient(c *http.Client, apiKey string) *Client {
 func (c *Client) AgentConfig(ctx context.Context, stackID string) (string, error) {
 	req, err := http.NewRequestWithContext(
 		ctx, "GET",
-		fmt.Sprintf("%s/stacks/%s/agent_config", integrationsAPIURL, stackID),
+		fmt.Sprintf("%s/stacks/%s/agent_config", c.apiURL, stackID),
 		nil,
 	)
 	if err != nil {

--- a/pkg/client/grafanacloud/client_test.go
+++ b/pkg/client/grafanacloud/client_test.go
@@ -40,7 +40,7 @@ func TestClient_AgentConfig(t *testing.T) {
 		assert.NoError(t, err)
 	}))
 
-	cli := NewClient(httpClient, testSecret)
+	cli := NewClient(httpClient, testSecret, "")
 	cfg, err := cli.AgentConfig(context.Background(), testStackID)
 	require.NoError(t, err)
 	fmt.Println(cfg)
@@ -62,7 +62,7 @@ func TestClient_AgentConfig_Error(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 
-	cli := NewClient(httpClient, testSecret)
+	cli := NewClient(httpClient, testSecret, "")
 	_, err := cli.AgentConfig(context.Background(), testStackID)
 	require.Error(t, err, "unexpected status code 404")
 }
@@ -77,7 +77,7 @@ func TestClient_AgentConfig_ErrorMessage(t *testing.T) {
 		assert.NoError(t, err)
 	}))
 
-	cli := NewClient(httpClient, testSecret)
+	cli := NewClient(httpClient, testSecret, "")
 	_, err := cli.AgentConfig(context.Background(), testStackID)
 	require.Error(t, err, "request was not successful: Something went wrong")
 }

--- a/production/grafanacloud-install.sh
+++ b/production/grafanacloud-install.sh
@@ -27,7 +27,8 @@ fatal() {
 # REQUIRED environment variables.
 #
 GCLOUD_STACK_ID=${GCLOUD_STACK_ID:=} # Stack ID where integrations are installed
-GCLOUD_API_KEY=${GCLOUD_API_KEY:=}   # API key to communicate to the integrations API
+GCLOUD_API_KEY=${GCLOUD_API_KEY:=}   # API key to authenticate against Grafana Cloud's API with
+GCLOUD_API_URL=${GCLOUD_API_URL:=}   # Grafana Cloud's API url
 
 [ -z "$GCLOUD_STACK_ID" ] && fatal "Required environment variable \$GCLOUD_STACK_ID not set."
 [ -z "$GCLOUD_API_KEY" ]  && fatal "Required environment variable \$GCLOUD_API_KEY not set."
@@ -118,7 +119,7 @@ install_rpm() {
 # retrieve_config downloads the config file for the Agent and prints out its
 # contents to stdout.
 retrieve_config() {
-  grafana-agentctl cloud-config -u "${GCLOUD_STACK_ID}" -p "${GCLOUD_API_KEY}" || fatal 'Failed to retrieve config'
+  grafana-agentctl cloud-config -u "${GCLOUD_STACK_ID}" -p "${GCLOUD_API_KEY}" -e "${GCLOUD_API_URL}" || fatal 'Failed to retrieve config'
 }
 
 main


### PR DESCRIPTION
#### PR Description 
Change the Grafana Cloud client to accept the API url as a parameter,
or default to the hardcoded value if it's empty.

Also update the installation script to look for a new environment
variable `GCLOUD_API_URL`.

#### Which issue(s) this PR fixes 
n.a.

#### Notes to the Reviewer
n.a.

#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added
- [x] Tests updated
