### PR TITLE
Add libbpfcc to final Dockerfile layer of agent/agentctl

### DIFF
--- a/cmd/agent/Dockerfile
+++ b/cmd/agent/Dockerfile
@@ -22,6 +22,10 @@ RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev &
   apt-get install -qy tzdata ca-certificates && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Add support for bcc bindings required to run the eBPF integration
+RUN echo "deb [trusted=yes] https://repo.iovisor.org/apt/bionic bionic-nightly main" | tee /etc/apt/sources.list.d/iovisor.list
+RUN apt-get update && apt-get install -qy libbpfcc-dev
+
 COPY --from=build /src/agent/cmd/agent/agent /bin/agent
 COPY cmd/agent/agent-local-config.yaml /etc/agent/agent.yaml
 

--- a/cmd/agent/Dockerfile.buildx
+++ b/cmd/agent/Dockerfile.buildx
@@ -31,6 +31,10 @@ RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev &
   apt-get install -qy tzdata ca-certificates libsystemd-dev && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Add support for bcc bindings required to run the eBPF integration
+RUN echo "deb [trusted=yes] https://repo.iovisor.org/apt/bionic bionic-nightly main" | tee /etc/apt/sources.list.d/iovisor.list
+RUN apt-get update && apt-get install -qy libbpfcc-dev
+
 COPY --from=build /src/agent/cmd/agent/agent /bin/agent
 COPY cmd/agent/agent-local-config.yaml /etc/agent/agent.yaml
 

--- a/cmd/agentctl/Dockerfile
+++ b/cmd/agentctl/Dockerfile
@@ -22,6 +22,10 @@ RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev &
   apt-get install -qy tzdata ca-certificates && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Add support for bcc bindings required to run the eBPF integration
+RUN echo "deb [trusted=yes] https://repo.iovisor.org/apt/bionic bionic-nightly main" | tee /etc/apt/sources.list.d/iovisor.list
+RUN apt-get update && apt-get install -qy libbpfcc-dev
+
 COPY --from=build /src/agent/cmd/agentctl/agentctl /bin/agentctl
 
 ENTRYPOINT ["/bin/agentctl"]

--- a/cmd/agentctl/Dockerfile.buildx
+++ b/cmd/agentctl/Dockerfile.buildx
@@ -32,6 +32,10 @@ RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev &
   apt-get install -qy tzdata ca-certificates libsystemd-dev && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Add support for bcc bindings required to run the eBPF integration
+RUN echo "deb [trusted=yes] https://repo.iovisor.org/apt/bionic bionic-nightly main" | tee /etc/apt/sources.list.d/iovisor.list
+RUN apt-get update && apt-get install -qy libbpfcc-dev
+
 COPY --from=build /src/agent/cmd/agentctl/agentctl /bin/agentctl
 
 ENTRYPOINT ["/bin/agentctl"]


### PR DESCRIPTION
#### PR Description
Last commit was able to fix cross-platform build of the Agent. Unfortunately, there's still one thing left to do, as the Agent was unable to run on our CD platform with the following error
```
/bin/agent: error while loading shared libraries: libbcc.so.0: cannot open shared object file: No such file or directory
```

The added libbpf bindings were good to go for the build stage, but the libraries are _also_ needed at runtime for Linux/AMD64 systems. 

#### Which issue(s) this PR fixes
No issue filed

#### Notes to the Reviewer
Nothing special, for now.

#### PR Checklist
- [X] CHANGELOG updated (N/A, bug fix)
- [X] Documentation added (N/A)
- [X] Tests updated (N/A)
