### PR TITLE
River: various small fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,6 @@ require (
 	github.com/prometheus/statsd_exporter v0.22.2
 	github.com/rancher/k3d/v5 v5.2.2
 	github.com/rfratto/ckit v0.0.0-20220401221852-009169323240
-	github.com/rfratto/gohcl v0.0.0-20220609143238-53312695dc8f
 	github.com/rs/cors v1.8.2
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.5.0
@@ -93,7 +92,7 @@ require (
 	github.com/vincent-petithory/dataurl v1.0.0
 	github.com/weaveworks/common v0.0.0-20211222122857-933588f98737
 	github.com/wk8/go-ordered-map v0.2.0
-	github.com/zclconf/go-cty v1.10.0
+	github.com/zclconf/go-cty v1.10.0 // indirect
 	go.opencensus.io v0.23.0
 	go.opentelemetry.io/collector v0.55.0
 	go.opentelemetry.io/otel/metric v0.30.0
@@ -120,8 +119,11 @@ require (
 
 require (
 	github.com/Lusitaniae/apache_exporter v0.11.1-0.20220518131644-f9522724dab4
+	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
+	github.com/fatih/color v1.13.0
 	go.opentelemetry.io/collector/pdata v0.55.0
 	go.opentelemetry.io/collector/semconv v0.55.0
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 )
 
 require (
@@ -159,7 +161,6 @@ require (
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/agext/levenshtein v1.2.1 // indirect
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
-	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/antonmedv/expr v1.9.0 // indirect
 	github.com/apache/thrift v0.16.0 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
@@ -231,7 +232,6 @@ require (
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb // indirect
-	github.com/fatih/color v1.13.0 // indirect
 	github.com/felixge/fgprof v0.9.1 // indirect
 	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/fvbommel/sortorder v1.0.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require (
 	github.com/vincent-petithory/dataurl v1.0.0
 	github.com/weaveworks/common v0.0.0-20211222122857-933588f98737
 	github.com/wk8/go-ordered-map v0.2.0
-	github.com/zclconf/go-cty v1.10.0 // indirect
+	github.com/zclconf/go-cty v1.10.0
 	go.opencensus.io v0.23.0
 	go.opentelemetry.io/collector v0.55.0
 	go.opentelemetry.io/otel/metric v0.30.0
@@ -121,9 +121,9 @@ require (
 	github.com/Lusitaniae/apache_exporter v0.11.1-0.20220518131644-f9522724dab4
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
 	github.com/fatih/color v1.13.0
+	github.com/rfratto/gohcl v0.0.0-20220609143238-53312695dc8f
 	go.opentelemetry.io/collector/pdata v0.55.0
 	go.opentelemetry.io/collector/semconv v0.55.0
-	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2258,8 +2258,6 @@ github.com/rfratto/ckit v0.0.0-20220401221852-009169323240 h1:aWVSpqwdAr+e0IU+zY
 github.com/rfratto/ckit v0.0.0-20220401221852-009169323240/go.mod h1:kr0K+4DiLWPdO8eSEQ9W0XZ6Y/WhVzAHWOZyIG3BTkI=
 github.com/rfratto/go-yaml v0.0.0-20211119180816-77389c3526dc h1:g196Usc63pWDzWallipxVhsEjDdh/+RLc/Oz7q3ihW4=
 github.com/rfratto/go-yaml v0.0.0-20211119180816-77389c3526dc/go.mod h1:rMzeXFmWpS5JnfDANtpzbklRJY4pqZMJNN9/SJHAXPA=
-github.com/rfratto/gohcl v0.0.0-20220609143238-53312695dc8f h1:M0xD8ycunxl8SuSIVej94MX652r6xxfg4tI0jGraAfw=
-github.com/rfratto/gohcl v0.0.0-20220609143238-53312695dc8f/go.mod h1:IOy7gzr7kMZOEwF4+DofdyoC4O0uPnanv+UkyVTs/2E=
 github.com/rgeyer/github-exporter v0.0.0-20210722215637-d0cec2ee0dc8 h1:wNuNGrFzFmZlhrtz1Q8EiK1Ob6yWli8lX7D2AGmSGzE=
 github.com/rgeyer/github-exporter v0.0.0-20210722215637-d0cec2ee0dc8/go.mod h1:6XoOvFDTfk3aqGaOLHLxoWiZNx4zHobApOhKc3oHF/g=
 github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=
@@ -2788,6 +2786,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/go.sum
+++ b/go.sum
@@ -2258,6 +2258,8 @@ github.com/rfratto/ckit v0.0.0-20220401221852-009169323240 h1:aWVSpqwdAr+e0IU+zY
 github.com/rfratto/ckit v0.0.0-20220401221852-009169323240/go.mod h1:kr0K+4DiLWPdO8eSEQ9W0XZ6Y/WhVzAHWOZyIG3BTkI=
 github.com/rfratto/go-yaml v0.0.0-20211119180816-77389c3526dc h1:g196Usc63pWDzWallipxVhsEjDdh/+RLc/Oz7q3ihW4=
 github.com/rfratto/go-yaml v0.0.0-20211119180816-77389c3526dc/go.mod h1:rMzeXFmWpS5JnfDANtpzbklRJY4pqZMJNN9/SJHAXPA=
+github.com/rfratto/gohcl v0.0.0-20220609143238-53312695dc8f h1:M0xD8ycunxl8SuSIVej94MX652r6xxfg4tI0jGraAfw=
+github.com/rfratto/gohcl v0.0.0-20220609143238-53312695dc8f/go.mod h1:IOy7gzr7kMZOEwF4+DofdyoC4O0uPnanv+UkyVTs/2E=
 github.com/rgeyer/github-exporter v0.0.0-20210722215637-d0cec2ee0dc8 h1:wNuNGrFzFmZlhrtz1Q8EiK1Ob6yWli8lX7D2AGmSGzE=
 github.com/rgeyer/github-exporter v0.0.0-20210722215637-d0cec2ee0dc8/go.mod h1:6XoOvFDTfk3aqGaOLHLxoWiZNx4zHobApOhKc3oHF/g=
 github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=
@@ -2786,8 +2788,6 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
-golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/pkg/river/ast/ast.go
+++ b/pkg/river/ast/ast.go
@@ -55,7 +55,7 @@ type Comment struct {
 
 // AttributeStmt is a key-value pair being set in a Body or BlockStmt.
 type AttributeStmt struct {
-	Name  *IdentifierExpr
+	Name  *Ident
 	Value Expr
 }
 
@@ -69,10 +69,15 @@ type BlockStmt struct {
 	LCurlyPos, RCurlyPos token.Pos
 }
 
-// IdentifierExpr refers to a named value.
-type IdentifierExpr struct {
+// Ident holds an identifier with its position.
+type Ident struct {
 	Name    string
 	NamePos token.Pos
+}
+
+// IdentifierExpr refers to a named value.
+type IdentifierExpr struct {
+	Ident *Ident
 }
 
 // LiteralExpr is a constant value of a specific token kind.
@@ -101,7 +106,7 @@ type ObjectExpr struct {
 // ObjectField defines an individual key-value pair within an object.
 // ObjectField does not implement Node.
 type ObjectField struct {
-	Name   *IdentifierExpr
+	Name   *Ident
 	Quoted bool // True if the name was wrapped in quotes
 	Value  Expr
 }
@@ -109,7 +114,7 @@ type ObjectField struct {
 // AccessExpr accesses a field in an object value by name.
 type AccessExpr struct {
 	Value Expr
-	Name  *IdentifierExpr
+	Name  *Ident
 }
 
 // IndexExpr accesses an index in an array value.
@@ -153,6 +158,7 @@ var (
 	_ Node = (*Body)(nil)
 	_ Node = (*AttributeStmt)(nil)
 	_ Node = (*BlockStmt)(nil)
+	_ Node = (*Ident)(nil)
 	_ Node = (*IdentifierExpr)(nil)
 	_ Node = (*LiteralExpr)(nil)
 	_ Node = (*ArrayExpr)(nil)
@@ -185,6 +191,7 @@ func (n CommentGroup) astNode()    {}
 func (n *Comment) astNode()        {}
 func (n *AttributeStmt) astNode()  {}
 func (n *BlockStmt) astNode()      {}
+func (n *Ident) astNode()          {}
 func (n *IdentifierExpr) astNode() {}
 func (n *LiteralExpr) astNode()    {}
 func (n *ArrayExpr) astNode()      {}
@@ -234,8 +241,10 @@ func StartPos(n Node) token.Pos {
 		return StartPos(n.Name)
 	case *BlockStmt:
 		return n.NamePos
-	case *IdentifierExpr:
+	case *Ident:
 		return n.NamePos
+	case *IdentifierExpr:
+		return StartPos(n.Ident)
 	case *LiteralExpr:
 		return n.ValuePos
 	case *ArrayExpr:
@@ -283,8 +292,10 @@ func EndPos(n Node) token.Pos {
 		return EndPos(n.Value)
 	case *BlockStmt:
 		return n.RCurlyPos
-	case *IdentifierExpr:
+	case *Ident:
 		return n.NamePos.Add(len(n.Name) - 1)
+	case *IdentifierExpr:
+		return EndPos(n.Ident)
 	case *LiteralExpr:
 		return n.ValuePos.Add(len(n.Value) - 1)
 	case *ArrayExpr:

--- a/pkg/river/ast/walk.go
+++ b/pkg/river/ast/walk.go
@@ -1,0 +1,73 @@
+package ast
+
+import "fmt"
+
+// A Visitor has its Visit method invoked for each node encountered by Walk. If
+// the resulting visitor w is not nil, Walk visits each of the children of node
+// with the visitor w, followed by a call of w.Visit(nil).
+type Visitor interface {
+	Visit(node Node) (w Visitor)
+}
+
+// Walk traverses an AST in depth-first order: it starts by calling
+// v.Visit(node); node must not be nil. If the visitor w returned by
+// v.Visit(node) is not nil, Walk is invoked recursively with visitor w for
+// each of the non-nil children of node, followed by a call of w.Visit(nil).
+func Walk(v Visitor, node Node) {
+	if v = v.Visit(node); v == nil {
+		return
+	}
+
+	// Walk children. The order of the cases matches the declared order of nodes
+	// in ast.go.
+	switch n := node.(type) {
+	case *File:
+		Walk(v, n.Body)
+	case Body:
+		for _, s := range n {
+			Walk(v, s)
+		}
+	case *AttributeStmt:
+		Walk(v, n.Name)
+		Walk(v, n.Value)
+	case *BlockStmt:
+		Walk(v, n.Body)
+	case *Ident:
+		// Nothing to do
+	case *IdentifierExpr:
+		Walk(v, n.Ident)
+	case *LiteralExpr:
+		// Nothing to do
+	case *ArrayExpr:
+		for _, e := range n.Elements {
+			Walk(v, e)
+		}
+	case *ObjectExpr:
+		for _, f := range n.Fields {
+			Walk(v, f.Name)
+			Walk(v, f.Value)
+		}
+	case *AccessExpr:
+		Walk(v, n.Value)
+		Walk(v, n.Name)
+	case *IndexExpr:
+		Walk(v, n.Value)
+		Walk(v, n.Index)
+	case *CallExpr:
+		Walk(v, n.Value)
+		for _, a := range n.Args {
+			Walk(v, a)
+		}
+	case *UnaryExpr:
+		Walk(v, n.Value)
+	case *BinaryExpr:
+		Walk(v, n.Left)
+		Walk(v, n.Right)
+	case *ParenExpr:
+		Walk(v, n.Inner)
+	default:
+		panic(fmt.Sprintf("river/ast: unexpected node type %T", n))
+	}
+
+	v.Visit(nil)
+}

--- a/pkg/river/diag/diag.go
+++ b/pkg/river/diag/diag.go
@@ -1,0 +1,84 @@
+// Package diag exposes error types used throughout River and a method to
+// pretty-print them to the screen.
+package diag
+
+import (
+	"fmt"
+
+	"github.com/grafana/agent/pkg/river/token"
+)
+
+// Severity denotes the severity level of a diagnostic. The zero value of
+// severity is invalid.
+type Severity int
+
+// Supported severity levels.
+const (
+	SeverityLevelWarn Severity = iota + 1
+	SeverityLevelError
+)
+
+// Diagnostic is an individual diagnostic message. Diagnostic messages can have
+// different levels of severities.
+type Diagnostic struct {
+	// Severity holds the severity level of this Diagnostic.
+	Severity Severity
+
+	// StartPos refers to a position in a file where this Diagnostic starts.
+	StartPos token.Position
+
+	// EndPos refers to an optional position in a file where this Diagnostic
+	// ends. If EndPos is the zero value, the Diagnostic should be treated as
+	// only covering a single character (i.e., StartPos == EndPos).
+	//
+	// When defined, EndPos must have the same Filename value as the StartPos.
+	EndPos token.Position
+
+	Message string
+	Value   string
+}
+
+// Error implements error.
+func (d Diagnostic) Error() string {
+	return fmt.Sprintf("%s: %s", d.StartPos, d.Message)
+}
+
+// Diagnostics is a collection of diagnostic messages.
+type Diagnostics []Diagnostic
+
+// Add adds an individual Diagnostic to the diagnostics list.
+func (ds *Diagnostics) Add(d Diagnostic) {
+	*ds = append(*ds, d)
+}
+
+// Error implements error.
+func (ds Diagnostics) Error() string {
+	switch len(ds) {
+	case 0:
+		return "no errors"
+	case 1:
+		return ds[0].Error()
+	default:
+		return fmt.Sprintf("%s (and %d more diagnostics)", ds[0], len(ds)-1)
+	}
+}
+
+// ErrorOrNil returns an error interface if the list diagnostics is non-empty,
+// nil otherwise.
+func (ds Diagnostics) ErrorOrNil() error {
+	if len(ds) == 0 {
+		return nil
+	}
+	return ds
+}
+
+// HasErrors reports whether the list of Diagnostics contain any error-level
+// diagnostic.
+func (ds Diagnostics) HasErrors() bool {
+	for _, d := range ds {
+		if d.Severity == SeverityLevelError {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/river/diag/printer.go
+++ b/pkg/river/diag/printer.go
@@ -1,0 +1,264 @@
+package diag
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/grafana/agent/pkg/river/token"
+)
+
+const tabWidth = 4
+
+// PrinterConfig controls different settings for the Printer.
+type PrinterConfig struct {
+	// When Color is true, the printer will output with color and special
+	// formatting characters (such as underlines).
+	//
+	// This should be disabled when not printing to a terminal.
+	Color bool
+
+	// ContextLinesBefore and ContextLinesAfter controls how many context lines
+	// before and after the range of the diagnostic are printed.
+	ContextLinesBefore, ContextLinesAfter int
+}
+
+// A Printer pretty-prints Diagnostics.
+type Printer struct {
+	cfg PrinterConfig
+}
+
+// NewPrinter creates a new diagnostics Printer with the provided config.
+func NewPrinter(cfg PrinterConfig) *Printer {
+	return &Printer{cfg: cfg}
+}
+
+// Fprint creates a Printer with default settings and prints diagnostics to the
+// provided writer. files is used to look up file contents by name for printing
+// diagnostics context. files may be set to nil to avoid printing context.
+func Fprint(w io.Writer, files map[string][]byte, diags Diagnostics) error {
+	p := NewPrinter(PrinterConfig{
+		Color:              false,
+		ContextLinesBefore: 1,
+		ContextLinesAfter:  1,
+	})
+	return p.Fprint(w, files, diags)
+}
+
+// Fprint pretty-prints errors to a writer. files is used to look up file
+// contents by name when printing context. files may be nil to avoid printing
+// context.
+func (p *Printer) Fprint(w io.Writer, files map[string][]byte, diags Diagnostics) error {
+	// Create a buffered writer since we'll have many small calls to Write while
+	// we print errors.
+	//
+	// Buffers writers track the first write error received and will return it
+	// (if any) when flushing, so we can ignore write errors throughout the code
+	// until the very end.
+	bw := bufio.NewWriter(w)
+
+	for i, diag := range diags {
+		p.printDiagnosticHeader(bw, diag)
+
+		// If there's no ending position, set the ending position to be the same as
+		// the start.
+		if !diag.EndPos.Valid() {
+			diag.EndPos = diag.StartPos
+		}
+
+		// We can print the file context if it was found.
+		fileContents, foundFile := files[diag.StartPos.Filename]
+		if foundFile && diag.StartPos.Filename == diag.EndPos.Filename {
+			p.printRange(bw, fileContents, diag)
+		}
+
+		// Print a blank line to separate diagnostics.
+		if i+1 < len(diags) {
+			fmt.Fprintf(bw, "\n")
+		}
+	}
+
+	return bw.Flush()
+}
+
+func (p *Printer) printDiagnosticHeader(w io.Writer, diag Diagnostic) {
+	if p.cfg.Color {
+		switch diag.Severity {
+		case SeverityLevelError:
+			cw := color.New(color.FgRed, color.Bold)
+			_, _ = cw.Fprintf(w, "Error: ")
+		case SeverityLevelWarn:
+			cw := color.New(color.FgYellow, color.Bold)
+			_, _ = cw.Fprintf(w, "Warning: ")
+		}
+
+		cw := color.New(color.Bold)
+		_, _ = cw.Fprintf(w, "%s: %s\n", diag.StartPos, diag.Message)
+		return
+	}
+
+	switch diag.Severity {
+	case SeverityLevelError:
+		_, _ = fmt.Fprintf(w, "Error: ")
+	case SeverityLevelWarn:
+		_, _ = fmt.Fprintf(w, "Warning: ")
+	}
+	fmt.Fprintf(w, "%s: %s\n", diag.StartPos, diag.Message)
+}
+
+func (p *Printer) printRange(w io.Writer, file []byte, diag Diagnostic) {
+	var (
+		start = diag.StartPos
+		end   = diag.EndPos
+	)
+
+	fmt.Fprintf(w, "\n")
+
+	var (
+		lines = strings.Split(string(file), "\n")
+
+		startLine = max(start.Line-p.cfg.ContextLinesBefore, 1)
+		endLine   = min(end.Line+p.cfg.ContextLinesAfter, len(lines))
+
+		multiline = end.Line-start.Line > 0
+	)
+
+	prefixWidth := len(strconv.Itoa(endLine))
+
+	for lineNum := startLine; lineNum <= endLine; lineNum++ {
+		line := lines[lineNum-1]
+
+		// Print line number and margin.
+		printPaddedNumber(w, prefixWidth, lineNum)
+		fmt.Fprintf(w, " | ")
+
+		if multiline {
+			if inRange(lineNum, 1, start, end) {
+				fmt.Fprint(w, "| ")
+			} else {
+				fmt.Fprint(w, "  ")
+			}
+		}
+
+		// Print the line, but filter out any \r and replace tabs with spaces.
+		for _, ch := range line {
+			if ch == '\r' {
+				continue
+			}
+			if ch == '\t' || ch == '\v' {
+				printCh(w, tabWidth, ' ')
+				continue
+			}
+			fmt.Fprintf(w, "%c", ch)
+		}
+
+		fmt.Fprintf(w, "\n")
+
+		// Print the focus indicator if we're on a line that needs it.
+		//
+		// The focus indicator line must preserve whitespace present in the line
+		// above it prior to the focus '^' characters. Tab characters are replaced
+		// with spaces for consistent printing.
+		if lineNum == start.Line || (multiline && lineNum == end.Line) {
+			printCh(w, prefixWidth, ' ') // Add empty space where line number would be
+
+			// Print the margin after the blank line number. On multi-line errors,
+			// the arrow is printed all the way to the margin, with with straight
+			// lines going down in between the lines.
+			switch {
+			case multiline && lineNum == start.Line:
+				// |_ would look like an incorrect right angle, so the second bar
+				// is dropped.
+				fmt.Fprintf(w, " |  _")
+			case multiline && lineNum == end.Line:
+				fmt.Fprintf(w, " | |_")
+			default:
+				fmt.Fprintf(w, " | ")
+			}
+
+			p.printFocus(w, line, lineNum, diag)
+			fmt.Fprintf(w, "\n")
+		}
+	}
+}
+
+// printFocus prints the focus indicator for the line number specified by line.
+// The contents of the line should be represented by data so whitespace can be
+// retained (injecting spaces where a tab should be, etc).
+func (p *Printer) printFocus(w io.Writer, data string, line int, diag Diagnostic) {
+	for i, ch := range data {
+		column := i + 1
+
+		if line == diag.EndPos.Line && column > diag.EndPos.Column {
+			// Stop printing the formatting line after printing all the ^.
+			break
+		}
+
+		blank := byte(' ')
+		if diag.EndPos.Line-diag.StartPos.Line > 0 {
+			blank = byte('_')
+		}
+
+		switch {
+		case ch == '\t' || ch == '\v':
+			printCh(w, tabWidth, blank)
+		case inRange(line, column, diag.StartPos, diag.EndPos):
+			fmt.Fprintf(w, "%c", '^')
+		default:
+			// Print a space.
+			fmt.Fprintf(w, "%c", blank)
+		}
+	}
+}
+
+func inRange(line, col int, start, end token.Position) bool {
+	if line < start.Line || line > end.Line {
+		return false
+	}
+
+	switch line {
+	case start.Line:
+		// If the current line is on the starting line, we have to be past the
+		// starting column.
+		return col >= start.Column
+	case end.Line:
+		// If the current line is on the ending line, we have to be before the
+		// final column.
+		return col <= end.Column
+	default:
+		// Otherwise, every column across all the lines in between
+		// is in the range.
+		return true
+	}
+}
+
+func printPaddedNumber(w io.Writer, width int, num int) {
+	numStr := strconv.Itoa(num)
+	for i := 0; i < width-len(numStr); i++ {
+		_, _ = w.Write([]byte{' '})
+	}
+	_, _ = w.Write([]byte(numStr))
+}
+
+func printCh(w io.Writer, count int, ch byte) {
+	for i := 0; i < count; i++ {
+		_, _ = w.Write([]byte{ch})
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/pkg/river/diag/printer_test.go
+++ b/pkg/river/diag/printer_test.go
@@ -1,0 +1,195 @@
+package diag_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/grafana/agent/pkg/river/diag"
+	"github.com/grafana/agent/pkg/river/token"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFprint(t *testing.T) {
+	// In all tests below, the filename is "testfile" and the severity is an
+	// error.
+
+	tt := []struct {
+		name       string
+		input      string
+		start, end token.Position
+		diag       diag.Diagnostic
+		expect     string
+	}{
+		{
+			name:  "highlight on same line",
+			start: token.Position{Line: 2, Column: 2},
+			end:   token.Position{Line: 2, Column: 5},
+			input: `test.block "label" {
+	attr       = 1
+	other_attr = 2
+}`,
+			expect: `Error: testfile:2:2: synthetic error
+
+1 | test.block "label" {
+2 |     attr       = 1
+  |     ^^^^
+3 |     other_attr = 2
+`,
+		},
+
+		{
+			name:  "end positions should be optional",
+			start: token.Position{Line: 1, Column: 4},
+			input: `foo,bar`,
+			expect: `Error: testfile:1:4: synthetic error
+
+1 | foo,bar
+  |    ^
+`,
+		},
+
+		{
+			name:  "padding should be inserted to fit line numbers of different lengths",
+			start: token.Position{Line: 9, Column: 1},
+			end:   token.Position{Line: 9, Column: 6},
+			input: `LINE_1
+LINE_2
+LINE_3
+LINE_4
+LINE_5
+LINE_6
+LINE_7
+LINE_8
+LINE_9
+LINE_10
+LINE_11`,
+			expect: `Error: testfile:9:1: synthetic error
+
+ 8 | LINE_8
+ 9 | LINE_9
+   | ^^^^^^
+10 | LINE_10
+`,
+		},
+
+		{
+			name:  "errors which cross multiple lines can be printed",
+			start: token.Position{Line: 2, Column: 8},
+			end:   token.Position{Line: 6, Column: 7},
+			input: `FILE_BEGIN
+before START
+TEXT
+	TEXT
+		TEXT
+			DONE after
+FILE_END`,
+			expect: `Error: testfile:2:8: synthetic error
+
+1 |   FILE_BEGIN
+2 |   before START
+  |  ________^^^^^
+3 | | TEXT
+4 | |     TEXT
+5 | |         TEXT
+6 | |             DONE after
+  | |_____________^^^^
+7 |   FILE_END
+`,
+		},
+	}
+
+	for _, tc := range tt {
+		files := map[string][]byte{
+			"testfile": []byte(tc.input),
+		}
+
+		tc.start.Filename = "testfile"
+		tc.end.Filename = "testfile"
+
+		diags := diag.Diagnostics{{
+			Severity: diag.SeverityLevelError,
+			StartPos: tc.start,
+			EndPos:   tc.end,
+			Message:  "synthetic error",
+		}}
+
+		var buf bytes.Buffer
+		_ = diag.Fprint(&buf, files, diags)
+		requireEqualStrings(t, tc.expect, buf.String())
+	}
+}
+
+func TestFprint_MultipleDiagnostics(t *testing.T) {
+	fileA := `old_field = 15
+3 & 4`
+	fileB := `old_field = 22`
+
+	files := map[string][]byte{
+		"file_a": []byte(fileA),
+		"file_b": []byte(fileB),
+	}
+
+	diags := diag.Diagnostics{
+		{
+			Severity: diag.SeverityLevelWarn,
+			StartPos: token.Position{Filename: "file_a", Line: 1, Column: 1},
+			EndPos:   token.Position{Filename: "file_a", Line: 1, Column: 9},
+			Message:  "old_field is deprecated",
+		},
+		{
+			Severity: diag.SeverityLevelError,
+			StartPos: token.Position{Filename: "file_a", Line: 2, Column: 3},
+			Message:  "unrecognized operator &",
+		},
+		{
+			Severity: diag.SeverityLevelWarn,
+			StartPos: token.Position{Filename: "file_b", Line: 1, Column: 1},
+			EndPos:   token.Position{Filename: "file_b", Line: 1, Column: 9},
+			Message:  "old_field is deprecated",
+		},
+	}
+
+	expect := `Warning: file_a:1:1: old_field is deprecated
+
+1 | old_field = 15
+  | ^^^^^^^^^
+2 | 3 & 4
+
+Error: file_a:2:3: unrecognized operator &
+
+1 | old_field = 15
+2 | 3 & 4
+  |   ^
+
+Warning: file_b:1:1: old_field is deprecated
+
+1 | old_field = 22
+  | ^^^^^^^^^
+`
+
+	var buf bytes.Buffer
+	_ = diag.Fprint(&buf, files, diags)
+	requireEqualStrings(t, expect, buf.String())
+}
+
+// requireEqualStrings is like require.Equal with two strings but it
+// pretty-prints multiline strings to make it easier to compare.
+func requireEqualStrings(t *testing.T, expected, actual string) {
+	if expected == actual {
+		return
+	}
+
+	msg := fmt.Sprintf(
+		"Not equal:\n"+
+			"raw expected: %#v\n"+
+			"raw actual  : %#v\n"+
+			"\n"+
+			"expected:\n%s\n"+
+			"actual:\n%s\n",
+		expected, actual,
+		expected, actual,
+	)
+
+	require.Fail(t, msg)
+}

--- a/pkg/river/internal/value/decode_test.go
+++ b/pkg/river/internal/value/decode_test.go
@@ -35,7 +35,6 @@ func TestDecode_Numbers(t *testing.T) {
 				require.NoError(t, value.Decode(val, vPtr))
 
 				actual := reflect.ValueOf(vPtr).Elem().Interface()
-
 				require.Equal(t, expect, actual)
 			})
 		}

--- a/pkg/river/internal/value/decode_test.go
+++ b/pkg/river/internal/value/decode_test.go
@@ -203,13 +203,29 @@ func TestDecode_ArrayCopy(t *testing.T) {
 }
 
 func TestDecode_CustomTypes(t *testing.T) {
-	t.Run("Unmarshaler", func(t *testing.T) {
+	t.Run("object to Unmarshaler", func(t *testing.T) {
 		var actual customUnmarshaler
 		require.NoError(t, value.Decode(value.Object(nil), &actual))
 		require.True(t, actual.Called, "UnmarshalRiver was not invoked")
 	})
 
-	t.Run("TextUnmarshaler", func(t *testing.T) {
+	t.Run("TextMarshaler to TextUnmarshaler", func(t *testing.T) {
+		now := time.Now()
+
+		var actual time.Time
+		require.NoError(t, value.Decode(value.Encode(now), &actual))
+		require.True(t, now.Equal(actual))
+	})
+
+	t.Run("time.Duration to time.Duration", func(t *testing.T) {
+		dur := 15 * time.Second
+
+		var actual time.Duration
+		require.NoError(t, value.Decode(value.Encode(dur), &actual))
+		require.Equal(t, dur, actual)
+	})
+
+	t.Run("string to TextUnmarshaler", func(t *testing.T) {
 		now := time.Now()
 		nowBytes, _ := now.MarshalText()
 
@@ -220,7 +236,7 @@ func TestDecode_CustomTypes(t *testing.T) {
 		require.Equal(t, nowBytes, actualBytes)
 	})
 
-	t.Run("time.Duration", func(t *testing.T) {
+	t.Run("string to time.Duration", func(t *testing.T) {
 		dur := 15 * time.Second
 
 		var actual time.Duration

--- a/pkg/river/internal/value/decode_test.go
+++ b/pkg/river/internal/value/decode_test.go
@@ -204,6 +204,12 @@ func TestDecode_ArrayCopy(t *testing.T) {
 }
 
 func TestDecode_CustomTypes(t *testing.T) {
+	t.Run("Unmarshaler", func(t *testing.T) {
+		var actual customUnmarshaler
+		require.NoError(t, value.Decode(value.Object(nil), &actual))
+		require.True(t, actual.Called, "UnmarshalRiver was not invoked")
+	})
+
 	t.Run("TextUnmarshaler", func(t *testing.T) {
 		now := time.Now()
 		nowBytes, _ := now.MarshalText()
@@ -222,6 +228,17 @@ func TestDecode_CustomTypes(t *testing.T) {
 		require.NoError(t, value.Decode(value.String(dur.String()), &actual))
 		require.Equal(t, dur.String(), actual.String())
 	})
+}
+
+type customUnmarshaler struct {
+	Called bool
+}
+
+func (cu *customUnmarshaler) UnmarshalRiver(f func(interface{}) error) error {
+	cu.Called = true
+
+	type s customUnmarshaler
+	return f((*s)(cu))
 }
 
 type textEnumType bool

--- a/pkg/river/internal/value/type.go
+++ b/pkg/river/internal/value/type.go
@@ -68,15 +68,23 @@ func RiverType(t reflect.Type) Type {
 	// or non-pointer type, so we have to check before and after dereferencing.
 
 	for t.Kind() == reflect.Pointer {
-		if t.Implements(goCapsule) {
+		switch {
+		case t.Implements(goCapsule):
 			return TypeCapsule
+		case t.Implements(goTextMarshaler):
+			return TypeString
 		}
 
 		t = t.Elem()
 	}
 
-	if t.Implements(goCapsule) {
+	switch {
+	case t.Implements(goCapsule):
 		return TypeCapsule
+	case t.Implements(goTextMarshaler):
+		return TypeString
+	case t == goDuration:
+		return TypeString
 	}
 
 	switch t.Kind() {

--- a/pkg/river/internal/value/value.go
+++ b/pkg/river/internal/value/value.go
@@ -206,7 +206,7 @@ func (v Value) Text() string {
 	}
 	switch {
 	case addrRV.Type().Implements(goTextMarshaler):
-		// TODO(rfratto): what shoudl we do if this fails?
+		// TODO(rfratto): what should we do if this fails?
 		text, _ := addrRV.Interface().(encoding.TextMarshaler).MarshalText()
 		return string(text)
 

--- a/pkg/river/internal/value/value.go
+++ b/pkg/river/internal/value/value.go
@@ -454,9 +454,7 @@ func convertValue(val Value, toType Type) (Value, error) {
 	return Null, TypeError{Value: val, Expected: toType}
 }
 
-func convertGoNumber(v reflect.Value, target reflect.Type) reflect.Value {
-	nval := newNumberValue(v)
-
+func convertGoNumber(nval Number, target reflect.Type) reflect.Value {
 	switch target.Kind() {
 	case reflect.Int:
 		return reflect.ValueOf(int(nval.Int()))

--- a/pkg/river/internal/value/value.go
+++ b/pkg/river/internal/value/value.go
@@ -21,6 +21,7 @@ var (
 	goStructWrapper   = reflect.TypeOf(structWrapper{})
 	goCapsule         = reflect.TypeOf((*Capsule)(nil)).Elem()
 	goDurationPtr     = reflect.TypeOf((*time.Duration)(nil))
+	goRiverDecoder    = reflect.TypeOf((*Unmarshaler)(nil)).Elem()
 )
 
 // NOTE(rfratto): This package is extremely sensitive to performance, so

--- a/pkg/river/parser/error_test.go
+++ b/pkg/river/parser/error_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/grafana/agent/pkg/river/diag"
 	"github.com/grafana/agent/pkg/river/scanner"
 	"github.com/grafana/agent/pkg/river/token"
 	"github.com/stretchr/testify/assert"
@@ -82,11 +83,11 @@ func isLiteral(t token.Token) bool {
 
 // compareErrors compes the map of expected error messages with the list of
 // found errors and reports mismatches.
-func compareErrors(t *testing.T, file *token.File, expected map[token.Pos]string, found ErrorList) {
+func compareErrors(t *testing.T, file *token.File, expected map[token.Pos]string, found diag.Diagnostics) {
 	t.Helper()
 
 	for _, checkError := range found {
-		pos := file.Pos(checkError.Position.Offset)
+		pos := file.Pos(checkError.StartPos.Offset)
 
 		if msg, found := expected[pos]; found {
 			// We expect a message at pos; check if it matches
@@ -97,13 +98,13 @@ func compareErrors(t *testing.T, file *token.File, expected map[token.Pos]string
 			assert.True(t,
 				rx.MatchString(checkError.Message),
 				"%s: %q does not match %q",
-				checkError.Position, checkError.Message, msg,
+				checkError.StartPos, checkError.Message, msg,
 			)
 			delete(expected, pos) // Eliminate consumed error
 		} else {
 			assert.Fail(t,
 				"Unexpected error",
-				"unexpected error: %s: %s", checkError.Position.String(), checkError.Message,
+				"unexpected error: %s: %s", checkError.StartPos.String(), checkError.Message,
 			)
 		}
 	}
@@ -143,5 +144,5 @@ func checkErrors(t *testing.T, filename string) {
 	_ = p.ParseFile()
 
 	expected := expectedErrors(p.file, src)
-	compareErrors(t, p.file, expected, p.errors)
+	compareErrors(t, p.file, expected, p.diags)
 }

--- a/pkg/river/parser/internal.go
+++ b/pkg/river/parser/internal.go
@@ -219,7 +219,7 @@ func (p *parser) parseStatement() ast.Stmt {
 		}
 
 		return &ast.AttributeStmt{
-			Name: &ast.IdentifierExpr{
+			Name: &ast.Ident{
 				Name:    blockName.Fragments[0],
 				NamePos: blockName.Start,
 			},
@@ -425,7 +425,7 @@ NextOper:
 
 			primary = &ast.AccessExpr{
 				Value: primary,
-				Name: &ast.IdentifierExpr{
+				Name: &ast.Ident{
 					Name:    name,
 					NamePos: namePos,
 				},
@@ -489,8 +489,10 @@ func (p *parser) parsePrimaryExpr() ast.Expr {
 	switch p.tok {
 	case token.IDENT:
 		res := &ast.IdentifierExpr{
-			Name:    p.lit,
-			NamePos: p.pos,
+			Ident: &ast.Ident{
+				Name:    p.lit,
+				NamePos: p.pos,
+			},
 		}
 		p.next()
 		return res
@@ -603,7 +605,7 @@ func (p *parser) parseField() *ast.ObjectField {
 	}
 
 	field := &ast.ObjectField{
-		Name: &ast.IdentifierExpr{
+		Name: &ast.Ident{
 			Name:    p.lit,
 			NamePos: p.pos,
 		},

--- a/pkg/river/parser/parser.go
+++ b/pkg/river/parser/parser.go
@@ -2,52 +2,21 @@
 package parser
 
 import (
-	"fmt"
-
 	"github.com/grafana/agent/pkg/river/ast"
-	"github.com/grafana/agent/pkg/river/token"
 )
-
-// Error is an error encountered during parsing.
-type Error struct {
-	Position token.Position
-	Message  string
-}
-
-// Error implements error.
-func (e Error) Error() string {
-	return fmt.Sprintf("%s: %s", e.Position, e.Message)
-}
-
-// ErrorList is a list of Error.
-type ErrorList []*Error
-
-// Add appends a new error into the ErrorList.
-func (l *ErrorList) Add(e *Error) { *l = append(*l, e) }
-
-// Error implements error.
-func (l ErrorList) Error() string {
-	switch len(l) {
-	case 0:
-		return "no errors"
-	case 1:
-		return l[0].Error()
-	}
-	return fmt.Sprintf("%s (and %d more errors)", l[0], len(l)-1)
-}
 
 // ParseFile parses an entire River configuration file. The data parameter
 // should hold the file contents to parse, while the filename parameter is used
 // for reporting errors.
 //
 // If an error was encountered during parsing, the returned AST will be nil and
-// err will be an ErrorList with all the errors encountered during parsing.
+// err will be an diag.Diagnostics all the errors encountered during parsing.
 func ParseFile(filename string, data []byte) (*ast.File, error) {
 	p := newParser(filename, data)
 
 	f := p.ParseFile()
-	if len(p.errors) > 0 {
-		return nil, p.errors
+	if len(p.diags) > 0 {
+		return nil, p.diags
 	}
 	return f, nil
 }
@@ -61,8 +30,8 @@ func ParseExpression(expr string) (ast.Expr, error) {
 	p := newParser("", []byte(expr))
 
 	e := p.ParseExpression()
-	if len(p.errors) > 0 {
-		return nil, p.errors
+	if len(p.diags) > 0 {
+		return nil, p.diags
 	}
 	return e, nil
 }

--- a/pkg/river/parser/parser_test.go
+++ b/pkg/river/parser/parser_test.go
@@ -25,7 +25,7 @@ func FuzzParser(f *testing.F) {
 		p := newParser(t.Name(), input)
 
 		_ = p.ParseFile()
-		if len(p.errors) > 0 {
+		if len(p.diags) > 0 {
 			t.SkipNow()
 		}
 	})
@@ -46,7 +46,7 @@ func TestValid(t *testing.T) {
 
 			res := p.ParseFile()
 			require.NotNil(t, res)
-			require.Len(t, p.errors, 0)
+			require.Len(t, p.diags, 0)
 		})
 
 		return nil
@@ -116,7 +116,7 @@ func TestParseExpressions(t *testing.T) {
 
 			res := p.ParseExpression()
 			require.NotNil(t, res)
-			require.Len(t, p.errors, 0)
+			require.Len(t, p.diags, 0)
 		})
 	}
 }

--- a/pkg/river/printer/printer.go
+++ b/pkg/river/printer/printer.go
@@ -196,7 +196,7 @@ func (p *printer) Write(args ...interface{}) {
 			p.lastTok = token.LITERAL
 			continue
 
-		case *ast.IdentifierExpr:
+		case *ast.Ident:
 			data = arg.Name
 			p.lastTok = token.IDENT
 

--- a/pkg/river/printer/walker.go
+++ b/pkg/river/printer/walker.go
@@ -105,7 +105,7 @@ func (w *walker) walkBlockStmt(s *ast.BlockStmt) {
 
 	w.p.Write(
 		s.NamePos,
-		&ast.IdentifierExpr{Name: joined, NamePos: s.NamePos},
+		&ast.Ident{Name: joined, NamePos: s.NamePos},
 	)
 
 	if s.Label != "" {
@@ -140,7 +140,7 @@ func (w *walker) walkExpr(e ast.Expr) {
 		w.walkObjectExpr(e)
 
 	case *ast.IdentifierExpr:
-		w.p.Write(e.NamePos, e)
+		w.p.Write(e.Ident.NamePos, e.Ident)
 
 	case *ast.AccessExpr:
 		w.walkExpr(e.Value)

--- a/pkg/river/token/builder/builder_test.go
+++ b/pkg/river/token/builder/builder_test.go
@@ -46,6 +46,7 @@ func TestBuilder_File(t *testing.T) {
 func TestBuilder_GoEncode(t *testing.T) {
 	f := builder.NewFile()
 
+	f.Body().AppendTokens([]builder.Token{{token.COMMENT, "// Hello, world!"}})
 	f.Body().SetAttributeValue("null_value", nil)
 	f.Body().AppendTokens([]builder.Token{{token.LITERAL, "\n"}})
 
@@ -69,6 +70,7 @@ func TestBuilder_GoEncode(t *testing.T) {
 	})
 
 	expect := format(t, `
+		// Hello, world!
 		null_value = null
 	
 		num     = 15 

--- a/pkg/river/token/builder/token.go
+++ b/pkg/river/token/builder/token.go
@@ -25,6 +25,8 @@ func printTokens(w io.Writer, toks []Token) (int, error) {
 		switch {
 		case tok.Tok == token.LITERAL:
 			raw.WriteString(tok.Lit)
+		case tok.Tok == token.COMMENT:
+			raw.WriteString(tok.Lit)
 		case tok.Tok.IsLiteral() || tok.Tok.IsKeyword():
 			raw.WriteString(tok.Lit)
 		default:

--- a/pkg/river/token/builder/value_tokens.go
+++ b/pkg/river/token/builder/value_tokens.go
@@ -10,6 +10,8 @@ import (
 	"github.com/grafana/agent/pkg/river/token"
 )
 
+// TODO(rfratto): check for optional values
+
 // Tokenizer is any value which can return a raw set of tokens.
 type Tokenizer interface {
 	// RiverTokenize returns the raw set of River tokens which are used when

--- a/pkg/river/token/builder/value_tokens.go
+++ b/pkg/river/token/builder/value_tokens.go
@@ -1,9 +1,7 @@
 package builder
 
 import (
-	"encoding"
 	"fmt"
-	"time"
 
 	"github.com/grafana/agent/pkg/river/internal/value"
 	"github.com/grafana/agent/pkg/river/scanner"
@@ -26,22 +24,9 @@ func tokenEncode(val interface{}) []Token {
 func valueTokens(v value.Value) []Token {
 	var toks []Token
 
-	// Check for interfces which override encoding behavior:
-	switch v := v.Interface().(type) {
-	case time.Duration:
-		return []Token{{
-			Tok: token.STRING,
-			Lit: fmt.Sprintf("%q", v.String()),
-		}}
-	case Tokenizer:
-		return v.RiverTokenize()
-	case encoding.TextMarshaler:
-		// TODO(rfratto): what if this fails?
-		bb, _ := v.MarshalText()
-		return []Token{{
-			Tok: token.STRING,
-			Lit: fmt.Sprintf("%q", string(bb)),
-		}}
+	// If v is a Tokenizer, allow it to override what tokens get generated.
+	if tk, ok := v.Interface().(Tokenizer); ok {
+		return tk.RiverTokenize()
 	}
 
 	switch v.Type() {


### PR DESCRIPTION
This PR fixes 7 small issues I found while testing River for Flow, and adds one new feature (river/diag). 

The small changes / bug fixes are as follows: 

* river/internal/value: Add support for an Unmarshaler interface so types can hook custom logic into decoding (e.g., like for applying default values) 

* river/ast: Create an ast.Walk function to allow for walking the AST. This also changes separates IdentExpr into an Ident so AST visitors can guarantee when an IdentExpr is part of an expression. This will be used for determining what references a Flow component is making to other Flow components. 

* river/token/builder: Support writing out comments. 

* river/token/builder: Allow encoding bodies from Go values. This was a missing piece of functionality needed to implement the /-/config endpoint. 

* river/internal/value: Minimize usage of Value.rv when decoding. Value.rv should be considered internal-only and not used throughout the decoder. This removes most usages, but complete elimination will require future work. 

* river/internal/value: Move logic for TextMarshaler/time.Duration to the value package so values of these types are actually treated as strings, instead of only displaying as strings. 

* river/internal/value: Properly detect River type for values which only implement an interface for a pointer receiver.   

The new `river/diag` package implements a shared error type and a pretty-printer to show these errors to users. The pretty-printer produces Rust-inspired error messages where the range of text from the offending file is displayed to the user:

```
1 |   test.block "label" {
2 |   	attr       = 1
  |   	^^^^
3 |   	other_attr = 2
```

These changes should be merged _prior_ to #1936, which will need to be updated to also handle some of the changes here. 

I've separated each of these changes into their own commits for easier reviewing. If reviewers would prefer separate PRs, please let me know. I decided to try for a single commit given the number of small changes needed.