### PR TITLE
Remove log-level flag from systemd unit file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 - [BUGFIX] Fix usage of POSTGRES_EXPORTER_DATA_SOURCE_NAME when using postgres_exporter integration (@f11r)
 
+- [CHANGE] Remove log-level flag from systemd unit file (@jpkrohling)
+
 # v0.21.2 (2021-12-08)
 
 - [SECURITY] This release contains a fix for

--- a/packaging/deb/grafana-agent.service
+++ b/packaging/deb/grafana-agent.service
@@ -9,7 +9,7 @@ Restart=always
 User=grafana-agent
 Environment=HOSTNAME=%H
 EnvironmentFile=/etc/default/grafana-agent
-ExecStart=/usr/bin/grafana-agent --config.file $CONFIG_FILE --log.level $LOG_LEVEL $CUSTOM_ARGS
+ExecStart=/usr/bin/grafana-agent --config.file $CONFIG_FILE $CUSTOM_ARGS
 # If running the Agent in scraping service mode, you will want to override this value with
 # something larger to allow the Agent to gracefully leave the cluster. 4800s is recommend.
 TimeoutStopSec=20s

--- a/packaging/environment-file
+++ b/packaging/environment-file
@@ -6,9 +6,6 @@
 #
 # Command line options for grafana-agent
 #
-# Log level. Valid levels: [debug, info, warn, error] (default info)
-LOG_LEVEL="error"
-
 # The configuration file holding the agent config
 CONFIG_FILE="/etc/grafana-agent.yaml"
 

--- a/packaging/rpm/grafana-agent.service
+++ b/packaging/rpm/grafana-agent.service
@@ -9,7 +9,7 @@ Restart=always
 User=grafana-agent
 Environment=HOSTNAME=%H
 EnvironmentFile=/etc/sysconfig/grafana-agent
-ExecStart=/usr/bin/grafana-agent --config.file $CONFIG_FILE --log.level $LOG_LEVEL $CUSTOM_ARGS
+ExecStart=/usr/bin/grafana-agent --config.file $CONFIG_FILE $CUSTOM_ARGS
 # If running the Agent in scraping service mode, you will want to override this value with
 # something larger to allow the Agent to gracefully leave the cluster. 4800s is recommend.
 TimeoutStopSec=20s


### PR DESCRIPTION
#### PR Description 

This PR removes the log-level flag from the systemd unit file, so that only the value from the config file is taken into consideration.

#### Which issue(s) this PR fixes 

Fixes #1172

#### Notes to the Reviewer

None.

#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>