### PR TITLE
[dev.operator-integrations] pkg/operator/config: Generate config for integrations

### DIFF
--- a/pkg/operator/config/config.go
+++ b/pkg/operator/config/config.go
@@ -26,6 +26,8 @@ const (
 	MetricsType Type = iota + 1
 	// LogsType generates a configuration for logs.
 	LogsType
+	// IntegrationsType generates a configuration for integrations.
+	IntegrationsType
 )
 
 // String returns the string form of Type.
@@ -35,6 +37,8 @@ func (t Type) String() string {
 		return "metrics"
 	case LogsType:
 		return "logs"
+	case IntegrationsType:
+		return "integrations"
 	default:
 		return fmt.Sprintf("unknown (%d)", int(t))
 	}
@@ -64,6 +68,8 @@ func BuildConfig(d *gragent.Deployment, ty Type) (string, error) {
 		return vm.EvaluateFile("./agent-metrics.libsonnet")
 	case LogsType:
 		return vm.EvaluateFile("./agent-logs.libsonnet")
+	case IntegrationsType:
+		return vm.EvaluateFile("./agent-integrations.libsonnet")
 	default:
 		panic(fmt.Sprintf("unexpected config type %v", ty))
 	}

--- a/pkg/operator/config/integration_templates_test.go
+++ b/pkg/operator/config/integration_templates_test.go
@@ -1,0 +1,66 @@
+package config
+
+import (
+	"testing"
+
+	gragent "github.com/grafana/agent/pkg/operator/apis/monitoring/v1alpha1"
+	"github.com/grafana/agent/pkg/util"
+	"github.com/grafana/agent/pkg/util/subset"
+	"github.com/stretchr/testify/require"
+	apiext_v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func TestIntegration(t *testing.T) {
+	toJSON := func(in string) apiext_v1.JSON {
+		t.Helper()
+		out, err := yaml.YAMLToJSONStrict([]byte(in))
+		require.NoError(t, err)
+		return apiext_v1.JSON{Raw: out}
+	}
+
+	tt := []struct {
+		name   string
+		input  map[string]interface{}
+		expect string
+	}{
+		{
+			name: "configured integration",
+			input: map[string]interface{}{
+				"integration": &gragent.Integration{
+					Spec: gragent.IntegrationSpec{
+						Name: "mysqld_exporter",
+						Config: toJSON(`
+              data_source_names: root@(server-a:3306)/
+            `),
+					},
+				},
+			},
+			expect: util.Untab(`
+				data_source_names: root@(server-a:3306)/
+      `),
+		},
+		{
+			name: "integration no config",
+			input: map[string]interface{}{
+				"integration": &gragent.Integration{
+					Spec: gragent.IntegrationSpec{
+						Name: "mysqld_exporter",
+					},
+				},
+			},
+			expect: util.Untab(`{}`),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			vm, err := createVM(testStore())
+			require.NoError(t, err)
+
+			actual, err := runSnippetTLA(t, vm, "./integrations.libsonnet", tc.input)
+			require.NoError(t, err)
+			require.NoError(t, subset.YAMLAssert([]byte(tc.expect), []byte(actual)), "incomplete yaml\n%s", actual)
+		})
+	}
+}

--- a/pkg/operator/config/templates/agent-integrations.libsonnet
+++ b/pkg/operator/config/templates/agent-integrations.libsonnet
@@ -54,6 +54,11 @@ function(ctx) marshal.YAML(optionals.trim({
 
     wal_directory: '/var/lib/grafana-agent/data',
     global: {
+      // NOTE(rfratto): we don't want to add the replica label here, since
+      // there will never be more than one HA replica for a running
+      // integration. Adding a replica label will cause it to be subject to
+      // HA dedupe and risk being discarded depending on what the active
+      // replica is server-side.
       external_labels: optionals.object(new_external_labels(ctx, false)),
       scrape_interval: optionals.string(metrics.ScrapeInterval),
       scrape_timeout: optionals.string(metrics.ScrapeTimeout),

--- a/pkg/operator/config/templates/component/metrics/external_labels.libsonnet
+++ b/pkg/operator/config/templates/component/metrics/external_labels.libsonnet
@@ -3,7 +3,8 @@
 // replica labels.
 //
 // @param {config.Deployment} ctx
-function(ctx) (
+// @param {bool} addReplica
+function(ctx, addReplica) (
   local meta = ctx.Agent.ObjectMeta;
   local metrics = ctx.Agent.Spec.Metrics;
 
@@ -26,7 +27,7 @@ function(ctx) (
 
   // Finally, add the replica label. We don't want the user to overrwrite the
   // replica label since it can cause duplicate sample problems.
-  (
+  if !addReplica then {} else (
     local replicaValue = 'replica-$(STATEFULSET_ORDINAL_NUMBER)';
     local replicaLabel = metrics.ReplicaExternalLabelName;
 

--- a/pkg/operator/config/templates/integrations.libsonnet
+++ b/pkg/operator/config/templates/integrations.libsonnet
@@ -1,0 +1,9 @@
+// Generates an individual integration.
+//
+// @param {Integration} integration
+function(integration)
+  // integration.Spec.Config.Raw is a base64 JSON string holding the raw config
+  // for the integration.
+  local raw = integration.Spec.Config.Raw;
+  if raw == null || std.length(raw) == 0 then {}
+  else std.parseJson(std.base64Decode(raw))


### PR DESCRIPTION
This PR adds the ability to generate an integrations-specific agent config for the operator. It is not wired in anywhere; nothing will currently generate the config.

Related to #1414 
(Supersedes the original attempt at #1314)