### PR TITLE
Draft of push receiver

### DIFF
--- a/pkg/traces/instance.go
+++ b/pkg/traces/instance.go
@@ -32,6 +32,8 @@ type Instance struct {
 	exporter  builder.Exporters
 	pipelines builder.BuiltPipelines
 	receivers builder.Receivers
+
+	factories component.Factories
 }
 
 // NewInstance creates and starts an instance of tracing pipelines.
@@ -167,6 +169,7 @@ func (i *Instance) buildAndStartPipeline(ctx context.Context, cfg InstanceConfig
 	if err != nil {
 		return fmt.Errorf("failed to load tracing factories: %w", err)
 	}
+	i.factories = factories
 
 	appinfo := component.BuildInfo{
 		Command:     "agent",
@@ -222,8 +225,13 @@ func (i *Instance) ReportFatalError(err error) {
 }
 
 // GetFactory implements component.Host
-func (i *Instance) GetFactory(component.Kind, config.Type) component.Factory {
-	return nil
+func (i *Instance) GetFactory(kind component.Kind, componentType config.Type) component.Factory {
+	switch kind {
+	case component.KindReceiver:
+		return i.factories.Receivers[componentType]
+	default:
+		return nil
+	}
 }
 
 // GetExtensions implements component.Host

--- a/pkg/traces/pushreceiver/factory.go
+++ b/pkg/traces/pushreceiver/factory.go
@@ -1,0 +1,44 @@
+package pushreceiver
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/receiver/receiverhelper"
+)
+
+const (
+	typeStr = "push_receiver"
+)
+
+func NewFactory() component.ReceiverFactory {
+	f := &pushReceiverFactory{}
+
+	return receiverhelper.NewFactory(
+		typeStr,
+		createDefaultConfig,
+		receiverhelper.WithTraces(f.createTracesReceiver),
+	)
+}
+
+func createDefaultConfig() config.Receiver {
+	return nil
+}
+
+type pushReceiverFactory struct {
+	receiver consumer.Traces
+}
+
+func (f *pushReceiverFactory) createTracesReceiver(
+	_ context.Context,
+	_ component.ReceiverCreateSettings,
+	_ config.Receiver,
+	_ consumer.Traces,
+) (component.TracesReceiver, error) {
+	r, err := newPushReceiver()
+	f.receiver = r.(consumer.Traces)
+
+	return r, err
+}

--- a/pkg/traces/pushreceiver/receiver.go
+++ b/pkg/traces/pushreceiver/receiver.go
@@ -1,0 +1,26 @@
+package pushreceiver
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+type receiver struct{}
+
+func (r *receiver) Start(_ context.Context, _ component.Host) error {
+	return nil
+}
+
+func (r *receiver) Shutdown(_ context.Context) error {
+	return nil
+}
+
+func (r *receiver) ConsumeTraces(_ context.Context, _ pdata.Traces) error {
+	return nil
+}
+
+func newPushReceiver() (component.TracesReceiver, error) {
+	return &receiver{}, nil
+}


### PR DESCRIPTION
`PushReceiver` is stored in its factory, so we can retrieve it after it's created and directly push traces to its pipeline.