### PR TITLE
operator/config: fix label used when targetPort is set in ServiceMonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Main (unreleased)
 
 ### Bugfixes
 
+- Operator: Fix issue where configured `targetPort` ServiceMonitors resulted in
+  generating an incorrect scrape_config. (@rfratto)
+
 
 v0.26.0 (2022-07-18)
 -------------------------

--- a/pkg/operator/config/templates/component/metrics/service_monitor.libsonnet
+++ b/pkg/operator/config/templates/component/metrics/service_monitor.libsonnet
@@ -131,7 +131,7 @@ function(
         action: 'keep',
       } else if endpoint.TargetPort != null then (
         if endpoint.TargetPort.StrVal != '' then {
-          source_labels: ['__meta_kubernetes_pod_container_name'],
+          source_labels: ['__meta_kubernetes_pod_container_port_name'],
           regex: endpoint.TargetPort.StrVal,
           action: 'keep',
         } else if endpoint.TargetPort.IntVal != 0 then {


### PR DESCRIPTION
The label name used here was wrong; it should match what Prometheus operator uses: https://github.com/prometheus-operator/prometheus-operator/blob/e0f7fea10258dcf5db63aee64a892420ac90009a/pkg/prometheus/promcfg.go#L840-L856