### PR TITLE
Update eventhandler labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,9 @@
 
 - [BUGFIX] Fix issue with windows_exporter mssql collector crashing the agent. (@mattdurham)
 
-- [BUGFIX] Configure eventhandler integration "cluster" label using logs client (@hjet)
+- [BUGFIX] Configure eventhandler integration "cluster" and "job" labels using logs client (@hjet)
+
+- [BUGFIX] Move eventhandler labels to log line
 
 # v0.22.0 (2022-01-13)
 

--- a/docs/configuration/integrations/integrations-next/eventhandler-config.md
+++ b/docs/configuration/integrations/integrations-next/eventhandler-config.md
@@ -66,6 +66,7 @@ logs:
         password: YOUR_LOKI_API_KEY
       external_labels:
         cluster: "cloud"
+        job: "integrations/kubernetes/eventhandler"
     positions:
       filename: /tmp/positions0.yaml
   ## The following stanza is optional and used to configure another client to forward
@@ -194,6 +195,7 @@ data:
             password: YOUR_LOKI_API_KEY
           external_labels:
             cluster: "cloud"
+            job: "integrations/kubernetes/eventhandler"
         positions:
           filename: /tmp/positions0.yaml
       - name: eventhandler_logs

--- a/pkg/integrations/v2/eventhandler/eventhandler.go
+++ b/pkg/integrations/v2/eventhandler/eventhandler.go
@@ -209,9 +209,6 @@ func (eh *EventHandler) extractEvent(event *v1.Event) (model.LabelSet, string, e
 	// we add these fields to the log line to reduce label bloat and cardinality
 	if obj.Kind != "" {
 		msg.WriteString(fmt.Sprintf("kind=%s ", obj.Kind))
-		// to enable k8s integration correlation
-		kindStr := strings.ToLower(obj.Kind)
-		msg.WriteString(fmt.Sprintf("%s=%s ", kindStr, obj.Name))
 	}
 	if event.Action != "" {
 		msg.WriteString(fmt.Sprintf("action=%s ", event.Action))


### PR DESCRIPTION
#### PR Description 
To enable correlation in K8s integration dashboards, we need labels to be configured in a specific way. 

This makes the `job` label configurable and also moves most existing labels to the log line where we have more flexibility with regex matching

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [ ] Tests updated
