### PR TITLE
prepare for v0.22.0 release

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -54,48 +54,6 @@ steps:
 depends_on:
   - Lint
 
----
-kind: pipeline
-type: docker
-name: E2E
-platform:
-  os: linux
-  arch: amd64
-trigger:
-  event:
-    - push
-    - pull_request
-    - tag
-  ref:
-    - refs/heads/main
-    - refs/pull/*/head
-    - refs/tags/**
-steps:
-  - name: lint
-    image: golangci/golangci-lint:v1.43.0
-    commands:
-      - make DRONE=true e2e/lint
-  - name: test
-    image: docker
-    volumes:
-      - name: docker
-        path: /var/run/docker.sock
-    commands:
-      - apk update && apk add make gcc libc-dev bash wget git
-      - mkdir -p /usr/local/go/bin
-      - wget -q https://golang.org/dl/go1.17.5.linux-amd64.tar.gz
-      - tar -C /usr/local -xzf go1.17.5.linux-amd64.tar.gz
-      - rm go1.17.5.linux-amd64.tar.gz
-      - export PATH=$PATH:/usr/local/go/bin
-      - make E2E_K8S_USE_DOCKER_NETWORK=1 DRONE=true e2e/test
-
-depends_on:
-  - Test
-
-volumes:
-  - name: docker
-    host:
-      path: /var/run/docker.sock
 
 ---
 kind: pipeline
@@ -122,7 +80,6 @@ steps:
       - make DRONE=true BUILD_IN_CONTAINER=false dist
 depends_on:
   - Test
-  - E2E
 ---
 kind: pipeline
 type: docker
@@ -285,6 +242,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: 8ad4ba391594eb265cb8737d77509da2633e5a19f889b126f01fa78f51358715
+hmac: 11038ae4592a13955388dff643b35bb1f07e53a659cdca946e863c9f2ac77066
 
 ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Main (unreleased)
 
+# v0.22.0 (2022-01-13)
+
 This release has deprecations. Please read [DEPRECATION] entries and consult
 the [upgrade guide](https://github.com/grafana/agent/blob/main/docs/upgrade-guide/_index.md)
 for detailed information.

--- a/docs/configuration/integrations/node-exporter-config.md
+++ b/docs/configuration/integrations/node-exporter-config.md
@@ -26,7 +26,7 @@ docker run \
   -v "/proc:/host/proc:ro,rslave" \
   -v /tmp/agent:/etc/agent \
   -v /path/to/config.yaml:/etc/agent-config/agent.yaml \
-  grafana/agent:v0.21.2 \
+  grafana/agent:v0.22.0 \
   --config.file=/etc/agent-config/agent.yaml
 ```
 
@@ -66,7 +66,7 @@ metadata:
   name: agent
 spec:
   containers:
-  - image: grafana/agent:v0.21.2
+  - image: grafana/agent:v0.22.0
     name: agent
     args:
     - --config.file=/etc/agent-config/agent.yaml

--- a/docs/configuration/integrations/process-exporter-config.md
+++ b/docs/configuration/integrations/process-exporter-config.md
@@ -18,7 +18,7 @@ docker run \
   -v "/proc:/proc:ro" \
   -v /tmp/agent:/etc/agent \
   -v /path/to/config.yaml:/etc/agent-config/agent.yaml \
-  grafana/agent:v0.21.2 \
+  grafana/agent:v0.22.0 \
   --config.file=/etc/agent-config/agent.yaml
 ```
 
@@ -35,7 +35,7 @@ metadata:
   name: agent
 spec:
   containers:
-  - image: grafana/agent:v0.21.2
+  - image: grafana/agent:v0.22.0
     name: agent
     args:
     - --config.file=/etc/agent-config/agent.yaml

--- a/docs/getting-started/_index.md
+++ b/docs/getting-started/_index.md
@@ -26,7 +26,7 @@ See the list of [Community Projects](#community-projects) for the community-driv
 docker run \
   -v /tmp/agent:/etc/agent/data \
   -v /path/to/config.yaml:/etc/agent/agent.yaml \
-  grafana/agent:v0.21.2
+  grafana/agent:v0.22.0
 ```
 
 Replace `/tmp/agent` with the folder you wish to store WAL data in. WAL data is

--- a/docs/operator/custom-resource-quickstart.md
+++ b/docs/operator/custom-resource-quickstart.md
@@ -43,7 +43,7 @@ metadata:
   labels:
     app: grafana-agent
 spec:
-  image: grafana/agent:v0.21.2
+  image: grafana/agent:v0.22.0
   logLevel: info
   serviceAccountName: grafana-agent
   metrics:

--- a/docs/operator/getting-started.md
+++ b/docs/operator/getting-started.md
@@ -72,7 +72,7 @@ spec:
       serviceAccountName: grafana-agent-operator
       containers:
       - name: operator
-        image: grafana/agent-operator:v0.21.2
+        image: grafana/agent-operator:v0.22.0
         args:
         - --kubelet-service=default/kubelet
 ---

--- a/docs/upgrade-guide/_index.md
+++ b/docs/upgrade-guide/_index.md
@@ -12,6 +12,8 @@ releases and how to migrate to newer versions.
 
 These changes will come in a future version.
 
+## v0.22.0
+
 ### `node_exporter` integration deprecated field names
 
 The following field names for the `node_exporter` integration are now deprecated:

--- a/pkg/operator/defaults.go
+++ b/pkg/operator/defaults.go
@@ -19,6 +19,7 @@ var (
 		"v0.21.0",
 		"v0.21.1",
 		"v0.21.2",
+		"v0.22.0",
 
 		// NOTE(rfratto): when performing an upgrade, add the newest version above instead of changing the existing reference.
 	}

--- a/production/README.md
+++ b/production/README.md
@@ -27,7 +27,7 @@ directory on your host that you want the agent to store its WAL.
 docker run \
   -v /tmp/agent:/etc/agent/data \
   -v /path/to/config.yaml:/etc/agent/agent.yaml \
-  grafana/agent:v0.21.2
+  grafana/agent:v0.22.0
 ```
 
 ## Running the Agent locally

--- a/production/grafanacloud-install.sh
+++ b/production/grafanacloud-install.sh
@@ -50,7 +50,7 @@ PACKAGE_SYSTEM=${PACKAGE_SYSTEM:=}
 #
 # Global constants.
 #
-RELEASE_VERSION="0.21.2"
+RELEASE_VERSION="0.22.0"
 
 RELEASE_URL="https://github.com/grafana/agent/releases/download/v${RELEASE_VERSION}"
 DEB_URL="${RELEASE_URL}/grafana-agent-${RELEASE_VERSION}-1.${ARCH}.deb"

--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -66,7 +66,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.21.2
+        image: grafana/agent:v0.22.0
         imagePullPolicy: IfNotPresent
         name: agent
         ports:

--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -64,7 +64,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.21.2
+        image: grafana/agent:v0.22.0
         imagePullPolicy: IfNotPresent
         name: agent
         ports:

--- a/production/kubernetes/agent-traces.yaml
+++ b/production/kubernetes/agent-traces.yaml
@@ -109,7 +109,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.21.2
+        image: grafana/agent:v0.22.0
         imagePullPolicy: IfNotPresent
         name: agent
         ports:

--- a/production/kubernetes/build/lib/version.libsonnet
+++ b/production/kubernetes/build/lib/version.libsonnet
@@ -1,1 +1,1 @@
-'grafana/agent:v0.21.2'
+'grafana/agent:v0.22.0'

--- a/production/kubernetes/install-bare.sh
+++ b/production/kubernetes/install-bare.sh
@@ -25,7 +25,7 @@ check_installed() {
 check_installed curl
 check_installed envsubst
 
-MANIFEST_BRANCH=v0.21.2
+MANIFEST_BRANCH=v0.22.0
 MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent-bare.yaml}
 NAMESPACE=${NAMESPACE:-default}
 

--- a/production/tanka/grafana-agent/v1/main.libsonnet
+++ b/production/tanka/grafana-agent/v1/main.libsonnet
@@ -15,8 +15,8 @@ local service = k.core.v1.service;
 (import './lib/traces.libsonnet') +
 {
   _images:: {
-    agent: 'grafana/agent:v0.21.2',
-    agentctl: 'grafana/agentctl:v0.21.2',
+    agent: 'grafana/agent:v0.22.0',
+    agentctl: 'grafana/agentctl:v0.22.0',
   },
 
   // new creates a new DaemonSet deployment of the grafana-agent. By default,

--- a/production/tanka/grafana-agent/v2/internal/base.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/base.libsonnet
@@ -10,8 +10,8 @@ function(name='grafana-agent', namespace='') {
   local this = self,
 
   _images:: {
-    agent: 'grafana/agent:v0.21.2',
-    agentctl: 'grafana/agentctl:v0.21.2',
+    agent: 'grafana/agent:v0.22.0',
+    agentctl: 'grafana/agentctl:v0.22.0',
   },
   _config:: {
     name: name,

--- a/production/tanka/grafana-agent/v2/internal/syncer.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/syncer.libsonnet
@@ -14,7 +14,7 @@ function(
 ) {
   local _config = {
     api: error 'api must be set',
-    image: 'grafana/agentctl:v0.21.2',
+    image: 'grafana/agentctl:v0.22.0',
     schedule: '*/5 * * * *',
     configs: [],
   } + config,


### PR DESCRIPTION
Prepare for v0.22.0 release by following the [release procedure](https://github.com/grafana/agent/blob/main/cmd/agent/DEVELOPERS.md#releasing)