### PR TITLE
default send_exemplars to true in remote_write config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 - [ENHANCEMENT] Added Kubernetes eventhandler integration (@hjet)
 
+- [ENHANCEMENT] Enables sending of exemplars over remote write by default. (@rlankfo)
+
 - [BUGFIX] Fixed issue where Grafana Agent may panic if there is a very large
   WAL loading while old WALs are being deleted or the `/agent/api/v1/targets`
   endpoint is called. (@tpaschalis)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"flag"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/grafana/agent/pkg/metrics"
 	"github.com/grafana/agent/pkg/metrics/instance"
 	"github.com/grafana/agent/pkg/util"
+	commonCfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	promCfg "github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -427,4 +429,26 @@ metrics:
 	require.Equal(t, "verysecret", cfg.Metrics.ServiceConfig.KVStore.Etcd.Password)
 	require.Equal(t, "verysecret", cfg.Metrics.ServiceConfig.Lifecycler.RingConfig.KVStore.Consul.ACLToken)
 	require.Equal(t, "verysecret", cfg.Metrics.ServiceConfig.Lifecycler.RingConfig.KVStore.Etcd.Password)
+}
+
+func TestConfig_RemoteWriteDefaults(t *testing.T) {
+	cfg := `
+metrics:
+  global:
+    remote_write:
+      - name: "foo"
+        url: "https://test/url"`
+
+	var c Config
+	err := LoadBytes([]byte(cfg), false, &c)
+	require.NoError(t, err)
+
+	expected := &promCfg.DefaultRemoteWriteConfig
+	expected.Name = "foo"
+	testURL, _ := url.Parse("https://test/url")
+	expected.URL = &commonCfg.URL{
+		URL: testURL,
+	}
+	require.Equal(t, expected, c.Metrics.Global.RemoteWrite[0])
+	require.True(t, c.Metrics.Global.RemoteWrite[0].SendExemplars)
 }

--- a/pkg/metrics/instance/configstore/api_test.go
+++ b/pkg/metrics/instance/configstore/api_test.go
@@ -151,6 +151,7 @@ remote_write:
 - url: http://localhost:9009/api/prom/push
   remote_timeout: 30s
   name: test-d0f32c
+  send_exemplars: true
   basic_auth:
     username: admin
     password: SCRUBME

--- a/pkg/metrics/instance/instance.go
+++ b/pkg/metrics/instance/instance.go
@@ -36,6 +36,9 @@ import (
 func init() {
 	remote.UserAgent = fmt.Sprintf("GrafanaAgent/%s", build.Version)
 	scrape.UserAgent = fmt.Sprintf("GrafanaAgent/%s", build.Version)
+
+	// default remote_write send_exemplars to true
+	config.DefaultRemoteWriteConfig.SendExemplars = true
 }
 
 var (

--- a/pkg/metrics/instance/marshal_test.go
+++ b/pkg/metrics/instance/marshal_test.go
@@ -47,6 +47,7 @@ remote_write:
 - url: http://admin:verysecret@localhost:9009/api/prom/push
   remote_timeout: 30s
   name: test-d0f32c
+  send_exemplars: true
   basic_auth:
     username: admin
     password: verysecret
@@ -99,6 +100,7 @@ remote_write:
 - url: http://username:SCRUBURL@localhost:9009/api/prom/push
   remote_timeout: 30s
   name: test-d0f32c
+  send_exemplars: true
   basic_auth:
     username: admin
     password: SCRUBME


### PR DESCRIPTION
#### PR Description 

initially I was going to make this config update in our dependency on `grafana/prometheus` to a version that defaults send_exemplars to true in remote_write config. See https://github.com/grafana/prometheus/pull/26. Opting to do this in init() function in the agent instead since this isn't something that would end up going upstream.

#### Which issue(s) this PR fixes 

Closes https://github.com/grafana/agent/issues/1116

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added
- [x] Tests updated
