### PR TITLE
add fake remote_write endpoint to smoke program

### DIFF
--- a/example/k3d/smoke/main.jsonnet
+++ b/example/k3d/smoke/main.jsonnet
@@ -1,9 +1,9 @@
 local monitoring = import './monitoring/main.jsonnet';
-local avalanche = import 'grafana-agent/smoke/avalanche/main.libsonnet';
 local cortex = import 'cortex/main.libsonnet';
+local avalanche = import 'grafana-agent/smoke/avalanche/main.libsonnet';
 local crow = import 'grafana-agent/smoke/crow/main.libsonnet';
-local smoke = import 'grafana-agent/smoke/main.libsonnet';
 local etcd = import 'grafana-agent/smoke/etcd/main.libsonnet';
+local smoke = import 'grafana-agent/smoke/main.libsonnet';
 local gragent = import 'grafana-agent/v2/main.libsonnet';
 local k = import 'ksonnet-util/kausal.libsonnet';
 
@@ -25,10 +25,9 @@ local new_crow(name, selector) =
   });
 
 local new_smoke(name) = smoke.new(name, namespace='smoke', config={
-    mutationFrequency: '5m',
-    chaosFrequency: '30m',
+  mutationFrequency: '5m',
+  chaosFrequency: '30m',
 });
-
 
 
 local smoke = {
@@ -56,7 +55,28 @@ local smoke = {
 
   local metric_instances(crow_name) = [{
     name: 'crow',
-    remote_write: [{ url: 'http://cortex/api/prom/push' }],
+    remote_write: [
+      {
+        url: 'http://cortex/api/prom/push',
+        write_relabel_configs: [
+          {
+            source_labels: ['__name__'],
+            regex: 'avalanche_.*',
+            action: 'drop',
+          },
+        ],
+      },
+      {
+        url: 'http://smoke-test:19090/api/prom/push',
+        write_relabel_configs: [
+          {
+            source_labels: ['__name__'],
+            regex: 'avalanche_.*',
+            action: 'keep',
+          },
+        ],
+      },
+    ],
     scrape_configs: [
       {
         job_name: 'crow',
@@ -81,7 +101,28 @@ local smoke = {
     ],
   }, {
     name: 'avalanche',
-    remote_write: [{ url: 'http://cortex/api/prom/push' }],
+    remote_write: [
+      {
+        url: 'http://cortex/api/prom/push',
+        write_relabel_configs: [
+          {
+            source_labels: ['__name__'],
+            regex: 'avalanche_.*',
+            action: 'drop',
+          },
+        ],
+      },
+      {
+        url: 'http://smoke-test:19090/api/prom/push',
+        write_relabel_configs: [
+          {
+            source_labels: ['__name__'],
+            regex: 'avalanche_.*',
+            action: 'keep',
+          },
+        ],
+      },
+    ],
     scrape_configs: [
       {
         job_name: 'avalanche',

--- a/production/tanka/grafana-agent/smoke/main.libsonnet
+++ b/production/tanka/grafana-agent/smoke/main.libsonnet
@@ -2,56 +2,67 @@ local k = import 'ksonnet-util/kausal.libsonnet';
 local policyRule = k.rbac.v1.policyRule;
 local serviceAccount = k.core.v1.serviceAccount;
 local container = k.core.v1.container;
+local containerPort = k.core.v1.containerPort;
 local deployment = k.apps.v1.deployment;
+local service = k.core.v1.service;
+local util = k.util;
 
 {
-    new(name='grafana-agent-smoke', namespace='default', config={}):: {
-        local k = (import 'ksonnet-util/kausal.libsonnet') { _config+:: { namespace: namespace } },
+  new(name='grafana-agent-smoke', namespace='default', config={}):: {
+    local k = (import 'ksonnet-util/kausal.libsonnet') { _config+:: { namespace: namespace } },
 
-        local this = self,
+    local this = self,
 
-        _images:: {
-            agentsmoke: 'us.gcr.io/kubernetes-dev/grafana/agent-smoke:main',
-        },
-
-        _config:: {
-            mutationFrequency: '5m',
-            chaosFrequency: '30m',
-            image: this._images.agentsmoke,
-            pull_secret: '',
-            podPrefix: 'grafana-agent',
-        } + config,
-
-        rbac:
-            k.util.rbac(name, [
-                policyRule.withApiGroups(['apps']) +
-                policyRule.withResources(['deployments/scale']) +
-                policyRule.withVerbs(['get', 'update']),
-                policyRule.withApiGroups(['']) +
-                policyRule.withResources(['pods']) +
-                policyRule.withVerbs(['list', 'delete']),
-            ]) {
-                service_account+:
-                  serviceAccount.mixin.metadata.withNamespace(namespace),
-            },
-
-        container::
-          container.new('agent-smoke', this._config.image) +
-          container.withCommand('/bin/grafana-agent-smoke') +
-          container.withArgsMixin(k.util.mapToFlags({
-            'log.level': 'debug',
-            'namespace': namespace,
-            'mutation-frequency': this._config.mutationFrequency,
-            'chaos-frequency': this._config.chaosFrequency,
-            'pod-prefix': this._config.podPrefix,
-          })),
-
-        agentsmoke_deployment:
-          deployment.new(name, 1, [self.container]) +
-          deployment.mixin.metadata.withNamespace(namespace) +
-          deployment.mixin.spec.template.spec.withServiceAccount(name) +
-          deployment.spec.template.spec.withImagePullSecrets({ name: this._config.pull_secret }),
+    _images:: {
+      agentsmoke: 'us.gcr.io/kubernetes-dev/grafana/agent-smoke:main',
     },
 
-    monitoring: (import './prometheus_monitoring.libsonnet'),
+    _config:: {
+      mutationFrequency: '5m',
+      chaosFrequency: '30m',
+      image: this._images.agentsmoke,
+      pull_secret: '',
+      podPrefix: 'grafana-agent',
+    } + config,
+
+    rbac:
+      k.util.rbac(name, [
+        policyRule.withApiGroups(['apps']) +
+        policyRule.withResources(['deployments/scale']) +
+        policyRule.withVerbs(['get', 'update']),
+        policyRule.withApiGroups(['']) +
+        policyRule.withResources(['pods']) +
+        policyRule.withVerbs(['list', 'delete']),
+      ]) {
+        service_account+:
+          serviceAccount.mixin.metadata.withNamespace(namespace),
+      },
+
+    container::
+      container.new('agent-smoke', this._config.image) +
+      container.withCommand('/bin/grafana-agent-smoke') +
+      container.withPorts([
+        containerPort.newNamed(name='remote-write', containerPort=19090),
+      ]) +
+      container.withArgsMixin(k.util.mapToFlags({
+        'log.level': 'debug',
+        namespace: namespace,
+        'mutation-frequency': this._config.mutationFrequency,
+        'chaos-frequency': this._config.chaosFrequency,
+        'pod-prefix': this._config.podPrefix,
+        'fake-remote-write': true,
+      })),
+
+    agentsmoke_deployment:
+      deployment.new(name, 1, [self.container]) +
+      deployment.mixin.metadata.withNamespace(namespace) +
+      deployment.mixin.spec.template.spec.withServiceAccount(name) +
+      deployment.spec.template.spec.withImagePullSecrets({ name: this._config.pull_secret }),
+
+    service:
+      util.serviceFor(self.agentsmoke_deployment) +
+      service.mixin.metadata.withNamespace(namespace),
+  },
+
+  monitoring: (import './prometheus_monitoring.libsonnet'),
 }


### PR DESCRIPTION
#### PR Description 

This uses write_relabel_configs in remote write to drop the avalanche metrics in smoke.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
