### PR TITLE
agent-operator: base image off of distroless base image.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Main (unreleased)
 
  - It is now possible to compile Grafana Agent using Go 1.19. (@rfratto)
 
+ - The agent-operator docker image is now based on [distroless](https://github.com/GoogleContainerTools/distroless) instead of the heavier debian base image. (@captncraig)
+
 v0.26.1 (2022-07-25)
 -------------------------
 

--- a/cmd/agent-operator/Dockerfile
+++ b/cmd/agent-operator/Dockerfile
@@ -1,16 +1,16 @@
-FROM golang:1.18.0-bullseye as build
+FROM golang:1.18.5-alpine3.16 as build
 COPY . /src/agent
 WORKDIR /src/agent
 ARG RELEASE_BUILD=false
 ARG IMAGE_TAG
 
+RUN apk add --update make bash git
+
 RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agent-operator
 
-FROM debian:bullseye-slim
+FROM alpine:3.16
 
-RUN apt-get update && \
-  apt-get install -qy tzdata ca-certificates && \
-  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 
 COPY --from=build /src/agent/cmd/agent-operator/agent-operator /bin/agent-operator
 

--- a/cmd/agent-operator/Dockerfile
+++ b/cmd/agent-operator/Dockerfile
@@ -1,16 +1,12 @@
-FROM golang:1.18.5-alpine3.16 as build
+FROM golang:1.18.0-bullseye as build
 COPY . /src/agent
 WORKDIR /src/agent
 ARG RELEASE_BUILD=false
 ARG IMAGE_TAG
 
-RUN apk add --update make bash git
-
 RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agent-operator
 
-FROM alpine:3.16
-
-RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+FROM gcr.io/distroless/static-debian11
 
 COPY --from=build /src/agent/cmd/agent-operator/agent-operator /bin/agent-operator
 

--- a/cmd/agent-operator/Dockerfile
+++ b/cmd/agent-operator/Dockerfile
@@ -6,7 +6,7 @@ ARG IMAGE_TAG
 
 RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agent-operator
 
-FROM gcr.io/distroless/static-debian11
+FROM gcr.io/distroless/base-debian11
 
 COPY --from=build /src/agent/cmd/agent-operator/agent-operator /bin/agent-operator
 

--- a/cmd/agent-operator/Dockerfile.buildx
+++ b/cmd/agent-operator/Dockerfile.buildx
@@ -19,7 +19,7 @@ ARG IMAGE_TAG
 
 RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false DRONE=true agent-operator
 
-FROM gcr.io/distroless/static-debian11
+FROM gcr.io/distroless/base-debian11
 
 COPY --from=build /src/agent/cmd/agent-operator/agent-operator /bin/agent-operator
 

--- a/cmd/agent-operator/Dockerfile.buildx
+++ b/cmd/agent-operator/Dockerfile.buildx
@@ -19,11 +19,7 @@ ARG IMAGE_TAG
 
 RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false DRONE=true agent-operator
 
-FROM debian:bullseye-slim
-
-RUN apt-get update && \
-  apt-get install -qy tzdata ca-certificates && \
-  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+FROM gcr.io/distroless/static-debian11
 
 COPY --from=build /src/agent/cmd/agent-operator/agent-operator /bin/agent-operator
 


### PR DESCRIPTION
This should lower the security footprint of the operator significantly, since it relies on many fewer things than the agent itself.

[distroless](https://github.com/GoogleContainerTools/distroless) is a much smaller, debian based image. It still has a few CVE hits from libc and openssl, but fewer than the full debian image. Tested working in my local cluster.