### PR TITLE
Stop appending duplicate exemplars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - [BUGFIX] Operator: Add missing proxy_url field from generated remote_write
   configs. (@rfratto)
 
+- [ENHANCEMENT] The agent no longer appends duplicate exemplars. (@tpaschalis)
+
 # v0.22.0 (2022-01-13)
 
 This release has deprecations. Please read [DEPRECATION] entries and consult

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - [ENHANCEMENT] integrations-next: Add `extra_labels` to add a custom set of
   labels to integration targets. (@rfratto)
 
+- [ENHANCEMENT] The agent no longer appends duplicate exemplars. (@tpaschalis)
+
 - [BUGFIX] Fixed issue where Grafana Agent may panic if there is a very large
   WAL loading while old WALs are being deleted or the `/agent/api/v1/targets`
   endpoint is called. (@tpaschalis)
@@ -15,8 +17,6 @@
   configs. (@rfratto)
 
 - [BUGFIX] Honor the specified log format in the traces subsystem (@mapno)
-
-- [ENHANCEMENT] The agent no longer appends duplicate exemplars. (@tpaschalis)
 
 # v0.22.0 (2022-01-13)
 

--- a/pkg/metrics/wal/series.go
+++ b/pkg/metrics/wal/series.go
@@ -239,8 +239,11 @@ func (s *stripeSeries) getLatestExemplar(id uint64) *exemplar.Exemplar {
 func (s *stripeSeries) setLatestExemplar(id uint64, exemplar *exemplar.Exemplar) {
 	i := id & uint64(s.size-1)
 
+	// Make sure that's a valid series id and record its latest exemplar
 	s.locks[i].Lock()
-	s.exemplars[i][id] = exemplar
+	if s.series[i][id] != nil {
+		s.exemplars[i][id] = exemplar
+	}
 	s.locks[i].Unlock()
 }
 

--- a/pkg/metrics/wal/wal.go
+++ b/pkg/metrics/wal/wal.go
@@ -649,12 +649,10 @@ func (a *appender) AppendExemplar(ref uint64, _ labels.Labels, e exemplar.Exempl
 	// Check for duplicate vs last stored exemplar for this series, and discard those.
 	// Otherwise, record the current exemplar as the latest
 	prevExemplar := a.w.series.getLatestExemplar(ref)
-	if prevExemplar != nil {
-		if exemplarsEqual(*prevExemplar, e) {
-			return 0, nil
-		}
-		a.w.series.setLatestExemplar(ref, &memExemplar{ts: e.Ts, value: e.Value, labels: e.Labels})
+	if prevExemplar != nil && exemplarsEqual(*prevExemplar, e) {
+		return 0, nil
 	}
+	a.w.series.setLatestExemplar(ref, &memExemplar{ts: e.Ts, value: e.Value, labels: e.Labels})
 
 	a.exemplars = append(a.exemplars, record.RefExemplar{
 		Ref:    ref,

--- a/pkg/metrics/wal/wal.go
+++ b/pkg/metrics/wal/wal.go
@@ -282,7 +282,7 @@ func (w *Storage) loadWAL(r *wal.Reader) (err error) {
 				decoded <- samples
 			case record.Tombstones, record.Exemplars:
 				// We don't care about decoding tombstones or exemplars
-				// If decide to decode exemplars, we should make sure to prepopulate
+				// TODO: If decide to decode exemplars, we should make sure to prepopulate
 				// stripeSeries.exemplars in the next block by using setLatestExemplar.
 				continue
 			default:

--- a/pkg/metrics/wal/wal.go
+++ b/pkg/metrics/wal/wal.go
@@ -282,6 +282,8 @@ func (w *Storage) loadWAL(r *wal.Reader) (err error) {
 				decoded <- samples
 			case record.Tombstones, record.Exemplars:
 				// We don't care about decoding tombstones or exemplars
+				// If decide to decode exemplars, we should make sure to prepopulate
+				// stripeSeries.exemplars in the next block by using setLatestExemplar.
 				continue
 			default:
 				errCh <- &wal.CorruptionErr{

--- a/pkg/metrics/wal/wal.go
+++ b/pkg/metrics/wal/wal.go
@@ -665,6 +665,7 @@ func (a *appender) AppendExemplar(ref uint64, _ labels.Labels, e exemplar.Exempl
 		Labels: e.Labels,
 	})
 
+	a.w.metrics.totalAppendedExemplars.Inc()
 	return s.ref, nil
 }
 

--- a/pkg/metrics/wal/wal.go
+++ b/pkg/metrics/wal/wal.go
@@ -647,7 +647,7 @@ func (a *appender) AppendExemplar(ref uint64, _ labels.Labels, e exemplar.Exempl
 	}
 
 	// Check for duplicate vs last stored exemplar for this series, and discard those.
-	// Otherwise, record the current exemplar as the latest
+	// Otherwise, record the current exemplar as the latest.
 	// Prometheus returns 0 when encountering duplicates, so we do the same here.
 	prevExemplar := a.w.series.getLatestExemplar(ref)
 	if prevExemplar != nil && prevExemplar.Equals(e) {

--- a/pkg/metrics/wal/wal_test.go
+++ b/pkg/metrics/wal/wal_test.go
@@ -104,6 +104,47 @@ func TestStorage(t *testing.T) {
 	require.Equal(t, expectedExemplars, actualExemplars)
 }
 
+func TestStorage_DuplicateExemplarsIgnored(t *testing.T) {
+	walDir, err := ioutil.TempDir(os.TempDir(), "wal")
+	require.NoError(t, err)
+	defer os.RemoveAll(walDir)
+
+	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
+	require.NoError(t, err)
+
+	app := s.Appender(context.Background())
+
+	sRef, err := app.Append(0, labels.Labels{{Name: "a", Value: "1"}}, 0, 0)
+	require.NoError(t, err, "should not reject valid series")
+
+	// If the Labels, Value or Timestamp are different than the last exemplar,
+	// then a new one should be appended; Otherwise, it should be skipped.
+	e := exemplar.Exemplar{Labels: labels.Labels{{Name: "a", Value: "1"}}, Value: 20, Ts: 10, HasTs: true}
+	app.AppendExemplar(sRef, nil, e)
+	app.AppendExemplar(sRef, nil, e)
+
+	e.Labels = labels.Labels{{Name: "b", Value: "2"}}
+	app.AppendExemplar(sRef, nil, e)
+	app.AppendExemplar(sRef, nil, e)
+	app.AppendExemplar(sRef, nil, e)
+
+	e.Value = 42
+	app.AppendExemplar(sRef, nil, e)
+	app.AppendExemplar(sRef, nil, e)
+
+	e.Ts = 25
+	app.AppendExemplar(sRef, nil, e)
+	app.AppendExemplar(sRef, nil, e)
+
+	require.NoError(t, app.Commit())
+	collector := walDataCollector{}
+	replayer := walReplayer{w: &collector}
+	require.NoError(t, replayer.Replay(s.wal.Dir()))
+
+	// We had 9 calls to AppendExemplar but only 4 of them should have been appended
+	require.Equal(t, 4, len(collector.exemplars))
+}
+
 func TestStorage_ExistingWAL(t *testing.T) {
 	walDir, err := ioutil.TempDir(os.TempDir(), "wal")
 	require.NoError(t, err)

--- a/pkg/metrics/wal/wal_test.go
+++ b/pkg/metrics/wal/wal_test.go
@@ -380,9 +380,9 @@ func BenchmarkAppendExemplar(b *testing.B) {
 	defer s.Close()
 	app := s.Appender(context.Background())
 	sRef, _ := app.Append(0, labels.Labels{{Name: "a", Value: "1"}}, 0, 0)
+	e := exemplar.Exemplar{Labels: labels.Labels{{Name: "a", Value: "1"}}, Value: 20, Ts: 10, HasTs: true}
 
 	b.StartTimer()
-	e := exemplar.Exemplar{Labels: labels.Labels{{Name: "a", Value: "1"}}, Value: 20, Ts: 10, HasTs: true}
 	for i := 0; i < b.N; i++ {
 		e.Ts = int64(i)
 		_, _ = app.AppendExemplar(sRef, nil, e)

--- a/pkg/metrics/wal/wal_test.go
+++ b/pkg/metrics/wal/wal_test.go
@@ -120,28 +120,28 @@ func TestStorage_DuplicateExemplarsIgnored(t *testing.T) {
 	// If the Labels, Value or Timestamp are different than the last exemplar,
 	// then a new one should be appended; Otherwise, it should be skipped.
 	e := exemplar.Exemplar{Labels: labels.Labels{{Name: "a", Value: "1"}}, Value: 20, Ts: 10, HasTs: true}
-	app.AppendExemplar(sRef, nil, e)
-	app.AppendExemplar(sRef, nil, e)
+	_, _ = app.AppendExemplar(sRef, nil, e)
+	_, _ = app.AppendExemplar(sRef, nil, e)
 
 	e.Labels = labels.Labels{{Name: "b", Value: "2"}}
-	app.AppendExemplar(sRef, nil, e)
-	app.AppendExemplar(sRef, nil, e)
-	app.AppendExemplar(sRef, nil, e)
+	_, _ = app.AppendExemplar(sRef, nil, e)
+	_, _ = app.AppendExemplar(sRef, nil, e)
+	_, _ = app.AppendExemplar(sRef, nil, e)
 
 	e.Value = 42
-	app.AppendExemplar(sRef, nil, e)
-	app.AppendExemplar(sRef, nil, e)
+	_, _ = app.AppendExemplar(sRef, nil, e)
+	_, _ = app.AppendExemplar(sRef, nil, e)
 
 	e.Ts = 25
-	app.AppendExemplar(sRef, nil, e)
-	app.AppendExemplar(sRef, nil, e)
+	_, _ = app.AppendExemplar(sRef, nil, e)
+	_, _ = app.AppendExemplar(sRef, nil, e)
 
 	require.NoError(t, app.Commit())
 	collector := walDataCollector{}
 	replayer := walReplayer{w: &collector}
 	require.NoError(t, replayer.Replay(s.wal.Dir()))
 
-	// We had 9 calls to AppendExemplar but only 4 of them should have been appended
+	// We had 9 calls to AppendExemplar but only 4 of those should have gotten through
 	require.Equal(t, 4, len(collector.exemplars))
 }
 

--- a/pkg/metrics/wal/wal_test.go
+++ b/pkg/metrics/wal/wal_test.go
@@ -387,7 +387,7 @@ func BenchmarkAppendExemplar(b *testing.B) {
 	}
 
 	// Actually use appended exemplars in case they get eliminated
-	app.Commit()
+	_ = app.Commit()
 }
 
 type sample struct {

--- a/pkg/metrics/wal/wal_test.go
+++ b/pkg/metrics/wal/wal_test.go
@@ -377,14 +377,17 @@ func BenchmarkAppendExemplar(b *testing.B) {
 	defer os.RemoveAll(walDir)
 
 	s, _ := NewStorage(log.NewNopLogger(), nil, walDir)
+	defer s.Close()
 	app := s.Appender(context.Background())
 	sRef, _ := app.Append(0, labels.Labels{{Name: "a", Value: "1"}}, 0, 0)
 
+	b.StartTimer()
 	e := exemplar.Exemplar{Labels: labels.Labels{{Name: "a", Value: "1"}}, Value: 20, Ts: 10, HasTs: true}
 	for i := 0; i < b.N; i++ {
 		e.Ts = int64(i)
 		_, _ = app.AppendExemplar(sRef, nil, e)
 	}
+	b.StopTimer()
 
 	// Actually use appended exemplars in case they get eliminated
 	_ = app.Commit()


### PR DESCRIPTION
#### PR Description 
This PR attempts to stop the Grafana Agent from sending duplicate exemplars, to avoid incurring extra I/O costs to the receiving side.

To achieve that, it adds a memExemplar struct to keep exemplars in memory. It's used to cache the latest exemplar (for series that have them) in a new field of stripeSeries, utilizing the same mechanism to distribute the lock contention.

#### Which issue(s) this PR fixes 
This fixes #1282 

#### Notes to the Reviewer
- I sketched out this with a couple of other approaches, either moving this one level up as a separate entry in the `Storage` struct, or in a separate `exemplars.go` file next to `series.go`. I didn't really like either of those options, I feel that this might be an acceptable solution comparing the added complexity with the benefit of keeping the code in one place
- Resources-wise, this will allocate defaultStripeSize pointers on startup (~130KB). Each series that has at least one exemplar appended will incur some move overhead (95 bytes on avg, 328 bytes on worst case) as an extra heap allocation.
- Running a benchmark that includes appending a valid exemplar (with its timestamp set to b.N in the benchmark loop) to gauge the performance of `AppendExemplar` before and after this change gives us

```
name              old time/op    new time/op    delta
AppendExemplar-8     255ns ±21%     332ns ±16%  +30.32%  (p=0.000 n=10+10)

name              old alloc/op   new alloc/op   delta
AppendExemplar-8      805B ± 4%      872B ± 7%   +8.37%  (p=0.001 n=10+10)

name              old allocs/op  new allocs/op  delta
AppendExemplar-8      2.00 ± 0%      3.00 ± 0%  +50.00%  (p=0.000 n=10+10)
```


#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added (N/A)
- [x] Tests updated
