### PR TITLE
Prepare for v0.20.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Main (unreleased)
 
-- [ENHANCEMENT] Documenting security recommendations for the users used by the embedded exporters,
-  to give only the strictly necessary roles as per the official docs.
+# v0.20.0 (2021-10-28)
 
 - [FEATURE] Operator: The Grafana Agent Operator can now generate a Kubelet
   service to allow a ServiceMonitor to collect Kubelet and cAdvisor metrics.

--- a/docs/configuration/integrations/node-exporter-config.md
+++ b/docs/configuration/integrations/node-exporter-config.md
@@ -26,7 +26,7 @@ docker run \
   -v "/proc:/host/proc:ro,rslave" \
   -v /tmp/agent:/etc/agent \
   -v /path/to/config.yaml:/etc/agent-config/agent.yaml \
-  grafana/agent:v0.19.0 \
+  grafana/agent:v0.20.0 \
   --config.file=/etc/agent-config/agent.yaml
 ```
 
@@ -66,7 +66,7 @@ metadata:
   name: agent
 spec:
   containers:
-  - image: grafana/agent:v0.19.0
+  - image: grafana/agent:v0.20.0
     name: agent
     args:
     - --config.file=/etc/agent-config/agent.yaml

--- a/docs/configuration/integrations/process-exporter-config.md
+++ b/docs/configuration/integrations/process-exporter-config.md
@@ -18,7 +18,7 @@ docker run \
   -v "/proc:/proc:ro" \
   -v /tmp/agent:/etc/agent \
   -v /path/to/config.yaml:/etc/agent-config/agent.yaml \
-  grafana/agent:v0.19.0 \
+  grafana/agent:v0.20.0 \
   --config.file=/etc/agent-config/agent.yaml
 ```
 
@@ -35,7 +35,7 @@ metadata:
   name: agent
 spec:
   containers:
-  - image: grafana/agent:v0.19.0
+  - image: grafana/agent:v0.20.0
     name: agent
     args:
     - --config.file=/etc/agent-config/agent.yaml

--- a/docs/getting-started/_index.md
+++ b/docs/getting-started/_index.md
@@ -26,7 +26,7 @@ See the list of [Community Projects](#community-projects) for the community-driv
 docker run \
   -v /tmp/agent:/etc/agent/data \
   -v /path/to/config.yaml:/etc/agent/agent.yaml \
-  grafana/agent:v0.19.0
+  grafana/agent:v0.20.0
 ```
 
 Replace `/tmp/agent` with the folder you wish to store WAL data in. WAL data is
@@ -76,7 +76,7 @@ Below is a list of community lead projects for working with Grafana Agent. These
 
 A publically available release of a Grafana Agent Helm chart is maintained [here](https://github.com/DandyDeveloper/charts/tree/master/charts/grafana-agent). Contributions and improvements are welcomed. Full details on rolling out and supported options can be found in the [readme](https://github.com/DandyDeveloper/charts/blob/master/charts/grafana-agent/README.md).
 
-This *does not* require the Grafana Agent Operator to rollout / deploy. 
+This *does not* require the Grafana Agent Operator to rollout / deploy.
 
 ### Juju (Charmed Operator)
 

--- a/docs/operator/getting-started.md
+++ b/docs/operator/getting-started.md
@@ -62,7 +62,7 @@ spec:
       serviceAccountName: grafana-agent-operator
       containers:
       - name: operator
-        image: grafana/agent-operator:v0.19.0
+        image: grafana/agent-operator:v0.20.0
         args:
         - --kubelet-service=default/kubelet
 ---
@@ -160,7 +160,7 @@ metadata:
   labels:
     app: grafana-agent
 spec:
-  image: grafana/agent:v0.19.0
+  image: grafana/agent:v0.20.0
   logLevel: info
   serviceAccountName: grafana-agent
   metrics:

--- a/docs/upgrade-guide/_index.md
+++ b/docs/upgrade-guide/_index.md
@@ -49,7 +49,7 @@ receivers:
 maintaining backwards compatibility.
 Refer to the [deprecation announcement](#tempo-push_config-deprecation) for how to upgrade.
 
-## v0.19.0
+## v0.20.0
 
 ### Traces: Deprecation of "tempo" in config and metrics. (Deprecation)
 

--- a/pkg/operator/defaults.go
+++ b/pkg/operator/defaults.go
@@ -14,6 +14,7 @@ var (
 		"v0.18.3",
 		"v0.18.4",
 		"v0.19.0",
+		"v0.20.0",
 
 		// NOTE(rfratto): when performing an upgrade, add the newest version above instead of changing the existing reference.
 	}

--- a/production/README.md
+++ b/production/README.md
@@ -26,7 +26,7 @@ directory on your host that you want the agent to store its WAL.
 docker run \
   -v /tmp/agent:/etc/agent/data \
   -v /path/to/config.yaml:/etc/agent/agent.yaml \
-  grafana/agent:v0.19.0
+  grafana/agent:v0.20.0
 ```
 
 ## Running the Agent locally

--- a/production/grafanacloud-install.sh
+++ b/production/grafanacloud-install.sh
@@ -48,7 +48,7 @@ PACKAGE_SYSTEM=${PACKAGE_SYSTEM:=}
 #
 # Global constants.
 #
-RELEASE_VERSION="0.19.0"
+RELEASE_VERSION="0.20.0"
 
 RELEASE_URL="https://github.com/grafana/agent/releases/download/v${RELEASE_VERSION}"
 DEB_URL="${RELEASE_URL}/grafana-agent-${RELEASE_VERSION}-1.${ARCH}.deb"

--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -66,7 +66,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.19.0
+        image: grafana/agent:v0.20.0
         imagePullPolicy: IfNotPresent
         name: agent
         ports:

--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -64,7 +64,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.19.0
+        image: grafana/agent:v0.20.0
         imagePullPolicy: IfNotPresent
         name: agent
         ports:

--- a/production/kubernetes/agent-traces.yaml
+++ b/production/kubernetes/agent-traces.yaml
@@ -109,7 +109,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.19.0
+        image: grafana/agent:v0.20.0
         imagePullPolicy: IfNotPresent
         name: agent
         ports:

--- a/production/kubernetes/build/lib/version.libsonnet
+++ b/production/kubernetes/build/lib/version.libsonnet
@@ -1,1 +1,1 @@
-'grafana/agent:v0.19.0'
+'grafana/agent:v0.20.0'

--- a/production/kubernetes/install-bare.sh
+++ b/production/kubernetes/install-bare.sh
@@ -25,7 +25,7 @@ check_installed() {
 check_installed curl
 check_installed envsubst
 
-MANIFEST_BRANCH=v0.19.0
+MANIFEST_BRANCH=v0.20.0
 MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent-bare.yaml}
 NAMESPACE=${NAMESPACE:-default}
 

--- a/production/tanka/grafana-agent/v1/main.libsonnet
+++ b/production/tanka/grafana-agent/v1/main.libsonnet
@@ -15,8 +15,8 @@ local service = k.core.v1.service;
 (import './lib/traces.libsonnet') +
 {
   _images:: {
-    agent: 'grafana/agent:v0.19.0',
-    agentctl: 'grafana/agentctl:v0.19.0',
+    agent: 'grafana/agent:v0.20.0',
+    agentctl: 'grafana/agentctl:v0.20.0',
   },
 
   // new creates a new DaemonSet deployment of the grafana-agent. By default,

--- a/production/tanka/grafana-agent/v2/internal/base.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/base.libsonnet
@@ -10,8 +10,8 @@ function(name='grafana-agent', namespace='') {
   local this = self,
 
   _images:: {
-    agent: 'grafana/agent:v0.19.0',
-    agentctl: 'grafana/agentctl:v0.19.0',
+    agent: 'grafana/agent:v0.20.0',
+    agentctl: 'grafana/agentctl:v0.20.0',
   },
   _config:: {
     name: name,

--- a/production/tanka/grafana-agent/v2/internal/syncer.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/syncer.libsonnet
@@ -14,7 +14,7 @@ function(
 ) {
   local _config = {
     api: error 'api must be set',
-    image: 'grafana/agentctl:v0.19.0',
+    image: 'grafana/agentctl:v0.20.0',
     schedule: '*/5 * * * *',
     configs: [],
   } + config,


### PR DESCRIPTION
Prepare for v0.20.0 release by following the [release procedure](https://github.com/grafana/agent/blob/main/cmd/agent/DEVELOPERS.md#performing-the-release)
