### PR TITLE
Makefile: support release candidate versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,11 @@ else
 IMAGE_TAG ?= $(RELEASE_TAG)
 
 # If $RELEASE_TAG is from a stable release we want to update :latest instead of
-# a branch.
+# a branch. Otherwise, we want to re-use the versioned tag name.
 ifeq (,$(findstring -rc.,$(RELEASE_TAG)))
 IMAGE_BRANCH_TAG = latest
+else
+IMAGE_BRANCH_TAG = $(RELEASE_TAG)
 endif
 
 endif


### PR DESCRIPTION
$IMAGE_BRANCH_TAG must not be an empty string for building images. This defaults $IMAGE_BRANCH_TAG for release candidates to be the same as $RELEASE_TAG.

This will redundantly cause the image to be tagged twice as $RELEASE_TAG, but will avoid build errors.