### PR TITLE
Fix typo in node_exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 - [BUGFIX] Honor the specified log format in the traces subsystem (@mapno)
 
+- [BUGFIX] Fix typo in node_exporter for runit_service_dir. (@mattdurham)
+
 # v0.22.0 (2022-01-13)
 
 This release has deprecations. Please read [DEPRECATION] entries and consult

--- a/pkg/integrations/node_exporter/config.go
+++ b/pkg/integrations/node_exporter/config.go
@@ -120,7 +120,7 @@ type Config struct {
 	PerfCPUS                         string              `yaml:"perf_cpus,omitempty"`
 	PerfTracepoint                   flagext.StringSlice `yaml:"perf_tracepoint,omitempty"`
 	PowersupplyIgnoredSupplies       string              `yaml:"powersupply_ignored_supplies,omitempty"`
-	RunitServiceDir                  string              `yaml:"runit_servic e_dir,omitempty"`
+	RunitServiceDir                  string              `yaml:"runit_service_dir,omitempty"`
 	SupervisordURL                   string              `yaml:"supervisord_url,omitempty"`
 	SystemdEnableRestartsMetrics     bool                `yaml:"systemd_enable_restarts_metrics,omitempty"`
 	SystemdEnableStartTimeMetrics    bool                `yaml:"systemd_enable_start_time_metrics,omitempty"`


### PR DESCRIPTION
#### PR Description 

Noticed this while working on dynamic configuration, space where one should not be

- [X] CHANGELOG updated 
