### PR TITLE
integrations-next: wait for integrations to exit after stopping them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
 
 - [BUGFIX] Allow inlining credentials in remote_write url. (@tpaschalis)
 
+- [BUGFIX] integrations-next: Wait for integrations to stop when starting new
+  instances or shutting down (@rfratto).
+
 # v0.22.0 (2022-01-13)
 
 This release has deprecations. Please read [DEPRECATION] entries and consult

--- a/pkg/integrations/v2/controller.go
+++ b/pkg/integrations/v2/controller.go
@@ -127,7 +127,7 @@ func (c *controller) run(ctx context.Context) {
 		workersMut.Lock()
 		defer workersMut.Unlock()
 
-		level.Debug(c.logger).Log("msg", "updating running integrations", "prev_count", len(workers), "new_count", len(c.integrations))
+		level.Debug(c.logger).Log("msg", "updating running integrations", "prev_count", len(workers), "new_count", len(newIntegrations))
 
 		// Shut down workers whose integrations have gone away.
 		var stopped []worker

--- a/pkg/integrations/v2/controller_metricsintegration_test.go
+++ b/pkg/integrations/v2/controller_metricsintegration_test.go
@@ -46,10 +46,11 @@ func Test_controller_MetricsIntegration_Targets(t *testing.T) {
 	waitIntegrations := func(t *testing.T, ctrl *controller) {
 		t.Helper()
 		_ = newSyncController(t, ctrl)
-		forEachIntegration(ctrl.integrations, "/", func(ci *controlledIntegration, _ string) {
+		err := forEachIntegration(ctrl.integrations, "/", func(ci *controlledIntegration, _ string) {
 			wsi := ci.i.(mockMetricsIntegration).Integration.(*waitStartedIntegration)
-			wsi.trigger.WaitContext(context.Background())
+			_ = wsi.trigger.WaitContext(context.Background())
 		})
+		require.NoError(t, err)
 	}
 
 	t.Run("All", func(t *testing.T) {
@@ -60,11 +61,6 @@ func Test_controller_MetricsIntegration_Targets(t *testing.T) {
 		)
 		require.NoError(t, err)
 		waitIntegrations(t, ctrl)
-
-		forEachIntegration(ctrl.integrations, "/", func(ci *controlledIntegration, _ string) {
-			wsi := ci.i.(mockMetricsIntegration).Integration.(*waitStartedIntegration)
-			wsi.trigger.WaitContext(context.Background())
-		})
 
 		result := ctrl.Targets(Endpoint{Prefix: "/"}, TargetOptions{})
 		expect := []*targetGroup{

--- a/pkg/integrations/v2/controller_metricsintegration_test.go
+++ b/pkg/integrations/v2/controller_metricsintegration_test.go
@@ -46,7 +46,7 @@ func Test_controller_MetricsIntegration_Targets(t *testing.T) {
 	waitIntegrations := func(t *testing.T, ctrl *controller) {
 		t.Helper()
 		_ = newSyncController(t, ctrl)
-		err := forEachIntegration(ctrl.integrations, "/", func(ci *controlledIntegration, _ string) {
+		err := ctrl.forEachIntegration("/", func(ci *controlledIntegration, _ string) {
 			wsi := ci.i.(mockMetricsIntegration).Integration.(*waitStartedIntegration)
 			_ = wsi.trigger.WaitContext(context.Background())
 		})
@@ -136,9 +136,7 @@ func Test_controller_MetricsIntegration_ScrapeConfig(t *testing.T) {
 		Globals{},
 	)
 	require.NoError(t, err)
-	// NOTE(rfratto): we explicitly don't run the controller here because
-	// ScrapeConfigs should return the list of scrape targets even when the
-	// integration isn't running.
+	_ = newSyncController(t, ctrl)
 
 	result := ctrl.ScrapeConfigs("/", &http.DefaultSDConfig)
 	expect := []*autoscrape.ScrapeConfig{

--- a/pkg/integrations/v2/controller_test.go
+++ b/pkg/integrations/v2/controller_test.go
@@ -134,57 +134,46 @@ func Test_controller_ConfigChanges(t *testing.T) {
 }
 
 type syncController struct {
-	inner   *controller
-	applyWg sync.WaitGroup
-
-	stop     context.CancelFunc
-	exitedCh chan struct{}
+	inner *controller
+	pool  *workerPool
 }
 
-// newSyncController makes calls to Controller synchronous. newSyncController
-// will start running the inner controller and wait for it to update.
+// newSyncController pairs an unstarted controller with a manually managed
+// worker pool to synchronously apply integrations.
 func newSyncController(t *testing.T, inner *controller) *syncController {
 	t.Helper()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() {
-		cancel()
-	})
-
 	sc := &syncController{
-		inner:    inner,
-		stop:     cancel,
-		exitedCh: make(chan struct{}),
+		inner: inner,
+		pool:  newWorkerPool(context.Background(), inner.logger),
 	}
-	inner.onUpdateDone = sc.applyWg.Done // Inform WG whenever an apply finishes
 
-	// There's always immediately ony applied queued from any successfully created controller.
-	sc.applyWg.Add(1)
-
-	go func() {
-		inner.run(ctx)
-		close(sc.exitedCh)
-	}()
-
-	sc.applyWg.Wait()
+	// There's always immediately one queued integration set from any
+	// successfully created controller.
+	sc.refresh()
 	return sc
 }
 
-func (sc *syncController) UpdateController(c controllerConfig, g Globals) error {
-	sc.applyWg.Add(1)
+func (sc *syncController) refresh() {
+	sc.inner.mut.Lock()
+	defer sc.inner.mut.Unlock()
 
-	if err := sc.inner.UpdateController(c, g); err != nil {
-		sc.applyWg.Done() // The wg won't ever be finished now
+	newIntegrations := <-sc.inner.runIntegrations
+	sc.pool.Reload(newIntegrations)
+	sc.inner.integrations = newIntegrations
+}
+
+func (sc *syncController) UpdateController(c controllerConfig, g Globals) error {
+	err := sc.inner.UpdateController(c, g)
+	if err != nil {
 		return err
 	}
-
-	sc.applyWg.Wait()
+	sc.refresh()
 	return nil
 }
 
 func (sc *syncController) Stop() {
-	sc.stop()
-	<-sc.exitedCh
+	sc.pool.Close()
 }
 
 const mockIntegrationName = "mock"

--- a/pkg/integrations/v2/workers.go
+++ b/pkg/integrations/v2/workers.go
@@ -1,0 +1,122 @@
+package integrations
+
+import (
+	"context"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+type workerPool struct {
+	log       log.Logger
+	parentCtx context.Context
+
+	mut     sync.Mutex
+	workers map[*controlledIntegration]worker
+
+	runningWorkers sync.WaitGroup
+}
+
+type worker struct {
+	ci     *controlledIntegration
+	stop   context.CancelFunc
+	exited chan struct{}
+}
+
+func newWorkerPool(ctx context.Context, l log.Logger) *workerPool {
+	return &workerPool{
+		log:       l,
+		parentCtx: ctx,
+
+		workers: make(map[*controlledIntegration]worker),
+	}
+}
+
+func (p *workerPool) Reload(newIntegrations []*controlledIntegration) {
+	p.mut.Lock()
+	defer p.mut.Unlock()
+
+	level.Debug(p.log).Log("msg", "updating running integrations", "prev_count", len(p.workers), "new_count", len(newIntegrations))
+
+	// Shut down workers whose integrations have gone away.
+	var stopped []worker
+	for ci, w := range p.workers {
+		var found bool
+		for _, current := range newIntegrations {
+			if ci == current {
+				found = true
+				break
+			}
+		}
+		if !found {
+			w.stop()
+			stopped = append(stopped, w)
+		}
+	}
+	for _, w := range stopped {
+		// Wait for stopped integrations to fully exit. We do this in a separate
+		// loop so context cancellations can be handled simultaneously, allowing
+		// the wait to complete faster.
+		<-w.exited
+	}
+
+	// Spawn new workers for integrations that don't have them.
+	for _, current := range newIntegrations {
+		if _, workerExists := p.workers[current]; workerExists {
+			continue
+		}
+		// This integration doesn't have an existing worker; schedule a new one.
+		p.scheduleWorker(current)
+	}
+}
+
+func (p *workerPool) Close() {
+	p.mut.Lock()
+	defer p.mut.Unlock()
+
+	level.Debug(p.log).Log("msg", "stopping all integrations")
+
+	defer p.runningWorkers.Wait()
+	for _, w := range p.workers {
+		w.stop()
+	}
+}
+
+func (p *workerPool) scheduleWorker(ci *controlledIntegration) {
+	p.runningWorkers.Add(1)
+
+	ctx, cancel := context.WithCancel(p.parentCtx)
+
+	w := worker{
+		ci:     ci,
+		stop:   cancel,
+		exited: make(chan struct{}),
+	}
+	p.workers[ci] = w
+
+	go func() {
+		ci.running.Store(true)
+
+		// When the integration stops running, we want to free any of our
+		// resources that will notify watchers waiting for the worker to stop.
+		//
+		// Afterwards, we'll block until we remove ourselves from the map; having
+		// an worker remove itself on shutdown allows exited integrations to
+		// re-start when the config is reloaded.
+		defer func() {
+			ci.running.Store(false)
+			close(w.exited)
+			p.runningWorkers.Done()
+
+			p.mut.Lock()
+			defer p.mut.Unlock()
+			delete(p.workers, ci)
+		}()
+
+		err := ci.i.RunIntegration(ctx)
+		if err != nil {
+			level.Error(p.log).Log("msg", "integration exited with error", "id", ci.id, "err", err)
+		}
+	}()
+}


### PR DESCRIPTION
#### PR Description 
Modifies integrations-next to wait for integrations to fully exit before stopping them. This prevents two instances of the same integration (with different configs) from being run concurrently, and also ensures that integrations fully stop when shutting down the agent. 

#### Which issue(s) this PR fixes 
Fixes #1317. 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [x] Tests updated
