### PR TITLE
docs/flow: Add documentation for Flow concepts

### DIFF
--- a/docs/flow/concepts/_index.md
+++ b/docs/flow/concepts/_index.md
@@ -6,3 +6,18 @@ weight: 100
 ---
 
 # Concepts
+
+Grafana Agent Flow has three primary concepts:
+
+1. [Components][]: The building blocks of Grafana Agent Flow which can be wired
+   together to construct a pipeline.
+
+2. [Component controller][]: The system within Grafana Agent Flow which manages
+   and updates components.
+
+3. [Configuration language][]: The language used to configure and wire together
+   components.
+
+[Components]: {{< relref "./components.md" >}}
+[Component controller]: {{< relref "./component_controller.md" >}}
+[Configuration language]: {{< relref "./configuration_language.md" >}}

--- a/docs/flow/concepts/component_controller.md
+++ b/docs/flow/concepts/component_controller.md
@@ -6,3 +6,115 @@ weight: 200
 ---
 
 # Component controller
+
+The _component controller_ is the core part of Grafana Agent Flow which manages
+components at runtime.
+
+It is responsible for:
+
+* Reading and validating the config file
+* Managing the lifecycle of defined components
+* Evaluating the arguments used to configure components
+* Reporting the health of defined components
+
+## Component graph
+
+As discussed in [Components][], a relationship between components is created
+when an expression is used to set the argument of one component to an export of
+another component.
+
+The set of all components and the relationships between them define a [directed
+acyclic graph][DAG] (DAG), which informs the component controller which
+references are valid and in what order components must be evaluated.
+
+For a config file to be valid, components must not reference themselves or
+contain a cyclic reference:
+
+```river
+// INVALID: local.file.some_file may not reference itself:
+local.file "self_reference" {
+  filename = local.file.self_reference.content
+}
+```
+
+```river
+// INVALID: cyclic reference between local.file.a and local.file.b:
+local.file "a" {
+  filename = local.file.b.content
+}
+local.file "b" {
+  filename = local.file.a.content
+}
+```
+
+## Component evaluation
+
+A component is _evaluated_ when its expressions are computed into concrete
+values and used to configure the component. The component controller is
+finished loading once all components have been evaluated and are running.
+
+The component controller is guaranteed to only evaluate a given component after
+evaluating all of the components the given component references. Components
+which do not reference other components may be evaluated at any time during the
+evaluation process.
+
+## Component reevaluation
+
+As mentioned in [Components][], a comonent is dynamic: a component may update
+its exports any number of times throughout its lifetime.
+
+When a component updates its exports, a _controller reevaluation_ is triggered:
+the component controller will reevaluate any component which references the
+changed component, any components which reference those components, and so on,
+until all affected components have been reevaluated.
+
+## Component health
+
+At any given time, a component may have one of the following health states:
+
+1. Unknown: default state, the component isn't running yet
+2. Healthy: the component is working as expected
+3. Unhealthy: the component is not working as expected
+4. Exited: the component has stopped and is no longer running
+
+By default, the component controller determines the health of a component. The
+component controller will mark a compoent has healthy as long as that component
+is running and its most recent evaluation was successful.
+
+Some components may report their own component-specific health information. For
+example, the `local.file` component will report itself unhealthy if the file it
+was watching gets deleted.
+
+The overall health of a component is reported by combining the
+controller-reported health of the component with the component-specific health
+information.
+
+An individual component's health is independent from the health of any other
+components it references: a component may be marked as healthy even if it
+references the exports of an unhealthy component.
+
+## Handling evaluation failures
+
+When a component fails to evaluate, it is marked as unhealthy with the reason
+for why the evaluation failed.
+
+When an evaluation fails, the component continues operating as normal: it
+continues using its previous set of evaluated arguments, and it may continue
+exporting new values.
+
+This prevents failure propagation: if your `local.file` component which watches
+API keys suddenly stops working, other components will continue using the last
+valid API key until the component returns to a healthy state.
+
+## Updating the config file
+
+Both the `/-/reload` HTTP endpoint and the `SIGHUP` singal can be used to
+inform the component controller to reload the config file. When this happens,
+the component controller will synchronize the set of running components with
+the ones in the config file, removing components which are no longer defined in
+the config file and creating new components which were added to the config
+file. All components managed by the controller will be reevaluated after
+reloading.
+
+[Components]: {{< relref "./components.md" >})
+[DAG]: https://en.wikipedia.org/wiki/Directed_acyclic_graph

--- a/docs/flow/concepts/component_controller.md
+++ b/docs/flow/concepts/component_controller.md
@@ -60,7 +60,7 @@ evaluation process.
 
 ## Component reevaluation
 
-As mentioned in [Components][], a comonent is dynamic: a component may update
+As mentioned in [Components][], a component is dynamic: a component may update
 its exports any number of times throughout its lifetime.
 
 When a component updates its exports, a _controller reevaluation_ is triggered:
@@ -78,8 +78,8 @@ At any given time, a component may have one of the following health states:
 4. Exited: the component has stopped and is no longer running
 
 By default, the component controller determines the health of a component. The
-component controller will mark a compoent has healthy as long as that component
-is running and its most recent evaluation was successful.
+component controller will mark a component has healthy as long as that
+component is running and its most recent evaluation was successful.
 
 Some components may report their own component-specific health information. For
 example, the `local.file` component will report itself unhealthy if the file it
@@ -108,7 +108,7 @@ valid API key until the component returns to a healthy state.
 
 ## Updating the config file
 
-Both the `/-/reload` HTTP endpoint and the `SIGHUP` singal can be used to
+Both the `/-/reload` HTTP endpoint and the `SIGHUP` signal can be used to
 inform the component controller to reload the config file. When this happens,
 the component controller will synchronize the set of running components with
 the ones in the config file, removing components which are no longer defined in

--- a/docs/flow/concepts/components.md
+++ b/docs/flow/concepts/components.md
@@ -6,3 +6,111 @@ weight: 100
 ---
 
 # Components
+
+_Components_ are the building blocks of Grafana Agent Flow. Each component is
+responsible for handling a single task, such as retrieving secrets or
+collecting Prometheus metrics.
+
+Components are composed of two parts:
+
+* Arguments: settings which configure a component
+* Exports: named values which a component exposes to other components
+
+Each component has a name which describes what that component is responsible
+for. For example, the `local.file` component is responsible for retrieving the
+contents of files on disk.
+
+Components are specified by users by first providing the component's name with
+a user-specified label, and then by providing arguments to configure the
+component.
+
+> Components are referenced by combining the component name with its label. For
+> example, a `local.file` component labeled `foo` would be referenced as
+> `local.file.foo`.
+>
+> The combination of a component's name and its label must be unique within the
+> configuration file.
+
+## Pipelines
+
+Most arguments a user specifies for a component will be some constant value,
+such setting a `log_level` attribute to the quoted string `"debug"` (`log_level
+= "debug"`).
+
+Users may also use _expressions_ to dynamically compute the value of an
+argument at runtime. Among other things, expressions may be used to retrieving
+the value of an environment variable (`log_level = env("LOG_LEVEL")`) or
+referencing the export of another component (`log_level =
+local.file.log_level.contents`).
+
+When a user configures a component's argument to reference an export of another
+component, a relationship is created: a component's input (arguments) now
+depends on another component's output (exports). The input of the component
+will now be re-evaluated any time the exports of the components it references
+get updated.
+
+The flow of data through the set of references between components forms a
+_pipeline_.
+
+An example pipeline may look like this:
+
+1. A `local.file` component watches a file on disk containing an API key.
+1. A `metrics.remote_write` component is configured to receive metrics and
+   forward them to an external database using the API key from the `local.file`
+   for authentication.
+2. A `discovery.kubernetes` component discovers and exports Kubernetes Pods
+   where metrics can be collected.
+3. A `metrics.scrape` component references the exports of the previous
+   component, and sends collected metrics to the `metrics.remote_write`
+   component.
+
+A user would use this config file to represent the above pipeline:
+
+```river
+// Get our API key from disk.
+//
+// This component has an exported value called "contents", holding the contents
+// of the file.
+//
+// local.file.api_key will watch the file and update its exports any time the
+// file changes.
+local.file "api_key" {
+  filename  = "/var/data/secrets/api-key"
+
+  // Mark this file as sensitive to prevent its value from being shown to
+  // users.
+  is_secret = true
+}
+
+// Create a metrics.remote_write component which other components can send
+// metrics to.
+//
+// This component exports a "receiver" value which can be used by other
+// components to send metrics.
+metrics.remote_write "prod" {
+  remote_write {
+    url = "https://prod:9090/api/v1/write"
+
+    basic_auth {
+      username = "admin"
+
+      // Use our password file for authenticating with the production database.
+      password = local.file.api_key.contents
+    }
+  }
+}
+
+// Find Kubernetes pods where we can collect metrics.
+//
+// This component exports a "targets" value which contains the list of
+// discovered pods.
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+
+// Collect metrics from Kubernetes pods and send them to prod.
+metrics.scrape "default" {
+  targets    = discovery.kubernetes.pods.targets
+  forward_to = [metrics.remote_write.prod.receiver]
+}
+```

--- a/docs/flow/concepts/configuration_language.md
+++ b/docs/flow/concepts/configuration_language.md
@@ -6,3 +6,37 @@ weight: 300
 ---
 
 # Configuration language
+
+The _configuration language_ refers to the language used in configuration files
+which define and configure components to run.
+
+The configuration language is called River, a Terraform/HCL-inspired language:
+
+```river
+metrics.scrape "default" {
+  targets = [{
+    "__address__" = "demo.robustperception.io:9090",
+  }]
+  forward_to = [metrics.remote_write.default.receiver]
+}
+
+metrics.remote_write "default" {
+  remote_write {
+    url = "http://localhost:9009/api/prom/push"
+  }
+}
+```
+
+River was designed with two requirements in mind:
+
+* _Fast_: The configuration language must be fast so the component controller
+  can evaluate changes as quickly as possible.
+* _Simple_: The configuration language must be easy to read and write to
+  minimize the learning curve.
+* _Debuggable_: The configuration language must give detailed information when
+  there's a mistake in the config file.
+
+Our dedicated [Configuration language][config-docs] section documents River in
+detail.
+
+[config-docs]: {{< relref "../config-language/" >}}

--- a/docs/flow/concepts/configuration_language.md
+++ b/docs/flow/concepts/configuration_language.md
@@ -7,8 +7,8 @@ weight: 300
 
 # Configuration language
 
-The _configuration language_ refers to the language used in configuration files
-which define and configure components to run.
+The Grafana Agent Flow _configuration language_ refers to the language used in
+configuration files which define and configure components to run.
 
 The configuration language is called River, a Terraform/HCL-inspired language:
 
@@ -36,7 +36,56 @@ River was designed with two requirements in mind:
 * _Debuggable_: The configuration language must give detailed information when
   there's a mistake in the config file.
 
-Our dedicated [Configuration language][config-docs] section documents River in
-detail.
+## Attributes
+
+_Attributes_ are used to configure individual settings. They always take the
+form of `<ATTRIBUTE_NAME> = <ATTRIBUTE_VALUE>`.
+
+```river
+log_level = "debug"
+```
+
+This sets the `log_level` attribute to `"debug"`.
+
+## Expressions
+
+Expressions are used to compute the value of an attribute. The simplest
+expressions are constant values like `"debug"`, `32`, or `[1, 2, 3, 4]`. River
+supports more complex expressions, such as:
+
+* Referencing the exports of components: `local.file.password_file.content`
+* Mathematical operations: `1 + 2`, `3 * 4`, `(5 * 6) + (7 + 8)`
+* Equality checks: `local.file.file_a.content == local.file.file_b.content`
+* Calling functions from River's standard library: `env("HOME")` (retrieve the
+  value of the `HOME` environment variable)
+
+Expressions may be used for any attribute inside a component definition.
+
+## Blocks
+
+_Blocks_ are used to configure components and groups of attributes. Each block
+can contain any number of attributes or nested blocks.
+
+```river
+metrics.remote_write "default" {
+  remote_write {
+    url = "http://localhost:9009/api/prom/push"
+  }
+}
+```
+
+This file has two blocks:
+
+* `metrics.remote_write "default"`: A labeled block which instantiates a
+  `metrics.remote_write` component. The label is the string `"default"`.
+
+* `remote_write`: An unlabeled block inside the component which configures an
+  endpoint to send metrics to. This block sets the `url` attribute to specify
+  what the endpoint is.
+
+## More information
+
+River is documented in detail in [Configuration language][config-docs] section
+of the Grafana Agent Flow docs.
 
 [config-docs]: {{< relref "../config-language/" >}}

--- a/docs/flow/concepts/configuration_language.md
+++ b/docs/flow/concepts/configuration_language.md
@@ -27,7 +27,7 @@ metrics.remote_write "default" {
 }
 ```
 
-River was designed with two requirements in mind:
+River was designed with the following requirements in mind:
 
 * _Fast_: The configuration language must be fast so the component controller
   can evaluate changes as quickly as possible.

--- a/docs/flow/reference/cli/run.md
+++ b/docs/flow/reference/cli/run.md
@@ -24,7 +24,7 @@ of the failure. When this happens, Grafana Agent Flow will continue functioning
 in the last valid state.
 
 `agent run` launches an HTTP server for expose metrics about itself and
-components. The HTTP server is also used for exposing `/debug/` endpoitns for
+components. The HTTP server is also used for exposing `/debug/` endpoints for
 various debugging needs.
 
 The following flags are supported:


### PR DESCRIPTION
The "concepts" section should explain everything there is to know about Flow at a high-level: 

1. What components are 
2. What the component controller is, how components get evaluated, component health
3. What the configuration language is 

If this is missing any other high-level documentation for Flow, please let me know and I'll add it. 

I think we'll want to eventually have high-level documentation for concepts like Prometheus metrics and service discovery, but I'm leaving that out for now to just focus on Flow-specific things.