### PR TITLE
dependabot: ignore opentelemetry-related dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 2
+    ignore:
+      # OpenTelemetry needs special handling due to a temporary fork; exempt
+      # from Dependabot auto-updating.
+      - dependency-name: "github.com/open-telemetry/opentelemetry-collector-contrib/*"
+      - dependency-name: "go.opentelemetry.io/collector"
+      - dependency-name: "go.opentelemetry.io/collector/model"


### PR DESCRIPTION
Usage of a temporary fork for go.opentelemetry.io/collector requires special handling of OpenTelemetry-related modules. Instead of having dependabot try to auto-update them, we should investigate them on a case-by-case basis.

Closes #1512