### PR TITLE
add policy rule for list and delete pods

### DIFF
--- a/production/tanka/grafana-agent/smoke/main.libsonnet
+++ b/production/tanka/grafana-agent/smoke/main.libsonnet
@@ -26,6 +26,9 @@ local deployment = k.apps.v1.deployment;
                 policyRule.withApiGroups(['apps']) +
                 policyRule.withResources(['deployments/scale']) +
                 policyRule.withVerbs(['get', 'update']),
+                policyRule.withApiGroups(['']) +
+                policyRule.withResources(['pods']) +
+                policyRule.withVerbs(['list', 'delete']),
             ]) {
                 service_account+:
                   serviceAccount.mixin.metadata.withNamespace(namespace),


### PR DESCRIPTION
Still a couple of loose ends for the smoke framework in `dev-us-central-0` on the deployment_tools side but I think this takes care all the issues I know about on the agent side for now.