### PR TITLE
Configure cluster label using logs client external_labels param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 
 - [BUGFIX] Fix issue with windows_exporter mssql collector crashing the agent. (@mattdurham)
 
+- [BUGFIX] Configure eventhandler integration "cluster" label using logs client (@hjet)
+
 # v0.22.0 (2022-01-13)
 
 This release has deprecations. Please read [DEPRECATION] entries and consult

--- a/docs/configuration/integrations/integrations-next/eventhandler-config.md
+++ b/docs/configuration/integrations/integrations-next/eventhandler-config.md
@@ -22,9 +22,6 @@ Configuration reference:
   ## before abandoning and moving on.
   [send_timeout: <int> | default = 60]
 
-  ## Configures a cluster= label to add to log lines
-  [cluster_name: <string> | default = "cloud"]
-
   ## Configures the path to a kubeconfig file. If not set, will fall back to using 
   ## an in-cluster config. If this fails, will fall back to checking the user's home
   ## directory for a kubeconfig.
@@ -57,7 +54,6 @@ server:
 
 integrations:
   eventhandler:
-    cluster_name: "cloud"
     cache_path: "/etc/eventhandler/eventhandler.cache"
   
 logs:
@@ -68,6 +64,8 @@ logs:
       basic_auth:
         username: YOUR_LOKI_USER
         password: YOUR_LOKI_API_KEY
+      external_labels:
+        cluster: "cloud"
     positions:
       filename: /tmp/positions0.yaml
   ## The following stanza is optional and used to configure another client to forward
@@ -184,7 +182,6 @@ data:
   
     integrations:
       eventhandler:
-        cluster_name: "cloud"
         cache_path: "/etc/eventhandler/eventhandler.cache"
       
     logs:
@@ -195,6 +192,8 @@ data:
           basic_auth:
             username: YOUR_LOKI_USER
             password: YOUR_LOKI_API_KEY
+          external_labels:
+            cluster: "cloud"
         positions:
           filename: /tmp/positions0.yaml
       - name: eventhandler_logs

--- a/pkg/integrations/v2/eventhandler/eventhandler.go
+++ b/pkg/integrations/v2/eventhandler/eventhandler.go
@@ -44,7 +44,6 @@ type EventHandler struct {
 	LastEvent     *ShippedEvents
 	InitEvent     *ShippedEvents
 	EventInformer cache.SharedIndexInformer
-	ClusterLabel  string
 	SendTimeout   time.Duration
 	ticker        *time.Ticker
 	sync.Mutex
@@ -106,7 +105,6 @@ func newEventHandler(l log.Logger, globals integrations.Globals, c *Config) (int
 		Log:           l,
 		CachePath:     c.CachePath,
 		EventInformer: eventInformer,
-		ClusterLabel:  c.ClusterName,
 		SendTimeout:   time.Duration(c.SendTimeout) * time.Second,
 	}
 	// set the resource handler fns
@@ -206,7 +204,6 @@ func (eh *EventHandler) extractEvent(event *v1.Event) (model.LabelSet, string, e
 	}
 
 	labels[model.LabelName("job")] = model.LabelValue("eventhandler")
-	labels[model.LabelName("cluster")] = model.LabelValue(eh.ClusterLabel)
 
 	kindStr := strings.ToLower(obj.Kind)
 	// TODO: match up labels with k8s integration so that log / metric correlation works

--- a/pkg/integrations/v2/eventhandler/integration.go
+++ b/pkg/integrations/v2/eventhandler/integration.go
@@ -8,7 +8,6 @@ import (
 // DefaultConfig sets defaults for Config
 var DefaultConfig = Config{
 	SendTimeout:    60,
-	ClusterName:    "cloud",
 	CachePath:      "./.eventcache/eventhandler.cache",
 	LogsInstance:   "default",
 	InformerResync: 120,
@@ -21,8 +20,6 @@ type Config struct {
 	// client channel. This parameter configures how long to wait (in seconds) on the channel
 	// before abandoning and moving on.
 	SendTimeout int `yaml:"send_timeout,omitempty"`
-	// Configures a cluster= label to add to log lines
-	ClusterName string `yaml:"cluster_name,omitempty"`
 	// Configures the path to a kubeconfig file. If not set, will fall back to using
 	// an in-cluster config. If this fails, will fall back to checking the user's home
 	// directory for a kubeconfig.


### PR DESCRIPTION
#### PR Description
Can just configure this using `external_labels`, no need to add to integration config. No integration test at the moment for this, but manually tested w/ a k3d cluster and Grafana Cloud

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer
As discussed today with @rfratto @rlankfo 

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added