### PR TITLE
Service graphs performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@
 
 - [CHANGE] **Breaking change** push_config is no longer supported in trace's config (@mapno)
 
+- [CHANGE] Changed service graphs store implementation to improve CPU performance (@mapno)
+
 # v0.19.0 (2021-09-29)
 
 This release has breaking changes. Please read [CHANGE] entries carefully and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - [CHANGE] Self-scraped integrations will now use an SUO-specific value for the `instance` label. (@rfratto)
 
+- [CHANGE] Changed service graphs store implementation to improve CPU performance (@mapno)
+
 # v0.20.0 (2021-10-28)
 
 - [FEATURE] Operator: The Grafana Agent Operator can now generate a Kubelet
@@ -69,8 +71,6 @@
 - [CHANGE] The windows_exporter now disables the textfile collector by default. (@rfratto)
 
 - [CHANGE] **Breaking change** push_config is no longer supported in trace's config (@mapno)
-
-- [CHANGE] Changed service graphs store implementation to improve CPU performance (@mapno)
 
 # v0.19.0 (2021-09-29)
 

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/hashicorp/consul/api v1.10.1
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-getter v1.5.3
-	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/infinityworks/github-exporter v0.0.0-20201016091012-831b72461034
 	github.com/jsternberg/zap-logfmt v1.2.0
 	github.com/lib/pq v1.10.1
@@ -42,7 +42,6 @@ require (
 	github.com/onsi/gomega v1.11.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.36.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.36.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.36.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.36.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor v0.36.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.36.0
@@ -53,7 +52,6 @@ require (
 	github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e
 	github.com/opentracing-contrib/go-stdlib v1.0.0
 	github.com/opentracing/opentracing-go v1.2.0
-	github.com/patrickmn/go-cache v0.0.0-20180527043350-9f6ff22cfff8
 	github.com/percona/mongodb_exporter v0.0.0-00010101000000-000000000000
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-community/elasticsearch_exporter v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -1676,7 +1676,6 @@ github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIw
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
-github.com/patrickmn/go-cache v0.0.0-20180527043350-9f6ff22cfff8 h1:BR6MM54q4W9pn0SySwg6yctZtBKlTdUq6a+b0kArBnE=
 github.com/patrickmn/go-cache v0.0.0-20180527043350-9f6ff22cfff8/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/paulbellamy/ratecounter v0.2.0/go.mod h1:Hfx1hDpSGoqxkVVpBi/IlYD7kChlfo5C6hzIHwPqfFE=
 github.com/pborman/getopt v0.0.0-20190409184431-ee0cd42419d3/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=

--- a/pkg/traces/servicegraphprocessor/factory.go
+++ b/pkg/traces/servicegraphprocessor/factory.go
@@ -16,7 +16,7 @@ const (
 
 	// DefaultWait is the default value to wait for an edge to be completed
 	DefaultWait = time.Second * 10
-	// DefaultMaxItems is the default amount of edges that will be stored in the store
+	// DefaultMaxItems is the default amount of edges that will be stored in the storeMap
 	DefaultMaxItems = 10_000
 )
 

--- a/pkg/traces/servicegraphprocessor/factory.go
+++ b/pkg/traces/servicegraphprocessor/factory.go
@@ -18,6 +18,8 @@ const (
 	DefaultWait = time.Second * 10
 	// DefaultMaxItems is the default amount of edges that will be stored in the storeMap
 	DefaultMaxItems = 10_000
+	// DefaultWorkers is the default amount of workers that will be used to process the edges
+	DefaultWorkers = 10
 )
 
 // Config holds the configuration for the Prometheus service graph processor.
@@ -26,6 +28,8 @@ type Config struct {
 
 	Wait     time.Duration `mapstructure:"wait"`
 	MaxItems int           `mapstructure:"max_items"`
+
+	Workers int `mapstructure:"workers"`
 
 	SuccessCodes *successCodes `mapstructure:"success_codes"`
 }

--- a/pkg/traces/servicegraphprocessor/factory.go
+++ b/pkg/traces/servicegraphprocessor/factory.go
@@ -14,7 +14,7 @@ const (
 	// TypeStr is the unique identifier for the Prometheus service graph exporter.
 	TypeStr = "service_graphs"
 
-	// DefaultWait is the default value to wait for an edgeRequest to be completed
+	// DefaultWait is the default value to wait for an edge to be completed
 	DefaultWait = time.Second * 10
 	// DefaultMaxItems is the default amount of edges that will be stored in the store
 	DefaultMaxItems = 10_000

--- a/pkg/traces/servicegraphprocessor/processor.go
+++ b/pkg/traces/servicegraphprocessor/processor.go
@@ -217,7 +217,7 @@ func (p *processor) ConsumeTraces(ctx context.Context, td pdata.Traces) error {
 
 	if err := p.consume(td); err != nil {
 		if errors.Is(err, errTooManyItems) {
-			level.Info(p.logger).Log("msg", "skipped processing of spans", "maxItems", p.maxItems, "err", errTooManyItems)
+			level.Warn(p.logger).Log("msg", "skipped processing of spans", "maxItems", p.maxItems, "err", errTooManyItems)
 		} else {
 			level.Error(p.logger).Log("msg", "failed consuming traces", "err", err)
 		}

--- a/pkg/traces/servicegraphprocessor/processor.go
+++ b/pkg/traces/servicegraphprocessor/processor.go
@@ -95,8 +95,8 @@ func newProcessor(nextConsumer consumer.Traces, cfg *Config) *processor {
 		cfg.MaxItems = DefaultMaxItems
 	}
 	if cfg.Workers == 0 {
-        cfg.Workers = DefaultWorkers
-    }
+		cfg.Workers = DefaultWorkers
+	}
 
 	var (
 		httpSuccessCode = make(map[int]struct{})

--- a/pkg/traces/servicegraphprocessor/processor.go
+++ b/pkg/traces/servicegraphprocessor/processor.go
@@ -70,8 +70,6 @@ type processor struct {
 	// completed edges are pushed through this channel to be processed.
 	collectCh chan<- string
 
-	closeCh chan struct{}
-
 	serviceGraphRequestTotal           *prometheus.CounterVec
 	serviceGraphRequestFailedTotal     *prometheus.CounterVec
 	serviceGraphRequestServerHistogram *prometheus.HistogramVec
@@ -118,8 +116,6 @@ func newProcessor(nextConsumer consumer.Traces, cfg *Config) *processor {
 		wait:     cfg.Wait,
 		maxItems: cfg.MaxItems,
 		workers:  cfg.Workers,
-
-		closeCh: make(chan struct{}, 1),
 	}
 
 	return p
@@ -190,7 +186,7 @@ func (p *processor) registerMetrics() error {
 }
 
 func (p *processor) Shutdown(context.Context) error {
-	close(p.closeCh)
+	p.store.shutdown()
 	p.unregisterMetrics()
 	return nil
 }

--- a/pkg/traces/servicegraphprocessor/processor.go
+++ b/pkg/traces/servicegraphprocessor/processor.go
@@ -37,9 +37,9 @@ type edge struct {
 	expiration int64
 }
 
-func newEdge() *edge {
+func newEdge(w time.Duration) *edge {
 	return &edge{
-		expiration: time.Now().Unix(),
+		expiration: time.Now().Add(w).Unix(),
 	}
 }
 
@@ -309,7 +309,7 @@ func (p *processor) consume(trace pdata.Traces) error {
 					if storedEdge, ok := p.store[k]; ok {
 						e = storedEdge
 					} else {
-						e = newEdge()
+						e = newEdge(p.wait)
 					}
 
 					e.clientService = svc.StringVal()
@@ -328,7 +328,7 @@ func (p *processor) consume(trace pdata.Traces) error {
 					if storedEdge, ok := p.store[k]; ok {
 						e = storedEdge
 					} else {
-						e = newEdge()
+						e = newEdge(p.wait)
 					}
 
 					e.serverService = svc.StringVal()

--- a/pkg/traces/servicegraphprocessor/processor.go
+++ b/pkg/traces/servicegraphprocessor/processor.go
@@ -208,7 +208,6 @@ func (p *processor) registerMetrics() error {
 
 func (p *processor) Shutdown(context.Context) error {
 	close(p.closeCh)
-	p.store.shutdown()
 	p.unregisterMetrics()
 	return nil
 }

--- a/pkg/traces/servicegraphprocessor/processor.go
+++ b/pkg/traces/servicegraphprocessor/processor.go
@@ -283,7 +283,7 @@ func (p *processor) consume(trace pdata.Traces) error {
 					edge := p.store.upsertEdge(k, func(e *edge) {
 						e.clientService = svc.StringVal()
 						e.clientLatency = spanDuration(span)
-						e.failed = p.spanFailed(span)
+						e.failed = e.failed || p.spanFailed(span) // keep request as failed if any span is failed
 					})
 
 					if edge.isCompleted() {
@@ -296,7 +296,7 @@ func (p *processor) consume(trace pdata.Traces) error {
 					edge := p.store.upsertEdge(k, func(e *edge) {
 						e.serverService = svc.StringVal()
 						e.serverLatency = spanDuration(span)
-						e.failed = p.spanFailed(span)
+						e.failed = e.failed || p.spanFailed(span) // keep request as failed if any span is failed
 					})
 
 					if edge.isCompleted() {
@@ -342,5 +342,5 @@ func spanDuration(span pdata.Span) time.Duration {
 }
 
 func key(k1, k2 string) string {
-	return fmt.Sprintf("%store-%store", k1, k2)
+	return fmt.Sprintf("%s-%s", k1, k2)
 }

--- a/pkg/traces/servicegraphprocessor/processor.go
+++ b/pkg/traces/servicegraphprocessor/processor.go
@@ -270,7 +270,7 @@ func (p *processor) consume(trace pdata.Traces) error {
 		rSpan := rSpansSlice.At(i)
 
 		svc, ok := rSpan.Resource().Attributes().Get(semconv.AttributeServiceName)
-		if !ok || svc.StringVal() == ""{
+		if !ok || svc.StringVal() == "" {
 			continue
 		}
 

--- a/pkg/traces/servicegraphprocessor/processor.go
+++ b/pkg/traces/servicegraphprocessor/processor.go
@@ -292,13 +292,13 @@ func (p *processor) consume(trace pdata.Traces) error {
 						e.failed = e.failed || p.spanFailed(span) // keep request as failed if any span is failed
 					})
 
+					if errors.Is(err, errTooManyItems) {
+						totalDroppedSpans++
+						p.serviceGraphDroppedSpansTotal.WithLabelValues(svc.StringVal(), "").Inc()
+						continue
+					}
+					// upsertEdge will only return this errTooManyItems
 					if err != nil {
-						// upsertEdge will only return this errTooManyItems
-						if errors.Is(err, errTooManyItems) {
-							totalDroppedSpans++
-							p.serviceGraphDroppedSpansTotal.WithLabelValues(svc.StringVal(), "").Inc()
-							continue
-						}
 						return err
 					}
 
@@ -315,13 +315,13 @@ func (p *processor) consume(trace pdata.Traces) error {
 						e.failed = e.failed || p.spanFailed(span) // keep request as failed if any span is failed
 					})
 
+					if errors.Is(err, errTooManyItems) {
+						totalDroppedSpans++
+						p.serviceGraphDroppedSpansTotal.WithLabelValues("", svc.StringVal()).Inc()
+						continue
+					}
+					// upsertEdge will only return this errTooManyItems
 					if err != nil {
-						// upsertEdge will only return this errTooManyItems
-						if errors.Is(err, errTooManyItems) {
-							totalDroppedSpans++
-							p.serviceGraphDroppedSpansTotal.WithLabelValues("", svc.StringVal()).Inc()
-							continue
-						}
 						return err
 					}
 

--- a/pkg/traces/servicegraphprocessor/processor.go
+++ b/pkg/traces/servicegraphprocessor/processor.go
@@ -49,7 +49,7 @@ func newEdge(key string, ttl time.Duration) *edge {
 	}
 }
 
-// completed returns true if the corresponding client and server
+// isCompleted returns true if the corresponding client and server
 // pair spans have been processed for the given edge
 func (e *edge) isCompleted() bool {
 	return len(e.clientService) != 0 && len(e.serverService) != 0
@@ -270,7 +270,7 @@ func (p *processor) consume(trace pdata.Traces) error {
 		rSpan := rSpansSlice.At(i)
 
 		svc, ok := rSpan.Resource().Attributes().Get(semconv.AttributeServiceName)
-		if !ok {
+		if !ok || svc.StringVal() == ""{
 			continue
 		}
 

--- a/pkg/traces/servicegraphprocessor/processor_test.go
+++ b/pkg/traces/servicegraphprocessor/processor_test.go
@@ -63,7 +63,9 @@ func TestConsumeMetrics(t *testing.T) {
 			expectedMetrics: `
         	    # HELP traces_service_graph_dropped_spans_total Total count of dropped spans
         	    # TYPE traces_service_graph_dropped_spans_total counter
-        	    traces_service_graph_dropped_spans_total{service="lb"} 1
+        	    traces_service_graph_dropped_spans_total{service="app"} 27
+        	    traces_service_graph_dropped_spans_total{service="db"} 4
+        	    traces_service_graph_dropped_spans_total{service="lb"} 4
 				# HELP traces_service_graph_unpaired_spans_total Total count of unpaired spans
 				# TYPE traces_service_graph_unpaired_spans_total counter
 				traces_service_graph_unpaired_spans_total{client="lb",server=""} 1

--- a/pkg/traces/servicegraphprocessor/processor_test.go
+++ b/pkg/traces/servicegraphprocessor/processor_test.go
@@ -114,14 +114,14 @@ func traceSamples(t *testing.T, path string) pdata.Traces {
 
 // helper function to force collection of all metrics
 func collectMetrics(p *processor) {
-	p.storeMtx.Lock()
-	defer p.storeMtx.Unlock()
+	p.store.mtx.Lock()
+	defer p.store.mtx.Unlock()
 
-	for h := p.store.Front(); h != nil; h = p.store.Front() {
+	for h := p.store.l.Front(); h != nil; h = p.store.l.Front() {
 		edge := h.Value.(*edge)
 		p.collectEdge(edge)
-		delete(p.storeMap, edge.key)
-		p.store.Remove(h)
+		delete(p.store.m, edge.key)
+		p.store.l.Remove(h)
 	}
 }
 

--- a/pkg/traces/servicegraphprocessor/processor_test.go
+++ b/pkg/traces/servicegraphprocessor/processor_test.go
@@ -59,13 +59,13 @@ func TestConsumeMetrics(t *testing.T) {
 			cfg: &Config{
 				Wait:     -time.Millisecond,
 				MaxItems: 1, // Configure max number of items in storeMap to 1. Only one edge will be processed.
-				Workers:  0, // Don't collect any edges, leave that to the test.
 			},
 			expectedMetrics: droppedSpansCaseMetrics,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			p := newProcessor(&mockConsumer{}, tc.cfg)
+			close(p.closeCh) // Don't collect any edges, leave that to the test.
 
 			reg := prometheus.NewRegistry()
 			ctx := context.WithValue(context.Background(), contextkeys.PrometheusRegisterer, reg)

--- a/pkg/traces/servicegraphprocessor/processor_test.go
+++ b/pkg/traces/servicegraphprocessor/processor_test.go
@@ -59,6 +59,7 @@ func TestConsumeMetrics(t *testing.T) {
 			cfg: &Config{
 				Wait:     -time.Millisecond,
 				MaxItems: 1, // Configure max number of items in storeMap to 1. Only one edge will be processed.
+				Workers:  0, // Don't collect any edges, leave that to the test.
 			},
 			expectedMetrics: droppedSpansCaseMetrics,
 		},

--- a/pkg/traces/servicegraphprocessor/processor_test.go
+++ b/pkg/traces/servicegraphprocessor/processor_test.go
@@ -56,7 +56,7 @@ func TestConsumeMetrics(t *testing.T) {
 			sampleDataPath: traceSamplePath,
 			cfg: &Config{
 				Wait:     time.Millisecond,
-				MaxItems: 1, // Configure max number of items in store to 1. Only one edgeRequest will be processed.
+				MaxItems: 1, // Configure max number of items in store to 1. Only one edge will be processed.
 			},
 			expectedMetrics: `
         	    # HELP traces_service_graph_dropped_spans_total Total count of dropped spans

--- a/pkg/traces/servicegraphprocessor/processor_test.go
+++ b/pkg/traces/servicegraphprocessor/processor_test.go
@@ -57,19 +57,10 @@ func TestConsumeMetrics(t *testing.T) {
 			name:           "max items in storeMap is reached",
 			sampleDataPath: traceSamplePath,
 			cfg: &Config{
-				Wait:     time.Millisecond,
+				Wait:     -time.Millisecond,
 				MaxItems: 1, // Configure max number of items in storeMap to 1. Only one edge will be processed.
 			},
-			expectedMetrics: `
-        	    # HELP traces_service_graph_dropped_spans_total Total count of dropped spans
-        	    # TYPE traces_service_graph_dropped_spans_total counter
-        	    traces_service_graph_dropped_spans_total{service="app"} 27
-        	    traces_service_graph_dropped_spans_total{service="db"} 4
-        	    traces_service_graph_dropped_spans_total{service="lb"} 4
-				# HELP traces_service_graph_unpaired_spans_total Total count of unpaired spans
-				# TYPE traces_service_graph_unpaired_spans_total counter
-				traces_service_graph_unpaired_spans_total{client="lb",server=""} 1
-`,
+			expectedMetrics: droppedSpansCaseMetrics,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -207,5 +198,53 @@ const (
 		# TYPE traces_service_graph_request_total counter
 		traces_service_graph_request_total{client="app",server="db"} 3
 		traces_service_graph_request_total{client="lb",server="app"} 3
+`
+	droppedSpansCaseMetrics = `
+        # HELP traces_service_graph_dropped_spans_total Total count of dropped spans
+        # TYPE traces_service_graph_dropped_spans_total counter
+        traces_service_graph_dropped_spans_total{client="",server="app"} 2
+        traces_service_graph_dropped_spans_total{client="",server="db"} 3
+        traces_service_graph_dropped_spans_total{client="app",server=""} 3
+        traces_service_graph_dropped_spans_total{client="lb",server=""} 2
+        # HELP traces_service_graph_request_client_seconds Time for a request between two nodes as seen from the client
+        # TYPE traces_service_graph_request_client_seconds histogram
+        traces_service_graph_request_client_seconds_bucket{client="lb",server="app",le="0.01"} 0
+        traces_service_graph_request_client_seconds_bucket{client="lb",server="app",le="0.02"} 0
+        traces_service_graph_request_client_seconds_bucket{client="lb",server="app",le="0.04"} 0
+        traces_service_graph_request_client_seconds_bucket{client="lb",server="app",le="0.08"} 0
+        traces_service_graph_request_client_seconds_bucket{client="lb",server="app",le="0.16"} 0
+        traces_service_graph_request_client_seconds_bucket{client="lb",server="app",le="0.32"} 0
+        traces_service_graph_request_client_seconds_bucket{client="lb",server="app",le="0.64"} 0
+        traces_service_graph_request_client_seconds_bucket{client="lb",server="app",le="1.28"} 0
+        traces_service_graph_request_client_seconds_bucket{client="lb",server="app",le="2.56"} 1
+        traces_service_graph_request_client_seconds_bucket{client="lb",server="app",le="5.12"} 1
+        traces_service_graph_request_client_seconds_bucket{client="lb",server="app",le="10.24"} 1
+        traces_service_graph_request_client_seconds_bucket{client="lb",server="app",le="20.48"} 1
+        traces_service_graph_request_client_seconds_bucket{client="lb",server="app",le="+Inf"} 1
+        traces_service_graph_request_client_seconds_sum{client="lb",server="app"} 2.5
+        traces_service_graph_request_client_seconds_count{client="lb",server="app"} 1
+        # HELP traces_service_graph_request_failed_total Total count of failed requests between two nodes
+        # TYPE traces_service_graph_request_failed_total counter
+        traces_service_graph_request_failed_total{client="lb",server="app"} 1
+        # HELP traces_service_graph_request_server_seconds Time for a request between two nodes as seen from the server
+        # TYPE traces_service_graph_request_server_seconds histogram
+        traces_service_graph_request_server_seconds_bucket{client="lb",server="app",le="0.01"} 0
+        traces_service_graph_request_server_seconds_bucket{client="lb",server="app",le="0.02"} 0
+        traces_service_graph_request_server_seconds_bucket{client="lb",server="app",le="0.04"} 0
+        traces_service_graph_request_server_seconds_bucket{client="lb",server="app",le="0.08"} 0
+        traces_service_graph_request_server_seconds_bucket{client="lb",server="app",le="0.16"} 0
+        traces_service_graph_request_server_seconds_bucket{client="lb",server="app",le="0.32"} 0
+        traces_service_graph_request_server_seconds_bucket{client="lb",server="app",le="0.64"} 0
+        traces_service_graph_request_server_seconds_bucket{client="lb",server="app",le="1.28"} 1
+        traces_service_graph_request_server_seconds_bucket{client="lb",server="app",le="2.56"} 1
+        traces_service_graph_request_server_seconds_bucket{client="lb",server="app",le="5.12"} 1
+        traces_service_graph_request_server_seconds_bucket{client="lb",server="app",le="10.24"} 1
+        traces_service_graph_request_server_seconds_bucket{client="lb",server="app",le="20.48"} 1
+        traces_service_graph_request_server_seconds_bucket{client="lb",server="app",le="+Inf"} 1
+        traces_service_graph_request_server_seconds_sum{client="lb",server="app"} 1
+        traces_service_graph_request_server_seconds_count{client="lb",server="app"} 1
+        # HELP traces_service_graph_request_total Total count of requests between two nodes
+        # TYPE traces_service_graph_request_total counter
+        traces_service_graph_request_total{client="lb",server="app"} 1
 `
 )

--- a/pkg/traces/servicegraphprocessor/store.go
+++ b/pkg/traces/servicegraphprocessor/store.go
@@ -1,0 +1,141 @@
+package servicegraphprocessor
+
+import (
+	"container/list"
+	"sync"
+	"time"
+)
+
+type store struct {
+	l   *list.List
+	mtx *sync.RWMutex
+	m   map[string]*list.Element
+
+	closeCh chan struct{}
+
+	evictCallback func(e *edge)
+	ttl           time.Duration
+	maxItems      int
+}
+
+func newStore(ttl time.Duration, maxItems, workers int, evictCallback func(e *edge)) (*store, chan<- string) {
+	s := &store{
+		l:   list.New(),
+		mtx: &sync.RWMutex{},
+		m:   make(map[string]*list.Element),
+
+		closeCh: make(chan struct{}, 1),
+
+		evictCallback: evictCallback,
+		ttl:           ttl,
+		maxItems:      maxItems,
+	}
+
+	collectCh := make(chan string, workers)
+
+	for i := 0; i < workers; i++ {
+		go func() {
+			for {
+				for {
+					select {
+					case k := <-collectCh:
+						s.mtx.Lock()
+
+						ele := s.m[k]
+						if ele == nil { // it may already have been processed
+							s.mtx.Unlock()
+							continue
+						}
+
+						edge := ele.Value.(*edge)
+						s.evictCallback(edge)
+						delete(s.m, k)
+						s.l.Remove(ele)
+
+						s.mtx.Unlock()
+
+					case <-s.closeCh:
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	return s, collectCh
+}
+
+func (s *store) shutdown() {
+	close(s.closeCh)
+}
+
+func (s *store) len() int {
+    s.mtx.RLock()
+    defer s.mtx.RUnlock()
+
+    return s.l.Len()
+}
+
+// shouldEvictHead checks if the oldest item (head of list) has expired and should be evicted.
+// Returns true if the item has expired, false otherwise.
+//
+// Must be called under lock.
+func (s *store) shouldEvictHead() bool {
+	h := s.l.Front()
+	if h == nil {
+		return false
+	}
+	ts := h.Value.(*edge).expiration
+	return ts < time.Now().Unix()
+}
+
+// evictHead removes the head from the store (and map).
+// It also collects metrics for the evicted edge.
+//
+// Must be called under lock.
+func (s *store) evictHead() {
+	front := s.l.Front()
+	oldest := &(*front.Value.(*edge))
+
+	s.evictCallback(oldest)
+
+	delete(s.m, oldest.key)
+	_ = s.l.Remove(front)
+}
+
+// Fetches an edge from the store.
+// If the edge doesn't exist, it creates a new one with the default TTL.
+func (s *store) upsertEdge(k string, cb func(e *edge)) *edge {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	if storedEdge, ok := s.m[k]; ok {
+		edge := storedEdge.Value.(*edge)
+		cb(edge)
+		return edge
+	}
+
+	newEdge := newEdge(k, s.ttl)
+	ele := s.l.PushBack(newEdge)
+	s.m[k] = ele
+	cb(newEdge)
+
+	return newEdge
+}
+
+// expire evicts all expired items in the store.
+func (s *store) expire() {
+	s.mtx.RLock()
+	if !s.shouldEvictHead() {
+		s.mtx.RUnlock()
+		return
+	}
+	s.mtx.RUnlock()
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	for s.shouldEvictHead() {
+		s.evictHead()
+	}
+}

--- a/pkg/traces/servicegraphprocessor/store.go
+++ b/pkg/traces/servicegraphprocessor/store.go
@@ -70,10 +70,10 @@ func (s *store) shutdown() {
 }
 
 func (s *store) len() int {
-    s.mtx.RLock()
-    defer s.mtx.RUnlock()
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
 
-    return s.l.Len()
+	return s.l.Len()
 }
 
 // shouldEvictHead checks if the oldest item (head of list) has expired and should be evicted.
@@ -95,7 +95,7 @@ func (s *store) shouldEvictHead() bool {
 // Must be called under lock.
 func (s *store) evictHead() {
 	front := s.l.Front()
-	oldest := &(*front.Value.(*edge))
+	oldest := front.Value.(*edge)
 
 	s.evictCallback(oldest)
 

--- a/pkg/traces/servicegraphprocessor/store_test.go
+++ b/pkg/traces/servicegraphprocessor/store_test.go
@@ -1,0 +1,74 @@
+package servicegraphprocessor
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var noopUpsertCb storeCallback = func(e *edge) {}
+
+func TestStore_upsertEdge(t *testing.T) {
+	const keyStr = "key"
+
+	var cbCallCount int
+	s := newStore(time.Hour, func(e *edge) {
+		cbCallCount++
+	})
+	assert.Equal(t, 0, s.len())
+
+	s.upsertEdge(keyStr, func(e *edge) {})
+	assert.Equal(t, 1, s.len())
+	assert.False(t, s.shouldEvictHead()) // ttl is set to 1h
+	assert.Equal(t, 0, cbCallCount)
+
+	e := getEdge(s, keyStr)
+	assert.NotNil(t, e)
+	assert.Equal(t, keyStr, e.key)
+
+	s.upsertEdge(keyStr, func(e *edge) {
+		e.clientService = "client"
+		e.serverService = "server"
+		e.expiration = 0 // expire immediately
+	})
+	assert.Equal(t, 0, cbCallCount)
+
+	e = getEdge(s, keyStr)
+	assert.NotNil(t, e)
+	assert.Equal(t, "client", e.clientService)
+	assert.Equal(t, "server", e.serverService)
+	assert.True(t, s.shouldEvictHead())
+
+	s.evictHead()
+	assert.Equal(t, 0, s.len())
+	assert.Equal(t, 1, cbCallCount)
+}
+
+func TestStore_expire(t *testing.T) {
+	keys := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		keys[fmt.Sprintf("key-%d", i)] = true
+	}
+
+	// all new keys are immediately expired.
+	s := newStore(-time.Second, func(e *edge) {
+		assert.True(t, keys[e.key])
+	})
+
+	for key := range keys {
+		s.upsertEdge(key, noopUpsertCb)
+	}
+
+	s.expire()
+	assert.Equal(t, 0, s.len())
+}
+
+func getEdge(s *store, k string) *edge {
+	ele, ok := s.m[k]
+	if !ok {
+        return nil
+    }
+	return ele.Value.(*edge)
+}

--- a/pkg/traces/servicegraphprocessor/store_test.go
+++ b/pkg/traces/servicegraphprocessor/store_test.go
@@ -14,7 +14,7 @@ func TestStore_upsertEdge(t *testing.T) {
 	const keyStr = "key"
 
 	var cbCallCount int
-	s := newStore(time.Hour, func(e *edge) {
+	s := newStore(time.Hour, 100, func(e *edge) {
 		cbCallCount++
 	})
 	assert.Equal(t, 0, s.len())
@@ -53,7 +53,7 @@ func TestStore_expire(t *testing.T) {
 	}
 
 	// all new keys are immediately expired.
-	s := newStore(-time.Second, func(e *edge) {
+	s := newStore(-time.Second, 100, func(e *edge) {
 		assert.True(t, keys[e.key])
 	})
 
@@ -68,7 +68,7 @@ func TestStore_expire(t *testing.T) {
 func getEdge(s *store, k string) *edge {
 	ele, ok := s.m[k]
 	if !ok {
-        return nil
-    }
+		return nil
+	}
 	return ele.Value.(*edge)
 }


### PR DESCRIPTION
#### PR Description 

The implementation with the cache library had a ver bad performance,
specially when calling `Items()`, since it would create a new map
and copy all items to it.

This commit changes the implementation to use a map and a list with a mutex.

The list is used to keep track of the oldest items.

Saw significant improvements in CPU usage. A new profile showed the processor to take ~2.55% of total CPU time.

#### PR Checklist

- [x] CHANGELOG updated 
- ~[ ] Documentation added~
- [x] Tests updated
