### PR TITLE
Enable integrations-next by default in agent-bare.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@ Main (unreleased)
 - Improve error message for `agentctl` when timeout happens calling
   `cloud-config` command (@marctc)
 
-- Enable integrations-next by default in agent-bare.yaml (@hjet)
+- Enable integrations-next by default in agent-bare.yaml. Please note #1262 (@hjet)
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,8 @@ Main (unreleased)
 - Improve error message for `agentctl` when timeout happens calling
   `cloud-config` command (@marctc)
 
+- Enable integrations-next by default in agent-bare.yaml (@hjet)
+
 ### Bugfixes
 
 - Ensure singleton integrations are honored in v2 integrations (@mattdurham)

--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -75,6 +75,7 @@ spec:
       containers:
       - args:
         - -config.file=/etc/agent/agent.yaml
+        - -enable-features=integrations-next
         - -server.http.address=0.0.0.0:80
         command:
         - /bin/agent

--- a/production/kubernetes/build/templates/bare/main.jsonnet
+++ b/production/kubernetes/build/templates/bare/main.jsonnet
@@ -19,6 +19,9 @@ local containerPort = k.core.v1.containerPort;
       ],
     ) +
     agent.withConfigHash(false) +
+    agent.withArgsMixin({
+      'enable-features': 'integrations-next'
+    },) +
     // add dummy config or else will fail
     agent.withAgentConfig({
       server: { log_level: 'error' },


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This enables `integrations-next` by default in `agent-bare.yaml`. 

Please note: https://github.com/grafana/agent/issues/1262

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated