### PR TITLE
Update base image and go

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -49,9 +49,9 @@ steps:
       - gem install --no-document fpm
       - rm -r /usr/local/go
       - mkdir -p /usr/local/go/bin
-      - wget -q https://golang.org/dl/go1.17.6.linux-amd64.tar.gz
-      - tar -C /usr/local -xzf go1.17.6.linux-amd64.tar.gz
-      - rm go1.17.6.linux-amd64.tar.gz
+      - wget -q https://golang.org/dl/go1.18.linux-amd64.tar.gz
+      - tar -C /usr/local -xzf go1.18.linux-amd64.tar.gz
+      - rm go1.18.linux-amd64.tar.gz
       - export PATH=$PATH:/usr/local/go/bin
       - make DOCKER_OPTS="" cmd/agent/agent cmd/agentctl/agentctl cmd/agent-operator/agent-operator tools/crow/grafana-agent-crow tools/smoke/grafana-agent-smoke
       - make DOCKER_OPTS="" K8S_USE_DOCKER_NETWORK=1 DRONE=true BUILD_IN_CONTAINER=false test
@@ -83,9 +83,9 @@ steps:
       - gem install --no-document fpm
       - rm -r /usr/local/go
       - mkdir -p /usr/local/go/bin
-      - wget -q https://golang.org/dl/go1.17.6.linux-amd64.tar.gz
-      - tar -C /usr/local -xzf go1.17.6.linux-amd64.tar.gz
-      - rm go1.17.6.linux-amd64.tar.gz
+      - wget -q https://golang.org/dl/go1.18.linux-amd64.tar.gz
+      - tar -C /usr/local -xzf go1.18.linux-amd64.tar.gz
+      - rm go1.18.linux-amd64.tar.gz
       - export PATH=$PATH:/usr/local/go/bin
       - make DOCKER_OPTS="" DRONE=true BUILD_IN_CONTAINER=false dist
 depends_on:
@@ -226,15 +226,15 @@ steps:
     commands:
       - apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release
       - curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
-      - add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian buster stable"
+      - add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian bullseye stable"
       - apt-get update &&  apt-get install -y rubygems rpm nsis docker-ce docker-ce-cli containerd.io gettext
       - docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
       - gem install --no-document fpm
       - rm -r /usr/local/go
       - mkdir -p /usr/local/go/bin
-      - wget -q https://golang.org/dl/go1.17.6.linux-amd64.tar.gz
-      - tar -C /usr/local -xzf go1.17.6.linux-amd64.tar.gz
-      - rm go1.17.6.linux-amd64.tar.gz
+      - wget -q https://golang.org/dl/go1.18.linux-amd64.tar.gz
+      - tar -C /usr/local -xzf go1.18.linux-amd64.tar.gz
+      - rm go1.18.linux-amd64.tar.gz
       - export PATH=$PATH:/usr/local/go/bin
       - GO111MODULE=on go get -u github.com/mitchellh/gox github.com/tcnksm/ghr
       - export PATH="$(go env GOPATH)/bin:$PATH"
@@ -272,6 +272,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: b17f2bff49e193cd026749acfde841ab567d203ea183d7a389010e0190794d66
+hmac: 9b6c80530677e3b0f7bbd038300e50f6c810f679aca4e9a966bab7053ff24128
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -67,32 +67,6 @@ volumes:
 ---
 kind: pipeline
 type: docker
-name: Dist
-platform:
-  os: linux
-  arch: amd64
-trigger:
-  ref:
-    - refs/tags/v*
-
-steps:
-  - name: distribute
-    image: rfratto/seego
-    commands:
-      - apt-get update &&  apt-get install -y rubygems rpm nsis
-      - gem install --no-document fpm
-      - rm -r /usr/local/go
-      - mkdir -p /usr/local/go/bin
-      - wget -q https://golang.org/dl/go1.18.linux-amd64.tar.gz
-      - tar -C /usr/local -xzf go1.18.linux-amd64.tar.gz
-      - rm go1.18.linux-amd64.tar.gz
-      - export PATH=$PATH:/usr/local/go/bin
-      - make DOCKER_OPTS="" DRONE=true BUILD_IN_CONTAINER=false dist
-depends_on:
-  - Test
----
-kind: pipeline
-type: docker
 name: Containerize
 platform:
   os: linux
@@ -240,7 +214,7 @@ steps:
       - export PATH="$(go env GOPATH)/bin:$PATH"
       - make -j4 DOCKER_OPTS="" BUILD_IN_CONTAINER=false RELEASE_BUILD=true RELEASE_TAG=${DRONE_TAG} publish
 depends_on:
-  - Dist
+  - Test
 
 volumes:
   - name: docker
@@ -272,6 +246,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: 9b6c80530677e3b0f7bbd038300e50f6c810f679aca4e9a966bab7053ff24128
+hmac: b14773ba7e50432dfe90920d442a850f85aed74f1419dd78502b1e76d91cde46
 
 ...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,5 @@ jobs:
           maximum-size: 16GB
           disk-root: "C:"
       if: ${{ matrix.platform == 'windows-latest' }}
-    - name: Build
-      run: make DOCKER_OPTS="" GOFLAGS="-tags=netgo,nodocker" BUILD_IN_CONTAINER=false cmd/agent/agent cmd/agentctl/agentctl cmd/agent-operator/agent-operator
     - name: Test
       run: make DOCKER_OPTS="" GOFLAGS="-tags=netgo,nodocker" BUILD_IN_CONTAINER=false test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
-    - name: Set up Go 1.17
+    - name: Set up Go 1.18
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17.6
+        go-version: 1.18.0
       id: go
     - name: Determine Go cache directories
       id: go-cache

--- a/.github/workflows/test_packages.yml
+++ b/.github/workflows/test_packages.yml
@@ -11,10 +11,10 @@ jobs:
     name: Test Packages
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.17
+    - name: Set up Go 1.18
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17.6
+        go-version: 1.18.0
       id: go
     - name: Checkout code
       uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Other changes
+
+- Update base image of official Docker containers from Debian buster to Debian
+  bullseye. (@rfratto)
+
+- Use Go 1.18 for builds. (@rfratto)
+
 v0.24.0 (2022-04-07)
 --------------------
 

--- a/cmd/agent-operator/Dockerfile
+++ b/cmd/agent-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.6-buster as build
+FROM golang:1.18.0-bullseye as build
 COPY . /src/agent
 WORKDIR /src/agent
 ARG RELEASE_BUILD=false
@@ -6,7 +6,7 @@ ARG IMAGE_TAG
 
 RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agent-operator
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 RUN apt-get update && \
   apt-get install -qy tzdata ca-certificates && \

--- a/cmd/agent-operator/Dockerfile.buildx
+++ b/cmd/agent-operator/Dockerfile.buildx
@@ -3,9 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
 # Use custom Go version instead of one prepacked in seego
-ENV GOLANG_VERSION 1.17.6
+ENV GOLANG_VERSION 1.18
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 231654bbf2dab3d86c1619ce799e77b03d96f9b50770297c8f4dff8836fc8ca2
+ENV GOLANG_DOWNLOAD_SHA256 e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f
 RUN  rm -rf /usr/local/go                                           \
   && curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz             \
   && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
@@ -19,7 +19,7 @@ ARG IMAGE_TAG
 
 RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false DRONE=true agent-operator
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 RUN apt-get update && \
   apt-get install -qy tzdata ca-certificates && \

--- a/cmd/agent/Dockerfile
+++ b/cmd/agent/Dockerfile
@@ -1,20 +1,20 @@
-FROM golang:1.17.6-buster as build
+FROM golang:1.18.0-bullseye as build
 COPY . /src/agent
 WORKDIR /src/agent
 ARG RELEASE_BUILD=true
 ARG IMAGE_TAG
 
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
-RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -t buster-backports -qy libsystemd-dev
+RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev
 
 RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agent
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
-RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -t buster-backports -qy libsystemd-dev && \
+RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev && \
   apt-get install -qy tzdata ca-certificates && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/cmd/agent/Dockerfile.buildx
+++ b/cmd/agent/Dockerfile.buildx
@@ -3,9 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
 # Use custom Go version instead of one prepacked in seego
-ENV GOLANG_VERSION 1.17.6
+ENV GOLANG_VERSION 1.18
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 231654bbf2dab3d86c1619ce799e77b03d96f9b50770297c8f4dff8836fc8ca2
+ENV GOLANG_DOWNLOAD_SHA256 e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f
 RUN  rm -rf /usr/local/go                                           \
   && curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz             \
   && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
@@ -19,11 +19,11 @@ ARG IMAGE_TAG
 
 RUN make clean && IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false DRONE=true make agent
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
-RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -t buster-backports -qy libsystemd-dev && \
+RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev && \
   apt-get install -qy tzdata ca-certificates libsystemd-dev && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/cmd/agentctl/Dockerfile
+++ b/cmd/agentctl/Dockerfile
@@ -1,20 +1,20 @@
-FROM golang:1.17.6-buster as build
+FROM golang:1.18.0-bullseye as build
 COPY . /src/agent
 WORKDIR /src/agent
 ARG RELEASE_BUILD=false
 ARG IMAGE_TAG
 
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
-RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -t buster-backports -qy libsystemd-dev
+RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev
 
 RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agentctl
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
-RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -t buster-backports -qy libsystemd-dev && \
+RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev && \
   apt-get install -qy tzdata ca-certificates && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/cmd/agentctl/Dockerfile.buildx
+++ b/cmd/agentctl/Dockerfile.buildx
@@ -3,9 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
 # Use custom Go version instead of one prepacked in seego
-ENV GOLANG_VERSION 1.17.6
+ENV GOLANG_VERSION 1.18
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 231654bbf2dab3d86c1619ce799e77b03d96f9b50770297c8f4dff8836fc8ca2
+ENV GOLANG_DOWNLOAD_SHA256 e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f
 RUN  rm -rf /usr/local/go                                           \
   && curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz             \
   && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
@@ -20,11 +20,11 @@ ARG IMAGE_TAG
 # Makefile.
 RUN make clean && IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false DRONE=true make agentctl
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
-RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -t buster-backports -qy libsystemd-dev && \
+RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev && \
   apt-get install -qy tzdata ca-certificates libsystemd-dev && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -56,7 +56,7 @@ down the issues involving the components you want to work on.
 To build Grafana Agent from source code, please install the following tools:
 
 1. [Git](https://git-scm.com/)
-2. [Go](https://golang.org/) (version 1.17 and up)
+2. [Go](https://golang.org/) (version 1.18 and up)
 3. [Make](https://www.gnu.org/software/make/)
 4. [Docker](https://www.docker.com/)
 

--- a/go.mod
+++ b/go.mod
@@ -408,7 +408,7 @@ require (
 	go.opentelemetry.io/otel/internal/metric v0.27.0 // indirect
 	go.uber.org/goleak v1.1.12 // indirect
 	go4.org/intern v0.0.0-20210108033219-3eb7198706b2 // indirect
-	go4.org/unsafe/assume-no-moving-gc v0.0.0-20201222180813-1025295fd063 // indirect
+	go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37 // indirect
 	gocloud.dev v0.24.0 // indirect
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
 	golang.org/x/mod v0.5.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/agent
 
-go 1.17
+go 1.18
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -2601,6 +2601,8 @@ go4.org/intern v0.0.0-20210108033219-3eb7198706b2/go.mod h1:vLqJ+12kCw61iCWsPto0
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20201222175341-b30ae309168e/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20201222180813-1025295fd063 h1:1tk03FUNpulq2cuWpXZWj649rwJpk0d20rxWiopKRmc=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20201222180813-1025295fd063/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37 h1:Tx9kY6yUkLge/pFG7IEMwDZy6CS2ajFc9TvQdPCW0uA=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
 gocloud.dev v0.24.0 h1:cNtHD07zQQiv02OiwwDyVMuHmR7iQt2RLkzoAgz7wBs=
 gocloud.dev v0.24.0/go.mod h1:uA+als++iBX5ShuG4upQo/3Zoz49iIPlYUWHV5mM8w8=
 golang.org/x/crypto v0.0.0-20171113213409-9f005a07e0d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/tools/crow/Dockerfile
+++ b/tools/crow/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.6-buster as build
+FROM golang:1.18.0-bullseye as build
 COPY . /src/agent
 WORKDIR /src/agent
 ARG RELEASE_BUILD=true
@@ -7,7 +7,7 @@ ARG IMAGE_TAG
 RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false grafana-agent-crow
 RUN apt update && apt install ca-certificates
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /src/agent/tools/crow/grafana-agent-crow /bin/grafana-agent-crow
 ENTRYPOINT ["/bin/grafana-agent-crow"]

--- a/tools/crow/Dockerfile.buildx
+++ b/tools/crow/Dockerfile.buildx
@@ -3,9 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
 # Use custom Go version instead of one prepacked in seego
-ENV GOLANG_VERSION 1.17.6
+ENV GOLANG_VERSION 1.18
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 231654bbf2dab3d86c1619ce799e77b03d96f9b50770297c8f4dff8836fc8ca2
+ENV GOLANG_DOWNLOAD_SHA256 e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f
 RUN  rm -rf /usr/local/go                                           \
   && curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz             \
   && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
@@ -19,7 +19,7 @@ ARG IMAGE_TAG
 
 RUN make clean && IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false DRONE=true make grafana-agent-crow
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /src/agent/tools/crow/grafana-agent-crow /bin/grafana-agent-crow
 ENTRYPOINT ["/bin/grafana-agent-crow"]

--- a/tools/seego/Dockerfile
+++ b/tools/seego/Dockerfile
@@ -1,9 +1,9 @@
 FROM rfratto/seego:latest as build
 
 # Use custom Go version instead of one prepacked in seego
-ENV GOLANG_VERSION 1.17.6
+ENV GOLANG_VERSION 1.18
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 231654bbf2dab3d86c1619ce799e77b03d96f9b50770297c8f4dff8836fc8ca2
+ENV GOLANG_DOWNLOAD_SHA256 e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f
 RUN  rm -rf /usr/local/go                                           \
   && curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz             \
   && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/tools/smoke/Dockerfile
+++ b/tools/smoke/Dockerfile
@@ -1,20 +1,20 @@
-FROM golang:1.17.6-buster as build
+FROM golang:1.18.0-bullseye as build
 COPY . /src/agent
 WORKDIR /src/agent
 ARG RELEASE_BUILD=true
 ARG IMAGE_TAG
 
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
-RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -t buster-backports -qy libsystemd-dev
+RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev
 
 RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agent-smoke
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
-RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -t buster-backports -qy libsystemd-dev && \
+RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev && \
   apt-get install -qy tzdata ca-certificates && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/tools/smoke/Dockerfile.buildx
+++ b/tools/smoke/Dockerfile.buildx
@@ -3,9 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
 # Use custom Go version instead of one prepacked in seego
-ENV GOLANG_VERSION 1.17.6
+ENV GOLANG_VERSION 1.18
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 231654bbf2dab3d86c1619ce799e77b03d96f9b50770297c8f4dff8836fc8ca2
+ENV GOLANG_DOWNLOAD_SHA256 e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f
 RUN  rm -rf /usr/local/go                                           \
   && curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz             \
   && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
@@ -19,11 +19,11 @@ ARG IMAGE_TAG
 
 RUN make clean && IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false DRONE=true make agent-smoke
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
-RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -t buster-backports -qy libsystemd-dev && \
+RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev && \
   apt-get install -qy tzdata ca-certificates libsystemd-dev && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
#### PR Description

Makes the following minor changes throughout the repo:

* Update base image for Docker containers to Bullseye 
* Update Go version to 1.18.0
* Remove unnecessary Dist job during release, since `make dist` is re-ran as a part of `make publish`. 
* Remove unnecessary build stage when testing Windows/macOS; `make test` should already cover building the binaries, and doing the builds add 5-6 minutes to the total CI time

#### Which issue(s) this PR fixes
Closes #1576

#### Notes to the Reviewer

rfratto/seego has also been updated to use bullseye.

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
