### PR TITLE
pkg/util: support custom yaml.Unmarshaler implementations for util.UnmarshalYAMLMerged

### DIFF
--- a/pkg/util/yaml.go
+++ b/pkg/util/yaml.go
@@ -70,6 +70,17 @@ func UnmarshalYAMLMerged(bb []byte, vv ...interface{}) error {
 		} else if err != nil {
 			return err
 		}
+
+		// It's common for custom yaml.Unmarshaler implementations to use
+		// UnmarshalYAML to apply default values both before and after calling the
+		// unmarshal method passed to them.
+		//
+		// We *must* do a second non-strict unmarshal *after* the strict unmarshal
+		// to ensure that every v was able to complete its unmarshal to completion,
+		// ignoring type errors from unrecognized fields.
+		if err := yaml.Unmarshal(bb, v); err != nil {
+			return err
+		}
 	}
 
 	var (

--- a/pkg/util/yaml_test.go
+++ b/pkg/util/yaml_test.go
@@ -1,0 +1,47 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestUnmarshalYAMLMerged_CustomUnmarshal checks to see that
+// UnmarshalYAMLMerged works with merging types that have custom unmarshal
+// methods which do extra checks after calling unmarshal.
+func TestUnmarshalYAMLMerged_CustomUnmarshal(t *testing.T) {
+	in := `
+  fieldA: foo
+  fieldB: bar
+  `
+
+	var (
+		val1 typeOne
+		val2 typeTwo
+	)
+
+	err := UnmarshalYAMLMerged([]byte(in), &val1, &val2)
+	require.NoError(t, err)
+
+	require.Equal(t, "foo", val1.FieldA)
+	require.Equal(t, "bar", val2.FieldB)
+	require.True(t, val2.Unmarshaled)
+}
+
+type typeOne struct {
+	FieldA string `yaml:"fieldA"`
+}
+
+type typeTwo struct {
+	FieldB      string `yaml:"fieldB"`
+	Unmarshaled bool   `yaml:"-"`
+}
+
+func (t *typeTwo) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type rawType typeTwo
+	if err := unmarshal((*rawType)(t)); err != nil {
+		return err
+	}
+	t.Unmarshaled = true
+	return nil
+}


### PR DESCRIPTION
#### PR Description 
It's common for config types to have implement yaml.Unmarshaler for:

* Applying defaults
* Applying extra logic post-unmarshal

If these config types were unmarshaled through util.UnmarshalYAMLMerged, the yaml.Unmarshaler implementation would never complete successfully, preventing the post-unmarshal logic from running.

This issue was introduced in #1192, but went unnoticed until #1228 implemented yaml.Unmarshaler to perform field migrations. #1240 reported the issue.

This commit fixes the bug by performing a second non-strict unmarshal to ensure that all input values unmarshal successfully, with the exception of unmarshal errors unrelated to unrecognized field names.

#### Which issue(s) this PR fixes 
Fixes #1240

#### Notes to the Reviewer
This is hacky, but it's worthwhile noting that util.UnmarshalYAMLMerged is a temporary workaround needed for the integrations-next migration, and will eventually be removed.

#### PR Checklist

- [x] CHANGELOG updated (N/A) 
- [x] Documentation added (N/A)
- [x] Tests updated
