### PR TITLE
Add continuous log testing to smoke env using Canary

### DIFF
--- a/example/k3d/README.md
+++ b/example/k3d/README.md
@@ -40,13 +40,13 @@ k3d cluster delete agent-k3d
 
 ## Smoke Test Environment
 
-The smoke test environment is used to validate samples end to end.
+The smoke test environment is used to validate the end-to-end flow of observability signals.
 
 ### Running
 
 Smoke Test environment is invoked via `/scripts/smoke-test.bash`
 
-This tool will spin up cluster of Grafana Agent, Cortex, Avalanche, Smoke and [Crow](../../tools/crow/README.md) instances. The Smoke deployment will then periodically kill instances and check for any failed alerts. At the end of the duration (default 3h) it will end the testing.
+This tool will spin up cluster of Grafana Agent, Cortex, Avalanche, Smoke, [Crow](../../tools/crow/README.md), [Canary](https://grafana.com/docs/loki/latest/operations/loki-canary/) and [Vulture](https://github.com/grafana/tempo/blob/main/README.md#tempo-vulture) instances. The Smoke deployment will then periodically kill instances and check for any failed alerts. At the end of the duration (default 3h) it will end the testing.
 
 For users who do not have access to the `us.gcr.io/kubernetes-dev` container registry, do the following to run the smoke test:
 
@@ -66,7 +66,7 @@ k3d image import -c agent-smoke-test us.gcr.io/kubernetes-dev/grafana/agent-crow
 These alerts are viewable [here](http://prometheus.k3d.localhost:50080/alerts).
 
 Prometheus alerts are triggered:
-- If any Crow instances are not running or Crow samples are not being propagated correctly.
+- If any Crow/Vulture/Canary instances are not running or their samples are not being propagated correctly.
 - If any Grafana Agents are not running or Grafana Agent limits are outside their norm.
 
 NOTE: The alerts might be in pending until the system settles down.
@@ -98,12 +98,24 @@ By default, a k3d cluster will be created running the following instances
 - cortex
 - avalanche - selection of avalanche instances serving traffic
 - smoke - scales avalanche replicas and introduces chaos by deleting agent pods during testing
+- vulture - emits traces and checks if are stored properly
+- tempo
+- canary - emits logs and checks if they're propagated properly
+- loki
 
-Crow instance will check to see if the metrics that were scraped shows up in the prometheus endpoint and then will emit metrics on the success of those metrics. This success/failure result will trigger an alert if it is incorrect.
+Crow, Canary and Vulture instances will check to see if the metrics, logs and traces that were scraped show up correctly in the corresponding Prometheus/Loki/Tempo endpoints and then will emit metrics on the success of those metrics. This success/failure result will trigger an alert if it is incorrect.
 
-### Flow
+### Metrics Flow
 
 ![](./assets/order.png)
+
+### Traces Flow
+
+![](./assets/traces_flow.png)
+
+### Logs Flow
+
+![](./assets/logs_flow.png)
 
 ### Avalanche
 

--- a/example/k3d/jsonnetfile.json
+++ b/example/k3d/jsonnetfile.json
@@ -4,7 +4,7 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/grafana/cortex-jsonnet",
+          "remote": "https://github.com/grafana/cortex-jsonnet.git",
           "subdir": "cortex-mixin"
         }
       },
@@ -13,7 +13,7 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/grafana/jsonnet-libs",
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
           "subdir": "ksonnet-util"
         }
       },
@@ -22,7 +22,7 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/jsonnet-libs/k8s-alpha",
+          "remote": "https://github.com/jsonnet-libs/k8s-alpha.git",
           "subdir": "1.14"
         }
       },

--- a/example/k3d/lib/canary/main.libsonnet
+++ b/example/k3d/lib/canary/main.libsonnet
@@ -1,0 +1,50 @@
+local config = import 'config.libsonnet';
+local k = import 'ksonnet-util/kausal.libsonnet';
+
+// backwards compatibility with ksonnet
+local envVar = if std.objectHasAll(k.core.v1, 'envVar') then k.core.v1.envVar else k.core.v1.container.envType;
+
+local container = k.core.v1.container;
+{
+  new(namespace=''):: {
+    local this = self,
+
+    _images+:: {
+      loki_canary: 'grafana/loki-canary:2.5.0',
+    },
+
+    loki_canary_args:: {
+      labelvalue: '$(POD_NAME)',
+      addr: 'loki',
+      tls: false,
+      port: 80,
+      labelname: 'pod',
+      interval: '500ms',
+      size: 1024,
+      wait: '1m',
+      'metric-test-interval': '30m',
+      'metric-test-range': '6h',
+      user: 104334,
+      pass: 'no-read-key',
+    },
+
+    container::
+      container.new('loki-canary', this._images.loki_canary) +
+      k.util.resourcesRequests('10m', '30Mi') +
+      container.withPorts(k.core.v1.containerPort.new(name='http-metrics', port=80)) +
+      container.withArgsMixin(k.util.mapToFlags(this.loki_canary_args)) +
+      container.withEnv([
+        envVar.fromFieldPath('HOSTNAME', 'spec.nodeName'),
+        envVar.fromFieldPath('POD_NAME', 'metadata.name'),
+      ]),
+    
+      local deployment = k.apps.v1.deployment,
+      local service = k.core.v1.service,
+    
+      deployment: deployment.new('canary', 1, [this.container]) +
+          	                  deployment.mixin.metadata.withNamespace(namespace),
+      service:
+          k.util.serviceFor(this.deployment) +
+          service.mixin.metadata.withNamespace(namespace),
+  }
+}


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR utilizes Loki's bird-themed [Canary](https://grafana.com/docs/loki/latest/operations/loki-canary/) to add continuous testing of logs to our smoke environment.

If this works correctly, we should utilize something similar to add it to the deployment_tools repo as well.

#### Which issue(s) this PR fixes
None filed.

#### Notes to the Reviewer

TODO: 
- [ ] Add alerts
- [ ] Add diagram

This should wait until after #1825.

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
