### PR TITLE
Remote write dashboard: show the sample rates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - [ENHANCEMENT] Updated OTel to v0.40.0 (@mapno)
 
+- [ENHANCEMENT] Remote write dashboard: show in and out sample rates (@bboreham)
+
 - [BUGFIX] Fix usage of POSTGRES_EXPORTER_DATA_SOURCE_NAME when using postgres_exporter integration (@f11r)
 
 - [CHANGE] Remove log-level flag from systemd unit file (@jpkrohling)

--- a/example/docker-compose/grafana/dashboards/agent-remote-write.json
+++ b/example/docker-compose/grafana/dashboards/agent-remote-write.json
@@ -224,12 +224,12 @@
                "repeat": null,
                "seriesOverrides": [ ],
                "spaceLength": 10,
-               "span": 12,
+               "span": 6,
                "stack": false,
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(agent_wal_samples_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m])\n-\n  ignoring(remote_name, url) group_right(pod)\n  (rate(prometheus_remote_storage_succeeded_samples_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m]) or rate(prometheus_remote_storage_samples_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m]))\n-\n  (rate(prometheus_remote_storage_dropped_samples_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m]) or rate(prometheus_remote_storage_samples_dropped_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m]))\n",
+                     "expr": "rate(agent_wal_samples_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}",
@@ -239,7 +239,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Rate, in vs. succeeded or dropped [5m]",
+               "title": "Rate in [5m]",
                "tooltip": {
                   "shared": true,
                   "sort": 0,
@@ -282,6 +282,87 @@
                "fillGradient": 0,
                "gridPos": { },
                "id": 5,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 6,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(prometheus_remote_storage_succeeded_samples_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m]) or rate(prometheus_remote_storage_samples_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[5m])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Rate succeeded [5m]",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 6,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -362,7 +443,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 6,
+               "id": 7,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -443,7 +524,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 7,
+               "id": 8,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -524,7 +605,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 8,
+               "id": 9,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -618,7 +699,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 9,
+               "id": 10,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -700,7 +781,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 10,
+               "id": 11,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -781,7 +862,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 11,
+               "id": 12,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -862,7 +943,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 12,
+               "id": 13,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -956,7 +1037,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 13,
+               "id": 14,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1050,7 +1131,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 14,
+               "id": 15,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1144,7 +1225,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 15,
+               "id": 16,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,

--- a/production/grafana-agent-mixin/dashboards.libsonnet
+++ b/production/grafana-agent-mixin/dashboards.libsonnet
@@ -112,21 +112,25 @@ local template = grafana.template;
           legendFormat='{{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}',
         ));
 
-      local samplesRate =
+      local samplesInRate =
         graphPanel.new(
-          'Rate, in vs. succeeded or dropped [5m]',
+          'Rate in [5m]',
           datasource='$datasource',
-          span=12,
+          span=6,
         )
         .addTarget(prometheus.target(
-          |||
-            rate(agent_wal_samples_appended_total{cluster=~"$cluster", namespace=~"$namespace", container=~"$container"}[5m])
-            -
-              ignoring(remote_name, url) group_right(pod)
-              (rate(prometheus_remote_storage_succeeded_samples_total{cluster=~"$cluster", namespace=~"$namespace", container=~"$container"}[5m]) or rate(prometheus_remote_storage_samples_total{cluster=~"$cluster", namespace=~"$namespace", container=~"$container"}[5m]))
-            -
-              (rate(prometheus_remote_storage_dropped_samples_total{cluster=~"$cluster", namespace=~"$namespace", container=~"$container"}[5m]) or rate(prometheus_remote_storage_samples_dropped_total{cluster=~"$cluster", namespace=~"$namespace", container=~"$container"}[5m]))
-          |||,
+          'rate(agent_wal_samples_appended_total{cluster=~"$cluster", namespace=~"$namespace", container=~"$container"}[5m])',
+          legendFormat='{{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}',
+        ));
+
+      local samplesOutRate =
+        graphPanel.new(
+          'Rate succeeded [5m]',
+          datasource='$datasource',
+          span=6,
+        )
+        .addTarget(prometheus.target(
+          'rate(prometheus_remote_storage_succeeded_samples_total{cluster=~"$cluster", namespace=~"$namespace", container=~"$container"}[5m]) or rate(prometheus_remote_storage_samples_total{cluster=~"$cluster", namespace=~"$namespace", container=~"$container"}[5m])',
           legendFormat='{{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}',
         ));
 
@@ -338,7 +342,8 @@ local template = grafana.template;
       )
       .addRow(
         row.new('Samples')
-        .addPanel(samplesRate)
+        .addPanel(samplesInRate)
+        .addPanel(samplesOutRate)
         .addPanel(pendingSamples)
         .addPanel(droppedSamples)
         .addPanel(failedSamples)


### PR DESCRIPTION
Instead of showing the diff between in and out rates, show them both.
The total rate is key information alongside shards, latency, etc., and the differential can be inferred from looking at in and out rates, or the backlog on the top line.

Making these panels the same width as those nearby also aids readability.

Dropped samples already had a separate panel.

Before:
![image](https://user-images.githubusercontent.com/8125524/146943719-49c98df4-2e3e-4599-b711-81d21a742b04.png)

After:
![image](https://user-images.githubusercontent.com/8125524/146943668-705c3813-9225-4621-8567-71533015086e.png)


#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added - couldn't find any to update
- NA Tests updated
