### PR TITLE
udpate import order in agentctl main.go

### DIFF
--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -13,8 +13,6 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	// Adds version information
-	_ "github.com/grafana/agent/pkg/build"
 	"github.com/grafana/agent/pkg/client/grafanacloud"
 	"github.com/grafana/agent/pkg/config"
 	"github.com/olekukonko/tablewriter"
@@ -45,6 +43,9 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	kconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	// Adds version information
+	_ "github.com/grafana/agent/pkg/build"
 )
 
 func main() {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This updates the import order to move our version info import so version info doesn't get overridden by loki build package.

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

Fixes failures we were seeing in homebrew/homebrew-core workflow when upgrading agent formula to v0.24.0:
https://github.com/Homebrew/homebrew-core/pull/98774

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
