### PR TITLE
river: reuse memory when decoding a map

### DIFF
--- a/pkg/river/internal/value/decode_benchmarks_test.go
+++ b/pkg/river/internal/value/decode_benchmarks_test.go
@@ -1,0 +1,30 @@
+package value_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/grafana/agent/pkg/river/internal/value"
+)
+
+func BenchmarkObjectDecode(b *testing.B) {
+	b.StopTimer()
+
+	// Create a value with 20 keys.
+	source := make(map[string]string, 20)
+	for i := 0; i < 20; i++ {
+		var (
+			key   = fmt.Sprintf("key_%d", i+1)
+			value = fmt.Sprintf("value_%d", i+1)
+		)
+		source[key] = value
+	}
+
+	sourceVal := value.Encode(source)
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		var dst map[string]string
+		_ = value.Decode(sourceVal, &dst)
+	}
+}


### PR DESCRIPTION
Benchmark results:

```
name             old time/op    new time/op    delta
ObjectDecode-10    5.83µs ± 2%    5.68µs ± 2%   -2.54%  (p=0.000 n=10+10)

name             old alloc/op   new alloc/op   delta
ObjectDecode-10    3.97kB ± 0%    3.67kB ± 0%   -7.66%  (p=0.000 n=9+10)

name             old allocs/op  new allocs/op  delta
ObjectDecode-10       125 ± 0%       106 ± 0%  -15.20%  (p=0.000 n=10+10)
```

This gives a tiny performance boost for decoding map values, but it creates far less garbage.

Other low-hanging fruit optimizations are possible, but I wanted to start with this one.