### PR TITLE
Set custom User-Agent header when scraping metrics

### DIFF
--- a/pkg/metrics/instance/instance.go
+++ b/pkg/metrics/instance/instance.go
@@ -35,6 +35,7 @@ import (
 
 func init() {
 	remote.UserAgent = fmt.Sprintf("GrafanaAgent/%s", build.Version)
+	scrape.UserAgent = fmt.Sprintf("GrafanaAgent/%s", build.Version)
 }
 
 var (


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

#### PR Description 
After Robert's PR in (prometheus/prometheus#9333) we can now set `scrape.UserAgent` when the `instance` package is imported. I believe this may be the only required change, but let me know if I've missed anything.

#### Which issue(s) this PR fixes 
This PR closes #910. I think at least, I'm still looking into how scraping mode works and  whether we have more work to do.

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
