### PR TITLE
Fix error with not quoting the install path for agent on windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 - [BUGFIX] Only stop WAL cleaner when it has been started (@56quarters)
 
+- [BUGFIX] Fix issue with unquoted install path on Windows, that could allow escalation or running an arbitrary executable (@mattdurham)  
+
 - [CHANGE] Remove log-level flag from systemd unit file (@jpkrohling)
 
 # v0.21.2 (2021-12-08)

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -126,10 +126,10 @@ Function Install
    
     # Create our batch file, since services cant run with parameters, nsexec is used to suppress console output, instead goes
     # to NSIS log window
-    nsExec::ExecToLog 'sc create "Grafana Agent" binpath= "$INSTDIR\agent-windows-amd64.exe"'
+    nsExec::ExecToLog 'sc create "Grafana Agent" binpath= "\"$INSTDIR\agent-windows-amd64.exe\""'
     Pop $0
     # These separate create and config commands are needed, on the config the binpath is required
-    nsExec::ExecToLog 'sc config "Grafana Agent" start= auto binpath= "$INSTDIR\agent-windows-amd64.exe -config.file=\"$INSTDIR\agent-config.yaml\""'
+    nsExec::ExecToLog 'sc config "Grafana Agent" start= auto binpath= "\"$INSTDIR\agent-windows-amd64.exe\" -config.file=\"$INSTDIR\agent-config.yaml\""'
     Pop $0
     nsExec::ExecToLog `sc start "Grafana Agent"`
     Pop $0


### PR DESCRIPTION
#### PR Description 

This is a change to the installer to quote the executable paths so that they are not vulnerable to the unquoted path.

#### Which issue(s) this PR fixes 

Closes #1213

#### Notes to the Reviewer

#### PR Checklist

- [X] CHANGELOG updated 
- [NA] Documentation added
- [NA] Tests updated
