### PR TITLE
river/printer: align object literal values

### DIFF
--- a/pkg/river/printer/testdata/object_align.expect
+++ b/pkg/river/printer/testdata/object_align.expect
@@ -1,0 +1,11 @@
+block {
+	some_object = {
+		key_1      = 5,
+		long_key   = 10,
+		longer_key = {
+			inner_key   = true,
+			inner_key_2 = false,
+		},
+		other_key = [0, 1, 2],
+	}
+}

--- a/pkg/river/printer/testdata/object_align.in
+++ b/pkg/river/printer/testdata/object_align.in
@@ -1,0 +1,11 @@
+block {
+	some_object = {
+		key_1 = 5,
+		long_key = 10,
+		longer_key = {
+			inner_key = true,
+			inner_key_2 = false,
+		},
+		other_key = [0, 1, 2],
+	}
+}

--- a/pkg/river/printer/walker.go
+++ b/pkg/river/printer/walker.go
@@ -242,7 +242,13 @@ func (w *walker) walkObjectExpr(e *ast.ObjectExpr) {
 		// Add a newline if this element starts on a different line than the last
 		// element ended.
 		if differentLines(prevPos, elementPos) {
-			w.p.Write(wsFormfeed)
+			// We want to align the equal sign for object attributes if the previous
+			// field only crossed one line.
+			if i > 0 && nodeLines(e.Fields[i-1].Value) == 1 {
+				w.p.Write(wsNewline)
+			} else {
+				w.p.Write(wsFormfeed)
+			}
 		} else if i > 0 {
 			// Make sure a space is injected before the next element if two successive
 			// elements are on the same line.


### PR DESCRIPTION
Align object literal field names similar to attributes in blocks so that 

```river
{
  short_key = "value",
  longer_key = "value",
}
```

becomes 

```river 
{
  short_key  = "value",
  longer_key = "value",
} 
```

Similarly to attributes in blocks, alignment with the previous field only applies if the previous field spanned a single line. These two field names will never be aligned:

```river 
{
  array_across_multiple_lines = [
    0,
    1,
    2,
  ],
  other_key = "value",
} 
```