### PR TITLE
Operator: Add relabel_config.libsonnet to logs templates dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - [BUGFIX] Validate logs config when using logs_instance with automatic logging processor (@mapno)
 
+- [BUGFIX] Add relabel_config.libsonnet to logs templates dir (@hjet)
+
 - [CHANGE] Self-scraped integrations will now use an SUO-specific value for the `instance` label. (@rfratto)
 
 # v0.20.0 (2021-10-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - [BUGFIX] Operator: Fix MetricsInstance Service port (@hjet)
 
-- [BUGFIX] Add relabel_config.libsonnet to logs templates dir (@hjet)
+- [BUGFIX] Operator: Fix relabel_config directive for PodLogs resource (@hjet)
 
 - [CHANGE] Self-scraped integrations will now use an SUO-specific value for the `instance` label. (@rfratto)
 

--- a/pkg/operator/config/logs_templates_test.go
+++ b/pkg/operator/config/logs_templates_test.go
@@ -474,6 +474,17 @@ func TestPodLogsConfig(t *testing.T) {
 						Namespace: "operator",
 						Name:      "podlogs",
 					},
+					Spec: gragent.PodLogsSpec{
+						RelabelConfigs: []*prom_v1.RelabelConfig{{
+							SourceLabels: []string{"input_a", "input_b"},
+							Separator:    ";",
+							TargetLabel:  "target_a",
+							Regex:        "regex",
+							Modulus:      1234,
+							Replacement:  "foobar",
+							Action:       "replace",
+						}},
+					},
 				},
 				"apiServer":                prom_v1.APIServerConfig{},
 				"ignoreNamespaceSelectors": false,
@@ -502,6 +513,13 @@ func TestPodLogsConfig(t *testing.T) {
 					target_label: __path__
 					separator: /
 					replacement: /var/log/pods/*$1/*.log
+				- source_labels: ["input_a", "input_b"]
+					separator: ";"
+					target_label: "target_a"
+					regex: regex
+					modulus: 1234
+					replacement: foobar
+					action: replace
 			`),
 		},
 	}

--- a/pkg/operator/config/templates/component/logs/relabel_config.libsonnet
+++ b/pkg/operator/config/templates/component/logs/relabel_config.libsonnet
@@ -1,0 +1,12 @@
+local optionals = import 'ext/optionals.libsonnet';
+
+// @param {RelabelConfig} cfg
+function(cfg) {
+  source_labels: optionals.array(cfg.SourceLabels),
+  separator: optionals.string(cfg.Separator),
+  regex: optionals.string(cfg.Regex),
+  modulus: optionals.number(cfg.Modulus),
+  target_label: optionals.string(cfg.TargetLabel),
+  replacement: optionals.string(cfg.Replacement),
+  action: optionals.string(cfg.Action),
+}


### PR DESCRIPTION
#### PR Description 

Discovered a bug today while testing Operator/PodLogs with some relabel_configs (this is from Operator logs):

```
level=error ts=2021-11-04T21:45:36.41286717Z component=controller.grafanaagent name=grafana-agent namespace=default msg="error during reconciling" err="unable to build config: RUNTIME ERROR: no such file: ./relabel_config.libsonnet\n\tcomponent/logs/pod_logs.libsonnet:5:28-63\tthunk <new_relabel_config> from <$>\n\tcomponent/logs/pod_logs.libsonnet:138:19-37\tfunction <anonymous>\n\t<std>:247:50-62\tfunction <anonymous>\n\t\t\n\text/optionals.libsonnet:40:17-50\tfunction <anonymous>\n\tagent-logs.libsonnet:(20:28)-(45:3)\tthunk from <function <anonymous>>\n\text/marshal.libsonnet:3:44-50\tthunk from <function <anonymous>>\n\text/marshal.libsonnet:3:18-51\tfunction <anonymous>\n\tagent-logs.libsonnet:(20:15)-(45:4)\tfunction <anonymous>\n\tTop-level function call\t\n"
```

Was due to `relabel_config.libsonnet` not having been copied into `../config/templates/component/logs/`. This quick fix copies it in, but perhaps with the forthcoming addition of traces we should begin sharing these sorts of files across components?

We also were not testing the `new_relabel_config` function so I added a relabel_config block to the existing PodLogsConfig test. I was able to replicate the bug with this test:

```
    logs_templates_test.go:533:
        	Error Trace:	logs_templates_test.go:533
        	Error:      	Received unexpected error:
        	            	RUNTIME ERROR: no such file: ./relabel_config.libsonnet
        	            		component/logs/pod_logs.libsonnet:5:28-63	thunk <new_relabel_config> from <$>
        	            		component/logs/pod_logs.libsonnet:138:19-37	function <anonymous>
        	            		<std>:247:50-62	function <anonymous>

        	            		ext/optionals.libsonnet:40:17-50	function <anonymous>
        	            		./component/logs/pod_logs.libsonnet:5:108-291	thunk from <function <anonymous>>
        	            		ext/marshal.libsonnet:3:44-50	thunk from <function <anonymous>>
        	            		ext/marshal.libsonnet:3:18-51	function <anonymous>
        	            		./component/logs/pod_logs.libsonnet:5:95-292	function <anonymous>
        	            		Top-level function call
        	Test:       	TestPodLogsConfig/default
```

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added
- [x] Tests updated
