### PR TITLE
river/internal/value: fix block representation in objects and lists

### DIFF
--- a/pkg/river/internal/rivertags/rivertags.go
+++ b/pkg/river/internal/rivertags/rivertags.go
@@ -45,9 +45,9 @@ func (f Flags) GoString() string { return f.String() }
 
 // Field is a tagged field within a struct.
 type Field struct {
-	Name  string // Name of tagged field
-	Index []int  // Index into field (reflect.Value.FieldByIndex)
-	Flags Flags  // Flags assigned to field
+	Name  []string // Name of tagged field
+	Index []int    // Index into field (reflect.Value.FieldByIndex)
+	Flags Flags    // Flags assigned to field
 }
 
 // Get returns the list of tagged fields for some struct type ty. Get panics if
@@ -121,15 +121,17 @@ func Get(ty reflect.Type) []Field {
 			panic(fmt.Sprintf("river: field %s tag is missing options", printPathToField(ty, field.Index)))
 		}
 
+		fullName := options[0]
+
 		tf := Field{
-			Name:  options[0],
+			Name:  strings.Split(fullName, "."),
 			Index: field.Index,
 		}
 
-		if first, used := usedNames[tf.Name]; used && tf.Name != "" {
-			panic(fmt.Sprintf("river: field name %s already used by %s", tf.Name, printPathToField(ty, first)))
+		if first, used := usedNames[fullName]; used && fullName != "" {
+			panic(fmt.Sprintf("river: field name %s already used by %s", fullName, printPathToField(ty, first)))
 		}
-		usedNames[tf.Name] = tf.Index
+		usedNames[fullName] = tf.Index
 
 		switch options[1] {
 		case "attr":
@@ -148,8 +150,12 @@ func Get(ty reflect.Type) []Field {
 
 		// Validate field
 
+		if len(tf.Name) > 1 && tf.Flags&FlagBlock == 0 {
+			panic(fmt.Sprintf("river: field names with `.` may only be used by blocks (found at %s)", printPathToField(ty, tf.Index)))
+		}
+
 		if tf.Flags&FlagLabel != 0 {
-			if tf.Name != "" {
+			if fullName != "" {
 				panic(fmt.Sprintf("river: label field at %s must not have a name", printPathToField(ty, tf.Index)))
 			}
 			if field.Type.Kind() != reflect.String {
@@ -162,7 +168,7 @@ func Get(ty reflect.Type) []Field {
 			usedLabelField = tf.Index
 		}
 
-		if tf.Name == "" && tf.Flags&FlagLabel == 0 /* (e.g., *not* a label) */ {
+		if fullName == "" && tf.Flags&FlagLabel == 0 /* (e.g., *not* a label) */ {
 			panic(fmt.Sprintf("river: non-empty field name required at %s", printPathToField(ty, tf.Index)))
 		}
 

--- a/pkg/river/internal/rivertags/rivertags_test.go
+++ b/pkg/river/internal/rivertags/rivertags_test.go
@@ -22,11 +22,11 @@ func Test_Get(t *testing.T) {
 	fs := rivertags.Get(reflect.TypeOf(Struct{}))
 
 	expect := []rivertags.Field{
-		{"req_attr", []int{1}, rivertags.FlagAttr},
-		{"opt_attr", []int{2}, rivertags.FlagAttr | rivertags.FlagOptional},
-		{"req_block", []int{3}, rivertags.FlagBlock},
-		{"opt_block", []int{4}, rivertags.FlagBlock | rivertags.FlagOptional},
-		{"", []int{5}, rivertags.FlagLabel},
+		{[]string{"req_attr"}, []int{1}, rivertags.FlagAttr},
+		{[]string{"opt_attr"}, []int{2}, rivertags.FlagAttr | rivertags.FlagOptional},
+		{[]string{"req_block"}, []int{3}, rivertags.FlagBlock},
+		{[]string{"opt_block"}, []int{4}, rivertags.FlagBlock | rivertags.FlagOptional},
+		{[]string{""}, []int{5}, rivertags.FlagLabel},
 	}
 
 	require.Equal(t, expect, fs)
@@ -47,10 +47,10 @@ func Test_Get_Embedded(t *testing.T) {
 	fs := rivertags.Get(reflect.TypeOf(Struct{}))
 
 	expect := []rivertags.Field{
-		{"parent_field_1", []int{0}, rivertags.FlagAttr},
-		{"inner_field_1", []int{1, 0}, rivertags.FlagAttr},
-		{"inner_field_2", []int{1, 1}, rivertags.FlagAttr},
-		{"parent_field_2", []int{2}, rivertags.FlagAttr},
+		{[]string{"parent_field_1"}, []int{0}, rivertags.FlagAttr},
+		{[]string{"inner_field_1"}, []int{1, 0}, rivertags.FlagAttr},
+		{[]string{"inner_field_2"}, []int{1, 1}, rivertags.FlagAttr},
+		{[]string{"parent_field_2"}, []int{2}, rivertags.FlagAttr},
 	}
 
 	require.Equal(t, expect, fs)

--- a/pkg/river/internal/value/decode.go
+++ b/pkg/river/internal/value/decode.go
@@ -146,6 +146,22 @@ func decode(val Value, into reflect.Value) error {
 	}
 }
 
+// decodeAny is invoked by decode when into is an interface{}. We assign the
+// interface{} a known type based on the River value being decoded:
+//
+//   Null values:   nil
+//   Number values: float64, int, or uint depending on the underlying Go type
+//                  of the River value
+//   Arrays:        []interface{}
+//   Objects:       map[string]interface{}
+//   Bool:          bool
+//   String:        string
+//   Function:      Passthrough of the underlying function value
+//   Capsule:       Passthrough of the underlying capsule value
+//
+// In the cases where we do not passthrough the underlying value, we create a
+// value of that type, recrusively call decode to populate that new value, and
+// then store that value into the interface{}.
 func decodeAny(val Value, into reflect.Value) error {
 	var ptr reflect.Value
 

--- a/pkg/river/internal/value/tag_cache.go
+++ b/pkg/river/internal/value/tag_cache.go
@@ -9,9 +9,9 @@ import (
 // tagsCache caches the river tags for a struct type. This is never cleared,
 // but since most structs will be statically created throughout the lifetime
 // of the process, this will consume a negligible amount of memory.
-var tagsCache = make(map[reflect.Type]objectFields)
+var tagsCache = make(map[reflect.Type]*objectFields)
 
-func getCachedTags(t reflect.Type) objectFields {
+func getCachedTags(t reflect.Type) *objectFields {
 	if t.Kind() != reflect.Struct {
 		panic("getCachedTags called with non-struct type")
 	}
@@ -22,34 +22,100 @@ func getCachedTags(t reflect.Type) objectFields {
 
 	ff := rivertags.Get(t)
 
-	ofs := objectFields{
-		lookup: make(map[string]rivertags.Field, len(ff)),
-		keys:   make([]string, len(ff)),
-	}
-	for i, f := range ff {
-		ofs.keys[i] = f.Name
-		ofs.lookup[f.Name] = f
+	// Build a tree of keys.
+	tree := &objectFields{
+		fields:       make(map[string]rivertags.Field),
+		nestedFields: make(map[string]*objectFields),
+		keys:         []string{},
 	}
 
-	tagsCache[t] = ofs
-	return ofs
+	for _, f := range ff {
+		if f.Flags&rivertags.FlagLabel != 0 {
+			// Skip over label tags.
+			tree.labelField = f
+			continue
+		}
+
+		node := tree
+		for i, name := range f.Name {
+			// Add to the list of keys if this is a new key.
+			if node.Has(name) == objectKeyTypeInvalid {
+				node.keys = append(node.keys, name)
+			}
+
+			if i+1 == len(f.Name) {
+				// Last fragment, add as a field.
+				node.fields[name] = f
+				continue
+			}
+
+			inner, ok := node.nestedFields[name]
+			if !ok {
+				inner = &objectFields{
+					fields:       make(map[string]rivertags.Field),
+					nestedFields: make(map[string]*objectFields),
+					keys:         []string{},
+				}
+				node.nestedFields[name] = inner
+			}
+			node = inner
+		}
+	}
+
+	tagsCache[t] = tree
+	return tree
 }
 
+// objectFields is a parsed tree of fields in rivertags. It forms a tree where
+// leaves are nested fields (e.g., for block names that have multiple name
+// fragments) and nodes are the fields themselves.
 type objectFields struct {
-	lookup map[string]rivertags.Field
-	keys   []string
+	fields       map[string]rivertags.Field
+	nestedFields map[string]*objectFields
+	keys         []string // Combination of fields + nestedFields
+	labelField   rivertags.Field
 }
 
-func (ff objectFields) Get(name string) (rivertags.Field, bool) {
-	f, ok := ff.lookup[name]
+type objectKeyType int
+
+const (
+	objectKeyTypeInvalid objectKeyType = iota
+	objectKeyTypeField
+	objectKeyTypeNestedField
+)
+
+// Has returns whether name exists as a field or a nested key inside keys.
+// Returns objectKeyTypeInvalid if name does not exist as either.
+func (of *objectFields) Has(name string) objectKeyType {
+	if _, ok := of.fields[name]; ok {
+		return objectKeyTypeField
+	}
+	if _, ok := of.nestedFields[name]; ok {
+		return objectKeyTypeNestedField
+	}
+	return objectKeyTypeInvalid
+}
+
+// Len returns the number of named keys.
+func (of *objectFields) Len() int { return len(of.keys) }
+
+// Keys returns all named keys (fields and nested fields).
+func (of *objectFields) Keys() []string { return of.keys }
+
+// Field gets a non-nested field. Returns false if name is a nested field.
+func (of *objectFields) Field(name string) (rivertags.Field, bool) {
+	f, ok := of.fields[name]
 	return f, ok
 }
 
-func (ff objectFields) Len() int { return len(ff.lookup) }
-
-// Index gets the field by index i. Panics if i < 0 or i >= ff.Len().
-func (ff objectFields) Index(i int) rivertags.Field {
-	return ff.lookup[ff.keys[i]]
+// NestedField gets a named nested field entry. Returns false if name is not a
+// nested field.
+func (of *objectFields) NestedField(name string) (*objectFields, bool) {
+	nk, ok := of.nestedFields[name]
+	return nk, ok
 }
 
-func (ff objectFields) Keys() []string { return ff.keys }
+// LabelField returns the field used for the label (if any).
+func (of *objectFields) LabelField() (rivertags.Field, bool) {
+	return of.labelField, of.labelField.Index != nil
+}

--- a/pkg/river/internal/value/type.go
+++ b/pkg/river/internal/value/type.go
@@ -83,6 +83,13 @@ func RiverType(t reflect.Type) Type {
 		return TypeBool
 
 	case reflect.Array, reflect.Slice:
+		if inner := t.Elem(); inner.Kind() == reflect.Struct {
+			if _, labeled := getCachedTags(inner).LabelField(); labeled {
+				// An slice/array of labeled blocks is an object, where each label is a
+				// top-level key.
+				return TypeObject
+			}
+		}
 		return TypeArray
 
 	case reflect.Map:

--- a/pkg/river/internal/value/type_test.go
+++ b/pkg/river/internal/value/type_test.go
@@ -34,6 +34,11 @@ var typeTests = []struct {
 
 	{struct{}{}, value.TypeObject},
 
+	// A slice of labeled blocks should be an object.
+	{[]struct {
+		Label string `river:",label"`
+	}{}, value.TypeObject},
+
 	{map[string]interface{}{}, value.TypeObject},
 
 	// Go functions must have one non-error return type and one optional error

--- a/pkg/river/internal/value/value_object.go
+++ b/pkg/river/internal/value/value_object.go
@@ -13,7 +13,7 @@ type structWrapper struct {
 	label     string // Non-empty string if this struct is wrapped in a label.
 }
 
-func wrapStruct(val reflect.Value) structWrapper {
+func wrapStruct(val reflect.Value, keepLabel bool) structWrapper {
 	if val.Kind() != reflect.Struct {
 		panic("river/value: wrapStruct called on non-struct value")
 	}
@@ -21,7 +21,7 @@ func wrapStruct(val reflect.Value) structWrapper {
 	fields := getCachedTags(val.Type())
 
 	var label string
-	if f, ok := fields.LabelField(); ok {
+	if f, ok := fields.LabelField(); ok && keepLabel {
 		label = val.FieldByIndex(f.Index).String()
 	}
 
@@ -29,6 +29,14 @@ func wrapStruct(val reflect.Value) structWrapper {
 		structVal: val,
 		fields:    fields,
 		label:     label,
+	}
+}
+
+// Value turns sw into a value.
+func (sw structWrapper) Value() Value {
+	return Value{
+		rv: reflect.ValueOf(sw),
+		ty: TypeObject,
 	}
 }
 

--- a/pkg/river/internal/value/value_object.go
+++ b/pkg/river/internal/value/value_object.go
@@ -2,11 +2,29 @@ package value
 
 import "reflect"
 
-// Most Go values can be represented and decoded directly. Objects are
-// different, since each field may indicate a deeply nested value.
+// structWrapper allows for partially traversing structs which contain fields
+// representing blocks. This is required due to how block names and labels
+// change the object representation.
 //
-// TODO(rfratto): document more
-
+// If a block name is a.b.c, then it is represented as three nested objects:
+//
+//	{
+// 	  a = {
+//	    b = {
+//	      c = { /* block contents */ },
+//	    },
+//	  }
+//	}
+//
+// Similarly, if a block name is labeled (a.b.c "label"), then the label is the
+// top-level key after c.
+//
+// structWrapper exposes Len, Keys, and Key methods similar to Value to allow
+// traversing through the synthetic object. The values it returns are
+// structWrappers.
+//
+// Code in value.go MUST check to see if a struct is a structWrapper *before*
+// checking the value kind to ensure the appropriate methods are invoked.
 type structWrapper struct {
 	structVal reflect.Value
 	fields    *objectFields

--- a/pkg/river/internal/value/value_object.go
+++ b/pkg/river/internal/value/value_object.go
@@ -1,0 +1,89 @@
+package value
+
+import "reflect"
+
+// Most Go values can be represented and decoded directly. Objects are
+// different, since each field may indicate a deeply nested value.
+//
+// TODO(rfratto): document more
+
+type structWrapper struct {
+	structVal reflect.Value
+	fields    *objectFields
+	label     string // Non-empty string if this struct is wrapped in a label.
+}
+
+func wrapStruct(val reflect.Value) structWrapper {
+	if val.Kind() != reflect.Struct {
+		panic("river/value: wrapStruct called on non-struct value")
+	}
+
+	fields := getCachedTags(val.Type())
+
+	var label string
+	if f, ok := fields.LabelField(); ok {
+		label = val.FieldByIndex(f.Index).String()
+	}
+
+	return structWrapper{
+		structVal: val,
+		fields:    fields,
+		label:     label,
+	}
+}
+
+func (sw structWrapper) Len() int {
+	if len(sw.label) > 0 {
+		return 1
+	}
+	return sw.fields.Len()
+}
+
+func (sw structWrapper) Keys() []string {
+	if len(sw.label) > 0 {
+		return []string{sw.label}
+	}
+	return sw.fields.Keys()
+}
+
+func (sw structWrapper) Key(key string) (index Value, ok bool) {
+	if len(sw.label) > 0 {
+		if key != sw.label {
+			return
+		}
+		next := reflect.ValueOf(structWrapper{
+			structVal: sw.structVal,
+			fields:    sw.fields,
+			// Unset the label now that we've traversed it
+		})
+		return Value{rv: next, ty: TypeObject}, true
+	}
+
+	keyType := sw.fields.Has(key)
+
+	switch keyType {
+	case objectKeyTypeInvalid:
+		return // No such key
+
+	case objectKeyTypeNestedField:
+		// Continue traversing.
+		nextNode, _ := sw.fields.NestedField(key)
+		return Value{
+			rv: reflect.ValueOf(structWrapper{
+				structVal: sw.structVal,
+				fields:    nextNode,
+			}),
+			ty: TypeObject,
+		}, true
+
+	case objectKeyTypeField:
+		f, _ := sw.fields.Field(key)
+		val, err := sw.structVal.FieldByIndexErr(f.Index)
+		if err != nil {
+			return Null, true
+		}
+		return makeValue(val), true
+	}
+
+	panic("river/value: unreachable")
+}

--- a/pkg/river/internal/value/value_object_test.go
+++ b/pkg/river/internal/value/value_object_test.go
@@ -1,0 +1,113 @@
+package value_test
+
+import (
+	"testing"
+
+	"github.com/grafana/agent/pkg/river/internal/value"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValue_Keys_Block ensures that the struct tags for blocks are represented
+// correctly.
+func TestBlockRepresentation(t *testing.T) {
+	type UnlabledBlock struct {
+		Value int `river:"value,attr"`
+	}
+	type LabeledBlock struct {
+		Value int    `river:"value,attr"`
+		Label string `river:",label"`
+	}
+	type OuterBlock struct {
+		Attr1 string `river:"attr_1,attr"`
+		Attr2 string `river:"attr_2,attr"`
+
+		UnlabledBlock1 UnlabledBlock `river:"unlabeled.a,block"`
+		UnlabledBlock2 UnlabledBlock `river:"unlabeled.b,block"`
+		UnlabledBlock3 UnlabledBlock `river:"other_unlabeled,block"`
+
+		LabeledBlock1 LabeledBlock `river:"labeled.a,block"`
+		LabeledBlock2 LabeledBlock `river:"labeled.b,block"`
+		LabeledBlock3 LabeledBlock `river:"other_labeled,block"`
+	}
+
+	val := OuterBlock{
+		Attr1: "value_1",
+		Attr2: "value_2",
+		UnlabledBlock1: UnlabledBlock{
+			Value: 1,
+		},
+		UnlabledBlock2: UnlabledBlock{
+			Value: 2,
+		},
+		UnlabledBlock3: UnlabledBlock{
+			Value: 3,
+		},
+		LabeledBlock1: LabeledBlock{
+			Value: 4,
+			Label: "label_a",
+		},
+		LabeledBlock2: LabeledBlock{
+			Value: 5,
+			Label: "label_b",
+		},
+		LabeledBlock3: LabeledBlock{
+			Value: 6,
+			Label: "label_c",
+		},
+	}
+
+	t.Run("Map decode", func(t *testing.T) {
+		var m map[string]interface{}
+		require.NoError(t, value.Decode(value.Encode(val), &m))
+
+		type object = map[string]interface{}
+
+		expect := object{
+			"attr_1": "value_1",
+			"attr_2": "value_2",
+			"unlabeled": object{
+				"a": object{"value": 1},
+				"b": object{"value": 2},
+			},
+			"other_unlabeled": object{"value": 3},
+			"labeled": object{
+				"a": object{
+					"label_a": object{"value": 4},
+				},
+				"b": object{
+					"label_b": object{"value": 5},
+				},
+			},
+			"other_labeled": object{
+				"label_c": object{"value": 6},
+			},
+		}
+
+		require.Equal(t, m, expect)
+	})
+
+	t.Run("Object decode from map", func(t *testing.T) {
+		// First decode into a map so the types aren't equal. This ensures that our
+		// decoding doesn't hit the fast path of assigning two structurally
+		// identical types.
+		var m map[string]interface{}
+		require.NoError(t, value.Decode(value.Encode(val), &m))
+
+		// Now decode the map into our actual value.
+		var actualVal OuterBlock
+		require.NoError(t, value.Decode(value.Encode(m), &actualVal))
+		require.Equal(t, val, actualVal)
+	})
+
+	t.Run("Object decode from other object", func(t *testing.T) {
+		// Decode into a separate type which is structurally identical but not
+		// literally the same.
+		type OuterBlock2 OuterBlock
+
+		var actualVal OuterBlock2
+		require.NoError(t, value.Decode(value.Encode(val), &actualVal))
+		require.Equal(t, val, OuterBlock(actualVal))
+	})
+}
+
+// TODO(rfratto): test slice of labeled blocks

--- a/pkg/river/token/builder/builder.go
+++ b/pkg/river/token/builder/builder.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/agent/pkg/river/token"
 )
 
-// A File reprents a River configuration file.
+// A File represents a River configuration file.
 type File struct {
 	body *Body
 }


### PR DESCRIPTION
This PR fixes how blocks are represented from objects and lists with the following rules:

1. A block name `a.b.c` is represented as a deeply nested object, where `a` is the top level key, `b` is a key inside `a`, and `c` is a key inside `b`. The block itself is then inside of `c`. 
2. A labeled block is represented as a key following the block name, where the key name is the label value. The block itself is then inside the label key. 
3. An array or slice of labeled blocks is rolled up into a single object, with each label being a key. 
  1. This implicitly requires that labels are unique per block name. 
  2. Like normal, an array or slice of _unlabeled_ blocks is still an array. 

For example, this file:

```river
discovery.kubernetes "pods" {} 
discovery.kubernetes "namespaces" {} 
discovery.static "healthchecks" {} 

metrics.scrape "default" {} 

node_exporter {}
```

is represented as the following object:

```river 
{
  discovery = {
    kubernetes = {
      pods       = { /* ... */ },
      namespaces = { /* ... */ },
    },
    static = {
      healthchecks = { /* ... */ },
    },
  },
  metrics = {
    scrape = {
      default = { /* ... */ }
    },
  },
  node_exporter = { /* ... */ }
}
```

This is accomplished by introducing `structWrapper`, a special type of struct which allows us to partially traverse through a real struct as we navigate keys. In support of this, the cached tags for a struct are now built into a tree.

This is a difficult chunk of code to follow. Please let me know if there's anything I can document or do to make it clearer.