### PR TITLE
river/vm: improve error messages for invalid field names

### DIFF
--- a/pkg/river/vm/vm.go
+++ b/pkg/river/vm/vm.go
@@ -406,9 +406,11 @@ func (vm *Evaluator) evaluateExpr(scope *Scope, assoc map[value.Value]ast.Node, 
 		case value.TypeObject:
 			res, ok := val.Key(expr.Name.Name)
 			if !ok {
-				return value.Null, value.MissingKeyError{
-					Value:   val,
-					Missing: expr.Name.Name,
+				return value.Null, diag.Diagnostic{
+					Severity: diag.SeverityLevelError,
+					StartPos: ast.StartPos(expr.Name).Position(),
+					EndPos:   ast.EndPos(expr.Name).Position(),
+					Message:  fmt.Sprintf("field %q does not exist", expr.Name.Name),
 				}
 			}
 			return res, nil
@@ -453,9 +455,11 @@ func (vm *Evaluator) evaluateExpr(scope *Scope, assoc map[value.Value]ast.Node, 
 
 			field, ok := val.Key(idx.Text())
 			if !ok {
-				return value.Null, value.MissingKeyError{
-					Value:   val,
-					Missing: idx.Text(),
+				return value.Null, diag.Diagnostic{
+					Severity: diag.SeverityLevelError,
+					StartPos: ast.StartPos(expr.Index).Position(),
+					EndPos:   ast.EndPos(expr.Index).Position(),
+					Message:  fmt.Sprintf("field %q does not exist", idx.Text()),
 				}
 			}
 			return field, nil

--- a/pkg/river/vm/vm_test.go
+++ b/pkg/river/vm/vm_test.go
@@ -221,7 +221,7 @@ func TestVM_Evaluate_AccessExpr(t *testing.T) {
 
 		var v interface{}
 		err = eval.Evaluate(nil, &v)
-		require.EqualError(t, err, `1:1: {a = 15} does not have field named "b"`)
+		require.EqualError(t, err, `1:12: field "b" does not exist`)
 	})
 }
 


### PR DESCRIPTION
#### PR Description

This changes errors such as

```
Error: ./cmd/agent/example-config.river:16:21: local.file.this_file does not have field named "kontent"

15 |         "__address__"   = "demo.robustperception.io:9090",
16 |         "dynamic_label" = local.file.this_file.kontent,
   |                           ^^^^^^^^^^^^^^^^^^^^
17 |     }]
```

into the more expected form

```
Error: ./cmd/agent/example-config.river:16:42: field "kontent" does not exist

15 |         "__address__"   = "demo.robustperception.io:9090",
16 |         "dynamic_label" = local.file.this_file.kontent,
   |                                                ^^^^^^^
17 |     }]
```

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated (N/A)
- [x] Documentation added (N/A)
- [x] Tests updated (N/A)
