### PR TITLE
Flow: add /-/config endpoint

### DIFF
--- a/cmd/agentflow/README.md
+++ b/cmd/agentflow/README.md
@@ -50,3 +50,12 @@ not necessarily the flow of data.
 
 Note that similarly to `go tool pprof`'s web interface, Graphviz must be
 installed for this component to work.
+
+### Config endpoint
+
+The `/-/config` endpoint will render the state of all components as HCL with
+expressions evaluated.
+
+You may invoke `/-/config?debug=1` to append health information for each
+component along with component-specific debug info (if exposed by the component
+through the DebugComponent interface).

--- a/cmd/agentflow/main.go
+++ b/cmd/agentflow/main.go
@@ -85,6 +85,7 @@ func run() error {
 		}
 
 		r := mux.NewRouter()
+		r.Handle("/-/config", f.ConfigHandler())
 		r.Handle("/metrics", promhttp.Handler())
 		r.Handle("/debug/graph", f.GraphHandler())
 		r.PathPrefix("/debug/pprof").Handler(http.DefaultServeMux)

--- a/component/component.go
+++ b/component/component.go
@@ -88,3 +88,19 @@ type Component interface {
 	// An error may be returned if the provided config is invalid.
 	Update(args Arguments) error
 }
+
+// DebugComponent is an extension interface for components which can report
+// debugging information upon request.
+type DebugComponent interface {
+	Component
+
+	// DebugInfo returns the current debug information of the component. May
+	// return nil if there is no debug info to currently report. The result of
+	// DebugInfo must be encodable to HCL like Arguments and Exports.
+	//
+	// Values from DebugInfo are not exposed to other components for use in
+	// expressions.
+	//
+	// DebugInfo must be safe for calling concurrently.
+	DebugInfo() interface{}
+}

--- a/component/component_health.go
+++ b/component/component_health.go
@@ -65,7 +65,7 @@ const (
 func (ht HealthType) String() string {
 	switch ht {
 	case HealthTypeHealthy:
-		return "health"
+		return "healthy"
 	case HealthTypeUnhealthy:
 		return "unhealthy"
 	case HealthTypeExited:

--- a/pkg/flow/flow_http.go
+++ b/pkg/flow/flow_http.go
@@ -2,12 +2,17 @@ package flow
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 
 	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/pkg/flow/internal/controller"
 	"github.com/grafana/agent/pkg/flow/internal/dag"
 	"github.com/grafana/agent/pkg/flow/internal/graphviz"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/rfratto/gohcl/hclfmt"
 )
 
 // GraphHandler returns an http.HandlerFunc which renders the current graph's
@@ -27,4 +32,38 @@ func (f *Flow) GraphHandler() http.HandlerFunc {
 			level.Error(f.log).Log("msg", "failed to write svg graph", "err", err)
 		}
 	}
+}
+
+// ConfigHandler returns an http.HandlerFunc which will render the most
+// recently loaded configuration file as HCL.
+func (f *Flow) ConfigHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		debugInfo := r.URL.Query().Get("debug") == "1"
+		_, _ = f.configBytes(w, debugInfo)
+	}
+}
+
+// configBytes dumps the current state of the flow config as HCL.
+func (c *Flow) configBytes(w io.Writer, debugInfo bool) (n int64, err error) {
+	file := hclwrite.NewFile()
+
+	blocks := c.loader.WriteBlocks(debugInfo)
+	for _, block := range blocks {
+		var id controller.ComponentID
+		id = append(id, block.Type())
+		id = append(id, block.Labels()...)
+
+		comment := fmt.Sprintf("// Component %s:\n", id.String())
+		file.Body().AppendUnstructuredTokens(hclwrite.Tokens{
+			{Type: hclsyntax.TokenComment, Bytes: []byte(comment)},
+		})
+
+		file.Body().AppendBlock(block)
+		file.Body().AppendNewline()
+	}
+
+	toks := file.BuildTokens(nil)
+	hclfmt.Format(toks)
+
+	return toks.WriteTo(w)
 }

--- a/pkg/flow/flow_http.go
+++ b/pkg/flow/flow_http.go
@@ -44,10 +44,10 @@ func (f *Flow) ConfigHandler() http.HandlerFunc {
 }
 
 // configBytes dumps the current state of the flow config as HCL.
-func (c *Flow) configBytes(w io.Writer, debugInfo bool) (n int64, err error) {
+func (f *Flow) configBytes(w io.Writer, debugInfo bool) (n int64, err error) {
 	file := hclwrite.NewFile()
 
-	blocks := c.loader.WriteBlocks(debugInfo)
+	blocks := f.loader.WriteBlocks(debugInfo)
 	for _, block := range blocks {
 		var id controller.ComponentID
 		id = append(id, block.Type())

--- a/pkg/flow/flow_http_test.go
+++ b/pkg/flow/flow_http_test.go
@@ -1,0 +1,55 @@
+package flow
+
+import (
+	"bytes"
+	"testing"
+
+	_ "github.com/grafana/agent/pkg/flow/internal/testcomponents" // Import testcomponents
+	"github.com/stretchr/testify/require"
+)
+
+func Test_configBytes(t *testing.T) {
+	configFile := `
+		testcomponents "tick" "ticker-a" {
+			frequency = "1s"
+		}
+
+		testcomponents "passthrough" "static" {
+			input = "hello, world!"
+		}
+	`
+
+	file, diags := ReadFile(t.Name(), []byte(configFile))
+	require.NotNil(t, file)
+	require.False(t, diags.HasErrors(), "Found errors when loading file")
+
+	f, _ := newFlow(testOptions(t))
+
+	err := f.LoadFile(file)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	_, _ = f.configBytes(&buf, false)
+	actual := buf.String()
+
+	// Exported fields aren't reported for testcomponents.tick.ticker-a because
+	// the controller isn't running, so all of its exports are the zero value and
+	// get omitted from the result.
+	expect :=
+		`// Component testcomponents.tick.ticker-a:
+testcomponents "tick" "ticker-a" {
+  frequency = "1s"
+}
+
+// Component testcomponents.passthrough.static:
+testcomponents "passthrough" "static" {
+  input = "hello, world!"
+
+  // Exported fields:
+  output = "hello, world!"
+}
+
+`
+
+	require.Equal(t, expect, actual)
+}

--- a/pkg/flow/internal/controller/component.go
+++ b/pkg/flow/internal/controller/component.go
@@ -351,6 +351,17 @@ func (cn *ComponentNode) CurrentHealth() component.Health {
 	return latestHealth
 }
 
+// DebugInfo returns debugging information from the managed component (if any).
+func (cn *ComponentNode) DebugInfo() interface{} {
+	cn.mut.RLock()
+	defer cn.mut.RUnlock()
+
+	if dc, ok := cn.managed.(component.DebugComponent); ok {
+		return dc.DebugInfo()
+	}
+	return nil
+}
+
 // setEvalHealth sets the internal health from a call to Evaluate. See Health
 // for information on how overall health is calculated.
 func (cn *ComponentNode) setEvalHealth(t component.HealthType, msg string) {

--- a/pkg/flow/internal/controller/component_write.go
+++ b/pkg/flow/internal/controller/component_write.go
@@ -1,0 +1,47 @@
+package controller
+
+import (
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/rfratto/gohcl"
+)
+
+// WriteComponent generates an hclwrite Block from a component. Health and
+// debug info will be included if debugInfo is true.
+func WriteComponent(cn *ComponentNode, debugInfo bool) *hclwrite.Block {
+	var (
+		id = cn.ID()
+
+		blockName = id[0]
+		labels    = id[1:]
+	)
+
+	b := hclwrite.NewBlock(blockName, labels)
+
+	if args := cn.Arguments(); args != nil {
+		gohcl.EncodeIntoBody(args, b.Body())
+	}
+
+	if exports := cn.Exports(); exports != nil {
+		b.Body().AppendUnstructuredTokens(hclwrite.Tokens{
+			{Type: hclsyntax.TokenNewline, Bytes: []byte("\n")},
+			{Type: hclsyntax.TokenComment, Bytes: []byte("// Exported fields:\n")},
+		})
+		gohcl.EncodeIntoBody(exports, b.Body())
+	}
+
+	if debugInfo {
+		b.Body().AppendUnstructuredTokens(hclwrite.Tokens{
+			{Type: hclsyntax.TokenNewline, Bytes: []byte("\n")},
+			{Type: hclsyntax.TokenComment, Bytes: []byte("// Debug info:\n")},
+		})
+
+		b.Body().AppendBlock(gohcl.EncodeAsBlock(cn.CurrentHealth(), "health"))
+
+		if di := cn.DebugInfo(); di != nil {
+			b.Body().AppendBlock(gohcl.EncodeAsBlock(di, "status"))
+		}
+	}
+
+	return b
+}

--- a/pkg/flow/internal/controller/component_write_test.go
+++ b/pkg/flow/internal/controller/component_write_test.go
@@ -1,0 +1,121 @@
+package controller
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/agent/component"
+	_ "github.com/grafana/agent/pkg/flow/internal/testcomponents" // Import test components
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteComponent(t *testing.T) {
+	config := `
+		testcomponents "passthrough" "example" {
+			input = "Hello, world!"
+		}
+	`
+
+	blocks := loadFile(t, []byte(config))
+
+	cn := NewComponentNode(ComponentGlobals{
+		Logger:          log.NewNopLogger(),
+		DataPath:        t.TempDir(),
+		OnExportsChange: func(cn *ComponentNode) { /* no-op */ },
+	}, blocks[0])
+
+	// Evaluate the component so we're sure it's built
+	err := cn.Evaluate(nil)
+	require.NoError(t, err)
+
+	outBlock := WriteComponent(cn, false)
+	actual := marshalBlock(outBlock)
+
+	expect := `
+testcomponents "passthrough" "example" {
+  input = "Hello, world!"
+
+  // Exported fields:
+  output = "Hello, world!"
+}`
+
+	// Remove leading and trailing whitespace so we don't have to get too picky
+	// about how we format the expected string.
+	expect = strings.TrimSpace(expect)
+	actual = strings.TrimSpace(actual)
+	require.Equal(t, expect, actual)
+}
+
+func TestWriteComponent_DebugInfo(t *testing.T) {
+	config := `
+		testcomponents "passthrough" "example" {
+			input = "Hello, world!"
+		}
+	`
+
+	blocks := loadFile(t, []byte(config))
+
+	cn := NewComponentNode(ComponentGlobals{
+		Logger:          log.NewNopLogger(),
+		DataPath:        t.TempDir(),
+		OnExportsChange: func(cn *ComponentNode) { /* no-op */ },
+	}, blocks[0])
+
+	// Evaluate the component so we're sure it's built
+	err := cn.Evaluate(nil)
+	require.NoError(t, err)
+
+	outBlock := WriteComponent(cn, true)
+	actual := marshalBlock(outBlock)
+
+	expect := fmt.Sprintf(`
+testcomponents "passthrough" "example" {
+  input = "Hello, world!"
+
+  // Exported fields:
+  output = "Hello, world!"
+
+  // Debug info:
+  health {
+    state       = "healthy"
+    message     = "component evaluated"
+    update_time = %q
+  }
+  status {
+    component_version = "v0.1-beta.0"
+  }
+}`, cn.evalHealth.UpdateTime.Format(time.RFC3339Nano))
+
+	// Remove leading and trailing whitespace so we don't have to get too picky
+	// about how we format the expected string.
+	expect = strings.TrimSpace(expect)
+	actual = strings.TrimSpace(actual)
+	require.Equal(t, expect, actual)
+}
+
+func loadFile(t *testing.T, bb []byte) hcl.Blocks {
+	file, diags := hclsyntax.ParseConfig(bb, t.Name(), hcl.InitialPos)
+	if diags.HasErrors() {
+		require.FailNow(t, diags.Error())
+	}
+
+	blockSchema := component.RegistrySchema()
+	content, contentDiags := file.Body.Content(blockSchema)
+	if contentDiags.HasErrors() {
+		require.FailNow(t, contentDiags.Error())
+	}
+
+	return content.Blocks
+}
+
+func marshalBlock(b *hclwrite.Block) string {
+	f := hclwrite.NewFile()
+	f.Body().AppendBlock(b)
+	return string(f.Bytes())
+}

--- a/pkg/flow/internal/testcomponents/passthrough.go
+++ b/pkg/flow/internal/testcomponents/passthrough.go
@@ -48,7 +48,8 @@ func NewPassthrough(o component.Options, cfg PassthroughConfig) (*Passthrough, e
 }
 
 var (
-	_ component.Component = (*Passthrough)(nil)
+	_ component.Component      = (*Passthrough)(nil)
+	_ component.DebugComponent = (*Passthrough)(nil)
 )
 
 // Run implements Component.
@@ -64,4 +65,18 @@ func (t *Passthrough) Update(args component.Arguments) error {
 	level.Info(t.log).Log("msg", "passing through value", "value", c.Input)
 	t.opts.OnStateChange(PassthroughExports{Output: c.Input})
 	return nil
+}
+
+func (t *Passthrough) DebugInfo() interface{} {
+	// Useless, but for demonstration purposes shows how to export debug
+	// information. Real components would want to use something interesting here
+	// which allow the user to investigate issues of the internal state of a
+	// component.
+	return passthroughDebugInfo{
+		ComponentVersion: "v0.1-beta.0",
+	}
+}
+
+type passthroughDebugInfo struct {
+	ComponentVersion string `hcl:"component_version"`
 }

--- a/pkg/flow/internal/testcomponents/passthrough.go
+++ b/pkg/flow/internal/testcomponents/passthrough.go
@@ -67,6 +67,7 @@ func (t *Passthrough) Update(args component.Arguments) error {
 	return nil
 }
 
+// DebugInfo implements DebugComponent.
 func (t *Passthrough) DebugInfo() interface{} {
 	// Useless, but for demonstration purposes shows how to export debug
 	// information. Real components would want to use something interesting here


### PR DESCRIPTION
The `/-/config` endpoint renders the current state of all components, with expressions evaluated, back as HCL to the user. 

`/-/config?debug=1` may be invoked to add health information per-component along with component-specific debug information if a component implements the `component.DebugComponent` interface.