### PR TITLE
handle retrieve_config failures

### DIFF
--- a/production/grafanacloud-install.sh
+++ b/production/grafanacloud-install.sh
@@ -121,7 +121,7 @@ install_rpm() {
 # retrieve_config downloads the config file for the Agent and prints out its
 # contents to stdout.
 retrieve_config() {
-  if ! grafana-agentctl cloud-config -u "${GCLOUD_STACK_ID}" -p "${GCLOUD_API_KEY}" -e "${GCLOUD_API_URL}"; then
+  if ! grafana-agentctl cloud-config -u "${GCLOUD_STACK_ID}" -p "${GCLOUD_API_KEY}" -e "${GCLOUD_API_URL}" 2>/dev/null; then
     fatal "Failed to retrieve config"
   fi
 }

--- a/production/grafanacloud-install.sh
+++ b/production/grafanacloud-install.sh
@@ -81,7 +81,6 @@ main() {
   fi
   kill %%
   rm -rf "$t"
-  cat /etc/grafana-agent.yaml
 
   log '--- Enabling and starting grafana-agent.service'
   sudo systemctl enable grafana-agent.service

--- a/production/grafanacloud-install.sh
+++ b/production/grafanacloud-install.sh
@@ -73,6 +73,9 @@ main() {
   esac
 
   log '--- Retrieving config and placing in /etc/grafana-agent.yaml'
+  # The named pipe "$t/config" is created below so we can tee the stdout of
+  # retrieve_config to /etc/grafana-agent.yaml with sudo privileges.
+  # This is a POSIX-compliant work around for dash not having pipefail shellopt.
   local t=$(mktemp -d)
   mkfifo "$t/config"
   sudo tee /etc/grafana-agent.yaml < "$t/config"  &

--- a/production/grafanacloud-install.sh
+++ b/production/grafanacloud-install.sh
@@ -76,8 +76,12 @@ main() {
   # The named pipe "$t/config" is created below so we can tee the stdout of
   # retrieve_config to /etc/grafana-agent.yaml with sudo privileges.
   # This is a POSIX-compliant work around for dash not having pipefail shellopt.
-  local t=$(mktemp -d)
+  local t
+  t=$(mktemp -d)
   mkfifo "$t/config"
+  # SC2024 can be safely ignored as we want to redirect using the current user's
+  # permissions. See https://github.com/koalaman/shellcheck/issues/2070
+  # shellcheck disable=SC2024
   sudo tee /etc/grafana-agent.yaml < "$t/config"  &
   if ! retrieve_config 2>/dev/null 1>"$t/config"; then
     fatal 'Failed to retrieve config'

--- a/production/grafanacloud-install.sh
+++ b/production/grafanacloud-install.sh
@@ -77,7 +77,7 @@ main() {
   mkfifo "$t/config"
   sudo tee /etc/grafana-agent.yaml < "$t/config"  &
   if ! retrieve_config 2>/dev/null 1>"$t/config"; then
-    fatal 'Failed to retrieve confing'
+    fatal 'Failed to retrieve config'
   fi
   kill %%
   rm -rf "$t"


### PR DESCRIPTION
#### PR Description 

A bug in `production/grafanacloud-install.sh` results in the script not exiting properly when `retrieve_config` fails. It also prints an ugly error message which this hides.

#### Which issue(s) this PR fixes 

Fixes #599 

#### Notes to the Reviewer

Typically I would use something like `set -o pipefail` in bash scripts to handle a case like this but I believe that's not POSIX compliant nor available in dash.

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
