### PR TITLE
operations/river-jsonnet: allow river.expr() to be used with std.prune()

### DIFF
--- a/operations/river-jsonnet/builder.jsonnet
+++ b/operations/river-jsonnet/builder.jsonnet
@@ -1,3 +1,5 @@
+local utils = import './internal/utils.jsonnet';
+
 {
   // attr returns the field name that should be used for River attributes.
   attr(name):: name,
@@ -8,9 +10,13 @@
     then ('block %s' % name)
     else ('block %s %s' % [name, label]),
 
-  // expr returns an object which reprents a literal River expression.
+  // expr returns an object which represents a literal River expression.
   expr(lit):: {
-    _river_expr:: true,
-    lit: lit,
+    // We need to use a special marker field to indicate that this object is an
+    // expression, otherwise manifest.jsonnet would treat it as an object
+    // literal.
+    //
+    // This field *must* be public. See utils.exprMarker for more information.
+    [utils.exprMarker]: lit,
   },
 }

--- a/operations/river-jsonnet/internal/utils.jsonnet
+++ b/operations/river-jsonnet/internal/utils.jsonnet
@@ -1,0 +1,13 @@
+{
+  // exprMarker is a field name which can be used to mark a Jsonnet object as a
+  // River expression literal.
+  //
+  // The field name *must* be public, otherwise std.prune will remove it and
+  // cause the expression literals to be treated as object literals.
+  //
+  // However, because the field name is public, it is technically possible for
+  // it to collide with an object literal key that a user would want to use. We
+  // pick a marker name here which is fairly unlikely to appear in a config
+  // file to reduce the chance of something being treated as an expr literal.
+  exprMarker: '$$__river_jsonnet__expr_literal',
+}

--- a/operations/river-jsonnet/main_test.jsonnet
+++ b/operations/river-jsonnet/main_test.jsonnet
@@ -148,6 +148,15 @@ local tests = [
       }])
     |||,
   },
+  {
+    name: 'Pruned expressions',
+    input: std.prune({
+      expr: river.expr('env("HOME")'),
+    }),
+    expect: |||
+      expr = env("HOME")
+    |||,
+  },
 ];
 
 std.map(function(test) (

--- a/operations/river-jsonnet/manifest.jsonnet
+++ b/operations/river-jsonnet/manifest.jsonnet
@@ -1,3 +1,5 @@
+local utils = import './internal/utils.jsonnet';
+
 // parseField parses a field name from a Jsonnet object and determines if it's
 // supposed to be a River attribute or block.
 local parseField(name) = (
@@ -19,7 +21,7 @@ local parseField(name) = (
 );
 
 // isRiverExpr returns true if value was constructed with river.expr().
-local isRiverExpr(value) = std.isObject(value) && '_river_expr' in value;
+local isRiverExpr(value) = std.isObject(value) && std.length(value) == 1 && utils.exprMarker in value;
 
 // linePadding returns number of spaces to indent a line with given a specific
 // indentation level.
@@ -81,7 +83,7 @@ local manifester(indent=0) = {
     if value == null then (
       'null'
     ) else if isRiverExpr(value) then (
-      local lines = std.split(value.lit, '\n');
+      local lines = std.split(value[utils.exprMarker], '\n');
 
       // When injecting literals, each line after the first should have the
       // current padding appended to it.


### PR DESCRIPTION
`std.prune` removes all hidden fields. This commit changes River expressions to have a non-hidden field which indicates that it's an expression.

The new object is constructed with a name which is very unlikely to appear as a key in an object literal to avoid invalid manifests from being generated.