### PR TITLE
pkg/river: introduce scanner package

### DIFF
--- a/pkg/river/scanner/scanner.go
+++ b/pkg/river/scanner/scanner.go
@@ -1,0 +1,701 @@
+// Package scanner implements a lexical scanner for River source files.
+package scanner
+
+import (
+	"fmt"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/grafana/agent/pkg/river/token"
+)
+
+// EBNF for the scanner:
+//
+//   COMMENT        = online_comment | block_comment
+//   online_comment = ("#" | "//") { character }
+//   block_comment  = "/*" { character | newline } "*/"
+//
+//   IDENT   = letter { letter | number }
+//   NULL    = "null"
+//   BOOL    = "true" | "false"
+//   NUMBER  = digit { digit }
+//   FLOAT   = [ digit ] "." digit { digit } [ "e" ("+" | "-") digit { digit } ]
+//   STRING  = '"' { character | escape_sequence } '"'
+//   OR      = "||"
+//   AND     = "&&"
+//   NOT     = "!"
+//   NEQ     = "!="
+//   ASSIGN  = "="
+//   EQ      = "=="
+//   LT      = "<"
+//   LTE     = "<="
+//   GT      = ">"
+//   GTE     = ">="
+//   ADD     = "+"
+//   SUB     = "-"
+//   MUL     = "*"
+//   DIV     = "/"
+//   MOD     = "%"
+//   POW     = "^"
+//   LCURLY  = "{"
+//   RCURLY  = "}"
+//   LPAREN  = "("
+//   RPAREN  = ")"
+//   LBRACK  = "["
+//   RBRACK  = "]"
+//   COMMA   = ","
+//   DOT     = "."
+
+// ErrorHandler is invoked whenever there is an error.
+type ErrorHandler func(pos token.Pos, msg string)
+
+// Mode is a set of bitewise flags which control scanner behavior.
+type Mode uint
+
+const (
+	// IncludeComments will cause comments to be returned as comment tokens.
+	// Otherwise, comments are ignored.
+	IncludeComments Mode = 1 << iota
+
+	// Avoids automatic insertion of terminators (for testing only).
+	dontInsertTerms
+)
+
+const (
+	bom = 0xFEFF // byte order mark, permitted as very first character
+	eof = -1     // end of file
+)
+
+// Scanner holds the internal state for the tokenizer while processing configs.
+type Scanner struct {
+	file  *token.File  // Config file handle for tracking line offsets
+	input []byte       // Input config
+	err   ErrorHandler // Error reporting (may be nil)
+	mode  Mode
+
+	// scanning state variables:
+
+	ch         rune // Current character
+	offset     int  // Byte offset of ch
+	readOffset int  // Byte offset of first character *after* ch
+	insertTerm bool // Insert a newline before the next newline
+	numErrors  int  // Number of errors encountered during scanning
+}
+
+// New creates a new scanner to tokenize the provided input config. The scanner
+// uses the provided file for adding line information for each token. The mode
+// parameter customizes scanner behavior.
+//
+// Calls to Scan will invoke the error handler eh when a lexical error is found
+// if eh is not nil.
+func New(file *token.File, input []byte, eh ErrorHandler, mode Mode) *Scanner {
+	s := &Scanner{
+		file:  file,
+		input: input,
+		err:   eh,
+		mode:  mode,
+	}
+
+	// Preload first character.
+	s.next()
+	if s.ch == bom {
+		s.next() // Ignore BOM if it's the first character.
+	}
+	return s
+}
+
+// peek gets the next byte after the current character without advancing the
+// scanner. Returns 0 if the scanner is at EOF.
+func (s *Scanner) peek() byte {
+	if s.readOffset < len(s.input) {
+		return s.input[s.readOffset]
+	}
+	return 0
+}
+
+// next advances the scanner and reads the next Unicode character into s.ch.
+// s.ch == eof indicates end of file.
+func (s *Scanner) next() {
+	if s.readOffset >= len(s.input) {
+		s.offset = len(s.input)
+		if s.ch == '\n' {
+			// Make sure we track final newlines at the end of the file
+			s.file.AddLine(s.offset)
+		}
+		s.ch = eof
+		return
+	}
+
+	s.offset = s.readOffset
+	if s.ch == '\n' {
+		s.file.AddLine(s.offset)
+	}
+
+	r, width := rune(s.input[s.readOffset]), 1
+	switch {
+	case r == 0:
+		s.onError(s.offset, "illegal character NUL")
+	case r >= utf8.RuneSelf:
+		r, width = utf8.DecodeRune(s.input[s.readOffset:])
+		if r == utf8.RuneError && width == 1 {
+			s.onError(s.offset, "illegal UTF-8 encoding")
+		} else if r == bom && s.offset > 0 {
+			s.onError(s.offset, "illegal byte order mark")
+		}
+	}
+	s.readOffset += width
+	s.ch = r
+}
+
+func (s *Scanner) onError(offset int, msg string) {
+	if s.err != nil {
+		s.err(s.file.Pos(offset), msg)
+	}
+	s.numErrors++
+}
+
+// NumErrors returns the current number of errors encountered during scanning.
+// This is useful as a fallback to detect errors when no ErrorHandler was
+// provided to the scanner.
+func (s *Scanner) NumErrors() int { return s.numErrors }
+
+// Scan scans the next token and returns the token's position, the token
+// itself, and the token's literal string (when applicable). The end of the
+// input is indicated by token.EOF.
+//
+// If the returned token is a literal (such as token.STRING), then lit contains
+// the corresponding literal text (including surrounding quotes).
+//
+// If the returned token is a keyword, lit is the keyword text that was
+// scanned.
+//
+// If the returned token is token.TERMINATOR, lit will contain "\n".
+//
+// If the returned token is token.ILLEGAL, lit contains the offending
+// character.
+//
+// In all other cases, lit will be an empty string.
+//
+// For more tolerant parsing, Scan returns a valid token character whenever
+// possible when a syntax error was encountered. Callers must check NumErrors
+// or the number of times the provided ErrorHandler was invoked to ensure there
+// were no errors found during scanning.
+//
+// Scan will inject line information to the file provided by NewScanner.
+// Returned token positions are relative to that file.
+func (s *Scanner) Scan() (pos token.Pos, tok token.Token, lit string) {
+scanAgain:
+	s.skipWhitespace()
+
+	// Start of current token.
+	pos = s.file.Pos(s.offset)
+
+	var insertTerm bool
+
+	// Determine token value
+	switch ch := s.ch; {
+	case isLetter(ch):
+		lit = s.scanIdentifier()
+		if len(lit) > 1 { // Keywords are always > 1 char
+			tok = token.Lookup(lit)
+			switch tok {
+			case token.IDENT, token.NULL, token.BOOL:
+				insertTerm = true
+			}
+		} else {
+			insertTerm = true
+			tok = token.IDENT
+		}
+
+	case isDecimal(ch) || (ch == '.' && isDecimal(rune(s.peek()))):
+		insertTerm = true
+		tok, lit = s.scanNumber()
+
+	default:
+		s.next() // Make progress
+
+		// ch is now the first character in a sequence and s.ch is the second
+		// character.
+
+		switch ch {
+		case eof:
+			if s.insertTerm {
+				s.insertTerm = false // Consumed EOF
+				return pos, token.TERMINATOR, "\n"
+			}
+			tok = token.EOF
+
+		case '\n':
+			// This case is only reachable when s.insertTerm is true, since otherwise
+			// skipWhitespace consumes all other newlines.
+			s.insertTerm = false // Consumed newline
+			return pos, token.TERMINATOR, "\n"
+
+		case '"':
+			insertTerm = true
+			tok = token.STRING
+			lit = s.scanString()
+
+		case '|':
+			if s.ch != '|' {
+				s.onError(s.offset, "missing second | in ||")
+			} else {
+				s.next() // consume second '|'
+			}
+			tok = token.OR
+		case '&':
+			if s.ch != '&' {
+				s.onError(s.offset, "missing second & in &&")
+			} else {
+				s.next() // consume second '&'
+			}
+			tok = token.AND
+
+		case '#': // #-style comment
+			if s.insertTerm {
+				// We're expenting a terminator prior to the comment. Reset the scanner
+				// state back to the start of the comment and force emit a terminator.
+				s.ch = '#'
+				s.offset = pos.Offset()
+				s.readOffset = s.offset + 1
+				s.insertTerm = false // Consumed newline
+				return pos, token.TERMINATOR, "\n"
+			}
+			comment := s.scanComment(false)
+			if s.mode&IncludeComments == 0 {
+				// Skip over comment
+				s.insertTerm = false // Consumed newline
+				goto scanAgain
+			}
+			tok = token.COMMENT
+			lit = comment
+
+		case '!': // !, !=
+			tok = s.switch2(token.NOT, token.NEQ, '=')
+		case '=': // =, ==
+			tok = s.switch2(token.ASSIGN, token.EQ, '=')
+		case '<': // <, <=
+			tok = s.switch2(token.LT, token.LTE, '=')
+		case '>': // >, >=
+			tok = s.switch2(token.GT, token.GTE, '=')
+		case '+':
+			tok = token.ADD
+		case '-':
+			tok = token.SUB
+		case '*':
+			tok = token.MUL
+		case '/':
+			if s.ch == '/' || s.ch == '*' {
+				// //- or /*-style comment.
+				//
+				// If we're expected to inject a terminator, we can only do so if our
+				// comment goes to the end of the line. Otherwise, the terminator will
+				// have to be injected after the comment token.
+				if s.insertTerm && s.findLineEnd() {
+					// Reset position to the beginning of the comment.
+					s.ch = '/'
+					s.offset = pos.Offset()
+					s.readOffset = s.offset + 1
+					s.insertTerm = false // Consumed newline
+					return pos, token.TERMINATOR, "\n"
+				}
+				comment := s.scanComment(true)
+				if s.mode&IncludeComments == 0 {
+					// Skip over comment
+					s.insertTerm = false // Consumed newline
+					goto scanAgain
+				}
+				tok = token.COMMENT
+				lit = comment
+			} else {
+				tok = token.DIV
+			}
+
+		case '%':
+			tok = token.MOD
+		case '^':
+			tok = token.POW
+		case '{':
+			tok = token.LCURLY
+		case '}':
+			insertTerm = true
+			tok = token.RCURLY
+		case '(':
+			tok = token.LPAREN
+		case ')':
+			insertTerm = true
+			tok = token.RPAREN
+		case '[':
+			tok = token.LBRACK
+		case ']':
+			insertTerm = true
+			tok = token.RBRACK
+		case ',':
+			tok = token.COMMA
+		case '.':
+			// NOTE: Fractions starting with '.' are handled by outer switch
+			tok = token.DOT
+
+		default:
+			// s.next() reports invalid BOMs so we don't need to repeat the error.
+			if ch != bom {
+				s.onError(pos.Offset(), fmt.Sprintf("illegal character %#U", ch))
+			}
+			insertTerm = s.insertTerm // Preverse previous s.insertTerm state
+			tok = token.ILLEGAL
+			lit = string(ch)
+		}
+	}
+
+	if s.mode&dontInsertTerms == 0 {
+		s.insertTerm = insertTerm
+	}
+	return
+}
+
+func (s *Scanner) skipWhitespace() {
+	for s.ch == ' ' || s.ch == '\t' || s.ch == '\r' || (s.ch == '\n' && !s.insertTerm) {
+		s.next()
+	}
+}
+
+func isLetter(ch rune) bool {
+	// We check for ASCII first as an optimization, and leave checking unicode
+	// (the slowest) to the very end.
+	return (lower(ch) >= 'a' && lower(ch) <= 'z') ||
+		ch == '_' ||
+		(ch >= utf8.RuneSelf && unicode.IsLetter(ch))
+}
+
+func lower(ch rune) rune     { return ('a' - 'A') | ch }
+func isDecimal(ch rune) bool { return '0' <= ch && ch <= '9' }
+func isDigit(ch rune) bool {
+	return isDecimal(ch) || (ch >= utf8.RuneSelf && unicode.IsDigit(ch))
+}
+
+// scanIdentifier reads the string of valid identifier characters starting at
+// s.offet. It must only be called when s.ch is a valid character which starts
+// an identifier.
+//
+// scanIdentifier is highly optimized for identifiers are modifications must be
+// made carefully.
+func (s *Scanner) scanIdentifier() string {
+	off := s.offset
+
+	// Optimize for common case of ASCII identifiers.
+	//
+	// Ranging over s.input[s.readOffset:] avoids bounds checks and avoids
+	// conversions to runes.
+	//
+	// We'll fall back to the slower path if we find a non-ASCII character.
+	for readOffset, b := range s.input[s.readOffset:] {
+		if (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || (b >= '0' && b <= '9') {
+			// Common case: ASCII character; don't assign a rune.
+			continue
+		}
+		s.readOffset += readOffset
+		if b > 0 && b < utf8.RuneSelf {
+			// Optimization: ASCII character that isn't a letter or number; we've
+			// reached the end of the identifier sequence and can terminate. We avoid
+			// the call to s.next() and the corresponding setup.
+			//
+			// This optimization only works because we know that s.ch (the current
+			// character when scanIdentifier was called) is never '\n' since '\n'
+			// cannot start an identifier.
+			s.ch = rune(b)
+			s.offset = s.readOffset
+			s.readOffset++
+			goto exit
+		}
+
+		// The preceding character is valid for an identifier because
+		// scanIdentifier is only called when s.ch is a letter; calling s.next() at
+		// s.readOffset will reset the scanner state.
+		s.next()
+		for isLetter(s.ch) || isDigit(s.ch) {
+			s.next()
+		}
+
+		// No more valid characters for the identifier; terminate.
+		goto exit
+	}
+
+exit:
+	return string(s.input[off:s.offset])
+}
+
+func (s *Scanner) scanNumber() (tok token.Token, lit string) {
+	tok = token.NUMBER
+	off := s.offset
+
+	// Integer part of number
+	if s.ch != '.' {
+		s.digits()
+	}
+
+	// Fractional part of number
+	for s.ch == '.' {
+		tok = token.FLOAT
+
+		s.next()
+		s.digits()
+	}
+
+	// Exponent
+	if lower(s.ch) == 'e' {
+		tok = token.FLOAT
+
+		s.next()
+		if s.ch == '+' || s.ch == '-' {
+			s.next()
+		}
+
+		if s.digits() == 0 {
+			s.onError(off, "exponent has no digits")
+		}
+	}
+
+	return tok, string(s.input[off:s.offset])
+}
+
+// digits scans a sequence of digits.
+func (s *Scanner) digits() (count int) {
+	for isDecimal(s.ch) {
+		s.next()
+		count++
+	}
+	return
+}
+
+func (s *Scanner) scanString() string {
+	// subtract 1 to account for the opening '"' which was already consumed by
+	// the scanner forcing progress.
+	off := s.offset - 1
+
+	for {
+		ch := s.ch
+		if ch == '\n' || ch == eof {
+			s.onError(off, "string literal not terminated")
+			break
+		}
+		s.next()
+		if ch == '"' {
+			break
+		}
+		if ch == '\\' {
+			s.scanEscape()
+		}
+	}
+
+	return string(s.input[off:s.offset])
+}
+
+// scanEscape parses an escape sequence. In case of a syntax error, scanEscape
+// stops at the offending character without consuming it.
+func (s *Scanner) scanEscape() {
+	off := s.offset
+
+	var (
+		n         int
+		base, max uint32
+	)
+
+	switch s.ch {
+	case 'a', 'b', 'f', 'n', 'r', 't', 'v', '\\', '"':
+		s.next()
+		return
+	case '0', '1', '2', '3', '4', '5', '6', '7':
+		n, base, max = 3, 8, 255
+	case 'x':
+		s.next()
+		n, base, max = 2, 16, 255
+	case 'u':
+		s.next()
+		n, base, max = 4, 16, unicode.MaxRune
+	case 'U':
+		s.next()
+		n, base, max = 8, 16, unicode.MaxRune
+	default:
+		msg := "unknown escape sequence"
+		if s.ch == eof {
+			msg = "escape sequence not terminated"
+		}
+		s.onError(off, msg)
+		return
+	}
+
+	var x uint32
+	for n > 0 {
+		d := uint32(digitVal(s.ch))
+		if d >= base {
+			msg := fmt.Sprintf("illegal character %#U in escape sequence", s.ch)
+			if s.ch == eof {
+				msg = "escape sequence not terminated"
+			}
+			s.onError(off, msg)
+			return
+		}
+		x = x*base + d
+		s.next()
+		n--
+	}
+
+	if x > max || x >= 0xD800 && x < 0xE000 {
+		s.onError(off, "escape sequence is invalid Unicode code point")
+	}
+}
+
+func digitVal(ch rune) int {
+	switch {
+	case ch >= '0' && ch <= '9':
+		return int(ch - '0')
+	case lower(ch) >= 'a' && lower(ch) <= 'f':
+		return int(lower(ch) - 'a' + 10)
+	}
+	return 16 // Larger than any legal digit val
+}
+
+func (s *Scanner) scanComment(slashComment bool) string {
+	// The initial character in the comment was already consumed from the scanner
+	// forcing progress.
+	//
+	// slashComment will be true when the comment is a //- or /*-style comment.
+
+	var (
+		off   = s.offset - 1 // Offset of initial character
+		numCR = 0
+
+		blockComment = false
+	)
+
+	if !slashComment || s.ch == '/' { // NOTE: s.ch is second character in comment sequence
+		// #-style or //-style comment.
+		//
+		// The final '\n' is not considered to be part of the comment.
+		if s.ch == '/' {
+			s.next() // Consume second '/'
+		}
+
+		for s.ch != '\n' && s.ch != eof {
+			if s.ch == '\r' {
+				numCR++
+			}
+			s.next()
+		}
+
+		goto exit
+	}
+
+	// /*-style comment.
+	blockComment = true
+	s.next()
+	for s.ch != eof {
+		ch := s.ch
+		if ch == '\r' {
+			numCR++
+		}
+		s.next()
+		if ch == '*' && s.ch == '/' {
+			s.next()
+			goto exit
+		}
+	}
+
+	s.onError(off, "block comment not terminated")
+
+exit:
+	lit := s.input[off:s.offset]
+
+	// On Windows, a single comment line may end in "\r\n". We want to remove the
+	// final \r.
+	if numCR > 0 && len(lit) >= 1 && lit[len(lit)-1] == '\r' {
+		lit = lit[:len(lit)-1]
+		numCR--
+	}
+
+	if numCR > 0 {
+		lit = stripCR(lit, blockComment)
+	}
+
+	return string(lit)
+}
+
+func stripCR(b []byte, blockComment bool) []byte {
+	c := make([]byte, len(b))
+	i := 0
+
+	for j, ch := range b {
+		if ch != '\r' || blockComment && i > len("/*") && c[i-1] == '*' && j+1 < len(b) && b[j+1] == '/' {
+			c[i] = ch
+			i++
+		}
+	}
+
+	return c[:i]
+}
+
+// findLineEnd checks to see if a //- or /*-style comment runs to the end of
+// the line.
+//
+// findLineEnd is not used for #-style comments, which always run to the end of
+// the line.
+func (s *Scanner) findLineEnd() bool {
+	// NOTE: initial '/' is already consumed by forcing the scanner to progress.
+
+	defer func(off int) {
+		// Reset scanner state to where it was upon calling findLineEnd.
+		s.ch = '/'
+		s.offset = off
+		s.readOffset = off + 1
+		s.next() // Consume initial starting '/' again
+	}(s.offset - 1)
+
+	// Read ahead until a newline, EOF, or non-comment token is found.
+	// We loop to consume multiple sequences of comment tokens.
+	for s.ch == '/' || s.ch == '*' {
+		if s.ch == '/' {
+			// //-style comments always contain newlines.
+			return true
+		}
+
+		// We're looking at a /*-style comment; look for its newline.
+		s.next()
+		for s.ch != eof {
+			ch := s.ch
+			if ch == '\n' {
+				return true
+			}
+			s.next()
+			if ch == '*' && s.ch == '/' { // End of block comment
+				s.next()
+				break
+			}
+		}
+
+		// Check to see if there's a newline after the block comment.
+		s.skipWhitespace() // s.insertTerm is set
+		if s.ch == eof || s.ch == '\n' {
+			return true
+		}
+		if s.ch != '/' {
+			// Non-comment token
+			return false
+		}
+		s.next() // Consume '/' at the end of the /* style-comment
+	}
+
+	return false
+}
+
+// switch2 returns a if s.ch is next, b otherwise. The scanner will be advanced
+// if b is returned.
+//
+// This is used for tokens which can either be a single character but also are
+// the starting character for a 2-length token (i.e., = and ==).
+func (s *Scanner) switch2(a, b token.Token, next rune) token.Token {
+	if s.ch == next {
+		s.next()
+		return b
+	}
+	return a
+}

--- a/pkg/river/scanner/scanner_test.go
+++ b/pkg/river/scanner/scanner_test.go
@@ -1,0 +1,249 @@
+package scanner
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/grafana/agent/pkg/river/token"
+	"github.com/stretchr/testify/assert"
+)
+
+type tokenExample struct {
+	tok token.Token
+	lit string
+}
+
+var tokens = []tokenExample{
+	// Special tokens
+	{token.COMMENT, "/* a comment */"},
+	{token.COMMENT, "# a comment \n"},
+	{token.COMMENT, "// a comment \n"},
+	{token.COMMENT, "/*\r*/"},
+	{token.COMMENT, "/**\r/*/"}, // golang/go#11151
+	{token.COMMENT, "/**\r\r/*/"},
+	{token.COMMENT, "#\r\n"},
+	{token.COMMENT, "//\r\n"},
+
+	// Identifiers and basic type literals
+	{token.IDENT, "foobar"},
+	{token.IDENT, "a۰۱۸"},
+	{token.IDENT, "foo६४"},
+	{token.IDENT, "bar９８７６"},
+	{token.IDENT, "ŝ"},    // golang/go#4000
+	{token.IDENT, "ŝfoo"}, // golang/go#4000
+	{token.NUMBER, "0"},
+	{token.NUMBER, "1"},
+	{token.NUMBER, "123456789012345678890"},
+	{token.NUMBER, "01234567"},
+	{token.FLOAT, "0."},
+	{token.FLOAT, ".0"},
+	{token.FLOAT, "3.14159265"},
+	{token.FLOAT, "1e0"},
+	{token.FLOAT, "1e+100"},
+	{token.FLOAT, "1e-100"},
+	{token.FLOAT, "2.71828e-1000"},
+	{token.STRING, `"Hello, world!"`},
+
+	// Operators and delimiters
+	{token.ADD, "+"},
+	{token.SUB, "-"},
+	{token.MUL, "*"},
+	{token.DIV, "/"},
+	{token.MOD, "%"},
+	{token.POW, "^"},
+
+	{token.AND, "&&"},
+	{token.OR, "||"},
+
+	{token.EQ, "=="},
+	{token.LT, "<"},
+	{token.GT, ">"},
+	{token.ASSIGN, "="},
+	{token.NOT, "!"},
+
+	{token.NEQ, "!="},
+	{token.LTE, "<="},
+	{token.GTE, ">="},
+
+	{token.LPAREN, "("},
+	{token.LBRACK, "["},
+	{token.LCURLY, "{"},
+	{token.COMMA, ","},
+	{token.DOT, "."},
+
+	{token.RPAREN, ")"},
+	{token.RBRACK, "]"},
+	{token.RCURLY, "}"},
+
+	// Keywords
+	{token.NULL, "null"},
+	{token.BOOL, "true"},
+	{token.BOOL, "false"},
+}
+
+const whitespace = "  \t  \n\n\n" // Various whitespace to separate tokens
+
+var source = func() []byte {
+	var src []byte
+	for _, t := range tokens {
+		src = append(src, t.lit...)
+		src = append(src, whitespace...)
+	}
+	return src
+}()
+
+func TestScanner_Scan(t *testing.T) {
+	whitespaceLinecount := newlineCount(whitespace)
+
+	var eh ErrorHandler = func(_ token.Pos, msg string) {
+		t.Errorf("ErrorHandler called (msg = %s)", msg)
+	}
+
+	f := token.NewFile(t.Name())
+	s := New(f, source, eh, IncludeComments|dontInsertTerms)
+
+	// Configure expected position
+	expectPos := token.Position{
+		Filename: t.Name(),
+		Offset:   0,
+		Line:     1,
+		Column:   1,
+	}
+
+	index := 0
+	for {
+		pos, tok, lit := s.Scan()
+
+		// Check position
+		checkPos(t, lit, tok, pos, expectPos)
+
+		// Check token
+		e := tokenExample{token.EOF, ""}
+		if index < len(tokens) {
+			e = tokens[index]
+			index++
+		}
+		assert.Equal(t, e.tok, tok)
+
+		// Check literal
+		expectLit := ""
+		switch e.tok {
+		case token.COMMENT:
+			// no CRs in comments
+			expectLit = string(stripCR([]byte(e.lit), e.lit[1] == '*'))
+			if expectLit[0] == '#' || expectLit[1] == '/' {
+				// Line comment literals doesn't contain newline
+				expectLit = expectLit[0 : len(expectLit)-1]
+			}
+		case token.IDENT:
+			expectLit = e.lit
+		case token.NUMBER, token.FLOAT, token.STRING, token.NULL, token.BOOL:
+			expectLit = e.lit
+		}
+		assert.Equal(t, expectLit, lit)
+
+		if tok == token.EOF {
+			break
+		}
+
+		// Update position
+		expectPos.Offset += len(e.lit) + len(whitespace)
+		expectPos.Line += newlineCount(e.lit) + whitespaceLinecount
+	}
+
+	if s.NumErrors() != 0 {
+		assert.Zero(t, s.NumErrors(), "expected number of scanning errors to be 0")
+	}
+}
+
+func newlineCount(s string) int {
+	var n int
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			n++
+		}
+	}
+	return n
+}
+
+func checkPos(t *testing.T, lit string, tok token.Token, p token.Pos, expected token.Position) {
+	t.Helper()
+
+	pos := p.Position()
+
+	// Check cleaned filenames so that we don't have to worry about different
+	// os.PathSeparator values.
+	if pos.Filename != expected.Filename && filepath.Clean(pos.Filename) != filepath.Clean(expected.Filename) {
+		assert.Equal(t, expected.Filename, pos.Filename, "Bad filename for %s (%q)", tok, lit)
+	}
+
+	assert.Equal(t, expected.Offset, pos.Offset, "Bad offset for %s (%q)", tok, lit)
+	assert.Equal(t, expected.Line, pos.Line, "Bad line for %s (%q)", tok, lit)
+	assert.Equal(t, expected.Column, pos.Column, "Bad column for %s (%q)", tok, lit)
+}
+
+var errorTests = []struct {
+	input string
+	tok   token.Token
+	pos   int
+	lit   string
+	err   string
+}{
+	{"\a", token.ILLEGAL, 0, "", "illegal character U+0007"},
+	{`…`, token.ILLEGAL, 0, "", "illegal character U+2026 '…'"},
+	{"..", token.DOT, 0, "", ""}, // two periods, not invalid token (golang/go#28112)
+	{`""`, token.STRING, 0, `""`, ""},
+	{`"abc`, token.STRING, 0, `"abc`, "string literal not terminated"},
+	{"\"abc\n", token.STRING, 0, `"abc`, "string literal not terminated"},
+	{"\"abc\n   ", token.STRING, 0, `"abc`, "string literal not terminated"},
+	{"\"abc\x00def\"", token.STRING, 4, "\"abc\x00def\"", "illegal character NUL"},
+	{"\"abc\x80def\"", token.STRING, 4, "\"abc\x80def\"", "illegal UTF-8 encoding"},
+	{"\ufeff\ufeff", token.ILLEGAL, 3, "\ufeff\ufeff", "illegal byte order mark"},                        // only first BOM is ignored
+	{"#\ufeff", token.COMMENT, 1, "#\ufeff", "illegal byte order mark"},                                  // only first BOM is ignored
+	{"//\ufeff", token.COMMENT, 2, "//\ufeff", "illegal byte order mark"},                                // only first BOM is ignored
+	{`"` + "abc\ufeffdef" + `"`, token.STRING, 4, `"` + "abc\ufeffdef" + `"`, "illegal byte order mark"}, // only first BOM is ignored
+	{"abc\x00def", token.IDENT, 3, "abc", "illegal character NUL"},
+	{"abc\x00", token.IDENT, 3, "abc", "illegal character NUL"},
+	{"10E", token.FLOAT, 0, "10E", "exponent has no digits"},
+}
+
+func TestScanner_Scan_Errors(t *testing.T) {
+	for _, e := range errorTests {
+		checkError(t, e.input, e.tok, e.pos, e.lit, e.err)
+	}
+}
+
+func checkError(t *testing.T, src string, tok token.Token, pos int, lit, err string) {
+	t.Helper()
+
+	var (
+		actualErrors int
+		latestError  string
+		latestPos    token.Pos
+	)
+
+	eh := func(pos token.Pos, msg string) {
+		actualErrors++
+		latestError = msg
+		latestPos = pos
+	}
+
+	f := token.NewFile(t.Name())
+	s := New(f, []byte(src), eh, IncludeComments|dontInsertTerms)
+
+	_, actualTok, actualLit := s.Scan()
+
+	assert.Equal(t, tok, actualTok)
+	if actualTok != token.ILLEGAL {
+		assert.Equal(t, lit, actualLit)
+	}
+
+	expectErrors := 0
+	if err != "" {
+		expectErrors = 1
+	}
+
+	assert.Equal(t, expectErrors, actualErrors, "Unexpected error count in src %q", src)
+	assert.Equal(t, err, latestError, "Unexpected error message in src %q", src)
+	assert.Equal(t, pos, latestPos.Offset(), "Unexpected offset in src %q", src)
+}

--- a/pkg/river/token/file.go
+++ b/pkg/river/token/file.go
@@ -1,0 +1,138 @@
+package token
+
+import (
+	"fmt"
+	"sort"
+)
+
+// NosPos is the zero value for Pos. It has no file or line information
+// associated with it, and NoPos.Valid is false.
+var NoPos = Pos{}
+
+// Pos is a compact representation of a position within a file. It can be
+// converted into a Position for a more convenient, but larger, representation.
+type Pos struct {
+	file *File
+	off  int
+}
+
+// File returns the file used by the Pos. This will be nil for invalid
+// positions.
+func (p Pos) File() *File { return p.file }
+
+// Position converts the Pos into a Position.
+func (p Pos) Position() Position { return p.file.PositionFor(p) }
+
+// Add creates a new Pos relative to p.
+func (p Pos) Add(n int) Pos {
+	return Pos{
+		file: p.file,
+		off:  p.off + n,
+	}
+}
+
+// Offset returns the byte offset associated with Pos.
+func (p Pos) Offset() int { return p.off }
+
+// Valid reports whether the Pos is valid.
+func (p Pos) Valid() bool { return p != NoPos }
+
+// Position holds full position information for a location within an individual
+// file.
+type Position struct {
+	Filename string // Filename (if any)
+	Offset   int    // Byte offset (starting at 0)
+	Line     int    // Line number (starting at 1)
+	Column   int    // Offset from start of line (starting at 1)
+}
+
+// Valid reports whether the position is valid. Valid positions must have a
+// Line value greater than 0.
+func (pos *Position) Valid() bool { return pos.Line > 0 }
+
+// String returns a string in one of the following forms:
+//
+//     file:line:column   Valid position with file name
+//     file:line          Valid position with file name but no column
+//     line:column        Valid position with no file name
+//     line               Valid position with no file name or column
+//     file               Invalid position with file name
+//     -                  Invalid position with no file name
+func (pos Position) String() string {
+	s := pos.Filename
+
+	if pos.Valid() {
+		if s != "" {
+			s += ":"
+		}
+		s += fmt.Sprintf("%d", pos.Line)
+		if pos.Column != 0 {
+			s += fmt.Sprintf(":%d", pos.Column)
+		}
+	}
+
+	if s == "" {
+		s = "-"
+	}
+	return s
+}
+
+// File holds position information for a specific file.
+type File struct {
+	filename string
+	lines    []int // Byte offset of each line number (first element is always 0).
+}
+
+// NewFile creates a new File for storing position information.
+func NewFile(filename string) *File {
+	return &File{
+		filename: filename,
+		lines:    []int{0},
+	}
+}
+
+// Pos returns a Pos given a byte offset. Pos panics if off is < 0.
+func (f *File) Pos(off int) Pos {
+	if off < 0 {
+		panic("Pos: illegal offset")
+	}
+	return Pos{file: f, off: off}
+}
+
+// Name returns the name of the file.
+func (f *File) Name() string { return f.filename }
+
+// AddLine tracks a new line from a byte offset. The line offset must be larger
+// than the offset for the previous line, otherwise the line offset is ignored.
+func (f *File) AddLine(offset int) {
+	lines := len(f.lines)
+	if f.lines[lines-1] < offset {
+		f.lines = append(f.lines, offset)
+	}
+}
+
+// PositionFor returns a Position from an offset.
+func (f *File) PositionFor(p Pos) Position {
+	if p == NoPos {
+		return Position{}
+	}
+
+	// Search through our line offsets to find the line/column info. The else
+	// case should never happen here, but if it does, Position.Valid will return
+	// false.
+	var line, column int
+	if i := searchInts(f.lines, p.off); i >= 0 {
+		line, column = i+1, p.off-f.lines[i]+1
+	}
+
+	return Position{
+		Filename: f.filename,
+		Offset:   p.off,
+		Line:     line,
+		Column:   column,
+	}
+}
+
+func searchInts(a []int, x int) int {
+	return sort.Search(len(a), func(i int) bool { return a[i] > x }) - 1
+}

--- a/pkg/river/token/token.go
+++ b/pkg/river/token/token.go
@@ -1,0 +1,168 @@
+// Package token defines the lexical elements of a River config and utilities
+// surrounding their position.
+package token
+
+// Token is an individual River lexical token.
+type Token int
+
+// List of all lexical tokens and examples that represent them.
+const (
+	ILLEGAL Token = iota // Invalid token.
+	EOF                  // End-of-file.
+	COMMENT              // // Hello, world!
+
+	literal_beg
+	IDENT  // foobar
+	NUMBER // 1234
+	FLOAT  // 1234.0
+	STRING // "foobar"
+	literal_end
+
+	keyword_beg
+	BOOL // true
+	NULL // null
+	keyword_end
+
+	operator_beg
+	OR  // ||
+	AND // &&
+	NOT // !
+
+	ASSIGN // =
+
+	EQ  // ==
+	NEQ // !=
+	LT  // <
+	LTE // <=
+	GT  // >
+	GTE // >=
+
+	ADD // +
+	SUB // -
+	MUL // *
+	DIV // /
+	MOD // %
+	POW // ^
+
+	LCURLY // {
+	RCURLY // }
+	LPAREN // (
+	RPAREN // )
+	LBRACK // [
+	RBRACK // ]
+	COMMA  // ,
+	DOT    // .
+	operator_end
+
+	TERMINATOR // \n
+)
+
+var tokenNames = [...]string{
+	ILLEGAL: "ILLEGAL",
+	EOF:     "EOF",
+	COMMENT: "COMMENT",
+
+	IDENT:  "IDENT",
+	NUMBER: "NUMBER",
+	FLOAT:  "FLOAT",
+	STRING: "STRING",
+	BOOL:   "BOOL",
+	NULL:   "NULL",
+
+	OR:  "||",
+	AND: "&&",
+	NOT: "!",
+
+	ASSIGN: "=",
+	EQ:     "==",
+	NEQ:    "!=",
+	LT:     "<",
+	LTE:    "<=",
+	GT:     ">",
+	GTE:    ">=",
+
+	ADD: "+",
+	SUB: "-",
+	MUL: "*",
+	DIV: "/",
+	MOD: "%",
+	POW: "^",
+
+	LCURLY: "{",
+	RCURLY: "}",
+	LPAREN: "(",
+	RPAREN: ")",
+	LBRACK: "[",
+	RBRACK: "]",
+	COMMA:  ",",
+	DOT:    ".",
+
+	TERMINATOR: "TERMINATOR",
+}
+
+// Lookup maps a string to its keyword token or IDENT if it's not a keyword.
+func Lookup(ident string) Token {
+	switch ident {
+	case "true", "false":
+		return BOOL
+	case "null":
+		return NULL
+	default:
+		return IDENT
+	}
+}
+
+// String returns the string representation corresponding to the token.
+func (t Token) String() string {
+	if int(t) >= len(tokenNames) {
+		return "ILLEGAL"
+	}
+
+	name := tokenNames[t]
+	if name == "" {
+		return "ILLEGAL"
+	}
+	return name
+}
+
+// GoString returns the %#v format of t.
+func (t Token) GoString() string { return t.String() }
+
+// IsKeyword returns true if the token corresponds to a keyword.
+func (t Token) IsKeyword() bool { return t > keyword_beg && t < keyword_end }
+
+// IsLiteral returns true if the token corresponds to a literal token or
+// identifier.
+func (t Token) IsLiteral() bool { return t > literal_beg && t < literal_end }
+
+// IsOperator returns true if the token corresponds to an operator or
+// delimiter.
+func (t Token) IsOperator() bool { return t > operator_beg && t < operator_end }
+
+// Precedence returns the operator precedence of the binary operator t. If t is
+// not a binary operator, the result is LowestPrecedence.
+func (t Token) BinaryPrecedence() int {
+	switch t {
+	case OR:
+		return 1
+	case AND:
+		return 2
+	case EQ, NEQ, LT, LTE, GT, GTE:
+		return 3
+	case ADD, SUB:
+		return 4
+	case MUL, DIV, MOD:
+		return 5
+	case POW:
+		return 6
+	}
+
+	return LowestPrecedence
+}
+
+// Levels of precedence for operator tokens.
+const (
+	LowestPrecedence  = 0 // non-operators
+	UnaryPrecedence   = 7
+	HighestPrecedence = 8
+)


### PR DESCRIPTION
This commit introduces the lexer for River (grafana/agent#1839). It is not wired in anywhere, and is the first of several PRs to slowly bring over functionality from the prototype. Most of the scanner code has been copied from go/scanner, adapted slightly for River and decorated with
extra comments.

Note that this commit does not indicate we will ship River, just that we are continuing the prototyping process in the main branch. pkg/river may still be removed in the future in favor of an alternative solution.