### PR TITLE
Partially revert b0c1e45c

### DIFF
--- a/production/tanka/grafana-agent/smoke/main.libsonnet
+++ b/production/tanka/grafana-agent/smoke/main.libsonnet
@@ -45,6 +45,7 @@ local util = k.util;
         containerPort.newNamed(name='remote-write', containerPort=19090),
       ]) +
       container.withArgsMixin(k.util.mapToFlags({
+        'log.level': 'debug',
         namespace: namespace,
         'mutation-frequency': this._config.mutationFrequency,
         'chaos-frequency': this._config.chaosFrequency,


### PR DESCRIPTION
b0c1e45c4ab884fd51c85687f51142ef85d2ca5d accidentally removed setting
`-log.level` in the smoke binary as part of removing the deprecated
`-log.level` field from agent code.