### PR TITLE
[dev.scraping-service-scalability] Batch the applying of configurations while running in scraping service mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ for specific instructions.
 
 - [BUGFIX] Fix warn-level logging of dropped targets. (@james-callahan)
 
+- [BUGFIX] Batch applying of configurations when running as scraping service for performance. (@mattdurham)
+
 - [CHANGE] Breaking change: reduced verbosity of tracing autologging
   by not logging `STATUS_CODE_UNSET` status codes. (@mapno)
 

--- a/pkg/integrations/manager_test.go
+++ b/pkg/integrations/manager_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/agent/pkg/util"
+
 	"github.com/cortexproject/cortex/pkg/util/test"
 	"github.com/go-kit/kit/log"
 	"github.com/grafana/agent/pkg/integrations/config"
@@ -115,8 +117,8 @@ func TestManager_instanceConfigForIntegration(t *testing.T) {
 	mock := newMockIntegration()
 	icfg := mockConfig{Integration: mock}
 
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory)
-	m, err := NewManager(mockManagerConfig(), log.NewNopLogger(), im, noOpValidator)
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, util.TestLogger(t), mockInstanceFactory)
+	m, err := NewManager(mockManagerConfig(), util.TestLogger(t), im, noOpValidator)
 	require.NoError(t, err)
 	defer m.Stop()
 
@@ -133,13 +135,13 @@ func TestManager_NoIntegrationsScrape(t *testing.T) {
 	mock := newMockIntegration()
 	icfg := mockConfig{Integration: mock}
 
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory)
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, util.TestLogger(t), mockInstanceFactory)
 
 	cfg := mockManagerConfig()
 	cfg.ScrapeIntegrations = false
 	cfg.Integrations = append(cfg.Integrations, &icfg)
 
-	m, err := NewManager(cfg, log.NewNopLogger(), im, noOpValidator)
+	m, err := NewManager(cfg, util.TestLogger(t), im, noOpValidator)
 	require.NoError(t, err)
 	defer m.Stop()
 
@@ -159,12 +161,12 @@ func TestManager_NoIntegrationScrape(t *testing.T) {
 	noScrape := false
 	mock.CommonCfg.ScrapeIntegration = &noScrape
 
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory)
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, util.TestLogger(t), mockInstanceFactory)
 
 	cfg := mockManagerConfig()
 	cfg.Integrations = append(cfg.Integrations, icfg)
 
-	m, err := NewManager(cfg, log.NewNopLogger(), im, noOpValidator)
+	m, err := NewManager(cfg, util.TestLogger(t), im, noOpValidator)
 	require.NoError(t, err)
 	defer m.Stop()
 
@@ -181,8 +183,8 @@ func TestManager_StartsIntegrations(t *testing.T) {
 	cfg := mockManagerConfig()
 	cfg.Integrations = append(cfg.Integrations, icfg)
 
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory)
-	m, err := NewManager(cfg, log.NewNopLogger(), im, noOpValidator)
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, util.TestLogger(t), mockInstanceFactory)
+	m, err := NewManager(cfg, util.TestLogger(t), im, noOpValidator)
 	require.NoError(t, err)
 	defer m.Stop()
 
@@ -203,8 +205,8 @@ func TestManager_RestartsIntegrations(t *testing.T) {
 	cfg := mockManagerConfig()
 	cfg.Integrations = append(cfg.Integrations, icfg)
 
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory)
-	m, err := NewManager(cfg, log.NewNopLogger(), im, noOpValidator)
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, util.TestLogger(t), mockInstanceFactory)
+	m, err := NewManager(cfg, util.TestLogger(t), im, noOpValidator)
 	require.NoError(t, err)
 	defer m.Stop()
 
@@ -222,8 +224,8 @@ func TestManager_GracefulStop(t *testing.T) {
 	cfg := mockManagerConfig()
 	cfg.Integrations = append(cfg.Integrations, icfg)
 
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory)
-	m, err := NewManager(cfg, log.NewNopLogger(), im, noOpValidator)
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, util.TestLogger(t), mockInstanceFactory)
+	m, err := NewManager(cfg, util.TestLogger(t), im, noOpValidator)
 	require.NoError(t, err)
 
 	test.Poll(t, time.Second, 1, func() interface{} {
@@ -246,8 +248,8 @@ func TestManager_IntegrationEnabledToDisabledReload(t *testing.T) {
 	cfg := mockManagerConfig()
 	cfg.Integrations = append(cfg.Integrations, icfg)
 
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory)
-	m, err := NewManager(cfg, log.NewNopLogger(), im, noOpValidator)
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, util.TestLogger(t), mockInstanceFactory)
+	m, err := NewManager(cfg, util.TestLogger(t), im, noOpValidator)
 	require.NoError(t, err)
 
 	// Test for Enabled -> Disabled
@@ -272,8 +274,8 @@ func TestManager_IntegrationDisabledToEnabledReload(t *testing.T) {
 	cfg := mockManagerConfig()
 	cfg.Integrations = append(cfg.Integrations, icfg)
 
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory)
-	m, err := NewManager(cfg, log.NewNopLogger(), im, noOpValidator)
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, util.TestLogger(t), mockInstanceFactory)
+	m, err := NewManager(cfg, util.TestLogger(t), im, noOpValidator)
 	require.NoError(t, err)
 	require.Len(t, m.integrations, 0, "Integration was disabled so should be removed from map")
 	_, err = m.im.GetInstance(mockIntegrationName)
@@ -306,13 +308,13 @@ func TestManager_PromConfigChangeReloads(t *testing.T) {
 	cfg := mockManagerConfig()
 	cfg.Integrations = append(cfg.Integrations, icfg)
 
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, log.NewNopLogger(), mockInstanceFactory)
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, util.TestLogger(t), mockInstanceFactory)
 
 	startingPromConfig := mockPromConfigWithValues(model.Duration(30*time.Second), model.Duration(25*time.Second))
 	cfg.PrometheusGlobalConfig = startingPromConfig
 	validator := PromDefaultsValidator{startingPromConfig}
 
-	m, err := NewManager(cfg, log.NewNopLogger(), im, validator.validate)
+	m, err := NewManager(cfg, util.TestLogger(t), im, validator.validate)
 	require.NoError(t, err)
 	require.Len(t, m.im.ListConfigs(), 1, "Integration was enabled so should be here")
 	//The integration never has the prom config overrides happen so go after the running instance config instead

--- a/pkg/integrations/manager_test.go
+++ b/pkg/integrations/manager_test.go
@@ -116,9 +116,10 @@ agent:
 func TestManager_instanceConfigForIntegration(t *testing.T) {
 	mock := newMockIntegration()
 	icfg := mockConfig{Integration: mock}
+	testLogger := util.TestLogger(t)
 
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, util.TestLogger(t), mockInstanceFactory)
-	m, err := NewManager(mockManagerConfig(), util.TestLogger(t), im, noOpValidator)
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, testLogger, mockInstanceFactory)
+	m, err := NewManager(mockManagerConfig(), testLogger, im, noOpValidator)
 	require.NoError(t, err)
 	defer m.Stop()
 
@@ -135,13 +136,15 @@ func TestManager_NoIntegrationsScrape(t *testing.T) {
 	mock := newMockIntegration()
 	icfg := mockConfig{Integration: mock}
 
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, util.TestLogger(t), mockInstanceFactory)
+	testLogger := util.TestLogger(t)
+
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, testLogger, mockInstanceFactory)
 
 	cfg := mockManagerConfig()
 	cfg.ScrapeIntegrations = false
 	cfg.Integrations = append(cfg.Integrations, &icfg)
 
-	m, err := NewManager(cfg, util.TestLogger(t), im, noOpValidator)
+	m, err := NewManager(cfg, testLogger, im, noOpValidator)
 	require.NoError(t, err)
 	defer m.Stop()
 
@@ -161,12 +164,14 @@ func TestManager_NoIntegrationScrape(t *testing.T) {
 	noScrape := false
 	mock.CommonCfg.ScrapeIntegration = &noScrape
 
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, util.TestLogger(t), mockInstanceFactory)
+	testLogger := util.TestLogger(t)
+
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, testLogger, mockInstanceFactory)
 
 	cfg := mockManagerConfig()
 	cfg.Integrations = append(cfg.Integrations, icfg)
 
-	m, err := NewManager(cfg, util.TestLogger(t), im, noOpValidator)
+	m, err := NewManager(cfg, testLogger, im, noOpValidator)
 	require.NoError(t, err)
 	defer m.Stop()
 
@@ -183,8 +188,10 @@ func TestManager_StartsIntegrations(t *testing.T) {
 	cfg := mockManagerConfig()
 	cfg.Integrations = append(cfg.Integrations, icfg)
 
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, util.TestLogger(t), mockInstanceFactory)
-	m, err := NewManager(cfg, util.TestLogger(t), im, noOpValidator)
+	testLogger := util.TestLogger(t)
+
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, testLogger, mockInstanceFactory)
+	m, err := NewManager(cfg, testLogger, im, noOpValidator)
 	require.NoError(t, err)
 	defer m.Stop()
 
@@ -205,8 +212,10 @@ func TestManager_RestartsIntegrations(t *testing.T) {
 	cfg := mockManagerConfig()
 	cfg.Integrations = append(cfg.Integrations, icfg)
 
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, util.TestLogger(t), mockInstanceFactory)
-	m, err := NewManager(cfg, util.TestLogger(t), im, noOpValidator)
+	testLogger := util.TestLogger(t)
+
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, testLogger, mockInstanceFactory)
+	m, err := NewManager(cfg, testLogger, im, noOpValidator)
 	require.NoError(t, err)
 	defer m.Stop()
 
@@ -224,8 +233,10 @@ func TestManager_GracefulStop(t *testing.T) {
 	cfg := mockManagerConfig()
 	cfg.Integrations = append(cfg.Integrations, icfg)
 
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, util.TestLogger(t), mockInstanceFactory)
-	m, err := NewManager(cfg, util.TestLogger(t), im, noOpValidator)
+	testLogger := util.TestLogger(t)
+
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, testLogger, mockInstanceFactory)
+	m, err := NewManager(cfg, testLogger, im, noOpValidator)
 	require.NoError(t, err)
 
 	test.Poll(t, time.Second, 1, func() interface{} {
@@ -248,8 +259,10 @@ func TestManager_IntegrationEnabledToDisabledReload(t *testing.T) {
 	cfg := mockManagerConfig()
 	cfg.Integrations = append(cfg.Integrations, icfg)
 
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, util.TestLogger(t), mockInstanceFactory)
-	m, err := NewManager(cfg, util.TestLogger(t), im, noOpValidator)
+	testLogger := util.TestLogger(t)
+
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, testLogger, mockInstanceFactory)
+	m, err := NewManager(cfg, testLogger, im, noOpValidator)
 	require.NoError(t, err)
 
 	// Test for Enabled -> Disabled
@@ -274,8 +287,10 @@ func TestManager_IntegrationDisabledToEnabledReload(t *testing.T) {
 	cfg := mockManagerConfig()
 	cfg.Integrations = append(cfg.Integrations, icfg)
 
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, util.TestLogger(t), mockInstanceFactory)
-	m, err := NewManager(cfg, util.TestLogger(t), im, noOpValidator)
+	testLogger := util.TestLogger(t)
+
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, testLogger, mockInstanceFactory)
+	m, err := NewManager(cfg, testLogger, im, noOpValidator)
 	require.NoError(t, err)
 	require.Len(t, m.integrations, 0, "Integration was disabled so should be removed from map")
 	_, err = m.im.GetInstance(mockIntegrationName)
@@ -308,13 +323,15 @@ func TestManager_PromConfigChangeReloads(t *testing.T) {
 	cfg := mockManagerConfig()
 	cfg.Integrations = append(cfg.Integrations, icfg)
 
-	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, util.TestLogger(t), mockInstanceFactory)
+	testLogger := util.TestLogger(t)
+
+	im := instance.NewBasicManager(instance.DefaultBasicManagerConfig, testLogger, mockInstanceFactory)
 
 	startingPromConfig := mockPromConfigWithValues(model.Duration(30*time.Second), model.Duration(25*time.Second))
 	cfg.PrometheusGlobalConfig = startingPromConfig
 	validator := PromDefaultsValidator{startingPromConfig}
 
-	m, err := NewManager(cfg, util.TestLogger(t), im, validator.validate)
+	m, err := NewManager(cfg, testLogger, im, validator.validate)
 	require.NoError(t, err)
 	require.Len(t, m.im.ListConfigs(), 1, "Integration was enabled so should be here")
 	//The integration never has the prom config overrides happen so go after the running instance config instead

--- a/pkg/logs/logs_test.go
+++ b/pkg/logs/logs_test.go
@@ -58,7 +58,7 @@ func TestLogs(t *testing.T) {
 	})
 	go func() {
 		_ = http.Serve(lis, http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-			req, err := loki_util.ParseRequest(log.NewNopLogger(), "user_id", r)
+			req, err := loki_util.ParseRequest(util.TestLogger(t), "user_id", r)
 			require.NoError(t, err)
 
 			pushes <- req
@@ -91,7 +91,7 @@ configs:
 	dec.SetStrict(true)
 	require.NoError(t, dec.Decode(&cfg))
 
-	logger := log.NewSyncLogger(log.NewNopLogger())
+	logger := log.NewSyncLogger(util.TestLogger(t))
 	l, err := New(prometheus.NewRegistry(), &cfg, logger)
 	require.NoError(t, err)
 	defer l.Stop()

--- a/pkg/metrics/agent_test.go
+++ b/pkg/metrics/agent_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/agent/pkg/util"
+
 	"github.com/cortexproject/cortex/pkg/util/test"
 	"github.com/go-kit/kit/log"
 	"github.com/grafana/agent/pkg/metrics/instance"
@@ -126,7 +128,7 @@ func TestAgent(t *testing.T) {
 
 	fact := newFakeInstanceFactory()
 
-	a, err := newAgent(prometheus.NewRegistry(), cfg, log.NewNopLogger(), fact.factory)
+	a, err := newAgent(prometheus.NewRegistry(), cfg, util.TestLogger(t), fact.factory)
 	require.NoError(t, err)
 
 	test.Poll(t, time.Second*30, true, func() interface{} {
@@ -187,7 +189,7 @@ func TestAgent_NormalInstanceExits(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			fact := newFakeInstanceFactory()
 
-			a, err := newAgent(prometheus.NewRegistry(), cfg, log.NewNopLogger(), fact.factory)
+			a, err := newAgent(prometheus.NewRegistry(), cfg, util.TestLogger(t), fact.factory)
 			require.NoError(t, err)
 
 			test.Poll(t, time.Second*30, true, func() interface{} {
@@ -231,7 +233,7 @@ func TestAgent_Stop(t *testing.T) {
 
 	fact := newFakeInstanceFactory()
 
-	a, err := newAgent(prometheus.NewRegistry(), cfg, log.NewNopLogger(), fact.factory)
+	a, err := newAgent(prometheus.NewRegistry(), cfg, util.TestLogger(t), fact.factory)
 	require.NoError(t, err)
 
 	test.Poll(t, time.Second*30, true, func() interface{} {

--- a/pkg/metrics/cluster/config_watcher_test.go
+++ b/pkg/metrics/cluster/config_watcher_test.go
@@ -234,8 +234,7 @@ type mockConfigManager struct {
 	mock.Mock
 }
 
-func (m *mockConfigManager) ApplyConfigs(configs []instance.Config) instance.BatchApplyResult {
-	successful := make([]instance.Config, 0)
+func (m *mockConfigManager) ApplyConfigs(configs []instance.Config) *instance.BatchApplyError {
 	failed := make([]instance.BatchFailure, 0)
 	for _, v := range configs {
 		err := m.ApplyConfig(v)
@@ -244,14 +243,9 @@ func (m *mockConfigManager) ApplyConfigs(configs []instance.Config) instance.Bat
 				Err:    err,
 				Config: v,
 			})
-		} else {
-			successful = append(successful, v)
 		}
 	}
-	return instance.BatchApplyResult{
-		Failed:     failed,
-		Successful: successful,
-	}
+	return instance.CreateBatchApplyErrorOrNil(failed, nil)
 }
 
 func (m *mockConfigManager) GetInstance(name string) (instance.ManagedInstance, error) {

--- a/pkg/metrics/cluster/config_watcher_test.go
+++ b/pkg/metrics/cluster/config_watcher_test.go
@@ -234,7 +234,7 @@ type mockConfigManager struct {
 	mock.Mock
 }
 
-func (m *mockConfigManager) ApplyConfigs(configs []instance.Config) (err error, successful []instance.Config, failed []instance.Config) {
+func (m *mockConfigManager) ApplyConfigs(configs []instance.Config) (successful []instance.Config, failed []instance.Config, err error) {
 	successful = make([]instance.Config, 0)
 	failed = make([]instance.Config, 0)
 
@@ -247,7 +247,7 @@ func (m *mockConfigManager) ApplyConfigs(configs []instance.Config) (err error, 
 			successful = append(successful, v)
 		}
 	}
-	return err, successful, failed
+	return successful, failed, err
 }
 
 func (m *mockConfigManager) GetInstance(name string) (instance.ManagedInstance, error) {

--- a/pkg/metrics/cluster/config_watcher_test.go
+++ b/pkg/metrics/cluster/config_watcher_test.go
@@ -234,6 +234,22 @@ type mockConfigManager struct {
 	mock.Mock
 }
 
+func (m *mockConfigManager) ApplyConfigs(configs []instance.Config) (err error, successful []instance.Config, failed []instance.Config) {
+	successful = make([]instance.Config, 0)
+	failed = make([]instance.Config, 0)
+
+	for _, v := range configs {
+		applyError := m.ApplyConfig(v)
+		if applyError != nil {
+			err = applyError
+			failed = append(failed, v)
+		} else {
+			successful = append(successful, v)
+		}
+	}
+	return err, successful, failed
+}
+
 func (m *mockConfigManager) GetInstance(name string) (instance.ManagedInstance, error) {
 	args := m.Mock.Called()
 	return args.Get(0).(instance.ManagedInstance), args.Error(1)

--- a/pkg/metrics/cluster/config_watcher_test.go
+++ b/pkg/metrics/cluster/config_watcher_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -234,7 +235,9 @@ type mockConfigManager struct {
 	mock.Mock
 }
 
-func (m *mockConfigManager) ApplyConfigs(configs []instance.Config) error { return nil }
+func (m *mockConfigManager) ApplyConfigs(_ []instance.Config) error {
+	panic(errors.New("ApplyConfigs should not be called"))
+}
 
 func (m *mockConfigManager) GetInstance(name string) (instance.ManagedInstance, error) {
 	args := m.Mock.Called()

--- a/pkg/metrics/cluster/config_watcher_test.go
+++ b/pkg/metrics/cluster/config_watcher_test.go
@@ -234,20 +234,24 @@ type mockConfigManager struct {
 	mock.Mock
 }
 
-func (m *mockConfigManager) ApplyConfigs(configs []instance.Config) (successful []instance.Config, failed []instance.Config, err error) {
-	successful = make([]instance.Config, 0)
-	failed = make([]instance.Config, 0)
-
+func (m *mockConfigManager) ApplyConfigs(configs []instance.Config) instance.BatchApplyResult {
+	successful := make([]instance.Config, 0)
+	failed := make([]instance.BatchFailure, 0)
 	for _, v := range configs {
-		applyError := m.ApplyConfig(v)
-		if applyError != nil {
-			err = applyError
-			failed = append(failed, v)
+		err := m.ApplyConfig(v)
+		if err != nil {
+			failed = append(failed, instance.BatchFailure{
+				Err:    err,
+				Config: v,
+			})
 		} else {
 			successful = append(successful, v)
 		}
 	}
-	return successful, failed, err
+	return instance.BatchApplyResult{
+		Failed:     failed,
+		Successful: successful,
+	}
 }
 
 func (m *mockConfigManager) GetInstance(name string) (instance.ManagedInstance, error) {

--- a/pkg/metrics/cluster/config_watcher_test.go
+++ b/pkg/metrics/cluster/config_watcher_test.go
@@ -234,7 +234,7 @@ type mockConfigManager struct {
 	mock.Mock
 }
 
-func (m *mockConfigManager) ApplyConfigs(configs []instance.Config) *instance.BatchApplyError {
+func (m *mockConfigManager) ApplyConfigs(configs []instance.Config) error {
 	failed := make([]instance.BatchFailure, 0)
 	for _, v := range configs {
 		err := m.ApplyConfig(v)

--- a/pkg/metrics/cluster/config_watcher_test.go
+++ b/pkg/metrics/cluster/config_watcher_test.go
@@ -234,9 +234,7 @@ type mockConfigManager struct {
 	mock.Mock
 }
 
-func (m *mockConfigManager) ApplyConfigs(configs []instance.Config) error {
-	return m.ApplyConfigs(configs)
-}
+func (m *mockConfigManager) ApplyConfigs(configs []instance.Config) error { return nil }
 
 func (m *mockConfigManager) GetInstance(name string) (instance.ManagedInstance, error) {
 	args := m.Mock.Called()

--- a/pkg/metrics/cluster/config_watcher_test.go
+++ b/pkg/metrics/cluster/config_watcher_test.go
@@ -235,17 +235,7 @@ type mockConfigManager struct {
 }
 
 func (m *mockConfigManager) ApplyConfigs(configs []instance.Config) error {
-	failed := make([]instance.BatchFailure, 0)
-	for _, v := range configs {
-		err := m.ApplyConfig(v)
-		if err != nil {
-			failed = append(failed, instance.BatchFailure{
-				Err:    err,
-				Config: v,
-			})
-		}
-	}
-	return instance.CreateBatchApplyErrorOrNil(failed, nil)
+	return m.ApplyConfigs(configs)
 }
 
 func (m *mockConfigManager) GetInstance(name string) (instance.ManagedInstance, error) {

--- a/pkg/metrics/http_test.go
+++ b/pkg/metrics/http_test.go
@@ -8,8 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/agent/pkg/util"
+
 	"github.com/cortexproject/cortex/pkg/util/test"
-	"github.com/go-kit/kit/log"
 	"github.com/grafana/agent/pkg/metrics/instance"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -23,7 +24,7 @@ func TestAgent_ListInstancesHandler(t *testing.T) {
 	fact := newFakeInstanceFactory()
 	a, err := newAgent(prometheus.NewRegistry(), Config{
 		WALDir: "/tmp/agent",
-	}, log.NewNopLogger(), fact.factory)
+	}, util.TestLogger(t), fact.factory)
 	require.NoError(t, err)
 	defer a.Stop()
 
@@ -53,7 +54,7 @@ func TestAgent_ListTargetsHandler(t *testing.T) {
 	fact := newFakeInstanceFactory()
 	a, err := newAgent(prometheus.NewRegistry(), Config{
 		WALDir: "/tmp/agent",
-	}, log.NewNopLogger(), fact.factory)
+	}, util.TestLogger(t), fact.factory)
 	require.NoError(t, err)
 
 	mockManager := &instance.MockManager{

--- a/pkg/metrics/instance/batchapplyerror.go
+++ b/pkg/metrics/instance/batchapplyerror.go
@@ -1,0 +1,63 @@
+package instance
+
+import "fmt"
+
+// BatchApplyError contains the failed configs with error, successful configurations, and then if there is an error
+// that is not tied to a specific config then NonConfigError contains it
+type BatchApplyError struct {
+	Failed []BatchFailure
+	// NonConfigError is used when the error is not with a specific configuration, but likely the grouping
+	// or applying the group.
+	NonConfigError error
+}
+
+// BatchFailure for a given config has the associated error
+type BatchFailure struct {
+	Err    error
+	Config Config
+}
+
+// CreateBatchApplyErrorOrNil will create an error if failed has > 0 elements on nonConfigError is not nil, else will
+// return nil
+func CreateBatchApplyErrorOrNil(failed []BatchFailure, nonConfigError error) *BatchApplyError {
+	if len(failed) == 0 && nonConfigError == nil {
+		return nil
+	}
+	return &BatchApplyError{
+		Failed:         failed,
+		NonConfigError: nonConfigError,
+	}
+}
+
+// FindSuccessfulConfigs will take the list of all configs and compare them against the failed
+// return the successful based on name
+func FindSuccessfulConfigs(e *BatchApplyError, allConfigs []Config) []Config {
+	if e == nil || len(e.Failed) == 0 {
+		return allConfigs
+	}
+	succeeded := make([]Config, 0)
+	// Need to get the list of successful configs that were applied
+	for _, c := range allConfigs {
+		var didFail = false
+		for _, failed := range e.Failed {
+			if failed.Config.Name == c.Name {
+				didFail = true
+				break
+			}
+
+		}
+		if didFail {
+			continue
+		}
+		succeeded = append(succeeded, c)
+	}
+
+	return succeeded
+}
+
+func (e *BatchApplyError) Error() string {
+	if len(e.Failed) == 0 && e.NonConfigError == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d configs failed to apply. Non config error %s ", len(e.Failed), e.NonConfigError)
+}

--- a/pkg/metrics/instance/batchapplyerror.go
+++ b/pkg/metrics/instance/batchapplyerror.go
@@ -13,8 +13,8 @@ type BatchApplyError struct {
 
 // BatchFailure for a given config has the associated error
 type BatchFailure struct {
-	Err    error
-	Config Config
+	Err        error
+	ConfigName string
 }
 
 // CreateBatchApplyErrorOrNil will create an error if failed has > 0 elements on nonConfigError is not nil, else will
@@ -40,7 +40,7 @@ func FindSuccessfulConfigs(e *BatchApplyError, allConfigs []Config) []Config {
 	for _, c := range allConfigs {
 		var didFail = false
 		for _, failed := range e.Failed {
-			if failed.Config.Name == c.Name {
+			if failed.ConfigName == c.Name {
 				didFail = true
 				break
 			}

--- a/pkg/metrics/instance/batchapplyerror.go
+++ b/pkg/metrics/instance/batchapplyerror.go
@@ -19,7 +19,7 @@ func FindSuccessfulConfigs(e *BatchApplyError, allConfigs []Config) []Config {
 	if e == nil || len(e.Failed) == 0 {
 		return allConfigs
 	}
-	succeeded := make([]Config, 0)
+	var succeeded []Config
 	// Need to get the list of successful configs that were applied
 	for _, c := range allConfigs {
 		var didFail = false

--- a/pkg/metrics/instance/batchapplyerror.go
+++ b/pkg/metrics/instance/batchapplyerror.go
@@ -19,7 +19,7 @@ type BatchFailure struct {
 
 // CreateBatchApplyErrorOrNil will create an error if failed has > 0 elements on nonConfigError is not nil, else will
 // return nil
-func CreateBatchApplyErrorOrNil(failed []BatchFailure, nonConfigError error) *BatchApplyError {
+func CreateBatchApplyErrorOrNil(failed []BatchFailure, nonConfigError error) error {
 	if len(failed) == 0 && nonConfigError == nil {
 		return nil
 	}
@@ -55,7 +55,7 @@ func FindSuccessfulConfigs(e *BatchApplyError, allConfigs []Config) []Config {
 	return succeeded
 }
 
-func (e *BatchApplyError) Error() string {
+func (e BatchApplyError) Error() string {
 	if len(e.Failed) == 0 && e.NonConfigError == nil {
 		return ""
 	}

--- a/pkg/metrics/instance/batchapplyerror.go
+++ b/pkg/metrics/instance/batchapplyerror.go
@@ -15,7 +15,7 @@ type BatchFailure struct {
 
 // FindSuccessfulConfigs will take the list of all configs and compare them against the failed
 // return the successful based on name
-func FindSuccessfulConfigs(e *BatchApplyError, allConfigs []Config) []Config {
+func (e *BatchApplyError) FindSuccessfulConfigs(allConfigs []Config) []Config {
 	if e == nil || len(e.Failed) == 0 {
 		return allConfigs
 	}

--- a/pkg/metrics/instance/batchapplyerror.go
+++ b/pkg/metrics/instance/batchapplyerror.go
@@ -2,31 +2,15 @@ package instance
 
 import "fmt"
 
-// BatchApplyError contains the failed configs with error, successful configurations, and then if there is an error
-// that is not tied to a specific config then NonConfigError contains it
+// BatchApplyError contains the failed configs with error, successful configurations
 type BatchApplyError struct {
 	Failed []BatchFailure
-	// NonConfigError is used when the error is not with a specific configuration, but likely the grouping
-	// or applying the group.
-	NonConfigError error
 }
 
 // BatchFailure for a given config has the associated error
 type BatchFailure struct {
 	Err        error
 	ConfigName string
-}
-
-// CreateBatchApplyErrorOrNil will create an error if failed has > 0 elements on nonConfigError is not nil, else will
-// return nil
-func CreateBatchApplyErrorOrNil(failed []BatchFailure, nonConfigError error) error {
-	if len(failed) == 0 && nonConfigError == nil {
-		return nil
-	}
-	return &BatchApplyError{
-		Failed:         failed,
-		NonConfigError: nonConfigError,
-	}
 }
 
 // FindSuccessfulConfigs will take the list of all configs and compare them against the failed
@@ -56,8 +40,8 @@ func FindSuccessfulConfigs(e *BatchApplyError, allConfigs []Config) []Config {
 }
 
 func (e BatchApplyError) Error() string {
-	if len(e.Failed) == 0 && e.NonConfigError == nil {
+	if len(e.Failed) == 0 {
 		return ""
 	}
-	return fmt.Sprintf("%d configs failed to apply. Non config error %s ", len(e.Failed), e.NonConfigError)
+	return fmt.Sprintf("%d configs failed to apply", len(e.Failed))
 }

--- a/pkg/metrics/instance/configstore/api_test.go
+++ b/pkg/metrics/instance/configstore/api_test.go
@@ -10,7 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/grafana/agent/pkg/util"
+
 	"github.com/gorilla/mux"
 	"github.com/grafana/agent/pkg/client"
 	"github.com/grafana/agent/pkg/metrics/cluster/configapi"
@@ -26,7 +27,7 @@ func TestAPI_ListConfigurations(t *testing.T) {
 		},
 	}
 
-	api := NewAPI(log.NewNopLogger(), s, nil)
+	api := NewAPI(util.TestLogger(t), s, nil)
 	env := newAPITestEnvironment(t, api)
 
 	resp, err := http.Get(env.srv.URL + "/agent/api/v1/configs")
@@ -60,7 +61,7 @@ func TestAPI_GetConfiguration_Invalid(t *testing.T) {
 		},
 	}
 
-	api := NewAPI(log.NewNopLogger(), s, nil)
+	api := NewAPI(util.TestLogger(t), s, nil)
 	env := newAPITestEnvironment(t, api)
 
 	resp, err := http.Get(env.srv.URL + "/agent/api/v1/configs/does-not-exist")
@@ -96,7 +97,7 @@ func TestAPI_GetConfiguration(t *testing.T) {
 		},
 	}
 
-	api := NewAPI(log.NewNopLogger(), s, nil)
+	api := NewAPI(util.TestLogger(t), s, nil)
 	env := newAPITestEnvironment(t, api)
 
 	resp, err := http.Get(env.srv.URL + "/agent/api/v1/configs/exists")
@@ -131,7 +132,7 @@ func TestAPI_GetConfiguration(t *testing.T) {
 func TestServer_PutConfiguration(t *testing.T) {
 	var s Mock
 
-	api := NewAPI(log.NewNopLogger(), &s, nil)
+	api := NewAPI(util.TestLogger(t), &s, nil)
 	env := newAPITestEnvironment(t, api)
 
 	cfg := instance.Config{Name: "newconfig"}
@@ -164,7 +165,7 @@ func TestServer_PutConfiguration(t *testing.T) {
 func TestServer_PutConfiguration_Invalid(t *testing.T) {
 	var s Mock
 
-	api := NewAPI(log.NewNopLogger(), &s, func(c *instance.Config) error {
+	api := NewAPI(util.TestLogger(t), &s, func(c *instance.Config) error {
 		return fmt.Errorf("custom validation error")
 	})
 	env := newAPITestEnvironment(t, api)
@@ -190,7 +191,7 @@ func TestServer_PutConfiguration_Invalid(t *testing.T) {
 
 func TestServer_PutConfiguration_WithClient(t *testing.T) {
 	var s Mock
-	api := NewAPI(log.NewNopLogger(), &s, nil)
+	api := NewAPI(util.TestLogger(t), &s, nil)
 	env := newAPITestEnvironment(t, api)
 
 	cfg := instance.DefaultConfig
@@ -216,7 +217,7 @@ func TestServer_DeleteConfiguration(t *testing.T) {
 		},
 	}
 
-	api := NewAPI(log.NewNopLogger(), s, nil)
+	api := NewAPI(util.TestLogger(t), s, nil)
 	env := newAPITestEnvironment(t, api)
 
 	req, err := http.NewRequest(http.MethodDelete, env.srv.URL+"/agent/api/v1/config/deleteme", nil)
@@ -235,7 +236,7 @@ func TestServer_DeleteConfiguration(t *testing.T) {
 func TestServer_URLEncoded(t *testing.T) {
 	var s Mock
 
-	api := NewAPI(log.NewNopLogger(), &s, nil)
+	api := NewAPI(util.TestLogger(t), &s, nil)
 	env := newAPITestEnvironment(t, api)
 
 	var cfg instance.Config

--- a/pkg/metrics/instance/configstore/remote_test.go
+++ b/pkg/metrics/instance/configstore/remote_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
 	"github.com/grafana/agent/pkg/metrics/instance"
 	"github.com/grafana/agent/pkg/metrics/instance/configstore/kv"
 	"github.com/grafana/agent/pkg/util"
@@ -17,7 +16,7 @@ import (
 )
 
 func TestRemote_List(t *testing.T) {
-	remote, err := NewRemote(log.NewNopLogger(), prometheus.NewRegistry(), kv.Config{
+	remote, err := NewRemote(util.TestLogger(t), prometheus.NewRegistry(), kv.Config{
 		Store:  "inmemory",
 		Prefix: "configs/",
 	}, true)
@@ -42,7 +41,7 @@ func TestRemote_List(t *testing.T) {
 }
 
 func TestRemote_Get(t *testing.T) {
-	remote, err := NewRemote(log.NewNopLogger(), prometheus.NewRegistry(), kv.Config{
+	remote, err := NewRemote(util.TestLogger(t), prometheus.NewRegistry(), kv.Config{
 		Store:  "inmemory",
 		Prefix: "configs/",
 	}, true)
@@ -66,7 +65,7 @@ func TestRemote_Get(t *testing.T) {
 }
 
 func TestRemote_Put(t *testing.T) {
-	remote, err := NewRemote(log.NewNopLogger(), prometheus.NewRegistry(), kv.Config{
+	remote, err := NewRemote(util.TestLogger(t), prometheus.NewRegistry(), kv.Config{
 		Store:  "inmemory",
 		Prefix: "configs/",
 	}, true)
@@ -119,7 +118,7 @@ scrape_configs:
 	conflictingBCfg, err := instance.UnmarshalConfig(strings.NewReader(conflictingB))
 	require.NoError(t, err)
 
-	remote, err := NewRemote(log.NewNopLogger(), prometheus.NewRegistry(), kv.Config{
+	remote, err := NewRemote(util.TestLogger(t), prometheus.NewRegistry(), kv.Config{
 		Store:  "inmemory",
 		Prefix: "configs/",
 	}, true)
@@ -138,7 +137,7 @@ scrape_configs:
 }
 
 func TestRemote_Delete(t *testing.T) {
-	remote, err := NewRemote(log.NewNopLogger(), prometheus.NewRegistry(), kv.Config{
+	remote, err := NewRemote(util.TestLogger(t), prometheus.NewRegistry(), kv.Config{
 		Store:  "inmemory",
 		Prefix: "configs/",
 	}, true)
@@ -166,7 +165,7 @@ func TestRemote_Delete(t *testing.T) {
 }
 
 func TestRemote_All(t *testing.T) {
-	remote, err := NewRemote(log.NewNopLogger(), prometheus.NewRegistry(), kv.Config{
+	remote, err := NewRemote(util.TestLogger(t), prometheus.NewRegistry(), kv.Config{
 		Store:  "inmemory",
 		Prefix: "all-configs/",
 	}, true)
@@ -197,7 +196,7 @@ func TestRemote_All(t *testing.T) {
 }
 
 func TestRemote_Watch(t *testing.T) {
-	remote, err := NewRemote(log.NewNopLogger(), prometheus.NewRegistry(), kv.Config{
+	remote, err := NewRemote(util.TestLogger(t), prometheus.NewRegistry(), kv.Config{
 		Store:  "inmemory",
 		Prefix: "watch-configs/",
 	}, true)
@@ -234,7 +233,7 @@ func TestRemote_Watch(t *testing.T) {
 }
 
 func TestRemote_ApplyConfig(t *testing.T) {
-	remote, err := NewRemote(log.NewNopLogger(), prometheus.NewRegistry(), kv.Config{
+	remote, err := NewRemote(util.TestLogger(t), prometheus.NewRegistry(), kv.Config{
 		Store:  "inmemory",
 		Prefix: "test-applyconfig/",
 	}, true)

--- a/pkg/metrics/instance/group_manager.go
+++ b/pkg/metrics/instance/group_manager.go
@@ -271,17 +271,7 @@ func (m *GroupManager) ListConfigs() map[string]Config {
 // exists, the group will have its settings merged with the Config and
 // will be updated.
 func (m *GroupManager) ApplyConfig(c Config) error {
-	cfgs := []Config{c}
-	err := m.ApplyConfigs(cfgs)
-	var bae BatchApplyError
-
-	if err != nil && errors.As(err, &bae) {
-		if len(bae.Failed) > 0 {
-			return bae.Failed[0].Err
-		}
-	}
-
-	return nil
+	return m.ApplyConfigs([]Config{c})
 }
 
 // DeleteConfig will remove a Config from its associated group. If there are

--- a/pkg/metrics/instance/group_manager.go
+++ b/pkg/metrics/instance/group_manager.go
@@ -101,9 +101,9 @@ func (m *GroupManager) applyConfigs(configs []Config, isRollback bool) error {
 	}
 	mergedHashes := make(map[string]int)
 	// The whole batch fails or succeeds here, so precompute if failures happen
-	var failedConfigs []BatchFailure
+	var groupFailedConfigs []BatchFailure
 	for _, c := range configs {
-		failedConfigs = append(failedConfigs, BatchFailure{
+		groupFailedConfigs = append(groupFailedConfigs, BatchFailure{
 			Err:        errors.New("failed during batch apply"),
 			ConfigName: c.Name,
 		})
@@ -115,7 +115,7 @@ func (m *GroupManager) applyConfigs(configs []Config, isRollback bool) error {
 			return err
 		} else if err != nil {
 			m.rollbackConfigs(oldConfigs)
-			return &BatchApplyError{Failed: failedConfigs}
+			return &BatchApplyError{Failed: groupFailedConfigs}
 		}
 		newHash, err := createMergedConfigHash(mergedConfig)
 
@@ -125,7 +125,7 @@ func (m *GroupManager) applyConfigs(configs []Config, isRollback bool) error {
 			return err
 		} else if err != nil {
 			m.rollbackConfigs(oldConfigs)
-			return &BatchApplyError{Failed: failedConfigs}
+			return &BatchApplyError{Failed: groupFailedConfigs}
 		}
 
 		// If we have the exact same config no need to reload it
@@ -139,7 +139,7 @@ func (m *GroupManager) applyConfigs(configs []Config, isRollback bool) error {
 			return err
 		} else if err != nil {
 			m.rollbackConfigs(oldConfigs)
-			return &BatchApplyError{Failed: failedConfigs}
+			return &BatchApplyError{Failed: groupFailedConfigs}
 		}
 	}
 	m.groups = groupsInConfigs

--- a/pkg/metrics/instance/group_manager.go
+++ b/pkg/metrics/instance/group_manager.go
@@ -67,8 +67,8 @@ func (m *GroupManager) applyConfigs(configs []Config, isRollback bool) error {
 	// Combined group of current and new configs
 	combinedConfigs := m.getCombinedConfigs(configs)
 
-	var oldConfigs []Config
 	// In case of an error in applying the new configs, we need to grab the old config for rollback
+	oldConfigs := make([]Config, len(m.activeConfigs))
 	copy(oldConfigs, m.activeConfigs)
 	var activeConfigs []Config
 	groupLookup := make(map[string]string)
@@ -174,6 +174,10 @@ func createMergedConfigHash(mergedConfig Config) (string, error) {
 // internal state is left corrupted since we've completely lost a
 // config.
 func (m *GroupManager) rollbackConfigs(oldConfigs []Config) {
+	if len(oldConfigs) == 0 {
+		level.Error(m.log).Log("err", "rollback was called but no configs to rollback to")
+		panic(errors.New("rollback was called but no configs to rollback to"))
+	}
 	if err := m.applyConfigs(oldConfigs, true); err != nil {
 		level.Error(m.log).Log("err", fmt.Sprintf("failed to rollback configs with error %s", err))
 		panic(err)

--- a/pkg/metrics/instance/group_manager.go
+++ b/pkg/metrics/instance/group_manager.go
@@ -117,10 +117,6 @@ func (m *GroupManager) applyConfigs(configs []Config, isRollback bool) error {
 			m.rollbackConfigs(oldConfigs)
 			return &BatchApplyError{Failed: failedConfigs}
 		}
-		if err != nil {
-			level.Error(m.log).Log("err", fmt.Sprintf("failed to group configs with groupname  %s with error %s", groupName, err))
-			continue
-		}
 		newHash, err := createMergedConfigHash(mergedConfig)
 
 		// Something terrible happened so roll back to the old configurations, this ensures that at least the agent
@@ -128,7 +124,6 @@ func (m *GroupManager) applyConfigs(configs []Config, isRollback bool) error {
 		if err != nil && isRollback {
 			return err
 		} else if err != nil {
-
 			m.rollbackConfigs(oldConfigs)
 			return &BatchApplyError{Failed: failedConfigs}
 		}

--- a/pkg/metrics/instance/group_manager.go
+++ b/pkg/metrics/instance/group_manager.go
@@ -174,10 +174,8 @@ func createMergedConfigHash(mergedConfig Config) (string, error) {
 // internal state is left corrupted since we've completely lost a
 // config.
 func (m *GroupManager) rollbackConfigs(oldConfigs []Config) {
-	if len(oldConfigs) == 0 {
-		level.Error(m.log).Log("err", "rollback was called but no configs to rollback to")
-		panic(errors.New("rollback was called but no configs to rollback to"))
-	}
+	// We dont do a len = 0 check and exit early since we still need to do cleanup
+	// even if there are 0 configs
 	if err := m.applyConfigs(oldConfigs, true); err != nil {
 		level.Error(m.log).Log("err", fmt.Sprintf("failed to rollback configs with error %s", err))
 		panic(err)

--- a/pkg/metrics/instance/group_manager.go
+++ b/pkg/metrics/instance/group_manager.go
@@ -99,7 +99,7 @@ func (m *GroupManager) applyConfigs(configs []Config, isRollback bool) error {
 			}
 		}
 	}
-	mergedHashes := make(map[string]int)
+	newMergedHashes := make(map[string]int)
 	// The whole batch fails or succeeds here, so precompute if failures happen
 	var groupFailedConfigs []BatchFailure
 	for _, c := range configs {
@@ -129,7 +129,7 @@ func (m *GroupManager) applyConfigs(configs []Config, isRollback bool) error {
 		}
 
 		// If we have the exact same config no need to reload it
-		mergedHashes[newHash] = 0
+		newMergedHashes[newHash] = 0
 		if _, exists := m.mergedConfigHashes[newHash]; exists {
 			continue
 		}
@@ -145,7 +145,7 @@ func (m *GroupManager) applyConfigs(configs []Config, isRollback bool) error {
 	m.groups = groupsInConfigs
 	m.activeConfigs = activeConfigs
 	m.groupLookup = groupLookup
-	m.mergedConfigHashes = mergedHashes
+	m.mergedConfigHashes = newMergedHashes
 	if len(failed) > 0 {
 		return &BatchApplyError{Failed: failed}
 	}

--- a/pkg/metrics/instance/group_manager.go
+++ b/pkg/metrics/instance/group_manager.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"fmt"
 
-	"gopkg.in/yaml.v2"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 
@@ -126,7 +124,7 @@ func (m *GroupManager) applyConfigs(configs []Config, isRollback bool) error {
 
 		// Something terrible happened so roll back to the old configurations, this ensures that at least the agent
 		// always has a valid configuration. If we are already in a rollback then dont try again
-		if err != nil && !isRollback {
+		if !isRollback {
 			m.rollbackConfigs(oldConfigs)
 			return CreateBatchApplyErrorOrNil(failed, err)
 		}
@@ -145,7 +143,7 @@ func (m *GroupManager) applyConfigs(configs []Config, isRollback bool) error {
 }
 
 func createMergedConfigHash(mergedConfig Config) (string, error) {
-	bb, err := yaml.Marshal(mergedConfig)
+	bb, err := MarshalConfig(&mergedConfig, false)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/metrics/instance/group_manager.go
+++ b/pkg/metrics/instance/group_manager.go
@@ -108,13 +108,17 @@ func (m *GroupManager) applyConfigs(configs []Config, isRollback bool) error {
 	mergedHashes := make(map[string]int)
 	// Now that we have grouped all the new and existing configurations we can apply them
 	for groupName, grouped := range groupsInConfigs {
-		groups[groupName] = grouped
 		mergedConfig, err := groupConfigs(groupName, grouped)
+		if err != nil {
+			level.Error(m.log).Log("err", fmt.Sprintf("failed to group configs with groupname  %s with error %s", groupName, err))
+		}
 		// If we have the exact same config no need to reload it
 		newHash, err := createMergedConfigHash(mergedConfig)
 		if err != nil {
 			level.Error(m.log).Log("err", fmt.Sprintf("failed to create merged hash named  %s with error %s", groupName, err))
+			continue
 		}
+		groups[groupName] = grouped
 		mergedHashes[newHash] = 0
 		if _, exists := m.mergedConfigHashes[newHash]; exists {
 			continue

--- a/pkg/metrics/instance/group_manager.go
+++ b/pkg/metrics/instance/group_manager.go
@@ -4,6 +4,10 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+
 	"sort"
 	"sync"
 
@@ -35,6 +39,105 @@ type GroupManager struct {
 
 	// groupLookup is a map of config name to group name.
 	groupLookup map[string]string
+
+	log log.Logger
+}
+
+func (m *GroupManager) ApplyConfigs(configs []Config) (err error, successful []Config, failed []Config) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	return m.applyConfigs(configs)
+}
+
+func (m *GroupManager) applyConfigs(configs []Config) (err error, successful []Config, failed []Config) {
+	if len(configs) == 0 {
+		return nil, nil, nil
+	}
+	successful = make([]Config, 0)
+	failed = make([]Config, 0)
+	// This is the grouping of the passed in configs
+	groupsInConfigs := make(map[string]groupedConfigs, 0)
+	oldConfigs := make([]Config, 0)
+	// Add the config to the group. If the config already exists within this
+	// group, it'll be overwritten.
+	for _, c := range configs {
+		groupName, err := hashConfig(c)
+		if err != nil {
+			failed = append(failed, c)
+			level.Error(m.log).Log("err", fmt.Sprintf("failed to get group name for config %s: %s", c.Name, err))
+			continue
+		}
+		if _, exists := groupsInConfigs[groupName]; !exists {
+			groupsInConfigs[groupName] = make(groupedConfigs, 0)
+		}
+		grouped := m.groups[groupName]
+		if grouped == nil {
+			grouped = make(groupedConfigs)
+		} else {
+			grouped = grouped.Copy()
+		}
+		groupsInConfigs[groupName] = grouped
+		grouped[c.Name] = c
+
+		// If this config already exists in another group, we have to delete it.
+		// If we can't delete it from the old group, we also can't apply it.
+		if oldGroup, ok := m.groupLookup[c.Name]; ok && oldGroup != groupName {
+			// There's a few cases here where if something fails, it's safer to crash
+			// out and restart the Agent from scratch than it would be to continue as
+			// normal. The panics here are for truly exceptional cases, otherwise if
+			// something is recoverable, we'll return an error like normal.
+
+			// If we can't find the old config, something got messed up when applying
+			// the config. But it also means that we're not going to be able to restore
+			// the config if something fails. Preemptively we should panic, since the
+			// internal state has gotten messed up and can't be fixed.
+			oldConfig, ok := m.groups[oldGroup][c.Name]
+			if !ok {
+				panic("failed to properly move config to new group. THIS IS A BUG!")
+			}
+
+			err = m.deleteConfig(c.Name)
+			if err != nil {
+				level.Error(m.log).Log("err", fmt.Sprintf("cannot apply config %s because deleting it from the old group failed: %s", c.Name, err))
+				failed = append(failed, c)
+				continue
+			}
+			oldConfigs = append(oldConfigs, oldConfig)
+
+			successful = append(successful, c)
+			m.groupLookup[c.Name] = groupName
+		}
+		m.groupLookup[c.Name] = groupName
+
+	}
+	for groupName, grouped := range groupsInConfigs {
+		mergedConfig, err := groupConfigs(groupName, grouped)
+		if err != nil {
+			m.rollbackConfigs(oldConfigs)
+			return err, nil, configs
+		}
+		err = m.inner.ApplyConfig(mergedConfig)
+		if err != nil {
+			m.rollbackConfigs(oldConfigs)
+			return err, nil, configs
+		}
+		m.groups[groupName] = grouped
+	}
+	return nil, successful, failed
+}
+
+func (m *GroupManager) rollbackConfigs(oldConfigs []Config) {
+	// THIS LOOKS LIKE RECURSION AND IT SORT OF IS, BUT OLD CONFIGS SHOULD NEVER FAIL
+	// If restoring a config fails, we've left the Agent in a really bad
+	// state: the new config can't be applied and the old config can't be
+	// brought back. Just crash and let the Agent start fresh.
+	//
+	// Restoring the config _shouldn't_ fail here since applies only fail
+	// if the config is invalid. Since the config was running before, it
+	// should already be valid. If it does happen to fail, though, the
+	// internal state is left corrupted since we've completely lost a
+	// config.
+	m.applyConfigs(oldConfigs)
 }
 
 // groupedConfigs holds a set of grouped configs, keyed by the config name.
@@ -53,11 +156,12 @@ func (g groupedConfigs) Copy() groupedConfigs {
 
 // NewGroupManager creates a new GroupManager for combining instances of the
 // same "group."
-func NewGroupManager(inner Manager) *GroupManager {
+func NewGroupManager(inner Manager, log log.Logger) *GroupManager {
 	return &GroupManager{
 		inner:       inner,
 		groups:      make(map[string]groupedConfigs),
 		groupLookup: make(map[string]string),
+		log:         log,
 	}
 }
 
@@ -104,89 +208,9 @@ func (m *GroupManager) ListConfigs() map[string]Config {
 // exists, the group will have its settings merged with the Config and
 // will be updated.
 func (m *GroupManager) ApplyConfig(c Config) error {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-	return m.applyConfig(c)
-}
-
-func (m *GroupManager) applyConfig(c Config) (err error) {
-	groupName, err := hashConfig(c)
-	if err != nil {
-		return fmt.Errorf("failed to get group name for config %s: %w", c.Name, err)
-	}
-
-	grouped := m.groups[groupName]
-	if grouped == nil {
-		grouped = make(groupedConfigs)
-	} else {
-		grouped = grouped.Copy()
-	}
-
-	// Add the config to the group. If the config already exists within this
-	// group, it'll be overwritten.
-	grouped[c.Name] = c
-	mergedConfig, err := groupConfigs(groupName, grouped)
-	if err != nil {
-		err = fmt.Errorf("failed to group configs for %s: %w", c.Name, err)
-		return
-	}
-
-	// If this config already exists in another group, we have to delete it.
-	// If we can't delete it from the old group, we also can't apply it.
-	if oldGroup, ok := m.groupLookup[c.Name]; ok && oldGroup != groupName {
-		// There's a few cases here where if something fails, it's safer to crash
-		// out and restart the Agent from scratch than it would be to continue as
-		// normal. The panics here are for truly exceptional cases, otherwise if
-		// something is recoverable, we'll return an error like normal.
-
-		// If we can't find the old config, something got messed up when applying
-		// the config. But it also means that we're not going to be able to restore
-		// the config if something fails. Preemptively we should panic, since the
-		// internal state has gotten messed up and can't be fixed.
-		oldConfig, ok := m.groups[oldGroup][c.Name]
-		if !ok {
-			panic("failed to properly move config to new group. THIS IS A BUG!")
-		}
-
-		err = m.deleteConfig(c.Name)
-		if err != nil {
-			err = fmt.Errorf("cannot apply config %s because deleting it from the old group failed: %w", c.Name, err)
-			return
-		}
-
-		// Now that the config is deleted, we need to restore it in case applying
-		// the new one happens to fail.
-		defer func() {
-			if err == nil {
-				return
-			}
-
-			// If restoring a config fails, we've left the Agent in a really bad
-			// state: the new config can't be applied and the old config can't be
-			// brought back. Just crash and let the Agent start fresh.
-			//
-			// Restoring the config _shouldn't_ fail here since applies only fail
-			// if the config is invalid. Since the config was running before, it
-			// should already be valid. If it does happen to fail, though, the
-			// internal state is left corrupted since we've completely lost a
-			// config.
-			restoreError := m.applyConfig(oldConfig)
-			if restoreError != nil {
-				panic(fmt.Sprintf("failed to properly restore config. THIS IS A BUG! error: %s", restoreError))
-			}
-		}()
-	}
-
-	err = m.inner.ApplyConfig(mergedConfig)
-	if err != nil {
-		err = fmt.Errorf("failed to apply grouped configs for config %s: %w", c.Name, err)
-		return
-	}
-
-	// If the inner apply succeeded, we can update our group and the lookup.
-	m.groups[groupName] = grouped
-	m.groupLookup[c.Name] = groupName
-	return
+	cfgs := []Config{c}
+	err, _, _ := m.ApplyConfigs(cfgs)
+	return err
 }
 
 // DeleteConfig will remove a Config from its associated group. If there are

--- a/pkg/metrics/instance/group_manager_test.go
+++ b/pkg/metrics/instance/group_manager_test.go
@@ -553,7 +553,7 @@ remote_write: []`
 	}
 	// this should trigger a rollback due to the applyconfigfunc above
 	err = groupManager.ApplyConfigs([]Config{configTriggerRollback})
-	require.NoError(t, err)
+	require.Error(t, err)
 	require.Len(t, groupManager.activeConfigs, 1)
 	// Ensure the config name is our original
 	require.Equal(t, groupManager.activeConfigs[0].Name, configA.Name)

--- a/pkg/metrics/instance/group_manager_test.go
+++ b/pkg/metrics/instance/group_manager_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestGroupManager_ListInstances_Configs(t *testing.T) {
-	gm := NewGroupManager(newFakeManager(), log.NewNopLogger())
+	gm := NewGroupManager(log.NewNopLogger(), newFakeManager())
 
 	// Create two configs in the same group and one in another
 	// group.
@@ -58,7 +58,7 @@ func testUnmarshalConfig(t *testing.T, cfg string) Config {
 func TestGroupManager_ApplyConfig(t *testing.T) {
 	t.Run("combining configs", func(t *testing.T) {
 		inner := newFakeManager()
-		gm := NewGroupManager(inner, log.NewNopLogger())
+		gm := NewGroupManager(log.NewNopLogger(), inner)
 		err := gm.ApplyConfig(testUnmarshalConfig(t, `
 name: configA
 scrape_configs: []
@@ -96,7 +96,7 @@ remote_write: []
 
 	t.Run("updating existing config within group", func(t *testing.T) {
 		inner := newFakeManager()
-		gm := NewGroupManager(inner, log.NewNopLogger())
+		gm := NewGroupManager(log.NewNopLogger(), inner)
 		err := gm.ApplyConfig(testUnmarshalConfig(t, `
 name: configA
 scrape_configs: []
@@ -133,7 +133,7 @@ remote_write: []
 
 	t.Run("updating existing config to new group", func(t *testing.T) {
 		inner := newFakeManager()
-		gm := NewGroupManager(inner, log.NewNopLogger())
+		gm := NewGroupManager(log.NewNopLogger(), inner)
 		err := gm.ApplyConfig(testUnmarshalConfig(t, `
 name: configA
 scrape_configs: []
@@ -176,7 +176,7 @@ remote_write: []
 
 func TestGroupManager_ApplyConfig_RemoteWriteName(t *testing.T) {
 	inner := newFakeManager()
-	gm := NewGroupManager(inner, log.NewNopLogger())
+	gm := NewGroupManager(log.NewNopLogger(), inner)
 	err := gm.ApplyConfig(testUnmarshalConfig(t, `
 name: configA
 scrape_configs: []
@@ -201,7 +201,7 @@ remote_write:
 func TestGroupManager_DeleteConfig(t *testing.T) {
 	t.Run("partial delete", func(t *testing.T) {
 		inner := newFakeManager()
-		gm := NewGroupManager(inner, log.NewNopLogger())
+		gm := NewGroupManager(log.NewNopLogger(), inner)
 
 		// Apply two configs in the same group and then delete one. The group
 		// should still be active with the one config inside of it.
@@ -243,7 +243,7 @@ remote_write: []`, gm.groupLookup["configB"]))
 
 	t.Run("full delete", func(t *testing.T) {
 		inner := newFakeManager()
-		gm := NewGroupManager(inner, log.NewNopLogger())
+		gm := NewGroupManager(log.NewNopLogger(), inner)
 
 		// Apply a single config but delete the entire group.
 		err := gm.ApplyConfig(testUnmarshalConfig(t, `

--- a/pkg/metrics/instance/group_manager_test.go
+++ b/pkg/metrics/instance/group_manager_test.go
@@ -1,4 +1,4 @@
-//nolint
+//nolint:goconst
 package instance
 
 import (

--- a/pkg/metrics/instance/group_manager_test.go
+++ b/pkg/metrics/instance/group_manager_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/grafana/agent/pkg/util"
+
 	"github.com/go-kit/log"
 
 	"github.com/stretchr/testify/require"
@@ -58,7 +60,7 @@ func testUnmarshalConfig(t *testing.T, cfg string) Config {
 func TestGroupManager_ApplyConfig(t *testing.T) {
 	t.Run("combining configs", func(t *testing.T) {
 		inner := newFakeManager()
-		gm := NewGroupManager(log.NewNopLogger(), inner)
+		gm := NewGroupManager(util.TestLogger(t), inner)
 		err := gm.ApplyConfig(testUnmarshalConfig(t, `
 name: configA
 scrape_configs: []
@@ -96,7 +98,7 @@ remote_write: []
 
 	t.Run("updating existing config within group", func(t *testing.T) {
 		inner := newFakeManager()
-		gm := NewGroupManager(log.NewNopLogger(), inner)
+		gm := NewGroupManager(util.TestLogger(t), inner)
 		err := gm.ApplyConfig(testUnmarshalConfig(t, `
 name: configA
 scrape_configs: []

--- a/pkg/metrics/instance/group_manager_test.go
+++ b/pkg/metrics/instance/group_manager_test.go
@@ -5,11 +5,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-kit/log"
+
 	"github.com/stretchr/testify/require"
 )
 
 func TestGroupManager_ListInstances_Configs(t *testing.T) {
-	gm := NewGroupManager(newFakeManager())
+	gm := NewGroupManager(newFakeManager(), log.NewNopLogger())
 
 	// Create two configs in the same group and one in another
 	// group.
@@ -56,7 +58,7 @@ func testUnmarshalConfig(t *testing.T, cfg string) Config {
 func TestGroupManager_ApplyConfig(t *testing.T) {
 	t.Run("combining configs", func(t *testing.T) {
 		inner := newFakeManager()
-		gm := NewGroupManager(inner)
+		gm := NewGroupManager(inner, log.NewNopLogger())
 		err := gm.ApplyConfig(testUnmarshalConfig(t, `
 name: configA
 scrape_configs: []
@@ -94,7 +96,7 @@ remote_write: []
 
 	t.Run("updating existing config within group", func(t *testing.T) {
 		inner := newFakeManager()
-		gm := NewGroupManager(inner)
+		gm := NewGroupManager(inner, log.NewNopLogger())
 		err := gm.ApplyConfig(testUnmarshalConfig(t, `
 name: configA
 scrape_configs: []
@@ -131,7 +133,7 @@ remote_write: []
 
 	t.Run("updating existing config to new group", func(t *testing.T) {
 		inner := newFakeManager()
-		gm := NewGroupManager(inner)
+		gm := NewGroupManager(inner, log.NewNopLogger())
 		err := gm.ApplyConfig(testUnmarshalConfig(t, `
 name: configA
 scrape_configs: []
@@ -174,7 +176,7 @@ remote_write: []
 
 func TestGroupManager_ApplyConfig_RemoteWriteName(t *testing.T) {
 	inner := newFakeManager()
-	gm := NewGroupManager(inner)
+	gm := NewGroupManager(inner, log.NewNopLogger())
 	err := gm.ApplyConfig(testUnmarshalConfig(t, `
 name: configA
 scrape_configs: []
@@ -199,7 +201,7 @@ remote_write:
 func TestGroupManager_DeleteConfig(t *testing.T) {
 	t.Run("partial delete", func(t *testing.T) {
 		inner := newFakeManager()
-		gm := NewGroupManager(inner)
+		gm := NewGroupManager(inner, log.NewNopLogger())
 
 		// Apply two configs in the same group and then delete one. The group
 		// should still be active with the one config inside of it.
@@ -241,7 +243,7 @@ remote_write: []`, gm.groupLookup["configB"]))
 
 	t.Run("full delete", func(t *testing.T) {
 		inner := newFakeManager()
-		gm := NewGroupManager(inner)
+		gm := NewGroupManager(inner, log.NewNopLogger())
 
 		// Apply a single config but delete the entire group.
 		err := gm.ApplyConfig(testUnmarshalConfig(t, `

--- a/pkg/metrics/instance/group_manager_test.go
+++ b/pkg/metrics/instance/group_manager_test.go
@@ -588,7 +588,6 @@ remote_write: []`
 	}
 	groupManager := NewGroupManager(logger, mockManager)
 
-	assert.Panics(t, func() {
-		_ = groupManager.ApplyConfigs([]Config{configA})
-	})
+	_ = groupManager.ApplyConfigs([]Config{configA})
+	require.Len(t, groupManager.activeConfigs, 0)
 }

--- a/pkg/metrics/instance/group_manager_test.go
+++ b/pkg/metrics/instance/group_manager_test.go
@@ -7,13 +7,11 @@ import (
 
 	"github.com/grafana/agent/pkg/util"
 
-	"github.com/go-kit/log"
-
 	"github.com/stretchr/testify/require"
 )
 
 func TestGroupManager_ListInstances_Configs(t *testing.T) {
-	gm := NewGroupManager(log.NewNopLogger(), newFakeManager())
+	gm := NewGroupManager(util.TestLogger(t), newFakeManager())
 
 	// Create two configs in the same group and one in another
 	// group.
@@ -135,7 +133,7 @@ remote_write: []
 
 	t.Run("updating existing config to new group", func(t *testing.T) {
 		inner := newFakeManager()
-		gm := NewGroupManager(log.NewNopLogger(), inner)
+		gm := NewGroupManager(util.TestLogger(t), inner)
 		err := gm.ApplyConfig(testUnmarshalConfig(t, `
 name: configA
 scrape_configs: []
@@ -178,7 +176,7 @@ remote_write: []
 
 func TestGroupManager_ApplyConfig_RemoteWriteName(t *testing.T) {
 	inner := newFakeManager()
-	gm := NewGroupManager(log.NewNopLogger(), inner)
+	gm := NewGroupManager(util.TestLogger(t), inner)
 	err := gm.ApplyConfig(testUnmarshalConfig(t, `
 name: configA
 scrape_configs: []
@@ -203,7 +201,7 @@ remote_write:
 func TestGroupManager_DeleteConfig(t *testing.T) {
 	t.Run("partial delete", func(t *testing.T) {
 		inner := newFakeManager()
-		gm := NewGroupManager(log.NewNopLogger(), inner)
+		gm := NewGroupManager(util.TestLogger(t), inner)
 
 		// Apply two configs in the same group and then delete one. The group
 		// should still be active with the one config inside of it.
@@ -245,7 +243,7 @@ remote_write: []`, gm.groupLookup["configB"]))
 
 	t.Run("full delete", func(t *testing.T) {
 		inner := newFakeManager()
-		gm := NewGroupManager(log.NewNopLogger(), inner)
+		gm := NewGroupManager(util.TestLogger(t), inner)
 
 		// Apply a single config but delete the entire group.
 		err := gm.ApplyConfig(testUnmarshalConfig(t, `

--- a/pkg/metrics/instance/group_manager_test.go
+++ b/pkg/metrics/instance/group_manager_test.go
@@ -490,13 +490,15 @@ remote_write: []`
 		StopFunc: nil,
 	}
 	groupManager := NewGroupManager(logger, mockManager)
-	groupManager.ApplyConfigs([]Config{configA})
+	err := groupManager.ApplyConfigs([]Config{configA})
+	require.NoError(t, err)
+
 	// This should panic because the configA is moved into the same group as configb
 	// will be different groups
 	// the groupA will no longer be valid and will delete, thus triggering a rollback
 	// that should panic
 	assert.Panics(t, func() {
-		groupManager.ApplyConfigs([]Config{configB, configAInB})
+		_ = groupManager.ApplyConfigs([]Config{configB, configAInB})
 	}, "should rollback")
 
 }
@@ -542,14 +544,15 @@ remote_write: []`
 		StopFunc: nil,
 	}
 	groupManager := NewGroupManager(logger, mockManager)
-	groupManager.ApplyConfigs([]Config{configA})
+	err := groupManager.ApplyConfigs([]Config{configA})
+	require.NoError(t, err)
 	require.Len(t, groupManager.mergedConfigHashes, 1)
 	for k := range groupManager.mergedConfigHashes {
 		hashOfOriginalMergedConfig = k
 	}
 	// this should trigger a rollback due to the applyconfigfunc above
-	groupManager.ApplyConfigs([]Config{configTriggerRollback})
-
+	err = groupManager.ApplyConfigs([]Config{configTriggerRollback})
+	require.NoError(t, err)
 	require.Len(t, groupManager.activeConfigs, 1)
 	// Ensure the config name is our original
 	require.Equal(t, groupManager.activeConfigs[0].Name, configA.Name)
@@ -585,6 +588,6 @@ remote_write: []`
 	groupManager := NewGroupManager(logger, mockManager)
 
 	assert.Panics(t, func() {
-		groupManager.ApplyConfigs([]Config{configA})
+		_ = groupManager.ApplyConfigs([]Config{configA})
 	})
 }

--- a/pkg/metrics/instance/group_manager_test.go
+++ b/pkg/metrics/instance/group_manager_test.go
@@ -1,3 +1,4 @@
+//nolint
 package instance
 
 import (

--- a/pkg/metrics/instance/manager.go
+++ b/pkg/metrics/instance/manager.go
@@ -340,25 +340,17 @@ type MockManager struct {
 	ListInstancesFunc func() map[string]ManagedInstance
 	ListConfigsFunc   func() map[string]Config
 	ApplyConfigFunc   func(Config) error
+	ApplyConfigsFunc  func([]Config) error
 	DeleteConfigFunc  func(name string) error
 	StopFunc          func()
 }
 
 // ApplyConfigs is used to batch apply configurations
 func (m MockManager) ApplyConfigs(configs []Config) error {
-	failed := make([]BatchFailure, 0)
-	for _, v := range configs {
-		if err := m.ApplyConfig(v); err != nil {
-			failed = append(failed, BatchFailure{
-				Err:        err,
-				ConfigName: v.Name,
-			})
-		}
+	if m.ApplyConfigsFunc != nil {
+		return m.ApplyConfigsFunc(configs)
 	}
-	if len(failed) > 0 {
-		return &BatchApplyError{Failed: failed}
-	}
-	return nil
+	panic("ListInstancesFunc not implemented")
 }
 
 // GetInstance implements Manager.

--- a/pkg/metrics/instance/manager.go
+++ b/pkg/metrics/instance/manager.go
@@ -51,13 +51,33 @@ type Manager interface {
 	ApplyConfig(Config) error
 
 	// ApplyConfigs batch applies the config
-	ApplyConfigs([]Config) (successful []Config, failed []Config, err error)
+	ApplyConfigs([]Config) BatchApplyResult
 
 	// DeleteConfig deletes a given managed instance based on its Config.Name.
 	DeleteConfig(name string) error
 
 	// Stop stops the Manager and all managed instances.
 	Stop()
+}
+
+// BatchApplyResult contains the failed configs with error, successful configurations, and then if there is an error
+// that is not tied to a specific config then NonConfigError contains it
+type BatchApplyResult struct {
+	Failed     []BatchFailure
+	Successful []Config
+	// NonConfigError is used when the error is not with a specific configuration, but likely the grouping
+	// or applying the group.
+	NonConfigError error
+}
+
+// BatchFailure for a given config has the associated error
+type BatchFailure struct {
+	Err    error
+	Config Config
+}
+
+func (e BatchApplyResult) Error() string {
+	return fmt.Sprintf("%d configs failed to apply", len(e.Failed))
 }
 
 // ManagedInstance is implemented by Instance. It is defined as an interface
@@ -92,19 +112,25 @@ type BasicManager struct {
 	launch Factory
 }
 
-func (m *BasicManager) ApplyConfigs(configs []Config) (successful []Config, failed []Config, lastError error) {
-	successful = make([]Config, 0)
-	failed = make([]Config, 0)
-	for _, k := range configs {
-		err := m.ApplyConfig(k)
+// ApplyConfigs is used to batch configurations for performance instead of the singular ApplyConfig
+func (m *BasicManager) ApplyConfigs(configs []Config) BatchApplyResult {
+	successful := make([]Config, 0)
+	failed := make([]BatchFailure, 0)
+	for _, v := range configs {
+		err := m.ApplyConfig(v)
 		if err != nil {
-			lastError = err
-			failed = append(failed, k)
+			failed = append(failed, BatchFailure{
+				Err:    err,
+				Config: v,
+			})
 		} else {
-			successful = append(successful, k)
+			successful = append(successful, v)
 		}
 	}
-	return successful, failed, lastError
+	return BatchApplyResult{
+		Failed:     failed,
+		Successful: successful,
+	}
 }
 
 // managedProcess represents a goroutine running a ManagedInstance. cancel
@@ -341,14 +367,24 @@ type MockManager struct {
 	StopFunc          func()
 }
 
-func (m MockManager) ApplyConfigs(configs []Config) (successful []Config, failed []Config, lastError error) {
+// ApplyConfigs is used to batch apply configurations
+func (m MockManager) ApplyConfigs(configs []Config) BatchApplyResult {
 
-	for _, k := range configs {
-		if err := m.ApplyConfig(k); err != nil {
-			lastError = err
+	successful := make([]Config, 0)
+	failed := make([]BatchFailure, 0)
+	for _, v := range configs {
+		if err := m.ApplyConfig(v); err != nil {
+			failed = append(failed, BatchFailure{
+				Err:    err,
+				Config: v,
+			})
 		}
 	}
-	return nil, successful, lastError
+	return BatchApplyResult{
+		Failed:         failed,
+		Successful:     successful,
+		NonConfigError: nil,
+	}
 }
 
 // GetInstance implements Manager.

--- a/pkg/metrics/instance/manager.go
+++ b/pkg/metrics/instance/manager.go
@@ -350,7 +350,7 @@ func (m MockManager) ApplyConfigs(configs []Config) error {
 	if m.ApplyConfigsFunc != nil {
 		return m.ApplyConfigsFunc(configs)
 	}
-	panic("ListInstancesFunc not implemented")
+	panic("ApplyConfigsFunc not implemented")
 }
 
 // GetInstance implements Manager.

--- a/pkg/metrics/instance/manager.go
+++ b/pkg/metrics/instance/manager.go
@@ -51,7 +51,7 @@ type Manager interface {
 	ApplyConfig(Config) error
 
 	// ApplyConfigs batch applies the config
-	ApplyConfigs([]Config) (err error, successful []Config, failed []Config)
+	ApplyConfigs([]Config) (successful []Config, failed []Config, err error)
 
 	// DeleteConfig deletes a given managed instance based on its Config.Name.
 	DeleteConfig(name string) error
@@ -92,7 +92,7 @@ type BasicManager struct {
 	launch Factory
 }
 
-func (m *BasicManager) ApplyConfigs(configs []Config) (lastError error, successful []Config, failed []Config) {
+func (m *BasicManager) ApplyConfigs(configs []Config) (successful []Config, failed []Config, lastError error) {
 	successful = make([]Config, 0)
 	failed = make([]Config, 0)
 	for _, k := range configs {
@@ -104,7 +104,7 @@ func (m *BasicManager) ApplyConfigs(configs []Config) (lastError error, successf
 			successful = append(successful, k)
 		}
 	}
-	return lastError, successful, failed
+	return successful, failed, lastError
 }
 
 // managedProcess represents a goroutine running a ManagedInstance. cancel
@@ -341,11 +341,14 @@ type MockManager struct {
 	StopFunc          func()
 }
 
-func (m MockManager) ApplyConfigs(configs []Config) (err error, successful []Config, failed []Config) {
+func (m MockManager) ApplyConfigs(configs []Config) (successful []Config, failed []Config, lastError error) {
+
 	for _, k := range configs {
-		m.ApplyConfig(k)
+		if err := m.ApplyConfig(k); err != nil {
+			lastError = err
+		}
 	}
-	return nil, successful, nil
+	return nil, successful, lastError
 }
 
 // GetInstance implements Manager.

--- a/pkg/metrics/instance/manager.go
+++ b/pkg/metrics/instance/manager.go
@@ -50,8 +50,8 @@ type Manager interface {
 	// one with Config.Name already exists.
 	ApplyConfig(Config) error
 
-	// ApplyConfigs batch applies the config
-	ApplyConfigs([]Config) *BatchApplyError
+	// ApplyConfigs batch applies the config, it will return a BatchApplyError if any error occurs
+	ApplyConfigs([]Config) error
 
 	// DeleteConfig deletes a given managed instance based on its Config.Name.
 	DeleteConfig(name string) error
@@ -93,7 +93,7 @@ type BasicManager struct {
 }
 
 // ApplyConfigs is used to batch configurations for performance instead of the singular ApplyConfig
-func (m *BasicManager) ApplyConfigs(configs []Config) *BatchApplyError {
+func (m *BasicManager) ApplyConfigs(configs []Config) error {
 	failed := make([]BatchFailure, 0)
 	for _, v := range configs {
 		err := m.ApplyConfig(v)
@@ -342,7 +342,7 @@ type MockManager struct {
 }
 
 // ApplyConfigs is used to batch apply configurations
-func (m MockManager) ApplyConfigs(configs []Config) *BatchApplyError {
+func (m MockManager) ApplyConfigs(configs []Config) error {
 	failed := make([]BatchFailure, 0)
 	for _, v := range configs {
 		if err := m.ApplyConfig(v); err != nil {
@@ -352,13 +352,7 @@ func (m MockManager) ApplyConfigs(configs []Config) *BatchApplyError {
 			})
 		}
 	}
-	if len(failed) == 0 {
-		return nil
-	}
-	return &BatchApplyError{
-		Failed:         failed,
-		NonConfigError: nil,
-	}
+	return CreateBatchApplyErrorOrNil(failed, nil)
 }
 
 // GetInstance implements Manager.

--- a/pkg/metrics/instance/manager.go
+++ b/pkg/metrics/instance/manager.go
@@ -99,12 +99,15 @@ func (m *BasicManager) ApplyConfigs(configs []Config) error {
 		err := m.ApplyConfig(v)
 		if err != nil {
 			failed = append(failed, BatchFailure{
-				Err:    err,
-				Config: v,
+				Err:        err,
+				ConfigName: v.Name,
 			})
 		}
 	}
-	return CreateBatchApplyErrorOrNil(failed, nil)
+	if len(failed) > 0 {
+		return &BatchApplyError{Failed: failed}
+	}
+	return nil
 }
 
 // managedProcess represents a goroutine running a ManagedInstance. cancel
@@ -347,12 +350,15 @@ func (m MockManager) ApplyConfigs(configs []Config) error {
 	for _, v := range configs {
 		if err := m.ApplyConfig(v); err != nil {
 			failed = append(failed, BatchFailure{
-				Err:    err,
-				Config: v,
+				Err:        err,
+				ConfigName: v.Name,
 			})
 		}
 	}
-	return CreateBatchApplyErrorOrNil(failed, nil)
+	if len(failed) > 0 {
+		return &BatchApplyError{Failed: failed}
+	}
+	return nil
 }
 
 // GetInstance implements Manager.

--- a/pkg/metrics/instance/modal_manager.go
+++ b/pkg/metrics/instance/modal_manager.go
@@ -76,10 +76,7 @@ func (m *ModalManager) ApplyConfigs(configs []Config) error {
 
 	err := m.active.ApplyConfigs(configs)
 	var bae BatchApplyError
-	if err != nil {
-		errors.As(err, &bae)
-	}
-
+	_ = errors.As(err, &bae)
 	for _, c := range FindSuccessfulConfigs(&bae, configs) {
 		if _, existingConfig := m.configs[c.Name]; !existingConfig {
 			m.currentActiveConfigs.Inc()

--- a/pkg/metrics/instance/modal_manager.go
+++ b/pkg/metrics/instance/modal_manager.go
@@ -144,7 +144,7 @@ func (m *ModalManager) SetMode(newMode Mode) error {
 	case ModeDistinct:
 		m.active = m.wrapped
 	case ModeShared:
-		m.active = NewGroupManager(m.wrapped, m.log)
+		m.active = NewGroupManager(m.log, m.wrapped)
 	default:
 		panic("unknown mode " + m.mode)
 	}

--- a/pkg/metrics/instance/modal_manager.go
+++ b/pkg/metrics/instance/modal_manager.go
@@ -68,11 +68,11 @@ type ModalManager struct {
 	wrapped, active Manager
 }
 
-func (m *ModalManager) ApplyConfigs(configs []Config) (lastError error, successful []Config, failed []Config) {
+func (m *ModalManager) ApplyConfigs(configs []Config) (successful []Config, failed []Config, lastError error) {
 	m.mut.Lock()
 	defer m.mut.Unlock()
 
-	err, successful, failed := m.active.ApplyConfigs(configs)
+	successful, failed, err := m.active.ApplyConfigs(configs)
 	if len(failed) > 0 {
 		level.Error(m.log).Log("msg", fmt.Sprintf("number of configs failed %d", len(failed)))
 	}
@@ -86,7 +86,7 @@ func (m *ModalManager) ApplyConfigs(configs []Config) (lastError error, successf
 
 		m.configs[c.Name] = c
 	}
-	return err, successful, failed
+	return successful, failed, err
 }
 
 // NewModalManager creates a new ModalManager.

--- a/pkg/metrics/instance/modal_manager.go
+++ b/pkg/metrics/instance/modal_manager.go
@@ -69,7 +69,7 @@ type ModalManager struct {
 }
 
 // ApplyConfigs is used to batch configurations for performance instead of the singular ApplyConfig
-func (m *ModalManager) ApplyConfigs(configs []Config) BatchApplyResult {
+func (m *ModalManager) ApplyConfigs(configs []Config) *BatchApplyError {
 	m.mut.Lock()
 	defer m.mut.Unlock()
 
@@ -78,7 +78,8 @@ func (m *ModalManager) ApplyConfigs(configs []Config) BatchApplyResult {
 	if len(result.Failed) > 0 {
 		level.Error(m.log).Log("msg", fmt.Sprintf("number of configs failed %d", len(result.Failed)))
 	}
-	for _, c := range result.Successful {
+
+	for _, c := range FindSuccessfulConfigs(result, configs) {
 		if _, existingConfig := m.configs[c.Name]; !existingConfig {
 			m.currentActiveConfigs.Inc()
 			m.changedConfigs.WithLabelValues("created").Inc()

--- a/pkg/metrics/wal/wal_test.go
+++ b/pkg/metrics/wal/wal_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
 	"github.com/grafana/agent/pkg/util"
 	"github.com/prometheus/prometheus/pkg/exemplar"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -25,7 +24,7 @@ func TestStorage_InvalidSeries(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(walDir)
 
-	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
+	s, err := NewStorage(util.TestLogger(t), nil, walDir)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, s.Close())
@@ -67,7 +66,7 @@ func TestStorage(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(walDir)
 
-	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
+	s, err := NewStorage(util.TestLogger(t), nil, walDir)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, s.Close())
@@ -109,7 +108,7 @@ func TestStorage_ExistingWAL(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(walDir)
 
-	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
+	s, err := NewStorage(util.TestLogger(t), nil, walDir)
 	require.NoError(t, err)
 
 	app := s.Appender(context.Background())
@@ -128,7 +127,7 @@ func TestStorage_ExistingWAL(t *testing.T) {
 	time.Sleep(time.Millisecond * 150)
 
 	// Create a new storage, write the other half of samples.
-	s, err = NewStorage(log.NewNopLogger(), nil, walDir)
+	s, err = NewStorage(util.TestLogger(t), nil, walDir)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, s.Close())
@@ -209,7 +208,7 @@ func TestStorage_Truncate(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(walDir)
 
-	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
+	s, err := NewStorage(util.TestLogger(t), nil, walDir)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, s.Close())
@@ -270,7 +269,7 @@ func TestStorage_WriteStalenessMarkers(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(walDir)
 
-	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
+	s, err := NewStorage(util.TestLogger(t), nil, walDir)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, s.Close())
@@ -324,7 +323,7 @@ func TestStorage_TruncateAfterClose(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(walDir)
 
-	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
+	s, err := NewStorage(util.TestLogger(t), nil, walDir)
 	require.NoError(t, err)
 
 	require.NoError(t, s.Close())

--- a/pkg/operator/selector_eventhandler_test.go
+++ b/pkg/operator/selector_eventhandler_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
 	"github.com/hashicorp/go-getter"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
@@ -39,7 +38,7 @@ var (
 // TestEnqueueRequestForSelector creates an example Kubenretes cluster and runs
 // EnqueueRequestForSelector to validate it works.
 func TestEnqueueRequestForSelector(t *testing.T) {
-	l := log.NewNopLogger()
+	l := util.TestLogger(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()

--- a/pkg/operator/selector_eventhandler_test.go
+++ b/pkg/operator/selector_eventhandler_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/hashicorp/go-getter"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
@@ -38,7 +39,7 @@ var (
 // TestEnqueueRequestForSelector creates an example Kubenretes cluster and runs
 // EnqueueRequestForSelector to validate it works.
 func TestEnqueueRequestForSelector(t *testing.T) {
-	l := util.TestLogger(t)
+	l := log.NewNopLogger()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()

--- a/pkg/traces/promsdprocessor/prom_sd_processor_test.go
+++ b/pkg/traces/promsdprocessor/prom_sd_processor_test.go
@@ -3,7 +3,8 @@ package promsdprocessor
 import (
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"github.com/grafana/agent/pkg/util"
+
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/pkg/relabel"
@@ -103,7 +104,7 @@ func TestSyncGroups(t *testing.T) {
 			}
 
 			p := &promServiceDiscoProcessor{
-				logger:         log.NewNopLogger(),
+				logger:         util.TestLogger(t),
 				relabelConfigs: tc.relabelCfgs,
 			}
 

--- a/pkg/traces/remotewriteexporter/exporter_test.go
+++ b/pkg/traces/remotewriteexporter/exporter_test.go
@@ -86,8 +86,7 @@ type mockManager struct {
 }
 
 // ApplyConfigs is used to batch configurations for performance instead of the singular ApplyConfig
-func (m *mockManager) ApplyConfigs(configs []instance.Config) instance.BatchApplyResult {
-	successful := make([]instance.Config, 0)
+func (m *mockManager) ApplyConfigs(configs []instance.Config) *instance.BatchApplyError {
 	failed := make([]instance.BatchFailure, 0)
 	for _, v := range configs {
 		err := m.ApplyConfig(v)
@@ -96,15 +95,9 @@ func (m *mockManager) ApplyConfigs(configs []instance.Config) instance.BatchAppl
 				Err:    err,
 				Config: v,
 			})
-		} else {
-			successful = append(successful, v)
 		}
 	}
-	return instance.BatchApplyResult{
-		Failed:         failed,
-		Successful:     successful,
-		NonConfigError: nil,
-	}
+	return instance.CreateBatchApplyErrorOrNil(failed, nil)
 
 }
 

--- a/pkg/traces/remotewriteexporter/exporter_test.go
+++ b/pkg/traces/remotewriteexporter/exporter_test.go
@@ -85,6 +85,21 @@ type mockManager struct {
 	instance *mockInstance
 }
 
+func (m *mockManager) ApplyConfigs(configs []instance.Config) (err error, successful []instance.Config, failed []instance.Config) {
+	successful = make([]instance.Config, 0)
+	failed = make([]instance.Config, 0)
+	for _, v := range configs {
+		err = m.ApplyConfig(v)
+		if err != nil {
+			failed = append(failed, v)
+		} else {
+			successful = append(successful, v)
+		}
+	}
+	return err, successful, failed
+
+}
+
 func (m *mockManager) GetInstance(name string) (instance.ManagedInstance, error) {
 	if m.instance == nil {
 		m.instance = &mockInstance{}

--- a/pkg/traces/remotewriteexporter/exporter_test.go
+++ b/pkg/traces/remotewriteexporter/exporter_test.go
@@ -85,19 +85,26 @@ type mockManager struct {
 	instance *mockInstance
 }
 
-func (m *mockManager) ApplyConfigs(configs []instance.Config) (successful []instance.Config, failed []instance.Config, lastError error) {
-	successful = make([]instance.Config, 0)
-	failed = make([]instance.Config, 0)
+// ApplyConfigs is used to batch configurations for performance instead of the singular ApplyConfig
+func (m *mockManager) ApplyConfigs(configs []instance.Config) instance.BatchApplyResult {
+	successful := make([]instance.Config, 0)
+	failed := make([]instance.BatchFailure, 0)
 	for _, v := range configs {
 		err := m.ApplyConfig(v)
 		if err != nil {
-			lastError = err
-			failed = append(failed, v)
+			failed = append(failed, instance.BatchFailure{
+				Err:    err,
+				Config: v,
+			})
 		} else {
 			successful = append(successful, v)
 		}
 	}
-	return successful, failed, lastError
+	return instance.BatchApplyResult{
+		Failed:         failed,
+		Successful:     successful,
+		NonConfigError: nil,
+	}
 
 }
 

--- a/pkg/traces/remotewriteexporter/exporter_test.go
+++ b/pkg/traces/remotewriteexporter/exporter_test.go
@@ -87,18 +87,7 @@ type mockManager struct {
 
 // ApplyConfigs is used to batch configurations for performance instead of the singular ApplyConfig
 func (m *mockManager) ApplyConfigs(configs []instance.Config) error {
-	failed := make([]instance.BatchFailure, 0)
-	for _, v := range configs {
-		err := m.ApplyConfig(v)
-		if err != nil {
-			failed = append(failed, instance.BatchFailure{
-				Err:    err,
-				Config: v,
-			})
-		}
-	}
-	return instance.CreateBatchApplyErrorOrNil(failed, nil)
-
+	return m.ApplyConfigs(configs)
 }
 
 func (m *mockManager) GetInstance(name string) (instance.ManagedInstance, error) {

--- a/pkg/traces/remotewriteexporter/exporter_test.go
+++ b/pkg/traces/remotewriteexporter/exporter_test.go
@@ -86,9 +86,7 @@ type mockManager struct {
 }
 
 // ApplyConfigs is used to batch configurations for performance instead of the singular ApplyConfig
-func (m *mockManager) ApplyConfigs(configs []instance.Config) error {
-	return m.ApplyConfigs(configs)
-}
+func (m *mockManager) ApplyConfigs(configs []instance.Config) error { return nil }
 
 func (m *mockManager) GetInstance(name string) (instance.ManagedInstance, error) {
 	if m.instance == nil {

--- a/pkg/traces/remotewriteexporter/exporter_test.go
+++ b/pkg/traces/remotewriteexporter/exporter_test.go
@@ -86,7 +86,7 @@ type mockManager struct {
 }
 
 // ApplyConfigs is used to batch configurations for performance instead of the singular ApplyConfig
-func (m *mockManager) ApplyConfigs(configs []instance.Config) error { return nil }
+func (m *mockManager) ApplyConfigs(_ []instance.Config) error { return nil }
 
 func (m *mockManager) GetInstance(name string) (instance.ManagedInstance, error) {
 	if m.instance == nil {

--- a/pkg/traces/remotewriteexporter/exporter_test.go
+++ b/pkg/traces/remotewriteexporter/exporter_test.go
@@ -85,18 +85,19 @@ type mockManager struct {
 	instance *mockInstance
 }
 
-func (m *mockManager) ApplyConfigs(configs []instance.Config) (err error, successful []instance.Config, failed []instance.Config) {
+func (m *mockManager) ApplyConfigs(configs []instance.Config) (successful []instance.Config, failed []instance.Config, lastError error) {
 	successful = make([]instance.Config, 0)
 	failed = make([]instance.Config, 0)
 	for _, v := range configs {
-		err = m.ApplyConfig(v)
+		err := m.ApplyConfig(v)
 		if err != nil {
+			lastError = err
 			failed = append(failed, v)
 		} else {
 			successful = append(successful, v)
 		}
 	}
-	return err, successful, failed
+	return successful, failed, lastError
 
 }
 

--- a/pkg/traces/remotewriteexporter/exporter_test.go
+++ b/pkg/traces/remotewriteexporter/exporter_test.go
@@ -86,7 +86,7 @@ type mockManager struct {
 }
 
 // ApplyConfigs is used to batch configurations for performance instead of the singular ApplyConfig
-func (m *mockManager) ApplyConfigs(configs []instance.Config) *instance.BatchApplyError {
+func (m *mockManager) ApplyConfigs(configs []instance.Config) error {
 	failed := make([]instance.BatchFailure, 0)
 	for _, v := range configs {
 		err := m.ApplyConfig(v)


### PR DESCRIPTION
#### PR Description 

This batches the configurations, so instead of handling them one at a time which at >1k configs can have a significant performance and scalability hit, this batches them and lessons that hit. 

#### Notes to the Reviewer

#### PR Checklist

- [X] CHANGELOG updated 
- [NA] Documentation added
- [X] Tests updated
