### PR TITLE
Introduce new consolidated build-image

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -13,8 +13,8 @@ FROM golang:1.17 as ghr
 RUN GO111MODULE=on go get github.com/tcnksm/ghr
 
 # Dependency: docker (for building images)
-FROM alpine:edge as docker
-RUN apk add --no-cache docker-cli
+FROM alpine:3.16 as docker
+RUN apk add --no-cache docker-cli docker-cli-buildx
 
 # Dependency: Go and Go dependencies
 FROM golang:1.18-bullseye as golang
@@ -24,6 +24,7 @@ ENV CONTROLLER_GEN_VERSION v0.8.0
 
 RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@$CONTROLLER_GEN_VERSION \
  && go install github.com/mitchellh/gox@v1.0.1                                         \
+ && go install github.com/tcnksm/ghr@v0.15.0                                           \
  && go install github.com/grafana/tanka/cmd/tk@v0.22.1                                 \
  && go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.5.1                \
  && go install github.com/google/go-jsonnet/cmd/jsonnet@v0.18.0                        \
@@ -39,20 +40,23 @@ RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@$CONTROLLER_GEN_V
 # dependencies.
 FROM rfratto/viceroy:v0.2.1
 
+# NOTE(rfratto): musl is installed so the Docker binaries from alpine work
+# properly.
 RUN apt-get update                               \
  && apt-get install -qy                          \
       build-essential file zip unzip gettext git \
-      libsystemd-dev nsis libbpfcc-dev nsis      \
+      musl libsystemd-dev nsis libbpfcc-dev nsis \
       rpm ruby ruby-dev rubygems                 \
       protobuf-compiler libprotobuf-dev          \
  && gem install --no-document fpm                \
  && rm -rf /var/lib/apt/lists/*
 
-COPY --from=golang   /usr/local/go      /usr/local/go
-COPY --from=golang   /go/bin            /go/bin
-COPY --from=golangci /bin/golangci-lint /usr/local/bin
-COPY --from=ghr      /go/bin/ghr        /usr/bin/ghr
-COPY --from=docker   /usr/bin/docker    /usr/bin/docker
+COPY --from=golang   /usr/local/go                   /usr/local/go
+COPY --from=golang   /go/bin                         /go/bin
+COPY --from=golangci /bin/golangci-lint              /usr/local/bin
+COPY --from=ghr      /go/bin/ghr                     /usr/bin/ghr
+COPY --from=docker   /usr/bin/docker                 /usr/bin/docker
+COPY --from=docker   /usr/libexec/docker/cli-plugins /usr/libexec/docker/cli-plugins
 
 # Set CC to viceroycc to ensure that the cross compilers are used for all C
 # compilation.

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,21 +1,62 @@
-# Use the loki-build-image as a base as it shares most of the common tooling.
-# We just need some additional tooling for building packages.
-FROM grafana/loki-build-image:0.18.0
+#
+# Dependencies
+#
+# We retrieve many of our dependencies by using various smaller containers.
+#
 
-RUN apt-get update && apt-get install -y \
-  build-essential \
-  rpm \
-  ruby \
-  ruby-dev \
-  rubygems \
-  && gem install --no-ri --no-rdoc fpm \
-  && rm -rf /var/lib/apt/lists/*
+# Dependency: golangci-lint (for linting)
+FROM alpine as golangci
+RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.46.2
 
-# Install dependencies used for the operator
-# Keep versions in sync with cmd/agent-operator/DEVELOPERS.md
-RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0
+# Dependency: ghr (for producing releases)
+FROM golang:1.17 as ghr
+RUN GO111MODULE=on go get github.com/tcnksm/ghr
 
-# Fix permissions for /go/bin directory.
-RUN chmod 0755 /go/bin
-# Use /src/agent directory instead of /src/loki.
-RUN sed -i -e 's /src/loki /src/agent ' /build.sh
+# Dependency: docker (for building images)
+FROM alpine:edge as docker
+RUN apk add --no-cache docker-cli
+
+# Dependency: Go and Go dependencies
+FROM golang:1.18-bullseye as golang
+
+# Keep in sync with cmd/agent-operator/DEVELOPERS.md
+ENV CONTROLLER_GEN_VERSION v0.8.0
+
+RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@$CONTROLLER_GEN_VERSION \
+ && go install github.com/mitchellh/gox@v1.0.1                                         \
+ && go install github.com/grafana/tanka/cmd/tk@v0.22.1                                 \
+ && go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.5.1                \
+ && go install github.com/google/go-jsonnet/cmd/jsonnet@v0.18.0                        \
+ && go install github.com/golang/protobuf/protoc-gen-go@v1.3.1                         \
+ && go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0                    \
+ && go install github.com/gogo/protobuf/gogoproto/...@v1.3.0
+
+#
+# Final image
+#
+
+# rfratto/viceroy contains C cross compilers can be used for our Cgo
+# dependencies.
+FROM rfratto/viceroy:v0.2.1
+
+RUN apt-get update                               \
+ && apt-get install -qy                          \
+      build-essential file zip unzip gettext git \
+      libsystemd-dev nsis libbpfcc-dev nsis      \
+      rpm ruby ruby-dev rubygems                 \
+      protobuf-compiler libprotobuf-dev          \
+ && gem install --no-document fpm                \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=golang   /usr/local/go      /usr/local/go
+COPY --from=golang   /go/bin            /go/bin
+COPY --from=golangci /bin/golangci-lint /usr/local/bin
+COPY --from=ghr      /go/bin/ghr        /usr/bin/ghr
+COPY --from=docker   /usr/bin/docker    /usr/bin/docker
+
+# Set CC to viceroycc to ensure that the cross compilers are used for all C
+# compilation.
+ENV CC viceroycc
+
+ENV GOPATH /go
+ENV PATH /usr/local/go/bin:/go/bin:$PATH

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -8,10 +8,6 @@
 FROM alpine as golangci
 RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.46.2
 
-# Dependency: ghr (for producing releases)
-FROM golang:1.17 as ghr
-RUN GO111MODULE=on go get github.com/tcnksm/ghr
-
 # Dependency: docker (for building images)
 FROM alpine:3.16 as docker
 RUN apk add --no-cache docker-cli docker-cli-buildx
@@ -51,12 +47,11 @@ RUN apt-get update                               \
  && gem install --no-document fpm                \
  && rm -rf /var/lib/apt/lists/*
 
-COPY --from=golang   /usr/local/go                   /usr/local/go
-COPY --from=golang   /go/bin                         /go/bin
 COPY --from=golangci /bin/golangci-lint              /usr/local/bin
-COPY --from=ghr      /go/bin/ghr                     /usr/bin/ghr
 COPY --from=docker   /usr/bin/docker                 /usr/bin/docker
 COPY --from=docker   /usr/libexec/docker/cli-plugins /usr/libexec/docker/cli-plugins
+COPY --from=golang   /usr/local/go                   /usr/local/go
+COPY --from=golang   /go/bin                         /go/bin
 
 # Set CC to viceroycc to ensure that the cross compilers are used for all C
 # compilation.


### PR DESCRIPTION
This will introduce 0.15.0 of the build-image, which contains all the tooling needed for building the agent locally and through CI.

The base image is rfratto/viceroy, which is a rewrite of rfratto/seego which is a little easier to work with. Note that while rfratto/viceroy has an arm64 image, grafana/agent-build-image doesn't (yet) and only amd64 images will be produced for the 0.15.0 release. 

If there are any missing tools here needed for any Github Action or Drone job, please let me know: this should be the only image we need and have all of the dependencies already installed. 

Related to #2052.