### PR TITLE
Migrate K8s quickstart manifests to tanka v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,10 @@ Main (unreleased)
 
 - Update cAdvisor dependency to v0.44.0. (@rfratto)
 
+- Use grafana-agent/v2 Tanka Jsonnet to generate K8s manifests (@hjet)
+
+- Replace agent-bare.yaml K8s sample Deployment with StatefulSet (@hjet)
+
 ### Bugfixes
 
 - Ensure singleton integrations are honored in v2 integrations (@mattdurham)
@@ -153,6 +157,10 @@ v0.23.0 (2022-01-13)
 
 - The deb and rpm files will now ensure the /var/lib/grafana-agent data
   directory is created with permissions set to 0770. (@rfratto)
+
+- Make agent-traces.yaml Namespace a template-friendly variable (@hjet)
+
+- Disable `machine-id` journal vol by default in sample logs manifest (@hjet)
 
 v0.22.0 (2022-01-13)
 --------------------

--- a/production/kubernetes/README.md
+++ b/production/kubernetes/README.md
@@ -4,7 +4,7 @@ This directory contains Kubernetes manifest templates for rolling out the Agent.
 
 Manifests:
 
-- Metric collection (Deployment): [`agent-bare.yaml`](./agent-bare.yaml)
+- Metric collection (StatefulSet): [`agent-bare.yaml`](./agent-bare.yaml)
 - Log collection (DaemonSet): [`agent-loki.yaml`](./agent-loki.yaml)
 - Trace collection (Deployment): [`agent-traces.yaml`](./agent-traces.yaml)
 

--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -39,18 +39,32 @@ subjects:
   name: grafana-agent
   namespace: ${NAMESPACE}
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: grafana-agent
+  name: grafana-agent
+  namespace: ${NAMESPACE}
+spec:
+  ports:
+  - name: grafana-agent-http-metrics
+    port: 80
+    targetPort: 80
+  selector:
+    name: grafana-agent
+---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: grafana-agent
   namespace: ${NAMESPACE}
 spec:
-  minReadySeconds: 10
   replicas: 1
-  revisionHistoryLimit: 10
   selector:
     matchLabels:
       name: grafana-agent
+  serviceName: grafana-agent
   template:
     metadata:
       labels:
@@ -61,18 +75,15 @@ spec:
         - -config.file=/etc/agent/agent.yaml
         command:
         - /bin/agent
-        env:
-        - name: HOSTNAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
         image: grafana/agent:v0.23.0
         imagePullPolicy: IfNotPresent
-        name: agent
+        name: grafana-agent
         ports:
-        - containerPort: 12345
+        - containerPort: 80
           name: http-metrics
         volumeMounts:
+        - mountPath: /var/lib/agent
+          name: agent-wal
         - mountPath: /etc/agent
           name: grafana-agent
       serviceAccount: grafana-agent
@@ -80,3 +91,17 @@ spec:
       - configMap:
           name: grafana-agent
         name: grafana-agent
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: agent-wal
+      namespace: ${NAMESPACE}
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi

--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -47,6 +47,7 @@ metadata:
   name: grafana-agent
   namespace: ${NAMESPACE}
 spec:
+  clusterIP: None
   ports:
   - name: grafana-agent-http-metrics
     port: 80

--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -17,6 +17,7 @@ rules:
   - services
   - endpoints
   - pods
+  - events
   verbs:
   - get
   - list

--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -51,8 +51,8 @@ spec:
   clusterIP: None
   ports:
   - name: grafana-agent-http-metrics
-    port: 12345
-    targetPort: 12345
+    port: 80
+    targetPort: 80
   selector:
     name: grafana-agent
 ---
@@ -75,6 +75,7 @@ spec:
       containers:
       - args:
         - -config.file=/etc/agent/agent.yaml
+        - -server.http.address=0.0.0.0:80
         command:
         - /bin/agent
         env:
@@ -86,7 +87,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: grafana-agent
         ports:
-        - containerPort: 12345
+        - containerPort: 80
           name: http-metrics
         volumeMounts:
         - mountPath: /var/lib/agent

--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -50,8 +50,8 @@ spec:
   clusterIP: None
   ports:
   - name: grafana-agent-http-metrics
-    port: 80
-    targetPort: 80
+    port: 12345
+    targetPort: 12345
   selector:
     name: grafana-agent
 ---
@@ -76,11 +76,16 @@ spec:
         - -config.file=/etc/agent/agent.yaml
         command:
         - /bin/agent
+        env:
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         image: grafana/agent:v0.23.0
         imagePullPolicy: IfNotPresent
         name: grafana-agent
         ports:
-        - containerPort: 80
+        - containerPort: 12345
           name: http-metrics
         volumeMounts:
         - mountPath: /var/lib/agent

--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -58,7 +58,7 @@ spec:
       containers:
       - args:
         - -config.file=/etc/agent/agent.yaml
-        - -server.http.address=0.0.0.0:8080
+        - -server.http.address=0.0.0.0:80
         command:
         - /bin/agent
         env:
@@ -70,7 +70,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: grafana-agent-logs
         ports:
-        - containerPort: 8080
+        - containerPort: 80
           name: http-metrics
         securityContext:
           privileged: true

--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -17,6 +17,7 @@ rules:
   - services
   - endpoints
   - pods
+  - events
   verbs:
   - get
   - list

--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -69,7 +69,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: grafana-agent-logs
         ports:
-        - containerPort: 80
+        - containerPort: 8080
           name: http-metrics
         securityContext:
           privileged: true

--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -67,9 +67,9 @@ spec:
               fieldPath: spec.nodeName
         image: grafana/agent:v0.23.0
         imagePullPolicy: IfNotPresent
-        name: agent
+        name: grafana-agent-logs
         ports:
-        - containerPort: 8080
+        - containerPort: 80
           name: http-metrics
         securityContext:
           privileged: true
@@ -81,9 +81,6 @@ spec:
           name: varlog
         - mountPath: /var/lib/docker/containers
           name: varlibdockercontainers
-          readOnly: true
-        - mountPath: /etc/machine-id
-          name: etcmachineid
           readOnly: true
       serviceAccount: grafana-agent-logs
       tolerations:
@@ -99,8 +96,5 @@ spec:
       - hostPath:
           path: /var/lib/docker/containers
         name: varlibdockercontainers
-      - hostPath:
-          path: /etc/machine-id
-        name: etcmachineid
   updateStrategy:
     type: RollingUpdate

--- a/production/kubernetes/agent-traces.yaml
+++ b/production/kubernetes/agent-traces.yaml
@@ -49,8 +49,8 @@ metadata:
 spec:
   ports:
   - name: grafana-agent-traces-http-metrics
-    port: 80
-    targetPort: 80
+    port: 8080
+    targetPort: 8080
   - name: grafana-agent-traces-thrift-compact
     port: 6831
     protocol: UDP
@@ -114,7 +114,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: grafana-agent-traces
         ports:
-        - containerPort: 80
+        - containerPort: 8080
           name: http-metrics
         - containerPort: 6831
           name: thrift-compact

--- a/production/kubernetes/agent-traces.yaml
+++ b/production/kubernetes/agent-traces.yaml
@@ -17,6 +17,7 @@ rules:
   - services
   - endpoints
   - pods
+  - events
   verbs:
   - get
   - list

--- a/production/kubernetes/agent-traces.yaml
+++ b/production/kubernetes/agent-traces.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: grafana-agent-traces
-  namespace: YOUR_NAMESPACE
+  namespace: ${NAMESPACE}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -37,7 +37,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: grafana-agent-traces
-  namespace: YOUR_NAMESPACE
+  namespace: ${NAMESPACE}
 ---
 apiVersion: v1
 kind: Service
@@ -45,37 +45,37 @@ metadata:
   labels:
     name: grafana-agent-traces
   name: grafana-agent-traces
-  namespace: YOUR_NAMESPACE
+  namespace: ${NAMESPACE}
 spec:
   ports:
-  - name: agent-http-metrics
-    port: 8080
-    targetPort: 8080
-  - name: agent-thrift-compact
+  - name: grafana-agent-traces-http-metrics
+    port: 80
+    targetPort: 80
+  - name: grafana-agent-traces-thrift-compact
     port: 6831
     protocol: UDP
     targetPort: 6831
-  - name: agent-thrift-binary
+  - name: grafana-agent-traces-thrift-binary
     port: 6832
     protocol: UDP
     targetPort: 6832
-  - name: agent-thrift-http
+  - name: grafana-agent-traces-thrift-http
     port: 14268
     protocol: TCP
     targetPort: 14268
-  - name: agent-thrift-grpc
+  - name: grafana-agent-traces-thrift-grpc
     port: 14250
     protocol: TCP
     targetPort: 14250
-  - name: agent-zipkin
+  - name: grafana-agent-traces-zipkin
     port: 9411
     protocol: TCP
     targetPort: 9411
-  - name: agent-otlp
+  - name: grafana-agent-traces-otlp
     port: 55680
     protocol: TCP
     targetPort: 55680
-  - name: agent-opencensus
+  - name: grafana-agent-traces-opencensus
     port: 55678
     protocol: TCP
     targetPort: 55678
@@ -86,7 +86,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana-agent-traces
-  namespace: YOUR_NAMESPACE
+  namespace: ${NAMESPACE}
 spec:
   minReadySeconds: 10
   replicas: 1
@@ -112,9 +112,9 @@ spec:
               fieldPath: spec.nodeName
         image: grafana/agent:v0.23.0
         imagePullPolicy: IfNotPresent
-        name: agent
+        name: grafana-agent-traces
         ports:
-        - containerPort: 8080
+        - containerPort: 80
           name: http-metrics
         - containerPort: 6831
           name: thrift-compact

--- a/production/kubernetes/agent-traces.yaml
+++ b/production/kubernetes/agent-traces.yaml
@@ -50,8 +50,8 @@ metadata:
 spec:
   ports:
   - name: grafana-agent-traces-http-metrics
-    port: 8080
-    targetPort: 8080
+    port: 80
+    targetPort: 80
   - name: grafana-agent-traces-thrift-compact
     port: 6831
     protocol: UDP
@@ -103,7 +103,7 @@ spec:
       containers:
       - args:
         - -config.file=/etc/agent/agent.yaml
-        - -server.http.address=0.0.0.0:8080
+        - -server.http.address=0.0.0.0:80
         command:
         - /bin/agent
         env:
@@ -115,7 +115,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: grafana-agent-traces
         ports:
-        - containerPort: 8080
+        - containerPort: 80
           name: http-metrics
         - containerPort: 6831
           name: thrift-compact

--- a/production/kubernetes/build/build.sh
+++ b/production/kubernetes/build/build.sh
@@ -9,6 +9,7 @@ pushd "${DIRNAME}" || exit 1
 # Make sure dependencies are up to date
 jb install
 tk show --dangerous-allow-redirect ./templates/bare > "${PWD}/../agent-bare.yaml"
+#tk eval ./templates/bare > "${PWD}/../agent-bare.yaml"
 tk show --dangerous-allow-redirect ./templates/loki > "${PWD}/../agent-loki.yaml"
 tk show --dangerous-allow-redirect ./templates/traces > "${PWD}/../agent-traces.yaml"
 popd || exit 1

--- a/production/kubernetes/build/build.sh
+++ b/production/kubernetes/build/build.sh
@@ -9,7 +9,6 @@ pushd "${DIRNAME}" || exit 1
 # Make sure dependencies are up to date
 jb install
 tk show --dangerous-allow-redirect ./templates/bare > "${PWD}/../agent-bare.yaml"
-#tk eval ./templates/bare > "${PWD}/../agent-bare.yaml"
 tk show --dangerous-allow-redirect ./templates/loki > "${PWD}/../agent-loki.yaml"
 tk show --dangerous-allow-redirect ./templates/traces > "${PWD}/../agent-traces.yaml"
 popd || exit 1

--- a/production/kubernetes/build/jsonnetfile.json
+++ b/production/kubernetes/build/jsonnetfile.json
@@ -4,7 +4,16 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/jsonnet-libs/k8s-libsonnet",
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "ksonnet-util"
+        }
+      },
+      "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/k8s-libsonnet.git",
           "subdir": "1.21"
         }
       },

--- a/production/kubernetes/build/jsonnetfile.lock.json
+++ b/production/kubernetes/build/jsonnetfile.lock.json
@@ -18,8 +18,8 @@
           "subdir": "1.21"
         }
       },
-      "version": "f47562c4e3bfaf46a5a5bc6a9e1e76a4fc76c18e",
-      "sum": "R4vw3zTrNH2hlwtMliAcnZ6ZlY21ACZHZ2tTkeU7QbM="
+      "version": "f8efa81cf15257bd151b97e31599e20b2ba5311b",
+      "sum": "FYub7WxElJkqjjXA++DemsKHwsPqUFW945BTgpVop6Q="
     },
     {
       "source": {

--- a/production/kubernetes/build/templates/bare/main.jsonnet
+++ b/production/kubernetes/build/templates/bare/main.jsonnet
@@ -4,9 +4,9 @@ local k = import 'ksonnet-util/kausal.libsonnet';
 local pvc = k.core.v1.persistentVolumeClaim;
 local volumeMount = k.core.v1.volumeMount;
 
-{ 
+{
   agent:
-    agent.new(name='grafana-agent', namespace='${NAMESPACE}') + 
+    agent.new(name='grafana-agent', namespace='${NAMESPACE}') +
     agent.withStatefulSetController(
       replicas=1,
       volumeClaims=[
@@ -21,19 +21,17 @@ local volumeMount = k.core.v1.volumeMount;
     // add dummy config or else will fail
     agent.withAgentConfig({
       server: { log_level: 'error' },
-    }) + 
+    }) +
     agent.withVolumeMountsMixin([volumeMount.new('agent-wal', '/var/lib/agent')]) +
     // todo: create headless svc
-    agent.withService({}) + 
-#    {
-#      agent+: {
-#        controller_service:+ {
-#          spec:+ {
-#            clusterIP: "None" 
-#          }
-#        }
-#      }
-#    } +
+    agent.withService({}) +
+    {
+      controller_service+: {
+        spec+: {
+          clusterIP: 'None',
+        },
+      },
+    } +
     // hack to disable ConfigMap
-    { configMap:: super.configMap }
+    { configMap:: super.configMap },
 }

--- a/production/kubernetes/build/templates/bare/main.jsonnet
+++ b/production/kubernetes/build/templates/bare/main.jsonnet
@@ -1,19 +1,39 @@
-local agent = import 'grafana-agent/v1/main.libsonnet';
+local agent = import 'grafana-agent/v2/main.libsonnet';
+local k = import 'ksonnet-util/kausal.libsonnet';
 
-{
+local pvc = k.core.v1.persistentVolumeClaim;
+local volumeMount = k.core.v1.volumeMount;
+
+{ 
   agent:
-    agent.newDeployment('grafana-agent', '${NAMESPACE}') +
+    agent.new(name='grafana-agent', namespace='${NAMESPACE}') + 
+    agent.withStatefulSetController(
+      replicas=1,
+      volumeClaims=[
+        pvc.new() +
+        pvc.mixin.metadata.withName('agent-wal') +
+        pvc.mixin.metadata.withNamespace('${NAMESPACE}') +
+        pvc.mixin.spec.withAccessModes('ReadWriteOnce') +
+        pvc.mixin.spec.resources.withRequests({ storage: '5Gi' }),
+      ],
+    ) +
     agent.withConfigHash(false) +
-    agent.withImages({
-      agent: (import 'version.libsonnet'),
-    }) + {
-      agent+: {
-        // The listen port from the cloud config is set to 12345.
-        listen_port:: 12345,
-
-        // The bare deployment doesn't provide a ConfigMap by default, so
-        // remove it from here.
-        config_map:: {},
-      },
-    },
+    // add dummy config or else will fail
+    agent.withAgentConfig({
+      server: { log_level: 'error' },
+    }) + 
+    agent.withVolumeMountsMixin([volumeMount.new('agent-wal', '/var/lib/agent')]) +
+    // todo: create headless svc
+    agent.withService({}) + 
+#    {
+#      agent+: {
+#        controller_service:+ {
+#          spec:+ {
+#            clusterIP: "None" 
+#          }
+#        }
+#      }
+#    } +
+    // hack to disable ConfigMap
+    { configMap:: super.configMap }
 }

--- a/production/kubernetes/build/templates/bare/main.jsonnet
+++ b/production/kubernetes/build/templates/bare/main.jsonnet
@@ -23,7 +23,7 @@ local volumeMount = k.core.v1.volumeMount;
       server: { log_level: 'error' },
     }) +
     agent.withVolumeMountsMixin([volumeMount.new('agent-wal', '/var/lib/agent')]) +
-    // todo: create headless svc
+    // headless svc needed by statefulset
     agent.withService({}) +
     {
       controller_service+: {

--- a/production/kubernetes/build/templates/bare/main.jsonnet
+++ b/production/kubernetes/build/templates/bare/main.jsonnet
@@ -3,6 +3,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
 
 local pvc = k.core.v1.persistentVolumeClaim;
 local volumeMount = k.core.v1.volumeMount;
+local containerPort = k.core.v1.containerPort;
 
 {
   agent:
@@ -23,6 +24,11 @@ local volumeMount = k.core.v1.volumeMount;
       server: { log_level: 'error' },
     }) +
     agent.withVolumeMountsMixin([volumeMount.new('agent-wal', '/var/lib/agent')]) +
+    {
+      _config+: {
+        default_http_port: 12345,
+      },
+    } +
     // headless svc needed by statefulset
     agent.withService({}) +
     {

--- a/production/kubernetes/build/templates/bare/main.jsonnet
+++ b/production/kubernetes/build/templates/bare/main.jsonnet
@@ -24,13 +24,8 @@ local containerPort = k.core.v1.containerPort;
       server: { log_level: 'error' },
     }) +
     agent.withVolumeMountsMixin([volumeMount.new('agent-wal', '/var/lib/agent')]) +
-    {
-      _config+: {
-        default_http_port: 12345,
-      },
-    } +
     // headless svc needed by statefulset
-    agent.withService({}) +
+    agent.withService() +
     {
       controller_service+: {
         spec+: {

--- a/production/kubernetes/build/templates/loki/main.jsonnet
+++ b/production/kubernetes/build/templates/loki/main.jsonnet
@@ -9,14 +9,9 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     // add dummy config or else will fail
     agent.withAgentConfig({
       server: { log_level: 'error' },
-    }) + 
-    {
-      _config+: {
-        default_http_port: 8080,
-      },
-    } +
-    agent.withLogVolumeMounts(config={}) +
-    agent.withLogPermissions(config={}) +
+    }) +
+    agent.withLogVolumeMounts() +
+    agent.withLogPermissions() +
     // hack to disable configmap
     { configMap:: super.configMap }
 }

--- a/production/kubernetes/build/templates/loki/main.jsonnet
+++ b/production/kubernetes/build/templates/loki/main.jsonnet
@@ -1,15 +1,17 @@
-local agent = import 'grafana-agent/v1/main.libsonnet';
+local agent = import 'grafana-agent/v2/main.libsonnet';
+local k = import 'ksonnet-util/kausal.libsonnet';
 
 {
   agent:
-    agent.new('grafana-agent-logs', '${NAMESPACE}') +
+    agent.new(name='grafana-agent-logs', namespace='${NAMESPACE}') + 
+    agent.withDaemonSetController() + 
     agent.withConfigHash(false) +
-    agent.withImages({
-      agent: (import 'version.libsonnet'),
-    }) + agent.withLogsConfig(agent.scrapeKubernetesLogs) + {
-      agent+: {
-        // Remove ConfigMap
-        config_map:: {},
-      },
-    },
+    // add dummy config or else will fail
+    agent.withAgentConfig({
+      server: { log_level: 'error' },
+    }) + 
+    agent.withLogVolumeMounts(config={}) +
+    agent.withLogPermissions(config={}) +
+    // hack to disable configmap
+    { configMap:: super.configMap }
 }

--- a/production/kubernetes/build/templates/loki/main.jsonnet
+++ b/production/kubernetes/build/templates/loki/main.jsonnet
@@ -10,6 +10,11 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     agent.withAgentConfig({
       server: { log_level: 'error' },
     }) + 
+    {
+      _config+: {
+        default_http_port: 8080,
+      },
+    } +
     agent.withLogVolumeMounts(config={}) +
     agent.withLogPermissions(config={}) +
     // hack to disable configmap

--- a/production/kubernetes/build/templates/traces/main.jsonnet
+++ b/production/kubernetes/build/templates/traces/main.jsonnet
@@ -30,12 +30,7 @@ local newPort(name, portNumber, protocol='TCP') =
       // Opencensus
       newPort('opencensus', 55678, 'TCP'),
     ]) + 
-    {
-      _config+: {
-        default_http_port: 8080,
-      },
-    } + 
-    agent.withService(config={}) +
+    agent.withService() +
     // add dummy config or will fail
     agent.withAgentConfig({
       server: { log_level: 'error' },

--- a/production/kubernetes/build/templates/traces/main.jsonnet
+++ b/production/kubernetes/build/templates/traces/main.jsonnet
@@ -1,6 +1,6 @@
-local agent = import 'grafana-agent/v1/main.libsonnet';
-
+local agent = import 'grafana-agent/v2/main.libsonnet';
 local k = import 'ksonnet-util/kausal.libsonnet';
+
 local containerPort = k.core.v1.containerPort;
 
 local newPort(name, portNumber, protocol='TCP') =
@@ -11,35 +11,9 @@ local newPort(name, portNumber, protocol='TCP') =
 
 {
   agent:
-    agent.newDeployment('grafana-agent-traces', 'YOUR_NAMESPACE') +
+    agent.new(name='grafana-agent-traces', namespace='${NAMESPACE}') +
+    agent.withDeploymentController(replicas=1) +
     agent.withConfigHash(false) +
-    agent.withImages({
-      agent: (import 'version.libsonnet'),
-    }) +
-    agent.withTracesConfig({
-      receivers: {
-        jaeger: {
-          protocols: {
-            thrift_http: null,
-            thrift_binary: null,
-            thrift_compact: null,
-            grpc: null,
-          },
-        },
-        zipkin: null,
-        otlp: {
-          protocols: {
-            http: null,
-            grpc: null,
-          },
-        },
-        opencensus: null,
-      },
-      batch: {
-        timeout: '5s',
-        send_batch_size: 1000,
-      },
-    }) +
     agent.withPortsMixin([
       // Jaeger receiver
       newPort('thrift-compact', 6831, 'UDP'),
@@ -55,29 +29,12 @@ local newPort(name, portNumber, protocol='TCP') =
 
       // Opencensus
       newPort('opencensus', 55678, 'TCP'),
-    ]) +
-    agent.withTracesRemoteWrite([
-      {
-        endpoint: '${TEMPO_ENDPOINT}',
-        basic_auth: {
-          username: '${TEMPO_USERNAME}',
-          password: '${TEMPO_PASSWORD}',
-        },
-        retry_on_failure: {
-          enabled: false,
-        },
-      },
-    ]) +
-    agent.withTracesSamplingStrategies({
-      default_strategy: {
-        type: 'probabilistic',
-        param: 0.001,
-      },
-    }) +
-    agent.withTracesScrapeConfigs(agent.tracesScrapeKubernetes) + {
-      agent+: {
-        // Remove this block to generate ConfigMap
-        config_map:: {},
-      },
-    },
+    ]) + 
+    agent.withService(config={}) +
+    // add dummy config or will fail
+    agent.withAgentConfig({
+      server: { log_level: 'error' },
+    }) + 
+    // remove configMap for generated manifests
+    { configMap:: super.configMap }
 }

--- a/production/kubernetes/build/templates/traces/main.jsonnet
+++ b/production/kubernetes/build/templates/traces/main.jsonnet
@@ -30,6 +30,11 @@ local newPort(name, portNumber, protocol='TCP') =
       // Opencensus
       newPort('opencensus', 55678, 'TCP'),
     ]) + 
+    {
+      _config+: {
+        default_http_port: 8080,
+      },
+    } + 
     agent.withService(config={}) +
     // add dummy config or will fail
     agent.withAgentConfig({

--- a/production/tanka/grafana-agent/v2/internal/base.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/base.libsonnet
@@ -49,6 +49,7 @@ function(name='grafana-agent', namespace='') {
     container.withPorts(containerPort.new('http-metrics', this._config.agent_port)) +
     container.withCommand('/bin/agent') +
     container.withArgsMixin(k.util.mapToFlags(this._config.agent_args)) +
+    // `HOSTNAME` is required for promtail (logs) otherwise it will silently do nothing
     container.withEnvMixin([
       envVar.fromFieldPath('HOSTNAME', 'spec.nodeName'),
     ]),

--- a/production/tanka/grafana-agent/v2/internal/base.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/base.libsonnet
@@ -6,6 +6,7 @@ function(name='grafana-agent', namespace='') {
   local containerPort = k.core.v1.containerPort,
   local policyRule = k.rbac.v1.policyRule,
   local serviceAccount = k.core.v1.serviceAccount,
+  local envVar = k.core.v1.envVar,
 
   local this = self,
 
@@ -47,5 +48,8 @@ function(name='grafana-agent', namespace='') {
     container.new(name, this._images.agent) +
     container.withPorts(containerPort.new('http-metrics', this._config.agent_port)) +
     container.withCommand('/bin/agent') +
-    container.withArgsMixin(k.util.mapToFlags(this._config.agent_args)),
+    container.withArgsMixin(k.util.mapToFlags(this._config.agent_args)) +
+    container.withEnvMixin([
+      envVar.fromFieldPath('HOSTNAME', 'spec.nodeName'),
+    ]),
 }

--- a/production/tanka/grafana-agent/v2/internal/base.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/base.libsonnet
@@ -28,7 +28,7 @@ function(name='grafana-agent', namespace='') {
 
   rbac: k.util.rbac(name, [
     policyRule.withApiGroups(['']) +
-    policyRule.withResources(['nodes', 'nodes/proxy', 'services', 'endpoints', 'pods']) +
+    policyRule.withResources(['nodes', 'nodes/proxy', 'services', 'endpoints', 'pods', 'events']) +
     policyRule.withVerbs(['get', 'list', 'watch']),
 
     policyRule.withNonResourceUrls('/metrics') +

--- a/production/tanka/grafana-agent/v2/internal/controllers/daemonset.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/controllers/daemonset.libsonnet
@@ -6,8 +6,6 @@ function() {
 
   local k = (import 'ksonnet-util/kausal.libsonnet') { _config+:: this._config },
   local daemonSet = k.apps.v1.daemonSet,
-  local container = k.core.v1.container,
-  local envVar = k.core.v1.envVar,
 
   controller:
     daemonSet.new(name, [this.container]) +
@@ -21,10 +19,4 @@ function() {
       else {}
     ) +
     k.util.configVolumeMount(name, '/etc/agent'),
-
-  // `HOSTNAME` is required for promtail (logs) otherwise it will silently do nothing
-  container+::
-    container.withEnvMixin([
-      envVar.fromFieldPath('HOSTNAME', 'spec.nodeName'),
-    ]),
 }

--- a/production/tanka/grafana-agent/v2/internal/controllers/deployment.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/controllers/deployment.libsonnet
@@ -6,8 +6,6 @@ function(replicas=1) {
 
   local k = (import 'ksonnet-util/kausal.libsonnet') { _config+:: this._config },
   local deployment = k.apps.v1.deployment,
-  local container = k.core.v1.container,
-  local envVar = k.core.v1.envVar,
 
   controller:
     deployment.new(name, replicas, [this.container]) +
@@ -21,11 +19,4 @@ function(replicas=1) {
       else {}
     ) +
     k.util.configVolumeMount(name, '/etc/agent'),
-  
-  // for traces
-  container+::
-    container.withEnvMixin([
-      envVar.fromFieldPath('HOSTNAME', 'spec.nodeName'),
-    ]),
-
 }

--- a/production/tanka/grafana-agent/v2/internal/controllers/deployment.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/controllers/deployment.libsonnet
@@ -5,8 +5,9 @@ function(replicas=1) {
   local namespace = _config.namespace,
 
   local k = (import 'ksonnet-util/kausal.libsonnet') { _config+:: this._config },
-
   local deployment = k.apps.v1.deployment,
+  local container = k.core.v1.container,
+  local envVar = k.core.v1.envVar,
 
   controller:
     deployment.new(name, replicas, [this.container]) +
@@ -20,4 +21,11 @@ function(replicas=1) {
       else {}
     ) +
     k.util.configVolumeMount(name, '/etc/agent'),
+  
+  // for traces
+  container+::
+    container.withEnvMixin([
+      envVar.fromFieldPath('HOSTNAME', 'spec.nodeName'),
+    ]),
+
 }

--- a/production/tanka/grafana-agent/v2/internal/helpers/k8s.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/helpers/k8s.libsonnet
@@ -484,7 +484,7 @@ local gen_scrape_config(job_name, pod_uid) = {
     },
   ],
 
-  traces(conifg={}):: [
+  traces(config={}):: [
     {
       bearer_token_file: '/var/run/secrets/kubernetes.io/serviceaccount/token',
       job_name: 'kubernetes-pods',

--- a/production/tanka/grafana-agent/v2/internal/helpers/logs.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/helpers/logs.libsonnet
@@ -3,6 +3,11 @@ local container = k.core.v1.container;
 
 {
   volumeMounts(config={}):: {
+    // Disable journald mount by default
+    local _config = {
+      journald: false,
+    } + config,
+
     controller+:
       // For reading docker containers. /var/log is used for the positions file
       // and shouldn't be set to readonly.
@@ -10,7 +15,8 @@ local container = k.core.v1.container;
       k.util.hostVolumeMount('varlibdockercontainers', '/var/lib/docker/containers', '/var/lib/docker/containers', readOnly=true) +
 
       // For reading journald
-      k.util.hostVolumeMount('etcmachineid', '/etc/machine-id', '/etc/machine-id', readOnly=true),
+      if _config.journald == false then {}
+      else k.util.hostVolumeMount('etcmachineid', '/etc/machine-id', '/etc/machine-id', readOnly=true),
   },
 
   permissions(config={}):: {


### PR DESCRIPTION
#### PR Description 
This PR migrates the generation of K8s manifests in `production/kubernetes` to `v2` of the Tanka jsonnet library.

Summary of changes to manifests:
- (all) Change default Agent http port to `80` from misc other ports (`8080`, `12345`, etc)
- `agent-bare.yaml`
   - Becomes a `StatefulSet` (prev `Deployment`)
   - Add headless Service for `StatefulSet`
- `agent-loki.yaml`
  - `machine-id` (journal) vol disabled by default
- `agent-traces.yaml`
  - make namespace templatable
  - change svc port names (no functional change)
  - remove config generation from jsonnet (`TODO` in a future PR: add this to tanka/v2 jsonnet library)

#### Which issue(s) this PR fixes 
Fixes https://github.com/grafana/agent/issues/451

#### Notes to the Reviewer
~~Still need to test these on clusters and update docs but submitting for preliminary review~~
Tested manifests on a DOKS cluster

#### PR Checklist
- [x] CHANGELOG updated 
- [x] (Agent) Documentation added