### PR TITLE
Use serviceAccountName instead of deprecated serviceAccount in V2 templates

### DIFF
--- a/production/tanka/grafana-agent/v2/internal/controllers/daemonset.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/controllers/daemonset.libsonnet
@@ -10,7 +10,7 @@ function() {
   controller:
     daemonSet.new(name, [this.container]) +
     daemonSet.mixin.metadata.withNamespace(namespace) +
-    daemonSet.mixin.spec.template.spec.withServiceAccount(name) +
+    daemonSet.mixin.spec.template.spec.withServiceAccountName(name) +
     (
       if _config.config_hash
       then daemonSet.mixin.spec.template.metadata.withAnnotationsMixin({

--- a/production/tanka/grafana-agent/v2/internal/controllers/deployment.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/controllers/deployment.libsonnet
@@ -10,7 +10,7 @@ function(replicas=1) {
   controller:
     deployment.new(name, replicas, [this.container]) +
     deployment.mixin.metadata.withNamespace(namespace) +
-    deployment.mixin.spec.template.spec.withServiceAccount(name) +
+    deployment.mixin.spec.template.spec.withServiceAccountName(name) +
     (
       if _config.config_hash
       then deployment.mixin.spec.template.metadata.withAnnotationsMixin({

--- a/production/tanka/grafana-agent/v2/internal/controllers/statefulset.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/controllers/statefulset.libsonnet
@@ -11,7 +11,7 @@ function(replicas=1, volumeClaims=[]) {
     statefulSet.new(name, replicas, [this.container], volumeClaims) +
     statefulSet.mixin.metadata.withNamespace(namespace) +
     statefulSet.mixin.spec.withServiceName(name) +
-    statefulSet.mixin.spec.template.spec.withServiceAccount(name) +
+    statefulSet.mixin.spec.template.spec.withServiceAccountName(name) +
     (
       if _config.config_hash
       then statefulSet.mixin.spec.template.metadata.withAnnotationsMixin({


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

Switch to using the non-deprecated `serviceAccountName` instead of `serviceAccount` in V2 templates. The deprecated field produces errors when we lint our kubernetes manifests.

