### PR TITLE
pkg/operator/config: don't set non-existent username_file field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ Main (unreleased)
 - Set the `Content-Type` HTTP header to `application/json` for API endpoints
   returning json objects. (@marctc)
 
+- Operator: fix issue where a `username_file` field was incorrectly set.
+  (@rfratto)
+
 ### Other changes
 
 - Update base image of official Docker containers from Debian buster to Debian

--- a/pkg/operator/config/config_test.go
+++ b/pkg/operator/config/config_test.go
@@ -80,7 +80,7 @@ func TestBuildConfigMetrics(t *testing.T) {
 								basicAuth:
 									username:
 										name: example-secret
-										key: uname
+										key: key
 									password:
 										name: example-secret
 										key: pword
@@ -113,7 +113,7 @@ func TestBuildConfigMetrics(t *testing.T) {
 							remote_write:
 							- url: http://localhost:9090/api/v1/write
 								basic_auth:
-									username_file: /var/lib/grafana-agent/secrets/_secrets_default_example_secret_uname
+									username: somesecret
 									password_file: /var/lib/grafana-agent/secrets/_secrets_default_example_secret_pword
 								tls_config:
 									ca_file: /var/lib/grafana-agent/secrets/_configMaps_default_example_cm_key

--- a/pkg/operator/config/metrics_templates_test.go
+++ b/pkg/operator/config/metrics_templates_test.go
@@ -568,7 +568,7 @@ func TestRemoteWrite(t *testing.T) {
 			expect: util.Untab(`
 				url: http://cortex/api/prom/push
 				basic_auth:
-					username_file: /var/lib/grafana-agent/secrets/_secrets_operator_obj_key
+					username: secretkey
 					password_file: /var/lib/grafana-agent/secrets/_secrets_operator_obj_key
 			`),
 		},

--- a/pkg/operator/config/templates/component/metrics/remote_write.libsonnet
+++ b/pkg/operator/config/templates/component/metrics/remote_write.libsonnet
@@ -30,7 +30,7 @@ function(namespace, rw) {
 
   basic_auth: (
     if rw.BasicAuth != null then {
-      username_file: secrets.pathForSecret(namespace, rw.BasicAuth.Username),
+      username: secrets.valueForSecret(namespace, rw.BasicAuth.Username),
       password_file: secrets.pathForSecret(namespace, rw.BasicAuth.Password),
     }
   ),


### PR DESCRIPTION

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

PR #1441 introduced a change to use password_file for basic auth, but
accidentally also generated a username_file field which doesn't exist.

This is a partial revert of #1441, keeping only the password_file change.

#### Which issue(s) this PR fixes

Fixes #1601

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
