### PR TITLE
[RFC] pkg/config: use -config.file.type flag to derive file type

### DIFF
--- a/docs/user/configuration/dynamic-config.md
+++ b/docs/user/configuration/dynamic-config.md
@@ -21,19 +21,23 @@ on what functions are available.
 
 ## Configuration
 
-Location of the dynamic configuration is used via the feature flag `dynamic-config`, then it will use `-config.dynamic-config-path` to
-load the configuration for dynamic configuration.
+Dynamic configuration files can be used by passing `-config.file.type=dynamic
+-enable-features=dynamic-config,integrations-next`. When these flags are
+passed, the file referred to `-config.file` will be loaded as a dynamic
+configuration file.
+
+Dynamic configuration files are YAML which conform the following schema:
 
 ```yaml
-# Sources to pull template values 
-datasources: 
+# Sources to pull template values
+datasources:
   [- <sources_config>]
 
 # Locations to use searching for templates, the system does NOT look into subdirectories. Follows gomplate schema
 # from [gomplate datasources](https://docs.gomplate.ca/datasources/). File and S3/GCP templates are currently supported
-template_paths: 
+template_paths:
   [ - string ]
-  
+
 # Filters allow you to override the default naming convention
 
 agent_filter:            string # defaults to agent-*.yml
@@ -43,14 +47,14 @@ metrics_instance_filter: string # defaults to metrics_instances-*.yml
 integrations_filter:     string # defaults to integrations-*.yml
 logs_filter:             string # defaults to logs-*.yml
 traces_filter:           string # defaults to traces-*.yml
-``` 
+```
 
 ### sources_config
 ```yaml
 # Name of the source to use when templating
 name: string
 
-# Path to datasource using schema from [gomplate datasources](https://docs.gomplate.ca/datasources/) 
+# Path to datasource using schema from [gomplate datasources](https://docs.gomplate.ca/datasources/)
 url: string
 
 ```
@@ -115,7 +119,7 @@ The default filter is `metrics_instances-*.yml`. Any metric instances are append
 
 ### Integrations
 
-The default filter is `integrations-*.yml`, these support more than one file, and multiple integrations can be defined in a file. Do not assume any order of loading for integrations. For any integration that is a singleton, loading multiple of those will result in an error. 
+The default filter is `integrations-*.yml`, these support more than one file, and multiple integrations can be defined in a file. Do not assume any order of loading for integrations. For any integration that is a singleton, loading multiple of those will result in an error.
 
 [Reference]({{< relref "./integrations/" >}})
 

--- a/docs/user/configuration/flags.md
+++ b/docs/user/configuration/flags.md
@@ -34,6 +34,7 @@ Valid feature names are:
 ## Configuration file
 
 * `-config.file`: Path to the configuration file to load. May be an HTTP(s) URL when the `remote-configs` feature is enabled
+* `-config.file.type`: Type of file which `-config.file` refers to (default `yaml`). Valid values are `yaml` and `dynamic`.
 * `-config.expand-env`: Expand environment variables in the loaded configuration file
 * `-config.enable-read-api`: Enables the `/-/config` and `/agent/api/v1/configs/{name}` API endpoints to print YAML configuration
 
@@ -46,9 +47,8 @@ These flags require the `remote-configs` feature to be enabled:
 
 ### Dynamic Configuration
 
-These flags require the `dynamic-config` feature to be enabled:
-
-* `-config.dynamic-config-path`: Path to the dynamic configuration file (mutually exclusive with setting `-config.file`).
+The `dynamic-config` and `integrations-next` features must be enabled when
+`-config.file.type` is set to `dynamic`.
 
 ## Server
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,13 @@ var (
 	}
 )
 
+var (
+	fileTypeYAML    = "yaml"
+	fileTypeDynamic = "dynamic"
+
+	fileTypes = []string{fileTypeYAML, fileTypeDynamic}
+)
+
 // DefaultConfig holds default settings for all the subsystems.
 var DefaultConfig = Config{
 	// All subsystems with a DefaultConfig should be listed here.
@@ -307,34 +314,47 @@ func getenv(name string) string {
 // to the flagset before parsing them with the values specified by
 // args.
 func Load(fs *flag.FlagSet, args []string) (*Config, error) {
-	return load(fs, args, func(url string, expand bool, c *Config) error {
-		if features.Enabled(fs, featRemoteConfigs) {
-			return LoadRemote(url, expand, c)
+	return load(fs, args, func(path, fileType string, expandArgs bool, c *Config) error {
+		switch fileType {
+		case fileTypeYAML:
+			if features.Enabled(fs, featRemoteConfigs) {
+				return LoadRemote(path, expandArgs, c)
+			}
+			return LoadFile(path, expandArgs, c)
+		case fileTypeDynamic:
+			if !features.Enabled(fs, featDynamicConfig) {
+				return fmt.Errorf("feature %q must be enabled to use file type %s", featDynamicConfig, fileTypeDynamic)
+			} else if !features.Enabled(fs, featIntegrationsNext) {
+				return fmt.Errorf("feature %q must be enabled to use file type %s", featIntegrationsNext, fileTypeDynamic)
+			} else if features.Enabled(fs, featRemoteConfigs) {
+				return fmt.Errorf("feature %q can not be enabled with file type %s", featRemoteConfigs, fileTypeDynamic)
+			} else if expandArgs {
+				return fmt.Errorf("-config.expand-env can not be used with file type %s", fileTypeDynamic)
+			}
+
+			return LoadDynamicConfiguration(path, expandArgs, c)
+		default:
+			return fmt.Errorf("unknown file type %q. accepted values: %s", fileType, strings.Join(fileTypes, ", "))
 		}
-		if features.Enabled(fs, featDynamicConfig) && !features.Enabled(fs, featIntegrationsNext) {
-			return fmt.Errorf("integrations-next must be enabled for dynamic configuration to work")
-		} else if features.Enabled(fs, featDynamicConfig) {
-			return LoadDynamicConfiguration(url, expand, c)
-		}
-		return LoadFile(url, expand, c)
 	})
 }
 
+type loaderFunc func(path string, fileType string, expandArgs bool, target *Config) error
+
 // load allows for tests to inject a function for retrieving the config file that
 // doesn't require having a literal file on disk.
-func load(fs *flag.FlagSet, args []string, loader func(string, bool, *Config) error) (*Config, error) {
+func load(fs *flag.FlagSet, args []string, loader loaderFunc) (*Config, error) {
 	var (
 		cfg = DefaultConfig
 
-		printVersion      bool
-		file              string
-		dynamicConfigPath string
-		configExpandEnv   bool
+		printVersion    bool
+		file            string
+		fileType        string
+		configExpandEnv bool
 	)
 
 	fs.StringVar(&file, "config.file", "", "configuration file to load")
-	fs.StringVar(&dynamicConfigPath, "config.dynamic-config-path", "", "dynamic configuration path that points to a single configuration file supports file:// or s3:// protocols. Must be enabled by -enable-features=dynamic-config,integrations-next")
-
+	fs.StringVar(&fileType, "config.file.type", "yaml", fmt.Sprintf("Type of file pointed to by -config.file flag. Supported values: %s. %s requires dynamic-config and integrations-next features to be enabled.", strings.Join(fileTypes, ", "), fileTypeDynamic))
 	fs.BoolVar(&printVersion, "version", false, "Print this build's version information")
 	fs.BoolVar(&configExpandEnv, "config.expand-env", false, "Expands ${var} in config according to the values of the environment variables.")
 	cfg.RegisterFlags(fs)
@@ -349,15 +369,9 @@ func load(fs *flag.FlagSet, args []string, loader func(string, bool, *Config) er
 		os.Exit(0)
 	}
 
-	if features.Enabled(fs, featDynamicConfig) {
-		if dynamicConfigPath == "" {
-			return nil, fmt.Errorf("-config.dynamic-config-path flag required when using dynamic configuration")
-		} else if err := loader(dynamicConfigPath, configExpandEnv, &cfg); err != nil {
-			return nil, fmt.Errorf("error loading dynamic configuration file %s: %w", dynamicConfigPath, err)
-		}
-	} else if file == "" {
+	if file == "" {
 		return nil, fmt.Errorf("-config.file flag required")
-	} else if err := loader(file, configExpandEnv, &cfg); err != nil {
+	} else if err := loader(file, fileType, configExpandEnv, &cfg); err != nil {
 		return nil, fmt.Errorf("error loading config file %s: %w", file, err)
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -31,7 +31,7 @@ metrics:
     scrape_timeout: 33s`
 
 	fs := flag.NewFlagSet("test", flag.ExitOnError)
-	c, err := load(fs, []string{"-config.file", "test"}, func(_ string, _ bool, c *Config) error {
+	c, err := load(fs, []string{"-config.file", "test"}, func(_, _ string, _ bool, c *Config) error {
 		return LoadBytes([]byte(cfg), false, c)
 	})
 	require.NoError(t, err)
@@ -47,7 +47,7 @@ func TestConfig_ConfigAPIFlag(t *testing.T) {
 	t.Run("Disabled", func(t *testing.T) {
 		cfg := `{}`
 		fs := flag.NewFlagSet("test", flag.ExitOnError)
-		c, err := load(fs, []string{"-config.file", "test"}, func(_ string, _ bool, c *Config) error {
+		c, err := load(fs, []string{"-config.file", "test"}, func(_, _ string, _ bool, c *Config) error {
 			return LoadBytes([]byte(cfg), false, c)
 		})
 		require.NoError(t, err)
@@ -57,7 +57,7 @@ func TestConfig_ConfigAPIFlag(t *testing.T) {
 	t.Run("Enabled", func(t *testing.T) {
 		cfg := `{}`
 		fs := flag.NewFlagSet("test", flag.ExitOnError)
-		c, err := load(fs, []string{"-config.file", "test", "-config.enable-read-api"}, func(_ string, _ bool, c *Config) error {
+		c, err := load(fs, []string{"-config.file", "test", "-config.enable-read-api"}, func(_, _ string, _ bool, c *Config) error {
 			return LoadBytes([]byte(cfg), false, c)
 		})
 		require.NoError(t, err)
@@ -81,7 +81,7 @@ metrics:
 	}
 
 	fs := flag.NewFlagSet("test", flag.ExitOnError)
-	c, err := load(fs, []string{"-config.file", "test"}, func(_ string, _ bool, c *Config) error {
+	c, err := load(fs, []string{"-config.file", "test"}, func(_, _ string, _ bool, c *Config) error {
 		return LoadBytes([]byte(cfg), false, c)
 	})
 	require.NoError(t, err)
@@ -104,7 +104,7 @@ metrics:
 	t.Setenv("SCRAPE_TIMEOUT", "33s")
 
 	fs := flag.NewFlagSet("test", flag.ExitOnError)
-	c, err := load(fs, []string{"-config.file", "test"}, func(_ string, _ bool, c *Config) error {
+	c, err := load(fs, []string{"-config.file", "test"}, func(_, _ string, _ bool, c *Config) error {
 		return LoadBytes([]byte(cfg), true, c)
 	})
 	require.NoError(t, err)
@@ -121,7 +121,7 @@ metrics:
 	expect := labels.Labels{{Name: "foo", Value: "${1}"}}
 
 	fs := flag.NewFlagSet("test", flag.ExitOnError)
-	c, err := load(fs, []string{"-config.file", "test"}, func(_ string, _ bool, c *Config) error {
+	c, err := load(fs, []string{"-config.file", "test"}, func(_, _ string, _ bool, c *Config) error {
 		return LoadBytes([]byte(cfg), true, c)
 	})
 	require.NoError(t, err)
@@ -141,7 +141,7 @@ metrics:
 		"-config.expand-env",
 	}
 
-	c, err := load(fs, args, func(_ string, _ bool, c *Config) error {
+	c, err := load(fs, args, func(_, _ string, _ bool, c *Config) error {
 		return LoadBytes([]byte(cfg), false, c)
 	})
 	require.NoError(t, err)
@@ -224,7 +224,7 @@ traces:
 
 	for _, tc := range tests {
 		fs := flag.NewFlagSet("test", flag.ExitOnError)
-		_, err := load(fs, []string{"-config.file", "test"}, func(_ string, _ bool, c *Config) error {
+		_, err := load(fs, []string{"-config.file", "test"}, func(_, _ string, _ bool, c *Config) error {
 			return LoadBytes([]byte(tc.cfg), false, c)
 		})
 
@@ -320,7 +320,7 @@ traces:
 
 	for _, tc := range tests {
 		fs := flag.NewFlagSet("test", flag.ExitOnError)
-		_, err := load(fs, []string{"-config.file", "test"}, func(_ string, _ bool, c *Config) error {
+		_, err := load(fs, []string{"-config.file", "test"}, func(_, _ string, _ bool, c *Config) error {
 			return LoadBytes([]byte(tc.cfg), false, c)
 		})
 
@@ -381,7 +381,7 @@ logs:
           source: filename
           expression: '\\temp\\Logs\\(?P<log_app>.+?)\\'`
 	fs := flag.NewFlagSet("test", flag.ExitOnError)
-	myCfg, err := load(fs, []string{"-config.file", "test"}, func(_ string, _ bool, c *Config) error {
+	myCfg, err := load(fs, []string{"-config.file", "test"}, func(_, _ string, _ bool, c *Config) error {
 		return LoadBytes([]byte(cfg), true, c)
 	})
 	require.NoError(t, err)

--- a/pkg/config/integrations_test.go
+++ b/pkg/config/integrations_test.go
@@ -19,7 +19,7 @@ integrations:
     enabled: true`
 
 	fs := flag.NewFlagSet("test", flag.ExitOnError)
-	c, err := load(fs, []string{"-config.file", "test"}, func(_ string, _ bool, c *Config) error {
+	c, err := load(fs, []string{"-config.file", "test"}, func(_, _ string, _ bool, c *Config) error {
 		return LoadBytes([]byte(cfg), false, c)
 	})
 	require.NoError(t, err)
@@ -37,7 +37,7 @@ integrations:
       enable: false`
 
 	fs := flag.NewFlagSet("test", flag.ExitOnError)
-	c, err := load(fs, []string{"-config.file", "test", "-enable-features=integrations-next"}, func(_ string, _ bool, c *Config) error {
+	c, err := load(fs, []string{"-config.file", "test", "-enable-features=integrations-next"}, func(_, _ string, _ bool, c *Config) error {
 		return LoadBytes([]byte(cfg), false, c)
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
Introduce a -config.file.type which acts as a hint for the contents of the config file being loaded. This then replaces the -config.dynamic-config-path flag with -config.file.type=dynamic.

Having a dedicated flag for file should be useful for avoiding having too many flags which load a config file and allows us to change the default type in the future (i.e., potentially default to `-config.file.type=flow` in the far future based on the success #1538).

Since the code change is small enough, I'm opening this as an RFC instead of proposing the flag as an issue. If nobody is opposed, we can merge as-is.