### PR TITLE
actions/stale: set close-issue-reason to not_planned

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
+          close-issue-reason: not_planned
           days-before-stale: 30
           days-before-close: 7
           stale-issue-message: >


### PR DESCRIPTION
actions/stale just released v5.1.0 which includes the ability to set a close reason for stale issues. Setting it to [`not_planned`][not_planned] will mark issues as [not-planned][] and can be filtered for when searching through issues.

I don't think we need to update the `uses:` field of the action, and it'll use the latest v5.Y.Z release.

Note that even though GitHub's blog announcement post says `not-planned` with a hyphen, the action expects to see `not_planned` with an underscore.

[not_planned]: https://github.com/actions/stale#close-issue-reason
[not-planned]: https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/
