### PR TITLE
Prototype adding a readiness check for metrics

### DIFF
--- a/cmd/agent/entrypoint.go
+++ b/cmd/agent/entrypoint.go
@@ -158,6 +158,13 @@ func (ep *Entrypoint) wire(mux *mux.Router, grpc *grpc.Server) {
 	ep.manager.WireAPI(mux)
 
 	mux.HandleFunc("/-/healthy", func(w http.ResponseWriter, r *http.Request) {
+		if !ep.promMetrics.Ready() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprintf(w, "Metrics are still loading.\n")
+
+			return
+		}
+
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, "Agent is Healthy.\n")
 	})

--- a/pkg/metrics/agent_test.go
+++ b/pkg/metrics/agent_test.go
@@ -271,6 +271,8 @@ func (i *fakeInstance) Run(ctx context.Context) error {
 	}
 }
 
+func (i *fakeInstance) Ready() bool { return true }
+
 func (i *fakeInstance) Update(_ instance.Config) error {
 	return instance.ErrInvalidUpdate{
 		Inner: fmt.Errorf("can't dynamically update fakeInstance"),

--- a/pkg/metrics/http_test.go
+++ b/pkg/metrics/http_test.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -15,7 +14,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/scrape"
-	"github.com/prometheus/prometheus/storage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -110,51 +108,35 @@ func TestAgent_ListTargetsHandler(t *testing.T) {
 		rr := httptest.NewRecorder()
 		a.ListTargetsHandler(rr, r)
 		expect := `{
-			"status": "success",
-			"data": [{
-				"instance": "test_instance",
-				"target_group": "group_a",
-				"endpoint": "http://localhost:12345/metrics",
-				"state": "down",
-				"labels": {
-					"foo": "bar",
-					"instance": "instance",
-					"job": "job"
-				},
-				"discovered_labels": {
-					"__discovered__": "yes"
-				},
-				"last_scrape": "1994-01-12T00:00:00Z",
-				"scrape_duration_ms": 60000,
-				"scrape_error":"something went wrong"
-			}]
-		}`
+      "status": "success",
+      "data": [{
+        "instance": "test_instance",
+        "target_group": "group_a",
+        "endpoint": "http://localhost:12345/metrics",
+        "state": "down",
+        "labels": {
+          "foo": "bar",
+          "instance": "instance",
+          "job": "job"
+        },
+        "discovered_labels": {
+          "__discovered__": "yes"
+        },
+        "last_scrape": "1994-01-12T00:00:00Z",
+        "scrape_duration_ms": 60000,
+        "scrape_error":"something went wrong"
+      }]
+    }`
 		require.JSONEq(t, expect, rr.Body.String())
 		require.Equal(t, http.StatusOK, rr.Result().StatusCode)
 	})
 }
 
 type mockInstanceScrape struct {
+	instance.NoOpInstance
 	tgts map[string][]*scrape.Target
-}
-
-func (i *mockInstanceScrape) Run(ctx context.Context) error {
-	<-ctx.Done()
-	return nil
-}
-
-func (i *mockInstanceScrape) Update(_ instance.Config) error {
-	return nil
 }
 
 func (i *mockInstanceScrape) TargetsActive() map[string][]*scrape.Target {
 	return i.tgts
-}
-
-func (i *mockInstanceScrape) StorageDirectory() string {
-	return ""
-}
-
-func (i *mockInstanceScrape) Appender(ctx context.Context) storage.Appender {
-	return nil
 }

--- a/pkg/metrics/instance/manager.go
+++ b/pkg/metrics/instance/manager.go
@@ -61,6 +61,7 @@ type Manager interface {
 // for the sake of testing from Manager implementations.
 type ManagedInstance interface {
 	Run(ctx context.Context) error
+	Ready() bool
 	Update(c Config) error
 	TargetsActive() map[string][]*scrape.Target
 	StorageDirectory() string

--- a/pkg/metrics/instance/manager_test.go
+++ b/pkg/metrics/instance/manager_test.go
@@ -99,6 +99,7 @@ func TestBasicManager_ApplyConfig(t *testing.T) {
 
 type mockInstance struct {
 	RunFunc              func(ctx context.Context) error
+	ReadyFunc            func() bool
 	UpdateFunc           func(c Config) error
 	TargetsActiveFunc    func() map[string][]*scrape.Target
 	StorageDirectoryFunc func() string
@@ -110,6 +111,13 @@ func (m mockInstance) Run(ctx context.Context) error {
 		return m.RunFunc(ctx)
 	}
 	panic("RunFunc not provided")
+}
+
+func (m mockInstance) Ready() bool {
+	if m.ReadyFunc != nil {
+		return m.ReadyFunc()
+	}
+	panic("ReadyFunc not provided")
 }
 
 func (m mockInstance) Update(c Config) error {

--- a/pkg/metrics/instance/noop.go
+++ b/pkg/metrics/instance/noop.go
@@ -17,6 +17,11 @@ func (NoOpInstance) Run(ctx context.Context) error {
 	return nil
 }
 
+// Ready implements Instance.
+func (NoOpInstance) Ready() bool {
+	return true
+}
+
 // Update implements Instance.
 func (NoOpInstance) Update(_ Config) error {
 	return nil

--- a/pkg/traces/remotewriteexporter/exporter_test.go
+++ b/pkg/traces/remotewriteexporter/exporter_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/agent/pkg/metrics/instance"
 	"github.com/prometheus/prometheus/pkg/exemplar"
 	"github.com/prometheus/prometheus/pkg/labels"
-	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/model/pdata"
@@ -103,16 +102,9 @@ func (m *mockManager) DeleteConfig(_ string) error { return nil }
 func (m *mockManager) Stop() {}
 
 type mockInstance struct {
+	instance.NoOpInstance
 	appender *mockAppender
 }
-
-func (m *mockInstance) Run(_ context.Context) error { return nil }
-
-func (m *mockInstance) Update(_ instance.Config) error { return nil }
-
-func (m *mockInstance) TargetsActive() map[string][]*scrape.Target { return nil }
-
-func (m *mockInstance) StorageDirectory() string { return "" }
 
 func (m *mockInstance) Appender(_ context.Context) storage.Appender {
 	if m.appender == nil {


### PR DESCRIPTION
#### PR Description 
Extends the `/-/ready` check to ensure that all current instances have been initialized. Waits for the first apply on startup to finish to ensure that at least the instances defined in the config file are available for checking.

#### Which issue(s) this PR fixes 
Fixes #1009

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
