### PR TITLE
Flow: Experiment using a worker pool with Receivers

### DIFF
--- a/component/common/appendable/appendable.go
+++ b/component/common/appendable/appendable.go
@@ -90,10 +90,10 @@ func (app *flowAppender) AppendExemplar(ref storage.SeriesRef, l labels.Labels, 
 func (app *flowAppender) Commit() error {
 	for _, r := range app.receivers {
 		for ts, metrics := range app.buffer {
-			if r == nil || r.Receive == nil {
+			if r == nil {
 				continue
 			}
-			r.Receive(ts, metrics)
+			r.Send(ts, metrics)
 		}
 	}
 	app.buffer = make(map[int64][]*metrics.FlowMetric)

--- a/component/common/appendable/appendable.go
+++ b/component/common/appendable/appendable.go
@@ -79,11 +79,7 @@ func (app *flowAppender) Append(ref storage.SeriesRef, l labels.Labels, t int64,
 	} else {
 		metrics.GlobalRefMapping.RemoveStaleMarker(uint64(ref))
 	}
-	app.buffer[t] = append(app.buffer[t], &metrics.FlowMetric{
-		GlobalRefID: uint64(ref),
-		Labels:      l,
-		Value:       v,
-	})
+	app.buffer[t] = append(app.buffer[t], metrics.NewFlowMetric(uint64(ref), l, v))
 	return ref, nil
 }
 

--- a/component/metrics/globalrefmap.go
+++ b/component/metrics/globalrefmap.go
@@ -44,7 +44,7 @@ func newGlobalRefMap() *GlobalRefMap {
 }
 
 // GetOrAddLink is called by a remote_write endpoint component to add mapping and get back the global id.
-func (g *GlobalRefMap) GetOrAddLink(componentID string, localRefID uint64, l labels.Labels) uint64 {
+func (g *GlobalRefMap) GetOrAddLink(componentID string, localRefID uint64, fm *FlowMetric) uint64 {
 	g.mut.Lock()
 	defer g.mut.Unlock()
 
@@ -59,7 +59,7 @@ func (g *GlobalRefMap) GetOrAddLink(componentID string, localRefID uint64, l lab
 		g.mappings[componentID] = m
 	}
 
-	labelHash := l.Hash()
+	labelHash := fm.labels.Hash()
 	globalID, found := g.labelsHashToGlobal[labelHash]
 	if found {
 		m.localToGlobal[localRefID] = globalID

--- a/component/metrics/globalrefmap_test.go
+++ b/component/metrics/globalrefmap_test.go
@@ -48,7 +48,8 @@ func TestAddingLocalMapping(t *testing.T) {
 	})
 
 	globalID := mapping.GetOrAddGlobalRefID(l)
-	shouldBeSameGlobalID := mapping.GetOrAddLink("1", 1, l)
+	fm := NewFlowMetric(globalID, l, 0)
+	shouldBeSameGlobalID := mapping.GetOrAddLink("1", 1, fm)
 	require.True(t, globalID == shouldBeSameGlobalID)
 	require.Len(t, mapping.labelsHashToGlobal, 1)
 	require.Len(t, mapping.mappings, 1)
@@ -66,8 +67,9 @@ func TestAddingLocalMappings(t *testing.T) {
 	})
 
 	globalID := mapping.GetOrAddGlobalRefID(l)
-	shouldBeSameGlobalID := mapping.GetOrAddLink("1", 1, l)
-	shouldBeSameGlobalID2 := mapping.GetOrAddLink("2", 1, l)
+	fm := NewFlowMetric(globalID, l, 0)
+	shouldBeSameGlobalID := mapping.GetOrAddLink("1", 1, fm)
+	shouldBeSameGlobalID2 := mapping.GetOrAddLink("2", 1, fm)
 	require.True(t, globalID == shouldBeSameGlobalID)
 	require.True(t, globalID == shouldBeSameGlobalID2)
 	require.Len(t, mapping.labelsHashToGlobal, 1)
@@ -90,8 +92,10 @@ func TestAddingLocalMappingsWithoutCreatingGlobalUpfront(t *testing.T) {
 		Value: "test",
 	})
 
-	shouldBeSameGlobalID := mapping.GetOrAddLink("1", 1, l)
-	shouldBeSameGlobalID2 := mapping.GetOrAddLink("2", 1, l)
+	fm := NewFlowMetric(1, l, 0)
+
+	shouldBeSameGlobalID := mapping.GetOrAddLink("1", 1, fm)
+	shouldBeSameGlobalID2 := mapping.GetOrAddLink("2", 1, fm)
 	require.True(t, shouldBeSameGlobalID2 == shouldBeSameGlobalID)
 	require.Len(t, mapping.labelsHashToGlobal, 1)
 	require.Len(t, mapping.mappings, 2)
@@ -118,8 +122,11 @@ func TestStaleness(t *testing.T) {
 		Value: "test2",
 	})
 
-	global1 := mapping.GetOrAddLink("1", 1, l)
-	_ = mapping.GetOrAddLink("2", 1, l2)
+	fm := NewFlowMetric(0, l, 0)
+	fm2 := NewFlowMetric(0, l2, 0)
+
+	global1 := mapping.GetOrAddLink("1", 1, fm)
+	_ = mapping.GetOrAddLink("2", 1, fm2)
 	mapping.AddStaleMarker(global1, l)
 	require.Len(t, mapping.staleGlobals, 1)
 	require.Len(t, mapping.labelsHashToGlobal, 2)
@@ -138,7 +145,9 @@ func TestRemovingStaleness(t *testing.T) {
 		Value: "test",
 	})
 
-	global1 := mapping.GetOrAddLink("1", 1, l)
+	fm := NewFlowMetric(0, l, 0)
+
+	global1 := mapping.GetOrAddLink("1", 1, fm)
 	mapping.AddStaleMarker(global1, l)
 	require.Len(t, mapping.staleGlobals, 1)
 	mapping.RemoveStaleMarker(global1)

--- a/component/metrics/mutate/mutate.go
+++ b/component/metrics/mutate/mutate.go
@@ -2,15 +2,13 @@ package mutate
 
 import (
 	"context"
+	"sync"
 
-	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/component"
-	fa "github.com/grafana/agent/component/common/appendable"
 	flow_relabel "github.com/grafana/agent/component/common/relabel"
 	"github.com/grafana/agent/component/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/relabel"
-	"github.com/prometheus/prometheus/storage"
 )
 
 func init() {
@@ -41,10 +39,10 @@ type Exports struct {
 
 // Component implements the metrics.mutate component.
 type Component struct {
-	opts component.Options
-	mrc  []*relabel.Config
-
-	appendable       *fa.FlowAppendable
+	mut              sync.RWMutex
+	opts             component.Options
+	mrc              []*relabel.Config
+	forwardto        []*metrics.Receiver
 	receiver         *metrics.Receiver
 	metricsProcessed prometheus.Counter
 }
@@ -56,7 +54,6 @@ var (
 // New creates a new metrics.mutate component.
 func New(o component.Options, args Arguments) (*Component, error) {
 	c := &Component{opts: o}
-	c.appendable = fa.NewFlowAppendable(args.ForwardTo...)
 	c.receiver = &metrics.Receiver{Receive: c.Receive}
 	c.metricsProcessed = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "agent_metrics_mutate_metrics_processed",
@@ -84,10 +81,13 @@ func (c *Component) Run(ctx context.Context) error {
 
 // Update implements component.Component.
 func (c *Component) Update(args component.Arguments) error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
 	newArgs := args.(Arguments)
 
 	c.mrc = flow_relabel.ComponentToPromRelabelConfigs(newArgs.MetricRelabelConfigs)
-	c.appendable.SetReceivers(newArgs.ForwardTo)
+	c.forwardto = newArgs.ForwardTo
 	c.opts.OnStateChange(Exports{Receiver: c.receiver})
 
 	return nil
@@ -101,19 +101,21 @@ func (c *Component) Update(args component.Arguments) error {
 // series. This is a blocker for releasing a production-grade  of the metrics.mutate
 // component.
 func (c *Component) Receive(ts int64, metricArr []*metrics.FlowMetric) {
-	app := c.appendable.Appender(context.Background())
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+
+	relabelledMetrics := make([]*metrics.FlowMetric, 0)
 	for _, m := range metricArr {
-		m.Labels = relabel.Process(m.Labels, c.mrc...)
-		if m.Labels == nil {
+		newFm := m.Relabel(c.mrc...)
+		if newFm == nil {
 			continue
 		}
-		_, err := app.Append(storage.SeriesRef(m.GlobalRefID), m.Labels, ts, m.Value)
-		if err != nil {
-			level.Error(c.opts.Logger).Log("msg", "failed to forward sample from metrics.mutate component", "err", err, "componentID", c.opts.ID)
-		}
+		relabelledMetrics = append(relabelledMetrics, newFm)
 	}
-	err := app.Commit()
-	if err != nil {
-		level.Error(c.opts.Logger).Log("msg", "failed to commit after relabelling metrics", "err", err)
+	if len(relabelledMetrics) == 0 {
+		return
+	}
+	for _, forward := range c.forwardto {
+		forward.Receive(ts, relabelledMetrics)
 	}
 }

--- a/component/metrics/mutate/mutate.go
+++ b/component/metrics/mutate/mutate.go
@@ -106,11 +106,12 @@ func (c *Component) Receive(ts int64, metricArr []*metrics.FlowMetric) {
 
 	relabelledMetrics := make([]*metrics.FlowMetric, 0)
 	for _, m := range metricArr {
-		newFm := m.Relabel(c.mrc...)
-		if newFm == nil {
+		// Relabel may return the original flowmetric if no changes applied, nil if everything was removed or an entirely new flowmetric.
+		relabelledFm := m.Relabel(c.mrc...)
+		if relabelledFm == nil {
 			continue
 		}
-		relabelledMetrics = append(relabelledMetrics, newFm)
+		relabelledMetrics = append(relabelledMetrics, relabelledFm)
 	}
 	if len(relabelledMetrics) == 0 {
 		return

--- a/component/metrics/mutate/mutate.go
+++ b/component/metrics/mutate/mutate.go
@@ -54,7 +54,7 @@ var (
 // New creates a new metrics.mutate component.
 func New(o component.Options, args Arguments) (*Component, error) {
 	c := &Component{opts: o}
-	c.receiver = &metrics.Receiver{Receive: c.Receive}
+	c.receiver = metrics.NewReceiver(c.Receive)
 	c.metricsProcessed = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "agent_metrics_mutate_metrics_processed",
 		Help: "Total number of metrics processed",
@@ -117,6 +117,6 @@ func (c *Component) Receive(ts int64, metricArr []*metrics.FlowMetric) {
 		return
 	}
 	for _, forward := range c.forwardto {
-		forward.Receive(ts, relabelledMetrics)
+		forward.Send(ts, relabelledMetrics)
 	}
 }

--- a/component/metrics/receiver.go
+++ b/component/metrics/receiver.go
@@ -53,11 +53,11 @@ func (fw *FlowMetric) RawLabels() labels.Labels {
 
 // Relabel applies normal prometheus relabel rules and returns a flow metric. NOTE this may return itself.
 func (fw *FlowMetric) Relabel(cfgs ...*promrelabel.Config) *FlowMetric {
-	retLbls := promrelabel.Process(fw.labels)
+	retLbls := promrelabel.Process(fw.labels, cfgs...)
 	if retLbls == nil {
 		return nil
 	}
-	if retLbls.Hash() == fw.labels.Hash() {
+	if retLbls.Hash() == fw.labels.Hash() && labels.Equal(retLbls, fw.labels) {
 		return fw
 	}
 	return NewFlowMetric(0, retLbls, fw.value)

--- a/component/metrics/receiver.go
+++ b/component/metrics/receiver.go
@@ -32,7 +32,6 @@ func (r *Receiver) Send(timestamp int64, metrics []*FlowMetric) {
 	} else {
 		r.rec(timestamp, metrics)
 	}
-
 }
 
 // RiverCapsule marks receivers as a capsule.

--- a/component/metrics/receiver.go
+++ b/component/metrics/receiver.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"github.com/prometheus/prometheus/model/labels"
+	promrelabel "github.com/prometheus/prometheus/model/relabel"
 )
 
 // Receiver is used to pass an array of metrics to another receiver
@@ -13,9 +14,48 @@ type Receiver struct {
 // RiverCapsule marks receivers as a capsule.
 func (r Receiver) RiverCapsule() {}
 
-// FlowMetric is a wrapper around a single metric without the timestamp
+// FlowMetric is a wrapper around a single metric without the timestamp.
 type FlowMetric struct {
-	GlobalRefID uint64
-	Labels      labels.Labels
-	Value       float64
+	globalRefID uint64
+	labels      labels.Labels
+	value       float64
+}
+
+// RefID wraps uint64 and used for a globally unique value
+type RefID uint64
+
+// NewFlowMetric instantiates a new flow metric
+func NewFlowMetric(globalRefID uint64, lbls labels.Labels, value float64) *FlowMetric {
+	// Always ensure we have a valid global ref id
+	if globalRefID == 0 {
+		globalRefID = GlobalRefMapping.GetOrAddGlobalRefID(lbls)
+	}
+	return &FlowMetric{
+		globalRefID: globalRefID,
+		labels:      lbls,
+		value:       value,
+	}
+}
+
+// GlobalRefID Retrieves the GlobalRefID
+func (fw *FlowMetric) GlobalRefID() uint64 { return fw.globalRefID }
+
+// Value returns the value
+func (fw *FlowMetric) Value() float64 { return fw.value }
+
+// LabelsCopy returns a copy of the labels structure
+func (fw *FlowMetric) LabelsCopy() labels.Labels {
+	return fw.labels.Copy()
+}
+
+// Relabel applies normal prometheus relabel rules and returns a flow metric. NOTE this may return itself.
+func (fw *FlowMetric) Relabel(cfgs ...*promrelabel.Config) *FlowMetric {
+	retLbls := promrelabel.Process(fw.labels)
+	if retLbls == nil {
+		return nil
+	}
+	if retLbls.Hash() == fw.labels.Hash() {
+		return fw
+	}
+	return NewFlowMetric(0, retLbls, fw.value)
 }

--- a/component/metrics/receiver.go
+++ b/component/metrics/receiver.go
@@ -21,9 +21,6 @@ type FlowMetric struct {
 	value       float64
 }
 
-// RefID wraps uint64 and used for a globally unique value
-type RefID uint64
-
 // NewFlowMetric instantiates a new flow metric
 func NewFlowMetric(globalRefID uint64, lbls labels.Labels, value float64) *FlowMetric {
 	// Always ensure we have a valid global ref id

--- a/component/metrics/receiver.go
+++ b/component/metrics/receiver.go
@@ -45,6 +45,12 @@ func (fw *FlowMetric) LabelsCopy() labels.Labels {
 	return fw.labels.Copy()
 }
 
+// RawLabels returns the actual underlying labels that SHOULD be treated as immutable. Usage of this
+// must be very careful to ensure that nothing that consume this mutates labels in anyway.
+func (fw *FlowMetric) RawLabels() labels.Labels {
+	return fw.labels
+}
+
 // Relabel applies normal prometheus relabel rules and returns a flow metric. NOTE this may return itself.
 func (fw *FlowMetric) Relabel(cfgs ...*promrelabel.Config) *FlowMetric {
 	retLbls := promrelabel.Process(fw.labels)

--- a/component/metrics/receiver_test.go
+++ b/component/metrics/receiver_test.go
@@ -93,6 +93,7 @@ func buildReceiverPyramid(
 	parent *receiverChain,
 	finalRec *Receiver,
 ) []*receiverChain {
+
 	children := make([]*receiverChain, 0)
 	for i := 0; i < childrenCount; i++ {
 		leaf := &receiverChain{

--- a/component/metrics/receiver_test.go
+++ b/component/metrics/receiver_test.go
@@ -1,0 +1,45 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	promrelabel "github.com/prometheus/prometheus/model/relabel"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelabel(t *testing.T) {
+	fm := NewFlowMetric(0, labels.FromStrings("key", "value"), 0)
+	require.True(t, fm.globalRefID != 0)
+	rg, _ := promrelabel.NewRegexp("(.*)")
+	newfm := fm.Relabel(&promrelabel.Config{
+		Replacement: "${1}_new",
+		Action:      "replace",
+		TargetLabel: "new",
+		Regex:       rg,
+	})
+	require.Len(t, fm.labels, 1)
+	require.True(t, fm.labels.Has("key"))
+
+	require.Len(t, newfm.labels, 2)
+	require.True(t, newfm.labels.Has("new"))
+
+}
+
+func TestRelabelTheSame(t *testing.T) {
+	fm := NewFlowMetric(0, labels.FromStrings("key", "value"), 0)
+	require.True(t, fm.globalRefID != 0)
+	rg, _ := promrelabel.NewRegexp("bad")
+	newfm := fm.Relabel(&promrelabel.Config{
+		Replacement: "${1}_new",
+		Action:      "replace",
+		TargetLabel: "new",
+		Regex:       rg,
+	})
+	require.Len(t, fm.labels, 1)
+	require.True(t, fm.labels.Has("key"))
+	require.Len(t, newfm.labels, 1)
+	require.True(t, newfm.globalRefID == fm.globalRefID)
+	require.True(t, labels.Equal(newfm.labels, fm.labels))
+
+}

--- a/component/metrics/receiver_test.go
+++ b/component/metrics/receiver_test.go
@@ -49,7 +49,6 @@ func BenchmarkWorkerReceiver(b *testing.B) {
 	useWorkers = true
 	for i := 0; i < b.N; i++ {
 		runTest()
-		// 1669357
 	}
 }
 
@@ -57,7 +56,6 @@ func BenchmarkFuncReceiver(b *testing.B) {
 	useWorkers = false
 	for i := 0; i < b.N; i++ {
 		runTest()
-		// 176162347
 	}
 }
 

--- a/component/metrics/receiver_test.go
+++ b/component/metrics/receiver_test.go
@@ -67,7 +67,7 @@ func runTest() {
 	cnt := atomic.NewInt64(0)
 	finalRec := NewReceiver(func(timestamp int64, metrics []*FlowMetric) {
 		cnt.Inc()
-		time.Sleep(1 * time.Millisecond)
+		time.Sleep(100 * time.Microsecond)
 	})
 	maxdepth := 4
 	childrencount := 2

--- a/component/metrics/receiver_test.go
+++ b/component/metrics/receiver_test.go
@@ -1,11 +1,14 @@
 package metrics
 
 import (
+	"math"
 	"testing"
+	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 	promrelabel "github.com/prometheus/prometheus/model/relabel"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 )
 
 func TestRelabel(t *testing.T) {
@@ -23,7 +26,6 @@ func TestRelabel(t *testing.T) {
 
 	require.Len(t, newfm.labels, 2)
 	require.True(t, newfm.labels.Has("new"))
-
 }
 
 func TestRelabelTheSame(t *testing.T) {
@@ -41,5 +43,85 @@ func TestRelabelTheSame(t *testing.T) {
 	require.Len(t, newfm.labels, 1)
 	require.True(t, newfm.globalRefID == fm.globalRefID)
 	require.True(t, labels.Equal(newfm.labels, fm.labels))
+}
 
+func BenchmarkWorkerReceiver(b *testing.B) {
+	useWorkers = true
+	for i := 0; i < b.N; i++ {
+		runTest()
+		// 1669357
+	}
+}
+
+func BenchmarkFuncReceiver(b *testing.B) {
+	useWorkers = false
+	for i := 0; i < b.N; i++ {
+		runTest()
+		// 176162347
+	}
+}
+
+func runTest() {
+	parent := &receiverChain{
+		parent:   nil,
+		children: make([]*Receiver, 0),
+	}
+	cnt := atomic.NewInt64(0)
+	finalRec := NewReceiver(func(timestamp int64, metrics []*FlowMetric) {
+		cnt.Inc()
+		time.Sleep(1 * time.Millisecond)
+	})
+	maxdepth := 4
+	childrencount := 2
+	expectedCount := math.Pow(float64(childrencount), float64(maxdepth))
+	childs := buildReceiverPyramid(1, maxdepth, childrencount, parent, finalRec)
+	for _, c := range childs {
+		nr := NewReceiver(c.Receive)
+		parent.children = append(parent.children, nr)
+	}
+	parent.Receive(time.Now().Unix(), nil)
+	for {
+		if cnt.Load() == int64(expectedCount) {
+			break
+		}
+		time.Sleep(1 * time.Microsecond)
+	}
+}
+
+func buildReceiverPyramid(
+	currentDepth, maxDepth, childrenCount int,
+	parent *receiverChain,
+	finalRec *Receiver,
+) []*receiverChain {
+	children := make([]*receiverChain, 0)
+	for i := 0; i < childrenCount; i++ {
+		leaf := &receiverChain{
+			parent:   parent,
+			children: make([]*Receiver, 0),
+		}
+		children = append(children, leaf)
+		if currentDepth == maxDepth {
+			leaf.children = append(leaf.children, finalRec)
+			continue
+		} else {
+			newDepth := currentDepth + 1
+			leafChildren := buildReceiverPyramid(newDepth, maxDepth, childrenCount, leaf, finalRec)
+			for _, lc := range leafChildren {
+				rc := NewReceiver(lc.Receive)
+				leaf.children = append(leaf.children, rc)
+			}
+		}
+	}
+	return children
+}
+
+type receiverChain struct {
+	parent   *receiverChain
+	children []*Receiver
+}
+
+func (rc *receiverChain) Receive(timestamp int64, metricArr []*FlowMetric) {
+	for _, f := range rc.children {
+		f.Send(timestamp, metricArr)
+	}
 }

--- a/component/metrics/remotewrite/remote_write.go
+++ b/component/metrics/remotewrite/remote_write.go
@@ -80,7 +80,7 @@ func NewComponent(o component.Options, c RemoteConfig) (*Component, error) {
 		remoteStore: remoteStore,
 		storage:     storage.NewFanout(o.Logger, walStorage, remoteStore),
 	}
-	res.receiver = &metrics.Receiver{Receive: res.Receive}
+	res.receiver = metrics.NewReceiver(res.Receive)
 	if err := res.Update(c); err != nil {
 		return nil, err
 	}

--- a/component/metrics/remotewrite/remote_write.go
+++ b/component/metrics/remotewrite/remote_write.go
@@ -173,16 +173,13 @@ func (c *Component) Update(newConfig component.Arguments) error {
 func (c *Component) Receive(ts int64, metricArr []*metrics.FlowMetric) {
 	app := c.storage.Appender(context.Background())
 	for _, m := range metricArr {
-		// TODO this should all be simplified into one call
-		if m.GlobalRefID == 0 {
-			globalID := metrics.GlobalRefMapping.GetOrAddGlobalRefID(m.Labels)
-			m.GlobalRefID = globalID
-		}
-		localID := metrics.GlobalRefMapping.GetLocalRefID(c.opts.ID, m.GlobalRefID)
-		newLocal, err := app.Append(storage.SeriesRef(localID), m.Labels, ts, m.Value)
+		localID := metrics.GlobalRefMapping.GetLocalRefID(c.opts.ID, m.GlobalRefID())
+		// Currently it doesn't look like the storage interfaces mutate the labels, but thats not a strong
+		// promise so copying the labels to go to the appendable.
+		newLocal, err := app.Append(storage.SeriesRef(localID), m.LabelsCopy(), ts, m.Value())
 		// Add link if there wasn't one before, and we received a valid local id
 		if localID == 0 && newLocal != 0 {
-			metrics.GlobalRefMapping.GetOrAddLink(c.opts.ID, uint64(newLocal), m.Labels)
+			metrics.GlobalRefMapping.GetOrAddLink(c.opts.ID, uint64(newLocal), m)
 		}
 		if err != nil {
 			_ = app.Rollback()

--- a/component/metrics/remotewrite/remote_write.go
+++ b/component/metrics/remotewrite/remote_write.go
@@ -175,8 +175,8 @@ func (c *Component) Receive(ts int64, metricArr []*metrics.FlowMetric) {
 	for _, m := range metricArr {
 		localID := metrics.GlobalRefMapping.GetLocalRefID(c.opts.ID, m.GlobalRefID())
 		// Currently it doesn't look like the storage interfaces mutate the labels, but thats not a strong
-		// promise so copying the labels to go to the appendable.
-		newLocal, err := app.Append(storage.SeriesRef(localID), m.LabelsCopy(), ts, m.Value())
+		// promise. So this should be treated with care.
+		newLocal, err := app.Append(storage.SeriesRef(localID), m.RawLabels(), ts, m.Value())
 		// Add link if there wasn't one before, and we received a valid local id
 		if localID == 0 && newLocal != 0 {
 			metrics.GlobalRefMapping.GetOrAddLink(c.opts.ID, uint64(newLocal), m)

--- a/component/metrics/scrape/scrape_test.go
+++ b/component/metrics/scrape/scrape_test.go
@@ -66,13 +66,9 @@ func TestForwardingToAppendable(t *testing.T) {
 
 	// Forwarding a sample to the mock receiver should succeed.
 	appender = s.appendable.Appender(context.Background())
-	sample := metrics.FlowMetric{
-		GlobalRefID: 1,
-		Labels:      labels.FromStrings("foo", "bar"),
-		Value:       42.0,
-	}
+	sample := metrics.NewFlowMetric(1, labels.FromStrings("foo", "bar"), 42.0)
 	timestamp := time.Now().Unix()
-	_, err = appender.Append(0, sample.Labels, timestamp, sample.Value)
+	_, err = appender.Append(0, sample.LabelsCopy(), timestamp, sample.Value())
 	require.NoError(t, err)
 
 	err = appender.Commit()

--- a/component/metrics/scrape/scrape_test.go
+++ b/component/metrics/scrape/scrape_test.go
@@ -49,13 +49,11 @@ func TestForwardingToAppendable(t *testing.T) {
 	// Update the component with a mock receiver; it should be passed along to the Appendable.
 	var receivedTs int64
 	var receivedSamples []*metrics.FlowMetric
-	mockReceiver := []*metrics.Receiver{
-		{
-			Receive: func(t int64, m []*metrics.FlowMetric) {
-				receivedTs = t
-				receivedSamples = m
-			},
-		},
+	mockReceiver := []*metrics.Receiver{metrics.NewReceiver(func(t int64, m []*metrics.FlowMetric) {
+		receivedTs = t
+		receivedSamples = m
+	},
+	),
 	}
 
 	args.ForwardTo = mockReceiver

--- a/component/metrics/scrape/scrape_test.go
+++ b/component/metrics/scrape/scrape_test.go
@@ -76,5 +76,5 @@ func TestForwardingToAppendable(t *testing.T) {
 
 	require.Equal(t, receivedTs, timestamp)
 	require.Len(t, receivedSamples, 1)
-	require.Equal(t, receivedSamples[0], &sample)
+	require.Equal(t, receivedSamples[0], sample)
 }

--- a/go.mod
+++ b/go.mod
@@ -124,6 +124,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.1
 	github.com/fatih/color v1.13.0
 	github.com/grafana/vmware_exporter v0.0.2-beta
+	github.com/panjf2000/ants/v2 v2.5.0
 	go.opentelemetry.io/collector/pdata v0.55.0
 	go.opentelemetry.io/collector/semconv v0.55.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2114,6 +2114,8 @@ github.com/ory/dockertest/v3 v3.8.1/go.mod h1:wSRQ3wmkz+uSARYMk7kVJFDBGm8x5gSxIh
 github.com/packethost/packngo v0.1.1-0.20180711074735-b9cb5096f54c h1:vwpFWvAO8DeIZfFeqASzZfsxuWPno9ncAebBEP0N3uE=
 github.com/packethost/packngo v0.1.1-0.20180711074735-b9cb5096f54c/go.mod h1:otzZQXgoO96RTzDB/Hycg0qZcXZsWJGJRSXbmEIJ+4M=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
+github.com/panjf2000/ants/v2 v2.5.0 h1:1rWGWSnxCsQBga+nQbA4/iY6VMeNoOIAM0ZWh9u3q2Q=
+github.com/panjf2000/ants/v2 v2.5.0/go.mod h1:cU93usDlihJZ5CfRGNDYsiBYvoilLvBF5Qp/BT2GNRE=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=


### PR DESCRIPTION
#### PR Description

Currently, the receiver uses chained functions, I want to add the ability to use a worker pool. With chained functions, each path to the furthest child must be executed each time this can have a huge performance bottleneck with really long metric chains.  In the basic benchmark, the worker pool one is 100x faster than the function on in heavy chain scenarios and 10x fast in very small scenarios. Note the benchmark adds a 100-microsecond delay to represent the endpoint doing some sort of work. 


