### PR TITLE
Don't use the optional config parameter (instance) as the Identity on apache_http integration v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Main (unreleased)
 
 - Register prometheus discovery metrics. (@mattdurham)
 
-- Don't use the optional config parameter (instance) as the Identity on apache_http integration v2. Resolves #2017 for the apache_http integration. (@rgeyer)
+- Fix seg fault when no instance parameter is provided for apache_http integration, using integrations-next feature flag. (@rgeyer)
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Main (unreleased)
 
 - Register prometheus discovery metrics. (@mattdurham)
 
-- Don't use the optional config parameter (instance) as the Identity on apache_http integration v2 (@rgeyer)
+- Don't use the optional config parameter (instance) as the Identity on apache_http integration v2. Resolves #2017 for the apache_http integration. (@rgeyer)
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Main (unreleased)
 
 - Register prometheus discovery metrics. (@mattdurham)
 
+- Don't use the optional config parameter (instance) as the Identity on apache_http integration v2 (@rgeyer)
+
 ### Other changes
 
  - Update several go dependencies to resolve warnings from certain security scanning tools. None of the resolved vulnerabilities were known to be exploitable through the agent. (@captncraig)

--- a/pkg/integrations/apache_http/apache_http.go
+++ b/pkg/integrations/apache_http/apache_http.go
@@ -42,7 +42,7 @@ func (c *Config) Name() string {
 func (c *Config) InstanceKey(agentKey string) (string, error) {
 	u, err := url.Parse(c.ApacheAddr)
 	if err != nil {
-		return agentKey, err
+		return "", err
 	}
 	return fmt.Sprintf("%s:%s", u.Hostname(), u.Port()), nil
 }

--- a/pkg/integrations/apache_http/apache_http.go
+++ b/pkg/integrations/apache_http/apache_http.go
@@ -42,7 +42,7 @@ func (c *Config) Name() string {
 func (c *Config) InstanceKey(agentKey string) (string, error) {
 	u, err := url.Parse(c.ApacheAddr)
 	if err != nil {
-		return "", err
+		return agentKey, err
 	}
 	return fmt.Sprintf("%s:%s", u.Hostname(), u.Port()), nil
 }

--- a/pkg/integrations/v2/apache_http/apache_http.go
+++ b/pkg/integrations/v2/apache_http/apache_http.go
@@ -39,7 +39,7 @@ func (c *Config) ApplyDefaults(globals integrations_v2.Globals) error {
 
 // Identifier returns a string that identifies the integration.
 func (c *Config) Identifier(globals integrations_v2.Globals) (string, error) {
-	return *c.Common.InstanceKey, nil
+	return c.Name(), nil
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler for Config

--- a/pkg/integrations/v2/apache_http/apache_http.go
+++ b/pkg/integrations/v2/apache_http/apache_http.go
@@ -39,7 +39,14 @@ func (c *Config) ApplyDefaults(globals integrations_v2.Globals) error {
 
 // Identifier returns a string that identifies the integration.
 func (c *Config) Identifier(globals integrations_v2.Globals) (string, error) {
-	return c.Name(), nil
+	if c.Common.InstanceKey != nil {
+		return *c.Common.InstanceKey, nil
+	}
+	u, err := url.Parse(c.ApacheAddr)
+	if err != nil {
+		return globals.AgentIdentifier, err
+	}
+	return fmt.Sprintf("%s:%s", u.Hostname(), u.Port()), nil
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler for Config
@@ -53,15 +60,6 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // Name returns the name of the integration this config is for.
 func (c *Config) Name() string {
 	return "apache_http"
-}
-
-// InstanceKey returns the addr of the apache server.
-func (c *Config) InstanceKey(agentKey string) (string, error) {
-	u, err := url.Parse(c.ApacheAddr)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%s:%s", u.Hostname(), u.Port()), nil
 }
 
 type apacheHandler struct {

--- a/pkg/integrations/v2/apache_http/apache_http.go
+++ b/pkg/integrations/v2/apache_http/apache_http.go
@@ -44,7 +44,7 @@ func (c *Config) Identifier(globals integrations_v2.Globals) (string, error) {
 	}
 	u, err := url.Parse(c.ApacheAddr)
 	if err != nil {
-		return globals.AgentIdentifier, err
+		return "", err
 	}
 	return fmt.Sprintf("%s:%s", u.Hostname(), u.Port()), nil
 }


### PR DESCRIPTION
#### PR Description
When the apache_http integration config does not include the `instance` parameter, a nil pointer dereference seg fault occurs.

With this config;
```
integrations:
    apache_http_configs:
        - autoscrape:
            enable: true
            metrics_instance: grafana-agent/primary-me
        #   instance: apache.default.svc.cluster.local
          scrape_uri: http://apache.default.svc.cluster.local/server-status?auto
```

The result is;
```
docker run --rm -it -v $(pwd):/config grafana/agent:v0.26.0 -config.file=/config/apacheagent.yaml -enable-features integrations-next

ts=2022-08-10T17:01:37.16927698Z caller=server.go:191 level=info msg="server listening on addresses" http=127.0.0.1:12345 grpc=127.0.0.1:12346 http_tls_enabled=false grpc_tls_enabled=false
ts=2022-08-10T17:01:37.17115058Z caller=node.go:85 level=info agent=prometheus component=cluster msg="applying config"
ts=2022-08-10T17:01:37.172059953Z caller=remote.go:180 level=info agent=prometheus component=cluster msg="not watching the KV, none set"
ts=2022-08-10T17:01:37Z level=info caller=traces/traces.go:143 msg="Traces Logger Initialized" component=traces
ts=2022-08-10T17:01:37.174547628Z caller=integrations.go:138 level=warn msg="integrations-next is enabled. integrations-next is subject to change"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x37815e9]

goroutine 1 [running]:
github.com/grafana/agent/pkg/integrations/v2/apache_http.(*Config).Identifier(0x2?, {{0xc000556a20, 0x12}, 0xc000d0d800, 0xc001198420, 0xc0010a5640, {{{0x1, {...}, 0xdf8475800, 0x2540be400}}, ...}, ...})
        /src/agent/pkg/integrations/v2/apache_http/apache_http.go:42 +0x9
github.com/grafana/agent/pkg/integrations/v2.(*controller).UpdateController(0xc001080dd0, {0xc000141ba0, 0x1, 0x1}, {{0xc000556a20, 0x12}, 0xc000d0d800, 0xc001198420, 0xc0010a5640, {{{0x1, ...}}, ...}, ...})
        /src/agent/pkg/integrations/v2/controller.go:130 +0x563
github.com/grafana/agent/pkg/integrations/v2.newController({0x52aa040?, 0xc0000e12c0}, {0xc000141ba0, 0x1, 0x1}, {{0xc000556a20, 0x12}, 0xc000d0d800, 0xc001198420, 0xc0010a5640, ...})
        /src/agent/pkg/integrations/v2/controller.go:46 +0x130
github.com/grafana/agent/pkg/integrations/v2.NewSubsystem({0x52ab420, 0xc00088bb60}, {{0xc000556a20, 0x12}, 0xc000d0d800, 0xc001198420, 0xc0010a5640, {{{0x1, {...}, 0xdf8475800, ...}}, ...}, ...})
        /src/agent/pkg/integrations/v2/subsystem.go:101 +0x16d
github.com/grafana/agent/pkg/config.NewIntegrations({0x52ab420, 0xc00088bb60}, 0xc0009178f0, {{0xc000556a20, 0x12}, 0xc000d0d800, 0xc001198420, 0xc0010a5640, {{{0x1, {...}, ...}}, ...}, ...})
        /src/agent/pkg/config/integrations.go:141 +0x289
main.NewEntrypoint(0xc00088bb60, 0xc000917200, 0x4c2d0d0)
        /src/agent/cmd/agent/entrypoint.go:93 +0x4b6
main.main()
        /src/agent/cmd/agent/main.go:55 +0xce
```

By uncommenting the instance parameter, the agent config can be correctly parsed.

This uses the `config.Name()` for `Identity` as is used in a few other v2 integrations. Not entirely certain if that's exactly the right thing to use, but it is at least always guaranteed to exist.

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
