### PR TITLE
Add 'autofs' to darwin FilesystemFSTypesExclude

### DIFF
--- a/pkg/integrations/node_exporter/config.go
+++ b/pkg/integrations/node_exporter/config.go
@@ -65,7 +65,10 @@ func init() {
 	case "linux":
 		DefaultConfig.FilesystemMountPointsExclude = "^/(dev|proc|run/credentials/.+|sys|var/lib/docker/.+)($|/)"
 		DefaultConfig.FilesystemFSTypesExclude = "^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$"
-	case "freebsd", "netbsd", "openbsd", "darwin":
+	case "darwin":
+		DefaultConfig.FilesystemMountPointsExclude = "^/(dev)($|/)"
+		DefaultConfig.FilesystemFSTypesExclude = "^(autofs|devfs)$"
+	case "freebsd", "netbsd", "openbsd":
 		DefaultConfig.FilesystemMountPointsExclude = "^/(dev)($|/)"
 		DefaultConfig.FilesystemFSTypesExclude = "^devfs$"
 	}


### PR DESCRIPTION
To exclude 'useless' map autohome datapoints on Mac:

```
agent % df -h
Filesystem       Size   Used  Avail Capacity iused      ifree %iused  Mounted on
/dev/disk3s1s1  926Gi   19Gi  642Gi     3%  553785 9712948015    0%   /
devfs           204Ki  204Ki    0Bi   100%     706          0  100%   /dev
/dev/disk3s6    926Gi   20Ki  642Gi     1%       0 9713501800    0%   /System/Volumes/VM
/dev/disk3s2    926Gi  418Mi  642Gi     1%    1172 9713500628    0%   /System/Volumes/Preboot
/dev/disk3s4    926Gi  590Mi  642Gi     1%     207 9713501593    0%   /System/Volumes/Update
/dev/disk1s2    500Mi  6.0Mi  481Mi     2%       4    5119996    0%   /System/Volumes/xarts
/dev/disk1s1    500Mi  7.2Mi  481Mi     2%      23    5119977    0%   /System/Volumes/iSCPreboot
/dev/disk1s3    500Mi  608Ki  481Mi     1%      36    5119964    0%   /System/Volumes/Hardware
/dev/disk3s5    926Gi  263Gi  642Gi    30% 2005103 9711496697    0%   /System/Volumes/Data
map auto_home     0Bi    0Bi    0Bi   100%       0          0  100%   /System/Volumes/Data/home
/dev/disk3s1    926Gi   19Gi  642Gi     3%  553787 9712948013    0%   /System/Volumes/Update/mnt1
```