### PR TITLE
operations/river-jsonnet: add jsonnetfile.json

### DIFF
--- a/operations/river-jsonnet/jsonnetfile.json
+++ b/operations/river-jsonnet/jsonnetfile.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "dependencies": [],
+  "legacyImports": true
+}


### PR DESCRIPTION
This allows river-jsonnet to be versioned separately from other dependencies.

Created using `jb init`.