### PR TITLE
Makefile: ensure that Docker containers can be canceled by the user

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -19,7 +19,7 @@ steps:
     image: golangci/golangci-lint:v1.44
     commands:
       - apt-get update -y && apt-get install -y libsystemd-dev
-      - make lint
+      - make DOCKER_OPTS="" lint
 
 ---
 kind: pipeline
@@ -53,8 +53,8 @@ steps:
       - tar -C /usr/local -xzf go1.17.6.linux-amd64.tar.gz
       - rm go1.17.6.linux-amd64.tar.gz
       - export PATH=$PATH:/usr/local/go/bin
-      - make cmd/agent/agent cmd/agentctl/agentctl cmd/agent-operator/agent-operator tools/crow/grafana-agent-crow tools/smoke/grafana-agent-smoke
-      - make K8S_USE_DOCKER_NETWORK=1 DRONE=true BUILD_IN_CONTAINER=false test
+      - make DOCKER_OPTS="" cmd/agent/agent cmd/agentctl/agentctl cmd/agent-operator/agent-operator tools/crow/grafana-agent-crow tools/smoke/grafana-agent-smoke
+      - make DOCKER_OPTS="" K8S_USE_DOCKER_NETWORK=1 DRONE=true BUILD_IN_CONTAINER=false test
 
 depends_on:
   - Lint
@@ -87,7 +87,7 @@ steps:
       - tar -C /usr/local -xzf go1.17.6.linux-amd64.tar.gz
       - rm go1.17.6.linux-amd64.tar.gz
       - export PATH=$PATH:/usr/local/go/bin
-      - make DRONE=true BUILD_IN_CONTAINER=false dist
+      - make DOCKER_OPTS="" DRONE=true BUILD_IN_CONTAINER=false dist
 depends_on:
   - Test
 ---
@@ -129,11 +129,11 @@ steps:
       - docker buildx create --name multiarch --driver docker-container --use
       - export RELEASE_TAG=${DRONE_TAG}
       - export IMAGE_BRANCH_TAG=${DRONE_BRANCH}
-      - make DRONE=true CROSS_BUILD=true BUILD_IN_CONTAINER=true RELEASE_BUILD=true agent-image
-      - make DRONE=true CROSS_BUILD=true BUILD_IN_CONTAINER=true RELEASE_BUILD=true agentctl-image
-      - make DRONE=true CROSS_BUILD=true BUILD_IN_CONTAINER=true RELEASE_BUILD=true agent-operator-image
-      - make DRONE=true CROSS_BUILD=true BUILD_IN_CONTAINER=true RELEASE_BUILD=true grafana-agent-crow-image
-      - make DRONE=true CROSS_BUILD=true BUILD_IN_CONTAINER=true RELEASE_BUILD=true agent-smoke-image
+      - make DOCKER_OPTS="" DRONE=true CROSS_BUILD=true BUILD_IN_CONTAINER=true RELEASE_BUILD=true agent-image
+      - make DOCKER_OPTS="" DRONE=true CROSS_BUILD=true BUILD_IN_CONTAINER=true RELEASE_BUILD=true agentctl-image
+      - make DOCKER_OPTS="" DRONE=true CROSS_BUILD=true BUILD_IN_CONTAINER=true RELEASE_BUILD=true agent-operator-image
+      - make DOCKER_OPTS="" DRONE=true CROSS_BUILD=true BUILD_IN_CONTAINER=true RELEASE_BUILD=true grafana-agent-crow-image
+      - make DOCKER_OPTS="" DRONE=true CROSS_BUILD=true BUILD_IN_CONTAINER=true RELEASE_BUILD=true agent-smoke-image
       - docker buildx rm multiarch
 
 depends_on:
@@ -238,7 +238,7 @@ steps:
       - export PATH=$PATH:/usr/local/go/bin
       - GO111MODULE=on go get -u github.com/mitchellh/gox github.com/tcnksm/ghr
       - export PATH="$(go env GOPATH)/bin:$PATH"
-      - make -j4 BUILD_IN_CONTAINER=false RELEASE_BUILD=true RELEASE_TAG=${DRONE_TAG} publish
+      - make -j4 DOCKER_OPTS="" BUILD_IN_CONTAINER=false RELEASE_BUILD=true RELEASE_TAG=${DRONE_TAG} publish
 depends_on:
   - Dist
 
@@ -272,6 +272,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: ea470a0d3e024c8fac2963e5868574414e6b957839b7f1db29fc22fa356eccc1
+hmac: b17f2bff49e193cd026749acfde841ab567d203ea183d7a389010e0190794d66
 
 ...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,6 @@ jobs:
           disk-root: "C:"
       if: ${{ matrix.platform == 'windows-latest' }}
     - name: Build
-      run: make GOFLAGS="-tags=netgo,nodocker" BUILD_IN_CONTAINER=false cmd/agent/agent cmd/agentctl/agentctl cmd/agent-operator/agent-operator
+      run: make DOCKER_OPTS="" GOFLAGS="-tags=netgo,nodocker" BUILD_IN_CONTAINER=false cmd/agent/agent cmd/agentctl/agentctl cmd/agent-operator/agent-operator
     - name: Test
-      run: make GOFLAGS="-tags=netgo,nodocker" BUILD_IN_CONTAINER=false test
+      run: make DOCKER_OPTS="" GOFLAGS="-tags=netgo,nodocker" BUILD_IN_CONTAINER=false test

--- a/.github/workflows/test_packages.yml
+++ b/.github/workflows/test_packages.yml
@@ -19,4 +19,4 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Test
-      run: make test-packages
+      run: DOCKER_OPTS="" make test-packages

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ SHELL = /usr/bin/env bash
 # Docker image info.
 IMAGE_PREFIX ?= grafana
 IMAGE_BRANCH_TAG ?= main
+DOCKER_OPTS ?= -it
 
 ifeq ($(RELEASE_TAG),)
 IMAGE_TAG ?= $(shell ./tools/image-tag)
@@ -126,7 +127,7 @@ endif
 
 # seego is used by default when running bare make commands such as `make dist` this uses an image that has all the necessary libraries to cross build
 #	when using drone the docker in docker is more problematic so instead drone uses seego has the base image then calls make running "raw" commands
-seego = docker run --init --rm -it $(MOD_MOUNT) -v "$(CURDIR):$(CURDIR)" -w "$(CURDIR)" -e "CGO_ENABLED=$$CGO_ENABLED" -e "GOOS=$$GOOS" -e "GOARCH=$$GOARCH" -e "GOARM=$$GOARM" -e "GOMIPS=$$GOMIPS"  grafana/agent/seego
+seego = docker run --init --rm $(DOCKER_OPTS) $(MOD_MOUNT) -v "$(CURDIR):$(CURDIR)" -w "$(CURDIR)" -e "CGO_ENABLED=$$CGO_ENABLED" -e "GOOS=$$GOOS" -e "GOARCH=$$GOARCH" -e "GOARM=$$GOARM" -e "GOMIPS=$$GOMIPS"  grafana/agent/seego
 docker-build = docker build $(DOCKER_BUILD_FLAGS)
 ifeq ($(CROSS_BUILD),true)
 DOCKERFILE = Dockerfile.buildx
@@ -149,7 +150,7 @@ crds: build-image/.uptodate
 ifeq ($(BUILD_IN_CONTAINER),true)
 	mkdir -p $(shell pwd)/.pkg
 	mkdir -p $(shell pwd)/.cache
-	docker run --init --rm -it \
+	docker run --init --rm $(DOCKER_OPTS) \
 		-v $(shell pwd)/.cache:/go/cache \
 		-v $(shell pwd)/.pkg:/go/pkg \
 		-v $(shell pwd):/src/agent \
@@ -173,7 +174,7 @@ touch-protos:
 ifeq ($(BUILD_IN_CONTAINER),true)
 	mkdir -p $(shell pwd)/.pkg
 	mkdir -p $(shell pwd)/.cache
-	docker run --init --rm -it \
+	docker run --init --rm $(DOCKER_OPTS) \
 		-v $(shell pwd)/.cache:/go/cache \
 		-v $(shell pwd)/.pkg:/go/pkg \
 		-v $(shell pwd):/src/agent \
@@ -317,7 +318,7 @@ dist/agent-windows-installer.exe: dist/agent-windows-amd64.exe
 	cp LICENSE ./packaging/windows
 ifeq ($(BUILD_IN_CONTAINER),true)
 	docker build -t windows_installer ./packaging/windows
-	docker run --init --rm -it -v "${PWD}:/home" -e VERSION=${RELEASE_TAG} windows_installer
+	docker run --init --rm $(DOCKER_OPTS) -v "${PWD}:/home" -e VERSION=${RELEASE_TAG} windows_installer
 else
 
 	makensis -V4 -DVERSION=${RELEASE_TAG} -DOUT="../../dist/grafana-agent-installer.exe" ./packaging/windows/install_script.nsis
@@ -395,7 +396,7 @@ dist-packages: dist-packages-amd64 dist-packages-arm64 dist-packages-armv6 dist-
 
 ifeq ($(BUILD_IN_CONTAINER), true)
 
-container_make = docker run --init --rm -it \
+container_make = docker run --init --rm $(DOCKER_OPTS) \
 	-v $(shell pwd):/src/agent:delegated \
 	-e RELEASE_TAG=$(RELEASE_TAG) \
 	-e SRC_PATH=/src/agent \

--- a/packaging/linux_packages_test.go
+++ b/packaging/linux_packages_test.go
@@ -65,6 +65,7 @@ func buildPackages(t *testing.T) {
 	cmd.Env = append(
 		os.Environ(),
 		"RELEASE_TAG=v0.0.0",
+		"DOCKER_OPTS=",
 	)
 	cmd.Dir = root
 	cmd.Stderr = os.Stderr

--- a/packaging/linux_packages_test.go
+++ b/packaging/linux_packages_test.go
@@ -67,7 +67,6 @@ func buildPackages(t *testing.T) {
 		"RELEASE_TAG=v0.0.0",
 	)
 	cmd.Dir = root
-	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 	require.NoError(t, cmd.Run())
 }

--- a/packaging/linux_packages_test.go
+++ b/packaging/linux_packages_test.go
@@ -67,6 +67,7 @@ func buildPackages(t *testing.T) {
 		"RELEASE_TAG=v0.0.0",
 	)
 	cmd.Dir = root
+	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 	require.NoError(t, cmd.Run())
 }


### PR DESCRIPTION
It was previously impossible to abort a `make` target which ran a docker container. Ensuring that the `--init -it` flags are passed to docker run guarantee that the user can always Ctrl+C to cancel the target and the container.

This commit also adds the `--rm` flag to commands that were missing it.