### PR TITLE
remove deprecated server YAML fields in favor of static flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+> **BREAKING CHANGES**: This release has breaking changes. Please read entries
+> carefully and consult the [upgrade guide][] for specific instructions.
+
+### Breaking changes
+
+- Deprecated `server` YAML block fields have now been removed in favor of the
+  command-line flags that replaced them. These fields were originally
+  deprecated in v0.24.0. (@rfratto)
+
 ### Features
 
 - Introduce Apache HTTP exporter integration. (@v-zhuravlev)
@@ -45,7 +54,7 @@ v0.25.0 (2022-06-06)
 
 - Add HTTP endpoints to fetch active instances and targets for the Logs subsystem.
   (@marctc)
-  
+
 - (beta) Add support for using windows certificate store for TLS connections. (@mattdurham)
 
 - Grafana Agent Operator: add support for integrations through an `Integration`

--- a/docs/sources/configuration/integrations/integrations-next/snmp-config.md
+++ b/docs/sources/configuration/integrations/integrations-next/snmp-config.md
@@ -8,7 +8,7 @@ title: snmp_exporter_config
 
 The `snmp` block configures the `snmp` integration,
 which is an embedded version of
-[`snmp_exporter`](https://github.com/prometheus/snmp_exporter). This allows collection of SNMP metrics from the network devices with ease. 
+[`snmp_exporter`](https://github.com/prometheus/snmp_exporter). This allows collection of SNMP metrics from the network devices with ease.
 
 
 ## Quick configuration example
@@ -65,7 +65,7 @@ metrics:
               target_label: __param_target
             - source_labels: [__param_target]
               target_label: instance
-            - replacement: 127.0.0.1:9090 # port must match grafana agent http_listen_port below
+            - replacement: 127.0.0.1:12345 # address must match grafana agent -server.http.address flag
               target_label: __address__
 integrations:
   snmp:
@@ -76,8 +76,6 @@ integrations:
         version: 2
         auth:
           community: secretpassword
-server:
-    http_listen_port: 9090
 ```
 
 
@@ -115,7 +113,7 @@ Full reference of options:
   #
 
   # SNMP configuration file with custom modules.
-  # See https://github.com/prometheus/snmp_exporter#generating-configuration for more details how to generate custom snmp.yml file. 
+  # See https://github.com/prometheus/snmp_exporter#generating-configuration for more details how to generate custom snmp.yml file.
   # If not defined, embedded snmp_exporter default set of modules is used.
   [config_file: <string> | default = ""]
 
@@ -170,9 +168,9 @@ Full reference of options:
     # Which are required depends on the security_level.
     # The equivalent options on NetSNMP commands like snmpbulkwalk
     # and snmpget are also listed. See snmpcmd(1).
-    
+
     # Required if v3 is used, no default. -u option to NetSNMP.
-    [username: <string> | default = "user"] 
+    [username: <string> | default = "user"]
 
     # Defaults to noAuthNoPriv. -l option to NetSNMP.
     # Can be noAuthNoPriv, authNoPriv or authPriv.
@@ -189,13 +187,13 @@ Full reference of options:
     # DES, AES, AES192, or AES256. Defaults to DES. -x option to NetSNMP.
     # Used if security_level is authPriv.
     [priv_protocol: <string> | default = "DES"]
-    
+
     # Has no default. Also known as privKey, -X option to NetSNMP.
     # Required if security_level is authPriv.
     [priv_password: <string> | default = ""]
 
     # Has no default. -n option to NetSNMP.
-    # Required if context is configured on the device.  
+    # Required if context is configured on the device.
     [context_name: <string> | default = ""]
 
 ```

--- a/docs/sources/configuration/integrations/snmp-config.md
+++ b/docs/sources/configuration/integrations/snmp-config.md
@@ -8,7 +8,7 @@ title: snmp_exporter_config
 
 The `snmp` block configures the `snmp` integration,
 which is an embedded version of
-[`snmp_exporter`](https://github.com/prometheus/snmp_exporter). This allows collection of SNMP metrics from the network devices with ease. 
+[`snmp_exporter`](https://github.com/prometheus/snmp_exporter). This allows collection of SNMP metrics from the network devices with ease.
 
 
 ## Quick configuration example
@@ -66,7 +66,7 @@ metrics:
               target_label: __param_target
             - source_labels: [__param_target]
               target_label: instance
-            - replacement: 127.0.0.1:9090 # port must match grafana agent http_listen_port below
+            - replacement: 127.0.0.1:12345 # address must match grafana agent -server.http.address flag
               target_label: __address__
 integrations:
   snmp:
@@ -77,8 +77,6 @@ integrations:
         version: 2
         auth:
           community: secretpassword
-server:
-    http_listen_port: 9090
 ```
 
 
@@ -128,7 +126,7 @@ Full reference of options:
   #
 
   # SNMP configuration file with custom modules.
-  # See https://github.com/prometheus/snmp_exporter#generating-configuration for more details how to generate custom snmp.yml file. 
+  # See https://github.com/prometheus/snmp_exporter#generating-configuration for more details how to generate custom snmp.yml file.
   # If not defined, embedded snmp_exporter default set of modules is used.
   [config_file: <string> | default = ""]
 
@@ -183,9 +181,9 @@ Full reference of options:
     # Which are required depends on the security_level.
     # The equivalent options on NetSNMP commands like snmpbulkwalk
     # and snmpget are also listed. See snmpcmd(1).
-    
+
     # Required if v3 is used, no default. -u option to NetSNMP.
-    [username: <string> | default = "user"] 
+    [username: <string> | default = "user"]
 
     # Defaults to noAuthNoPriv. -l option to NetSNMP.
     # Can be noAuthNoPriv, authNoPriv or authPriv.
@@ -202,13 +200,13 @@ Full reference of options:
     # DES, AES, AES192, or AES256. Defaults to DES. -x option to NetSNMP.
     # Used if security_level is authPriv.
     [priv_protocol: <string> | default = "DES"]
-    
+
     # Has no default. Also known as privKey, -X option to NetSNMP.
     # Required if security_level is authPriv.
     [priv_password: <string> | default = ""]
 
     # Has no default. -n option to NetSNMP.
-    # Required if context is configured on the device.  
+    # Required if context is configured on the device.
     [context_name: <string> | default = ""]
 
 ```

--- a/docs/sources/cookbook/dynamic-configuration/01_Basics/01_assets/final.yml
+++ b/docs/sources/cookbook/dynamic-configuration/01_Basics/01_assets/final.yml
@@ -1,12 +1,4 @@
 server:
-  http_listen_network: "tcp"
-  http_listen_address: "127.0.0.1"
-  http_listen_port: 12345
-  http_listen_conn_limit: 0
-  grpc_listen_network: "tcp"
-  grpc_listen_address: "127.0.0.1"
-  grpc_listen_port: 12346
-  grpc_listen_conn_limit: 0
   http_tls_config:
     cert_file: ""
     key_file: ""
@@ -27,27 +19,8 @@ server:
     min_version: 0
     max_version: 0
     prefer_server_cipher_suites: false
-  register_instrumentation: false
-  graceful_shutdown_timeout: 0s
-  http_server_read_timeout: 0s
-  http_server_write_timeout: 0s
-  http_server_idle_timeout: 0s
-  grpc_server_max_recv_msg_size: 0
-  grpc_server_max_send_msg_size: 0
-  grpc_server_max_concurrent_streams: 0
-  grpc_server_max_connection_idle: 0s
-  grpc_server_max_connection_age: 0s
-  grpc_server_max_connection_age_grace: 0s
-  grpc_server_keepalive_time: 0s
-  grpc_server_keepalive_timeout: 0s
-  grpc_server_min_time_between_pings: 0s
-  grpc_server_ping_without_stream_allowed: false
   log_format: ""
   log_level: info
-  log_source_ips_enabled: false
-  log_source_ips_header: ""
-  log_source_ips_regex: ""
-  http_path_prefix: ""
 metrics:
   global:
     scrape_interval: 1m

--- a/docs/sources/cookbook/dynamic-configuration/01_Basics/02_assets/final.yml
+++ b/docs/sources/cookbook/dynamic-configuration/01_Basics/02_assets/final.yml
@@ -1,12 +1,4 @@
 server:
-  http_listen_network: ""
-  http_listen_address: ""
-  http_listen_port: 12345
-  http_listen_conn_limit: 0
-  grpc_listen_network: ""
-  grpc_listen_address: ""
-  grpc_listen_port: 12346
-  grpc_listen_conn_limit: 0
   http_tls_config:
     cert_file: ""
     key_file: ""
@@ -27,27 +19,8 @@ server:
     min_version: 0
     max_version: 0
     prefer_server_cipher_suites: false
-  register_instrumentation: false
-  graceful_shutdown_timeout: 0s
-  http_server_read_timeout: 0s
-  http_server_write_timeout: 0s
-  http_server_idle_timeout: 0s
-  grpc_server_max_recv_msg_size: 0
-  grpc_server_max_send_msg_size: 0
-  grpc_server_max_concurrent_streams: 0
-  grpc_server_max_connection_idle: 0s
-  grpc_server_max_connection_age: 0s
-  grpc_server_max_connection_age_grace: 0s
-  grpc_server_keepalive_time: 0s
-  grpc_server_keepalive_timeout: 0s
-  grpc_server_min_time_between_pings: 0s
-  grpc_server_ping_without_stream_allowed: false
   log_format: ""
   log_level: info
-  log_source_ips_enabled: false
-  log_source_ips_header: ""
-  log_source_ips_regex: ""
-  http_path_prefix: ""
 metrics:
   global:
     scrape_interval: 1m

--- a/docs/sources/cookbook/dynamic-configuration/01_Basics/03_assets/final.yml
+++ b/docs/sources/cookbook/dynamic-configuration/01_Basics/03_assets/final.yml
@@ -1,12 +1,4 @@
 server:
-  http_listen_network: "tcp"
-  http_listen_address: "127.0.0.1"
-  http_listen_port: 12345
-  http_listen_conn_limit: 0
-  grpc_listen_network: "tcp"
-  grpc_listen_address: "127.0.0.1"
-  grpc_listen_port: 12346
-  grpc_listen_conn_limit: 0
   http_tls_config:
     cert_file: ""
     key_file: ""
@@ -27,27 +19,8 @@ server:
     min_version: 0
     max_version: 0
     prefer_server_cipher_suites: false
-  register_instrumentation: false
-  graceful_shutdown_timeout: 0s
-  http_server_read_timeout: 0s
-  http_server_write_timeout: 0s
-  http_server_idle_timeout: 0s
-  grpc_server_max_recv_msg_size: 0
-  grpc_server_max_send_msg_size: 0
-  grpc_server_max_concurrent_streams: 0
-  grpc_server_max_connection_idle: 0s
-  grpc_server_max_connection_age: 0s
-  grpc_server_max_connection_age_grace: 0s
-  grpc_server_keepalive_time: 0s
-  grpc_server_keepalive_timeout: 0s
-  grpc_server_min_time_between_pings: 0s
-  grpc_server_ping_without_stream_allowed: false
   log_format: ""
   log_level: info
-  log_source_ips_enabled: false
-  log_source_ips_header: ""
-  log_source_ips_regex: ""
-  http_path_prefix: ""
 metrics:
   global:
     scrape_interval: 1m

--- a/docs/sources/cookbook/dynamic-configuration/01_Basics/04_assets/final.yml
+++ b/docs/sources/cookbook/dynamic-configuration/01_Basics/04_assets/final.yml
@@ -1,12 +1,4 @@
 server:
-  http_listen_network: "tcp"
-  http_listen_address: "127.0.0.1"
-  http_listen_port: 12345
-  http_listen_conn_limit: 0
-  grpc_listen_network: "tcp"
-  grpc_listen_address: "127.0.0.1"
-  grpc_listen_port: 12346
-  grpc_listen_conn_limit: 0
   http_tls_config:
     cert_file: ""
     key_file: ""
@@ -27,27 +19,8 @@ server:
     min_version: 0
     max_version: 0
     prefer_server_cipher_suites: false
-  register_instrumentation: false
-  graceful_shutdown_timeout: 0s
-  http_server_read_timeout: 0s
-  http_server_write_timeout: 0s
-  http_server_idle_timeout: 0s
-  grpc_server_max_recv_msg_size: 0
-  grpc_server_max_send_msg_size: 0
-  grpc_server_max_concurrent_streams: 0
-  grpc_server_max_connection_idle: 0s
-  grpc_server_max_connection_age: 0s
-  grpc_server_max_connection_age_grace: 0s
-  grpc_server_keepalive_time: 0s
-  grpc_server_keepalive_timeout: 0s
-  grpc_server_min_time_between_pings: 0s
-  grpc_server_ping_without_stream_allowed: false
   log_format: ""
   log_level: info
-  log_source_ips_enabled: false
-  log_source_ips_header: ""
-  log_source_ips_regex: ""
-  http_path_prefix: ""
 metrics:
   global:
     scrape_interval: 1m

--- a/docs/sources/cookbook/dynamic-configuration/02_Templates/01_assets/final.yml
+++ b/docs/sources/cookbook/dynamic-configuration/02_Templates/01_assets/final.yml
@@ -1,12 +1,4 @@
 server:
-  http_listen_network: "tcp"
-  http_listen_address: "127.0.0.1"
-  http_listen_port: 12345
-  http_listen_conn_limit: 0
-  grpc_listen_network: "tcp"
-  grpc_listen_address: "127.0.0.1"
-  grpc_listen_port: 12346
-  grpc_listen_conn_limit: 0
   http_tls_config:
     cert_file: ""
     key_file: ""
@@ -27,27 +19,8 @@ server:
     min_version: 0
     max_version: 0
     prefer_server_cipher_suites: false
-  register_instrumentation: true
-  graceful_shutdown_timeout: 30s
-  http_server_read_timeout: 30s
-  http_server_write_timeout: 30s
-  http_server_idle_timeout: 2m0s
-  grpc_server_max_recv_msg_size: 4194304
-  grpc_server_max_send_msg_size: 4194304
-  grpc_server_max_concurrent_streams: 100
-  grpc_server_max_connection_idle: 2562047h47m16.854775807s
-  grpc_server_max_connection_age: 2562047h47m16.854775807s
-  grpc_server_max_connection_age_grace: 2562047h47m16.854775807s
-  grpc_server_keepalive_time: 2h0m0s
-  grpc_server_keepalive_timeout: 20s
-  grpc_server_min_time_between_pings: 5m0s
-  grpc_server_ping_without_stream_allowed: false
   log_format: logfmt
   log_level: debug
-  log_source_ips_enabled: false
-  log_source_ips_header: ""
-  log_source_ips_regex: ""
-  http_path_prefix: ""
 metrics:
   global:
     scrape_interval: 1m

--- a/docs/sources/cookbook/dynamic-configuration/02_Templates/02_assets/final.yml
+++ b/docs/sources/cookbook/dynamic-configuration/02_Templates/02_assets/final.yml
@@ -1,12 +1,4 @@
 server:
-  http_listen_network: "tcp"
-  http_listen_address: "127.0.0.1"
-  http_listen_port: 12345
-  http_listen_conn_limit: 0
-  grpc_listen_network: "tcp"
-  grpc_listen_address: "127.0.0.1"
-  grpc_listen_port: 12346
-  grpc_listen_conn_limit: 0
   http_tls_config:
     cert_file: ""
     key_file: ""
@@ -27,27 +19,8 @@ server:
     min_version: 0
     max_version: 0
     prefer_server_cipher_suites: false
-  register_instrumentation: true
-  graceful_shutdown_timeout: 30s
-  http_server_read_timeout: 30s
-  http_server_write_timeout: 30s
-  http_server_idle_timeout: 2m0s
-  grpc_server_max_recv_msg_size: 4194304
-  grpc_server_max_send_msg_size: 4194304
-  grpc_server_max_concurrent_streams: 100
-  grpc_server_max_connection_idle: 2562047h47m16.854775807s
-  grpc_server_max_connection_age: 2562047h47m16.854775807s
-  grpc_server_max_connection_age_grace: 2562047h47m16.854775807s
-  grpc_server_keepalive_time: 2h0m0s
-  grpc_server_keepalive_timeout: 20s
-  grpc_server_min_time_between_pings: 5m0s
-  grpc_server_ping_without_stream_allowed: false
   log_format: logfmt
   log_level: debug
-  log_source_ips_enabled: false
-  log_source_ips_header: ""
-  log_source_ips_regex: ""
-  http_path_prefix: ""
 metrics:
   global:
     scrape_interval: 1m

--- a/docs/sources/cookbook/dynamic-configuration/02_Templates/03_assets/final.yml
+++ b/docs/sources/cookbook/dynamic-configuration/02_Templates/03_assets/final.yml
@@ -1,12 +1,4 @@
 server:
-  http_listen_network: "tcp"
-  http_listen_address: "127.0.0.1"
-  http_listen_port: 12345
-  http_listen_conn_limit: 0
-  grpc_listen_network: "tcp"
-  grpc_listen_address: "127.0.0.1"
-  grpc_listen_port: 12346
-  grpc_listen_conn_limit: 0
   http_tls_config:
     cert_file: ""
     key_file: ""
@@ -27,27 +19,8 @@ server:
     min_version: 0
     max_version: 0
     prefer_server_cipher_suites: false
-  register_instrumentation: true
-  graceful_shutdown_timeout: 30s
-  http_server_read_timeout: 30s
-  http_server_write_timeout: 30s
-  http_server_idle_timeout: 2m0s
-  grpc_server_max_recv_msg_size: 4194304
-  grpc_server_max_send_msg_size: 4194304
-  grpc_server_max_concurrent_streams: 100
-  grpc_server_max_connection_idle: 2562047h47m16.854775807s
-  grpc_server_max_connection_age: 2562047h47m16.854775807s
-  grpc_server_max_connection_age_grace: 2562047h47m16.854775807s
-  grpc_server_keepalive_time: 2h0m0s
-  grpc_server_keepalive_timeout: 20s
-  grpc_server_min_time_between_pings: 5m0s
-  grpc_server_ping_without_stream_allowed: false
   log_format: logfmt
   log_level: debug
-  log_source_ips_enabled: false
-  log_source_ips_header: ""
-  log_source_ips_regex: ""
-  http_path_prefix: ""
 metrics:
   global:
     scrape_interval: 1m

--- a/docs/sources/cookbook/dynamic-configuration/03_Advanced_Datasources/01_assets/final.yml
+++ b/docs/sources/cookbook/dynamic-configuration/03_Advanced_Datasources/01_assets/final.yml
@@ -1,12 +1,4 @@
 server:
-  http_listen_network: "tcp"
-  http_listen_address: "127.0.0.1"
-  http_listen_port: 12345
-  http_listen_conn_limit: 0
-  grpc_listen_network: "tcp"
-  grpc_listen_address: "127.0.0.1"
-  grpc_listen_port: 12346
-  grpc_listen_conn_limit: 0
   http_tls_config:
     cert_file: ""
     key_file: ""
@@ -27,27 +19,8 @@ server:
     min_version: 0
     max_version: 0
     prefer_server_cipher_suites: false
-  register_instrumentation: true
-  graceful_shutdown_timeout: 30s
-  http_server_read_timeout: 30s
-  http_server_write_timeout: 30s
-  http_server_idle_timeout: 2m0s
-  grpc_server_max_recv_msg_size: 4194304
-  grpc_server_max_send_msg_size: 4194304
-  grpc_server_max_concurrent_streams: 100
-  grpc_server_max_connection_idle: 2562047h47m16.854775807s
-  grpc_server_max_connection_age: 2562047h47m16.854775807s
-  grpc_server_max_connection_age_grace: 2562047h47m16.854775807s
-  grpc_server_keepalive_time: 2h0m0s
-  grpc_server_keepalive_timeout: 20s
-  grpc_server_min_time_between_pings: 5m0s
-  grpc_server_ping_without_stream_allowed: false
   log_format: logfmt
   log_level: debug
-  log_source_ips_enabled: false
-  log_source_ips_header: ""
-  log_source_ips_regex: ""
-  http_path_prefix: ""
 metrics:
   global:
     scrape_interval: 1m

--- a/docs/sources/upgrade-guide/_index.md
+++ b/docs/sources/upgrade-guide/_index.md
@@ -14,6 +14,14 @@ releases and how to migrate to newer versions.
 
 These changes will come in a future version.
 
+### Breaking change: Deprecated YAML fields in `server` block removed
+
+The YAML fields which were first [deprecated in the v0.24.0
+release](#deprecation-on-yaml-fields-in-server-block-that-have-flags) have now
+been removed, replaced by equivalent command line flags. Please refer to the
+original deprecation notice for instructions for how to migrate to the command
+line flags.
+
 ## v0.24.0
 
 ### Breaking change: Integrations renamed when `integrations-next` feature flag is used

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -38,7 +38,7 @@ metrics:
 	require.NotEmpty(t, c.Metrics.ServiceConfig.Lifecycler.InfNames)
 	require.NotZero(t, c.Metrics.ServiceConfig.Lifecycler.NumTokens)
 	require.NotZero(t, c.Metrics.ServiceConfig.Lifecycler.HeartbeatPeriod)
-	require.True(t, c.Server.Flags.RegisterInstrumentation)
+	require.True(t, c.ServerFlags.RegisterInstrumentation)
 }
 
 // TestConfig_ConfigAPIFlag makes sure that the read API flag is passed
@@ -451,29 +451,4 @@ func TestLoadDynamicConfigurationExpandError(t *testing.T) {
 	err := LoadDynamicConfiguration("", true, nil)
 	assert.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "expand var is not supported when using dynamic configuration, use gomplate env instead"))
-}
-
-func TestGRPCListenAddress(t *testing.T) {
-	cfgText := `
-metrics:
-  wal_directory: /tmp
-  scraping_service:
-    enabled: true
-    kvstore:
-      store: consul
-      consul: {}
-    lifecycler:
-      ring:
-        kvstore:
-          store: consul
-          consul: {}
-`
-	var c Config
-	err := LoadBytes([]byte(cfgText), false, &c)
-	require.NoError(t, err)
-	c.Server.Flags.GRPC.ListenAddress = "192.168.1.1:9090"
-	err = c.Validate(nil)
-	require.NoError(t, err)
-	require.Equal(t, 9090, c.Server.Flags.GRPC.ListenPort)
-	require.Equal(t, "192.168.1.1", c.Server.Flags.GRPC.ListenHost)
 }

--- a/pkg/config/dynamicloader_configs_test.go
+++ b/pkg/config/dynamicloader_configs_test.go
@@ -223,7 +223,7 @@ windows: {}
 	// Since the normal agent uses deferred parsing this is required to load the integration from agent-1.yml
 	err = cfg.Integrations.setVersion(integrationsVersion2)
 	require.NoError(t, err)
-	assert.True(t, cfg.Server.Flags.HTTP.ListenPort == 12345)
+	assert.True(t, cfg.ServerFlags.HTTP.ListenAddress == "127.0.0.1:12345")
 	assert.True(t, cfg.Server.LogLevel.String() == "debug")
 	assert.True(t, cfg.Metrics.WALDir == "/tmp/grafana-agent-normal")
 	assert.True(t, cfg.Metrics.Global.RemoteWrite[0].URL.String() == "https://www.example.com")
@@ -248,7 +248,9 @@ integrations:
   windows: {}
 `
 	serverStr := `
-http_listen_port: 1111
+http_tls_config:
+  cert_file: /fake/file.cert
+  key_file: /fake/file.key
 `
 	metricsStr := `
 wal_directory: /tmp/grafana-agent-normal
@@ -311,7 +313,8 @@ configs:
 	err = cfg.Integrations.setVersion(integrationsVersion2)
 	require.NoError(t, err)
 	// Test server override
-	assert.True(t, cfg.Server.Flags.HTTP.ListenPort == 1111)
+	assert.Equal(t, "/fake/file.cert", cfg.Server.HTTP.TLSConfig.TLSCertPath)
+	assert.Equal(t, "/fake/file.key", cfg.Server.HTTP.TLSConfig.TLSKeyPath)
 	// Test metric
 	assert.True(t, cfg.Metrics.WALDir == "/tmp/grafana-agent-normal")
 	// Test Metric Instances

--- a/pkg/config/integrations.go
+++ b/pkg/config/integrations.go
@@ -79,9 +79,9 @@ func (c VersionedIntegrations) IsZero() bool {
 }
 
 // ApplyDefaults applies defaults to the subsystem based on globals.
-func (c *VersionedIntegrations) ApplyDefaults(scfg *server.Config, mcfg *metrics.Config) error {
+func (c *VersionedIntegrations) ApplyDefaults(sflags *server.Flags, mcfg *metrics.Config) error {
 	if c.version != integrationsVersion2 {
-		return c.configV1.ApplyDefaults(scfg, mcfg)
+		return c.configV1.ApplyDefaults(sflags, mcfg)
 	}
 	return c.configV2.ApplyDefaults(mcfg)
 }

--- a/pkg/integrations/manager.go
+++ b/pkg/integrations/manager.go
@@ -3,10 +3,8 @@ package integrations
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"path"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -118,20 +116,15 @@ func (c *ManagerConfig) DefaultRelabelConfigs(instanceKey string) []*relabel.Con
 //
 // If any integrations are enabled and are configured to be scraped, the
 // Prometheus configuration must have a WAL directory configured.
-func (c *ManagerConfig) ApplyDefaults(scfg *server.Config, mcfg *metrics.Config) error {
-	hostPort := scfg.Flags.HTTP.GetListenAddress()
-	host, portStr, err := net.SplitHostPort(hostPort)
+func (c *ManagerConfig) ApplyDefaults(sflags *server.Flags, mcfg *metrics.Config) error {
+	host, port, err := sflags.HTTP.ListenHostPort()
 	if err != nil {
 		return fmt.Errorf("reading HTTP host:port: %w", err)
-	}
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		return fmt.Errorf("reading HTTP port: %w", err)
 	}
 
 	c.ListenHost = host
 	c.ListenPort = port
-	c.ServerUsingTLS = scfg.Flags.HTTP.UseTLS
+	c.ServerUsingTLS = sflags.HTTP.UseTLS
 
 	if len(c.PrometheusRemoteWrite) == 0 {
 		c.PrometheusRemoteWrite = mcfg.Global.RemoteWrite

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -13,13 +13,6 @@ type Config struct {
 
 	GRPC GRPCConfig `yaml:",inline"`
 	HTTP HTTPConfig `yaml:",inline"`
-
-	// Flags is a DEPRECATED field holding static coniguration options.
-	// It will be removed from YAML and only be exposed by command-line flags in
-	// v0.26.0.
-	//
-	// Updating any field found in Flags will cause updating the Server to fail.
-	Flags Flags `yaml:",inline"`
 }
 
 // UnmarshalYAML unmarshals the server config with defaults applied.
@@ -45,7 +38,6 @@ var (
 	DefaultConfig = Config{
 		GRPC:      DefaultGRPCConfig,
 		HTTP:      DefaultHTTPConfig,
-		Flags:     DefaultFlags,
 		LogLevel:  DefaultLogLevel,
 		LogFormat: DefaultLogFormat,
 	}
@@ -70,8 +62,3 @@ var (
 		return fmt
 	}()
 )
-
-// RegisterFlags registers flags for c to the given FlagSet.
-func (c *Config) RegisterFlags(f *flag.FlagSet) {
-	c.Flags.RegisterFlags(f)
-}

--- a/pkg/server/testdata/windows/agent-config.yml
+++ b/pkg/server/testdata/windows/agent-config.yml
@@ -1,5 +1,4 @@
 server:
-  http_listen_port: 12345
   log_level: debug
   http_tls_config:
     client_auth_type: RequireAndVerifyClientCert

--- a/tools/crow/main.go
+++ b/tools/crow/main.go
@@ -29,11 +29,13 @@ func main() {
 		fs = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
 		serverCfg   = server.DefaultConfig
+		serverFlags = server.DefaultFlags
+
 		crowCfg     = crow.DefaultConfig
 		showVersion bool
 	)
 
-	serverCfg.RegisterFlags(fs)
+	serverFlags.RegisterFlags(fs)
 	crowCfg.RegisterFlagsWithPrefix(fs, "crow.")
 	fs.BoolVar(&showVersion, "version", false, "show version")
 
@@ -49,7 +51,7 @@ func main() {
 	l := server.NewLogger(&serverCfg)
 	crowCfg.Log = l
 
-	s, err := server.New(l, prometheus.DefaultRegisterer, prometheus.DefaultGatherer, serverCfg)
+	s, err := server.New(l, prometheus.DefaultRegisterer, prometheus.DefaultGatherer, serverCfg, serverFlags)
 	if err != nil {
 		level.Error(l).Log("msg", "failed to initialize server", "err", err)
 		os.Exit(1)


### PR DESCRIPTION
Many `server` YAML fields were deprecated in v0.24.0 and scheduled for removal in v0.26.0. This commit removes those fields in favor of just using the flags.

This also removes the logic for determining listen address by examining both the configured listen address and listen host/port combination, as the latter was only available in the flags. This simplifies the fix introduced by #1762, which can reliably look up the port used for the
gRPC server.