### PR TITLE
Embed time zone data for logs package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Main (unreleased)
 - Add `metrics` prefix to the url of list instances endpoint (`GET /agent/api/v1/instances`) and 
   list targets endpoint (`GET /agent/api/v1/metrics/targets`). (@marctc)
 
-- Embed time zone data to enable Promtail pipelines using the `location` field on Windows machines. (@tpaschalis)
+- Embed timezone data to enable Promtail pipelines using the `location` field on Windows machines. (@tpaschalis)
 
 
 v0.24.0 (2022-04-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Main (unreleased)
 - Add `metrics` prefix to the url of list instances endpoint (`GET /agent/api/v1/instances`) and 
   list targets endpoint (`GET /agent/api/v1/metrics/targets`). (@marctc)
 
+- Embed time zone data to enable Promtail pipelines using the `location` field on Windows machines. (@tpaschalis)
+
 
 v0.24.0 (2022-04-07)
 --------------------

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+	_ "time/tzdata" // embed time zone data
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
-	_ "time/tzdata" // embed time zone data
+	_ "time/tzdata" // embed timezone data
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR embeds time zone data with for the logs package.

#### Which issue(s) this PR fixes
Fixes #1571

#### Notes to the Reviewer
Before merging, I'd like to verify that this actually fixes the issue on Windows machines. I tried to check the before/after behavior with our Windows Github Action runners here https://github.com/tpaschalis/agent/pull/29/commits/6427836d95e3b4addef8e19a54e35242c6a6f978, but it passes even with the current main branch.

I'm not sure if the %ZONEINFO% variable is correctly set or if it's somethig else?

Also, this change inflates our binary data by about 400KB.

#### PR Checklist

- [X] CHANGELOG updated
- [X] Documentation added
- [ ] Tests updated
