### PR TITLE
Update agent-build-image for go 1.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ CROSS_BUILD ?= false
 # run make BUILD_IN_CONTAINER=false <target>, or you can set BUILD_IN_CONTAINER=true
 # as an environment variable.
 BUILD_IN_CONTAINER ?= true
-BUILD_IMAGE_VERSION := 0.12.0
+BUILD_IMAGE_VERSION := 0.13.0
 BUILD_IMAGE := $(IMAGE_PREFIX)/agent-build-image:$(BUILD_IMAGE_VERSION)
 
 # Enables the binary to be built with optimizations (i.e., doesn't strip the image of

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,5 +1,6 @@
-# Use the loki-build-image as a base as it shares most of the common tooling. We just need some additional tooling for building packages.
-FROM grafana/loki-build-image
+# Use the loki-build-image as a base as it shares most of the common tooling.
+# We just need some additional tooling for building packages.
+FROM grafana/loki-build-image:0.18.0
 
 RUN apt-get update && apt-get install -y \
   build-essential \
@@ -12,7 +13,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install dependencies used for the operator
 # Keep versions in sync with cmd/agent-operator/DEVELOPERS.md
-RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2
+RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0
 
 # Fix permissions for /go/bin directory.
 RUN chmod 0755 /go/bin


### PR DESCRIPTION
(also use a consistent base image tag instead of latest)
