### PR TITLE
Remove Brenda as CODEOWNER for docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,2 @@
 /pkg/traces/ @joe-elliott @mapno
 /pkg/integrations/ @rgeyer @gaantunes
-/docs/sources/ @brendamuir


### PR DESCRIPTION
Brenda isn't going to have time to maintain the docs anymore, and after a chat was willing to be taken off so she doesn't keep getting spammed over PRs which update the docs :)