### PR TITLE
docs: fix broken prometheus links

### DIFF
--- a/docs/sources/configuration/metrics-config.md
+++ b/docs/sources/configuration/metrics-config.md
@@ -250,7 +250,7 @@ remote_write:
   - [<remote_write>]
 ```
 
-> **Note:** For more informaton on remote_write, refer to the [Prometheus documentation](https://prometheus.io/docs/prometheus/2.27/configuration/configuration/#remote_write)
+> **Note:** For more informaton on remote_write, refer to the [Prometheus documentation](https://prometheus.io/docs/prometheus/1.8/configuration/configuration/#remote_write)
 
 ## metrics_instance_config
 
@@ -322,6 +322,6 @@ remote_write:
 > **Note:** More information on the following types can be found on the Prometheus
 > website:
 >
-> * [`relabel_config`](https://prometheus.io/docs/prometheus/2.27/configuration/configuration/#relabel_config)
-> * [`scrape_config`](https://prometheus.io/docs/prometheus/2.27/configuration/configuration/#scrape_config)
-> * [`remote_write`](https://prometheus.io/docs/prometheus/2.27/configuration/configuration/#remote_write)
+> * [`relabel_config`](https://prometheus.io/docs/prometheus/1.8/configuration/configuration/#relabel_config)
+> * [`scrape_config`](https://prometheus.io/docs/prometheus/1.8/configuration/configuration/#scrape_config)
+> * [`remote_write`](https://prometheus.io/docs/prometheus/1.8/configuration/configuration/#remote_write)


### PR DESCRIPTION
Signed-off-by: Furkan <furkan.turkal@trendyol.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Agent [uses Prometheus v1.8.2](https://github.com/grafana/agent/blob/d5b5dcf5c847c308d21b2e2fdad77339728f13f3/go.mod#L82) so correct documentation version should be `1.8` instead of `2.27`. The following link also broken:

https://prometheus.io/docs/prometheus/2.27/configuration/configuration/#remote_write

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [X] Documentation added
- [ ] Tests updated
