### PR TITLE
Set up the default logger parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Main (unreleased)
 - Operator: fix issue where a `username_file` field was incorrectly set.
   (@rfratto)
 
+- Initialize the logger with default `log_level` and `log_format` parameters. (@tpaschalis)
+
 ### Other changes
 
 - Update base image of official Docker containers from Debian buster to Debian

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -344,6 +344,9 @@ type loaderFunc func(path string, fileType string, expandArgs bool, target *Conf
 // load allows for tests to inject a function for retrieving the config file that
 // doesn't require having a literal file on disk.
 func load(fs *flag.FlagSet, args []string, loader loaderFunc) (*Config, error) {
+	// Set up the default logger parameters.
+	DefaultConfig.Server.LogLevel.Set("info")
+	DefaultConfig.Server.LogFormat.Set("json")
 	var (
 		cfg = DefaultConfig
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -49,6 +49,7 @@ var (
 // DefaultConfig holds default settings for all the subsystems.
 var DefaultConfig = Config{
 	// All subsystems with a DefaultConfig should be listed here.
+	Server:                server.DefaultConfig,
 	Metrics:               metrics.DefaultConfig,
 	Integrations:          DefaultVersionedIntegrations,
 	EnableConfigEndpoints: false,
@@ -344,9 +345,6 @@ type loaderFunc func(path string, fileType string, expandArgs bool, target *Conf
 // load allows for tests to inject a function for retrieving the config file that
 // doesn't require having a literal file on disk.
 func load(fs *flag.FlagSet, args []string, loader loaderFunc) (*Config, error) {
-	// Set up the default logger parameters.
-	DefaultConfig.Server.LogLevel.Set("info")
-	DefaultConfig.Server.LogFormat.Set("json")
 	var (
 		cfg = DefaultConfig
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -43,9 +43,11 @@ type GRPCConfig struct {
 // Default configuration structs.
 var (
 	DefaultConfig = Config{
-		GRPC:  DefaultGRPCConfig,
-		HTTP:  DefaultHTTPConfig,
-		Flags: DefaultFlags,
+		GRPC:      DefaultGRPCConfig,
+		HTTP:      DefaultHTTPConfig,
+		Flags:     DefaultFlags,
+		LogLevel:  DefaultLogLevel,
+		LogFormat: DefaultLogFormat,
 	}
 
 	DefaultHTTPConfig = HTTPConfig{
@@ -55,6 +57,18 @@ var (
 	DefaultGRPCConfig = GRPCConfig{
 		// No non-zero defaults yet
 	}
+
+	emptyFlagSet    = flag.NewFlagSet("", flag.ExitOnError)
+	DefaultLogLevel = func() logging.Level {
+		var lvl logging.Level
+		lvl.RegisterFlags(emptyFlagSet)
+		return lvl
+	}()
+	DefaultLogFormat = func() logging.Format {
+		var fmt logging.Format
+		fmt.RegisterFlags(emptyFlagSet)
+		return fmt
+	}()
 )
 
 // RegisterFlags registers flags for c to the given FlagSet.

--- a/pkg/server/logger_test.go
+++ b/pkg/server/logger_test.go
@@ -10,6 +10,16 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+func TestLogger_DefaultParameters(t *testing.T) {
+	makeLogger := func(cfg *Config) (log.Logger, error) {
+		var l log.Logger
+		require.Equal(t, "info", cfg.LogLevel.String())
+		require.Equal(t, "logfmt", cfg.LogFormat.String())
+		return l, nil
+	}
+	newLogger(&DefaultConfig, makeLogger).makeLogger(&DefaultConfig)
+}
+
 func TestLogger_ApplyConfig(t *testing.T) {
 	var buf bytes.Buffer
 	makeLogger := func(cfg *Config) (log.Logger, error) {


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

#### PR Description
This PR re-introduces the correct default log level and log format, after being removed in https://github.com/grafana/agent/commit/b0c1e45c4ab884fd51c85687f51142ef85d2ca5d.

They used to have their default values implicitly set when registering the `-log.level` and `-log.format` flags, but it fell through when changing from weaveworks/common/server with agent/pkg/server.

There are a couple of places and ways to go about it, reintroducing them in main.go, in the server.Config.RegisterFlags method, or the server.Config.UnmarshalYAML method.

I prefer the option presented here, allowing the correct default values to be set, whether the `server:` top-level block exists in the YAML or not.

#### Which issue(s) this PR fixes
Fixes #1586 

#### Notes to the Reviewer
Is there any test we should add?

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added (N/A)
- [x] Tests updated