### PR TITLE
agentflow: add /debug/graph endpoint to render current dependency DAG

### DIFF
--- a/cmd/agentflow/README.md
+++ b/cmd/agentflow/README.md
@@ -47,3 +47,6 @@ with the `-server.http-listen-addr` flag.
 The `/debug/graph` endpoint will render the state of the Flow controller as a
 DAG. The resulting DAG is a dependency graph of references between nodes and
 not necessarily the flow of data.
+
+Note that similarly to `go tool pprof`'s web interface, Graphviz must be
+installed for this component to work.

--- a/cmd/agentflow/README.md
+++ b/cmd/agentflow/README.md
@@ -39,3 +39,11 @@ with the `-server.http-listen-addr` flag.
 
 [example config file]: ./example-config.flow
 [component package]: ../../component/component.go
+
+## Debug endpoints
+
+### Graph visualization
+
+The `/debug/graph` endpoint will render the state of the Flow controller as a
+DAG. The resulting DAG is a dependency graph of references between nodes and
+not necessarily the flow of data.

--- a/cmd/agentflow/main.go
+++ b/cmd/agentflow/main.go
@@ -86,6 +86,7 @@ func run() error {
 
 		r := mux.NewRouter()
 		r.Handle("/metrics", promhttp.Handler())
+		r.Handle("/debug/graph", f.GraphHandler())
 		r.PathPrefix("/debug/pprof").Handler(http.DefaultServeMux)
 
 		r.HandleFunc("/-/reload", func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/flow/flow_http.go
+++ b/pkg/flow/flow_http.go
@@ -1,0 +1,30 @@
+package flow
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+
+	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/pkg/flow/internal/dag"
+	"github.com/grafana/agent/pkg/flow/internal/graphviz"
+)
+
+// GraphHandler returns an http.HandlerFunc which renders the current graph's
+// DAG as an SVG. Graphviz must be installed for this function to work.
+func (f *Flow) GraphHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		g := f.loader.Graph()
+		dot := dag.MarshalDOT(g)
+
+		svgBytes, err := graphviz.Dot(dot, "svg")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		_, err = io.Copy(w, bytes.NewReader(svgBytes))
+		if err != nil {
+			level.Error(f.log).Log("msg", "failed to write svg graph", "err", err)
+		}
+	}
+}

--- a/pkg/flow/internal/dag/marshal.go
+++ b/pkg/flow/internal/dag/marshal.go
@@ -19,11 +19,11 @@ func MarshalDOT(g *Graph) []byte {
 	}
 
 	fmt.Fprintf(&buf, "\n\t// Edges:\n")
-	for _, edge := range g.Edges() {
+	for _, edge := range sortedEdges(g.Edges()) {
 		fmt.Fprintf(&buf, "\t%q -> %q\n", edge.From.NodeID(), edge.To.NodeID())
 	}
 
-	fmt.Fprintln(&buf, "}")
+	fmt.Fprintf(&buf, "}")
 	return buf.Bytes()
 }
 
@@ -34,4 +34,27 @@ func sortedNodeNames(nn []Node) []string {
 	}
 	sort.Strings(names)
 	return names
+}
+
+func sortedEdges(edge []Edge) []Edge {
+	res := make([]Edge, len(edge))
+	copy(res, edge)
+
+	sort.Slice(res, func(i, j int) bool {
+		var (
+			fromNodeI = res[i].From.NodeID()
+			fromNodeJ = res[j].From.NodeID()
+
+			toNodeI = res[i].To.NodeID()
+			toNodeJ = res[j].To.NodeID()
+		)
+
+		// Sort first by from nodes, then by to nodes
+		if fromNodeI != fromNodeJ {
+			return fromNodeI < fromNodeJ
+		}
+		return toNodeI < toNodeJ
+	})
+
+	return res
 }

--- a/pkg/flow/internal/dag/marshal_test.go
+++ b/pkg/flow/internal/dag/marshal_test.go
@@ -1,0 +1,44 @@
+package dag_test
+
+import (
+	"testing"
+
+	"github.com/grafana/agent/pkg/flow/internal/dag"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalDOT(t *testing.T) {
+	var (
+		nodeA = stringNode("a")
+		nodeB = stringNode("b")
+		nodeC = stringNode("c")
+	)
+
+	var g dag.Graph
+	g.Add(nodeA)
+	g.Add(nodeB)
+	g.Add(nodeC)
+
+	g.AddEdge(dag.Edge{From: nodeA, To: nodeB})
+	g.AddEdge(dag.Edge{From: nodeA, To: nodeC})
+
+	expect := `digraph {
+	rankdir="LR"
+
+	// Vertices:
+	"a"
+	"b"
+	"c"
+
+	// Edges:
+	"a" -> "b"
+	"a" -> "c"
+}`
+
+	marshaled := dag.MarshalDOT(&g)
+	require.Equal(t, expect, string(marshaled))
+}
+
+type stringNode string
+
+func (s stringNode) NodeID() string { return string(s) }

--- a/pkg/flow/internal/graphviz/graphviz.go
+++ b/pkg/flow/internal/graphviz/graphviz.go
@@ -1,0 +1,30 @@
+// Package graphviz implements some graphviz utilities. Graphviz must be
+// installed for these to work.
+package graphviz
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+)
+
+// NotFoundError is generated when a Graphviz tool could not be found.
+type NotFoundError struct {
+	ToolName string
+}
+
+func (e NotFoundError) Error() string {
+	return fmt.Sprintf("Failed to execute %s. Is Graphviz installed?", e.ToolName)
+}
+
+// Dot renders the DOT-language input with the provided format.
+func Dot(in []byte, format string) ([]byte, error) {
+	dotPath, err := exec.LookPath("dot")
+	if err != nil {
+		return nil, NotFoundError{ToolName: "dot"}
+	}
+
+	cmd := exec.Command(dotPath, "-T"+format)
+	cmd.Stdin = bytes.NewReader(in)
+	return cmd.Output()
+}

--- a/pkg/flow/internal/graphviz/grpahviz_test.go
+++ b/pkg/flow/internal/graphviz/grpahviz_test.go
@@ -1,0 +1,32 @@
+package graphviz_test
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/grafana/agent/pkg/flow/internal/graphviz"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGraphviz(t *testing.T) {
+	_, err := exec.LookPath("dot")
+	if err != nil {
+		t.Skip("Skipping because graphviz is not installed")
+	}
+
+	testDot := `
+		digraph G {
+			a -> b 
+			a -> c
+		}
+	`
+
+	resp, err := graphviz.Dot([]byte(testDot), "dot")
+	require.NoError(t, err)
+
+	// We don't test the entire output of dot since it will do a lot of mutations
+	// on even a simple graph (setting positions, sizes, etc.). However, we at least
+	// make sure that it contains something we've expected, like the name of the
+	// graph itself.
+	require.Contains(t, string(resp), "digraph G")
+}


### PR DESCRIPTION
Adds a /debug/graph endpoint to render the currently loaded dependency graph (with transitive reduction applied). 