### PR TITLE
metrics.scrape: use rivertypes.Secret for sensitive attributes

### DIFF
--- a/component/metrics/scrape/types.go
+++ b/component/metrics/scrape/types.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/alecthomas/units"
+	"github.com/grafana/agent/pkg/flow/rivertypes"
 	common_config "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
@@ -69,16 +70,16 @@ type Config struct {
 
 // BasicAuth configures Basic HTTP authentication credentials.
 type BasicAuth struct {
-	Username     string `river:"username,attr,optional"`
-	Password     string `river:"password,attr,optional"`
-	PasswordFile string `river:"password_file,attr,optional"`
+	Username     string            `river:"username,attr,optional"`
+	Password     rivertypes.Secret `river:"password,attr,optional"`
+	PasswordFile string            `river:"password_file,attr,optional"`
 }
 
 // Authorization sets up HTTP authorization credentials.
 type Authorization struct {
-	Type            string `river:"authorization_type,attr,optional"`
-	Credential      string `river:"authorization_credential,attr,optional"`
-	CredentialsFile string `river:"authorization_credentials_file,attr,optional"`
+	Type            string            `river:"authorization_type,attr,optional"`
+	Credential      rivertypes.Secret `river:"authorization_credential,attr,optional"`
+	CredentialsFile string            `river:"authorization_credentials_file,attr,optional"`
 }
 
 // TLSConfig sets up options for TLS connections.
@@ -93,7 +94,7 @@ type TLSConfig struct {
 // OAuth2Config sets up the OAuth2 client.
 type OAuth2Config struct {
 	ClientID         string            `river:"client_id,attr,optional"`
-	ClientSecret     string            `river:"client_secret,attr,optional"`
+	ClientSecret     rivertypes.Secret `river:"client_secret,attr,optional"`
 	ClientSecretFile string            `river:"client_secret_file,attr,optional"`
 	Scopes           []string          `river:"scopes,attr,optional"`
 	TokenURL         string            `river:"token_url,attr,optional"`

--- a/docs/flow/components/metrics.scrape.md
+++ b/docs/flow/components/metrics.scrape.md
@@ -66,7 +66,7 @@ basic_auth               | basic_auth block    | Setup of Basic HTTP authenticat
 authorization            | authorization block | Setup of HTTP Authorization credentials. | | no
 oauth2                   | oauth2 block        | Setup of the OAuth2 client. | | no
 tls_config               | tls_config block    | Configuration options for TLS connections. | | no
-bearer_token             | string   | Used to set up the Bearer Token. | | no
+bearer_token             | secret   | Used to set up the Bearer Token. | | no
 bearer_token_file        | string   | Used to set up the Bearer Token file. | | no
 proxy_url                | string   | Used to set up a Proxy URL. | | no
 follow_redirects         | bool     | Whether the scraper should follow redirects. | true | no
@@ -76,21 +76,21 @@ enable_http_2            | bool     | Whether the scraper should use HTTP2. | | 
 Name          | Type     | Description                                     | Default | Required
 --------------| -------- | ----------------------------------------------- | ------- | -------
 username      | string   | Setup of Basic HTTP authentication credentials. |         | no
-password      | string   | Setup of Basic HTTP authentication credentials. |         | no
+password      | secret   | Setup of Basic HTTP authentication credentials. |         | no
 password_file | string   | Setup of Basic HTTP authentication credentials. |         | no
 
 #### authorization block
 Name                | Type     | Description                              | Default | Required
 ------------------- | -------- | -----------------------------------------| ------- | --------
 type                | string   | Setup of HTTP Authorization credentials. |         | no
-credential          | string   | Setup of HTTP Authorization credentials. |         | no
+credential          | secret   | Setup of HTTP Authorization credentials. |         | no
 credentials_file    | string   | Setup of HTTP Authorization credentials. |         | no
 
 #### oauth2 block
 Name               | Type             | Description                              | Default | Required
 ------------------ | ---------------- | -----------------------------------------| ------- | --------
 client_id          | string           | Setup of the OAuth2 client.              |         | no
-client_secret      | string           | Setup of the OAuth2 client.              |         | no
+client_secret      | secret           | Setup of the OAuth2 client.              |         | no
 client_secret_file | string           | Setup of the OAuth2 client.              |         | no
 scopes             | list(string)     | Setup of the OAuth2 client.              |         | no
 token_url          | string           | Setup of the OAuth2 client.              |         | no


### PR DESCRIPTION
All sensitive attributes should use the rivertypes.Secret type and not raw strings.