### PR TITLE
Fix metrics.scrape panic with nil receiver

### DIFF
--- a/component/common/appendable/appendable.go
+++ b/component/common/appendable/appendable.go
@@ -17,11 +17,15 @@ type FlowMetric struct {
 }
 
 // FlowAppendable is a flow-specific implementation of an Appender.
-type FlowAppendable []*metrics.Receiver
+type FlowAppendable struct {
+	receivers []*metrics.Receiver
+}
 
 // NewFlowAppendable initializes the appendable.
-func NewFlowAppendable(receivers ...*metrics.Receiver) FlowAppendable {
-	return receivers
+func NewFlowAppendable(receivers ...*metrics.Receiver) *FlowAppendable {
+	return &FlowAppendable{
+		receivers: receivers,
+	}
 }
 
 type flowAppender struct {
@@ -33,8 +37,13 @@ type flowAppender struct {
 func (app FlowAppendable) Appender(_ context.Context) storage.Appender {
 	return &flowAppender{
 		buffer:    make(map[int64][]*metrics.FlowMetric),
-		receivers: app,
+		receivers: app.receivers,
 	}
+}
+
+// SetReceivers defines the list of receivers for this appendable.
+func (app *FlowAppendable) SetReceivers(receivers []*metrics.Receiver) {
+	app.receivers = receivers
 }
 
 func (app *flowAppender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v float64) (storage.SeriesRef, error) {

--- a/component/common/appendable/appendable.go
+++ b/component/common/appendable/appendable.go
@@ -53,6 +53,13 @@ func (app *FlowAppendable) SetReceivers(receivers []*metrics.Receiver) {
 	app.mut.Unlock()
 }
 
+// ListReceivers is a test method for exposing the Appender's receivers.
+func (app *FlowAppendable) ListReceivers() []*metrics.Receiver {
+	app.mut.RLock()
+	defer app.mut.RUnlock()
+	return app.receivers
+}
+
 func (app *flowAppender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v float64) (storage.SeriesRef, error) {
 	if len(app.receivers) == 0 {
 		return 0, nil

--- a/component/common/appendable/appendable.go
+++ b/component/common/appendable/appendable.go
@@ -87,7 +87,7 @@ func (app *flowAppender) AppendExemplar(ref storage.SeriesRef, l labels.Labels, 
 func (app *flowAppender) Commit() error {
 	for _, r := range app.receivers {
 		for ts, metrics := range app.buffer {
-			if r.Receive == nil {
+			if r == nil || r.Receive == nil {
 				continue
 			}
 			r.Receive(ts, metrics)

--- a/component/common/appendable/appendable.go
+++ b/component/common/appendable/appendable.go
@@ -37,6 +37,13 @@ func (app FlowAppendable) Appender(_ context.Context) storage.Appender {
 	}
 }
 
+// SetReceivers sets the list of receivers the appendable should forward to.
+func (app FlowAppendable) SetReceivers(receivers ...*metrics.Receiver) {
+	if receivers != nil {
+		app = FlowAppendable(receivers)
+	}
+}
+
 func (app *flowAppender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v float64) (storage.SeriesRef, error) {
 	if len(app.receivers) == 0 {
 		return 0, nil
@@ -71,7 +78,7 @@ func (app *flowAppender) AppendExemplar(ref storage.SeriesRef, l labels.Labels, 
 func (app *flowAppender) Commit() error {
 	for _, r := range app.receivers {
 		for ts, metrics := range app.buffer {
-			if r.Receive == nil {
+			if r == nil || r.Receive == nil {
 				continue
 			}
 			r.Receive(ts, metrics)

--- a/component/common/appendable/appendable.go
+++ b/component/common/appendable/appendable.go
@@ -37,13 +37,6 @@ func (app FlowAppendable) Appender(_ context.Context) storage.Appender {
 	}
 }
 
-// SetReceivers sets the list of receivers the appendable should forward to.
-func (app FlowAppendable) SetReceivers(receivers ...*metrics.Receiver) {
-	if receivers != nil {
-		app = FlowAppendable(receivers)
-	}
-}
-
 func (app *flowAppender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v float64) (storage.SeriesRef, error) {
 	if len(app.receivers) == 0 {
 		return 0, nil
@@ -78,7 +71,7 @@ func (app *flowAppender) AppendExemplar(ref storage.SeriesRef, l labels.Labels, 
 func (app *flowAppender) Commit() error {
 	for _, r := range app.receivers {
 		for ts, metrics := range app.buffer {
-			if r == nil || r.Receive == nil {
+			if r.Receive == nil {
 				continue
 			}
 			r.Receive(ts, metrics)

--- a/component/metrics/mutate/mutate.go
+++ b/component/metrics/mutate/mutate.go
@@ -77,7 +77,7 @@ func (c *Component) Update(args component.Arguments) error {
 	newArgs := args.(Arguments)
 
 	c.mrc = flow_relabel.HCLToPromRelabelConfigs(newArgs.MetricRelabelConfigs)
-	c.appendable = fa.FlowAppendable(newArgs.ForwardTo)
+	c.appendable.SetReceivers(newArgs.ForwardTo...)
 	c.opts.OnStateChange(Exports{Receiver: c.receiver})
 
 	return nil

--- a/component/metrics/mutate/mutate.go
+++ b/component/metrics/mutate/mutate.go
@@ -77,7 +77,7 @@ func (c *Component) Update(args component.Arguments) error {
 	newArgs := args.(Arguments)
 
 	c.mrc = flow_relabel.HCLToPromRelabelConfigs(newArgs.MetricRelabelConfigs)
-	c.appendable.SetReceivers(newArgs.ForwardTo...)
+	c.appendable = fa.FlowAppendable(newArgs.ForwardTo)
 	c.opts.OnStateChange(Exports{Receiver: c.receiver})
 
 	return nil

--- a/component/metrics/mutate/mutate.go
+++ b/component/metrics/mutate/mutate.go
@@ -44,7 +44,7 @@ type Component struct {
 	opts component.Options
 	mrc  []*relabel.Config
 
-	appendable fa.FlowAppendable
+	appendable *fa.FlowAppendable
 	receiver   *metrics.Receiver
 }
 
@@ -77,7 +77,7 @@ func (c *Component) Update(args component.Arguments) error {
 	newArgs := args.(Arguments)
 
 	c.mrc = flow_relabel.HCLToPromRelabelConfigs(newArgs.MetricRelabelConfigs)
-	c.appendable = fa.FlowAppendable(newArgs.ForwardTo)
+	c.appendable.SetReceivers(newArgs.ForwardTo)
 	c.opts.OnStateChange(Exports{Receiver: c.receiver})
 
 	return nil

--- a/component/metrics/scrape/scrape.go
+++ b/component/metrics/scrape/scrape.go
@@ -128,7 +128,7 @@ func (c *Component) Update(args component.Arguments) error {
 	defer c.mut.Unlock()
 	c.args = newArgs
 
-	c.appendable.SetReceivers(newArgs.ForwardTo...)
+	c.appendable = fa.FlowAppendable(newArgs.ForwardTo)
 
 	sc, err := newArgs.ScrapeConfig.getPromScrapeConfigs(c.opts.ID)
 	if err != nil {

--- a/component/metrics/scrape/scrape.go
+++ b/component/metrics/scrape/scrape.go
@@ -59,7 +59,7 @@ type Component struct {
 	mut        sync.RWMutex
 	args       Arguments
 	scraper    *scrape.Manager
-	appendable fa.FlowAppendable
+	appendable *fa.FlowAppendable
 }
 
 var (
@@ -128,7 +128,7 @@ func (c *Component) Update(args component.Arguments) error {
 	defer c.mut.Unlock()
 	c.args = newArgs
 
-	c.appendable = fa.FlowAppendable(newArgs.ForwardTo)
+	c.appendable.SetReceivers(newArgs.ForwardTo)
 
 	sc, err := newArgs.ScrapeConfig.getPromScrapeConfigs(c.opts.ID)
 	if err != nil {

--- a/component/metrics/scrape/scrape.go
+++ b/component/metrics/scrape/scrape.go
@@ -128,7 +128,7 @@ func (c *Component) Update(args component.Arguments) error {
 	defer c.mut.Unlock()
 	c.args = newArgs
 
-	c.appendable = fa.FlowAppendable(newArgs.ForwardTo)
+	c.appendable.SetReceivers(newArgs.ForwardTo...)
 
 	sc, err := newArgs.ScrapeConfig.getPromScrapeConfigs(c.opts.ID)
 	if err != nil {

--- a/component/metrics/scrape/scrape_test.go
+++ b/component/metrics/scrape/scrape_test.go
@@ -1,0 +1,78 @@
+package scrape
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/metrics"
+	"github.com/grafana/agent/pkg/flow/logging"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+func TestForwardingToAppendable(t *testing.T) {
+	l, err := logging.New(os.Stderr, logging.DefaultOptions)
+	require.NoError(t, err)
+	opts := component.Options{Logger: l}
+
+	nilReceivers := []*metrics.Receiver{nil, nil}
+
+	args := Arguments{
+		Targets:      []Target{},
+		ForwardTo:    nilReceivers,
+		ScrapeConfig: DefaultConfig,
+	}
+
+	s, err := New(opts, args)
+	require.NoError(t, err)
+
+	// List the Appendable's receivers; they are nil.
+	require.Equal(t, nilReceivers, s.appendable.ListReceivers())
+
+	// Forwarding samples to the nil receivers shouldn't fail.
+	appender := s.appendable.Appender(context.Background())
+	_, err = appender.Append(0, labels.FromStrings("foo", "bar"), 0, 0)
+	require.NoError(t, err)
+
+	err = appender.Commit()
+	require.NoError(t, err)
+
+	// Update the component with a mock receiver; it should be passed along to the Appendable.
+	var receivedTs int64
+	var receivedSamples []*metrics.FlowMetric
+	mockReceiver := []*metrics.Receiver{
+		{
+			Receive: func(t int64, m []*metrics.FlowMetric) {
+				receivedTs = t
+				receivedSamples = m
+			},
+		},
+	}
+
+	args.ForwardTo = mockReceiver
+	err = s.Update(args)
+	require.NoError(t, err)
+
+	require.Equal(t, mockReceiver, s.appendable.ListReceivers())
+
+	// Forwarding a sample to the mock receiver should succeed.
+	appender = s.appendable.Appender(context.Background())
+	sample := metrics.FlowMetric{
+		GlobalRefID: 1,
+		Labels:      labels.FromStrings("foo", "bar"),
+		Value:       42.0,
+	}
+	timestamp := time.Now().Unix()
+	_, err = appender.Append(0, sample.Labels, timestamp, sample.Value)
+	require.NoError(t, err)
+
+	err = appender.Commit()
+	require.NoError(t, err)
+
+	require.Equal(t, receivedTs, timestamp)
+	require.Len(t, receivedSamples, 1)
+	require.Equal(t, receivedSamples[0], &sample)
+}

--- a/component/metrics/scrape/types.go
+++ b/component/metrics/scrape/types.go
@@ -14,18 +14,11 @@ import (
 	"github.com/rfratto/gohcl"
 )
 
-// var emptyAuthorization = common_config.Authorization{}
-// var emptyBasicAuth = common_config.BasicAuth{}
-// var emptyOAuth2 = &common_config.OAuth2{}
-
 const bearer string = "Bearer"
 
 // Config holds all of the attributes that can be used to configure a scrape
 // component.
 type Config struct {
-	// TODO (@tpaschalis) I think we need to override this to be the same value
-	// as the key in the targetGroups map that is being passed through the
-	// channel, and not allow it to be freely set.
 	// The job name to which the job label is set by default.
 	JobName string `hcl:"job_name,attr"`
 
@@ -208,15 +201,6 @@ func (c *Config) getPromScrapeConfigs(jobName string) (*config.ScrapeConfig, err
 			TLSConfig:        oauth2TLSConfig,
 		}
 	}
-	// TODO(@tpaschalis) had to include this workaround with the OAuth2 config
-	// object, otherwise it would get resolved to a non-nil object, trigger a
-	// different behavior in the scrape requests and fail them. Let's check if
-	// it's the same case with the other nested HTTPClientConfigs structs.
-	// if reflect.DeepEqual(oauth2Config, emptyOAuth2) {
-	// 	dec.HTTPClientConfig.OAuth2 = nil
-	// } else {
-	// 	dec.HTTPClientConfig.OAuth2 = oauth2Config
-	// }
 
 	dec.HTTPClientConfig.BearerToken = common_config.Secret(c.BearerToken)
 	dec.HTTPClientConfig.BearerTokenFile = c.BearerTokenFile


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This behavior appeared when we changed the `type struct { receivers []*metrics.Receiver }` definition to the `type FlowAppendable []*metrics.Receiver` type alias in 7be5f6c04c3d8b814c1c74de40d46bb7ce7c1f37.

This PR fixes the panic which occurs when the `metrics.scrape` component tries to forward to a nil receiver by reverting to the previous behavior

#### Which issue(s) this PR fixes
Fixes #1945

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated (N/A) until Flow is out of the PoC
- [ ] Documentation added (N/A)
- [ ] Tests updated
