### PR TITLE
enable extra scrape metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Main (unreleased)
   network. As a result of this change, the `client_config` field has been
   removed. (@rfratto)
 
+-  `extra-scrape-metrics` can now be enabled with the `--enable-features=extra-scrape-metrics` feature flag. See https://prometheus.io/docs/prometheus/2.31/feature_flags/#extra-scrape-metrics for details. (@rlankfo)
+
 ### Other changes
 
 - Update base image of official Docker containers from Debian buster to Debian

--- a/docs/user/configuration/flags.md
+++ b/docs/user/configuration/flags.md
@@ -30,6 +30,7 @@ Valid feature names are:
 * `remote-configs`: Enable [retrieving]({{< relref "./_index.md#remote-configuration-experimental" >}}) config files over HTTP/HTTPS
 * `integrations-next`: Enable [revamp]({{< relref "./integrations/integrations-next/" >}}) of the integrations subsystem
 * `dynamic-config`: Enable support for [dynamic configuration]({{< relref "./dynamic-config" >}})
+* `extra-scrape-metrics`: When enabled, additional time series  are exposed for each metrics instance scrape. See [Extra scrape metrics](https://prometheus.io/docs/prometheus/latest/feature_flags/#extra-scrape-metrics).
 
 ## Configuration file
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,11 +31,13 @@ var (
 	featRemoteConfigs    = features.Feature("remote-configs")
 	featIntegrationsNext = features.Feature("integrations-next")
 	featDynamicConfig    = features.Feature("dynamic-config")
+	featExtraMetrics     = features.Feature("extra-scrape-metrics")
 
 	allFeatures = []features.Feature{
 		featRemoteConfigs,
 		featIntegrationsNext,
 		featDynamicConfig,
+		featExtraMetrics,
 	}
 )
 
@@ -391,6 +393,10 @@ func load(fs *flag.FlagSet, args []string, loader loaderFunc) (*Config, error) {
 
 	if err := cfg.Integrations.setVersion(version); err != nil {
 		return nil, fmt.Errorf("error loading config file %s: %w", file, err)
+	}
+
+	if features.Enabled(fs, featExtraMetrics) {
+		cfg.Metrics.Global.ExtraMetrics = true
 	}
 
 	// Finally, apply defaults to config that wasn't specified by file or flag

--- a/pkg/metrics/instance/global.go
+++ b/pkg/metrics/instance/global.go
@@ -11,6 +11,8 @@ var DefaultGlobalConfig = GlobalConfig{
 type GlobalConfig struct {
 	Prometheus  config.GlobalConfig         `yaml:",inline"`
 	RemoteWrite []*config.RemoteWriteConfig `yaml:"remote_write,omitempty"`
+
+	ExtraMetrics bool `yaml:"-"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.


### PR DESCRIPTION
#### PR Description 

This adds a feature flag for enabling [extra scrape metrics](https://prometheus.io/docs/prometheus/2.31/feature_flags/#extra-scrape-metrics). 

#### Which issue(s) this PR fixes 

Closes https://github.com/grafana/agent/issues/1073

#### Notes to the Reviewer

This is still experimental in prometheus so I've included the feature flag (instead of defaulting this to true). The latest version of prometheus includes additional scrape metrics which aren't included yet in the agent. See https://prometheus.io/docs/prometheus/latest/feature_flags/

#### PR Checklist

- [x] CHANGELOG updated 
- [x] Documentation added
- [ ] Tests updated
