### PR TITLE
Rename metrics in the metrics subsystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ for specific instructions.
 - [CHANGE] Breaking change: `prom_instance` in the spanmetrics config is now
   named `metrics_instance`. (@rfratto)
 
+
 - [DEPRECATION] The `loki` key at the root of the config file has been
   deprecated in favor of `logs`. `loki`-named fields in `automatic_logging`
   have been renamed accordinly: `loki_name` is now `logs_instance_name`,
@@ -85,9 +86,11 @@ for specific instructions.
 - [DEPRECATION] The `prometheus` key at the root of the config file has been
   deprecated in favor of `metrics`. Flag names starting with `prometheus.` have
   also been deprecated in favor of the same flags with the `metrics.` prefix.
-  (@rfratto)
-  
-- [DEPRECATION] Rename Tempo to Traces (@mattdurham)
+  Metrics prefixed with `agent_prometheus_` are now prefixed with
+  `agent_metrics_`. (@rfratto)
+
+- [DEPRECATION] The `tempo` key at the root of the config file has been
+  deprecated in favor of `traces`. (@mattdurham)
 
 # v0.18.4 (2021-09-14)
 

--- a/pkg/integrations/manager.go
+++ b/pkg/integrations/manager.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	integrationAbnormalExits = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "agent_prometheus_integration_abnormal_exits_total",
+		Name: "agent_metrics_integration_abnormal_exits_total",
 		Help: "Total number of times an agent integration exited unexpectedly, causing it to be restarted.",
 	}, []string{"integration_name"})
 )

--- a/pkg/metrics/cleaner.go
+++ b/pkg/metrics/cleaner.go
@@ -24,7 +24,7 @@ const (
 var (
 	discoveryError = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "agent_prometheus_cleaner_storage_error_total",
+			Name: "agent_metrics_cleaner_storage_error_total",
 			Help: "Errors encountered discovering local storage paths",
 		},
 		[]string{"storage"},
@@ -32,7 +32,7 @@ var (
 
 	segmentError = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "agent_prometheus_cleaner_segment_error_total",
+			Name: "agent_metrics_cleaner_segment_error_total",
 			Help: "Errors encountered finding most recent WAL segments",
 		},
 		[]string{"storage"},
@@ -40,35 +40,35 @@ var (
 
 	managedStorage = promauto.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "agent_prometheus_cleaner_managed_storage",
+			Name: "agent_metrics_cleaner_managed_storage",
 			Help: "Number of storage directories associated with managed instances",
 		},
 	)
 
 	abandonedStorage = promauto.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "agent_prometheus_cleaner_abandoned_storage",
+			Name: "agent_metrics_cleaner_abandoned_storage",
 			Help: "Number of storage directories not associated with any managed instance",
 		},
 	)
 
 	cleanupRunsSuccess = promauto.NewCounter(
 		prometheus.CounterOpts{
-			Name: "agent_prometheus_cleaner_success_total",
+			Name: "agent_metrics_cleaner_success_total",
 			Help: "Number of successfully removed abandoned WALs",
 		},
 	)
 
 	cleanupRunsErrors = promauto.NewCounter(
 		prometheus.CounterOpts{
-			Name: "agent_prometheus_cleaner_errors_total",
+			Name: "agent_metrics_cleaner_errors_total",
 			Help: "Number of errors removing abandoned WALs",
 		},
 	)
 
 	cleanupTimes = promauto.NewHistogram(
 		prometheus.HistogramOpts{
-			Name: "agent_prometheus_cleaner_cleanup_seconds",
+			Name: "agent_metrics_cleaner_cleanup_seconds",
 			Help: "Time spent performing each periodic WAL cleanup",
 		},
 	)

--- a/pkg/metrics/cluster/config_watcher.go
+++ b/pkg/metrics/cluster/config_watcher.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	reshardDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "agent_prometheus_scraping_service_reshard_duration",
+		Name: "agent_metrics_scraping_service_reshard_duration",
 		Help: "How long it took for resharding to run.",
 	}, []string{"success"})
 )

--- a/pkg/metrics/instance/configstore/api.go
+++ b/pkg/metrics/instance/configstore/api.go
@@ -41,15 +41,15 @@ func NewAPI(l log.Logger, store Store, v Validator) *API {
 		validator: v,
 
 		totalCreatedConfigs: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "agent_prometheus_ha_configs_created_total",
+			Name: "agent_metrics_ha_configs_created_total",
 			Help: "Total number of created scraping service configs",
 		}),
 		totalUpdatedConfigs: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "agent_prometheus_ha_configs_updated_total",
+			Name: "agent_metrics_ha_configs_updated_total",
 			Help: "Total number of updated scraping service configs",
 		}),
 		totalDeletedConfigs: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "agent_prometheus_ha_configs_deleted_total",
+			Name: "agent_metrics_ha_configs_deleted_total",
 			Help: "Total number of deleted scraping service configs",
 		}),
 	}

--- a/pkg/metrics/instance/manager.go
+++ b/pkg/metrics/instance/manager.go
@@ -17,12 +17,12 @@ import (
 
 var (
 	instanceAbnormalExits = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "agent_prometheus_instance_abnormal_exits_total",
+		Name: "agent_metrics_instance_abnormal_exits_total",
 		Help: "Total number of times a Prometheus instance exited unexpectedly, causing it to be restarted.",
 	}, []string{"instance_name"})
 
 	currentActiveInstances = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "agent_prometheus_active_instances",
+		Name: "agent_metrics_active_instances",
 		Help: "Current number of active instances being used by the agent.",
 	})
 

--- a/pkg/metrics/instance/modal_manager.go
+++ b/pkg/metrics/instance/modal_manager.go
@@ -71,11 +71,11 @@ type ModalManager struct {
 // NewModalManager creates a new ModalManager.
 func NewModalManager(reg prometheus.Registerer, l log.Logger, next Manager, mode Mode) (*ModalManager, error) {
 	changedConfigs := promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
-		Name: "agent_prometheus_configs_changed_total",
+		Name: "agent_metrics_configs_changed_total",
 		Help: "Total number of dynamically updated configs",
 	}, []string{"event"})
 	currentActiveConfigs := promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-		Name: "agent_prometheus_active_configs",
+		Name: "agent_metrics_active_configs",
 		Help: "Current number of active configs being used by the agent.",
 	})
 


### PR DESCRIPTION
#### PR Description 
Metrics prefixed with `agent_prometheus_` will now be prefixed with `agent_metrics_` instead.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer
We might not want to do this, mostly opening for spurring a discussion.

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
