### PR TITLE
config/features: create package to standardize experimental features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Main (unreleased)
 
 - [FEATURE] (beta) Enable experimental config urls for fetching remote configs. Currently,
-   only HTTP/S is supported. Use `-experiment.config-urls.enable` flag to turn this on. (@rlankfo)
+   only HTTP/S is supported. Pass the `-enable-features=remote-configs` flag to turn this on. (@rlankfo)
 
 - [ENHANCEMENT] Traces: Improved pod association in PromSD processor (@mapno)
 

--- a/docs/configuration/_index.md
+++ b/docs/configuration/_index.md
@@ -119,7 +119,7 @@ Support contents and default values of `agent.yaml`:
 ## Remote Configuration (Beta)
 
 An experimental feature for fetching remote configuration files over HTTP/S can be
-enabled by passing the `-experiment.config-urls.enable` flag at the command line.
+enabled by passing the `-enable-features=remote-configs` flag at the command line.
 With this feature enabled, you may pass an HTTP/S URL to the `-config.file` flag.
 
 The following flags will configure basic auth for requests made to HTTP/S remote config URLs:

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -241,7 +241,7 @@ loki:
 `)
 	var cfg Config
 	require.NoError(t, LoadBytes([]byte(input), false, &cfg))
-	require.NoError(t, cfg.ApplyDefaults())
+	require.NoError(t, cfg.Validate(nil))
 
 	require.NotNil(t, cfg.Logs)
 	require.Equal(t, "foo", cfg.Logs.Configs[0].Name)
@@ -267,7 +267,7 @@ func TestConfig_PrometheusNonNil(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var cfg Config
 			require.NoError(t, LoadBytes([]byte(tc.input), false, &cfg))
-			require.NoError(t, cfg.ApplyDefaults())
+			require.NoError(t, cfg.Validate(nil))
 
 			require.NotNil(t, cfg.Metrics)
 		})
@@ -283,7 +283,7 @@ prometheus:
 `)
 	var cfg Config
 	require.NoError(t, LoadBytes([]byte(input), false, &cfg))
-	require.NoError(t, cfg.ApplyDefaults())
+	require.NoError(t, cfg.Validate(nil))
 
 	require.Equal(t, "default", cfg.Metrics.Configs[0].Name)
 	require.Equal(t, "/tmp", cfg.Metrics.WALDir)
@@ -336,7 +336,7 @@ tempo:
       spans: true`)
 	var cfg Config
 	require.NoError(t, LoadBytes([]byte(input), false, &cfg))
-	require.NoError(t, cfg.ApplyDefaults())
+	require.NoError(t, cfg.Validate(nil))
 
 	require.NotNil(t, cfg.Traces)
 

--- a/pkg/config/features/features.go
+++ b/pkg/config/features/features.go
@@ -1,4 +1,4 @@
-// Package features enables a way to encode enabled enabled features in a
+// Package features enables a way to encode enabled features in a
 // flag.FlagSet.
 package features
 

--- a/pkg/config/features/features.go
+++ b/pkg/config/features/features.go
@@ -1,0 +1,155 @@
+// Package features enables a way to encode enabled enabled features in a
+// flag.FlagSet.
+package features
+
+import (
+	"flag"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Feature is an experimental feature. Features are case-insensitive.
+type Feature string
+
+const setFlagName = "enabled-features"
+
+// Register sets a flag in fs to track enabled features. The list of possible
+// features is enumerated by ff. ff must contain a unique set of case-insensitive
+// features. Register will panic if ff is invalid.
+func Register(fs *flag.FlagSet, ff []Feature) {
+	var (
+		cache = make(map[Feature]struct{}, len(ff))
+		names = make([]string, len(ff))
+	)
+	for i, f := range ff {
+		normalized := normalize(f)
+		if _, found := cache[normalized]; found {
+			panic(fmt.Sprintf("case-insensitive feature %q registered twice", normalized))
+		}
+		cache[normalized] = struct{}{}
+		names[i] = string(normalized)
+	}
+
+	help := fmt.Sprintf("Comma-delimited list of features to enable. Valid values: %s", strings.Join(names, ", "))
+
+	s := set{valid: cache, validString: strings.Join(names, ", ")}
+	fs.Var(&s, setFlagName, help)
+}
+
+func normalize(f Feature) Feature {
+	return Feature(strings.ToLower(string(f)))
+}
+
+// Enabled retruns true if a feature is enabled. Enable will panic if fs has
+// not been passed to Register or name is an unknown feature.
+func Enabled(fs *flag.FlagSet, name Feature) bool {
+	name = normalize(name)
+
+	f := fs.Lookup(setFlagName)
+	if f == nil {
+		panic("feature flag not registered to fs")
+	}
+	s, ok := f.Value.(*set)
+	if !ok {
+		panic("registered feature flag not appropriate type")
+	}
+
+	if _, valid := s.valid[name]; !valid {
+		panic(fmt.Sprintf("unknown feature %q", name))
+	}
+	_, enabled := s.enabled[name]
+	return enabled
+}
+
+// Dependency marks a Flag as depending on a specific feature being enabled.
+type Dependency struct {
+	// Flag must be a flag name from a FlagSet.
+	Flag string
+	// Feature which must be enabled for Flag to be provided at the command line.
+	Feature Feature
+}
+
+// Validate returns an error if any flags from deps were used without the
+// corresponding feature being enabled.
+//
+// If deps references a flag that is not in fs, Validate will panic.
+func Validate(fs *flag.FlagSet, deps []Dependency) error {
+	depLookup := make(map[string]Dependency, len(deps))
+
+	for _, dep := range deps {
+		if fs.Lookup(dep.Flag) == nil {
+			panic(fmt.Sprintf("flag %q does not eixst in fs", dep.Flag))
+		}
+		depLookup[dep.Flag] = dep
+
+		// Ensure that the feature also exists. We ignore the result here;
+		// we just want to propagate the panic behavior.
+		_ = Enabled(fs, dep.Feature)
+	}
+
+	var err error
+
+	// Iterate over all the flags that were passed at the command line.
+	// Flags that were passed and are present in deps MUST also have their
+	// corresponding feature enabled.
+	fs.Visit(func(f *flag.Flag) {
+		// If we have an error to return, stop iterating.
+		if err != nil {
+			return
+		}
+
+		dep, ok := depLookup[f.Name]
+		if !ok {
+			return
+		}
+
+		// Flag was provided and exists in deps.
+		if !Enabled(fs, dep.Feature) {
+			err = fmt.Errorf("flag %q requires feature %q to be provided in --%s", f.Name, dep.Feature, setFlagName)
+		}
+	})
+
+	return err
+}
+
+// set implements flag.Value and holds the set of enabled features.
+// set should be provided to a flag.FlagSet with:
+//
+//  var s features.set
+//  fs.Var(&s, features.SetFlag, "")
+type set struct {
+	valid       map[Feature]struct{}
+	validString string // Comma-delimited list of acceptable values
+
+	enabled map[Feature]struct{}
+}
+
+// Set implements flag.Value.
+func (s *set) String() string {
+	res := make([]string, 0, len(s.enabled))
+	for k := range s.enabled {
+		res = append(res, string(k))
+	}
+	sort.Strings(res)
+	return strings.Join(res, ",")
+}
+
+// Set implements flag.Value.
+func (s *set) Set(in string) error {
+	slice := strings.Split(in, ",")
+
+	m := make(map[Feature]struct{}, len(slice))
+	for _, input := range slice {
+		f := normalize(Feature(input))
+		if _, valid := s.valid[f]; !valid {
+			return fmt.Errorf("unknown feature %q. possible options: %s", f, s.validString)
+		} else if _, ok := m[f]; ok {
+			return fmt.Errorf("%q already set", f)
+		}
+		m[f] = struct{}{}
+	}
+
+	s.enabled = m
+	return nil
+}

--- a/pkg/config/features/features.go
+++ b/pkg/config/features/features.go
@@ -12,7 +12,7 @@ import (
 // Feature is an experimental feature. Features are case-insensitive.
 type Feature string
 
-const setFlagName = "enabled-features"
+const setFlagName = "enable-features"
 
 // Register sets a flag in fs to track enabled features. The list of possible
 // features is enumerated by ff. ff must contain a unique set of case-insensitive

--- a/pkg/config/features/features.go
+++ b/pkg/config/features/features.go
@@ -79,7 +79,7 @@ func Validate(fs *flag.FlagSet, deps []Dependency) error {
 
 	for _, dep := range deps {
 		if fs.Lookup(dep.Flag) == nil {
-			panic(fmt.Sprintf("flag %q does not eixst in fs", dep.Flag))
+			panic(fmt.Sprintf("flag %q does not exist in fs", dep.Flag))
 		}
 		depLookup[dep.Flag] = dep
 

--- a/pkg/config/features/features_test.go
+++ b/pkg/config/features/features_test.go
@@ -1,0 +1,133 @@
+package features
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Example() {
+	var (
+		testFeature = Feature("test-feature")
+
+		// Set of flags which require a specific feature to be enabled.
+		dependencies = []Dependency{
+			{Flag: "protected", Feature: testFeature},
+		}
+	)
+
+	fs := flag.NewFlagSet("feature-flags", flag.PanicOnError)
+	fs.String("protected", "", `Requires "test-feature" to be enabled to set.`)
+	Register(fs, []Feature{testFeature})
+
+	if err := fs.Parse([]string{"--protected", "foo"}); err != nil {
+		fmt.Println(err)
+	}
+
+	err := Validate(fs, dependencies)
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println("Everything is valid!")
+	}
+	// Output: flag "protected" requires feature "test-feature" to be provided in --enabled-features
+}
+
+var (
+	exampleFeature  = Feature("test-feature")
+	exampleFeatures = []Feature{exampleFeature}
+)
+
+func TestFeatures_Flag(t *testing.T) {
+	fs := flag.NewFlagSet(t.Name(), flag.PanicOnError)
+	Register(fs, exampleFeatures)
+
+	f := fs.Lookup(setFlagName)
+	require.Equal(t,
+		"Comma-delimited list of features to enable. Valid values: test-feature",
+		f.Usage,
+	)
+
+	t.Run("Exact match", func(t *testing.T) {
+		err := f.Value.Set(string(exampleFeature))
+		require.NoError(t, err)
+		require.True(t, Enabled(fs, exampleFeature))
+	})
+
+	t.Run("Case insensitive", func(t *testing.T) {
+		err := f.Value.Set(strings.ToUpper(string(exampleFeature)))
+		require.NoError(t, err)
+		require.True(t, Enabled(fs, exampleFeature))
+	})
+
+	t.Run("Feature does not exist", func(t *testing.T) {
+		err := f.Value.Set(fmt.Sprintf("%s,bad-feature", exampleFeature))
+		require.EqualError(t, err, `unknown feature "bad-feature". possible options: test-feature`)
+	})
+}
+
+func TestValidate(t *testing.T) {
+	tt := []struct {
+		name    string
+		input   []string
+		enabled bool
+		expect  error
+	}{
+		{
+			name:    "Not enabled and not provided",
+			input:   []string{},
+			enabled: false,
+			expect:  nil,
+		},
+		{
+			name:    "Not enabled but provided",
+			input:   []string{"--example-value", "foo"},
+			enabled: false,
+			expect:  fmt.Errorf(`flag "example-value" requires feature "test-feature" to be provided in --enabled-features`),
+		},
+		{
+			name: "Enabled and provided",
+			input: []string{
+				"--enabled-features=test-feature",
+				"--example-value", "foo",
+			},
+			enabled: true,
+			expect:  nil,
+		},
+		{
+			name: "Enabled and not provided",
+			input: []string{
+				"--enabled-features=test-feature",
+			},
+			enabled: true,
+			expect:  nil,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			var exampleValue string
+
+			fs := flag.NewFlagSet(t.Name(), flag.PanicOnError)
+			fs.StringVar(&exampleValue, "example-value", "", "")
+			Register(fs, exampleFeatures)
+
+			err := fs.Parse(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.enabled, Enabled(fs, exampleFeature))
+
+			err = Validate(fs, []Dependency{{
+				Flag:    "example-value",
+				Feature: exampleFeature,
+			}})
+			if tc.expect == nil {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.expect.Error())
+			}
+		})
+	}
+}

--- a/pkg/config/features/features_test.go
+++ b/pkg/config/features/features_test.go
@@ -33,7 +33,7 @@ func Example() {
 	} else {
 		fmt.Println("Everything is valid!")
 	}
-	// Output: flag "protected" requires feature "test-feature" to be provided in --enabled-features
+	// Output: flag "protected" requires feature "test-feature" to be provided in --enable-features
 }
 
 var (
@@ -86,12 +86,12 @@ func TestValidate(t *testing.T) {
 			name:    "Not enabled but provided",
 			input:   []string{"--example-value", "foo"},
 			enabled: false,
-			expect:  fmt.Errorf(`flag "example-value" requires feature "test-feature" to be provided in --enabled-features`),
+			expect:  fmt.Errorf(`flag "example-value" requires feature "test-feature" to be provided in --enable-features`),
 		},
 		{
 			name: "Enabled and provided",
 			input: []string{
-				"--enabled-features=test-feature",
+				"--enable-features=test-feature",
 				"--example-value", "foo",
 			},
 			enabled: true,
@@ -100,7 +100,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "Enabled and not provided",
 			input: []string{
-				"--enabled-features=test-feature",
+				"--enable-features=test-feature",
 			},
 			enabled: true,
 			expect:  nil,


### PR DESCRIPTION
#### PR Description 
This commit introduces a new package, pkg/config/features, which allows defining a set of features and validating whether flags associated with those features are allowed to be set.

#### Which issue(s) this PR fixes 
Closes #1163

#### Notes to the Reviewer
Renames the `config-urls` feature flag to `remote-configs`, since they might not necessarily be URLs forever.

Removes the old `--experiment.config-urls.enable` flag in favor of `--enable-features=remote-configs`.

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
