### PR TITLE
Show curl progress bar agent install

### DIFF
--- a/production/grafanacloud-install.sh
+++ b/production/grafanacloud-install.sh
@@ -108,7 +108,7 @@ detect_package_system() {
 
 # install_deb downloads and installs the deb package of the Grafana Agent.
 install_deb() {
-  curl -fsL "${DEB_URL}" -o /tmp/grafana-agent.deb || fatal 'Failed to download package'
+  curl -fL# "${DEB_URL}" -o /tmp/grafana-agent.deb || fatal 'Failed to download package'
   sudo dpkg -i /tmp/grafana-agent.deb
   rm /tmp/grafana-agent.deb
 }


### PR DESCRIPTION
Adds progress bar and removes silent flag when downloading agent deb package via curl. Sometimes the deb package can take a long time to download - Showing progress bar will provide feedback on when the agent install will complete.

Ref: https://curl.se/docs/manpage.html