### PR TITLE
update withVolumesMixin for agent jsonnet

### DIFF
--- a/production/tanka/grafana-agent/v2/main.libsonnet
+++ b/production/tanka/grafana-agent/v2/main.libsonnet
@@ -1,5 +1,6 @@
 local k = import 'ksonnet-util/kausal.libsonnet';
 local container = k.core.v1.container;
+local podTemplateSpec = k.core.v1.podTemplateSpec.spec;
 
 {
   new(name='grafana-agent', namespace='')::
@@ -24,7 +25,11 @@ local container = k.core.v1.container;
   withPortsMixin(ports=[]):: { container+:: container.withPortsMixin(ports) },
   withVolumeMountsMixin(mounts=[]):: { container+:: container.withVolumeMountsMixin(mounts) },
   withVolumesMixin(volumes=[]):: {
-    controller+: self.controller.mixin.spec.template.spec.withVolumesMixin(volumes),
+    controller+: {
+        spec+: {
+            template+: podTemplateSpec.withVolumesMixin(volumes)
+        },
+    },
   },
 
   // Helpers


### PR DESCRIPTION
Signed-off-by: Robbie Lankford <robert.lankford@grafana.com>

#### PR Description 

Discovered a bug in agent jsonnet when attempting to use `withVolumesMixin`.  This fixes it and allows you to create an agent with volumes, for example:

```
gragent.new(name='grafana-agent', namespace=namespace) +
gragent.withVolumesMixin([volume.fromSecret(remote_write.secret.prefix + remote_write.name, remote_write.secret.prefix + remote_write.name)]) +
```

When doing the above with the previous code, it would recurse into `withVolumesMixin` until max stack frames are exceeded causing an error.

#### Which issue(s) this PR fixes 

Didn't file an issue for this.

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
