### PR TITLE
metrics.remote_write: use correct storage.Appendable when writing metrics

### DIFF
--- a/component/metrics/remotewrite/remote_write.go
+++ b/component/metrics/remotewrite/remote_write.go
@@ -171,7 +171,7 @@ func (c *Component) Update(newConfig component.Arguments) error {
 
 // Receive implements the receiver.receive func that allows an array of metrics to be passed
 func (c *Component) Receive(ts int64, metricArr []*metrics.FlowMetric) {
-	app := c.walStore.Appender(context.Background())
+	app := c.storage.Appender(context.Background())
 	for _, m := range metricArr {
 		// TODO this should all be simplified into one call
 		if m.GlobalRefID == 0 {

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -243,6 +243,10 @@ func (l *Loader) EvaluateDependencies(parentScope *vm.Scope, c *ComponentNode) {
 	l.mut.RLock()
 	defer l.mut.RUnlock()
 
+	l.cm.controllerEvaluation.Set(1)
+	defer l.cm.controllerEvaluation.Set(0)
+	start := time.Now()
+
 	// Make sure we're in-sync with the current exports of c.
 	l.cache.CacheExports(c.ID(), c.Exports())
 
@@ -256,6 +260,8 @@ func (l *Loader) EvaluateDependencies(parentScope *vm.Scope, c *ComponentNode) {
 		_ = l.evaluate(parentScope, n.(*ComponentNode))
 		return nil
 	})
+
+	l.cm.componentEvaluationTime.Observe(time.Since(start).Seconds())
 }
 
 // evaluate constructs the final context for c and evaluates it. mut must be


### PR DESCRIPTION
The fanout appender should be used for appending metrics so the prometheus_remote_storage_highest_timestamp_in_seconds metric gets updated.

Also fixes the `agent_component_evaluation_seconds` histogram and the `agent_component_controller_evaluating` metrics to track whether a runtime reevaluation is ongoing, not just graph loads.