### PR TITLE
0.21.0 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Main (unreleased)
 
+# v0.21.0 (2021-11-17)
+
 - [ENHANCEMENT] Update Cortex dependency to v1.10.0-92-g85c378182. (@rlankfo)
 
 - [ENHANCEMENT] Update Loki dependency to v2.1.0-656-g0ae0d4da1. (@rlankfo)

--- a/docs/configuration/integrations/node-exporter-config.md
+++ b/docs/configuration/integrations/node-exporter-config.md
@@ -26,7 +26,7 @@ docker run \
   -v "/proc:/host/proc:ro,rslave" \
   -v /tmp/agent:/etc/agent \
   -v /path/to/config.yaml:/etc/agent-config/agent.yaml \
-  grafana/agent:v0.20.0 \
+  grafana/agent:v0.21.0 \
   --config.file=/etc/agent-config/agent.yaml
 ```
 
@@ -66,7 +66,7 @@ metadata:
   name: agent
 spec:
   containers:
-  - image: grafana/agent:v0.20.0
+  - image: grafana/agent:v0.21.0
     name: agent
     args:
     - --config.file=/etc/agent-config/agent.yaml

--- a/docs/configuration/integrations/process-exporter-config.md
+++ b/docs/configuration/integrations/process-exporter-config.md
@@ -18,7 +18,7 @@ docker run \
   -v "/proc:/proc:ro" \
   -v /tmp/agent:/etc/agent \
   -v /path/to/config.yaml:/etc/agent-config/agent.yaml \
-  grafana/agent:v0.20.0 \
+  grafana/agent:v0.21.0 \
   --config.file=/etc/agent-config/agent.yaml
 ```
 
@@ -35,7 +35,7 @@ metadata:
   name: agent
 spec:
   containers:
-  - image: grafana/agent:v0.20.0
+  - image: grafana/agent:v0.21.0
     name: agent
     args:
     - --config.file=/etc/agent-config/agent.yaml

--- a/docs/getting-started/_index.md
+++ b/docs/getting-started/_index.md
@@ -26,7 +26,7 @@ See the list of [Community Projects](#community-projects) for the community-driv
 docker run \
   -v /tmp/agent:/etc/agent/data \
   -v /path/to/config.yaml:/etc/agent/agent.yaml \
-  grafana/agent:v0.20.0
+  grafana/agent:v0.21.0
 ```
 
 Replace `/tmp/agent` with the folder you wish to store WAL data in. WAL data is

--- a/docs/operator/custom-resource-quickstart.md
+++ b/docs/operator/custom-resource-quickstart.md
@@ -43,7 +43,7 @@ metadata:
   labels:
     app: grafana-agent
 spec:
-  image: grafana/agent:v0.20.0
+  image: grafana/agent:v0.21.0
   logLevel: info
   serviceAccountName: grafana-agent
   metrics:

--- a/docs/operator/getting-started.md
+++ b/docs/operator/getting-started.md
@@ -72,7 +72,7 @@ spec:
       serviceAccountName: grafana-agent-operator
       containers:
       - name: operator
-        image: grafana/agent-operator:v0.20.0
+        image: grafana/agent-operator:v0.21.0
         args:
         - --kubelet-service=default/kubelet
 ---

--- a/docs/upgrade-guide/_index.md
+++ b/docs/upgrade-guide/_index.md
@@ -37,7 +37,7 @@ and ignored from the YAML file, permanently treated as true. A future release
 will fully remove these fields, causing YAML errors on load instead of being
 silently ignored.
 
-## v0.20.0
+## v0.21.0
 
 ### Traces: Changes to receiver's TLS config (Breaking change).
 

--- a/example/docker-compose/grafana/dashboards/agent-operational.json
+++ b/example/docker-compose/grafana/dashboards/agent-operational.json
@@ -7,7 +7,7 @@
    "graphTooltip": 0,
    "hideControls": false,
    "links": [ ],
-   "refresh": "1m",
+   "refresh": "30s",
    "rows": [
       {
          "collapse": false,

--- a/example/docker-compose/grafana/dashboards/agent-remote-write.json
+++ b/example/docker-compose/grafana/dashboards/agent-remote-write.json
@@ -10,7 +10,7 @@
    "hideControls": false,
    "id": null,
    "links": [ ],
-   "refresh": "1m",
+   "refresh": "30s",
    "rows": [
       {
          "collapse": false,
@@ -131,7 +131,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "(\n  rate(prometheus_remote_storage_highest_timestamp_in_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m])\n  -\n  ignoring(url, remote_name) group_right(pod)\n  rate(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m])\n)\n",
+                     "expr": "histogram_quantile(0.99, rate(prometheus_remote_storage_sent_batch_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[1m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}",
@@ -141,7 +141,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Rate[5m]",
+               "title": "P99 Latency [1m]",
                "tooltip": {
                   "shared": true,
                   "sort": 0,

--- a/example/docker-compose/grafana/dashboards/agent.json
+++ b/example/docker-compose/grafana/dashboards/agent.json
@@ -7,7 +7,7 @@
    "graphTooltip": 0,
    "hideControls": false,
    "links": [ ],
-   "refresh": "1m",
+   "refresh": "30s",
    "rows": [
       {
          "collapse": false,

--- a/pkg/operator/defaults.go
+++ b/pkg/operator/defaults.go
@@ -15,6 +15,7 @@ var (
 		"v0.18.4",
 		"v0.19.0",
 		"v0.20.0",
+		"v0.21.0",
 
 		// NOTE(rfratto): when performing an upgrade, add the newest version above instead of changing the existing reference.
 	}

--- a/production/README.md
+++ b/production/README.md
@@ -27,7 +27,7 @@ directory on your host that you want the agent to store its WAL.
 docker run \
   -v /tmp/agent:/etc/agent/data \
   -v /path/to/config.yaml:/etc/agent/agent.yaml \
-  grafana/agent:v0.20.0
+  grafana/agent:v0.21.0
 ```
 
 ## Running the Agent locally

--- a/production/grafanacloud-install.sh
+++ b/production/grafanacloud-install.sh
@@ -50,7 +50,7 @@ PACKAGE_SYSTEM=${PACKAGE_SYSTEM:=}
 #
 # Global constants.
 #
-RELEASE_VERSION="0.20.0"
+RELEASE_VERSION="0.21.0"
 
 RELEASE_URL="https://github.com/grafana/agent/releases/download/v${RELEASE_VERSION}"
 DEB_URL="${RELEASE_URL}/grafana-agent-${RELEASE_VERSION}-1.${ARCH}.deb"

--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -66,7 +66,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.20.0
+        image: grafana/agent:v0.21.0
         imagePullPolicy: IfNotPresent
         name: agent
         ports:

--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -64,7 +64,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.20.0
+        image: grafana/agent:v0.21.0
         imagePullPolicy: IfNotPresent
         name: agent
         ports:

--- a/production/kubernetes/agent-traces.yaml
+++ b/production/kubernetes/agent-traces.yaml
@@ -109,7 +109,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.20.0
+        image: grafana/agent:v0.21.0
         imagePullPolicy: IfNotPresent
         name: agent
         ports:

--- a/production/kubernetes/build/lib/version.libsonnet
+++ b/production/kubernetes/build/lib/version.libsonnet
@@ -1,1 +1,1 @@
-'grafana/agent:v0.20.0'
+'grafana/agent:v0.21.0'

--- a/production/kubernetes/install-bare.sh
+++ b/production/kubernetes/install-bare.sh
@@ -25,7 +25,7 @@ check_installed() {
 check_installed curl
 check_installed envsubst
 
-MANIFEST_BRANCH=v0.20.0
+MANIFEST_BRANCH=v0.21.0
 MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent-bare.yaml}
 NAMESPACE=${NAMESPACE:-default}
 

--- a/production/tanka/grafana-agent/v1/main.libsonnet
+++ b/production/tanka/grafana-agent/v1/main.libsonnet
@@ -15,8 +15,8 @@ local service = k.core.v1.service;
 (import './lib/traces.libsonnet') +
 {
   _images:: {
-    agent: 'grafana/agent:v0.20.0',
-    agentctl: 'grafana/agentctl:v0.20.0',
+    agent: 'grafana/agent:v0.21.0',
+    agentctl: 'grafana/agentctl:v0.21.0',
   },
 
   // new creates a new DaemonSet deployment of the grafana-agent. By default,

--- a/production/tanka/grafana-agent/v2/internal/base.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/base.libsonnet
@@ -10,8 +10,8 @@ function(name='grafana-agent', namespace='') {
   local this = self,
 
   _images:: {
-    agent: 'grafana/agent:v0.20.0',
-    agentctl: 'grafana/agentctl:v0.20.0',
+    agent: 'grafana/agent:v0.21.0',
+    agentctl: 'grafana/agentctl:v0.21.0',
   },
   _config:: {
     name: name,

--- a/production/tanka/grafana-agent/v2/internal/syncer.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/syncer.libsonnet
@@ -14,7 +14,7 @@ function(
 ) {
   local _config = {
     api: error 'api must be set',
-    image: 'grafana/agentctl:v0.20.0',
+    image: 'grafana/agentctl:v0.21.0',
     schedule: '*/5 * * * *',
     configs: [],
   } + config,


### PR DESCRIPTION
Prepare for v0.21.0 release by following the [release procedure](https://github.com/grafana/agent/blob/main/cmd/agent/DEVELOPERS.md#performing-the-release)