### PR TITLE
Fix panic when using 'stdout' in automatic logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ for detailed information.
 
 - [BUGFIX] Fix cAdvisor so it collects all defined metrics instead of the last (@pkoenig10)
 
+- [BUGFIX] Fix panic when using 'stdout' in automatic logging (@mapno)
+
 - [DEPRECATION] The node_exporter integration's `netdev_device_whitelist` field
   is deprecated in favor of `netdev_device_include`. Support for the old field
   name will be removed in a future version. (@rfratto)

--- a/pkg/traces/automaticloggingprocessor/automaticloggingprocessor.go
+++ b/pkg/traces/automaticloggingprocessor/automaticloggingprocessor.go
@@ -183,8 +183,8 @@ func (p *automaticLoggingProcessor) Capabilities() consumer.Capabilities {
 
 // Start is invoked during service startup.
 func (p *automaticLoggingProcessor) Start(ctx context.Context, _ component.Host) error {
-	logs := ctx.Value(contextkeys.Logs).(*logs.Logs)
-	if logs == nil {
+	logs, ok := ctx.Value(contextkeys.Logs).(*logs.Logs)
+	if !ok {
 		return fmt.Errorf("key does not contain a logs instance")
 	}
 


### PR DESCRIPTION
#### PR Description

Fix panic when using 'stdout' in automatic logging

#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
