### PR TITLE
river/parser: Enforce block labels to be valid identifiers

### DIFF
--- a/pkg/river/parser/internal.go
+++ b/pkg/river/parser/internal.go
@@ -618,10 +618,6 @@ var fieldStarter = map[token.Token]struct{}{
 
 func isValidIdentifier(in string) bool {
 	s := scanner.New(nil, []byte(in), nil, 0)
-	_, tok1, _ := s.Scan()
-	_, tok2, _ := s.Scan()
-	if !(tok1 == token.IDENT && tok2 == token.TERMINATOR) {
-		return false
-	}
-	return true
+	_, tok, lit := s.Scan()
+	return tok == token.IDENT && lit == in
 }

--- a/pkg/river/parser/internal.go
+++ b/pkg/river/parser/internal.go
@@ -278,6 +278,9 @@ func (p *parser) parseBlockName() *blockName {
 	if p.tok != token.ASSIGN && p.tok != token.LCURLY {
 		if p.tok == token.STRING && len(p.lit) > 2 {
 			bn.Label = p.lit[1 : len(p.lit)-1] // Strip quotes from label
+			if !isValidIdentifier(bn.Label) {
+				p.addErrorf("expected block label to be a valid identifier")
+			}
 			bn.LabelPos = p.pos
 		} else {
 			p.addErrorf("expected block label, got %s", p.tok)
@@ -611,4 +614,14 @@ func (p *parser) parseField() *ast.ObjectField {
 var fieldStarter = map[token.Token]struct{}{
 	token.STRING: {},
 	token.IDENT:  {},
+}
+
+func isValidIdentifier(in string) bool {
+	s := scanner.New(nil, []byte(in), nil, 0)
+	_, tok1, _ := s.Scan()
+	_, tok2, _ := s.Scan()
+	if !(tok1 == token.IDENT && tok2 == token.TERMINATOR) {
+		return false
+	}
+	return true
 }

--- a/pkg/river/parser/testdata/block_names.rvr
+++ b/pkg/river/parser/testdata/block_names.rvr
@@ -19,3 +19,7 @@ other_valid_block {
 
   }
 }
+
+invalid_block "with space" /* ERROR "expected block label to be a valid identifier" */ {
+
+}


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR updates the river parser with a new helper to validate that block labels are valid identifiers (eg. don't contain spaces).

#### Which issue(s) this PR fixes
Fixes #1893 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated (N/A, until we talk to people about Flow/River)
- [ ] Documentation added (N/A)
- [X] Tests updated
