### PR TITLE
Remove any port number from the incoming connection address for PromSD processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Main (unreleased)
 
 ### Bugfixes
 
+- Tracing: Fixed issue with the PromSD processor using the `connection` method to discover the IP
+  address.  It was failing to match because the port number was included in the address string. (@jphx)
+
 ### Other changes
 
  - Update several go dependencies to resolve warnings from certain security scanning tools. None of the resolved vulnerabilities were known to be exploitable through the agent. (@captncraig)

--- a/pkg/traces/promsdprocessor/prom_sd_processor_test.go
+++ b/pkg/traces/promsdprocessor/prom_sd_processor_test.go
@@ -231,6 +231,20 @@ func TestPodAssociation(t *testing.T) {
 			expectedIP: ipStr,
 		},
 		{
+			name: "connection IP that includes a port number",
+			ctxFn: func(t *testing.T) context.Context {
+				info := client.Info{
+					Addr: &net.TCPAddr{
+						IP:   net.ParseIP(net.ParseIP(ipStr).String()),
+						Port: 1234,
+					},
+				}
+				return client.NewContext(context.Background(), info)
+			},
+			attrMapFn:  func(*testing.T) pcommon.Map { return pcommon.NewMap() },
+			expectedIP: ipStr,
+		},
+		{
 			name:            "connection IP is empty",
 			podAssociations: []string{podAssociationConnectionIP},
 			ctxFn: func(t *testing.T) context.Context {


### PR DESCRIPTION
#### PR Description

When the PromSD processor is using the `connection`  method to deduce the IP address of the client sending the span, remove any port number from the address string before matching against known IP addresses.

#### Which issue(s) this PR fixes

Fixes #1984

#### Notes to the Reviewer

I tested this change in the scenario where my trace spans were not getting any pod information attached.  After this change, there are `pod` and `container` labels in the `Process` section of the spans.

#### PR Checklist

- [X] CHANGELOG updated
- [ ] Documentation added
- [X] Tests updated
