### PR TITLE
Operator: Add support for managing a kubelet service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ for specific instructions.
 - [FEATURE] Add `operator-detach` command to agentctl to allow zero-downtime
   upgrades when removing an Operator CRD. (@rfratto)
 
+- [FEATURE] Operator: The Grafana Agent Operator can now generate a Kubelet
+  service to allow a ServiceMonitor to collect Kubelet and cAdvisor metrics.
+  This requires passing a `--kubelet-service` flag to the Operator in
+  `namespace/name` format (like `kube-system/kubelet`). (@rfratto)
+
 - [ENHANCEMENT] The Grafana Agent Operator will now default to deploying
   the matching release version of the Grafana Agent instead of v0.14.0.
   (@rfratto)

--- a/cmd/agent-operator/agent-example-config.yaml
+++ b/cmd/agent-operator/agent-example-config.yaml
@@ -102,6 +102,99 @@ spec:
   pipelineStages:
     - cri: {}
 
+---
+
+# With -kubelet-service=default/kubelet provided as a flag to the Grafana Agent
+# Operator, it will maintain a Service called "kubelet" in the default namespace
+# with one endpoint per Node. This allows using the ServiceMonitor below to
+# monitor Kubernetes itself.
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: kubelet
+    instance: primary
+  name: kubelet
+  namespace: default
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
+    interval: 30s
+    metricRelabelings:
+    - action: drop
+      regex: kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds|network_plugin_operations_latency_microseconds)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: scheduler_(e2e_scheduling_latency_microseconds|scheduling_algorithm_predicate_evaluation|scheduling_algorithm_priority_evaluation|scheduling_algorithm_preemption_evaluation|scheduling_algorithm_latency_microseconds|binding_latency_microseconds|scheduling_latency_seconds)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: apiserver_(request_count|request_latencies|request_latencies_summary|dropped_requests|storage_data_key_generation_latencies_microseconds|storage_transformation_failures_total|storage_transformation_latencies_microseconds|proxy_tunnel_sync_latency_secs)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: kubelet_docker_(operations|operations_latency_microseconds|operations_errors|operations_timeout)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: reflector_(items_per_list|items_per_watch|list_duration_seconds|lists_total|short_watches_total|watch_duration_seconds|watches_total)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: etcd_(helper_cache_hit_count|helper_cache_miss_count|helper_cache_entry_count|object_counts|request_cache_get_latencies_summary|request_cache_add_latencies_summary|request_latencies_summary)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: transformation_(transformation_latencies_microseconds|failures_total)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: (admission_quota_controller_adds|admission_quota_controller_depth|admission_quota_controller_longest_running_processor_microseconds|admission_quota_controller_queue_latency|admission_quota_controller_unfinished_work_seconds|admission_quota_controller_work_duration|APIServiceOpenAPIAggregationControllerQueue1_adds|APIServiceOpenAPIAggregationControllerQueue1_depth|APIServiceOpenAPIAggregationControllerQueue1_longest_running_processor_microseconds|APIServiceOpenAPIAggregationControllerQueue1_queue_latency|APIServiceOpenAPIAggregationControllerQueue1_retries|APIServiceOpenAPIAggregationControllerQueue1_unfinished_work_seconds|APIServiceOpenAPIAggregationControllerQueue1_work_duration|APIServiceRegistrationController_adds|APIServiceRegistrationController_depth|APIServiceRegistrationController_longest_running_processor_microseconds|APIServiceRegistrationController_queue_latency|APIServiceRegistrationController_retries|APIServiceRegistrationController_unfinished_work_seconds|APIServiceRegistrationController_work_duration|autoregister_adds|autoregister_depth|autoregister_longest_running_processor_microseconds|autoregister_queue_latency|autoregister_retries|autoregister_unfinished_work_seconds|autoregister_work_duration|AvailableConditionController_adds|AvailableConditionController_depth|AvailableConditionController_longest_running_processor_microseconds|AvailableConditionController_queue_latency|AvailableConditionController_retries|AvailableConditionController_unfinished_work_seconds|AvailableConditionController_work_duration|crd_autoregistration_controller_adds|crd_autoregistration_controller_depth|crd_autoregistration_controller_longest_running_processor_microseconds|crd_autoregistration_controller_queue_latency|crd_autoregistration_controller_retries|crd_autoregistration_controller_unfinished_work_seconds|crd_autoregistration_controller_work_duration|crdEstablishing_adds|crdEstablishing_depth|crdEstablishing_longest_running_processor_microseconds|crdEstablishing_queue_latency|crdEstablishing_retries|crdEstablishing_unfinished_work_seconds|crdEstablishing_work_duration|crd_finalizer_adds|crd_finalizer_depth|crd_finalizer_longest_running_processor_microseconds|crd_finalizer_queue_latency|crd_finalizer_retries|crd_finalizer_unfinished_work_seconds|crd_finalizer_work_duration|crd_naming_condition_controller_adds|crd_naming_condition_controller_depth|crd_naming_condition_controller_longest_running_processor_microseconds|crd_naming_condition_controller_queue_latency|crd_naming_condition_controller_retries|crd_naming_condition_controller_unfinished_work_seconds|crd_naming_condition_controller_work_duration|crd_openapi_controller_adds|crd_openapi_controller_depth|crd_openapi_controller_longest_running_processor_microseconds|crd_openapi_controller_queue_latency|crd_openapi_controller_retries|crd_openapi_controller_unfinished_work_seconds|crd_openapi_controller_work_duration|DiscoveryController_adds|DiscoveryController_depth|DiscoveryController_longest_running_processor_microseconds|DiscoveryController_queue_latency|DiscoveryController_retries|DiscoveryController_unfinished_work_seconds|DiscoveryController_work_duration|kubeproxy_sync_proxy_rules_latency_microseconds|non_structural_schema_condition_controller_adds|non_structural_schema_condition_controller_depth|non_structural_schema_condition_controller_longest_running_processor_microseconds|non_structural_schema_condition_controller_queue_latency|non_structural_schema_condition_controller_retries|non_structural_schema_condition_controller_unfinished_work_seconds|non_structural_schema_condition_controller_work_duration|rest_client_request_latency_seconds|storage_operation_errors_total|storage_operation_status_count)
+      sourceLabels:
+      - __name__
+    port: https-metrics
+    relabelings:
+    - sourceLabels:
+      - __metrics_path__
+      targetLabel: metrics_path
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
+    honorTimestamps: false
+    interval: 30s
+    metricRelabelings:
+    - action: drop
+      regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: (container_fs_.*|container_spec_.*|container_blkio_device_usage_total|container_file_descriptors|container_sockets|container_threads_max|container_threads|container_start_time_seconds|container_last_seen);;
+      sourceLabels:
+      - __name__
+      - pod
+      - namespace
+    path: /metrics/cadvisor
+    port: https-metrics
+    relabelings:
+    - sourceLabels:
+      - __metrics_path__
+      targetLabel: metrics_path
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames:
+    - default
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubelet
+
 #
 # Pretend credentials
 #
@@ -139,6 +232,7 @@ rules:
   resources:
   - nodes
   - nodes/proxy
+  - nodes/metrics
   - services
   - endpoints
   - pods
@@ -148,6 +242,7 @@ rules:
   - watch
 - nonResourceURLs:
   - /metrics
+  - /metrics/cadvisor
   verbs:
   - get
 ---

--- a/cmd/agent-operator/example-grafana.yaml
+++ b/cmd/agent-operator/example-grafana.yaml
@@ -103,11 +103,20 @@ data:
   loki.yml: |
     apiVersion: 1
     datasources:
+    - name: prometheus
+      type: prometheus
+      access: proxy
+      url: http://prometheus.default.svc.cluster.local:9090
+      isDefault: true
+      version: 1
+      editable: false
+      jsonData:
+        httpMethod: GET
     - name: loki
       type: loki
       access: proxy
       url: http://loki.default.svc.cluster.local:8080
-      isDefault: true
+      isDefault: false
       version: 1
       editable: false
       jsonData:

--- a/docs/operator/getting-started.md
+++ b/docs/operator/getting-started.md
@@ -63,6 +63,8 @@ spec:
       containers:
       - name: operator
         image: grafana/agent-operator:v0.19.0
+        args:
+        - --kubelet-service=default/kubelet
 ---
 
 apiVersion: v1
@@ -94,12 +96,14 @@ rules:
 - apiGroups: [""]
   resources:
   - namespaces
+  - nodes
   verbs: [get, list, watch]
 - apiGroups: [""]
   resources:
   - secrets
   - services
   - configmaps
+  - endpoints
   verbs: [get, list, watch, create, update, patch, delete]
 - apiGroups: ["apps"]
   resources:
@@ -305,4 +309,103 @@ spec:
       k8s-app: kube-dns
   endpoints:
   - port: metrics
+```
+
+## Monitor Kubelets
+
+The `--kubelet-service=default/kubelet` argument passed to the Grafana Agent
+Operator container tells the Operator to manage a Service called `kubelet` in
+the `default` namespace. The Service will have one endpoint created per Node in
+the cluster, allowing a ServiceMonitor to scrape both Kubelet and cAdvisor
+metrics.
+
+Use the following ServiceMonitor as a base to collect Kubelet and cAdvisor
+metrics:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: kubelet
+    instance: primary
+  name: kubelet
+  namespace: default
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
+    interval: 30s
+    metricRelabelings:
+    - action: drop
+      regex: kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds|network_plugin_operations_latency_microseconds)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: scheduler_(e2e_scheduling_latency_microseconds|scheduling_algorithm_predicate_evaluation|scheduling_algorithm_priority_evaluation|scheduling_algorithm_preemption_evaluation|scheduling_algorithm_latency_microseconds|binding_latency_microseconds|scheduling_latency_seconds)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: apiserver_(request_count|request_latencies|request_latencies_summary|dropped_requests|storage_data_key_generation_latencies_microseconds|storage_transformation_failures_total|storage_transformation_latencies_microseconds|proxy_tunnel_sync_latency_secs)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: kubelet_docker_(operations|operations_latency_microseconds|operations_errors|operations_timeout)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: reflector_(items_per_list|items_per_watch|list_duration_seconds|lists_total|short_watches_total|watch_duration_seconds|watches_total)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: etcd_(helper_cache_hit_count|helper_cache_miss_count|helper_cache_entry_count|object_counts|request_cache_get_latencies_summary|request_cache_add_latencies_summary|request_latencies_summary)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: transformation_(transformation_latencies_microseconds|failures_total)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: (admission_quota_controller_adds|admission_quota_controller_depth|admission_quota_controller_longest_running_processor_microseconds|admission_quota_controller_queue_latency|admission_quota_controller_unfinished_work_seconds|admission_quota_controller_work_duration|APIServiceOpenAPIAggregationControllerQueue1_adds|APIServiceOpenAPIAggregationControllerQueue1_depth|APIServiceOpenAPIAggregationControllerQueue1_longest_running_processor_microseconds|APIServiceOpenAPIAggregationControllerQueue1_queue_latency|APIServiceOpenAPIAggregationControllerQueue1_retries|APIServiceOpenAPIAggregationControllerQueue1_unfinished_work_seconds|APIServiceOpenAPIAggregationControllerQueue1_work_duration|APIServiceRegistrationController_adds|APIServiceRegistrationController_depth|APIServiceRegistrationController_longest_running_processor_microseconds|APIServiceRegistrationController_queue_latency|APIServiceRegistrationController_retries|APIServiceRegistrationController_unfinished_work_seconds|APIServiceRegistrationController_work_duration|autoregister_adds|autoregister_depth|autoregister_longest_running_processor_microseconds|autoregister_queue_latency|autoregister_retries|autoregister_unfinished_work_seconds|autoregister_work_duration|AvailableConditionController_adds|AvailableConditionController_depth|AvailableConditionController_longest_running_processor_microseconds|AvailableConditionController_queue_latency|AvailableConditionController_retries|AvailableConditionController_unfinished_work_seconds|AvailableConditionController_work_duration|crd_autoregistration_controller_adds|crd_autoregistration_controller_depth|crd_autoregistration_controller_longest_running_processor_microseconds|crd_autoregistration_controller_queue_latency|crd_autoregistration_controller_retries|crd_autoregistration_controller_unfinished_work_seconds|crd_autoregistration_controller_work_duration|crdEstablishing_adds|crdEstablishing_depth|crdEstablishing_longest_running_processor_microseconds|crdEstablishing_queue_latency|crdEstablishing_retries|crdEstablishing_unfinished_work_seconds|crdEstablishing_work_duration|crd_finalizer_adds|crd_finalizer_depth|crd_finalizer_longest_running_processor_microseconds|crd_finalizer_queue_latency|crd_finalizer_retries|crd_finalizer_unfinished_work_seconds|crd_finalizer_work_duration|crd_naming_condition_controller_adds|crd_naming_condition_controller_depth|crd_naming_condition_controller_longest_running_processor_microseconds|crd_naming_condition_controller_queue_latency|crd_naming_condition_controller_retries|crd_naming_condition_controller_unfinished_work_seconds|crd_naming_condition_controller_work_duration|crd_openapi_controller_adds|crd_openapi_controller_depth|crd_openapi_controller_longest_running_processor_microseconds|crd_openapi_controller_queue_latency|crd_openapi_controller_retries|crd_openapi_controller_unfinished_work_seconds|crd_openapi_controller_work_duration|DiscoveryController_adds|DiscoveryController_depth|DiscoveryController_longest_running_processor_microseconds|DiscoveryController_queue_latency|DiscoveryController_retries|DiscoveryController_unfinished_work_seconds|DiscoveryController_work_duration|kubeproxy_sync_proxy_rules_latency_microseconds|non_structural_schema_condition_controller_adds|non_structural_schema_condition_controller_depth|non_structural_schema_condition_controller_longest_running_processor_microseconds|non_structural_schema_condition_controller_queue_latency|non_structural_schema_condition_controller_retries|non_structural_schema_condition_controller_unfinished_work_seconds|non_structural_schema_condition_controller_work_duration|rest_client_request_latency_seconds|storage_operation_errors_total|storage_operation_status_count)
+      sourceLabels:
+      - __name__
+    port: https-metrics
+    relabelings:
+    - sourceLabels:
+      - __metrics_path__
+      targetLabel: metrics_path
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
+    honorTimestamps: false
+    interval: 30s
+    metricRelabelings:
+    - action: drop
+      regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: (container_fs_.*|container_spec_.*|container_blkio_device_usage_total|container_file_descriptors|container_sockets|container_threads_max|container_threads|container_start_time_seconds|container_last_seen);;
+      sourceLabels:
+      - __name__
+      - pod
+      - namespace
+    path: /metrics/cadvisor
+    port: https-metrics
+    relabelings:
+    - sourceLabels:
+      - __metrics_path__
+      targetLabel: metrics_path
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames:
+    - default
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubelet
 ```

--- a/pkg/operator/kubelet.go
+++ b/pkg/operator/kubelet.go
@@ -128,5 +128,5 @@ func nodeAddress(node core_v1.Node) (string, error) {
 	if addresses, ok := m[core_v1.NodeExternalIP]; ok {
 		return addresses[0], nil
 	}
-	return "", m, fmt.Errorf("host address unknown")
+	return "", fmt.Errorf("host address unknown")
 }

--- a/pkg/operator/kubelet.go
+++ b/pkg/operator/kubelet.go
@@ -1,0 +1,132 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/grafana/agent/pkg/operator/clientutil"
+	"github.com/grafana/agent/pkg/operator/logutil"
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	controller "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type kubeletReconciler struct {
+	client.Client
+	kubeletNamespace, kubeletName string
+}
+
+func (r *kubeletReconciler) Reconcile(ctx context.Context, req controller.Request) (res controller.Result, err error) {
+	l := logutil.FromContext(ctx)
+	level.Info(l).Log("msg", "reconciling node")
+
+	var nodes core_v1.NodeList
+	if err := r.List(ctx, &nodes); err != nil {
+		level.Error(l).Log("msg", "failed to list nodes for kubelet service", "err", err)
+		return res, fmt.Errorf("unable to list nodes: %w", err)
+	}
+	nodeAddrs, err := getNodeAddrs(l, &nodes)
+	if err != nil {
+		level.Error(l).Log("msg", "could not get addresses from all nodes", "err", err)
+		return res, fmt.Errorf("unable to get addresses from nodes: %w", err)
+	}
+
+	svc := &core_v1.Service{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      r.kubeletName,
+			Namespace: r.kubeletNamespace,
+			Labels:    managedByOperatorLabels,
+		},
+		Spec: core_v1.ServiceSpec{
+			Type:      core_v1.ServiceTypeClusterIP,
+			ClusterIP: "None",
+			Ports: []core_v1.ServicePort{
+				{Name: "https-metrics", Port: 10250},
+				{Name: "http-metrics", Port: 10255},
+				{Name: "cadvisor", Port: 4194},
+			},
+		},
+	}
+
+	eps := &core_v1.Endpoints{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      r.kubeletName,
+			Namespace: r.kubeletNamespace,
+			Labels:    managedByOperatorLabels,
+		},
+		Subsets: []core_v1.EndpointSubset{{
+			Addresses: nodeAddrs,
+			Ports: []core_v1.EndpointPort{
+				// Taken from https://github.com/prometheus-operator/prometheus-operator/blob/2c81b0cf6a5673e08057499a08ddce396b19dda4/pkg/prometheus/operator.go#L593
+				{Name: "https-metrics", Port: 10250},
+				{Name: "http-metrics", Port: 10255},
+				{Name: "cadvisor", Port: 4194},
+			},
+		}},
+	}
+
+	level.Debug(l).Log("msg", "reconciling kubelet service", "svc", client.ObjectKeyFromObject(svc))
+	err = clientutil.CreateOrUpdateService(ctx, r.Client, svc)
+	if err != nil {
+		return res, fmt.Errorf("failed to reconcile kubelet service %s: %w", client.ObjectKeyFromObject(svc), err)
+	}
+
+	level.Debug(l).Log("msg", "reconciling kubelet endpoints", "eps", client.ObjectKeyFromObject(eps))
+	err = clientutil.CreateOrUpdateEndpoints(ctx, r.Client, eps)
+	if err != nil {
+		return res, fmt.Errorf("failed to reconcile kubelet endpoints %s: %w", client.ObjectKeyFromObject(eps), err)
+	}
+
+	return
+}
+
+func getNodeAddrs(l log.Logger, nodes *core_v1.NodeList) (addrs []core_v1.EndpointAddress, err error) {
+	var failed bool
+
+	for _, n := range nodes.Items {
+		addr, err := nodeAddress(n)
+		if err != nil {
+			level.Error(l).Log("msg", "failed to get address from node", "node", n.Name, "err", err)
+			failed = true
+		}
+
+		addrs = append(addrs, core_v1.EndpointAddress{
+			IP: addr,
+			TargetRef: &core_v1.ObjectReference{
+				Kind:       n.Kind,
+				APIVersion: n.APIVersion,
+				Name:       n.Name,
+				UID:        n.UID,
+			},
+		})
+	}
+
+	if failed {
+		return nil, fmt.Errorf("failed to get the address from one or more nodes")
+	}
+	return
+}
+
+// nodeAddresses returns the provided node's address, based on the priority:
+//
+// 1. NodeInternalIP
+// 2. NodeExternalIP
+//
+// Copied from github.com/prometheus/prometheus/discovery/kubernetes/node.go
+func nodeAddress(node core_v1.Node) (string, error) {
+	m := map[core_v1.NodeAddressType][]string{}
+	for _, a := range node.Status.Addresses {
+		m[a.Type] = append(m[a.Type], a.Address)
+	}
+
+	if addresses, ok := m[core_v1.NodeInternalIP]; ok {
+		return addresses[0], nil
+	}
+	if addresses, ok := m[core_v1.NodeExternalIP]; ok {
+		return addresses[0], nil
+	}
+	return "", m, fmt.Errorf("host address unknown")
+}

--- a/pkg/operator/kubelet_test.go
+++ b/pkg/operator/kubelet_test.go
@@ -1,0 +1,121 @@
+// These tests depend on test assets from controller-runtime which don't work on Windows.
+
+// +build !windows,has_network
+
+package operator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/pkg/operator/logutil"
+	"github.com/grafana/agent/pkg/util"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	clog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// TestKubelet tests the Kubelet reconciler.
+func TestKubelet(t *testing.T) {
+	l := util.TestLogger(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	ctx = clog.IntoContext(ctx, logutil.Wrap(l))
+
+	var env envtest.Environment
+	setupEnvtest(t, &env)
+
+	cfg, err := env.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = env.Stop() })
+
+	cli, err := client.New(cfg, client.Options{})
+	require.NoError(t, err)
+
+	nodes := []core_v1.Node{
+		{
+			ObjectMeta: meta_v1.ObjectMeta{Name: "node-a"},
+			Status: core_v1.NodeStatus{
+				Addresses: []core_v1.NodeAddress{
+					{Type: core_v1.NodeInternalIP, Address: "10.0.0.10"},
+				},
+			},
+		},
+		{
+			ObjectMeta: meta_v1.ObjectMeta{Name: "node-b"},
+			Status: core_v1.NodeStatus{
+				Addresses: []core_v1.NodeAddress{
+					{Type: core_v1.NodeExternalIP, Address: "10.24.0.11"},
+				},
+			},
+		},
+		{
+			ObjectMeta: meta_v1.ObjectMeta{Name: "node-c"},
+			Status: core_v1.NodeStatus{
+				Addresses: []core_v1.NodeAddress{
+					{Type: core_v1.NodeExternalIP, Address: "10.24.0.12"},
+					{Type: core_v1.NodeInternalIP, Address: "10.0.0.12"},
+				},
+			},
+		},
+	}
+
+	for _, n := range nodes {
+		err := cli.Create(ctx, &n)
+		require.NoError(t, err)
+	}
+
+	ns := &core_v1.Namespace{
+		ObjectMeta: meta_v1.ObjectMeta{Name: "kube-system"},
+	}
+	_ = cli.Create(ctx, ns)
+
+	r := &kubeletReconciler{
+		Client:           cli,
+		kubeletNamespace: "kube-system",
+		kubeletName:      "kubelet",
+	}
+	_, err = r.Reconcile(ctx, reconcile.Request{})
+	require.NoError(t, err)
+
+	var (
+		eps core_v1.Endpoints
+		svc core_v1.Service
+
+		key = types.NamespacedName{Namespace: r.kubeletNamespace, Name: r.kubeletName}
+	)
+	require.NoError(t, cli.Get(ctx, key, &eps))
+	require.NoError(t, cli.Get(ctx, key, &svc))
+
+	require.Len(t, eps.Subsets, 1)
+
+	expect := map[string]string{
+		"node-a": "10.0.0.10",
+		"node-b": "10.24.0.11",
+
+		// When a node has internal and external IPs, use internal first.
+		"node-c": "10.0.0.12",
+	}
+	for nodeName, expectIP := range expect {
+		var epa *core_v1.EndpointAddress
+
+		for _, addr := range eps.Subsets[0].Addresses {
+			if addr.TargetRef.Name == nodeName {
+				epa = &addr
+				break
+			}
+		}
+
+		require.NotNilf(t, epa, "did not find endpoint address for node %s", nodeName)
+		require.Equalf(t, expectIP, epa.IP, "node %s had incorrect ip address", nodeName)
+	}
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"flag"
 	"fmt"
+	"strings"
 
 	"github.com/go-kit/kit/log"
 	"github.com/weaveworks/common/logging"
@@ -28,11 +29,12 @@ import (
 
 // Config controls the configuration of the Operator.
 type Config struct {
-	LogLevel      logging.Level
-	LogFormat     logging.Format
-	Labels        promop.Labels
-	Controller    controller.Options
-	AgentSelector string
+	LogLevel            logging.Level
+	LogFormat           logging.Format
+	Labels              promop.Labels
+	Controller          controller.Options
+	AgentSelector       string
+	KubelsetServiceName string
 
 	// TODO(rfratto): extra settings from Prometheus Operator:
 	//
@@ -67,6 +69,8 @@ func (c *Config) registerFlags(f *flag.FlagSet) error {
 	f.IntVar(&c.Controller.Port, "listen-port", 9443, "Port to listen on.")
 	f.StringVar(&c.Controller.MetricsBindAddress, "metrics-listen-address", ":8080", "Address to expose Operator metrics on")
 	f.StringVar(&c.Controller.HealthProbeBindAddress, "health-listen-address", "", "Address to expose Operator health probes on")
+
+	f.StringVar(&c.KubelsetServiceName, "kubelet-service", "", "Service and Endpoints objects to write kubelets into. Allows for monitoring Kubelet and cAdvisor metrics using a ServiceMonitor. Must be in format \"namespace/name\". If empty, nothing will be created.")
 
 	// Custom initial values for the endpoint names.
 	c.Controller.ReadinessEndpointName = "/-/ready"
@@ -117,6 +121,29 @@ func New(l log.Logger, c *Config, m manager.Manager) error {
 		agentPredicates = append(agentPredicates, selPredicate)
 	}
 
+	if c.KubelsetServiceName != "" {
+		parts := strings.Split(c.KubelsetServiceName, "/")
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid format for kubelet-service %q, must be formatted as \"namespace/name\"", c.KubelsetServiceName)
+		}
+		kubeletNamespace := parts[0]
+		kubeletName := parts[1]
+
+		err := controller.NewControllerManagedBy(m).
+			For(applyGVK(&core_v1.Node{})).
+			Owns(applyGVK(&core_v1.Service{})).
+			Owns(applyGVK(&core_v1.Endpoints{})).
+			Complete(&kubeletReconciler{
+				Client: m.GetClient(),
+
+				kubeletNamespace: kubeletNamespace,
+				kubeletName:      kubeletName,
+			})
+		if err != nil {
+			return fmt.Errorf("failed to create kubelet controller: %w", err)
+		}
+	}
+
 	err := controller.NewControllerManagedBy(m).
 		For(applyGVK(&grafana_v1alpha1.GrafanaAgent{}), builder.WithPredicates(agentPredicates...)).
 		Owns(applyGVK(&apps_v1.StatefulSet{})).
@@ -139,7 +166,7 @@ func New(l log.Logger, c *Config, m manager.Manager) error {
 			config:        c,
 		})
 	if err != nil {
-		return fmt.Errorf("failed to create controller: %w", err)
+		return fmt.Errorf("failed to create GrafanaAgent controller: %w", err)
 	}
 
 	return nil

--- a/pkg/operator/resources_metrics.go
+++ b/pkg/operator/resources_metrics.go
@@ -22,7 +22,7 @@ const (
 var (
 	minShards                   int32 = 1
 	minReplicas                 int32 = 1
-	managedByOperatorLabel            = "managed-by"
+	managedByOperatorLabel            = "app.kubernetes.io/managed-by"
 	managedByOperatorLabelValue       = "grafana-agent-operator"
 	managedByOperatorLabels           = map[string]string{
 		managedByOperatorLabel: managedByOperatorLabelValue,


### PR DESCRIPTION
#### PR Description 
Enables the operator to manage a Kubelet service, creating one endpoint per node in the cluster. This allows users to define a cAdvisor/Kubelet ServiceMonitor for collecting metrics. Previously, this had to be done by using additional manually-created scrape configs with custom `kubernetes_sd_configs` rules. 

#### Which issue(s) this PR fixes 
Fixes #885.

#### Notes to the Reviewer
This copies the Prometheus Operator default of not providing this behavior OOTB and _must_ be configured by passing the flag. cc @hjet for the Helm charts.

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
