### PR TITLE
Update k3d example grafana/grafonnet-lib version

### DIFF
--- a/example/k3d/jsonnetfile.lock.json
+++ b/example/k3d/jsonnetfile.lock.json
@@ -18,8 +18,8 @@
           "subdir": "grafonnet"
         }
       },
-      "version": "7ab8a79738de007c407b939b35e54e84c213d542",
-      "sum": "q2B0w9iyqTD99PJacSpHg9XshQN7kiupxaORQcAlb2E="
+      "version": "0d4f64154ee2024820396aa66841a64d851302b0",
+      "sum": "1DvaFCCiwjI9624YYhLPdwiEPDvLsrCOES0aBxr7wrM="
     },
     {
       "source": {


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

#### PR Description 
This PR bumps the `grafana/grafonnet-lib` to the commit which introduced the `graph_panel.interval` attribute so that the k3d environment can be applied using tanka.

#### Which issue(s) this PR fixes 
This PR fixes #1245 

#### Notes to the Reviewer
I'm not sure to which version we should bump the dependency to; either to just the one that introduces the 'interval' attribute to the latest, or if you have some other idea; I'd be happy to hear about it.

#### PR Checklist
I'm not sure if any of the following are required
- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
