### PR TITLE
Flow: use cobra for the CLI and add an `agent run` command

### DIFF
--- a/cmd/agent/flow.go
+++ b/cmd/agent/flow.go
@@ -1,29 +1,10 @@
 package main
 
 import (
-	"context"
-	"errors"
-	"flag"
-	"fmt"
-	"net"
-	"net/http"
 	"os"
-	"os/signal"
-	"sync"
 
-	"go.uber.org/atomic"
-
-	"github.com/fatih/color"
-	"github.com/go-kit/log/level"
-	"github.com/gorilla/mux"
-	"github.com/grafana/agent/pkg/flow"
-	"github.com/grafana/agent/pkg/flow/logging"
-	"github.com/grafana/agent/pkg/river/diag"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-
-	// Install Components
-	_ "github.com/grafana/agent/component/all"
+	"github.com/prometheus/common/version"
+	"github.com/spf13/cobra"
 )
 
 func isFlowEnabled() bool {
@@ -31,158 +12,24 @@ func isFlowEnabled() bool {
 	if !found {
 		return false
 	}
-	return key == "true"
+	return key == "true" || key == "1"
 }
 
-func runFlow() error {
-	var wg sync.WaitGroup
-	defer wg.Wait()
+func runFlow() {
+	var cmd = &cobra.Command{
+		Use:     "agent [global options] <subcommand>",
+		Short:   "Grafana Agent Flow",
+		Version: version.Print("agent"),
 
-	ctx, cancel := interruptContext()
-	defer cancel()
-
-	var (
-		httpListenAddr = "127.0.0.1:12345"
-		configFile     string
-		storagePath    = "data-agent/"
-		ready          = atomic.NewBool(true)
-	)
-
-	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	fs.StringVar(&httpListenAddr, "server.http-listen-addr", httpListenAddr, "address to listen for http traffic on")
-	fs.StringVar(&configFile, "config.file", configFile, "path to config file to load")
-	fs.StringVar(&storagePath, "storage.path", storagePath, "Base directory where Flow components can store data")
-
-	if err := fs.Parse(os.Args[1:]); err != nil {
-		return fmt.Errorf("error parsing flags: %w", err)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Usage()
+		},
 	}
+	cmd.SetVersionTemplate("{{ .Version }}\n")
 
-	// Validate flags
-	if configFile == "" {
-		return fmt.Errorf("the -config.file flag is required")
+	cmd.AddCommand(runCommand())
+
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
 	}
-
-	l, err := logging.New(os.Stderr, logging.DefaultOptions)
-	if err != nil {
-		return fmt.Errorf("building logger: %w", err)
-	}
-
-	f := flow.New(flow.Options{
-		Logger:   l,
-		DataPath: storagePath,
-		Reg:      prometheus.DefaultRegisterer,
-	})
-
-	reload := func() error {
-		flowCfg, err := loadFlowFile(configFile)
-		if err != nil {
-			return fmt.Errorf("reading config file %q: %w", configFile, err)
-		}
-		if err := f.LoadFile(flowCfg); err != nil {
-			return fmt.Errorf("error during the initial gragent load: %w", err)
-		}
-		return nil
-	}
-
-	if err := reload(); err != nil {
-		var diags diag.Diagnostics
-		if errors.As(err, &diags) {
-			bb, _ := os.ReadFile(configFile)
-
-			p := diag.NewPrinter(diag.PrinterConfig{
-				Color:              !color.NoColor,
-				ContextLinesBefore: 1,
-				ContextLinesAfter:  1,
-			})
-			_ = p.Fprint(os.Stderr, map[string][]byte{configFile: bb}, diags)
-
-			// Print newline after the diagnostics.
-			fmt.Println()
-
-			return fmt.Errorf("could not perform the initial load successfully")
-		}
-
-		// Exit if the initial load files
-		return err
-	}
-
-	// HTTP server
-	{
-		lis, err := net.Listen("tcp", httpListenAddr)
-		if err != nil {
-			return fmt.Errorf("failed to listen on %s: %w", httpListenAddr, err)
-		}
-
-		r := mux.NewRouter()
-		r.HandleFunc("/-/ready", func(w http.ResponseWriter, r *http.Request) {
-			if ready.Load() {
-				w.WriteHeader(http.StatusOK)
-				fmt.Fprintf(w, "Agent is Ready.\n")
-			} else {
-				w.WriteHeader(http.StatusServiceUnavailable)
-				fmt.Fprint(w, "Config failed to load.\n")
-			}
-		})
-		r.Handle("/metrics", promhttp.Handler())
-		r.Handle("/debug/config", f.ConfigHandler())
-		r.Handle("/debug/graph", f.GraphHandler())
-		r.Handle("/debug/scope", f.ScopeHandler())
-		r.PathPrefix("/debug/pprof").Handler(http.DefaultServeMux)
-
-		r.HandleFunc("/-/reload", func(w http.ResponseWriter, _ *http.Request) {
-			err := reload()
-			ready.Store(err == nil)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-			fmt.Fprintln(w, "config reloaded")
-		})
-
-		srv := &http.Server{Handler: r}
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			defer cancel()
-
-			level.Info(l).Log("msg", "now listening for http traffic", "addr", httpListenAddr)
-			if err := srv.Serve(lis); err != nil {
-				level.Info(l).Log("msg", "http server closed", "err", err)
-			}
-		}()
-
-		defer func() { _ = srv.Shutdown(ctx) }()
-	}
-
-	<-ctx.Done()
-	return f.Close()
-}
-
-func loadFlowFile(filename string) (*flow.File, error) {
-	bb, err := os.ReadFile(filename)
-	if err != nil {
-		return nil, err
-	}
-
-	return flow.ReadFile(filename, bb)
-}
-
-func interruptContext() (context.Context, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(context.Background())
-
-	go func() {
-		defer cancel()
-		sig := make(chan os.Signal, 1)
-		signal.Notify(sig, os.Interrupt)
-		select {
-		case <-sig:
-		case <-ctx.Done():
-		}
-		signal.Stop(sig)
-
-		fmt.Fprintln(os.Stderr, "interrupt received")
-	}()
-
-	return ctx, cancel
 }

--- a/cmd/agent/flow_run.go
+++ b/cmd/agent/flow_run.go
@@ -43,8 +43,8 @@ River file wasn't specified, can't be loaded, or contains errors, run will exit
 immediately.
 
 run starts an HTTP server which can be used to debug Grafana Agent Flow or
-force it to reload (by POSTing to /-/reload). The listen address can be changed
-through the --server.http.listen-addr flag.
+force it to reload (by sending a GET or POST request to /-/reload). The listen
+address can be changed through the --server.http.listen-addr flag.
 
 By default, the HTTP server exposes the following debug endpoints:
 
@@ -173,7 +173,7 @@ func (fr *flowRun) Run(configFile string) error {
 				return
 			}
 			fmt.Fprintln(w, "config reloaded")
-		})
+		}).Methods(http.MethodGet, http.MethodPost)
 
 		srv := &http.Server{Handler: r}
 

--- a/cmd/agent/flow_run.go
+++ b/cmd/agent/flow_run.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+
+	"github.com/fatih/color"
+	"github.com/go-kit/log/level"
+	"github.com/gorilla/mux"
+	"github.com/grafana/agent/pkg/flow"
+	"github.com/grafana/agent/pkg/flow/logging"
+	"github.com/grafana/agent/pkg/river/diag"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/spf13/cobra"
+	"go.uber.org/atomic"
+
+	// Install Components
+	_ "github.com/grafana/agent/component/all"
+)
+
+func runCommand() *cobra.Command {
+	r := &flowRun{
+		httpListenAddr:       "127.0.0.1:12345",
+		storagePath:          "data-agent/",
+		enableDebugEndpoints: true,
+	}
+
+	var cmd = &cobra.Command{
+		Use:   "run [flags] file",
+		Short: "Run Grafana Agent Flow",
+		Long: `The run subcommand runs Grafana Agent Flow in the foreground until an interrupt
+is received.
+
+run must be provided an argument pointing at the River file to use. If the
+River file wasn't specified, can't be loaded, or contains errors, run will exit
+immediately.
+
+run starts an HTTP server which can be used to debug Grafana Agent Flow or
+force it to reload (by POSTing to /-/reload). The listen address can be changed
+through the --server.http.listen-addr flag.
+
+By default, the HTTP server exposes the following debug endpoints:
+
+  /debug/config  Display the state of running components. Values marked as
+                 secret are not shown. /debug/config?debug=1 shows extra
+                 information.
+  /debug/graph   Display the dependency graph of components. Graphviz must be
+                 installed for this to work.
+  /debug/scope   Display the variables available for components to use.
+  /debug/pprof   Go performance profiling tools
+
+The debug endpoints can be disabled by providing --debug.endpoints.enabled=false.
+
+If reloading the config file fails, Grafana Agent Flow will continue running in
+its last valid state. Components which failed may be be listed as unhealthy,
+depending on the nature of the reload error.
+`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return r.Run(args[0])
+		},
+	}
+
+	cmd.Flags().StringVar(&r.httpListenAddr, "server.http.listen-addr", r.httpListenAddr, "address to listen for HTTP traffic on")
+	cmd.Flags().StringVar(&r.storagePath, "storage.path", r.storagePath, "Base directory where components can store data")
+	cmd.Flags().BoolVar(&r.enableDebugEndpoints, "debug.endpoints.enabled", r.enableDebugEndpoints, "Enables /debug/ HTTP endpoints")
+	return cmd
+}
+
+type flowRun struct {
+	httpListenAddr       string
+	storagePath          string
+	enableDebugEndpoints bool
+}
+
+func (fr *flowRun) Run(configFile string) error {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	ctx, cancel := interruptContext()
+	defer cancel()
+
+	if configFile == "" {
+		return fmt.Errorf("file argument not provided")
+	}
+
+	l, err := logging.New(os.Stderr, logging.DefaultOptions)
+	if err != nil {
+		return fmt.Errorf("building logger: %w", err)
+	}
+
+	f := flow.New(flow.Options{
+		Logger:   l,
+		DataPath: fr.storagePath,
+		Reg:      prometheus.DefaultRegisterer,
+	})
+
+	reload := func() error {
+		flowCfg, err := loadFlowFile(configFile)
+		if err != nil {
+			return fmt.Errorf("reading config file %q: %w", configFile, err)
+		}
+		if err := f.LoadFile(flowCfg); err != nil {
+			return fmt.Errorf("error during the initial gragent load: %w", err)
+		}
+		return nil
+	}
+
+	if err := reload(); err != nil {
+		var diags diag.Diagnostics
+		if errors.As(err, &diags) {
+			bb, _ := os.ReadFile(configFile)
+
+			p := diag.NewPrinter(diag.PrinterConfig{
+				Color:              !color.NoColor,
+				ContextLinesBefore: 1,
+				ContextLinesAfter:  1,
+			})
+			_ = p.Fprint(os.Stderr, map[string][]byte{configFile: bb}, diags)
+
+			// Print newline after the diagnostics.
+			fmt.Println()
+
+			return fmt.Errorf("could not perform the initial load successfully")
+		}
+
+		// Exit if the initial load files
+		return err
+	}
+
+	// HTTP server
+	{
+		lis, err := net.Listen("tcp", fr.httpListenAddr)
+		if err != nil {
+			return fmt.Errorf("failed to listen on %s: %w", fr.httpListenAddr, err)
+		}
+
+		r := mux.NewRouter()
+		r.Handle("/metrics", promhttp.Handler())
+
+		if fr.enableDebugEndpoints {
+			r.Handle("/debug/config", f.ConfigHandler())
+			r.Handle("/debug/graph", f.GraphHandler())
+			r.Handle("/debug/scope", f.ScopeHandler())
+			r.PathPrefix("/debug/pprof").Handler(http.DefaultServeMux)
+		}
+
+		ready := atomic.NewBool(true)
+		r.HandleFunc("/-/ready", func(w http.ResponseWriter, r *http.Request) {
+			if ready.Load() {
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, "Agent is Ready.\n")
+			} else {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				fmt.Fprint(w, "Config failed to load.\n")
+			}
+		})
+
+		r.HandleFunc("/-/reload", func(w http.ResponseWriter, _ *http.Request) {
+			err := reload()
+			ready.Store(err == nil)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			fmt.Fprintln(w, "config reloaded")
+		})
+
+		srv := &http.Server{Handler: r}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer cancel()
+
+			level.Info(l).Log("msg", "now listening for http traffic", "addr", fr.httpListenAddr)
+			if err := srv.Serve(lis); err != nil {
+				level.Info(l).Log("msg", "http server closed", "err", err)
+			}
+		}()
+
+		defer func() { _ = srv.Shutdown(ctx) }()
+	}
+
+	<-ctx.Done()
+	return f.Close()
+}
+
+func loadFlowFile(filename string) (*flow.File, error) {
+	bb, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	return flow.ReadFile(filename, bb)
+}
+
+func interruptContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		defer cancel()
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, os.Interrupt)
+		select {
+		case <-sig:
+		case <-ctx.Done():
+		}
+		signal.Stop(sig)
+
+		fmt.Fprintln(os.Stderr, "interrupt received")
+	}()
+
+	return ctx, cancel
+}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	"os"
 
@@ -43,10 +42,7 @@ func main() {
 	// If flow is enabled go into that working mode
 	// TODO allow flow to run as a windows service
 	if isFlowEnabled() {
-		if err := runFlow(); err != nil {
-			fmt.Fprintf(os.Stderr, "error: %s\n", err)
-			os.Exit(1)
-		}
+		runFlow()
 		return
 	}
 

--- a/docs/flow/reference/cli/run.md
+++ b/docs/flow/reference/cli/run.md
@@ -6,3 +6,29 @@ weight: 100
 ---
 
 # `agent run` command
+
+The `agent run` command runs Grafana Agent Flow in the foreground until an
+interrupt is received.
+
+## Usage
+
+Usage: `agent run [flags] file`
+
+`agent run` must be provided an argument which points at the River config file
+to use. `agent run` will immediately exit with an error if the River file
+wasn't specified, can't be loaded, or contained errors during the initial load.
+
+Grafana Agent Flow will continue to run if subsequent reloads of the config
+file fail, potentially marking components as unhealthy depending on the nature
+of the failure. When this happens, Grafana Agent Flow will continue functioning
+in the last valid state.
+
+`agent run` launches an HTTP server for expose metrics about itself and
+components. The HTTP server is also used for exposing `/debug/` endpoitns for
+various debugging needs.
+
+The following flags are supported:
+
+* `--server.http.listen-addr`: Address to listen for HTTP traffic on (default `127.0.0.1:12345`).
+* `--storage.path`: Base directory where components can store data (default `data-agent/`).
+* `--debug.endpoints.enabled`: Whether to enable HTTP debug endpoints (default `true`).


### PR DESCRIPTION
This changes

```
ENABLE_FLOW_EXPERIMENTAL=true agent --config.file=/path/to/file.river
```

to 

```
ENABLE_FLOW_EXPERIMENTAL=true agent run /path/to/file.river
```

Help text is added to help users understand basic information about Flow. 

Additionally, `ENABLE_FLOW_EXPERIMENTAL=1` is also accepted to enable Flow.