### PR TITLE
Minor changes to remote.s3 documentation

### DIFF
--- a/docs/flow/reference/components/remote.s3.md
+++ b/docs/flow/reference/components/remote.s3.md
@@ -1,14 +1,25 @@
+---
+aliases:
+- /docs/agent/latest/flow/reference/components/remote.s3
+title: remote.s3
+---
+
 # remote.s3
 
-The `remote.s3` component exposes the contents of a file located in an S3 compatible system to other components. The file will be polled for changes so that the most recent content is always available.
+`remote.s3` exposes the contents of a file located in an S3 compatible system
+to other components. The file will be polled for changes so that the most
+recent content is always available.
 
-Multiple `remote.s3` components can be specified by giving them different name labels. By default the component will use AWS environment vars or profiles that are setup. If those are not setup or overrides are required then `key` and `secret` can be used.
+Multiple `remote.s3` components can be specified by giving them different name
+labels. By default, AWS environment variables are used to authenticate against
+S3. The `key` and `secret` arguments can be used to provide custom
+authentication.
 
 ## Example
 
 ```river
 remote.s3 "data" {
-	path = "s3://test-bucket/file.txt"
+  path = "s3://test-bucket/file.txt"
 }
 ```
 
@@ -18,10 +29,9 @@ The following arguments are supported:
 
 Name | Type | Description                                                             | Default | Required
 ---- | ---- |-------------------------------------------------------------------------| ------- | --------
-`path` | `string` | Path in the format of `"s3://bucket/file"`                              | | **yes**
+`path` | `string` | Path in the format of `"s3://bucket/file"` | | **yes**
 `poll_frequency` | `duration` | How often to poll the file for changes, must be greater than 30 seconds | `"10m"` | no
-`is_secret` | `bool` | Marks the file as containing a [secret][]                               | `false` | no
-`client_options` | `client_options` | Additional [options](#client_options) for configuring the client      | | no
+`is_secret` | `bool` | Marks the file as containing a [secret][] | `false` | no
 
 ### client_options
 
@@ -36,6 +46,8 @@ Name | Type | Description | Default | Required
 
 ## Exported fields
 
+The following fields are exported and can be referenced by other components:
+
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `content` | `string` or `secret` | The contents of the file | | no
@@ -44,12 +56,15 @@ The `content` field will be secret is `is_secret` was set.
 
 ## Component health
 
-Any `remote.s3` component will report as healthy if the watched file was read successfully.
-
-Failed to read the file will cause the component to be unhealthy but the last good read will kept. The error will be exposed on the health information
+Instances of `remote.s3` will reported as healthy if the most recent read of
+the watched file succeeded.
 
 ## Debug information
 
-`remote.s3` does not expose any component-specific debug information
+`remote.s3` does not expose any component-specific debug information.
+
+### Debug metrics
+
+`remote.s3` does not expose any component-specific debug metrics.
 
 [secret]: ../secrets.md#is_secret-argument-in-components


### PR DESCRIPTION
1. Fix file path (should be in reference/components)
2. File file name (should be remote.s3.md)
3. Fix sentences missing a period
4. Standardize sections from other reference docs
5. Minor rewording
