### PR TITLE
Update flags used for metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /.vscode
 /.eventcache
 vendor
+data-agent
 
 /cmd/agent/agent
 /cmd/agentctl/agentctl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ Main (unreleased)
 
 - The deprecated `-prometheus.*` flags have been removed in favor of
   their `-metrics.*` counterparts. The `-prometheus.*` flags were first
-  deprecated in v0.19.0.
+  deprecated in v0.19.0. (@rfratto)
 
 ### Deprecations
 
@@ -139,13 +139,13 @@ Main (unreleased)
   properly provide these custom mounts. (@rfratto)
 
 - Flags accidentally prefixed with `-metrics.service..` (two `.` in a row) have
-  now been fixed to only have one `.`.
+  now been fixed to only have one `.`. (@rfratto)
 
 ### Other changes
 
 - The `-metrics.wal-directory` flag and `metrics.wal_directory` config option
   will now default to `data-agent/`, the same default WAL directory as
-  Prometheus Agent.
+  Prometheus Agent. (@rfratto)
 
 v0.23.0 (2022-01-13)
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,12 @@ Main (unreleased)
 - Flags accidentally prefixed with `-metrics.service..` (two `.` in a row) have
   now been fixed to only have one `.`.
 
+### Other changes
+
+- The `-metrics.wal-directory` flag and `metrics.wal_directory` config option
+  will now default to `data-agent/`, the same default WAL directory as
+  Prometheus Agent.
+
 v0.23.0 (2022-01-13)
 --------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,9 @@ Main (unreleased)
   `integrations-next`-enabled configuration files. This change also changes
   integration names shown in metric labels. (@rfratto)
 
-- The already-deprecated `-prometheus.*` flags have been removed in favor of
-  their `-metrics.*` counterparts.
+- The deprecated `-prometheus.*` flags have been removed in favor of
+  their `-metrics.*` counterparts. The `-prometheus.*` flags were first
+  deprecated in v0.19.0.
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ Main (unreleased)
   `integrations-next`-enabled configuration files. This change also changes
   integration names shown in metric labels. (@rfratto)
 
+- The already-deprecated `-prometheus.*` flags have been removed in favor of
+  their `-metrics.*` counterparts.
+
 ### Deprecations
 
 - Most fields in the `server` block of the configuration file are
@@ -107,7 +110,7 @@ Main (unreleased)
 
 ### Bugfixes
 
-- Fix Kubernetes manifests to use port `4317` for OTLP instead of the previous 
+- Fix Kubernetes manifests to use port `4317` for OTLP instead of the previous
   `55680` in line with the default exposed port in the agent.
 
 - Ensure singleton integrations are honored in v2 integrations (@mattdurham)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,9 @@ Main (unreleased)
   name>`. This is not a breaking change as it was previously impossible to
   properly provide these custom mounts. (@rfratto)
 
+- Flags accidentally prefixed with `-metrics.service..` (two `.` in a row) have
+  now been fixed to only have one `.`.
+
 v0.23.0 (2022-01-13)
 --------------------
 

--- a/cmd/agent/Dockerfile
+++ b/cmd/agent/Dockerfile
@@ -22,4 +22,4 @@ COPY --from=build /src/agent/cmd/agent/agent /bin/agent
 COPY cmd/agent/agent-local-config.yaml /etc/agent/agent.yaml
 
 ENTRYPOINT ["/bin/agent"]
-CMD ["--config.file=/etc/agent/agent.yaml", "--prometheus.wal-directory=/etc/agent/data"]
+CMD ["--config.file=/etc/agent/agent.yaml", "--metrics.wal-directory=/etc/agent/data"]

--- a/cmd/agent/Dockerfile.buildx
+++ b/cmd/agent/Dockerfile.buildx
@@ -31,4 +31,4 @@ COPY --from=build /src/agent/cmd/agent/agent /bin/agent
 COPY cmd/agent/agent-local-config.yaml /etc/agent/agent.yaml
 
 ENTRYPOINT ["/bin/agent"]
-CMD ["--config.file=/etc/agent/agent.yaml", "--prometheus.wal-directory=/etc/agent/data"]
+CMD ["--config.file=/etc/agent/agent.yaml", "--metrics.wal-directory=/etc/agent/data"]

--- a/docs/user/getting-started/_index.md
+++ b/docs/user/getting-started/_index.md
@@ -40,7 +40,7 @@ to the end of the `docker run` command:
 - `--config.file=path/to/agent.yaml`, replacing the argument with the full path
   to your Agent's YAML configuration file.
 
-- `--prometheus.wal-directory=/tmp/agent/data`, replacing `/tmp/agent/data` with
+- `--metrics.wal-directory=/tmp/agent/data`, replacing `/tmp/agent/data` with
   the directory you wish to use for storing data. Note that `/tmp` may get
   deleted by most operating systems after a reboot.
 

--- a/pkg/metrics/agent.go
+++ b/pkg/metrics/agent.go
@@ -105,14 +105,11 @@ func (c *Config) ApplyDefaults() error {
 // RegisterFlags defines flags corresponding to the Config.
 func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.RegisterFlagsWithPrefix("metrics.", f)
-
-	// Register deprecated flag names.
-	c.RegisterFlagsWithPrefix("prometheus.", f)
 }
 
 // RegisterFlagsWithPrefix defines flags with the provided prefix.
 func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
-	f.StringVar(&c.WALDir, prefix+"wal-directory", "", "base directory to store the WAL in")
+	f.StringVar(&c.WALDir, prefix+"wal-directory", DefaultConfig.WALDir, "base directory to store the WAL in")
 	f.DurationVar(&c.WALCleanupAge, prefix+"wal-cleanup-age", DefaultConfig.WALCleanupAge, "remove abandoned (unused) WALs older than this")
 	f.DurationVar(&c.WALCleanupPeriod, prefix+"wal-cleanup-period", DefaultConfig.WALCleanupPeriod, "how often to check for abandoned WALs")
 	f.DurationVar(&c.InstanceRestartBackoff, prefix+"instance-restart-backoff", DefaultConfig.InstanceRestartBackoff, "how long to wait before restarting a failed Prometheus instance")

--- a/pkg/metrics/agent.go
+++ b/pkg/metrics/agent.go
@@ -26,6 +26,7 @@ import (
 var DefaultConfig = Config{
 	Global:                 instance.DefaultGlobalConfig,
 	InstanceRestartBackoff: instance.DefaultBasicManagerConfig.InstanceRestartBackoff,
+	WALDir:                 "data-agent/",
 	WALCleanupAge:          DefaultCleanupAge,
 	WALCleanupPeriod:       DefaultCleanupPeriod,
 	ServiceConfig:          cluster.DefaultConfig,

--- a/pkg/metrics/cluster/config.go
+++ b/pkg/metrics/cluster/config.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"flag"
+	"strings"
 	"time"
 
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
@@ -58,5 +59,9 @@ func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.DurationVar(&c.ClusterReshardEventTimeout, prefix+"cluster-reshard-event-timeout", time.Second*30, "timeout for the cluster reshard. Timeout of 0s disables timeout.")
 	c.KVStore.RegisterFlagsWithPrefix(prefix+"config-store.", "configurations/", f)
 	c.Lifecycler.RegisterFlagsWithPrefix(prefix, f, util_log.Logger)
-	c.Client.GRPCClientConfig.RegisterFlagsWithPrefix(prefix, f)
+
+	// GRPCClientConfig.RegisterFlags expects that prefix does not end in a ".",
+	// unlike all other flags.
+	noDotPrefix := strings.TrimSuffix(prefix, ".")
+	c.Client.GRPCClientConfig.RegisterFlagsWithPrefix(noDotPrefix, f)
 }


### PR DESCRIPTION
#### PR Description

This PR contains a number of small changes:

* Remove the already-deprecated `-prometheus.*` flags in favor of their `-metrics.*` counterparts. `-prometheus.*` flags were first deprecated in v0.19.0.
* Fix an issue where some flags were prefixed with `-metrics.service..` instead of `-metrics.service.` (two dots instead of the intended one).
* Default the WAL directory for metrics to `data-agent/`, which is the same default value Prometheus Agent uses.

#### Which issue(s) this PR fixes

N/A 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
