### PR TITLE
Operator: Fix metrics service port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - [BUGFIX] Validate logs config when using logs_instance with automatic logging processor (@mapno)
 
+- [BUGFIX] Operator: Fix MetricsInstance Service port (@hjet)
+
 - [CHANGE] Self-scraped integrations will now use an SUO-specific value for the `instance` label. (@rfratto)
 
 # v0.20.0 (2021-10-28)

--- a/pkg/operator/resources_metrics.go
+++ b/pkg/operator/resources_metrics.go
@@ -71,7 +71,7 @@ func generateMetricsStatefulSetService(cfg *Config, d config.Deployment) *v1.Ser
 			ClusterIP: "None",
 			Ports: []v1.ServicePort{{
 				Name:       d.Agent.Spec.PortName,
-				Port:       9090,
+				Port:       8080,
 				TargetPort: intstr.FromString(d.Agent.Spec.PortName),
 			}},
 			Selector: map[string]string{


### PR DESCRIPTION
#### PR Description 

The MetricsInstance Service created by Operator was using port `9090` when the Agent ContainerPorts [are set to 8080](https://github.com/grafana/agent/blob/beccf9b6f9d32298571dbba2038763b5be19fe02/pkg/operator/resources_metrics.go#L230). This PR fixes this bug.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated