### PR TITLE
Skip non-ready entries when listing instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - [ENHANCEMENT] Go 1.17 is now used for all builds of the Agent. (@tpaschalis)
 
+- [BUGFIX] Fixed issue where Grafana Agent may panic if there is a very large
+  WAL loading while old WALs are being deleted or the `/agent/api/v1/targets`
+  endpoint is called. (@tpaschalis)
+
 # v0.22.0 (2022-01-13)
 
 This release has deprecations. Please read [DEPRECATION] entries and consult

--- a/pkg/metrics/instance/manager.go
+++ b/pkg/metrics/instance/manager.go
@@ -149,6 +149,9 @@ func (m *BasicManager) ListInstances() map[string]ManagedInstance {
 
 	res := make(map[string]ManagedInstance, len(m.processes))
 	for name, process := range m.processes {
+		if process == nil {
+			continue
+		}
 		res[name] = process.inst
 	}
 	return res


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

#### PR Description
As mentioned in the linked issue, the ListInstances() method may return nil values in `map[string]ManagedInstance`, when an instance's process has not launched yet.

For instances that aren't ready yet this can result to panics in two places
- When WALCleaner runs, trying to get an instance's storage directory
- When someone calls `/agent/api/v1/targets` to list an instance's active targets

This PR tries to amend the issue by skipping over nil values in ListInstances(); so these instances will have their WAL cleaned and will be listed on the endpoint the next time that the method is called.

#### Which issue(s) this PR fixes 
This PR closes #1126.

#### Notes to the Reviewer
Do y'all think we should add a test for this?

#### PR Checklist

- [x] CHANGELOG updated (N/A)
- [x] Documentation added (N/A)
- [ ] Tests updated
