### PR TITLE
Use opt-out flag for ebpf_exporter when building release artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Main (unreleased)
 - Operator: Fix issue where configured `targetPort` ServiceMonitors resulted in
   generating an incorrect scrape_config. (@rfratto)
 
+- Build the Linux/AMD64 artifacts using the opt-out flag for the ebpf_exporter. (@tpaschalis)
 
 v0.26.0 (2022-07-18)
 -------------------------

--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,7 @@ dist: dist-agent dist-agentctl dist-packages
 ####################
 
 dist-agent: seego dist/agent-linux-amd64 dist/agent-linux-arm64 dist/agent-linux-armv6 dist/agent-linux-armv7 dist/agent-linux-ppc64le dist/agent-darwin-amd64 dist/agent-darwin-arm64 dist/agent-windows-amd64.exe dist/agent-freebsd-amd64 dist/agent-windows-installer.exe
+dist/agent-linux-amd64: CGO_FLAGS := -ldflags "-s -w $(GO_LDFLAGS)" -tags "netgo noebpf" $(GOFLAGS)
 dist/agent-linux-amd64: seego
 	$(call SetBuildVarsConditional,linux/amd64) ;      $(seego) build $(CGO_FLAGS) -o $@ ./cmd/agent
 
@@ -340,6 +341,7 @@ dist/agent-freebsd-amd64: seego
 
 dist-agentctl: seego dist/agentctl-linux-amd64 dist/agentctl-linux-arm64 dist/agentctl-linux-armv6 dist/agentctl-linux-armv7 dist/agentctl-darwin-amd64 dist/agentctl-darwin-arm64 dist/agentctl-windows-amd64.exe dist/agentctl-freebsd-amd64
 
+dist/agentctl-linux-amd64: CGO_FLAGS := -ldflags "-s -w $(GO_LDFLAGS)" -tags "netgo noebpf" $(GOFLAGS)
 dist/agentctl-linux-amd64: seego
 	$(call SetBuildVarsConditional,linux/amd64);    $(seego) build $(CGO_FLAGS) -o $@ ./cmd/agentctl
 

--- a/Makefile
+++ b/Makefile
@@ -489,6 +489,7 @@ enforce-release-tag:
 	sh -c '[ -n "${RELEASE_TAG}" ] || (echo \$$RELEASE_TAG environment variable not set; exit 1)'
 
 test-packages:
+	docker pull $(BUILD_IMAGE)
 	go test -tags=packaging  ./packaging
 .PHONY: test-packages
 

--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,8 @@ dist: dist-agent dist-agentctl dist-packages
 ####################
 
 dist-agent: seego dist/agent-linux-amd64 dist/agent-linux-arm64 dist/agent-linux-armv6 dist/agent-linux-armv7 dist/agent-linux-ppc64le dist/agent-darwin-amd64 dist/agent-darwin-arm64 dist/agent-windows-amd64.exe dist/agent-freebsd-amd64 dist/agent-windows-installer.exe
+
+# Override CGO_FLAGS to add the noebpf build tag in linux/amd64 builds
 dist/agent-linux-amd64: CGO_FLAGS := -ldflags "-s -w $(GO_LDFLAGS)" -tags "netgo noebpf" $(GOFLAGS)
 dist/agent-linux-amd64: seego
 	$(call SetBuildVarsConditional,linux/amd64) ;      $(seego) build $(CGO_FLAGS) -o $@ ./cmd/agent
@@ -341,6 +343,7 @@ dist/agent-freebsd-amd64: seego
 
 dist-agentctl: seego dist/agentctl-linux-amd64 dist/agentctl-linux-arm64 dist/agentctl-linux-armv6 dist/agentctl-linux-armv7 dist/agentctl-darwin-amd64 dist/agentctl-darwin-arm64 dist/agentctl-windows-amd64.exe dist/agentctl-freebsd-amd64
 
+# Override CGO_FLAGS to add the noebpf build tag in linux/amd64 builds
 dist/agentctl-linux-amd64: CGO_FLAGS := -ldflags "-s -w $(GO_LDFLAGS)" -tags "netgo noebpf" $(GOFLAGS)
 dist/agentctl-linux-amd64: seego
 	$(call SetBuildVarsConditional,linux/amd64);    $(seego) build $(CGO_FLAGS) -o $@ ./cmd/agentctl

--- a/Makefile
+++ b/Makefile
@@ -489,7 +489,6 @@ enforce-release-tag:
 	sh -c '[ -n "${RELEASE_TAG}" ] || (echo \$$RELEASE_TAG environment variable not set; exit 1)'
 
 test-packages:
-	docker pull $(BUILD_IMAGE)
 	go test -tags=packaging  ./packaging
 .PHONY: test-packages
 

--- a/packaging/linux_packages_test.go
+++ b/packaging/linux_packages_test.go
@@ -61,13 +61,11 @@ func buildPackages(t *testing.T) {
 	root, err := filepath.Abs(filepath.Join(wd, ".."))
 	require.NoError(t, err)
 
-	gocache := filepath.Join(wd, ".cache")
 	cmd := exec.Command("make", fmt.Sprintf("dist-packages-%s", runtime.GOARCH))
 	cmd.Env = append(
 		os.Environ(),
 		"RELEASE_TAG=v0.0.0",
 		"DOCKER_OPTS=",
-		fmt.Sprintf("GOCACHE=%s", gocache),
 	)
 	cmd.Dir = root
 	cmd.Stderr = os.Stderr

--- a/packaging/linux_packages_test.go
+++ b/packaging/linux_packages_test.go
@@ -61,11 +61,13 @@ func buildPackages(t *testing.T) {
 	root, err := filepath.Abs(filepath.Join(wd, ".."))
 	require.NoError(t, err)
 
+	gocache := filepath.Join(wd, ".cache")
 	cmd := exec.Command("make", fmt.Sprintf("dist-packages-%s", runtime.GOARCH))
 	cmd.Env = append(
 		os.Environ(),
 		"RELEASE_TAG=v0.0.0",
 		"DOCKER_OPTS=",
+		fmt.Sprintf("GOCACHE=%s", gocache),
 	)
 	cmd.Dir = root
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR utilizes Makefile's [target-specific variables](https://www.gnu.org/software/make/manual/html_node/Target_002dspecific.html) to override `CGO_FLAGS` when building linux/amd64 binaries and packages for distributions.

This change will
- [x]  Ensure `make dist` compiles binaries and packages with the `noebpf` flag passed
- [x] Continue depending on the bcc toolkit being present when compiling the Agent manually on linux, as described on [contributing.md](https://github.com/grafana/agent/blob/main/docs/developer/contributing.md)
- [x] Allow the Docker images to continue using the eBPF exporter as before

#### Which issue(s) this PR fixes
Fixes #1923.

#### Notes to the Reviewer
This does make the Makefile a tad more complicated, plus if we ever change CGO_FLAGS we'll also need to remember to change it here, but I believe this is one of the less intrusive solutions to this problem.

Please let me know if I've missed any corner cases here :) 

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [ ] Tests updated (N/A)
