### PR TITLE
Fix link on 'Create a config file' guide

### DIFF
--- a/docs/user/getting-started/create-config-file.md
+++ b/docs/user/getting-started/create-config-file.md
@@ -58,7 +58,7 @@ source of metrics if you are running multiple Grafana Agents across multiple
 machines.
 
 Full configuration options can be found in the
-[configuration reference]({{< relref "../configuration/index.md" >}}).
+[configuration reference]({{< relref "../configuration/_index.md" >}}).
 
 ## Prometheus config/migrating from Prometheus
 
@@ -104,7 +104,7 @@ metrics:
 ```
 
 Like with integrations, full configuration options can be found in the
-[configuration]({{< relref "../configuration/index.md" >}}).
+[configuration]({{< relref "../configuration/_index.md" >}}).
 
 ## Loki Config/Migrating from Promtail
 


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

#### PR Description 
I think this should work, in the same way that this relref works [here](https://github.com/grafana/agent/blob/449db00d930fc5429fab5edd7c525c2c9cb72f16/docs/user/operator/architecture.md?plain=1#L53) on [this page](https://grafana.com/docs/agent/latest/operator/architecture/)
```
https://grafana.com/docs/agent/latest/operator/architecture/ --> https://grafana.com/docs/agent/latest/configuration/
https://grafana.com/docs/agent/latest/getting-started/create-config-file/ --> https://grafana.com/docs/agent/latest/configuration/
```
#### Which issue(s) this PR fixes 
Fixes #1467 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated (N/A)
- [x] Documentation added (N/A)
- [x] Tests updated (N/A)
