### PR TITLE
Instance Name Prefixing Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ Main (unreleased)
 
 - Added config watcher delay to prevent race condition in cases where scraping service mode has not gracefully exited. (@mattdurham)
 
+- Resolved issue in v2 integrations where instance names that were substrings of another instance name did not scrape properly (@mattdurham)
+
 ### Other changes
 
 - Update base image of official Docker containers from Debian buster to Debian

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,8 @@ Main (unreleased)
 
 - Added config watcher delay to prevent race condition in cases where scraping service mode has not gracefully exited. (@mattdurham)
 
-- Resolved issue in v2 integrations where instance names that were substrings of another instance name did not scrape properly (@mattdurham)
+- Resolved issue in v2 integrations where if an instance name was a prefix of another the route handler would fail to
+  match requests on the longer name (@mattdurham)
 
 ### Other changes
 


### PR DESCRIPTION


#### PR Description

Prefix Path did not have a closing `/` so if an instance name was a prefix of another then the smaller one always took precedence. 

#### Which issue(s) this PR fixes

Closes #1718 

#### Notes to the Reviewer

#### PR Checklist

- [X] CHANGELOG updated
- [NA] Documentation added
- [X] Tests updated <- No tests added but code was added to fix the test and ensure original behavior is retained.
