### PR TITLE
cadvisor config Fixes #1281

### DIFF
--- a/pkg/integrations/cadvisor/cadvisor.go
+++ b/pkg/integrations/cadvisor/cadvisor.go
@@ -153,7 +153,7 @@ func (i *Integration) Run(ctx context.Context) error {
 	if err := rm.Stop(); err != nil {
 		return fmt.Errorf("failed to stop manager: %w", err)
 	}
-	return ctx.Err()
+	return nil
 }
 
 // New creates a new cadvisor integration

--- a/pkg/integrations/cadvisor/cadvisor.go
+++ b/pkg/integrations/cadvisor/cadvisor.go
@@ -91,6 +91,10 @@ type Integration struct {
 func (i *Integration) Run(ctx context.Context) error {
 	// Do gross global configs. This works, so long as there is only one instance of the cAdvisor integration
 	// per host.
+
+	// klog
+	klog.SetLogger(i.c.logger)
+
 	// Containerd
 	containerd.ArgContainerdEndpoint = &i.c.Containerd
 	containerd.ArgContainerdNamespace = &i.c.ContainerdNamespace
@@ -154,7 +158,7 @@ func (i *Integration) Run(ctx context.Context) error {
 
 // New creates a new cadvisor integration
 func New(logger log.Logger, c *Config) (integrations.Integration, error) {
-	klog.SetLogger(logger)
+	c.logger = logger
 
 	ci := integrations.NewCollectorIntegration(c.Name())
 	integration := Integration{

--- a/pkg/integrations/cadvisor/cadvisor_test.go
+++ b/pkg/integrations/cadvisor/cadvisor_test.go
@@ -1,3 +1,6 @@
+//go:build !nonetwork && !nodocker
+// +build !nonetwork,!nodocker
+
 package cadvisor
 
 import (

--- a/pkg/integrations/cadvisor/cadvisor_test.go
+++ b/pkg/integrations/cadvisor/cadvisor_test.go
@@ -1,0 +1,49 @@
+package cadvisor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func run_integration(t *testing.T, cfgStr string) error {
+	var cfg Config
+
+	err := yaml.Unmarshal([]byte(cfgStr), &cfg)
+	assert.NoError(t, err)
+	ig, err := cfg.NewIntegration(log.NewNopLogger())
+	assert.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ig.Run(ctx)
+}
+
+func TestConfig_DockerOnly(t *testing.T) {
+	t.Run("docker_only with default configuration is successful", func(t *testing.T) {
+		// Run it once with the default config, expecting success.
+		defaultCfg := `
+docker_only: true
+`
+		var err error
+
+		assert.NotPanics(t, func() { err = run_integration(t, defaultCfg) })
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	// 	t.Run("docker_only with empty raw_cgroup_prefix_allowlist panics", func(t *testing.T) {
+	// 		// then again when docker_only is true, and raw_cgroup_prefix_allowlist is an empty array,
+	// 		// expecting the cadvisor collectors to panic. If this suddenly starts hanging, or does not panic, the default
+	// 		// value for raw_cgroup_prefix_allowlist should be returned to a zero value string slice.
+	// 		//
+	// 		var err error
+	// 		panicCfgStr := `
+	// docker_only: true
+	// raw_cgroup_prefix_allowlist: []
+	// `
+	// 		assert.Panics(t, func() { err = run_integration(t, panicCfgStr) })
+	// 		assert.NoError(t, err)
+	// 	})
+}

--- a/pkg/integrations/cadvisor/cadvisor_test.go
+++ b/pkg/integrations/cadvisor/cadvisor_test.go
@@ -9,7 +9,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func run_integration(t *testing.T, cfgStr string) error {
+func runIntegration(t *testing.T, cfgStr string) error {
 	var cfg Config
 
 	err := yaml.Unmarshal([]byte(cfgStr), &cfg)
@@ -29,7 +29,7 @@ docker_only: true
 `
 		var err error
 
-		assert.NotPanics(t, func() { err = run_integration(t, defaultCfg) })
+		assert.NotPanics(t, func() { err = runIntegration(t, defaultCfg) })
 		assert.ErrorIs(t, err, context.Canceled)
 	})
 
@@ -43,7 +43,7 @@ docker_only: true
 	// docker_only: true
 	// raw_cgroup_prefix_allowlist: []
 	// `
-	// 		assert.Panics(t, func() { err = run_integration(t, panicCfgStr) })
+	// 		assert.Panics(t, func() { err = runIntegration(t, panicCfgStr) })
 	// 		assert.NoError(t, err)
 	// 	})
 }

--- a/pkg/integrations/cadvisor/common.go
+++ b/pkg/integrations/cadvisor/common.go
@@ -12,6 +12,9 @@ const name = "cadvisor"
 var DefaultConfig Config = Config{
 	// Common cadvisor config defaults
 	StoreContainerLabels: true,
+	AllowlistedContainerLabels: []string{},
+	EnvMetadataAllowlist: []string{},
+	RawCgroupPrefixAllowlist: []string{"",},
 	ResctrlInterval:      0,
 
 	StorageDuration: 2 * time.Minute,

--- a/pkg/integrations/cadvisor/common.go
+++ b/pkg/integrations/cadvisor/common.go
@@ -11,11 +11,11 @@ const name = "cadvisor"
 // DefaultConfig holds the default settings for the cadvisor integration
 var DefaultConfig Config = Config{
 	// Common cadvisor config defaults
-	StoreContainerLabels: true,
+	StoreContainerLabels:       true,
 	AllowlistedContainerLabels: []string{},
-	EnvMetadataAllowlist: []string{},
-	RawCgroupPrefixAllowlist: []string{""},
-	ResctrlInterval:      0,
+	EnvMetadataAllowlist:       []string{},
+	RawCgroupPrefixAllowlist:   []string{""},
+	ResctrlInterval:            0,
 
 	StorageDuration: 2 * time.Minute,
 

--- a/pkg/integrations/cadvisor/common.go
+++ b/pkg/integrations/cadvisor/common.go
@@ -12,11 +12,8 @@ const name = "cadvisor"
 // DefaultConfig holds the default settings for the cadvisor integration
 var DefaultConfig Config = Config{
 	// Common cadvisor config defaults
-	StoreContainerLabels:       true,
-	AllowlistedContainerLabels: []string{},
-	EnvMetadataAllowlist:       []string{},
-	RawCgroupPrefixAllowlist:   []string{""},
-	ResctrlInterval:            0,
+	StoreContainerLabels: true,
+	ResctrlInterval:      0,
 
 	StorageDuration: 2 * time.Minute,
 
@@ -102,7 +99,23 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	type plain Config
 	err := unmarshal((*plain)(c))
-	return err
+	if err != nil {
+		return err
+	}
+
+	// In the cadvisor cmd, these are passed as CSVs, and turned into slices using strings.split. As a result the
+	// default values are always a slice with 1 or more elements.
+	// See: https://github.com/google/cadvisor/blob/v0.43.0/cmd/cadvisor.go#L136
+	if len(c.AllowlistedContainerLabels) == 0 {
+		c.AllowlistedContainerLabels = []string{""}
+	}
+	if len(c.RawCgroupPrefixAllowlist) == 0 {
+		c.RawCgroupPrefixAllowlist = []string{""}
+	}
+	if len(c.EnvMetadataAllowlist) == 0 {
+		c.EnvMetadataAllowlist = []string{""}
+	}
+	return nil
 }
 
 // Name returns the name of the integration that this config represents.

--- a/pkg/integrations/cadvisor/common.go
+++ b/pkg/integrations/cadvisor/common.go
@@ -3,6 +3,7 @@ package cadvisor
 import (
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/integrations"
 )
 
@@ -90,6 +91,9 @@ type Config struct {
 	// Raw config options
 	// DockerOnly only report docker containers in addition to root stats
 	DockerOnly bool `yaml:"docker_only,omitempty"`
+
+	// Hold on to the logger passed to config.NewIntegration, to be passed to klog, as yet another unsafe global that needs to be set.
+	logger log.Logger
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler for Config

--- a/pkg/integrations/cadvisor/common.go
+++ b/pkg/integrations/cadvisor/common.go
@@ -14,7 +14,7 @@ var DefaultConfig Config = Config{
 	StoreContainerLabels: true,
 	AllowlistedContainerLabels: []string{},
 	EnvMetadataAllowlist: []string{},
-	RawCgroupPrefixAllowlist: []string{"",},
+	RawCgroupPrefixAllowlist: []string{""},
 	ResctrlInterval:      0,
 
 	StorageDuration: 2 * time.Minute,

--- a/pkg/integrations/integration.go
+++ b/pkg/integrations/integration.go
@@ -43,5 +43,8 @@ type Integration interface {
 	// For example, an Integration that requires a persistent connection to a
 	// database would establish that connection here. If the integration doesn't
 	// need to do anything, it should wait for the ctx to be canceled.
+	//
+	// An error will be returned if the integration failed. Integrations should
+	// not return the ctx error.
 	Run(ctx context.Context) error
 }

--- a/pkg/integrations/v2/integrations.go
+++ b/pkg/integrations/v2/integrations.go
@@ -120,6 +120,9 @@ func (g Globals) CloneAgentBaseURL() *url.URL {
 type Integration interface {
 	// RunIntegration starts the integration and performs background tasks. It
 	// must not return until ctx is canceled, even if there is no work to do.
+	//
+	// An error will be returned if the integration failed. Integrations will
+	// never return the ctx error.
 	RunIntegration(ctx context.Context) error
 }
 


### PR DESCRIPTION
#### PR Description
This adds the expected zero value for `raw_cgroup_prefix_allowlist` as the default for the cadvisor integration configuration.

#### Which issue(s) this PR fixes 
Fixes #1281 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- N/A Documentation added
- N/A Tests updated
