### PR TITLE
Use new `metrics:` key in example config

### DIFF
--- a/production/tanka/grafana-agent/config.libsonnet
+++ b/production/tanka/grafana-agent/config.libsonnet
@@ -58,7 +58,7 @@ local k8s_v2 = import './v2/internal/helpers/k8s.libsonnet';
         log_level: 'info',
       },
 
-      prometheus: {
+      metrics: {
         global: {
           scrape_interval: '1m',
         },

--- a/production/tanka/grafana-agent/scraping-svc/main.libsonnet
+++ b/production/tanka/grafana-agent/scraping-svc/main.libsonnet
@@ -33,7 +33,7 @@ local policyRule = k.rbac.v1.policyRule;
       agent_ring_kvstore: error 'must configure ring kvstore',
 
       agent_config+: {
-        prometheus+: {
+        metrics+: {
           // No configs are used in the scraping service mode.
           configs:: [],
 


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

#### PR Description 
Since we can't have both `prometheus:` and `metrics:` keys in our config, use the first one until it's time for its proper deprecation.

#### Which issue(s) this PR fixes 
This PR fixes #1255 

#### Notes to the Reviewer
We could also go the other way around, and change the `prometheus:` key in scraping-svc to `metrics:`.

However I'm not sure if there's anything else depending on scraping-svc; in any case the changes could be made to both places in a later deprecation/cleanup PR.

What do you think?

#### PR Checklist
- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
