### PR TITLE
remove duplicate suffix from calls_total spanmetric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Main (unreleased)
 
+- [BUGFIX] spanmetric `traces_spanmetrics_calls_total_total` renamed to `traces_spanmetrics_calls_total`
+
 - [ENHANCEMENT] opentelemetry trace exporters can now be configured to support Oauth utilizing
   the opentelemetry-collector-contrib oauth2clientauthextension. (@canuteson)
 

--- a/pkg/traces/remotewriteexporter/exporter.go
+++ b/pkg/traces/remotewriteexporter/exporter.go
@@ -22,14 +22,13 @@ import (
 )
 
 const (
-	nameLabelKey  = "__name__"
-	sumSuffix     = "sum"
-	countSuffix   = "count"
-	bucketSuffix  = "bucket"
-	leStr         = "le"
-	infBucket     = "+Inf"
-	counterSuffix = "total"
-	noSuffix      = ""
+	nameLabelKey = "__name__"
+	sumSuffix    = "sum"
+	countSuffix  = "count"
+	bucketSuffix = "bucket"
+	leStr        = "le"
+	infBucket    = "+Inf"
+	noSuffix     = ""
 )
 
 type dataPoint interface {
@@ -163,25 +162,17 @@ func (e *remoteWriteExporter) handleHistogramIntDataPoints(app storage.Appender,
 }
 
 func (e *remoteWriteExporter) processScalarMetric(app storage.Appender, m pdata.Metric) error {
-	switch m.DataType() {
-	case pdata.MetricDataTypeSum:
-		dataPoints := m.Sum().DataPoints()
-		if err := e.handleScalarIntDataPoints(app, m.Name(), counterSuffix, dataPoints); err != nil {
-			return err
-		}
-	case pdata.MetricDataTypeGauge:
-		dataPoints := m.Gauge().DataPoints()
-		if err := e.handleScalarIntDataPoints(app, m.Name(), noSuffix, dataPoints); err != nil {
-			return err
-		}
+	dataPoints := m.Gauge().DataPoints()
+	if err := e.handleScalarIntDataPoints(app, m.Name(), dataPoints); err != nil {
+		return err
 	}
 	return nil
 }
 
-func (e *remoteWriteExporter) handleScalarIntDataPoints(app storage.Appender, name, suffix string, dataPoints pdata.NumberDataPointSlice) error {
+func (e *remoteWriteExporter) handleScalarIntDataPoints(app storage.Appender, name string, dataPoints pdata.NumberDataPointSlice) error {
 	for ix := 0; ix < dataPoints.Len(); ix++ {
 		dataPoint := dataPoints.At(ix)
-		if err := e.appendDataPoint(app, name, suffix, dataPoint, float64(dataPoint.IntVal())); err != nil {
+		if err := e.appendDataPoint(app, name, noSuffix, dataPoint, float64(dataPoint.IntVal())); err != nil {
 			return err
 		}
 	}

--- a/pkg/traces/remotewriteexporter/exporter.go
+++ b/pkg/traces/remotewriteexporter/exporter.go
@@ -160,10 +160,19 @@ func (e *remoteWriteExporter) handleHistogramIntDataPoints(app storage.Appender,
 }
 
 func (e *remoteWriteExporter) processScalarMetric(app storage.Appender, m pdata.Metric) error {
-	dataPoints := m.Gauge().DataPoints()
-	if err := e.handleScalarIntDataPoints(app, m.Name(), dataPoints); err != nil {
-		return err
+	switch m.DataType() {
+	case pdata.MetricDataTypeSum:
+		dataPoints := m.Sum().DataPoints()
+		if err := e.handleScalarIntDataPoints(app, m.Name(), dataPoints); err != nil {
+			return err
+		}
+	case pdata.MetricDataTypeGauge:
+		dataPoints := m.Gauge().DataPoints()
+		if err := e.handleScalarIntDataPoints(app, m.Name(), dataPoints); err != nil {
+			return err
+		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
#### PR Description 
Because of an [upstream fix](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2837/files), the metric have duplicate `_total` suffixes and comes out as `traces_spanmetrics_calls_total_total`

#### Notes to the Reviewer
I wanted to write a test for this as well, but didn't find a way of doing it, since the name is being created in the processor upstream. If you have any suggestions on a test, please let me know.

#### PR Checklist

- [x] CHANGELOG updated 
- [ ] Documentation added
- [ ] Tests updated
