### PR TITLE
Traces: Improved pod association in PromSD processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Main (unreleased)
 
-# v0.21.1 (2021-11-18)
-
 - [ENHANCEMENT] Traces: Improved pod association in PromSD processor (@mapno)
+
+# v0.21.1 (2021-11-18)
 
 - [BUGFIX] Fix panic when using postgres_exporter integration (@saputradharma)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # v0.21.1 (2021-11-18)
 
+- [ENHANCEMENT] Traces: Improved pod association in PromSD processor (@mapno)
+
 - [BUGFIX] Fix panic when using postgres_exporter integration (@saputradharma)
 
 - [BUGFIX] Fix panic when dnsamsq_exporter integration tried to log a warning (@rfratto)

--- a/docs/configuration/traces-config.md
+++ b/docs/configuration/traces-config.md
@@ -145,7 +145,17 @@ scrape_configs:
 # `update` only modifies an existing k/v and `insert` only appends if the k/v
 # is not present. `upsert` does both.
 [ prom_sd_operation_type: <string> | default = "upsert" ]
-# Configures something
+# Configures what methods to use to do association between spans and pods.
+# PromSD processor matches the IP address of the metadata labels from the k8s API
+# with the IP address obtained from the specified pod association method.
+# If a match is found then the span is labeled.
+#
+# Options are `ip`, `net.host.ip`, `k8s.pod.ip`, `hostname` and `connection`.
+#   - `ip`, `net.host.ip` and `k8s.pod.ip`, `hostname` match spans tags.
+#   - `connection` inspects the context from the incoming requests (gRPC and HTTP).
+#
+# By default, all methods are enabled, and evaluated in the order specified above.
+# Order of evaluation is honored when multiple methods are enabled.
 prom_sd_pod_association: 
   - [ <string>... ]
 

--- a/docs/configuration/traces-config.md
+++ b/docs/configuration/traces-config.md
@@ -154,6 +154,13 @@ scrape_configs:
 #   - `ip`, `net.host.ip` and `k8s.pod.ip`, `hostname` match spans tags.
 #   - `connection` inspects the context from the incoming requests (gRPC and HTTP).
 #
+# Tracing instrumentation is commonly the responsible for tagging spans
+# with IP address to the labels mentioned above.
+# If running on kubernetes, `k8s.pod.ip` can be automatically attached via the
+# downward API. For example, if you're using OTel instrumentation libraries, set 
+# OTEL_RESOURCE_ATTRIBUTES=k8s.pod.ip=$(POD_IP) to inject spans with the sender
+# pod's IP.
+#
 # By default, all methods are enabled, and evaluated in the order specified above.
 # Order of evaluation is honored when multiple methods are enabled.
 prom_sd_pod_association: 

--- a/docs/configuration/traces-config.md
+++ b/docs/configuration/traces-config.md
@@ -145,6 +145,9 @@ scrape_configs:
 # `update` only modifies an existing k/v and `insert` only appends if the k/v
 # is not present. `upsert` does both.
 [ prom_sd_operation_type: <string> | default = "upsert" ]
+# Configures something
+prom_sd_pod_association: 
+  - [ <string>... ]
 
 # spanmetrics supports aggregating Request, Error and Duration (R.E.D) metrics
 # from span data.

--- a/pkg/traces/config.go
+++ b/pkg/traces/config.go
@@ -110,8 +110,9 @@ type InstanceConfig struct {
 	Attributes map[string]interface{} `yaml:"attributes,omitempty"`
 
 	// prom service discovery config
-	ScrapeConfigs []interface{} `yaml:"scrape_configs,omitempty"`
-	OperationType string        `yaml:"prom_sd_operation_type,omitempty"`
+	ScrapeConfigs   []interface{} `yaml:"scrape_configs,omitempty"`
+	OperationType   string        `yaml:"prom_sd_operation_type,omitempty"`
+	PodAssociations []string      `yaml:"prom_sd_pod_associations,omitempty"`
 
 	// SpanMetricsProcessor: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/README.md
 	SpanMetrics *SpanMetricsConfig `yaml:"spanmetrics,omitempty"`
@@ -402,8 +403,9 @@ func (c *InstanceConfig) otelConfig() (*config.Config, error) {
 		}
 		processorNames = append(processorNames, promsdprocessor.TypeStr)
 		processors[promsdprocessor.TypeStr] = map[string]interface{}{
-			"scrape_configs": c.ScrapeConfigs,
-			"operation_type": opType,
+			"scrape_configs":   c.ScrapeConfigs,
+			"operation_type":   opType,
+			"pod_associations": c.PodAssociations,
 		}
 	}
 

--- a/pkg/traces/promsdprocessor/factory.go
+++ b/pkg/traces/promsdprocessor/factory.go
@@ -22,6 +22,12 @@ const (
 	OperationTypeUpdate = "update"
 	// OperationTypeUpsert does both of above
 	OperationTypeUpsert = "upsert"
+
+	PodAssociationIPLabel       = "ip"
+	PodAssociationOTelIPLabel   = "net.host.ip"
+	PodAssociationk8sIPLabel    = "k8s.pod.ip"
+	PodAssociationHostnameLabel = "hostname"
+	PodAssociationConnectionIP  = "connection"
 )
 
 // Config holds the configuration for the Prometheus SD processor.
@@ -29,6 +35,7 @@ type Config struct {
 	config.ProcessorSettings `mapstructure:",squash"`
 	ScrapeConfigs            []interface{} `mapstructure:"scrape_configs"`
 	OperationType            string        `mapstructure:"operation_type"`
+	PodAssociations          []string      `mapstructure:"pod_associations"`
 }
 
 // NewFactory returns a new factory for the Attributes processor.
@@ -65,5 +72,5 @@ func createTraceProcessor(
 		return nil, fmt.Errorf("unable to unmarshal bytes to []*config.ScrapeConfig: %w", err)
 	}
 
-	return newTraceProcessor(nextConsumer, oCfg.OperationType, scrapeConfigs)
+	return newTraceProcessor(nextConsumer, oCfg.OperationType, oCfg.PodAssociations, scrapeConfigs)
 }

--- a/pkg/traces/promsdprocessor/factory.go
+++ b/pkg/traces/promsdprocessor/factory.go
@@ -23,11 +23,11 @@ const (
 	// OperationTypeUpsert does both of above
 	OperationTypeUpsert = "upsert"
 
-	PodAssociationIPLabel       = "ip"
-	PodAssociationOTelIPLabel   = "net.host.ip"
-	PodAssociationk8sIPLabel    = "k8s.pod.ip"
-	PodAssociationHostnameLabel = "hostname"
-	PodAssociationConnectionIP  = "connection"
+	podAssociationIPLabel       = "ip"
+	podAssociationOTelIPLabel   = "net.host.ip"
+	podAssociationk8sIPLabel    = "k8s.pod.ip"
+	podAssociationHostnameLabel = "hostname"
+	podAssociationConnectionIP  = "connection"
 )
 
 // Config holds the configuration for the Prometheus SD processor.

--- a/pkg/traces/promsdprocessor/prom_sd_processor.go
+++ b/pkg/traces/promsdprocessor/prom_sd_processor.go
@@ -24,11 +24,6 @@ import (
 	semconv "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 )
 
-const (
-	ipTagName    = "ip"
-	k8sIPTagName = "k8s.pod.ip"
-)
-
 type promServiceDiscoProcessor struct {
 	nextConsumer     consumer.Traces
 	discoveryMgr     *discovery.Manager

--- a/pkg/traces/promsdprocessor/prom_sd_processor.go
+++ b/pkg/traces/promsdprocessor/prom_sd_processor.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	ipTagName    = "ip"
-	k8sIPTagName = "k8s.host.ip"
+	k8sIPTagName = "k8s.pod.ip"
 )
 
 type promServiceDiscoProcessor struct {

--- a/pkg/traces/promsdprocessor/prom_sd_processor.go
+++ b/pkg/traces/promsdprocessor/prom_sd_processor.go
@@ -75,7 +75,7 @@ func newTraceProcessor(nextConsumer consumer.Traces, operationType string, podAs
 
 	for _, podAssociation := range podAssociations {
 		switch podAssociation {
-		case PodAssociationIPLabel, PodAssociationOTelIPLabel, PodAssociationk8sIPLabel, PodAssociationHostnameLabel, PodAssociationConnectionIP:
+		case podAssociationIPLabel, podAssociationOTelIPLabel, podAssociationk8sIPLabel, podAssociationHostnameLabel, podAssociationConnectionIP:
 		default:
 			cancel()
 			return nil, fmt.Errorf("unknown pod association %s", podAssociation)
@@ -83,7 +83,7 @@ func newTraceProcessor(nextConsumer consumer.Traces, operationType string, podAs
 	}
 
 	if len(podAssociations) == 0 {
-		podAssociations = []string{PodAssociationIPLabel, PodAssociationOTelIPLabel, PodAssociationk8sIPLabel, PodAssociationHostnameLabel, PodAssociationConnectionIP}
+		podAssociations = []string{podAssociationIPLabel, podAssociationOTelIPLabel, podAssociationk8sIPLabel, podAssociationHostnameLabel, podAssociationConnectionIP}
 	}
 
 	if nextConsumer == nil {
@@ -133,18 +133,17 @@ func getConnectionIP(ctx context.Context) string {
 func (p *promServiceDiscoProcessor) getPodIP(ctx context.Context, attrs pdata.AttributeMap) string {
 	for _, podAssociation := range p.podAssociations {
 		switch podAssociation {
-		case PodAssociationIPLabel, PodAssociationOTelIPLabel, PodAssociationk8sIPLabel:
-			fmt.Println(podAssociation)
+		case podAssociationIPLabel, podAssociationOTelIPLabel, podAssociationk8sIPLabel:
 			ip := stringAttributeFromMap(attrs, podAssociation)
 			if ip != "" {
 				return ip
 			}
-		case PodAssociationHostnameLabel:
+		case podAssociationHostnameLabel:
 			hostname := stringAttributeFromMap(attrs, semconv.AttributeHostName)
 			if net.ParseIP(hostname) != nil {
 				return hostname
 			}
-		case PodAssociationConnectionIP:
+		case podAssociationConnectionIP:
 			ip := getConnectionIP(ctx)
 			if ip != "" {
 				return ip

--- a/pkg/traces/promsdprocessor/prom_sd_processor.go
+++ b/pkg/traces/promsdprocessor/prom_sd_processor.go
@@ -115,7 +115,7 @@ func getConnectionIP(ctx context.Context) string {
 	return ""
 }
 
-func getPODIP(ctx context.Context, attrs pdata.AttributeMap) string {
+func getPodIP(ctx context.Context, attrs pdata.AttributeMap) string {
 	// find the ip
 	ipTagNames := []string{
 		ipTagName,                  // jaeger/opentracing? default
@@ -139,7 +139,7 @@ func getPODIP(ctx context.Context, attrs pdata.AttributeMap) string {
 }
 
 func (p *promServiceDiscoProcessor) processAttributes(ctx context.Context, attrs pdata.AttributeMap) {
-	ip := getPODIP(ctx, attrs)
+	ip := getPodIP(ctx, attrs)
 	// have to have an ip for labels lookup
 	if ip == "" {
 		level.Debug(p.logger).Log("msg", "unable to find ip in span attributes, skipping attribute addition")

--- a/pkg/traces/promsdprocessor/prom_sd_processor_test.go
+++ b/pkg/traces/promsdprocessor/prom_sd_processor_test.go
@@ -251,7 +251,7 @@ func TestPodAssociation(t *testing.T) {
 			ctxFn: func(t *testing.T) context.Context { return context.Background() },
 			attrMapFn: func(*testing.T) pdata.AttributeMap {
 				attrMap := pdata.NewAttributeMap()
-				attrMap.Insert(podAssociationIPLabel, pdata.NewAttributeValueString(ipStr))
+				attrMap.Insert("ip", pdata.NewAttributeValueString(ipStr))
 				return attrMap
 			},
 			expectedIP: ipStr,
@@ -271,7 +271,7 @@ func TestPodAssociation(t *testing.T) {
 			ctxFn: func(t *testing.T) context.Context { return context.Background() },
 			attrMapFn: func(*testing.T) pdata.AttributeMap {
 				attrMap := pdata.NewAttributeMap()
-				attrMap.Insert(podAssociationk8sIPLabel, pdata.NewAttributeValueString(ipStr))
+				attrMap.Insert("k8s.pod.ip", pdata.NewAttributeValueString(ipStr))
 				return attrMap
 			},
 			expectedIP: ipStr,
@@ -318,7 +318,7 @@ func TestPodAssociation(t *testing.T) {
 			ctxFn:           func(t *testing.T) context.Context { return context.Background() },
 			attrMapFn: func(*testing.T) pdata.AttributeMap {
 				attrMap := pdata.NewAttributeMap()
-				attrMap.Insert(podAssociationIPLabel, pdata.NewAttributeValueString(ipStr))
+				attrMap.Insert("ip", pdata.NewAttributeValueString(ipStr))
 				return attrMap
 			},
 			expectedIP: "",

--- a/pkg/traces/promsdprocessor/prom_sd_processor_test.go
+++ b/pkg/traces/promsdprocessor/prom_sd_processor_test.go
@@ -314,7 +314,7 @@ func TestPodAssociation(t *testing.T) {
 		},
 		{
 			name:            "ip attribute but not as pod association",
-			podAssociations: []string{PodAssociationk8sIPLabel},
+			podAssociations: []string{podAssociationk8sIPLabel},
 			ctxFn:           func(t *testing.T) context.Context { return context.Background() },
 			attrMapFn: func(*testing.T) pdata.AttributeMap {
 				attrMap := pdata.NewAttributeMap()
@@ -325,7 +325,7 @@ func TestPodAssociation(t *testing.T) {
 		},
 		{
 			name:            "uses hostname before attribute (reverse order from default)",
-			podAssociations: []string{PodAssociationHostnameLabel, PodAssociationOTelIPLabel},
+			podAssociations: []string{podAssociationHostnameLabel, podAssociationOTelIPLabel},
 			ctxFn:           func(t *testing.T) context.Context { return context.Background() },
 			attrMapFn: func(*testing.T) pdata.AttributeMap {
 				attrMap := pdata.NewAttributeMap()

--- a/pkg/traces/promsdprocessor/prom_sd_processor_test.go
+++ b/pkg/traces/promsdprocessor/prom_sd_processor_test.go
@@ -183,7 +183,7 @@ func TestOperationType(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockProcessor := new(consumertest.TracesSink)
-			p, err := newTraceProcessor(mockProcessor, tc.operationType, nil)
+			p, err := newTraceProcessor(mockProcessor, tc.operationType, nil, nil)
 			require.NoError(t, err)
 
 			attrValue := pdata.NewAttributeValueString("old-value")
@@ -213,10 +213,11 @@ func TestPodAssociation(t *testing.T) {
 	const ipStr = "1.1.1.1"
 
 	testCases := []struct {
-		name       string
-		ctxFn      func(t *testing.T) context.Context
-		attrMapFn  func(t *testing.T) pdata.AttributeMap
-		expectedIP string
+		name            string
+		podAssociations []string
+		ctxFn           func(t *testing.T) context.Context
+		attrMapFn       func(t *testing.T) pdata.AttributeMap
+		expectedIP      string
 	}{
 		{
 			name: "HTTP connection IP",
@@ -315,7 +316,11 @@ func TestPodAssociation(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ip := getPodIP(tc.ctxFn(t), tc.attrMapFn(t))
+			mockProcessor := new(consumertest.TracesSink)
+			p, err := newTraceProcessor(mockProcessor, "", tc.podAssociations, nil)
+			require.NoError(t, err)
+
+			ip := p.(*promServiceDiscoProcessor).getPodIP(tc.ctxFn(t), tc.attrMapFn(t))
 			assert.Equal(t, tc.expectedIP, ip)
 		})
 	}

--- a/pkg/traces/promsdprocessor/prom_sd_processor_test.go
+++ b/pkg/traces/promsdprocessor/prom_sd_processor_test.go
@@ -251,7 +251,7 @@ func TestPodAssociation(t *testing.T) {
 			ctxFn: func(t *testing.T) context.Context { return context.Background() },
 			attrMapFn: func(*testing.T) pdata.AttributeMap {
 				attrMap := pdata.NewAttributeMap()
-				attrMap.Insert(ipTagName, pdata.NewAttributeValueString(ipStr))
+				attrMap.Insert(podAssociationIPLabel, pdata.NewAttributeValueString(ipStr))
 				return attrMap
 			},
 			expectedIP: ipStr,
@@ -271,7 +271,7 @@ func TestPodAssociation(t *testing.T) {
 			ctxFn: func(t *testing.T) context.Context { return context.Background() },
 			attrMapFn: func(*testing.T) pdata.AttributeMap {
 				attrMap := pdata.NewAttributeMap()
-				attrMap.Insert(k8sIPTagName, pdata.NewAttributeValueString(ipStr))
+				attrMap.Insert(podAssociationk8sIPLabel, pdata.NewAttributeValueString(ipStr))
 				return attrMap
 			},
 			expectedIP: ipStr,
@@ -318,7 +318,7 @@ func TestPodAssociation(t *testing.T) {
 			ctxFn:           func(t *testing.T) context.Context { return context.Background() },
 			attrMapFn: func(*testing.T) pdata.AttributeMap {
 				attrMap := pdata.NewAttributeMap()
-				attrMap.Insert(ipTagName, pdata.NewAttributeValueString(ipStr))
+				attrMap.Insert(podAssociationIPLabel, pdata.NewAttributeValueString(ipStr))
 				return attrMap
 			},
 			expectedIP: "",

--- a/pkg/traces/promsdprocessor/prom_sd_processor_test.go
+++ b/pkg/traces/promsdprocessor/prom_sd_processor_test.go
@@ -2,6 +2,8 @@ package promsdprocessor
 
 import (
 	"context"
+	"net"
+	"net/http"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -10,9 +12,11 @@ import (
 	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/model/pdata"
 	semconv "go.opentelemetry.io/collector/model/semconv/v1.6.1"
+	"google.golang.org/grpc/peer"
 )
 
 func TestSyncGroups(t *testing.T) {
@@ -201,6 +205,118 @@ func TestOperationType(t *testing.T) {
 
 			actualAttrValue, _ := attrMap.Get(attrKey)
 			assert.Equal(t, tc.expectedValue, actualAttrValue.StringVal())
+		})
+	}
+}
+
+func TestPodAssociation(t *testing.T) {
+	const ipStr = "1.1.1.1"
+
+	testCases := []struct {
+		name       string
+		ctxFn      func(t *testing.T) context.Context
+		attrMapFn  func(t *testing.T) pdata.AttributeMap
+		expectedIP string
+	}{
+		{
+			name: "HTTP connection IP",
+			ctxFn: func(t *testing.T) context.Context {
+				r := &http.Request{RemoteAddr: ipStr}
+				c, ok := client.FromHTTP(r)
+				require.True(t, ok)
+				return client.NewContext(context.Background(), c)
+			},
+			attrMapFn:  func(*testing.T) pdata.AttributeMap { return pdata.NewAttributeMap() },
+			expectedIP: ipStr,
+		},
+		{
+			name: "gRPC connection IP",
+			ctxFn: func(t *testing.T) context.Context {
+				grpcCtx := peer.NewContext(context.Background(), &peer.Peer{
+					Addr: &net.TCPAddr{
+						IP:   net.ParseIP(ipStr),
+						Port: 80,
+					},
+				})
+				c, ok := client.FromGRPC(grpcCtx)
+				require.True(t, ok)
+				return client.NewContext(context.Background(), c)
+			},
+			attrMapFn:  func(*testing.T) pdata.AttributeMap { return pdata.NewAttributeMap() },
+			expectedIP: ipStr,
+		},
+		{
+			name:  "ip attribute",
+			ctxFn: func(t *testing.T) context.Context { return context.Background() },
+			attrMapFn: func(*testing.T) pdata.AttributeMap {
+				attrMap := pdata.NewAttributeMap()
+				attrMap.Insert(ipTagName, pdata.NewAttributeValueString(ipStr))
+				return attrMap
+			},
+			expectedIP: ipStr,
+		},
+		{
+			name:  "net.host.ip attribute",
+			ctxFn: func(t *testing.T) context.Context { return context.Background() },
+			attrMapFn: func(*testing.T) pdata.AttributeMap {
+				attrMap := pdata.NewAttributeMap()
+				attrMap.Insert(semconv.AttributeNetHostIP, pdata.NewAttributeValueString(ipStr))
+				return attrMap
+			},
+			expectedIP: ipStr,
+		},
+		{
+			name:  "k8s ip attribute",
+			ctxFn: func(t *testing.T) context.Context { return context.Background() },
+			attrMapFn: func(*testing.T) pdata.AttributeMap {
+				attrMap := pdata.NewAttributeMap()
+				attrMap.Insert(k8sIPTagName, pdata.NewAttributeValueString(ipStr))
+				return attrMap
+			},
+			expectedIP: ipStr,
+		},
+		{
+			name:  "ip from hostname",
+			ctxFn: func(t *testing.T) context.Context { return context.Background() },
+			attrMapFn: func(*testing.T) pdata.AttributeMap {
+				attrMap := pdata.NewAttributeMap()
+				attrMap.Insert(semconv.AttributeHostName, pdata.NewAttributeValueString(ipStr))
+				return attrMap
+			},
+			expectedIP: ipStr,
+		},
+		{
+			name: "uses attr before context",
+			ctxFn: func(t *testing.T) context.Context {
+				r := &http.Request{RemoteAddr: "2.2.2.2"}
+				c, ok := client.FromHTTP(r)
+				require.True(t, ok)
+				return client.NewContext(context.Background(), c)
+			},
+			attrMapFn: func(*testing.T) pdata.AttributeMap {
+				attrMap := pdata.NewAttributeMap()
+				attrMap.Insert(semconv.AttributeNetHostIP, pdata.NewAttributeValueString(ipStr))
+				return attrMap
+			},
+			expectedIP: ipStr,
+		},
+		{
+			name:  "uses attr before hostname",
+			ctxFn: func(t *testing.T) context.Context { return context.Background() },
+			attrMapFn: func(*testing.T) pdata.AttributeMap {
+				attrMap := pdata.NewAttributeMap()
+				attrMap.Insert(semconv.AttributeNetHostIP, pdata.NewAttributeValueString(ipStr))
+				attrMap.Insert(semconv.AttributeHostName, pdata.NewAttributeValueString("3.3.3.3"))
+				return attrMap
+			},
+			expectedIP: ipStr,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ip := getPodIP(tc.ctxFn(t), tc.attrMapFn(t))
+			assert.Equal(t, tc.expectedIP, ip)
 		})
 	}
 }

--- a/pkg/traces/promsdprocessor/prom_sd_processor_test.go
+++ b/pkg/traces/promsdprocessor/prom_sd_processor_test.go
@@ -287,7 +287,7 @@ func TestPodAssociation(t *testing.T) {
 			expectedIP: ipStr,
 		},
 		{
-			name: "uses attr before context",
+			name: "uses attr before context (default associations)",
 			ctxFn: func(t *testing.T) context.Context {
 				r := &http.Request{RemoteAddr: "2.2.2.2"}
 				c, ok := client.FromHTTP(r)
@@ -302,12 +302,35 @@ func TestPodAssociation(t *testing.T) {
 			expectedIP: ipStr,
 		},
 		{
-			name:  "uses attr before hostname",
+			name:  "uses attr before hostname (default associations)",
 			ctxFn: func(t *testing.T) context.Context { return context.Background() },
 			attrMapFn: func(*testing.T) pdata.AttributeMap {
 				attrMap := pdata.NewAttributeMap()
 				attrMap.Insert(semconv.AttributeNetHostIP, pdata.NewAttributeValueString(ipStr))
 				attrMap.Insert(semconv.AttributeHostName, pdata.NewAttributeValueString("3.3.3.3"))
+				return attrMap
+			},
+			expectedIP: ipStr,
+		},
+		{
+			name:            "ip attribute but not as pod association",
+			podAssociations: []string{PodAssociationk8sIPLabel},
+			ctxFn:           func(t *testing.T) context.Context { return context.Background() },
+			attrMapFn: func(*testing.T) pdata.AttributeMap {
+				attrMap := pdata.NewAttributeMap()
+				attrMap.Insert(ipTagName, pdata.NewAttributeValueString(ipStr))
+				return attrMap
+			},
+			expectedIP: "",
+		},
+		{
+			name:            "uses hostname before attribute (reverse order from default)",
+			podAssociations: []string{PodAssociationHostnameLabel, PodAssociationOTelIPLabel},
+			ctxFn:           func(t *testing.T) context.Context { return context.Background() },
+			attrMapFn: func(*testing.T) pdata.AttributeMap {
+				attrMap := pdata.NewAttributeMap()
+				attrMap.Insert(semconv.AttributeNetHostIP, pdata.NewAttributeValueString("3.3.3.3"))
+				attrMap.Insert(semconv.AttributeHostName, pdata.NewAttributeValueString(ipStr))
 				return attrMap
 			},
 			expectedIP: ipStr,

--- a/pkg/traces/promsdprocessor/prom_sd_processor_test.go
+++ b/pkg/traces/promsdprocessor/prom_sd_processor_test.go
@@ -1,6 +1,7 @@
 package promsdprocessor
 
 import (
+	"context"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -196,7 +197,7 @@ func TestOperationType(t *testing.T) {
 				},
 			}
 			p.(*promServiceDiscoProcessor).hostLabels = hostLabels
-			p.(*promServiceDiscoProcessor).processAttributes(attrMap)
+			p.(*promServiceDiscoProcessor).processAttributes(context.TODO(), attrMap)
 
 			actualAttrValue, _ := attrMap.Get(attrKey)
 			assert.Equal(t, tc.expectedValue, actualAttrValue.StringVal())


### PR DESCRIPTION
#### PR Description

Improves pod association in PromSD processor by adding new techniques to get the IP of the trace sender.

#### Which issue(s) this PR fixes 

Fixes https://github.com/grafana/agent/issues/1095

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added
- [x] Tests updated
