### PR TITLE
Prototype: OpenTelemetry components for Flow

### DIFF
--- a/cmd/agentflow/example-config.flow
+++ b/cmd/agentflow/example-config.flow
@@ -10,9 +10,38 @@ local "file" "this-file" {
   detector = "fsnotify"
 }
 
+otel "receiver_zipkin" "default" {
+  http {}
+
+  output {
+    traces = [otel.exporter_logging.default.input, otel.exporter_otlp.default.input]
+  }
+}
+
+otel "receiver_jaeger" "default" {
+  grpc {}
+  http {}
+
+  output {
+    traces = [otel.exporter_logging.default.input, otel.exporter_otlp.default.input]
+  }
+}
+
 otel "receiver_otlp" "default" {
   grpc {}
   http {}
 
-  output {}
+  output {
+    traces = [otel.exporter_logging.default.input, otel.exporter_otlp.default.input]
+  }
 }
+
+otel "exporter_logging" "default" {}
+
+otel "exporter_otlp" "default" {
+  client {
+    endpoint = "localhost:54317"
+  }
+}
+
+

--- a/cmd/agentflow/example-config.flow
+++ b/cmd/agentflow/example-config.flow
@@ -10,3 +10,9 @@ local "file" "this-file" {
   detector = "fsnotify"
 }
 
+otel "receiver_otlp" "default" {
+  grpc {}
+  http {}
+
+  output {}
+}

--- a/component/all/all.go
+++ b/component/all/all.go
@@ -2,6 +2,7 @@
 package all
 
 import (
-	_ "github.com/grafana/agent/component/local/file"     // Import local.file
-	_ "github.com/grafana/agent/component/targets/mutate" // Import targets.mutate
+	_ "github.com/grafana/agent/component/local/file"        // Import local.file
+	_ "github.com/grafana/agent/component/otel/otlpreceiver" // Import otel.receiver_otlp
+	_ "github.com/grafana/agent/component/targets/mutate"    // Import targets.mutate
 )

--- a/component/all/all.go
+++ b/component/all/all.go
@@ -2,7 +2,11 @@
 package all
 
 import (
-	_ "github.com/grafana/agent/component/local/file"        // Import local.file
-	_ "github.com/grafana/agent/component/otel/otlpreceiver" // Import otel.receiver_otlp
-	_ "github.com/grafana/agent/component/targets/mutate"    // Import targets.mutate
+	_ "github.com/grafana/agent/component/local/file"           // Import local.file
+	_ "github.com/grafana/agent/component/otel/jaegerreceiver"  // Import otel.receiver_jaeger
+	_ "github.com/grafana/agent/component/otel/loggingexporter" // Import otel.exporter_logging
+	_ "github.com/grafana/agent/component/otel/otlpexporter"    // Import otel.receiver_otlp
+	_ "github.com/grafana/agent/component/otel/otlpreceiver"    // Import otel.exporter_otlp
+	_ "github.com/grafana/agent/component/otel/zipkinreceiver"  // Import otel.receiver_zipkin
+	_ "github.com/grafana/agent/component/targets/mutate"       // Import targets.mutate
 )

--- a/component/otel/component_runner.go
+++ b/component/otel/component_runner.go
@@ -1,0 +1,155 @@
+package otel
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/component"
+	otelcomponent "go.opentelemetry.io/collector/component"
+	otelconfig "go.opentelemetry.io/collector/config"
+	"go.uber.org/multierr"
+)
+
+// componentRunner is shared between Flow component implementations, manaaging
+// the running of OpenTelemetry Collector components.
+type componentRunner struct {
+	log log.Logger
+
+	healthMut sync.RWMutex
+	health    component.Health
+
+	schedMut        sync.Mutex
+	schedComponents []otelcomponent.Component // Most recently created components
+	host            otelcomponent.Host
+
+	onComponents chan struct{}
+}
+
+func newComponentRunner(l log.Logger) *componentRunner {
+	return &componentRunner{
+		log:          l,
+		onComponents: make(chan struct{}, 1),
+	}
+}
+
+// Schedule schedules a new set of components to run. Schedule may be called
+// before Run, but scheduled components won't start until Run has been invoked.
+func (cr *componentRunner) Schedule(h otelcomponent.Host, cc ...otelcomponent.Component) {
+	cr.schedMut.Lock()
+	defer cr.schedMut.Unlock()
+
+	cr.schedComponents = cc
+
+	select {
+	case cr.onComponents <- struct{}{}:
+		// Queued new message.
+	default:
+		// Nothing to do: this would be the case if onComponents is full (i.e., the
+		// message is already sent but not handled yet) and we don't need to do
+		// anything else.
+	}
+}
+
+// Run starts the componentRunner. Run will watch for scheduled components to
+// appear and run them, terminating previously running components if they
+// exist.
+func (cr *componentRunner) Run(ctx context.Context) error {
+	var components []otelcomponent.Component
+
+	// Make sure we terminate all of our running components on shutdown.
+	defer func() {
+		cr.stopComponents(context.Background(), components...)
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-cr.onComponents:
+			// We must stop the old components before running the new scheduled ones.
+			cr.stopComponents(ctx, components...)
+
+			cr.schedMut.Lock()
+			components = cr.schedComponents
+			host := cr.host
+			cr.schedMut.Unlock()
+			cr.startComponents(ctx, host, components...)
+		}
+	}
+}
+
+func (cr *componentRunner) stopComponents(ctx context.Context, cc ...otelcomponent.Component) {
+	for _, c := range cc {
+		if err := c.Shutdown(ctx); err != nil {
+			level.Error(cr.log).Log("msg", "failed to stop down inner otel component, future updates may fail", "err", err)
+		}
+	}
+}
+
+func (cr *componentRunner) startComponents(ctx context.Context, h otelcomponent.Host, cc ...otelcomponent.Component) {
+	var errs error
+
+	for _, c := range cc {
+		if err := c.Start(ctx, h); err != nil {
+			errs = multierr.Append(errs, err)
+		}
+	}
+
+	if errs != nil {
+		cr.setHealth(component.Health{
+			Health:     component.HealthTypeUnhealthy,
+			Message:    fmt.Sprintf("failed to create components: %s", errs),
+			UpdateTime: time.Now(),
+		})
+	} else {
+		cr.setHealth(component.Health{
+			Health:     component.HealthTypeHealthy,
+			Message:    "created components",
+			UpdateTime: time.Now(),
+		})
+	}
+}
+
+// CurrentHealth implements component.HealthComponent.
+func (cr *componentRunner) CurrentHealth() component.Health {
+	cr.healthMut.RLock()
+	defer cr.healthMut.RUnlock()
+	return cr.health
+}
+
+func (cr *componentRunner) setHealth(h component.Health) {
+	cr.healthMut.Lock()
+	defer cr.healthMut.Unlock()
+	cr.health = h
+}
+
+type flowHost struct {
+	log log.Logger
+
+	extensions map[otelconfig.ComponentID]otelcomponent.Extension
+	exporters  map[otelconfig.DataType]map[otelconfig.ComponentID]otelcomponent.Exporter
+}
+
+var _ otelcomponent.Host = (*flowHost)(nil)
+
+func (h *flowHost) ReportFatalError(err error) {
+	level.Error(h.log).Log("msg", "fatal error running component", "err", err)
+}
+
+func (h *flowHost) GetFactory(kind otelcomponent.Kind, componentType otelconfig.Type) otelcomponent.Factory {
+	// GetFactory is used for components to create other components. It's not
+	// clear if we want to allow this right now, so it's disabled.
+	return nil
+}
+
+func (h *flowHost) GetExtensions() map[otelconfig.ComponentID]otelcomponent.Extension {
+	return h.extensions
+}
+
+func (h *flowHost) GetExporters() map[otelconfig.DataType]map[otelconfig.ComponentID]otelcomponent.Exporter {
+	return h.exporters
+}

--- a/component/otel/config_exporter.go
+++ b/component/otel/config_exporter.go
@@ -1,0 +1,77 @@
+package otel
+
+import (
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+)
+
+// Defaults for Exporter settings. These types don't implement gohcl.Decoder
+// and so defaults must be applied by the wrapping type.
+var (
+	DefaultExporterQueueSettings = ExporterQueueSettings{
+		Enabled:      true,
+		NumConsumers: 10,
+		// For 5000 queue elements at 100 requests/sec gives about 50 sec of
+		// survive of destination outage. This is a pretty decent value for
+		// production. Users should calculate this from the perspective of how many
+		// seconds to buffer in case of a backend outage, and then multiple that by
+		// the number of requests per second.
+		QueueSize: 5000,
+	}
+
+	DefaultExporterRetrySettings = ExporterRetrySettings{
+		Enabled:        true,
+		InitalInterval: 5 * time.Second,
+		MaxInterval:    30 * time.Second,
+		MaxElapsedTime: 5 * time.Minute,
+	}
+)
+
+// ExporterQueueSettings holds common settings for a queue_config block.
+type ExporterQueueSettings struct {
+	Enabled      bool `hcl:"enabled,optional"`
+	NumConsumers int  `hcl:"num_consumers,optional"`
+	QueueSize    int  `hcl:"queue_size,optional"`
+}
+
+// Convert transforms s into the otel QueueSettings type.
+func (s *ExporterQueueSettings) Convert() exporterhelper.QueueSettings {
+	return exporterhelper.QueueSettings{
+		Enabled:      s.Enabled,
+		NumConsumers: s.NumConsumers,
+		QueueSize:    s.QueueSize,
+	}
+}
+
+// Validate retursn an error if s is invalid.
+func (s *ExporterQueueSettings) Validate() error {
+	if !s.Enabled {
+		return nil
+	}
+
+	if s.QueueSize <= 0 {
+		return fmt.Errorf("queue_size must be greater than 0, got %d", s.QueueSize)
+	}
+
+	return nil
+}
+
+// ExporterRetrySettings holds common settings for a retry_on_failure block.
+type ExporterRetrySettings struct {
+	Enabled        bool          `hcl:"enabled,optional"`
+	InitalInterval time.Duration `hcl:"initial_interval,optional"`
+	MaxInterval    time.Duration `hcl:"max_interval,optional"`
+	MaxElapsedTime time.Duration `hcl:"max_elapsed_time,optional"`
+}
+
+// Convert transforms s into the otel RetrySettings type.
+func (s *ExporterRetrySettings) Convert() exporterhelper.RetrySettings {
+	return exporterhelper.RetrySettings{
+		Enabled:         s.Enabled,
+		InitialInterval: s.InitalInterval,
+		MaxInterval:     s.MaxInterval,
+		MaxElapsedTime:  s.MaxElapsedTime,
+	}
+}

--- a/component/otel/consumer_exports.go
+++ b/component/otel/consumer_exports.go
@@ -1,0 +1,88 @@
+package otel
+
+import (
+	"context"
+	"sync"
+
+	"github.com/grafana/agent/component"
+	otelconsumer "go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+func init() {
+	component.RegisterGoStruct("Consumer", Consumer{})
+}
+
+// CombinedConsumer is a combined consumer of all telemetry types.
+type CombinedConsumer interface {
+	otelconsumer.Metrics
+	otelconsumer.Logs
+	otelconsumer.Traces
+}
+
+// Consumer is the registered Go struct used by components to pass around
+// consumers.
+type Consumer struct{ CombinedConsumer }
+
+// ConsumerExports is a common Exports type for components which are processors
+// or exporters.
+type ConsumerExports struct {
+	// Input is a collection of consumers that other components can use to send
+	// telemetry data.
+	Input *Consumer `hcl:"input,attr"`
+}
+
+// lazyCombinedConsumer is used by FlowExporter and FlowProcessor to expose
+// their consumers as fast as possible even before components are constructed.
+// Calls to process telemetry data will block while there is no active
+// consumer.
+type lazyCombinedConsumer struct {
+	mut             sync.RWMutex
+	metricsConsumer otelconsumer.Metrics
+	logsConsumer    otelconsumer.Logs
+	tracesConsumer  otelconsumer.Traces
+}
+
+var _ CombinedConsumer = (*lazyCombinedConsumer)(nil)
+
+func newLazyCombinedConsumer() *lazyCombinedConsumer {
+	return &lazyCombinedConsumer{}
+}
+
+func (c *lazyCombinedConsumer) Capabilities() otelconsumer.Capabilities {
+	// TODO(rfratto): this is probably fairly inefficient over the upstream
+	// collector and needs to be improved. As long as lazyCombinedConsumer is
+	// always used in a context where MutatesData is constant (i.e., because the
+	// consumers created by a component always have the same value for
+	// MutatesData, we can pass the value here).
+	return otelconsumer.Capabilities{
+		MutatesData: true,
+	}
+}
+
+func (c *lazyCombinedConsumer) ConsumeMetrics(ctx context.Context, md pdata.Metrics) error {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+	return c.metricsConsumer.ConsumeMetrics(ctx, md)
+}
+
+func (c *lazyCombinedConsumer) ConsumeLogs(ctx context.Context, md pdata.Logs) error {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+	return c.logsConsumer.ConsumeLogs(ctx, md)
+}
+
+func (c *lazyCombinedConsumer) ConsumeTraces(ctx context.Context, md pdata.Traces) error {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+	return c.tracesConsumer.ConsumeTraces(ctx, md)
+}
+
+func (c *lazyCombinedConsumer) SetConsumers(m otelconsumer.Metrics, l otelconsumer.Logs, t otelconsumer.Traces) {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	c.metricsConsumer = m
+	c.logsConsumer = l
+	c.tracesConsumer = t
+}

--- a/component/otel/consumer_exports.go
+++ b/component/otel/consumer_exports.go
@@ -63,18 +63,30 @@ func (c *lazyCombinedConsumer) Capabilities() otelconsumer.Capabilities {
 func (c *lazyCombinedConsumer) ConsumeMetrics(ctx context.Context, md pdata.Metrics) error {
 	c.mut.RLock()
 	defer c.mut.RUnlock()
+	if c.metricsConsumer == nil {
+		// TODO(rfratto): should this log?
+		return nil
+	}
 	return c.metricsConsumer.ConsumeMetrics(ctx, md)
 }
 
 func (c *lazyCombinedConsumer) ConsumeLogs(ctx context.Context, md pdata.Logs) error {
 	c.mut.RLock()
 	defer c.mut.RUnlock()
+	if c.logsConsumer == nil {
+		// TODO(rfratto): should this log?
+		return nil
+	}
 	return c.logsConsumer.ConsumeLogs(ctx, md)
 }
 
 func (c *lazyCombinedConsumer) ConsumeTraces(ctx context.Context, md pdata.Traces) error {
 	c.mut.RLock()
 	defer c.mut.RUnlock()
+	if c.tracesConsumer == nil {
+		// TODO(rfratto): should this log?
+		return nil
+	}
 	return c.tracesConsumer.ConsumeTraces(ctx, md)
 }
 

--- a/component/otel/flow_exporter.go
+++ b/component/otel/flow_exporter.go
@@ -1,0 +1,142 @@
+package otel
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	otelcomponent "go.opentelemetry.io/collector/component"
+	otelcomponenterror "go.opentelemetry.io/collector/component/componenterror"
+	otelconfig "go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otel/internal/zapadapter"
+	"github.com/grafana/agent/pkg/build"
+)
+
+// FlowExporter is a Flow component implementation which manages OpenTelemetry
+// Collector exporter.
+type FlowExporter struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	opts    component.Options
+	factory otelcomponent.ExporterFactory
+
+	runner *componentRunner
+}
+
+type ExporterArguments interface {
+	component.Arguments
+
+	// Convert should convert the ExporterArguments into a Exporter confguration
+	// used by OpenTelemetry Collector.
+	Convert() otelconfig.Exporter
+
+	// Extensions should return the set of extensions that this component is
+	// allowed to use.
+	Extensions() map[otelconfig.ComponentID]otelcomponent.Extension
+
+	// Exporters should return the set of exporters that are exposed to this
+	// component.
+	Exporters() map[otelconfig.DataType]map[otelconfig.ComponentID]otelcomponent.Exporter
+}
+
+// NewFlowExporter creates a new Flow component which encapsules an
+// OpenTelemetry Collector exporter. args must be the argument type registered
+// with the component.
+func NewFlowExporter(opts component.Options, f otelcomponent.ExporterFactory, args ExporterArguments) (*FlowExporter, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	fr := &FlowExporter{
+		ctx:    ctx,
+		cancel: cancel,
+
+		opts:    opts,
+		factory: f,
+
+		runner: newComponentRunner(opts.Logger),
+	}
+	if err := fr.Update(args); err != nil {
+		return nil, err
+	}
+	return fr, nil
+}
+
+var (
+	_ component.Component       = (*FlowExporter)(nil)
+	_ component.HealthComponent = (*FlowExporter)(nil)
+)
+
+// Run runs the exporter. Run will wait for OpenTelemetry Collector exporter
+// configs to be created.
+func (r *FlowExporter) Run(ctx context.Context) error {
+	defer r.cancel()
+	return r.runner.Run(ctx)
+}
+
+// Update implements component.Component. It will generate OpenTelemetry
+// Collector exporter configs and schedule components to get created in the
+// background once the FlowExporter is running.
+func (r *FlowExporter) Update(args component.Arguments) error {
+	rargs := args.(ExporterArguments)
+
+	h := flowHost{
+		log: r.opts.Logger,
+
+		extensions: rargs.Extensions(),
+		exporters:  rargs.Exporters(),
+	}
+
+	settings := otelcomponent.ExporterCreateSettings{
+		TelemetrySettings: otelcomponent.TelemetrySettings{
+			Logger: zapadapter.New(r.opts.Logger),
+
+			// TODO(rfratto): should these be set to something real at some point?
+			TracerProvider: trace.NewNoopTracerProvider(),
+			MeterProvider:  metric.NewNoopMeterProvider(),
+		},
+
+		BuildInfo: otelcomponent.BuildInfo{
+			Command:     os.Args[0],
+			Description: "Grafana Agent",
+			Version:     build.Version,
+		},
+	}
+
+	var exporterConfig = rargs.Convert()
+
+	var schedule []otelcomponent.Component
+
+	metricsRecv, err := r.factory.CreateMetricsExporter(r.ctx, settings, exporterConfig)
+	if err != nil && !errors.Is(err, otelcomponenterror.ErrDataTypeIsNotSupported) {
+		return err
+	} else if metricsRecv != nil {
+		schedule = append(schedule, metricsRecv)
+	}
+
+	logsRecv, err := r.factory.CreateLogsExporter(r.ctx, settings, exporterConfig)
+	if err != nil && !errors.Is(err, otelcomponenterror.ErrDataTypeIsNotSupported) {
+		return err
+	} else if metricsRecv != nil {
+		schedule = append(schedule, logsRecv)
+	}
+
+	tracesRecv, err := r.factory.CreateTracesExporter(r.ctx, settings, exporterConfig)
+	if err != nil && !errors.Is(err, otelcomponenterror.ErrDataTypeIsNotSupported) {
+		return err
+	} else if metricsRecv != nil {
+		schedule = append(schedule, tracesRecv)
+	}
+
+	// Schedule the components to run when our component is running.
+	r.runner.Schedule(&h, schedule...)
+	return nil
+}
+
+// CurrentHealth implements component.HealthComponent.
+func (r *FlowExporter) CurrentHealth() component.Health {
+	return r.runner.CurrentHealth()
+}

--- a/component/otel/flow_processor.go
+++ b/component/otel/flow_processor.go
@@ -1,0 +1,151 @@
+package otel
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	otelcomponent "go.opentelemetry.io/collector/component"
+	otelcomponenterror "go.opentelemetry.io/collector/component/componenterror"
+	otelconfig "go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otel/internal/zapadapter"
+	"github.com/grafana/agent/pkg/build"
+)
+
+// FlowProcessor is a Flow component implementation which manages OpenTelemetry
+// Collector processors.
+type FlowProcessor struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	opts    component.Options
+	factory otelcomponent.ProcessorFactory
+
+	runner *componentRunner
+}
+
+type ProcessorArguments interface {
+	component.Arguments
+
+	// Convert should convert the ProcessorArguments into a Processor confguration
+	// used by OpenTelemetry Collector.
+	Convert() otelconfig.Processor
+
+	// Extensions should return the set of extensions that this component is
+	// allowed to use.
+	Extensions() map[otelconfig.ComponentID]otelcomponent.Extension
+
+	// Exporters should return the set of exporters that are exposed to this
+	// component.
+	Exporters() map[otelconfig.DataType]map[otelconfig.ComponentID]otelcomponent.Exporter
+
+	// NextArguments returns the set of components to send data to.
+	NextArguments() *NextReceiverArguments
+}
+
+// NewFlowProcessor creates a new Flow component which encapsules an
+// OpenTelemetry Collector processor. args must be the argument type registered
+// with the component.
+func NewFlowProcessor(opts component.Options, f otelcomponent.ProcessorFactory, args ProcessorArguments) (*FlowProcessor, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	fp := &FlowProcessor{
+		ctx:    ctx,
+		cancel: cancel,
+
+		opts:    opts,
+		factory: f,
+
+		runner: newComponentRunner(opts.Logger),
+	}
+	if err := fp.Update(args); err != nil {
+		return nil, err
+	}
+	return fp, nil
+}
+
+var (
+	_ component.Component       = (*FlowProcessor)(nil)
+	_ component.HealthComponent = (*FlowProcessor)(nil)
+)
+
+// Run runs the processor. Run will wait for OpenTelemetry Collector receiver
+// configs to be created.
+func (p *FlowProcessor) Run(ctx context.Context) error {
+	defer p.cancel()
+	return p.runner.Run(ctx)
+}
+
+// Update implements component.Component. It will generate OpenTelemetry
+// Collector processor configs and schedule components to get created in the
+// background once the FlowReceiver is running.
+func (p *FlowProcessor) Update(args component.Arguments) error {
+	rargs := args.(ProcessorArguments)
+
+	h := flowHost{
+		log: p.opts.Logger,
+
+		extensions: rargs.Extensions(),
+		exporters:  rargs.Exporters(),
+	}
+
+	settings := otelcomponent.ProcessorCreateSettings{
+		TelemetrySettings: otelcomponent.TelemetrySettings{
+			Logger: zapadapter.New(p.opts.Logger),
+
+			// TODO(rfratto): should these be set to something real at some point?
+			TracerProvider: trace.NewNoopTracerProvider(),
+			MeterProvider:  metric.NewNoopMeterProvider(),
+		},
+
+		BuildInfo: otelcomponent.BuildInfo{
+			Command:     os.Args[0],
+			Description: "Grafana Agent",
+			Version:     build.Version,
+		},
+	}
+
+	var (
+		processorConfig = rargs.Convert()
+
+		nextMetrics = rargs.NextArguments().MetricsConsumer()
+		nextLogs    = rargs.NextArguments().LogsConsumer()
+		nextTraces  = rargs.NextArguments().TracesConsumer()
+	)
+
+	var schedule []otelcomponent.Component
+
+	metricsProc, err := p.factory.CreateMetricsProcessor(p.ctx, settings, processorConfig, nextMetrics)
+	if err != nil && !errors.Is(err, otelcomponenterror.ErrDataTypeIsNotSupported) {
+		return err
+	} else if metricsProc != nil {
+		schedule = append(schedule, metricsProc)
+	}
+
+	logsProc, err := p.factory.CreateLogsProcessor(p.ctx, settings, processorConfig, nextLogs)
+	if err != nil && !errors.Is(err, otelcomponenterror.ErrDataTypeIsNotSupported) {
+		return err
+	} else if metricsProc != nil {
+		schedule = append(schedule, logsProc)
+	}
+
+	tracesProc, err := p.factory.CreateTracesProcessor(p.ctx, settings, processorConfig, nextTraces)
+	if err != nil && !errors.Is(err, otelcomponenterror.ErrDataTypeIsNotSupported) {
+		return err
+	} else if metricsProc != nil {
+		schedule = append(schedule, tracesProc)
+	}
+
+	// Schedule the components to run when our component is running.
+	p.runner.Schedule(&h, schedule...)
+	return nil
+}
+
+// CurrentHealth implements component.HealthComponent.
+func (p *FlowProcessor) CurrentHealth() component.Health {
+	return p.runner.CurrentHealth()
+}

--- a/component/otel/flow_receiver.go
+++ b/component/otel/flow_receiver.go
@@ -129,14 +129,14 @@ func (r *FlowReceiver) Update(args component.Arguments) error {
 	logsRecv, err := r.factory.CreateLogsReceiver(r.ctx, settings, receiverConfig, nextLogs)
 	if err != nil && !errors.Is(err, otelcomponenterror.ErrDataTypeIsNotSupported) {
 		return err
-	} else if metricsRecv != nil {
+	} else if logsRecv != nil {
 		schedule = append(schedule, logsRecv)
 	}
 
 	tracesRecv, err := r.factory.CreateTracesReceiver(r.ctx, settings, receiverConfig, nextTraces)
 	if err != nil && !errors.Is(err, otelcomponenterror.ErrDataTypeIsNotSupported) {
 		return err
-	} else if metricsRecv != nil {
+	} else if tracesRecv != nil {
 		schedule = append(schedule, tracesRecv)
 	}
 

--- a/component/otel/flow_receiver.go
+++ b/component/otel/flow_receiver.go
@@ -1,0 +1,151 @@
+package otel
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	otelcomponent "go.opentelemetry.io/collector/component"
+	otelcomponenterror "go.opentelemetry.io/collector/component/componenterror"
+	otelconfig "go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otel/internal/zapadapter"
+	"github.com/grafana/agent/pkg/build"
+)
+
+// FlowReceiver is a Flow component implementation which manages OpenTelemetry
+// Collector receivers.
+type FlowReceiver struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	opts    component.Options
+	factory otelcomponent.ReceiverFactory
+
+	runner *componentRunner
+}
+
+type ReceiverArguments interface {
+	component.Arguments
+
+	// Convert should convert the ReceiverArguments into a Receiver confguration
+	// used by OpenTelemetry Collector.
+	Convert() otelconfig.Receiver
+
+	// Extensions should return the set of extensions that this component is
+	// allowed to use.
+	Extensions() map[otelconfig.ComponentID]otelcomponent.Extension
+
+	// Exporters should return the set of exporters that are exposed to this
+	// component.
+	Exporters() map[otelconfig.DataType]map[otelconfig.ComponentID]otelcomponent.Exporter
+
+	// NextArguments returns the set of components to send data to.
+	NextArguments() *NextReceiverArguments
+}
+
+// NewFlowReceiver creates a new Flow component which encapsules an
+// OpenTelemetry Collector receiver. args must be the argument type registered
+// with the component.
+func NewFlowReceiver(opts component.Options, f otelcomponent.ReceiverFactory, args ReceiverArguments) (*FlowReceiver, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	fr := &FlowReceiver{
+		ctx:    ctx,
+		cancel: cancel,
+
+		opts:    opts,
+		factory: f,
+
+		runner: newComponentRunner(opts.Logger),
+	}
+	if err := fr.Update(args); err != nil {
+		return nil, err
+	}
+	return fr, nil
+}
+
+var (
+	_ component.Component       = (*FlowReceiver)(nil)
+	_ component.HealthComponent = (*FlowReceiver)(nil)
+)
+
+// Run runs the receiver. Run will wait for OpenTelemetry Collector receiver
+// configs to be created.
+func (r *FlowReceiver) Run(ctx context.Context) error {
+	defer r.cancel()
+	return r.runner.Run(ctx)
+}
+
+// Update implements component.Component. It will generate OpenTelemetry
+// Collector receiver configs and schedule components to get created in the
+// background once the FlowReceiver is running.
+func (r *FlowReceiver) Update(args component.Arguments) error {
+	rargs := args.(ReceiverArguments)
+
+	h := flowHost{
+		log: r.opts.Logger,
+
+		extensions: rargs.Extensions(),
+		exporters:  rargs.Exporters(),
+	}
+
+	settings := otelcomponent.ReceiverCreateSettings{
+		TelemetrySettings: otelcomponent.TelemetrySettings{
+			Logger: zapadapter.New(r.opts.Logger),
+
+			// TODO(rfratto): should these be set to something real at some point?
+			TracerProvider: trace.NewNoopTracerProvider(),
+			MeterProvider:  metric.NewNoopMeterProvider(),
+		},
+
+		BuildInfo: otelcomponent.BuildInfo{
+			Command:     os.Args[0],
+			Description: "Grafana Agent",
+			Version:     build.Version,
+		},
+	}
+
+	var (
+		receiverConfig = rargs.Convert()
+
+		nextMetrics = rargs.NextArguments().MetricsConsumer()
+		nextLogs    = rargs.NextArguments().LogsConsumer()
+		nextTraces  = rargs.NextArguments().TracesConsumer()
+	)
+
+	var schedule []otelcomponent.Component
+
+	metricsRecv, err := r.factory.CreateMetricsReceiver(r.ctx, settings, receiverConfig, nextMetrics)
+	if err != nil && !errors.Is(err, otelcomponenterror.ErrDataTypeIsNotSupported) {
+		return err
+	} else if metricsRecv != nil {
+		schedule = append(schedule, metricsRecv)
+	}
+
+	logsRecv, err := r.factory.CreateLogsReceiver(r.ctx, settings, receiverConfig, nextLogs)
+	if err != nil && !errors.Is(err, otelcomponenterror.ErrDataTypeIsNotSupported) {
+		return err
+	} else if metricsRecv != nil {
+		schedule = append(schedule, logsRecv)
+	}
+
+	tracesRecv, err := r.factory.CreateTracesReceiver(r.ctx, settings, receiverConfig, nextTraces)
+	if err != nil && !errors.Is(err, otelcomponenterror.ErrDataTypeIsNotSupported) {
+		return err
+	} else if metricsRecv != nil {
+		schedule = append(schedule, tracesRecv)
+	}
+
+	// Schedule the components to run when our component is running.
+	r.runner.Schedule(&h, schedule...)
+	return nil
+}
+
+// CurrentHealth implements component.HealthComponent.
+func (r *FlowReceiver) CurrentHealth() component.Health {
+	return r.runner.CurrentHealth()
+}

--- a/component/otel/grpc.go
+++ b/component/otel/grpc.go
@@ -1,0 +1,40 @@
+package otel
+
+import (
+	"go.opentelemetry.io/collector/config/configcompression"
+	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/config/configtls"
+)
+
+// GRPCClientSettings defines common settings for a gRPC client configuration.
+type GRPCClientSettings struct {
+	Endpoint    string                            `hcl:"endpoint,attr"`
+	Compression configcompression.CompressionType `hcl:"compression,optional"`
+	// TODO(rfratto): TLSSetting
+	// TODO(rfratto): keepalive
+	ReadBufferSize  int               `hcl:"read_buffer_size,optional"`
+	WriteBufferSize int               `hcl:"write_buffer_size,optional"`
+	WaitForReady    bool              `hcl:"wait_for_ready,optional"`
+	Headers         map[string]string `hcl:"headers,optional"`
+	BalancerName    string            `hcl:"balancer_name,optional"`
+	// TODO(rfratto): Auth
+}
+
+// Convert converts s into otel's GRPCClientSettings type.
+func (s *GRPCClientSettings) Convert() configgrpc.GRPCClientSettings {
+	return configgrpc.GRPCClientSettings{
+		Endpoint:    s.Endpoint,
+		Compression: s.Compression,
+		// TODO(rfratto): TLSSetting
+		TLSSetting: configtls.TLSClientSetting{
+			Insecure: true,
+		},
+		// TODO(rfratto): keepalive
+		ReadBufferSize:  s.ReadBufferSize,
+		WriteBufferSize: s.WriteBufferSize,
+		WaitForReady:    s.WaitForReady,
+		Headers:         s.Headers,
+		BalancerName:    s.BalancerName,
+		// TODO(rfratto): auth
+	}
+}

--- a/component/otel/internal/errorconsumer/errorconsumer.go
+++ b/component/otel/internal/errorconsumer/errorconsumer.go
@@ -1,0 +1,34 @@
+// Package errorconsumer exposes consumers which always fail.
+package errorconsumer
+
+import (
+	"context"
+	"fmt"
+
+	otelconsumer "go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+var (
+	Metrics otelconsumer.Metrics = errorConsumer{}
+	Logs    otelconsumer.Logs    = errorConsumer{}
+	Traces  otelconsumer.Traces  = errorConsumer{}
+)
+
+type errorConsumer struct{}
+
+func (errorConsumer) Capabilities() otelconsumer.Capabilities {
+	return otelconsumer.Capabilities{MutatesData: false}
+}
+
+func (errorConsumer) ConsumeMetrics(context.Context, pdata.Metrics) error {
+	return fmt.Errorf("component does not accept metrics")
+}
+
+func (errorConsumer) ConsumeLogs(context.Context, pdata.Logs) error {
+	return fmt.Errorf("component does not accept logs")
+}
+
+func (errorConsumer) ConsumeTraces(context.Context, pdata.Traces) error {
+	return fmt.Errorf("component does not accept traces")
+}

--- a/component/otel/internal/fanoutconsumer/logs.go
+++ b/component/otel/internal/fanoutconsumer/logs.go
@@ -1,0 +1,76 @@
+package fanoutconsumer
+
+// This file is a near copy of
+// https://github.com/open-telemetry/opentelemetry-collector/blob/v0.54.0/service/internal/fanoutconsumer/logs.go
+//
+// A copy was made because the upstream package is internal. If it is ever made
+// public, our copy can be removed.
+
+import (
+	"context"
+
+	otelconsumer "go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/multierr"
+)
+
+// Logs creates a new fanout consumer for logs.
+func Logs(in []otelconsumer.Logs) otelconsumer.Logs {
+	if len(in) == 1 {
+		return in[0]
+	}
+
+	var passthrough, clone []otelconsumer.Logs
+
+	// Iterate through all the consumers besides the last.
+	for i := 0; i < len(in)-1; i++ {
+		consumer := in[i]
+
+		if consumer.Capabilities().MutatesData {
+			clone = append(clone, consumer)
+		} else {
+			passthrough = append(passthrough, consumer)
+		}
+	}
+
+	last := in[len(in)-1]
+
+	// The final consumer can be given to the passthrough list regardless of
+	// whether it mutates as long as there's no other read-only consumers.
+	if len(passthrough) == 0 || !last.Capabilities().MutatesData {
+		passthrough = append(passthrough, last)
+	} else {
+		clone = append(clone, last)
+	}
+
+	return &logsFanout{
+		passthrough: passthrough,
+		clone:       clone,
+	}
+}
+
+type logsFanout struct {
+	passthrough []otelconsumer.Logs // Consumers where data can be passed through directly
+	clone       []otelconsumer.Logs // Consumes which require cloning data
+}
+
+func (f *logsFanout) Capabilities() otelconsumer.Capabilities {
+	return otelconsumer.Capabilities{MutatesData: false}
+}
+
+// ConsumeLogs exports the pmetric.Logs to all consumers wrapped by the current one.
+func (f *logsFanout) ConsumeLogs(ctx context.Context, md pdata.Logs) error {
+	var errs error
+
+	// Initially pass to clone exporter to avoid the case where the optimization
+	// of sending the incoming data to a mutating consumer is used that may
+	// change the incoming data before cloning.
+	for _, f := range f.clone {
+		errs = multierr.Append(errs, f.ConsumeLogs(ctx, md.Clone()))
+	}
+	for _, f := range f.passthrough {
+		errs = multierr.Append(errs, f.ConsumeLogs(ctx, md))
+	}
+
+	return errs
+}

--- a/component/otel/internal/fanoutconsumer/metrics.go
+++ b/component/otel/internal/fanoutconsumer/metrics.go
@@ -1,0 +1,76 @@
+package fanoutconsumer
+
+// This file is a near copy of
+// https://github.com/open-telemetry/opentelemetry-collector/blob/v0.54.0/service/internal/fanoutconsumer/metrics.go
+//
+// A copy was made because the upstream package is internal. If it is ever made
+// public, our copy can be removed.
+
+import (
+	"context"
+
+	otelconsumer "go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/multierr"
+)
+
+// Metrics creates a new fanout consumer for metrics.
+func Metrics(in []otelconsumer.Metrics) otelconsumer.Metrics {
+	if len(in) == 1 {
+		return in[0]
+	}
+
+	var passthrough, clone []otelconsumer.Metrics
+
+	// Iterate through all the consumers besides the last.
+	for i := 0; i < len(in)-1; i++ {
+		consumer := in[i]
+
+		if consumer.Capabilities().MutatesData {
+			clone = append(clone, consumer)
+		} else {
+			passthrough = append(passthrough, consumer)
+		}
+	}
+
+	last := in[len(in)-1]
+
+	// The final consumer can be given to the passthrough list regardless of
+	// whether it mutates as long as there's no other read-only consumers.
+	if len(passthrough) == 0 || !last.Capabilities().MutatesData {
+		passthrough = append(passthrough, last)
+	} else {
+		clone = append(clone, last)
+	}
+
+	return &metricsFanout{
+		passthrough: passthrough,
+		clone:       clone,
+	}
+}
+
+type metricsFanout struct {
+	passthrough []otelconsumer.Metrics // Consumers where data can be passed through directly
+	clone       []otelconsumer.Metrics // Consumes which require cloning data
+}
+
+func (f *metricsFanout) Capabilities() otelconsumer.Capabilities {
+	return otelconsumer.Capabilities{MutatesData: false}
+}
+
+// ConsumeMetrics exports the pmetric.Metrics to all consumers wrapped by the current one.
+func (f *metricsFanout) ConsumeMetrics(ctx context.Context, md pdata.Metrics) error {
+	var errs error
+
+	// Initially pass to clone exporter to avoid the case where the optimization
+	// of sending the incoming data to a mutating consumer is used that may
+	// change the incoming data before cloning.
+	for _, f := range f.clone {
+		errs = multierr.Append(errs, f.ConsumeMetrics(ctx, md.Clone()))
+	}
+	for _, f := range f.passthrough {
+		errs = multierr.Append(errs, f.ConsumeMetrics(ctx, md))
+	}
+
+	return errs
+}

--- a/component/otel/internal/fanoutconsumer/traces.go
+++ b/component/otel/internal/fanoutconsumer/traces.go
@@ -1,0 +1,76 @@
+package fanoutconsumer
+
+// This file is a near copy of
+// https://github.com/open-telemetry/opentelemetry-collector/blob/v0.54.0/service/internal/fanoutconsumer/traces.go
+//
+// A copy was made because the upstream package is internal. If it is ever made
+// public, our copy can be removed.
+
+import (
+	"context"
+
+	otelconsumer "go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/multierr"
+)
+
+// Traces creates a new fanout consumer for traces.
+func Traces(in []otelconsumer.Traces) otelconsumer.Traces {
+	if len(in) == 1 {
+		return in[0]
+	}
+
+	var passthrough, clone []otelconsumer.Traces
+
+	// Iterate through all the consumers besides the last.
+	for i := 0; i < len(in)-1; i++ {
+		consumer := in[i]
+
+		if consumer.Capabilities().MutatesData {
+			clone = append(clone, consumer)
+		} else {
+			passthrough = append(passthrough, consumer)
+		}
+	}
+
+	last := in[len(in)-1]
+
+	// The final consumer can be given to the passthrough list regardless of
+	// whether it mutates as long as there's no other read-only consumers.
+	if len(passthrough) == 0 || !last.Capabilities().MutatesData {
+		passthrough = append(passthrough, last)
+	} else {
+		clone = append(clone, last)
+	}
+
+	return &tracesFanout{
+		passthrough: passthrough,
+		clone:       clone,
+	}
+}
+
+type tracesFanout struct {
+	passthrough []otelconsumer.Traces // Consumers where data can be passed through directly
+	clone       []otelconsumer.Traces // Consumes which require cloning data
+}
+
+func (f *tracesFanout) Capabilities() otelconsumer.Capabilities {
+	return otelconsumer.Capabilities{MutatesData: false}
+}
+
+// ConsumeTraces exports the pmetric.Traces to all consumers wrapped by the current one.
+func (f *tracesFanout) ConsumeTraces(ctx context.Context, md pdata.Traces) error {
+	var errs error
+
+	// Initially pass to clone exporter to avoid the case where the optimization
+	// of sending the incoming data to a mutating consumer is used that may
+	// change the incoming data before cloning.
+	for _, f := range f.clone {
+		errs = multierr.Append(errs, f.ConsumeTraces(ctx, md.Clone()))
+	}
+	for _, f := range f.passthrough {
+		errs = multierr.Append(errs, f.ConsumeTraces(ctx, md))
+	}
+
+	return errs
+}

--- a/component/otel/internal/zapadapter/zapadapter.go
+++ b/component/otel/internal/zapadapter/zapadapter.go
@@ -23,8 +23,6 @@ type loggerCore struct {
 
 var _ zapcore.Core = (*loggerCore)(nil)
 
-// LevelEnabler
-
 func (lc *loggerCore) Enabled(zapcore.Level) bool { return true }
 
 func (lc *loggerCore) With(ff []zapcore.Field) zapcore.Core {

--- a/component/otel/internal/zapadapter/zapadapter.go
+++ b/component/otel/internal/zapadapter/zapadapter.go
@@ -1,0 +1,208 @@
+// Package zapadapter allows go-kit/log to be used as a zap core.
+package zapadapter
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// New returns a new zap.Logger that logs to the provided log.Logger.
+func New(l log.Logger) *zap.Logger {
+	return zap.New(&loggerCore{inner: l})
+}
+
+type loggerCore struct {
+	inner log.Logger
+}
+
+var _ zapcore.Core = (*loggerCore)(nil)
+
+// LevelEnabler
+
+func (lc *loggerCore) Enabled(zapcore.Level) bool { return true }
+
+func (lc *loggerCore) With(ff []zapcore.Field) zapcore.Core {
+	enc := fieldEncoder{
+		// TODO(rfratto): pool?
+		fields: make([]interface{}, 0, len(ff)*2),
+	}
+
+	for _, f := range ff {
+		f.AddTo(&enc)
+	}
+
+	return &loggerCore{
+		inner: log.With(lc.inner, enc.fields...),
+	}
+}
+
+func (lc *loggerCore) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	return ce.AddCore(e, lc)
+}
+
+func (lc *loggerCore) Write(e zapcore.Entry, ff []zapcore.Field) error {
+	enc := fieldEncoder{
+		// TODO(rfratto): pool?
+		fields: make([]interface{}, 0, len(ff)*2),
+	}
+
+	for _, f := range ff {
+		f.AddTo(&enc)
+	}
+
+	enc.fields = append(enc.fields, "msg", e.Message)
+
+	switch e.Level {
+	case zapcore.DebugLevel:
+		return level.Debug(lc.inner).Log(enc.fields...)
+	case zapcore.InfoLevel:
+		return level.Info(lc.inner).Log(enc.fields...)
+	case zapcore.WarnLevel:
+		return level.Warn(lc.inner).Log(enc.fields...)
+	case zapcore.ErrorLevel, zapcore.DPanicLevel, zapcore.PanicLevel, zapcore.FatalLevel:
+		// We ignore panics/fatals hwere because we really don't want components to
+		// be able to do that.
+		return level.Error(lc.inner).Log(enc.fields...)
+	default:
+		return lc.inner.Log(enc.fields...)
+	}
+}
+
+func (lc *loggerCore) Sync() error {
+	return nil
+}
+
+type fieldEncoder struct {
+	fields []interface{}
+
+	namespace []string
+}
+
+var _ zapcore.ObjectEncoder = (*fieldEncoder)(nil)
+
+func (fe *fieldEncoder) keyName(k string) interface{} {
+	if len(fe.namespace) == 0 {
+		return k
+	}
+	return key(append(fe.namespace, k))
+}
+
+func (fe *fieldEncoder) AddArray(key string, marshaler zapcore.ArrayMarshaler) error {
+	fe.fields = append(fe.fields, fe.keyName(key), "<array>")
+	return nil
+}
+
+func (fe *fieldEncoder) AddObject(key string, marshaler zapcore.ObjectMarshaler) error {
+	fe.fields = append(fe.fields, fe.keyName(key), "<object>")
+	return nil
+}
+
+func (fe *fieldEncoder) AddBinary(key string, value []byte) {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+}
+
+func (fe *fieldEncoder) AddByteString(key string, value []byte) {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+}
+
+func (fe *fieldEncoder) AddBool(key string, value bool) {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+}
+
+func (fe *fieldEncoder) AddComplex128(key string, value complex128) {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+}
+
+func (fe *fieldEncoder) AddComplex64(key string, value complex64) {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+}
+
+func (fe *fieldEncoder) AddDuration(key string, value time.Duration) {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+}
+
+func (fe *fieldEncoder) AddFloat64(key string, value float64) {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+}
+
+func (fe *fieldEncoder) AddFloat32(key string, value float32) {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+}
+
+func (fe *fieldEncoder) AddInt(key string, value int) {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+}
+
+func (fe *fieldEncoder) AddInt64(key string, value int64) {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+}
+
+func (fe *fieldEncoder) AddInt32(key string, value int32) {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+}
+
+func (fe *fieldEncoder) AddInt16(key string, value int16) {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+}
+
+func (fe *fieldEncoder) AddInt8(key string, value int8) {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+}
+
+func (fe *fieldEncoder) AddString(key, value string) {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+}
+
+func (fe *fieldEncoder) AddTime(key string, value time.Time) {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+}
+
+func (fe *fieldEncoder) AddUint(key string, value uint) {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+}
+
+func (fe *fieldEncoder) AddUint64(key string, value uint64) {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+}
+
+func (fe *fieldEncoder) AddUint32(key string, value uint32) {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+}
+
+func (fe *fieldEncoder) AddUint16(key string, value uint16) {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+}
+
+func (fe *fieldEncoder) AddUint8(key string, value uint8) {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+}
+
+func (fe *fieldEncoder) AddUintptr(key string, value uintptr) {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+}
+
+func (fe *fieldEncoder) AddReflected(key string, value interface{}) error {
+	fe.fields = append(fe.fields, fe.keyName(key), value)
+	return nil
+}
+
+func (fe *fieldEncoder) OpenNamespace(key string) {
+	fe.namespace = append(fe.namespace, key)
+}
+
+type key []string
+
+var _ fmt.Stringer = (key)(nil)
+
+func (k key) String() string {
+	if len(k) == 1 {
+		return k[0]
+	}
+	return strings.Join(k, ".")
+}

--- a/component/otel/jaegerreceiver/jaegerreceiver.go
+++ b/component/otel/jaegerreceiver/jaegerreceiver.go
@@ -1,0 +1,96 @@
+package jaegerreceiver
+
+import (
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otel"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver"
+	"github.com/rfratto/gohcl"
+
+	otelcomponent "go.opentelemetry.io/collector/component"
+	otelconfig "go.opentelemetry.io/collector/config"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name: "otel.receiver_jaeger",
+		Args: Arguments{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			fact := jaegerreceiver.NewFactory()
+			return otel.NewFlowReceiver(opts, fact, args.(Arguments))
+		},
+	})
+}
+
+type (
+	// Arguments configures the OTLP receiver.
+	Arguments struct {
+		GRPC *GRPCServerArguments `hcl:"grpc,block"`
+		HTTP *HTTPServerArguments `hcl:"http,block"`
+
+		// Output configures where to send data. Must be provided.
+		Output otel.NextReceiverArguments `hcl:"output,block"`
+	}
+
+	// GRPCServerArguments includes GRPC arguments with receiver_otlp-specific
+	// defaults.
+	GRPCServerArguments otel.GRPCServerArguments
+
+	// HTTPServerArguments includes HTTP arguments with receiver_otlp-specific
+	// defaults.
+	HTTPServerArguments otel.HTTPServerArguments
+)
+
+var (
+	_ otel.ReceiverArguments = (*Arguments)(nil)
+	_ gohcl.Decoder          = (*GRPCServerArguments)(nil)
+	_ gohcl.Decoder          = (*HTTPServerArguments)(nil)
+)
+
+// Default settings.
+var (
+	DefaultGRPCServerArguments = GRPCServerArguments{
+		Endpoint:  "0.0.0.0:14250",
+		Transport: "tcp",
+	}
+
+	DefaultHTTPServerArguments = HTTPServerArguments{
+		Endpoint: "0.0.0.0:14268",
+	}
+)
+
+// Convert transforms OTLPReceiverArguments into the upstream otlpreceiver
+// Config.
+func (args Arguments) Convert() otelconfig.Receiver {
+	return &jaegerreceiver.Config{
+		ReceiverSettings: otelconfig.NewReceiverSettings(otelconfig.NewComponentID("jaeger")),
+		Protocols: jaegerreceiver.Protocols{
+			GRPC:       (*otel.GRPCServerArguments)(args.GRPC).Convert(),
+			ThriftHTTP: (*otel.HTTPServerArguments)(args.HTTP).Convert(),
+			// TODO(rfratto): ProtocolUDP for ThriftBinary/ThiftCompact
+		},
+	}
+}
+
+func (args Arguments) Extensions() map[otelconfig.ComponentID]otelcomponent.Extension {
+	return nil
+}
+
+func (args Arguments) Exporters() map[otelconfig.DataType]map[otelconfig.ComponentID]otelcomponent.Exporter {
+	return nil
+}
+
+func (args Arguments) NextArguments() *otel.NextReceiverArguments {
+	return &args.Output
+}
+
+func (args *GRPCServerArguments) DecodeHCL(body hcl.Body, ctx *hcl.EvalContext) error {
+	*args = DefaultGRPCServerArguments
+	return gohcl.DecodeBody(body, ctx, (*otel.GRPCServerArguments)(args))
+}
+
+func (args *HTTPServerArguments) DecodeHCL(body hcl.Body, ctx *hcl.EvalContext) error {
+	*args = DefaultHTTPServerArguments
+	return gohcl.DecodeBody(body, ctx, (*otel.HTTPServerArguments)(args))
+}

--- a/component/otel/loggingexporter/loggingexporter.go
+++ b/component/otel/loggingexporter/loggingexporter.go
@@ -1,0 +1,122 @@
+package loggingexporter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otel"
+	"github.com/grafana/agent/pkg/flow/logging"
+	otelcomponent "go.opentelemetry.io/collector/component"
+	otelconsumer "go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:    "otel.exporter_logging",
+		Args:    Arguments{},
+		Exports: otel.ConsumerExports{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			return New(opts, args.(Arguments))
+		},
+	})
+}
+
+// Arguments configures the logging exporter.
+type Arguments struct {
+	// TODO(rfratto): don't ignore this field
+	Level logging.Level `hcl:"level,optional"`
+}
+
+// Component implements the otlp.exporter_logging component.
+type Component struct{}
+
+func New(o component.Options, _ Arguments) (*Component, error) {
+	impl := &exporterImpl{
+		log: o.Logger,
+	}
+
+	// The only thing our component needs to do is initially set exports for the
+	// implementation. This lasts through the lifetime of our component.
+	o.OnStateChange(otel.ConsumerExports{
+		Input: &otel.Consumer{CombinedConsumer: impl},
+	})
+
+	return &Component{}, nil
+}
+
+// Run implements component.Component.
+func (c *Component) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+// Update implements component.Component.
+func (c *Component) Update(args component.Arguments) error {
+	// no-op: nothing to update (Arguments is empty struct).
+	return nil
+}
+
+type exporterImpl struct {
+	log log.Logger
+}
+
+func (e *exporterImpl) Capabilities() otelconsumer.Capabilities {
+	return otelconsumer.Capabilities{MutatesData: false}
+}
+
+func (e *exporterImpl) Start(ctx context.Context, host otelcomponent.Host) error {
+	// no-op
+	return nil
+}
+
+func (e *exporterImpl) Shutdown(ctx context.Context) error {
+	// no-op
+	return nil
+}
+
+func (e *exporterImpl) ConsumeMetrics(ctx context.Context, td pdata.Metrics) error {
+	return fmt.Errorf("cannot yet log metrics")
+}
+
+func (e *exporterImpl) ConsumeLogs(ctx context.Context, td pdata.Logs) error {
+	return fmt.Errorf("cannot yet log logs")
+}
+
+func (e *exporterImpl) ConsumeTraces(ctx context.Context, td pdata.Traces) error {
+	level.Debug(e.log).Log("msg", "got batch of traces")
+
+	resSpans := td.ResourceSpans()
+	for i := 0; i < resSpans.Len(); i++ {
+		resSpan := resSpans.At(i)
+
+		libSpans := resSpan.InstrumentationLibrarySpans()
+		for j := 0; j < libSpans.Len(); j++ {
+			libSpan := libSpans.At(j)
+
+			spans := libSpan.Spans()
+			for k := 0; k < spans.Len(); k++ {
+				span := spans.At(k)
+
+				level.Info(e.log).Log(
+					"msg", "received span",
+					"trace_id", span.TraceID().HexString(),
+					"parent_id", span.ParentSpanID().HexString(),
+					"id", span.SpanID().HexString(),
+					"name", span.Name(),
+					"kind", span.Kind(),
+					"start_time", span.StartTimestamp().String(),
+					"end_time", span.EndTimestamp().String(),
+					"status_code", span.Status().Code().String(),
+					"status_message", span.Status().Message(),
+				)
+			}
+		}
+	}
+
+	return nil
+}

--- a/component/otel/otel.go
+++ b/component/otel/otel.go
@@ -1,0 +1,217 @@
+// Package otel holds a collection of OpenTelemetry Collector components.
+package otel
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otel/internal/errorconsumer"
+	"github.com/grafana/agent/component/otel/internal/fanoutconsumer"
+	otelconfiggrpc "go.opentelemetry.io/collector/config/configgrpc"
+	otelconfighttp "go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/confignet"
+	otelconsumer "go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+func init() {
+	component.RegisterGoStruct("MetricsConsumer", MetricsConsumer{})
+	component.RegisterGoStruct("LogsConsumer", LogsConsumer{})
+	component.RegisterGoStruct("TracesConsumer", TracesConsumer{})
+}
+
+// GRPCServerArguments holds shared gRPC settings for components which launch gRPC
+// servers.
+type GRPCServerArguments struct {
+	Endpoint  string `hcl:"endpoint,optional"`
+	Transport string `hcl:"transport,optional"`
+
+	// TODO(rfratto): TLS
+
+	MaxRecvMsgSizeMiB    uint64 `hcl:"max_recv_msg_size_mib,optional"`
+	MaxConcurrentStreams uint32 `hcl:"max_concurrent_streams,optional"`
+	ReadBufferSize       int    `hcl:"read_buffer_size,optional"`
+	WriteBufferSize      int    `hcl:"write_buffer_size,optional"`
+
+	// TODO(rfratto): keepalive
+	// TODO(rfratto): auth
+
+	IncludeMetadata bool `hcl:"include_metadata,optional"`
+}
+
+func (args *GRPCServerArguments) Convert() *otelconfiggrpc.GRPCServerSettings {
+	if args == nil {
+		return nil
+	}
+
+	return &otelconfiggrpc.GRPCServerSettings{
+		NetAddr: confignet.NetAddr{
+			Endpoint:  args.Endpoint,
+			Transport: args.Transport,
+		},
+		// TODO(rfratto): TLS
+		MaxRecvMsgSizeMiB:    args.MaxRecvMsgSizeMiB,
+		MaxConcurrentStreams: args.MaxConcurrentStreams,
+		ReadBufferSize:       args.ReadBufferSize,
+		WriteBufferSize:      args.WriteBufferSize,
+		// TODO(rfratto): keepalive
+		// TODO(rfratto): auth
+		IncludeMetadata: args.IncludeMetadata,
+	}
+}
+
+func NewGRPCServerSettings(args *GRPCServerArguments) *otelconfiggrpc.GRPCServerSettings {
+	if args == nil {
+		return nil
+	}
+
+	return &otelconfiggrpc.GRPCServerSettings{}
+}
+
+// HTTPServerArguments holds shared gRPC settings for components which launch HTTP
+// servers.
+type HTTPServerArguments struct {
+	Endpoint string `hcl:"endpoint,optional"`
+
+	// TODO(rfratto): TLS
+	// TODO(rfratto): CORS
+	// TODO(rfratto): Auth
+
+	MaxRequestBodySize int64 `hcl:"max_request_body_size,optional"`
+
+	IncludeMetadata bool `hcl:"include_metadata,optional"`
+}
+
+func (args *HTTPServerArguments) Convert() *otelconfighttp.HTTPServerSettings {
+	if args == nil {
+		return nil
+	}
+
+	return &otelconfighttp.HTTPServerSettings{
+		Endpoint: args.Endpoint,
+		// TODO(rfratto): TLS
+		// TODO(rfratto): CORS
+		// TODO(rfratto): Auth
+		MaxRequestBodySize: args.MaxRequestBodySize,
+		IncludeMetadata:    args.IncludeMetadata,
+	}
+}
+
+type NextReceiverArguments struct {
+	Metrics []MetricsConsumer `hcl:"metrics,optional"`
+	Logs    []LogsConsumer    `hcl:"logs,optional"`
+	Traces  []TracesConsumer  `hcl:"traces,optional"`
+}
+
+type (
+	MetricsConsumer struct{ otelconsumer.Metrics }
+	LogsConsumer    struct{ otelconsumer.Logs }
+	TracesConsumer  struct{ otelconsumer.Traces }
+)
+
+func (args *NextReceiverArguments) MetricsConsumer() otelconsumer.Metrics {
+	if args == nil || len(args.Metrics) == 0 {
+		return errorconsumer.Metrics
+	}
+
+	conv := make([]otelconsumer.Metrics, len(args.Metrics))
+	for i := range args.Metrics {
+		conv[i] = args.Metrics[i]
+	}
+	return fanoutconsumer.Metrics(conv)
+}
+
+func (args *NextReceiverArguments) LogsConsumer() otelconsumer.Logs {
+	if args == nil || len(args.Logs) == 0 {
+		return errorconsumer.Logs
+	}
+
+	conv := make([]otelconsumer.Logs, len(args.Logs))
+	for i := range args.Logs {
+		conv[i] = args.Logs[i]
+	}
+	return fanoutconsumer.Logs(conv)
+}
+
+func (args *NextReceiverArguments) TracesConsumer() otelconsumer.Traces {
+	if args == nil || len(args.Traces) == 0 {
+		return errorconsumer.Traces
+	}
+
+	conv := make([]otelconsumer.Traces, len(args.Traces))
+	for i := range args.Traces {
+		conv[i] = args.Traces[i]
+	}
+	return fanoutconsumer.Traces(conv)
+}
+
+type lazyConsumer struct {
+	mut     sync.RWMutex
+	metrics otelconsumer.Metrics
+	logs    otelconsumer.Logs
+	traces  otelconsumer.Traces
+}
+
+var (
+	_ otelconsumer.Metrics = (*lazyConsumer)(nil)
+	_ otelconsumer.Logs    = (*lazyConsumer)(nil)
+	_ otelconsumer.Traces  = (*lazyConsumer)(nil)
+)
+
+func (lazy *lazyConsumer) Capabilities() otelconsumer.Capabilities {
+	// TODO(rfratto): this implementation is inefficient since it always requires
+	// data to be copied in the pipeline.
+	//
+	// To make things more efficient, we would have to:
+	//
+	// - Block on calls to Capabilities until our inner consumers are set
+	// - Split up lazyConsumer into a lazyConsumer for Metrics/Logs/Traces
+	return otelconsumer.Capabilities{MutatesData: true}
+}
+
+func (lazy *lazyConsumer) ConsumeMetrics(ctx context.Context, md pdata.Metrics) error {
+	lazy.mut.RLock()
+	defer lazy.mut.RUnlock()
+
+	if lazy.metrics == nil {
+		return fmt.Errorf("metrics consumer doesn't exist")
+	}
+	return lazy.metrics.ConsumeMetrics(ctx, md)
+}
+
+func (lazy *lazyConsumer) ConsumeLogs(ctx context.Context, md pdata.Logs) error {
+	lazy.mut.RLock()
+	defer lazy.mut.RUnlock()
+
+	if lazy.logs == nil {
+		return fmt.Errorf("logs consumer doesn't exist")
+	}
+	return lazy.logs.ConsumeLogs(ctx, md)
+}
+
+func (lazy *lazyConsumer) ConsumeTraces(ctx context.Context, md pdata.Traces) error {
+	lazy.mut.RLock()
+	defer lazy.mut.RUnlock()
+
+	if lazy.traces == nil {
+		return fmt.Errorf("traces consumer doesn't exist")
+	}
+	return lazy.traces.ConsumeTraces(ctx, md)
+}
+
+type updateConsumerFunc func() (otelconsumer.Metrics, otelconsumer.Logs, otelconsumer.Traces)
+
+// Update updates the lazy consumer with the result of calling f. Data sent to
+// the consumer is blocked while f is being invoked.
+func (lazy *lazyConsumer) Update(f updateConsumerFunc) {
+	lazy.mut.Lock()
+	defer lazy.mut.Unlock()
+
+	// TODO(rfratto): we're assuming that metrics/logs/traces will be nil when
+	// something failed, but it'd be nice to have some kind of unhealthy consumer
+	// which reports specific errors back to the caller when a component goes
+	// unhealthy.
+	lazy.metrics, lazy.logs, lazy.traces = f()
+}

--- a/component/otel/otel.go
+++ b/component/otel/otel.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otel/internal/errorconsumer"
 	"github.com/grafana/agent/component/otel/internal/fanoutconsumer"
 	otelconfiggrpc "go.opentelemetry.io/collector/config/configgrpc"
@@ -15,12 +14,6 @@ import (
 	otelconsumer "go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/model/pdata"
 )
-
-func init() {
-	component.RegisterGoStruct("MetricsConsumer", MetricsConsumer{})
-	component.RegisterGoStruct("LogsConsumer", LogsConsumer{})
-	component.RegisterGoStruct("TracesConsumer", TracesConsumer{})
-}
 
 // GRPCServerArguments holds shared gRPC settings for components which launch gRPC
 // servers.
@@ -100,9 +93,9 @@ func (args *HTTPServerArguments) Convert() *otelconfighttp.HTTPServerSettings {
 }
 
 type NextReceiverArguments struct {
-	Metrics []MetricsConsumer `hcl:"metrics,optional"`
-	Logs    []LogsConsumer    `hcl:"logs,optional"`
-	Traces  []TracesConsumer  `hcl:"traces,optional"`
+	Metrics []*Consumer `hcl:"metrics,optional"`
+	Logs    []*Consumer `hcl:"logs,optional"`
+	Traces  []*Consumer `hcl:"traces,optional"`
 }
 
 type (

--- a/component/otel/otlpexporter/otlpexporter.go
+++ b/component/otel/otlpexporter/otlpexporter.go
@@ -1,0 +1,90 @@
+package otlpexporter
+
+import (
+	"time"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otel"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/rfratto/gohcl"
+
+	otelcomponent "go.opentelemetry.io/collector/component"
+	otelconfig "go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/configcompression"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/exporter/otlpexporter"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:    "otel.exporter_otlp",
+		Args:    Arguments{},
+		Exports: otel.ConsumerExports{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			fact := otlpexporter.NewFactory()
+			return otel.NewFlowExporter(opts, fact, args.(Arguments))
+		},
+	})
+}
+
+type (
+	// Arguments configures the OTLP exporter.
+	Arguments struct {
+		Timeout        time.Duration               `hcl:"timeout,optional"`
+		QueueSetttings *otel.ExporterQueueSettings `hcl:"sending_queue,block"`
+		RetrySettings  *otel.ExporterRetrySettings `hcl:"retry_on_failure,block"`
+		ClientSettings *otel.GRPCClientSettings    `hcl:"client,block"`
+
+		// TODO(rfratto): ClientSettings should be squashed, if that were supported
+		// by gohcl.
+	}
+)
+
+var (
+	_ otel.ExporterArguments = (*Arguments)(nil)
+	_ gohcl.Decoder          = (*Arguments)(nil)
+)
+
+// Default values
+var (
+	DefaultArguments = Arguments{
+		Timeout:        5 * time.Second,
+		QueueSetttings: &otel.DefaultExporterQueueSettings,
+		RetrySettings:  &otel.DefaultExporterRetrySettings,
+		ClientSettings: &otel.GRPCClientSettings{
+			Headers:         make(map[string]string),
+			Compression:     configcompression.Gzip,
+			WriteBufferSize: 512 * 1024,
+		},
+	}
+)
+
+// DecodeHCL implements gohcl.Decoder.
+func (args *Arguments) DecodeHCL(body hcl.Body, ctx *hcl.EvalContext) error {
+	*args = DefaultArguments
+	type arguments Arguments
+	return gohcl.DecodeBody(body, ctx, (*arguments)(args))
+}
+
+// Convert transforms OTLPReceiverArguments into the upstream otlpreceiver
+// Config.
+func (args Arguments) Convert() otelconfig.Exporter {
+	return &otlpexporter.Config{
+		ExporterSettings: otelconfig.NewExporterSettings(otelconfig.NewComponentID("otlp")),
+		TimeoutSettings: exporterhelper.TimeoutSettings{
+			Timeout: args.Timeout,
+		},
+		QueueSettings:      args.QueueSetttings.Convert(),
+		RetrySettings:      args.RetrySettings.Convert(),
+		GRPCClientSettings: args.ClientSettings.Convert(),
+	}
+}
+
+func (args Arguments) Extensions() map[otelconfig.ComponentID]otelcomponent.Extension {
+	return nil
+}
+
+func (args Arguments) Exporters() map[otelconfig.DataType]map[otelconfig.ComponentID]otelcomponent.Exporter {
+	return nil
+}

--- a/component/otel/otlpreceiver/otlpreceiver.go
+++ b/component/otel/otlpreceiver/otlpreceiver.go
@@ -1,0 +1,97 @@
+package otlpreceiver
+
+import (
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otel"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/rfratto/gohcl"
+
+	otelcomponent "go.opentelemetry.io/collector/component"
+	otelconfig "go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/receiver/otlpreceiver"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name: "otel.receiver_otlp",
+		Args: Arguments{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			fact := otlpreceiver.NewFactory()
+			return otel.NewFlowReceiver(opts, fact, args.(Arguments))
+		},
+	})
+}
+
+type (
+	// Arguments configures the OTLP receiver.
+	Arguments struct {
+		GRPC *GRPCServerArguments `hcl:"grpc,block"`
+		HTTP *HTTPServerArguments `hcl:"http,block"`
+
+		// Output configures where to send data. Must be provided.
+		Output otel.NextReceiverArguments `hcl:"output,block"`
+	}
+
+	// GRPCServerArguments includes GRPC arguments with receiver_otlp-specific
+	// defaults.
+	GRPCServerArguments otel.GRPCServerArguments
+
+	// HTTPServerArguments includes HTTP arguments with receiver_otlp-specific
+	// defaults.
+	HTTPServerArguments otel.HTTPServerArguments
+)
+
+var (
+	_ otel.ReceiverArguments = (*Arguments)(nil)
+	_ gohcl.Decoder          = (*GRPCServerArguments)(nil)
+	_ gohcl.Decoder          = (*HTTPServerArguments)(nil)
+)
+
+// Default settings.
+var (
+	DefaultGRPCServerArguments = GRPCServerArguments{
+		Endpoint:       "0.0.0.0:4317",
+		Transport:      "tcp",
+		ReadBufferSize: 512 * 1024,
+		// We almost write 0 bytes, so no need to tune WriteBufferSize.
+	}
+
+	DefaultHTTPServerArguments = HTTPServerArguments{
+		Endpoint: "0.0.0.0:4318",
+	}
+)
+
+// Convert transforms OTLPReceiverArguments into the upstream otlpreceiver
+// Config.
+func (args Arguments) Convert() otelconfig.Receiver {
+	return &otlpreceiver.Config{
+		ReceiverSettings: otelconfig.NewReceiverSettings(otelconfig.NewComponentID("otlp")),
+		Protocols: otlpreceiver.Protocols{
+			GRPC: (*otel.GRPCServerArguments)(args.GRPC).Convert(),
+			HTTP: (*otel.HTTPServerArguments)(args.HTTP).Convert(),
+		},
+	}
+}
+
+func (args Arguments) Extensions() map[otelconfig.ComponentID]otelcomponent.Extension {
+	return nil
+}
+
+func (args Arguments) Exporters() map[otelconfig.DataType]map[otelconfig.ComponentID]otelcomponent.Exporter {
+	return nil
+}
+
+func (args Arguments) NextArguments() *otel.NextReceiverArguments {
+	return &args.Output
+}
+
+func (args *GRPCServerArguments) DecodeHCL(body hcl.Body, ctx *hcl.EvalContext) error {
+	*args = DefaultGRPCServerArguments
+	return gohcl.DecodeBody(body, ctx, (*otel.GRPCServerArguments)(args))
+}
+
+func (args *HTTPServerArguments) DecodeHCL(body hcl.Body, ctx *hcl.EvalContext) error {
+	*args = DefaultHTTPServerArguments
+	return gohcl.DecodeBody(body, ctx, (*otel.HTTPServerArguments)(args))
+}

--- a/component/otel/zipkinreceiver/zipkinreceiver.go
+++ b/component/otel/zipkinreceiver/zipkinreceiver.go
@@ -1,0 +1,75 @@
+package zipkinreceiver
+
+import (
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otel"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver"
+	"github.com/rfratto/gohcl"
+
+	otelcomponent "go.opentelemetry.io/collector/component"
+	otelconfig "go.opentelemetry.io/collector/config"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name: "otel.receiver_zipkin",
+		Args: Arguments{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			fact := zipkinreceiver.NewFactory()
+			return otel.NewFlowReceiver(opts, fact, args.(Arguments))
+		},
+	})
+}
+
+type (
+	// Arguments configures the Zipkin receiver.
+	Arguments struct {
+		HTTP *HTTPServerArguments `hcl:"http,block"`
+
+		// Output configures where to send data. Must be provided.
+		Output otel.NextReceiverArguments `hcl:"output,block"`
+	}
+
+	// HTTPServerArguments includes HTTP arguments with receiver-specific
+	// defaults.
+	HTTPServerArguments otel.HTTPServerArguments
+)
+
+var (
+	_ otel.ReceiverArguments = (*Arguments)(nil)
+	_ gohcl.Decoder          = (*HTTPServerArguments)(nil)
+)
+
+// Default settings.
+var (
+	DefaultHTTPServerArguments = HTTPServerArguments{
+		Endpoint: "0.0.0.0:9411",
+	}
+)
+
+// Convert transforms OTLPReceiverArguments into the upstream Config.
+func (args Arguments) Convert() otelconfig.Receiver {
+	return &zipkinreceiver.Config{
+		ReceiverSettings:   otelconfig.NewReceiverSettings(otelconfig.NewComponentID("zipkin")),
+		HTTPServerSettings: *(*otel.HTTPServerArguments)(args.HTTP).Convert(),
+	}
+}
+
+func (args Arguments) Extensions() map[otelconfig.ComponentID]otelcomponent.Extension {
+	return nil
+}
+
+func (args Arguments) Exporters() map[otelconfig.DataType]map[otelconfig.ComponentID]otelcomponent.Exporter {
+	return nil
+}
+
+func (args Arguments) NextArguments() *otel.NextReceiverArguments {
+	return &args.Output
+}
+
+func (args *HTTPServerArguments) DecodeHCL(body hcl.Body, ctx *hcl.EvalContext) error {
+	*args = DefaultHTTPServerArguments
+	return gohcl.DecodeBody(body, ctx, (*otel.HTTPServerArguments)(args))
+}

--- a/example/docker-compose/docker-compose.yaml
+++ b/example/docker-compose/docker-compose.yaml
@@ -48,7 +48,7 @@ services:
       - "-server.http-listen-port=3200"
     ports:
       - "3200:3200"
-      - "54317:4317"
+      - "4317:4317"
 
   avalanche:
     image: quay.io/freshtracks.io/avalanche:latest

--- a/example/docker-compose/docker-compose.yaml
+++ b/example/docker-compose/docker-compose.yaml
@@ -48,6 +48,7 @@ services:
       - "-server.http-listen-port=3200"
     ports:
       - "3200:3200"
+      - "54317:4317"
 
   avalanche:
     image: quay.io/freshtracks.io/avalanche:latest


### PR DESCRIPTION
This (large) draft PR demonstrates how OpenTelemetry components can be added as Flow components. 

This is just a draft to demonstrate the capability, and needs a lot of attention before it's mergeable. 

The implementation of these components completely bypasses the OpenTelemetry Collector pipeline system, instead relying on the Flow controller to bind OTel components together, passing around consumers as interfaces. 

Each component which can receive telemetry data is bundled as a generic `TelemetryConsumer`, which accepts metrics, logs, and traces. It is a combination of the three consumer interfaces from OpenTelemetry Collector. If the underlying consumer does not support one of the telemetry types, the request will fail. In the future, this should probably be changed to be validated at load time instead of failing at runtime. 

The following example components are included:

* `otel.reciever_jaeger`: The upstream Jaeger receiver 
* `otel.exporter_otlp`: The upstream OTLP exporter 
* `otel.receiver_otlp`: The upstream OTLP receiver 
* `otel.receiver_zipkin`: The upstream Zipkin receiver. 
* `otel.exporter_logging:` A custom component which uses go-kit's logger for logging about received traces.

There is generic code for constructing and running the various OpenTelmetry Collector components. The remainder of the code involves recreating config structs for unmarshaling and converting it to the upstream types on-demand. While this is more repetitive than the pkg/traces approach of unmarshaling into a `map[string]interface{}`, I personally find it preferable since it is more discoverable when examining the code and more likely to fail fast at compile time if upstream changes the type definition unexpectedly. 

Example config: 

```hcl
otel "exporter_logging" "default" {
  // Exported fields: 
  // input: <TelemetryConsumer>
}

otel "exporter_otlp" "default" {
  client {
    endpoint = "localhost:4317" // Tempo
  }

  // Exported fields: 
  // input: <TelemetryConsumer>
}

otel "receiver_zipkin" "default" {
  http {}

  output {
    traces = [otel.exporter_logging.default.input, otel.exporter_otlp.default.input]
  }
}
```

After running, follow Tempo's guide to [push Zipkin traces using cURL](https://grafana.com/docs/tempo/latest/api_docs/pushing-spans-with-http/#pushing-spans) to see Spans appear in Tempo. 

Note that running these components will break the /-/config endpoint, since rfratto/gohcl isn't able to properly serialize a list of capsule values. The fix for that doesn't seem straightforward, and a long-term fix may need to wait for #1839.