### PR TITLE
river/parser: improve error reporting

### DIFF
--- a/pkg/river/parser/testdata/assign_block_to_attr.river
+++ b/pkg/river/parser/testdata/assign_block_to_attr.river
@@ -1,0 +1,32 @@
+rw = metrics/* ERROR "cannot use a block as an expression" */.remote_write "default" {
+  remote_write {
+    url = "some_url"
+    basic_auth {
+      username = "username"
+      password = "password"
+    }
+  }
+}
+
+attr_1 = 15
+attr_2 = 51
+
+block {
+	rw_2 = metrics/* ERROR "cannot use a block as an expression" */.remote_write "other" {
+		remote_write {
+			url = "other_url"
+			basic_auth {
+				username = "username_2"
+				password = "password_2"
+			}
+		}
+	}
+}
+
+other_block {
+	// This is an expression which looks like it might be a block at first, but
+	// then isn't.
+	rw_3 = metrics.remote_write "other" "other" /* ERROR "expected {, got STRING" */ 12345
+}
+
+attr_3 = 15


### PR DESCRIPTION
This changes error reporting from the parser to cover three new cases:

1. Parse errors which occur on the same line as the previously reported parse error are now ignored.

2. If a TERMINATOR (newline) is not found at the end of a statement, tokens are consumed until a qualifying TERMINATOR is found. Qualifying TERMINATORs are TERMINATORS which end all accumulated pairs of curly brances, square brackets, and parenthesis encountered while consuming tokens.

3. If a user is trying to assign a block to an attribute (e.g., using it as an expression), a specific error is returned to them to let them know that is not acceptable by the parser.

Fixes #1964 