### PR TITLE
docs: deploy main -> /next, release -> /latest and /<tag>

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         host: github.com
         github_pat: '${{ secrets.GH_BOT_ACCESS_TOKEN }}'
         source_folder: docs
-        target_folder: content/docs/agent/latest
+        target_folder: content/docs/agent/next
     - shell: bash
       run: |
         test -n "${{ steps.publish.outputs.commit_hash }}"

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,45 @@
+name: publish_release_docs
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync
+
+    # Sync tag docs to versioned folder
+    - name: publish-tag-to-git
+      uses: ./.github/actions/website-sync
+      id: publish_tag
+      with:
+        repository: grafana/website
+        branch: master
+        host: github.com
+        github_pat: '${{ secrets.GH_BOT_ACCESS_TOKEN }}'
+        source_folder: docs
+        target_folder: 'content/docs/agent/${GITHUB_REF##*/}'
+    - shell: bash
+      run: |
+        test -n "${{ steps.publish_tag.outputs.commit_hash }}"
+        test -n "${{ steps.publish_tag.outputs.working_directory }}"
+
+    # Also send it to latest folder
+    - name: publish-latest-to-git
+      uses: ./.github/actions/website-sync
+      id: publish_latest
+      with:
+        repository: grafana/website
+        branch: master
+        host: github.com
+        github_pat: '${{ secrets.GH_BOT_ACCESS_TOKEN }}'
+        source_folder: docs
+        target_folder: 'content/docs/agent/latest'
+    - shell: bash
+      run: |
+        test -n "${{ steps.publish_latest.outputs.commit_hash }}"
+        test -n "${{ steps.publish_latest.outputs.working_directory }}"


### PR DESCRIPTION
Deploys main commits to the /next folder to make it clearer that it's documenting unreleased software. Tags, when one is made, will be pushed to both that tag name and the /latest folder.

This will need a commit to manually make do the /next, /latest and /<tag> changes for v0.19.0
