### PR TITLE
Add note about ports in tempo remote_write enpoint

### DIFF
--- a/docs/configuration/traces-config.md
+++ b/docs/configuration/traces-config.md
@@ -40,6 +40,10 @@ name: <string>
 
 remote_write:
   # host:port to send traces to
+  # Here must be the port of gRPC receiver, not the Tempo default port.
+  # Example for cloud instances: something like `tempo-us-central1.grafana.net:443`
+  # For local / on-premises instances: `localhost:55680` or `tempo.example.com:14250`
+  # Note: for non-encrypted connections you must also set `insecure: true`
   - endpoint: <string>
 
     # Custom HTTP headers to be sent along with each remote write request.

--- a/docs/configuration/traces-config.md
+++ b/docs/configuration/traces-config.md
@@ -41,7 +41,7 @@ name: <string>
 remote_write:
   # host:port to send traces to
   # Here must be the port of gRPC receiver, not the Tempo default port.
-  # Example for cloud instances: something like `tempo-us-central1.grafana.net:443`
+  # Example for cloud instances:  `tempo-us-central1.grafana.net:443`
   # For local / on-premises instances: `localhost:55680` or `tempo.example.com:14250`
   # Note: for non-encrypted connections you must also set `insecure: true`
   - endpoint: <string>


### PR DESCRIPTION
Added comment with examples how to fill port of `remote_write` tempo endpoint for local and on-premises instances.
For new users it's unclear which port to choose, and in most cases they try to fill the default `3200` Tempo port, instead of gRPC receiver port.

#### PR Description 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [x] Documentation added
- [ ] Tests updated
