### PR TITLE
Don't create a WAL cleaner when there's no configured WAL directory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - [BUGFIX] Operator: fix bug where version was a required field (@rfratto)
 
+- [BUGFIX] Metrics: Only run WAL cleaner when metrics are being used and a WAL is configured. (@rfratto)
+
 # v0.21.0 (2021-11-17)
 
 - [ENHANCEMENT] Update Cortex dependency to v1.10.0-92-g85c378182. (@rlankfo)

--- a/pkg/metrics/agent.go
+++ b/pkg/metrics/agent.go
@@ -233,14 +233,17 @@ func (a *Agent) ApplyConfig(cfg Config) error {
 
 	if a.cleaner != nil {
 		a.cleaner.Stop()
+		a.cleaner = nil
 	}
-	a.cleaner = NewWALCleaner(
-		a.logger,
-		a.mm,
-		cfg.WALDir,
-		cfg.WALCleanupAge,
-		cfg.WALCleanupPeriod,
-	)
+	if cfg.WALDir != "" {
+		a.cleaner = NewWALCleaner(
+			a.logger,
+			a.mm,
+			cfg.WALDir,
+			cfg.WALCleanupAge,
+			cfg.WALCleanupPeriod,
+		)
+	}
 
 	a.bm.UpdateManagerConfig(instance.BasicManagerConfig{
 		InstanceRestartBackoff: cfg.InstanceRestartBackoff,


### PR DESCRIPTION
#### PR Description 

This avoids noisy logs when someone uses the agent only for logs/traces.

Fixes #735

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
