### PR TITLE
Remove duplicate wrapping of logger with component key

### DIFF
--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -36,8 +36,6 @@ type Logs struct {
 
 // New creates and starts Loki log collection.
 func New(reg prometheus.Registerer, c *Config, l log.Logger) (*Logs, error) {
-	l = log.With(l, "component", "logs")
-
 	logs := &Logs{
 		instances: make(map[string]*Instance),
 		reg:       reg,


### PR DESCRIPTION
#### PR Description 

This change removes the duplicate wrapping of the logger with the key-value-pair `component=logs`.

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
