### PR TITLE
Setup CD for agent

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -129,6 +129,32 @@ volumes:
 ---
 kind: pipeline
 type: docker
+name: Deploy-To-Deployment-Tools 
+platform:
+  os: linux
+  arch: amd64
+trigger:
+  ref:
+    - refs/heads/main
+
+steps:
+  - name: Update Deployment Tools 
+    image: us.gcr.io/kubernetes-dev/drone/plugins/updater
+    settings:
+      config_json: "{\r\n  \"destination_branch\": \"master\",\r\n  \"pull_request_branch_prefix\": \"cd-agent-\",\r\n  \"pull_request_enabled\": true,\r\n  \"pull_request_existing_strategy\": \"fail\",\r\n  \"pull_request_message\": \"Created by Drone build https:\/\/drone.grafana.net\/api\/repos\/grafana\/agent\/builds\/${DRONE_BUILD_NUMBER}\\n\\nBuild commit: ${DRONE_COMMIT_LINK}\\n\",\r\n  \"pull_request_team_reviewers\": [\r\n    \"agent-squad\"\r\n  ],\r\n  \"repo_name\": \"agent\",\r\n  \"update_jsonnet_attribute_configs\": [\r\n    {\r\n      \"file_path\": \"ksonnet\/environments\/platform-observability\/images.libsonnet\",\r\n      \"jsonnet_key\": \"agent\",\r\n      \"jsonnet_value\": \"grafana\/agent:$DRONE_TAG\"\r\n    }\r\n  ]\r\n}"
+      github_token:
+        from_secret: gh_token
+ 
+depends_on:
+  - Containerize
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+---
+kind: pipeline
+type: docker
 name: Release
 platform:
   os: linux

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -138,6 +138,10 @@ trigger:
     - refs/heads/main
 
 steps:
+  - name: put image tag in a file
+    image: alpine
+    commands:
+      - echo grafana/agent:$(shell ./tools/image-tag) > .image-tag
   - name: Update Deployment Tools 
     image: us.gcr.io/kubernetes-dev/drone/plugins/updater
     settings:
@@ -149,16 +153,14 @@ steps:
           "pull_request_existing_strategy": "fail",
           "pull_request_message": "Created by Drone build https://drone.grafana.net/api/repos/grafana/agent/builds/${DRONE_BUILD_NUMBER}\n\nBuild commit: ${DRONE_COMMIT_LINK}\n",
           "pull_request_team_reviewers": [
-            "rfratto",
-            "mattdurham",
-            "gouthamve"
+            "agent-squad"
           ],
           "repo_name": "deployment_tools",
           "update_jsonnet_attribute_configs": [
             {
               "file_path": "ksonnet/environments/platform-observability/waves/agent.libsonnet",
               "jsonnet_key": "dev_canary",
-              "jsonnet_value": "grafana/agent:$DRONE_TAG"
+              "jsonnet_value_file": ".image-tag"
             }
           ]
         }
@@ -220,6 +222,6 @@ volumes:
       path: /var/run/docker.sock
 ---
 kind: signature
-hmac: 4a6148a31002cae1d4932abe18cb0a3ca1ba309d822aedb9bc38e058291b01fd
+hmac: f3d9528f8900aa0f42fb6fcc4de354b9ed5b85901561e3b7130e1df48657a51e
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -141,7 +141,27 @@ steps:
   - name: Update Deployment Tools 
     image: us.gcr.io/kubernetes-dev/drone/plugins/updater
     settings:
-      config_json: "{\r\n  \"destination_branch\": \"master\",\r\n  \"pull_request_branch_prefix\": \"cd-agent-\",\r\n  \"pull_request_enabled\": true,\r\n  \"pull_request_existing_strategy\": \"fail\",\r\n  \"pull_request_message\": \"Created by Drone build https:\/\/drone.grafana.net\/api\/repos\/grafana\/agent\/builds\/${DRONE_BUILD_NUMBER}\\n\\nBuild commit: ${DRONE_COMMIT_LINK}\\n\",\r\n  \"pull_request_team_reviewers\": [\r\n    \"agent-squad\"\r\n  ],\r\n  \"repo_name\": \"agent\",\r\n  \"update_jsonnet_attribute_configs\": [\r\n    {\r\n      \"file_path\": \"ksonnet\/environments\/platform-observability\/images.libsonnet\",\r\n      \"jsonnet_key\": \"agent\",\r\n      \"jsonnet_value\": \"grafana\/agent:$DRONE_TAG\"\r\n    }\r\n  ]\r\n}"
+      config_json: |- 
+        {
+          "destination_branch": "master",
+          "pull_request_branch_prefix": "cd-agent",
+          "pull_request_enabled": true,
+          "pull_request_existing_strategy": "fail",
+          "pull_request_message": "Created by Drone build https://drone.grafana.net/api/repos/grafana/agent/builds/${DRONE_BUILD_NUMBER}\n\nBuild commit: ${DRONE_COMMIT_LINK}\n",
+          "pull_request_team_reviewers": [
+            "rfratto",
+            "mattdurham",
+            "gouthamve"
+          ],
+          "repo_name": "deployment_tools",
+          "update_jsonnet_attribute_configs": [
+            {
+              "file_path": "ksonnet/environments/platform-observability/waves/agent.libsonnet",
+              "jsonnet_key": "dev_canary",
+              "jsonnet_value": "grafana/agent:$DRONE_TAG"
+            }
+          ]
+        }
       github_token:
         from_secret: gh_token
  
@@ -200,6 +220,6 @@ volumes:
       path: /var/run/docker.sock
 ---
 kind: signature
-hmac: 1cab98e575942179c9a157058799b9d44119b1d6c170feefbeefe303eb44823d
+hmac: 4a6148a31002cae1d4932abe18cb0a3ca1ba309d822aedb9bc38e058291b01fd
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -137,11 +137,15 @@ trigger:
   ref:
     - refs/heads/main
 
+image_pull_secrets:
+  - dockerconfigjson
+
 steps:
   - name: put image tag in a file
     image: alpine
     commands:
-      - echo grafana/agent:$(shell ./tools/image-tag) > .image-tag
+      - apk update && apk add git
+      - echo "grafana/agent:$(sh ./tools/image-tag)" > .image-tag
   - name: Update Deployment Tools 
     image: us.gcr.io/kubernetes-dev/drone/plugins/updater
     settings:
@@ -149,9 +153,7 @@ steps:
         {
           "destination_branch": "master",
           "pull_request_branch_prefix": "cd-agent",
-          "pull_request_enabled": true,
-          "pull_request_existing_strategy": "fail",
-          "pull_request_message": "Created by Drone build https://drone.grafana.net/api/repos/grafana/agent/builds/${DRONE_BUILD_NUMBER}\n\nBuild commit: ${DRONE_COMMIT_LINK}\n",
+          "pull_request_enabled": false,
           "pull_request_team_reviewers": [
             "agent-squad"
           ],
@@ -168,7 +170,7 @@ steps:
         from_secret: gh_token
  
 depends_on:
-  - Containerize
+  - Containerize 
 
 volumes:
   - name: docker
@@ -220,8 +222,24 @@ volumes:
   - name: docker
     host:
       path: /var/run/docker.sock
+
+---
+kind: secret
+name: dockerconfigjson
+
+get:
+  path: secret/data/common/gcr
+  name: .dockerconfigjson
+
+---
+kind: secret
+name: gh_token
+
+get:
+  path: infra/data/ci/github/grafanabot
+  name: pat
 ---
 kind: signature
-hmac: f3d9528f8900aa0f42fb6fcc4de354b9ed5b85901561e3b7130e1df48657a51e
+hmac: 53e9986dcd0fdbb78e1c09b6ba363ebcb94bc0801796510923f647b5c7d4ec46
 
 ...


### PR DESCRIPTION
This deploys agent to dev on a merge to main.

Depends on https://github.com/grafana/deployment_tools/pull/19936

Currently this automation only opens a PR, but I want to double check things and then I'll deploy directly to dev without a PR.

Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>