### PR TITLE
Windows Service accept commands immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 - [BUGFIX] Fix usage of POSTGRES_EXPORTER_DATA_SOURCE_NAME when using postgres_exporter integration (@f11r)
 
+- [BUGFIX] Change ordering of the entrypoint for windows service so that it accepts commands immediately (@mattdurham)
+
 - [CHANGE] Remove log-level flag from systemd unit file (@jpkrohling)
 
 # v0.21.2 (2021-12-08)


### PR DESCRIPTION
#### PR Description 

This PR starts the command loop for handling windows service messages immediately instead of waiting for the agent to fully load. It still ensures that the config is loaded correctly. There are some possible race conditions but those are if the service is told to shutdown so impact is low. ie if you start the service then immediately send the stop signal, the entrypoint stop command may not be called.

#### Which issue(s) this PR fixes 

Closes #1128 

#### PR Checklist

- [x] CHANGELOG updated 
- [na] Documentation added
- [na] Tests updated
