### PR TITLE
Issue 1536 - OTLP Default Port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,9 @@ Main (unreleased)
 
 ### Bugfixes
 
+- Fix Kubernetes manifests to use port `4317` for OTLP instead of the previous 
+  `55680` in line with the default exposed port in the agent.
+
 - Ensure singleton integrations are honored in v2 integrations (@mattdurham)
 
 - Tracing: `const_labels` is now correctly parsed in the remote write exporter.

--- a/production/kubernetes/agent-traces.yaml
+++ b/production/kubernetes/agent-traces.yaml
@@ -73,9 +73,9 @@ spec:
     protocol: TCP
     targetPort: 9411
   - name: grafana-agent-traces-otlp
-    port: 55680
+    port: 4317
     protocol: TCP
-    targetPort: 55680
+    targetPort: 4317
   - name: grafana-agent-traces-opencensus
     port: 55678
     protocol: TCP
@@ -132,7 +132,7 @@ spec:
         - containerPort: 9411
           name: zipkin
           protocol: TCP
-        - containerPort: 55680
+        - containerPort: 4317
           name: otlp
           protocol: TCP
         - containerPort: 55678

--- a/production/kubernetes/build/templates/traces/main.jsonnet
+++ b/production/kubernetes/build/templates/traces/main.jsonnet
@@ -25,7 +25,7 @@ local newPort(name, portNumber, protocol='TCP') =
       newPort('zipkin', 9411, 'TCP'),
 
       // OTLP
-      newPort('otlp', 55680, 'TCP'),
+      newPort('otlp', 4317, 'TCP'),
 
       // Opencensus
       newPort('opencensus', 55678, 'TCP'),


### PR DESCRIPTION
#### PR Description

Move default OTLP port to `4317` in line with the default exposed by `agent` binary.

#### Which issue(s) this PR fixes

Fixes https://github.com/grafana/agent/issues/1536

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
