### PR TITLE
simulate errors on remote write endpoint

### DIFF
--- a/production/tanka/grafana-agent/smoke/main.libsonnet
+++ b/production/tanka/grafana-agent/smoke/main.libsonnet
@@ -51,6 +51,7 @@ local util = k.util;
         'chaos-frequency': this._config.chaosFrequency,
         'pod-prefix': this._config.podPrefix,
         'fake-remote-write': true,
+        'simulate-errors': true,
       })),
 
     agentsmoke_deployment:

--- a/production/tanka/grafana-agent/smoke/main.libsonnet
+++ b/production/tanka/grafana-agent/smoke/main.libsonnet
@@ -23,6 +23,7 @@ local util = k.util;
       image: this._images.agentsmoke,
       pull_secret: '',
       podPrefix: 'grafana-agent',
+      simulateErrors: true,
     } + config,
 
     rbac:
@@ -51,7 +52,7 @@ local util = k.util;
         'chaos-frequency': this._config.chaosFrequency,
         'pod-prefix': this._config.podPrefix,
         'fake-remote-write': true,
-        'simulate-errors': true,
+        'simulate-errors': this._config.simulateErrors,
       })),
 
     agentsmoke_deployment:

--- a/tools/smoke/internal/smoke.go
+++ b/tools/smoke/internal/smoke.go
@@ -84,7 +84,7 @@ func New(logger log.Logger, cfg Config) (*Smoke, error) {
 		if cfg.SimulateErrors {
 			count := 0
 			s.fakeRemoteWriteHandler = func(w http.ResponseWriter, _ *http.Request) {
-				if count += 1; count%100 == 0 {
+				if count++; count%100 == 0 {
 					w.WriteHeader(http.StatusInternalServerError)
 					return
 				}

--- a/tools/smoke/internal/smoke.go
+++ b/tools/smoke/internal/smoke.go
@@ -43,7 +43,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&c.PodPrefix, "pod-prefix", DefaultConfig.PodPrefix, "prefix for grafana agent pods")
 	f.BoolVar(&c.FakeRemoteWrite, "fake-remote-write", DefaultConfig.FakeRemoteWrite, "remote write endpoint for series which are discarded, useful for testing and not storing metrics")
 	f.BoolVar(&c.SimulateErrors, "simulate-errors", DefaultConfig.SimulateErrors, "remote write endpoint will return a 500 error response randomly")
-	f.Float64Var(&c.ErrorPrrcentage, "simulate-errors-percentage", DefaultConfig.ErrorPercentage, "percentage chance a request will result in an error")
+	f.Float64Var(&c.ErrorPercentage, "simulate-errors-percentage", DefaultConfig.ErrorPercentage, "percentage chance a request will result in an error")
 	f.DurationVar(&c.ChaosFrequency, "chaos-frequency", DefaultConfig.ChaosFrequency, "chaos frequency duration")
 	f.DurationVar(&c.MutationFrequency, "mutation-frequency", DefaultConfig.MutationFrequency, "mutation frequency duration")
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This adds an option to return 500 on the fake remote write endpoint used in the smoke test 1% of the time if enabled.

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
