### PR TITLE
[docs] fix typo of node-exporter-config  

### DIFF
--- a/docs/user/configuration/integrations/node-exporter-config.md
+++ b/docs/user/configuration/integrations/node-exporter-config.md
@@ -73,7 +73,7 @@ spec:
     securityContext:
       capabilities:
         add: ["SYS_TIME"]
-      priviliged: true
+      privileged: true
       runAsUser: 0
     volumeMounts:
     - name: rootfs


### PR DESCRIPTION
which should be `privileged` instead of `priviliged`

#### PR Description 

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [*] CHANGELOG updated 
- [*] Documentation added
- [*] Tests updated
