### PR TITLE
Remove journald mount by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 - [FEATURE] Added config read API support to GrafanaAgent Custom Resource Definition.
 
+- [BUGFIX] Remove /etc/machine-id hostPath volume in sample K8s logs manifests (@hjet)
+
 # v0.23.0 (2022-01-13)
 
 - [ENHANCEMENT] Go 1.17 is now used for all builds of the Agent. (@tpaschalis)

--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -81,9 +81,6 @@ spec:
         - mountPath: /var/lib/docker/containers
           name: varlibdockercontainers
           readOnly: true
-        - mountPath: /etc/machine-id
-          name: etcmachineid
-          readOnly: true
       serviceAccount: grafana-agent-logs
       tolerations:
       - effect: NoSchedule
@@ -98,8 +95,5 @@ spec:
       - hostPath:
           path: /var/lib/docker/containers
         name: varlibdockercontainers
-      - hostPath:
-          path: /etc/machine-id
-        name: etcmachineid
   updateStrategy:
     type: RollingUpdate

--- a/production/tanka/grafana-agent/v1/lib/logs.libsonnet
+++ b/production/tanka/grafana-agent/v1/lib/logs.libsonnet
@@ -70,10 +70,10 @@ local container = k.core.v1.container;
       // For reading docker containers. /var/log is used for the positions file
       // and shouldn't be set to readonly.
       k.util.hostVolumeMount('varlog', '/var/log', '/var/log') +
-      k.util.hostVolumeMount('varlibdockercontainers', '/var/lib/docker/containers', '/var/lib/docker/containers', readOnly=true) +
+      k.util.hostVolumeMount('varlibdockercontainers', '/var/lib/docker/containers', '/var/lib/docker/containers', readOnly=true),
 
       // For reading journald
-      k.util.hostVolumeMount('etcmachineid', '/etc/machine-id', '/etc/machine-id', readOnly=true),
+      //k.util.hostVolumeMount('etcmachineid', '/etc/machine-id', '/etc/machine-id', readOnly=true),
   },
 
   // scrapeKubernetesLogs defines a Logs config that can collect logs from


### PR DESCRIPTION
#### PR Description
Since these sample manifests are mostly used in tandem with the Cloud agent/logs [quickstart](https://grafana.com/docs/grafana-cloud/kubernetes/agent-k8s/k8s_agent_logs/) ConfigMap and soon the K8s integration ConfigMap (which will be even more streamlined), and neither scrapes logs from the journal, I propose omitting the mount and volume from the default manifests entirely. 

An alternative solution is changing the `etcmachineid` volume type to `file` but this is cleaner IMO. I prefer reducing the scope of our defaults.

#### Which issue(s) this PR fixes 
Fixes https://github.com/grafana/agent/issues/451
Also see https://github.com/grafana/agent/issues/1178

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
