### PR TITLE
Global refid usage in wal

### DIFF
--- a/pkg/metrics/wal/wal.go
+++ b/pkg/metrics/wal/wal.go
@@ -26,7 +26,7 @@ import (
 
 func init() {
 	GlobalRefID = &RefIdSource{
-      ref: atomic.NewUint64(0),
+		ref: atomic.NewUint64(0),
 	}
 }
 
@@ -118,16 +118,18 @@ func (r *RefIdSource) Inc() uint64 {
 	return r.ref.Inc()
 }
 
+// Load returns the current value
 func (r *RefIdSource) Load() uint64 {
 	return r.ref.Load()
 }
 
+// Store sets the valid
 func (r *RefIdSource) Store(v uint64) {
 	r.ref.Store(v)
 }
 
+// GlobalRefID can be used when a singleton is needed to keep all reference ids unique
 var GlobalRefID *RefIdSource
-
 
 // Storage implements storage.Storage, and just writes to the WAL.
 type Storage struct {
@@ -166,12 +168,12 @@ func NewStorageWithRefidSource(logger log.Logger, registerer prometheus.Register
 	}
 
 	storage := &Storage{
-		path:    path,
-		wal:     w,
-		logger:  logger,
-		deleted: map[chunks.HeadSeriesRef]int{},
-		series:  newStripeSeries(),
-		metrics: newStorageMetrics(registerer),
+		path:        path,
+		wal:         w,
+		logger:      logger,
+		deleted:     map[chunks.HeadSeriesRef]int{},
+		series:      newStripeSeries(),
+		metrics:     newStorageMetrics(registerer),
 		refIdSource: refid,
 	}
 
@@ -204,12 +206,10 @@ func NewStorageWithRefidSource(logger log.Logger, registerer prometheus.Register
 	return storage, nil
 }
 
-
 // NewStorage makes a new Storage.
 func NewStorage(logger log.Logger, registerer prometheus.Registerer, path string) (*Storage, error) {
 	return NewStorageWithRefidSource(logger, registerer, path, &RefIdSource{ref: atomic.NewUint64(0)})
 }
-
 
 func (w *Storage) replayWAL() error {
 	w.walMtx.RLock()

--- a/pkg/metrics/wal/wal_test.go
+++ b/pkg/metrics/wal/wal_test.go
@@ -239,7 +239,7 @@ func TestStorage_ExistingWAL_RefID(t *testing.T) {
 	require.NoError(t, err)
 	defer require.NoError(t, s.Close())
 
-	require.Equal(t, uint64(len(payload)), s.refIdSource.Load(), "cached ref ID should be equal to the number of series written")
+	require.Equal(t, uint64(len(payload)), s.refIDSource.Load(), "cached ref ID should be equal to the number of series written")
 }
 
 func TestStorage_Truncate(t *testing.T) {

--- a/pkg/metrics/wal/wal_test.go
+++ b/pkg/metrics/wal/wal_test.go
@@ -239,7 +239,7 @@ func TestStorage_ExistingWAL_RefID(t *testing.T) {
 	require.NoError(t, err)
 	defer require.NoError(t, s.Close())
 
-	require.Equal(t, uint64(len(payload)), s.ref.Load(), "cached ref ID should be equal to the number of series written")
+	require.Equal(t, uint64(len(payload)), s.refIdSource.Load(), "cached ref ID should be equal to the number of series written")
 }
 
 func TestStorage_Truncate(t *testing.T) {

--- a/pkg/metrics/wal/wal_test.go
+++ b/pkg/metrics/wal/wal_test.go
@@ -239,7 +239,7 @@ func TestStorage_ExistingWAL_RefID(t *testing.T) {
 	require.NoError(t, err)
 	defer require.NoError(t, s.Close())
 
-	require.Equal(t, uint64(len(payload)), s.refIDSource.Load(), "cached ref ID should be equal to the number of series written")
+	require.Equal(t, uint64(len(payload)), s.ref.Load(), "cached ref ID should be equal to the number of series written")
 }
 
 func TestStorage_Truncate(t *testing.T) {
@@ -406,13 +406,13 @@ func TestGlobalReferenceID_UsingGlobal(t *testing.T) {
 	walDir, _ := ioutil.TempDir(os.TempDir(), "wal")
 	defer os.RemoveAll(walDir)
 
-	s, _ := NewStorageWithRefidSource(log.NewNopLogger(), nil, walDir, GlobalRefID)
+	s, _ := NewStorageWithRefIDSource(log.NewNopLogger(), nil, walDir, GlobalRefID)
 	defer s.Close()
 
 	walDir2, _ := ioutil.TempDir(os.TempDir(), "wal")
 	defer os.RemoveAll(walDir2)
 
-	s2, _ := NewStorageWithRefidSource(log.NewNopLogger(), nil, walDir2, GlobalRefID)
+	s2, _ := NewStorageWithRefIDSource(log.NewNopLogger(), nil, walDir2, GlobalRefID)
 	defer s2.Close()
 
 	app1 := s.Appender(context.Background())

--- a/pkg/metrics/wal/wal_test.go
+++ b/pkg/metrics/wal/wal_test.go
@@ -373,6 +373,65 @@ func TestStorage_TruncateAfterClose(t *testing.T) {
 	require.Error(t, ErrWALClosed, s.Truncate(0))
 }
 
+func TestGlobalReferenceID_Normal(t *testing.T) {
+	walDir, _ := ioutil.TempDir(os.TempDir(), "wal")
+	defer os.RemoveAll(walDir)
+
+	s, _ := NewStorage(log.NewNopLogger(), nil, walDir)
+	defer s.Close()
+	app := s.Appender(context.Background())
+	l := labels.New(labels.Label{
+		Name:  "__name__",
+		Value: "label1",
+	})
+	ref, err := app.Append(0, l, time.Now().UnixMilli(), 0.1)
+	_ = app.Commit()
+	require.NoError(t, err)
+	require.True(t, ref == 1)
+	ref2, err := app.Append(0, l, time.Now().UnixMilli(), 0.1)
+	require.NoError(t, err)
+	require.True(t, ref2 == 1)
+
+	l2 := labels.New(labels.Label{
+		Name:  "__name__",
+		Value: "label2",
+	})
+	ref3, err := app.Append(0, l2, time.Now().UnixMilli(), 0.1)
+	require.NoError(t, err)
+	require.True(t, ref3 == 2)
+}
+
+func TestGlobalReferenceID_UsingGlobal(t *testing.T) {
+	// By passing in a global refid we want to ensure that reference ids are not reused between wals
+	walDir, _ := ioutil.TempDir(os.TempDir(), "wal")
+	defer os.RemoveAll(walDir)
+
+	s, _ := NewStorageWithRefidSource(log.NewNopLogger(), nil, walDir, GlobalRefID)
+	defer s.Close()
+
+	walDir2, _ := ioutil.TempDir(os.TempDir(), "wal")
+	defer os.RemoveAll(walDir2)
+
+	s2, _ := NewStorageWithRefidSource(log.NewNopLogger(), nil, walDir2, GlobalRefID)
+	defer s2.Close()
+
+	app1 := s.Appender(context.Background())
+	app2 := s2.Appender(context.Background())
+
+	l := labels.New(labels.Label{
+		Name:  "__name__",
+		Value: "label1",
+	})
+	// Add the same label to two references should create separate reference ids
+	ref, err := app1.Append(0, l, time.Now().UnixMilli(), 0.1)
+	_ = app1.Commit()
+	require.NoError(t, err)
+	require.True(t, ref == 1)
+	ref2, err := app2.Append(0, l, time.Now().UnixMilli(), 0.1)
+	require.NoError(t, err)
+	require.True(t, ref2 == 2)
+}
+
 func BenchmarkAppendExemplar(b *testing.B) {
 	walDir, _ := ioutil.TempDir(os.TempDir(), "wal")
 	defer os.RemoveAll(walDir)


### PR DESCRIPTION
#### PR Description

This allows overriding the reference id with a global reference id provider. By default `NewStorage` works are before, but if calling `NewStorageWithRefidSource` you can pass in a custom provider. A global provider is available. This will allow us to move forward with flow
#### PR Checklist

- [NA] CHANGELOG updated
- [NA] Documentation added
- [X] Tests updated
