### PR TITLE
Fix parsePostgresURL issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Main (unreleased)
 
+- [BUGFIX] Fix panic when using postgres_exporter (@saputradharma)
+
 # v0.21.0 (2021-11-17)
 
 - [ENHANCEMENT] Update Cortex dependency to v1.10.0-92-g85c378182. (@rlankfo)
@@ -23,8 +25,6 @@
 - [BUGFIX] Operator: Fix relabel_config directive for PodLogs resource (@hjet)
 
 - [BUGFIX] Traces: Fix `success_logic` code in service graphs processor (@mapno)
-
-- [BUGFIX] Fix panic when using postgres_exporter (@saputradharma)
 
 - [CHANGE] Self-scraped integrations will now use an SUO-specific value for the `instance` label. (@rfratto)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 - [BUGFIX] Traces: Fix `success_logic` code in service graphs processor (@mapno)
 
+- [BUGFIX] Fix panic when using postgres_exporter (@saputradharma)
+
 - [CHANGE] Self-scraped integrations will now use an SUO-specific value for the `instance` label. (@rfratto)
 
 - [CHANGE] Traces: Changed service graphs store implementation to improve CPU performance (@mapno)

--- a/pkg/integrations/postgres_exporter/postgres_exporter.go
+++ b/pkg/integrations/postgres_exporter/postgres_exporter.go
@@ -85,7 +85,7 @@ func parsePostgresURL(url string) (map[string]string, error) {
 	res := map[string]string{}
 
 	for _, keypair := range strings.Split(raw, " ") {
-		parts := strings.SplitN(keypair, "=", 1)
+		parts := strings.Split(keypair, "=")
 		if len(parts) != 2 {
 			panic(fmt.Sprintf("unexpected keypair %s from pq", keypair))
 		}

--- a/pkg/integrations/postgres_exporter/postgres_exporter.go
+++ b/pkg/integrations/postgres_exporter/postgres_exporter.go
@@ -84,13 +84,24 @@ func parsePostgresURL(url string) (map[string]string, error) {
 
 	res := map[string]string{}
 
+	unescaper := strings.NewReplacer(`\'`, `'`, `\\`, `\`)
+
 	for _, keypair := range strings.Split(raw, " ") {
-		parts := strings.Split(keypair, "=")
+		parts := strings.SplitN(keypair, "=", 2)
 		if len(parts) != 2 {
 			panic(fmt.Sprintf("unexpected keypair %s from pq", keypair))
 		}
 
-		res[parts[0]] = parts[1]
+		key := parts[0]
+		value := parts[1]
+
+		// Undo all the transformations ParseURL did: remove wrapping
+		// quotes and then unescape the escaped characters.
+		value = strings.TrimPrefix(value, "'")
+		value = strings.TrimSuffix(value, "'")
+		value = unescaper.Replace(value)
+
+		res[key] = value
 	}
 
 	return res, nil

--- a/pkg/integrations/postgres_exporter/postgres_exporter_test.go
+++ b/pkg/integrations/postgres_exporter/postgres_exporter_test.go
@@ -1,0 +1,24 @@
+package postgres_exporter
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_ParsePostgresURL(t *testing.T) {
+	dsn := "postgresql://linus:42secret@localhost:5432/postgres?sslmode=disable"
+	expected := map[string]string{
+		"dbname":   "'postgres'",
+		"host":     "'localhost'",
+		"password": "'42secret'",
+		"port":     "'5432'",
+		"sslmode":  "'disable'",
+		"user":     "'linus'",
+	}
+
+	actual, _ := parsePostgresURL(dsn)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("parsePortgresURL failed, actual: %v, expected: %v", actual, expected)
+	}
+
+}

--- a/pkg/integrations/postgres_exporter/postgres_exporter_test.go
+++ b/pkg/integrations/postgres_exporter/postgres_exporter_test.go
@@ -1,8 +1,9 @@
-package postgres_exporter
+package postgres_exporter //nolint:golint
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_ParsePostgresURL(t *testing.T) {
@@ -16,9 +17,8 @@ func Test_ParsePostgresURL(t *testing.T) {
 		"user":     "linus",
 	}
 
-	actual, _ := parsePostgresURL(dsn)
-	if !reflect.DeepEqual(actual, expected) {
-		t.Errorf("parsePortgresURL failed, actual: %v, expected: %v", actual, expected)
-	}
+	actual, err := parsePostgresURL(dsn)
+	require.NoError(t, err)
+	require.Equal(t, actual, expected)
 
 }

--- a/pkg/integrations/postgres_exporter/postgres_exporter_test.go
+++ b/pkg/integrations/postgres_exporter/postgres_exporter_test.go
@@ -8,12 +8,12 @@ import (
 func Test_ParsePostgresURL(t *testing.T) {
 	dsn := "postgresql://linus:42secret@localhost:5432/postgres?sslmode=disable"
 	expected := map[string]string{
-		"dbname":   "'postgres'",
-		"host":     "'localhost'",
-		"password": "'42secret'",
-		"port":     "'5432'",
-		"sslmode":  "'disable'",
-		"user":     "'linus'",
+		"dbname":   "postgres",
+		"host":     "localhost",
+		"password": "42secret",
+		"port":     "5432",
+		"sslmode":  "disable",
+		"user":     "linus",
 	}
 
 	actual, _ := parsePostgresURL(dsn)


### PR DESCRIPTION
#### PR Description 
This PR fix issue `postgres_exporter.parsePostgresURL()` that causes the grafana-agent service wont start.

#### Which issue(s) this PR fixes 
Fixes #1110 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [x] Tests updated
