### PR TITLE
builds for linux/ppc64le

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ Main (unreleased)
 
 - Introduced endpoint that accepts remote_write requests and pushes metrics data directly into an instance's WAL. (@tpaschalis)
 
+- Added builds for linux/ppc64le. (@aklyachkin)
+
 ### Enhancements
 
 - Tracing: Exporters can now be configured to use OAuth. (@canuteson)

--- a/tools/release-note.md
+++ b/tools/release-note.md
@@ -28,7 +28,11 @@ The Windows installer is provided as a [release asset](https://github.com/grafan
 
 #### Binary
 
-We provide precompiled binary executables for the most common operating systems. Choose from the assets below for your matching operating system. Example for the `linux` operating system on `amd64`:
+We provide precompiled binary executables for the most common operating systems. Choose from the assets below for your matching operating system. 
+
+Note: ppc64le builds are currently considered secondary release targets and do not have the same level of support and testing as other platforms.
+
+Example for the `linux` operating system on `amd64`:
 
 ```bash
 # download the binary


### PR DESCRIPTION
#### PR Description

This PR adds builds for linux/ppc64le into Makefile. 

#### Notes to the Reviewer

It builds correctly on my test system and creates all the packages. Obvious change to add a new architecture. ppc64le is in use on some of the biggest supercomputers (https://www.top500.org/lists/top500/2021/11/ - Nr. 2 and 3), on OpenPOWER (https://osuosl.org/, CERN, etc.) and on IBM Power Systems.

#### PR Checklist

- [X] CHANGELOG updated
- [ ] Documentation added - no platform-dependent documentation
- [ ] Tests updated - no platform-dependent tests
