### PR TITLE
update .gitignore to be explicit about root paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,20 @@
-.rpmdb/
-.idea
-.uptodate
-.published
-.pkg
-.cache
-.vscode
-vendor
-cover*.out
-vendor
+/.rpmdb/
+/.idea
+/.published
+/.pkg
+/.cache
+/.vscode
+/vendor
 
-cmd/agent/agent
-cmd/agentctl/agentctl
-cmd/agent-operator/agent-operator
-cmd/grafana-agent-crow/grafana-agent-crow
-dist/
-packaging/windows/LICENSE
-packaging/windows/agent-windows-amd64.exe
+/cmd/agent/agent
+/cmd/agentctl/agentctl
+/cmd/agent-operator/agent-operator
+/cmd/grafana-agent-crow/grafana-agent-crow
+/dist/
+/packaging/windows/LICENSE
+/packaging/windows/agent-windows-amd64.exe
 
 .DS_Store
 buildx-v*
+cover*.out
+.uptodate


### PR DESCRIPTION
#925 found that the .gitignore was being too aggressive: we don't want to ignore all vendor folders, just the Go module vendor folder. 

This commit changes the .gitignore to be explicit about what is being ignored at the root path.
