### PR TITLE
River: preserve pointers and references when decoding

### DIFF
--- a/component/component.go
+++ b/component/component.go
@@ -33,6 +33,17 @@
 // Default values for Arguments may be provided by implementing
 // river.Unmarshaler.
 //
+// Arguments and Exports immutability
+//
+// Arguments passed to a component should be treated as immutable, as memory
+// can be shared between components as an optimization. Components should make
+// copies for fields they need to modify. An exception to this is for fields
+// which are expected to be mutable (e.g., interfaces which expose a
+// goroutine-safe API).
+//
+// Similarly, Exports and the fields within Exports must be considered
+// immutable after they are written for the same reason.
+//
 // Mapping River strings to custom types
 //
 // Custom encoding and decoding of fields is available by implementing

--- a/pkg/river/internal/value/decode_test.go
+++ b/pkg/river/internal/value/decode_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/grafana/agent/pkg/river/internal/value"
 	"github.com/stretchr/testify/require"
@@ -104,6 +105,47 @@ func TestDecode(t *testing.T) {
 	}
 }
 
+// TestDecode_PreservePointer ensures that pointer addresses can be preserved
+// when decoding.
+func TestDecode_PreservePointer(t *testing.T) {
+	num := 5
+	val := value.Encode(&num)
+
+	var nump *int
+	require.NoError(t, value.Decode(val, &nump))
+	require.Equal(t, unsafe.Pointer(nump), unsafe.Pointer(&num))
+}
+
+// TestDecode_PreserveMapReference ensures that map references can be preserved
+// when decoding.
+func TestDecode_PreserveMapReference(t *testing.T) {
+	m := make(map[string]string)
+	val := value.Encode(m)
+
+	var actual map[string]string
+	require.NoError(t, value.Decode(val, &actual))
+
+	// We can't check to see if the pointers of m and actual match, but we can
+	// modify m to see if actual is also modified.
+	m["foo"] = "bar"
+	require.Equal(t, "bar", actual["foo"])
+}
+
+// TestDecode_PreserveSliceReference ensures that slice references can be
+// preserved when decoding.
+func TestDecode_PreserveSliceReference(t *testing.T) {
+	s := make([]string, 3)
+	val := value.Encode(s)
+
+	var actual []string
+	require.NoError(t, value.Decode(val, &actual))
+
+	// We can't check to see if the pointers of m and actual match, but we can
+	// modify s to see if actual is also modified.
+	s[0] = "Hello, world!"
+	require.Equal(t, "Hello, world!", actual[0])
+}
+
 func TestDecode_EmbeddedField(t *testing.T) {
 	t.Run("Non-pointer", func(t *testing.T) {
 		type Phone struct {
@@ -178,25 +220,25 @@ func TestDecode_Capsules(t *testing.T) {
 	require.Equal(t, expect, actual)
 }
 
-// TestDecode_SliceCopy ensures that copies are made during decoding instead of
-// setting values directly.
-func TestDecode_SliceCopy(t *testing.T) {
+// TestDecodeCopy_SliceCopy ensures that copies are made during decoding
+// instead of setting values directly.
+func TestDecodeCopy_SliceCopy(t *testing.T) {
 	orig := []int{1, 2, 3}
 
 	var res []int
-	require.NoError(t, value.Decode(value.Encode(orig), &res))
+	require.NoError(t, value.DecodeCopy(value.Encode(orig), &res))
 
 	res[0] = 10
 	require.Equal(t, []int{1, 2, 3}, orig, "Original slice should not have been modified")
 }
 
-// TestDecode_ArrayCopy ensures that copies are made during decoding instead of
-// setting values directly.
+// TestDecodeCopy_ArrayCopy ensures that copies are made during decoding
+// instead of setting values directly.
 func TestDecode_ArrayCopy(t *testing.T) {
 	orig := [...]int{1, 2, 3}
 
 	var res [3]int
-	require.NoError(t, value.Decode(value.Encode(orig), &res))
+	require.NoError(t, value.DecodeCopy(value.Encode(orig), &res))
 
 	res[0] = 10
 	require.Equal(t, [3]int{1, 2, 3}, orig, "Original array should not have been modified")

--- a/pkg/river/internal/value/value.go
+++ b/pkg/river/internal/value/value.go
@@ -420,7 +420,8 @@ func (v Value) Call(args ...Value) (Value, error) {
 			argVal = reflect.New(argType).Elem()
 		}
 
-		if err := decode(arg, argVal); err != nil {
+		var d decoder
+		if err := d.decode(arg, argVal); err != nil {
 			return Null, ArgError{
 				Function: v,
 				Argument: arg,

--- a/pkg/river/vm/vm.go
+++ b/pkg/river/vm/vm.go
@@ -513,6 +513,10 @@ type Scope struct {
 
 	// Variables holds the list of available variable names that can be used when
 	// evaluating a node.
+	//
+	// Values in the Variables map should considered immutable after passed to
+	// Evaluate; maps and slices will be copied by reference for performance
+	// optimizations.
 	Variables map[string]interface{}
 }
 


### PR DESCRIPTION
This change modifies River so that decoded values only make a copy when the Go values do not match directly.

This means that pointer addresses, map references, and slice references are preserved.

When direct assignment is performed, River bypasses invoking the TextUnmarshaler and river.Unmarshaler interfaces.

As an exception, copies are made if the target Go type has an interface{} anywhere within its type definition, since interface{} values are expected to decode into known types (where River objects always decode into map[string]interface{}, etc).

This change make sa dramatic improvement to object decoding:

```
name             old time/op    new time/op    delta
ObjectDecode-10    5.84µs ± 2%    0.04µs ± 1%  -99.27%  (p=0.000 n=19+18)

name             old alloc/op   new alloc/op   delta
ObjectDecode-10    3.67kB ± 0%    0.01kB ± 0%  -99.75%  (p=0.000 n=20+20)

name             old allocs/op  new allocs/op  delta
ObjectDecode-10       106 ± 0%         2 ± 0%  -98.11%  (p=0.000 n=20+20)
```

However, this change puts larger pressure on components to treat Arguments and Exports as immutable. Documentation has been updated to reflect this new requirement.

Closes #1947.