### PR TITLE
Fix cadvisor metrics configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 - [CHANGE] Remove log-level flag from systemd unit file (@jpkrohling)
 
+- [BUGFIX] Fix cAdvisor so it collects all defined metrics instead of the last (@pkoenig10)
+
 # v0.21.2 (2021-12-08)
 
 - [SECURITY] This release contains a fix for

--- a/docs/configuration/integrations/cadvisor-config.md
+++ b/docs/configuration/integrations/cadvisor-config.md
@@ -75,14 +75,14 @@ Full reference of options:
   # resctrl mon groups updating interval. Zero value disables updating mon groups.
   [resctrl_interval: <int> | default = 0]
 
-  # List of `metrics` to be disabled.
+  # List of `metrics` to be disabled. If set, overrides the default disabled metrics.
   disabled_metrics:
     [ - <string> ]
 
   # List of `metrics` to be enabled. If set, overrides disabled_metrics
   enabled_metrics:
     [ - <string> ]
-  
+
   # Length of time to keep data stored in memory
   [storage_duration: <duration> | default = "2m"]
 


### PR DESCRIPTION
#### PR Description 

The `cadvisor` metrics configuration has a couple bugs:
- When configuring `disabled_metrics` or `enabled_metrics`, only the last metric value will be applied.

    The [`MetricSet.Set`](https://github.com/google/cadvisor/blob/e0fab6233991e198fe53c25ee031e3d5a42c3f05/container/factory.go#L123-L136) method takes a comma-separated list of metrics and overwrites the metric set. It does not add the given metric to the set.

- Explicitly configuring `disabled_metrics` to be an empty list does not enable all metrics. Instead, the default disable metrics are still disabled.

    The current implementation does not differentiate between an absent configuration and an explicit empty configuration.

#### PR Checklist

- [ ] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
