### PR TITLE
Revert "agent-operator: base image off of distroless base image. (#20…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,6 @@ Main (unreleased)
 
  - It is now possible to compile Grafana Agent using Go 1.19. (@rfratto)
 
- - The agent-operator docker image is now based on [distroless](https://github.com/GoogleContainerTools/distroless) instead of the heavier debian base image. (@captncraig)
-
 v0.26.1 (2022-07-25)
 -------------------------
 

--- a/cmd/agent-operator/Dockerfile
+++ b/cmd/agent-operator/Dockerfile
@@ -6,7 +6,11 @@ ARG IMAGE_TAG
 
 RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agent-operator
 
-FROM gcr.io/distroless/base-debian11
+FROM debian:bullseye-slim
+
+RUN apt-get update && \
+  apt-get install -qy tzdata ca-certificates && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY --from=build /src/agent/cmd/agent-operator/agent-operator /bin/agent-operator
 

--- a/cmd/agent-operator/Dockerfile.buildx
+++ b/cmd/agent-operator/Dockerfile.buildx
@@ -19,7 +19,11 @@ ARG IMAGE_TAG
 
 RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false DRONE=true agent-operator
 
-FROM gcr.io/distroless/base-debian11
+FROM debian:bullseye-slim
+
+RUN apt-get update && \
+  apt-get install -qy tzdata ca-certificates && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY --from=build /src/agent/cmd/agent-operator/agent-operator /bin/agent-operator
 


### PR DESCRIPTION
Looks like distroless does not support all the arch combos we need.