### PR TITLE
Operator: fix bug where /-/ready and /-/healthy always returned 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ for detailed information.
 
 - [BUGFIX] Fix panic when using 'stdout' in automatic logging (@mapno)
 
+- [BUGFIX] Grafana Agent Operator: The /-/ready and /-/healthy endpoints will
+  no longer always return 404 (@rfratto).
+
 - [DEPRECATION] The node_exporter integration's `netdev_device_whitelist` field
   is deprecated in favor of `netdev_device_include`. Support for the old field
   name will be removed in a future version. (@rfratto)

--- a/cmd/agent-operator/main.go
+++ b/cmd/agent-operator/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 
 	cortex_log "github.com/cortexproject/cortex/pkg/util/log"
@@ -32,6 +33,9 @@ func main() {
 		level.Error(logger).Log("msg", "unable to create manager", "err", err)
 		os.Exit(1)
 	}
+
+	m.AddReadyzCheck("running", func(req *http.Request) error { return nil })
+	m.AddHealthzCheck("running", func(req *http.Request) error { return nil })
 
 	if err := operator.New(logger, cfg, m); err != nil {
 		level.Error(logger).Log("msg", "unable to create operator", "err", err)


### PR DESCRIPTION
#### PR Description 
controller-runtime must have at least one ready/healthy check for the endpoints to exist

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [ ] Tests updated
