### PR TITLE
Attempting to get or delete a config which does not exist 404's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
 
 - [BUGFIX] Traces: remove extra line feed/spaces/tabs when reading password_file content (@nicoche)
 
+- [CHANGE] Configuration API now returns 404 instead of 400 when attempting to get or delete a config 
+  which does not exist. (@kgeckhart)
+
 # v0.19.0 (2021-09-29)
 
 This release has breaking changes. Please read [CHANGE] entries carefully and

--- a/pkg/metrics/instance/configstore/api.go
+++ b/pkg/metrics/instance/configstore/api.go
@@ -122,7 +122,7 @@ func (api *API) GetConfiguration(rw http.ResponseWriter, r *http.Request) {
 	case errors.Is(err, ErrNotConnected):
 		api.writeError(rw, http.StatusNotFound, err)
 	case errors.As(err, &NotExistError{}):
-		api.writeError(rw, http.StatusBadRequest, err)
+		api.writeError(rw, http.StatusNotFound, err)
 	case err != nil:
 		api.writeError(rw, http.StatusInternalServerError, err)
 	case err == nil:
@@ -218,7 +218,7 @@ func (api *API) DeleteConfiguration(rw http.ResponseWriter, r *http.Request) {
 	case errors.Is(err, ErrNotConnected):
 		api.writeError(rw, http.StatusNotFound, err)
 	case errors.As(err, &NotExistError{}):
-		api.writeError(rw, http.StatusBadRequest, err)
+		api.writeError(rw, http.StatusNotFound, err)
 	case err != nil:
 		api.writeError(rw, http.StatusInternalServerError, err)
 	default:

--- a/pkg/metrics/instance/configstore/api_test.go
+++ b/pkg/metrics/instance/configstore/api_test.go
@@ -65,7 +65,7 @@ func TestAPI_GetConfiguration_Invalid(t *testing.T) {
 
 	resp, err := http.Get(env.srv.URL + "/agent/api/v1/configs/does-not-exist")
 	require.NoError(t, err)
-	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 
 	expect := `{
 		"status": "error",
@@ -229,6 +229,30 @@ func TestServer_DeleteConfiguration(t *testing.T) {
 		cli := client.New(env.srv.URL)
 		err := cli.DeleteConfiguration(context.Background(), "deleteme")
 		require.NoError(t, err)
+	})
+}
+
+func TestServer_DeleteConfiguration_Invalid(t *testing.T) {
+	s := &Mock{
+		DeleteFunc: func(ctx context.Context, key string) error {
+			assert.Equal(t, "deleteme", key)
+			return NotExistError{Key: key}
+		},
+	}
+
+	api := NewAPI(log.NewNopLogger(), s, nil)
+	env := newAPITestEnvironment(t, api)
+
+	req, err := http.NewRequest(http.MethodDelete, env.srv.URL+"/agent/api/v1/config/deleteme", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+
+	t.Run("With Client", func(t *testing.T) {
+		cli := client.New(env.srv.URL)
+		err := cli.DeleteConfiguration(context.Background(), "deleteme")
+		require.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
#### PR Description 
Right now if you want to ignore the error for a delete of a config which does not exist you have to do some error string checking. This adjusts the behavior in the config API to 404 instead of 400 when attempting to get or delete a non-existent config. 

It's possible to get a 404 from all endpoints if there's no configstore configured which makes sense. It's also possible to get a 404 if there's [no connection to the config store](https://github.com/grafana/agent/blob/main/pkg/metrics/instance/configstore/api.go#L122). This one feels like it might be a 500 instead of 404 since it seems to indicate a config/system issue vs no config store at all like the other 404. I can't tell if it's purely a safety check or possible to configure the agent in a certain way to hit it though.

#### Which issue(s) this PR fixes 
N/A

#### Notes to the Reviewer
N/A

#### PR Checklist

- [x] CHANGELOG updated 
- [na] Documentation added
- [x] Tests updated
