### PR TITLE
Update statsd_exporter to v0.22.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Main (unreleased)
 
 - Introduce eBPF exporter integration. (@tpaschalis)
 
+### Enhancements
+
+- Update statsd_exporter dependency to v0.22.5 (@tpaschalis)
+
 ### Bugfixes
 
 - Relative symlinks for promtail now work as expected. (@RangerCD, @mukerjee)

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/prometheus/procfs v0.7.4-0.20211011103944-1a7a2bd3279f
 	github.com/prometheus/prometheus v1.8.2-0.20220308163432-03831554a519
 	github.com/prometheus/snmp_exporter v0.20.1-0.20220111173215-83399c23888f
-	github.com/prometheus/statsd_exporter v0.22.2
+	github.com/prometheus/statsd_exporter v0.22.5
 	github.com/rancher/k3d/v5 v5.2.2
 	github.com/rfratto/ckit v0.0.0-20220401221852-009169323240
 	github.com/rfratto/gohcl v0.0.0-20220609143238-53312695dc8f


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR updates memcached_exporter to the latest version. Looking at the changes included in the [latest releases](https://github.com/prometheus/statsd_exporter/releases), I see some bugfixes and new metrics added, so nothing scary there.

#### Which issue(s) this PR fixes
Fixes #1695

#### Notes to the Reviewer
Nothing major here.

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
