### PR TITLE
Add --platforms flag to agentctl cloud-config command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Main (unreleased)
 
 - Configure the agent to report the use of feature flags to grafana.com. (@marctc)
 
+- Add `--platforms` flag to agentctl cloud-config command. (@tpaschalis)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,6 @@ Main (unreleased)
 
 - Configure the agent to report the use of feature flags to grafana.com. (@marctc)
 
-- Add `--platforms` flag to agentctl cloud-config command. (@tpaschalis)
-
 ### Enhancements
 
 - integrations-next: Integrations using autoscrape will now autoscrape metrics

--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -431,9 +431,10 @@ func filterAgentOwners(refs []meta_v1.OwnerReference) (filtered []meta_v1.OwnerR
 
 func cloudConfigCmd() *cobra.Command {
 	var (
-		stackID string
-		apiURL  string
-		apiKey  string
+		stackID   string
+		apiURL    string
+		apiKey    string
+		platforms string
 	)
 
 	cmd := &cobra.Command{
@@ -460,7 +461,7 @@ config that may be used with this agent.`,
 			}
 			cli := grafanacloud.NewClient(httpClient, apiKey, apiURL)
 
-			cfg, err := cli.AgentConfig(context.Background(), stackID)
+			cfg, err := cli.AgentConfig(context.Background(), stackID, platforms)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "could not retrieve agent cloud config: %s\n", err)
 				os.Exit(1)
@@ -474,6 +475,7 @@ config that may be used with this agent.`,
 	cmd.Flags().StringVarP(&stackID, "stack", "u", "", "stack ID to get a config for")
 	cmd.Flags().StringVarP(&apiKey, "api-key", "p", "", "API key to authenticate against Grafana Cloud's API with")
 	cmd.Flags().StringVarP(&apiURL, "api-url", "e", "", "Grafana Cloud's API url")
+	cmd.Flags().StringVar(&platforms, "platforms", "", "Platforms/OSes to retrieve configuration for")
 	must(cmd.MarkFlagRequired("stack"))
 	must(cmd.MarkFlagRequired("api-key"))
 

--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"sort"
 	"strings"
 	"time"
@@ -475,7 +476,7 @@ config that may be used with this agent.`,
 	cmd.Flags().StringVarP(&stackID, "stack", "u", "", "stack ID to get a config for")
 	cmd.Flags().StringVarP(&apiKey, "api-key", "p", "", "API key to authenticate against Grafana Cloud's API with")
 	cmd.Flags().StringVarP(&apiURL, "api-url", "e", "", "Grafana Cloud's API url")
-	cmd.Flags().StringVar(&platforms, "platforms", "", "Platforms/OSes to retrieve configuration for")
+	cmd.Flags().StringVar(&platforms, "platforms", goruntime.GOOS, "comma-separated list of Platforms/OSes")
 	must(cmd.MarkFlagRequired("stack"))
 	must(cmd.MarkFlagRequired("api-key"))
 

--- a/pkg/client/grafanacloud/client.go
+++ b/pkg/client/grafanacloud/client.go
@@ -36,12 +36,13 @@ func NewClient(c *http.Client, apiKey, apiURL string) *Client {
 
 // AgentConfig generates a Grafana Agent config from the given stack.
 // The config is returned as a string in YAML form.
-func (c *Client) AgentConfig(ctx context.Context, stackID string) (string, error) {
-	req, err := http.NewRequestWithContext(
-		ctx, "GET",
-		fmt.Sprintf("%s/stacks/%s/agent_config", c.apiURL, stackID),
-		nil,
-	)
+func (c *Client) AgentConfig(ctx context.Context, stackID, platforms string) (string, error) {
+	url := fmt.Sprintf("%s/stacks/%s/agent_config", c.apiURL, stackID)
+	if platforms != "" {
+		url = fmt.Sprintf("%s?platforms=%s", url, platforms)
+	}
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+
 	if err != nil {
 		return "", fmt.Errorf("failed to generate request: %w", err)
 	}

--- a/production/grafanacloud-install.sh
+++ b/production/grafanacloud-install.sh
@@ -121,7 +121,7 @@ install_rpm() {
 # retrieve_config downloads the config file for the Agent and prints out its
 # contents to stdout.
 retrieve_config() {
-  if ! grafana-agentctl cloud-config -platforms "linux" -u "${GCLOUD_STACK_ID}" -p "${GCLOUD_API_KEY}" -e "${GCLOUD_API_URL}"  2>/dev/null; then
+  if ! grafana-agentctl cloud-config -u "${GCLOUD_STACK_ID}" -p "${GCLOUD_API_KEY}" -e "${GCLOUD_API_URL}" 2>/dev/null; then
     fatal "Failed to retrieve config"
   fi
 }

--- a/production/grafanacloud-install.sh
+++ b/production/grafanacloud-install.sh
@@ -121,7 +121,7 @@ install_rpm() {
 # retrieve_config downloads the config file for the Agent and prints out its
 # contents to stdout.
 retrieve_config() {
-  if ! grafana-agentctl cloud-config -u "${GCLOUD_STACK_ID}" -p "${GCLOUD_API_KEY}" -e "${GCLOUD_API_URL}" 2>/dev/null; then
+  if ! grafana-agentctl cloud-config -platforms "linux" -u "${GCLOUD_STACK_ID}" -p "${GCLOUD_API_KEY}" -e "${GCLOUD_API_URL}"  2>/dev/null; then
     fatal "Failed to retrieve config"
   fi
 }


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

#### PR Description
This PR adds a `--platforms` flag to the `agentctl cloud-config` command. 

Last quarter, we enhanced our cloud API to receive filters based on platforms and include/exclude options. This enabled us to have both Linux and macOS integrations based on `node_exporter` and avoiding errors about duplicate keys; the Grafana Cloud API would be smart enough to request platform-specific configuration bring only one of the two keys.

Currently, when new users go through onboarding, they're using the `grafanacloud-install.sh` script to retrieve their Cloud configuration locally. If they have both the Linux and macOS integrations, calling the cloud-config command will return a 500 error with a message along the lines of 
```msg="could not unmarshal agent config" err="yaml: unmarshal errors:\n  line XX: mapping key \"node_exporter\" already defined at line XX"```

This new flag is instructs the Linux-specific script mentioned above to only request configuration for Linux-based integrations and ignore everything else.

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer
Should we also add flags for the `include` and `exclude` filters in the Grafana Cloud API? Also, if you think there's a cleaner way of achieving the same result, please let me know.

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added (N/A)
- [x] Tests updated
