### PR TITLE
river/token/builder: print keys in sorted order for unordered objects

### DIFF
--- a/pkg/river/internal/value/value.go
+++ b/pkg/river/internal/value/value.go
@@ -289,6 +289,25 @@ func makeValue(v reflect.Value) Value {
 	return Value{rv: v, ty: riverType}
 }
 
+// OrderedKeys reports if v represents an object with consistently ordered
+// keys. If panics if v is not an object.
+func (v Value) OrderedKeys() bool {
+	if v.ty != TypeObject {
+		panic("river/value: OrderedKeys called on non-object value")
+	}
+
+	switch {
+	case v.rv.Kind() == reflect.Map:
+		// Maps aren't ordered since you can't iterate over their keys in a
+		// consistent order.
+		return false
+
+	default:
+		// Everything else is ordered.
+		return true
+	}
+}
+
 // Keys returns the keys in v in unspecified order. It panics if v is not an
 // object.
 func (v Value) Keys() []string {

--- a/pkg/river/internal/value/value.go
+++ b/pkg/river/internal/value/value.go
@@ -296,16 +296,11 @@ func (v Value) OrderedKeys() bool {
 		panic("river/value: OrderedKeys called on non-object value")
 	}
 
-	switch {
-	case v.rv.Kind() == reflect.Map:
-		// Maps aren't ordered since you can't iterate over their keys in a
-		// consistent order.
-		return false
-
-	default:
-		// Everything else is ordered.
-		return true
-	}
+	// Maps are the only type of unordered River object, since their keys can't
+	// be iterated over in a deterministic order. Every other type of River
+	// object comes from a struct or a slice where the order of keys stays the
+	// same.
+	return v.rv.Kind() != reflect.Map
 }
 
 // Keys returns the keys in v in unspecified order. It panics if v is not an

--- a/pkg/river/token/builder/builder_test.go
+++ b/pkg/river/token/builder/builder_test.go
@@ -95,6 +95,10 @@ func TestBuilder_GoEncode(t *testing.T) {
 	require.Equal(t, expect, string(f.Bytes()))
 }
 
+// TestBuilder_GoEncode_SortMapKeys ensures that object literals from unordered
+// values (i.e., Go maps) are printed in a deterministic order by sorting the
+// keys lexicographically. Other object literals should be printed in the order
+// the keys are reported in (i.e., in the order presented by the Go structs).
 func TestBuilder_GoEncode_SortMapKeys(t *testing.T) {
 	f := builder.NewFile()
 

--- a/pkg/river/token/builder/builder_test.go
+++ b/pkg/river/token/builder/builder_test.go
@@ -95,6 +95,40 @@ func TestBuilder_GoEncode(t *testing.T) {
 	require.Equal(t, expect, string(f.Bytes()))
 }
 
+func TestBuilder_GoEncode_SortMapKeys(t *testing.T) {
+	f := builder.NewFile()
+
+	type Ordered struct {
+		SomeKey  string `river:"some_key,attr"`
+		OtherKey string `river:"other_key,attr"`
+	}
+
+	// Maps are unordered because you can't iterate over their keys in a
+	// consistent order.
+	var unordered = map[string]interface{}{
+		"key_a": 1,
+		"key_c": 3,
+		"key_b": 2,
+	}
+
+	f.Body().SetAttributeValue("ordered", Ordered{SomeKey: "foo", OtherKey: "bar"})
+	f.Body().SetAttributeValue("unordered", unordered)
+
+	expect := format(t, `
+		ordered = {
+			some_key  = "foo",
+			other_key = "bar",
+		}
+		unordered = {
+			key_a = 1,
+			key_b = 2,
+			key_c = 3,
+		}
+	`)
+
+	require.Equal(t, expect, string(f.Bytes()))
+}
+
 func TestBuilder_AppendFrom(t *testing.T) {
 	type InnerBlock struct {
 		Number int `river:"number,attr"`

--- a/pkg/river/token/builder/value_tokens.go
+++ b/pkg/river/token/builder/value_tokens.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/grafana/agent/pkg/river/internal/value"
 	"github.com/grafana/agent/pkg/river/scanner"
@@ -59,6 +60,13 @@ func valueTokens(v value.Value) []Token {
 		toks = append(toks, Token{token.LCURLY, ""}, Token{token.LITERAL, "\n"})
 
 		keys := v.Keys()
+
+		// If v isn't an ordered object (i.e., a go map), sort the keys so they
+		// have a deterministic print order.
+		if !v.OrderedKeys() {
+			sort.Strings(keys)
+		}
+
 		for i := 0; i < len(keys); i++ {
 			if isValidIdentifier(keys[i]) {
 				toks = append(toks, Token{token.IDENT, keys[i]})


### PR DESCRIPTION
This change consistently prints object keys which come from unordered objects (i.e., a map[string]V). All other types of River objects have ordered keys, and can be printed in normal order.