### PR TITLE
[dev.multiple-integrations] integrations/v2: allow shimming between v1 and v2 integrations.

### DIFF
--- a/cmd/agent/agent-local-config.yaml
+++ b/cmd/agent/agent-local-config.yaml
@@ -5,14 +5,8 @@ server:
 metrics:
   global:
     scrape_interval: 1m
-  configs:
-    - name: test
-      host_filter: false
-      scrape_configs:
-        - job_name: local_scrape
-          static_configs:
-            - targets: ['127.0.0.1:12345']
-              labels:
-                cluster: 'localhost'
-      remote_write:
-        - url: http://localhost:9009/api/prom/push
+    remote_write:
+      - url: http://localhost:9009/api/prom/push
+
+integrations:
+  agent: {}

--- a/pkg/integrations/install/install.go
+++ b/pkg/integrations/install/install.go
@@ -1,8 +1,11 @@
 // Package install registers all in-source integrations for use.
 package install
 
-// v1 integrations
 import (
+	//
+	// v1 integrations
+	//
+
 	_ "github.com/grafana/agent/pkg/integrations/agent"                  // register agent
 	_ "github.com/grafana/agent/pkg/integrations/consul_exporter"        // register consul_exporter
 	_ "github.com/grafana/agent/pkg/integrations/dnsmasq_exporter"       // register dnsmasq_exporter
@@ -18,9 +21,10 @@ import (
 	_ "github.com/grafana/agent/pkg/integrations/redis_exporter"         // register redis_exporter
 	_ "github.com/grafana/agent/pkg/integrations/statsd_exporter"        // register statsd_exporter
 	_ "github.com/grafana/agent/pkg/integrations/windows_exporter"       // register windows_exporter
-)
 
-// v2 integrations
-import (
+	//
+	// v2 integrations
+	//
+
 	_ "github.com/grafana/agent/pkg/integrations/v2/agent" // register agent
 )

--- a/pkg/integrations/install/install.go
+++ b/pkg/integrations/install/install.go
@@ -1,6 +1,7 @@
 // Package install registers all in-source integrations for use.
 package install
 
+// v1 integrations
 import (
 	_ "github.com/grafana/agent/pkg/integrations/agent"                  // register agent
 	_ "github.com/grafana/agent/pkg/integrations/consul_exporter"        // register consul_exporter
@@ -17,6 +18,9 @@ import (
 	_ "github.com/grafana/agent/pkg/integrations/redis_exporter"         // register redis_exporter
 	_ "github.com/grafana/agent/pkg/integrations/statsd_exporter"        // register statsd_exporter
 	_ "github.com/grafana/agent/pkg/integrations/windows_exporter"       // register windows_exporter
+)
 
+// v2 integrations
+import (
 	_ "github.com/grafana/agent/pkg/integrations/v2/agent" // register agent
 )

--- a/pkg/integrations/install/shims.go
+++ b/pkg/integrations/install/shims.go
@@ -24,8 +24,8 @@ func init() {
 			}
 		}
 		if !found {
-			v2.RegisterDynamic(v1Integration, v1Integration.Name(), v2.TypeSingleton, func(in interface{}) v2.WrappedConfig {
-				return metricsutils.CreateShim(in.(v1.Config))
+			v2.RegisterLegacy(v1Integration, v2.TypeSingleton, func(cfg v1.Config) v2.UpgradedConfig {
+				return metricsutils.CreateShim(cfg)
 			})
 		}
 	}

--- a/pkg/integrations/install/shims.go
+++ b/pkg/integrations/install/shims.go
@@ -1,0 +1,32 @@
+package install
+
+import (
+	v1 "github.com/grafana/agent/pkg/integrations"
+	v2 "github.com/grafana/agent/pkg/integrations/v2"
+	metricsutils "github.com/grafana/agent/pkg/integrations/v2/metricsutils"
+)
+
+// Perform a migration of v1 integrations which do not yet have a v2
+// counterpart. These integrations will be registered as Singletons
+// to maintain existing behavior.
+//
+// To migrate a v1 integration to a v2 migration with support for multiple
+// instances, v1 integrations must manually migrate themselves by calling
+// v2.RegisterDynamic directly.
+func init() {
+	for _, v1Integration := range v1.RegisteredIntegrations() {
+		// Look to see if there's a v2 integration with the same name.
+		var found bool
+		for _, v2Integration := range v2.Registered() {
+			if v2Integration.Name() == v1Integration.Name() {
+				found = true
+				break
+			}
+		}
+		if !found {
+			v2.RegisterDynamic(v1Integration, v1Integration.Name(), v2.TypeSingleton, func(in interface{}) v2.WrappedConfig {
+				return metricsutils.CreateShim(in.(v1.Config))
+			})
+		}
+	}
+}

--- a/pkg/integrations/v2/metricsutils/versionshim.go
+++ b/pkg/integrations/v2/metricsutils/versionshim.go
@@ -15,7 +15,7 @@ import (
 
 // CreateShim creates a shim between the v1.Config and v2.Config. The resulting
 // config is NOT registered.
-func CreateShim(before v1.Config) (after v2.WrappedConfig) {
+func CreateShim(before v1.Config) (after v2.UpgradedConfig) {
 	return &configShim{Orig: before}
 }
 
@@ -24,12 +24,12 @@ type configShim struct {
 }
 
 var (
-	_ v2.Config        = (*configShim)(nil)
-	_ v2.WrappedConfig = (*configShim)(nil)
+	_ v2.Config         = (*configShim)(nil)
+	_ v2.UpgradedConfig = (*configShim)(nil)
 )
 
-// UnwrapConfig implements v2.WrappedConfig.
-func (s *configShim) UnwrapConfig() interface{} { return s.Orig }
+// LegacyConfig implements v2.UpgradedConfig.
+func (s *configShim) LegacyConfig() v1.Config { return s.Orig }
 
 func (s *configShim) Name() string { return s.Orig.Name() }
 func (s *configShim) Identifier(g v2.Globals) (string, error) {

--- a/pkg/integrations/v2/metricsutils/versionshim.go
+++ b/pkg/integrations/v2/metricsutils/versionshim.go
@@ -1,0 +1,119 @@
+package metricsutils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/common/model"
+
+	v1 "github.com/grafana/agent/pkg/integrations"
+	v2 "github.com/grafana/agent/pkg/integrations/v2"
+)
+
+// CreateShim creates a shim between the v1.Config and v2.Config. The resulting
+// config is NOT registered.
+func CreateShim(before v1.Config) (after v2.WrappedConfig) {
+	return &configShim{Orig: before}
+}
+
+type configShim struct {
+	Orig v1.Config
+}
+
+var (
+	_ v2.Config        = (*configShim)(nil)
+	_ v2.WrappedConfig = (*configShim)(nil)
+)
+
+// UnwrapConfig implements v2.WrappedConfig.
+func (s *configShim) UnwrapConfig() interface{} { return s.Orig }
+
+func (s *configShim) Name() string { return s.Orig.Name() }
+func (s *configShim) Identifier(g v2.Globals) (string, error) {
+	return s.Orig.InstanceKey(g.AgentIdentifier)
+}
+
+func (s *configShim) NewIntegration(l log.Logger, g v2.Globals) (v2.Integration, error) {
+	v1Integration, err := s.Orig.NewIntegration(l)
+	if err != nil {
+		return nil, err
+	}
+
+	id, err := s.Identifier(g)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map from the original CommonConfig to the new settings. This is a 1:1
+	// mapping, minus the loss of WALTruncateFrequency.
+	origCommon := s.Orig.CommonConfig()
+	newCommon := CommonConfig{
+		Enabled:              origCommon.Enabled,
+		InstanceKey:          origCommon.InstanceKey,
+		ScrapeIntegration:    origCommon.ScrapeIntegration,
+		ScrapeInterval:       origCommon.ScrapeInterval,
+		ScrapeTimeout:        origCommon.ScrapeTimeout,
+		RelabelConfigs:       origCommon.RelabelConfigs,
+		MetricRelabelConfigs: origCommon.MetricRelabelConfigs,
+	}
+
+	// Generate our handler. Original integrations didn't accept a prefix, and
+	// just assumed that they would be wired to /metrics somewhere.
+	handler, err := v1Integration.MetricsHandler()
+	if err != nil {
+		return nil, fmt.Errorf("generating http handler: %w", err)
+	} else if handler == nil {
+		handler = http.NotFoundHandler()
+	}
+
+	// Generate targets. Original integrations used a static set of targets,
+	// so this mapping can always be generated just once.
+	//
+	// Targets are generated from the result of ScrapeConfigs(), which returns a
+	// tuple of job name and relative metrics path.
+	//
+	// Job names were prefixed at the subsystem level with integrations/, so we
+	// will retain that behavior here.
+	v1ScrapeConfigs := v1Integration.ScrapeConfigs()
+	targets := make([]handlerTarget, 0, len(v1ScrapeConfigs))
+	for _, sc := range v1ScrapeConfigs {
+		targets = append(targets, handlerTarget{
+			MetricsPath: sc.MetricsPath,
+			Labels: model.LabelSet{
+				model.JobLabel: model.LabelValue("integrations/" + sc.JobName),
+			},
+		})
+	}
+
+	// Convert he run function. Original integrations sometimes returned
+	// ctx.Err() on exit. This isn't recommended anymore, but we need to hide the
+	// error if it happens, since the error was previously ignored.
+	runFunc := func(ctx context.Context) error {
+		err := v1Integration.Run(ctx)
+		switch {
+		case err == nil:
+			return nil
+		case errors.Is(err, context.Canceled) && ctx.Err() != nil:
+			// Hide error that no longer happens in newer integrations.
+			return nil
+		default:
+			return err
+		}
+	}
+
+	// Aggregate our converted settings into a v2 integration.
+	return &metricsHandlerIntegration{
+		integrationName: s.Orig.Name(),
+		instanceID:      id,
+
+		common:  newCommon,
+		globals: g,
+		handler: handler,
+		targets: targets,
+
+		runFunc: runFunc,
+	}, nil
+}

--- a/pkg/integrations/v2/register.go
+++ b/pkg/integrations/v2/register.go
@@ -140,10 +140,6 @@ func Registered() []Config {
 	return res
 }
 
-func cloneIntegration(c Config) Config {
-	return cloneDynamic(c).(Config)
-}
-
 func cloneDynamic(in interface{}) interface{} {
 	return reflect.New(reflect.TypeOf(in).Elem()).Interface()
 }

--- a/pkg/integrations/v2/register.go
+++ b/pkg/integrations/v2/register.go
@@ -58,7 +58,7 @@ func registerIntegration(v interface{}, name string, ty Type, upgrader UpgradeFu
 // upgrader will only be invoked after unmarshaling cfg from YAML, and the
 // upgraded Config will be unwrapped again when marshaling back to YAML.
 //
-// Deprecated: RegisterLegacy only exists for the transition period where the v2
+// RegisterLegacy only exists for the transition period where the v2
 // integrations subsystem is an experiment. RegisterLegacy will be removed at a
 // later date.
 func RegisterLegacy(cfg v1.Config, ty Type, upgrader UpgradeFunc) {

--- a/pkg/integrations/v2/register_test.go
+++ b/pkg/integrations/v2/register_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	v1 "github.com/grafana/agent/pkg/integrations"
+	agent_v1 "github.com/grafana/agent/pkg/integrations/agent"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
@@ -74,44 +76,40 @@ test_configs:
 	require.Equal(t, expect, fullCfg)
 }
 
-func TestIntegrationRegistration_Dynamic(t *testing.T) {
+func TestIntegrationRegistration_Legacy(t *testing.T) {
 	setRegistered(t, nil)
 
-	type raw struct {
-		Name string `yaml:"name"`
-	}
-
-	RegisterDynamic(&raw{}, "dyn", TypeSingleton, func(in interface{}) WrappedConfig {
-		return &dynamicShim{IntegrationName: "dyn", Data: in}
+	RegisterLegacy(&agent_v1.Config{}, TypeSingleton, func(in v1.Config) UpgradedConfig {
+		return &legacyShim{Data: in}
 	})
 
 	var cfgToParse = `
 name: John Doe
 duration: 500ms
-dyn:
-  name: Hello, world!`
+agent:
+  instance: foo`
 
 	var fullCfg testFullConfig
 	err := yaml.UnmarshalStrict([]byte(cfgToParse), &fullCfg)
 	require.NoError(t, err)
 
 	require.Len(t, fullCfg.Configs, 1)
-	require.IsType(t, &dynamicShim{}, fullCfg.Configs[0])
+	require.IsType(t, &legacyShim{}, fullCfg.Configs[0])
 
-	dynShim := fullCfg.Configs[0].(*dynamicShim)
-	require.IsType(t, &raw{}, dynShim.Data)
-	require.Equal(t, &raw{Name: "Hello, world!"}, dynShim.Data)
+	shim := fullCfg.Configs[0].(*legacyShim)
+	require.IsType(t, &agent_v1.Config{}, shim.Data)
+
+	agentConfig := shim.Data.(*agent_v1.Config)
+	require.Equal(t, "foo", *agentConfig.Common.InstanceKey)
+	require.Equal(t, true, agentConfig.Enabled)
 }
 
-type dynamicShim struct {
-	IntegrationName string
-	Data            interface{}
-}
+type legacyShim struct{ Data v1.Config }
 
-func (s *dynamicShim) UnwrapConfig() interface{}            { return s.Data }
-func (s *dynamicShim) Name() string                         { return s.IntegrationName }
-func (s *dynamicShim) Identifier(g Globals) (string, error) { return g.AgentIdentifier, nil }
-func (s *dynamicShim) NewIntegration(log.Logger, Globals) (Integration, error) {
+func (s *legacyShim) LegacyConfig() v1.Config              { return s.Data }
+func (s *legacyShim) Name() string                         { return s.Data.Name() }
+func (s *legacyShim) Identifier(g Globals) (string, error) { return g.AgentIdentifier, nil }
+func (s *legacyShim) NewIntegration(log.Logger, Globals) (Integration, error) {
 	return NoOpIntegration, nil
 }
 


### PR DESCRIPTION
#### PR Description 
Shimming is done by changing how the integration registration works; a new RegisterDynamic function is introduced. This function allows registering any type as an integration and converting it to a Config later. Here be dragons; this should be removed whenever we no longer have a need for it.

I tried pretty hard to do this another way, but the fact that unmarshaled integrations will almost always be the zero value for the registered type prevents something less confusing. Instead, we marshal/unmarshal the "real" type (i.e., the v1 integration) and define a wrapper to work around our constraints. 

