### PR TITLE
Pin version of 'Markdown link check' Github Action

### DIFF
--- a/.github/workflows/check_docs.yml
+++ b/.github/workflows/check_docs.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Check links in docs
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      uses: gaurav-nelson/github-action-markdown-link-check@v1.0.13
       # checks all markdown files from /docs including all subfolders
       with:
         use-quiet-mode: 'yes'


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR pins the 'Markdown link check' Github Action to v1.0.13 (one previous to the latest).

#### Which issue(s) this PR fixes
No issue filed; all new PRs are failing on the "Check link in docs" step since the action handles anchor links erroneously.

#### Notes to the Reviewer
Not sure if I should add a changelog entry, it's not a user-facing change.

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
