### PR TITLE
tools/riverfmt: introduce riverfmt for formatting files

### DIFF
--- a/cmd/agent/example-config.river
+++ b/cmd/agent/example-config.river
@@ -1,29 +1,29 @@
 logging {
-  level  = "debug"
-  format = "logfmt"
+	level  = "debug"
+	format = "logfmt"
 }
 
 local.file "this_file" {
-  // Must be running from the root directory of the repository for this relative
-  // path to work.
-  filename = "./cmd/agent/test-local-file.txt"
-  detector = "fsnotify"
+	// Must be running from the root directory of the repository for this relative
+	// path to work.
+	filename = "./cmd/agent/test-local-file.txt"
+	detector = "fsnotify"
 }
 
 metrics.scrape "default" {
-  targets = [{
-    "__address__"   = "demo.robustperception.io:9090",
-    "dynamic_label" = local.file.this_file.content,
-  }]
-  forward_to = [metrics.remote_write.default.receiver]
+	targets = [{
+		"__address__"   = "demo.robustperception.io:9090",
+		"dynamic_label" = local.file.this_file.content,
+	}]
+	forward_to = [metrics.remote_write.default.receiver]
 
-  scrape_config {
-    job_name = "default"
-  }
+	scrape_config {
+		job_name = "default"
+	}
 }
 
 metrics.remote_write "default" {
-  remote_write {
-    url = "http://localhost:9009/api/prom/push"
-  }
+	remote_write {
+		url = "http://localhost:9009/api/prom/push"
+	}
 }

--- a/tools/riverfmt/main.go
+++ b/tools/riverfmt/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/grafana/agent/pkg/river/parser"
+	"github.com/grafana/agent/pkg/river/printer"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var (
+		write bool
+	)
+
+	fs := flag.NewFlagSet("riverfmt", flag.ExitOnError)
+	fs.BoolVar(&write, "w", write, "write result to (source) file instead of stdout")
+
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		return err
+	}
+
+	args := fs.Args()
+	switch len(args) {
+	case 0:
+		if write {
+			return fmt.Errorf("cannot use -w with standard input")
+		}
+		return format("<stdin>", nil, os.Stdin, write)
+
+	case 1:
+		fi, err := os.Stat(args[0])
+		if err != nil {
+			return err
+		}
+		if fi.IsDir() {
+			return fmt.Errorf("cannot format a directory")
+		}
+		f, err := os.Open(args[0])
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		return format(args[0], fi, f, write)
+
+	default:
+		return fmt.Errorf("can only format one file")
+	}
+}
+
+func format(filename string, fi os.FileInfo, r io.Reader, write bool) error {
+	bb, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	f, err := parser.ParseFile(filename, bb)
+	if err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+	if err := printer.Fprint(&buf, f); err != nil {
+		return err
+	}
+
+	// Add a newline at the endi
+	_, _ = buf.Write([]byte{'\n'})
+
+	if !write {
+		_, err := io.Copy(os.Stdout, &buf)
+		return err
+	}
+
+	wf, err := os.OpenFile(filename, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, fi.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer wf.Close()
+
+	_, err = io.Copy(wf, &buf)
+	return err
+}

--- a/tools/riverfmt/main.go
+++ b/tools/riverfmt/main.go
@@ -2,17 +2,27 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 
+	"github.com/grafana/agent/pkg/river/diag"
 	"github.com/grafana/agent/pkg/river/parser"
 	"github.com/grafana/agent/pkg/river/printer"
 )
 
 func main() {
-	if err := run(); err != nil {
+	err := run()
+
+	var diags diag.Diagnostics
+	if errors.As(err, &diags) {
+		for _, diag := range diags {
+			fmt.Fprintln(os.Stderr, diag)
+		}
+		os.Exit(1)
+	} else if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %s\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
This is an initial commit for a basic formatting tool for River files. 

* Supports formatting stdin: `cat file.river | riverfmt` 
* Supports rewriting files: `riverfmt -w file.river` 
* Supports printing diff to stdout: `riverfmt file.river`