### PR TITLE
updated config URL

### DIFF
--- a/docs/getting-started/create-config-file.md
+++ b/docs/getting-started/create-config-file.md
@@ -58,7 +58,7 @@ source of metrics if you are running multiple Grafana Agents across multiple
 machines.
 
 Full configuration options can be found in the
-[configuration reference](../configuration/_index.md).
+[configuration reference](https://grafana.com/docs/agent/latest/configuration/).
 
 ## Prometheus config/migrating from Prometheus
 
@@ -104,7 +104,7 @@ metrics:
 ```
 
 Like with integrations, full configuration options can be found in the
-[configuration](../configuration/_index.md).
+[configuration](https://grafana.com/docs/agent/latest/configuration/).
 
 ## Loki Config/Migrating from Promtail
 


### PR DESCRIPTION
#### PR Description 
Updated the URL for agent configuration reference.

#### Which issue(s) this PR fixes 
The existing URL in this doc currently returns a 404: https://grafana.com/docs/agent/latest/getting-started/configuration/_index.md 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
