### PR TITLE
Create a govern metrics service per Grafana Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - [BUGFIX] Operator: Fix MetricsInstance Service port (@hjet)
 
+- [BUGFIX] Operator: Create govern service per Grafana Agent (@shturman)
+
 - [CHANGE] Self-scraped integrations will now use an SUO-specific value for the `instance` label. (@rfratto)
 
 # v0.20.0 (2021-10-28)

--- a/pkg/operator/resources_metrics.go
+++ b/pkg/operator/resources_metrics.go
@@ -16,7 +16,6 @@ import (
 )
 
 const (
-	// governingServiceName = "grafana-agent-operated"
 	defaultPortName = "http-metrics"
 )
 


### PR DESCRIPTION
#### PR Description 

Currently operator tries to create a single govern service for all Agents. It fails due to multiple controller owners for a single k8s object.

PR creates a govern service dedicated to a `Grafana Agent`.

#### Which issue(s) this PR fixes 

Fixes https://github.com/grafana/agent/issues/964

#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
