### PR TITLE
Jsonnet: add withService() helper for all v2 controllers

### DIFF
--- a/example/k3d/smoke/main.jsonnet
+++ b/example/k3d/smoke/main.jsonnet
@@ -108,6 +108,7 @@ local smoke = {
       ],
     ) +
     gragent.withVolumeMountsMixin([volumeMount.new('agent-wal', '/var/lib/agent')]) +
+    gragent.withService({}) +
     gragent.withAgentConfig({
       server: { log_level: 'debug' },
 
@@ -137,6 +138,7 @@ local smoke = {
       ],
     ) +
     gragent.withVolumeMountsMixin([volumeMount.new('agent-cluster-wal', '/var/lib/agent')]) +
+    gragent.withService({}) +
     gragent.withAgentConfig({
       server: { log_level: 'debug' },
 

--- a/production/tanka/grafana-agent/v2/README.md
+++ b/production/tanka/grafana-agent/v2/README.md
@@ -76,5 +76,7 @@ scraping service config management API.
   logs.
 - `withLogPermissions()`: Runs the container as privileged and as the root user
   so logs can be collected properly.
+- `withService(config)`: Add a service for the deployment, statefulset, or daemonset.
+  Note that this must be called after any ports are added via `withPortsMixin`.
 
 

--- a/production/tanka/grafana-agent/v2/internal/controllers/statefulset.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/controllers/statefulset.libsonnet
@@ -5,9 +5,7 @@ function(replicas=1, volumeClaims=[]) {
   local namespace = _config.namespace,
 
   local k = (import 'ksonnet-util/kausal.libsonnet') { _config+:: this._config },
-
   local statefulSet = k.apps.v1.statefulSet,
-  local service = k.core.v1.service,
 
   controller:
     statefulSet.new(name, replicas, [this.container], volumeClaims) +
@@ -22,8 +20,4 @@ function(replicas=1, volumeClaims=[]) {
       else {}
     ) +
     k.util.configVolumeMount(name, '/etc/agent'),
-
-  service:
-    k.util.serviceFor(this.controller) +
-    service.mixin.metadata.withNamespace(namespace),
 }

--- a/production/tanka/grafana-agent/v2/internal/helpers/service.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/helpers/service.libsonnet
@@ -1,0 +1,13 @@
+local k = import 'ksonnet-util/kausal.libsonnet';
+local svc = k.core.v1.service;
+
+{
+  service(config={}):: {
+    local this = self,
+    local _config = this._config,
+
+    controller_service:
+      k.util.serviceFor(this.controller) +
+      svc.mixin.metadata.withNamespace(_config.namespace),
+  },
+}

--- a/production/tanka/grafana-agent/v2/main.libsonnet
+++ b/production/tanka/grafana-agent/v2/main.libsonnet
@@ -38,4 +38,6 @@ local container = k.core.v1.container;
     (import './internal/helpers/logs.libsonnet').volumeMounts(config),
   withLogPermissions(config)::
     (import './internal/helpers/logs.libsonnet').permissions(config),
+  withService(config)::
+    (import './internal/helpers/service.libsonnet').service(config),
 }


### PR DESCRIPTION
Add a helper method that allows people to create associated services
for deployment, statefulset, or daemonset Agents. This is particularly
useful for Agents that need to accept traces since they are pushed
to the agent and clients need a consistent URL.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
