### PR TITLE
tempo: if relabel config drops target, don't attempt to process (#904)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ for specific instructions.
 
 - [BUGFIX] Fix yaml marshalling tag for cert_file in kafka exporter agent config. (@rgeyer)
 
+- [BUGFIX] Fix warn-level logging of dropped targets. (@james-callahan)
+
 - [CHANGE] Breaking change: reduced verbosity of tracing autologging
   by not logging `STATUS_CODE_UNSET` status codes. (@mapno)
 

--- a/pkg/tempo/promsdprocessor/prom_sd_processor.go
+++ b/pkg/tempo/promsdprocessor/prom_sd_processor.go
@@ -187,6 +187,9 @@ func (p *promServiceDiscoProcessor) syncTargets(jobName string, group *targetgro
 		}
 		processedLabels := relabel.Process(labels.FromMap(labelMap), relabelConfig...)
 		level.Debug(p.logger).Log("processedLabels", processedLabels)
+		if processedLabels == nil { // dropped
+			continue
+		}
 
 		var labels = make(model.LabelSet)
 		for k, v := range processedLabels.Map() {


### PR DESCRIPTION
#### PR Description 

tempo agent: if relabel config drops target, don't attempt to process it.
This avoids e.g. logging a warning when a target is intentionally dropped

#### Which issue(s) this PR fixes 

#904

#### Notes to the Reviewer

The current setup for testing doesn't have any easy path to test output of logging; so I wasn't able to add a test for this.

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
