### PR TITLE
Fix POSTGRES_EXPORTER_DATA_SOURCE_NAME usage for postgres_exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Main (unreleased)
 
+- [BUGFIX] Fix usage of POSTGRES_EXPORTER_DATA_SOURCE_NAME when using postgres_exporter integration (@f11r)
+
 - [FEATURE] (beta) Enable experimental config urls for fetching remote configs. Currently,
    only HTTP/S is supported. Use `-experiment.config-urls.enable` flag to turn this on. (@rlankfo)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Main (unreleased)
 
-- [BUGFIX] Fix usage of POSTGRES_EXPORTER_DATA_SOURCE_NAME when using postgres_exporter integration (@f11r)
-
 - [FEATURE] (beta) Enable experimental config urls for fetching remote configs. Currently,
    only HTTP/S is supported. Use `-experiment.config-urls.enable` flag to turn this on. (@rlankfo)
 
 - [ENHANCEMENT] Traces: Improved pod association in PromSD processor (@mapno)
+
+- [BUGFIX] Fix usage of POSTGRES_EXPORTER_DATA_SOURCE_NAME when using postgres_exporter integration (@f11r)
 
 # v0.21.2 (2021-12-08)
 

--- a/pkg/integrations/postgres_exporter/postgres_exporter.go
+++ b/pkg/integrations/postgres_exporter/postgres_exporter.go
@@ -121,7 +121,7 @@ func (c *Config) getDataSourceNames() ([]string, error) {
 			stringDsn = append(stringDsn, string(d))
 		}
 	}
-	if len(dsn) == 0 {
+	if len(stringDsn) == 0 {
 		return nil, fmt.Errorf("cannot create postgres_exporter; neither postgres_exporter.data_source_name or $POSTGRES_EXPORTER_DATA_SOURCE_NAME is set")
 	}
 	return stringDsn, nil

--- a/pkg/integrations/postgres_exporter/postgres_exporter_test.go
+++ b/pkg/integrations/postgres_exporter/postgres_exporter_test.go
@@ -1,9 +1,11 @@
 package postgres_exporter //nolint:golint
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
 
 func Test_ParsePostgresURL(t *testing.T) {
@@ -20,5 +22,64 @@ func Test_ParsePostgresURL(t *testing.T) {
 	actual, err := parsePostgresURL(dsn)
 	require.NoError(t, err)
 	require.Equal(t, actual, expected)
+}
 
+func Test_getDataSourceNames(t *testing.T) {
+	tt := []struct {
+		name   string
+		config string
+		env    string
+		expect []string
+	}{
+		{
+			name:   "env",
+			config: "{}",
+			env:    "foo",
+			expect: []string{"foo"},
+		},
+		{
+			name:   "multi-env",
+			config: "{}",
+			env:    "foo,bar",
+			expect: []string{"foo", "bar"},
+		},
+		{
+			name: "config",
+			config: `{
+        "data_source_names": [
+          "foo"
+        ]
+      }`,
+			env:    "",
+			expect: []string{"foo"},
+		},
+		{
+			name: "config and env",
+			config: `{
+        "data_source_names": [
+          "foo"
+        ]
+      }`,
+			env:    "bar",
+			expect: []string{"foo"},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			orig := os.Getenv("POSTGRES_EXPORTER_DATA_SOURCE_NAME")
+			t.Cleanup(func() {
+				os.Setenv("POSTGRES_EXPORTER_DATA_SOURCE_NAME", orig)
+			})
+			os.Setenv("POSTGRES_EXPORTER_DATA_SOURCE_NAME", tc.env)
+
+			var cfg Config
+			err := yaml.Unmarshal([]byte(tc.config), &cfg)
+			require.NoError(t, err)
+
+			res, err := cfg.getDataSourceNames()
+			require.NoError(t, err)
+			require.Equal(t, tc.expect, res)
+		})
+	}
 }


### PR DESCRIPTION
A recent change broke the usage of POSTGRES_EXPORTER_DATA_SOURCE_NAME for the postgres_exporter.
As the incorrect variable was checked in the if clause, it always raises an error.

#### Notes to the Reviewer

As I'm not familiar with the codebase (and more generally go) it would take me a lot of time to add a regression test for this. It would be great if someone else could do this.

#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
