### PR TITLE
[RFC] Dynamic Documentation

### DIFF
--- a/docs/configuration/dynamic-config.md
+++ b/docs/configuration/dynamic-config.md
@@ -7,7 +7,7 @@ Dynamic Configuration is the combination of two things:
 * Loading from multiple files
 * Using templates and datasources
 
-Both of these make heavy use of the excellent [gomplate](https://github.com/hairyhenderson/gomplate). The idea goal is
+Both of these make heavy use of the excellent [gomplate](https://github.com/hairyhenderson/gomplate). The goal is
 that as the configuration grows that it can be split it up into smaller segments to allow better readability and handling.
 The configurations cannot be patched in any order and instead are allowed at several levels.
 

--- a/docs/configuration/dynamic-config.md
+++ b/docs/configuration/dynamic-config.md
@@ -1,0 +1,118 @@
+# Dynamic Configuration - BETA
+
+**This is BETA and subject to change at anytime, feedback is much appreciated**
+
+Dynamic Configuration is the combination of two things:
+
+* Loading from multiple files
+* Using templates and datasources
+
+Both of these make heavy use of the excellent [gomplate](https://github.com/hairyhenderson/gomplate). The idea goal is
+that as the configuration grows that it can be split it up into smaller segments to allow better readability and handling.
+The configurations cannot be patched in any order and instead are allowed at several levels.
+
+The second goal is to allow the use of templating, functions for [gomplate doc](https://docs.gomplate.ca/) go into detail
+on what functions are available.
+
+## Configuration
+
+Location of the dynamic configuration is used via the feature flag `dynamic-config`, then it will use `-config.file` to
+load the configuration for dynamic configuration.
+
+```yaml
+# Sources to pull template values 
+[sources: <sources_config>]
+
+# Locations to use searching for templates, the system does NOT look into subdirectories. Follows gomplate schema
+# from [gomplate datasources](https://docs.gomplate.ca/datasources/). File and S3/GCP templates are currently supported
+templates: 
+[ - string ]
+
+``` 
+
+### sources_config
+```yaml
+# Name of the source to use when templating
+name: string
+
+# Path to datasource using schema from [gomplate datasources](https://docs.gomplate.ca/datasources/) 
+url: string
+
+```
+
+## Templates
+
+Note when adding a template you do NOT need to add the type as the top level yaml field. For instance if using traces:
+
+Incorrect
+
+```yaml
+traces:
+  configs:
+  - name: default
+    automatic_logging:
+      backend: loki
+      loki_name: default
+      spans: true
+```
+
+Correct
+
+```yaml
+configs:
+- name: default
+  automatic_logging:
+    backend: loki
+    loki_name: default
+    spans: true
+```
+
+Configurations are loaded in the order as they are listed below.
+
+### Agent
+
+
+Agent template is the standard agent configuration file in its entirety. It is defined by the pattern `agent-*.yml`. Only
+one file is supported. This is processed first then any subsequent configurations found REPLACE the values here, it is
+not additive.
+
+Reference {{< relref "./" >}})
+
+### Server
+
+Server is defined using the pattern `server-*.yml`, only ONE server file is supported.
+
+Reference {{< relref "./server-config.md" >}})
+
+
+### Metrics
+
+Metrics are defined using the pattern `metrics-*.yml`, only ONE metrics file is supported.
+
+Reference {{< relref "./metrics-config.md" >}})
+
+### Metric Instances
+
+Metric Instances are defined using the pattern `metrics_instances-*.yml`.
+
+Reference {{< relref "./metrics-config.md#metrics_instance_config" >}}) in the metrics instance
+
+
+### Integrations
+
+Integrations are defined using the pattern `integrations-*.yml`, these support more than one file, and multiple
+integrations can be defined in a file. Do not assume any order of loading for integrations.
+
+Reference {{< relref "./integrations/" >}})
+
+### Traces
+
+Traces are defined using the pattern `traces-*.yml`. This supports one file.
+
+Reference {{< relref "./traces-config.md" >}})
+
+### Logs
+
+Logs are defined using the pattern `logs-*.yml`. This supports on file.
+
+Reference {{< relref "./logs-config.md" >}})

--- a/docs/configuration/dynamic-config.md
+++ b/docs/configuration/dynamic-config.md
@@ -21,14 +21,23 @@ load the configuration for dynamic configuration.
 
 ```yaml
 # Sources to pull template values 
-sources: 
+datasources: 
   [- <sources_config>]
 
 # Locations to use searching for templates, the system does NOT look into subdirectories. Follows gomplate schema
 # from [gomplate datasources](https://docs.gomplate.ca/datasources/). File and S3/GCP templates are currently supported
 template_paths: 
   [ - string ]
+  
+# Filters allow you to override the default naming convention
 
+agent_filter:            string # defaults to agent-*.yml
+server_filter:           string # defaults to server-*.yml
+metrics_filter:          string # defaults to metrics-*.yml
+metrics_instance_filter: string # defaults to metrics_instances-*.yml
+integrations_filter:     string # defaults to integrations-*.yml
+logs_filter:             string # defaults to logs-*.yml
+traces_filter:           string # defaults to traces-*.yml
 ``` 
 
 ### sources_config
@@ -73,7 +82,7 @@ Configurations are loaded in the order as they are listed below.
 ### Agent
 
 
-Agent template is the standard agent configuration file in its entirety. It is defined by the pattern `agent-*.yml`. Only
+Agent template is the standard agent configuration file in its entirety. The default filter is `agent-*.yml`. Only
 one file is supported. This is processed first then any subsequent configurations found REPLACE the values here, it is
 not additive.
 
@@ -81,38 +90,38 @@ Reference {{< relref "./" >}})
 
 ### Server
 
-Server is defined using the pattern `server-*.yml`, only ONE server file is supported.
+The default filter is `server-*.yml`, only ONE server file is supported.
 
 Reference {{< relref "./server-config.md" >}})
 
 
 ### Metrics
 
-Metrics are defined using the pattern `metrics-*.yml`, only ONE metrics file is supported.
+The default filter is `metrics-*.yml`, only ONE metrics file is supported.
 
 Reference {{< relref "./metrics-config.md" >}})
 
 ### Metric Instances
 
-Metric Instances are defined using the pattern `metrics_instances-*.yml`. Any metric instances are appended to the instances defined in Metrics above. Any number of metric instance files are supporter.
+The default filter is `metrics_instances-*.yml`. Any metric instances are appended to the instances defined in Metrics above. Any number of metric instance files are supporter.
 
 Reference {{< relref "./metrics-config.md#metrics_instance_config" >}}) in the metrics instance
 
 
 ### Integrations
 
-Integrations are defined using the pattern `integrations-*.yml`, these support more than one file, and multiple integrations can be defined in a file. Do not assume any order of loading for integrations. For any integration that is a singleton, loading multiple of those will result in an error. 
+The default filter is `integrations-*.yml`, these support more than one file, and multiple integrations can be defined in a file. Do not assume any order of loading for integrations. For any integration that is a singleton, loading multiple of those will result in an error. 
 
 Reference {{< relref "./integrations/" >}})
 
 ### Traces
 
-Traces are defined using the pattern `traces-*.yml`. This supports ONE file.
+The default filter is `traces-*.yml`. This supports ONE file.
 
 Reference {{< relref "./traces-config.md" >}})
 
 ### Logs
 
-Logs are defined using the pattern `logs-*.yml`. This supports ONE file.
+The default filter is `logs-*.yml`. This supports ONE file.
 
 Reference {{< relref "./logs-config.md" >}})

--- a/docs/configuration/dynamic-config.md
+++ b/docs/configuration/dynamic-config.md
@@ -1,6 +1,6 @@
-# Dynamic Configuration - BETA
+# Dynamic Configuration - Experimental
 
-**This is BETA and subject to change at anytime, feedback is much appreciated**
+**This is experimental and subject to change at anytime, feedback is much appreciated. This is a feature that MAY NOT make it production.**
 
 Dynamic Configuration is the combination of two things:
 
@@ -16,17 +16,18 @@ on what functions are available.
 
 ## Configuration
 
-Location of the dynamic configuration is used via the feature flag `dynamic-config`, then it will use `-config.file` to
+Location of the dynamic configuration is used via the feature flag `dynamic-config`, then it will use `-config.dynamic-config-path` to
 load the configuration for dynamic configuration.
 
 ```yaml
 # Sources to pull template values 
-[sources: <sources_config>]
+sources: 
+  [- <sources_config>]
 
 # Locations to use searching for templates, the system does NOT look into subdirectories. Follows gomplate schema
 # from [gomplate datasources](https://docs.gomplate.ca/datasources/). File and S3/GCP templates are currently supported
-templates: 
-[ - string ]
+template_paths: 
+  [ - string ]
 
 ``` 
 
@@ -42,7 +43,7 @@ url: string
 
 ## Templates
 
-Note when adding a template you do NOT need to add the type as the top level yaml field. For instance if using traces:
+Note when adding a template you MUST NOT add the type as the top level yaml field. For instance if using traces:
 
 Incorrect
 
@@ -93,26 +94,25 @@ Reference {{< relref "./metrics-config.md" >}})
 
 ### Metric Instances
 
-Metric Instances are defined using the pattern `metrics_instances-*.yml`.
+Metric Instances are defined using the pattern `metrics_instances-*.yml`. Any metric instances are appended to the instances defined in Metrics above. Any number of metric instance files are supporter.
 
 Reference {{< relref "./metrics-config.md#metrics_instance_config" >}}) in the metrics instance
 
 
 ### Integrations
 
-Integrations are defined using the pattern `integrations-*.yml`, these support more than one file, and multiple
-integrations can be defined in a file. Do not assume any order of loading for integrations.
+Integrations are defined using the pattern `integrations-*.yml`, these support more than one file, and multiple integrations can be defined in a file. Do not assume any order of loading for integrations. For any integration that is a singleton, loading multiple of those will result in an error. 
 
 Reference {{< relref "./integrations/" >}})
 
 ### Traces
 
-Traces are defined using the pattern `traces-*.yml`. This supports one file.
+Traces are defined using the pattern `traces-*.yml`. This supports ONE file.
 
 Reference {{< relref "./traces-config.md" >}})
 
 ### Logs
 
-Logs are defined using the pattern `logs-*.yml`. This supports on file.
+Logs are defined using the pattern `logs-*.yml`. This supports ONE file.
 
 Reference {{< relref "./logs-config.md" >}})

--- a/docs/cookbook/dynamic-configuration/01_Basics/01_Structure.md
+++ b/docs/cookbook/dynamic-configuration/01_Basics/01_Structure.md
@@ -1,7 +1,6 @@
 # 01 Structure
 
-Dynamic Configuration uses a series of files to load templates. This example will show how they all combine together. 
-Running the below command will combine all the templates into the final.yml
+Dynamic Configuration uses a series of files to load templates. This example will show how they all combine together. Running the below command will combine all the templates into the final.yml.
 
 `docker run -v ${PWD}/:/etc/grafana grafana/agentctl:latest template-parse /etc/grafana/02_config.yml`
 
@@ -9,7 +8,12 @@ Running the below command will combine all the templates into the final.yml
 
 [config.yml](./01_config.yml)
 
-Tells the Grafana Agent where to load files from.
+```yaml
+template_paths:
+  - "file:///etc/grafana/01_assets"
+```
+
+Tells the Grafana Agent where to load files from. It is important to note that dynamic configuration does NOT traverse directories. It will look at the directory specified only, if you need more directories then add them to the `template_paths` array.
 
 ## Agent
 

--- a/docs/cookbook/dynamic-configuration/01_Basics/01_Structure.md
+++ b/docs/cookbook/dynamic-configuration/01_Basics/01_Structure.md
@@ -1,0 +1,61 @@
+# 01 Structure
+
+Dynamic Configuration uses a series of files to load templates. This example will show how they all combine together. 
+Running the below command will combine all the templates into the final.yml
+
+`docker run -v ${PWD}/:/etc/grafana grafana/agentctl:latest template-parse /etc/grafana/02_config.yml`
+
+## Dynamic Configuration
+
+[config.yml](./01_config.yml)
+
+Tells the Grafana Agent where to load files from.
+
+## Agent
+
+Dynamic Configuration will find the first file matching pattern `agent-*.yml` and load that as the base. You can only have
+one agent template.
+
+[agent-1.yml](./01_assets/agent-1.yml)
+
+```yaml
+server:
+  http_listen_port: 12345
+  log_level: debug
+metrics:
+  wal_directory: /tmp/grafana-agent-normal
+  global:
+    scrape_interval: 60s
+    remote_write:
+      - url: https://prometheus-us-central1.grafana.net/api/prom/push
+        basic_auth:
+          username: 12345
+          password: secretpassword
+integrations:
+  node_exporter:
+    enabled: true
+  agent:
+    enabled: true
+```
+
+## Server
+
+Dynamic configuration will find the first file matching pattern `server-*.yml` and replace the `Server` config block in
+the Agent Configuration. Note that you do NOT include the `server:` tag, dynamic configuration knows by the name that it
+is a configuration block.
+
+You can only have 1 server template.
+
+[server-1.yml](./01_assets/server-1.yml)
+
+
+```yaml
+http_listen_port: 12345
+log_level: info
+```
+
+## Final
+
+[final.yml](./01_assets/final.yml)
+
+In the above example the `log_level: debug` block will be replaced with `log_level: info` from the server-1.yml

--- a/docs/cookbook/dynamic-configuration/01_Basics/01_Structure.md
+++ b/docs/cookbook/dynamic-configuration/01_Basics/01_Structure.md
@@ -1,8 +1,8 @@
 # 01 Structure
 
-Dynamic Configuration uses a series of files to load templates. This example will show how they all combine together. Running the below command will combine all the templates into the final.yml.
+Dynamic Configuration uses a series of files to load templates. This example will show how they all combine together. Running the below command will combine all the templates into the final.yml. Any failure while loading the config will revert to the original config, or if this is the initial load Grafana Agent will quit. 
 
-`docker run -v ${PWD}/:/etc/grafana grafana/agentctl:latest template-parse /etc/grafana/02_config.yml`
+`docker run -v ${PWD}/:/etc/grafana grafana/agentctl:latest template-parse /etc/grafana/01_config.yml`
 
 ## Dynamic Configuration
 
@@ -13,12 +13,11 @@ template_paths:
   - "file:///etc/grafana/01_assets"
 ```
 
-Tells the Grafana Agent where to load files from. It is important to note that dynamic configuration does NOT traverse directories. It will look at the directory specified only, if you need more directories then add them to the `template_paths` array.
+Tells the Grafana Agent where to load files from. It is important to note that dynamic configuration does NOT traverse directories. It will look at the directory specified only, if you need more directories then add them to the `template_paths` array. NOTE, if no protocol specified ie `file://` above, then file access will be assumed. `file:///etc/grafana/01_assets` is equivalent to `//etc/grafana/01_assets`
 
 ## Agent
 
-Dynamic Configuration will find the first file matching pattern `agent-*.yml` and load that as the base. You can only have
-one agent template.
+Dynamic Configuration will find the first file matching pattern `agent-*.yml` and load that as the base. You can only have one agent template. If multiple matching templates are found then the configuration will fail to load. 
 
 [agent-1.yml](./01_assets/agent-1.yml)
 

--- a/docs/cookbook/dynamic-configuration/01_Basics/01_assets/agent-1.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/01_assets/agent-1.yml
@@ -1,0 +1,17 @@
+server:
+  http_listen_port: 12345
+  log_level: debug
+metrics:
+  wal_directory: /tmp/grafana-agent-normal
+  global:
+    scrape_interval: 60s
+    remote_write:
+      - url: https://prometheus-us-central1.grafana.net/api/prom/push
+        basic_auth:
+          username: 12345
+          password: secretpassword
+integrations:
+  node_exporter:
+    enabled: true
+  agent:
+    enabled: true

--- a/docs/cookbook/dynamic-configuration/01_Basics/01_assets/final.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/01_assets/final.yml
@@ -1,0 +1,186 @@
+server:
+  http_listen_network: ""
+  http_listen_address: ""
+  http_listen_port: 12345
+  http_listen_conn_limit: 0
+  grpc_listen_network: ""
+  grpc_listen_address: ""
+  grpc_listen_port: 0
+  grpc_listen_conn_limit: 0
+  http_tls_config:
+    cert_file: ""
+    key_file: ""
+    client_auth_type: ""
+    client_ca_file: ""
+    cipher_suites: []
+    curve_preferences: []
+    min_version: 0
+    max_version: 0
+    prefer_server_cipher_suites: false
+  grpc_tls_config:
+    cert_file: ""
+    key_file: ""
+    client_auth_type: ""
+    client_ca_file: ""
+    cipher_suites: []
+    curve_preferences: []
+    min_version: 0
+    max_version: 0
+    prefer_server_cipher_suites: false
+  register_instrumentation: false
+  graceful_shutdown_timeout: 0s
+  http_server_read_timeout: 0s
+  http_server_write_timeout: 0s
+  http_server_idle_timeout: 0s
+  grpc_server_max_recv_msg_size: 0
+  grpc_server_max_send_msg_size: 0
+  grpc_server_max_concurrent_streams: 0
+  grpc_server_max_connection_idle: 0s
+  grpc_server_max_connection_age: 0s
+  grpc_server_max_connection_age_grace: 0s
+  grpc_server_keepalive_time: 0s
+  grpc_server_keepalive_timeout: 0s
+  grpc_server_min_time_between_pings: 0s
+  grpc_server_ping_without_stream_allowed: false
+  log_format: ""
+  log_level: info
+  log_source_ips_enabled: false
+  log_source_ips_header: ""
+  log_source_ips_regex: ""
+  http_path_prefix: ""
+metrics:
+  global:
+    scrape_interval: 1m
+    scrape_timeout: 10s
+    evaluation_interval: 1m
+    remote_write:
+    - url: https://prometheus-us-central1.grafana.net/api/prom/push
+      remote_timeout: 30s
+      basic_auth:
+        username: "12345"
+        password: <secret>
+      follow_redirects: true
+      queue_config:
+        capacity: 2500
+        max_shards: 200
+        min_shards: 1
+        max_samples_per_send: 500
+        batch_send_deadline: 5s
+        min_backoff: 30ms
+        max_backoff: 100ms
+      metadata_config:
+        send: true
+        send_interval: 1m
+        max_samples_per_send: 500
+  wal_directory: /tmp/grafana-agent-normal
+  wal_cleanup_age: 12h0m0s
+  wal_cleanup_period: 30m0s
+  scraping_service:
+    enabled: false
+    reshard_interval: 1m0s
+    reshard_timeout: 30s
+    cluster_reshard_event_timeout: 30s
+    kvstore:
+      store: consul
+      prefix: configurations/
+      consul:
+        host: localhost:8500
+        acl_token: <secret>
+        http_client_timeout: 20s
+        consistent_reads: false
+        watch_rate_limit: 1
+        watch_burst_size: 1
+      etcd:
+        endpoints: []
+        dial_timeout: 10s
+        max_retries: 10
+        tls_enabled: false
+        tls_cert_path: ""
+        tls_key_path: ""
+        tls_ca_path: ""
+        tls_server_name: ""
+        tls_insecure_skip_verify: false
+        username: ""
+        password: <secret>
+      multi:
+        primary: ""
+        secondary: ""
+        mirror_enabled: false
+        mirror_timeout: 2s
+    lifecycler:
+      ring:
+        kvstore:
+          store: consul
+          prefix: collectors/
+          consul:
+            host: localhost:8500
+            acl_token: <secret>
+            http_client_timeout: 20s
+            consistent_reads: false
+            watch_rate_limit: 1
+            watch_burst_size: 1
+          etcd:
+            endpoints: []
+            dial_timeout: 10s
+            max_retries: 10
+            tls_enabled: false
+            tls_cert_path: ""
+            tls_key_path: ""
+            tls_ca_path: ""
+            tls_server_name: ""
+            tls_insecure_skip_verify: false
+            username: ""
+            password: <secret>
+          multi:
+            primary: ""
+            secondary: ""
+            mirror_enabled: false
+            mirror_timeout: 2s
+        heartbeat_timeout: 1m0s
+        replication_factor: 3
+        zone_awareness_enabled: false
+      num_tokens: 128
+      heartbeat_period: 5s
+      observe_period: 0s
+      join_after: 0s
+      min_ready_duration: 1m0s
+      interface_names:
+      - eth0
+      - en0
+      final_sleep: 30s
+      tokens_file_path: ""
+      availability_zone: ""
+      unregister_on_shutdown: true
+      address: ""
+      port: 0
+      id: 4c1ed28ad826
+    dangerous_allow_reading_files: false
+  scraping_service_client:
+    grpc_client_config:
+      max_recv_msg_size: 104857600
+      max_send_msg_size: 16777216
+      grpc_compression: ""
+      rate_limit: 0
+      rate_limit_burst: 0
+      backoff_on_ratelimits: false
+      backoff_config:
+        min_period: 100ms
+        max_period: 10s
+        max_retries: 10
+      tls_enabled: false
+      tls_cert_path: ""
+      tls_key_path: ""
+      tls_ca_path: ""
+      tls_server_name: ""
+      tls_insecure_skip_verify: false
+  instance_restart_backoff: 5s
+  instance_mode: shared
+integrations:
+  metrics:
+    autoscrape:
+      enable: true
+      metrics_instance: default
+      scrape_interval: 1m
+      scrape_timeout: 10s
+  agent: {}
+

--- a/docs/cookbook/dynamic-configuration/01_Basics/01_assets/server-1.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/01_assets/server-1.yml
@@ -1,0 +1,2 @@
+http_listen_port: 12345
+log_level: info

--- a/docs/cookbook/dynamic-configuration/01_Basics/01_config.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/01_config.yml
@@ -1,0 +1,2 @@
+template_paths:
+  - "file:///etc/grafana/01_assets"

--- a/docs/cookbook/dynamic-configuration/01_Basics/01_config.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/01_config.yml
@@ -1,2 +1,2 @@
 template_paths:
-  - "file:///etc/grafana/01_assets"
+  - "/etc/grafana/01_assets"

--- a/docs/cookbook/dynamic-configuration/01_Basics/02_Instances.md
+++ b/docs/cookbook/dynamic-configuration/01_Basics/02_Instances.md
@@ -1,0 +1,63 @@
+# 02 Instances
+
+Dynamic configuration allows multiple prometheus instances to be loaded with a parent metric. This uses
+the same agent-1 and server-1 yml from 01.
+
+`docker run -v ${PWD}/:/etc/grafana grafana/agentctl:latest template-parse /etc/grafana/02_config.yml`
+
+## Dynamic Configuration
+
+[config.yml](./02_config.yml)
+
+Tells the Grafana Agent where to load files from.
+
+## Metrics
+
+Dynamic Configuration will find the first file matching pattern `metrics-*.yml` and load that as the base. You can only have one metrics template.
+
+[metrics-1.yml](./02_assets/metrics-1.yml)
+
+```yaml
+configs:
+  - name: default
+global:
+  scrape_interval: 60s
+  scrape_timeout: 20s
+wal_directory: /tmp/grafana-agent-wal
+```
+
+## Metrics Instances
+
+You can have any number of metrics_instances and they are added to any existing metrics instances defined previously.
+
+[metrics_instances-1.yml](./02_assets/metrics_instances-1.yml)
+
+```yaml
+name: instance1
+scrape_configs:
+  - job_name: instance1_job
+    static_configs:
+      - targets:
+          - localhost:4000
+```
+
+[metrics_instances-2.yml](./02_assets/metrics_instances-2.yml)
+
+```yaml
+name: instance2
+scrape_configs:
+  - job_name: instance2_job
+    static_configs:
+      - targets:
+          - localhost:5555
+```
+
+## Final
+
+[final.yml](./01_assets/final.yml)
+
+In the above you will see the `final.yml` includes all the instance configurations
+- default
+- instance1
+- instance2
+

--- a/docs/cookbook/dynamic-configuration/01_Basics/02_assets/agent-1.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/02_assets/agent-1.yml
@@ -1,0 +1,17 @@
+server:
+  http_listen_port: 12345
+  log_level: debug
+metrics:
+  wal_directory: /tmp/grafana-agent-normal
+  global:
+    scrape_interval: 60s
+    remote_write:
+      - url: https://prometheus-us-central1.grafana.net/api/prom/push
+        basic_auth:
+          username: 12345
+          password: secretpassword
+integrations:
+  node_exporter:
+    enabled: true
+  agent:
+    enabled: true

--- a/docs/cookbook/dynamic-configuration/01_Basics/02_assets/final.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/02_assets/final.yml
@@ -1,0 +1,205 @@
+server:
+  http_listen_network: ""
+  http_listen_address: ""
+  http_listen_port: 12345
+  http_listen_conn_limit: 0
+  grpc_listen_network: ""
+  grpc_listen_address: ""
+  grpc_listen_port: 0
+  grpc_listen_conn_limit: 0
+  http_tls_config:
+    cert_file: ""
+    key_file: ""
+    client_auth_type: ""
+    client_ca_file: ""
+    cipher_suites: []
+    curve_preferences: []
+    min_version: 0
+    max_version: 0
+    prefer_server_cipher_suites: false
+  grpc_tls_config:
+    cert_file: ""
+    key_file: ""
+    client_auth_type: ""
+    client_ca_file: ""
+    cipher_suites: []
+    curve_preferences: []
+    min_version: 0
+    max_version: 0
+    prefer_server_cipher_suites: false
+  register_instrumentation: false
+  graceful_shutdown_timeout: 0s
+  http_server_read_timeout: 0s
+  http_server_write_timeout: 0s
+  http_server_idle_timeout: 0s
+  grpc_server_max_recv_msg_size: 0
+  grpc_server_max_send_msg_size: 0
+  grpc_server_max_concurrent_streams: 0
+  grpc_server_max_connection_idle: 0s
+  grpc_server_max_connection_age: 0s
+  grpc_server_max_connection_age_grace: 0s
+  grpc_server_keepalive_time: 0s
+  grpc_server_keepalive_timeout: 0s
+  grpc_server_min_time_between_pings: 0s
+  grpc_server_ping_without_stream_allowed: false
+  log_format: ""
+  log_level: info
+  log_source_ips_enabled: false
+  log_source_ips_header: ""
+  log_source_ips_regex: ""
+  http_path_prefix: ""
+metrics:
+  global:
+    scrape_interval: 1m
+    scrape_timeout: 20s
+    evaluation_interval: 1m
+  wal_directory: /tmp/grafana-agent-wal
+  wal_cleanup_age: 12h0m0s
+  wal_cleanup_period: 30m0s
+  scraping_service:
+    enabled: false
+    reshard_interval: 1m0s
+    reshard_timeout: 30s
+    cluster_reshard_event_timeout: 30s
+    kvstore:
+      store: consul
+      prefix: configurations/
+      consul:
+        host: localhost:8500
+        acl_token: <secret>
+        http_client_timeout: 20s
+        consistent_reads: false
+        watch_rate_limit: 1
+        watch_burst_size: 1
+      etcd:
+        endpoints: []
+        dial_timeout: 10s
+        max_retries: 10
+        tls_enabled: false
+        tls_cert_path: ""
+        tls_key_path: ""
+        tls_ca_path: ""
+        tls_server_name: ""
+        tls_insecure_skip_verify: false
+        username: ""
+        password: <secret>
+      multi:
+        primary: ""
+        secondary: ""
+        mirror_enabled: false
+        mirror_timeout: 2s
+    lifecycler:
+      ring:
+        kvstore:
+          store: consul
+          prefix: collectors/
+          consul:
+            host: localhost:8500
+            acl_token: <secret>
+            http_client_timeout: 20s
+            consistent_reads: false
+            watch_rate_limit: 1
+            watch_burst_size: 1
+          etcd:
+            endpoints: []
+            dial_timeout: 10s
+            max_retries: 10
+            tls_enabled: false
+            tls_cert_path: ""
+            tls_key_path: ""
+            tls_ca_path: ""
+            tls_server_name: ""
+            tls_insecure_skip_verify: false
+            username: ""
+            password: <secret>
+          multi:
+            primary: ""
+            secondary: ""
+            mirror_enabled: false
+            mirror_timeout: 2s
+        heartbeat_timeout: 1m0s
+        replication_factor: 3
+        zone_awareness_enabled: false
+      num_tokens: 128
+      heartbeat_period: 5s
+      observe_period: 0s
+      join_after: 0s
+      min_ready_duration: 1m0s
+      interface_names:
+      - eth0
+      - en0
+      final_sleep: 30s
+      tokens_file_path: ""
+      availability_zone: ""
+      unregister_on_shutdown: true
+      address: ""
+      port: 0
+      id: 04802136a818
+    dangerous_allow_reading_files: false
+  scraping_service_client:
+    grpc_client_config:
+      max_recv_msg_size: 104857600
+      max_send_msg_size: 16777216
+      grpc_compression: ""
+      rate_limit: 0
+      rate_limit_burst: 0
+      backoff_on_ratelimits: false
+      backoff_config:
+        min_period: 100ms
+        max_period: 10s
+        max_retries: 10
+      tls_enabled: false
+      tls_cert_path: ""
+      tls_key_path: ""
+      tls_ca_path: ""
+      tls_server_name: ""
+      tls_insecure_skip_verify: false
+  configs:
+  - name: default
+    wal_truncate_frequency: 1h0m0s
+    min_wal_time: 5m0s
+    max_wal_time: 4h0m0s
+    remote_flush_deadline: 1m0s
+  - name: instance1
+    scrape_configs:
+    - job_name: instance1_job
+      honor_timestamps: true
+      scrape_interval: 1m
+      scrape_timeout: 20s
+      metrics_path: /metrics
+      scheme: http
+      follow_redirects: true
+      static_configs:
+      - targets:
+        - localhost:4000
+    wal_truncate_frequency: 1h0m0s
+    min_wal_time: 5m0s
+    max_wal_time: 4h0m0s
+    remote_flush_deadline: 1m0s
+  - name: instance2
+    scrape_configs:
+    - job_name: instance2_job
+      honor_timestamps: true
+      scrape_interval: 1m
+      scrape_timeout: 20s
+      metrics_path: /metrics
+      scheme: http
+      follow_redirects: true
+      static_configs:
+      - targets:
+        - localhost:5555
+    wal_truncate_frequency: 1h0m0s
+    min_wal_time: 5m0s
+    max_wal_time: 4h0m0s
+    remote_flush_deadline: 1m0s
+  instance_restart_backoff: 5s
+  instance_mode: shared
+integrations:
+  metrics:
+    autoscrape:
+      enable: true
+      metrics_instance: default
+      scrape_interval: 1m
+      scrape_timeout: 20s
+  agent: {}
+

--- a/docs/cookbook/dynamic-configuration/01_Basics/02_assets/metrics-1.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/02_assets/metrics-1.yml
@@ -1,0 +1,6 @@
+configs:
+- name: default
+global:
+  scrape_interval: 60s
+  scrape_timeout: 20s
+wal_directory: /tmp/grafana-agent-wal

--- a/docs/cookbook/dynamic-configuration/01_Basics/02_assets/metrics_instances-1.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/02_assets/metrics_instances-1.yml
@@ -1,0 +1,6 @@
+name: instance1
+scrape_configs:
+  - job_name: instance1_job
+    static_configs:
+      - targets:
+          - localhost:4000

--- a/docs/cookbook/dynamic-configuration/01_Basics/02_assets/metrics_instances-2.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/02_assets/metrics_instances-2.yml
@@ -1,0 +1,6 @@
+name: instance2
+scrape_configs:
+  - job_name: instance2_job
+    static_configs:
+      - targets:
+          - localhost:5555

--- a/docs/cookbook/dynamic-configuration/01_Basics/02_assets/server-1.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/02_assets/server-1.yml
@@ -1,0 +1,2 @@
+http_listen_port: 12345
+log_level: info

--- a/docs/cookbook/dynamic-configuration/01_Basics/02_config.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/02_config.yml
@@ -1,0 +1,2 @@
+template_paths:
+  - "file:///etc/grafana/02_assets"

--- a/docs/cookbook/dynamic-configuration/01_Basics/03_Integrations.md
+++ b/docs/cookbook/dynamic-configuration/01_Basics/03_Integrations.md
@@ -1,0 +1,43 @@
+# 03 Integrations
+
+Dynamic configuration requires the use of `integrations-next` feature flag, to allow arrays of integrations. In this we will load integrations of various types. This is all built on the previous examples.
+
+`docker run -v ${PWD}/:/etc/grafana grafana/agentctl:latest template-parse /etc/grafana/03_config.yml`
+
+## Dynamic Configuration
+
+[config.yml](./03_config.yml)
+
+Tells the Grafana Agent where to load files from.
+
+## Integrations
+
+Integrations are loaded from files matching `integrations-*.yml` and are combined together. You can declare for example multiple sets of `redis_exporter_configs` across several files. 
+
+[integrations-node.yml](./03_assets/integrations-node.yml)
+
+Note: You do NOT have to name the above file `integrations-node.yml` with `node`, `integrations-1.yml` would work the same. The name does NOT determine the type of integrations a template can contain and a template can contain integrations of different types.  
+
+```yaml
+node_exporter: {}
+```
+
+[integrations-redis.yml](./03_assets/integrations-redis.yml)
+
+```yaml
+redis_exporter_configs:
+  - redis_addr: localhost:6379
+    autoscrape:
+      metric_relabel_configs:
+        - source_labels: [__address__]
+          target_label: "banana"
+          replacement: "apple"
+  - redis_addr: localhost:6380
+```
+
+## Final
+
+[final.yml](./03_assets/final.yml)
+
+The final result should have 3 integrations enabled, 1 node_exporter and 2 redis_exporters.
+

--- a/docs/cookbook/dynamic-configuration/01_Basics/03_assets/agent-1.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/03_assets/agent-1.yml
@@ -1,0 +1,17 @@
+server:
+  http_listen_port: 12345
+  log_level: debug
+metrics:
+  wal_directory: /tmp/grafana-agent-normal
+  global:
+    scrape_interval: 60s
+    remote_write:
+      - url: https://prometheus-us-central1.grafana.net/api/prom/push
+        basic_auth:
+          username: 12345
+          password: secretpassword
+integrations:
+  node_exporter:
+    enabled: true
+  agent:
+    enabled: true

--- a/docs/cookbook/dynamic-configuration/01_Basics/03_assets/final.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/03_assets/final.yml
@@ -1,0 +1,253 @@
+server:
+  http_listen_network: ""
+  http_listen_address: ""
+  http_listen_port: 12345
+  http_listen_conn_limit: 0
+  grpc_listen_network: ""
+  grpc_listen_address: ""
+  grpc_listen_port: 0
+  grpc_listen_conn_limit: 0
+  http_tls_config:
+    cert_file: ""
+    key_file: ""
+    client_auth_type: ""
+    client_ca_file: ""
+    cipher_suites: []
+    curve_preferences: []
+    min_version: 0
+    max_version: 0
+    prefer_server_cipher_suites: false
+  grpc_tls_config:
+    cert_file: ""
+    key_file: ""
+    client_auth_type: ""
+    client_ca_file: ""
+    cipher_suites: []
+    curve_preferences: []
+    min_version: 0
+    max_version: 0
+    prefer_server_cipher_suites: false
+  register_instrumentation: false
+  graceful_shutdown_timeout: 0s
+  http_server_read_timeout: 0s
+  http_server_write_timeout: 0s
+  http_server_idle_timeout: 0s
+  grpc_server_max_recv_msg_size: 0
+  grpc_server_max_send_msg_size: 0
+  grpc_server_max_concurrent_streams: 0
+  grpc_server_max_connection_idle: 0s
+  grpc_server_max_connection_age: 0s
+  grpc_server_max_connection_age_grace: 0s
+  grpc_server_keepalive_time: 0s
+  grpc_server_keepalive_timeout: 0s
+  grpc_server_min_time_between_pings: 0s
+  grpc_server_ping_without_stream_allowed: false
+  log_format: ""
+  log_level: info
+  log_source_ips_enabled: false
+  log_source_ips_header: ""
+  log_source_ips_regex: ""
+  http_path_prefix: ""
+metrics:
+  global:
+    scrape_interval: 1m
+    scrape_timeout: 20s
+    evaluation_interval: 1m
+  wal_directory: /tmp/grafana-agent-wal
+  wal_cleanup_age: 12h0m0s
+  wal_cleanup_period: 30m0s
+  scraping_service:
+    enabled: false
+    reshard_interval: 1m0s
+    reshard_timeout: 30s
+    cluster_reshard_event_timeout: 30s
+    kvstore:
+      store: consul
+      prefix: configurations/
+      consul:
+        host: localhost:8500
+        acl_token: <secret>
+        http_client_timeout: 20s
+        consistent_reads: false
+        watch_rate_limit: 1
+        watch_burst_size: 1
+      etcd:
+        endpoints: []
+        dial_timeout: 10s
+        max_retries: 10
+        tls_enabled: false
+        tls_cert_path: ""
+        tls_key_path: ""
+        tls_ca_path: ""
+        tls_server_name: ""
+        tls_insecure_skip_verify: false
+        username: ""
+        password: <secret>
+      multi:
+        primary: ""
+        secondary: ""
+        mirror_enabled: false
+        mirror_timeout: 2s
+    lifecycler:
+      ring:
+        kvstore:
+          store: consul
+          prefix: collectors/
+          consul:
+            host: localhost:8500
+            acl_token: <secret>
+            http_client_timeout: 20s
+            consistent_reads: false
+            watch_rate_limit: 1
+            watch_burst_size: 1
+          etcd:
+            endpoints: []
+            dial_timeout: 10s
+            max_retries: 10
+            tls_enabled: false
+            tls_cert_path: ""
+            tls_key_path: ""
+            tls_ca_path: ""
+            tls_server_name: ""
+            tls_insecure_skip_verify: false
+            username: ""
+            password: <secret>
+          multi:
+            primary: ""
+            secondary: ""
+            mirror_enabled: false
+            mirror_timeout: 2s
+        heartbeat_timeout: 1m0s
+        replication_factor: 3
+        zone_awareness_enabled: false
+      num_tokens: 128
+      heartbeat_period: 5s
+      observe_period: 0s
+      join_after: 0s
+      min_ready_duration: 1m0s
+      interface_names:
+      - eth0
+      - en0
+      final_sleep: 30s
+      tokens_file_path: ""
+      availability_zone: ""
+      unregister_on_shutdown: true
+      address: ""
+      port: 0
+      id: 920e9b32116a
+    dangerous_allow_reading_files: false
+  scraping_service_client:
+    grpc_client_config:
+      max_recv_msg_size: 104857600
+      max_send_msg_size: 16777216
+      grpc_compression: ""
+      rate_limit: 0
+      rate_limit_burst: 0
+      backoff_on_ratelimits: false
+      backoff_config:
+        min_period: 100ms
+        max_period: 10s
+        max_retries: 10
+      tls_enabled: false
+      tls_cert_path: ""
+      tls_key_path: ""
+      tls_ca_path: ""
+      tls_server_name: ""
+      tls_insecure_skip_verify: false
+  configs:
+  - name: default
+    wal_truncate_frequency: 1h0m0s
+    min_wal_time: 5m0s
+    max_wal_time: 4h0m0s
+    remote_flush_deadline: 1m0s
+  - name: instance1
+    scrape_configs:
+    - job_name: instance1_job
+      honor_timestamps: true
+      scrape_interval: 1m
+      scrape_timeout: 20s
+      metrics_path: /metrics
+      scheme: http
+      follow_redirects: true
+      static_configs:
+      - targets:
+        - localhost:4000
+    wal_truncate_frequency: 1h0m0s
+    min_wal_time: 5m0s
+    max_wal_time: 4h0m0s
+    remote_flush_deadline: 1m0s
+  - name: instance2
+    scrape_configs:
+    - job_name: instance2_job
+      honor_timestamps: true
+      scrape_interval: 1m
+      scrape_timeout: 20s
+      metrics_path: /metrics
+      scheme: http
+      follow_redirects: true
+      static_configs:
+      - targets:
+        - localhost:5555
+    wal_truncate_frequency: 1h0m0s
+    min_wal_time: 5m0s
+    max_wal_time: 4h0m0s
+    remote_flush_deadline: 1m0s
+  instance_restart_backoff: 5s
+  instance_mode: shared
+integrations:
+  metrics:
+    autoscrape:
+      enable: true
+      metrics_instance: default
+      scrape_interval: 1m
+      scrape_timeout: 20s
+  node_exporter:
+    procfs_path: /proc
+    sysfs_path: /sys
+    rootfs_path: /
+    diskstats_ignored_devices: ^(ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\d+n\d+p)\d+$
+    ethtool_metrics_include: .*
+    filesystem_fs_types_exclude: ^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
+    filesystem_mount_points_exclude: ^/(dev|proc|run/credentials/.+|sys|var/lib/docker/.+)($|/)
+    filesystem_mount_timeout: 5s
+    ntp_ip_ttl: 1
+    ntp_local_offset_tolerance: 1ms
+    ntp_max_distance: 3.46608s
+    ntp_protocol_version: 4
+    ntp_server: 127.0.0.1
+    netclass_ignored_devices: ^$
+    netstat_fields: ^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_(Listen.*|Syncookies.*|TCPSynRetrans|TCPTimeouts)|Tcp_(ActiveOpens|InSegs|OutSegs|OutRsts|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts|RcvbufErrors|SndbufErrors))$
+    powersupply_ignored_supplies: ^$
+    runit_service_dir: /etc/service
+    supervisord_url: http://localhost:9001/RPC2
+    systemd_unit_exclude: .+\.(automount|device|mount|scope|slice)
+    systemd_unit_include: .+
+    tapestats_ignored_devices: ^$
+    vmstat_fields: ^(oom_kill|pgpg|pswp|pg.*fault).*
+  redis_exporter_configs:
+  - autoscrape:
+      metric_relabel_configs:
+      - source_labels:
+        - __address__
+        separator: ;
+        regex: (.*)
+        target_label: banana
+        replacement: apple
+        action: replace
+    include_exporter_metrics: false
+    redis_addr: localhost:6379
+    namespace: redis
+    config_command: CONFIG
+    check_key_groups_batch_size: 10000
+    max_distinct_key_groups: 100
+    connection_timeout: 15s
+    set_client_name: true
+  - include_exporter_metrics: false
+    redis_addr: localhost:6380
+    namespace: redis
+    config_command: CONFIG
+    check_key_groups_batch_size: 10000
+    max_distinct_key_groups: 100
+    connection_timeout: 15s
+    set_client_name: true
+

--- a/docs/cookbook/dynamic-configuration/01_Basics/03_assets/integrations-node.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/03_assets/integrations-node.yml
@@ -1,0 +1,1 @@
+node_exporter: {}

--- a/docs/cookbook/dynamic-configuration/01_Basics/03_assets/integrations-redis.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/03_assets/integrations-redis.yml
@@ -1,0 +1,8 @@
+redis_exporter_configs:
+  - redis_addr: localhost:6379
+    autoscrape:
+      metric_relabel_configs:
+        - source_labels: [__address__]
+          target_label: "banana"
+          replacement: "apple"
+  - redis_addr: localhost:6380

--- a/docs/cookbook/dynamic-configuration/01_Basics/03_assets/metrics-1.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/03_assets/metrics-1.yml
@@ -1,0 +1,6 @@
+configs:
+- name: default
+global:
+  scrape_interval: 60s
+  scrape_timeout: 20s
+wal_directory: /tmp/grafana-agent-wal

--- a/docs/cookbook/dynamic-configuration/01_Basics/03_assets/metrics_instances-1.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/03_assets/metrics_instances-1.yml
@@ -1,0 +1,6 @@
+name: instance1
+scrape_configs:
+  - job_name: instance1_job
+    static_configs:
+      - targets:
+          - localhost:4000

--- a/docs/cookbook/dynamic-configuration/01_Basics/03_assets/metrics_instances-2.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/03_assets/metrics_instances-2.yml
@@ -1,0 +1,6 @@
+name: instance2
+scrape_configs:
+  - job_name: instance2_job
+    static_configs:
+      - targets:
+          - localhost:5555

--- a/docs/cookbook/dynamic-configuration/01_Basics/03_assets/server-1.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/03_assets/server-1.yml
@@ -1,0 +1,2 @@
+http_listen_port: 12345
+log_level: info

--- a/docs/cookbook/dynamic-configuration/01_Basics/03_config.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/03_config.yml
@@ -1,0 +1,2 @@
+template_paths:
+  - "file:///etc/grafana/03_assets"

--- a/docs/cookbook/dynamic-configuration/01_Basics/04_Logs_and_Traces.md
+++ b/docs/cookbook/dynamic-configuration/01_Basics/04_Logs_and_Traces.md
@@ -1,0 +1,46 @@
+# 04 Logs and Traces
+
+Logs and Traces can also be templated. This is built ontop of the previous examples.
+
+`docker run -v ${PWD}/:/etc/grafana grafana/agentctl:latest template-parse /etc/grafana/04_config.yml`
+
+## Dynamic Configuration
+
+[config.yml](./04_config.yml)
+
+Tells the Grafana Agent where to load files from.
+
+## Logs
+
+Logs are loaded from a template matching `logs-*.yml`. There can ONLY be 1 template loaded
+
+[logs-1.yml](./04_assets/logs-1.yml)
+
+```yaml
+configs:
+  - name: test_logs
+    positions:
+      filename: /tmp/positions.yaml
+    scrape_configs:
+      - job_name: test
+        pipeline_stages:
+          - regex:
+            source: filename
+            expression: '\\temp\\Logs\\(?P<log_app>.+?)\\'
+```
+
+[traces.yml](./04_assets/traces-1.yml)
+
+```yaml
+configs:
+  - name: test_traces
+    automatic_logging:
+      backend: stdout
+      loki_name: default
+      spans: true
+```
+
+## Final
+
+[final.yml](./04_assets/final.yml)
+

--- a/docs/cookbook/dynamic-configuration/01_Basics/04_assets/agent-1.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/04_assets/agent-1.yml
@@ -1,0 +1,17 @@
+server:
+  http_listen_port: 12345
+  log_level: debug
+metrics:
+  wal_directory: /tmp/grafana-agent-normal
+  global:
+    scrape_interval: 60s
+    remote_write:
+      - url: https://prometheus-us-central1.grafana.net/api/prom/push
+        basic_auth:
+          username: 12345
+          password: secretpassword
+integrations:
+  node_exporter:
+    enabled: true
+  agent:
+    enabled: true

--- a/docs/cookbook/dynamic-configuration/01_Basics/04_assets/final.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/04_assets/final.yml
@@ -1,0 +1,278 @@
+server:
+  http_listen_network: ""
+  http_listen_address: ""
+  http_listen_port: 12345
+  http_listen_conn_limit: 0
+  grpc_listen_network: ""
+  grpc_listen_address: ""
+  grpc_listen_port: 0
+  grpc_listen_conn_limit: 0
+  http_tls_config:
+    cert_file: ""
+    key_file: ""
+    client_auth_type: ""
+    client_ca_file: ""
+    cipher_suites: []
+    curve_preferences: []
+    min_version: 0
+    max_version: 0
+    prefer_server_cipher_suites: false
+  grpc_tls_config:
+    cert_file: ""
+    key_file: ""
+    client_auth_type: ""
+    client_ca_file: ""
+    cipher_suites: []
+    curve_preferences: []
+    min_version: 0
+    max_version: 0
+    prefer_server_cipher_suites: false
+  register_instrumentation: false
+  graceful_shutdown_timeout: 0s
+  http_server_read_timeout: 0s
+  http_server_write_timeout: 0s
+  http_server_idle_timeout: 0s
+  grpc_server_max_recv_msg_size: 0
+  grpc_server_max_send_msg_size: 0
+  grpc_server_max_concurrent_streams: 0
+  grpc_server_max_connection_idle: 0s
+  grpc_server_max_connection_age: 0s
+  grpc_server_max_connection_age_grace: 0s
+  grpc_server_keepalive_time: 0s
+  grpc_server_keepalive_timeout: 0s
+  grpc_server_min_time_between_pings: 0s
+  grpc_server_ping_without_stream_allowed: false
+  log_format: ""
+  log_level: info
+  log_source_ips_enabled: false
+  log_source_ips_header: ""
+  log_source_ips_regex: ""
+  http_path_prefix: ""
+metrics:
+  global:
+    scrape_interval: 1m
+    scrape_timeout: 20s
+    evaluation_interval: 1m
+  wal_directory: /tmp/grafana-agent-wal
+  wal_cleanup_age: 12h0m0s
+  wal_cleanup_period: 30m0s
+  scraping_service:
+    enabled: false
+    reshard_interval: 1m0s
+    reshard_timeout: 30s
+    cluster_reshard_event_timeout: 30s
+    kvstore:
+      store: consul
+      prefix: configurations/
+      consul:
+        host: localhost:8500
+        acl_token: <secret>
+        http_client_timeout: 20s
+        consistent_reads: false
+        watch_rate_limit: 1
+        watch_burst_size: 1
+      etcd:
+        endpoints: []
+        dial_timeout: 10s
+        max_retries: 10
+        tls_enabled: false
+        tls_cert_path: ""
+        tls_key_path: ""
+        tls_ca_path: ""
+        tls_server_name: ""
+        tls_insecure_skip_verify: false
+        username: ""
+        password: <secret>
+      multi:
+        primary: ""
+        secondary: ""
+        mirror_enabled: false
+        mirror_timeout: 2s
+    lifecycler:
+      ring:
+        kvstore:
+          store: consul
+          prefix: collectors/
+          consul:
+            host: localhost:8500
+            acl_token: <secret>
+            http_client_timeout: 20s
+            consistent_reads: false
+            watch_rate_limit: 1
+            watch_burst_size: 1
+          etcd:
+            endpoints: []
+            dial_timeout: 10s
+            max_retries: 10
+            tls_enabled: false
+            tls_cert_path: ""
+            tls_key_path: ""
+            tls_ca_path: ""
+            tls_server_name: ""
+            tls_insecure_skip_verify: false
+            username: ""
+            password: <secret>
+          multi:
+            primary: ""
+            secondary: ""
+            mirror_enabled: false
+            mirror_timeout: 2s
+        heartbeat_timeout: 1m0s
+        replication_factor: 3
+        zone_awareness_enabled: false
+      num_tokens: 128
+      heartbeat_period: 5s
+      observe_period: 0s
+      join_after: 0s
+      min_ready_duration: 1m0s
+      interface_names:
+      - eth0
+      - en0
+      final_sleep: 30s
+      tokens_file_path: ""
+      availability_zone: ""
+      unregister_on_shutdown: true
+      address: ""
+      port: 0
+      id: 2555e70c377f
+    dangerous_allow_reading_files: false
+  scraping_service_client:
+    grpc_client_config:
+      max_recv_msg_size: 104857600
+      max_send_msg_size: 16777216
+      grpc_compression: ""
+      rate_limit: 0
+      rate_limit_burst: 0
+      backoff_on_ratelimits: false
+      backoff_config:
+        min_period: 100ms
+        max_period: 10s
+        max_retries: 10
+      tls_enabled: false
+      tls_cert_path: ""
+      tls_key_path: ""
+      tls_ca_path: ""
+      tls_server_name: ""
+      tls_insecure_skip_verify: false
+  configs:
+  - name: default
+    wal_truncate_frequency: 1h0m0s
+    min_wal_time: 5m0s
+    max_wal_time: 4h0m0s
+    remote_flush_deadline: 1m0s
+  - name: instance1
+    scrape_configs:
+    - job_name: instance1_job
+      honor_timestamps: true
+      scrape_interval: 1m
+      scrape_timeout: 20s
+      metrics_path: /metrics
+      scheme: http
+      follow_redirects: true
+      static_configs:
+      - targets:
+        - localhost:4000
+    wal_truncate_frequency: 1h0m0s
+    min_wal_time: 5m0s
+    max_wal_time: 4h0m0s
+    remote_flush_deadline: 1m0s
+  - name: instance2
+    scrape_configs:
+    - job_name: instance2_job
+      honor_timestamps: true
+      scrape_interval: 1m
+      scrape_timeout: 20s
+      metrics_path: /metrics
+      scheme: http
+      follow_redirects: true
+      static_configs:
+      - targets:
+        - localhost:5555
+    wal_truncate_frequency: 1h0m0s
+    min_wal_time: 5m0s
+    max_wal_time: 4h0m0s
+    remote_flush_deadline: 1m0s
+  instance_restart_backoff: 5s
+  instance_mode: shared
+integrations:
+  metrics:
+    autoscrape:
+      enable: true
+      metrics_instance: default
+      scrape_interval: 1m
+      scrape_timeout: 20s
+  redis_exporter_configs:
+  - autoscrape:
+      metric_relabel_configs:
+      - source_labels:
+        - __address__
+        separator: ;
+        regex: (.*)
+        target_label: banana
+        replacement: apple
+        action: replace
+    include_exporter_metrics: false
+    redis_addr: localhost:6379
+    namespace: redis
+    config_command: CONFIG
+    check_key_groups_batch_size: 10000
+    max_distinct_key_groups: 100
+    connection_timeout: 15s
+    set_client_name: true
+  - include_exporter_metrics: false
+    redis_addr: localhost:6380
+    namespace: redis
+    config_command: CONFIG
+    check_key_groups_batch_size: 10000
+    max_distinct_key_groups: 100
+    connection_timeout: 15s
+    set_client_name: true
+  node_exporter:
+    procfs_path: /proc
+    sysfs_path: /sys
+    rootfs_path: /
+    diskstats_ignored_devices: ^(ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\d+n\d+p)\d+$
+    ethtool_metrics_include: .*
+    filesystem_fs_types_exclude: ^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
+    filesystem_mount_points_exclude: ^/(dev|proc|run/credentials/.+|sys|var/lib/docker/.+)($|/)
+    filesystem_mount_timeout: 5s
+    ntp_ip_ttl: 1
+    ntp_local_offset_tolerance: 1ms
+    ntp_max_distance: 3.46608s
+    ntp_protocol_version: 4
+    ntp_server: 127.0.0.1
+    netclass_ignored_devices: ^$
+    netstat_fields: ^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_(Listen.*|Syncookies.*|TCPSynRetrans|TCPTimeouts)|Tcp_(ActiveOpens|InSegs|OutSegs|OutRsts|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts|RcvbufErrors|SndbufErrors))$
+    powersupply_ignored_supplies: ^$
+    runit_servic e_dir: /etc/service
+    supervisord_url: http://localhost:9001/RPC2
+    systemd_unit_exclude: .+\.(automount|device|mount|scope|slice)
+    systemd_unit_include: .+
+    tapestats_ignored_devices: ^$
+    vmstat_fields: ^(oom_kill|pgpg|pswp|pg.*fault).*
+traces:
+  configs:
+  - name: test_traces
+    automatic_logging:
+      backend: stdout
+      logs_instance_name: default
+      spans: true
+    load_balancing: null
+logs:
+  configs:
+  - name: test_logs
+    positions:
+      sync_period: 10s
+      filename: /tmp/positions.yaml
+      ignore_invalid_yaml: false
+    scrape_configs:
+    - job_name: test
+      pipeline_stages:
+      - expression: \\temp\\Logs\\(?P<log_app>.+?)\\
+        regex: null
+        source: filename
+      static_configs: []
+    target_config:
+      sync_period: 10s
+      stdin: false
+

--- a/docs/cookbook/dynamic-configuration/01_Basics/04_assets/integrations-node.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/04_assets/integrations-node.yml
@@ -1,0 +1,1 @@
+node_exporter: {}

--- a/docs/cookbook/dynamic-configuration/01_Basics/04_assets/integrations-redis.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/04_assets/integrations-redis.yml
@@ -1,0 +1,8 @@
+redis_exporter_configs:
+  - redis_addr: localhost:6379
+    autoscrape:
+      metric_relabel_configs:
+        - source_labels: [__address__]
+          target_label: "banana"
+          replacement: "apple"
+  - redis_addr: localhost:6380

--- a/docs/cookbook/dynamic-configuration/01_Basics/04_assets/logs-1.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/04_assets/logs-1.yml
@@ -1,0 +1,10 @@
+configs:
+  - name: test_logs
+    positions:
+      filename: /tmp/positions.yaml
+    scrape_configs:
+      - job_name: test
+        pipeline_stages:
+          - regex:
+            source: filename
+            expression: '\\temp\\Logs\\(?P<log_app>.+?)\\'

--- a/docs/cookbook/dynamic-configuration/01_Basics/04_assets/metrics-1.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/04_assets/metrics-1.yml
@@ -1,0 +1,6 @@
+configs:
+- name: default
+global:
+  scrape_interval: 60s
+  scrape_timeout: 20s
+wal_directory: /tmp/grafana-agent-wal

--- a/docs/cookbook/dynamic-configuration/01_Basics/04_assets/metrics_instances-1.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/04_assets/metrics_instances-1.yml
@@ -1,0 +1,6 @@
+name: instance1
+scrape_configs:
+  - job_name: instance1_job
+    static_configs:
+      - targets:
+          - localhost:4000

--- a/docs/cookbook/dynamic-configuration/01_Basics/04_assets/metrics_instances-2.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/04_assets/metrics_instances-2.yml
@@ -1,0 +1,6 @@
+name: instance2
+scrape_configs:
+  - job_name: instance2_job
+    static_configs:
+      - targets:
+          - localhost:5555

--- a/docs/cookbook/dynamic-configuration/01_Basics/04_assets/server-1.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/04_assets/server-1.yml
@@ -1,0 +1,2 @@
+http_listen_port: 12345
+log_level: info

--- a/docs/cookbook/dynamic-configuration/01_Basics/04_assets/traces-1.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/04_assets/traces-1.yml
@@ -1,0 +1,6 @@
+configs:
+  - name: test_traces
+    automatic_logging:
+      backend: stdout
+      loki_name: default
+      spans: true

--- a/docs/cookbook/dynamic-configuration/01_Basics/04_config.yml
+++ b/docs/cookbook/dynamic-configuration/01_Basics/04_config.yml
@@ -1,0 +1,2 @@
+template_paths:
+  - "file:///etc/grafana/04_assets"

--- a/docs/cookbook/dynamic-configuration/02_Templates/01_Looping.md
+++ b/docs/cookbook/dynamic-configuration/02_Templates/01_Looping.md
@@ -1,0 +1,42 @@
+# 01 Basics of Templating
+
+The templating is based on the excellent [gomplate](https://docs.gomplate.ca/) library. Currently using a custom fork to allow loading gomplate as a library in addition to some new commands. This will NOT try to cover the full range of gomplate, would recommend reading the documentation for full knowledge. 
+
+`docker run -v ${PWD}/:/etc/grafana grafana/agentctl:latest template-parse /etc/grafana/01_config.yml`
+
+## Looping
+
+[agent-1.yml](./01_assets/agent-1.yml)
+
+```yaml
+server:
+  http_listen_port: 12345
+  log_level: debug
+metrics:
+  wal_directory: /tmp/grafana-agent-normal
+  global:
+    scrape_interval: 60s
+    remote_write:
+      - url: https://prometheus-us-central1.grafana.net/api/prom/push
+        basic_auth:
+          username: 12345
+          password: secretpassword
+  configs:
+    - name: default
+  {{ range slice "apple" "banana" "pear" }}
+    - name: {{ . }}
+  {{ end }}
+```
+
+The templating engine uses directives that are wrapped in `{{ command }}`, in the above the dynamic configuration engine will loop over the three values, and those values can be accessed by `{{ . }}` which means current value. 
+
+## Final
+
+[final.yml](./01_assets/final.yml)
+
+The final.yml contains 4 prometheus configs
+
+- default
+- apple
+- banana
+- pear

--- a/docs/cookbook/dynamic-configuration/02_Templates/01_assets/agent-1.yml
+++ b/docs/cookbook/dynamic-configuration/02_Templates/01_assets/agent-1.yml
@@ -1,0 +1,17 @@
+server:
+  http_listen_port: 12345
+  log_level: debug
+metrics:
+  wal_directory: /tmp/grafana-agent-normal
+  global:
+    scrape_interval: 60s
+    remote_write:
+      - url: https://prometheus-us-central1.grafana.net/api/prom/push
+        basic_auth:
+          username: 12345
+          password: secretpassword
+  configs:
+    - name: default
+  {{ range slice "apple" "banana" "pear" }}
+    - name: {{ . }}
+  {{ end }}

--- a/docs/cookbook/dynamic-configuration/02_Templates/01_assets/final.yml
+++ b/docs/cookbook/dynamic-configuration/02_Templates/01_assets/final.yml
@@ -1,0 +1,285 @@
+server:
+  http_listen_network: tcp
+  http_listen_address: ""
+  http_listen_port: 12345
+  http_listen_conn_limit: 0
+  grpc_listen_network: tcp
+  grpc_listen_address: ""
+  grpc_listen_port: 9095
+  grpc_listen_conn_limit: 0
+  http_tls_config:
+    cert_file: ""
+    key_file: ""
+    client_auth_type: ""
+    client_ca_file: ""
+    cipher_suites: []
+    curve_preferences: []
+    min_version: 0
+    max_version: 0
+    prefer_server_cipher_suites: false
+  grpc_tls_config:
+    cert_file: ""
+    key_file: ""
+    client_auth_type: ""
+    client_ca_file: ""
+    cipher_suites: []
+    curve_preferences: []
+    min_version: 0
+    max_version: 0
+    prefer_server_cipher_suites: false
+  register_instrumentation: true
+  graceful_shutdown_timeout: 30s
+  http_server_read_timeout: 30s
+  http_server_write_timeout: 30s
+  http_server_idle_timeout: 2m0s
+  grpc_server_max_recv_msg_size: 4194304
+  grpc_server_max_send_msg_size: 4194304
+  grpc_server_max_concurrent_streams: 100
+  grpc_server_max_connection_idle: 2562047h47m16.854775807s
+  grpc_server_max_connection_age: 2562047h47m16.854775807s
+  grpc_server_max_connection_age_grace: 2562047h47m16.854775807s
+  grpc_server_keepalive_time: 2h0m0s
+  grpc_server_keepalive_timeout: 20s
+  grpc_server_min_time_between_pings: 5m0s
+  grpc_server_ping_without_stream_allowed: false
+  log_format: logfmt
+  log_level: debug
+  log_source_ips_enabled: false
+  log_source_ips_header: ""
+  log_source_ips_regex: ""
+  http_path_prefix: ""
+metrics:
+  global:
+    scrape_interval: 1m
+    scrape_timeout: 10s
+    evaluation_interval: 1m
+    remote_write:
+    - url: https://prometheus-us-central1.grafana.net/api/prom/push
+      remote_timeout: 30s
+      name: default-a098e3
+      basic_auth:
+        username: "12345"
+        password: <secret>
+      follow_redirects: true
+      queue_config:
+        capacity: 2500
+        max_shards: 200
+        min_shards: 1
+        max_samples_per_send: 500
+        batch_send_deadline: 5s
+        min_backoff: 30ms
+        max_backoff: 100ms
+      metadata_config:
+        send: true
+        send_interval: 1m
+        max_samples_per_send: 500
+  wal_directory: /tmp/grafana-agent-normal
+  wal_cleanup_age: 12h0m0s
+  wal_cleanup_period: 30m0s
+  scraping_service:
+    enabled: false
+    reshard_interval: 1m0s
+    reshard_timeout: 30s
+    cluster_reshard_event_timeout: 30s
+    kvstore:
+      store: consul
+      prefix: configurations/
+      consul:
+        host: localhost:8500
+        acl_token: <secret>
+        http_client_timeout: 20s
+        consistent_reads: false
+        watch_rate_limit: 1
+        watch_burst_size: 1
+      etcd:
+        endpoints: []
+        dial_timeout: 10s
+        max_retries: 10
+        tls_enabled: false
+        tls_cert_path: ""
+        tls_key_path: ""
+        tls_ca_path: ""
+        tls_server_name: ""
+        tls_insecure_skip_verify: false
+        username: ""
+        password: <secret>
+      multi:
+        primary: ""
+        secondary: ""
+        mirror_enabled: false
+        mirror_timeout: 2s
+    lifecycler:
+      ring:
+        kvstore:
+          store: consul
+          prefix: collectors/
+          consul:
+            host: localhost:8500
+            acl_token: <secret>
+            http_client_timeout: 20s
+            consistent_reads: false
+            watch_rate_limit: 1
+            watch_burst_size: 1
+          etcd:
+            endpoints: []
+            dial_timeout: 10s
+            max_retries: 10
+            tls_enabled: false
+            tls_cert_path: ""
+            tls_key_path: ""
+            tls_ca_path: ""
+            tls_server_name: ""
+            tls_insecure_skip_verify: false
+            username: ""
+            password: <secret>
+          multi:
+            primary: ""
+            secondary: ""
+            mirror_enabled: false
+            mirror_timeout: 2s
+        heartbeat_timeout: 1m0s
+        replication_factor: 3
+        zone_awareness_enabled: false
+      num_tokens: 128
+      heartbeat_period: 5s
+      observe_period: 0s
+      join_after: 0s
+      min_ready_duration: 1m0s
+      interface_names:
+      - eth0
+      - en0
+      final_sleep: 30s
+      tokens_file_path: ""
+      availability_zone: ""
+      unregister_on_shutdown: true
+      address: ""
+      port: 0
+      id: 4d5f79f1dd4d
+    dangerous_allow_reading_files: false
+  scraping_service_client:
+    grpc_client_config:
+      max_recv_msg_size: 104857600
+      max_send_msg_size: 16777216
+      grpc_compression: ""
+      rate_limit: 0
+      rate_limit_burst: 0
+      backoff_on_ratelimits: false
+      backoff_config:
+        min_period: 100ms
+        max_period: 10s
+        max_retries: 10
+      tls_enabled: false
+      tls_cert_path: ""
+      tls_key_path: ""
+      tls_ca_path: ""
+      tls_server_name: ""
+      tls_insecure_skip_verify: false
+  configs:
+  - name: default
+    remote_write:
+    - url: https://prometheus-us-central1.grafana.net/api/prom/push
+      remote_timeout: 30s
+      name: default-a098e3
+      basic_auth:
+        username: "12345"
+        password: <secret>
+      follow_redirects: true
+      queue_config:
+        capacity: 2500
+        max_shards: 200
+        min_shards: 1
+        max_samples_per_send: 500
+        batch_send_deadline: 5s
+        min_backoff: 30ms
+        max_backoff: 100ms
+      metadata_config:
+        send: true
+        send_interval: 1m
+        max_samples_per_send: 500
+    wal_truncate_frequency: 1h0m0s
+    min_wal_time: 5m0s
+    max_wal_time: 4h0m0s
+    remote_flush_deadline: 1m0s
+  - name: apple
+    remote_write:
+    - url: https://prometheus-us-central1.grafana.net/api/prom/push
+      remote_timeout: 30s
+      name: default-a098e3
+      basic_auth:
+        username: "12345"
+        password: <secret>
+      follow_redirects: true
+      queue_config:
+        capacity: 2500
+        max_shards: 200
+        min_shards: 1
+        max_samples_per_send: 500
+        batch_send_deadline: 5s
+        min_backoff: 30ms
+        max_backoff: 100ms
+      metadata_config:
+        send: true
+        send_interval: 1m
+        max_samples_per_send: 500
+    wal_truncate_frequency: 1h0m0s
+    min_wal_time: 5m0s
+    max_wal_time: 4h0m0s
+    remote_flush_deadline: 1m0s
+  - name: banana
+    remote_write:
+    - url: https://prometheus-us-central1.grafana.net/api/prom/push
+      remote_timeout: 30s
+      name: default-a098e3
+      basic_auth:
+        username: "12345"
+        password: <secret>
+      follow_redirects: true
+      queue_config:
+        capacity: 2500
+        max_shards: 200
+        min_shards: 1
+        max_samples_per_send: 500
+        batch_send_deadline: 5s
+        min_backoff: 30ms
+        max_backoff: 100ms
+      metadata_config:
+        send: true
+        send_interval: 1m
+        max_samples_per_send: 500
+    wal_truncate_frequency: 1h0m0s
+    min_wal_time: 5m0s
+    max_wal_time: 4h0m0s
+    remote_flush_deadline: 1m0s
+  - name: pear
+    remote_write:
+    - url: https://prometheus-us-central1.grafana.net/api/prom/push
+      remote_timeout: 30s
+      name: default-a098e3
+      basic_auth:
+        username: "12345"
+        password: <secret>
+      follow_redirects: true
+      queue_config:
+        capacity: 2500
+        max_shards: 200
+        min_shards: 1
+        max_samples_per_send: 500
+        batch_send_deadline: 5s
+        min_backoff: 30ms
+        max_backoff: 100ms
+      metadata_config:
+        send: true
+        send_interval: 1m
+        max_samples_per_send: 500
+    wal_truncate_frequency: 1h0m0s
+    min_wal_time: 5m0s
+    max_wal_time: 4h0m0s
+    remote_flush_deadline: 1m0s
+  instance_restart_backoff: 5s
+  instance_mode: shared
+integrations:
+  scrape_integrations: true
+  integration_restart_backoff: 5s
+  replace_instance_label: true
+  use_hostname_label: true
+

--- a/docs/cookbook/dynamic-configuration/02_Templates/01_config.yml
+++ b/docs/cookbook/dynamic-configuration/02_Templates/01_config.yml
@@ -1,0 +1,2 @@
+template_paths:
+  - "file:///etc/grafana/01_assets"

--- a/docs/cookbook/dynamic-configuration/02_Templates/02_Datasources.md
+++ b/docs/cookbook/dynamic-configuration/02_Templates/02_Datasources.md
@@ -12,7 +12,7 @@ The [config.yml](./02_config.yml) adds a new field `sources`. Sources can be any
 ```yaml
 template_paths:
   - "file:///etc/grafana/01_assets"
-sources:
+datasources:
   - name: fruit
     url: "file://etc/grafana/01_assets/fruit.json"
 ```

--- a/docs/cookbook/dynamic-configuration/02_Templates/02_Datasources.md
+++ b/docs/cookbook/dynamic-configuration/02_Templates/02_Datasources.md
@@ -1,0 +1,50 @@
+# 02 Datasources
+
+Datasources are a powerful concept in gomplate. They allow you to reach out to other files, systems and resources to pull data. 
+
+`docker run -v ${PWD}/:/etc/grafana grafana/agentctl:latest template-parse /etc/grafana/02_config.yml`
+
+
+## Config
+
+The [config.yml](./02_config.yml) adds a new field `sources`. Sources can be any number of things defined in the gomplate [datasources](https://docs.gomplate.ca/datasources/) documentation. In this example using fruit.
+
+```yaml
+template_paths:
+  - "file:///etc/grafana/01_assets"
+sources:
+  - name: fruit
+    url: "file://etc/grafana/01_assets/fruit.json"
+```
+
+[fruit.json](./02_assets/fruit.json)
+
+```json
+["mango","peach","orange"]
+```
+
+## Usage
+
+[agent-1.yml](./02_assets/agent-1.yml)
+
+```yaml
+server:
+  http_listen_port: 12345
+  log_level: debug
+metrics:
+  wal_directory: /tmp/grafana-agent-normal
+  global:
+    scrape_interval: 60s
+    remote_write:
+      - url: https://prometheus-us-central1.grafana.net/api/prom/push
+        basic_auth:
+          username: 12345
+          password: secretpassword
+  configs:
+    - name: default
+  {{ range (datasource "fruit") }}
+    - name: {{ . }}
+  {{ end }}
+```
+
+A Datasource is reference by name and in this case it is an array and used exactly like the looping example.

--- a/docs/cookbook/dynamic-configuration/02_Templates/02_assets/agent-1.yml
+++ b/docs/cookbook/dynamic-configuration/02_Templates/02_assets/agent-1.yml
@@ -1,0 +1,17 @@
+server:
+  http_listen_port: 12345
+  log_level: debug
+metrics:
+  wal_directory: /tmp/grafana-agent-normal
+  global:
+    scrape_interval: 60s
+    remote_write:
+      - url: https://prometheus-us-central1.grafana.net/api/prom/push
+        basic_auth:
+          username: 12345
+          password: secretpassword
+  configs:
+    - name: default
+  {{ range (datasource "fruit") }}
+    - name: {{ . }}
+  {{ end }}

--- a/docs/cookbook/dynamic-configuration/02_Templates/02_assets/final.yml
+++ b/docs/cookbook/dynamic-configuration/02_Templates/02_assets/final.yml
@@ -1,0 +1,285 @@
+server:
+  http_listen_network: tcp
+  http_listen_address: ""
+  http_listen_port: 12345
+  http_listen_conn_limit: 0
+  grpc_listen_network: tcp
+  grpc_listen_address: ""
+  grpc_listen_port: 9095
+  grpc_listen_conn_limit: 0
+  http_tls_config:
+    cert_file: ""
+    key_file: ""
+    client_auth_type: ""
+    client_ca_file: ""
+    cipher_suites: []
+    curve_preferences: []
+    min_version: 0
+    max_version: 0
+    prefer_server_cipher_suites: false
+  grpc_tls_config:
+    cert_file: ""
+    key_file: ""
+    client_auth_type: ""
+    client_ca_file: ""
+    cipher_suites: []
+    curve_preferences: []
+    min_version: 0
+    max_version: 0
+    prefer_server_cipher_suites: false
+  register_instrumentation: true
+  graceful_shutdown_timeout: 30s
+  http_server_read_timeout: 30s
+  http_server_write_timeout: 30s
+  http_server_idle_timeout: 2m0s
+  grpc_server_max_recv_msg_size: 4194304
+  grpc_server_max_send_msg_size: 4194304
+  grpc_server_max_concurrent_streams: 100
+  grpc_server_max_connection_idle: 2562047h47m16.854775807s
+  grpc_server_max_connection_age: 2562047h47m16.854775807s
+  grpc_server_max_connection_age_grace: 2562047h47m16.854775807s
+  grpc_server_keepalive_time: 2h0m0s
+  grpc_server_keepalive_timeout: 20s
+  grpc_server_min_time_between_pings: 5m0s
+  grpc_server_ping_without_stream_allowed: false
+  log_format: logfmt
+  log_level: debug
+  log_source_ips_enabled: false
+  log_source_ips_header: ""
+  log_source_ips_regex: ""
+  http_path_prefix: ""
+metrics:
+  global:
+    scrape_interval: 1m
+    scrape_timeout: 10s
+    evaluation_interval: 1m
+    remote_write:
+    - url: https://prometheus-us-central1.grafana.net/api/prom/push
+      remote_timeout: 30s
+      name: default-a098e3
+      basic_auth:
+        username: "12345"
+        password: <secret>
+      follow_redirects: true
+      queue_config:
+        capacity: 2500
+        max_shards: 200
+        min_shards: 1
+        max_samples_per_send: 500
+        batch_send_deadline: 5s
+        min_backoff: 30ms
+        max_backoff: 100ms
+      metadata_config:
+        send: true
+        send_interval: 1m
+        max_samples_per_send: 500
+  wal_directory: /tmp/grafana-agent-normal
+  wal_cleanup_age: 12h0m0s
+  wal_cleanup_period: 30m0s
+  scraping_service:
+    enabled: false
+    reshard_interval: 1m0s
+    reshard_timeout: 30s
+    cluster_reshard_event_timeout: 30s
+    kvstore:
+      store: consul
+      prefix: configurations/
+      consul:
+        host: localhost:8500
+        acl_token: <secret>
+        http_client_timeout: 20s
+        consistent_reads: false
+        watch_rate_limit: 1
+        watch_burst_size: 1
+      etcd:
+        endpoints: []
+        dial_timeout: 10s
+        max_retries: 10
+        tls_enabled: false
+        tls_cert_path: ""
+        tls_key_path: ""
+        tls_ca_path: ""
+        tls_server_name: ""
+        tls_insecure_skip_verify: false
+        username: ""
+        password: <secret>
+      multi:
+        primary: ""
+        secondary: ""
+        mirror_enabled: false
+        mirror_timeout: 2s
+    lifecycler:
+      ring:
+        kvstore:
+          store: consul
+          prefix: collectors/
+          consul:
+            host: localhost:8500
+            acl_token: <secret>
+            http_client_timeout: 20s
+            consistent_reads: false
+            watch_rate_limit: 1
+            watch_burst_size: 1
+          etcd:
+            endpoints: []
+            dial_timeout: 10s
+            max_retries: 10
+            tls_enabled: false
+            tls_cert_path: ""
+            tls_key_path: ""
+            tls_ca_path: ""
+            tls_server_name: ""
+            tls_insecure_skip_verify: false
+            username: ""
+            password: <secret>
+          multi:
+            primary: ""
+            secondary: ""
+            mirror_enabled: false
+            mirror_timeout: 2s
+        heartbeat_timeout: 1m0s
+        replication_factor: 3
+        zone_awareness_enabled: false
+      num_tokens: 128
+      heartbeat_period: 5s
+      observe_period: 0s
+      join_after: 0s
+      min_ready_duration: 1m0s
+      interface_names:
+      - eth0
+      - en0
+      final_sleep: 30s
+      tokens_file_path: ""
+      availability_zone: ""
+      unregister_on_shutdown: true
+      address: ""
+      port: 0
+      id: 7fdd8f46a28a
+    dangerous_allow_reading_files: false
+  scraping_service_client:
+    grpc_client_config:
+      max_recv_msg_size: 104857600
+      max_send_msg_size: 16777216
+      grpc_compression: ""
+      rate_limit: 0
+      rate_limit_burst: 0
+      backoff_on_ratelimits: false
+      backoff_config:
+        min_period: 100ms
+        max_period: 10s
+        max_retries: 10
+      tls_enabled: false
+      tls_cert_path: ""
+      tls_key_path: ""
+      tls_ca_path: ""
+      tls_server_name: ""
+      tls_insecure_skip_verify: false
+  configs:
+  - name: default
+    remote_write:
+    - url: https://prometheus-us-central1.grafana.net/api/prom/push
+      remote_timeout: 30s
+      name: default-a098e3
+      basic_auth:
+        username: "12345"
+        password: <secret>
+      follow_redirects: true
+      queue_config:
+        capacity: 2500
+        max_shards: 200
+        min_shards: 1
+        max_samples_per_send: 500
+        batch_send_deadline: 5s
+        min_backoff: 30ms
+        max_backoff: 100ms
+      metadata_config:
+        send: true
+        send_interval: 1m
+        max_samples_per_send: 500
+    wal_truncate_frequency: 1h0m0s
+    min_wal_time: 5m0s
+    max_wal_time: 4h0m0s
+    remote_flush_deadline: 1m0s
+  - name: mango
+    remote_write:
+    - url: https://prometheus-us-central1.grafana.net/api/prom/push
+      remote_timeout: 30s
+      name: default-a098e3
+      basic_auth:
+        username: "12345"
+        password: <secret>
+      follow_redirects: true
+      queue_config:
+        capacity: 2500
+        max_shards: 200
+        min_shards: 1
+        max_samples_per_send: 500
+        batch_send_deadline: 5s
+        min_backoff: 30ms
+        max_backoff: 100ms
+      metadata_config:
+        send: true
+        send_interval: 1m
+        max_samples_per_send: 500
+    wal_truncate_frequency: 1h0m0s
+    min_wal_time: 5m0s
+    max_wal_time: 4h0m0s
+    remote_flush_deadline: 1m0s
+  - name: peach
+    remote_write:
+    - url: https://prometheus-us-central1.grafana.net/api/prom/push
+      remote_timeout: 30s
+      name: default-a098e3
+      basic_auth:
+        username: "12345"
+        password: <secret>
+      follow_redirects: true
+      queue_config:
+        capacity: 2500
+        max_shards: 200
+        min_shards: 1
+        max_samples_per_send: 500
+        batch_send_deadline: 5s
+        min_backoff: 30ms
+        max_backoff: 100ms
+      metadata_config:
+        send: true
+        send_interval: 1m
+        max_samples_per_send: 500
+    wal_truncate_frequency: 1h0m0s
+    min_wal_time: 5m0s
+    max_wal_time: 4h0m0s
+    remote_flush_deadline: 1m0s
+  - name: orange
+    remote_write:
+    - url: https://prometheus-us-central1.grafana.net/api/prom/push
+      remote_timeout: 30s
+      name: default-a098e3
+      basic_auth:
+        username: "12345"
+        password: <secret>
+      follow_redirects: true
+      queue_config:
+        capacity: 2500
+        max_shards: 200
+        min_shards: 1
+        max_samples_per_send: 500
+        batch_send_deadline: 5s
+        min_backoff: 30ms
+        max_backoff: 100ms
+      metadata_config:
+        send: true
+        send_interval: 1m
+        max_samples_per_send: 500
+    wal_truncate_frequency: 1h0m0s
+    min_wal_time: 5m0s
+    max_wal_time: 4h0m0s
+    remote_flush_deadline: 1m0s
+  instance_restart_backoff: 5s
+  instance_mode: shared
+integrations:
+  scrape_integrations: true
+  integration_restart_backoff: 5s
+  replace_instance_label: true
+  use_hostname_label: true
+

--- a/docs/cookbook/dynamic-configuration/02_Templates/02_assets/fruit.json
+++ b/docs/cookbook/dynamic-configuration/02_Templates/02_assets/fruit.json
@@ -1,0 +1,1 @@
+["mango","peach","orange"]

--- a/docs/cookbook/dynamic-configuration/02_Templates/02_config.yml
+++ b/docs/cookbook/dynamic-configuration/02_Templates/02_config.yml
@@ -1,0 +1,5 @@
+template_paths:
+  - "file:///etc/grafana/02_assets"
+sources:
+  - name: fruit
+    url: "file:///etc/grafana/02_assets/fruit.json"

--- a/docs/cookbook/dynamic-configuration/02_Templates/03_Datasource_and_Objects.md
+++ b/docs/cookbook/dynamic-configuration/02_Templates/03_Datasource_and_Objects.md
@@ -12,7 +12,7 @@ The [config.yml](./02_config.yml) adds a new field `sources`. Sources can be any
 ```yaml
 template_paths:
   - "file:///etc/grafana/03_assets"
-sources:
+datasources:
   - name: computers
     url: "file:///etc/grafana/03_assets/computers.json"
 ```

--- a/docs/cookbook/dynamic-configuration/02_Templates/03_Datasource_and_Objects.md
+++ b/docs/cookbook/dynamic-configuration/02_Templates/03_Datasource_and_Objects.md
@@ -1,0 +1,86 @@
+# 02 Datasources
+
+Datasources can also access objects.
+
+`docker run -v ${PWD}/:/etc/grafana grafana/agentctl:latest template-parse /etc/grafana/03_config.yml`
+
+
+## Config
+
+The [config.yml](./02_config.yml) adds a new field `sources`. Sources can be any number of things defined in the gomplate [datasources](https://docs.gomplate.ca/datasources/) documentation. In this example using fruit.
+
+```yaml
+template_paths:
+  - "file:///etc/grafana/03_assets"
+sources:
+  - name: computers
+    url: "file:///etc/grafana/03_assets/computers.json"
+```
+
+[computers.json](./03_assets/computers.json)
+
+```json
+[
+  {
+    "name": "webhost1",
+    "ip" : "192.168.1.1",
+    "enabled": true
+  },
+  {
+    "name": "webhost2",
+    "ip" : "192.168.1.2",
+    "enabled": false
+
+  },
+  {
+    "name": "webhost3",
+    "ip" : "192.168.1.3",
+    "enabled": true
+  }
+]
+```
+
+## Usage
+
+[agent-1.yml](./02_assets/agent-1.yml)
+
+```yaml
+server:
+  http_listen_port: 12345
+  log_level: debug
+metrics:
+  wal_directory: /tmp/grafana-agent-normal
+  global:
+    scrape_interval: 60s
+    remote_write:
+      - url: https://prometheus-us-central1.grafana.net/api/prom/push
+        basic_auth:
+          username: 12345
+          password: secretpassword
+  configs:
+    - name: default
+      # Check for length so that if it is 0, we dont write any scrape configs
+  {{ if $length := len (datasource "computers") }}
+  {{ if gt $length 0 }}
+  scrape_configs:
+  {{ end }}
+  {{ end }}
+  {{ range (datasource "computers") }}
+  # Only add if the computers are enabled
+  # the . references our current object
+  {{ if eq .enabled true }}
+  - job_name: {{ .name }}
+    static_configs:
+      - targets:
+          - {{ .ip }}
+  {{ end }}
+  {{ end }}
+```
+
+This is a much more complex example, in the above we are doing:
+
+- comparisons
+- creating and setting variables
+- looping over objects
+
+The final output will only list `webhost1` and `webhost3` since `webhost2` is not enabled.

--- a/docs/cookbook/dynamic-configuration/02_Templates/03_assets/agent-1.yml
+++ b/docs/cookbook/dynamic-configuration/02_Templates/03_assets/agent-1.yml
@@ -1,0 +1,30 @@
+server:
+  http_listen_port: 12345
+  log_level: debug
+metrics:
+  wal_directory: /tmp/grafana-agent-normal
+  global:
+    scrape_interval: 60s
+    remote_write:
+      - url: https://prometheus-us-central1.grafana.net/api/prom/push
+        basic_auth:
+          username: 12345
+          password: secretpassword
+  configs:
+    - name: default
+      # Check for length so that if it is 0, we dont write any scrape configs
+  {{ if $length := len (datasource "computers") }}
+  {{ if gt $length 0 }}
+      scrape_configs:
+  {{ end }}
+  {{ end }}
+  {{ range (datasource "computers") }}
+    # Only add if the computers are enabled
+    # the . references our current object
+    {{ if eq .enabled true }}
+        - job_name: {{ .name }}
+          static_configs:
+            - targets:
+                - {{ .ip }}
+    {{ end }}
+  {{ end }}

--- a/docs/cookbook/dynamic-configuration/02_Templates/03_assets/computers.json
+++ b/docs/cookbook/dynamic-configuration/02_Templates/03_assets/computers.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "webhost1",
+    "ip" : "192.168.1.1",
+    "enabled": true
+  },
+  {
+    "name": "webhost2",
+    "ip" : "192.168.1.2",
+    "enabled": false
+
+  },
+  {
+    "name": "webhost3",
+    "ip" : "192.168.1.3",
+    "enabled": true
+  }
+]

--- a/docs/cookbook/dynamic-configuration/02_Templates/03_assets/final.yml
+++ b/docs/cookbook/dynamic-configuration/02_Templates/03_assets/final.yml
@@ -1,0 +1,231 @@
+server:
+  http_listen_network: tcp
+  http_listen_address: ""
+  http_listen_port: 12345
+  http_listen_conn_limit: 0
+  grpc_listen_network: tcp
+  grpc_listen_address: ""
+  grpc_listen_port: 9095
+  grpc_listen_conn_limit: 0
+  http_tls_config:
+    cert_file: ""
+    key_file: ""
+    client_auth_type: ""
+    client_ca_file: ""
+    cipher_suites: []
+    curve_preferences: []
+    min_version: 0
+    max_version: 0
+    prefer_server_cipher_suites: false
+  grpc_tls_config:
+    cert_file: ""
+    key_file: ""
+    client_auth_type: ""
+    client_ca_file: ""
+    cipher_suites: []
+    curve_preferences: []
+    min_version: 0
+    max_version: 0
+    prefer_server_cipher_suites: false
+  register_instrumentation: true
+  graceful_shutdown_timeout: 30s
+  http_server_read_timeout: 30s
+  http_server_write_timeout: 30s
+  http_server_idle_timeout: 2m0s
+  grpc_server_max_recv_msg_size: 4194304
+  grpc_server_max_send_msg_size: 4194304
+  grpc_server_max_concurrent_streams: 100
+  grpc_server_max_connection_idle: 2562047h47m16.854775807s
+  grpc_server_max_connection_age: 2562047h47m16.854775807s
+  grpc_server_max_connection_age_grace: 2562047h47m16.854775807s
+  grpc_server_keepalive_time: 2h0m0s
+  grpc_server_keepalive_timeout: 20s
+  grpc_server_min_time_between_pings: 5m0s
+  grpc_server_ping_without_stream_allowed: false
+  log_format: logfmt
+  log_level: debug
+  log_source_ips_enabled: false
+  log_source_ips_header: ""
+  log_source_ips_regex: ""
+  http_path_prefix: ""
+metrics:
+  global:
+    scrape_interval: 1m
+    scrape_timeout: 10s
+    evaluation_interval: 1m
+    remote_write:
+    - url: https://prometheus-us-central1.grafana.net/api/prom/push
+      remote_timeout: 30s
+      name: default-a098e3
+      basic_auth:
+        username: "12345"
+        password: <secret>
+      follow_redirects: true
+      queue_config:
+        capacity: 2500
+        max_shards: 200
+        min_shards: 1
+        max_samples_per_send: 500
+        batch_send_deadline: 5s
+        min_backoff: 30ms
+        max_backoff: 100ms
+      metadata_config:
+        send: true
+        send_interval: 1m
+        max_samples_per_send: 500
+  wal_directory: /tmp/grafana-agent-normal
+  wal_cleanup_age: 12h0m0s
+  wal_cleanup_period: 30m0s
+  scraping_service:
+    enabled: false
+    reshard_interval: 1m0s
+    reshard_timeout: 30s
+    cluster_reshard_event_timeout: 30s
+    kvstore:
+      store: consul
+      prefix: configurations/
+      consul:
+        host: localhost:8500
+        acl_token: <secret>
+        http_client_timeout: 20s
+        consistent_reads: false
+        watch_rate_limit: 1
+        watch_burst_size: 1
+      etcd:
+        endpoints: []
+        dial_timeout: 10s
+        max_retries: 10
+        tls_enabled: false
+        tls_cert_path: ""
+        tls_key_path: ""
+        tls_ca_path: ""
+        tls_server_name: ""
+        tls_insecure_skip_verify: false
+        username: ""
+        password: <secret>
+      multi:
+        primary: ""
+        secondary: ""
+        mirror_enabled: false
+        mirror_timeout: 2s
+    lifecycler:
+      ring:
+        kvstore:
+          store: consul
+          prefix: collectors/
+          consul:
+            host: localhost:8500
+            acl_token: <secret>
+            http_client_timeout: 20s
+            consistent_reads: false
+            watch_rate_limit: 1
+            watch_burst_size: 1
+          etcd:
+            endpoints: []
+            dial_timeout: 10s
+            max_retries: 10
+            tls_enabled: false
+            tls_cert_path: ""
+            tls_key_path: ""
+            tls_ca_path: ""
+            tls_server_name: ""
+            tls_insecure_skip_verify: false
+            username: ""
+            password: <secret>
+          multi:
+            primary: ""
+            secondary: ""
+            mirror_enabled: false
+            mirror_timeout: 2s
+        heartbeat_timeout: 1m0s
+        replication_factor: 3
+        zone_awareness_enabled: false
+      num_tokens: 128
+      heartbeat_period: 5s
+      observe_period: 0s
+      join_after: 0s
+      min_ready_duration: 1m0s
+      interface_names:
+      - eth0
+      - en0
+      final_sleep: 30s
+      tokens_file_path: ""
+      availability_zone: ""
+      unregister_on_shutdown: true
+      address: ""
+      port: 0
+      id: 7538ea8d493e
+    dangerous_allow_reading_files: false
+  scraping_service_client:
+    grpc_client_config:
+      max_recv_msg_size: 104857600
+      max_send_msg_size: 16777216
+      grpc_compression: ""
+      rate_limit: 0
+      rate_limit_burst: 0
+      backoff_on_ratelimits: false
+      backoff_config:
+        min_period: 100ms
+        max_period: 10s
+        max_retries: 10
+      tls_enabled: false
+      tls_cert_path: ""
+      tls_key_path: ""
+      tls_ca_path: ""
+      tls_server_name: ""
+      tls_insecure_skip_verify: false
+  configs:
+  - name: default
+    scrape_configs:
+    - job_name: webhost1
+      honor_timestamps: true
+      scrape_interval: 1m
+      scrape_timeout: 10s
+      metrics_path: /metrics
+      scheme: http
+      follow_redirects: true
+      static_configs:
+      - targets:
+        - 192.168.1.1
+    - job_name: webhost3
+      honor_timestamps: true
+      scrape_interval: 1m
+      scrape_timeout: 10s
+      metrics_path: /metrics
+      scheme: http
+      follow_redirects: true
+      static_configs:
+      - targets:
+        - 192.168.1.3
+    remote_write:
+    - url: https://prometheus-us-central1.grafana.net/api/prom/push
+      remote_timeout: 30s
+      name: default-a098e3
+      basic_auth:
+        username: "12345"
+        password: <secret>
+      follow_redirects: true
+      queue_config:
+        capacity: 2500
+        max_shards: 200
+        min_shards: 1
+        max_samples_per_send: 500
+        batch_send_deadline: 5s
+        min_backoff: 30ms
+        max_backoff: 100ms
+      metadata_config:
+        send: true
+        send_interval: 1m
+        max_samples_per_send: 500
+    wal_truncate_frequency: 1h0m0s
+    min_wal_time: 5m0s
+    max_wal_time: 4h0m0s
+    remote_flush_deadline: 1m0s
+  instance_restart_backoff: 5s
+  instance_mode: shared
+integrations:
+  scrape_integrations: true
+  integration_restart_backoff: 5s
+  replace_instance_label: true
+  use_hostname_label: true
+

--- a/docs/cookbook/dynamic-configuration/02_Templates/03_config.yml
+++ b/docs/cookbook/dynamic-configuration/02_Templates/03_config.yml
@@ -1,5 +1,5 @@
 template_paths:
   - "file:///etc/grafana/03_assets"
-sources:
+datasources:
   - name: computers
     url: "file:///etc/grafana/03_assets/computers.json"

--- a/docs/cookbook/dynamic-configuration/02_Templates/03_config.yml
+++ b/docs/cookbook/dynamic-configuration/02_Templates/03_config.yml
@@ -1,0 +1,5 @@
+template_paths:
+  - "file:///etc/grafana/03_assets"
+sources:
+  - name: computers
+    url: "file:///etc/grafana/03_assets/computers.json"

--- a/docs/cookbook/dynamic-configuration/03_Advanced_Datasources/01_AWS.md
+++ b/docs/cookbook/dynamic-configuration/03_Advanced_Datasources/01_AWS.md
@@ -1,0 +1,39 @@
+# 01 AWS
+
+The AWS datasource assumes that you have appropriate credentials and environment variables set to access AWS resources. The custom fork of gomplate adds a new command to the existing AWS commands.
+
+Unfortunately there is not a specific docker command but generic examples are below.
+
+## Looping
+
+[agent-1.yml](./01_assets/agent-1.yml)
+
+```yaml
+server:
+  http_listen_port: 12345
+  log_level: debug
+metrics:
+  wal_directory: /tmp/grafana-agent-normal
+  global:
+    scrape_interval: 60s
+    remote_write:
+      - url: https://prometheus-us-central1.grafana.net/api/prom/push
+        basic_auth:
+          username: 12345
+          password: secretpassword
+  configs:
+    - name: default
+      scrape_configs:
+      {{ range $index , $value := aws.EC2Query "tag:service=webhost" -}}
+      - job_name: {{ $value.InstanceId }}
+        static_configs:
+          - targets:
+              - {{ $value.PrivateDnsName }}
+        {{ end -}}
+```
+
+The `aws.EC2Query` command is a new command added for Grafana Agent and takes a string in the [DescribeInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html) format 
+
+## Final
+
+[final.yml](./01_assets/final.yml)

--- a/docs/cookbook/dynamic-configuration/03_Advanced_Datasources/01_assets/agent-1.yml
+++ b/docs/cookbook/dynamic-configuration/03_Advanced_Datasources/01_assets/agent-1.yml
@@ -1,0 +1,21 @@
+server:
+  http_listen_port: 12345
+  log_level: debug
+metrics:
+  wal_directory: /tmp/grafana-agent-normal
+  global:
+    scrape_interval: 60s
+    remote_write:
+      - url: https://prometheus-us-central1.grafana.net/api/prom/push
+        basic_auth:
+          username: 12345
+          password: secretpassword
+  configs:
+  - name: default
+    scrape_configs:
+    {{ range $index , $value := aws.EC2Query "tag:service=webhost" -}}
+    - job_name: {{ $value.InstanceId }}
+      static_configs:
+        - targets:
+            - {{ $value.PrivateDnsName }}
+      {{ end -}}

--- a/docs/cookbook/dynamic-configuration/03_Advanced_Datasources/01_assets/final.yml
+++ b/docs/cookbook/dynamic-configuration/03_Advanced_Datasources/01_assets/final.yml
@@ -1,0 +1,220 @@
+server:
+  http_listen_network: tcp
+  http_listen_address: ""
+  http_listen_port: 12345
+  http_listen_conn_limit: 0
+  grpc_listen_network: tcp
+  grpc_listen_address: ""
+  grpc_listen_port: 9095
+  grpc_listen_conn_limit: 0
+  http_tls_config:
+    cert_file: ""
+    key_file: ""
+    client_auth_type: ""
+    client_ca_file: ""
+    cipher_suites: []
+    curve_preferences: []
+    min_version: 0
+    max_version: 0
+    prefer_server_cipher_suites: false
+  grpc_tls_config:
+    cert_file: ""
+    key_file: ""
+    client_auth_type: ""
+    client_ca_file: ""
+    cipher_suites: []
+    curve_preferences: []
+    min_version: 0
+    max_version: 0
+    prefer_server_cipher_suites: false
+  register_instrumentation: true
+  graceful_shutdown_timeout: 30s
+  http_server_read_timeout: 30s
+  http_server_write_timeout: 30s
+  http_server_idle_timeout: 2m0s
+  grpc_server_max_recv_msg_size: 4194304
+  grpc_server_max_send_msg_size: 4194304
+  grpc_server_max_concurrent_streams: 100
+  grpc_server_max_connection_idle: 2562047h47m16.854775807s
+  grpc_server_max_connection_age: 2562047h47m16.854775807s
+  grpc_server_max_connection_age_grace: 2562047h47m16.854775807s
+  grpc_server_keepalive_time: 2h0m0s
+  grpc_server_keepalive_timeout: 20s
+  grpc_server_min_time_between_pings: 5m0s
+  grpc_server_ping_without_stream_allowed: false
+  log_format: logfmt
+  log_level: debug
+  log_source_ips_enabled: false
+  log_source_ips_header: ""
+  log_source_ips_regex: ""
+  http_path_prefix: ""
+metrics:
+  global:
+    scrape_interval: 1m
+    scrape_timeout: 10s
+    evaluation_interval: 1m
+    remote_write:
+      - url: https://prometheus-us-central1.grafana.net/api/prom/push
+        remote_timeout: 30s
+        name: default-a098e3
+        basic_auth:
+          username: "12345"
+          password: <secret>
+        follow_redirects: true
+        queue_config:
+          capacity: 2500
+          max_shards: 200
+          min_shards: 1
+          max_samples_per_send: 500
+          batch_send_deadline: 5s
+          min_backoff: 30ms
+          max_backoff: 100ms
+        metadata_config:
+          send: true
+          send_interval: 1m
+          max_samples_per_send: 500
+  wal_directory: /tmp/grafana-agent-normal
+  wal_cleanup_age: 12h0m0s
+  wal_cleanup_period: 30m0s
+  scraping_service:
+    enabled: false
+    reshard_interval: 1m0s
+    reshard_timeout: 30s
+    cluster_reshard_event_timeout: 30s
+    kvstore:
+      store: consul
+      prefix: configurations/
+      consul:
+        host: localhost:8500
+        acl_token: <secret>
+        http_client_timeout: 20s
+        consistent_reads: false
+        watch_rate_limit: 1
+        watch_burst_size: 1
+      etcd:
+        endpoints: []
+        dial_timeout: 10s
+        max_retries: 10
+        tls_enabled: false
+        tls_cert_path: ""
+        tls_key_path: ""
+        tls_ca_path: ""
+        tls_server_name: ""
+        tls_insecure_skip_verify: false
+        username: ""
+        password: <secret>
+      multi:
+        primary: ""
+        secondary: ""
+        mirror_enabled: false
+        mirror_timeout: 2s
+    lifecycler:
+      ring:
+        kvstore:
+          store: consul
+          prefix: collectors/
+          consul:
+            host: localhost:8500
+            acl_token: <secret>
+            http_client_timeout: 20s
+            consistent_reads: false
+            watch_rate_limit: 1
+            watch_burst_size: 1
+          etcd:
+            endpoints: []
+            dial_timeout: 10s
+            max_retries: 10
+            tls_enabled: false
+            tls_cert_path: ""
+            tls_key_path: ""
+            tls_ca_path: ""
+            tls_server_name: ""
+            tls_insecure_skip_verify: false
+            username: ""
+            password: <secret>
+          multi:
+            primary: ""
+            secondary: ""
+            mirror_enabled: false
+            mirror_timeout: 2s
+        heartbeat_timeout: 1m0s
+        replication_factor: 3
+        zone_awareness_enabled: false
+      num_tokens: 128
+      heartbeat_period: 5s
+      observe_period: 0s
+      join_after: 0s
+      min_ready_duration: 1m0s
+      interface_names:
+        - eth0
+        - en0
+      final_sleep: 30s
+      tokens_file_path: ""
+      availability_zone: ""
+      unregister_on_shutdown: true
+      address: ""
+      port: 0
+      id: juniper.local
+    dangerous_allow_reading_files: false
+  scraping_service_client:
+    grpc_client_config:
+      max_recv_msg_size: 104857600
+      max_send_msg_size: 16777216
+      grpc_compression: ""
+      rate_limit: 0
+      rate_limit_burst: 0
+      backoff_on_ratelimits: false
+      backoff_config:
+        min_period: 100ms
+        max_period: 10s
+        max_retries: 10
+      tls_enabled: false
+      tls_cert_path: ""
+      tls_key_path: ""
+      tls_ca_path: ""
+      tls_server_name: ""
+      tls_insecure_skip_verify: false
+  configs:
+    - name: default
+      scrape_configs:
+        - job_name: i-1234512345e
+          honor_timestamps: true
+          scrape_interval: 1m
+          scrape_timeout: 10s
+          metrics_path: /metrics
+          scheme: http
+          follow_redirects: true
+          static_configs:
+            - targets:
+                - ip-192-168-1-1.us-east-2.compute.internal
+      remote_write:
+        - url: https://prometheus-us-central1.grafana.net/api/prom/push
+          remote_timeout: 30s
+          name: default-a098e3
+          basic_auth:
+            username: "12345"
+            password: <secret>
+          follow_redirects: true
+          queue_config:
+            capacity: 2500
+            max_shards: 200
+            min_shards: 1
+            max_samples_per_send: 500
+            batch_send_deadline: 5s
+            min_backoff: 30ms
+            max_backoff: 100ms
+          metadata_config:
+            send: true
+            send_interval: 1m
+            max_samples_per_send: 500
+      wal_truncate_frequency: 1h0m0s
+      min_wal_time: 5m0s
+      max_wal_time: 4h0m0s
+      remote_flush_deadline: 1m0s
+  instance_restart_backoff: 5s
+  instance_mode: shared
+integrations:
+  scrape_integrations: true
+  integration_restart_backoff: 5s
+  replace_instance_label: true
+  use_hostname_label: true

--- a/docs/cookbook/dynamic-configuration/03_Advanced_Datasources/01_config.yml
+++ b/docs/cookbook/dynamic-configuration/03_Advanced_Datasources/01_config.yml
@@ -1,2 +1,2 @@
 template_paths:
-  - "file:///Users/mdurham/source/agents/agent_clean/agent/docs/cookbook/dynamic-configuration/03_Advanced_Datasources/01_assets"
+  - "file:///etc/grafana/01_assets"

--- a/docs/cookbook/dynamic-configuration/03_Advanced_Datasources/01_config.yml
+++ b/docs/cookbook/dynamic-configuration/03_Advanced_Datasources/01_config.yml
@@ -1,0 +1,2 @@
+template_paths:
+  - "file:///Users/mdurham/source/agents/agent_clean/agent/docs/cookbook/dynamic-configuration/03_Advanced_Datasources/01_assets"

--- a/docs/cookbook/dynamic-configuration/README.md
+++ b/docs/cookbook/dynamic-configuration/README.md
@@ -1,0 +1,19 @@
+# Dyanmic Configuration Cookbook
+
+The purpose of the cookbook is to guide you through common scenarios of using dynamic configuration. Each folder contains increasingly more complex use cases, but feel free to jump in whereeve you feel appropriate.
+
+## Basics
+
+[Basics](./01_Basics) covers
+- [Structure](./01_Basics/01_Structure.md) of how agent and server templates are loaded
+- [Instances](./01_Basics/02_Instances.md) of metrics and metrics instances are loaded
+- [Integrations](./01_Basics/03_Integrations.md) of how integrations are loaded
+- [Logs and Traces](./01_Basics/04_Logs_and_Traces.md) of how traces and logs are loaded
+
+[Templates](./02_Templates) covers
+- [Looping](./02_Templates/01_Looping.md) covers basic command usage and simple loops
+- [Datasource](./02_Templates/02_Datasources.md) covers usage of datasource which are external datastores you can use to pull in data
+- [Datasources and Objects](./02_Templates/03_Datasource_and_Objects.md) covers the usage of complex json objects
+
+[Advanced Datasources](./03_Advanced_Datasources) covers non file based datasources
+- [AWS](./03_Advanced_Datasources/01_AWS.md) covers querying EC2 for instances

--- a/docs/cookbook/dynamic-configuration/README.md
+++ b/docs/cookbook/dynamic-configuration/README.md
@@ -1,4 +1,4 @@
-# Dyanmic Configuration Cookbook
+# Dynamic Configuration Cookbook
 
 The purpose of the cookbook is to guide you through common scenarios of using dynamic configuration. Each folder contains increasingly more complex use cases, but feel free to jump in wherever you feel appropriate.
 

--- a/docs/cookbook/dynamic-configuration/README.md
+++ b/docs/cookbook/dynamic-configuration/README.md
@@ -1,6 +1,6 @@
 # Dyanmic Configuration Cookbook
 
-The purpose of the cookbook is to guide you through common scenarios of using dynamic configuration. Each folder contains increasingly more complex use cases, but feel free to jump in whereeve you feel appropriate.
+The purpose of the cookbook is to guide you through common scenarios of using dynamic configuration. Each folder contains increasingly more complex use cases, but feel free to jump in wherever you feel appropriate.
 
 ## Basics
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -261,6 +261,8 @@ func LoadRemote(url string, expandEnvVars bool, c *Config) error {
 	return LoadBytes(bb, expandEnvVars, c)
 }
 
+// LoadDynamicConfiguration is used to load configuration from a variety of sources using
+// ConfigLoader, this is a templated approach
 func LoadDynamicConfiguration(url string, _ bool, c *Config, fs *flag.FlagSet) error {
 	// will be filled in by future pr
 	return nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,10 +31,12 @@ import (
 var (
 	featRemoteConfigs    = features.Feature("remote-configs")
 	featIntegrationsNext = features.Feature("integrations-next")
+	featDynamicConfig    = features.Feature("dynamic-config")
 
 	allFeatures = []features.Feature{
 		featRemoteConfigs,
 		featIntegrationsNext,
+		featDynamicConfig,
 	}
 )
 
@@ -259,6 +261,11 @@ func LoadRemote(url string, expandEnvVars bool, c *Config) error {
 	return LoadBytes(bb, expandEnvVars, c)
 }
 
+func LoadDynamicConfiguration(url string, _ bool, c *Config, fs *flag.FlagSet) error {
+	// will be filled in by future pr
+	return nil
+}
+
 // LoadBytes unmarshals a config from a buffer. Defaults are not
 // applied to the file and must be done manually if LoadBytes
 // is called directly.
@@ -301,6 +308,12 @@ func Load(fs *flag.FlagSet, args []string) (*Config, error) {
 	return load(fs, args, func(url string, expand bool, c *Config) error {
 		if features.Enabled(fs, featRemoteConfigs) {
 			return LoadRemote(url, expand, c)
+		}
+		if features.Enabled(fs, featDynamicConfig) {
+			if !features.Enabled(fs, featIntegrationsNext) {
+				panic("integrations-next must be enabled for dynamic configuration to work")
+			}
+			return LoadDynamicConfiguration(url, expand, c, fs)
 		}
 		return LoadFile(url, expand, c)
 	})
@@ -350,8 +363,12 @@ func load(fs *flag.FlagSet, args []string, loader func(string, bool, *Config) er
 	if features.Enabled(fs, featIntegrationsNext) {
 		version = integrationsVersion2
 	}
-	if err := cfg.Integrations.setVersion(version); err != nil {
-		return nil, fmt.Errorf("error loading config file %s: %w", file, err)
+	// This is due to an odd interaction between dynamic loading and v2 integrations feature, if dynamic loading
+	// is enabled the cfg version is already set and this will actually override it
+	if cfg.Integrations.version != integrationsVersion2 && !features.Enabled(fs, featDynamicConfig) {
+		if err := cfg.Integrations.setVersion(version); err != nil {
+			return nil, fmt.Errorf("error loading config file %s: %w", file, err)
+		}
 	}
 
 	// Finally, apply defaults to config that wasn't specified by file or flag

--- a/pkg/integrations/node_exporter/config.go
+++ b/pkg/integrations/node_exporter/config.go
@@ -120,7 +120,7 @@ type Config struct {
 	PerfCPUS                         string              `yaml:"perf_cpus,omitempty"`
 	PerfTracepoint                   flagext.StringSlice `yaml:"perf_tracepoint,omitempty"`
 	PowersupplyIgnoredSupplies       string              `yaml:"powersupply_ignored_supplies,omitempty"`
-	RunitServiceDir                  string              `yaml:"runit_servic e_dir,omitempty"`
+	RunitServiceDir                  string              `yaml:"runit_service_dir,omitempty"`
 	SupervisordURL                   string              `yaml:"supervisord_url,omitempty"`
 	SystemdEnableRestartsMetrics     bool                `yaml:"systemd_enable_restarts_metrics,omitempty"`
 	SystemdEnableStartTimeMetrics    bool                `yaml:"systemd_enable_start_time_metrics,omitempty"`


### PR DESCRIPTION
This covers only the documentation which broadly defines what happens, and the feature flag itself.

This is to address issues #1121, #869, and #868. 

The goal is to 
* Allow the loading of all configuration files locally and remotely from a variety of sources. 
* Allow the templating of configuration files from a variety of sources, for instance pull secrets from Consul/Vault other sources
* Allow the configuration file itself to be broken down into logical sections that are recombined in a set order.  

The major mechanism it will be using to do this is by a custom fork of the [gomplate](https://github.com/hairyhenderson/gomplate) tool, that allows one to embed it has a library. 
