### PR TITLE
Fix panic in prom_sd_processor when address is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ for detailed information.
 - [BUGFIX] Grafana Agent Operator: The /-/ready and /-/healthy endpoints will
   no longer always return 404 (@rfratto).
 
+- [BUGFIX] Fix panic in prom_sd_processor when address is empty (@mapno)
+
 - [DEPRECATION] The node_exporter integration's `netdev_device_whitelist` field
   is deprecated in favor of `netdev_device_include`. Support for the old field
   name will be removed in a future version. (@rfratto)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,6 @@ for detailed information.
 - [BUGFIX] Grafana Agent Operator: The /-/ready and /-/healthy endpoints will
   no longer always return 404 (@rfratto).
 
-- [BUGFIX] Fix panic in prom_sd_processor when address is empty (@mapno)
-
 - [DEPRECATION] The node_exporter integration's `netdev_device_whitelist` field
   is deprecated in favor of `netdev_device_include`. Support for the old field
   name will be removed in a future version. (@rfratto)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   WAL loading while old WALs are being deleted or the `/agent/api/v1/targets`
   endpoint is called. (@tpaschalis)
 
+- [BUGFIX] Fix panic in prom_sd_processor when address is empty (@mapno)
+
 # v0.22.0 (2022-01-13)
 
 This release has deprecations. Please read [DEPRECATION] entries and consult

--- a/docs/configuration/traces-config.md
+++ b/docs/configuration/traces-config.md
@@ -168,7 +168,7 @@ scrape_configs:
 #
 # By default, all methods are enabled, and evaluated in the order specified above.
 # Order of evaluation is honored when multiple methods are enabled.
-prom_sd_pod_association: 
+prom_sd_pod_associations:
   - [ <string>... ]
 
 # spanmetrics supports aggregating Request, Error and Duration (R.E.D) metrics

--- a/pkg/traces/promsdprocessor/prom_sd_processor.go
+++ b/pkg/traces/promsdprocessor/prom_sd_processor.go
@@ -119,7 +119,12 @@ func stringAttributeFromMap(attrs pdata.AttributeMap, key string) string {
 }
 
 func getConnectionIP(ctx context.Context) string {
-	return client.FromContext(ctx).Addr.String()
+	c := client.FromContext(ctx)
+	if c.Addr == nil {
+		return ""
+	}
+
+	return c.Addr.String()
 }
 
 func (p *promServiceDiscoProcessor) getPodIP(ctx context.Context, attrs pdata.AttributeMap) string {

--- a/pkg/traces/promsdprocessor/prom_sd_processor_test.go
+++ b/pkg/traces/promsdprocessor/prom_sd_processor_test.go
@@ -249,6 +249,16 @@ func TestPodAssociation(t *testing.T) {
 			expectedIP: ipStr,
 		},
 		{
+			name: "connection IP is empty",
+			podAssociations: []string{podAssociationConnectionIP},
+			ctxFn: func(t *testing.T) context.Context {
+				c := client.FromContext(context.Background())
+				return client.NewContext(context.Background(), c)
+			},
+			attrMapFn:  func(*testing.T) pdata.AttributeMap { return pdata.NewAttributeMap() },
+			expectedIP: "",
+		},
+		{
 			name:  "ip attribute",
 			ctxFn: func(t *testing.T) context.Context { return context.Background() },
 			attrMapFn: func(*testing.T) pdata.AttributeMap {

--- a/pkg/traces/promsdprocessor/prom_sd_processor_test.go
+++ b/pkg/traces/promsdprocessor/prom_sd_processor_test.go
@@ -249,7 +249,7 @@ func TestPodAssociation(t *testing.T) {
 			expectedIP: ipStr,
 		},
 		{
-			name: "connection IP is empty",
+			name:            "connection IP is empty",
 			podAssociations: []string{podAssociationConnectionIP},
 			ctxFn: func(t *testing.T) context.Context {
 				c := client.FromContext(context.Background())


### PR DESCRIPTION
#### PR Description

Fix panic in prom_sd_processor when address is empty and configs docs

#### Which issue(s) this PR fixes 

Fixes https://github.com/grafana/agent/issues/1276 and https://github.com/grafana/agent/issues/1277

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
