### PR TITLE
Fix docs for Windows certificate store

### DIFF
--- a/docs/sources/configuration/server-config.md
+++ b/docs/sources/configuration/server-config.md
@@ -87,10 +87,10 @@ issuer_common_names:
   [- <string> ... ]
 
 # Regular expression to match Subject name
-[client_subject_regex: <string>]
+[subject_regex: <string>]
 
 # Client Template ID to match in ASN1 format ex "1.2.3"
-[client_template_id: <string>]
+[template_id: <string>]
 ```
 
 ### windows_server_config


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The documentation has these two fields prefixed by `client_`, while in the actual code they aren't.
https://github.com/grafana/agent/blob/2366945e5ea88bffdef4d1949b0353ce82d03374/pkg/server/tls.go#L42-L43

Leaving the error here for future grepping :)
```
2022-07-12 13:24:45.760650 I | error loading config file agent-local-config.yaml: yaml: unmarshal errors:
  line 11: field client_subject_regex not found in type server.WindowsClientFilter
  line 12: field client_template_id not found in type server.WindowsClientFilter
```

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer
Nothing in particular.

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [x] Documentation added
- [ ] Tests updated (N/A)
