### PR TITLE
Operator: generate proxy_url for remote_write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 - [BUGFIX] Fix panic in prom_sd_processor when address is empty (@mapno)
 
+- [BUGFIX] Operator: Add missing proxy_url field from generated remote_write
+  configs. (@rfratto)
+
 # v0.22.0 (2022-01-13)
 
 This release has deprecations. Please read [DEPRECATION] entries and consult

--- a/pkg/operator/config/metrics_templates_test.go
+++ b/pkg/operator/config/metrics_templates_test.go
@@ -640,7 +640,7 @@ func TestRemoteWrite(t *testing.T) {
 				},
 			},
 			expect: util.Untab(`
-				url: http://cortex/api/prom/push
+        url: http://cortex/api/prom/push
         proxy_url: http://proxy
 			`),
 		},

--- a/pkg/operator/config/metrics_templates_test.go
+++ b/pkg/operator/config/metrics_templates_test.go
@@ -630,6 +630,20 @@ func TestRemoteWrite(t *testing.T) {
 					send_interval: 5m
 			`),
 		},
+		{
+			name: "proxy_url",
+			input: map[string]interface{}{
+				"namespace": "operator",
+				"rw": v1alpha1.RemoteWriteSpec{
+					URL:      "http://cortex/api/prom/push",
+					ProxyURL: "http://proxy",
+				},
+			},
+			expect: util.Untab(`
+				url: http://cortex/api/prom/push
+        proxy_url: http://proxy
+			`),
+		},
 	}
 
 	for _, tc := range tt {

--- a/pkg/operator/config/templates/component/metrics/remote_write.libsonnet
+++ b/pkg/operator/config/templates/component/metrics/remote_write.libsonnet
@@ -16,6 +16,7 @@ function(namespace, rw) {
   name: optionals.string(rw.Name),
   remote_timeout: optionals.string(rw.RemoteTimeout),
   headers: optionals.object(rw.Headers),
+  proxy_url: optionals.string(rw.ProxyURL),
 
   write_relabel_configs: optionals.array(std.map(
     new_relabel_config,


### PR DESCRIPTION
#### PR Description 
proxyUrl from MetricsInstance wasn't not being used in the generated config. 

#### Which issue(s) this PR fixes 
Fixes #1297 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
