### PR TITLE
Log config watcher reshard timer at debug level

### DIFF
--- a/pkg/metrics/cluster/config_watcher.go
+++ b/pkg/metrics/cluster/config_watcher.go
@@ -99,7 +99,7 @@ func (w *configWatcher) run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-w.nextReshard(lastReshard):
-			level.Info(w.log).Log("msg", "reshard timer ticked, scheduling refresh")
+			level.Debug(w.log).Log("msg", "reshard timer ticked, scheduling refresh")
 			w.RequestRefresh()
 			lastReshard = time.Now()
 		case <-w.refreshCh:


### PR DESCRIPTION
#### PR Description 
Since this message is logged periodically and an implementation detail we can
log it at a debug level.

#### Which issue(s) this PR fixes 

Resolves #1048


#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
