### PR TITLE
Flow: use common Target type amongst related components

### DIFF
--- a/component/discovery/discovery.go
+++ b/component/discovery/discovery.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"time"
 
-	"github.com/grafana/agent/component/metrics/scrape"
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 )
+
+// Target refers to a singular discovered endpoint found by a discovery
+// component.
+type Target map[string]string
 
 // maxUpdateFrequency is the minimum time to wait between updating targets.
 // Currently not settable, since prometheus uses a static threshold, but
@@ -21,7 +24,7 @@ type Discoverer discovery.Discoverer
 // RunDiscovery is a utility for consuming and forwarding target groups from a discoverer.
 // It will handle collating targets (and clearing), as well as time based throttling of updates.
 // f should be a function that updates the component's exports, most likely calling `opts.OnStateChange()`.
-func RunDiscovery(ctx context.Context, d Discoverer, f func([]scrape.Target)) {
+func RunDiscovery(ctx context.Context, d Discoverer, f func([]Target)) {
 	// all targets we have seen so far
 	cache := map[string]*targetgroup.Group{}
 
@@ -30,7 +33,7 @@ func RunDiscovery(ctx context.Context, d Discoverer, f func([]scrape.Target)) {
 
 	// function to convert and send targets in format scraper expects
 	send := func() {
-		allTargets := []scrape.Target{}
+		allTargets := []Target{}
 		for _, group := range cache {
 			for _, target := range group.Targets {
 				labels := map[string]string{}

--- a/component/discovery/kubernetes/k8s.go
+++ b/component/discovery/kubernetes/k8s.go
@@ -7,7 +7,6 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
-	"github.com/grafana/agent/component/metrics/scrape"
 	promk8s "github.com/prometheus/prometheus/discovery/kubernetes"
 )
 
@@ -91,7 +90,7 @@ func (sc *SelectorConfig) convert() *promk8s.SelectorConfig {
 
 // Exports holds values which are exported by the discovery.k8s component.
 type Exports struct {
-	Targets []scrape.Target `river:"targets,attr"`
+	Targets []discovery.Target `river:"targets,attr"`
 }
 
 // Component implements the discovery.k8s component.
@@ -126,7 +125,7 @@ func (c *Component) Run(ctx context.Context) error {
 				cancel()
 			}
 			// function to send updates on change
-			f := func(t []scrape.Target) {
+			f := func(t []discovery.Target) {
 				c.opts.OnStateChange(Exports{Targets: t})
 			}
 			// create new context so we can cancel it if we get any future updates

--- a/component/metrics/scrape/scrape.go
+++ b/component/metrics/scrape/scrape.go
@@ -41,7 +41,6 @@ type Arguments struct {
 
 	// Scrape Options
 	ExtraMetrics bool `river:"extra_metrics,attr,optional"`
-	// TODO(@tpaschalis) enable HTTPClientOptions []config_util.HTTPClientOption
 }
 
 // Component implements the metrics.Scrape component.

--- a/component/metrics/scrape/scrape.go
+++ b/component/metrics/scrape/scrape.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/component"
 	fa "github.com/grafana/agent/component/common/appendable"
+	"github.com/grafana/agent/component/discovery"
 	"github.com/grafana/agent/component/metrics"
 	"github.com/grafana/agent/pkg/build"
 	"github.com/prometheus/common/model"
@@ -33,7 +34,7 @@ func init() {
 // Arguments holds values which are used to configure the metrics.scrape
 // component.
 type Arguments struct {
-	Targets   []Target            `river:"targets,attr"`
+	Targets   []discovery.Target  `river:"targets,attr"`
 	ForwardTo []*metrics.Receiver `river:"forward_to,attr"`
 
 	ScrapeConfig Config `river:"scrape_config,block"`
@@ -42,12 +43,6 @@ type Arguments struct {
 	ExtraMetrics bool `river:"extra_metrics,attr,optional"`
 	// TODO(@tpaschalis) enable HTTPClientOptions []config_util.HTTPClientOption
 }
-
-// Target refers to a singular HTTP or HTTPS endpoint that will be used for
-// scraping. Here, we're using a map[string]string instead of labels.Labels;
-// if the label ordering is important, we can change to follow the upstream
-// logic instead.
-type Target map[string]string
 
 // Component implements the metrics.Scrape component.
 type Component struct {
@@ -193,7 +188,7 @@ func (c *Component) DebugInfo() interface{} {
 	return ScraperStatus{TargetStatus: res}
 }
 
-func (c *Component) componentTargetsToProm(tgs []Target) map[string][]*targetgroup.Group {
+func (c *Component) componentTargetsToProm(tgs []discovery.Target) map[string][]*targetgroup.Group {
 	promGroup := &targetgroup.Group{Source: c.opts.ID}
 	for _, tg := range tgs {
 		promGroup.Targets = append(promGroup.Targets, convertLabelSet(tg))
@@ -202,7 +197,7 @@ func (c *Component) componentTargetsToProm(tgs []Target) map[string][]*targetgro
 	return map[string][]*targetgroup.Group{c.opts.ID: {promGroup}}
 }
 
-func convertLabelSet(tg Target) model.LabelSet {
+func convertLabelSet(tg discovery.Target) model.LabelSet {
 	lset := make(model.LabelSet, len(tg))
 	for k, v := range tg {
 		lset[model.LabelName(k)] = model.LabelValue(v)

--- a/component/metrics/scrape/scrape_test.go
+++ b/component/metrics/scrape/scrape_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/discovery"
 	"github.com/grafana/agent/component/metrics"
 	"github.com/grafana/agent/pkg/flow/logging"
 	"github.com/prometheus/prometheus/model/labels"
@@ -26,7 +27,7 @@ func TestForwardingToAppendable(t *testing.T) {
 	nilReceivers := []*metrics.Receiver{nil, nil}
 
 	args := Arguments{
-		Targets:      []Target{},
+		Targets:      []discovery.Target{},
 		ForwardTo:    nilReceivers,
 		ScrapeConfig: DefaultConfig,
 	}

--- a/component/targets/mutate/mutate.go
+++ b/component/targets/mutate/mutate.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/agent/component"
 	flow_relabel "github.com/grafana/agent/component/common/relabel"
+	"github.com/grafana/agent/component/discovery"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
 )
@@ -24,22 +25,15 @@ func init() {
 // Arguments holds values which are used to configure the targets.mutate component.
 type Arguments struct {
 	// Targets contains the input 'targets' passed by a service discovery component.
-	Targets []Target `river:"targets,attr"`
+	Targets []discovery.Target `river:"targets,attr"`
 
 	// The relabelling steps to apply to the each target's label set.
 	RelabelConfigs []*flow_relabel.Config `river:"relabel_config,block,optional"`
 }
 
-// Target refers to a singular HTTP or HTTPS endpoint that will be used for scraping.
-// Here, we're using a map[string]string instead of labels.Labels; if the label ordering
-// is important, we can change to follow the upstream logic instead.
-// TODO (@tpaschalis) Maybe the target definitions should be part of the
-// Service Discovery components package. Let's reconsider once it's ready.
-type Target map[string]string
-
 // Exports holds values which are exported by the targets.mutate component.
 type Exports struct {
-	Output []Target `river:"output,attr"`
+	Output []discovery.Target `river:"output,attr"`
 }
 
 // Component implements the targets.mutate component.
@@ -73,7 +67,7 @@ func (c *Component) Run(ctx context.Context) error {
 func (c *Component) Update(args component.Arguments) error {
 	newArgs := args.(Arguments)
 
-	targets := make([]Target, 0, len(newArgs.Targets))
+	targets := make([]discovery.Target, 0, len(newArgs.Targets))
 	relabelConfigs := flow_relabel.ComponentToPromRelabelConfigs(newArgs.RelabelConfigs)
 
 	for _, t := range newArgs.Targets {
@@ -91,7 +85,7 @@ func (c *Component) Update(args component.Arguments) error {
 	return nil
 }
 
-func componentMapToPromLabels(ls Target) labels.Labels {
+func componentMapToPromLabels(ls discovery.Target) labels.Labels {
 	res := make([]labels.Label, 0, len(ls))
 	for k, v := range ls {
 		res = append(res, labels.Label{Name: k, Value: v})
@@ -100,7 +94,7 @@ func componentMapToPromLabels(ls Target) labels.Labels {
 	return res
 }
 
-func promLabelsToComponent(ls labels.Labels) Target {
+func promLabelsToComponent(ls labels.Labels) discovery.Target {
 	res := make(map[string]string, len(ls))
 	for _, l := range ls {
 		res[l.Name] = l.Value

--- a/component/targets/mutate/mutate_test.go
+++ b/component/targets/mutate/mutate_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/agent/component/discovery"
 	"github.com/grafana/agent/component/targets/mutate"
 	"github.com/grafana/agent/pkg/flow/componenttest"
 	"github.com/grafana/agent/pkg/river/parser"
@@ -55,7 +56,7 @@ relabel_config {
 }
 `
 	expectedExports := mutate.Exports{
-		Output: []mutate.Target{
+		Output: []discovery.Target{
 			map[string]string{"__address__": "localhost", "app": "backend", "destination": "localhost/one", "meta_bar": "bar", "meta_foo": "foo", "name": "one"},
 		},
 	}


### PR DESCRIPTION
To be able to take advantage of the performance improvement from #2016, the various Flow components need to use a common Target type, since values can only be directly assigned if the Go types are exactly the same.