### PR TITLE
Scraping Service needs to honor the new server flags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ Main (unreleased)
 - Resolved issue in v2 integrations where if an instance name was a prefix of another the route handler would fail to
   match requests on the longer name (@mattdurham)
 
+
+### Bugfixes
+
+- Scraping service was not honoring the new server grpc flags `server.grpc.address`.  (@mattdurham)
+
 ### Other changes
 
 - Update base image of official Docker containers from Debian buster to Debian

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"unicode"
@@ -179,6 +180,16 @@ func (c *Config) Validate(fs *flag.FlagSet) error {
 		return err
 	}
 
+	// Need to propagate the listen address to the host and port
+	if c.Server.Flags.GRPC.ListenAddress != "" {
+		addressPort := strings.Split(c.Server.Flags.GRPC.ListenAddress, ":")
+		port, err := strconv.Atoi(addressPort[1])
+		if err != nil {
+			return err
+		}
+		c.Server.Flags.GRPC.ListenPort = port
+		c.Server.Flags.GRPC.ListenHost = addressPort[0]
+	}
 	c.Metrics.ServiceConfig.Lifecycler.ListenPort = c.Server.Flags.GRPC.ListenPort
 
 	if err := c.Integrations.ApplyDefaults(&c.Server, &c.Metrics); err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -452,3 +452,28 @@ func TestLoadDynamicConfigurationExpandError(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "expand var is not supported when using dynamic configuration, use gomplate env instead"))
 }
+
+func TestGRPCListenAddress(t *testing.T) {
+	cfgText := `
+metrics:
+  wal_directory: /tmp
+  scraping_service:
+    enabled: true
+    kvstore:
+      store: consul
+      consul: {}
+    lifecycler:
+      ring:
+        kvstore:
+          store: consul
+          consul: {}
+`
+	var c Config
+	err := LoadBytes([]byte(cfgText), false, &c)
+	require.NoError(t, err)
+	c.Server.Flags.GRPC.ListenAddress = "192.168.1.1:9090"
+	err = c.Validate(nil)
+	require.NoError(t, err)
+	require.Equal(t, 9090, c.Server.Flags.GRPC.ListenPort)
+	require.Equal(t, "192.168.1.1", c.Server.Flags.GRPC.ListenHost)
+}


### PR DESCRIPTION
#### PR Description

With the change to server flags, the GRPC flags were not being propagated correctly to the life cycle listener.

#### PR Checklist

- [X] CHANGELOG updated
- [X] Tests updated
