### PR TITLE
Add readiness check to metrics component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Main (unreleased)
 
+- [ENHANCEMENT] Strengthen readiness check for metrics instances. (@tpaschalis)
+
 # v0.23.0 (2022-01-13)
 
 - [ENHANCEMENT] Go 1.17 is now used for all builds of the Agent. (@tpaschalis)

--- a/cmd/agent/entrypoint.go
+++ b/cmd/agent/entrypoint.go
@@ -196,6 +196,12 @@ func (ep *Entrypoint) wire(mux *mux.Router, grpc *grpc.Server) {
 	})
 
 	mux.HandleFunc("/-/ready", func(w http.ResponseWriter, r *http.Request) {
+		if !ep.promMetrics.Ready() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprint(w, "Metrics are not ready yet.\n")
+
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, "Agent is Ready.\n")
 	})

--- a/pkg/integrations/v2/autoscrape/autoscrape_test.go
+++ b/pkg/integrations/v2/autoscrape/autoscrape_test.go
@@ -1,6 +1,7 @@
 package autoscrape
 
 import (
+	"context"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
@@ -99,3 +100,5 @@ type mockInstance struct {
 	instance.NoOpInstance
 	app storage.Appender
 }
+
+func (mi *mockInstance) Appender(ctx context.Context) storage.Appender { return mi.app }

--- a/pkg/integrations/v2/autoscrape/autoscrape_test.go
+++ b/pkg/integrations/v2/autoscrape/autoscrape_test.go
@@ -1,7 +1,6 @@
 package autoscrape
 
 import (
-	"context"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
@@ -15,7 +14,6 @@ import (
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/pkg/exemplar"
 	"github.com/prometheus/prometheus/pkg/labels"
-	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -98,11 +96,6 @@ func (ma *mockAppender) AppendExemplar(ref uint64, l labels.Labels, e exemplar.E
 }
 
 type mockInstance struct {
+	instance.NoOpInstance
 	app storage.Appender
 }
-
-func (mi *mockInstance) Run(ctx context.Context) error                 { return nil }
-func (mi *mockInstance) Update(c instance.Config) error                { return nil }
-func (mi *mockInstance) TargetsActive() map[string][]*scrape.Target    { return nil }
-func (mi *mockInstance) StorageDirectory() string                      { return "" }
-func (mi *mockInstance) Appender(ctx context.Context) storage.Appender { return mi.app }

--- a/pkg/metrics/agent_test.go
+++ b/pkg/metrics/agent_test.go
@@ -271,6 +271,10 @@ func (i *fakeInstance) Run(ctx context.Context) error {
 	}
 }
 
+func (i *fakeInstance) Ready() bool {
+	return true
+}
+
 func (i *fakeInstance) Update(_ instance.Config) error {
 	return instance.ErrInvalidUpdate{
 		Inner: fmt.Errorf("can't dynamically update fakeInstance"),

--- a/pkg/metrics/http_test.go
+++ b/pkg/metrics/http_test.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -15,7 +14,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/scrape"
-	"github.com/prometheus/prometheus/storage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -135,26 +133,10 @@ func TestAgent_ListTargetsHandler(t *testing.T) {
 }
 
 type mockInstanceScrape struct {
+	instance.NoOpInstance
 	tgts map[string][]*scrape.Target
-}
-
-func (i *mockInstanceScrape) Run(ctx context.Context) error {
-	<-ctx.Done()
-	return nil
-}
-
-func (i *mockInstanceScrape) Update(_ instance.Config) error {
-	return nil
 }
 
 func (i *mockInstanceScrape) TargetsActive() map[string][]*scrape.Target {
 	return i.tgts
-}
-
-func (i *mockInstanceScrape) StorageDirectory() string {
-	return ""
-}
-
-func (i *mockInstanceScrape) Appender(ctx context.Context) storage.Appender {
-	return nil
 }

--- a/pkg/metrics/instance/instance.go
+++ b/pkg/metrics/instance/instance.go
@@ -454,7 +454,7 @@ func (i *Instance) initialize(ctx context.Context, reg prometheus.Registerer, cf
 // Ready returns true if the Instance has been initialized and is ready
 // to start scraping and delivering metrics.
 func (i *Instance) Ready() bool {
-	return true
+	return i.ready.Load()
 }
 
 // Update accepts a new Config for the Instance and will dynamically update any

--- a/pkg/metrics/instance/manager.go
+++ b/pkg/metrics/instance/manager.go
@@ -61,6 +61,7 @@ type Manager interface {
 // for the sake of testing from Manager implementations.
 type ManagedInstance interface {
 	Run(ctx context.Context) error
+	Ready() bool
 	Update(c Config) error
 	TargetsActive() map[string][]*scrape.Target
 	StorageDirectory() string

--- a/pkg/metrics/instance/manager_test.go
+++ b/pkg/metrics/instance/manager_test.go
@@ -99,6 +99,7 @@ func TestBasicManager_ApplyConfig(t *testing.T) {
 
 type mockInstance struct {
 	RunFunc              func(ctx context.Context) error
+	ReadyFunc            func() bool
 	UpdateFunc           func(c Config) error
 	TargetsActiveFunc    func() map[string][]*scrape.Target
 	StorageDirectoryFunc func() string
@@ -110,6 +111,13 @@ func (m mockInstance) Run(ctx context.Context) error {
 		return m.RunFunc(ctx)
 	}
 	panic("RunFunc not provided")
+}
+
+func (m mockInstance) Ready() bool {
+	if m.ReadyFunc != nil {
+		return m.ReadyFunc()
+	}
+	panic("ReadyFunc not provided")
 }
 
 func (m mockInstance) Update(c Config) error {

--- a/pkg/metrics/instance/noop.go
+++ b/pkg/metrics/instance/noop.go
@@ -17,6 +17,11 @@ func (NoOpInstance) Run(ctx context.Context) error {
 	return nil
 }
 
+// Ready implements Instance.
+func (NoOpInstance) Ready() bool {
+	return true
+}
+
 // Update implements Instance.
 func (NoOpInstance) Update(_ Config) error {
 	return nil

--- a/pkg/traces/remotewriteexporter/exporter_test.go
+++ b/pkg/traces/remotewriteexporter/exporter_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/agent/pkg/metrics/instance"
 	"github.com/prometheus/prometheus/pkg/exemplar"
 	"github.com/prometheus/prometheus/pkg/labels"
-	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/model/pdata"
@@ -103,16 +102,9 @@ func (m *mockManager) DeleteConfig(_ string) error { return nil }
 func (m *mockManager) Stop() {}
 
 type mockInstance struct {
+	instance.NoOpInstance
 	appender *mockAppender
 }
-
-func (m *mockInstance) Run(_ context.Context) error { return nil }
-
-func (m *mockInstance) Update(_ instance.Config) error { return nil }
-
-func (m *mockInstance) TargetsActive() map[string][]*scrape.Target { return nil }
-
-func (m *mockInstance) StorageDirectory() string { return "" }
 
 func (m *mockInstance) Appender(_ context.Context) storage.Appender {
 	if m.appender == nil {


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

#### PR Description 
This is a revival of #1047 (I'd work from there, but I can't push on rfratto's fork) and an attempt to add a readiness check based on whether the metrics instances are initialized, up and running.

#### Which issue(s) this PR fixes 
This fixes #1009 

#### Notes to the Reviewer

I was able to see this behavior changing by adding some custom delay to the instance's Run() method and the function passed to the agent's actor channel, loadWAL or replaceWAL.

Before (main branch):
```
./agent -config.file agent-local-config.yaml &> mylog &; while gsleep 0.5s; do curl localhost:12345/-/ready; done
[1] 69466
curl: (7) Failed to connect to localhost port 12345: Connection refused
curl: (7) Failed to connect to localhost port 12345: Connection refused
Agent is Ready.
Agent is Ready.
Agent is Ready.
```
After (PR branch):
```
./agent -config.file agent-local-config.yaml &> mylog &; while gsleep 0.5s; do curl localhost:12345/-/ready; done
[1] 68235
curl: (7) Failed to connect to localhost port 12345: Connection refused
curl: (7) Failed to connect to localhost port 12345: Connection refused
Metrics are not ready yet.
Metrics are not ready yet.
Metrics are not ready yet.
Metrics are not ready yet.
Metrics are not ready yet.
Agent is Ready.
Agent is Ready.
Agent is Ready.
```

Let me know if you think we should add a test for this.

#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
