### PR TITLE
docs/operator: stop using FQDN for kube-apiserver __address__

### DIFF
--- a/docs/operator/add-custom-scrape-jobs.md
+++ b/docs/operator/add-custom-scrape-jobs.md
@@ -41,7 +41,7 @@ stringData:
       kubernetes_sd_configs:
       - role: node
       relabel_configs:
-      - replacement: kubernetes.default.svc.cluster.local:443
+      - replacement: kubernetes.default.svc:443
         target_label: __address__
       - regex: (.+)
         source_labels: [__meta_kubernetes_node_name]
@@ -64,7 +64,7 @@ stringData:
       kubernetes_sd_configs:
       - role: node
       relabel_configs:
-      - replacement: kubernetes.default.svc.cluster.local:443
+      - replacement: kubernetes.default.svc:443
         target_label: __address__
       - regex: (.+)
         replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor


### PR DESCRIPTION
This example only works when cluster domain is set to cluster.local.

When the cluster domain is changed, scraping silently fails (hidden
behind the "debug" log level):

grafana-agent ts=2021-10-08T15:10:06.054149178Z level=debug agent=prometheus instance=320d908d14feeac9f916f752b6276792 component="scrape manager" scrape_pool=integrations/kubernetes/cadvisor target=https://kubernetes.default.svc.cluster.local:443/api/v1/nodes/ns100566-865ef3ad/proxy/metrics/cadvisor msg="Scrape failed" err="Get "https://kubernetes.default.svc.cluster.local:443/api/v1/nodes/ns100566-865ef3ad/proxy/metrics/cadvisor\": dial tcp: lookup kubernetes.default.svc.cluster.local on 10.43.0.10:53: no such host"

Luckily, kubernetes also populates /etc/resolv.conf with search domains,
so we can simply specify kubernetes.default.svc, and it works with all
cluster domains.

#### Notes to the Reviewer
This might also need some updates on the website (which isn't open source)

#### PR Checklist

- [ ] CHANGELOG updated 
- [x] Documentation added
- [ ] Tests updated
