### PR TITLE
Run windows tests without -race

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,8 @@ jobs:
       # Tests on Windows can use a lot of memory, and we need to increase the
       # pagefile to compensate.
       with:
-          minimum-size: 16GB
-          maximum-size: 16GB
+          minimum-size: 32GB
+          maximum-size: 32GB
           disk-root: "C:"
       if: ${{ matrix.platform == 'windows-latest' }}
     - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,9 @@ jobs:
       # Tests on Windows can use a lot of memory, and we need to increase the
       # pagefile to compensate.
       with:
-          minimum-size: 32GB
-          maximum-size: 32GB
+          minimum-size: 16GB
+          maximum-size: 16GB
           disk-root: "C:"
       if: ${{ matrix.platform == 'windows-latest' }}
     - name: Test
-      run: make DOCKER_OPTS="" GOFLAGS="-tags=netgo,nodocker" BUILD_IN_CONTAINER=false test
+      run: make DOCKER_OPTS="" GOFLAGS="-tags=netgo,nodocker" BUILD_IN_CONTAINER=false test-windows

--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,13 @@ lint:
 # more without -race for packages that have known race detection issues.
 test:
 	CGO_ENABLED=1 go test $(CGO_FLAGS) -race -cover -coverprofile=cover.out -p=4 ./...
+	test-no-race
+
+test-windows:
+	CGO_ENABLED=1 go test $(CGO_FLAGS) -cover -coverprofile=cover.out -p=4 ./...
+	test-no-race
+
+test-no-race:
 	CGO_ENABLED=1 go test $(CGO_FLAGS) -cover -coverprofile=cover-norace.out -p=4 ./pkg/integrations/node_exporter ./pkg/logs ./pkg/operator ./pkg/util/k8s
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ lint:
 # We have to run test twice: once for all packages with -race and then once
 # more without -race for packages that have known race detection issues.
 test:
-	CGO_ENABLED=1 go test $(CGO_FLAGS) -cover -coverprofile=cover.out -p=4 ./...
+	CGO_ENABLED=1 go test $(CGO_FLAGS) -race -cover -coverprofile=cover.out -p=4 ./...
 	CGO_ENABLED=1 go test $(CGO_FLAGS) -cover -coverprofile=cover-norace.out -p=4 ./pkg/integrations/node_exporter ./pkg/logs ./pkg/operator ./pkg/util/k8s
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ lint:
 # We have to run test twice: once for all packages with -race and then once
 # more without -race for packages that have known race detection issues.
 test:
-	CGO_ENABLED=1 go test $(CGO_FLAGS) -race -cover -coverprofile=cover.out -p=4 ./...
+	CGO_ENABLED=1 go test $(CGO_FLAGS) -cover -coverprofile=cover.out -p=4 ./...
 	CGO_ENABLED=1 go test $(CGO_FLAGS) -cover -coverprofile=cover-norace.out -p=4 ./pkg/integrations/node_exporter ./pkg/logs ./pkg/operator ./pkg/util/k8s
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,9 @@ lint:
 
 # We have to run test twice: once for all packages with -race and then once
 # more without -race for packages that have known race detection issues.
+test-no-race:
+	CGO_ENABLED=1 go test $(CGO_FLAGS) -cover -coverprofile=cover-norace.out -p=4 ./pkg/integrations/node_exporter ./pkg/logs ./pkg/operator ./pkg/util/k8s
+	
 test:
 	CGO_ENABLED=1 go test $(CGO_FLAGS) -race -cover -coverprofile=cover.out -p=4 ./...
 	test-no-race
@@ -255,9 +258,6 @@ test:
 test-windows:
 	CGO_ENABLED=1 go test $(CGO_FLAGS) -cover -coverprofile=cover.out -p=4 ./...
 	test-no-race
-
-test-no-race:
-	CGO_ENABLED=1 go test $(CGO_FLAGS) -cover -coverprofile=cover-norace.out -p=4 ./pkg/integrations/node_exporter ./pkg/logs ./pkg/operator ./pkg/util/k8s
 
 clean:
 	rm -rf cmd/agent/agent

--- a/Makefile
+++ b/Makefile
@@ -248,16 +248,13 @@ lint:
 
 # We have to run test twice: once for all packages with -race and then once
 # more without -race for packages that have known race detection issues.
-test-no-race:
-	CGO_ENABLED=1 go test $(CGO_FLAGS) -cover -coverprofile=cover-norace.out -p=4 ./pkg/integrations/node_exporter ./pkg/logs ./pkg/operator ./pkg/util/k8s
-	
 test:
 	CGO_ENABLED=1 go test $(CGO_FLAGS) -race -cover -coverprofile=cover.out -p=4 ./...
-	test-no-race
+	CGO_ENABLED=1 go test $(CGO_FLAGS) -cover -coverprofile=cover-norace.out -p=4 ./pkg/integrations/node_exporter ./pkg/logs ./pkg/operator ./pkg/util/k8s
 
 test-windows:
 	CGO_ENABLED=1 go test $(CGO_FLAGS) -cover -coverprofile=cover.out -p=4 ./...
-	test-no-race
+	CGO_ENABLED=1 go test $(CGO_FLAGS) -cover -coverprofile=cover-norace.out -p=4 ./pkg/integrations/node_exporter ./pkg/logs ./pkg/operator ./pkg/util/k8s
 
 clean:
 	rm -rf cmd/agent/agent


### PR DESCRIPTION
[Windows tests](https://github.com/grafana/agent/runs/7068553894?check_suite_focus=true) are broken as they consume a lot of memory. This PR remove `-race` option as it increases the memory consumption of such tests.