### PR TITLE
cmd/agentflow: introduce temporary agentflow main package for prototyping

### DIFF
--- a/cmd/agentflow/README.md
+++ b/cmd/agentflow/README.md
@@ -15,7 +15,10 @@ configured and wired together by the user.
 Grafana Agent Flow currently uses HCL for its configuration language rather
 than the YAML used by the existing project.
 
-## Runing
+See the package-level comments in the [component package][] for information on
+how to write new components.
+
+## Running
 
 You can run the Grafana Agent Flow prototype from the root of the repository
 with:
@@ -26,8 +29,13 @@ go run ./cmd/agentflow -config.file ./cmd/agentflow/example-config.flow
 
 This starts Grafana Agent Flow with the provided [example config file][].
 
-See the package-level comments in the [component package][] for information on
-how to write new components.
+## Reloading
+
+Agent Flow can reload its config file by sending a `POST` request to
+`/-/reload` against Flow's HTTP server.
+
+The default HTTP server address is `http://127.0.0.1:12345` and can be modified
+with the `-server.http-listen-addr` flag.
 
 [example config file]: ./example-config.flow
 [component package]: ../../component/component.go

--- a/cmd/agentflow/README.md
+++ b/cmd/agentflow/README.md
@@ -1,0 +1,33 @@
+# Grafana Agent Flow Prototype
+
+> **NOTE**: Grafana Agent Flow is a prototype in active development and
+> everything is subject to breaking changes; don't use this in production.
+
+`cmd/agentflow` is the entrypoint for the experimental Grafana Agent Flow
+prototype. It is presented as a separate command while the prototype is still
+being developed. Support for Flow will eventually be added directly into
+`cmd/agent` and this command will be removed.
+
+Grafana Agent Flow is a component-based reimagining of Grafana Agent, where
+units of logic are broken up into "components" which can independently
+configured and wired together by the user.
+
+Grafana Agent Flow currently uses HCL for its configuration language rather
+than the YAML used by the existing project.
+
+## Runing
+
+You can run the Grafana Agent Flow prototype from the root of the repository
+with:
+
+```
+go run ./cmd/agentflow -config.file ./cmd/agentflow/example-config.flow
+```
+
+This starts Grafana Agent Flow with the provided [example config file][].
+
+See the package-level comments in the [component package][] for information on
+how to write new components.
+
+[example config file]: ./example-config.flow
+[component package]: ../../component/component.go

--- a/cmd/agentflow/example-config.flow
+++ b/cmd/agentflow/example-config.flow
@@ -1,0 +1,1 @@
+# TODO: add components here for the example config once components exist.

--- a/cmd/agentflow/main.go
+++ b/cmd/agentflow/main.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	_ "net/http/pprof" // anonymous import to get the pprof handler registered
+	"os"
+	"os/signal"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/gorilla/mux"
+	"github.com/grafana/agent/pkg/flow"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	// Install components
+	_ "github.com/grafana/agent/component/all"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	ctx, cancel := interruptContext()
+	defer cancel()
+
+	var (
+		httpListenAddr = "127.0.0.1:12345"
+		configFile     string
+		storagePath    = "data-agent/"
+	)
+
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.StringVar(&httpListenAddr, "server.http-listen-addr", httpListenAddr, "address to listen for http traffic on")
+	fs.StringVar(&configFile, "config.file", configFile, "path to config file to load")
+	fs.StringVar(&storagePath, "storage.path", storagePath, "Base directory where Flow components can store data")
+
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		return fmt.Errorf("error parsing flags: %w", err)
+	}
+
+	// Validate flags
+	if configFile == "" {
+		return fmt.Errorf("the -config.file flag is required")
+	}
+
+	l := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	f := flow.New(flow.Options{
+		Logger:   l,
+		DataPath: storagePath,
+	})
+
+	reload := func() error {
+		flowCfg, err := loadFlowFile(configFile)
+		if err != nil {
+			return fmt.Errorf("reading config file %q: %w", configFile, err)
+		}
+		if err := f.LoadFile(flowCfg); err != nil {
+			return fmt.Errorf("error during the initial gragent load: %w", err)
+		}
+		return nil
+	}
+
+	if err := reload(); err != nil {
+		// Exit if the initial load files
+		return err
+	}
+
+	// HTTP server
+	{
+		lis, err := net.Listen("tcp", httpListenAddr)
+		if err != nil {
+			return fmt.Errorf("failed to listen on %s: %w", httpListenAddr, err)
+		}
+
+		r := mux.NewRouter()
+		r.Handle("/metrics", promhttp.Handler())
+		r.PathPrefix("/debug/pprof").Handler(http.DefaultServeMux)
+
+		r.HandleFunc("/-/reload", func(w http.ResponseWriter, _ *http.Request) {
+			err := reload()
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			fmt.Fprintln(w, "config reloaded")
+		})
+
+		srv := &http.Server{Handler: r}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer cancel()
+
+			level.Info(l).Log("msg", "now listening for http traffic", "addr", httpListenAddr)
+			if err := srv.Serve(lis); err != nil {
+				level.Info(l).Log("msg", "http server closed", "err", err)
+			}
+		}()
+
+		defer func() { _ = srv.Shutdown(ctx) }()
+	}
+
+	<-ctx.Done()
+	return f.Close()
+}
+
+func loadFlowFile(filename string) (*flow.File, error) {
+	bb, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	f, diags := flow.ReadFile(filename, bb)
+	if !diags.HasErrors() {
+		return f, nil
+	}
+	return f, diags
+}
+
+func interruptContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		defer cancel()
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, os.Interrupt)
+		select {
+		case <-sig:
+		case <-ctx.Done():
+		}
+		signal.Stop(sig)
+
+		fmt.Fprintln(os.Stderr, "interrupt received")
+	}()
+
+	return ctx, cancel
+}


### PR DESCRIPTION
This commit introduces cmd/agentflow as a separate binary which allows for developers to test components end-to-end and merge them into the main branch without having to add flow support into cmd/agent itself.

After Flow is ready for wider use, cmd/agentflow will be replaced with native cmd/agent support.