### PR TITLE
add Craig and Marc as maintainers of operator and integrations

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,4 @@
+/cmd/agent-operator @captncraig @marctc
+/pkg/integrations/ @rgeyer @gaantunes @captncraig @marctc
+/pkg/operator @captncraig @marctc
 /pkg/traces/ @joe-elliott @mapno
-/pkg/integrations/ @rgeyer @gaantunes

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,9 +7,10 @@ The following people are the primary maintainers of the project:
 
 Some parts of the codebase have other maintainers:
 
+* `cmd/agent-operator`: Craig Peterson (<craig.peterson@grafana.com> / @catpncraig), Marc Tudurí (<marc.tuduri@grafana.com> / @marctc)
+* `pkg/integrations`: Gabriel Antunes (<gabriel.antunes@grafana.com> / @gaantunes), Ryan Geyer (<ryan.geyer@grafana.com> / @rgeyer), Craig Peterson (<craig.peterson@grafana.com> / @catpncraig), Marc Tudurí (<marc.tuduri@grafana.com> / @marctc)
+* `pkg/operator`: Craig Peterson (<craig.peterson@grafana.com> / @catpncraig), Marc Tudurí (<marc.tuduri@grafana.com> / @marctc)
 * `pkg/traces`: Joe Elliott (<joe.elliott@grafana.com> / @joe-elliott), Mario Rodriguez (<mario.rodriguez@grafana.com>/ @mapno)
-* `pkg/integrations`: Gabriel Antunes (<gabriel.antunes@grafana.com> / @gaantunes), Ryan Geyer (<ryan.geyer@grafana.com> / @rgeyer)
-* `docs/sources`: Brenda Muir (<brenda.muir@grafana.com> / @brendamuir)
 
 For the sake of brevity, not all subtrees are explicitly listed. Due to the
 size of this repository, the natural changes in focus of maintainers over time,


### PR DESCRIPTION
This change marks @marctc and @captncraig as maintainers of the following packages:

* cmd/agent-operator 
* pkg/operator 
* pkg/integrations 

Also removes Brenda as a maintainer of docs, which was left in by accident after removing her as a code owner.