### PR TITLE
remote config with http(s) provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Main (unreleased)
 
-- [FEATURE] (beta) Enable experimental config urls for fetching remote configs over http(s). (@rlankfo)
+- [FEATURE] (beta) Enable experimental config urls for fetching remote configs. Currently,
+   only HTTP/S is supported. Use `-experiment.config-urls.enable` flag to turn this on. (@rlankfo)
 
 - [ENHANCEMENT] Traces: Improved pod association in PromSD processor (@mapno)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Main (unreleased)
 
+- [FEATURE] (beta) Enable experimental config urls for fetching remote configs over http(s). (@rlankfo)
+
 - [ENHANCEMENT] Traces: Improved pod association in PromSD processor (@mapno)
 
 # v0.21.1 (2021-11-18)

--- a/docs/configuration/_index.md
+++ b/docs/configuration/_index.md
@@ -120,11 +120,9 @@ Support contents and default values of `agent.yaml`:
 
 An experimental feature for fetching remote configuration files over HTTP/S can be
 enabled by passing the `-experiment.config-urls.enable` flag at the command line.
-When this feature is enabled, you may pass an HTTP/S URL to the `-config.file` flag.
+With this feature enabled, you may pass an HTTP/S URL to the `-config.file` flag.
 
-As configurations may contain sensitive information, we suggest protecting your HTTP/S
-configurations using basic auth. The following flags will configure basic auth for requests
-made to your remote config URLs:
+The following flags will configure basic auth for requests made to HTTP/S remote config URLs:
 - `-config.url.basic-auth-user <user>`: the basic auth username
 - `-config.url.basic-auth-password-file <file>`: path to a file containing the basic auth password
 

--- a/docs/configuration/_index.md
+++ b/docs/configuration/_index.md
@@ -115,3 +115,17 @@ Support contents and default values of `agent.yaml`:
 # Configures integrations for the Agent.
 [integrations: <integrations_config>]
 ```
+
+## Remote Configuration (Beta)
+
+An experimental feature for fetching remote configuration files over HTTP/S can be
+enabled by passing the `-experiment.config-urls.enable` flag at the command line.
+When this feature is enabled, you may pass an HTTP/S URL to the `-config.file` flag.
+
+As configurations may contain sensitive information, we suggest protecting your HTTP/S
+configurations using basic auth. The following flags will configure basic auth for requests
+made to your remote config URLs:
+- `-config.url.basic-auth-user <user>`: the basic auth username
+- `-config.url.basic-auth-password-file <file>`: path to a file containing the basic auth password
+
+Note that this beta feature is subject to change in future releases.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -105,7 +105,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // messages.
 func (c *Config) LogDeprecations(l log.Logger) {
 	for _, d := range c.Deprecations {
-		_ = level.Warn(l).Log("msg", fmt.Sprintf("DEPRECATION NOTICE: %s", d))
+		level.Warn(l).Log("msg", fmt.Sprintf("DEPRECATION NOTICE: %s", d))
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -242,7 +242,12 @@ func getenv(name string) string {
 // to the flagset before parsing them with the values specified by
 // args.
 func Load(fs *flag.FlagSet, args []string) (*Config, error) {
-	return load(fs, args, LoadFile)
+	return load(fs, args, func(url string, expand bool, c *Config) error {
+		if c.ExperimentalConfigURLs {
+			return LoadRemote(url, expand, c)
+		}
+		return LoadFile(url, expand, c)
+	})
 }
 
 // load allows for tests to inject a function for retrieving the config file that
@@ -268,10 +273,6 @@ func load(fs *flag.FlagSet, args []string, loader func(string, bool, *Config) er
 	if printVersion {
 		fmt.Println(version.Print("agent"))
 		os.Exit(0)
-	}
-
-	if cfg.ExperimentalConfigURLs {
-		loader = LoadRemote
 	}
 
 	if file == "" {

--- a/pkg/config/remote_config.go
+++ b/pkg/config/remote_config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"net/url"
 
 	"github.com/prometheus/common/config"
@@ -18,33 +17,24 @@ const (
 
 // RemoteOpts struct contains agent remote config options
 type RemoteOpts struct {
-	ExpandEnv bool
-
 	URL              *url.URL
 	HTTPClientConfig *config.HTTPClientConfig
 }
 
 // RemoteProvider ...
 type RemoteProvider interface {
-	Retrieve() (*Config, error)
-}
-
-// RemoteConfig ...
-type RemoteConfig struct {
-	RemoteProvider
+	Retrieve() ([]byte, error)
 }
 
 // NewRemoteConfig ...
-func NewRemoteConfig(rawURL string, opts *RemoteOpts) (*RemoteConfig, error) {
+func NewRemoteConfig(rawURL string, opts *RemoteOpts) (RemoteProvider, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, err
 	}
 	if opts == nil {
 		// Default provider opts
-		opts = &RemoteOpts{
-			ExpandEnv: false,
-		}
+		opts = &RemoteOpts{}
 	}
 	opts.URL = u
 
@@ -53,75 +43,58 @@ func NewRemoteConfig(rawURL string, opts *RemoteOpts) (*RemoteConfig, error) {
 		// if no scheme, assume local file path, return nil and let caller handle.
 		return nil, nil
 	case HTTP, HTTPS:
-		return &RemoteConfig{
-			RemoteProvider: newHTTPProvider(opts),
-		}, nil
+		httpP, err := newHTTPProvider(opts)
+		if err != nil {
+			return nil, err
+		}
+		return httpP, nil
+	default:
+		return nil, fmt.Errorf("remote config scheme not supported: %s", u.Scheme)
 	}
-	return nil, fmt.Errorf("remote config scheme not supported: %s", u.Scheme)
 }
 
 // Remote Config Providers
-// httpP - http/https provider
-type httpP struct {
-	myURL            *url.URL
-	expandEnv        bool
-	httpClientConfig *config.HTTPClientConfig
+// httpProvider - http/https provider
+type httpProvider struct {
+	myURL            url.URL
+	httpClientConfig config.HTTPClientConfig
 }
 
-func newHTTPProvider(opts *RemoteOpts) *httpP {
-	return &httpP{
-		myURL:            opts.URL,
-		expandEnv:        opts.ExpandEnv,
-		httpClientConfig: opts.HTTPClientConfig,
+func newHTTPProvider(opts *RemoteOpts) (*httpProvider, error) {
+	httpClientConfig := config.HTTPClientConfig{}
+	if opts.HTTPClientConfig != nil {
+		err := opts.HTTPClientConfig.Validate()
+		if err != nil {
+			return nil, err
+		}
+		httpClientConfig = *opts.HTTPClientConfig
 	}
+	return &httpProvider{
+		myURL:            *opts.URL,
+		httpClientConfig: httpClientConfig,
+	}, nil
 }
 
 // Retrieve implements RemoteProvider and fetches the config
 // TODO: token auth, oauth2, etc.
-func (p httpP) Retrieve() (*Config, error) {
-	var (
-		bb  []byte
-		err error
-
-		request  *http.Request
-		response *http.Response
-		client   *http.Client
-
-		result = &Config{}
-	)
-
-	if p.httpClientConfig != nil {
-		err = p.httpClientConfig.Validate()
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		p.httpClientConfig = &config.HTTPClientConfig{}
-	}
-	client, err = config.NewClientFromConfig(*p.httpClientConfig, "remote-config")
+func (p httpProvider) Retrieve() ([]byte, error) {
+	client, err := config.NewClientFromConfig(p.httpClientConfig, "remote-config")
 	if err != nil {
 		return nil, err
 	}
 
-	request, err = http.NewRequest(http.MethodGet, p.myURL.String(), nil)
+	response, err := client.Get(p.myURL.String())
 	if err != nil {
 		return nil, err
 	}
-	response, err = client.Do(request)
-	if err != nil {
-		return nil, err
-	}
+	defer response.Body.Close()
 
-	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+	if response.StatusCode/100 != 2 {
 		return nil, fmt.Errorf("error fetching config: status code: %d", response.StatusCode)
 	}
-	bb, err = ioutil.ReadAll(response.Body)
+	bb, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
 	}
-	err = LoadBytes(bb, p.expandEnv, result)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
+	return bb, nil
 }

--- a/pkg/config/remote_config.go
+++ b/pkg/config/remote_config.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 
 	"github.com/prometheus/common/config"
@@ -88,21 +87,20 @@ func (p httpP) Retrieve() (*Config, error) {
 		request   *http.Request
 		response  *http.Response
 		basicAuth *config.BasicAuth
+		client    *http.Client
 
 		result = &Config{}
-		client = &http.Client{}
 	)
 
+	client, err = config.NewClientFromConfig(*p.httpClientConfig, "remote-config", nil)
+	if err != nil {
+		return nil, err
+	}
 	if p.httpClientConfig != nil {
 		err = p.httpClientConfig.Validate()
 		if err != nil {
 			return nil, err
 		}
-		dir, err := os.Getwd()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get current working directory: %s", err.Error())
-		}
-		p.httpClientConfig.SetDirectory(dir)
 		if p.httpClientConfig.BasicAuth != nil {
 			basicAuth = p.httpClientConfig.BasicAuth
 		}

--- a/pkg/config/remote_config.go
+++ b/pkg/config/remote_config.go
@@ -1,0 +1,142 @@
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/prometheus/common/config"
+)
+
+// supported remote config provider schemes
+const (
+	HTTP  = "http"
+	HTTPS = "https"
+	// TODO: add s3, gcs, blob, and git providers backed by go-fsimpl
+)
+
+// RemoteOpts struct contains agent remote config options
+type RemoteOpts struct {
+	ExpandEnv bool
+
+	URL              *url.URL
+	HTTPClientConfig *config.HTTPClientConfig
+}
+
+// RemoteProvider ...
+type RemoteProvider interface {
+	Retrieve() (*Config, error)
+}
+
+// RemoteConfig ...
+type RemoteConfig struct {
+	RemoteProvider
+}
+
+// NewRemoteConfig ...
+func NewRemoteConfig(rawURL string, opts *RemoteOpts) (*RemoteConfig, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	if opts == nil {
+		// Default provider opts
+		opts = &RemoteOpts{
+			ExpandEnv: false,
+		}
+	}
+	opts.URL = u
+
+	switch u.Scheme {
+	case "":
+		// if no scheme, assume local file path, return nil and let caller handle.
+		return nil, nil
+	case HTTP, HTTPS:
+		return &RemoteConfig{
+			RemoteProvider: newHTTPProvider(opts),
+		}, nil
+	}
+	return nil, fmt.Errorf("remote config scheme not supported: %s", u.Scheme)
+}
+
+// Remote Config Providers
+// httpP - http/https provider
+type httpP struct {
+	myURL            *url.URL
+	expandEnv        bool
+	httpClientConfig *config.HTTPClientConfig
+}
+
+func newHTTPProvider(opts *RemoteOpts) *httpP {
+	return &httpP{
+		myURL:            opts.URL,
+		expandEnv:        opts.ExpandEnv,
+		httpClientConfig: opts.HTTPClientConfig,
+	}
+}
+
+// Retrieve implements RemoteProvider and fetches the config
+// TODO: token auth, oauth2, etc.
+func (p httpP) Retrieve() (*Config, error) {
+	var (
+		bb  []byte
+		err error
+
+		request   *http.Request
+		response  *http.Response
+		basicAuth *config.BasicAuth
+
+		result = &Config{}
+		client = &http.Client{}
+	)
+
+	if p.httpClientConfig != nil {
+		err = p.httpClientConfig.Validate()
+		if err != nil {
+			return nil, err
+		}
+		dir, err := os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get current working directory: %s", err.Error())
+		}
+		p.httpClientConfig.SetDirectory(dir)
+		if p.httpClientConfig.BasicAuth != nil {
+			basicAuth = p.httpClientConfig.BasicAuth
+		}
+	}
+
+	request, err = http.NewRequest(http.MethodGet, p.myURL.String(), nil)
+	if basicAuth != nil {
+		if basicAuth.PasswordFile != "" {
+			bs, err := ioutil.ReadFile(basicAuth.PasswordFile)
+			if err != nil {
+				return nil, fmt.Errorf("unable to read basic auth password file %s: %s", basicAuth.PasswordFile, err)
+			}
+			basicAuth.Password = config.Secret(strings.TrimSpace(string(bs)))
+		}
+		request.SetBasicAuth(basicAuth.Username, string(basicAuth.Password))
+	}
+	if err != nil {
+		return nil, err
+	}
+	response, err = client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("error fetching config: status code: %d", response.StatusCode)
+	}
+	bb, err = ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	err = LoadBytes(bb, p.expandEnv, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/pkg/config/remote_config_test.go
+++ b/pkg/config/remote_config_test.go
@@ -47,6 +47,18 @@ metrics:
 		t.Error(err.Error())
 		t.FailNow()
 	}
+	passwdFileCfg := &config.HTTPClientConfig{
+		BasicAuth: &config.BasicAuth{
+			Username:     "foo",
+			PasswordFile: fmt.Sprintf("%s/password-file.txt", tempDir),
+		},
+	}
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Error(err.Error())
+		t.FailNow()
+	}
+	passwdFileCfg.SetDirectory(dir)
 
 	type args struct {
 		rawURL string
@@ -87,12 +99,7 @@ metrics:
 			args: args{
 				rawURL: fmt.Sprintf("%s/agent.yml", svrWithBasicAuth.URL),
 				opts: &RemoteOpts{
-					HTTPClientConfig: &config.HTTPClientConfig{
-						BasicAuth: &config.BasicAuth{
-							Username:     "foo",
-							PasswordFile: fmt.Sprintf("%s/password-file.txt", tempDir),
-						},
-					},
+					HTTPClientConfig: passwdFileCfg,
 				},
 			},
 			want:    wantCfg,

--- a/pkg/config/remote_config_test.go
+++ b/pkg/config/remote_config_test.go
@@ -41,7 +41,7 @@ metrics:
 		}
 	}))
 
-	tempDir := os.TempDir()
+	tempDir := t.TempDir()
 	err = os.WriteFile(fmt.Sprintf("%s/password-file.txt", tempDir), []byte("bar"), 0644)
 	if err != nil {
 		t.Error(err.Error())

--- a/pkg/config/remote_config_test.go
+++ b/pkg/config/remote_config_test.go
@@ -47,12 +47,6 @@ metrics:
 		t.Error(err.Error())
 		t.FailNow()
 	}
-	defer func(path string) {
-		err := os.RemoveAll(path)
-		if err != nil {
-			t.Logf("failed to remove temp dir: %s\n", tempDir)
-		}
-	}(tempDir)
 
 	type args struct {
 		rawURL string

--- a/pkg/config/remote_config_test.go
+++ b/pkg/config/remote_config_test.go
@@ -1,0 +1,128 @@
+package config
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/prometheus/common/config"
+	"gopkg.in/yaml.v2"
+)
+
+func TestRemoteConfigHTTP(t *testing.T) {
+	testCfg := `
+metrics:
+  global:
+    scrape_timeout: 33s
+`
+	wantCfg := &Config{}
+	err := LoadBytes([]byte(testCfg), false, wantCfg)
+	if err != nil {
+		t.Error(err.Error())
+		t.FailNow()
+	}
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/agent.yml" {
+			_, _ = w.Write([]byte(testCfg))
+		}
+	}))
+
+	svrWithBasicAuth := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, _ := r.BasicAuth()
+		if user != "foo" && pass != "bar" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.URL.Path == "/agent.yml" {
+			_, _ = w.Write([]byte(testCfg))
+		}
+	}))
+
+	tempDir := os.TempDir()
+	err = os.WriteFile(fmt.Sprintf("%s/password-file.txt", tempDir), []byte("bar"), 0644)
+	if err != nil {
+		t.Error(err.Error())
+		t.FailNow()
+	}
+	defer func(path string) {
+		err := os.RemoveAll(path)
+		if err != nil {
+			t.Logf("failed to remove temp dir: %s\n", tempDir)
+		}
+	}(tempDir)
+
+	type args struct {
+		rawURL string
+		opts   *RemoteOpts
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *Config
+		wantErr bool
+	}{
+		{
+			name: "HTTP config",
+			args: args{
+				rawURL: fmt.Sprintf("%s/agent.yml", svr.URL),
+			},
+			want:    wantCfg,
+			wantErr: false,
+		},
+		{
+			name: "HTTP config with basic auth",
+			args: args{
+				rawURL: fmt.Sprintf("%s/agent.yml", svrWithBasicAuth.URL),
+				opts: &RemoteOpts{
+					HTTPClientConfig: &config.HTTPClientConfig{
+						BasicAuth: &config.BasicAuth{
+							Username: "foo",
+							Password: "bar",
+						},
+					},
+				},
+			},
+			want:    wantCfg,
+			wantErr: false,
+		},
+		{
+			name: "HTTP config with basic auth password file",
+			args: args{
+				rawURL: fmt.Sprintf("%s/agent.yml", svrWithBasicAuth.URL),
+				opts: &RemoteOpts{
+					HTTPClientConfig: &config.HTTPClientConfig{
+						BasicAuth: &config.BasicAuth{
+							Username:     "foo",
+							PasswordFile: fmt.Sprintf("%s/password-file.txt", tempDir),
+						},
+					},
+				},
+			},
+			want:    wantCfg,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rc, err := NewRemoteConfig(tt.args.rawURL, tt.args.opts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RemoteConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			cfg, err := rc.Retrieve()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Retrieve() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			actual, _ := yaml.Marshal(cfg)
+			expected, _ := yaml.Marshal(tt.want)
+			if string(actual) != string(expected) {
+				t.Errorf("Retrieve() cfg =\n %v\n, want\n %v", string(actual), string(expected))
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### PR Description 

This PR adds a simple remote configuration framework and implements an http(s) provider. More providers to come in following PRs.

#### Which issue(s) this PR fixes 

https://github.com/grafana/agent/issues/1121  (partially)

#### Notes to the Reviewer

Currently the http remote provider supports basic auth, by passing the password, or a password file. To enable the feature, pass the `-experiment.config-urls.enable` flag when starting the agent.

The following command line flags have been added for auth for the http/https provider:
* `-config.url.basic-auth-user`
* `-config.url.basic-auth-password-file`


#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
