### PR TITLE
Update go-kit logger package to remove debug logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@
 
 - [BUGFIX] Operator: Fix relabel_config directive for PodLogs resource (@hjet)
 
-- [BUGFIX] Update go-kit logger package to remove debug logs (@mapno)
-
 - [CHANGE] Self-scraped integrations will now use an SUO-specific value for the `instance` label. (@rfratto)
 
 - [CHANGE] Changed service graphs store implementation to improve CPU performance (@mapno)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 - [BUGFIX] Operator: Fix relabel_config directive for PodLogs resource (@hjet)
 
+- [BUGFIX] Update go-kit logger package to remove debug logs (@mapno)
+
 - [CHANGE] Self-scraped integrations will now use an SUO-specific value for the `instance` label. (@rfratto)
 
 - [CHANGE] Changed service graphs store implementation to improve CPU performance (@mapno)

--- a/cmd/agent-operator/main.go
+++ b/cmd/agent-operator/main.go
@@ -6,8 +6,8 @@ import (
 	"os"
 
 	cortex_log "github.com/cortexproject/cortex/pkg/util/log"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/operator"
 	"github.com/grafana/agent/pkg/operator/logutil"
 	"github.com/prometheus/common/version"

--- a/cmd/agent/entrypoint.go
+++ b/cmd/agent/entrypoint.go
@@ -25,7 +25,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaveworks/common/signals"
 
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 )
 
 // Entrypoint is the entrypoint of the application that starts all subsystems.

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/config"
 	"github.com/grafana/agent/pkg/util"
 	"github.com/weaveworks/common/logging"

--- a/cmd/agent/service_windows.go
+++ b/cmd/agent/service_windows.go
@@ -9,7 +9,7 @@ import (
 	"os"
 
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/config"
 	"github.com/grafana/agent/pkg/util"
 	"github.com/weaveworks/common/logging"

--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -17,8 +17,8 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/prometheus/common/version"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/agentctl"
 	"github.com/grafana/agent/pkg/client"
 	"github.com/spf13/cobra"

--- a/cmd/grafana-agent-crow/main.go
+++ b/cmd/grafana-agent-crow/main.go
@@ -11,7 +11,7 @@ import (
 	// Adds version information
 	_ "github.com/grafana/agent/pkg/build"
 
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/crow"
 	"github.com/grafana/agent/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46
 	github.com/fatih/color v1.12.0 // indirect
 	github.com/fatih/structs v1.1.0
-	github.com/go-kit/kit v0.11.0
 	github.com/go-kit/log v0.2.0
 	github.com/go-logfmt/logfmt v0.5.1
 	github.com/go-logr/logr v1.0.0

--- a/pkg/agentctl/sync.go
+++ b/pkg/agentctl/sync.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/client"
 	"github.com/grafana/agent/pkg/metrics/instance"
 )

--- a/pkg/agentctl/walstats_test.go
+++ b/pkg/agentctl/walstats_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/timestamp"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"unicode"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/weaveworks/common/server"
 
 	"github.com/drone/envsubst/v2"

--- a/pkg/crow/crow.go
+++ b/pkg/crow/crow.go
@@ -14,8 +14,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/prometheus/client_golang/api"
 	promapi "github.com/prometheus/client_golang/api/prometheus/v1"

--- a/pkg/integrations/agent/agent.go
+++ b/pkg/integrations/agent/agent.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/config"
 	"github.com/prometheus/client_golang/prometheus/promhttp"

--- a/pkg/integrations/consul_exporter/consul_exporter.go
+++ b/pkg/integrations/consul_exporter/consul_exporter.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/config"
 	consul_api "github.com/hashicorp/consul/api"

--- a/pkg/integrations/dnsmasq_exporter/dnsmasq_exporter.go
+++ b/pkg/integrations/dnsmasq_exporter/dnsmasq_exporter.go
@@ -2,7 +2,7 @@
 package dnsmasq_exporter //nolint:golint
 
 import (
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/google/dnsmasq_exporter/collector"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/config"

--- a/pkg/integrations/elasticsearch_exporter/elasticsearch_exporter.go
+++ b/pkg/integrations/elasticsearch_exporter/elasticsearch_exporter.go
@@ -9,8 +9,8 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/config"
 	"github.com/prometheus/client_golang/prometheus"

--- a/pkg/integrations/github_exporter/github_exporter.go
+++ b/pkg/integrations/github_exporter/github_exporter.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/config"
 	gh_config "github.com/infinityworks/github-exporter/config"

--- a/pkg/integrations/integration.go
+++ b/pkg/integrations/integration.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/integrations/config"
 )
 

--- a/pkg/integrations/kafka_exporter/kafka_exporter.go
+++ b/pkg/integrations/kafka_exporter/kafka_exporter.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/Shopify/sarama"
 	kafka_exporter "github.com/davidmparrott/kafka_exporter/v2/exporter"
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/config"
 )

--- a/pkg/integrations/manager.go
+++ b/pkg/integrations/manager.go
@@ -11,8 +11,8 @@ import (
 
 	config_util "github.com/prometheus/common/config"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/gorilla/mux"
 	"github.com/grafana/agent/pkg/metrics"
 	"github.com/grafana/agent/pkg/metrics/instance"

--- a/pkg/integrations/manager_test.go
+++ b/pkg/integrations/manager_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/util/test"
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/integrations/config"
 	"github.com/grafana/agent/pkg/metrics/instance"
 	"github.com/prometheus/client_golang/prometheus/promhttp"

--- a/pkg/integrations/memcached_exporter/memcached_exporter.go
+++ b/pkg/integrations/memcached_exporter/memcached_exporter.go
@@ -4,7 +4,7 @@ package memcached_exporter //nolint:golint
 import (
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/config"
 	"github.com/prometheus/memcached_exporter/pkg/exporter"

--- a/pkg/integrations/mongodb_exporter/mongodb_exporter.go
+++ b/pkg/integrations/mongodb_exporter/mongodb_exporter.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/config"
 	"github.com/percona/mongodb_exporter/exporter"

--- a/pkg/integrations/mysqld_exporter/mysqld-exporter.go
+++ b/pkg/integrations/mysqld_exporter/mysqld-exporter.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/go-sql-driver/mysql"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/config"

--- a/pkg/integrations/node_exporter/config.go
+++ b/pkg/integrations/node_exporter/config.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/config"
 	"github.com/grafana/dskit/flagext"

--- a/pkg/integrations/node_exporter/node_exporter.go
+++ b/pkg/integrations/node_exporter/node_exporter.go
@@ -7,8 +7,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/integrations/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"

--- a/pkg/integrations/node_exporter/node_exporter_test.go
+++ b/pkg/integrations/node_exporter/node_exporter_test.go
@@ -11,7 +11,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/prometheus/pkg/textparse"
 	"github.com/stretchr/testify/require"

--- a/pkg/integrations/postgres_exporter/postgres_exporter.go
+++ b/pkg/integrations/postgres_exporter/postgres_exporter.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/config"
 	"github.com/lib/pq"

--- a/pkg/integrations/process_exporter/config.go
+++ b/pkg/integrations/process_exporter/config.go
@@ -2,7 +2,7 @@
 package process_exporter //nolint:golint
 
 import (
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/config"
 

--- a/pkg/integrations/process_exporter/process-exporter.go
+++ b/pkg/integrations/process_exporter/process-exporter.go
@@ -8,8 +8,8 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/integrations/config"
 )
 

--- a/pkg/integrations/process_exporter/process-exporter_linux.go
+++ b/pkg/integrations/process_exporter/process-exporter_linux.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/integrations/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"

--- a/pkg/integrations/redis_exporter/redis_exporter.go
+++ b/pkg/integrations/redis_exporter/redis_exporter.go
@@ -7,8 +7,8 @@ import (
 	"io/ioutil"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 
 	re "github.com/oliver006/redis_exporter/exporter"
 

--- a/pkg/integrations/redis_exporter/redis_exporter_test.go
+++ b/pkg/integrations/redis_exporter/redis_exporter_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/prometheus/pkg/textparse"
 	"github.com/stretchr/testify/require"

--- a/pkg/integrations/register_test.go
+++ b/pkg/integrations/register_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/integrations/config"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"

--- a/pkg/integrations/statsd_exporter/statsd_exporter.go
+++ b/pkg/integrations/statsd_exporter/statsd_exporter.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/prometheus/statsd_exporter/pkg/mappercache/lru"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/config"
 	"github.com/prometheus/client_golang/prometheus"

--- a/pkg/integrations/windows_exporter/config.go
+++ b/pkg/integrations/windows_exporter/config.go
@@ -1,6 +1,6 @@
 package windows_exporter //nolint:golint
 import (
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/config"
 )

--- a/pkg/integrations/windows_exporter/windows_exporter.go
+++ b/pkg/integrations/windows_exporter/windows_exporter.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/integrations/config"
 )
 

--- a/pkg/integrations/windows_exporter/windows_exporter_windows.go
+++ b/pkg/integrations/windows_exporter/windows_exporter_windows.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/prometheus-community/windows_exporter/collector"
 	"github.com/prometheus/statsd_exporter/pkg/level"

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/util"
 	"github.com/grafana/loki/clients/pkg/promtail"
 	"github.com/grafana/loki/clients/pkg/promtail/api"

--- a/pkg/logs/logs_test.go
+++ b/pkg/logs/logs_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/grafana/loki/pkg/loghttp/push"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/util"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/prometheus/client_golang/prometheus"

--- a/pkg/metrics/agent.go
+++ b/pkg/metrics/agent.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/metrics/cluster"
 	"github.com/grafana/agent/pkg/metrics/cluster/client"
 	"github.com/grafana/agent/pkg/metrics/instance"

--- a/pkg/metrics/agent_test.go
+++ b/pkg/metrics/agent_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/util/test"
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/metrics/instance"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/scrape"

--- a/pkg/metrics/cleaner.go
+++ b/pkg/metrics/cleaner.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/metrics/instance"
 	"github.com/grafana/agent/pkg/metrics/wal"
 	"github.com/prometheus/client_golang/prometheus"

--- a/pkg/metrics/cleaner_test.go
+++ b/pkg/metrics/cleaner_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/metrics/instance"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/metrics/cluster/cluster.go
+++ b/pkg/metrics/cluster/cluster.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/gorilla/mux"
 	"github.com/grafana/agent/pkg/agentproto"

--- a/pkg/metrics/cluster/config_watcher.go
+++ b/pkg/metrics/cluster/config_watcher.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/metrics/instance"
 	"github.com/grafana/agent/pkg/metrics/instance/configstore"
 	"github.com/grafana/agent/pkg/util"

--- a/pkg/metrics/cluster/node.go
+++ b/pkg/metrics/cluster/node.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/ring"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/gorilla/mux"
 	pb "github.com/grafana/agent/pkg/agentproto"
 	"github.com/grafana/agent/pkg/metrics/cluster/client"

--- a/pkg/metrics/cluster/node_test.go
+++ b/pkg/metrics/cluster/node_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/ring"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/grafana/agent/pkg/agentproto"
 	"github.com/grafana/agent/pkg/util"

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 	"github.com/gorilla/mux"
 	"github.com/grafana/agent/pkg/metrics/cluster/configapi"
 	"github.com/prometheus/common/model"

--- a/pkg/metrics/http_test.go
+++ b/pkg/metrics/http_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/util/test"
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/metrics/instance"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"

--- a/pkg/metrics/instance/configstore/api.go
+++ b/pkg/metrics/instance/configstore/api.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/gorilla/mux"
 	"github.com/grafana/agent/pkg/metrics/cluster/configapi"
 	"github.com/grafana/agent/pkg/metrics/instance"

--- a/pkg/metrics/instance/configstore/api_test.go
+++ b/pkg/metrics/instance/configstore/api_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/gorilla/mux"
 	"github.com/grafana/agent/pkg/client"
 	"github.com/grafana/agent/pkg/metrics/cluster/configapi"

--- a/pkg/metrics/instance/configstore/remote.go
+++ b/pkg/metrics/instance/configstore/remote.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/hashicorp/consul/api"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/metrics/instance"
 	"github.com/grafana/agent/pkg/util"
 	"github.com/grafana/dskit/kv"

--- a/pkg/metrics/instance/configstore/remote_test.go
+++ b/pkg/metrics/instance/configstore/remote_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/metrics/instance"
 	"github.com/grafana/agent/pkg/util"
 	"github.com/grafana/dskit/kv"

--- a/pkg/metrics/instance/instance.go
+++ b/pkg/metrics/instance/instance.go
@@ -16,8 +16,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/build"
 	"github.com/grafana/agent/pkg/metrics/wal"
 	"github.com/grafana/agent/pkg/util"

--- a/pkg/metrics/instance/instance_integration_test.go
+++ b/pkg/metrics/instance/instance_integration_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/util/test"
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"

--- a/pkg/metrics/instance/instance_test.go
+++ b/pkg/metrics/instance/instance_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/util/test"
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/model"

--- a/pkg/metrics/instance/manager.go
+++ b/pkg/metrics/instance/manager.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/scrape"

--- a/pkg/metrics/instance/manager_test.go
+++ b/pkg/metrics/instance/manager_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/stretchr/testify/require"

--- a/pkg/metrics/instance/modal_manager.go
+++ b/pkg/metrics/instance/modal_manager.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )

--- a/pkg/metrics/wal/wal.go
+++ b/pkg/metrics/wal/wal.go
@@ -8,8 +8,8 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pkg/exemplar"

--- a/pkg/metrics/wal/wal_test.go
+++ b/pkg/metrics/wal/wal_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/util"
 	"github.com/prometheus/prometheus/pkg/exemplar"
 	"github.com/prometheus/prometheus/pkg/labels"

--- a/pkg/operator/deployment_builder.go
+++ b/pkg/operator/deployment_builder.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	grafana "github.com/grafana/agent/pkg/operator/apis/monitoring/v1alpha1"
 	"github.com/grafana/agent/pkg/operator/assets"
 	"github.com/grafana/agent/pkg/operator/config"

--- a/pkg/operator/kubelet.go
+++ b/pkg/operator/kubelet.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/operator/clientutil"
 	"github.com/grafana/agent/pkg/operator/logutil"
 	core_v1 "k8s.io/api/core/v1"

--- a/pkg/operator/logutil/log.go
+++ b/pkg/operator/logutil/log.go
@@ -5,8 +5,8 @@ package logutil
 import (
 	"context"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/go-logr/logr"
 	clog "sigs.k8s.io/controller-runtime/pkg/log"
 )

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/weaveworks/common/logging"
 	"k8s.io/apimachinery/pkg/runtime"
 	controller "sigs.k8s.io/controller-runtime"

--- a/pkg/operator/reconciler.go
+++ b/pkg/operator/reconciler.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	grafana_v1alpha1 "github.com/grafana/agent/pkg/operator/apis/monitoring/v1alpha1"
 	"github.com/grafana/agent/pkg/operator/assets"
 	"github.com/grafana/agent/pkg/operator/clientutil"

--- a/pkg/operator/reconciler_logs.go
+++ b/pkg/operator/reconciler_logs.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/operator/assets"
 	"github.com/grafana/agent/pkg/operator/clientutil"
 	"github.com/grafana/agent/pkg/operator/config"

--- a/pkg/operator/reconciler_metrics.go
+++ b/pkg/operator/reconciler_metrics.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/google/go-jsonnet"
 	"github.com/grafana/agent/pkg/operator/assets"
 	"github.com/grafana/agent/pkg/operator/clientutil"

--- a/pkg/operator/secondary_resource.go
+++ b/pkg/operator/secondary_resource.go
@@ -1,7 +1,7 @@
 package operator
 
 import (
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/pkg/operator/selector_eventhandler.go
+++ b/pkg/operator/selector_eventhandler.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/operator/config"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/pkg/operator/selector_eventhandler_test.go
+++ b/pkg/operator/selector_eventhandler_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/hashicorp/go-getter"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"

--- a/pkg/traces/automaticloggingprocessor/automaticloggingprocessor.go
+++ b/pkg/traces/automaticloggingprocessor/automaticloggingprocessor.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	util "github.com/cortexproject/cortex/pkg/util/log"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/go-logfmt/logfmt"
 	"github.com/grafana/agent/pkg/logs"
 	"github.com/grafana/agent/pkg/operator/config"

--- a/pkg/traces/promsdprocessor/prom_sd_processor.go
+++ b/pkg/traces/promsdprocessor/prom_sd_processor.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 
 	util "github.com/cortexproject/cortex/pkg/util/log"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"

--- a/pkg/traces/promsdprocessor/prom_sd_processor_test.go
+++ b/pkg/traces/promsdprocessor/prom_sd_processor_test.go
@@ -3,7 +3,7 @@ package promsdprocessor
 import (
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/pkg/relabel"

--- a/pkg/traces/remotewriteexporter/exporter.go
+++ b/pkg/traces/remotewriteexporter/exporter.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	util "github.com/cortexproject/cortex/pkg/util/log"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/metrics/instance"
 	"github.com/grafana/agent/pkg/traces/contextkeys"
 	"github.com/prometheus/prometheus/pkg/labels"

--- a/pkg/traces/servicegraphprocessor/processor.go
+++ b/pkg/traces/servicegraphprocessor/processor.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	util "github.com/cortexproject/cortex/pkg/util/log"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/traces/contextkeys"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/collector/component"

--- a/pkg/util/server/server.go
+++ b/pkg/util/server/server.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/gorilla/mux"
 	"github.com/grafana/agent/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"

--- a/pkg/util/test_logger.go
+++ b/pkg/util/test_logger.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 )
 
 // TestLogger generates a logger for a test.


### PR DESCRIPTION
#### PR Description 

Some upstream code is now using `go-kit/log` instead of `go-kit/kit/log`, some debug logging from that code will pass through the level filter. `go-kit/kit` v0.12.0 addresses this by making `go-kit/kit/log` just a pass-through to `go-kit/log`, but upgrading to that version causes an issue while importing `github.com/prometheus/procfs/sysfs`.

#### PR Checklist

- NA CHANGELOG updated 
- [x] Documentation added
- NA Tests updated
