### PR TITLE
bug: fix bunmarshalling app agent receiver config multiple times

### DIFF
--- a/pkg/integrations/v2/app_agent_receiver/config.go
+++ b/pkg/integrations/v2/app_agent_receiver/config.go
@@ -86,6 +86,7 @@ type Config struct {
 // UnmarshalYAML implements the Unmarshaler interface
 func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	*c = DefaultConfig
+	c.LogsLabels = make(map[string]string)
 	type plain Config
 	return unmarshal((*plain)(c))
 }

--- a/pkg/integrations/v2/app_agent_receiver/config_test.go
+++ b/pkg/integrations/v2/app_agent_receiver/config_test.go
@@ -45,3 +45,35 @@ server:
 	require.Equal(t, 142.0, cfg.Server.RateLimiting.RPS)
 	require.Equal(t, 50, cfg.Server.RateLimiting.Burstiness)
 }
+
+func TestConfig_MultipleUnmarshals(t *testing.T) {
+	var cfg1 Config
+	cb1 := `
+sourcemaps:
+  download_origins: ["one"]
+logs_labels:
+  app: frontend
+  one: two`
+	var cfg2 Config
+	cb2 := `
+logs_labels:
+  app: backend
+  bar: baz`
+
+	err := yaml.UnmarshalStrict([]byte(cb1), &cfg1)
+	require.NoError(t, err)
+	err = yaml.UnmarshalStrict([]byte(cb2), &cfg2)
+	require.NoError(t, err)
+
+	require.Equal(t, map[string]string{
+		"app": "frontend",
+		"one": "two",
+	}, cfg1.LogsLabels)
+	require.Equal(t, []string{"one"}, cfg1.SourceMaps.DownloadFromOrigins)
+
+	require.Equal(t, map[string]string{
+		"app": "backend",
+		"bar": "baz",
+	}, cfg2.LogsLabels)
+	require.Equal(t, []string{"*"}, cfg2.SourceMaps.DownloadFromOrigins)
+}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Unmarshalling app agent receiver config multiple times might fail because it's default config was not properly copied each time, with `LogsLabels` map only being copied by reference and ending up with items from previous instance.

This PR fixes the problem by instantiating new `LogsLabels` map every time.

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [x] Tests updated
