### PR TITLE
flow/hcltypes: add a Secret and OptionalSecret type

### DIFF
--- a/pkg/flow/hcltypes/optional_secret.go
+++ b/pkg/flow/hcltypes/optional_secret.go
@@ -13,12 +13,12 @@ import (
 // OptionalSecret holds a potentially sensitive value. When Sensitive is true,
 // Value will be treated as a Secret and its value will be hidden from users.
 //
-// Both Strings and Secrets may be converted into OptionalSecret, which will
-// set the Secret field accordingly.
+// HCL expressions permit converting both Strings and Secrets may be converted
+// into OptionalSecret, which will set the Sensitive field accordingly.
 //
-// OptionalSecret may be converted into a Secret regardless of the value of
-// Sensitive. OptionalSecret may only be converted into a String if Sensitive
-// is false.
+// HCL expressions may also convert OptionalSecret into a Secret regardless of
+// the value of Sensitive. However, OptionalSecret may only be converted into a
+// String if Sensitive is false.
 type OptionalSecret struct {
 	Sensitive bool
 	Value     string

--- a/pkg/flow/hcltypes/optional_secret.go
+++ b/pkg/flow/hcltypes/optional_secret.go
@@ -1,0 +1,98 @@
+package hcltypes
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/rfratto/gohcl"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// OptionalSecret holds a potentially sensitive value. When Sensitive is true,
+// Value will be treated as a Secret and its value will be hidden from users.
+//
+// Both Strings and Secrets may be converted into OptionalSecret, which will
+// set the Secret field accordingly.
+//
+// OptionalSecret may be converted into a Secret regardless of the value of
+// Sensitive. OptionalSecret may only be converted into a String if Sensitive
+// is false.
+type OptionalSecret struct {
+	Sensitive bool
+	Value     string
+}
+
+var optionalSecretTy cty.Type
+
+func init() {
+	optionalSecretTy = cty.CapsuleWithOps("OptionalSecret", reflect.TypeOf(OptionalSecret{}), &cty.CapsuleOps{
+		ConversionFrom: func(src cty.Type) func(interface{}, cty.Path) (cty.Value, error) {
+			switch {
+			case src.Equals(cty.String): // OptionalSecret -> Secret
+				return func(v interface{}, _ cty.Path) (cty.Value, error) {
+					os := v.(*OptionalSecret)
+					if os.Sensitive {
+						// Only allow conversion to string if the OptionalSecret is non-sensitive.
+						return cty.NilVal, fmt.Errorf("cannot convert secret to string")
+					}
+					return cty.StringVal(os.Value), nil
+				}
+			case src.Equals(secretTy): // OptionalSecret -> Secret
+				// Always allow conversion to a Secret.
+				return func(v interface{}, _ cty.Path) (cty.Value, error) {
+					os := v.(*OptionalSecret)
+					s := Secret(os.Value)
+					return cty.CapsuleVal(secretTy, &s), nil
+				}
+			default:
+				return nil
+			}
+		},
+
+		ConversionTo: func(dst cty.Type) func(cty.Value, cty.Path) (interface{}, error) {
+			switch {
+			case dst.Equals(cty.String): // String -> OptionalSecret
+				return func(v cty.Value, _ cty.Path) (interface{}, error) {
+					return &OptionalSecret{Sensitive: false, Value: v.AsString()}, nil
+				}
+			case dst.Equals(secretTy): // Secret -> OptionalSecret
+				return func(v cty.Value, _ cty.Path) (interface{}, error) {
+					secret := v.EncapsulatedValue().(*Secret)
+					return &OptionalSecret{Sensitive: true, Value: string(*secret)}, nil
+				}
+
+			default:
+				return nil
+			}
+		},
+
+		ExtensionData: func(key interface{}) interface{} {
+			switch key {
+			case gohcl.CapsuleTokenExtensionKey:
+				return gohcl.CapsuleTokenExtension(func(v cty.Value) hclwrite.Tokens {
+					os := v.EncapsulatedValue().(*OptionalSecret)
+
+					if os.Sensitive {
+						return hclwrite.Tokens{
+							{Type: hclsyntax.TokenOParen, Bytes: []byte("(")},
+							{Type: hclsyntax.TokenIdent, Bytes: []byte("secret")},
+							{Type: hclsyntax.TokenCParen, Bytes: []byte(")")},
+						}
+					}
+
+					return hclwrite.Tokens{
+						// NOTE(rfratto): the space before the %q below is intentional; for
+						// some reason, for only TokenQuotedLit, no space between = and the
+						// value is added unless the token itself contains one.
+						{Type: hclsyntax.TokenQuotedLit, Bytes: []byte(fmt.Sprintf(" %q", os.Value))},
+					}
+				})
+			}
+			return nil
+		},
+	})
+
+	gohcl.RegisterCapsuleType(optionalSecretTy)
+}

--- a/pkg/flow/hcltypes/optional_secret_test.go
+++ b/pkg/flow/hcltypes/optional_secret_test.go
@@ -1,0 +1,93 @@
+package hcltypes
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/rfratto/gohcl"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+)
+
+func TestOptionalSecret(t *testing.T) {
+	t.Run("non-sensitive conversion to string is allowed", func(t *testing.T) {
+		input := OptionalSecret{Sensitive: false, Value: "testval"}
+
+		result, err := convert.Convert(cty.CapsuleVal(optionalSecretTy, &input), cty.String)
+		require.NoError(t, err)
+		require.Equal(t, input.Value, result.AsString())
+	})
+
+	t.Run("sensitive conversion to string is disallowed", func(t *testing.T) {
+		input := OptionalSecret{Sensitive: true, Value: "testval"}
+
+		result, err := convert.Convert(cty.CapsuleVal(optionalSecretTy, &input), cty.String)
+		require.EqualError(t, err, "cannot convert secret to string")
+		require.Equal(t, cty.NilVal, result)
+	})
+
+	t.Run("non-sensitive conversion to secret is allowed", func(t *testing.T) {
+		input := OptionalSecret{Sensitive: false, Value: "secretval"}
+
+		result, err := convert.Convert(cty.CapsuleVal(optionalSecretTy, &input), secretTy)
+		require.NoError(t, err)
+		require.Equal(t, input.Value, string(*result.EncapsulatedValue().(*Secret)))
+	})
+
+	t.Run("sensitive conversion to secret is allowed", func(t *testing.T) {
+		input := OptionalSecret{Sensitive: true, Value: "secretval"}
+
+		result, err := convert.Convert(cty.CapsuleVal(optionalSecretTy, &input), secretTy)
+		require.NoError(t, err)
+		require.Equal(t, input.Value, string(*result.EncapsulatedValue().(*Secret)))
+	})
+
+	t.Run("conversion from string is allowed", func(t *testing.T) {
+		input := "hello, world!"
+
+		result, err := convert.Convert(cty.StringVal(input), optionalSecretTy)
+		require.NoError(t, err)
+
+		os := result.EncapsulatedValue().(*OptionalSecret)
+		require.False(t, os.Sensitive)
+		require.Equal(t, os.Value, input)
+	})
+
+	t.Run("conversion from secret is allowed", func(t *testing.T) {
+		input := Secret("sensitive")
+
+		result, err := convert.Convert(cty.CapsuleVal(secretTy, &input), optionalSecretTy)
+		require.NoError(t, err)
+
+		os := result.EncapsulatedValue().(*OptionalSecret)
+		require.True(t, os.Sensitive)
+		require.Equal(t, os.Value, string(input))
+	})
+}
+
+func TestOptionalSecret_Write(t *testing.T) {
+	type testBlock struct {
+		Value OptionalSecret `hcl:"value,attr"`
+	}
+
+	t.Run("non-sensitive", func(t *testing.T) {
+		b := testBlock{
+			Value: OptionalSecret{Sensitive: false, Value: "not-hidden"},
+		}
+
+		f := hclwrite.NewFile()
+		gohcl.EncodeIntoBody(&b, f.Body())
+		require.Equal(t, "value = \"not-hidden\"\n", string(f.Bytes()))
+	})
+
+	t.Run("sensitive", func(t *testing.T) {
+		b := testBlock{
+			Value: OptionalSecret{Sensitive: true, Value: "hidden"},
+		}
+
+		f := hclwrite.NewFile()
+		gohcl.EncodeIntoBody(&b, f.Body())
+		require.Equal(t, "value = (secret)\n", string(f.Bytes()))
+	})
+}

--- a/pkg/flow/hcltypes/secret.go
+++ b/pkg/flow/hcltypes/secret.go
@@ -1,0 +1,75 @@
+package hcltypes
+
+import (
+	"reflect"
+
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/rfratto/gohcl"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Secret holds a sensitive value. Secrets are never displayed to the user when
+// rendering HCL.
+//
+// String values may be implicitly converted to a Secret, but the inverse isn't
+// true: this ensures that it's not possible for a user to accidentally leak a
+// sensitive value.
+type Secret string
+
+var secretTy cty.Type
+
+func init() {
+	secretTy = cty.CapsuleWithOps("secret", reflect.TypeOf(Secret("")), &cty.CapsuleOps{
+		// We allow strings to be converted into secrets, but don't allow secrets
+		// to be converted back to strings to prevent them from being leaked.
+
+		ConversionFrom: func(src cty.Type) func(interface{}, cty.Path) (cty.Value, error) {
+			switch {
+			case src.Equals(optionalSecretTy): // Secret -> OptionalSecret
+				return func(v interface{}, _ cty.Path) (cty.Value, error) {
+					return cty.CapsuleVal(optionalSecretTy, &OptionalSecret{
+						Sensitive: true,
+						Value:     string(*v.(*Secret)),
+					}), nil
+				}
+			default:
+				return nil
+			}
+		},
+
+		ConversionTo: func(dst cty.Type) func(cty.Value, cty.Path) (interface{}, error) {
+			switch {
+			case dst.Equals(cty.String): // string -> Secret
+				return func(v cty.Value, _ cty.Path) (interface{}, error) {
+					res := Secret(v.AsString())
+					return &res, nil
+				}
+			case dst.Equals(optionalSecretTy): // OptionalSecret -> Secret
+				return func(v cty.Value, _ cty.Path) (interface{}, error) {
+					os := v.EncapsulatedValue().(*OptionalSecret)
+					res := Secret(os.Value)
+					return &res, nil
+				}
+			default:
+				return nil
+			}
+		},
+
+		ExtensionData: func(key interface{}) interface{} {
+			switch key {
+			case gohcl.CapsuleTokenExtensionKey:
+				return gohcl.CapsuleTokenExtension(func(v cty.Value) hclwrite.Tokens {
+					return hclwrite.Tokens{
+						{Type: hclsyntax.TokenOParen, Bytes: []byte("(")},
+						{Type: hclsyntax.TokenIdent, Bytes: []byte("secret")},
+						{Type: hclsyntax.TokenCParen, Bytes: []byte(")")},
+					}
+				})
+			}
+			return nil
+		},
+	})
+
+	gohcl.RegisterCapsuleType(secretTy)
+}

--- a/pkg/flow/hcltypes/secret.go
+++ b/pkg/flow/hcltypes/secret.go
@@ -12,8 +12,8 @@ import (
 // Secret holds a sensitive value. Secrets are never displayed to the user when
 // rendering HCL.
 //
-// String values may be implicitly converted to a Secret, but the inverse isn't
-// true: this ensures that it's not possible for a user to accidentally leak a
+// HCL expressions permit implicitly converting string values to a Secret, but
+// not the inverse. This ensures that a user can't accidentally leak a
 // sensitive value.
 type Secret string
 

--- a/pkg/flow/hcltypes/secret_test.go
+++ b/pkg/flow/hcltypes/secret_test.go
@@ -1,0 +1,53 @@
+package hcltypes
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/rfratto/gohcl"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+)
+
+func TestSecret(t *testing.T) {
+	t.Run("strings can be converted to secret", func(t *testing.T) {
+		expect := "hello, world!"
+
+		secretVal, err := convert.Convert(cty.StringVal(expect), secretTy)
+		require.NoError(t, err)
+
+		actual := secretVal.EncapsulatedValue().(*Secret)
+		require.Equal(t, string(*actual), expect)
+	})
+
+	t.Run("secrets cannot be converted to strings", func(t *testing.T) {
+		s := Secret("hello, world!")
+
+		result, err := convert.Convert(cty.CapsuleVal(secretTy, &s), cty.String)
+		require.EqualError(t, err, "string required")
+		require.Equal(t, cty.NilVal, result)
+	})
+
+	t.Run("secrets can be passed to secrets", func(t *testing.T) {
+		s := Secret("hello, world!")
+
+		result, err := convert.Convert(cty.CapsuleVal(secretTy, &s), secretTy)
+		require.NoError(t, err)
+
+		actual := result.EncapsulatedValue().(*Secret)
+		require.Equal(t, (*actual), s)
+	})
+}
+
+func TestSecret_Write(t *testing.T) {
+	type testBlock struct {
+		Value Secret `hcl:"value,attr"`
+	}
+
+	b := testBlock{Value: Secret("sensitive")}
+
+	f := hclwrite.NewFile()
+	gohcl.EncodeIntoBody(&b, f.Body())
+	require.Equal(t, "value = (secret)\n", string(f.Bytes()))
+}


### PR DESCRIPTION
Closes #1688.

Secret
------

hcltypes.Secret allows components to declare a value as sensitive.
Secret types are never shown to the user at the /-/config endpoint,
appearing as `(secret)`.

Both strings and OptionalSecrets may be converted into a Secret.

Secrets may be converted back to OptionalSecrets, but may never be
converted back into a string.

OptionalSecret
--------------

hcltypes.OptionalSecret allows components to configure whether a string
value is sensitive. This is useful for components like local.file where
some files contain sensitive information and others don't.

Both strings and Secrets may be convertd into an OptionalSecret.

OptionalSecrets may be converted into Secrets. OptionalSecrets may only
be converted back into a string if their underlying value is not marked
as sensitive.
