### PR TITLE
metrics/instance: use native Prometheus capabilities to get rw timestamp

### DIFF
--- a/pkg/metrics/instance/instance.go
+++ b/pkg/metrics/instance/instance.go
@@ -12,7 +12,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -250,8 +249,6 @@ type Instance struct {
 
 	reg    prometheus.Registerer
 	newWal walStorageFactory
-
-	vc *MetricValueCollector
 }
 
 // New creates a new Instance with a directory for storing the WAL. The instance
@@ -269,8 +266,6 @@ func New(reg prometheus.Registerer, cfg Config, walDir string, logger log.Logger
 }
 
 func newInstance(cfg Config, reg prometheus.Registerer, logger log.Logger, newWal walStorageFactory) (*Instance, error) {
-	vc := NewMetricValueCollector(prometheus.DefaultGatherer, remoteWriteMetricName)
-
 	hostname, err := Hostname()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get hostname: %w", err)
@@ -279,7 +274,6 @@ func newInstance(cfg Config, reg prometheus.Registerer, logger log.Logger, newWa
 	i := &Instance{
 		cfg:        cfg,
 		logger:     logger,
-		vc:         vc,
 		hostFilter: NewHostFilter(hostname, cfg.HostFilterRelabelConfigs),
 
 		reg:    reg,
@@ -710,33 +704,11 @@ func (i *Instance) getRemoteWriteTimestamp() int64 {
 		return timestamp.FromTime(time.Now())
 	}
 
-	lbls := make([]string, len(i.cfg.RemoteWrite))
-	for idx := 0; idx < len(lbls); idx++ {
-		lbls[idx] = i.cfg.RemoteWrite[idx].Name
-	}
-
-	vals, err := i.vc.GetValues("remote_name", lbls...)
-	if err != nil {
-		level.Error(i.logger).Log("msg", "could not get remote write timestamps", "err", err)
+	if i.remoteStore == nil {
+		// Instance still being initialized; start at 0.
 		return 0
 	}
-	if len(vals) == 0 {
-		return 0
-	}
-
-	// We use the lowest value from the metric since we don't want to delete any
-	// segments from the WAL until they've been written by all of the remote_write
-	// configurations.
-	ts := int64(math.MaxInt64)
-	for _, val := range vals {
-		ival := int64(val)
-		if ival < ts {
-			ts = ival
-		}
-	}
-
-	// Convert to the millisecond precision which is used by the WAL
-	return ts * 1000
+	return i.remoteStore.LowestSentTimestamp()
 }
 
 // walStorage is an interface satisfied by wal.Storage, and created for testing.
@@ -778,79 +750,6 @@ func getHash(data interface{}) (string, error) {
 	}
 	hash := md5.Sum(bytes)
 	return hex.EncodeToString(hash[:]), nil
-}
-
-// MetricValueCollector wraps around a Gatherer and provides utilities for
-// pulling metric values from a given metric name and label matchers.
-//
-// This is used by the agent instances to find the most recent timestamp
-// successfully remote_written to for purposes of safely truncating the WAL.
-//
-// MetricValueCollector is only intended for use with Gauges and Counters.
-type MetricValueCollector struct {
-	g     prometheus.Gatherer
-	match string
-}
-
-// NewMetricValueCollector creates a new MetricValueCollector.
-func NewMetricValueCollector(g prometheus.Gatherer, match string) *MetricValueCollector {
-	return &MetricValueCollector{
-		g:     g,
-		match: match,
-	}
-}
-
-// GetValues looks through all the tracked metrics and returns all values
-// for metrics that match some key value pair.
-func (vc *MetricValueCollector) GetValues(label string, labelValues ...string) ([]float64, error) {
-	vals := []float64{}
-
-	families, err := vc.g.Gather()
-	if err != nil {
-		return nil, err
-	}
-
-	for _, family := range families {
-		if !strings.Contains(family.GetName(), vc.match) {
-			continue
-		}
-
-		for _, m := range family.GetMetric() {
-			matches := false
-			for _, l := range m.GetLabel() {
-				if l.GetName() != label {
-					continue
-				}
-
-				v := l.GetValue()
-				for _, match := range labelValues {
-					if match == v {
-						matches = true
-						break
-					}
-				}
-				break
-			}
-			if !matches {
-				continue
-			}
-
-			var value float64
-			if m.Gauge != nil {
-				value = m.Gauge.GetValue()
-			} else if m.Counter != nil {
-				value = m.Counter.GetValue()
-			} else if m.Untyped != nil {
-				value = m.Untyped.GetValue()
-			} else {
-				return nil, errors.New("tracking unexpected metric type")
-			}
-
-			vals = append(vals, value)
-		}
-	}
-
-	return vals, nil
 }
 
 func newScrapeManager(logger log.Logger, app storage.Appendable) *scrape.Manager {

--- a/pkg/metrics/instance/instance.go
+++ b/pkg/metrics/instance/instance.go
@@ -41,10 +41,6 @@ func init() {
 	config.DefaultRemoteWriteConfig.SendExemplars = true
 }
 
-var (
-	managerMtx sync.Mutex
-)
-
 // Default configuration values
 var (
 	DefaultConfig = Config{
@@ -750,6 +746,8 @@ func getHash(data interface{}) (string, error) {
 	hash := md5.Sum(bytes)
 	return hex.EncodeToString(hash[:]), nil
 }
+
+var managerMtx sync.Mutex
 
 func newScrapeManager(logger log.Logger, app storage.Appendable) *scrape.Manager {
 	// scrape.NewManager modifies a global variable in Prometheus. To avoid a

--- a/pkg/metrics/instance/instance.go
+++ b/pkg/metrics/instance/instance.go
@@ -42,8 +42,7 @@ func init() {
 }
 
 var (
-	remoteWriteMetricName = "queue_highest_sent_timestamp_seconds"
-	managerMtx            sync.Mutex
+	managerMtx sync.Mutex
 )
 
 // Default configuration values

--- a/pkg/metrics/instance/instance_test.go
+++ b/pkg/metrics/instance/instance_test.go
@@ -291,64 +291,6 @@ func TestInstance_Recreate(t *testing.T) {
 	})
 }
 
-func TestMetricValueCollector(t *testing.T) {
-	r := prometheus.NewRegistry()
-	vc := NewMetricValueCollector(r, "this_should_be_tracked")
-
-	shouldTrack := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "this_should_be_tracked",
-		ConstLabels: prometheus.Labels{
-			"foo": "bar",
-		},
-	})
-
-	shouldTrack.Set(12345)
-
-	shouldNotTrack := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "this_should_not_be_tracked",
-	})
-
-	r.MustRegister(shouldTrack, shouldNotTrack)
-
-	vals, err := vc.GetValues("foo", "bar")
-	require.NoError(t, err)
-	require.Equal(t, []float64{12345}, vals)
-}
-
-func TestRemoteWriteMetricInterceptor_AllValues(t *testing.T) {
-	r := prometheus.NewRegistry()
-	vc := NewMetricValueCollector(r, "track")
-
-	valueA := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "this_should_be_tracked",
-		ConstLabels: prometheus.Labels{
-			"foo": "bar",
-		},
-	})
-	valueA.Set(12345)
-
-	valueB := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "track_this_too",
-		ConstLabels: prometheus.Labels{
-			"foo": "bar",
-		},
-	})
-	valueB.Set(67890)
-
-	shouldNotReturn := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "track_this_but_label_does_not_match",
-		ConstLabels: prometheus.Labels{
-			"foo": "nope",
-		},
-	})
-
-	r.MustRegister(valueA, valueB, shouldNotReturn)
-
-	vals, err := vc.GetValues("foo", "bar")
-	require.NoError(t, err)
-	require.Equal(t, []float64{12345, 67890}, vals)
-}
-
 func getTestServer(t *testing.T) (addr string, closeFunc func()) {
 	t.Helper()
 


### PR DESCRIPTION
#### PR Description
Prometheus Agent extended the API of remote.Storage to natively find the lowest sent timestamp across all queues. Now that we're embedding a new enough version of Prometheus, we can remove our old hack of collecting metrics to find the timestamp.

#### Which issue(s) this PR fixes
N/A

#### Notes to the Reviewer
CHANGELOG not needed; this is a purely internal change to simplify some of our code.

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
