### PR TITLE
[operator] - Use _file variants for basic auth credentials.

### DIFF
--- a/pkg/operator/config/config_test.go
+++ b/pkg/operator/config/config_test.go
@@ -79,10 +79,10 @@ func TestBuildConfigMetrics(t *testing.T) {
 								basicAuth:
 									username:
 										name: example-secret
-										key: key
+										key: uname
 									password:
 										name: example-secret
-										key: key
+										key: pword
 								tlsConfig:
 									ca:
 										configMap:
@@ -113,8 +113,8 @@ func TestBuildConfigMetrics(t *testing.T) {
 							remote_write:
 							- url: http://localhost:9090/api/v1/write
 								basic_auth:
-									username: somesecret
-									password: somesecret
+									username_file: /var/lib/grafana-agent/secrets/_secrets_default_example_secret_uname
+									password_file: /var/lib/grafana-agent/secrets/_secrets_default_example_secret_pword
 								tls_config:
 									ca_file: /var/lib/grafana-agent/secrets/_configMaps_default_example_cm_key
 									cert_file: /var/lib/grafana-agent/secrets/_secrets_default_example_secret_key

--- a/pkg/operator/config/metrics_templates_test.go
+++ b/pkg/operator/config/metrics_templates_test.go
@@ -547,8 +547,8 @@ func TestRemoteWrite(t *testing.T) {
 			expect: util.Untab(`
 				url: http://cortex/api/prom/push
 				basic_auth:
-					username: secretkey
-					password: secretkey
+					username_file: /var/lib/grafana-agent/secrets/_secrets_operator_obj_key
+					password_file: /var/lib/grafana-agent/secrets/_secrets_operator_obj_key
 			`),
 		},
 		{

--- a/pkg/operator/config/templates/component/metrics/remote_write.libsonnet
+++ b/pkg/operator/config/templates/component/metrics/remote_write.libsonnet
@@ -30,8 +30,8 @@ function(namespace, rw) {
 
   basic_auth: (
     if rw.BasicAuth != null then {
-      username: secrets.valueForSecret(namespace, rw.BasicAuth.Username),
-      password: secrets.valueForSecret(namespace, rw.BasicAuth.Password),
+      username_file: secrets.pathForSecret(namespace, rw.BasicAuth.Username),
+      password_file: secrets.pathForSecret(namespace, rw.BasicAuth.Password),
     }
   ),
 


### PR DESCRIPTION
#### PR Description 

Operator-generated configs now use password_file and username_file instead of embedding directly. Should allow for faster recognition of changes, and marginally more secure configs.

#### Which issue(s) this PR fixes 
Fixes #1061 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated 
- [ ] Documentation added
- [x ] Tests updated
