### PR TITLE
Add Hugo link checking to PR check_docs workflow

### DIFF
--- a/.github/workflows/check_docs.yml
+++ b/.github/workflows/check_docs.yml
@@ -15,3 +15,12 @@ jobs:
         use-verbose-mode: 'yes'
         config-file: '.github/workflows/markdown.links.config.json'
         folder-path: 'docs/,example/,production/'
+
+  build-technical-documentation:
+    runs-on: "ubuntu-latest"
+    steps:
+    - name: "Check out code"
+      uses: "actions/checkout@v3"
+    - name: "Build technical documentation"
+      run: |
+        docker run -v ${PWD}/docs/user:/hugo/content/docs/agent/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'make hugo'


### PR DESCRIPTION
#### PR Description

Builds the technical documentation in the grafana.com website as part of the PR `check_docs` workflow. Hugo performs link checking of relrefs and refs and the passed environment variable causes this build to fail if any of those links are broken.

#### Notes to the Reviewer

#### PR Checklist

- [na] CHANGELOG updated
- [ ] Documentation added
- [na] Tests updated
