### PR TITLE
Show remote write latency on dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 
 - [ENHANCEMENT] Update windows_exporter to v0.16.0 (@rfratto, @mattdurham)
 
+- [ENHANCEMENT] Add send latency to agent dashboard (@bboreham)
+
 - [BUGFIX] Do not immediately cancel context when creating a new trace
   processor. This was preventing scrape_configs in traces from
   functioning. (@lheinlen)


### PR DESCRIPTION
#### PR Description 

If samples are getting backlogged, it may be due to latency between the agent and the backend it is sending to.

Replaced the differential panel which doesn't add much to the timestamp panel to the left, and essentially duplicates the differential samples rate panel below.

Before:
![image](https://user-images.githubusercontent.com/8125524/139686882-08353751-6159-4ca7-bb32-873c0d5400ab.png)

After:
![image](https://user-images.githubusercontent.com/8125524/139686454-a1086558-7254-423b-9a25-b7fdff8cb122.png)

#### PR Checklist

- [x] CHANGELOG updated 
- NA Documentation added
- NA Tests updated
