### PR TITLE
[ci] do not check github docs links

### DIFF
--- a/.github/workflows/markdown.links.config.json
+++ b/.github/workflows/markdown.links.config.json
@@ -8,6 +8,9 @@
     },
     {
       "pattern": "^http://prometheus.k3d.localhost:50080"
+    },
+    {
+      "pattern": "^https://docs.github.com/.*$"
     }
   ]
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

CI fails because [links do github docs can't be accessed by markdown links checker](https://github.com/github/docs/issues/17358). Let's temporarily ignore them to keep things moving?

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
