### PR TITLE
river: have `concat` bypass decoder

### DIFF
--- a/pkg/river/internal/stdlib/stdlib.go
+++ b/pkg/river/internal/stdlib/stdlib.go
@@ -4,7 +4,12 @@ package stdlib
 import (
 	"encoding/json"
 	"os"
+	"reflect"
+
+	"github.com/grafana/agent/pkg/river/internal/value"
 )
+
+var goAny = reflect.TypeOf((*interface{})(nil)).Elem()
 
 // Functions returns the list of stdlib functions by name. The interface{}
 // value is always a River-compatible function value, where functions have at
@@ -13,13 +18,75 @@ import (
 var Functions = map[string]interface{}{
 	"env": os.Getenv,
 
-	"concat": func(arrays ...[]interface{}) []interface{} {
-		var res []interface{}
-		for _, array := range arrays {
-			res = append(res, array...)
+	// concat is implemented as a raw function so it can bypass allocations
+	// converting arguments into []interface{}. concat is optimized to allow it
+	// to perform well when it is in the hot path for combining targets from many
+	// other blocks.
+	"concat": value.RawFunction(func(funcValue value.Value, args ...value.Value) (value.Value, error) {
+		if len(args) == 0 {
+			return value.Array(), nil
 		}
-		return res
-	},
+
+		// finalSize is the final size of the resulting concatenated array. We type
+		// check our arguments while computing what finalSize will be.
+		var finalSize int
+		for i, arg := range args {
+			if arg.Type() != value.TypeArray {
+				return value.Null, value.ArgError{
+					Function: funcValue,
+					Argument: arg,
+					Index:    i,
+					Inner: value.TypeError{
+						Value:    arg,
+						Expected: value.TypeArray,
+					},
+				}
+			}
+
+			finalSize += arg.Len()
+		}
+
+		// Optimization: if there's only one array, we can just return it directly.
+		// This is done *after* the previous loop to ensure that args[0] is a River
+		// array.
+		if len(args) == 1 {
+			return args[0], nil
+		}
+
+		// If the imcoming Go slices have the same type, we can have our resulting
+		// slice use the same type. This will allow decoding to use the direct
+		// assignment optimization.
+		//
+		// However, if the types don't match, then we're forced to fall back to
+		// returning []interface{}.
+		//
+		// TODO(rfratto): This could fall back to checking the elements if the
+		// array/slice types don't match. It would be slower, but the direct
+		// assignment optimization probably justifies it.
+		useType := args[0].Reflect().Type()
+		for i := 1; i < len(args); i++ {
+			if args[i].Reflect().Type() != useType {
+				useType = reflect.SliceOf(goAny)
+				break
+			}
+		}
+
+		// Build out the final array.
+		raw := reflect.MakeSlice(useType, finalSize, finalSize)
+
+		var argNum int
+		for _, arg := range args {
+			for i := 0; i < arg.Len(); i++ {
+				elem := arg.Index(i)
+				if elem.Type() != value.TypeNull {
+					raw.Index(argNum).Set(elem.Reflect())
+				}
+				argNum++
+			}
+		}
+
+		return value.Encode(raw.Interface()), nil
+	}),
 
 	"unmarshal_json": func(in string) (interface{}, error) {
 		var res interface{}

--- a/pkg/river/internal/value/raw_function.go
+++ b/pkg/river/internal/value/raw_function.go
@@ -1,0 +1,9 @@
+package value
+
+// RawFunction allows creating function implemenations using raw River values.
+// This is useful for functions which wish to operate over dynamic types while
+// avoiding decoding to interface{} for performance reasons.
+//
+// The func value itself is provided as an argument so error types can be
+// filled.
+type RawFunction func(funcValue Value, args ...Value) (Value, error)

--- a/pkg/river/internal/value/value.go
+++ b/pkg/river/internal/value/value.go
@@ -24,6 +24,7 @@ var (
 	goDuration        = reflect.TypeOf((time.Duration)(0))
 	goDurationPtr     = reflect.TypeOf((*time.Duration)(nil))
 	goRiverDecoder    = reflect.TypeOf((*Unmarshaler)(nil)).Elem()
+	goRawRiverFunc    = reflect.TypeOf((RawFunction)(nil))
 )
 
 // NOTE(rfratto): This package is extremely sensitive to performance, so
@@ -258,6 +259,9 @@ func (v Value) Interface() interface{} {
 	return v.rv.Interface()
 }
 
+// Reflect returns the raw reflection value backing v.
+func (v Value) Reflect() reflect.Value { return v.rv }
+
 // makeValue converts a reflect value into a Value, deferencing any pointers or
 // interface{} values.
 func makeValue(v reflect.Value) Value {
@@ -390,6 +394,10 @@ func (v Value) Key(key string) (index Value, ok bool) {
 func (v Value) Call(args ...Value) (Value, error) {
 	if v.ty != TypeFunction {
 		panic("river/value: Call called on non-function type")
+	}
+
+	if v.rv.Type() == goRawRiverFunc {
+		return v.rv.Interface().(RawFunction)(v, args...)
 	}
 
 	var (


### PR DESCRIPTION
This introduces the concept of a "raw function" which can be used to implement River functions that don't decode to Go values.

Then, `concat` is changed to be implemented as a raw function. This has a dramatic impact on its performance:

```
name       old time/op    new time/op    delta
Concat-10    23.3µs ± 1%     2.3µs ± 2%  -90.27%  (p=0.000 n=19+18)

name       old alloc/op   new alloc/op   delta
Concat-10    21.3kB ± 0%     1.5kB ± 0%  -93.14%  (p=0.000 n=20+20)

name       old allocs/op  new allocs/op  delta
Concat-10       451 ± 0%        20 ± 0%  -95.57%  (p=0.000 n=20+20)
```

`concat` is in the hot path for Flow when there are many service discoveries updating at the maximum rate (once per 5 seconds).
