### PR TITLE
Add title, fix links in dynamic configuration docs

### DIFF
--- a/docs/user/configuration/dynamic-config.md
+++ b/docs/user/configuration/dynamic-config.md
@@ -1,3 +1,8 @@
++++
+title = "dynamic_config"
+weight = 500
++++
+
 # Dynamic Configuration - Experimental
 
 **This is experimental and subject to change at anytime, feedback is much appreciated. This is a feature that MAY NOT make it production.**
@@ -86,42 +91,42 @@ Agent template is the standard agent configuration file in its entirety. The def
 one file is supported. This is processed first then any subsequent configurations found REPLACE the values here, it is
 not additive.
 
-Reference {{< relref "./" >}})
+[Reference]({{< relref "./" >}})
 
 ### Server
 
 The default filter is `server-*.yml`, only ONE server file is supported.
 
-Reference {{< relref "./server-config.md" >}})
+[Reference]({{< relref "./server-config.md" >}})
 
 
 ### Metrics
 
 The default filter is `metrics-*.yml`, only ONE metrics file is supported.
 
-Reference {{< relref "./metrics-config.md" >}})
+[Reference]({{< relref "./metrics-config.md" >}})
 
 ### Metric Instances
 
 The default filter is `metrics_instances-*.yml`. Any metric instances are appended to the instances defined in Metrics above. Any number of metric instance files are supporter.
 
-Reference {{< relref "./metrics-config.md#metrics_instance_config" >}}) in the metrics instance
+[Reference]({{< relref "./metrics-config.md#metrics_instance_config" >}}) in the metrics instance
 
 
 ### Integrations
 
 The default filter is `integrations-*.yml`, these support more than one file, and multiple integrations can be defined in a file. Do not assume any order of loading for integrations. For any integration that is a singleton, loading multiple of those will result in an error. 
 
-Reference {{< relref "./integrations/" >}})
+[Reference]({{< relref "./integrations/" >}})
 
 ### Traces
 
 The default filter is `traces-*.yml`. This supports ONE file.
 
-Reference {{< relref "./traces-config.md" >}})
+[Reference]({{< relref "./traces-config/" >}})
 
 ### Logs
 
 The default filter is `logs-*.yml`. This supports ONE file.
 
-Reference {{< relref "./logs-config.md" >}})
+[Reference]({{< relref "./logs-config/" >}})


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

#### PR Description 

#### Which issue(s) this PR fixes 
Adding the title should fill the page name in the left menu. Currently there's a blank, clickable link in place there. 
<img src="https://user-images.githubusercontent.com/17771679/157209913-ee149423-5bae-4a58-9c32-35d5558982c3.png" width="200" height="200">


This should also fix the rendering the *Reference* relref links in each section
<img src="https://user-images.githubusercontent.com/17771679/157210294-ee26818d-b314-45ae-bba8-202fbf74ea5e.png" width="400">

I've also been super confused with how relref links work, and hopefully we get a nicer way of previewing documentation builds soon.

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated  (N/A)
- [x] Documentation added (N/A)
- [x] Tests updated (N/A)
