### PR TITLE
add website test for docs sync, add docs preview/readme

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,8 +8,17 @@ on:
     - 'docs/user/**'
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+      - name: Build Website
+        run: |
+          docker run -v ${PWD}/sources:/hugo/content/docs/grafana-cloud --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
   sync:
     runs-on: ubuntu-latest
+    needs: test
     steps:
     - uses: actions/checkout@v1
     - run: git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,11 @@
+IMAGE = grafana/docs-base:latest
+CONTENT_PATH = /hugo/content/docs/agent/latest
+PORT = 3002:3002
+
+.PHONY: pull
+pull:
+	docker pull $(IMAGE)
+
+.PHONY: docs
+docs: pull
+	docker run -v $(shell pwd)/user:$(CONTENT_PATH):Z -p $(PORT) --rm -it $(IMAGE)

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,3 +9,8 @@ parts:
   Github.
 * `developer/`: Documentation for contributors and maintainers.
 * `rfcs/`: RFCs for proposals relating to Grafana Agent.
+
+## Preview the website
+
+Run `make docs`. This launches a preview of the website with the current grafana docs at `http://localhost:3002/docs/agent/latest/` which will refresh automatically when changes are made to content in the `sources` directory.
+Make sure Docker is running.


### PR DESCRIPTION
#### PR Description

Adds a test to confirm the website builds before syncing the docs.

Also adds a docs Makefile and updates the readme with instuctions on how to preview the docs locally from this repo.

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

<!-- When updating the CHANGELOG, please:

1. Keep entries grouped by SECURITY/FEATURE/ENHANCEMENT/BUGFIX/CHANGE/DEPRECATION
2. Add your CHANGELOG entry to the bottom of the appropriate group
3. Give yourself credit for your work with your GitHub username!

-->

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
