### PR TITLE
Set timeout 2x as default HTTP Transport for agentctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,9 @@ Main (unreleased)
 
 - Replace agent-bare.yaml K8s sample Deployment with StatefulSet (@hjet)
 
+- Improve error message for `agentctl` when timeout happens calling
+  `cloud-config` command (@marctc)
+
 ### Bugfixes
 
 - Ensure singleton integrations are honored in v2 integrations (@mattdurham)

--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
@@ -452,13 +453,13 @@ config that may be used with this agent.`,
 				return fmt.Errorf("--api-key must be provided")
 			}
 
-			cli := grafanacloud.NewClient(nil, apiKey, apiURL)
-
 			// setting timeout 2x as the default HTTP transport timeout (30s)
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
-			defer cancel()
+			httpClient := &http.Client{
+				Timeout: time.Minute,
+			}
+			cli := grafanacloud.NewClient(httpClient, apiKey, apiURL)
 
-			cfg, err := cli.AgentConfig(ctx, stackID)
+			cfg, err := cli.AgentConfig(context.Background(), stackID)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "could not retrieve agent cloud config: %s\n", err)
 				os.Exit(1)

--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -454,7 +454,8 @@ config that may be used with this agent.`,
 
 			cli := grafanacloud.NewClient(nil, apiKey, apiURL)
 
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+			// setting timeout 2x as the default HTTP transport timeout (30s)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
 			defer cancel()
 
 			cfg, err := cli.AgentConfig(ctx, stackID)


### PR DESCRIPTION
#### PR Description

Setting a timeout for the execution of this command lower than the HTTP Transport timeout (30s) 
leads to show messages that are not very clear to users when this is exceeded as it explained in 
#1410. This PR increased the timeout for  `context.Background()` to 60s. 

Change this would  trigger first the HTTP client transport timeout first and show 
`dial tcp: i/o timeout`.

#### Which issue(s) this PR fixes

Fixes #1410 