### PR TITLE
[dev.frontend-receiver] Add API key support to app o11y receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This release has deprecations. Please read [DEPRECATION] entries and consult
 the [upgrade guide](https://github.com/grafana/agent/blob/main/docs/upgrade-guide/_index.md)
 for detailed information.
 
+- [FEATURE] (beta) Add API key support to app o11y receiver integration (@domasx2)
+
 - [FEATURE] (beta) Add app o11y integration. This depends on integrations-next being enabled
    via the `integrations-next` feature flag. Use `-enable-features=integrations-next` to used
    this integration. (@kpelelis)
@@ -200,7 +202,6 @@ consult the
 [upgrade guide](https://github.com/grafana/agent/blob/main/docs/upgrade-guide/_index.md)
 for specific instructions.
 
-
 - [FEATURE] Added [Github exporter](https://github.com/infinityworks/github-exporter) integration. (@rgeyer)
 
 - [FEATURE] Add TLS config options for tempo `remote_write`s. (@mapno)
@@ -262,8 +263,8 @@ for specific instructions.
 - [CHANGE] Breaking change: reduced verbosity of tracing autologging
   by not logging `STATUS_CODE_UNSET` status codes. (@mapno)
 
-- [CHANGE] Breaking change: Operator: rename Prometheus* CRDs to Metrics* and
-  Prometheus* fields to Metrics*. (@rfratto)
+- [CHANGE] Breaking change: Operator: rename Prometheus*CRDs to Metrics* and
+  Prometheus*fields to Metrics*. (@rfratto)
 
 - [CHANGE] Breaking change: Operator: CRDs are no longer referenced using a
   hyphen in the name to be consistent with how Kubernetes refers to resources.
@@ -985,10 +986,10 @@ files to the new format.
 - [FEATURE] The Prometheus remote write protocol will now send scraped metadata (metric name, help, type and unit). This results in almost negligent bytes sent increase as metadata is only sent every minute. It is on by default. (@gotjosh)
 
   These metrics are available to monitor metadata being sent:
-    - `prometheus_remote_storage_succeeded_metadata_total`
-    - `prometheus_remote_storage_failed_metadata_total`
-    - `prometheus_remote_storage_retried_metadata_total`
-    - `prometheus_remote_storage_sent_batch_duration_seconds` and
+  - `prometheus_remote_storage_succeeded_metadata_total`
+  - `prometheus_remote_storage_failed_metadata_total`
+  - `prometheus_remote_storage_retried_metadata_total`
+  - `prometheus_remote_storage_sent_batch_duration_seconds` and
       `prometheus_remote_storage_sent_bytes_total` have a new label “type” with
       the values of `metadata` or `samples`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This release has deprecations. Please read [DEPRECATION] entries and consult
 the [upgrade guide](https://github.com/grafana/agent/blob/main/docs/upgrade-guide/_index.md)
 for detailed information.
 
-- [FEATURE] (beta) Add API key support to app o11y receiver integration (@domasx2)
+- [FEATURE] (beta) Add API key based authentication support to app o11y receiver integration (@domasx2)
 
 - [FEATURE] (beta) Add app o11y integration. This depends on integrations-next being enabled
    via the `integrations-next` feature flag. Use `-enable-features=integrations-next` to used

--- a/docs/configuration/integrations/integrations-next/app-o11y-receiver-config.md
+++ b/docs/configuration/integrations/integrations-next/app-o11y-receiver-config.md
@@ -44,6 +44,9 @@ Full reference of options:
     [rps: <number> | default = 100]
     [burstiness: <number> | default = 50]
 
+  # If configured, incoming requests will be required to specify this key in "x-api-key" header
+  [api_key: <string>]
+
   # Max allowed payload size in bytes for the JSON payload. Interanlly the
   # Content-Length header is used to make this check
   [max_allowed_payload_size: <number> | default = 0]

--- a/pkg/integrations/v2/app_o11y_receiver/config/config.go
+++ b/pkg/integrations/v2/app_o11y_receiver/config/config.go
@@ -48,6 +48,7 @@ type RateLimitingConfig struct {
 type AppO11yReceiverConfig struct {
 	CORSAllowedOrigins    []string           `yaml:"cors_allowed_origins,omitempty"`
 	RateLimiting          RateLimitingConfig `yaml:"rate_limiting,omitempty"`
+	APIKey                string             `yaml:"api_key,omitempty"`
 	MaxAllowedPayloadSize int64              `yaml:"max_allowed_payload_size,omitempty"`
 	Server                ServerConfig       `yaml:"server,omitempty"`
 	LogsInstance          string             `yaml:"logs_instance"`

--- a/pkg/integrations/v2/app_o11y_receiver/handler/handler.go
+++ b/pkg/integrations/v2/app_o11y_receiver/handler/handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"sync"
 
+	"crypto/subtle"
 	"encoding/json"
 	"net/http"
 
@@ -60,7 +61,7 @@ func (ar *AppO11yHandler) HTTPHandler(logger log.Logger) http.Handler {
 		}
 
 		// check API key if one is provided
-		if len(ar.config.APIKey) > 0 && r.Header.Get("x-api-key") != ar.config.APIKey {
+		if len(ar.config.APIKey) > 0 && subtle.ConstantTimeCompare([]byte(r.Header.Get("x-api-key")), []byte(ar.config.APIKey)) == 0 {
 			http.Error(w, "api key not provided or incorrect", http.StatusUnauthorized)
 			return
 		}

--- a/pkg/integrations/v2/app_o11y_receiver/handler/handler.go
+++ b/pkg/integrations/v2/app_o11y_receiver/handler/handler.go
@@ -59,6 +59,12 @@ func (ar *AppO11yHandler) HTTPHandler(logger log.Logger) http.Handler {
 			return
 		}
 
+		// check API key if one is provided
+		if len(ar.config.APIKey) > 0 && r.Header.Get("x-api-key") != ar.config.APIKey {
+			http.Error(w, "api key not provided or incorrect", http.StatusUnauthorized)
+			return
+		}
+
 		// Verify content length. We trust net/http to give us the correct number
 		if ar.config.MaxAllowedPayloadSize > 0 && r.ContentLength > ar.config.MaxAllowedPayloadSize {
 			http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
@@ -92,6 +98,7 @@ func (ar *AppO11yHandler) HTTPHandler(logger log.Logger) http.Handler {
 	if len(ar.config.CORSAllowedOrigins) > 0 {
 		c := cors.New(cors.Options{
 			AllowedOrigins: ar.config.CORSAllowedOrigins,
+			AllowedHeaders: []string{"x-api-key", "content-type"},
 		})
 		handler = c.Handler(handler)
 	}


### PR DESCRIPTION
#### PR Description 

Adds api key support to app o11y receiver. `api_key` can be configured for receiver, and if it is, it is required to be provided via `x-api-key` header on the http request.

#### Which issue(s) this PR fixes 
fixes #1294 

#### Notes to the Reviewer

#### PR Checklist

- [X] CHANGELOG updated 
- [X] Documentation added
- [X] Tests updated
