### PR TITLE
Add metrics to url of targets and instances endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Enhancements
+
+- Add `metrics` prefix to the url of list instances and list targets endpoints (@marctc)
+
 v0.24.0 (2022-04-07)
 --------------------
 

--- a/docs/user/api/_index.md
+++ b/docs/user/api/_index.md
@@ -161,7 +161,7 @@ Response on success:
 ### List current running instances
 
 ```
-GET /agent/api/v1/instances
+GET /agent/api/v1/metrics/instances
 ```
 
 Status code: 200 on success.
@@ -179,7 +179,7 @@ Response on success:
 ### List current scrape targets
 
 ```
-GET /agent/api/v1/targets
+GET /agent/api/v1/metrics/targets
 ```
 
 This endpoint collects all targets known to the Agent across all running

--- a/docs/user/getting-started/install-agent-on-windows.md
+++ b/docs/user/getting-started/install-agent-on-windows.md
@@ -15,7 +15,7 @@ found by either:
 
 ## Installation
 
-After installation, ensure that you can reach `http://localhost:12345/-/healthy` and `http://localhost:12345/agent/api/v1/targets`.
+After installation, ensure that you can reach `http://localhost:12345/-/healthy` and `http://localhost:12345/agent/api/v1/metrics/targets`.
 
 After installation, you can adjust `C:\Program Files\Grafana Agent\agent-config.yaml` to meet your specific needs. After changing the configuration file, the Grafana Agent service must be restarted to load changes to the configuration.
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -59,7 +59,7 @@ type prometheusClient struct {
 }
 
 func (c *prometheusClient) Instances(ctx context.Context) ([]string, error) {
-	url := fmt.Sprintf("%s/agent/api/v1/instances", c.addr)
+	url := fmt.Sprintf("%s/agent/api/v1/metrics/instances", c.addr)
 
 	resp, err := c.doRequest(ctx, "GET", url, nil)
 	if err != nil {

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -20,8 +20,12 @@ import (
 func (a *Agent) WireAPI(r *mux.Router) {
 	a.cluster.WireAPI(r)
 
+	// Backwards compatible endpoints. Use endpoints with `metrics` prefix instead
 	r.HandleFunc("/agent/api/v1/instances", a.ListInstancesHandler).Methods("GET")
 	r.HandleFunc("/agent/api/v1/targets", a.ListTargetsHandler).Methods("GET")
+
+	r.HandleFunc("/agent/api/v1/metrics/instances", a.ListInstancesHandler).Methods("GET")
+	r.HandleFunc("/agent/api/v1/metrics/targets", a.ListTargetsHandler).Methods("GET")
 	r.HandleFunc("/agent/api/v1/metrics/instance/{instance}/write", a.PushMetricsHandler).Methods("POST")
 }
 

--- a/pkg/metrics/http_test.go
+++ b/pkg/metrics/http_test.go
@@ -25,7 +25,7 @@ func TestAgent_ListInstancesHandler(t *testing.T) {
 	require.NoError(t, err)
 	defer a.Stop()
 
-	r := httptest.NewRequest("GET", "/agent/api/v1/instances", nil)
+	r := httptest.NewRequest("GET", "/agent/api/v1/metrics/instances", nil)
 
 	t.Run("no instances", func(t *testing.T) {
 		rr := httptest.NewRecorder()
@@ -64,7 +64,7 @@ func TestAgent_ListTargetsHandler(t *testing.T) {
 	a.mm, err = instance.NewModalManager(prometheus.NewRegistry(), a.logger, mockManager, instance.ModeDistinct)
 	require.NoError(t, err)
 
-	r := httptest.NewRequest("GET", "/agent/api/v1/targets", nil)
+	r := httptest.NewRequest("GET", "/agent/api/v1/metrics/targets", nil)
 
 	t.Run("scrape manager not ready", func(t *testing.T) {
 		mockManager.ListInstancesFunc = func() map[string]instance.ManagedInstance {


### PR DESCRIPTION
#### PR Description

We want to extend our API to also return the list of instances and targets when
agent is configured to use logs and traces. In order to be consistent with the naming,
the urls for `/agent/api/v1/instances` and `/agent/api/v1/targets` are renamed to 
include the `metrics` word on them.

#### Which issue(s) this PR fixes
Partially fixes #1404