### PR TITLE
Rename prom_instance -> metrics_instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ for specific instructions.
   hyphen in the name to be consistent with how Kubernetes refers to resources.
   (@rfratto)
 
+- [CHANGE] Breaking change: `prom_instance` in the spanmetrics config is now
+  named `metrics_instance`. (@rfratto)
+
 - [DEPRECATION] The `loki` key at the root of the config file has been
   deprecated in favor of `logs`. `loki`-named fields in `automatic_logging`
   have been renamed accordinly: `loki_name` is now `logs_instance_name`,

--- a/docs/configuration/tempo-config.md
+++ b/docs/configuration/tempo-config.md
@@ -139,7 +139,7 @@ scrape_configs:
 # OpenTelemetry Prometheus exporters to serve the metrics locally.
 #
 # In order to use the remote_write exporter, you have to configure a Prometheus
-# instance in the Agent and pass its name to the `prom_instance` field.
+# instance in the Agent and pass its name to the `metrics_instance` field.
 #
 # If you want to use the OpenTelemetry Prometheus exporter, you have to
 # configure handler_endpoint and then scrape that endpoint.
@@ -168,8 +168,8 @@ spanmetrics:
   # They can be further namespaced, i.e. `{namespace}_tempo_spanmetrics`
   [ namespace: <string> ]
 
-  # prom_instance is the prometheus used to remote write metrics.
-  [ prom_instance: <string> ]
+  # metrics_instance is the metrics instance used to remote write metrics.
+  [ metrics_instance: <string> ]
   # handler_endpoint defines the endpoint where the OTel prometheus exporter will be exposed.
   [ handler_endpoint: <string> ]
 
@@ -204,7 +204,7 @@ tail_sampling:
 # Enabling this feature is required for tail_sampling to correctly work when
 # different agent instances can receive spans for the same trace.
 #
-# Load balancing works by layering two pipelines and consistently exporting 
+# Load balancing works by layering two pipelines and consistently exporting
 # spans belonging to a trace to the same agent instance.
 # Agent instances need to be able to communicate with each other via gRPC.
 #

--- a/docs/upgrade-guide/_index.md
+++ b/docs/upgrade-guide/_index.md
@@ -165,6 +165,31 @@ metrics:
         - url: http://localhost:9009/api/prom/push
 ```
 
+### Tempo: prom_instance rename (Breaking change)
+
+As part of `prometheus` being renamed to `metrics`, the spanmetrics
+`prom_instance` field has been renamed to `metrics_instance`. This is a breaking
+change, and the old name will no longer work.
+
+Example old config:
+
+```yaml
+tempo:
+  configs:
+  - name: default
+    spanmetrics:
+      prom_instance: default
+```
+
+Example new config:
+
+```yaml
+tempo:
+  configs:
+  - name: default
+    spanmetrics:
+      metrics_instance: default
+```
 
 ### Logs: Deprecation of "loki" in config. (Deprecation)
 

--- a/example/docker-compose/agent/config/agent.yaml
+++ b/example/docker-compose/agent/config/agent.yaml
@@ -97,4 +97,4 @@ tempo:
       processes: true
       roots: true
     spanmetrics:
-      prom_instance: test
+      metrics_instance: test

--- a/pkg/tempo/config.go
+++ b/pkg/tempo/config.go
@@ -209,8 +209,8 @@ type SpanMetricsConfig struct {
 	Namespace string `yaml:"namespace,omitempty"`
 	// ConstLabels are values that are applied for every exported metric.
 	ConstLabels *prometheus.Labels `yaml:"const_labels,omitempty"`
-	// PromInstance is the Agent's prometheus instance that will be used to push metrics
-	PromInstance string `yaml:"prom_instance"`
+	// MetricsInstance is the Agent's metrics instance that will be used to push metrics
+	MetricsInstance string `yaml:"metrics_instance"`
 	// HandlerEndpoint is the address where a prometheus exporter will be exposed
 	HandlerEndpoint string `yaml:"handler_endpoint"`
 }
@@ -479,14 +479,14 @@ func (c *InstanceConfig) otelConfig() (*config.Config, error) {
 		}
 
 		var exporterName string
-		if len(c.SpanMetrics.PromInstance) != 0 && len(c.SpanMetrics.HandlerEndpoint) == 0 {
+		if len(c.SpanMetrics.MetricsInstance) != 0 && len(c.SpanMetrics.HandlerEndpoint) == 0 {
 			exporterName = remotewriteexporter.TypeStr
 			exporters[remotewriteexporter.TypeStr] = map[string]interface{}{
-				"namespace":     namespace,
-				"const_labels":  c.SpanMetrics.ConstLabels,
-				"prom_instance": c.SpanMetrics.PromInstance,
+				"namespace":        namespace,
+				"const_labels":     c.SpanMetrics.ConstLabels,
+				"metrics_instance": c.SpanMetrics.MetricsInstance,
 			}
-		} else if len(c.SpanMetrics.PromInstance) == 0 && len(c.SpanMetrics.HandlerEndpoint) != 0 {
+		} else if len(c.SpanMetrics.MetricsInstance) == 0 && len(c.SpanMetrics.HandlerEndpoint) != 0 {
 			exporterName = "prometheus"
 			exporters[exporterName] = map[string]interface{}{
 				"endpoint":     c.SpanMetrics.HandlerEndpoint,

--- a/pkg/tempo/config_test.go
+++ b/pkg/tempo/config_test.go
@@ -447,7 +447,7 @@ spanmetrics:
     - name: http.method
       default: GET
     - name: http.status_code
-  prom_instance: tempo
+  metrics_instance: tempo
 `,
 			expectedConfig: `
 receivers:
@@ -463,7 +463,7 @@ exporters:
       max_elapsed_time: 60s
   remote_write:
     namespace: tempo_spanmetrics
-    prom_instance: tempo
+    metrics_instance: tempo
 processors:
   spanmetrics:
     metrics_exporter: remote_write
@@ -535,7 +535,7 @@ remote_write:
   - endpoint: example.com:12345
 spanmetrics:
   handler_endpoint: "0.0.0.0:8889"
-  prom_instance: tempo
+  metrics_instance: tempo
 `,
 			expectedError: true,
 		},
@@ -858,7 +858,7 @@ spanmetrics:
     - name: http.method
       default: GET
     - name: http.status_code
-  prom_instance: tempo
+  metrics_instance: tempo
 automatic_logging:
   spans: true
 batch:
@@ -906,7 +906,7 @@ spanmetrics:
     - name: http.method
       default: GET
     - name: http.status_code
-  prom_instance: tempo
+  metrics_instance: tempo
 automatic_logging:
   spans: true
 batch:
@@ -963,7 +963,7 @@ spanmetrics:
     - name: http.method
       default: GET
     - name: http.status_code
-  prom_instance: tempo
+  metrics_instance: tempo
 automatic_logging:
   spans: true
 batch:

--- a/pkg/tempo/instance.go
+++ b/pkg/tempo/instance.go
@@ -148,7 +148,7 @@ func (i *Instance) buildAndStartPipeline(ctx context.Context, cfg InstanceConfig
 		}
 	}
 
-	if cfg.SpanMetrics != nil && len(cfg.SpanMetrics.PromInstance) != 0 {
+	if cfg.SpanMetrics != nil && len(cfg.SpanMetrics.MetricsInstance) != 0 {
 		ctx = context.WithValue(ctx, contextkeys.Prometheus, promManager)
 	}
 

--- a/pkg/tempo/remotewriteexporter/factory.go
+++ b/pkg/tempo/remotewriteexporter/factory.go
@@ -20,7 +20,7 @@ type Config struct {
 
 	ConstLabels  labels.Labels `mapstructure:"const_labels"`
 	Namespace    string        `mapstructure:"namespace"`
-	PromInstance string        `mapstructure:"prom_instance"`
+	PromInstance string        `mapstructure:"metrics_instance"`
 }
 
 // NewFactory returns a new factory for the Attributes processor.


### PR DESCRIPTION
I think this is the only thing mentioning `prom`/`prometheus` in the tracing code. Let me know if I missed something else.

Related to #722.