### PR TITLE
Update MongoDB to use the collect all flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Main (unreleased)
 
 - Relative symlinks for promtail now work as expected. (@RangerCD, @mukerjee)
 - Fix rate limiting implementation for the app agent receiver integration. (@domasx2)
+- Fix mongodb exporter so that it now collects all metrics. (@mattdurham)
 
 v0.25.1 (2022-06-16)
 -------------------------

--- a/pkg/integrations/mongodb_exporter/mongodb_exporter.go
+++ b/pkg/integrations/mongodb_exporter/mongodb_exporter.go
@@ -62,7 +62,7 @@ func New(logger log.Logger, c *Config) (integrations.Integration, error) {
 		// the old names, so we hard-code it to true now. We may wish to make this
 		// configurable in the future.
 		CompatibleMode: true,
-		CollectAll: true,
+		CollectAll:     true,
 	})
 
 	return integrations.NewHandlerIntegration(c.Name(), exp.Handler()), nil

--- a/pkg/integrations/mongodb_exporter/mongodb_exporter.go
+++ b/pkg/integrations/mongodb_exporter/mongodb_exporter.go
@@ -62,6 +62,7 @@ func New(logger log.Logger, c *Config) (integrations.Integration, error) {
 		// the old names, so we hard-code it to true now. We may wish to make this
 		// configurable in the future.
 		CompatibleMode: true,
+		CollectAll: true,
 	})
 
 	return integrations.NewHandlerIntegration(c.Name(), exp.Handler()), nil


### PR DESCRIPTION
#### PR Description

When we updated MongoDB it also changed the behavior to requiring which metrics to collect. Added the collect all = true fixes that. Compared the metrics from a previous version and this version, this version has all the previous metrics and adds roughly 100 more, so collect all seems reasonable.

Closes #1834

- [X] CHANGELOG updated
- [NA] Documentation added
- [NA] Tests updated
