### PR TITLE
river/token/builder: add builder package to build files

### DIFF
--- a/pkg/river/internal/value/value.go
+++ b/pkg/river/internal/value/value.go
@@ -123,7 +123,7 @@ func (v Value) Describe() string {
 	if v.ty != TypeCapsule {
 		return v.ty.String()
 	}
-	return fmt.Sprintf("capsule(%s)", v.rv.Type())
+	return fmt.Sprintf("capsule(%q)", v.rv.Type())
 }
 
 // Bool returns the boolean value for v. It panics if v is not a bool.
@@ -134,17 +134,25 @@ func (v Value) Bool() bool {
 	return v.rv.Bool()
 }
 
+// Number returns a Number value for v. It panics if v is not a Number.
+func (v Value) Number() Number {
+	if v.ty != TypeNumber {
+		panic("river/value: Number called on non-number type")
+	}
+	return newNumberValue(v.rv)
+}
+
 // Int returns an int value for v. It panics if v is not a number.
 func (v Value) Int() int64 {
 	if v.ty != TypeNumber {
 		panic("river/value: Int called on non-number type")
 	}
 	switch makeNumberKind(v.rv.Kind()) {
-	case numberKindInt:
+	case NumberKindInt:
 		return v.rv.Int()
-	case numberKindUint:
+	case NumberKindUint:
 		return int64(v.rv.Uint())
-	case numberKindFloat:
+	case NumberKindFloat:
 		return int64(v.rv.Float())
 	}
 	panic("river/value: unreachable")
@@ -156,11 +164,11 @@ func (v Value) Uint() uint64 {
 		panic("river/value: Uint called on non-number type")
 	}
 	switch makeNumberKind(v.rv.Kind()) {
-	case numberKindInt:
+	case NumberKindInt:
 		return uint64(v.rv.Int())
-	case numberKindUint:
+	case NumberKindUint:
 		return v.rv.Uint()
-	case numberKindFloat:
+	case NumberKindFloat:
 		return uint64(v.rv.Float())
 	}
 	panic("river/value: unreachable")
@@ -172,14 +180,22 @@ func (v Value) Float() float64 {
 		panic("river/value: Float called on non-number type")
 	}
 	switch makeNumberKind(v.rv.Kind()) {
-	case numberKindInt:
+	case NumberKindInt:
 		return float64(v.rv.Int())
-	case numberKindUint:
+	case NumberKindUint:
 		return float64(v.rv.Uint())
-	case numberKindFloat:
+	case NumberKindFloat:
 		return v.rv.Float()
 	}
 	panic("river/value: unreachable")
+}
+
+// Text returns a string value fo v. It panics if v is not a string.
+func (v Value) Text() string {
+	if v.ty != TypeString {
+		panic("river/value: Text called on non-string type")
+	}
+	return v.rv.String()
 }
 
 // Len returns the length of v. Panics if v is not an array or object.

--- a/pkg/river/printer/testdata/mixed_list.expect
+++ b/pkg/river/printer/testdata/mixed_list.expect
@@ -1,0 +1,16 @@
+mixed_list = [0, true, {
+	key_1 = true,
+	key_2 = true,
+	key_3 = true,
+}, "Hello!"]
+
+mixed_list_2 = [
+	0,
+	true,
+	{
+		key_1 = true,
+		key_2 = true,
+		key_3 = true,
+	},
+	"Hello!",
+]

--- a/pkg/river/printer/testdata/mixed_list.in
+++ b/pkg/river/printer/testdata/mixed_list.in
@@ -1,0 +1,16 @@
+mixed_list = [0, true, {
+	key_1 = true,
+	key_2 = true,
+	key_3 = true,
+}, "Hello!"]
+
+mixed_list_2 = [
+	0,
+	true,
+	{
+		key_1 = true,
+		key_2 = true,
+		key_3 = true,
+	},
+	"Hello!",
+]

--- a/pkg/river/printer/testdata/mixed_object.expect
+++ b/pkg/river/printer/testdata/mixed_object.expect
@@ -1,0 +1,8 @@
+mixed_object = {
+	key_1 = true,
+	key_2 = [0, true, {
+		inner_1 = true,
+		inner_2 = true,
+	}],
+}
+

--- a/pkg/river/printer/testdata/mixed_object.in
+++ b/pkg/river/printer/testdata/mixed_object.in
@@ -1,0 +1,7 @@
+mixed_object = {
+	key_1 = true,
+	key_2 = [0, true, {
+		inner_1 = true,
+		inner_2 = true,
+	}],
+}

--- a/pkg/river/token/builder/builder.go
+++ b/pkg/river/token/builder/builder.go
@@ -1,0 +1,186 @@
+// Package builder exposes an API to create a River configuration file by
+// constructing a set of tokens.
+package builder
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/grafana/agent/pkg/river/token"
+)
+
+// A File reprents a River configuration file.
+type File struct {
+	body *Body
+}
+
+// NewFile creates a new File.
+func NewFile() *File { return &File{body: newBody()} }
+
+// Tokens returns the File as a set of Tokens.
+func (f *File) Tokens() []Token { return f.Body().Tokens() }
+
+// Body returns the Body contents of the file.
+func (f *File) Body() *Body { return f.body }
+
+// WriteTo renders and formats the File, writing the contents to w.
+func (f *File) WriteTo(w io.Writer) (int64, error) {
+	n, err := printTokens(w, f.Tokens())
+	return int64(n), err
+}
+
+// Bytes renders the File to a formatted byte slice.
+func (f *File) Bytes() []byte {
+	var buf bytes.Buffer
+	_, _ = f.WriteTo(&buf)
+	return buf.Bytes()
+}
+
+// Body is a list of block and attribute statements. A Body cannot be manually
+// created, but is retrieved from a File or Block.
+type Body struct {
+	nodes []tokenNode
+}
+
+// A tokenNode is a structural element which can be converted into a set of
+// Tokens.
+type tokenNode interface {
+	// Tokens builds the set of Tokens from the node.
+	Tokens() []Token
+}
+
+func newBody() *Body {
+	return &Body{}
+}
+
+// Tokens returns the File as a set of Tokens.
+func (b *Body) Tokens() []Token {
+	var rawToks []Token
+	for i, node := range b.nodes {
+		rawToks = append(rawToks, node.Tokens()...)
+
+		if i+1 < len(b.nodes) {
+			// Append a terminator between each statement in the Body.
+			rawToks = append(rawToks, Token{
+				Type: token.ILLEGAL,
+				Lit:  "\n",
+			})
+		}
+	}
+	return rawToks
+}
+
+// AppendTokens appens raw tokens to the Body.
+func (b *Body) AppendTokens(tokens []Token) {
+	b.nodes = append(b.nodes, tokensSlice(tokens))
+}
+
+// AppendBlock adds a new block inside of the Body.
+func (b *Body) AppendBlock(block *Block) {
+	b.nodes = append(b.nodes, block)
+}
+
+// SetAttributeTokens sets an attribute to the Body whose value is a set of raw
+// tokens. If the attribute was previously set, its value tokens are updated.
+//
+// Attributes will be written out in the order they were initially created.
+func (b *Body) SetAttributeTokens(name string, tokens []Token) {
+	attr := b.getOrCreateAttribute(name)
+	attr.RawTokens = tokens
+}
+
+func (b *Body) getOrCreateAttribute(name string) *attribute {
+	for _, n := range b.nodes {
+		if attr, ok := n.(*attribute); ok && attr.Name == name {
+			return attr
+		}
+	}
+
+	newAttr := &attribute{Name: name}
+	b.nodes = append(b.nodes, newAttr)
+	return newAttr
+}
+
+// SetAttributeValue sets an attribute in the Body whose value is converted
+// from a Go value to a River value. The Go value is encoded using the normal
+// Go to River encoding rules.
+//
+// If the attribute was previously set, its value tokens are updated.
+//
+// Attributes will be written out in the order they were initially crated.
+func (b *Body) SetAttributeValue(name string, goValue interface{}) {
+	attr := b.getOrCreateAttribute(name)
+	attr.RawTokens = tokenEncode(goValue)
+}
+
+type attribute struct {
+	Name      string
+	RawTokens []Token
+}
+
+func (attr *attribute) Tokens() []Token {
+	var toks []Token
+
+	toks = append(toks, Token{Type: token.IDENT, Lit: attr.Name})
+	toks = append(toks, Token{Type: token.ASSIGN})
+	toks = append(toks, attr.RawTokens...)
+
+	return toks
+}
+
+// A Block encapsulates a body within a named and labeled River block. Blocks
+// must be created by calling NewBlock, but its public struct fields may be
+// safely modified by callers.
+type Block struct {
+	// Public fields, safe to be changed by callers:
+
+	Name  []string
+	Label string
+
+	// Private fields:
+
+	body *Body
+}
+
+// NewBlock returns a new Block with the given name and label. The name/label
+// can be updated later by modifying the Block's public fields.
+func NewBlock(name []string, label string) *Block {
+	return &Block{
+		Name:  name,
+		Label: label,
+
+		body: newBody(),
+	}
+}
+
+// Tokens returns the File as a set of Tokens.
+func (b *Block) Tokens() []Token {
+	var toks []Token
+
+	for i, frag := range b.Name {
+		toks = append(toks, Token{Type: token.IDENT, Lit: frag})
+		if i+1 < len(b.Name) {
+			toks = append(toks, Token{Type: token.DOT})
+		}
+	}
+
+	toks = append(toks, Token{Type: token.ILLEGAL, Lit: " "})
+
+	if b.Label != "" {
+		toks = append(toks, Token{Type: token.STRING, Lit: fmt.Sprintf("%q", b.Label)})
+	}
+
+	toks = append(toks, Token{Type: token.LCURLY}, Token{Type: token.ILLEGAL, Lit: "\n"})
+	toks = append(toks, b.body.Tokens()...)
+	toks = append(toks, Token{Type: token.ILLEGAL, Lit: "\n"}, Token{Type: token.RCURLY})
+
+	return toks
+}
+
+// Body returns the Body contained within the Block.
+func (b *Block) Body() *Body { return b.body }
+
+type tokensSlice []Token
+
+func (tn tokensSlice) Tokens() []Token { return []Token(tn) }

--- a/pkg/river/token/builder/builder_test.go
+++ b/pkg/river/token/builder/builder_test.go
@@ -1,0 +1,110 @@
+package builder_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/grafana/agent/pkg/river/parser"
+	"github.com/grafana/agent/pkg/river/printer"
+	"github.com/grafana/agent/pkg/river/token"
+	"github.com/grafana/agent/pkg/river/token/builder"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuilder_File(t *testing.T) {
+	f := builder.NewFile()
+
+	f.Body().SetAttributeTokens("attr_1", []builder.Token{{Type: token.NUMBER, Lit: "15"}})
+	f.Body().SetAttributeTokens("attr_2", []builder.Token{{Type: token.BOOL, Lit: "true"}})
+
+	b1 := builder.NewBlock([]string{"test", "block"}, "")
+	b1.Body().SetAttributeTokens("inner_attr", []builder.Token{{Type: token.STRING, Lit: `"block 1"`}})
+	f.Body().AppendBlock(b1)
+
+	b2 := builder.NewBlock([]string{"test", "block"}, "labeled")
+	b2.Body().SetAttributeTokens("inner_attr", []builder.Token{{Type: token.STRING, Lit: `"block 2"`}})
+	f.Body().AppendBlock(b2)
+
+	expect := format(t, `
+		attr_1 = 15
+		attr_2 = true
+
+		test.block {
+			inner_attr = "block 1"
+		}
+
+		test.block "labeled" {
+			inner_attr = "block 2"
+		}
+	`)
+
+	require.Equal(t, expect, string(f.Bytes()))
+}
+
+func TestBuilder_GoEncode(t *testing.T) {
+	f := builder.NewFile()
+
+	f.Body().SetAttributeValue("null_value", nil)
+	f.Body().AppendTokens([]builder.Token{{token.ILLEGAL, "\n"}})
+
+	f.Body().SetAttributeValue("num", 15)
+	f.Body().SetAttributeValue("string", "Hello, world!")
+	f.Body().SetAttributeValue("bool", true)
+	f.Body().SetAttributeValue("list", []int{0, 1, 2})
+	f.Body().SetAttributeValue("func", func(int, int) int { return 0 })
+	f.Body().SetAttributeValue("capsule", make(chan int))
+	f.Body().AppendTokens([]builder.Token{{token.ILLEGAL, "\n"}})
+
+	f.Body().SetAttributeValue("map", map[string]interface{}{"foo": "bar"})
+	f.Body().SetAttributeValue("map_2", map[string]interface{}{"non ident": "bar"})
+	f.Body().AppendTokens([]builder.Token{{token.ILLEGAL, "\n"}})
+
+	f.Body().SetAttributeValue("mixed_list", []interface{}{
+		0,
+		true,
+		map[string]interface{}{
+			"key_1": true,
+			"key_2": true,
+			"key_3": true,
+		},
+		"Hello!",
+	})
+
+	expect := format(t, `
+		null_value = null
+	
+		num     = 15 
+		string  = "Hello, world!"
+		bool    = true
+		list    = [0, 1, 2]
+		func    = function
+		capsule = capsule("chan int")
+
+		map = {
+			foo = "bar",
+		}
+		map_2 = {
+			"non ident" = "bar",
+		}
+
+		mixed_list = [0, true, {
+			key_1 = true,
+			key_2 = true,
+			key_3 = true,
+		}, "Hello!"]
+	`)
+
+	require.Equal(t, expect, string(f.Bytes()))
+}
+
+func format(t *testing.T, in string) string {
+	t.Helper()
+
+	f, err := parser.ParseFile(t.Name(), []byte(in))
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, printer.Fprint(&buf, f))
+
+	return buf.String()
+}

--- a/pkg/river/token/builder/token.go
+++ b/pkg/river/token/builder/token.go
@@ -1,0 +1,54 @@
+package builder
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/grafana/agent/pkg/river/parser"
+	"github.com/grafana/agent/pkg/river/printer"
+	"github.com/grafana/agent/pkg/river/token"
+)
+
+// A Token is a wrapper around token.Token which contains the token type
+// alongside its literal. Use token.ILLEGAL to write literal characters such as
+// whitespace.
+type Token struct {
+	Type token.Token
+	Lit  string
+}
+
+// printTokens prints out the tokens as River text and formats them, writing
+// the final result to w.
+func printTokens(w io.Writer, toks []Token) (int, error) {
+	var raw bytes.Buffer
+	for _, tok := range toks {
+		switch {
+		case tok.Type == token.ILLEGAL:
+			raw.WriteString(tok.Lit)
+		case tok.Type.IsLiteral() || tok.Type.IsKeyword():
+			raw.WriteString(tok.Lit)
+		default:
+			raw.WriteString(tok.Type.String())
+		}
+	}
+
+	f, err := parser.ParseFile("", raw.Bytes())
+	if err != nil {
+		return 0, err
+	}
+
+	wc := &writerCount{w: w}
+	err = printer.Fprint(wc, f)
+	return wc.n, err
+}
+
+type writerCount struct {
+	w io.Writer
+	n int
+}
+
+func (wc *writerCount) Write(p []byte) (n int, err error) {
+	n, err = wc.w.Write(p)
+	wc.n += n
+	return
+}

--- a/pkg/river/token/builder/value_tokens.go
+++ b/pkg/river/token/builder/value_tokens.go
@@ -1,0 +1,79 @@
+package builder
+
+import (
+	"fmt"
+
+	"github.com/grafana/agent/pkg/river/internal/value"
+	"github.com/grafana/agent/pkg/river/scanner"
+	"github.com/grafana/agent/pkg/river/token"
+)
+
+func tokenEncode(val interface{}) []Token {
+	return valueTokens(value.Encode(val))
+}
+
+func valueTokens(v value.Value) []Token {
+	var toks []Token
+
+	switch v.Type() {
+	case value.TypeNull:
+		toks = append(toks, Token{token.NULL, "null"})
+
+	case value.TypeNumber:
+		toks = append(toks, Token{token.NUMBER, v.Number().ToString()})
+
+	case value.TypeString:
+		toks = append(toks, Token{token.STRING, fmt.Sprintf("%q", v.Text())})
+
+	case value.TypeBool:
+		toks = append(toks, Token{token.STRING, fmt.Sprintf("%v", v.Bool())})
+
+	case value.TypeArray:
+		toks = append(toks, Token{token.LBRACK, ""})
+		elems := v.Len()
+		for i := 0; i < elems; i++ {
+			elem := v.Index(i)
+
+			toks = append(toks, valueTokens(elem)...)
+			if i+1 < elems {
+				toks = append(toks, Token{token.COMMA, ""})
+			}
+		}
+		toks = append(toks, Token{token.RBRACK, ""})
+
+	case value.TypeObject:
+		toks = append(toks, Token{token.LCURLY, ""}, Token{token.ILLEGAL, "\n"})
+
+		keys := v.Keys()
+		for i := 0; i < len(keys); i++ {
+			if isValidIdentifier(keys[i]) {
+				toks = append(toks, Token{token.IDENT, keys[i]})
+			} else {
+				toks = append(toks, Token{token.STRING, fmt.Sprintf("%q", keys[i])})
+			}
+
+			field, _ := v.Key(keys[i])
+			toks = append(toks, Token{token.ASSIGN, ""})
+			toks = append(toks, valueTokens(field)...)
+			toks = append(toks, Token{token.COMMA, ""}, Token{token.ILLEGAL, "\n"})
+		}
+		toks = append(toks, Token{token.RCURLY, ""})
+
+	case value.TypeFunction:
+		toks = append(toks, Token{token.ILLEGAL, v.Describe()})
+
+	case value.TypeCapsule:
+		toks = append(toks, Token{token.ILLEGAL, v.Describe()})
+
+	default:
+		panic(fmt.Sprintf("river/token/builder: unrecognized value type %q", v.Type()))
+	}
+
+	return toks
+}
+
+func isValidIdentifier(in string) bool {
+	s := scanner.New(nil, []byte(in), nil, 0)
+	_, tok, lit := s.Scan()
+	return tok == token.IDENT && lit == in
+}


### PR DESCRIPTION
#### PR Description
The river/token/builder package exposes an API to construct a River file, inspired by github.com/hashicorp/v2/hclwrite. It builds a list of tokens and then formats them back to the user.

It can also encode Go values directly into tokens.

#### Which issue(s) this PR fixes
Related to #1839. 

#### Notes to the Reviewer
This also fixes some new small formatting bugs found when printing out lists that contain objects.

#### PR Checklist

- [x] CHANGELOG updated (N/A)
- [x] Documentation added (N/A)
- [x] Tests updated
