### PR TITLE
[dev.scraping-service-scalability] Catch delete events from kv.WatchPrefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ for specific instructions.
 - [BUGFIX] Reloading the scraping service kvstore config for loading instance
   configs will no longer use the clustering config instead. (@rfratto)
 
+- [BUGFIX] Scraping service: deleted configs will now properly immediately fire
+  off a change event for nodes to respond to. (@rfratto)
+
 - [CHANGE] Breaking change: reduced verbosity of tracing autologging
   by not logging `STATUS_CODE_UNSET` status codes. (@mapno)
 

--- a/pkg/metrics/instance/configstore/kv/consul/mock.go
+++ b/pkg/metrics/instance/configstore/kv/consul/mock.go
@@ -192,7 +192,12 @@ func (m *mockKV) List(prefix string, q *consul.QueryOptions) (consul.KVPairs, *c
 func (m *mockKV) Delete(key string, q *consul.WriteOptions) (*consul.WriteMeta, error) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
+
+	// Deletes increment the ModifyIndex
 	delete(m.kvps, key)
+	m.current++
+	m.cond.Broadcast()
+
 	return nil, nil
 }
 

--- a/pkg/metrics/instance/configstore/kv/consul/mock.go
+++ b/pkg/metrics/instance/configstore/kv/consul/mock.go
@@ -181,8 +181,7 @@ func (m *mockKV) List(prefix string, q *consul.QueryOptions) (consul.KVPairs, *c
 
 	result := consul.KVPairs{}
 	for _, kvp := range m.kvps {
-		if strings.HasPrefix(kvp.Key, prefix) && kvp.ModifyIndex >= q.WaitIndex {
-			// unfortunately real consul doesn't do index check and returns everything with given prefix.
+		if strings.HasPrefix(kvp.Key, prefix) {
 			result = append(result, copyKVPair(kvp))
 		}
 	}

--- a/pkg/metrics/instance/configstore/kv/kv_test.go
+++ b/pkg/metrics/instance/configstore/kv/kv_test.go
@@ -264,6 +264,44 @@ func TestWatchPrefix(t *testing.T) {
 	})
 }
 
+func TestWatchPrefix_Deletes(t *testing.T) {
+	withFixtures(t, func(t *testing.T, client Client) {
+		observedKVPs := make(chan pair.KVP, 1)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		go func() {
+			// start watching before we even start generating values. values will be buffered
+			client.WatchPrefix(ctx, "", func(key string, val interface{}) bool {
+				if val != nil {
+					err := client.Delete(ctx, key)
+					require.NoError(t, err)
+					return true
+				}
+
+				observedKVPs <- pair.KVP{Key: key, Value: val}
+				return false
+			})
+		}()
+
+		// Wait before generating a key to be deleted.
+		time.Sleep(250 * time.Millisecond)
+		err := client.CAS(ctx, "key", func(in interface{}) (out interface{}, retry bool, err error) {
+			return "value", false, nil
+		})
+		require.NoError(t, err)
+
+		select {
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "test timed out waiting for delete event")
+		case kvp := <-observedKVPs:
+			require.Equal(t, "key", kvp.Key)
+			require.Nil(t, kvp.Value, "value must be nil to indicate deleteion")
+		}
+	})
+}
+
 // TestList makes sure stored keys are listed back.
 func TestList(t *testing.T) {
 	kvpsToCreate := []pair.KVP{

--- a/pkg/metrics/instance/configstore/kv/pair/kvp.go
+++ b/pkg/metrics/instance/configstore/kv/pair/kvp.go
@@ -5,5 +5,6 @@ type KVP struct {
 	Key string
 
 	// Value should be deserialised through the Client's codec.
+	// Nil indicates a deletion.
 	Value interface{}
 }


### PR DESCRIPTION
#### PR Description 
The Cortex KV package had ignore deleted events from etcd because other implementations didn't detect when a key had gone away. 

This PR detects deleted keys in Consul by keeping track of configs that go away in between List calls. 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer
Note that there's no guarantee a delete event will be detected if there are multiple sequential calls to WatchPrefix. If a key is deleted in between calls, the subsequent call will be unaware that the key used to exist. I believe the same effect exists for the etcd watch though: the etcd watch only returns mutation events from the start of the watch, and keys may be deleted in between. 

Despite this, it still may be worthwhile to have this enhancement, since it's better than it was before and will detect most deletes. 

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
