### PR TITLE
Remove server.http.address flag in main k8s manifest :)

### DIFF
--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -59,7 +59,6 @@ spec:
       containers:
       - args:
         - -config.file=/etc/agent/agent.yaml
-        - -server.http.address=0.0.0.0:12345
         command:
         - /bin/agent
         env:


### PR DESCRIPTION
#### PR Description
Remove server.http.address flag in main to fix CrashLoopBackOff when following docs grafana-easystart-app/integrations-management/integrations/kubernetes

#### Which issue(s) this PR fixes
N / A

#### Notes to the Reviewer
"Happy path" doesn't work when following agent installation on K8s (grafana-easystart-app/integrations-management/integrations/kubernetes)
