### PR TITLE
river/internal/value: support calling function values

### DIFF
--- a/pkg/river/internal/value/errors.go
+++ b/pkg/river/internal/value/errors.go
@@ -55,6 +55,17 @@ type FieldError struct {
 // Error returns the text of the inner error.
 func (fe FieldError) Error() string { return fe.Inner.Error() }
 
+// ArgError is used to report on an invalid argument to a function.
+type ArgError struct {
+	Function Value
+	Argument Value
+	Index    int
+	Inner    error
+}
+
+// Error returns the text of the inner error.
+func (ae ArgError) Error() string { return ae.Inner.Error() }
+
 // WalkError walks err for all value-related errors in this package.
 // WalkError returns false if err is not an error from this package.
 func WalkError(err error, f func(err error)) bool {
@@ -80,6 +91,10 @@ func WalkError(err error, f func(err error)) bool {
 			nextError = ne.Inner
 			foundOne = true
 		case FieldError:
+			f(nextError)
+			nextError = ne.Inner
+			foundOne = true
+		case ArgError:
 			f(nextError)
 			nextError = ne.Inner
 			foundOne = true

--- a/pkg/river/internal/value/value_test.go
+++ b/pkg/river/internal/value/value_test.go
@@ -54,6 +54,39 @@ func TestFunction(t *testing.T) {
 		})
 	})
 
+	t.Run("partially variadic", func(t *testing.T) {
+		add := func(firstNum int, nums ...int) int {
+			sum := firstNum
+			for _, num := range nums {
+				sum += num
+			}
+			return sum
+		}
+		addVal := value.Encode(add)
+
+		t.Run("no variadic args", func(t *testing.T) {
+			res, err := addVal.Call(value.Int(52))
+			require.NoError(t, err)
+			require.Equal(t, int64(52), res.Int())
+		})
+
+		t.Run("one variadic arg", func(t *testing.T) {
+			res, err := addVal.Call(value.Int(52), value.Int(32))
+			require.NoError(t, err)
+			require.Equal(t, int64(52+32), res.Int())
+		})
+
+		t.Run("many variadic args", func(t *testing.T) {
+			res, err := addVal.Call(
+				value.Int(32),
+				value.Int(59),
+				value.Int(12),
+			)
+			require.NoError(t, err)
+			require.Equal(t, int64(32+59+12), res.Int())
+		})
+	})
+
 	t.Run("returns error", func(t *testing.T) {
 		failWhenTrue := func(val bool) (int, error) {
 			if val {

--- a/pkg/river/internal/value/value_test.go
+++ b/pkg/river/internal/value/value_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFunction(t *testing.T) {
+func TestValue_Call(t *testing.T) {
 	t.Run("simple", func(t *testing.T) {
 		add := func(a, b int) int { return a + b }
 		addVal := value.Encode(add)

--- a/pkg/river/internal/value/value_test.go
+++ b/pkg/river/internal/value/value_test.go
@@ -1,0 +1,77 @@
+package value_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/grafana/agent/pkg/river/internal/value"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFunction(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		add := func(a, b int) int { return a + b }
+		addVal := value.Encode(add)
+
+		res, err := addVal.Call(
+			value.Int(15),
+			value.Int(43),
+		)
+		require.NoError(t, err)
+		require.Equal(t, int64(15+43), res.Int())
+	})
+
+	t.Run("fully variadic", func(t *testing.T) {
+		add := func(nums ...int) int {
+			var sum int
+			for _, num := range nums {
+				sum += num
+			}
+			return sum
+		}
+		addVal := value.Encode(add)
+
+		t.Run("no args", func(t *testing.T) {
+			res, err := addVal.Call()
+			require.NoError(t, err)
+			require.Equal(t, int64(0), res.Int())
+		})
+
+		t.Run("one arg", func(t *testing.T) {
+			res, err := addVal.Call(value.Int(32))
+			require.NoError(t, err)
+			require.Equal(t, int64(32), res.Int())
+		})
+
+		t.Run("many args", func(t *testing.T) {
+			res, err := addVal.Call(
+				value.Int(32),
+				value.Int(59),
+				value.Int(12),
+			)
+			require.NoError(t, err)
+			require.Equal(t, int64(32+59+12), res.Int())
+		})
+	})
+
+	t.Run("returns error", func(t *testing.T) {
+		failWhenTrue := func(val bool) (int, error) {
+			if val {
+				return 0, fmt.Errorf("function failed for a very good reason")
+			}
+			return 0, nil
+		}
+		funcVal := value.Encode(failWhenTrue)
+
+		t.Run("no error", func(t *testing.T) {
+			res, err := funcVal.Call(value.Bool(false))
+			require.NoError(t, err)
+			require.Equal(t, int64(0), res.Int())
+		})
+
+		t.Run("error", func(t *testing.T) {
+			_, err := funcVal.Call(value.Bool(true))
+			require.EqualError(t, err, "function failed for a very good reason")
+		})
+	})
+}


### PR DESCRIPTION
Adds a `Value.Call` method which can invoke function values. 

This supports variadic functions; passing all Values as arguments to the function. See the tests for examples of calling functions in various configurations.

Additionally, if the function call has a `(T, error)` return type, and the error is non-nil, the error will be returned as the error for the Call method.