### PR TITLE
flow: remove unnecessary component evaluations

### DIFF
--- a/pkg/flow/flow.go
+++ b/pkg/flow/flow.go
@@ -139,7 +139,7 @@ func (c *Flow) run(ctx context.Context) {
 			updated := c.updateQueue.TryDequeue()
 			if updated != nil {
 				level.Debug(c.log).Log("msg", "handling component with updated state", "node_id", updated.NodeID())
-				c.loader.Reevaluate(rootEvalContext, updated)
+				c.loader.EvaluateDependencies(rootEvalContext, updated)
 			}
 
 		case <-c.loadFinished:

--- a/pkg/flow/internal/controller/component.go
+++ b/pkg/flow/internal/controller/component.go
@@ -138,7 +138,7 @@ func NewComponentNode(globals ComponentGlobals, b *hcl.Block) *ComponentNode {
 }
 
 func getRegistration(id ComponentID) (component.Registration, bool) {
-	// id is the fully qualfied name of the component, including the custom user
+	// id is the fully qualified name of the component, including the custom user
 	// identifier, if supported by the component. We don't know if the component
 	// we're looking up is a singleton or not, so we have to try the lookup
 	// twice: once with all name fragments in the ID and once without the last
@@ -172,7 +172,8 @@ func getExportsType(reg component.Registration) reflect.Type {
 func (cn *ComponentNode) ID() ComponentID { return cn.id }
 
 // NodeID implements dag.Node and returns the unique ID for this node. The
-// NodeID is the string reprsentation of the component's ID from its HCL block.
+// NodeID is the string representation of the component's ID from its HCL
+// block.
 func (cn *ComponentNode) NodeID() string { return cn.nodeID }
 
 // UpdateBlock updates the HCL block used to construct arguments for the
@@ -317,12 +318,12 @@ func (cn *ComponentNode) setExports(e component.Exports) {
 		panic(fmt.Sprintf("Component %s changed Exports types from %T to %T", cn.nodeID, cn.reg.Exports, e))
 	}
 
-	// Some components may aggressively re-export values even though no exposed
+	// Some components may aggressively reexport values even though no exposed
 	// state has changed. This may be done for components which always supply
 	// exports whenever their arguments are evaluated without tracking internal
 	// state to see if anything actually changed.
 	//
-	// To avoid needessly re-evaluating components we'll ignore unchanged
+	// To avoid needlessly reevaluating components we'll ignore unchanged
 	// exports.
 	var changed bool
 
@@ -335,7 +336,7 @@ func (cn *ComponentNode) setExports(e component.Exports) {
 
 	if cn.doingEval.Load() {
 		// Optimization edge case: some components supply exports when they're
-		// being evaluted.
+		// being evaluated.
 		//
 		// Since components that are being evaluated will always cause their
 		// dependencies to also be evaluated, there's no reason to call
@@ -352,7 +353,7 @@ func (cn *ComponentNode) setExports(e component.Exports) {
 // CurrentHealth returns the current health of the ComponentNode.
 //
 // The health of a ComponentNode is tracked from three parts, in descending
-// prescedence order:
+// precedence order:
 //
 //     1. Exited health from a call to Run()
 //     2. Unhealthy status from last call to Evaluate
@@ -363,7 +364,8 @@ func (cn *ComponentNode) CurrentHealth() component.Health {
 	cn.healthMut.RLock()
 	defer cn.healthMut.RUnlock()
 
-	// A component which stopped running takes predence over all other health states
+	// A component which stopped running takes precedence over all other health
+	// states
 	if cn.runHealth.Health == component.HealthTypeExited {
 		return cn.runHealth
 	}


### PR DESCRIPTION
- Don't pass unchanged arguments to components to avoid unnecessary expensive component updates.
- Ignore unchanged exports from components to avoid unnecessary re-evaluations.
- When dequeuing a changed component, only re-evaluate its dependencies. There's no point in re-evaluating the changed component since none of its arguments would need reprocessing.