### PR TITLE
Flow: Add /debug/scope endpoint

### DIFF
--- a/cmd/agent/flow.go
+++ b/cmd/agent/flow.go
@@ -112,6 +112,7 @@ func runFlow() error {
 		r.Handle("/metrics", promhttp.Handler())
 		r.Handle("/debug/config", f.ConfigHandler())
 		r.Handle("/debug/graph", f.GraphHandler())
+		r.Handle("/debug/scope", f.ScopeHandler())
 		r.PathPrefix("/debug/pprof").Handler(http.DefaultServeMux)
 
 		r.HandleFunc("/-/reload", func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/flow/flow_http.go
+++ b/pkg/flow/flow_http.go
@@ -49,7 +49,7 @@ func (f *Flow) ConfigHandler() http.HandlerFunc {
 	}
 }
 
-// ConfigHandler returns an http.HandlerFunc which will render the scope used
+// ScopeHandler returns an http.HandlerFunc which will render the scope used
 // for variable references throughout River expressions.
 func (f *Flow) ScopeHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/flow/flow_http.go
+++ b/pkg/flow/flow_http.go
@@ -49,6 +49,23 @@ func (f *Flow) ConfigHandler() http.HandlerFunc {
 	}
 }
 
+// ConfigHandler returns an http.HandlerFunc which will render the scope used
+// for variable references throughout River expressions.
+func (f *Flow) ScopeHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		be := builder.NewExpr()
+		be.SetValue(f.loader.Variables())
+
+		var buf bytes.Buffer
+		_, err := be.WriteTo(&buf)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		} else {
+			_, _ = io.Copy(w, &buf)
+		}
+	}
+}
+
 // configBytes dumps the current state of the flow config as River.
 func (f *Flow) configBytes(w io.Writer, debugInfo bool) (n int64, err error) {
 	file := builder.NewFile()

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -179,6 +179,12 @@ func (l *Loader) wireGraphEdges(g *dag.Graph) diag.Diagnostics {
 	return diags
 }
 
+// Variables returns the Variables the Loader exposes for other Flow components
+// to reference.
+func (l *Loader) Variables() map[string]interface{} {
+	return l.cache.BuildContext(nil).Variables
+}
+
 // Components returns the current set of loaded components.
 func (l *Loader) Components() []*ComponentNode {
 	l.mut.RLock()

--- a/pkg/flow/internal/controller/value_cache.go
+++ b/pkg/flow/internal/controller/value_cache.go
@@ -85,6 +85,9 @@ func (vc *valueCache) SyncIDs(ids []ComponentID) {
 // BuildContext builds a vm.Scope based on the current set of cached values.
 // The arguments and exports for the same ID are merged into one object.
 func (vc *valueCache) BuildContext(parent *vm.Scope) *vm.Scope {
+	vc.mut.RLock()
+	defer vc.mut.RUnlock()
+
 	scope := &vm.Scope{
 		Parent:    parent,
 		Variables: make(map[string]interface{}),


### PR DESCRIPTION
/debug/scope prints the variables varaible to be referenced by other
components.

For cmd/agent/example-config.river, the following is printed:

```river
{
  local = {
    file = {
      this_file = {
        content = "Change me!",
      },
    },
  },
  metrics = {
    remote_write = {
      default = {
        receiver = capsule("metrics.Receiver"),
      },
    },
    scrape = {
      default = {},
    },
  },
}
```

This is useful for debugging errors where the scope isn't updated with expected values, something @captncraig and I ran into while testing #1941.