### PR TITLE
docs/flow: remove reference/flags.md

### DIFF
--- a/docs/flow/reference/flags.md
+++ b/docs/flow/reference/flags.md
@@ -1,8 +1,0 @@
----
-aliases:
-- /docs/agent/latest/flow/reference/command-line-flags
-title: Command-line flags
-weight: 100
----
-
-# Command-line flags


### PR DESCRIPTION
There is no general set of command-line flags that should be documented; instead, each cli command will document its command line flags. Command line flags for `run` are already documented in reference/cli/run.md.
