### PR TITLE
Bump GitHub exporter version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ Main (unreleased)
 - Add HTTP endpoints to fetch active instances and targets for the Logs subsytem.
   (@marctc)
 
+### Bugfixes
+
+- Add missing version information back into `agentctl --version`. (@rlankfo)
+
+- Bump version of github-exporter to latest upstream SHA 284088c21e7d, which
+  includes fixes from bugs found in their latest tag. This includes a fix
+  where not all releases where retrieved when pulling release information.
+  (@rfratto)
+
 ### Other changes
 
 - Update base image of official Docker containers from Debian buster to Debian

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/hashicorp/consul/api v1.12.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/infinityworks/github-exporter v0.0.0-20201016091012-831b72461034
+	github.com/infinityworks/github-exporter v0.0.0-20210802160115-284088c21e7d
 	github.com/johannesboyne/gofakes3 v0.0.0-20210819161434-5c8dfcfe5310
 	github.com/jsternberg/zap-logfmt v1.2.0
 	github.com/lib/pq v1.10.2


### PR DESCRIPTION
This bumps the version of github-exporter to the latest upstream commit, fixing numerous bugs since the latest development release.

Closes #1588.

Additionally, a retroactive changelog entry for #1584 is added.