### PR TITLE
[dev.multiple-integrations] Revert deprecated changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Please review the [migration guide](./docs/migration-guide.md) for details.
 - [CHANGE] Integrations present in the `integrations:` map will now default to
   being enabled. (@rfratto)
 
+- [CHANGE] The `wal_truncate_frequency` field in integrations has been removed
+  and will fail to load when defined. This change is to improve the future
+  performance of running many integrations. (@rfratto)
+
 - [DEPRECATION] Integrations: The `enabled` field is now deprecated and will be
   removed in a future release. (@rfratto)
 

--- a/docs/upgrade-guide/_index.md
+++ b/docs/upgrade-guide/_index.md
@@ -42,6 +42,29 @@ integrations:
 No change is necessary for configs that are not listed inside of `integrations:`.
 For example, as `node_exporter` is not defined, it will not be run.
 
+### Integrations: Removal of `wal_truncate_frequency` (Breaking change)
+
+Integrations will no longer support `wal_truncate_frequency` being supplied.
+Supporting this field required integrations to run as separate metrics instances,
+which has a significant performance penalty over running a single instance.
+Removing support for the field enables integrations to share an instance and
+have better performance.
+
+Example old config:
+
+```yaml
+integrations:
+  agent:
+    wal_truncate_frequency: 60m
+```
+
+Example new config:
+
+```yaml
+integrations:
+  agent: {}
+```
+
 ## v0.21.0
 
 ### Integrations: Change in how instance labels are handled (Breaking change)

--- a/pkg/integrations/config/config.go
+++ b/pkg/integrations/config/config.go
@@ -34,9 +34,6 @@ type Common struct {
 	ScrapeTimeout        time.Duration     `yaml:"scrape_timeout,omitempty"`
 	RelabelConfigs       []*relabel.Config `yaml:"relabel_configs,omitempty"`
 	MetricRelabelConfigs []*relabel.Config `yaml:"metric_relabel_configs,omitempty"`
-
-	// TODO(rfratto): remove this field.
-	WALTruncateFrequency time.Duration `yaml:"wal_truncate_frequency,omitempty"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.

--- a/pkg/integrations/manager.go
+++ b/pkg/integrations/manager.go
@@ -421,9 +421,6 @@ func (m *Manager) instanceConfigForIntegration(p *integrationProcess, cfg Manage
 	instanceCfg.Name = integrationKey(p.cfg.Name())
 	instanceCfg.ScrapeConfigs = scrapeConfigs
 	instanceCfg.RemoteWrite = cfg.PrometheusRemoteWrite
-	if common.WALTruncateFrequency > 0 {
-		instanceCfg.WALTruncateFrequency = common.WALTruncateFrequency
-	}
 	return instanceCfg
 }
 

--- a/pkg/integrations/manager_test.go
+++ b/pkg/integrations/manager_test.go
@@ -66,10 +66,9 @@ scrape_integrations: true
 replace_instance_label: true
 integration_restart_backoff: 5s
 use_hostname_label: true
-test_configs:
-  - text: Hello, world!
-    truth: true
-  `
+test:
+  text: Hello, world!
+  truth: true`
 
 	var (
 		cfg        ManagerConfig
@@ -87,37 +86,6 @@ test_configs:
 	require.NoError(t, err, "Failed creating integration")
 	fmt.Println(string(outBytes))
 	require.YAMLEq(t, expect, string(outBytes))
-}
-
-// Test that marshaling works for *_configs integrations.
-func TestConfig_Remarshal_ConfigsSlice(t *testing.T) {
-	setRegisteredIntegrations([]Config{&testIntegrationA{}})
-	cfgText := `
-scrape_integrations: true
-replace_instance_label: true
-integration_restart_backoff: 5s
-use_hostname_label: true
-test_configs:
-  - text: Hello, world!
-    truth: true
-  - text: Hello again!
-    truth: true`
-	var (
-		cfg        ManagerConfig
-		listenPort = 12345
-		listenHost = "127.0.0.1"
-	)
-	require.NoError(t, yaml.Unmarshal([]byte(cfgText), &cfg))
-
-	// Listen port must be set before applying defaults. Normally applied by the
-	// config package.
-	cfg.ListenPort = listenPort
-	cfg.ListenHost = listenHost
-
-	outBytes, err := yaml.Marshal(cfg)
-	require.NoError(t, err, "Failed creating integration")
-	fmt.Println(string(outBytes))
-	require.YAMLEq(t, cfgText, string(outBytes))
 }
 
 func TestConfig_AddressRelabels(t *testing.T) {

--- a/pkg/integrations/register.go
+++ b/pkg/integrations/register.go
@@ -100,14 +100,12 @@ func MarshalYAML(v interface{}) (interface{}, error) {
 	}
 
 	for _, c := range configs {
-		// TODO(rfratto): check to see if integration is a singleton only
-
 		fieldName, ok := configFieldNames[reflect.TypeOf(c)]
 		if !ok {
 			return nil, fmt.Errorf("integrations: cannot marshal unregistered Config type: %T", c)
 		}
-		field := cfgVal.FieldByName("XXX_Configs_" + fieldName)
-		field.Set(reflect.Append(field, reflect.ValueOf(c)))
+		field := cfgVal.FieldByName("XXX_Config_" + fieldName)
+		field.Set(reflect.ValueOf(c))
 	}
 
 	return cfgPointer.Interface(), nil
@@ -178,25 +176,16 @@ func unmarshalIntegrationsWithList(integrations []Config, out interface{}, unmar
 		outVal.Field(i).Set(cfgVal.Field(i))
 	}
 
-	// Iterate through the remainder of our fields, which should all be
-	// either a Config or a slice of types that implement Config.
+	// Iterate through the remainder of our fields, which should all be of
+	// type Config.
 	for i := outVal.NumField(); i < cfgVal.NumField(); i++ {
 		field := cfgVal.Field(i)
 
 		if field.IsNil() {
 			continue
 		}
-
-		switch field.Kind() {
-		case reflect.Slice:
-			for i := 0; i < field.Len(); i++ {
-				val := field.Index(i).Interface().(Config)
-				*configs = append(*configs, val)
-			}
-		default:
-			val := field.Interface().(Config)
-			*configs = append(*configs, val)
-		}
+		val := cfgVal.Field(i).Interface().(Config)
+		*configs = append(*configs, val)
 	}
 
 	return nil
@@ -219,18 +208,13 @@ func getConfigTypeForIntegrations(integrations []Config, out reflect.Type) refle
 			})
 		}
 	}
-
 	for _, cfg := range integrations {
-		// Fields use a prefix that's unlikely to collide with anything else.
+		// Use a prefix that's unlikely to collide with anything else.
+		fieldName := "XXX_Config_" + cfg.Name()
 		fields = append(fields, reflect.StructField{
-			Name: "XXX_Config_" + cfg.Name(),
+			Name: fieldName,
 			Tag:  reflect.StructTag(fmt.Sprintf(`yaml:"%s,omitempty"`, cfg.Name())),
 			Type: reflect.TypeOf(cfg),
-		})
-		fields = append(fields, reflect.StructField{
-			Name: "XXX_Configs_" + cfg.Name(),
-			Tag:  reflect.StructTag(fmt.Sprintf(`yaml:"%s_configs,omitempty"`, cfg.Name())),
-			Type: reflect.SliceOf(reflect.TypeOf(cfg)),
 		})
 	}
 	return reflect.StructOf(fields)

--- a/pkg/integrations/register.go
+++ b/pkg/integrations/register.go
@@ -30,17 +30,6 @@ func RegisterIntegration(cfg Config) {
 	configFieldNames[reflect.TypeOf(cfg)] = cfg.Name()
 }
 
-// setRegisteredIntegrations clears the set of registered integrations and
-// overrides it with cc. Used by tests.
-func setRegisteredIntegrations(cc []Config) {
-	registeredIntegrations = registeredIntegrations[:0]
-	configFieldNames = make(map[reflect.Type]string)
-
-	for _, c := range cc {
-		RegisterIntegration(c)
-	}
-}
-
 // RegisteredIntegrations all Configs that were passed to RegisterIntegration.
 // Each call will generate a new set of pointers.
 func RegisteredIntegrations() []Config {

--- a/pkg/integrations/register_test.go
+++ b/pkg/integrations/register_test.go
@@ -42,30 +42,6 @@ test:
 	require.Equal(t, expect, fullCfg)
 }
 
-func TestIntegrationRegistration_Multiple(t *testing.T) {
-	var cfgToParse = `
-name: John Doe
-duration: 500ms
-test_configs:
-  - text: Hello, world!
-  - text: Hello again!`
-
-	var fullCfg testFullConfig
-	err := yaml.UnmarshalStrict([]byte(cfgToParse), &fullCfg)
-	require.NoError(t, err)
-
-	expect := testFullConfig{
-		Name:     "John Doe",
-		Duration: 500 * time.Millisecond,
-		Default:  12345,
-		Configs: []Config{
-			&testIntegrationA{Text: "Hello, world!", Truth: true},
-			&testIntegrationA{Text: "Hello again!", Truth: true},
-		},
-	}
-	require.Equal(t, expect, fullCfg)
-}
-
 type testIntegrationA struct {
 	Text  string `yaml:"text"`
 	Truth bool   `yaml:"truth"`


### PR DESCRIPTION
#### PR Description 
This PR reverts 69ba2ddfa9483cc8ac6e010dd7abccd319580c80 in favor of allowing the new subsystem to handle multiple instances of integrations.

This PR also removes the `wal_truncate_frequency` field from integrations as it is the only field from old integrations that does not have a current counterpart, and gives negative performance implications to the current integrations by existing.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
