### PR TITLE
Parse const_labels correctly in exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ This release has deprecations. Please read [DEPRECATION] entries and consult
 the [upgrade guide](https://github.com/grafana/agent/blob/main/docs/upgrade-guide/_index.md)
 for detailed information.
 
+
 - [FEATURE] (beta) Enable experimental config urls for fetching remote configs. Currently,
    only HTTP/S is supported. Pass the `-enable-features=remote-configs` flag to turn this on. (@rlankfo)
 
@@ -249,6 +250,7 @@ consult the
 [upgrade guide](https://github.com/grafana/agent/blob/main/docs/upgrade-guide/_index.md)
 for specific instructions.
 
+
 - [FEATURE] Added [Github exporter](https://github.com/infinityworks/github-exporter) integration. (@rgeyer)
 
 - [FEATURE] Add TLS config options for tempo `remote_write`s. (@mapno)
@@ -310,8 +312,8 @@ for specific instructions.
 - [CHANGE] Breaking change: reduced verbosity of tracing autologging
   by not logging `STATUS_CODE_UNSET` status codes. (@mapno)
 
-- [CHANGE] Breaking change: Operator: rename Prometheus*CRDs to Metrics* and
-  Prometheus*fields to Metrics*. (@rfratto)
+- [CHANGE] Breaking change: Operator: rename Prometheus* CRDs to Metrics* and
+  Prometheus* fields to Metrics*. (@rfratto)
 
 - [CHANGE] Breaking change: Operator: CRDs are no longer referenced using a
   hyphen in the name to be consistent with how Kubernetes refers to resources.
@@ -1033,10 +1035,10 @@ files to the new format.
 - [FEATURE] The Prometheus remote write protocol will now send scraped metadata (metric name, help, type and unit). This results in almost negligent bytes sent increase as metadata is only sent every minute. It is on by default. (@gotjosh)
 
   These metrics are available to monitor metadata being sent:
-  - `prometheus_remote_storage_succeeded_metadata_total`
-  - `prometheus_remote_storage_failed_metadata_total`
-  - `prometheus_remote_storage_retried_metadata_total`
-  - `prometheus_remote_storage_sent_batch_duration_seconds` and
+    - `prometheus_remote_storage_succeeded_metadata_total`
+    - `prometheus_remote_storage_failed_metadata_total`
+    - `prometheus_remote_storage_retried_metadata_total`
+    - `prometheus_remote_storage_sent_batch_duration_seconds` and
       `prometheus_remote_storage_sent_bytes_total` have a new label “type” with
       the values of `metadata` or `samples`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Main (unreleased)
 
+- [BUGFIX] `const_labels` in `traces_config` is now correctly parsed in the remote writer exporter (@fredr)
+
 - [ENHANCEMENT] opentelemetry trace exporters can now be configured to support Oauth utilizing
   the opentelemetry-collector-contrib oauth2clientauthextension. (@canuteson)
 
@@ -49,7 +51,6 @@
 This release has deprecations. Please read [DEPRECATION] entries and consult
 the [upgrade guide](https://github.com/grafana/agent/blob/main/docs/upgrade-guide/_index.md)
 for detailed information.
-
 
 - [FEATURE] (beta) Enable experimental config urls for fetching remote configs. Currently,
    only HTTP/S is supported. Pass the `-enable-features=remote-configs` flag to turn this on. (@rlankfo)
@@ -248,7 +249,6 @@ consult the
 [upgrade guide](https://github.com/grafana/agent/blob/main/docs/upgrade-guide/_index.md)
 for specific instructions.
 
-
 - [FEATURE] Added [Github exporter](https://github.com/infinityworks/github-exporter) integration. (@rgeyer)
 
 - [FEATURE] Add TLS config options for tempo `remote_write`s. (@mapno)
@@ -310,8 +310,8 @@ for specific instructions.
 - [CHANGE] Breaking change: reduced verbosity of tracing autologging
   by not logging `STATUS_CODE_UNSET` status codes. (@mapno)
 
-- [CHANGE] Breaking change: Operator: rename Prometheus* CRDs to Metrics* and
-  Prometheus* fields to Metrics*. (@rfratto)
+- [CHANGE] Breaking change: Operator: rename Prometheus*CRDs to Metrics* and
+  Prometheus*fields to Metrics*. (@rfratto)
 
 - [CHANGE] Breaking change: Operator: CRDs are no longer referenced using a
   hyphen in the name to be consistent with how Kubernetes refers to resources.
@@ -1033,10 +1033,10 @@ files to the new format.
 - [FEATURE] The Prometheus remote write protocol will now send scraped metadata (metric name, help, type and unit). This results in almost negligent bytes sent increase as metadata is only sent every minute. It is on by default. (@gotjosh)
 
   These metrics are available to monitor metadata being sent:
-    - `prometheus_remote_storage_succeeded_metadata_total`
-    - `prometheus_remote_storage_failed_metadata_total`
-    - `prometheus_remote_storage_retried_metadata_total`
-    - `prometheus_remote_storage_sent_batch_duration_seconds` and
+  - `prometheus_remote_storage_succeeded_metadata_total`
+  - `prometheus_remote_storage_failed_metadata_total`
+  - `prometheus_remote_storage_retried_metadata_total`
+  - `prometheus_remote_storage_sent_batch_duration_seconds` and
       `prometheus_remote_storage_sent_bytes_total` have a new label “type” with
       the values of `metadata` or `samples`.
 

--- a/pkg/traces/remotewriteexporter/exporter.go
+++ b/pkg/traces/remotewriteexporter/exporter.go
@@ -55,8 +55,8 @@ func newRemoteWriteExporter(cfg *Config) (component.MetricsExporter, error) {
 	if cfg.ConstLabels != nil {
 		ls = make(labels.Labels, 0, len(*cfg.ConstLabels))
 
-		for name := range *cfg.ConstLabels {
-			ls = append(ls, labels.Label{Name: name, Value: (*cfg.ConstLabels)[name]})
+		for name, value := range *cfg.ConstLabels {
+			ls = append(ls, labels.Label{Name: name, Value: value})
 		}
 	}
 

--- a/pkg/traces/remotewriteexporter/exporter.go
+++ b/pkg/traces/remotewriteexporter/exporter.go
@@ -50,12 +50,14 @@ type remoteWriteExporter struct {
 func newRemoteWriteExporter(cfg *Config) (component.MetricsExporter, error) {
 	logger := log.With(util.Logger, "component", "traces remote write exporter")
 
-	ls := make(labels.Labels, 0, len(cfg.ConstLabels))
-	for _, constLabel := range cfg.ConstLabels {
-		ls = append(ls, labels.Label{
-			Name:  constLabel.Name,
-			Value: constLabel.Value,
-		})
+	var ls labels.Labels
+
+	if cfg.ConstLabels != nil {
+		ls = make(labels.Labels, 0, len(*cfg.ConstLabels))
+
+		for name := range *cfg.ConstLabels {
+			ls = append(ls, labels.Label{Name: name, Value: (*cfg.ConstLabels)[name]})
+		}
 	}
 
 	return &remoteWriteExporter{

--- a/pkg/traces/remotewriteexporter/exporter.go
+++ b/pkg/traces/remotewriteexporter/exporter.go
@@ -50,14 +50,10 @@ type remoteWriteExporter struct {
 func newRemoteWriteExporter(cfg *Config) (component.MetricsExporter, error) {
 	logger := log.With(util.Logger, "component", "traces remote write exporter")
 
-	var ls labels.Labels
+	ls := make(labels.Labels, 0, len(cfg.ConstLabels))
 
-	if cfg.ConstLabels != nil {
-		ls = make(labels.Labels, 0, len(*cfg.ConstLabels))
-
-		for name, value := range *cfg.ConstLabels {
-			ls = append(ls, labels.Label{Name: name, Value: value})
-		}
+	for name, value := range cfg.ConstLabels {
+		ls = append(ls, labels.Label{Name: name, Value: value})
 	}
 
 	return &remoteWriteExporter{

--- a/pkg/traces/remotewriteexporter/factory.go
+++ b/pkg/traces/remotewriteexporter/factory.go
@@ -20,9 +20,9 @@ var _ config.Exporter = (*Config)(nil)
 type Config struct {
 	config.ExporterSettings `mapstructure:",squash"`
 
-	ConstLabels  *prometheus.Labels `mapstructure:"const_labels"`
-	Namespace    string             `mapstructure:"namespace"`
-	PromInstance string             `mapstructure:"metrics_instance"`
+	ConstLabels  prometheus.Labels `mapstructure:"const_labels"`
+	Namespace    string            `mapstructure:"namespace"`
+	PromInstance string            `mapstructure:"metrics_instance"`
 }
 
 // NewFactory returns a new factory for the Prometheus remote write processor.

--- a/pkg/traces/remotewriteexporter/factory.go
+++ b/pkg/traces/remotewriteexporter/factory.go
@@ -3,6 +3,7 @@ package remotewriteexporter
 import (
 	"context"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
@@ -13,20 +14,15 @@ const (
 	TypeStr = "remote_write"
 )
 
-type label struct {
-	Name  string `mapstructure:"name"`
-	Value string `mapstructure:"name"`
-}
-
 var _ config.Exporter = (*Config)(nil)
 
 // Config holds the configuration for the Prometheus remote write processor.
 type Config struct {
 	config.ExporterSettings `mapstructure:",squash"`
 
-	ConstLabels  []label `mapstructure:"const_labels"`
-	Namespace    string  `mapstructure:"namespace"`
-	PromInstance string  `mapstructure:"metrics_instance"`
+	ConstLabels  *prometheus.Labels `mapstructure:"const_labels"`
+	Namespace    string             `mapstructure:"namespace"`
+	PromInstance string             `mapstructure:"metrics_instance"`
 }
 
 // NewFactory returns a new factory for the Prometheus remote write processor.

--- a/pkg/traces/traces_test.go
+++ b/pkg/traces/traces_test.go
@@ -96,7 +96,6 @@ configs:
 	traces, err := New(nil, nil, prometheus.NewRegistry(), cfg, logrus.InfoLevel, logging.Format{})
 	require.NoError(t, err)
 	t.Cleanup(traces.Stop)
-
 }
 
 func TestTrace_ApplyConfig(t *testing.T) {

--- a/pkg/traces/traces_test.go
+++ b/pkg/traces/traces_test.go
@@ -65,6 +65,40 @@ configs:
 	}
 }
 
+func TestTraceWithSpanmetricsConfig(t *testing.T) {
+	tracesCfgText := util.Untab(`
+configs:
+- name: test
+  receivers:
+    zipkin:
+      endpoint: 0.0.0.0:9999
+  remote_write:
+    - endpoint: 0.0.0.0:5555
+      insecure: false
+      tls_config:
+          insecure_skip_verify: true
+  spanmetrics:
+    handler_endpoint: 0.0.0.0:9090
+    const_labels:
+      key1: "value1"
+      key2: "value2"
+	`)
+
+	var cfg Config
+	dec := yaml.NewDecoder(strings.NewReader(tracesCfgText))
+	dec.SetStrict(true)
+	err := dec.Decode(&cfg)
+	require.NoError(t, err)
+
+	var loggingLevel logging.Level
+	require.NoError(t, loggingLevel.Set("debug"))
+
+	traces, err := New(nil, nil, prometheus.NewRegistry(), cfg, logrus.InfoLevel, logging.Format{})
+	require.NoError(t, err)
+	t.Cleanup(traces.Stop)
+
+}
+
 func TestTrace_ApplyConfig(t *testing.T) {
 	tracesCh := make(chan pdata.Traces)
 	tracesAddr := traceutils.NewTestServer(t, func(t pdata.Traces) {


### PR DESCRIPTION
#### PR Description 

Config field `const_labels` have different types in the remotewriterexporter than it has in the [main config type](https://github.com/grafana/agent/blob/main/pkg/traces/config.go#L255). This causes an error when starting the agent:
```
error reading exporters configuration for \"remote_write\": 1 error(s) decoding:\n\n* 'const_labels[0]' has invalid keys: key, some"
```
With this example config:
```yaml
server:
  log_level: info
  http_listen_port: 12345

traces:
  configs:
  - name: test
    receivers:
      zipkin:
        endpoint: 0.0.0.0:9999
    remote_write:
      - endpoint: traces.local:5555
        insecure: false
        tls_config:
            insecure_skip_verify: true
    spanmetrics:
      metrics_instance: test
      const_labels:
        some: "somevalue"
        key: "value"
```

#### Notes to the Reviewer

The previous implementation also had a bug in the mapstructure field, where both value and name where named `name`.

#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added
- [x] Tests updated
