### PR TITLE
Fix links referencing old documentation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="docs/user/assets/logo_and_name.png" alt="Grafana Agent logo"></p>
+<p align="center"><img src="docs/sources/assets/logo_and_name.png" alt="Grafana Agent logo"></p>
 
 Grafana Agent is a telemetry collector for sending metrics, logs,
 and trace data to the opinionated Grafana observability stack. It works best

--- a/docs/sources/cookbook/dynamic-configuration/01_Basics/01_Structure.md
+++ b/docs/sources/cookbook/dynamic-configuration/01_Basics/01_Structure.md
@@ -13,7 +13,7 @@ Dynamic Configuration uses a series of files to load templates. This example wil
 
 ## Dynamic Configuration
 
-[config.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/01_Basics/01_config.yml)
+[config.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/01_Basics/01_config.yml)
 
 ```yaml
 template_paths:
@@ -26,7 +26,7 @@ Tells the Grafana Agent where to load files from. It is important to note that d
 
 Dynamic Configuration will find the first file matching pattern `agent-*.yml` and load that as the base. You can only have one agent template. If multiple matching templates are found then the configuration will fail to load.
 
-[agent-1.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/01_Basics/01_assets/agent-1.yml)
+[agent-1.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/01_Basics/01_assets/agent-1.yml)
 
 ```yaml
 server:
@@ -55,7 +55,7 @@ is a configuration block.
 
 You can only have 1 server template.
 
-[server-1.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/01_Basics/01_assets/server-1.yml)
+[server-1.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/01_Basics/01_assets/server-1.yml)
 
 
 ```yaml
@@ -64,6 +64,6 @@ log_level: info
 
 ## Final
 
-[final.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/01_Basics/01_assets/final.yml)
+[final.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/01_Basics/01_assets/final.yml)
 
 In the above example the `log_level: debug` block will be replaced with `log_level: info` from the server-1.yml

--- a/docs/sources/cookbook/dynamic-configuration/01_Basics/02_Instances.md
+++ b/docs/sources/cookbook/dynamic-configuration/01_Basics/02_Instances.md
@@ -14,7 +14,7 @@ the same agent-1 and server-1 yml from 01.
 
 ## Dynamic Configuration
 
-[config.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/01_Basics/02_config.yml)
+[config.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/01_Basics/02_config.yml)
 
 Tells the Grafana Agent where to load files from.
 
@@ -22,7 +22,7 @@ Tells the Grafana Agent where to load files from.
 
 Dynamic Configuration will find the first file matching pattern `metrics-*.yml` and load that as the base. You can only have one metrics template.
 
-[metrics-1.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/01_Basics/02_assets/metrics-1.yml)
+[metrics-1.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/01_Basics/02_assets/metrics-1.yml)
 
 ```yaml
 configs:
@@ -37,7 +37,7 @@ wal_directory: /tmp/grafana-agent-wal
 
 You can have any number of metrics_instances and they are added to any existing metrics instances defined previously.
 
-[metrics_instances-1.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/01_Basics/02_assets/metrics_instances-1.yml)
+[metrics_instances-1.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/01_Basics/02_assets/metrics_instances-1.yml)
 
 ```yaml
 name: instance1
@@ -48,7 +48,7 @@ scrape_configs:
           - localhost:4000
 ```
 
-[metrics_instances-2.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/01_Basics/02_assets/metrics_instances-2.yml)
+[metrics_instances-2.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/01_Basics/02_assets/metrics_instances-2.yml)
 
 ```yaml
 name: instance2
@@ -61,7 +61,7 @@ scrape_configs:
 
 ## Final
 
-[final.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/01_Basics/01_assets/final.yml)
+[final.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/01_Basics/01_assets/final.yml)
 
 In the above you will see the `final.yml` includes all the instance configurations
 - default

--- a/docs/sources/cookbook/dynamic-configuration/01_Basics/03_Integrations.md
+++ b/docs/sources/cookbook/dynamic-configuration/01_Basics/03_Integrations.md
@@ -13,7 +13,7 @@ Dynamic configuration requires the use of `integrations-next` feature flag, to a
 
 ## Dynamic Configuration
 
-[config.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/01_Basics/03_config.yml)
+[config.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/01_Basics/03_config.yml)
 
 Tells the Grafana Agent where to load files from.
 
@@ -21,7 +21,7 @@ Tells the Grafana Agent where to load files from.
 
 Integrations are loaded from files matching `integrations-*.yml` and are combined together. You can declare for example multiple sets of `redis_configs` across several files.
 
-[integrations-node.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/01_Basics/03_assets/integrations-node.yml)
+[integrations-node.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/01_Basics/03_assets/integrations-node.yml)
 
 Note: You do NOT have to name the above file `integrations-node.yml` with `node`, `integrations-1.yml` would work the same. The name does NOT determine the type of integrations a template can contain and a template can contain integrations of different types.
 
@@ -29,7 +29,7 @@ Note: You do NOT have to name the above file `integrations-node.yml` with `node`
 node_exporter: {}
 ```
 
-[integrations-redis.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/01_Basics/03_assets/integrations-redis.yml)
+[integrations-redis.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/01_Basics/03_assets/integrations-redis.yml)
 
 ```yaml
 redis_configs:
@@ -44,7 +44,7 @@ redis_configs:
 
 ## Final
 
-[final.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/01_Basics/03_assets/final.yml)
+[final.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/01_Basics/03_assets/final.yml)
 
 The final result should have 3 integrations enabled, 1 node_exporter and 2 redis.
 

--- a/docs/sources/cookbook/dynamic-configuration/01_Basics/04_Logs_and_Traces.md
+++ b/docs/sources/cookbook/dynamic-configuration/01_Basics/04_Logs_and_Traces.md
@@ -12,7 +12,7 @@ Logs and Traces can also be templated. This is built ontop of the previous examp
 
 ## Dynamic Configuration
 
-[config.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/01_Basics/04_config.yml)
+[config.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/01_Basics/04_config.yml)
 
 Tells the Grafana Agent where to load files from.
 
@@ -20,7 +20,7 @@ Tells the Grafana Agent where to load files from.
 
 Logs are loaded from a template matching `logs-*.yml`. There can ONLY be 1 template loaded
 
-[logs-1.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/01_Basics/04_assets/logs-1.yml)
+[logs-1.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/01_Basics/04_assets/logs-1.yml)
 
 ```yaml
 configs:
@@ -35,7 +35,7 @@ configs:
             expression: '\\temp\\Logs\\(?P<log_app>.+?)\\'
 ```
 
-[traces.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/01_Basics/04_assets/traces-1.yml)
+[traces.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/01_Basics/04_assets/traces-1.yml)
 
 ```yaml
 configs:
@@ -48,5 +48,5 @@ configs:
 
 ## Final
 
-[final.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/01_Basics/04_assets/final.yml)
+[final.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/01_Basics/04_assets/final.yml)
 

--- a/docs/sources/cookbook/dynamic-configuration/02_Templates/01_Looping.md
+++ b/docs/sources/cookbook/dynamic-configuration/02_Templates/01_Looping.md
@@ -13,7 +13,7 @@ The templating is based on the excellent [gomplate](https://docs.gomplate.ca/) l
 
 ## Looping
 
-[agent-1.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/02_Templates/01_assets/agent-1.yml)
+[agent-1.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/02_Templates/01_assets/agent-1.yml)
 
 ```yaml
 server:
@@ -38,7 +38,7 @@ The templating engine uses directives that are wrapped in `{{ command }}`, in th
 
 ## Final
 
-[final.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/02_Templates/01_assets/final.yml)
+[final.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/02_Templates/01_assets/final.yml)
 
 The final.yml contains 4 prometheus configs
 

--- a/docs/sources/cookbook/dynamic-configuration/02_Templates/02_Datasources.md
+++ b/docs/sources/cookbook/dynamic-configuration/02_Templates/02_Datasources.md
@@ -14,7 +14,7 @@ Datasources are a powerful concept in gomplate. They allow you to reach out to o
 
 ## Config
 
-The [config.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/02_Templates/02_config.yml) adds a new field `sources`. Sources can be any number of things defined in the gomplate [datasources](https://docs.gomplate.ca/datasources/) documentation. In this example using fruit.
+The [config.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/02_Templates/02_config.yml) adds a new field `sources`. Sources can be any number of things defined in the gomplate [datasources](https://docs.gomplate.ca/datasources/) documentation. In this example using fruit.
 
 ```yaml
 template_paths:
@@ -24,7 +24,7 @@ datasources:
     url: "file://etc/grafana/01_assets/fruit.json"
 ```
 
-[fruit.json](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/02_Templates/02_assets/fruit.json)
+[fruit.json](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/02_Templates/02_assets/fruit.json)
 
 ```json
 ["mango","peach","orange"]
@@ -32,7 +32,7 @@ datasources:
 
 ## Usage
 
-[agent-1.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/02_Templates/02_assets/agent-1.yml)
+[agent-1.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/02_Templates/02_assets/agent-1.yml)
 
 ```yaml
 server:

--- a/docs/sources/cookbook/dynamic-configuration/02_Templates/03_Datasource_and_Objects.md
+++ b/docs/sources/cookbook/dynamic-configuration/02_Templates/03_Datasource_and_Objects.md
@@ -14,7 +14,7 @@ Datasources can also access objects.
 
 ## Config
 
-The [config.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/02_Templates/02_config.yml) adds a new field `sources`. Sources can be any number of things defined in the gomplate [datasources](https://docs.gomplate.ca/datasources/) documentation. In this example using fruit.
+The [config.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/02_Templates/02_config.yml) adds a new field `sources`. Sources can be any number of things defined in the gomplate [datasources](https://docs.gomplate.ca/datasources/) documentation. In this example using fruit.
 
 ```yaml
 template_paths:
@@ -24,7 +24,7 @@ datasources:
     url: "file:///etc/grafana/03_assets/computers.json"
 ```
 
-[computers.json](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/02_Templates/03_assets/computers.json)
+[computers.json](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/02_Templates/03_assets/computers.json)
 
 ```json
 [
@@ -49,7 +49,7 @@ datasources:
 
 ## Usage
 
-[agent-1.yml](https://github.com/grafana/agent/blob/main/docs/user/cookbook/dynamic-configuration/02_Templates/02_assets/agent-1.yml)
+[agent-1.yml](https://github.com/grafana/agent/blob/main/docs/sources/cookbook/dynamic-configuration/02_Templates/02_assets/agent-1.yml)
 
 ```yaml
 server:


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The latest change (renaming the technical documentation directory), broke two things: our logo on the repo root README and the Github links to snippets in the dynamic configuration cookbook.

This PR amends the paths in those two cases. I've also grepped to see if there's any other "docs/user" or "../user" paths remaining, but there wasn't anything.

#### Which issue(s) this PR fixes
No issue files

#### Notes to the Reviewer
None.

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
