### PR TITLE
docs/flow: Document local.file and secrets

### DIFF
--- a/component/local/file/file.go
+++ b/component/local/file/file.go
@@ -43,9 +43,9 @@ type Arguments struct {
 	// PollFrequency determines the frequency to check for changes when Type is
 	// UpdateTypePoll.
 	PollFrequency time.Duration `hcl:"poll_freqency,optional"`
-	// Sensitive marks the file as holding a sensitive value which should not be
+	// Secret marks the file as holding a secret value which should not be
 	// displayed to the user.
-	Sensitive bool `hcl:"sensitive,optional"`
+	Secret bool `hcl:"secret,optional"`
 }
 
 // DefaultArguments provides the default arguments for the local.file
@@ -166,8 +166,8 @@ func (c *Component) readFile() error {
 
 	c.opts.OnStateChange(Exports{
 		Content: &hcltypes.OptionalSecret{
-			Sensitive: c.args.Sensitive,
-			Value:     c.latestContent,
+			IsSecret: c.args.Secret,
+			Value:    c.latestContent,
 		},
 	})
 

--- a/component/local/file/file.go
+++ b/component/local/file/file.go
@@ -43,9 +43,9 @@ type Arguments struct {
 	// PollFrequency determines the frequency to check for changes when Type is
 	// UpdateTypePoll.
 	PollFrequency time.Duration `hcl:"poll_freqency,optional"`
-	// Secret marks the file as holding a secret value which should not be
+	// IsSecret marks the file as holding a secret value which should not be
 	// displayed to the user.
-	Secret bool `hcl:"secret,optional"`
+	IsSecret bool `hcl:"is_secret,optional"`
 }
 
 // DefaultArguments provides the default arguments for the local.file
@@ -166,7 +166,7 @@ func (c *Component) readFile() error {
 
 	c.opts.OnStateChange(Exports{
 		Content: &hcltypes.OptionalSecret{
-			IsSecret: c.args.Secret,
+			IsSecret: c.args.IsSecret,
 			Value:    c.latestContent,
 		},
 	})

--- a/component/local/file/file_test.go
+++ b/component/local/file/file_test.go
@@ -48,8 +48,8 @@ func runFileTests(t *testing.T, ut file.Detector) {
 		require.NoError(t, tc.WaitExports(time.Second))
 		require.Equal(t, file.Exports{
 			Content: &hcltypes.OptionalSecret{
-				Sensitive: false,
-				Value:     "First load!",
+				IsSecret: false,
+				Value:    "First load!",
 			},
 		}, tc.Exports())
 		return tc
@@ -65,8 +65,8 @@ func runFileTests(t *testing.T, ut file.Detector) {
 		require.NoError(t, sc.WaitExports(time.Second))
 		require.Equal(t, file.Exports{
 			Content: &hcltypes.OptionalSecret{
-				Sensitive: false,
-				Value:     "New content!",
+				IsSecret: false,
+				Value:    "New content!",
 			},
 		}, sc.Exports())
 	})
@@ -82,8 +82,8 @@ func runFileTests(t *testing.T, ut file.Detector) {
 		require.NoError(t, sc.WaitExports(time.Second))
 		require.Equal(t, file.Exports{
 			Content: &hcltypes.OptionalSecret{
-				Sensitive: false,
-				Value:     "New content!",
+				IsSecret: false,
+				Value:    "New content!",
 			},
 		}, sc.Exports())
 	})
@@ -109,8 +109,8 @@ func TestFile_ImmediateExports(t *testing.T) {
 	require.NoError(t, tc.WaitExports(time.Second))
 	require.Equal(t, file.Exports{
 		Content: &hcltypes.OptionalSecret{
-			Sensitive: false,
-			Value:     "Hello, world!",
+			IsSecret: false,
+			Value:    "Hello, world!",
 		},
 	}, tc.Exports())
 }

--- a/docs/flow/components/local.file.md
+++ b/docs/flow/components/local.file.md
@@ -28,7 +28,7 @@ Name | Type | Description | Default | Required
 `filename` | `string` | Path of the file on disk to watch | | **yes**
 `detector` | `string` | Which file change detector to use (fsnotify, poll) | `"fsnotify"` | no
 `poll_frequency` | `duration` | How often to poll for file changes | `"1m"` | no
-`secret` | `bool` | Marks the file as [secret][] | `false` | no
+`is_secret` | `bool` | Marks the file as containing a [secret][] | `false` | no
 
 ### File change detectors
 
@@ -66,8 +66,8 @@ Name | Type | Description
 ---- | ---- | -----------
 `content` | `string` or `secret` | The contents of the file from the most recent read
 
-The `content` field will have the `secret` type only if the `secret` argument
-was set to true.
+The `content` field will have the `secret` type only if the `is_secret`
+argument was true.
 
 ## Component health
 
@@ -88,4 +88,4 @@ component.
 
 `local.file` does not expose any component-specific debug metrics.
 
-[secret]: ../secrets.md#secret-argument-in-components
+[secret]: ../secrets.md#is_secret-argument-in-components

--- a/docs/flow/components/local.file.md
+++ b/docs/flow/components/local.file.md
@@ -1,0 +1,91 @@
+# local.file
+
+The `local.file` component exposes the contents of a file on disk to other
+components. The file will be watched for changes so that its latest content is
+always exposed.
+
+The most common use of `local.file` is to load secrets (e.g., API keys) from
+files.
+
+Multiple `local.file` components can be specified by giving them different name
+labels.
+
+## Example
+
+```hcl
+local "file" "my-file" {
+  filename = "path/to/my/file"
+}
+```
+
+## Arguments
+
+The following arguments are supported and can be referenced by other
+components:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`filename` | `string` | Path of the file on disk to watch | `""` | **yes**
+`detector` | `string` | Which file change detector to use (fsnotify, poll) | `"fsnotify"` | no
+`poll_frequency` | `duration` | How often to poll for file changes | `"1m"` | no
+`sensitive` | `bool` | Marks the file as [sensitive][] | `false` | no
+
+### File change detectors
+
+File change detectors are used for detecting when the file needs to be re-read
+from disk. `local.file` supports two detectors: `fsnotify` and `poll`.
+
+#### fsnotify
+
+The `fsnotify` detector subscribes to filesystem events which indicate when the
+watched file had been updated. This requires a filesystem which supports events
+at the Operating System level: network-based filesystems like NFS or FUSE won't
+work.
+
+When a filesystem event is received, the component will reread the watched
+file. This will happen for any filesystem event to the file, including a change
+of permissions.
+
+`fsnotify` also polls for changes to the file with the configured
+`poll_frequency` as a fallback.
+
+`fsnotify` will stop receiving filesystem events if the watched file has been
+deleted, renamed, or moved. The subscription will be re-established on the next
+poll once the watched file exists again.
+
+#### poll
+
+The `poll` file change detector will cause the watched file to be reread
+every `poll_frequency`, regardless of whether the file changed.
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+Name | Type | Description
+---- | ---- | -----------
+`content` | `string` or `secret` | The contents of the file from the most recent read
+
+The `content` field will have the `secret` type only if the `sensitive`
+argument was set to true.
+
+## Component health
+
+Any `local.file` component will be reported as healthy whenever if the watched
+file was read successfully.
+
+Failing to read the file whenever an update is detected (or after the poll
+period elapses) will cause the component to be reported as unhealthy. When
+unhealthy, exported fields will be kept at the last healthy value. The read
+error will be exposed as a log message and in the debug information for the
+component.
+
+## Debug information
+
+`local.file` does not expose any component-specific debug information.
+
+### Debug metrics
+
+`local.file` does not expose any component-specific debug metrics.
+
+[sensitive]: ../secrets.md#sensitive-argument-in-components

--- a/docs/flow/components/local.file.md
+++ b/docs/flow/components/local.file.md
@@ -25,7 +25,7 @@ components:
 
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`filename` | `string` | Path of the file on disk to watch | `""` | **yes**
+`filename` | `string` | Path of the file on disk to watch | | **yes**
 `detector` | `string` | Which file change detector to use (fsnotify, poll) | `"fsnotify"` | no
 `poll_frequency` | `duration` | How often to poll for file changes | `"1m"` | no
 `sensitive` | `bool` | Marks the file as [sensitive][] | `false` | no

--- a/docs/flow/components/local.file.md
+++ b/docs/flow/components/local.file.md
@@ -28,7 +28,7 @@ Name | Type | Description | Default | Required
 `filename` | `string` | Path of the file on disk to watch | | **yes**
 `detector` | `string` | Which file change detector to use (fsnotify, poll) | `"fsnotify"` | no
 `poll_frequency` | `duration` | How often to poll for file changes | `"1m"` | no
-`sensitive` | `bool` | Marks the file as [sensitive][] | `false` | no
+`secret` | `bool` | Marks the file as [secret][] | `false` | no
 
 ### File change detectors
 
@@ -66,8 +66,8 @@ Name | Type | Description
 ---- | ---- | -----------
 `content` | `string` or `secret` | The contents of the file from the most recent read
 
-The `content` field will have the `secret` type only if the `sensitive`
-argument was set to true.
+The `content` field will have the `secret` type only if the `secret` argument
+was set to true.
 
 ## Component health
 
@@ -88,4 +88,4 @@ component.
 
 `local.file` does not expose any component-specific debug metrics.
 
-[sensitive]: ../secrets.md#sensitive-argument-in-components
+[secret]: ../secrets.md#secret-argument-in-components

--- a/docs/flow/secrets.md
+++ b/docs/flow/secrets.md
@@ -9,11 +9,11 @@ Any `string` value may be assigned to a `secret` field, but not the inverse: a
 When a value is a `secret`, its contents are scrubbed from the `/-/config`
 endpoint, instead displaying as `(secret)`.
 
-## Secret argument in components
+## is_secret argument in components
 
 Components which may load secrets (such as API keys) commonly have an argument
-named `secret`.
+named `is_secret`.
 
-When the `secret` argument is set to `true`, the component will export a
+When the `is_secret` argument is `true`, the component will export a
 `secret` value instead of a `string`. This hides its value from the `/-/config`
 endpoint and restricts use of the export to fields which expect secrets.

--- a/docs/flow/secrets.md
+++ b/docs/flow/secrets.md
@@ -1,0 +1,20 @@
+# Secrets
+
+`secret` is a primitive type in Flow. Secrets are string-like values which
+contain sensitive information.
+
+Any `string` value may be assigned to a `secret` field, but not the inverse: a
+`secret` value cannot be assigned to a field which expects a `string`.
+
+When a value is a `secret`, its contents are scrubbed from the `/-/config`
+endpoint, instead displaying as `(secret)`.
+
+## Sensitive argument in components
+
+Components which may load sensitive information (such as API keys) commonly
+have an argument named `sensitive`.
+
+When the `sensitive` argument is set to `true`, the component will export a
+`secret` value instead of a `string`. This hides its value from the `/-/config`
+endpoint and restricts use of the export to fields which expect sensitive
+information.

--- a/docs/flow/secrets.md
+++ b/docs/flow/secrets.md
@@ -1,7 +1,7 @@
 # Secrets
 
 `secret` is a primitive type in Flow. Secrets are string-like values which
-contain sensitive information.
+contain confidential information like passwords or API keys.
 
 Any `string` value may be assigned to a `secret` field, but not the inverse: a
 `secret` value cannot be assigned to a field which expects a `string`.
@@ -9,12 +9,11 @@ Any `string` value may be assigned to a `secret` field, but not the inverse: a
 When a value is a `secret`, its contents are scrubbed from the `/-/config`
 endpoint, instead displaying as `(secret)`.
 
-## Sensitive argument in components
+## Secret argument in components
 
-Components which may load sensitive information (such as API keys) commonly
-have an argument named `sensitive`.
+Components which may load secrets (such as API keys) commonly have an argument
+named `secret`.
 
-When the `sensitive` argument is set to `true`, the component will export a
+When the `secret` argument is set to `true`, the component will export a
 `secret` value instead of a `string`. This hides its value from the `/-/config`
-endpoint and restricts use of the export to fields which expect sensitive
-information.
+endpoint and restricts use of the export to fields which expect secrets.

--- a/pkg/flow/hcltypes/optional_secret_test.go
+++ b/pkg/flow/hcltypes/optional_secret_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestOptionalSecret(t *testing.T) {
 	t.Run("non-sensitive conversion to string is allowed", func(t *testing.T) {
-		input := OptionalSecret{Sensitive: false, Value: "testval"}
+		input := OptionalSecret{IsSecret: false, Value: "testval"}
 
 		result, err := convert.Convert(cty.CapsuleVal(optionalSecretTy, &input), cty.String)
 		require.NoError(t, err)
@@ -20,7 +20,7 @@ func TestOptionalSecret(t *testing.T) {
 	})
 
 	t.Run("sensitive conversion to string is disallowed", func(t *testing.T) {
-		input := OptionalSecret{Sensitive: true, Value: "testval"}
+		input := OptionalSecret{IsSecret: true, Value: "testval"}
 
 		result, err := convert.Convert(cty.CapsuleVal(optionalSecretTy, &input), cty.String)
 		require.EqualError(t, err, "cannot convert secret to string")
@@ -28,7 +28,7 @@ func TestOptionalSecret(t *testing.T) {
 	})
 
 	t.Run("non-sensitive conversion to secret is allowed", func(t *testing.T) {
-		input := OptionalSecret{Sensitive: false, Value: "secretval"}
+		input := OptionalSecret{IsSecret: false, Value: "secretval"}
 
 		result, err := convert.Convert(cty.CapsuleVal(optionalSecretTy, &input), secretTy)
 		require.NoError(t, err)
@@ -36,7 +36,7 @@ func TestOptionalSecret(t *testing.T) {
 	})
 
 	t.Run("sensitive conversion to secret is allowed", func(t *testing.T) {
-		input := OptionalSecret{Sensitive: true, Value: "secretval"}
+		input := OptionalSecret{IsSecret: true, Value: "secretval"}
 
 		result, err := convert.Convert(cty.CapsuleVal(optionalSecretTy, &input), secretTy)
 		require.NoError(t, err)
@@ -50,7 +50,7 @@ func TestOptionalSecret(t *testing.T) {
 		require.NoError(t, err)
 
 		os := result.EncapsulatedValue().(*OptionalSecret)
-		require.False(t, os.Sensitive)
+		require.False(t, os.IsSecret)
 		require.Equal(t, os.Value, input)
 	})
 
@@ -61,7 +61,7 @@ func TestOptionalSecret(t *testing.T) {
 		require.NoError(t, err)
 
 		os := result.EncapsulatedValue().(*OptionalSecret)
-		require.True(t, os.Sensitive)
+		require.True(t, os.IsSecret)
 		require.Equal(t, os.Value, string(input))
 	})
 }
@@ -73,7 +73,7 @@ func TestOptionalSecret_Write(t *testing.T) {
 
 	t.Run("non-sensitive", func(t *testing.T) {
 		b := testBlock{
-			Value: OptionalSecret{Sensitive: false, Value: "not-hidden"},
+			Value: OptionalSecret{IsSecret: false, Value: "not-hidden"},
 		}
 
 		f := hclwrite.NewFile()
@@ -83,7 +83,7 @@ func TestOptionalSecret_Write(t *testing.T) {
 
 	t.Run("sensitive", func(t *testing.T) {
 		b := testBlock{
-			Value: OptionalSecret{Sensitive: true, Value: "hidden"},
+			Value: OptionalSecret{IsSecret: true, Value: "hidden"},
 		}
 
 		f := hclwrite.NewFile()

--- a/pkg/flow/hcltypes/secret.go
+++ b/pkg/flow/hcltypes/secret.go
@@ -29,8 +29,8 @@ func init() {
 			case src.Equals(optionalSecretTy): // Secret -> OptionalSecret
 				return func(v interface{}, _ cty.Path) (cty.Value, error) {
 					return cty.CapsuleVal(optionalSecretTy, &OptionalSecret{
-						Sensitive: true,
-						Value:     string(*v.(*Secret)),
+						IsSecret: true,
+						Value:    string(*v.(*Secret)),
 					}), nil
 				}
 			default:


### PR DESCRIPTION
This PR creates documentation for the newly introduced `local.file` component (#1746). 

I've temporarily placed this in `docs/flow` while Grafana Agent Flow is still being worked on. This should eventually be moved to the `docs/sources` once the MVP is ready for shipping to users.

Note that there is much more to document regarding Grafana Agent Flow, and this is just serves as an example for how reference-level documentation for components should be written. Higher level documentation explaining how to use Flow and common use cases should be done in a later PR. 