### PR TITLE
k3d/smoke: don't override crow args

### DIFF
--- a/example/k3d/smoke/main.jsonnet
+++ b/example/k3d/smoke/main.jsonnet
@@ -18,7 +18,7 @@ local images = {
 
 local new_crow(name, selector) =
   crow.new(name, namespace='smoke', config={
-    args: {
+    args+: {
       'crow.prometheus-addr': 'http://cortex/api/prom',
       'crow.extra-selectors': selector,
     },


### PR DESCRIPTION
Building a new crow was overriding the jsonnet default listen address, we need to merge the config overrides instead of providing a whole new set.