### PR TITLE
Jsonnet: set HOSTNAME to ensure the log subsystem works

### DIFF
--- a/production/tanka/grafana-agent/v2/internal/base.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/base.libsonnet
@@ -4,6 +4,7 @@ function(name='grafana-agent', namespace='') {
   local container = k.core.v1.container,
   local configMap = k.core.v1.configMap,
   local containerPort = k.core.v1.containerPort,
+  local envVar = k.core.v1.envVar,
   local policyRule = k.rbac.v1.policyRule,
   local serviceAccount = k.core.v1.serviceAccount,
 
@@ -44,5 +45,9 @@ function(name='grafana-agent', namespace='') {
     container.withCommand('/bin/agent') +
     container.withArgsMixin(k.util.mapToFlags({
       'config.file': '/etc/agent/agent.yaml',
-    })),
+    })) +
+    // `HOSTNAME` is required for promtail otherwise it will silently do nothing
+    container.withEnvMixin([
+      envVar.fromFieldPath('HOSTNAME', 'spec.nodeName'),
+    ]),
 }


### PR DESCRIPTION
Promtail requires the HOSTNAME env var to be set otherwise it will
silently do nothing resulting in logs not being scraped with no indication
anything is wrong.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
