### PR TITLE
Tune threshold of vulture alerts

### DIFF
--- a/example/k3d/smoke/monitoring/prometheus_monitoring.libsonnet
+++ b/example/k3d/smoke/monitoring/prometheus_monitoring.libsonnet
@@ -193,7 +193,7 @@ local agent_prometheus = import 'grafana-agent/v1/lib/metrics.libsonnet';
           {
             alert: 'VultureFailures',
             expr: |||
-              (rate(tempo_vulture_error_total[2m]) / rate(tempo_vulture_trace_total[2m])) > 0 
+              (rate(tempo_vulture_error_total[5m]) / rate(tempo_vulture_trace_total[5m])) > 0.3 
             |||,
             'for': '5m',
             annotations: {

--- a/production/grafana-agent-mixin/alerts.libsonnet
+++ b/production/grafana-agent-mixin/alerts.libsonnet
@@ -227,7 +227,7 @@ local _config = config._config;
           {
             alert: 'VultureFailures',
             expr: |||
-              (rate(tempo_vulture_error_total[2m]) / rate(tempo_vulture_trace_total[2m])) > 0 
+              (rate(tempo_vulture_error_total[5m]) / rate(tempo_vulture_trace_total[5m])) > 0.3
             |||,
             'for': '5m',
             annotations: {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR tunes the threshold of vulture alerting when traces are not found in Tempo
