### PR TITLE
Fix kubernetes directory link

### DIFF
--- a/docs/getting-started/_index.md
+++ b/docs/getting-started/_index.md
@@ -49,7 +49,7 @@ container through a bind mount for the flags to work properly.
 
 ## Kubernetes manifests
 
-If you wish to manually modify the Kubernetes manifests before deploying them, you can do so by downloading them from the [`kubernetes` directory](../../production/kubernetes/). Note that these manifests do not include Agent configuration files. For sample configuration, please see the Grafana Cloud Kubernetes quickstarts.
+If you wish to manually modify the Kubernetes manifests before deploying them, you can do so by downloading them from the [`kubernetes` directory](https://github.com/grafana/agent/tree/main/production/kubernetes). Note that these manifests do not include Agent configuration files. For sample configuration, please see the Grafana Cloud Kubernetes quickstarts.
 
 ## Grafana Cloud kubernetes quickstart guides
 


### PR DESCRIPTION
#### PR Description 
Replace relative path with full URL to the `production/kubernetes`.
The curent link is returning a 404 [here](https://grafana.com/docs/agent/latest/getting-started/#kubernetes-manifests)

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
