### PR TITLE
River: capsule markers, capsule conversion, and custom tokenization 

### DIFF
--- a/pkg/river/internal/value/capsule.go
+++ b/pkg/river/internal/value/capsule.go
@@ -1,0 +1,51 @@
+package value
+
+import (
+	"fmt"
+)
+
+// Capsule is a marker interface for Go values which forces a type to be
+// represented as a River capsule. This is useful for types whose underlying
+// value is not a capsule, such as:
+//
+//   // Secret is a secret value. It would normally be a River string since the
+//   // underlying Go type is string, but it's a capsule since it implements
+//   // the Capsule interface.
+//   type Secret string
+//
+//   func (s Secret) RiverCapsule() {}
+//
+// Extension interfaces are used to describe additional behaviors for Capsules.
+// ConvertibleCapsule allows defining custom conversion rules to convert
+// between other Go values.
+type Capsule interface {
+	RiverCapsule()
+}
+
+// ErrNoConversion is returned by implementations of ConvertibleCapsule to
+// denote that a custom conversion from or to a specific type is unavailable.
+var ErrNoConversion = fmt.Errorf("no custom capsule conversion available")
+
+// ConvertibleCapsule is a Capsule which supports custom conversion rules
+// between Go types which are not the same.
+//
+// ConvertibleCapsule's methods are used even if the other type in the
+// conversion is not a capsule; such as converting a bool into a capsule type
+// or vice-versa.
+type ConvertibleCapsule interface {
+	Capsule
+
+	// ConvertFrom should modify the ConvertibleCapsule value based on the value
+	// of src.
+	//
+	// ConvertFrom should return ErrNoConversion if no conversion is available
+	// from src.
+	ConvertFrom(src interface{}) error
+
+	// ConvertInto should convert its value and store it into dst. dst will be a
+	// pointer to a value which ConvertInto is expected to update.
+	//
+	// ConvertInto should return ErrNoConversion if no conversion into dst is
+	// available.
+	ConvertInto(dst interface{}) error
+}

--- a/pkg/river/internal/value/capsule.go
+++ b/pkg/river/internal/value/capsule.go
@@ -26,13 +26,9 @@ type Capsule interface {
 // denote that a custom conversion from or to a specific type is unavailable.
 var ErrNoConversion = fmt.Errorf("no custom capsule conversion available")
 
-// ConvertibleCapsule is a Capsule which supports custom conversion rules
-// between Go types which are not the same.
-//
-// ConvertibleCapsule's methods are used even if the other type in the
-// conversion is not a capsule; such as converting a bool into a capsule type
-// or vice-versa.
-type ConvertibleCapsule interface {
+// ConvertibleFromCapsule is a Capsule which supports custom conversion rules
+// from any Go type which is not the same as the capsule type.
+type ConvertibleFromCapsule interface {
 	Capsule
 
 	// ConvertFrom should modify the ConvertibleCapsule value based on the value
@@ -41,6 +37,12 @@ type ConvertibleCapsule interface {
 	// ConvertFrom should return ErrNoConversion if no conversion is available
 	// from src.
 	ConvertFrom(src interface{}) error
+}
+
+// ConvertibleIntoCapsule is a Capsule which supports custom conversion rules
+// into any Go type which is not the same as the capsule type.
+type ConvertibleIntoCapsule interface {
+	Capsule
 
 	// ConvertInto should convert its value and store it into dst. dst will be a
 	// pointer to a value which ConvertInto is expected to update.

--- a/pkg/river/internal/value/decode.go
+++ b/pkg/river/internal/value/decode.go
@@ -98,7 +98,7 @@ func decode(val Value, into reflect.Value) error {
 	case convVal.Type() != targetType:
 		// Check to see if we can use capsule conversion.
 		if convVal.Type() == TypeCapsule {
-			cc, ok := convVal.Interface().(ConvertibleCapsule)
+			cc, ok := convVal.Interface().(ConvertibleIntoCapsule)
 			if ok {
 				// It's always possible to Addr the reflect.Value below since we expect
 				// it to be a settable non-pointer value.
@@ -112,7 +112,7 @@ func decode(val Value, into reflect.Value) error {
 		}
 
 		if targetType == TypeCapsule {
-			cc, ok := into.Addr().Interface().(ConvertibleCapsule)
+			cc, ok := into.Addr().Interface().(ConvertibleFromCapsule)
 			if ok {
 				err := cc.ConvertFrom(convVal.rv.Interface())
 				if err == nil {

--- a/pkg/river/internal/value/decode.go
+++ b/pkg/river/internal/value/decode.go
@@ -2,14 +2,18 @@ package value
 
 import (
 	"encoding"
+	"errors"
 	"fmt"
 	"reflect"
 )
 
-// Decode assigns a Value val to a Go pointer target. Decode will attempt to
-// convert val to the type expected by target for assignment. If val cannot be
-// converted, an error is returned. Pointers will be allocated as necessary
-// when decoding.
+// Decode assigns a Value val to a Go pointer target. Pointers will be
+// allocated as necessary when decoding.
+//
+// Decode will attempt to convert val to the type expected by target for
+// assignment. If val or target implement ConvertibleCapsule, conversion
+// between values will be attempted by calling ConvertFrom and ConvertInto as
+// appropriate. If val cannot be converted, an error is returned.
 //
 // New arrays and slices will be allocated when decoding into target.
 //
@@ -92,6 +96,33 @@ func decode(val Value, into reflect.Value) error {
 		into.Set(val.rv.Convert(goByteSlice))
 		return nil
 	case convVal.Type() != targetType:
+		// Check to see if we can use capsule conversion.
+		if convVal.Type() == TypeCapsule {
+			cc, ok := convVal.Interface().(ConvertibleCapsule)
+			if ok {
+				// It's always possible to Addr the reflect.Value below since we expect
+				// it to be a settable non-pointer value.
+				err := cc.ConvertInto(into.Addr().Interface())
+				if err == nil {
+					return nil
+				} else if err != nil && !errors.Is(err, ErrNoConversion) {
+					return Error{Value: convVal, Inner: err}
+				}
+			}
+		}
+
+		if targetType == TypeCapsule {
+			cc, ok := into.Addr().Interface().(ConvertibleCapsule)
+			if ok {
+				err := cc.ConvertFrom(convVal.rv.Interface())
+				if err == nil {
+					return nil
+				} else if err != nil && !errors.Is(err, ErrNoConversion) {
+					return Error{Value: convVal, Inner: err}
+				}
+			}
+		}
+
 		var err error
 		convVal, err = convertValue(convVal, targetType)
 		if err != nil {

--- a/pkg/river/internal/value/decode_test.go
+++ b/pkg/river/internal/value/decode_test.go
@@ -282,3 +282,69 @@ func TestDecode_ErrorChain(t *testing.T) {
 	expectErr := `expected number, got string`
 	require.EqualError(t, err, expectErr)
 }
+
+type boolish int
+
+var _ value.ConvertibleCapsule = (*boolish)(nil)
+
+func (b boolish) RiverCapsule() {}
+
+func (b *boolish) ConvertFrom(src interface{}) error {
+	switch v := src.(type) {
+	case bool:
+		if v {
+			*b = 1
+		} else {
+			*b = 0
+		}
+		return nil
+	}
+
+	return value.ErrNoConversion
+}
+
+func (b boolish) ConvertInto(dst interface{}) error {
+	switch d := dst.(type) {
+	case *bool:
+		if b == 0 {
+			*d = false
+		} else {
+			*d = true
+		}
+		return nil
+	}
+
+	return value.ErrNoConversion
+}
+
+func TestDecode_CustomConvert(t *testing.T) {
+	t.Run("compatible type to custom", func(t *testing.T) {
+		var b boolish
+		err := value.Decode(value.Bool(true), &b)
+		require.NoError(t, err)
+		require.Equal(t, boolish(1), b)
+	})
+
+	t.Run("custom to compatible type", func(t *testing.T) {
+		src := boolish(10)
+
+		var b bool
+		err := value.Decode(value.Encapsulate(&src), &b)
+		require.NoError(t, err)
+		require.Equal(t, true, b)
+	})
+
+	t.Run("incompatible type to custom", func(t *testing.T) {
+		var b boolish
+		err := value.Decode(value.String("true"), &b)
+		require.EqualError(t, err, "expected capsule, got string")
+	})
+
+	t.Run("custom to incompatible type", func(t *testing.T) {
+		src := boolish(10)
+
+		var s string
+		err := value.Decode(value.Encapsulate(&src), &s)
+		require.EqualError(t, err, "expected string, got capsule")
+	})
+}

--- a/pkg/river/internal/value/decode_test.go
+++ b/pkg/river/internal/value/decode_test.go
@@ -285,7 +285,8 @@ func TestDecode_ErrorChain(t *testing.T) {
 
 type boolish int
 
-var _ value.ConvertibleCapsule = (*boolish)(nil)
+var _ value.ConvertibleFromCapsule = (*boolish)(nil)
+var _ value.ConvertibleIntoCapsule = (boolish)(0)
 
 func (b boolish) RiverCapsule() {}
 
@@ -326,10 +327,8 @@ func TestDecode_CustomConvert(t *testing.T) {
 	})
 
 	t.Run("custom to compatible type", func(t *testing.T) {
-		src := boolish(10)
-
 		var b bool
-		err := value.Decode(value.Encapsulate(&src), &b)
+		err := value.Decode(value.Encapsulate(boolish(10)), &b)
 		require.NoError(t, err)
 		require.Equal(t, true, b)
 	})

--- a/pkg/river/internal/value/type.go
+++ b/pkg/river/internal/value/type.go
@@ -9,7 +9,7 @@ import (
 // be TypeArray, but this does not imply anything about the type of that
 // array's elements (all of which may be any type).
 //
-// The Capsule type is a special type which encapsulates arbitrary Go values.
+// TypeCapsule is a special type which encapsulates arbitrary Go values.
 type Type uint8
 
 // Supported Type values.
@@ -60,9 +60,23 @@ func (t Type) String() string {
 // Go functions are only valid for River if they have one non-error return type
 // (the first return type) and one optional error return type (the second
 // return type). Other function types are treated as capsules.
+//
+// As an exception, any type which implements the Capsule interface is forced
+// to be a capsule.
 func RiverType(t reflect.Type) Type {
+	// We don't know if the RiverCapsule interface is implemented for a pointer
+	// or non-pointer type, so we have to check before and after dereferencing.
+
 	for t.Kind() == reflect.Pointer {
+		if t.Implements(goCapsule) {
+			return TypeCapsule
+		}
+
 		t = t.Elem()
+	}
+
+	if t.Implements(goCapsule) {
+		return TypeCapsule
 	}
 
 	switch t.Kind() {

--- a/pkg/river/internal/value/type_test.go
+++ b/pkg/river/internal/value/type_test.go
@@ -8,6 +8,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type customCapsule bool
+
+var _ value.Capsule = (customCapsule)(false)
+
+func (customCapsule) RiverCapsule() {}
+
 var typeTests = []struct {
 	input  interface{}
 	expect value.Type
@@ -54,6 +60,11 @@ var typeTests = []struct {
 
 	{make(chan struct{}), value.TypeCapsule},
 	{map[bool]interface{}{}, value.TypeCapsule}, // Maps with non-string types are capsules
+
+	// Types with capsule markers should be capsules.
+	{customCapsule(false), value.TypeCapsule},
+	{(*customCapsule)(nil), value.TypeCapsule},
+	{(**customCapsule)(nil), value.TypeCapsule},
 }
 
 func Test_RiverType(t *testing.T) {

--- a/pkg/river/internal/value/value.go
+++ b/pkg/river/internal/value/value.go
@@ -18,6 +18,7 @@ var (
 	goError           = reflect.TypeOf((*error)(nil)).Elem()
 	goTextUnmarshaler = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
 	goStructWrapper   = reflect.TypeOf(structWrapper{})
+	goCapsule         = reflect.TypeOf((*Capsule)(nil)).Elem()
 )
 
 // NOTE(rfratto): This package is extremely sensitive to performance, so
@@ -89,9 +90,9 @@ func Func(f interface{}) Value {
 	return Value{rv: rv, ty: TypeFunction}
 }
 
-// Capsule creates a new Capsule value from v. Capsule panics if v does not map
-// to a River capsule.
-func Capsule(v interface{}) Value {
+// Encapsulate creates a new Capsule value from v. Encapsulate panics if v does
+// not map to a River capsule.
+func Encapsulate(v interface{}) Value {
 	rv := reflect.ValueOf(v)
 	if RiverType(rv.Type()) != TypeCapsule {
 		panic("river/value: Capsule called with non-capsule type")
@@ -220,6 +221,14 @@ func (v Value) Index(i int) Value {
 		panic("river/value: Index called on non-array value")
 	}
 	return makeValue(v.rv.Index(i))
+}
+
+// Interface returns the underlying Go value for the Value.
+func (v Value) Interface() interface{} {
+	if v.ty == TypeNull {
+		return nil
+	}
+	return v.rv.Interface()
 }
 
 // makeValue converts a reflect value into a Value, deferencing any pointers or

--- a/pkg/river/internal/value/value_object_test.go
+++ b/pkg/river/internal/value/value_object_test.go
@@ -3,7 +3,6 @@ package value_test
 import (
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/grafana/agent/pkg/river/internal/value"
 	"github.com/stretchr/testify/require"
 )
@@ -87,19 +86,6 @@ func TestBlockRepresentation(t *testing.T) {
 		require.Equal(t, m, expect)
 	})
 
-	t.Run("Object decode from map", func(t *testing.T) {
-		// First decode into a map so the types aren't equal. This ensures that our
-		// decoding doesn't hit the fast path of assigning two structurally
-		// identical types.
-		var m map[string]interface{}
-		require.NoError(t, value.Decode(value.Encode(val), &m))
-
-		// Now decode the map into our actual value.
-		var actualVal OuterBlock
-		require.NoError(t, value.Decode(value.Encode(m), &actualVal))
-		require.Equal(t, val, actualVal)
-	})
-
 	t.Run("Object decode from other object", func(t *testing.T) {
 		// Decode into a separate type which is structurally identical but not
 		// literally the same.
@@ -164,22 +150,7 @@ func TestSliceOfBlocks(t *testing.T) {
 			},
 		}
 
-		spew.Dump(m)
-
 		require.Equal(t, m, expect)
-	})
-
-	t.Run("Object decode from map", func(t *testing.T) {
-		// First decode into a map so the types aren't equal. This ensures that our
-		// decoding doesn't hit the fast path of assigning two structurally
-		// identical types.
-		var m map[string]interface{}
-		require.NoError(t, value.Decode(value.Encode(val), &m))
-
-		// Now decode the map into our actual value.
-		var actualVal OuterBlock
-		require.NoError(t, value.Decode(value.Encode(m), &actualVal))
-		require.Equal(t, val, actualVal)
 	})
 
 	t.Run("Object decode from other object", func(t *testing.T) {

--- a/pkg/river/token/builder/builder.go
+++ b/pkg/river/token/builder/builder.go
@@ -104,7 +104,9 @@ func (b *Body) getOrCreateAttribute(name string) *attribute {
 
 // SetAttributeValue sets an attribute in the Body whose value is converted
 // from a Go value to a River value. The Go value is encoded using the normal
-// Go to River encoding rules.
+// Go to River encoding rules. If any value reachable from goValue implements
+// Tokenizer, the printed tokens will instead be retrieved by calling the
+// RiverTokenize method.
 //
 // If the attribute was previously set, its value tokens are updated.
 //

--- a/pkg/river/token/builder/builder_test.go
+++ b/pkg/river/token/builder/builder_test.go
@@ -114,10 +114,16 @@ func (ct CustomTokenizer) RiverTokenize() []builder.Token {
 func TestBuilder_GoEncode_Tokenizer(t *testing.T) {
 	f := builder.NewFile()
 
-	f.Body().SetAttributeValue("custom_tokens", map[string]interface{}{
-		"number":           15,
-		"custom_tokenizer": CustomTokenizer(true),
-		"string":           "Hello, world!",
+	type block struct {
+		Number int             `river:"number,attr"`
+		Custom CustomTokenizer `river:"custom_tokenizer,attr"`
+		String string          `river:"string,attr"`
+	}
+
+	f.Body().SetAttributeValue("custom_tokens", block{
+		Number: 15,
+		Custom: CustomTokenizer(true),
+		String: "Hello, world!",
 	})
 
 	expect := format(t, `

--- a/pkg/river/token/builder/builder_test.go
+++ b/pkg/river/token/builder/builder_test.go
@@ -102,3 +102,31 @@ func format(t *testing.T, in string) string {
 
 	return buf.String()
 }
+
+type CustomTokenizer bool
+
+var _ builder.Tokenizer = (CustomTokenizer)(false)
+
+func (ct CustomTokenizer) RiverTokenize() []builder.Token {
+	return []builder.Token{{Tok: token.LITERAL, Lit: "CUSTOM_TOKENS"}}
+}
+
+func TestBuilder_GoEncode_Tokenizer(t *testing.T) {
+	f := builder.NewFile()
+
+	f.Body().SetAttributeValue("custom_tokens", map[string]interface{}{
+		"number":           15,
+		"custom_tokenizer": CustomTokenizer(true),
+		"string":           "Hello, world!",
+	})
+
+	expect := format(t, `
+		custom_tokens = {
+			number = 15,
+			custom_tokenizer = CUSTOM_TOKENS,
+			string = "Hello, world!",
+		}
+	`)
+
+	require.Equal(t, expect, string(f.Bytes()))
+}

--- a/pkg/river/token/builder/value_tokens.go
+++ b/pkg/river/token/builder/value_tokens.go
@@ -8,12 +8,23 @@ import (
 	"github.com/grafana/agent/pkg/river/token"
 )
 
+// Tokenizer is any value which can return a raw set of tokens.
+type Tokenizer interface {
+	// RiverTokenize returns the raw set of River tokens which are used when
+	// printing out the value with river/token/builder.
+	RiverTokenize() []Token
+}
+
 func tokenEncode(val interface{}) []Token {
 	return valueTokens(value.Encode(val))
 }
 
 func valueTokens(v value.Value) []Token {
 	var toks []Token
+
+	if tk, ok := v.Interface().(Tokenizer); ok {
+		return tk.RiverTokenize()
+	}
 
 	switch v.Type() {
 	case value.TypeNull:


### PR DESCRIPTION
This PR introduces three small additions required for a River equivalent of our [hcltypes][] package:

1. Define a Capsule interface which explicitly marks a Go type as being a capsule. This is needed for Go types which should be capsules but whose underlying types are non-capsules by default. For example: 

```go
type Secret string

// RiverCapsule ensures that Secret values are treated as a capsule.
func (s Secret) RiverCapsule() {}
``` 

2. Define a ConvertibleFromCapsule and ConvertibleIntoCapsule extension interfaces to allow converting capsule values from and to other Go values respectively. For a Secret type, this will be used to allow converting a string into a Secret, but not a Secret into a string. Two interface types are defined to allow ConvertibleFromCapsule to be implemented on a non-pointer type.

3. Define a Tokenizer interface which is used to print custom tokens for a Go value. This will allow custom printing of types like an OptionalSecret, which should be shown as a literal string when it is marked as cleartext, and hidden when it is marked as sensitive.

[hcltypes]: https://github.com/grafana/agent/tree/main/pkg/flow/hcltypes