### PR TITLE
Switch from Github Windows to Drone Testing

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -86,7 +86,7 @@ steps:
     commands:
       - powershell wget https://go.dev/dl/go1.18.3.windows-amd64.zip -OutFile ./go.zip
       - powershell Expand-Archive -Path './go.zip' -DestinationPath './go'
-      - powershell ./go/go/bin/go.exe test -p 1 ./...
+      - powershell ./go/go/bin/go.exe test -p 1 ./agent/...
 depends_on:
   - Lint
 volumes:
@@ -279,6 +279,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: 66c4b50c5e0d005cc85660a12912ad3b9f2a9b26e7205988b1cf426660b064cb
+hmac: d262f4da17f11a8416208e6e258dfee1c09094111fa4b9d17d2fa845a247549e
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -87,7 +87,7 @@ steps:
       - powershell wget https://go.dev/dl/go1.18.3.windows-amd64.zip -OutFile ~/go.zip
       - powershell Expand-Archive -Path '~/go.zip' -DestinationPath '~/go'
       - powershell ls
-      - powershell ~/go/go/bin/go.exe test -p 1 ./...
+      - powershell ~/go/go/bin/go.exe test -tags=nodocker,nonetwork -p 1 ./...
 depends_on:
   - Lint
 volumes:
@@ -280,6 +280,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: ed1527861042863d9f1ae3045b75810bc7dc43bf10bbfa7d2afffb567badcf30
+hmac: 05a5ee193466610fe78fc0835cba384893f076b0b5fd8441c874be7689b70b6c
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -85,7 +85,7 @@ steps:
     image: mcr.microsoft.com/windows:1809
     commands:
       - powershell wget https://go.dev/dl/go1.18.3.windows-amd64.zip -OutFile ./go.zip
-      - unzip ./go.zip
+      - powershell Expand-Archive -Path '~/go.zip' -DestinationPath '~/go'
       - powershell ~/go/bin/go.exe test ./...
 depends_on:
   - Lint
@@ -279,6 +279,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: e72b2bfd94192529ec76f1ee4b1bc8c8cf2043156de219d484e5b5e804071a06
+hmac: e5e8e036281eaba712dc91da01cf8e062187eb320e7cca7392fc8cb24fac0eff
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -86,6 +86,7 @@ steps:
     commands:
       - powershell wget https://go.dev/dl/go1.18.3.windows-amd64.zip -OutFile ./go.zip
       - powershell Expand-Archive -Path './go.zip' -DestinationPath './go'
+      - powershell ls
       - powershell ./go/go/bin/go.exe test -p 1 ./agent/...
 depends_on:
   - Lint
@@ -279,6 +280,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: d262f4da17f11a8416208e6e258dfee1c09094111fa4b9d17d2fa845a247549e
+hmac: 801dc42417db80d14af27128c21b8f19708b038b88fcf798f8f3694e5051ef24
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -85,8 +85,8 @@ steps:
     image: mcr.microsoft.com/windows:1809
     commands:
       - powershell wget https://go.dev/dl/go1.18.3.windows-amd64.zip -OutFile ./go.zip
-      - powershell Expand-Archive -Path './go.zip' -DestinationPath '~/go'
-      - powershell ~/go/bin/go.exe test -p 1 ./...
+      - powershell Expand-Archive -Path './go.zip' -DestinationPath './go'
+      - powershell ./go/bin/go.exe test -p 1 ./...
 depends_on:
   - Lint
 volumes:
@@ -279,6 +279,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: a961739c1516f0b6516080f96dbfddb9b2338fd968426f2f13c365554030bf3c
+hmac: c67c66215dd947246bf9a8ad01066cda8865c19d1de53be00bae8d643f6dc52c
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -58,6 +58,11 @@ steps:
 
 depends_on:
   - Lint
+
+volumes:
+ - name: docker
+   host:
+     path: /var/run/docker.sock
 ---
 kind: pipeline
 type: docker
@@ -82,10 +87,6 @@ steps:
       - go test -tags="nodocker,nonetwork" ./...
 depends_on:
   - Lint
-volumes:
-  - host:
-      path: /var/run/docker.sock
-    name: docker
 ---
 kind: pipeline
 type: docker
@@ -272,6 +273,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: 547ab28a7bc6a447e04daac9157db573a1774c27e02154cd22a496d087bf75b6
+hmac: 56508186d2cd2cb71ab0596c9d0210735177404efbf0fdc2e5109727ef39aede
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -58,11 +58,6 @@ steps:
 
 depends_on:
   - Lint
-
-volumes:
- - name: docker
-   host:
-     path: /var/run/docker.sock
 ---
 kind: pipeline
 type: docker
@@ -277,6 +272,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: 4fae74a5468c4f718d78c218d8b95572dc267ab9cb015858b413d83707a86a36
+hmac: 547ab28a7bc6a447e04daac9157db573a1774c27e02154cd22a496d087bf75b6
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -87,7 +87,7 @@ steps:
       - powershell wget https://go.dev/dl/go1.18.3.windows-amd64.zip -OutFile ~/go.zip
       - powershell Expand-Archive -Path '~/go.zip' -DestinationPath '~/go'
       - powershell ls
-      - powershell ~/go/go/bin/go.exe test -tags=nodocker,nonetwork -p 1 ./...
+      - powershell ~/go/go/bin/go.exe test -tags="nodocker,nonetwork" -p 1 ./...
 depends_on:
   - Lint
 volumes:
@@ -280,6 +280,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: 05a5ee193466610fe78fc0835cba384893f076b0b5fd8441c874be7689b70b6c
+hmac: a3b7bae8d06064de898eaabf22e9e2bd40c4749a823113f5be119750ed9f78d3
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -82,12 +82,9 @@ trigger:
     - refs/tags/**
 steps:
   - name: test
-    image: mcr.microsoft.com/windows:1809
+    image: grafana/ci-build-windows:0.3.4
     commands:
-      - powershell
-      - wget https://go.dev/dl/go1.18.3.windows-amd64.zip -OutFile ~/go.zip
-      - Expand-Archive -Path '~/go.zip' -DestinationPath '~/go'
-      - ~/go/go/bin/go.exe test -tags="nodocker,nonetwork" -p 1 ./...
+      - go test -tags="nodocker,nonetwork" -p 1 ./...
 depends_on:
   - Lint
 volumes:
@@ -280,6 +277,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: 631e359ac724cbd26f71a05d4b24544f9f5a948b9dc0fbf589e13c68d1887140
+hmac: c7c25266657986274f538566578fdc9a9b4bba45bad7a37b8054ed07ee72d296
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -86,7 +86,7 @@ steps:
     commands:
       - powershell wget https://go.dev/dl/go1.18.3.windows-amd64.zip -OutFile ./go.zip
       - powershell Expand-Archive -Path './go.zip' -DestinationPath './go'
-      - powershell ./go/bin/go.exe test -p 1 ./...
+      - powershell ./go/go/bin/go.exe test -p 1 ./...
 depends_on:
   - Lint
 volumes:
@@ -279,6 +279,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: c67c66215dd947246bf9a8ad01066cda8865c19d1de53be00bae8d643f6dc52c
+hmac: 66c4b50c5e0d005cc85660a12912ad3b9f2a9b26e7205988b1cf426660b064cb
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -84,10 +84,10 @@ steps:
   - name: test
     image: mcr.microsoft.com/windows:1809
     commands:
-      - powershell wget https://go.dev/dl/go1.18.3.windows-amd64.zip -OutFile ./go.zip
-      - powershell Expand-Archive -Path './go.zip' -DestinationPath './go'
+      - powershell wget https://go.dev/dl/go1.18.3.windows-amd64.zip -OutFile ~/go.zip
+      - powershell Expand-Archive -Path '~/go.zip' -DestinationPath '~/go'
       - powershell ls
-      - powershell ./go/go/bin/go.exe test -p 1 ./agent/...
+      - powershell ~/go/go/bin/go.exe test -p 1 ./...
 depends_on:
   - Lint
 volumes:
@@ -280,6 +280,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: 801dc42417db80d14af27128c21b8f19708b038b88fcf798f8f3694e5051ef24
+hmac: ed1527861042863d9f1ae3045b75810bc7dc43bf10bbfa7d2afffb567badcf30
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -63,7 +63,36 @@ volumes:
  - name: docker
    host:
      path: /var/run/docker.sock
-
+---
+kind: pipeline
+type: docker
+name: Windows-Test
+platform:
+  arch: amd64
+  os: windows
+  version: "1809"
+trigger:
+  event:
+    - push
+    - pull_request
+    - tag
+  ref:
+    - refs/heads/main
+    - refs/pull/*/head
+    - refs/tags/**
+steps:
+  - name: test
+    image: mcr.microsoft.com/windows:1809
+    commands:
+      - powershell wget https://go.dev/dl/go1.18.3.windows-amd64.zip -OutFile ./go.zip
+      - unzip ./go.zip
+      - powershell ~/go/bin/go.exe test ./...
+depends_on:
+  - Lint
+volumes:
+  - host:
+      path: /var/run/docker.sock
+    name: docker
 ---
 kind: pipeline
 type: docker
@@ -76,7 +105,6 @@ trigger:
     - refs/heads/main
     - refs/tags/v*
     - refs/heads/dev.*
-
 steps:
   - name: Build Containers
     image: docker
@@ -251,6 +279,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: cda6ffc7bad038f7f7d92c83fc76571b20da11ad4eac2316c10a14f3d1221091
+hmac: e72b2bfd94192529ec76f1ee4b1bc8c8cf2043156de219d484e5b5e804071a06
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -85,7 +85,7 @@ steps:
     image: mcr.microsoft.com/windows:1809
     commands:
       - powershell wget https://go.dev/dl/go1.18.3.windows-amd64.zip -OutFile ./go.zip
-      - powershell Expand-Archive -Path '~/go.zip' -DestinationPath '~/go'
+      - powershell Expand-Archive -Path './go.zip' -DestinationPath '~/go'
       - powershell ~/go/bin/go.exe test ./...
 depends_on:
   - Lint
@@ -279,6 +279,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: e5e8e036281eaba712dc91da01cf8e062187eb320e7cca7392fc8cb24fac0eff
+hmac: 6404cfd065aef90b7f2f743d9e9704be06b4031355702da54ef6084d2e683f8f
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -86,7 +86,6 @@ steps:
     commands:
       - powershell wget https://go.dev/dl/go1.18.3.windows-amd64.zip -OutFile ~/go.zip
       - powershell Expand-Archive -Path '~/go.zip' -DestinationPath '~/go'
-      - powershell ls
       - powershell ~/go/go/bin/go.exe test -tags="nodocker,nonetwork" -p 1 ./...
 depends_on:
   - Lint
@@ -280,6 +279,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: a3b7bae8d06064de898eaabf22e9e2bd40c4749a823113f5be119750ed9f78d3
+hmac: 26404623adbc24252ef209c4dbd56d27b1ea268b94bf799c4504fde62eb26423
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -86,7 +86,7 @@ steps:
     commands:
       - powershell wget https://go.dev/dl/go1.18.3.windows-amd64.zip -OutFile ./go.zip
       - powershell Expand-Archive -Path './go.zip' -DestinationPath '~/go'
-      - powershell ~/go/bin/go.exe test ./...
+      - powershell ~/go/bin/go.exe test -p 1 ./...
 depends_on:
   - Lint
 volumes:
@@ -279,6 +279,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: 6404cfd065aef90b7f2f743d9e9704be06b4031355702da54ef6084d2e683f8f
+hmac: a961739c1516f0b6516080f96dbfddb9b2338fd968426f2f13c365554030bf3c
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -84,7 +84,7 @@ steps:
   - name: test
     image: grafana/ci-build-windows:0.3.4
     commands:
-      - go test -tags="nodocker,nonetwork" -p 2 ./...
+      - go test -tags="nodocker,nonetwork" ./...
 depends_on:
   - Lint
 volumes:
@@ -277,6 +277,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: 0562d162993db41b630a0fcc949bc45736b1d7177d50f4adf2db40dfd9f0309e
+hmac: 4fae74a5468c4f718d78c218d8b95572dc267ab9cb015858b413d83707a86a36
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -84,7 +84,7 @@ steps:
   - name: test
     image: grafana/ci-build-windows:0.3.4
     commands:
-      - go test -tags="nodocker,nonetwork" -p 1 ./...
+      - go test -tags="nodocker,nonetwork" -p 2 ./...
 depends_on:
   - Lint
 volumes:
@@ -277,6 +277,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: c7c25266657986274f538566578fdc9a9b4bba45bad7a37b8054ed07ee72d296
+hmac: 0562d162993db41b630a0fcc949bc45736b1d7177d50f4adf2db40dfd9f0309e
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -84,9 +84,10 @@ steps:
   - name: test
     image: mcr.microsoft.com/windows:1809
     commands:
-      - powershell wget https://go.dev/dl/go1.18.3.windows-amd64.zip -OutFile ~/go.zip
-      - powershell Expand-Archive -Path '~/go.zip' -DestinationPath '~/go'
-      - powershell ~/go/go/bin/go.exe test -tags="nodocker,nonetwork" -p 1 ./...
+      - powershell
+      - wget https://go.dev/dl/go1.18.3.windows-amd64.zip -OutFile ~/go.zip
+      - Expand-Archive -Path '~/go.zip' -DestinationPath '~/go'
+      - ~/go/go/bin/go.exe test -tags="nodocker,nonetwork" -p 1 ./...
 depends_on:
   - Lint
 volumes:
@@ -279,6 +280,6 @@ get:
   name: pat
 ---
 kind: signature
-hmac: 26404623adbc24252ef209c4dbd56d27b1ea268b94bf799c4504fde62eb26423
+hmac: 631e359ac724cbd26f71a05d4b24544f9f5a948b9dc0fbf589e13c68d1887140
 
 ...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        platform: [macos-latest, windows-latest]
+        platform: [macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code
@@ -29,14 +29,5 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - name: Increase pagefile
-      uses: al-cheb/configure-pagefile-action@v1.2
-      # Tests on Windows can use a lot of memory, and we need to increase the
-      # pagefile to compensate.
-      with:
-          minimum-size: 16GB
-          maximum-size: 16GB
-          disk-root: "C:"
-      if: ${{ matrix.platform == 'windows-latest' }}
     - name: Test
       run: make DOCKER_OPTS="" GOFLAGS="-tags=netgo,nodocker" BUILD_IN_CONTAINER=false test

--- a/Makefile
+++ b/Makefile
@@ -249,8 +249,8 @@ lint:
 # We have to run test twice: once for all packages with -race and then once
 # more without -race for packages that have known race detection issues.
 test:
-	CGO_ENABLED=1 go test $(CGO_FLAGS) -race -cover -coverprofile=cover.out -p=4 ./...
-	CGO_ENABLED=1 go test $(CGO_FLAGS) -cover -coverprofile=cover-norace.out -p=4 ./pkg/integrations/node_exporter ./pkg/logs ./pkg/operator ./pkg/util/k8s
+	CGO_ENABLED=1 go test $(CGO_FLAGS) -race -cover -coverprofile=cover.out  ./...
+	CGO_ENABLED=1 go test $(CGO_FLAGS) -cover -coverprofile=cover-norace.out ./pkg/integrations/node_exporter ./pkg/logs ./pkg/operator ./pkg/util/k8s
 
 clean:
 	rm -rf cmd/agent/agent
@@ -495,7 +495,7 @@ enforce-release-tag:
 	sh -c '[ -n "${RELEASE_TAG}" ] || (echo \$$RELEASE_TAG environment variable not set; exit 1)'
 
 test-packages:
-	go test -tags=packaging -p=4 ./packaging
+	go test -tags=packaging  ./packaging
 .PHONY: test-packages
 
 clean-dist:


### PR DESCRIPTION
#### PR Description

Remove the Github Actions Windows Test and use Drone as the default. The Github Action has increasingly been harder to successfully succeed due to issues outside the test. Utilizing the grafana drone system we have much more control over the machines running. In testing the windows tests have been reduced by half in time.
