### PR TITLE
actions/stale: use v5.1.0 explicitly

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v5.1.0
         with:
           close-issue-reason: not_planned
           days-before-stale: 30


### PR DESCRIPTION
actions/stale@v5 didn't seem to pick up on close-issue-reason:
https://github.com/grafana/agent/runs/7363742537?check_suite_focus=true
