### PR TITLE
Update for `## Deploy GrafanaAgent` clusterrole

### DIFF
--- a/docs/operator/getting-started.md
+++ b/docs/operator/getting-started.md
@@ -184,6 +184,7 @@ rules:
   resources:
   - nodes
   - nodes/proxy
+  - nodes/metrics
   - services
   - endpoints
   - pods
@@ -191,8 +192,17 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
 - nonResourceURLs:
   - /metrics
+  - /metrics/cadvisor
   verbs:
   - get
 


### PR DESCRIPTION
Update `## Deploy GrafanaAgent` section to include additional kubelet metrics.  Reason:  When checking the metrics sent to Grafana Cloud, we noticed that some of kubelet metrics (cpu/memory usage) was missing.  On the agent, we are using the backwards compatibility with the Prometheus Operator CRDs ServiceMonitor and PodMonitor , so that metric instance discovery is exactly as it is with our hosted prometheus.

#### PR Description 
Update `## Deploy GrafanaAgent` section to include additional kubelet metrics.  Reason:  When checking the metrics sent to Grafana Cloud, we noticed that some of kubelet metrics (cpu/memory usage) was missing.  On the agent, we are using the backwards compatibility with the Prometheus Operator CRDs ServiceMonitor and PodMonitor , so that metric instance discovery is exactly as it is with our hosted prometheus.

#### Which issue(s) this PR fixes 
None - documentation update 

#### Notes to the Reviewer
available on slack for any questions or review! 

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
