### PR TITLE
Allow remote_write URL credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 - [BUGFIX] Fix typo in node_exporter for runit_service_dir. (@mattdurham)
 
+- [BUGFIX] Allow inlining credentials in remote_write url. (@tpaschalis)
+
 # v0.22.0 (2022-01-13)
 
 This release has deprecations. Please read [DEPRECATION] entries and consult

--- a/pkg/metrics/instance/marshal.go
+++ b/pkg/metrics/instance/marshal.go
@@ -37,6 +37,8 @@ func MarshalConfigToWriter(c *Config, w io.Writer, scrubSecrets bool) error {
 			switch v := in.(type) {
 			case config_util.Secret:
 				return true, string(v), nil
+			case *config_util.URL:
+				return true, v.String(), nil
 			default:
 				return false, nil, nil
 			}

--- a/pkg/metrics/instance/marshal_test.go
+++ b/pkg/metrics/instance/marshal_test.go
@@ -96,7 +96,7 @@ scrape_configs:
     username: admin
     password: SCRUBME
 remote_write:
-- url: http://localhost:9009/api/prom/push
+- url: http://username:SCRUBURL@localhost:9009/api/prom/push
   remote_timeout: 30s
   name: test-d0f32c
   basic_auth:
@@ -122,7 +122,9 @@ remote_flush_deadline: 1m0s
 `
 
 	scrub := func(in string) string {
-		return strings.ReplaceAll(in, "SCRUBME", "<secret>")
+		in = strings.ReplaceAll(in, "SCRUBME", "<secret>")
+		in = strings.ReplaceAll(in, "SCRUBURL", "xxxxx")
+		return in
 	}
 
 	t.Run("direct marshal", func(t *testing.T) {

--- a/pkg/metrics/instance/marshal_test.go
+++ b/pkg/metrics/instance/marshal_test.go
@@ -44,7 +44,7 @@ scrape_configs:
     username: admin
     password: foobar
 remote_write:
-- url: http://localhost:9009/api/prom/push
+- url: http://admin:verysecret@localhost:9009/api/prom/push
   remote_timeout: 30s
   name: test-d0f32c
   basic_auth:


### PR DESCRIPTION
#### PR Description 
This is an attempt to re-allow inlined credentials in remote_write URLs.

The underlying issue will be dealt with by metrics V2, and while no issues have been raised by the community yet, it might be worth fixing.

#### Which issue(s) this PR fixes 
This fixes #1211 

#### Notes to the Reviewer
I checked that when calling /-/config, the secret there is scrubbed.

Also, I kinda abused an existing RetainSecrets test (adding credentials both inline and in a basic_auth block), but I don't believe this small change warrants 40 extra lines of test code.

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added (N/A)
- [x] Tests updated
