### PR TITLE
Register metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Main (unreleased)
 - Tracing: Fixed issue with the PromSD processor using the `connection` method to discover the IP
   address.  It was failing to match because the port number was included in the address string. (@jphx)
 
+- Register prometheus discovery metrics. (@mattdurham)
+
 ### Other changes
 
  - Update several go dependencies to resolve warnings from certain security scanning tools. None of the resolved vulnerabilities were known to be exploitable through the agent. (@captncraig)

--- a/pkg/metrics/agent.go
+++ b/pkg/metrics/agent.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/agent/pkg/metrics/cluster/client"
 	"github.com/grafana/agent/pkg/metrics/instance"
 	"github.com/grafana/agent/pkg/util"
+	"github.com/prometheus/prometheus/discovery"
 )
 
 // DefaultConfig is the default settings for the Prometheus-lite client.
@@ -149,6 +150,8 @@ type Agent struct {
 
 // New creates and starts a new Agent.
 func New(reg prometheus.Registerer, cfg Config, logger log.Logger) (*Agent, error) {
+	// This registers discovery metrics with the default registry which should be the reg specified above.
+	discovery.RegisterMetrics()
 	return newAgent(reg, cfg, logger, defaultInstanceFactory)
 }
 


### PR DESCRIPTION
#### PR Description

Register the prometheus discovery metrics. Its not ideal since it uses the default register but during normal operation that is the register passed into the New agent. 

- [X] CHANGELOG updated
