### PR TITLE
Consulagent sd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - [FEATURE] Added config read API support to GrafanaAgent Custom Resource Definition.
 
+- [FEATURE] Added consulagent_sd to target discovery. (@chuckyz)
+
 # v0.23.0 (2022-01-13)
 
 - [ENHANCEMENT] Go 1.17 is now used for all builds of the Agent. (@tpaschalis)

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prometheus/common/version"
 
 	// Register Prometheus SD components
+	_ "github.com/grafana/loki/clients/pkg/promtail/discovery/consulagent"
 	_ "github.com/prometheus/prometheus/discovery/install"
 
 	// Register integrations

--- a/pkg/metrics/cluster/validation.go
+++ b/pkg/metrics/cluster/validation.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/agent/pkg/metrics/instance"
+	"github.com/grafana/loki/clients/pkg/promtail/discovery/consulagent"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/aws"
@@ -74,6 +75,10 @@ func validateDiscoveryNoFiles(disc discovery.Config) error {
 		// no-op
 	case *consul.SDConfig:
 		if err := validateHTTPNoFiles(&config.HTTPClientConfig{TLSConfig: d.HTTPClientConfig.TLSConfig}); err != nil {
+			return err
+		}
+	case *consulagent.SDConfig:
+		if err := validateHTTPNoFiles(&config.HTTPClientConfig{TLSConfig: d.TLSConfig}); err != nil {
 			return err
 		}
 	case *digitalocean.SDConfig:


### PR DESCRIPTION
#### PR Description 
This enables the [consulagent_sd_config](https://github.com/grafana/loki/blob/main/docs/sources/clients/promtail/configuration.md#consulagent_sd_config) provider which is presently part of Loki via Promtail.

This allows those with either large Consul clusters or those with very limited hardware backing their Consul clusters to scale metrics by running a grafana agent per node and just scraping the agent on the host it's running on for services, causing no requests to go back to the main cluster.

#### Which issue(s) this PR fixes 
#1419 

#### Notes to the Reviewer

There doesn't seem to be any documentation for any of the service discovery mechanisms within Grafana Agent?  Also from the discussion in #1419 I don't think this PR needs tests.

#### PR Checklist

- [x] CHANGELOG updated 
