### PR TITLE
Rename Prometheus to Metrics in docs / jsonnet

### DIFF
--- a/docs/api/_index.md
+++ b/docs/api/_index.md
@@ -108,7 +108,7 @@ URL-encoded names are stored in decoded form. e.g., `hello%2Fworld` will
 represent the config named `hello/world`.
 
 The request body passed to this endpoint must match the format of
-[prometheus_instance_config]({{< relref "../configuration/prometheus-config" >}})
+[metrics_instance_config]({{< relref "../configuration/metrics-config" >}})
 defined in the Configuration Reference. The name field of the configuration is
 ignored and the name in the URL takes precedence. The request body must be
 formatted as YAML.

--- a/docs/configuration/_index.md
+++ b/docs/configuration/_index.md
@@ -7,10 +7,10 @@ weight = 300
 
 The Grafana Agent is configured in a YAML file (usually called
 `agent.yaml`) which contains information on the Grafana Agent and its
-Prometheus instances.
+metrics instances.
 
 - [server_config]({{< relref "./server-config" >}})
-- [prometheus_config]({{< relref "./prometheus-config" >}})
+- [metrics_config]({{< relref "./metrics-config" >}})
 - [logs_config]({{< relref "./logs-config.md" >}})
 - [traces_config]({{< relref "./traces-config" >}})
 - [integrations_config]({{< relref "./integrations/_index.md" >}})
@@ -100,14 +100,16 @@ Support contents and default values of `agent.yaml`:
 # Configures the server of the Agent used to enable self-scraping.
 [server: <server_config>]
 
-# Configures Prometheus instances.
-[prometheus: <prometheus_config>]
+# Configures metric collection.
+# In previous versions of the agent, this field was called "prometheus".
+[prometheus: <metrics_config>]
 
 # Configures log collection.
-# In previous versions of the Agent, this field was called "loki".
+# In previous versions of the agent, this field was called "loki".
 [logs: <logs_config>]
 
 # Configures Traces trace collection.
+# In previous versions of the agent, this field was called "tempo".
 [traces: <traces_config>]
 
 # Configures integrations for the Agent.

--- a/docs/configuration/integrations/mongodb_exporter-config.md
+++ b/docs/configuration/integrations/mongodb_exporter-config.md
@@ -14,13 +14,13 @@ The second one is mongodb_cluster, which is the name of your mongodb cluster, an
 Here`s an example:
 
 ```yaml
-relabel_configs:        
+relabel_configs:
     - source_labels: [__address__]
       target_label: service_name
-      replacement: 'replicaset1-node1'   
+      replacement: 'replicaset1-node1'
     - source_labels: [__address__]
       target_label: mongodb_cluster
-      replacement: 'prod-cluster'  
+      replacement: 'prod-cluster'
 ```
 
 Besides that, there's not much to configure. Please refer to the full reference of options:
@@ -37,11 +37,11 @@ Besides that, there's not much to configure. Please refer to the full reference 
   [scrape_integration: <boolean> | default = <integrations_config.scrape_integrations>]
 
   # How often should the metrics be collected? Defaults to
-  # prometheus.global.scrape_interval.
+  # metrics.global.scrape_interval.
   [scrape_interval: <duration> | default = <global_config.scrape_interval>]
 
   # The timeout before considering the scrape a failure. Defaults to
-  # prometheus.global.scrape_timeout.
+  # metrics.global.scrape_timeout.
   [scrape_timeout: <duration> | default = <global_config.scrape_timeout>]
 
   # Allows for relabeling labels on the target.

--- a/docs/configuration/logs-config.md
+++ b/docs/configuration/logs-config.md
@@ -1,13 +1,13 @@
 +++
-title = "loki_config"
+title = "logs_config"
 weight = 300
 aliases = ["/docs/agent/latest/configuration/loki-config/"]
 +++
 
-# loki_config
+# logs_config
 
-The `loki_config` block configures how the Agent collects logs and sends them to
-a Loki push API endpoint. `loki_config` is identical to how Promtail is
+The `logs_config` block configures how the Agent collects logs and sends them to
+a Loki push API endpoint. `logs_config` is identical to how Promtail is
 configured, except deprecated fields have been removed and the server_config is
 not supported.
 
@@ -19,7 +19,7 @@ for the supported values for these fields.
 # Directory to store Loki Promtail positions files in. Positions files are
 # required to read logs, and are used to store the last read offset of log
 # sources. The positions files will be stored in
-# <positions_directory>/<loki_instance_config.name>.yml.
+# <positions_directory>/<logs_instance_config.name>.yml.
 #
 # Optional only if every config has a positions.filename manually provided.
 #
@@ -28,19 +28,19 @@ for the supported values for these fields.
 
 # Loki Promtail instances to run for log collection.
 configs:
-  - [<loki_instance_config>]
+  - [<logs_instance_config>]
 ```
 
-## loki_instance_config
+## logs_instance_config
 
-The `loki_instance_config` block is an individual instance of Promtail with its
+The `logs_instance_config` block is an individual instance of Promtail with its
 own set of scrape rules and where to forward logs. It is identical to how
 Promtail is configured, except deprecated fields have been removed and the
 `server_config` block is not supported.
 
 ```yaml
 # Name of this config. Required, and must be unique across all Loki configs.
-# The name of the config will be the value of a loki_config label for all
+# The name of the config will be the value of a logs_config label for all
 # Loki Promtail metrics.
 name: <string>
 
@@ -49,7 +49,7 @@ clients:
 
 # Optional configuration for where to store the positions files. If
 # positions.filename is left empty, the file will be stored in
-# <loki_config.positions_directory>/<loki_instance_config.name>.yml.
+# <logs_config.positions_directory>/<logs_instance_config.name>.yml.
 #
 # The directory of the positions file will automatically be created on start up
 # if it doesn't already exist..

--- a/docs/configuration/metrics-config.md
+++ b/docs/configuration/metrics-config.md
@@ -1,12 +1,14 @@
 +++
-title = "prometheus_config"
+title = "metrics_config"
 weight = 200
+aliases = ["/docs/agent/latest/configuration/prometheus-config/"]
 +++
 
-# prometheus_config
+# metrics_config
 
-The `prometheus_config` block is used to define a collection of Prometheus
-Instances, each of which is its own mini-Agent. Most users will only need to
+The `metrics_config` block is used to define a collection of metrics
+instances. Each instance defines a collection of Prometheus-compatible
+scrape_configs and remote_write rules. Most users will only need to
 define one instance.
 
 ```yaml
@@ -37,7 +39,7 @@ define one instance.
 
 # The list of Prometheus instances to launch with the agent.
 configs:
-  [- <prometheus_instance_config>]
+  [- <metrics_instance_config>]
 
 # If an instance crashes abnormally, how long should we wait before trying
 # to restart it. 0s disables the backoff period and restarts the agent
@@ -68,7 +70,7 @@ agents distribute discovery and scrape load between nodes.
 # events are not sent by an agent.
 [reshard_interval: <duration> | default = "1m"]
 
-# The timeout for configuration refreshes. This can occur on cluster events or 
+# The timeout for configuration refreshes. This can occur on cluster events or
 # on the reshard interval. A timeout of 0 indicates no timeout.
 [reshard_timeout: <duration> | default = "30s"]
 
@@ -248,10 +250,11 @@ remote_write:
 
 > **Note:** For more informaton on remote_write, refer to the [Prometheus documentation](https://prometheus.io/docs/prometheus/2.27/configuration/configuration/#remote_write)
 
-## prometheus_instance_config
+## metrics_instance_config
 
-The `prometheus_instance_config` block configures an individual Prometheus
-instance, which acts as its own mini Prometheus agent.
+The `metrics_instance_config` block configures an individual metrics
+instance, which acts as its own mini Prometheus-compatible agent, though
+without support for the TSDB.
 
 ```yaml
 # Name of the instance. Must be present. Will be added as a label to agent

--- a/docs/operation-guide/_index.md
+++ b/docs/operation-guide/_index.md
@@ -182,7 +182,7 @@ from that `remote_write` config separated by a `-`.
 The shared instances mode is the new default, and the previous behavior is
 deprecated. If you wish to restore the old behavior, set `instance_mode:
 distinct` in the
-[`prometheus_config`]({{< relref "../configuration/prometheus-config" >}}) block of
+[`metrics_config`]({{< relref "../configuration/metrics-config" >}}) block of
 your config file.
 
 Shared instances are completely transparent to the user with the exception of

--- a/example/k3d/environment/main.jsonnet
+++ b/example/k3d/environment/main.jsonnet
@@ -40,7 +40,7 @@ local images = {
 
     grafana_agent.new('grafana-agent', 'default') +
     grafana_agent.withImages(images) +
-    grafana_agent.withPrometheusConfig({
+    grafana_agent.withMetricsConfig({
       wal_directory: '/var/lib/agent/data',
       global: {
         scrape_interval: '15s',
@@ -49,7 +49,7 @@ local images = {
         },
       },
     }) +
-    grafana_agent.withPrometheusInstances(grafana_agent.scrapeInstanceKubernetes {
+    grafana_agent.withMetricsInstances(grafana_agent.scrapeInstanceKubernetes {
       // We want our cluster and label to remain static for this deployment, so
       // if they are overwritten by a metric we will change them to the values
       // set by external_labels.
@@ -63,8 +63,8 @@ local images = {
     grafana_agent.withRemoteWrite([{
       url: 'http://cortex.default.svc.cluster.local/api/prom/push',
     }]) +
-    grafana_agent.withLokiConfig(loki_config) +
-    grafana_agent.withLokiClients(grafana_agent.newLokiClient({
+    grafana_agent.withLogsConfig(loki_config) +
+    grafana_agent.withLogsClients(grafana_agent.newLogsClient({
       scheme: 'http',
       hostname: 'loki.default.svc.cluster.local',
       external_labels: { cluster: cluster_label },
@@ -136,7 +136,7 @@ local images = {
 
       local cluster_label = 'k3d-agent/cluster',
       agent_config+: {
-        prometheus+: {
+        metrics+: {
           global+: {
             external_labels+: {
               cluster: cluster_label,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -20,7 +20,7 @@ import (
 // when parsing the config.
 func TestConfig_FlagDefaults(t *testing.T) {
 	cfg := `
-prometheus:
+metrics:
   wal_directory: /tmp/wal
   global:
     scrape_timeout: 33s`
@@ -38,7 +38,7 @@ prometheus:
 
 func TestConfig_OverrideDefaultsOnLoad(t *testing.T) {
 	cfg := `
-prometheus:
+metrics:
   wal_directory: /tmp/wal
   global:
     scrape_timeout: 33s`
@@ -60,7 +60,7 @@ prometheus:
 
 func TestConfig_OverrideByEnvironmentOnLoad(t *testing.T) {
 	cfg := `
-prometheus:
+metrics:
   wal_directory: /tmp/wal
   global:
     scrape_timeout: ${SCRAPE_TIMEOUT}`
@@ -83,7 +83,7 @@ prometheus:
 
 func TestConfig_OverrideByEnvironmentOnLoad_NoDigits(t *testing.T) {
 	cfg := `
-prometheus:
+metrics:
   wal_directory: /tmp/wal
   global:
     external_labels:
@@ -100,14 +100,14 @@ prometheus:
 
 func TestConfig_FlagsAreAccepted(t *testing.T) {
 	cfg := `
-prometheus:
+metrics:
   global:
     scrape_timeout: 33s`
 
 	fs := flag.NewFlagSet("test", flag.ExitOnError)
 	args := []string{
 		"-config.file", "test",
-		"-prometheus.wal-directory", "/tmp/wal",
+		"-metrics.wal-directory", "/tmp/wal",
 		"-config.expand-env",
 	}
 
@@ -121,7 +121,7 @@ prometheus:
 func TestConfig_StrictYamlParsing(t *testing.T) {
 	t.Run("duplicate key", func(t *testing.T) {
 		cfg := `
-prometheus:
+metrics:
   wal_directory: /tmp/wal
   global:
     scrape_timeout: 10s
@@ -133,7 +133,7 @@ prometheus:
 
 	t.Run("non existing key", func(t *testing.T) {
 		cfg := `
-prometheus:
+metrics:
   wal_directory: /tmp/wal
   global:
   scrape_timeout: 10s`
@@ -232,7 +232,7 @@ func TestConfig_PrometheusNonNil(t *testing.T) {
 		},
 		{
 			name:  "null",
-			input: `prometheus: null`,
+			input: `metrics: null`,
 		},
 	}
 

--- a/pkg/metrics/cluster/client/client.go
+++ b/pkg/metrics/cluster/client/client.go
@@ -41,6 +41,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // RegisterFlags registers flags to the provided flag set.
 func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.RegisterFlagsWithPrefix("prometheus.", f)
+	c.RegisterFlagsWithPrefix("metrics.", f)
 }
 
 // RegisterFlagsWithPrefix registers flags to the provided flag set with the

--- a/pkg/operator/config/config_test.go
+++ b/pkg/operator/config/config_test.go
@@ -47,7 +47,7 @@ func TestBuildConfigMetrics(t *testing.T) {
 					http_listen_port: 8080
 					log_level: debug
 
-				prometheus:
+				metrics:
 					wal_directory: /var/lib/grafana-agent/data
 					global:
 						scrape_interval: 15s
@@ -101,7 +101,7 @@ func TestBuildConfigMetrics(t *testing.T) {
 						http_listen_port: 8080
 						log_level: debug
 
-					prometheus:
+					metrics:
 						wal_directory: /var/lib/grafana-agent/data
 						global:
 							scrape_interval: 15s
@@ -190,7 +190,7 @@ func TestAdditionalScrapeConfigsMetrics(t *testing.T) {
 server:
   http_listen_port: 8080
 
-prometheus:
+metrics:
   wal_directory: /var/lib/grafana-agent/data
   global:
     external_labels:

--- a/pkg/operator/config/templates/agent-metrics.libsonnet
+++ b/pkg/operator/config/templates/agent-metrics.libsonnet
@@ -14,7 +14,7 @@
 local marshal = import 'ext/marshal.libsonnet';
 local optionals = import 'ext/optionals.libsonnet';
 
-local new_prometheus_instance = import './prometheus.libsonnet';
+local new_metrics_instance = import './metrics.libsonnet';
 local new_external_labels = import 'component/metrics/external_labels.libsonnet';
 local new_remote_write = import 'component/metrics/remote_write.libsonnet';
 
@@ -35,7 +35,7 @@ function(ctx) marshal.YAML(optionals.trim({
     log_format: optionals.string(spec.LogFormat),
   },
 
-  prometheus: {
+  metrics: {
     wal_directory: '/var/lib/grafana-agent/data',
     global: {
       external_labels: optionals.object(new_external_labels(ctx)),
@@ -47,7 +47,7 @@ function(ctx) marshal.YAML(optionals.trim({
       )),
     },
     configs: optionals.array(std.map(
-      function(inst) new_prometheus_instance(
+      function(inst) new_metrics_instance(
         agentNamespace=ctx.Agent.ObjectMeta.Namespace,
         instance=inst,
         apiServer=spec.APIServerConfig,

--- a/pkg/operator/config/templates/metrics.libsonnet
+++ b/pkg/operator/config/templates/metrics.libsonnet
@@ -8,7 +8,7 @@ local new_probe = import 'component/metrics/probe.libsonnet';
 local new_remote_write = import 'component/metrics/remote_write.libsonnet';
 local new_service_monitor = import 'component/metrics/service_monitor.libsonnet';
 
-// Generates a prometheus_instance.
+// Generates a metrics_instance.
 //
 // @param {string} agentNamespace - namespace of the GrafanaAgent
 // @param {MetricsInstance} instance

--- a/pkg/traces/contextkeys/keys.go
+++ b/pkg/traces/contextkeys/keys.go
@@ -6,6 +6,6 @@ const (
 	// Logs is used to pass *logs.Logs through the context
 	Logs key = iota
 
-	// Prometheus is used to pass instance.Manager through the context
-	Prometheus
+	// Metrics is used to pass instance.Manager through the context
+	Metrics
 )

--- a/pkg/traces/instance.go
+++ b/pkg/traces/instance.go
@@ -149,7 +149,7 @@ func (i *Instance) buildAndStartPipeline(ctx context.Context, cfg InstanceConfig
 	}
 
 	if cfg.SpanMetrics != nil && len(cfg.SpanMetrics.MetricsInstance) != 0 {
-		ctx = context.WithValue(ctx, contextkeys.Prometheus, promManager)
+		ctx = context.WithValue(ctx, contextkeys.Metrics, promManager)
 	}
 
 	if cfg.TailSampling != nil && cfg.LoadBalancing == nil {

--- a/pkg/traces/remotewriteexporter/exporter.go
+++ b/pkg/traces/remotewriteexporter/exporter.go
@@ -60,7 +60,7 @@ func newRemoteWriteExporter(cfg *Config) (component.MetricsExporter, error) {
 }
 
 func (e *remoteWriteExporter) Start(ctx context.Context, _ component.Host) error {
-	manager, ok := ctx.Value(contextkeys.Prometheus).(instance.Manager)
+	manager, ok := ctx.Value(contextkeys.Metrics).(instance.Manager)
 	if !ok || manager == nil {
 		return fmt.Errorf("key does not contain a Prometheus instance")
 	}

--- a/production/kubernetes/build/templates/loki/main.jsonnet
+++ b/production/kubernetes/build/templates/loki/main.jsonnet
@@ -6,7 +6,7 @@ local agent = import 'grafana-agent/v1/main.libsonnet';
     agent.withConfigHash(false) +
     agent.withImages({
       agent: (import 'version.libsonnet'),
-    }) + agent.withLokiConfig(agent.scrapeKubernetesLogs) + {
+    }) + agent.withLogsConfig(agent.scrapeKubernetesLogs) + {
       agent+: {
         // Remove ConfigMap
         config_map:: {},

--- a/production/tanka/grafana-agent/v1/README.md
+++ b/production/tanka/grafana-agent/v1/README.md
@@ -15,11 +15,11 @@ incompatible changes will be made.
 This library is significantly more flexible than its `v0` counterpart. It tries
 to allow to deploy and configure the Agent in a feature matrix:
 
-| Mechanism        | Prometheus Metrics | Logs      | Traces | Integrations |
-| ---------------- | ------------------ | --------- | ------ | ------------ |
-| DaemonSet        | Yes                | Yes       | Yes    | Yes          |
-| Deployment       | Yes                | No        | No     | No           |
-| Scraping Service | Yes                | No        | No     | No           |
+| Mechanism        | Metrics | Logs      | Traces | Integrations |
+| ---------------- | ------- | --------- | ------ | ------------ |
+| DaemonSet        | Yes     | Yes       | Yes    | Yes          |
+| Deployment       | Yes     | No        | No     | No           |
+| Scraping Service | Yes     | No        | No     | No           |
 
 The library can be invoked multiple times to get full coverage. For example, you
 may wish to deploy a scraping service for scalable metrics collection, and a
@@ -39,15 +39,15 @@ example, you may not deploy a scraping service with Loki logs collection.
 - `newScrapingService(name, namespace, replicas)`: (Not yet available). Create a
   scalable deployment of clustered Agents. Requires being given a KV store such as Redis or ETCD.
 
-## Configure Prometheus
+## Configure Metrics
 
-- `withPrometheusConfig(config)`: Creates a Prometheus config block.
-- `defaultPrometheusConfig`: Default Prometheus config block.
-- `withPrometheusInstances(instances)`: Creates a Prometheus instance config to
+- `withMetricsConfig(config)`: Creates a metrics config block.
+- `defaultMetricsConfig`: Default metrics config block.
+- `withMetricsInstances(instances)`: Creates a metrics instance config to
   tell the Agent what to scrape.
 - `withRemoteWrite(remote_writes)`: Configures locations to remote write metrics
    to. Controls remote writes globally.
-- `scrapeInstanceKubernetes`: Default Prometheus instance config to scrape from
+- `scrapeInstanceKubernetes`: Default metrics instance config to scrape from
   Kubernetes.
 
 ## Configure Logs

--- a/production/tanka/grafana-agent/v1/lib/deployment.libsonnet
+++ b/production/tanka/grafana-agent/v1/lib/deployment.libsonnet
@@ -10,13 +10,13 @@ local container = k.core.v1.container;
   // grafana-agent. By default, this deployment will do no collection. You must
   // merge the result of this function with the following:
   //
-  // - withPrometheusConfig
-  // - withPrometheusInstances
+  // - withMetricsConfig
+  // - withMetricsInstances
   // - optionally withRemoteWrite
   //
   // newDeployment does not support log collection.
   newDeployment(name='grafana-agent', namespace='default'):: {
-    assert !std.objectHas(self, '_loki_config') : |||
+    assert !std.objectHas(self, '_logs_config') : |||
       Log collection is not supported with newDeployment.
     |||,
     assert !std.objectHas(self, '_integrations') : |||
@@ -29,8 +29,8 @@ local container = k.core.v1.container;
     _images:: $._images,
     _config_hash:: true,
 
-    local has_prometheus_config = std.objectHasAll(self, '_prometheus_config'),
-    local has_prometheus_instances = std.objectHasAll(self, '_prometheus_instances'),
+    local has_metrics_config = std.objectHasAll(self, '_metrics_config'),
+    local has_metrics_instances = std.objectHasAll(self, '_metrics_instances'),
     local has_trace_config = std.objectHasAll(self, '_trace_config'),
     local has_sampling_strategies = std.objectHasAll(self, '_traces_sampling_strategies'),
 
@@ -40,13 +40,13 @@ local container = k.core.v1.container;
         http_listen_port: 8080,
       },
     } + (
-      if has_prometheus_config
+      if has_metrics_config
       then {
-        prometheus:
-          this._prometheus_config {
+        metrics:
+          this._metrics_config {
             configs:
-              if has_prometheus_instances
-              then this._prometheus_instances
+              if has_metrics_instances
+              then this._metrics_instances
               else [],
           },
       }

--- a/production/tanka/grafana-agent/v1/lib/metrics.libsonnet
+++ b/production/tanka/grafana-agent/v1/lib/metrics.libsonnet
@@ -1,15 +1,15 @@
 local scrape_k8s = import '../internal/kubernetes_instance.libsonnet';
 
 {
-  // defaultPrometheusConfig holds the default Prometheus Config with all
+  // defaultMetricsConfig holds the default Metrics Config with all
   // options that the Agent supports. It is better to use this object as a
   // reference rather than extending it; since all fields are defined here, if
   // the Agent changes a default value in the future, the default change will
   // be overridden by the values here.
   //
   // Required fields will be marked as REQUIRED.
-  defaultPrometheusConfig:: {
-    // Settings that apply to all launched Prometheus instances by default.
+  defaultMetricsConfig:: {
+    // Settings that apply to all launched Metrics instances by default.
     // These settings may be overridden on a per-instance basis.
     global: {
       // How frequently to scrape for metrics.
@@ -37,12 +37,12 @@ local scrape_k8s = import '../internal/kubernetes_instance.libsonnet';
     instance_mode: 'shared',
   },
 
-  // withPrometheusConfig controls the Prometheus engine settings for the Agent.
-  // defaultPrometheusConfig explicitly defines all supported values that can be
+  // withMetricsConfig controls the Metrics engine settings for the Agent.
+  // defaultMetricsConfig explicitly defines all supported values that can be
   // provided within config.
-  withPrometheusConfig(config):: { _prometheus_config:: config },
+  withMetricsConfig(config):: { _metrics_config:: config },
 
-  // withPrometheusInstances controls the Prometheus instances the Agent will
+  // withMetricsInstances controls the Metrics instances the Agent will
   // launch. Instances may be a single object or an array of objects. Each
   // object must have a name key that is unique to that object.
   //
@@ -51,7 +51,7 @@ local scrape_k8s = import '../internal/kubernetes_instance.libsonnet';
   // values for scrape configs and remote_write. For detailed information on
   // instance config settings, consult the Agent documentation:
   //
-  // https://github.com/grafana/agent/blob/main/docs/configuration-reference.md#prometheus_instance_config
+  // https://github.com/grafana/agent/blob/main/docs/configuration-reference.md#metrics_instance_config
   //
   // host_filter does not need to be applied here; the library will apply it
   // automatically based on how the Agent is being deployed.
@@ -59,9 +59,9 @@ local scrape_k8s = import '../internal/kubernetes_instance.libsonnet';
   // remote_write rules may be defined in the instance object. Optionally,
   // remove_write rules may be applied to every instance object by using the
   // withRemoteWrite function.
-  withPrometheusInstances(instances):: {
+  withMetricsInstances(instances):: {
     assert std.objectHasAll(self, '_mode') : |||
-      withPrometheusInstances must be merged with the result of calling new,
+      withMetricsInstances must be merged with the result of calling new,
       newDeployment, or newScrapingService.
     |||,
 
@@ -73,7 +73,7 @@ local scrape_k8s = import '../internal/kubernetes_instance.libsonnet';
     local host_filter = super._mode == 'daemonset',
 
     // Apply host_filtering over our list of instances.
-    _prometheus_instances:: std.map(function(inst) inst {
+    _metrics_instances:: std.map(function(inst) inst {
       host_filter: host_filter,
 
       // Make sure remote_write is an empty array if it doesn't exist.
@@ -85,7 +85,7 @@ local scrape_k8s = import '../internal/kubernetes_instance.libsonnet';
   },
 
   // withRemoteWrite overwrites all the remote_write configs provided in
-  // withPrometheusInstances with the specified remote_writes. This is
+  // withMetricsInstances with the specified remote_writes. This is
   // useful when there are multiple instances and you just want everything
   // to remote_write to the same place.
   //
@@ -93,12 +93,12 @@ local scrape_k8s = import '../internal/kubernetes_instance.libsonnet';
   //   https://github.com/grafana/agent/blob/main/docs/configuration-reference.md#remote_write
   withRemoteWrite(remote_writes):: {
     assert std.objectHasAll(self, '_mode') : |||
-      withPrometheusInstances must be merged with the result of calling new,
+      withMetricsInstances must be merged with the result of calling new,
       newDeployment, or newScrapingService.
     |||,
 
     local list = if std.isArray(remote_writes) then remote_writes else [remote_writes],
-    _prometheus_config+:: { global+: { remote_write: list } },
+    _metrics_config+:: { global+: { remote_write: list } },
   },
 
   // scrapeInstanceKubernetes defines an instance config Grafana Labs uses to

--- a/production/tanka/grafana-agent/v1/main.libsonnet
+++ b/production/tanka/grafana-agent/v1/main.libsonnet
@@ -9,7 +9,7 @@ local service = k.core.v1.service;
 // Merge all of our libraries to create the final exposed library.
 (import './lib/deployment.libsonnet') +
 (import './lib/integrations.libsonnet') +
-(import './lib/prometheus.libsonnet') +
+(import './lib/metrics.libsonnet') +
 (import './lib/scraping_service.libsonnet') +
 (import './lib/logs.libsonnet') +
 (import './lib/traces.libsonnet') +
@@ -23,10 +23,10 @@ local service = k.core.v1.service;
   // the deployment will do no collection. You must merge the result of this
   // function with one or more of the following:
   //
-  // - withPrometheusConfig, withPrometheusInstances (and optionally withRemoteWrite)
+  // - withMetricsConfig, withMetricsInstances (and optionally withRemoteWrite)
   // - withLogsConfig
   //
-  // When using withPrometheusInstances, a [name]-etc deployment
+  // When using withMetricsInstances, a [name]-etc deployment
   // with one replica will be created alongside the DaemonSet. This deployment
   // is responsible for handling scrape configs that will not work on the host
   // machine.
@@ -36,7 +36,7 @@ local service = k.core.v1.service;
   // on any node in the cluster.
   //
   // scrapeInstanceKubernetes provides the default
-  // PrometheusInstanceConfig Grafana Labs uses in production.
+  // MetricsInstanceConfig Grafana Labs uses in production.
   new(name='grafana-agent', namespace='default'):: {
     local this = self,
 
@@ -46,15 +46,15 @@ local service = k.core.v1.service;
 
     local has_logs_config = std.objectHasAll(self, '_logs_config'),
     local has_trace_config = std.objectHasAll(self, '_trace_config'),
-    local has_prometheus_config = std.objectHasAll(self, '_prometheus_config'),
-    local has_prometheus_instances = std.objectHasAll(self, '_prometheus_instances'),
+    local has_metrics_config = std.objectHasAll(self, '_metrics_config'),
+    local has_metrics_instances = std.objectHasAll(self, '_metrics_instances'),
     local has_integrations = std.objectHasAll(self, '_integrations'),
     local has_sampling_strategies = std.objectHasAll(self, '_traces_sampling_strategies'),
 
-    local prometheus_instances =
-      if has_prometheus_instances then this._prometheus_instances else [],
-    local host_filter_instances = utils.transformInstances(prometheus_instances, true),
-    local etc_instances = utils.transformInstances(prometheus_instances, false),
+    local metrics_instances =
+      if has_metrics_instances then this._metrics_instances else [],
+    local host_filter_instances = utils.transformInstances(metrics_instances, true),
+    local etc_instances = utils.transformInstances(metrics_instances, false),
 
     config:: {
       server: {
@@ -62,8 +62,8 @@ local service = k.core.v1.service;
         http_listen_port: 8080,
       },
     } + (
-      if has_prometheus_config
-      then { prometheus: this._prometheus_config { configs: host_filter_instances } }
+      if has_metrics_config
+      then { metrics: this._metrics_config { configs: host_filter_instances } }
       else {}
     ) + (
       if has_logs_config then {
@@ -87,10 +87,10 @@ local service = k.core.v1.service;
       if has_integrations then { integrations: this._integrations } else {}
     ),
 
-    etc_config:: if has_prometheus_config then this.config {
+    etc_config:: if has_metrics_config then this.config {
       // Hide logs and integrations from our extra configs, we just want the
       // scrape configs that wouldn't work for the DaemonSet.
-      prometheus+: {
+      metrics+: {
         configs: std.map(function(cfg) cfg { host_filter: false }, etc_instances),
       },
       logs:: {},


### PR DESCRIPTION
#### PR Description 
Related to #739. 

#### Which issue(s) this PR fixes 
Closes #722 (:tada:)

#### Notes to the Reviewer
This doesn't change any `agent_prometheus_` metrics name. It also doesn't change `prometheus_remote_write` in integrations. Not sure if we want to do that?

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
