### PR TITLE
Remote write dashboard: add mean latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - [ENHANCEMENT] Updated OTel to v0.40.0 (@mapno)
 
+- [ENHANCEMENT] Remote write dashboard: add mean latency (@bboreham)
+
 - [BUGFIX] Fix usage of POSTGRES_EXPORTER_DATA_SOURCE_NAME when using postgres_exporter integration (@f11r)
 
 - [CHANGE] Remove log-level flag from systemd unit file (@jpkrohling)

--- a/example/docker-compose/grafana/dashboards/agent-remote-write.json
+++ b/example/docker-compose/grafana/dashboards/agent-remote-write.json
@@ -135,17 +135,24 @@
                "steppedLine": false,
                "targets": [
                   {
+                     "expr": "rate(prometheus_remote_storage_sent_batch_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[1m]) / rate(prometheus_remote_storage_sent_batch_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[1m])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "mean {{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}",
+                     "refId": "A"
+                  },
+                  {
                      "expr": "histogram_quantile(0.99, rate(prometheus_remote_storage_sent_batch_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[1m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}",
-                     "refId": "A"
+                     "legendFormat": "p99 {{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}",
+                     "refId": "B"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "P99 Latency [1m]",
+               "title": "Latency [1m]",
                "tooltip": {
                   "shared": true,
                   "sort": 0,

--- a/production/grafana-agent-mixin/dashboards.libsonnet
+++ b/production/grafana-agent-mixin/dashboards.libsonnet
@@ -103,13 +103,17 @@ local template = grafana.template;
 
       local remoteSendLatency =
         graphPanel.new(
-          'P99 Latency [1m]',
+          'Latency [1m]',
           datasource='$datasource',
           span=6,
         )
         .addTarget(prometheus.target(
+          'rate(prometheus_remote_storage_sent_batch_duration_seconds_sum{cluster=~"$cluster", namespace=~"$namespace", container=~"$container"}[1m]) / rate(prometheus_remote_storage_sent_batch_duration_seconds_count{cluster=~"$cluster", namespace=~"$namespace", container=~"$container"}[1m])',
+          legendFormat='mean {{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}',
+        ))
+        .addTarget(prometheus.target(
           'histogram_quantile(0.99, rate(prometheus_remote_storage_sent_batch_duration_seconds_bucket{cluster=~"$cluster", namespace=~"$namespace", container=~"$container"}[1m]))',
-          legendFormat='{{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}',
+          legendFormat='p99 {{cluster}}:{{pod}}-{{instance_group_name}}-{{url}}',
         ));
 
       local samplesRate =


### PR DESCRIPTION
While p99 latency is an indicator of problems, overall throughput is more dependent on mean latency so add it to the panel.

Before:
![image](https://user-images.githubusercontent.com/8125524/146944619-4d593da7-3795-4035-859e-0cfd45ffb670.png)

After:
![image](https://user-images.githubusercontent.com/8125524/146944454-2c8761f4-1257-4753-a4c7-12ccefdb213b.png)

Or, selecting just one mean:
![image](https://user-images.githubusercontent.com/8125524/146944553-ad02d204-7d9f-407f-b68a-958de990cb3f.png)

#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added - couldn't find any to update
- NA Tests updated
