### PR TITLE
Add Logs system API endpoints for instance and targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Features
+
+- Add HTTP endpoints to fetch active instances and targets for the Logs subsytem.
+  (@marctc)
+
+
 v0.24.0 (2022-04-07)
 --------------------
 

--- a/cmd/agent/entrypoint.go
+++ b/cmd/agent/entrypoint.go
@@ -185,6 +185,7 @@ func (ep *Entrypoint) wire(mux *mux.Router, grpc *grpc.Server) {
 	ep.promMetrics.WireGRPC(grpc)
 
 	ep.integrations.WireAPI(mux)
+	ep.lokiLogs.WireAPI(mux)
 
 	mux.HandleFunc("/-/healthy", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/docs/user/api/_index.md
+++ b/docs/user/api/_index.md
@@ -245,6 +245,75 @@ Status code: 204 on success, 400 for bad requests related to the provided
 instance or POST payload format and content, 500 for cases where appending
 to the WAL failed.
 
+### List current running instances of logs subsystem
+
+```
+GET /agent/api/v1/logs/instances
+```
+
+Status code: 200 on success.
+Response on success:
+
+```
+{
+  "status": "success",
+  "data": [
+    <strings of instance names that are currently running>
+  ]
+}
+```
+
+### List current scrape targets of logs subsystem
+
+```
+GET /agent/api/v1/logs/targets
+```
+
+This endpoint collects all logs subsystem targets known to the Agent across 
+all running instances. Only targets being scraped from Promtail will be returned. 
+
+The `labels` fields shows the labels that will be added to metrics from the
+target, while the `discovered_labels` field shows all labels found during
+service discovery.
+
+Status code: 200 on success.
+Response on success:
+
+```
+{
+  "status": "success",
+  "data": [
+    {
+      "instance": "default",
+      "target_group": "varlogs",
+      "type": "File",
+      "labels": {
+        "job": "varlogs"
+      },
+      "discovered_labels": {
+        "__address__": "localhost",
+        "__path__": "/var/log/*log",
+        "job": "varlogs"
+      },
+      "ready": true,
+      "details": {
+        "/var/log/alternatives.log": 13386,
+        "/var/log/apport.log": 0,
+        "/var/log/auth.log": 37009,
+        "/var/log/bootstrap.log": 107347,
+        "/var/log/dpkg.log": 374420,
+        "/var/log/faillog": 0,
+        "/var/log/fontconfig.log": 11629,
+        "/var/log/gpu-manager.log": 1541,
+        "/var/log/kern.log": 782582,
+        "/var/log/lastlog": 0,
+        "/var/log/syslog": 788450
+      }
+    }
+  ]
+}
+```
+
 ### Reload configuration file (beta)
 
 This endpoint is currently in beta and may have issues. Please open any issues

--- a/go.mod
+++ b/go.mod
@@ -22,8 +22,8 @@ require (
 	github.com/google/dnsmasq_exporter v0.0.0-00010101000000-000000000000
 	github.com/google/go-jsonnet v0.18.0
 	github.com/gorilla/mux v1.8.0
-	github.com/grafana/dskit v0.0.0-20220211095946-19921f863583
-	github.com/grafana/loki v1.6.2-0.20220309062021-295dc4ee3ae5
+	github.com/grafana/dskit v0.0.0-20220329084310-1c453c3bd57a
+	github.com/grafana/loki v1.6.2-0.20220411060007-0315102c34cf
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/hairyhenderson/go-fsimpl v0.0.0-20211102185733-857ee891b38d
 	github.com/hairyhenderson/gomplate/v3 v3.0.0
@@ -235,7 +235,7 @@ require (
 	github.com/gophercloud/gophercloud v0.24.0 // indirect
 	github.com/gosimple/slug v1.12.0 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
-	github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2 // indirect
+	github.com/grafana/regexp v0.0.0-20220304100321-149c8afcd6cb // indirect
 	github.com/grobie/gomemcache v0.0.0-20201204163352-08d7c80fcac6 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/hairyhenderson/toml v0.4.2-0.20210923231440-40456b8e66cf // indirect

--- a/go.sum
+++ b/go.sum
@@ -1270,11 +1270,15 @@ github.com/grafana/dskit v0.0.0-20210908150159-fcf48cb19aa4/go.mod h1:m3eHzwe5IT
 github.com/grafana/dskit v0.0.0-20211021180445-3bd016e9d7f1/go.mod h1:uPG2nyK4CtgNDmWv7qyzYcdI+S90kHHRWvHnBtEMBXM=
 github.com/grafana/dskit v0.0.0-20220211095946-19921f863583 h1:UCLVGNJptATClAs4CbClVmn5b4YA6GTG3yoCObI//0E=
 github.com/grafana/dskit v0.0.0-20220211095946-19921f863583/go.mod h1:q51XdMLLHNZJSG6KOGujC20ed2OoLFdx0hBmOEVfRs0=
+github.com/grafana/dskit v0.0.0-20220329084310-1c453c3bd57a h1:UZ2OOtCZl2SbNrvE1BK0+3e35jryMiIuQIVikMfM1IM=
+github.com/grafana/dskit v0.0.0-20220329084310-1c453c3bd57a/go.mod h1:q51XdMLLHNZJSG6KOGujC20ed2OoLFdx0hBmOEVfRs0=
 github.com/grafana/go-gelf v0.0.0-20211112153804-126646b86de8 h1:aEOagXOTqtN9gd4jiDuP/5a81HdoJBqkVfn8WaxbsK4=
 github.com/grafana/go-gelf v0.0.0-20211112153804-126646b86de8/go.mod h1:QAvS2C7TtQRhhv9Uf/sxD+BUhpkrPFm5jK/9MzUiDCY=
 github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85/go.mod h1:crI9WX6p0IhrqB+DqIUHulRW853PaNFf7o4UprV//3I=
 github.com/grafana/loki v1.6.2-0.20220309062021-295dc4ee3ae5 h1:PkPYLj9XdiW2JEWyTkOffqoaDDVflDGrsbkDW8mmNwc=
 github.com/grafana/loki v1.6.2-0.20220309062021-295dc4ee3ae5/go.mod h1:mlPs2KxK9e6MkOS+i1ubsHywU7wjuo8i8zltLQRz0mo=
+github.com/grafana/loki v1.6.2-0.20220411060007-0315102c34cf h1:BGlyo3GR2a8shuhwhpdq9bHKhwyenraUiFFDiMPy65I=
+github.com/grafana/loki v1.6.2-0.20220411060007-0315102c34cf/go.mod h1:ws3kKUScE0E+jUyG2/0bNTx5BIImu7RYpd89O4CL4gY=
 github.com/grafana/mongodb_exporter v0.20.8-0.20211006135645-bef0f0239601 h1:k5VTHQsSBs/jZHWXEvjW4QAZQcoGB3QQfUN0XGA6pB4=
 github.com/grafana/mongodb_exporter v0.20.8-0.20211006135645-bef0f0239601/go.mod h1:BCuUaP3ocoAYt8xTCaCXWQttYMKUcg36e1NJdOEx56M=
 github.com/grafana/mysqld_exporter v0.12.2-0.20201015182516-5ac885b2d38a h1:D5NSR64/6xMXnSFD9y1m1DPYIcBcHvtfeuI9/M/0qtI=
@@ -1291,6 +1295,8 @@ github.com/grafana/prometheus v1.8.2-0.20220323140010-4d4232590b14 h1:CoQuhNNbuZ
 github.com/grafana/prometheus v1.8.2-0.20220323140010-4d4232590b14/go.mod h1:migbGwmKEePaplmYVdzPdztaUixU4oxRYUg/JG9tiDU=
 github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2 h1:uirlL/j72L93RhV4+mkWhjv0cov2I0MIgPOG9rMDr1k=
 github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
+github.com/grafana/regexp v0.0.0-20220304100321-149c8afcd6cb h1:wwzNkyaQwcXCzQuKoWz3lwngetmcyg+EhW0fF5lz73M=
+github.com/grafana/regexp v0.0.0-20220304100321-149c8afcd6cb/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/grafana/statsd_exporter v0.18.1-0.20211118164740-8e806158da0b h1:eFIcZ12/3lY1Ot3PJswIhfKTOQTAZzYA1eN+XR8Ijho=
 github.com/grafana/statsd_exporter v0.18.1-0.20211118164740-8e806158da0b/go.mod h1:N4Z1+iSqc9rnxlT1N8Qn3l65Vzb5t4Uq0jpg8nxyhio=
 github.com/grafana/tail v0.0.0-20201004203643-7aa4e4a91f03 h1:fGgFrAraMB0BaPfYumu+iulfDXwHm+GFyHA4xEtBqI8=

--- a/pkg/logs/http.go
+++ b/pkg/logs/http.go
@@ -13,7 +13,6 @@ import (
 
 // WireAPI adds API routes to the provided mux router.
 func (l *Logs) WireAPI(r *mux.Router) {
-
 	r.HandleFunc("/agent/api/v1/logs/instances", l.ListInstancesHandler).Methods("GET")
 	r.HandleFunc("/agent/api/v1/logs/targets", l.ListTargetsHandler).Methods("GET")
 }
@@ -42,7 +41,6 @@ func (l *Logs) ListTargetsHandler(w http.ResponseWriter, r *http.Request) {
 		allTagets[instName] = inst.promtail.ActiveTargets()
 	}
 	listTargetsHandler(allTagets).ServeHTTP(w, r)
-
 }
 
 func listTargetsHandler(targets map[string]TargetSet) http.Handler {

--- a/pkg/logs/http.go
+++ b/pkg/logs/http.go
@@ -39,7 +39,7 @@ func (l *Logs) ListTargetsHandler(w http.ResponseWriter, r *http.Request) {
 	instances := l.instances
 	allTagets := make(map[string]TargetSet, len(instances))
 	for instName, inst := range instances {
-		allTagets[instName] = inst.ActiveTargets()
+		allTagets[instName] = inst.promtail.ActiveTargets()
 	}
 	listTargetsHandler(allTagets).ServeHTTP(w, r)
 

--- a/pkg/logs/http.go
+++ b/pkg/logs/http.go
@@ -1,0 +1,86 @@
+package logs
+
+import (
+	"net/http"
+	"sort"
+
+	"github.com/go-kit/log/level"
+	"github.com/gorilla/mux"
+	"github.com/grafana/agent/pkg/metrics/cluster/configapi"
+	"github.com/grafana/loki/clients/pkg/promtail/targets/target"
+	"github.com/prometheus/common/model"
+)
+
+// WireAPI adds API routes to the provided mux router.
+func (l *Logs) WireAPI(r *mux.Router) {
+
+	r.HandleFunc("/agent/api/v1/logs/instances", l.ListInstancesHandler).Methods("GET")
+	r.HandleFunc("/agent/api/v1/logs/targets", l.ListTargetsHandler).Methods("GET")
+}
+
+// ListInstancesHandler writes the set of currently running instances to the http.ResponseWriter.
+func (l *Logs) ListInstancesHandler(w http.ResponseWriter, _ *http.Request) {
+	instances := l.instances
+	instanceNames := make([]string, 0, len(instances))
+	for instance := range instances {
+		instanceNames = append(instanceNames, instance)
+	}
+	sort.Strings(instanceNames)
+
+	err := configapi.WriteResponse(w, http.StatusOK, instanceNames)
+	if err != nil {
+		level.Error(l.l).Log("msg", "failed to write response", "err", err)
+	}
+}
+
+// ListTargetsHandler retrieves the full set of targets across all instances and shows
+// information on them.
+func (l *Logs) ListTargetsHandler(w http.ResponseWriter, r *http.Request) {
+	instances := l.instances
+	allTagets := make(map[string]TargetSet, len(instances))
+	for instName, inst := range instances {
+		allTagets[instName] = inst.ActiveTargets()
+	}
+	listTargetsHandler(allTagets).ServeHTTP(w, r)
+
+}
+
+func listTargetsHandler(targets map[string]TargetSet) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		resp := ListTargetsResponse{}
+		for instance, tset := range targets {
+			for key, targets := range tset {
+				for _, tgt := range targets {
+					resp = append(resp, TargetInfo{
+						InstanceName:     instance,
+						TargetGroup:      key,
+						Type:             tgt.Type(),
+						DiscoveredLabels: tgt.DiscoveredLabels(),
+						Labels:           tgt.Labels(),
+						Ready:            tgt.Ready(),
+						Details:          tgt.Details(),
+					})
+				}
+			}
+		}
+		_ = configapi.WriteResponse(rw, http.StatusOK, resp)
+	})
+}
+
+// TargetSet is a set of targets for an individual scraper.
+type TargetSet map[string][]target.Target
+
+// ListTargetsResponse is returned by the ListTargetsHandler.
+type ListTargetsResponse []TargetInfo
+
+// TargetInfo describes a specific target.
+type TargetInfo struct {
+	InstanceName string `json:"instance"`
+	TargetGroup  string `json:"target_group"`
+
+	Type             target.TargetType `json:"type"`
+	Labels           model.LabelSet    `json:"labels"`
+	DiscoveredLabels model.LabelSet    `json:"discovered_labels"`
+	Ready            bool              `json:"ready"`
+	Details          interface{}       `json:"details"`
+}

--- a/pkg/logs/http_test.go
+++ b/pkg/logs/http_test.go
@@ -1,0 +1,178 @@
+package logs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cortexproject/cortex/pkg/util/test"
+	"github.com/grafana/agent/pkg/util"
+	"github.com/grafana/loki/clients/pkg/promtail/targets/target"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestAgent_ListInstancesHandler(t *testing.T) {
+	cfgText := util.Untab(`
+configs:
+- name: instance-a
+  positions:
+    filename: /tmp/positions.yaml
+  clients:
+	- url: http://127.0.0.1:80/loki/api/v1/push
+	`)
+
+	var cfg Config
+
+	logger := util.TestLogger(t)
+	l, err := New(prometheus.NewRegistry(), &cfg, logger)
+	require.NoError(t, err)
+	defer l.Stop()
+
+	r := httptest.NewRequest("GET", "/agent/api/v1/logs/instances", nil)
+
+	t.Run("no instances", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		l.ListInstancesHandler(rr, r)
+		expect := `{"status":"success","data":[]}`
+		require.Equal(t, expect, rr.Body.String())
+	})
+
+	dec := yaml.NewDecoder(strings.NewReader(cfgText))
+	dec.SetStrict(true)
+	require.NoError(t, dec.Decode(&cfg))
+	t.Run("non-empty", func(t *testing.T) {
+		require.NoError(t, l.ApplyConfig(&cfg))
+
+		expect := `{"status":"success","data":["instance-a"]}`
+		test.Poll(t, time.Second, true, func() interface{} {
+			rr := httptest.NewRecorder()
+			l.ListInstancesHandler(rr, r)
+			return expect == rr.Body.String()
+		})
+	})
+}
+
+func TestAgent_ListTargetsHandler(t *testing.T) {
+	cfgText := util.Untab(`
+configs:
+- name: instance-a
+  positions:
+    filename: /tmp/positions.yaml
+  clients:
+	- url: http://127.0.0.1:80/loki/api/v1/push
+	`)
+
+	var cfg Config
+	dec := yaml.NewDecoder(strings.NewReader(cfgText))
+	dec.SetStrict(true)
+	require.NoError(t, dec.Decode(&cfg))
+
+	logger := util.TestLogger(t)
+	l, err := New(prometheus.NewRegistry(), &cfg, logger)
+	require.NoError(t, err)
+	defer l.Stop()
+
+	r := httptest.NewRequest("GET", "/agent/api/v1/logs/targets", nil)
+
+	t.Run("scrape manager not ready", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		l.ListTargetsHandler(rr, r)
+		expect := `{"status": "success", "data": []}`
+		require.JSONEq(t, expect, rr.Body.String())
+		require.Equal(t, http.StatusOK, rr.Result().StatusCode)
+	})
+
+	t.Run("scrape manager targets", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		targets := map[string]TargetSet{
+			"instance-a": mockActiveTargets(),
+		}
+		listTargetsHandler(targets).ServeHTTP(rr, r)
+		expect := `{
+			"status": "success",
+			"data": [
+				{
+				  "instance": "instance-a",
+				  "target_group": "varlogs",
+				  "type": "File",
+				  "labels": {
+					"job": "varlogs"
+				  },
+				  "discovered_labels": {
+					"__address__": "localhost",
+					"__path__": "/var/log/*log",
+					"job": "varlogs"
+				  },
+				  "ready": true,
+				  "details": {
+					"/var/log/alternatives.log": 13386,
+					"/var/log/apport.log": 0,
+					"/var/log/auth.log": 37009,
+					"/var/log/bootstrap.log": 107347,
+					"/var/log/dpkg.log": 374420,
+					"/var/log/faillog": 0,
+					"/var/log/fontconfig.log": 11629,
+					"/var/log/gpu-manager.log": 1541,
+					"/var/log/kern.log": 782582,
+					"/var/log/lastlog": 0,
+					"/var/log/syslog": 788450
+				  }
+				}
+			]  
+		}`
+		require.JSONEq(t, expect, rr.Body.String())
+		require.Equal(t, http.StatusOK, rr.Result().StatusCode)
+	})
+}
+
+func mockActiveTargets() map[string][]target.Target {
+	return map[string][]target.Target{
+		"varlogs": {&mockTarget{}},
+	}
+}
+
+type mockTarget struct {
+}
+
+func (mt *mockTarget) Type() target.TargetType {
+	return target.TargetType("File")
+}
+
+func (mt *mockTarget) DiscoveredLabels() model.LabelSet {
+	return map[model.LabelName]model.LabelValue{
+		"__address__": "localhost",
+		"__path__":    "/var/log/*log",
+		"job":         "varlogs",
+	}
+}
+
+func (mt *mockTarget) Labels() model.LabelSet {
+	return map[model.LabelName]model.LabelValue{
+		"job": "varlogs",
+	}
+}
+
+func (mt *mockTarget) Ready() bool {
+	return true
+}
+
+func (d *mockTarget) Details() interface{} {
+	return map[string]int{
+		"/var/log/alternatives.log": 13386,
+		"/var/log/apport.log":       0,
+		"/var/log/auth.log":         37009,
+		"/var/log/bootstrap.log":    107347,
+		"/var/log/dpkg.log":         374420,
+		"/var/log/faillog":          0,
+		"/var/log/fontconfig.log":   11629,
+		"/var/log/gpu-manager.log":  1541,
+		"/var/log/kern.log":         782582,
+		"/var/log/lastlog":          0,
+		"/var/log/syslog":           788450,
+	}
+}

--- a/pkg/logs/http_test.go
+++ b/pkg/logs/http_test.go
@@ -161,7 +161,7 @@ func (mt *mockTarget) Ready() bool {
 	return true
 }
 
-func (d *mockTarget) Details() interface{} {
+func (mt *mockTarget) Details() interface{} {
 	return map[string]int{
 		"/var/log/alternatives.log": 13386,
 		"/var/log/apport.log":       0,

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/loki/clients/pkg/promtail/client"
 	"github.com/grafana/loki/clients/pkg/promtail/config"
 	"github.com/grafana/loki/clients/pkg/promtail/server"
-	"github.com/grafana/loki/clients/pkg/promtail/targets/target"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/version"
 )
@@ -203,11 +202,6 @@ func (i *Instance) SendEntry(entry api.Entry, dur time.Duration) bool {
 	}
 
 	return false
-}
-
-// ActiveTargets returns active targets of the instance
-func (i *Instance) ActiveTargets() map[string][]target.Target {
-	return i.promtail.ActiveTargets()
 }
 
 // Stop stops the Promtail instance.

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/loki/clients/pkg/promtail/client"
 	"github.com/grafana/loki/clients/pkg/promtail/config"
 	"github.com/grafana/loki/clients/pkg/promtail/server"
+	"github.com/grafana/loki/clients/pkg/promtail/targets/target"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/version"
 )
@@ -202,6 +203,11 @@ func (i *Instance) SendEntry(entry api.Entry, dur time.Duration) bool {
 	}
 
 	return false
+}
+
+// ActiveTargets returns active targets of the instance
+func (i *Instance) ActiveTargets() map[string][]target.Target {
+	return i.promtail.ActiveTargets()
 }
 
 // Stop stops the Promtail instance.

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -170,13 +170,14 @@ func (i *Instance) ApplyConfig(c *InstanceConfig) error {
 		return nil
 	}
 
+	clientMetrics := client.NewMetrics(i.reg, nil)
 	p, err := promtail.New(config.Config{
 		ServerConfig:    server.Config{Disable: true},
 		ClientConfigs:   c.ClientConfigs,
 		PositionsConfig: c.PositionsConfig,
 		ScrapeConfig:    c.ScrapeConfig,
 		TargetConfig:    c.TargetConfig,
-	}, false, i.reg, promtail.WithLogger(i.log), promtail.WithRegisterer(i.reg))
+	}, clientMetrics, false, promtail.WithLogger(i.log), promtail.WithRegisterer(i.reg))
 	if err != nil {
 		return fmt.Errorf("unable to create logs instance: %w", err)
 	}


### PR DESCRIPTION
#### PR Description

Add HTTP endpoints to fetch active instances and targets for the Logs subsytem.

-  `GET /agent/api/v1/logs/instances`
-  `GET /agent/api/v1/logs/targets`

#### Which issue(s) this PR fixes
Related to https://github.com/grafana/agent/issues/1404

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
