### PR TITLE
operator/hierarchy: stop using field selector when listing Secrets & ConfigMaps

### DIFF
--- a/pkg/operator/build_hierarchy.go
+++ b/pkg/operator/build_hierarchy.go
@@ -236,7 +236,7 @@ func buildSecrets(ctx context.Context, cli client.Client, deploy config.Deployme
 			case *corev1.Secret:
 				rawValue, ok := o.Data[ref.Reference.Secret.Key]
 				if !ok {
-					return fmt.Errorf("no key %s in Secret %s", ref.Reference.ConfigMap.Key, o.Name)
+					return fmt.Errorf("no key %s in Secret %s", ref.Reference.Secret.Key, o.Name)
 				}
 				value = string(rawValue)
 			case *corev1.ConfigMap:

--- a/pkg/operator/hierarchy/selector.go
+++ b/pkg/operator/hierarchy/selector.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -79,7 +78,6 @@ var _ Selector = (*KeySelector)(nil)
 // ApplyToList implements Selector.
 func (ks *KeySelector) ApplyToList(lo *client.ListOptions) {
 	lo.Namespace = ks.Namespace
-	lo.FieldSelector = fields.OneTermEqualSelector("metadata.name", ks.Name)
 }
 
 // Matches implements Selector.


### PR DESCRIPTION
#### PR Description 
The initial implementation of hierarchy.KeySelector injected a FieldSelector when listing Secrets and ConfigMaps to immediately return the single object being queried for.

This causes a problem with the client generated by the controller-runtime framework, where the client is wrapped in a cache and field indexer (where only the namespace is indexed by default).

This commit avoids using the field selector and the index lookup. The resulting behavior aligns more closely with discovering other resources in the hierarchy (i.e., ServiceMonitors), where the List call is also insufficient and needs post-processing via Matches to find the final list of resources.

Given the controller-runtime client uses an informer for reads, all relevant Secrets and ConfigMaps are already in-memory anyway, and using the index for a faster List is a bit of an over-optimization at the moment.

#### Which issue(s) this PR fixes 
Closes #1339. 

#### Notes to the Reviewer
Relevant tests have been updated to use a client which is identical to the client generated by the operator (i.e., one that uses a cache informer & index).

#### PR Checklist

- [x] CHANGELOG updated (N/A: commit introducing bug not released) 
- [x] Documentation added 
- [x] Tests updated
