### PR TITLE
CI: prevent all -rc* tags from opening formula PRs

### DIFF
--- a/.github/workflows/bump-formula-pr.yml
+++ b/.github/workflows/bump-formula-pr.yml
@@ -5,7 +5,7 @@ on:
   push:
     tags:
       - 'v*'
-      - '!v*-rc.*' # Ignore release candidates
+      - '!v*-rc*' # Ignore release candidates
 jobs:
   homebrew-core:
     name: homebrew-core


### PR DESCRIPTION
The previous pattern matched -rc.* tags, but an accidental push to -rc0 can cause unwanted PRs (grafana/homebrew-grafana#34, Homebrew/homebrew-core#105564).
