### PR TITLE
integrations-next: fix bug where v2 integrations were not being strictly unmarshaled

### DIFF
--- a/pkg/config/integrations_test.go
+++ b/pkg/config/integrations_test.go
@@ -34,7 +34,7 @@ metrics:
 integrations:
   agent:
     autoscrape:
-      enabled: false`
+      enable: false`
 
 	fs := flag.NewFlagSet("test", flag.ExitOnError)
 	c, err := load(fs, []string{"-config.file", "test", "-enable-features=integrations-next"}, func(_ string, _ bool, c *Config) error {

--- a/pkg/integrations/v2/register.go
+++ b/pkg/integrations/v2/register.go
@@ -345,7 +345,7 @@ func deferredConfigUnmarshal(raw util.RawYAML, ref interface{}) (Config, error) 
 	switch ref := ref.(type) {
 	case Config:
 		out := cloneValue(ref).(Config)
-		err := yaml.Unmarshal(raw, out)
+		err := yaml.UnmarshalStrict(raw, out)
 		return out, err
 	case v1.Config:
 		mut, ok := upgraders[ref.Name()]

--- a/pkg/integrations/v2/subsystem_test.go
+++ b/pkg/integrations/v2/subsystem_test.go
@@ -1,0 +1,65 @@
+package integrations
+
+import (
+	"testing"
+
+	v1 "github.com/grafana/agent/pkg/integrations"
+	"github.com/grafana/agent/pkg/integrations/v2/common"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestSubsystemOptions_Unmarshal(t *testing.T) {
+	setRegistered(t, map[Config]Type{
+		&testIntegrationA{}: TypeSingleton,
+	})
+
+	RegisterLegacy(&legacyConfig{}, TypeSingleton, func(in v1.Config, mc common.MetricsConfig) UpgradedConfig {
+		return &legacyShim{Data: in, Common: mc}
+	})
+
+	tt := []struct {
+		name        string
+		in          string
+		expectError string
+	}{
+		{
+			name: "invalid integration",
+			in: `
+        invalidintegration: 
+          autoscrape:
+            enabled: true
+      `,
+			expectError: "line 2: field invalidintegration not found in type integrations.SubsystemOptions",
+		},
+		{
+			name: "invalid field",
+			in: `
+        test:
+          invalidfield: true
+      `,
+			expectError: "line 1: field invalidfield not found in type integrations.plain",
+		},
+		{
+			name: "invalid v1 field",
+			in: `
+        legacy:
+          invalidfield: true
+      `,
+			expectError: "line 1: field invalidfield not found",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+
+			var so SubsystemOptions
+			err := yaml.UnmarshalStrict([]byte(tc.in), &so)
+
+			var te *yaml.TypeError
+			require.ErrorAs(t, err, &te)
+			require.Len(t, te.Errors, 1)
+			require.Equal(t, tc.expectError, te.Errors[0])
+		})
+	}
+}


### PR DESCRIPTION
(No changelog entry because integrations-next isn't released yet)
(This was only a problem for v2 integrations, the v1 shims were fine)