### PR TITLE
Parametrize logs DaemonSet K8s manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 - [ENHANCEMENT] Strengthen readiness check for metrics instances. (@tpaschalis)
 
+- [ENHANCEMENT] Parameterize namespace field in sample K8s logs manifests (@hjet)
+
 - [FEATURE] Added config read API support to GrafanaAgent Custom Resource Definition.
 
 # v0.23.0 (2022-01-13)

--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: grafana-agent-logs
-  namespace: YOUR_NAMESPACE
+  namespace: ${NAMESPACE}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -37,13 +37,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: grafana-agent-logs
-  namespace: YOUR_NAMESPACE
+  namespace: ${NAMESPACE}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: grafana-agent-logs
-  namespace: YOUR_NAMESPACE
+  namespace: ${NAMESPACE}
 spec:
   minReadySeconds: 10
   selector:

--- a/production/kubernetes/build/templates/loki/main.jsonnet
+++ b/production/kubernetes/build/templates/loki/main.jsonnet
@@ -2,7 +2,7 @@ local agent = import 'grafana-agent/v1/main.libsonnet';
 
 {
   agent:
-    agent.new('grafana-agent-logs', 'YOUR_NAMESPACE') +
+    agent.new('grafana-agent-logs', '${NAMESPACE}') +
     agent.withConfigHash(false) +
     agent.withImages({
       agent: (import 'version.libsonnet'),


### PR DESCRIPTION
#### PR Description
This PR parameterizes the `namespace` field in the sample logs K8s manifests. This will allow users to install them using `envsubst` and `install-bare.sh` (and consequently also the K8s integration onboarding plugin using the same method we use for metrics). Ideally we should rename `install-bare` but since this deployment path will soon be deprecated, we can punt on this for now. 

I will update the Cloud docs K8s/Agent/Logs quickstart accordingly.

#### Which issue(s) this PR fixes 

#### Notes to the Reviewer
Regenerated manifests using `make example-kubernetes`

#### PR Checklist
- [x] CHANGELOG updated 
- [x] Documentation added
- [ ] Tests updated