### PR TITLE
[dev.operator-integrations] Generate integrations config

### DIFF
--- a/pkg/operator/config/config_test.go
+++ b/pkg/operator/config/config_test.go
@@ -261,74 +261,74 @@ func TestBuildConfigLogs(t *testing.T) {
 }
 
 func TestBuildConfigIntegrations(t *testing.T) {
-	in := `
-  Agent:
-    kind: GrafanaAgent
-    metadata:
-      name: test-agent
-      namespace: monitoring
-  Integrations:
-    - kind: MetricsIntegration
-      metadata:
-        name: mysql-a
-        namespace: databases
-      spec:
-        name: mysqld_exporter
-        type: normal
-        config: 
-          data_source_names: root@(server-a:3306)/
-    - kind: MetricsIntegration
-      metadata:
-        name: node
-        namespace: kube-system
-      spec:
-        name: node_exporter
-        type: daemonset
-        config: 
-          rootfs_path: /host/root
-          sysfs_path: /host/sys
-          procfs_path: /host/proc
-    - kind: MetricsIntegration
-      metadata:
-        name: mysql-b
-        namespace: databases
-      spec:
-        name: mysqld_exporter
-        type: normal
-        config: 
-          data_source_names: root@(server-b:3306)/
-    - kind: MetricsIntegration
-      metadata:
-        name: redis-a
-        namespace: databases
-      spec:
-        name: redis_exporter
-        type: normal
-        config: 
-          redis_addr: redis-a:6379
-  `
+	in := util.Untab(`
+	Agent:
+		kind: GrafanaAgent
+		metadata:
+			name: test-agent
+			namespace: monitoring
+	Integrations:
+	- kind: MetricsIntegration
+		metadata:
+			name: mysql-a
+			namespace: databases
+		spec:
+			name: mysqld_exporter
+			type: normal
+			config: 
+				data_source_names: root@(server-a:3306)/
+	- kind: MetricsIntegration
+		metadata:
+			name: node
+			namespace: kube-system
+		spec:
+			name: node_exporter
+			type: daemonset
+			config: 
+				rootfs_path: /host/root
+				sysfs_path: /host/sys
+				procfs_path: /host/proc
+	- kind: MetricsIntegration
+		metadata:
+			name: mysql-b
+			namespace: databases
+		spec:
+			name: mysqld_exporter
+			type: normal
+			config: 
+				data_source_names: root@(server-b:3306)/
+	- kind: MetricsIntegration
+		metadata:
+			name: redis-a
+			namespace: databases
+		spec:
+			name: redis_exporter
+			type: normal
+			config: 
+				redis_addr: redis-a:6379
+  `)
 
 	var h grafana.Hierarchy
 	err := k8s_yaml.UnmarshalStrict([]byte(in), &h)
 	require.NoError(t, err)
 
-	expect := `
-  server:
-    http_listen_port: 8080
-  integrations:
-    metrics:
-      autoscrape:
-        enable: false
-    mysqld_exporter_configs:
-    - data_source_names: root@(server-a:3306)/
-    - data_source_names: root@(server-b:3306)/
-    node_exporter:
-      rootfs_path: /host/root 
-      sysfs_path: /host/sys
-      procfs_path: /host/proc
-    redis_exporter_configs:
-    - redis_addr: redis-a:6379
-  `
+	expect := util.Untab(`
+	server:
+		http_listen_port: 8080
+	integrations:
+		metrics:
+			autoscrape:
+				enable: false
+		mysqld_exporter_configs:
+		- data_source_names: root@(server-a:3306)/
+		- data_source_names: root@(server-b:3306)/
+		node_exporter:
+			rootfs_path: /host/root 
+			sysfs_path: /host/sys
+			procfs_path: /host/proc
+		redis_exporter_configs:
+		- redis_addr: redis-a:6379
+  `)
 
 	result, err := BuildConfig(h, IntegrationsType)
 	require.NoError(t, err)

--- a/pkg/operator/config/integration_templates_test.go
+++ b/pkg/operator/config/integration_templates_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	gragent "github.com/grafana/agent/pkg/operator/apis/monitoring/v1alpha1"
+	"github.com/grafana/agent/pkg/util"
 	"github.com/grafana/agent/pkg/util/subset"
 	"github.com/stretchr/testify/require"
 	apiext_v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -38,11 +39,11 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 			},
-			expect: `
-      autoscrape:
-        enable: false
-      data_source_names: root@(server-a:3306)/
-      `,
+			expect: util.Untab(`
+				autoscrape:
+					enable: false
+				data_source_names: root@(server-a:3306)/
+      `),
 		},
 		{
 			name: "integration no config",
@@ -55,10 +56,10 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 			},
-			expect: `
-      autoscrape:
-        enable: false
-      `,
+			expect: util.Untab(`
+			autoscrape:
+				enable: false
+      `),
 		},
 		{
 			name: "extra_labels",
@@ -84,18 +85,18 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 			},
-			expect: `
-      extra_labels:
-        __meta_agentoperator_grafanaagent_name: some-grafanaagent
-        __meta_agentoperator_grafanaagent_namespace: monitoring
-        __meta_agentoperator_integration_type: normal
-        __meta_agentoperator_integration_cr_name: some-integration
-        __meta_agentoperator_integration_cr_namespace: default
-        __meta_agentoperator_integration_cr_label_label_a: label-a-value
-        __meta_agentoperator_integration_cr_label_label_b: label-b-value
-        __meta_agentoperator_integration_cr_labelpresent_label_a: "true"
-        __meta_agentoperator_integration_cr_labelpresent_label_b: "true"
-      `,
+			expect: util.Untab(`
+			extra_labels:
+				__meta_agentoperator_grafanaagent_name: some-grafanaagent
+				__meta_agentoperator_grafanaagent_namespace: monitoring
+				__meta_agentoperator_integration_type: normal
+				__meta_agentoperator_integration_cr_name: some-integration
+				__meta_agentoperator_integration_cr_namespace: default
+				__meta_agentoperator_integration_cr_label_label_a: label-a-value
+				__meta_agentoperator_integration_cr_label_label_b: label-b-value
+				__meta_agentoperator_integration_cr_labelpresent_label_a: "true"
+				__meta_agentoperator_integration_cr_labelpresent_label_b: "true"
+      `),
 		},
 		{
 			name: "extra_labels merge",
@@ -121,14 +122,14 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 			},
-			expect: `
-      extra_labels:
-        # Make sure that our custom label exists with at least some of our
-        # custom labels
-        __meta_agentoperator_integration_cr_name: some-integration
-        __meta_agentoperator_integration_cr_namespace: default
-        hello: world
-      `,
+			expect: util.Untab(`
+			extra_labels:
+				# Make sure that our custom label exists with at least some of our
+				# custom labels
+				__meta_agentoperator_integration_cr_name: some-integration
+				__meta_agentoperator_integration_cr_namespace: default
+				hello: world
+      `),
 		},
 	}
 

--- a/pkg/operator/config/integration_templates_test.go
+++ b/pkg/operator/config/integration_templates_test.go
@@ -1,0 +1,145 @@
+package config
+
+import (
+	"testing"
+
+	gragent "github.com/grafana/agent/pkg/operator/apis/monitoring/v1alpha1"
+	"github.com/grafana/agent/pkg/util/subset"
+	"github.com/stretchr/testify/require"
+	apiext_v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func TestIntegration(t *testing.T) {
+	toJSON := func(in string) apiext_v1.JSON {
+		t.Helper()
+		out, err := yaml.YAMLToJSONStrict([]byte(in))
+		require.NoError(t, err)
+		return apiext_v1.JSON{Raw: out}
+	}
+
+	tt := []struct {
+		name   string
+		input  map[string]interface{}
+		expect string
+	}{
+		{
+			name: "configured integration",
+			input: map[string]interface{}{
+				"agent": &gragent.GrafanaAgent{},
+				"integration": &gragent.MetricsIntegration{
+					Spec: gragent.MetricsIntegrationSpec{
+						Name: "mysqld_exporter",
+						Type: gragent.IntegrationTypeNormal,
+						Config: toJSON(`
+              data_source_names: root@(server-a:3306)/
+            `),
+					},
+				},
+			},
+			expect: `
+      autoscrape:
+        enable: false
+      data_source_names: root@(server-a:3306)/
+      `,
+		},
+		{
+			name: "integration no config",
+			input: map[string]interface{}{
+				"agent": &gragent.GrafanaAgent{},
+				"integration": &gragent.MetricsIntegration{
+					Spec: gragent.MetricsIntegrationSpec{
+						Name: "mysqld_exporter",
+						Type: gragent.IntegrationTypeNormal,
+					},
+				},
+			},
+			expect: `
+      autoscrape:
+        enable: false
+      `,
+		},
+		{
+			name: "extra_labels",
+			input: map[string]interface{}{
+				"agent": &gragent.GrafanaAgent{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "some-grafanaagent",
+						Namespace: "monitoring",
+					},
+				},
+				"integration": &gragent.MetricsIntegration{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "some-integration",
+						Namespace: "default",
+						Labels: map[string]string{
+							"label-a": "label-a-value",
+							"label-b": "label-b-value",
+						},
+					},
+					Spec: gragent.MetricsIntegrationSpec{
+						Name: "mysqld_exporter",
+						Type: gragent.IntegrationTypeNormal,
+					},
+				},
+			},
+			expect: `
+      extra_labels:
+        __meta_agentoperator_grafanaagent_name: some-grafanaagent
+        __meta_agentoperator_grafanaagent_namespace: monitoring
+        __meta_agentoperator_integration_type: normal
+        __meta_agentoperator_integration_cr_name: some-integration
+        __meta_agentoperator_integration_cr_namespace: default
+        __meta_agentoperator_integration_cr_label_label_a: label-a-value
+        __meta_agentoperator_integration_cr_label_label_b: label-b-value
+        __meta_agentoperator_integration_cr_labelpresent_label_a: "true"
+        __meta_agentoperator_integration_cr_labelpresent_label_b: "true"
+      `,
+		},
+		{
+			name: "extra_labels merge",
+			input: map[string]interface{}{
+				"agent": &gragent.GrafanaAgent{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "some-grafanaagent",
+						Namespace: "monitoring",
+					},
+				},
+				"integration": &gragent.MetricsIntegration{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "some-integration",
+						Namespace: "default",
+					},
+					Spec: gragent.MetricsIntegrationSpec{
+						Name: "mysqld_exporter",
+						Type: gragent.IntegrationTypeNormal,
+						Config: toJSON(`
+              extra_labels: 
+                hello: world
+            `),
+					},
+				},
+			},
+			expect: `
+      extra_labels:
+        # Make sure that our custom label exists with at least some of our
+        # custom labels
+        __meta_agentoperator_integration_cr_name: some-integration
+        __meta_agentoperator_integration_cr_namespace: default
+        hello: world
+      `,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			vm, err := createVM(testStore())
+			require.NoError(t, err)
+
+			actual, err := runSnippetTLA(t, vm, "./integration.libsonnet", tc.input)
+			require.NoError(t, err)
+			require.NoError(t, subset.YAMLAssert([]byte(tc.expect), []byte(actual)), "incomplete yaml\n%s", actual)
+		})
+	}
+}

--- a/pkg/operator/config/marshal.go
+++ b/pkg/operator/config/marshal.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"encoding/json"
+	"reflect"
+
+	"github.com/fatih/structs"
+)
+
+// jsonnetMarshal marshals a value for passing to Jsonnet.
+//
+// Structs are marshaled to the JSON representation of the Go value, ignoring
+// all json struct tags. Fields from structs must be accesed as they would from
+// Go, with the exception of embedded fields which can only be accessed through
+// the embedded type name.
+func jsonnetMarshal(val interface{}) ([]byte, error) {
+	return json.Marshal(jsonnetValue(val))
+}
+
+func jsonnetValue(in interface{}) interface{} {
+	inValue := reflect.ValueOf(in)
+
+	switch inValue.Kind() {
+	case reflect.Ptr:
+		if inValue.IsNil() {
+			return nil
+		}
+		return jsonnetValue(inValue.Elem().Interface())
+	case reflect.Struct:
+		return structs.Map(in)
+	case reflect.Array, reflect.Slice:
+		elem := make([]interface{}, inValue.Len())
+		for i := 0; i < inValue.Len(); i++ {
+			elem[i] = jsonnetValue(inValue.Index(i).Interface())
+		}
+		return elem
+	default:
+		return in
+	}
+}

--- a/pkg/operator/config/marshal_test.go
+++ b/pkg/operator/config/marshal_test.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_jsonnetMarshal(t *testing.T) {
+	tt := []struct {
+		name   string
+		in     interface{}
+		expect string
+	}{
+		{name: "string", in: "hello", expect: `"hello"`},
+		{name: "bool", in: true, expect: `true`},
+		{name: "number", in: 5, expect: `5`},
+		{name: "array", in: []int{0, 1, 2}, expect: `[0, 1, 2]`},
+
+		{
+			name: "struct",
+			in: struct {
+				Name string `json:"name"`
+				Age  int    `json:"age"`
+			}{"John", 42},
+			expect: `{"Name":"John","Age":42}`,
+		},
+		{
+			name: "array of structs",
+			in: func() interface{} {
+				type ty struct {
+					Name string `json:"name"`
+					Age  int    `json:"age"`
+				}
+				return []ty{{"John", 42}, {"Anne", 41}, {"Peter", 40}}
+			}(),
+			expect: `[
+        {"Name": "John", "Age": 42},
+        {"Name": "Anne", "Age": 41},
+        {"Name": "Peter", "Age": 40}
+      ]`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := jsonnetMarshal(tc.in)
+			require.NoError(t, err)
+			require.JSONEq(t, tc.expect, string(actual))
+		})
+	}
+}

--- a/pkg/operator/config/metrics_templates_test.go
+++ b/pkg/operator/config/metrics_templates_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 )
 
 func TestExternalLabels(t *testing.T) {
@@ -69,8 +70,8 @@ func TestExternalLabels(t *testing.T) {
 					},
 					Spec: v1alpha1.GrafanaAgentSpec{
 						Metrics: v1alpha1.MetricsSubsystemSpec{
-							MetricsExternalLabelName: strPointer("deployment"),
-							ReplicaExternalLabelName: strPointer("replica"),
+							MetricsExternalLabelName: pointer.String("deployment"),
+							ReplicaExternalLabelName: pointer.String("replica"),
 							ExternalLabels:           map[string]string{"foo": "bar"},
 						},
 					},

--- a/pkg/operator/config/templates/agent-integrations.libsonnet
+++ b/pkg/operator/config/templates/agent-integrations.libsonnet
@@ -1,0 +1,49 @@
+// agent-integrations.libsonnet is the entrypoint for rendering a Grafana Agent
+// config file for integrations based on the Operator custom resources.
+//
+// When writing an object, any field will null will be removed from the final
+// YAML. This is useful as we don't want to always translate unfilled values
+// from the custom resources to a field in the YAML.
+//
+// A series of helper methods to convert default values into null (so they can
+// be trimmed) are in ./ext/optionals.libsonnet.
+//
+// When writing a new function, please document the expected types of the
+// arguments.
+
+local marshal = import 'ext/marshal.libsonnet';
+local optionals = import 'ext/optionals.libsonnet';
+
+local new_integration = import './integration.libsonnet';
+local integrations = import 'utils/integrations.libsonnet';
+
+// @param {Hierarchy} ctx
+function(ctx) marshal.YAML(optionals.trim({
+  local spec = ctx.Agent.Spec,
+  local prometheus = spec.Metrics,
+  local namespace = ctx.Agent.ObjectMeta.Namespace,
+
+  server: {
+    http_listen_port: 8080,
+    log_level: optionals.string(spec.LogLevel),
+    log_format: optionals.string(spec.LogFormat),
+  },
+
+  integrations: {
+    metrics: {
+      autoscrape: {
+        enable: false,
+      },
+    },
+  } + {
+    [integrations.groupName(group)]: (
+      if group[0].Spec.Type == 'normal'
+      then [new_integration(ctx.Agent, integration) for integration in group]
+      else (
+        assert std.length(group) == 1 : 'non-normal integration can only have 1 instance';
+        new_integration(ctx.Agent, group[0])
+      )
+    )
+    for group in integrations.group(ctx.Integrations)
+  },
+}))

--- a/pkg/operator/config/templates/component/metrics/pod_monitor.libsonnet
+++ b/pkg/operator/config/templates/component/metrics/pod_monitor.libsonnet
@@ -49,6 +49,7 @@ function(
       namespace=agentNamespace,
       namespaces=k8s.namespacesFromSelector(
         monitor.Spec.NamespaceSelector,
+
         meta.Namespace,
         ignoreNamespaceSelectors,
       ),

--- a/pkg/operator/config/templates/ext/marshal.libsonnet
+++ b/pkg/operator/config/templates/ext/marshal.libsonnet
@@ -5,6 +5,10 @@
   // fromYAML unmarshals YAML text into an object.
   fromYAML(text):: std.native('unmarshalYAML')(text),
 
+  // fromRawJSON unmarshals apiextensions.JSON into an object.
+  // @param {apiext_v1.JSON} json
+  fromRawJSON(json):: std.native('unmarshalRawJSON')(json),
+
   // intoStages unmarshals YAML text into []*PipelineStageSpec.
   // This is required because the "match" stage from Promtail is
   // recursive and you can't define recursive types in CRDs.

--- a/pkg/operator/config/templates/integration.libsonnet
+++ b/pkg/operator/config/templates/integration.libsonnet
@@ -1,0 +1,42 @@
+local marshal = import 'ext/marshal.libsonnet';
+local optionals = import 'ext/optionals.libsonnet';
+local k8s = import 'utils/k8s.libsonnet';
+
+// Returns the YAML config for the integration.
+//
+// @param {MetricsIntegrationSpec} spec
+local instance_config(spec) =
+  local raw = spec.Config.Raw;
+  if raw == null || std.length(raw) == 0 then {}
+  else (
+    local data = marshal.fromRawJSON(spec.Config.Raw);
+    if data != null then data else {}
+  );
+
+// Generates the individual config for the specified integration.
+//
+// @param {GrafanaAgent} agent
+// @param {MetricsIntegration} integration
+function(agent, integration) instance_config(integration.Spec) {
+  // Force settings so the integration never scrapes itself. In the future we
+  // may want to remove this restriction.
+  autoscrape: { enable: false },
+
+  extra_labels: {
+    __meta_agentoperator_grafanaagent_name: agent.ObjectMeta.Name,
+    __meta_agentoperator_grafanaagent_namespace: agent.ObjectMeta.Namespace,
+    __meta_agentoperator_integration_type: integration.Spec.Type,
+    __meta_agentoperator_integration_cr_name: integration.ObjectMeta.Name,
+    __meta_agentoperator_integration_cr_namespace: integration.ObjectMeta.Namespace,
+  } + std.foldl(
+    function(acc, key) acc {
+      local labels = integration.ObjectMeta.Labels,
+      ['__meta_agentoperator_integration_cr_label_' + k8s.sanitize(key)]: labels[key],
+      ['__meta_agentoperator_integration_cr_labelpresent_' + k8s.sanitize(key)]: 'true',
+    },
+    std.objectFields(if integration.ObjectMeta.Labels != null then integration.ObjectMeta.Labels else {}),
+    {},
+  ) + (
+    if 'extra_labels' in super then super.extra_labels else {}
+  ),
+}

--- a/pkg/operator/config/templates/utils/integrations.libsonnet
+++ b/pkg/operator/config/templates/utils/integrations.libsonnet
@@ -1,0 +1,46 @@
+{
+  // group groups the set of input integrations based on the integration name.
+  // The result is multiple sets of integrations where each set holds
+  // integrations of the same name.
+  //
+  // @param {MetricsIntegration[]} set
+  // @returns {MetricsIntegration[][]}
+  group(set)::
+    // Group into an object by using the integration name as the key.
+    local map = std.foldl(
+      function(acc, element) acc {
+        [element.Spec.Name]: (
+          local key = element.Spec.Name;
+          if std.objectHas(acc, key) then (
+            assert $.integrationsMatch(acc[key][0], element) : 'integrations do not match';
+            acc[key] + [element]
+          ) else [element]
+        ),
+      }, set, {},
+    );
+    // Then flatten our object into an array.
+    std.foldl(
+      function(acc, key) acc + [map[key]],
+      std.objectFields(map),
+      [],
+    ),
+
+  // Returns true if a and b have the same name and type.
+  //
+  // @param {MetricsIntegration} a
+  // @param {MetricsIntegration} b
+  // @returns {Boolean}
+  integrationsMatch(a, b)::
+    a.Spec.Type == b.Spec.Type &&
+    a.Spec.Name == b.Spec.Name,
+
+  // groupName returns the name of a group. It is assumed that every element in
+  // group is of the same integration.
+  //
+  // @param {MetricsIntegration[]} group
+  // @returns {String}
+  groupName(group)::
+    assert std.length(group) > 0 : 'unexpected empty group of integrations';
+    if group[0].Spec.Type == 'normal' then group[0].Spec.Name + '_configs'
+    else group[0].Spec.Name,
+}


### PR DESCRIPTION
#### PR Description 
This PR extends the operator config generator with the ability to generate an agent config which runs integrations.

This is not wired up anywhere, and no additional Kubernetes resources will be generated as of this commit.

#### Which issue(s) this PR fixes 
Related to #1224.

#### Notes to the Reviewer
See the `TestBuildConfigIntegrations` test for a full example of a hierarchy and the resulting agent config file. 

#### PR Checklist

- [x] CHANGELOG updated (N/A) 
- [x] Documentation added (N/A)
- [x] Tests updated
