### PR TITLE
Flow: change /-/config to /debug/config

### DIFF
--- a/cmd/agent/flow.go
+++ b/cmd/agent/flow.go
@@ -23,21 +23,12 @@ import (
 	_ "github.com/grafana/agent/component/all"
 )
 
-// IsFlowEnabled checks to see if the environment var is set
-func IsFlowEnabled() bool {
+func isFlowEnabled() bool {
 	key, found := os.LookupEnv("EXPERIMENTAL_ENABLE_FLOW")
 	if !found {
 		return false
 	}
 	return key == "true"
-}
-
-// RunFlow runs the flow subsystem
-func RunFlow() {
-	if err := runFlow(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %s\n", err)
-		os.Exit(1)
-	}
 }
 
 func runFlow() error {
@@ -118,8 +109,8 @@ func runFlow() error {
 		}
 
 		r := mux.NewRouter()
-		r.Handle("/-/config", f.ConfigHandler())
 		r.Handle("/metrics", promhttp.Handler())
+		r.Handle("/debug/config", f.ConfigHandler())
 		r.Handle("/debug/graph", f.GraphHandler())
 		r.PathPrefix("/debug/pprof").Handler(http.DefaultServeMux)
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
 
@@ -41,8 +42,11 @@ func main() {
 
 	// If flow is enabled go into that working mode
 	// TODO allow flow to run as a windows service
-	if IsFlowEnabled() {
-		RunFlow()
+	if isFlowEnabled() {
+		if err := runFlow(); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %s\n", err)
+			os.Exit(1)
+		}
 		return
 	}
 


### PR DESCRIPTION
This makes /-/config now aligned with the existing /debug/graph and /debug/pprof endpoints.

This commit also unexports functions that didn't need to be exported, so their required godoc comments can be removed.