### PR TITLE
integrations-next: allow all integrations to be unmarshaled as an array or object

### DIFF
--- a/pkg/integrations/v2/controller_test.go
+++ b/pkg/integrations/v2/controller_test.go
@@ -167,7 +167,7 @@ func Test_controller_SingletonCheck(t *testing.T) {
 	globals := Globals{}
 	_, err := newController(util.TestLogger(t), cfg, globals)
 	require.Error(t, err)
-	require.True(t, strings.Contains(err.Error(), "found multiple instances of singleton integration mock"))
+	require.True(t, strings.Contains(err.Error(), `integration "mock" may only be defined once`))
 }
 
 type syncController struct {


### PR DESCRIPTION
This PR relaxes the restrictions on how v2 integrations are unmarshaled so that any integration, regardless of type, can be unmarshaled as an JSON object or an array.

Introducing this change makes it *much* easier for the operator to generate configs for integrations, as we no longer have to switch between the _configs and non-_configs key based on the integration being generated.

With this change, configurations like these are now valid:

```yaml
integrations:
  node_exporter_configs:
  - {}
```

Such a configuration would not be recommended to users, but as there is only one defined instance of node_exporter, it still satisfies the singleton requirements. It is unlikely that we would document this is possible.

Instead, the following configuration would still be documented and recommended for singleton integrations:

```yaml
integrations:
  node_exporter: {}
```

## Re-marshaling 

Regardless of how the integrations config is unmarshaled, it will be re-marshaled as the non-array type. This means this config:

```yaml 
integrations:
  node_exporter_configs:
  - {}
```

Will display as the following at the `/-/config` endpoint:

```yaml
integrations:
  node_exporter: {}
```