### PR TITLE
Document relabelling in integrations-next

### DIFF
--- a/docs/user/configuration/integrations/integrations-next/_index.md
+++ b/docs/user/configuration/integrations/integrations-next/_index.md
@@ -145,7 +145,7 @@ autoscrape:
   # Specifies the metrics instance name to send metrics to.
   [metrics_instance: <string> | default = <integrations.metrics.autoscrape.metrics_instance>]
 
-  # Allows for relabeling labels on the target.
+  # Relabel the autoscrape job.
   relabel_configs:
     [- <relabel_config> ... ]
 

--- a/docs/user/configuration/integrations/integrations-next/_index.md
+++ b/docs/user/configuration/integrations/integrations-next/_index.md
@@ -145,6 +145,14 @@ autoscrape:
   # Specifies the metrics instance name to send metrics to.
   [metrics_instance: <string> | default = <integrations.metrics.autoscrape.metrics_instance>]
 
+  # Allows for relabeling labels on the target.
+  relabel_configs:
+    [- <relabel_config> ... ]
+
+  # Relabel metrics coming from the integration.
+  metric_relabel_configs:
+    [ - <relabel_config> ... ]
+
   # Autoscrape interval and timeout.
   [scrape_interval: <duration> | default = <integrations.metrics.autoscrape.scrape_interval>]
   [scrape_timeout: <duration> | default = <integrations.metrics.autoscrape.scrape_timeout>]


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

#### PR Description
We currently don't mention how users should add relabelling steps when running integrations-next.

These two keys are not available in the `autoscrape.Global` struct, but have to be configured per-integration in `autoscrape.Config`.

#### Which issue(s) this PR fixes
Closes #1731

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [X] Documentation added
- [ ] Tests updated (N/A)
