### PR TITLE
server: Change default HTTP/gRPC listen address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,16 @@
   deprecated server block fields. Changing a deprecated field will be ignored
   and cause the reload to fail. (@rfratto)
 
+- [CHANGE] The default HTTP listen address is now `127.0.0.1:12345`. Use the
+  `-server.http.address` flag to change this value. (@rfratto)
+
+- [CHANGE] The default gRPC listen address is now `127.0.0.1:12346`. Use the
+  `-server.grpc.address` flag to change this value.(@rfratto)
+
+- [CHANGE] BREAKING CHANGE: `-reload-addr` and `-reload-port` have been
+  removed. They are no longer necessary as the primary HTTP server is now
+  static and can't be shut down in the middle of a `/-/reload` call. (@rfratto)
+
 # v0.23.0 (2022-01-13)
 
 - [ENHANCEMENT] Go 1.17 is now used for all builds of the Agent. (@tpaschalis)

--- a/cmd/agent/agent-local-config.yaml
+++ b/cmd/agent/agent-local-config.yaml
@@ -10,7 +10,7 @@ metrics:
       scrape_configs:
         - job_name: local_scrape
           static_configs:
-            - targets: ['127.0.0.1:80']
+            - targets: ['127.0.0.1:12345']
               labels:
                 cluster: 'localhost'
       remote_write:

--- a/cmd/agent/entrypoint.go
+++ b/cmd/agent/entrypoint.go
@@ -60,19 +60,6 @@ func NewEntrypoint(logger *server.Logger, cfg *config.Config, reloader Reloader)
 		err error
 	)
 
-	if cfg.ReloadPort != 0 {
-		reloadURL := fmt.Sprintf("%s:%d", cfg.ReloadAddress, cfg.ReloadPort)
-		ep.reloadListener, err = net.Listen("tcp", reloadURL)
-		if err != nil {
-			return nil, fmt.Errorf("failed to listen on address for secondary /-/reload server: %w", err)
-		}
-
-		reloadMux := mux.NewRouter()
-		reloadMux.HandleFunc("/-/reload", ep.reloadHandler).Methods("GET", "POST")
-		ep.reloadServer = &http.Server{Handler: reloadMux}
-		level.Info(ep.log).Log("msg", "reload server started", "url", reloadURL)
-	}
-
 	ep.srv, err = server.New(logger, prometheus.DefaultRegisterer, prometheus.DefaultGatherer, cfg.Server)
 	if err != nil {
 		return nil, err

--- a/docs/user/api/_index.md
+++ b/docs/user/api/_index.md
@@ -244,15 +244,6 @@ Valid configurations will be applied to each of the subsystems listed above, and
 updated. Malformed configuration files (invalid YAML, failed validation checks)
 will be immediately rejected with a status code of 400.
 
-If the configuration for the HTTP server is changed, it will be restarted.
-Because of this, it is not recommended to call `/-/reload` against the main HTTP
-server, as restarting it will prevent an HTTP client from reading the response
-of the reload. Instead, use the `--reload-addr` and `--reload-port` flags
-supported by the Agent. That will launch a secondary HTTP server that only
-responds to `/-/reload` and can be used to safely reload the system. This HTTP
-server does not respect any options in the `config` struct, and is currently
-TTP-only (no TLS support).
-
 Well-formed configuration files can still be invalid for various reasons, such
 as not having permissions to read the WAL directory. Issues such as these will
 cause per-subsystem problems while reloading the configuration, and will leave

--- a/docs/user/configuration/_index.md
+++ b/docs/user/configuration/_index.md
@@ -79,16 +79,6 @@ documentation]({{< relref "../api#reload-configuration-file-beta" >}}) for more 
 This functionality is in beta, and may have issues. Please open GitHub issues
 for any problems you encounter.
 
-A reload-only HTTP server can be started to safely reload the system. To start
-this, provide `--reload-addr` and `--reload-port` as command line flags.
-`reload-port` must be set to a non-zero port to launch the reload server. The
-reload server is currently HTTP-only and supports no other options; it does not
-read any values from the `server` block in the config file.
-
-While `/-/reload` is enabled on the primary HTTP server, it is not recommended
-to use it, since changing the HTTP server configuration will cause it to
-restart.
-
 ## File format
 
 To specify which configuration file to load, pass the `-config.file` flag at

--- a/docs/user/configuration/flags.md
+++ b/docs/user/configuration/flags.md
@@ -36,8 +36,6 @@ Valid feature names are:
 * `-config.file`: Path to the configuration file to load. May be an HTTP(s) URL when the `remote-configs` feature is enabled
 * `-config.expand-env`: Expand environment variables in the loaded configuration file
 * `-config.enable-read-api`: Enables the `/-/config` and `/agent/api/v1/configs/{name}` API endpoints to print YAML configuration
-* `-reload-addr`: Additional hostname to expose the `/-/reload` endpoint on
-* `-reload-port`: Port to use for the secondary `/-/reload` endpoint server (0 = disable the additional server)
 
 ### Remote Configuration
 
@@ -60,14 +58,14 @@ These flags require the `dynamic-config` feature to be enabled:
 * `-server.log.source-ips.header`: Header field to extract incoming IP requests from (defaults to Forwarded, X-Real-IP, X-Forwarded-For)
 * `-server.log.source-ips.regex`: Regex to extract the IP out of the read header, using the first capture group as the IP address
 * `-server.http.network`: HTTP server listen network (default `tcp`)
-* `-server.http.address`: HTTP server listen:port (default `0.0.0.0:80`)
+* `-server.http.address`: HTTP server listen:port (default `127.0.0.1:12345`)
 * `-server.http.enable-tls`: Enable TLS for the HTTP server
 * `-server.http.conn-limit`: Maximum number of simultaneous HTTP connections
 * `-server.http.idle-timeout`: HTTP server idle timeout
 * `-server.http.read-timeout`: HTTP server read timeout
 * `-server.http.write-timeout`: HTTP server write timeout
 * `-server.grpc.network` gRPC server listen network (default `grpc`)
-* `-server.grpc.address`: gRPC server listen host:port (default `0.0.0.0:9095`)
+* `-server.grpc.address`: gRPC server listen host:port (default `127.0.0.1:12346`)
 * `-server.grpc.enable-tls`: Enable TLS for the gRPC server
 * `-server.grpc.conn-limit`: Maximum number of simultaneous gRPC connections
 * `-server.grpc.keepalive.max-connection-age` Maximum age for any gRPC connection for a graceful shutdown

--- a/docs/user/cookbook/dynamic-configuration/01_Basics/01_assets/final.yml
+++ b/docs/user/cookbook/dynamic-configuration/01_Basics/01_assets/final.yml
@@ -1,11 +1,11 @@
 server:
-  http_listen_network: ""
-  http_listen_address: ""
-  http_listen_port: 80
+  http_listen_network: "tcp"
+  http_listen_address: "127.0.0.1"
+  http_listen_port: 12345
   http_listen_conn_limit: 0
-  grpc_listen_network: ""
-  grpc_listen_address: ""
-  grpc_listen_port: 0
+  grpc_listen_network: "tcp"
+  grpc_listen_address: "127.0.0.1"
+  grpc_listen_port: 12346
   grpc_listen_conn_limit: 0
   http_tls_config:
     cert_file: ""

--- a/docs/user/cookbook/dynamic-configuration/01_Basics/02_assets/final.yml
+++ b/docs/user/cookbook/dynamic-configuration/01_Basics/02_assets/final.yml
@@ -1,11 +1,11 @@
 server:
   http_listen_network: ""
   http_listen_address: ""
-  http_listen_port: 80
+  http_listen_port: 12345
   http_listen_conn_limit: 0
   grpc_listen_network: ""
   grpc_listen_address: ""
-  grpc_listen_port: 0
+  grpc_listen_port: 12346
   grpc_listen_conn_limit: 0
   http_tls_config:
     cert_file: ""

--- a/docs/user/cookbook/dynamic-configuration/01_Basics/03_assets/final.yml
+++ b/docs/user/cookbook/dynamic-configuration/01_Basics/03_assets/final.yml
@@ -1,11 +1,11 @@
 server:
-  http_listen_network: ""
-  http_listen_address: ""
-  http_listen_port: 80
+  http_listen_network: "tcp"
+  http_listen_address: "127.0.0.1"
+  http_listen_port: 12345
   http_listen_conn_limit: 0
-  grpc_listen_network: ""
-  grpc_listen_address: ""
-  grpc_listen_port: 0
+  grpc_listen_network: "tcp"
+  grpc_listen_address: "127.0.0.1"
+  grpc_listen_port: 12346
   grpc_listen_conn_limit: 0
   http_tls_config:
     cert_file: ""

--- a/docs/user/cookbook/dynamic-configuration/01_Basics/04_assets/final.yml
+++ b/docs/user/cookbook/dynamic-configuration/01_Basics/04_assets/final.yml
@@ -1,11 +1,11 @@
 server:
-  http_listen_network: ""
-  http_listen_address: ""
-  http_listen_port: 80
+  http_listen_network: "tcp"
+  http_listen_address: "127.0.0.1"
+  http_listen_port: 12345
   http_listen_conn_limit: 0
-  grpc_listen_network: ""
-  grpc_listen_address: ""
-  grpc_listen_port: 0
+  grpc_listen_network: "tcp"
+  grpc_listen_address: "127.0.0.1"
+  grpc_listen_port: 12346
   grpc_listen_conn_limit: 0
   http_tls_config:
     cert_file: ""

--- a/docs/user/cookbook/dynamic-configuration/02_Templates/01_assets/final.yml
+++ b/docs/user/cookbook/dynamic-configuration/02_Templates/01_assets/final.yml
@@ -1,11 +1,11 @@
 server:
-  http_listen_network: tcp
-  http_listen_address: ""
-  http_listen_port: 80
+  http_listen_network: "tcp"
+  http_listen_address: "127.0.0.1"
+  http_listen_port: 12345
   http_listen_conn_limit: 0
-  grpc_listen_network: tcp
-  grpc_listen_address: ""
-  grpc_listen_port: 9095
+  grpc_listen_network: "tcp"
+  grpc_listen_address: "127.0.0.1"
+  grpc_listen_port: 12346
   grpc_listen_conn_limit: 0
   http_tls_config:
     cert_file: ""

--- a/docs/user/cookbook/dynamic-configuration/02_Templates/02_assets/final.yml
+++ b/docs/user/cookbook/dynamic-configuration/02_Templates/02_assets/final.yml
@@ -1,11 +1,11 @@
 server:
-  http_listen_network: tcp
-  http_listen_address: ""
-  http_listen_port: 80
+  http_listen_network: "tcp"
+  http_listen_address: "127.0.0.1"
+  http_listen_port: 12345
   http_listen_conn_limit: 0
-  grpc_listen_network: tcp
-  grpc_listen_address: ""
-  grpc_listen_port: 9095
+  grpc_listen_network: "tcp"
+  grpc_listen_address: "127.0.0.1"
+  grpc_listen_port: 12346
   grpc_listen_conn_limit: 0
   http_tls_config:
     cert_file: ""

--- a/docs/user/cookbook/dynamic-configuration/02_Templates/03_assets/final.yml
+++ b/docs/user/cookbook/dynamic-configuration/02_Templates/03_assets/final.yml
@@ -1,11 +1,11 @@
 server:
-  http_listen_network: tcp
-  http_listen_address: ""
-  http_listen_port: 80
+  http_listen_network: "tcp"
+  http_listen_address: "127.0.0.1"
+  http_listen_port: 12345
   http_listen_conn_limit: 0
-  grpc_listen_network: tcp
-  grpc_listen_address: ""
-  grpc_listen_port: 9095
+  grpc_listen_network: "tcp"
+  grpc_listen_address: "127.0.0.1"
+  grpc_listen_port: 12346
   grpc_listen_conn_limit: 0
   http_tls_config:
     cert_file: ""

--- a/docs/user/cookbook/dynamic-configuration/03_Advanced_Datasources/01_assets/final.yml
+++ b/docs/user/cookbook/dynamic-configuration/03_Advanced_Datasources/01_assets/final.yml
@@ -1,11 +1,11 @@
 server:
-  http_listen_network: tcp
-  http_listen_address: ""
-  http_listen_port: 80
+  http_listen_network: "tcp"
+  http_listen_address: "127.0.0.1"
+  http_listen_port: 12345
   http_listen_conn_limit: 0
-  grpc_listen_network: tcp
-  grpc_listen_address: ""
-  grpc_listen_port: 9095
+  grpc_listen_network: "tcp"
+  grpc_listen_address: "127.0.0.1"
+  grpc_listen_port: 12346
   grpc_listen_conn_limit: 0
   http_tls_config:
     cert_file: ""

--- a/docs/user/upgrade-guide/_index.md
+++ b/docs/user/upgrade-guide/_index.md
@@ -138,7 +138,23 @@ must be provided for TLS support to be enabled.
 This is a change over the previous behavior where TLS was automatically enabled
 when a certificate pair was provided.
 
-### Deprecation:
+### Breaking change: Default HTTP/gRPC address changes
+
+The HTTP and gRPC listen addresses now default to `127.0.0.1:12345` and
+`127.0.0.1:12346` respectively.
+
+If running inside of a container, you must change these to `0.0.0.0` to
+externally communicate with the agent's HTTP server.
+
+The listen addresses may be changed via `-server.http.address` and
+`-server.grpc.address` respectively.
+
+### Breaking change: Removal of `-reload-addr` and `-reload-port` flags
+
+The `-reload-addr` and `-reload-port` flags have been removed. They were
+initially added to workaround an issue where reloading a changed server block
+would cause the primary HTTP server to restart. As the HTTP server settings are
+now static, this can no longer happen, and as such the flags have been removed.
 
 ## v0.22.0
 

--- a/example/docker-compose/docker-compose.yaml
+++ b/example/docker-compose/docker-compose.yaml
@@ -77,7 +77,6 @@ services:
       - -enable-features=integrations-next
       - -config.expand-env
       - -config.enable-read-api
-      - -server.http.address=127.0.0.1:12345
     environment:
       HOSTNAME: agent
       REMOTE_WRITE_HOST: cortex:9009

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -129,7 +129,7 @@ Function Install
     nsExec::ExecToLog 'sc create "Grafana Agent" binpath= "\"$INSTDIR\agent-windows-amd64.exe\""'
     Pop $0
     # These separate create and config commands are needed, on the config the binpath is required
-    nsExec::ExecToLog 'sc config "Grafana Agent" start= auto binpath= "\"$INSTDIR\agent-windows-amd64.exe\" -config.file=\"$INSTDIR\agent-config.yaml\" -server.http.address=0.0.0.0:12345"'
+    nsExec::ExecToLog 'sc config "Grafana Agent" start= auto binpath= "\"$INSTDIR\agent-windows-amd64.exe\" -config.file=\"$INSTDIR\agent-config.yaml\""'
     Pop $0
     nsExec::ExecToLog `sc start "Grafana Agent"`
     Pop $0

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,12 +56,6 @@ type Config struct {
 	Traces       traces.Config         `yaml:"traces,omitempty"`
 	Logs         *logs.Config          `yaml:"logs,omitempty"`
 
-	// We support a secondary server just for the /-/reload endpoint, since
-	// invoking /-/reload against the primary server can cause the server
-	// to restart.
-	ReloadAddress string `yaml:"-"`
-	ReloadPort    int    `yaml:"-"`
-
 	// Deprecated fields user has used. Generated during UnmarshalYAML.
 	Deprecations []string `yaml:"-"`
 
@@ -203,9 +197,6 @@ func (c *Config) Validate(fs *flag.FlagSet) error {
 func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.Metrics.RegisterFlags(f)
 	c.Server.RegisterFlags(f)
-
-	f.StringVar(&c.ReloadAddress, "reload-addr", "127.0.0.1", "address to expose a secondary server for /-/reload on.")
-	f.IntVar(&c.ReloadPort, "reload-port", 0, "port to expose a secondary server for /-/reload on. 0 disables secondary server.")
 
 	f.StringVar(&c.BasicAuthUser, "config.url.basic-auth-user", "",
 		"basic auth username for fetching remote config. (requires remote-configs experiment to be enabled")

--- a/pkg/server/flags.go
+++ b/pkg/server/flags.go
@@ -89,8 +89,8 @@ var (
 
 	DefaultHTTPFlags = HTTPFlags{
 		ListenNetwork: "tcp",
-		ListenHost:    "0.0.0.0",
-		ListenPort:    80,
+		ListenHost:    "127.0.0.1",
+		ListenPort:    12345,
 		ReadTimeout:   30 * time.Second,
 		WriteTimeout:  30 * time.Second,
 		IdleTimeout:   120 * time.Second,
@@ -98,8 +98,8 @@ var (
 
 	DefaultGRPCFlags = GRPCFlags{
 		ListenNetwork:         "tcp",
-		ListenHost:            "0.0.0.0",
-		ListenPort:            9095,
+		ListenHost:            "127.0.0.1",
+		ListenPort:            12346,
 		MaxRecvMsgSize:        4 * 1024 * 1024,
 		MaxSendMsgSize:        4 * 1024 * 1024,
 		MaxConcurrentStreams:  100,


### PR DESCRIPTION
This commit changes the default listen addresses to be 127.0.0.1:12345
(for HTTP) and 127.0.0.1:12346 (for gRPC). This makes listening on all
interfaces opt-in rather than opt-out, avoiding accidental overexposure
of access.

Closes grafana/agent#852.

Additionally, the `-reload-addr` and `-reload-port` flags have been
removed as a follow up to #1476. Now that the HTTP and gRPC server are
static for the lifetime of the application, it is impossible for the
user to change their configuration file in such a way to cause it to
shut down while performing a reload. This means that the `-reload-addr`
and `-reload-port` no longer have a use and can be removed safely.