### PR TITLE
integrations-next: Add extra_labels to inject extra labels for an integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - [ENHANCEMENT] Go 1.17 is now used for all builds of the Agent. (@tpaschalis)
 
+- [ENHANCEMENT] integrations-next: Add `extra_labels` to add a custom set of
+  labels to integration targets. (@rfratto)
+
 - [BUGFIX] Fixed issue where Grafana Agent may panic if there is a very large
   WAL loading while old WALs are being deleted or the `/agent/api/v1/targets`
   endpoint is called. (@tpaschalis)

--- a/docs/configuration/integrations/integrations-next/_index.md
+++ b/docs/configuration/integrations/integrations-next/_index.md
@@ -144,6 +144,13 @@ autoscrape:
   # Autoscrape interval and timeout.
   [scrape_interval: <duration> | default = <integrations.metrics.autoscrape.scrape_interval>]
   [scrape_timeout: <duration> | default = <integrations.metrics.autoscrape.scrape_timeout>]
+
+# An optional extra set of labels to add to metrics from the integration target. These
+# labels are only exposed via the integration service discovery HTTP API and
+# added when autoscrape is used. They will not be found directly on the metrics
+# page for an integration.
+extra_labels:
+  [ <labelname>: <labelvalue> ... ]
 ```
 
 The old set of common options have been removed and do not work when the revamp

--- a/pkg/integrations/v2/common/metrics.go
+++ b/pkg/integrations/v2/common/metrics.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"github.com/grafana/agent/pkg/integrations/v2/autoscrape"
+	"github.com/prometheus/prometheus/pkg/labels"
 )
 
 // MetricsConfig is a set of common options shared by metrics integrations. It
@@ -14,6 +15,7 @@ import (
 type MetricsConfig struct {
 	Autoscrape  autoscrape.Config `yaml:"autoscrape,omitempty"`
 	InstanceKey *string           `yaml:"instance,omitempty"`
+	ExtraLabels labels.Labels     `yaml:"extra_labels,omitempty"`
 }
 
 // ApplyDefaults applies defaults to mc.

--- a/pkg/integrations/v2/metricsutils/metricshandler_integration.go
+++ b/pkg/integrations/v2/metricsutils/metricshandler_integration.go
@@ -105,6 +105,10 @@ func (i *metricsHandlerIntegration) Targets(ep integrations.Endpoint) []*targetg
 		Source: fmt.Sprintf("%s/%s", i.integrationName, i.instanceID),
 	}
 
+	for _, lbl := range i.common.ExtraLabels {
+		group.Labels[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
+	}
+
 	for _, t := range i.targets {
 		group.Targets = append(group.Targets, model.LabelSet{
 			model.AddressLabel:     model.LabelValue(ep.Host),

--- a/pkg/integrations/v2/metricsutils/metricshandler_integration_test.go
+++ b/pkg/integrations/v2/metricsutils/metricshandler_integration_test.go
@@ -1,0 +1,69 @@
+package metricsutils
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/agent/pkg/integrations/v2"
+	"github.com/grafana/agent/pkg/integrations/v2/common"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetricsHandlerIntegration_Targets(t *testing.T) {
+	globals := integrations.Globals{
+		AgentIdentifier: "testagent",
+		AgentBaseURL: func() *url.URL {
+			u, err := url.Parse("http://testagent/")
+			require.NoError(t, err)
+			return u
+		}(),
+		SubsystemOpts: integrations.DefaultSubsystemOptions,
+	}
+
+	t.Run("Extra labels", func(t *testing.T) {
+		common := common.MetricsConfig{
+			ExtraLabels: labels.FromMap(map[string]string{"foo": "bar", "fizz": "buzz"}),
+		}
+		common.ApplyDefaults(globals.SubsystemOpts.Metrics.Autoscrape)
+
+		i, err := NewMetricsHandlerIntegration(nil, fakeConfig{}, common, globals, http.NotFoundHandler())
+		require.NoError(t, err)
+
+		actual := i.Targets(integrations.Endpoint{Host: "test", Prefix: "/test/"})
+		expect := []*targetgroup.Group{{
+			Source: "fake/testagent",
+			Labels: model.LabelSet{
+				"instance":       "testagent",
+				"job":            "integrations/fake",
+				"agent_hostname": "testagent",
+
+				"__meta_agent_integration_name":       "fake",
+				"__meta_agent_integration_instance":   "testagent",
+				"__meta_agent_integration_autoscrape": "1",
+
+				"foo":  "bar",
+				"fizz": "buzz",
+			},
+			Targets: []model.LabelSet{{
+				"__address__":      "test", // from integrations.Endpoint
+				"__metrics_path__": "/test/metrics",
+			}},
+		}}
+		require.Equal(t, expect, actual)
+	})
+}
+
+type fakeConfig struct{}
+
+func (fakeConfig) Name() string                                      { return "fake" }
+func (fakeConfig) ApplyDefaults(_ integrations.Globals) error        { return nil }
+func (fakeConfig) Identifier(g integrations.Globals) (string, error) { return g.AgentIdentifier, nil }
+func (fakeConfig) NewIntegration(_ log.Logger, _ integrations.Globals) (integrations.Integration, error) {
+	return nil, fmt.Errorf("not implemented")
+}


### PR DESCRIPTION
#### PR Description 
This PR adds the ability to define a set of extra labels for integration SD and autoscrape through a common `extra_labels` config. 

This is needed for #1224, where integrations are expected to have a set of labels which represents metadata from the owning `MetricsIntegration`.

#### Which issue(s) this PR fixes 
Note that this is different than configuring `relabel_configs` or `metric_relabel_configs` within autoscrape; any label specified `extra_labels` affects both autoscrape and the integrations SD API, while the relabel configs only impact autoscrape.

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
