### PR TITLE
Use correct user/group env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Main (unreleased)
 
+- [BUGFIX] Packaging: Use correct user/group env variables in RPM %post script (@simonc6372)
+
+
 # v0.20.0 (2021-10-28)
 
 - [FEATURE] Operator: The Grafana Agent Operator can now generate a Kubelet

--- a/packaging/rpm/control/postinst
+++ b/packaging/rpm/control/postinst
@@ -10,10 +10,10 @@ set -e
 add_to_logging_groups() {
   # Add grafana agent user to groups used for reading logs.
   if getent group adm > /dev/null 2>&1 ; then
-      usermod -a -G adm "$GRAFANA_AGENT_USER"
+      usermod -a -G adm "$AGENT_USER"
   fi
   if getent group systemd-journal > /dev/null 2>&1 ; then
-      usermod -a -G systemd-journal "$GRAFANA_AGENT_USER"
+      usermod -a -G systemd-journal "$AGENT_USER"
   fi
 }
 


### PR DESCRIPTION
The env variables in add_to_logging_group() did not match the names set at the start of the post install script.

#### PR Description 
Correct names of user & group environment variables so uniform name is used throughout. 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
