### PR TITLE
Add ebpf bindings to agentctl build image

### DIFF
--- a/cmd/agentctl/Dockerfile
+++ b/cmd/agentctl/Dockerfile
@@ -8,6 +8,10 @@ ARG IMAGE_TAG
 RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev
 
+# Add support for bcc bindings required to compile the eBPF integration
+RUN echo "deb [trusted=yes] https://repo.iovisor.org/apt/bionic bionic-nightly main" | tee /etc/apt/sources.list.d/iovisor.list
+RUN apt-get update && apt-get install -qy libbpfcc-dev
+
 RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agentctl
 
 FROM debian:bullseye-slim

--- a/cmd/agentctl/Dockerfile.buildx
+++ b/cmd/agentctl/Dockerfile.buildx
@@ -12,6 +12,10 @@ RUN  rm -rf /usr/local/go                                           \
   && tar -C /usr/local -xzf golang.tar.gz                           \
   && rm golang.tar.gz
 
+# Add support for bcc bindings required to compile the eBPF integration
+RUN echo "deb [trusted=yes] https://repo.iovisor.org/apt/bionic bionic-nightly main" | tee /etc/apt/sources.list.d/iovisor.list
+RUN apt-get update && apt-get install -qy libbpfcc-dev
+
 COPY . /src/agent
 WORKDIR /src/agent
 ARG RELEASE_BUILD=true


### PR DESCRIPTION
#### PR Description
We've recently introduced an eBPF integration. In the process, we should have also updated the agentctl build image to include the necessary libraries, as it imports the new `ebpf` package.

#### Which issue(s) this PR fixes
No issue filed

#### Notes to the Reviewer
Hopefully, this is the last change required... The "Containerize" step in Drone, runs the following commands
https://github.com/grafana/agent/blob/9f03dcf4f001ae2c7cd178b5ddc997428db92a14/.drone/drone.yml#L108-L113

Only `agent` and `agentctl` happen to import the integration package, thus requiring these extra libraries.

#### PR Checklist

- [x] CHANGELOG updated (N/A)
- [x] Documentation added (N/A)
- [x] Tests updated (N/A)
