### PR TITLE
Add amd64-specific build tag for eBPF integration

### DIFF
--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -86,7 +86,7 @@ The Makefile provides several targets:
 Compiling the Agent on Linux requires a couple of extra dependencies.
 These are 
 * [systemd headers](https://github.com/grafana/agent/blob/main/cmd/agent/Dockerfile#L8-L9) for Promtail
-* [bcc tools](https://github.com/grafana/agent/blob/main/cmd/agent/Dockerfile#L12-L13) for the eBPF integration
+* [bcc tools](https://github.com/grafana/agent/blob/main/cmd/agent/Dockerfile#L12-L13) for the eBPF integration on AMD64 systems
 
 If you have issues installing the bcc tooling, you can use `-tags=noebpf` to compile the Agent without the eBPF integration.
 

--- a/docs/user/configuration/integrations/integrations-next/ebpf-config.md
+++ b/docs/user/configuration/integrations/integrations-next/ebpf-config.md
@@ -10,10 +10,10 @@ It is an embedded version of
 that allows the Agent to attach eBPF programs to the host kernel
 and export defined metrics in a Prometheus-compatible format.
 
-As such, this integration comes with the relevant caveats of
-running eBPF programs on your host, like being on a kernel 
-version >4.1, specific kernel flags being enabled, plus 
-superuser access is most usually required.
+As such, this integration is only supported on Linux/AMD64, and
+it comes with the relevant caveats of running eBPF programs 
+on your host, like being on a kernel version >4.1, specific
+kernel flags being enabled, plus having superuser access.
 
 Currently, the exporter only supports `kprobes`, that is
 kernel-space probes.

--- a/pkg/integrations/v2/ebpf/integration.go
+++ b/pkg/integrations/v2/ebpf/integration.go
@@ -1,5 +1,5 @@
-//go:build linux && !noebpf
-// +build linux,!noebpf
+//go:build linux && amd64 && !noebpf
+// +build linux,amd64,!noebpf
 
 package ebpf
 

--- a/pkg/integrations/v2/ebpf/integration_stub.go
+++ b/pkg/integrations/v2/ebpf/integration_stub.go
@@ -1,5 +1,5 @@
-//go:build !linux || noebpf
-// +build !linux noebpf
+//go:build !linux || !amd64 || noebpf
+// +build !linux !amd64 noebpf
 
 package ebpf
 


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR constraints the eBPF integration to be only built on AMD64 systems, since cross-compilation fails on other architectures

#### Which issue(s) this PR fixes
No filed issues.

#### Notes to the Reviewer
If we think the current solution (limiting access to users running on a certain architecture) is acceptable, we can go ahead with it. It's not a defacto limitation of eBPF as a technology, but a limitation of our current dependencies.

If we would like to amend this, we can go ahead with the other PR which reverts the entire integration and revisit it once upstream packaging for the bcc toolchain is improved.

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added (N/A)
- [x] Tests updated (N/A)
