### PR TITLE
operator: Generate pod template from non-sharded agent name.

### DIFF
--- a/pkg/operator/resources_metrics.go
+++ b/pkg/operator/resources_metrics.go
@@ -112,7 +112,7 @@ func generateMetricsStatefulSet(
 	d = *d.DeepCopy()
 
 	opts := metricsPodTemplateOptions(name, d, shard)
-	templateSpec, selector, err := generatePodTemplate(cfg, name, d, opts)
+	templateSpec, selector, err := generatePodTemplate(cfg, d.Agent.Name, d, opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
(fixes #1817)

The name passed to `generatePodTemplate` is only used for the config secret to mount.

Since there is no sharded config generated, just use the original agent name (without `shard-n` snuck in.)