### PR TITLE
Add delay that is 3 x heartbeat for scraping service in the config wa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,11 @@ Main (unreleased)
   network. As a result of this change, the `client_config` field has been
   removed. (@rfratto)
 
--  `extra-scrape-metrics` can now be enabled with the `--enable-features=extra-scrape-metrics` feature flag. See https://prometheus.io/docs/prometheus/2.31/feature_flags/#extra-scrape-metrics for details. (@rlankfo)
+- `extra-scrape-metrics` can now be enabled with the `--enable-features=extra-scrape-metrics` feature flag. See https://prometheus.io/docs/prometheus/2.31/feature_flags/#extra-scrape-metrics for details. (@rlankfo)
+
+### Bugfixes
+
+- Added config watcher delay to prevent race condition in cases where scraping service mode has not gracefully exited. (@mattdurham)
 
 ### Other changes
 


### PR DESCRIPTION
#### PR Description

Add delay to prevent a race condition, it's using a hammer to fix something that could be more elegantly solved. 

#### Which issue(s) this PR fixes

This hopefully explains it

https://gist.github.com/mattdurham/c15f27de17a6da97bf2e6a870991c7f2

#### Notes to the Reviewer

#### PR Checklist

- [X] CHANGELOG updated
