### PR TITLE
RPM: GPG signing

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -227,6 +227,12 @@ steps:
         from_secret: DOCKER_PASSWORD
       GITHUB_TOKEN:
         from_secret: GITHUB_KEY
+      GPG_PRIVATE_KEY: 
+        from_secret: gpg_private_key
+      GPG_PUBLIC_KEY:
+        from_secret: gpg_public_key
+      GPG_PASSPHRASE:
+        from_secret: gpg_passphrase
     commands:
       - apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release
       - curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
@@ -274,8 +280,33 @@ name: gh_token
 get:
   path: infra/data/ci/github/grafanabot
   name: pat
+
+---
+kind: secret
+name: gpg_public_key
+
+get:
+  name: public-key
+  path: infra/data/ci/packages-publish/gpg
+
+---
+kind: secret
+name: gpg_private_key
+
+get:
+  name: private-key
+  path: infra/data/ci/packages-publish/gpg
+
+---
+kind: secret
+name: gpg_passphrase
+
+get:
+  name: passphrase
+  path: infra/data/ci/packages-publish/gpg
+
 ---
 kind: signature
-hmac: 1eb649e21ef645fccbdde5fff6577f6c56666bf7683f68b91b753887d2952069
+hmac: 1b8681557ad1771fcc97f0a57ddbc65a394b80f6db83c11b474e35b513bb462b
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -503,6 +503,7 @@ clean-dist:
 .PHONY: clean
 
 publish: dist
+	./packaging/rpm/gpg-sign.sh
 	./tools/release
 
 # Drone signs the yaml, you will need to specify DRONE_TOKEN, which can be found by logging into your profile in drone

--- a/packaging/rpm/gpg-sign.sh
+++ b/packaging/rpm/gpg-sign.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# We are not using fpm's signing functionality because it does not work anymore
+# https://github.com/jordansissel/fpm/issues/1626
+
+set -euxo pipefail
+shopt -s extglob
+
+# Write GPG key to GPG keyring
+printf "%s" "${GPG_PUBLIC_KEY}" > /tmp/gpg-public-key
+gpg --import /tmp/gpg-public-key
+printf "%s" "${GPG_PRIVATE_KEY}" | gpg --import --no-tty --batch --yes --passphrase "${GPG_PASSPHRASE}"
+
+rpm --import /tmp/gpg-public-key
+
+echo "%_gpg_name Grafana <info@grafana.com>
+%_signature gpg
+%_gpg_path /root/.gnupg
+%_gpgbin /usr/bin/gpg
+%__gpg /usr/bin/gpg
+%__gpg_sign_cmd     %{__gpg} \
+         gpg --no-tty --batch --yes --no-verbose --no-armor \
+         --passphrase ${GPG_PASSPHRASE} \
+         --pinentry-mode loopback \
+         %{?_gpg_digest_algo:--digest-algo %{_gpg_digest_algo}} \
+         --no-secmem-warning \
+         -u \"%{_gpg_name}\" -sbo %{__signature_filename} %{__plaintext_filename}
+" > ~/.rpmmacros
+
+for f in dist/*.rpm; do
+  rpm --addsign "${f}"
+  rpm --checksig "${f}"
+done


### PR DESCRIPTION
Sign the RPM packages in releases with the Grafana key (packages.grafana.com/gpg.key)
We're building a central package repository and all (RPM) packages need to be signed with that key