### PR TITLE
CHANGELOG: fix entries

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,19 @@
-#### PR Description 
+#### PR Description
 
-#### Which issue(s) this PR fixes 
+#### Which issue(s) this PR fixes
 
 #### Notes to the Reviewer
 
 #### PR Checklist
 
-- [ ] CHANGELOG updated 
+<!-- When updating the CHANGELOG, please:
+
+1. Keep entries grouped by SECURITY/FEATURE/ENHANCEMENT/BUGFIX/CHANGE/DEPRECATION
+2. Add your CHANGELOG entry to the bottom of the appropriate group
+3. Give yourself credit for your work with your GitHub username!
+
+-->
+
+- [ ] CHANGELOG updated
 - [ ] Documentation added
 - [ ] Tests updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,42 @@
 # Main (unreleased)
 
-- [BUGFIX] spanmetric `traces_spanmetrics_calls_total_total` renamed to `traces_spanmetrics_calls_total`
-
-- [BUGFIX] `const_labels` in `traces_config` is now correctly parsed in the remote writer exporter (@fredr)
-
-- [ENHANCEMENT] opentelemetry trace exporters can now be configured to support Oauth utilizing
-  the opentelemetry-collector-contrib oauth2clientauthextension. (@canuteson)
-
-- [ENHANCEMENT] Strengthen readiness check for metrics instances. (@tpaschalis)
-
-- [ENHANCEMENT] Parameterize namespace field in sample K8s logs manifests (@hjet)
-
-- [ENHANCEMENT] Upgrade to loki v2.4.2. The following metrics will now be prefixed with `agent_dskit_` instead of `cortex_`: `cortex_kv_request_duration_seconds`, `cortex_member_consul_heartbeats_total`, `cortex_member_ring_tokens_owned`, `cortex_member_ring_tokens_to_own`, `cortex_ring_member_ownership_percent`, `cortex_ring_members`, `cortex_ring_oldest_member_timestamp`, `cortex_ring_tokens_owned`, `cortex_ring_tokens_total`. (@rlankfo)
-
-- [ENHANCEMENT] Introduce EXPERIMENTAL support for dynamic configuration. (@mattdurham)
-
-- [ENHANCEMENT] Update Prometheus dependency to v2.31.1. (@rfratto)
-
-- [FEATURE] Added config read API support to GrafanaAgent Custom Resource Definition.
+- [FEATURE] Added config read API support to GrafanaAgent Custom Resource
+  Definition. (@shamsalmon)
 
 - [FEATURE] Added consulagent_sd to target discovery. (@chuckyz)
 
-- [BUGFIX] Ensure singleton integrations are honored in v2 integrations (@mattdurham)
+- [FEATURE] Introduce EXPERIMENTAL support for dynamic configuration.
+  (@mattdurham)
+
+- [ENHANCEMENT] Tracing: Exporters can now be configured to use
+  OAuth. (@canuteson)
+
+- [ENHANCEMENT] Strengthen readiness check for metrics instances. (@tpaschalis)
+
+- [ENHANCEMENT] Parameterize namespace field in sample K8s logs manifests
+  (@hjet)
+
+- [ENHANCEMENT] Upgrade to loki v2.4.2. The following metrics will now be
+  prefixed with `agent_dskit_` instead of `cortex_`:
+  `cortex_kv_request_duration_seconds`,
+  `cortex_member_consul_heartbeats_total`, `cortex_member_ring_tokens_owned`,
+  `cortex_member_ring_tokens_to_own`, `cortex_ring_member_ownership_percent`,
+  `cortex_ring_members`, `cortex_ring_oldest_member_timestamp`,
+  `cortex_ring_tokens_owned`, `cortex_ring_tokens_total`. (@rlankfo)
+
+- [ENHANCEMENT] Update Prometheus dependency to v2.31.1. (@rfratto)
+
+- [BUGFIX] Ensure singleton integrations are honored in v2 integrations
+  (@mattdurham)
+
+- [BUGFIX] Tracing: `const_labels` is now correctly parsed in the remote write
+  exporter. (@fredr)
 
 - [BUGFIX] integrations-next: Fix race condition where metrics endpoints for
   integrations may disappear after reloading the config file. (@rfratto)
+
+- [CHANGE] Traces: the `traces_spanmetrics_calls_total_total` metric has been
+  renamed to `traces_spanmetrics_calls_total` (@fredr)
 
 # v0.23.0 (2022-01-13)
 


### PR DESCRIPTION
This restores the ordering we try to keep for our CHANGELOG, and adds a
note into the pull_request_template for contributors to retain that
order.

I also did some formatting and reclassified/rephrased some entries.