### PR TITLE
river: add river/printer package

### DIFF
--- a/pkg/river/ast/ast.go
+++ b/pkg/river/ast/ast.go
@@ -280,7 +280,7 @@ func EndPos(n Node) token.Pos {
 	case *Comment:
 		return n.Start.Add(len(n.Text) - 1)
 	case *AttributeStmt:
-		return EndPos(n.Name)
+		return EndPos(n.Value)
 	case *BlockStmt:
 		return n.RCurly
 	case *IdentifierExpr:

--- a/pkg/river/ast/ast.go
+++ b/pkg/river/ast/ast.go
@@ -48,7 +48,7 @@ type CommentGroup []*Comment
 // removed, EndPos will not be accurate for any comment which contained
 // carriage returns.
 type Comment struct {
-	Start token.Pos // Starting position of comment
+	StartPos token.Pos // Starting position of comment
 	// Text of the comment. Text will not contain '\n' for line comments.
 	Text string
 }
@@ -66,7 +66,7 @@ type BlockStmt struct {
 	Label   string
 	Body    Body
 
-	LCurly, RCurly token.Pos
+	LCurlyPos, RCurlyPos token.Pos
 }
 
 // IdentifierExpr refers to a named value.
@@ -88,14 +88,14 @@ type LiteralExpr struct {
 
 // ArrayExpr is an array of values.
 type ArrayExpr struct {
-	Elements       []Expr
-	LBrack, RBrack token.Pos
+	Elements             []Expr
+	LBrackPos, RBrackPos token.Pos
 }
 
 // ObjectExpr declares an object of key-value pairs.
 type ObjectExpr struct {
-	Fields         []*ObjectField
-	LCurly, RCurly token.Pos
+	Fields               []*ObjectField
+	LCurlyPos, RCurlyPos token.Pos
 }
 
 // ObjectField defines an individual key-value pair within an object.
@@ -114,8 +114,8 @@ type AccessExpr struct {
 
 // IndexExpr accesses an index in an array value.
 type IndexExpr struct {
-	Value, Index   Expr
-	LBrack, RBrack token.Pos
+	Value, Index         Expr
+	LBrackPos, RBrackPos token.Pos
 }
 
 // CallExpr invokes a function value with a set of arguments.
@@ -123,7 +123,7 @@ type CallExpr struct {
 	Value Expr
 	Args  []Expr
 
-	LParen, RParen token.Pos
+	LParenPos, RParenPos token.Pos
 }
 
 // UnaryExpr performs a unary operation on a single value.
@@ -142,8 +142,8 @@ type BinaryExpr struct {
 
 // ParenExpr represents an expression wrapped in parenthesis.
 type ParenExpr struct {
-	Inner          Expr
-	LParen, RParen token.Pos
+	Inner                Expr
+	LParenPos, RParenPos token.Pos
 }
 
 // Type assertions
@@ -229,7 +229,7 @@ func StartPos(n Node) token.Pos {
 		}
 		return StartPos(n[0])
 	case *Comment:
-		return n.Start
+		return n.StartPos
 	case *AttributeStmt:
 		return StartPos(n.Name)
 	case *BlockStmt:
@@ -239,9 +239,9 @@ func StartPos(n Node) token.Pos {
 	case *LiteralExpr:
 		return n.ValuePos
 	case *ArrayExpr:
-		return n.LBrack
+		return n.LBrackPos
 	case *ObjectExpr:
-		return n.LCurly
+		return n.LCurlyPos
 	case *AccessExpr:
 		return StartPos(n.Value)
 	case *IndexExpr:
@@ -253,7 +253,7 @@ func StartPos(n Node) token.Pos {
 	case *BinaryExpr:
 		return StartPos(n.Left)
 	case *ParenExpr:
-		return n.LParen
+		return n.LParenPos
 	default:
 		panic(fmt.Sprintf("Unhandled Node type %T", n))
 	}
@@ -278,31 +278,31 @@ func EndPos(n Node) token.Pos {
 		}
 		return EndPos(n[len(n)-1])
 	case *Comment:
-		return n.Start.Add(len(n.Text) - 1)
+		return n.StartPos.Add(len(n.Text) - 1)
 	case *AttributeStmt:
 		return EndPos(n.Value)
 	case *BlockStmt:
-		return n.RCurly
+		return n.RCurlyPos
 	case *IdentifierExpr:
 		return n.NamePos.Add(len(n.Name) - 1)
 	case *LiteralExpr:
 		return n.ValuePos.Add(len(n.Value) - 1)
 	case *ArrayExpr:
-		return n.RBrack
+		return n.RBrackPos
 	case *ObjectExpr:
-		return n.RCurly
+		return n.RCurlyPos
 	case *AccessExpr:
 		return EndPos(n.Name)
 	case *IndexExpr:
-		return n.RBrack
+		return n.RBrackPos
 	case *CallExpr:
-		return n.RParen
+		return n.RParenPos
 	case *UnaryExpr:
 		return EndPos(n.Value)
 	case *BinaryExpr:
 		return EndPos(n.Right)
 	case *ParenExpr:
-		return n.RParen
+		return n.RParenPos
 	default:
 		panic(fmt.Sprintf("Unhandled Node type %T", n))
 	}

--- a/pkg/river/parser/internal.go
+++ b/pkg/river/parser/internal.go
@@ -96,7 +96,7 @@ func (p *parser) consumeComment() (comment *ast.Comment, endline int) {
 		}
 	}
 
-	comment = &ast.Comment{Start: p.pos, Text: p.lit}
+	comment = &ast.Comment{StartPos: p.pos, Text: p.lit}
 	p.next0()
 	return
 }
@@ -223,9 +223,9 @@ func (p *parser) parseStatement() ast.Stmt {
 			Label:   blockName.Label,
 		}
 
-		block.LCurly, _, _ = p.expect(token.LCURLY)
+		block.LCurlyPos, _, _ = p.expect(token.LCURLY)
 		block.Body = p.parseBody(token.RCURLY)
-		block.RCurly, _, _ = p.expect(token.RCURLY)
+		block.RCurlyPos, _, _ = p.expect(token.RCURLY)
 
 		return block
 
@@ -424,10 +424,10 @@ NextOper:
 			rBrack, _, _ := p.expect(token.RBRACK)
 
 			primary = &ast.IndexExpr{
-				Value:  primary,
-				LBrack: lBrack,
-				Index:  index,
-				RBrack: rBrack,
+				Value:     primary,
+				LBrackPos: lBrack,
+				Index:     index,
+				RBrackPos: rBrack,
 			}
 
 		case token.LPAREN: // CallExpr
@@ -440,10 +440,10 @@ NextOper:
 			rParen, _, _ := p.expect(token.RPAREN)
 
 			primary = &ast.CallExpr{
-				Value:  primary,
-				LParen: lParen,
-				Args:   args,
-				RParen: rParen,
+				Value:     primary,
+				LParenPos: lParen,
+				Args:      args,
+				RParenPos: rParen,
 			}
 
 		default:
@@ -497,29 +497,29 @@ func (p *parser) parsePrimaryExpr() ast.Expr {
 		rParen, _, _ := p.expect(token.RPAREN)
 
 		return &ast.ParenExpr{
-			LParen: lParen,
-			Inner:  expr,
-			RParen: rParen,
+			LParenPos: lParen,
+			Inner:     expr,
+			RParenPos: rParen,
 		}
 
 	case token.LBRACK:
 		var res ast.ArrayExpr
 
-		res.LBrack, _, _ = p.expect(token.LBRACK)
+		res.LBrackPos, _, _ = p.expect(token.LBRACK)
 		if p.tok != token.RBRACK {
 			res.Elements = p.parseExpressionList(token.RBRACK)
 		}
-		res.RBrack, _, _ = p.expect(token.RBRACK)
+		res.RBrackPos, _, _ = p.expect(token.RBRACK)
 		return &res
 
 	case token.LCURLY:
 		var res ast.ObjectExpr
 
-		res.LCurly, _, _ = p.expect(token.LCURLY)
+		res.LCurlyPos, _, _ = p.expect(token.LCURLY)
 		if p.tok != token.RBRACK {
 			res.Fields = p.parseFieldList(token.RCURLY)
 		}
-		res.RCurly, _, _ = p.expect(token.RCURLY)
+		res.RCurlyPos, _, _ = p.expect(token.RCURLY)
 		return &res
 	}
 

--- a/pkg/river/printer/printer.go
+++ b/pkg/river/printer/printer.go
@@ -1,0 +1,544 @@
+// Package printer contains utilities for pretty-printing River ASTs.
+package printer
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"text/tabwriter"
+
+	"github.com/grafana/agent/pkg/river/ast"
+	"github.com/grafana/agent/pkg/river/token"
+)
+
+// Config configures behavior of the printer.
+type Config struct {
+	Indent int // Identation to apply to all emitted code. Default 0.
+}
+
+// Fprint pretty-prints the specified node to w. The Node type must be an
+// *ast.File, ast.Body, or a type that implements ast.Stmt or ast.Expr.
+func (c *Config) Fprint(w io.Writer, node ast.Node) (err error) {
+	var p printer
+	p.Init(c)
+
+	// Pass all of our text through a trimmer to ignore trailing whitespace.
+	w = &trimmer{next: w}
+
+	if err = (&walker{p: &p}).Walk(node); err != nil {
+		return
+	}
+
+	// Call flush one more time to write trailing comments.
+	p.flush(token.Position{
+		Offset: math.MaxInt,
+		Line:   math.MaxInt,
+		Column: math.MaxInt,
+	}, token.EOF)
+
+	w = tabwriter.NewWriter(w, 0, 8, 1, ' ', tabwriter.DiscardEmptyColumns|tabwriter.TabIndent)
+
+	if _, err = w.Write(p.output); err != nil {
+		return
+	}
+	if tw, _ := w.(*tabwriter.Writer); tw != nil {
+		// Flush tabwriter if defined
+		err = tw.Flush()
+	}
+
+	return
+}
+
+// Fprint pretty-prints the specified node to w. The Node type must be an
+// *ast.File, ast.Body, or a type that implements ast.Stmt or ast.Expr.
+func Fprint(w io.Writer, node ast.Node) error {
+	c := &Config{}
+	return c.Fprint(w, node)
+}
+
+// The printer writes lexical tokens and whitespace to an internal buffer.
+// Comments are written by the printer itself, while all other tokens and
+// formatting characters are sent through calls to Write.
+//
+// Internally, printer depends on a tabwriter for formatting text and aligning
+// runs of characters. Horizontal '\t' and vertical '\v' tab characters are
+// used to introduce new columns in the row. Runs of characters are stopped
+// be either introducing a linefeed '\f' or by having a line with a different
+// number of columns from the previous line. See the text/tabwriter package for
+// more information on the elastic tabstop algorithm it uses for formatting
+// text.
+type printer struct {
+	cfg Config
+
+	// State variables
+
+	output  []byte
+	indent  int         // Current indentation level
+	lastTok token.Token // Last token printed (token.ILLEGAL if it's whitespace)
+
+	// Whitespace holds a buffer of whitespace characters to print prior to the
+	// next non-whitespace token. Whitespace is held in a buffer to avoid
+	// printing unnecessary whitespace at the end of a file.
+	whitespace []whitespace
+
+	// comments stores comments to be processed as elements are printed.
+	comments commentInfo
+
+	// pos is an approximation of the current position in AST space, and is used
+	// to determine space between AST elements (e.g., if a comment should come
+	// before a token). pos automatically as elements are written and can be manually
+	// set to guarantee an accurate position by passing a token.Pos to Write.
+	pos  token.Position
+	last token.Position // Last pos written to output (through writeString)
+
+	// out is an accurate representation of the current position in output space,
+	// used to inject extra formatting like indentation based on the output
+	// position.
+	//
+	// out may differ from pos in terms of whitespace.
+	out token.Position
+}
+
+type commentInfo struct {
+	list []ast.CommentGroup
+	idx  int
+	cur  ast.CommentGroup
+	pos  token.Pos
+}
+
+func (ci *commentInfo) commentBefore(next token.Position) bool {
+	return ci.pos != token.NoPos && ci.pos.Offset() <= next.Offset
+}
+
+// nextComment preloads the next comment.
+func (ci *commentInfo) nextComment() {
+	for ci.idx < len(ci.list) {
+		c := ci.list[ci.idx]
+		ci.idx++
+		if len(c) > 0 {
+			ci.cur = c
+			ci.pos = ast.StartPos(c[0])
+			return
+		}
+	}
+	ci.pos = token.NoPos
+}
+
+// Init initializes the printer for printing. Init is intended to be called
+// once per printer and doesn't fully reset its state.
+func (p *printer) Init(cfg *Config) {
+	p.cfg = *cfg
+	p.pos = token.Position{Line: 1, Column: 1}
+	p.out = token.Position{Line: 1, Column: 1}
+	// Capacity is set low since most whitespace sequences are short.
+	p.whitespace = make([]whitespace, 0, 16)
+}
+
+// SetComments set the comments to use.
+func (p *printer) SetComments(comments []ast.CommentGroup) {
+	p.comments = commentInfo{
+		list: comments,
+		idx:  0,
+		pos:  token.NoPos,
+	}
+	p.comments.nextComment()
+}
+
+// Write writes a list of writable arguments to the printer.
+//
+// Arguments can be one of the types described below:
+//
+// If arg is a whitespace value, it is accumulated into a buffer and flushed
+// only after a non-whitespace value is processed. The whitespace buffer will
+// be forcibly flushed if the buffer becomes full without writing a
+// non-whitespace token.
+//
+// If arg is an *ast.IdentifierExpr, *ast.LiteralExpr, or a token.Token, the
+// human-readable representation of that value will be written.
+//
+// When writing text, comments which need to appear before that text in
+// AST-space are written first, followed by leftover whitespace and then the
+// text to write. The written text will update the AST-space position.
+//
+// If arg is a token.Pos, the AST-space position of the printer is updated to
+// the provided Pos. Writing token.Pos values can help make sure the printer's
+// AST-space position is accurate, as AST-space position is otherwise an
+// estimation based on written data.
+func (p *printer) Write(args ...interface{}) {
+	for _, arg := range args {
+		var (
+			data  string
+			isLit bool
+		)
+
+		switch arg := arg.(type) {
+		case whitespace:
+			// Whitespace token; add it to our token buffer. Note that a whitespace
+			// token is different than the actual whitespace which will get written
+			// (e.g., wsIndent increases indentation level by one instead of setting
+			// it to one.)
+			if arg == wsIgnore {
+				continue
+			}
+			i := len(p.whitespace)
+			if i == cap(p.whitespace) {
+				// We built up too much whitespace; this can happen if too many calls
+				// to Write happen without appending a non-comment token. We will
+				// force-flush the existing whitespace to avoid a panic.
+				//
+				// Ideally this line is never hit based on how we walk the AST, but
+				// it's kept for safety.
+				p.writeWritespace(i)
+				i = 0
+			}
+			p.whitespace = p.whitespace[0 : i+1]
+			p.whitespace[i] = arg
+			p.lastTok = token.ILLEGAL
+			continue
+
+		case *ast.IdentifierExpr:
+			data = arg.Name
+			p.lastTok = token.IDENT
+
+		case *ast.LiteralExpr:
+			data = arg.Value
+			p.lastTok = arg.Kind
+
+		case token.Pos:
+			if arg.Valid() {
+				p.pos = arg.Position()
+			}
+			// Don't write anything; token.Pos is an instruction and doesn't include
+			// any text to write.
+			continue
+
+		case token.Token:
+			s := arg.String()
+			data = s
+
+			// We will need to inject whitespace if the previous token and the
+			// current token would combine into a single token when re-scanned. This
+			// ensures that the sequence of tokens emitted by the output of the
+			// printer match the sequence of tokens from the input.
+			if mayCombine(p.lastTok, s[0]) {
+				if len(p.whitespace) != 0 {
+					// It shouldn't be possible for the whitespace buffer to be not empty
+					// here; p.lastTok would've had to been a non-whitespace token and so
+					// whitespace would've been flushed when it was written to the output
+					// buffer.
+					panic("whitespace buffer not empty")
+				}
+				p.whitespace = p.whitespace[0:1]
+				p.whitespace[0] = ' '
+			}
+			p.lastTok = arg
+
+		default:
+			panic(fmt.Sprintf("printer: unsupported argument %v (%T)\n", arg, arg))
+		}
+
+		next := p.pos
+
+		p.flush(next, p.lastTok)
+		p.writeString(next, data, isLit)
+	}
+}
+
+// mayCombine returns true if two tokes must not be combined, because combining
+// them would format in a different token sequence being generated.
+func mayCombine(prev token.Token, next byte) (b bool) {
+	switch prev {
+	case token.NUMBER:
+		return next == '.' // 1.
+	case token.DIV:
+		return next == '*' // /*
+	default:
+		return false
+	}
+}
+
+// flush prints any pending comments and whitespace occurring textually before
+// the position of the next token tok. The flush result indicates if a newline
+// was written or if a formfeed \f character was dropped from the whitespace
+// buffer.
+func (p *printer) flush(next token.Position, tok token.Token) {
+	if p.comments.commentBefore(next) {
+		p.injectComments(next, tok)
+	} else if tok != token.EOF {
+		// Write all remaining whitespace.
+		p.writeWritespace(len(p.whitespace))
+	}
+}
+
+func (p *printer) injectComments(next token.Position, tok token.Token) {
+	var lastComment *ast.Comment
+
+	for p.comments.commentBefore(next) {
+		for _, c := range p.comments.cur {
+			p.writeCommentPrefix(next, c)
+			p.writeComment(next, c)
+			lastComment = c
+		}
+		p.comments.nextComment()
+	}
+
+	p.writeCommentSuffix(next, tok, lastComment)
+}
+
+// writeCommentPrefix writes whitespace that should appear before c.
+func (p *printer) writeCommentPrefix(next token.Position, c *ast.Comment) {
+	if len(p.output) == 0 {
+		// The comment is the first thing written to the output. Don't write any
+		// whitespace before it.
+		return
+	}
+
+	cPos := c.Start.Position()
+
+	if cPos.Line == p.last.Line {
+		// Our comment is on the same line as the last token. Write a separator
+		// between the last token and the comment.
+		separator := byte('\t')
+		if cPos.Line == next.Line {
+			// The comment is on the same line as the next token, which means it has
+			// to be a block comment (since line comments run to the end of the
+			// line.) Use a space as the separator instead since a tab in the middle
+			// of a line between comments would look weird.
+			separator = byte(' ')
+		}
+		p.writeByte(separator, 1)
+	} else {
+		// Our comment is on a different line from the last token. First write
+		// pending whitespace from the last token up to the first newline.
+		var wsCount int
+
+		for i, ws := range p.whitespace {
+			switch ws {
+			case wsBlank, wsVTab:
+				// Drop any whitespace before the comment.
+				p.whitespace[i] = wsIgnore
+			case wsIndent, wsUnindent:
+				// Allow indentation to be applied.
+				continue
+			case wsNewline, wsFormfeed:
+				// Drop the whitespace since we're about to write our own.
+				p.whitespace[i] = wsIgnore
+			}
+			wsCount = i
+			break
+		}
+		p.writeWritespace(wsCount)
+
+		var newlines int
+		if cPos.Valid() && p.last.Valid() {
+			newlines = cPos.Line - p.last.Line
+		}
+		if newlines > 0 {
+			p.writeByte('\f', newlineLimit(newlines))
+		}
+	}
+}
+
+func (p *printer) writeComment(next token.Position, c *ast.Comment) {
+	p.writeString(c.Start.Position(), c.Text, true)
+}
+
+// writeCommentSuffix writes any whitespace necessary between the last comment
+// and next. lastComment should be the final comment written.
+func (p *printer) writeCommentSuffix(next token.Position, tok token.Token, lastComment *ast.Comment) {
+	if tok == token.EOF {
+		// We don't want to add any blank newlines before the end of the file;
+		// return early.
+		return
+	}
+
+	// If our final comment is a block comment and is on the same line as the
+	// next token, add a space as a suffix to separate them.
+	lastCommentPos := ast.EndPos(lastComment).Position()
+	if lastComment.Text[1] == '*' && next.Line == lastCommentPos.Line {
+		p.writeByte(' ', 1)
+	}
+
+	newlines := next.Line - p.last.Line
+
+	for i, ws := range p.whitespace {
+		switch ws {
+		case wsBlank, wsVTab:
+			p.whitespace[i] = wsIgnore
+		case wsIndent, wsUnindent:
+			continue
+		case wsNewline, wsFormfeed:
+			p.whitespace[i] = wsIgnore
+		}
+	}
+	p.writeWritespace(len(p.whitespace))
+
+	// Write newlines as long as the next token isn't EOF (so that there's no
+	// blank newlines at the end of the file).
+	if newlines > 0 {
+		p.writeByte('\n', newlineLimit(newlines))
+	}
+}
+
+// writeString writes the literal string s into the printer's output.
+// Formatting characters in s such as '\t' and '\n' will be interpreted by
+// underlying tabwriter unless isLit is set.
+func (p *printer) writeString(pos token.Position, s string, isLit bool) {
+	if p.out.Column == 1 {
+		// We haven't written any text to this line yet; prepend our indentation
+		// for the line.
+		p.writeIndent()
+	}
+
+	if pos.Valid() {
+		// Update p.pos if pos is valid. This is done *after* handling indentation
+		// since we want to interpret pos as the literal position for s (and
+		// writeIndent will update p.pos).
+		p.pos = pos
+	}
+
+	if isLit {
+		// Wrap our literal string in tabwriter.Escape if it's meant to be written
+		// without interpretation by the tabwriter.
+		p.output = append(p.output, tabwriter.Escape)
+
+		defer func() {
+			p.output = append(p.output, tabwriter.Escape)
+		}()
+	}
+
+	p.output = append(p.output, s...)
+
+	var (
+		newlines       int
+		lastNewlineIdx int
+	)
+
+	for i := 0; i < len(s); i++ {
+		if ch := s[i]; ch == '\n' || ch == '\f' {
+			newlines++
+			lastNewlineIdx = i
+		}
+	}
+
+	p.pos.Offset += len(s)
+
+	if newlines > 0 {
+		p.pos.Line += newlines
+		p.out.Line += newlines
+
+		newColumn := len(s) - lastNewlineIdx
+		p.pos.Column = newColumn
+		p.out.Column = newColumn
+	} else {
+		p.pos.Column += len(s)
+		p.out.Column += len(s)
+	}
+
+	p.last = p.pos
+}
+
+func (p *printer) writeIndent() {
+	depth := p.cfg.Indent + p.indent
+	for i := 0; i < depth; i++ {
+		p.output = append(p.output, '\t')
+	}
+
+	p.pos.Offset += depth
+	p.pos.Column += depth
+	p.out.Column += depth
+}
+
+// writeByte writes ch n times to the output, updating the position of the
+// printer. writeByte is only used for writing whitespace characters.
+func (p *printer) writeByte(ch byte, n int) {
+	if p.out.Column == 1 {
+		p.writeIndent()
+	}
+
+	for i := 0; i < n; i++ {
+		p.output = append(p.output, ch)
+	}
+
+	// Update positions.
+	p.pos.Offset += n
+	if ch == '\n' || ch == '\f' {
+		p.pos.Line += n
+		p.out.Line += n
+		p.pos.Column = 1
+		p.out.Column = 1
+		return
+	}
+	p.pos.Column += n
+	p.out.Column += n
+}
+
+// writeWhitespace writes the first n whitespace entries in the whitespace
+// buffer.
+//
+// writeWritespace is only safe to be called when len(p.whitespace) >= n.
+func (p *printer) writeWritespace(n int) {
+	for i := 0; i < n; i++ {
+		switch ch := p.whitespace[i]; ch {
+		case wsIgnore: // no-op
+		case wsIndent:
+			p.indent++
+		case wsUnindent:
+			p.indent--
+			if p.indent < 0 {
+				panic("printer: negative indentation")
+			}
+		default:
+			p.writeByte(byte(ch), 1)
+		}
+	}
+
+	// Shift remaining entries down
+	l := copy(p.whitespace, p.whitespace[n:])
+	p.whitespace = p.whitespace[:l]
+}
+
+const maxNewlines = 2
+
+// newlineLimit limits a newline count to maxNewlines.
+func newlineLimit(count int) int {
+	if count > maxNewlines {
+		count = maxNewlines
+	}
+	return count
+}
+
+// whitespace represents a whitespace token to write to the printer's internal
+// buffer.
+type whitespace byte
+
+const (
+	wsIgnore   = whitespace(0)
+	wsBlank    = whitespace(' ')
+	wsVTab     = whitespace('\v')
+	wsNewline  = whitespace('\n')
+	wsFormfeed = whitespace('\f')
+	wsIndent   = whitespace('>')
+	wsUnindent = whitespace('<')
+)
+
+func (ws whitespace) String() string {
+	switch ws {
+	case wsIgnore:
+		return "wsIgnore"
+	case wsBlank:
+		return "wsBlank"
+	case wsVTab:
+		return "wsVTab"
+	case wsNewline:
+		return "wsNewline"
+	case wsFormfeed:
+		return "wsFormfeed"
+	case wsIndent:
+		return "wsIndent"
+	case wsUnindent:
+		return "wsUnindent"
+	default:
+		return fmt.Sprintf("whitespace(%d)", ws)
+	}
+}

--- a/pkg/river/printer/printer.go
+++ b/pkg/river/printer/printer.go
@@ -293,7 +293,7 @@ func (p *printer) writeCommentPrefix(next token.Position, c *ast.Comment) {
 		return
 	}
 
-	cPos := c.Start.Position()
+	cPos := c.StartPos.Position()
 
 	if cPos.Line == p.last.Line {
 		// Our comment is on the same line as the last token. Write a separator
@@ -340,7 +340,7 @@ func (p *printer) writeCommentPrefix(next token.Position, c *ast.Comment) {
 }
 
 func (p *printer) writeComment(next token.Position, c *ast.Comment) {
-	p.writeString(c.Start.Position(), c.Text, true)
+	p.writeString(c.StartPos.Position(), c.Text, true)
 }
 
 // writeCommentSuffix writes any whitespace necessary between the last comment

--- a/pkg/river/printer/printer_test.go
+++ b/pkg/river/printer/printer_test.go
@@ -1,0 +1,53 @@
+package printer_test
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/grafana/agent/pkg/river/parser"
+	"github.com/grafana/agent/pkg/river/printer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrinter(t *testing.T) {
+	filepath.WalkDir("testdata", func(path string, d fs.DirEntry, _ error) error {
+		if d.IsDir() {
+			return nil
+		}
+
+		if strings.HasSuffix(path, ".in") {
+			inputFile := path
+			expectFile := strings.TrimSuffix(path, ".in") + ".expect"
+
+			inputBB, err := os.ReadFile(inputFile)
+			require.NoError(t, err)
+			expectBB, err := os.ReadFile(expectFile)
+			require.NoError(t, err)
+
+			caseName := filepath.Base(path)
+			caseName = strings.TrimSuffix(caseName, ".in")
+
+			t.Run(caseName, func(t *testing.T) {
+				testPrinter(t, inputBB, expectBB)
+			})
+		}
+
+		return nil
+	})
+}
+
+func testPrinter(t *testing.T, input, expect []byte) {
+	f, err := parser.ParseFile(t.Name()+".rvr", input)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, printer.Fprint(&buf, f))
+
+	trimmed := strings.TrimRightFunc(string(expect), unicode.IsSpace)
+	require.Equal(t, trimmed, buf.String(), "%s", buf.String())
+}

--- a/pkg/river/printer/testdata/.gitattributes
+++ b/pkg/river/printer/testdata/.gitattributes
@@ -1,0 +1,1 @@
+* -text eol=lf

--- a/pkg/river/printer/testdata/block_comments.expect
+++ b/pkg/river/printer/testdata/block_comments.expect
@@ -1,0 +1,23 @@
+// block_comments.in expects that comments within blocks are formatted to
+// remain within the block with the proper indentation.
+
+// Comment is on same line as block header.
+block { // comment
+}
+
+// Comment is alone in block body.
+block {
+	// comment
+}
+
+// Comment is before a statement.
+block {
+	// comment
+	attr = 5
+}
+
+// Comment is after a statement.
+block {
+	attr = 5
+	// comment
+}

--- a/pkg/river/printer/testdata/block_comments.in
+++ b/pkg/river/printer/testdata/block_comments.in
@@ -1,0 +1,23 @@
+// block_comments.in expects that comments within blocks are formatted to
+// remain within the block with the proper indentation.
+
+// Comment is on same line as block header.
+block { // comment
+}
+
+// Comment is alone in block body.
+block {
+// comment
+}
+
+// Comment is before a statement.
+block {
+// comment
+	attr = 5
+}
+
+// Comment is after a statement.
+block {
+	attr = 5
+// comment
+}

--- a/pkg/river/printer/testdata/example.expect
+++ b/pkg/river/printer/testdata/example.expect
@@ -1,0 +1,62 @@
+// This file tests a little bit of everything that the formatter should do. For
+// example, this block of comments itself ensures that the output retains
+// comments found in the source file.
+
+//
+// Whitespace tests
+//
+
+// Attributes should be given whitespace
+attr_1 = 15
+attr_2 = 30 * 2 + 5
+attr_3 = field.access * 2
+
+// Blocks with nothing inside of them should be truncated.
+empty.block {
+}
+
+empty.block "labeled" {
+}
+
+//
+// Alignment tests
+//
+
+// Sequences of attributes which aren't separated by a blank line should have
+// the equal sign aligned.
+short_name       = true
+really_long_name = true
+
+extremely_long_name = true
+
+// Sequences of comments on aligned lines should also be aligned.
+short_name       = "short value"       // Align me
+really_long_name = "really long value" // Align me
+
+extremely_long_name = true // Unaligned
+
+//
+// Identation tests
+//
+
+// Array literals, object literals, and blocks should all be indented properly.
+multiline_array = [
+	0,
+	1,
+]
+
+mulitiline_object = {
+	foo = "bar",
+}
+
+some_block {
+	attr = 15
+
+	inner_block {
+		attr = 20
+	}
+}
+
+// Trailing comments should be retained in the output. If this comment gets
+// trimmed out, it usually indicates that a final flush is missing after
+// traversing the AST.

--- a/pkg/river/printer/testdata/example.in
+++ b/pkg/river/printer/testdata/example.in
@@ -1,0 +1,64 @@
+// This file tests a little bit of everything that the formatter should do. For
+// example, this block of comments itself ensures that the output retains
+// comments found in the source file.
+
+//
+// Whitespace tests
+//
+
+// Attributes should be given whitespace
+attr_1=15
+attr_2=30*2+5
+attr_3=field.access*2
+
+// Blocks with nothing inside of them should be truncated.
+empty.block {
+
+}
+
+empty.block "labeled" {
+
+}
+
+//
+// Alignment tests
+//
+
+// Sequences of attributes which aren't separated by a blank line should have
+// the equal sign aligned.
+short_name = true
+really_long_name = true
+
+extremely_long_name = true
+
+// Sequences of comments on aligned lines should also be aligned.
+short_name = "short value" // Align me
+really_long_name = "really long value" // Align me
+
+extremely_long_name = true // Unaligned
+
+//
+// Identation tests
+//
+
+// Array literals, object literals, and blocks should all be indented properly.
+multiline_array = [
+0,
+1,
+]
+
+mulitiline_object = {
+foo = "bar",
+}
+
+some_block {
+attr = 15
+
+inner_block {
+attr = 20
+}
+}
+
+// Trailing comments should be retained in the output. If this comment gets
+// trimmed out, it usually indicates that a final flush is missing after
+// traversing the AST.

--- a/pkg/river/printer/trimmer.go
+++ b/pkg/river/printer/trimmer.go
@@ -1,0 +1,115 @@
+package printer
+
+import (
+	"io"
+	"text/tabwriter"
+)
+
+// A trimmer is an io.Writer which filters tabwriter.Escape characters,
+// trailing blanks and tabs from lines, and converting \f and \v characters
+// into \n and \t (if no text/tabwriter is used when printing).
+//
+// Text wrapped by tabwriter.Escape characters is written to the underlying
+// io.Writer unmodified.
+type trimmer struct {
+	next  io.Writer
+	state int
+	space []byte
+}
+
+const (
+	trimStateSpace  = iota // Trimmer is reading space characters
+	trimStateEscape        // Trimmer is reading escaped characters
+	trimStateText          // Trimmer is reading text
+)
+
+func (t *trimmer) discardWhitespace() {
+	t.state = trimStateSpace
+	t.space = t.space[0:0]
+}
+
+func (t *trimmer) Write(data []byte) (n int, err error) {
+	// textStart holds the index of the start of a chunk of text not containing
+	// whitespace. It is reset every time a new chunk of text is encountered.
+	var textStart int
+
+	for off, b := range data {
+		// Convert \v to \t
+		if b == '\v' {
+			b = '\t'
+		}
+
+		switch t.state {
+		case trimStateSpace:
+			// Accumulate tabs and spaces in t.space until finding a non-tab or
+			// non-space character.
+			//
+			// If we find a newline, we write it directly and discard our pending
+			// whitespace (so that trailing whitespace up to the newline is ignored).
+			//
+			// If we find a tabwriter.Escape or text character we transition states.
+			switch b {
+			case '\t', ' ':
+				t.space = append(t.space, b)
+			case '\n', '\f':
+				// Disard all unwritten whitespace before the end of the line and write
+				// a newline.
+				t.discardWhitespace()
+				_, err = t.next.Write([]byte("\n"))
+			case tabwriter.Escape:
+				_, err = t.next.Write(t.space)
+				t.state = trimStateEscape
+				textStart = off + 1 // Skip escape character
+			default:
+				// Non-space character. Write our pending whitespace
+				// and then move to text state.
+				_, err = t.next.Write(t.space)
+				t.state = trimStateText
+				textStart = off
+			}
+
+		case trimStateText:
+			// We're reading a chunk of text. Accumulate characters in the chunk
+			// until we find a whitespace character or a tabwriter.Escape.
+			switch b {
+			case '\t', ' ':
+				_, err = t.next.Write(data[textStart:off])
+				t.discardWhitespace()
+				t.space = append(t.space, b)
+			case '\n', '\f':
+				_, err = t.next.Write(data[textStart:off])
+				t.discardWhitespace()
+				if err == nil {
+					_, err = t.next.Write([]byte("\n"))
+				}
+			case tabwriter.Escape:
+				_, err = t.next.Write(data[textStart:off])
+				t.state = trimStateEscape
+				textStart = off + 1 // +1: skip tabwriter.Escape
+			}
+
+		case trimStateEscape:
+			// Accumulate everything until finding the closing tabwriter.Escape.
+			if b == tabwriter.Escape {
+				_, err = t.next.Write(data[textStart:off])
+				t.discardWhitespace()
+			}
+
+		default:
+			panic("unreachable")
+		}
+		if err != nil {
+			return off, err
+		}
+	}
+	n = len(data)
+
+	// Flush the remainder of the text (as long as it's not whitespace).
+	switch t.state {
+	case trimStateEscape, trimStateText:
+		_, err = t.next.Write(data[textStart:n])
+		t.discardWhitespace()
+	}
+
+	return
+}

--- a/pkg/river/printer/walker.go
+++ b/pkg/river/printer/walker.go
@@ -1,0 +1,281 @@
+package printer
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/grafana/agent/pkg/river/ast"
+	"github.com/grafana/agent/pkg/river/token"
+)
+
+// A walker walks an AST and sends lexical tokens and formatting information to
+// a printer.
+type walker struct {
+	p *printer
+}
+
+func (w *walker) Walk(node ast.Node) error {
+	switch node := node.(type) {
+	case *ast.File:
+		w.walkFile(node)
+	case ast.Body:
+		w.walkStmts(node)
+	case ast.Stmt:
+		w.walkStmt(node)
+	case ast.Expr:
+		w.walkExpr(node)
+	default:
+		return fmt.Errorf("unsupported node type %T", node)
+	}
+
+	return nil
+}
+
+func (w *walker) walkFile(f *ast.File) {
+	w.p.SetComments(f.Comments)
+	w.walkStmts(f.Body)
+}
+
+func (w *walker) walkStmts(ss []ast.Stmt) {
+	for i, s := range ss {
+		var addedSpacing bool
+
+		// Two blocks should always be separated by a blank line.
+		if _, isBlock := s.(*ast.BlockStmt); i > 0 && isBlock {
+			w.p.Write(wsNewline)
+			addedSpacing = true
+		}
+
+		// A blank line should always be added if there is a blank line in the
+		// source between two statements.
+		if i > 0 && !addedSpacing {
+			var (
+				prevLine = ast.EndPos(ss[i-1]).Position().Line
+				curLine  = ast.StartPos(ss[i-0]).Position().Line
+
+				lineDiff = curLine - prevLine
+			)
+
+			if lineDiff > 1 {
+				w.p.Write(wsFormfeed)
+			}
+		}
+
+		w.walkStmt(s)
+
+		// Statements which cross multiple lines don't belong to the same row run.
+		// Add a formfeed to start a new row run if the node crossed more than one
+		// line, otherwise add the normal newline.
+		if nodeLines(s) > 1 {
+			w.p.Write(wsFormfeed)
+		} else {
+			w.p.Write(wsNewline)
+		}
+	}
+}
+
+func nodeLines(n ast.Node) int {
+	var (
+		startLine = ast.StartPos(n).Position().Line
+		endLine   = ast.EndPos(n).Position().Line
+	)
+
+	return endLine - startLine + 1
+}
+
+func (w *walker) walkStmt(s ast.Stmt) {
+	switch s := s.(type) {
+	case *ast.AttributeStmt:
+		w.walkAttributeStmt(s)
+	case *ast.BlockStmt:
+		w.walkBlockStmt(s)
+	}
+}
+
+func (w *walker) walkAttributeStmt(s *ast.AttributeStmt) {
+	w.p.Write(s.Name.NamePos, s.Name, wsVTab, token.ASSIGN, wsBlank)
+	w.walkExpr(s.Value)
+}
+
+func (w *walker) walkBlockStmt(s *ast.BlockStmt) {
+	joined := strings.Join(s.Name, ".")
+
+	// TODO(rfratto): Should blocks have a oneline format if they're short or
+	// empty? e.g.: `empty_block { attr = 5 }`, `empty_block {}`
+
+	w.p.Write(
+		s.NamePos,
+		&ast.IdentifierExpr{Name: joined, NamePos: s.NamePos},
+	)
+
+	if s.Label != "" {
+		label := fmt.Sprintf("%q", s.Label)
+
+		w.p.Write(
+			wsBlank,
+			&ast.LiteralExpr{Kind: token.STRING, Value: label},
+		)
+	}
+
+	w.p.Write(
+		wsBlank,
+		s.LCurly, token.LCURLY, wsIndent,
+		wsNewline,
+	)
+
+	w.walkStmts(s.Body)
+
+	w.p.Write(wsUnindent, s.RCurly, token.RCURLY)
+}
+
+func (w *walker) walkExpr(e ast.Expr) {
+	switch e := e.(type) {
+	case *ast.LiteralExpr:
+		w.p.Write(e.ValuePos, e)
+
+	case *ast.ArrayExpr:
+		w.walkArrayExpr(e)
+
+	case *ast.ObjectExpr:
+		w.walkObjectExpr(e)
+
+	case *ast.IdentifierExpr:
+		w.p.Write(e.NamePos, e)
+
+	case *ast.AccessExpr:
+		w.walkExpr(e.Value)
+		w.p.Write(token.DOT, e.Name)
+
+	case *ast.IndexExpr:
+		w.walkExpr(e.Value)
+		w.p.Write(e.LBrack, token.LBRACK)
+		w.walkExpr(e.Index)
+		w.p.Write(e.RBrack, token.RBRACK)
+
+	case *ast.CallExpr:
+		// TODO(rfratto): allow arguments to be on a new line
+		w.walkExpr(e.Value)
+		w.p.Write(token.LPAREN)
+		for i, arg := range e.Args {
+			w.walkExpr(arg)
+
+			if i+1 < len(e.Args) {
+				w.p.Write(token.COMMA, wsBlank)
+			}
+		}
+		w.p.Write(token.RPAREN)
+
+	case *ast.UnaryExpr:
+		w.p.Write(e.KindPos, e.Kind)
+		w.walkExpr(e.Value)
+
+	case *ast.BinaryExpr:
+		// TODO(rfratto):
+		//
+		//   1. allow RHS to be on a new line
+		//
+		//   2. remove spacing between some operators to make precedence
+		//      clearer like Go does
+		w.walkExpr(e.Left)
+		w.p.Write(wsBlank, e.KindPos, e.Kind, wsBlank)
+		w.walkExpr(e.Right)
+
+	case *ast.ParenExpr:
+		w.p.Write(token.LPAREN)
+		w.walkExpr(e.Inner)
+		w.p.Write(token.RPAREN)
+	}
+}
+
+func (w *walker) walkArrayExpr(e *ast.ArrayExpr) {
+	w.p.Write(e.LBrack, token.LBRACK, wsIndent)
+
+	prevPos := e.LBrack
+
+	for i := 0; i < len(e.Elements); i++ {
+		elementPos := ast.StartPos(e.Elements[i])
+
+		// Add a newline if this element starts on a different line from the last
+		// element.
+		if differentLines(prevPos, elementPos) {
+			w.p.Write(wsFormfeed)
+		} else if i > 0 {
+			// Make sure a space is injected before the next element if two
+			// successive elements are on the same line.
+			w.p.Write(wsBlank)
+		}
+		prevPos = elementPos
+
+		// Write the expression.
+		w.walkExpr(e.Elements[i])
+
+		// Always add commas in between successive elements.
+		if i+1 < len(e.Elements) {
+			w.p.Write(token.COMMA)
+		}
+	}
+
+	// If the closing bracket is on a different line than the final element,
+	// we need to add a trailing comma.
+	if len(e.Elements) > 0 && differentLines(prevPos, e.RBrack) {
+		w.p.Write(token.COMMA, wsFormfeed)
+	}
+
+	w.p.Write(wsUnindent, e.RBrack, token.RBRACK)
+}
+
+func (w *walker) walkObjectExpr(e *ast.ObjectExpr) {
+	w.p.Write(token.LCURLY, wsIndent)
+
+	prevPos := e.LCurly
+
+	for i := 0; i < len(e.Fields); i++ {
+		field := e.Fields[i]
+		elementPos := ast.StartPos(field.Name)
+
+		// Add a newline if this element starts on a different line from the last
+		// element.
+		if differentLines(prevPos, elementPos) {
+			w.p.Write(wsFormfeed)
+		} else if i > 0 {
+			// Make sure a space is injected before the next element if two successive
+			// elements are on the same line.
+			w.p.Write(wsBlank)
+		}
+		prevPos = elementPos
+
+		w.p.Write(field.Name.NamePos)
+
+		// Write the field.
+		if field.Quoted {
+			w.p.Write(&ast.LiteralExpr{
+				Kind:     token.STRING,
+				ValuePos: field.Name.NamePos,
+				Value:    fmt.Sprintf("%q", field.Name.Name),
+			})
+		} else {
+			w.p.Write(field.Name)
+		}
+
+		w.p.Write(wsVTab, token.ASSIGN, wsBlank)
+		w.walkExpr(field.Value)
+
+		// Always add commas in between successive elements.
+		if i+1 < len(e.Fields) {
+			w.p.Write(token.COMMA)
+		}
+	}
+
+	// If the closing bracket is on a different line than the final element,
+	// we need to add a trailing comma.
+	if len(e.Fields) > 0 && differentLines(prevPos, e.RCurly) {
+		w.p.Write(token.COMMA, wsFormfeed)
+	}
+
+	w.p.Write(wsUnindent, e.RCurly, token.RCURLY)
+}
+
+// differentLines returns true if a and b are on different lines.
+func differentLines(a, b token.Pos) bool {
+	return a.Position().Line != b.Position().Line
+}

--- a/pkg/river/printer/walker.go
+++ b/pkg/river/printer/walker.go
@@ -119,13 +119,13 @@ func (w *walker) walkBlockStmt(s *ast.BlockStmt) {
 
 	w.p.Write(
 		wsBlank,
-		s.LCurly, token.LCURLY, wsIndent,
+		s.LCurlyPos, token.LCURLY, wsIndent,
 		wsNewline,
 	)
 
 	w.walkStmts(s.Body)
 
-	w.p.Write(wsUnindent, s.RCurly, token.RCURLY)
+	w.p.Write(wsUnindent, s.RCurlyPos, token.RCURLY)
 }
 
 func (w *walker) walkExpr(e ast.Expr) {
@@ -148,9 +148,9 @@ func (w *walker) walkExpr(e ast.Expr) {
 
 	case *ast.IndexExpr:
 		w.walkExpr(e.Value)
-		w.p.Write(e.LBrack, token.LBRACK)
+		w.p.Write(e.LBrackPos, token.LBRACK)
 		w.walkExpr(e.Index)
-		w.p.Write(e.RBrack, token.RBRACK)
+		w.p.Write(e.RBrackPos, token.RBRACK)
 
 	case *ast.CallExpr:
 		// TODO(rfratto): allow arguments to be on a new line
@@ -188,9 +188,9 @@ func (w *walker) walkExpr(e ast.Expr) {
 }
 
 func (w *walker) walkArrayExpr(e *ast.ArrayExpr) {
-	w.p.Write(e.LBrack, token.LBRACK, wsIndent)
+	w.p.Write(e.LBrackPos, token.LBRACK, wsIndent)
 
-	prevPos := e.LBrack
+	prevPos := e.LBrackPos
 
 	for i := 0; i < len(e.Elements); i++ {
 		elementPos := ast.StartPos(e.Elements[i])
@@ -217,17 +217,17 @@ func (w *walker) walkArrayExpr(e *ast.ArrayExpr) {
 
 	// If the closing bracket is on a different line than the final element,
 	// we need to add a trailing comma.
-	if len(e.Elements) > 0 && differentLines(prevPos, e.RBrack) {
+	if len(e.Elements) > 0 && differentLines(prevPos, e.RBrackPos) {
 		w.p.Write(token.COMMA, wsFormfeed)
 	}
 
-	w.p.Write(wsUnindent, e.RBrack, token.RBRACK)
+	w.p.Write(wsUnindent, e.RBrackPos, token.RBRACK)
 }
 
 func (w *walker) walkObjectExpr(e *ast.ObjectExpr) {
 	w.p.Write(token.LCURLY, wsIndent)
 
-	prevPos := e.LCurly
+	prevPos := e.LCurlyPos
 
 	for i := 0; i < len(e.Fields); i++ {
 		field := e.Fields[i]
@@ -268,11 +268,11 @@ func (w *walker) walkObjectExpr(e *ast.ObjectExpr) {
 
 	// If the closing bracket is on a different line than the final element,
 	// we need to add a trailing comma.
-	if len(e.Fields) > 0 && differentLines(prevPos, e.RCurly) {
+	if len(e.Fields) > 0 && differentLines(prevPos, e.RCurlyPos) {
 		w.p.Write(token.COMMA, wsFormfeed)
 	}
 
-	w.p.Write(wsUnindent, e.RCurly, token.RCURLY)
+	w.p.Write(wsUnindent, e.RCurlyPos, token.RCURLY)
 }
 
 // differentLines returns true if a and b are on different lines.

--- a/pkg/river/token/file.go
+++ b/pkg/river/token/file.go
@@ -3,6 +3,7 @@ package token
 import (
 	"fmt"
 	"sort"
+	"strconv"
 )
 
 // NoPos is the zero value for Pos. It has no file or line information
@@ -15,6 +16,9 @@ type Pos struct {
 	file *File
 	off  int
 }
+
+// String returns the string form of the Pos (the offset).
+func (p Pos) String() string { return strconv.Itoa(p.off) }
 
 // File returns the file used by the Pos. This will be nil for invalid
 // positions.


### PR DESCRIPTION
#### PR Description
river/printer is a pretty-printer of River AST nodes, which will be used for error message formatting when a specific AST node should be displayed to the user.

Much of the implementation river/printer is inspired by go/printer, and so the way it formats files is very similar. For example, this input:

```
secure = true // Enable secure mode
access_log = "/tmp/access_log.txt" // Enable access log
```

is transformed to be aligned with [elastic tabstops](https://nickgravgaard.com/elastic-tabstops/):

```
secure     = true                  // Enable secure mode
access_log = "/tmp/access_log.txt" // Enable access log
```

The formatting rules applied by river/printer are purposefully not formally specified to allow them to change over time as formatting recommendations are established.

river/printer will only print out files with LF; CRLF output is not supported.

Additionally, since river/printer pretty-prints nodes, it also can serve as the basis for a formatter. While a user-facing tool like `riverfmt` is possible, one isn't introduced in this commit; more tests around river/printer are needed for validating that the printer can never produce a different AST than the one it formatted.

See pkg/river/printer/testdata for before-and-after formatting examples, where *.in denote files prior to formating and *.expect denote what files should look like after formatting.

#### Which issue(s) this PR fixes
Related to #1839.

#### Notes to the Reviewer

Please let me know if the code is hard to follow and needs a comment explaining why something is being done. It took me some time to understand go/printer, and even though I added more comments here that should make things easier to understand for first-time readers, it's possible there are more opportunities for making reasoning clearer.  

#### PR Checklist

- [x] CHANGELOG updated (N/A)
- [x] Documentation added (N/A)
- [x] Tests updated (N/A)
