### PR TITLE
fix continuous delivery job errors

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -185,7 +185,7 @@ steps:
               "file_path": "ksonnet/environments/agent-smoke-test/dev-us-central-0.agent-smoke-test/main.jsonnet",
               "jsonnet_key": "image_tag",
               "jsonnet_value_file": ".tag-only"
-            },
+            }
           ]
         }
       github_token:
@@ -271,6 +271,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: 3ef90dcc6f804d18a7facecf2caa4ce44f52062aa060ac36f34c9f502efa00e2
+hmac: 3da266cfeead0295f439b0ec44ba62b6b9c53f2774aef54fe58585e4d51d8990
 
 ...


### PR DESCRIPTION
Signed-off-by: Robbie Lankford <robert.lankford@grafana.com>

#### PR Description 

Looks like trailing comma caused issue in drone job
```
time="2022-02-19T01:01:32Z" level=info msg="Using the configuration from the config.json flag"
time="2022-02-19T01:01:32Z" level=error msg="Problem unmarshalling request config into request struct: invalid character ']' looking for beginning of value"
time="2022-02-19T01:01:32Z" level=fatal msg="Plugin execution failed: invalid character ']' looking for beginning of value"
```


#### Which issue(s) this PR fixes 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
