### PR TITLE
[dev.multiple-integrations] Enable present integrations by default, deprecate enabled field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,19 @@
 # Main (unreleased)
 
+BREAKING CHANGE: Integrations have changed in this release.
+Please review the [migration guide](./docs/migration-guide.md) for details.
+
 - [BUGFIX] Packaging: Use correct user/group env variables in RPM %post script (@simonc6372)
 
 - [BUGFIX] Validate logs config when using logs_instance with automatic logging processor (@mapno)
 
 - [CHANGE] Self-scraped integrations will now use an SUO-specific value for the `instance` label. (@rfratto)
+
+- [CHANGE] Integrations present in the `integrations:` map will now default to
+  being enabled. (@rfratto)
+
+- [DEPRECATION] Integrations: The `enabled` field is now deprecated and will be
+  removed in a future release. (@rfratto)
 
 # v0.20.0 (2021-10-28)
 

--- a/docs/configuration/integrations/_index.md
+++ b/docs/configuration/integrations/_index.md
@@ -14,7 +14,11 @@ manually write `scrape_configs`:
 agent:
   # Enables the Agent integration, allowing the Agent to automatically
   # collect and send metrics about itself.
-  [enabled: <boolean> | default = false]
+  #
+  # Enabled is DEPRECATED and will be removed in a future release. To disable
+  # an integration, comment it out or remove it from your config instead of
+  # setting `enabled: false`.
+  [enabled: <boolean> | default = true]
 
   # Sets an explicit value for the instance label when the integration is
   # self-scraped. Overrides inferred values.
@@ -54,6 +58,39 @@ agent:
 #  (Client Auth Type = RequireAndVerifyClientCert || RequireAnyClientCert).
 http_tls_config: <tls_config>
 
+# Automatically collect metrics from enabled integrations. If disabled,
+# integrations will be run but not scraped and thus not remote_written. Metrics
+# for integrations will be exposed at /integrations/<integration_key>/metrics
+# and can be scraped by an external process.
+[scrape_integrations: <boolean> | default = true]
+
+# Extra labels to add to all samples coming from integrations.
+labels:
+  { <string>: <string> }
+
+# The period to wait before restarting an integration that exits with an
+# error.
+[integration_restart_backoff: <duration> | default = "5s"]
+
+# A list of remote_write targets. Defaults to global_config.remote_write.
+# If provided, overrides the global defaults.
+prometheus_remote_write:
+  - [<remote_write>]
+
+#
+# List of integrations.
+#
+# Integrations will not run unless they are defined inside of the
+# `integrations` block. Once they are defined, they will run unless
+# explicitly disabled. For example, this config will run ONLY the
+# node_exporter integration:
+#
+# ```
+# integrations:
+#   node_exporter: {}
+# ```
+#
+
 # Controls the node_exporter integration
 node_exporter: <node_exporter_config>
 
@@ -92,25 +129,8 @@ kafka_exporter: <kafka_exporter_config>
 
 # Controls the mongodb_exporter integration
 mongodb_exporter: <mongodb_exporter_config>
+
 # Controls the github_exporter integration
 github_exporter: <github_exporter_config>
 
-# Automatically collect metrics from enabled integrations. If disabled,
-# integrations will be run but not scraped and thus not remote_written. Metrics
-# for integrations will be exposed at /integrations/<integration_key>/metrics
-# and can be scraped by an external process.
-[scrape_integrations: <boolean> | default = true]
-
-# Extra labels to add to all samples coming from integrations.
-labels:
-  { <string>: <string> }
-
-# The period to wait before restarting an integration that exits with an
-# error.
-[integration_restart_backoff: <duration> | default = "5s"]
-
-# A list of remote_write targets. Defaults to global_config.remote_write.
-# If provided, overrides the global defaults.
-prometheus_remote_write:
-  - [<remote_write>]
 ```

--- a/docs/configuration/integrations/consul-exporter-config.md
+++ b/docs/configuration/integrations/consul-exporter-config.md
@@ -14,7 +14,11 @@ Full reference of options:
 ```yaml
   # Enables the consul_exporter integration, allowing the Agent to automatically
   # collect system metrics from the configured consul server address
-  [enabled: <boolean> | default = false]
+  #
+  # Enabled is DEPRECATED and will be removed in a future release. To disable
+  # an integration, comment it out or remove it from your config instead of
+  # setting `enabled: false`.
+  [enabled: <boolean> | default = true]
 
   # Sets an explicit value for the instance label when the integration is
   # self-scraped. Overrides inferred values.

--- a/docs/configuration/integrations/dnsmasq-exporter-config.md
+++ b/docs/configuration/integrations/dnsmasq-exporter-config.md
@@ -16,7 +16,6 @@ the servers:
 
 ```yaml
 dnsmasq_exporter:
-  enabled: true
   dnsmasq_address: dnsmasq-a:53
   relabel_configs:
   - source_labels: [__address__]
@@ -29,7 +28,11 @@ Full reference of options:
 ```yaml
   # Enables the dnsmasq_exporter integration, allowing the Agent to automatically
   # collect system metrics from the configured dnsmasq server address
-  [enabled: <boolean> | default = false]
+  #
+  # Enabled is DEPRECATED and will be removed in a future release. To disable
+  # an integration, comment it out or remove it from your config instead of
+  # setting `enabled: false`.
+  [enabled: <boolean> | default = true]
 
   # Sets an explicit value for the instance label when the integration is
   # self-scraped. Overrides inferred values.

--- a/docs/configuration/integrations/elasticsearch-exporter-config.md
+++ b/docs/configuration/integrations/elasticsearch-exporter-config.md
@@ -20,7 +20,11 @@ Full reference of options:
 ```yaml
   # Enables the elasticsearch_exporter integration, allowing the Agent to automatically
   # collect system metrics from the configured ElasticSearch server address
-  [enabled: <boolean> | default = false]
+  #
+  # Enabled is DEPRECATED and will be removed in a future release. To disable
+  # an integration, comment it out or remove it from your config instead of
+  # setting `enabled: false`.
+  [enabled: <boolean> | default = true]
 
   # Sets an explicit value for the instance label when the integration is
   # self-scraped. Overrides inferred values.

--- a/docs/configuration/integrations/github-exporter-config.md
+++ b/docs/configuration/integrations/github-exporter-config.md
@@ -17,7 +17,11 @@ Full reference of options:
 ```yaml
   # Enables the github_exporter integration, allowing the Agent to automatically
   # collect metrics for the specified github objects.
-  [enabled: <boolean> | default = false]
+  #
+  # Enabled is DEPRECATED and will be removed in a future release. To disable
+  # an integration, comment it out or remove it from your config instead of
+  # setting `enabled: false`.
+  [enabled: <boolean> | default = true]
 
   # Sets an explicit value for the instance label when the integration is
   # self-scraped. Overrides inferred values.

--- a/docs/configuration/integrations/kafka-exporter-config.md
+++ b/docs/configuration/integrations/kafka-exporter-config.md
@@ -16,7 +16,11 @@ Full reference of options:
 ```yaml
   # Enables the kafka_exporter integration, allowing the Agent to automatically
   # collect system metrics from the configured dnsmasq server address
-  [enabled: <boolean> | default = false]
+  #
+  # Enabled is DEPRECATED and will be removed in a future release. To disable
+  # an integration, comment it out or remove it from your config instead of
+  # setting `enabled: false`.
+  [enabled: <boolean> | default = true]
 
   # Sets an explicit value for the instance label when the integration is
   # self-scraped. Overrides inferred values.

--- a/docs/configuration/integrations/memcached-exporter-config.md
+++ b/docs/configuration/integrations/memcached-exporter-config.md
@@ -16,7 +16,6 @@ the servers:
 
 ```yaml
 memcached_exporter:
-  enabled: true
   memcached_address: memcached-a:53
   relabel_configs:
   - source_labels: [__address__]
@@ -29,7 +28,11 @@ Full reference of options:
 ```yaml
   # Enables the memcached_exporter integration, allowing the Agent to automatically
   # collect system metrics from the configured memcached server address
-  [enabled: <boolean> | default = false]
+  #
+  # Enabled is DEPRECATED and will be removed in a future release. To disable
+  # an integration, comment it out or remove it from your config instead of
+  # setting `enabled: false`.
+  [enabled: <boolean> | default = true]
 
   # Sets an explicit value for the instance label when the integration is
   # self-scraped. Overrides inferred values.

--- a/docs/configuration/integrations/mongodb_exporter-config.md
+++ b/docs/configuration/integrations/mongodb_exporter-config.md
@@ -29,8 +29,12 @@ security privileges necessary for monitoring your node, as per the [official doc
 Besides that, there's not much to configure. Please refer to the full reference of options:
 
 ```yaml
-  # Enables the mongodb_exporter integration
-  [enabled: <boolean> | default = false]
+  # Enables the mongodb_exporter integration.
+  #
+  # Enabled is DEPRECATED and will be removed in a future release. To disable
+  # an integration, comment it out or remove it from your config instead of
+  # setting `enabled: false`.
+  [enabled: <boolean> | default = true]
 
   # Sets an explicit value for the instance label when the integration is
   # self-scraped. Overrides inferred values.

--- a/docs/configuration/integrations/mysqld-exporter-config.md
+++ b/docs/configuration/integrations/mysqld-exporter-config.md
@@ -16,7 +16,6 @@ servers:
 
 ```yaml
 mysqld_exporter:
-  enabled: true
   data_source_name: root@(server-a:3306)/
   relabel_configs:
   - source_labels: [__address__]
@@ -32,7 +31,11 @@ Full reference of options:
 ```yaml
   # Enables the mysqld_exporter integration, allowing the Agent to collect
   # metrics from a MySQL server.
-  [enabled: <boolean> | default = false]
+  #
+  # Enabled is DEPRECATED and will be removed in a future release. To disable
+  # an integration, comment it out or remove it from your config instead of
+  # setting `enabled: false`.
+  [enabled: <boolean> | default = true]
 
   # Sets an explicit value for the instance label when the integration is
   # self-scraped. Overrides inferred values.

--- a/docs/configuration/integrations/node-exporter-config.md
+++ b/docs/configuration/integrations/node-exporter-config.md
@@ -50,7 +50,6 @@ metrics:
 
 integrations:
   node_exporter:
-    enabled: true
     rootfs_path: /host/root
     sysfs_path: /host/sys
     procfs_path: /host/proc
@@ -172,7 +171,11 @@ the Agent is running on is a no-op.
 ```yaml
   # Enables the node_exporter integration, allowing the Agent to automatically
   # collect system metrics from the host UNIX system.
-  [enabled: <boolean> | default = false]
+  #
+  # Enabled is DEPRECATED and will be removed in a future release. To disable
+  # an integration, comment it out or remove it from your config instead of
+  # setting `enabled: false`.
+  [enabled: <boolean> | default = true]
 
   # Sets an explicit value for the instance label when the integration is
   # self-scraped. Overrides inferred values.

--- a/docs/configuration/integrations/postgres-exporter-config.md
+++ b/docs/configuration/integrations/postgres-exporter-config.md
@@ -17,7 +17,11 @@ Full reference of options:
 ```yaml
   # Enables the postgres_exporter integration, allowing the Agent to automatically
   # collect system metrics from the configured postgres server address
-  [enabled: <boolean> | default = false]
+  #
+  # Enabled is DEPRECATED and will be removed in a future release. To disable
+  # an integration, comment it out or remove it from your config instead of
+  # setting `enabled: false`.
+  [enabled: <boolean> | default = true]
 
   # Sets an explicit value for the instance label when the integration is
   # self-scraped. Overrides inferred values.

--- a/docs/configuration/integrations/process-exporter-config.md
+++ b/docs/configuration/integrations/process-exporter-config.md
@@ -56,7 +56,6 @@ An example config for `process_exporter_config` that tracks all processes is the
 following:
 
 ```
-enabled: true
 process_names:
 - name: "{{.Comm}}"
   cmdline:
@@ -68,7 +67,11 @@ Full reference of options:
 ```yaml
   # Enables the process_exporter integration, allowing the Agent to automatically
   # collect system metrics from the host UNIX system.
-  [enabled: <boolean> | default = false]
+  #
+  # Enabled is DEPRECATED and will be removed in a future release. To disable
+  # an integration, comment it out or remove it from your config instead of
+  # setting `enabled: false`.
+  [enabled: <boolean> | default = true]
 
   # Sets an explicit value for the instance label when the integration is
   # self-scraped. Overrides inferred values.

--- a/docs/configuration/integrations/redis-exporter-config.md
+++ b/docs/configuration/integrations/redis-exporter-config.md
@@ -10,7 +10,6 @@ Note that currently, an Agent can only collect metrics from a single Redis serve
 
 ```yaml
 redis_exporter:
-  enabled: true
   redis_addr: "redis-2:6379"
   relabel_configs:
   - source_labels: [__address__]
@@ -25,7 +24,11 @@ Full reference of options:
 ```yaml
   # Enables the redis_exporter integration, allowing the Agent to automatically
   # collect system metrics from the configured redis address
-  [enabled: <boolean> | default = false]
+  #
+  # Enabled is DEPRECATED and will be removed in a future release. To disable
+  # an integration, comment it out or remove it from your config instead of
+  # setting `enabled: false`.
+  [enabled: <boolean> | default = true]
 
   # Sets an explicit value for the instance label when the integration is
   # self-scraped. Overrides inferred values.

--- a/docs/configuration/integrations/statsd-exporter-config.md
+++ b/docs/configuration/integrations/statsd-exporter-config.md
@@ -14,7 +14,11 @@ Full reference of options:
 ```yaml
   # Enables the statsd_exporter integration, allowing the Agent to automatically
   # collect system metrics from the configured statsd server address
-  [enabled: <boolean> | default = false]
+  #
+  # Enabled is DEPRECATED and will be removed in a future release. To disable
+  # an integration, comment it out or remove it from your config instead of
+  # setting `enabled: false`.
+  [enabled: <boolean> | default = true]
 
   # Sets an explicit value for the instance label when the integration is
   # self-scraped. Overrides inferred values.

--- a/docs/configuration/integrations/windows-exporter-config.md
+++ b/docs/configuration/integrations/windows-exporter-config.md
@@ -14,7 +14,11 @@ Full reference of options:
 ```yaml
   # Enables the windows_exporter integration, allowing the Agent to automatically
   # collect system metrics from the local windows instance
-  [enabled: <boolean> | default = false]
+  #
+  # Enabled is DEPRECATED and will be removed in a future release. To disable
+  # an integration, comment it out or remove it from your config instead of
+  # setting `enabled: false`.
+  [enabled: <boolean> | default = true]
 
   # Sets an explicit value for the instance label when the integration is
   # self-scraped. Overrides inferred values.

--- a/docs/getting-started/create-config-file.md
+++ b/docs/getting-started/create-config-file.md
@@ -34,8 +34,7 @@ metrics:
       - url: http://localhost:9009/api/prom/push
 
 integrations:
-  agent:
-    enabled: true
+  agent: {}
 ```
 
 In this example, we first must configure the `wal_directory` which is used to
@@ -180,6 +179,5 @@ traces:
       send_batch_size: 100
 
 integrations:
-  node_exporter:
-    enabled: true
+  node_exporter: {}
 ```

--- a/docs/upgrade-guide/_index.md
+++ b/docs/upgrade-guide/_index.md
@@ -12,6 +12,36 @@ releases and how to migrate to newer versions.
 
 These changes will come in a future version.
 
+### Integrations: Defined integrations are enabled by default (Breaking change)
+
+Integrations which are defined inside of `integrations` will now run by default
+and must be explicitly disabled. Previously, integrations had to be explicitly
+enabled, even if they were present in the config file.
+
+This change makes it easier to define many integrations without repeating
+`enabled: true`. Example old config:
+
+```yaml
+integrations:
+  # Previously, not defining `enabled` meant that it would be disabled by default.
+  memcached_exporter:
+    memcached_addresss: localhost:11211
+```
+
+Example new config:
+
+```yaml
+integrations:
+  memcached_exporter:
+    # `enabled: false` must now be given to explicitly disable an integration.
+    # If `enabled` is not present, `enabled: true` is inferred.
+    enabled: false
+    memcached_addresss: localhost:11211
+```
+
+No change is necessary for configs that are not listed inside of `integrations:`.
+For example, as `node_exporter` is not defined, it will not be run.
+
 ### Integrations: Change in how instance labels are handled (Breaking change)
 
 Integrations will now use a SUO-specific `instance` label value. Integrations
@@ -36,6 +66,12 @@ Both `use_hostname_label` and `replace_instance_label` are now both deprecated
 and ignored from the YAML file, permanently treated as true. A future release
 will fully remove these fields, causing YAML errors on load instead of being
 silently ignored.
+
+### Integrations: Deprecation of `enabled` field (Deprecation)
+
+`enabled` is now deprecated and will be removed in a future release. To disable
+an integration, it is recommended to either fully remove it from the YAML, or
+comment it out.
 
 ## v0.20.0
 

--- a/example/docker-compose/agent/config/agent-local.yaml
+++ b/example/docker-compose/agent/config/agent-local.yaml
@@ -34,55 +34,41 @@ logs:
           __path__: /var/log/*log
 
 integrations:
-  agent:
-    enabled: true
-  node_exporter:
-    enabled: true
+  agent: {}
+  node_exporter: {}
   process_exporter:
-    enabled: true
     process_names:
       - name: "{{.Comm}}"
         cmdline:
         - '.+'
   mysqld_exporter:
-    enabled: true
     data_source_name: root@(localhost:3306)/
   postgres_exporter:
-    enabled: true
     data_source_names:
       - postgresql://postgres:password@localhost:5432/postgres?sslmode=disable
   redis_exporter:
-    enabled: true
     redis_addr: localhost:6379
   dnsmasq_exporter:
-    enabled: true
     dnsmasq_address: localhost:30053
     leases_path: /tmp/dnsmasq-leases/dnsmasq.leases
   memcached_exporter:
-    enabled: true
     memcached_address: localhost:11211
     timeout: 10s
   statsd_exporter:
-    enabled: true
   consul_exporter:
-    enabled: true
   elasticsearch_exporter:
-    enabled: true
     address: http://localhost:9200
   kafka_exporter:
-    enabled: true
     kafka_uris: [localhost:9093]
   github_exporter:
-    enabled: true
     repositories:
       - grafana/agent
   mongodb_exporter:
-    enabled: true
     mongodb_uri: mongodb://mongodb:27017
-    relabel_configs:        
+    relabel_configs:
     - source_labels: [__address__]
       target_label: service_name
-      replacement: 'mongodb'   
+      replacement: 'mongodb'
     - source_labels: [__address__]
       target_label: mongodb_cluster
-      replacement: 'mongodb-cluster'  
+      replacement: 'mongodb-cluster'

--- a/packaging/grafana-agent.yaml
+++ b/packaging/grafana-agent.yaml
@@ -19,10 +19,8 @@ metrics:
     #         - targets: ['127.0.0.1:9090']
 
 integrations:
-  agent:
-    enabled: true
+  agent: {}
   node_exporter:
-    enabled: true
     include_exporter_metrics: true
     disable_collectors:
       - "mdadm"

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -123,7 +123,7 @@ Function Install
     WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "NoRepair" 1
     Call WriteConfig
 
-   
+
     # Create our batch file, since services cant run with parameters, nsexec is used to suppress console output, instead goes
     # to NSIS log window
     nsExec::ExecToLog 'sc create "Grafana Agent" binpath= "$INSTDIR\agent-windows-amd64.exe"'
@@ -140,7 +140,7 @@ Function WriteConfig
     IfFileExists "$INSTDIR\agent-config.yaml" ReturnEarly WriteFile
     ReturnEarly:
         Return
-    WriteFile: 
+    WriteFile:
         # Write the config file, its easier to do this way than replacing an values in a templated file
         FileOpen $9 "$INSTDIR\agent-config.yaml" w #Opens a Empty File and fills it
         FileWrite $9 `server:$\n`
@@ -160,8 +160,7 @@ Function WriteConfig
         FileWrite $9 `    - name: integrations$\n`
         ${If} $EnableExporterValue == "true"
         FileWrite $9 `integrations:$\n`
-        FileWrite $9 `  windows_exporter:$\n`
-        FileWrite $9 `    enabled: true`
+        FileWrite $9 `  windows_exporter: {}$\n`
         ${EndIf}
         FileClose $9 # and close the file
         Return

--- a/pkg/integrations/agent/agent.go
+++ b/pkg/integrations/agent/agent.go
@@ -15,7 +15,7 @@ import (
 
 // Config controls the Agent integration.
 type Config struct {
-	Common config.Common `yaml:",inline"`
+	config.Common `yaml:",inline"`
 }
 
 // Name returns the name of the integration that this config represents.

--- a/pkg/integrations/config/config.go
+++ b/pkg/integrations/config/config.go
@@ -8,6 +8,12 @@ import (
 	"github.com/prometheus/prometheus/pkg/relabel"
 )
 
+// DefaultCommon is the default common settings for all integrations.
+var DefaultCommon = Common{
+	// Integrations are enabled by default when defined.
+	Enabled: true,
+}
+
 // Common is a set of common options shared by all integrations. It should be
 // utilised by an integration's config by inlining the common options:
 //
@@ -23,6 +29,14 @@ type Common struct {
 	RelabelConfigs       []*relabel.Config `yaml:"relabel_configs,omitempty"`
 	MetricRelabelConfigs []*relabel.Config `yaml:"metric_relabel_configs,omitempty"`
 	WALTruncateFrequency time.Duration     `yaml:"wal_truncate_frequency,omitempty"`
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler.
+func (c *Common) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultCommon
+
+	type common Common
+	return unmarshal((*common)(c))
 }
 
 // ScrapeConfig is a subset of options used by integrations to inform how samples

--- a/pkg/integrations/config/config.go
+++ b/pkg/integrations/config/config.go
@@ -21,7 +21,13 @@ var DefaultCommon = Common{
 //     Common config.Common `yaml:",inline"`
 //   }
 type Common struct {
-	Enabled              bool              `yaml:"enabled,omitempty"`
+	// Enabled controls whether a present integration should run.
+	//
+	// Enabled is DEPRECATED and will be removed in a future version. Users
+	// should change to removing or commenting out integrations instead of
+	// using `enabled: false` to prevent it from running.
+	Enabled bool `yaml:"enabled,omitempty"`
+
 	InstanceKey          *string           `yaml:"instance,omitempty"`
 	ScrapeIntegration    *bool             `yaml:"scrape_integration,omitempty"`
 	ScrapeInterval       time.Duration     `yaml:"scrape_interval,omitempty"`

--- a/pkg/integrations/consul_exporter/consul_exporter.go
+++ b/pkg/integrations/consul_exporter/consul_exporter.go
@@ -15,6 +15,7 @@ import (
 
 // DefaultConfig holds the default settings for the consul_exporter integration.
 var DefaultConfig = Config{
+	Common:        config.DefaultCommon,
 	Server:        "http://localhost:8500",
 	Timeout:       500 * time.Millisecond,
 	AllowStale:    true,

--- a/pkg/integrations/dnsmasq_exporter/dnsmasq_exporter.go
+++ b/pkg/integrations/dnsmasq_exporter/dnsmasq_exporter.go
@@ -11,6 +11,7 @@ import (
 
 // DefaultConfig is the default config for dnsmasq_exporter.
 var DefaultConfig Config = Config{
+	Common:         config.DefaultCommon,
 	DnsmasqAddress: "localhost:53",
 	LeasesPath:     "/var/lib/misc/dnsmasq.leases",
 }

--- a/pkg/integrations/elasticsearch_exporter/elasticsearch_exporter.go
+++ b/pkg/integrations/elasticsearch_exporter/elasticsearch_exporter.go
@@ -22,6 +22,7 @@ import (
 // DefaultConfig holds the default settings for the elasticsearch_exporter
 // integration.
 var DefaultConfig = Config{
+	Common:                    config.DefaultCommon,
 	Address:                   "http://localhost:9200",
 	Timeout:                   5 * time.Second,
 	Node:                      "_local",

--- a/pkg/integrations/github_exporter/github_exporter.go
+++ b/pkg/integrations/github_exporter/github_exporter.go
@@ -14,6 +14,7 @@ import (
 
 // DefaultConfig holds the default settings for the github_exporter integration
 var DefaultConfig Config = Config{
+	Common: config.DefaultCommon,
 	APIURL: "https://api.github.com",
 }
 

--- a/pkg/integrations/install/verify_test.go
+++ b/pkg/integrations/install/verify_test.go
@@ -1,0 +1,17 @@
+package install
+
+import (
+	"testing"
+
+	"github.com/grafana/agent/pkg/integrations"
+)
+
+// TestRegisteredIntegrations runs the integration tests suite for all
+// registered integrations.
+func TestRegisteredIntegrations(t *testing.T) {
+	for _, cfg := range integrations.RegisteredIntegrations() {
+		t.Run(cfg.Name(), func(t *testing.T) {
+			integrations.TestIntegration(t, cfg)
+		})
+	}
+}

--- a/pkg/integrations/kafka_exporter/kafka_exporter.go
+++ b/pkg/integrations/kafka_exporter/kafka_exporter.go
@@ -13,6 +13,7 @@ import (
 // DefaultConfig holds the default settings for the kafka_lag_exporter
 // integration.
 var DefaultConfig = Config{
+	Common:                  config.DefaultCommon,
 	UseSASLHandshake:        true,
 	KafkaVersion:            sarama.V2_0_0_0.String(),
 	MetadataRefreshInterval: "1m",

--- a/pkg/integrations/manager_test.go
+++ b/pkg/integrations/manager_test.go
@@ -85,8 +85,7 @@ test:
 
 func TestConfig_AddressRelabels(t *testing.T) {
 	cfgText := `
-agent:
-  enabled: true
+agent: {}
 `
 
 	var (

--- a/pkg/integrations/memcached_exporter/memcached_exporter.go
+++ b/pkg/integrations/memcached_exporter/memcached_exporter.go
@@ -12,6 +12,7 @@ import (
 
 // DefaultConfig is the default config for memcached_exporter.
 var DefaultConfig Config = Config{
+	Common:           config.DefaultCommon,
 	MemcachedAddress: "localhost:11211",
 	Timeout:          time.Second,
 }

--- a/pkg/integrations/mongodb_exporter/mongodb_exporter.go
+++ b/pkg/integrations/mongodb_exporter/mongodb_exporter.go
@@ -12,17 +12,10 @@ import (
 
 // Config controls mongodb_exporter
 type Config struct {
-	Common config.Common `yaml:",inline"`
+	config.Common `yaml:",inline"`
 
 	// MongoDB connection URI. example:mongodb://user:pass@127.0.0.1:27017/admin?ssl=true"
 	URI string `yaml:"mongodb_uri"`
-}
-
-// UnmarshalYAML implements yaml.Unmarshaler for Config
-func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
-
-	type plain Config
-	return unmarshal((*plain)(c))
 }
 
 // Name returns the name of the integration that this config represents.

--- a/pkg/integrations/mysqld_exporter/mysqld-exporter.go
+++ b/pkg/integrations/mysqld_exporter/mysqld-exporter.go
@@ -16,6 +16,7 @@ import (
 
 // DefaultConfig holds the default settings for the mysqld_exporter integration.
 var DefaultConfig = Config{
+	Common:          config.DefaultCommon,
 	LockWaitTimeout: 2,
 
 	InfoSchemaProcessListProcessesByUser: true,

--- a/pkg/integrations/node_exporter/config.go
+++ b/pkg/integrations/node_exporter/config.go
@@ -15,36 +15,35 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
-var (
-	// DefaultConfig holds non-zero default options for the Config when it is
-	// unmarshaled from YAML.
-	DefaultConfig = Config{
-		ProcFSPath: procfs.DefaultMountPoint,
-		SysFSPath:  sysfs.DefaultMountPoint,
-		RootFSPath: "/",
+// DefaultConfig holds non-zero default options for the Config when it is
+// unmarshaled from YAML.
+var DefaultConfig = Config{
+	Common:     config.DefaultCommon,
+	ProcFSPath: procfs.DefaultMountPoint,
+	SysFSPath:  sysfs.DefaultMountPoint,
+	RootFSPath: "/",
 
-		DiskStatsIgnoredDevices: "^(ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\\d+n\\d+p)\\d+$",
+	DiskStatsIgnoredDevices: "^(ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\\d+n\\d+p)\\d+$",
 
-		NetclassIgnoredDevices: "^$",
-		NetstatFields:          "^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_(Listen.*|Syncookies.*|TCPSynRetrans)|Tcp_(ActiveOpens|InSegs|OutSegs|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts|RcvbufErrors|SndbufErrors))$",
+	NetclassIgnoredDevices: "^$",
+	NetstatFields:          "^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_(Listen.*|Syncookies.*|TCPSynRetrans)|Tcp_(ActiveOpens|InSegs|OutSegs|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts|RcvbufErrors|SndbufErrors))$",
 
-		NTPServer:               "127.0.0.1",
-		NTPProtocolVersion:      4,
-		NTPIPTTL:                1,
-		NTPMaxDistance:          time.Microsecond * 3466080,
-		NTPLocalOffsetTolerance: time.Millisecond,
+	NTPServer:               "127.0.0.1",
+	NTPProtocolVersion:      4,
+	NTPIPTTL:                1,
+	NTPMaxDistance:          time.Microsecond * 3466080,
+	NTPLocalOffsetTolerance: time.Millisecond,
 
-		PowersupplyIgnoredSupplies: "^$",
+	PowersupplyIgnoredSupplies: "^$",
 
-		RunitServiceDir: "/etc/service",
+	RunitServiceDir: "/etc/service",
 
-		SupervisordURL: "http://localhost:9001/RPC2",
+	SupervisordURL: "http://localhost:9001/RPC2",
 
-		SystemdUnitWhitelist: ".+",
-		SystemdUnitBlacklist: ".+\\.(automount|device|mount|scope|slice)",
-		VMStatFields:         "^(oom_kill|pgpg|pswp|pg.*fault).*",
-	}
-)
+	SystemdUnitWhitelist: ".+",
+	SystemdUnitBlacklist: ".+\\.(automount|device|mount|scope|slice)",
+	VMStatFields:         "^(oom_kill|pgpg|pswp|pg.*fault).*",
+}
 
 func init() {
 	// The default values for the filesystem collector are to ignore everything,

--- a/pkg/integrations/postgres_exporter/postgres_exporter.go
+++ b/pkg/integrations/postgres_exporter/postgres_exporter.go
@@ -15,7 +15,7 @@ import (
 
 // Config controls the postgres_exporter integration.
 type Config struct {
-	Common config.Common `yaml:",inline"`
+	config.Common `yaml:",inline"`
 
 	// DataSourceNames to use to connect to Postgres.
 	DataSourceNames []string `yaml:"data_source_names,omitempty"`

--- a/pkg/integrations/process_exporter/config.go
+++ b/pkg/integrations/process_exporter/config.go
@@ -11,6 +11,7 @@ import (
 
 // DefaultConfig holds the default settings for the process_exporter integration.
 var DefaultConfig = Config{
+	Common:     config.DefaultCommon,
 	ProcFSPath: "/proc",
 	Children:   true,
 	Threads:    true,

--- a/pkg/integrations/redis_exporter/redis_exporter.go
+++ b/pkg/integrations/redis_exporter/redis_exporter.go
@@ -19,6 +19,7 @@ import (
 // DefaultConfig holds non-zero default options for the Config when it is
 // unmarshaled from YAML.
 var DefaultConfig = Config{
+	Common:                  config.DefaultCommon,
 	Namespace:               "redis",
 	ConfigCommand:           "CONFIG",
 	ConnectionTimeout:       (15 * time.Second),

--- a/pkg/integrations/statsd_exporter/statsd_exporter.go
+++ b/pkg/integrations/statsd_exporter/statsd_exporter.go
@@ -32,6 +32,7 @@ import (
 
 // DefaultConfig holds the default settings for the statsd_exporter integration.
 var DefaultConfig = Config{
+	Common:         config.DefaultCommon,
 	ListenUDP:      ":9125",
 	ListenTCP:      ":9125",
 	UnixSocketMode: "755",

--- a/pkg/integrations/test_utils.go
+++ b/pkg/integrations/test_utils.go
@@ -1,0 +1,22 @@
+package integrations
+
+import (
+	"testing"
+
+	"github.com/grafana/agent/pkg/integrations/config"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// TestIntegration can be used by integrations to run common tests against
+// their integration implementation.
+func TestIntegration(t *testing.T, c Config) {
+	t.Helper()
+
+	t.Run("Common Defaults", func(t *testing.T) {
+		c := cloneIntegration(c)
+		err := yaml.Unmarshal([]byte(`{}`), c)
+		require.NoError(t, err)
+		require.Equal(t, config.DefaultCommon, c.CommonConfig(), "integrations should unmarshal with common config defaults")
+	})
+}

--- a/pkg/integrations/windows_exporter/config.go
+++ b/pkg/integrations/windows_exporter/config.go
@@ -7,6 +7,7 @@ import (
 
 // DefaultConfig holds the default settings for the windows_exporter integration.
 var DefaultConfig = Config{
+	Common:            config.DefaultCommon,
 	EnabledCollectors: "cpu,cs,logical_disk,net,os,service,system",
 
 	// NOTE(rfratto): there is an init function in config_windows.go that


### PR DESCRIPTION
#### PR Description 
Integrations will now default to being enabled when they are present in the `integrations` block. This is a breaking change from before, where `enabled: true` must be explicitly provided to enable an integration that was defined.

Note that here "defined" means that its key is inside `integrations`:

```yaml
integrations:
  # node_exporter is defined, agent is not. 
  node_exporter: {} 
```

Integrations that are not defined will not be run regardless of the value of `enabled`.
Integrations that are defined may still be explicitly disabled with `enabled: false`. 

The difference between "enabled" and "defined" is _really_ confusing, and I don't think 
provides any value. This PR also marks `enabled` as deprecated in favor of recommending 
that users un-define (through removal or commenting out) integrations instead of 
setting `enabled`.  

#### Which issue(s) this PR fixes 
Related to #1059.

#### Notes to the Reviewer
I know #1059 proposed that `enabled` would have a different default based on the context, but it was difficult to get cleanly in the code. I think it makes sense to just make this change now instead of pushing it off. 

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
