### PR TITLE
Replace dots for underscores in autologged labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ for specific instructions.
 
 - [BUGFIX] Standardize scrape_interval to 1m in examples. (@mattdurham)
 
+- [BUGFIX] Replace dots for underscores when autologging span attributes or tags
+  as Loki labels (@mapno)
+
 - [CHANGE] Breaking change: reduced verbosity of tracing autologging
   by not logging `STATUS_CODE_UNSET` status codes. (@mapno)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,8 +63,7 @@ for specific instructions.
 
 - [BUGFIX] Standardize scrape_interval to 1m in examples. (@mattdurham)
 
-- [BUGFIX] Replace dots for underscores when autologging span attributes or tags
-  as Loki labels (@mapno)
+- [BUGFIX] Sanitize autologged Loki labels by replacing invalid characters with underscores (@mapno)
 
 - [CHANGE] Breaking change: reduced verbosity of tracing autologging
   by not logging `STATUS_CODE_UNSET` status codes. (@mapno)

--- a/docs/configuration/traces-config.md
+++ b/docs/configuration/traces-config.md
@@ -114,7 +114,7 @@ automatic_logging:
   # This feature only applies when `backend = logs_instance`
   #
   # Loki only accepts alphanumeric and "_" as valid characters for labels.
-  # Attributes containing dots are replaced for underscores
+  # Labels are sanitized by replacing invalid characters with underscores.
   [ labels: <string array> ]
   overrides:
     [ logs_instance_tag: <string> | default = "traces" ]

--- a/docs/configuration/traces-config.md
+++ b/docs/configuration/traces-config.md
@@ -112,6 +112,9 @@ automatic_logging:
   # They need to be span or process attributes logged in the log line
   #
   # This feature only applies when `backend = logs_instance`
+  #
+  # Loki only accepts alphanumeric and "_" as valid characters for labels.
+  # Attributes containing dots are replaced for underscores
   [ labels: <string array> ]
   overrides:
     [ logs_instance_tag: <string> | default = "traces" ]

--- a/pkg/traces/automaticloggingprocessor/automaticloggingprocessor.go
+++ b/pkg/traces/automaticloggingprocessor/automaticloggingprocessor.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	util "github.com/cortexproject/cortex/pkg/util/log"
@@ -13,6 +12,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/go-logfmt/logfmt"
 	"github.com/grafana/agent/pkg/logs"
+	"github.com/grafana/agent/pkg/operator/config"
 	"github.com/grafana/agent/pkg/traces/contextkeys"
 	"github.com/grafana/loki/clients/pkg/promtail/api"
 	"github.com/grafana/loki/pkg/logproto"
@@ -39,9 +39,6 @@ const (
 	typeRoot    = "root"
 	typeProcess = "process"
 )
-
-// todo: make configurable
-var replacer = strings.NewReplacer(".", "_")
 
 type automaticLoggingProcessor struct {
 	nextConsumer consumer.Traces
@@ -172,7 +169,7 @@ func (p *automaticLoggingProcessor) spanLabels(keyValues []interface{}) model.La
 		if _, ok := p.labels[k]; ok {
 			// Loki does not accept "." as a valid character for labels
 			// Dots . are replaced by underscores _
-			k = replacer.Replace(k)
+			k = config.SanitizeLabelName(k)
 
 			ls[model.LabelName(k)] = model.LabelValue(v)
 		}

--- a/pkg/traces/automaticloggingprocessor/automaticloggingprocessor.go
+++ b/pkg/traces/automaticloggingprocessor/automaticloggingprocessor.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	util "github.com/cortexproject/cortex/pkg/util/log"
@@ -38,6 +39,9 @@ const (
 	typeRoot    = "root"
 	typeProcess = "process"
 )
+
+// todo: make configurable
+var replacer = strings.NewReplacer(".", "_")
 
 type automaticLoggingProcessor struct {
 	nextConsumer consumer.Traces
@@ -166,6 +170,10 @@ func (p *automaticLoggingProcessor) spanLabels(keyValues []interface{}) model.La
 			v = fmt.Sprintf("%v", keyValues[i+1])
 		}
 		if _, ok := p.labels[k]; ok {
+			// Loki does not accept "." as a valid character for labels
+			// Dots . are replaced by underscores _
+			k = replacer.Replace(k)
+
 			ls[model.LabelName(k)] = model.LabelValue(v)
 		}
 	}

--- a/pkg/traces/automaticloggingprocessor/automaticloggingprocessor_test.go
+++ b/pkg/traces/automaticloggingprocessor/automaticloggingprocessor_test.go
@@ -288,6 +288,15 @@ func TestLabels(t *testing.T) {
 			},
 		},
 		{
+			name:      "happy case with dots",
+			labels:    []string{"loki", "service.name"},
+			keyValues: []interface{}{"loki", "loki", "service.name", "gateway", "duration", "1s"},
+			expectedLabels: map[model.LabelName]model.LabelValue{
+				"loki":         "loki",
+				"service_name": "gateway",
+			},
+		},
+		{
 			name:           "no labels",
 			labels:         []string{},
 			keyValues:      []interface{}{"loki", "loki", "svc", "gateway", "duration", "1s"},


### PR DESCRIPTION
#### PR Description 

Replace dots for underscores in autologged labels.

Loki only accepts alphanumeric and "_" as valid characters for labels. Attributes containing dots are replaced for underscores

#### Which issue(s) this PR fixes

Fixes https://github.com/grafana/agent/issues/941

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
