### PR TITLE
Standardize default scrape interval to 1m

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -154,7 +154,7 @@ steps:
       - apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release
       - curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
       - add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian buster stable"
-      - apt-get update &&  apt-get install -y rubygems rpm nsis docker-ce docker-ce-cli containerd.io
+      - apt-get update &&  apt-get install -y rubygems rpm nsis docker-ce docker-ce-cli containerd.io envsubst
       - docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
       - gem install --no-document fpm
       - mkdir -p /usr/local/go/bin
@@ -174,6 +174,6 @@ volumes:
       path: /var/run/docker.sock
 ---
 kind: signature
-hmac: cc7f41904fd7d2422d034650f4445f681a19d68a85062297d30c972cf4deff76
+hmac: 1c517e225e5c4e218528072d5772a15d1e084e46cd773a71fc7573b6484d8fcd
 
 ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ consult the
 [upgrade guide](https://github.com/grafana/agent/blob/main/docs/upgrade-guide/_index.md)
 for specific instructions.
 
-- [ENHANCEMENT] Update jsonnet-libs to 1.21 for Kubernetes 1.21+ compatability. (@MurzNN)
-
 - [FEATURE] Added [Github exporter](https://github.com/infinityworks/github-exporter) integration. (@rgeyer)
 
 - [FEATURE] Add TLS config options for tempo `remote_write`s. (@mapno)
@@ -30,6 +28,8 @@ for specific instructions.
 
 - [ENHANCEMENT] Add HOSTNAME environment variable to service file to allow for expanding
   the $HOSTNAME variable in agent config.  (@dfrankel33)
+
+- [ENHANCEMENT] Update jsonnet-libs to 1.21 for Kubernetes 1.21+ compatability. (@MurzNN)
 
 - [BUGFIX] Regex capture groups like `${1}` will now be kept intact when
   using `-config.expand-env`. (@rfratto)
@@ -57,6 +57,8 @@ for specific instructions.
 - [BUGFIX] Fix yaml marshalling tag for cert_file in kafka exporter agent config. (@rgeyer)
 
 - [BUGFIX] Fix warn-level logging of dropped targets. (@james-callahan)
+
+- [BUGFIX] Standardize scrape_interval to 1m in examples. (@mattdurham)
 
 - [CHANGE] Breaking change: reduced verbosity of tracing autologging
   by not logging `STATUS_CODE_UNSET` status codes. (@mapno)

--- a/cmd/agent/agent-local-config.yaml
+++ b/cmd/agent/agent-local-config.yaml
@@ -4,7 +4,7 @@ server:
 
 prometheus:
   global:
-    scrape_interval: 5s
+    scrape_interval: 1m
   configs:
     - name: test
       host_filter: false

--- a/docs/getting-started/create-config-file.md
+++ b/docs/getting-started/create-config-file.md
@@ -92,7 +92,7 @@ server:
 
 prometheus:
   global:
-    scrape_interval: 5s
+    scrape_interval: 1m
   configs:
     - name: agent
       scrape_configs:
@@ -138,7 +138,7 @@ server:
 
 prometheus:
   global:
-    scrape_interval: 5s
+    scrape_interval: 1m
     remote_write:
       - url: http://localhost:9009/api/prom/push
   configs:

--- a/docs/scraping-service/_index.md
+++ b/docs/scraping-service/_index.md
@@ -133,7 +133,7 @@ server:
 
 prometheus:
   global:
-    scrape_interval: 5s
+    scrape_interval: 1m
   scraping_service:
     enabled: true
     kvstore:

--- a/example/docker-compose/agent/config/agent-local.yaml
+++ b/example/docker-compose/agent/config/agent-local.yaml
@@ -6,7 +6,7 @@ server:
 prometheus:
   wal_directory: /tmp/agent
   global:
-    scrape_interval: 5s
+    scrape_interval: 1m
     remote_write:
       - url: http://localhost:9009/api/prom/push
   configs:

--- a/example/docker-compose/agent/config/agent-scraping-service.yaml
+++ b/example/docker-compose/agent/config/agent-scraping-service.yaml
@@ -4,7 +4,7 @@ server:
 
 prometheus:
   global:
-    scrape_interval: 5s
+    scrape_interval: 1m
   scraping_service:
     enabled: true
     kvstore:

--- a/example/docker-compose/agent/config/agent.yaml
+++ b/example/docker-compose/agent/config/agent.yaml
@@ -4,7 +4,7 @@ server:
 
 prometheus:
   global:
-    scrape_interval: 30s
+    scrape_interval: 1m
   configs:
     - name: test
       host_filter: false

--- a/example/k3d/environment/main.jsonnet
+++ b/example/k3d/environment/main.jsonnet
@@ -43,7 +43,7 @@ local images = {
     grafana_agent.withPrometheusConfig({
       wal_directory: '/var/lib/agent/data',
       global: {
-        scrape_interval: '15s',
+        scrape_interval: '1m',
         external_labels: {
           cluster: cluster_label,
         },

--- a/example/k3d/smoke/main.jsonnet
+++ b/example/k3d/smoke/main.jsonnet
@@ -113,7 +113,7 @@ local smoke = {
 
       prometheus: {
         global: {
-          scrape_interval: '15s',
+          scrape_interval: '1m',
           external_labels: {
             cluster: 'grafana-agent',
           },
@@ -142,7 +142,7 @@ local smoke = {
 
       prometheus: {
         global: {
-          scrape_interval: '15s',
+          scrape_interval: '1m',
           external_labels: {
             cluster: 'grafana-agent-cluster',
           },

--- a/example/k3d/smoke/monitoring/prometheus_monitoring.libsonnet
+++ b/example/k3d/smoke/monitoring/prometheus_monitoring.libsonnet
@@ -3,7 +3,7 @@ local agent_prometheus = import 'grafana-agent/v1/lib/prometheus.libsonnet';
 {
   config: {
     global: {
-      scrape_interval: '15s',
+      scrape_interval: '1m',
     },
     scrape_configs: agent_prometheus.scrapeInstanceKubernetes.scrape_configs,
   },

--- a/packaging/grafana-agent.yaml
+++ b/packaging/grafana-agent.yaml
@@ -6,7 +6,7 @@ server:
 
 prometheus:
   global:
-    scrape_interval: 15s
+    scrape_interval: 1m
   wal_directory: '/var/lib/grafana-agent'
   configs:
     # Example Prometheus scrape configuration to scrape the agent itself for metrics.

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -142,7 +142,7 @@ Function WriteConfig
         FileWrite $9 `prometheus:$\n`
         FileWrite $9 `  wal_directory: $APPDATA\grafana-agent-wal$\n`
         FileWrite $9 `  global:$\n`
-        FileWrite $9 `    scrape_interval: 15s$\n`
+        FileWrite $9 `    scrape_interval: 1m$\n`
         FileWrite $9 `  configs:$\n`
         FileWrite $9 `    - name: integrations$\n`
         ${If} $EnableExporterValue == "true"

--- a/production/tanka/grafana-agent/config.libsonnet
+++ b/production/tanka/grafana-agent/config.libsonnet
@@ -60,7 +60,7 @@ local k8s_v2 = import './v2/internal/helpers/k8s.libsonnet';
 
       prometheus: {
         global: {
-          scrape_interval: '15s',
+          scrape_interval: '1m',
         },
 
         wal_directory: $._config.agent_wal_dir,


### PR DESCRIPTION
#### PR Description 

This PR changes most of our documentation and examples to use 1m has the default scrape interval. Also changes our testing/smoke test environments to also use 1m. 

#### Which issue(s) this PR fixes 

Closes #755
Closes #919 

#### Notes to the Reviewer

#### PR Checklist

- [X] CHANGELOG updated 
- [] Documentation added
- [] Tests updated
