### PR TITLE
Use -dev version of libbpfcc libraries for final Dockerfile layer

### DIFF
--- a/cmd/agent/Dockerfile
+++ b/cmd/agent/Dockerfile
@@ -20,11 +20,8 @@ FROM debian:bullseye-slim
 RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev && \
   apt-get install -qy tzdata ca-certificates && \
+  if [ "$(dpkg --print-architure)" = "amd64" ]; then apt-get install libbpfcc; fi && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Add support for bcc bindings required to run the eBPF integration
-RUN echo "deb [trusted=yes] https://repo.iovisor.org/apt/bionic bionic-nightly main" | tee /etc/apt/sources.list.d/iovisor.list
-RUN apt-get update && apt-get install -qy libbpfcc-dev
 
 COPY --from=build /src/agent/cmd/agent/agent /bin/agent
 COPY cmd/agent/agent-local-config.yaml /etc/agent/agent.yaml

--- a/cmd/agent/Dockerfile
+++ b/cmd/agent/Dockerfile
@@ -19,8 +19,12 @@ FROM debian:bullseye-slim
 # plus the libbpfcc library for running the eBPF integration.
 RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev && \
-  apt-get install -qy tzdata ca-certificates libbpfcc && \
+  apt-get install -qy tzdata ca-certificates && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Add support for bcc bindings required to run the eBPF integration
+RUN echo "deb [trusted=yes] https://repo.iovisor.org/apt/bionic bionic-nightly main" | tee /etc/apt/sources.list.d/iovisor.list
+RUN apt-get update && apt-get install -qy libbpfcc-dev
 
 COPY --from=build /src/agent/cmd/agent/agent /bin/agent
 COPY cmd/agent/agent-local-config.yaml /etc/agent/agent.yaml

--- a/cmd/agent/Dockerfile.buildx
+++ b/cmd/agent/Dockerfile.buildx
@@ -29,11 +29,8 @@ FROM debian:bullseye-slim
 RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev && \
   apt-get install -qy tzdata ca-certificates libsystemd-dev && \
+  if [ "$(dpkg --print-architure)" = "amd64" ]; then apt-get install libbpfcc; fi && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Add support for bcc bindings required to run the eBPF integration
-RUN echo "deb [trusted=yes] https://repo.iovisor.org/apt/bionic bionic-nightly main" | tee /etc/apt/sources.list.d/iovisor.list
-RUN apt-get update && apt-get install -qy libbpfcc-dev
 
 COPY --from=build /src/agent/cmd/agent/agent /bin/agent
 COPY cmd/agent/agent-local-config.yaml /etc/agent/agent.yaml

--- a/cmd/agent/Dockerfile.buildx
+++ b/cmd/agent/Dockerfile.buildx
@@ -28,8 +28,12 @@ FROM debian:bullseye-slim
 # plus the libbpfcc library for running the eBPF integration.
 RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev && \
-  apt-get install -qy tzdata ca-certificates libsystemd-dev libbpfcc && \
+  apt-get install -qy tzdata ca-certificates libsystemd-dev && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Add support for bcc bindings required to run the eBPF integration
+RUN echo "deb [trusted=yes] https://repo.iovisor.org/apt/bionic bionic-nightly main" | tee /etc/apt/sources.list.d/iovisor.list
+RUN apt-get update && apt-get install -qy libbpfcc-dev
 
 COPY --from=build /src/agent/cmd/agent/agent /bin/agent
 COPY cmd/agent/agent-local-config.yaml /etc/agent/agent.yaml

--- a/cmd/agentctl/Dockerfile
+++ b/cmd/agentctl/Dockerfile
@@ -20,11 +20,8 @@ FROM debian:bullseye-slim
 RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev && \
   apt-get install -qy tzdata ca-certificates && \
+  if [ "$(dpkg --print-architure)" = "amd64" ]; then apt-get install libbpfcc; fi && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Add support for bcc bindings required to run the eBPF integration
-RUN echo "deb [trusted=yes] https://repo.iovisor.org/apt/bionic bionic-nightly main" | tee /etc/apt/sources.list.d/iovisor.list
-RUN apt-get update && apt-get install -qy libbpfcc-dev
 
 COPY --from=build /src/agent/cmd/agentctl/agentctl /bin/agentctl
 

--- a/cmd/agentctl/Dockerfile
+++ b/cmd/agentctl/Dockerfile
@@ -19,8 +19,12 @@ FROM debian:bullseye-slim
 # plus the libbpfcc library for running the eBPF integration.
 RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev && \
-  apt-get install -qy tzdata ca-certificates libbpfcc && \
+  apt-get install -qy tzdata ca-certificates && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Add support for bcc bindings required to run the eBPF integration
+RUN echo "deb [trusted=yes] https://repo.iovisor.org/apt/bionic bionic-nightly main" | tee /etc/apt/sources.list.d/iovisor.list
+RUN apt-get update && apt-get install -qy libbpfcc-dev
 
 COPY --from=build /src/agent/cmd/agentctl/agentctl /bin/agentctl
 

--- a/cmd/agentctl/Dockerfile.buildx
+++ b/cmd/agentctl/Dockerfile.buildx
@@ -29,8 +29,12 @@ FROM debian:bullseye-slim
 # plus the libbpfcc library for running the eBPF integration.
 RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev && \
-  apt-get install -qy tzdata ca-certificates libsystemd-dev libbpfcc && \
+  apt-get install -qy tzdata ca-certificates libsystemd-dev && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Add support for bcc bindings required to run the eBPF integration
+RUN echo "deb [trusted=yes] https://repo.iovisor.org/apt/bionic bionic-nightly main" | tee /etc/apt/sources.list.d/iovisor.list
+RUN apt-get update && apt-get install -qy libbpfcc-dev
 
 COPY --from=build /src/agent/cmd/agentctl/agentctl /bin/agentctl
 

--- a/cmd/agentctl/Dockerfile.buildx
+++ b/cmd/agentctl/Dockerfile.buildx
@@ -30,11 +30,8 @@ FROM debian:bullseye-slim
 RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev && \
   apt-get install -qy tzdata ca-certificates libsystemd-dev && \
+  if [ "$(dpkg --print-architure)" = "amd64" ]; then apt-get install libbpfcc; fi && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Add support for bcc bindings required to run the eBPF integration
-RUN echo "deb [trusted=yes] https://repo.iovisor.org/apt/bionic bionic-nightly main" | tee /etc/apt/sources.list.d/iovisor.list
-RUN apt-get update && apt-get install -qy libbpfcc-dev
 
 COPY --from=build /src/agent/cmd/agentctl/agentctl /bin/agentctl
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Since last commit, we tried adding the libbpfcc libraries to the final, runtime Dockerfile layer that will run the Agent.

Unfortunately, the `libbpfcc` package is not correctly available, and we need to get back to the `libbpfcc-dev` variant.

#### Which issue(s) this PR fixes
No issue filed

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [ ] Tests updated
