### PR TITLE
Append APPDATA to bookmark files in agent config for Windows event logs

### DIFF
--- a/production/grafanacloud-install.ps1
+++ b/production/grafanacloud-install.ps1
@@ -81,7 +81,7 @@ if ($jsonObj.status -eq "success") {
 	Start-Service "Grafana Agent"
 
 	# Wait for service to startup after restart
-	Write-Host "Wait for Grafana service to initialize"
+	Write-Host "Wait for Grafana service to initialize after restart"
 	Start-Sleep -s 10
 
 	# Show Grafana agent service status

--- a/production/grafanacloud-install.ps1
+++ b/production/grafanacloud-install.ps1
@@ -80,6 +80,10 @@ if ($jsonObj.status -eq "success") {
 	Stop-Service "Grafana Agent"
 	Start-Service "Grafana Agent"
 
+	# Wait for service to startup after restart
+	Write-Host "Wait for Grafana service to initialize"
+	Start-Sleep -s 10
+
 	# Show Grafana agent service status
 	Get-Service "Grafana Agent"
 } else {


### PR DESCRIPTION
For the windows integration - the default windows event log configuration contains relative bookmark file paths.

```
job_name: integrations/windows-exporter-application
        windows_events:
          use_incoming_timestamp: true
          bookmark_path: "./bookmark-application.xml"
          eventlog_name: "Application"
          xpath_query: '*'
          labels:
            job: integrations/windows_exporter
        relabel_configs:
          - source_labels: ['computer']
            target_label: 'agent_hostname'
        pipeline_stages:
          - json:
              expressions:
                source: source
          - labels:
              source:
```

When running the agent with relative paths in bookmark_path - the agent service fails to start as it is not able to create these files in the relative paths. This PR appends %APPDATA% into all bookmark_path (s) present in the agent config when installing the agent for windows though the powershell script.

The agent itself does not support expanding the %APPDATA% variable in Windows. Therefore the powershell script is updated to do the replacement when installing the agent for windows through the script.

The resulting bookmark path becomes:
```
bookmark_path: C:\Users\shb\AppData\Roaming\bookmark-application.xml
```