### PR TITLE
Remove WAL on startup

### DIFF
--- a/pkg/metrics/wal/wal.go
+++ b/pkg/metrics/wal/wal.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
 	"sync"
 	"time"
 	"unicode/utf8"
@@ -132,6 +133,11 @@ type Storage struct {
 
 // NewStorage makes a new Storage.
 func NewStorage(logger log.Logger, registerer prometheus.Registerer, path string) (*Storage, error) {
+	// First clear the WAL directory. See: https://github.com/prometheus/prometheus/issues/9848
+	if err := os.RemoveAll(path); err != nil {
+		return nil, err
+	}
+
 	w, err := wal.NewSize(logger, registerer, SubDirectory(path), wal.DefaultSegmentSize, true)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Agent / Remote Write code currently doesn't send the samples from
the WAL on startup at all. We only send the new samples so replaying
the WAL doesn't give us much.

It does let us load series references from the WAL but we save much more
by not reading the WAL at all.

See: https://github.com/prometheus/prometheus/issues/9848 and https://github.com/prometheus/prometheus/pull/8918

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [x] Tests updated
