### PR TITLE
Set include_metadata to true by default for OTLP traces receivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ Main (unreleased)
 - Resolved issue in v2 integrations where if an instance name was a prefix of another the route handler would fail to
   match requests on the longer name (@mattdurham)
 
+- Set `include_metadata` to true by default for OTLP traces receivers (@mapno)
+
 
 ### Bugfixes
 

--- a/pkg/traces/config.go
+++ b/pkg/traces/config.go
@@ -156,13 +156,18 @@ func (r *ReceiverMap) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	for k := range *r {
 		if strings.HasPrefix(k, otlpReceiverName) {
 			// for http and grpc receivers, include_metadata is set to true by default
+			protocolsCfg, ok := (*r)[k].(map[interface{}]interface{})["protocols"].(map[interface{}]interface{})
+			if !ok {
+				return fmt.Errorf("failed to parse OTLP receiver config: %s", k)
+			}
+
 			for _, p := range protocols {
-				if cfg, ok := (*r)[k].(map[interface{}]interface{})["protocols"].(map[interface{}]interface{})[p]; ok {
+				if cfg, ok := protocolsCfg[p]; ok {
 					if cfg == nil {
-						(*r)[k].(map[interface{}]interface{})["protocols"].(map[interface{}]interface{})[p] = map[interface{}]interface{}{"include_metadata": true}
+						protocolsCfg[p] = map[interface{}]interface{}{"include_metadata": true}
 					} else {
 						if _, ok := cfg.(map[interface{}]interface{})["include_metadata"]; !ok {
-							(*r)[k].(map[interface{}]interface{})["protocols"].(map[interface{}]interface{})[p].(map[interface{}]interface{})["include_metadata"] = true
+							protocolsCfg[p].(map[interface{}]interface{})["include_metadata"] = true
 						}
 					}
 				}

--- a/pkg/traces/config.go
+++ b/pkg/traces/config.go
@@ -58,6 +58,9 @@ const (
 
 	// sampling policies
 	alwaysSamplePolicy = "always_sample"
+
+	// otlp receiver
+	otlpReceiverName = "otlp"
 )
 
 // Config controls the configuration of Traces trace pipelines.
@@ -140,6 +143,35 @@ type InstanceConfig struct {
 // with an unknown set of sensitive information, ReceiverMap will marshal as
 // YAML to the text "<secret>".
 type ReceiverMap map[string]interface{}
+
+// UnmarshalYAML implements yaml.Unmarshaler.
+func (r *ReceiverMap) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type plain ReceiverMap
+	if err := unmarshal((*plain)(r)); err != nil {
+		return err
+	}
+
+	protocols := []string{protocolHTTP, protocolGRPC}
+	// enable include_metadata by default if receiver is OTLP
+	for k := range *r {
+		if k == otlpReceiverName {
+			// for http and grpc receivers, include_metadata is set to true by default
+			for _, p := range protocols {
+				if cfg, ok := (*r)[k].(map[interface{}]interface{})["protocols"].(map[interface{}]interface{})[p]; ok {
+					if cfg == nil {
+						(*r)[k].(map[interface{}]interface{})["protocols"].(map[interface{}]interface{})[p] = map[interface{}]interface{}{"include_metadata": true}
+					} else {
+						if _, ok := cfg.(map[interface{}]interface{})["include_metadata"]; !ok {
+							(*r)[k].(map[interface{}]interface{})["protocols"].(map[interface{}]interface{})[p].(map[interface{}]interface{})["include_metadata"] = true
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
 
 // MarshalYAML implements yaml.Marshaler.
 func (r ReceiverMap) MarshalYAML() (interface{}, error) {

--- a/pkg/traces/config.go
+++ b/pkg/traces/config.go
@@ -154,7 +154,7 @@ func (r *ReceiverMap) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	protocols := []string{protocolHTTP, protocolGRPC}
 	// enable include_metadata by default if receiver is OTLP
 	for k := range *r {
-		if k == otlpReceiverName {
+		if strings.HasPrefix(k, otlpReceiverName) {
 			// for http and grpc receivers, include_metadata is set to true by default
 			for _, p := range protocols {
 				if cfg, ok := (*r)[k].(map[interface{}]interface{})["protocols"].(map[interface{}]interface{})[p]; ok {

--- a/pkg/traces/config_test.go
+++ b/pkg/traces/config_test.go
@@ -1335,43 +1335,12 @@ service:
 			name: "OTLP receivers get include_metadata set to true by default",
 			cfg: `
 receivers:
-  otlp:
-    protocols:
-      grpc:
-      http:
-        endpoint: localhost:4318
-remote_write:
-  - endpoint: example.com:12345
-`,
-			expectedConfig: `
-receivers:
-  push_receiver:
-  otlp:
-    protocols:
-      grpc:
-        include_metadata: true
-      http:
-        include_metadata: true
-        endpoint: localhost:4318
-exporters:
   otlp/0:
-    endpoint: example.com:12345
-    compression: gzip
-    retry_on_failure:
-      max_elapsed_time: 60s
-service:
-  pipelines:
-    traces:
-      exporters: ["otlp/0"]
-      processors: []
-      receivers: ["push_receiver", "otlp"]
-`,
-		},
-		{
-			name: "include_metadata respected for OTLP receivers",
-			cfg: `
-receivers:
-  otlp:
+    protocols:
+      grpc:
+      http:
+        endpoint: localhost:4318
+  otlp/1:
     protocols:
       grpc:
         include_metadata: false
@@ -1384,7 +1353,14 @@ remote_write:
 			expectedConfig: `
 receivers:
   push_receiver:
-  otlp:
+  otlp/0:
+    protocols:
+      grpc:
+        include_metadata: true
+      http:
+        include_metadata: true
+        endpoint: localhost:4318
+  otlp/1:
     protocols:
       grpc:
         include_metadata: false
@@ -1402,7 +1378,7 @@ service:
     traces:
       exporters: ["otlp/0"]
       processors: []
-      receivers: ["push_receiver", "otlp"]
+      receivers: ["push_receiver", "otlp/0", "otlp/1"]
 `,
 		},
 	}

--- a/pkg/traces/config_test.go
+++ b/pkg/traces/config_test.go
@@ -1331,6 +1331,80 @@ service:
       receivers: ["push_receiver", "jaeger"]
 `,
 		},
+		{
+			name: "OTLP receivers get include_metadata set to true by default",
+			cfg: `
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+        endpoint: localhost:4318
+remote_write:
+  - endpoint: example.com:12345
+`,
+			expectedConfig: `
+receivers:
+  push_receiver:
+  otlp:
+    protocols:
+      grpc:
+        include_metadata: true
+      http:
+        include_metadata: true
+        endpoint: localhost:4318
+exporters:
+  otlp/0:
+    endpoint: example.com:12345
+    compression: gzip
+    retry_on_failure:
+      max_elapsed_time: 60s
+service:
+  pipelines:
+    traces:
+      exporters: ["otlp/0"]
+      processors: []
+      receivers: ["push_receiver", "otlp"]
+`,
+		},
+		{
+			name: "include_metadata respected for OTLP receivers",
+			cfg: `
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        include_metadata: false
+      http:
+        include_metadata: false
+        endpoint: localhost:4318
+remote_write:
+  - endpoint: example.com:12345
+`,
+			expectedConfig: `
+receivers:
+  push_receiver:
+  otlp:
+    protocols:
+      grpc:
+        include_metadata: false
+      http:
+        include_metadata: false
+        endpoint: localhost:4318
+exporters:
+  otlp/0:
+    endpoint: example.com:12345
+    compression: gzip
+    retry_on_failure:
+      max_elapsed_time: 60s
+service:
+  pipelines:
+    traces:
+      exporters: ["otlp/0"]
+      processors: []
+      receivers: ["push_receiver", "otlp"]
+`,
+		},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
#### PR Description

Set include_metadata to true by default for OTLP traces receivers.

Adding this metadata to requests is extremely useful for the PromSD processor, which relies on getting the IP of the batch sender in order to attach attributes to traces. One of the methods it uses for getting the IP is inspecting the context received, with the hope that it contains metadata from the connection from where the batch came from. This is rarely the case since it's disabled by default.

#### Which issue(s) this PR fixes

Fixes https://github.com/grafana/agent/issues/1721

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [x] Tests updated
