### PR TITLE
fix(mixin): grafanaDashboardFolder is a top-level attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@
 - [BUGFIX] Fix issue where installing the DEB/RPM packages would overwrite the
   existing config files and environment files. (@rfratto)
 
+- [BUGFIX] Set `grafanaDashboardFolder` as top level key in the mixin.
+  (@Duologic)
+
 - [DEPRECATION] Most fields in the `server` block of the configuration file are
   now deprecated in favor of command line flags. These fields will be removed
   in the v0.26.0 release. Please consult the upgrade guide for more information

--- a/production/grafana-agent-mixin/mixin.libsonnet
+++ b/production/grafana-agent-mixin/mixin.libsonnet
@@ -1,8 +1,4 @@
-local dashboards = import 'dashboards.libsonnet';
-local debugging = import 'debugging.libsonnet';
-
-{
-  grafanaDashboards+:: std.mapWithKey(function(field, obj) obj {
-    grafanaDashboardFolder: 'Grafana Agent',
-  }, dashboards.grafanaDashboards + debugging.grafanaDashboards),
-} + (import 'alerts.libsonnet')
+{ grafanaDashboardFolder: 'Grafana Agent' }
++ (import 'dashboards.libsonnet')
++ (import 'debugging.libsonnet')
++ (import 'alerts.libsonnet')


### PR DESCRIPTION
#### PR Description
The mixin used to make the `grafanaDashboardFolder` key a part of the dashboard json, this
is not correct. This PR moves the attribute to the same level as the `grafanaDashboards`,
as such it will be consumed by the Grafana jsonnet library as a mixin.

#### Which issue(s) this PR fixes
NA

#### Notes to the Reviewer

#### PR Checklist

<!-- When updating the CHANGELOG, please:

1. Keep entries grouped by SECURITY/FEATURE/ENHANCEMENT/BUGFIX/CHANGE/DEPRECATION
2. Add your CHANGELOG entry to the bottom of the appropriate group
3. Give yourself credit for your work with your GitHub username!

-->

- [x] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated