### PR TITLE
Bug: fix rate limiting for app agent receiver intgeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Main (unreleased)
 ### Bugfixes
 
 - Relative symlinks for promtail now work as expected. (@RangerCD, @mukerjee)
+- Fix rate limiting implementation for the app agent receiver integration. (@domasx2)
 
 v0.25.1 (2022-06-16)
 -------------------------

--- a/pkg/integrations/v2/app_agent_receiver/handler.go
+++ b/pkg/integrations/v2/app_agent_receiver/handler.go
@@ -71,7 +71,7 @@ func (ar *AppAgentReceiverHandler) HTTPHandler(logger log.Logger) http.Handler {
 	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Check rate limiting state
 		if ar.config.Server.RateLimiting.Enabled {
-			if rsv := ar.rateLimiter.Reserve(); !rsv.OK() {
+			if ok := ar.rateLimiter.Allow(); !ok {
 				http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
 				return
 			}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

App agent receiver rate limiting feature is not working due to some mistaken assumptions. It was using `Reserve()` method which is not intended for our use case of skipping events. This PR switches to using the `Allow()` method. 

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [x] Tests updated
