### PR TITLE
Use custom Go version in agent-operator Dockerfile

### DIFF
--- a/cmd/agent-operator/Dockerfile.buildx
+++ b/cmd/agent-operator/Dockerfile.buildx
@@ -2,6 +2,16 @@ FROM --platform=$BUILDPLATFORM rfratto/seego:latest as build
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
+# Use custom Go version instead of one prepacked in seego
+ENV GOLANG_VERSION 1.17.6
+ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
+ENV GOLANG_DOWNLOAD_SHA256 231654bbf2dab3d86c1619ce799e77b03d96f9b50770297c8f4dff8836fc8ca2
+RUN  rm -rf /usr/local/go                                           \
+  && curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz             \
+  && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
+  && tar -C /usr/local -xzf golang.tar.gz                           \
+  && rm golang.tar.gz
+
 COPY . /src/agent
 WORKDIR /src/agent
 ARG RELEASE_BUILD=true


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

#### PR Description 
This PR attempts to fix the "Build Containers" stage of our pipeline that was broken by #1278.

In other images, we download and use a custom Go version, but in the agent-operator build we were still using the one pre-packed with seego; ergo why everything passed locally and failed remotely on Drone.

#### Which issue(s) this PR fixes 
No linked issue

#### Notes to the Reviewer
I pushed this to a dev branch (`grafana:dev.fix-containerize-stage-go117`) to see whether the "Containerize" step runs successfully. It seems like it does

https://drone.grafana.net/grafana/agent/1379/1/2

#### PR Checklist

- [x] CHANGELOG updated (N/A)
- [x] Documentation added (N/A)
- [x] Tests updated (N/A)
