### PR TITLE
Make gossip test work on Ubuntu

### DIFF
--- a/pkg/cluster/gossip_test.go
+++ b/pkg/cluster/gossip_test.go
@@ -3,8 +3,8 @@ package cluster
 import (
 	"fmt"
 	stdlog "log"
+	"net"
 	"os"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -19,11 +19,14 @@ import (
 const examplePort = 8888
 
 func TestConfig_ApplyDefaults(t *testing.T) {
-	advertiseInterfaces := advertise.DefaultInterfaces
-	if runtime.GOOS == "windows" {
-		// Try a few common names for Windows since advertise.DefaultInterfaces is
-		// *nix-only.
-		advertiseInterfaces = []string{"Ethernet", "Ethernet 2", "Ethernet 3"}
+	ifaces, err := net.Interfaces()
+	require.NoError(t, err)
+
+	var advertiseInterfaces []string
+	for _, iface := range ifaces {
+		if iface.Flags != net.FlagLoopback {
+			advertiseInterfaces = append(advertiseInterfaces, iface.Name)
+		}
 	}
 
 	defaultConfig := DefaultGossipConfig


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

`gossip_test.go` fails on Ubuntu 20.04. It seems it checks for hardcoded network interfaces `eth0` or `en0`, but Ubuntu and most likely other distros use [predictable network interface names](https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/), so ethernet can look like `enp4s0f1`. 

This PR fixes it  by getting interface list via `net.Interfaces()`. Not 100% this is appropriate, but it does make the test pass :) I opened an [issue on the upstream ckit repo as well
](https://github.com/rfratto/ckit/issues)
#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
