### PR TITLE
production: make it harder to forget updating grafanacloud-install.sh

### DIFF
--- a/production/grafanacloud-install.sh
+++ b/production/grafanacloud-install.sh
@@ -50,11 +50,11 @@ PACKAGE_SYSTEM=${PACKAGE_SYSTEM:=}
 #
 # Global constants.
 #
-RELEASE_VERSION="0.26.1"
+RELEASE_VERSION="v0.26.1"
 
-RELEASE_URL="https://github.com/grafana/agent/releases/download/v${RELEASE_VERSION}"
-DEB_URL="${RELEASE_URL}/grafana-agent-${RELEASE_VERSION}-1.${ARCH}.deb"
-RPM_URL="${RELEASE_URL}/grafana-agent-${RELEASE_VERSION}-1.${ARCH}.rpm"
+RELEASE_URL="https://github.com/grafana/agent/releases/download/${RELEASE_VERSION}"
+DEB_URL="${RELEASE_URL}/grafana-agent-${RELEASE_VERSION#v}-1.${ARCH}.deb"
+RPM_URL="${RELEASE_URL}/grafana-agent-${RELEASE_VERSION#v}-1.${ARCH}.rpm"
 
 main() {
   if [ -z "$PACKAGE_SYSTEM" ]; then

--- a/production/grafanacloud-install.sh
+++ b/production/grafanacloud-install.sh
@@ -52,6 +52,8 @@ PACKAGE_SYSTEM=${PACKAGE_SYSTEM:=}
 #
 RELEASE_VERSION="v0.26.1"
 
+# The DEB and RPM urls don't include the `v` version prefix in the file names,
+# so we trim it out using ${RELEASE_VERSION#v} below.
 RELEASE_URL="https://github.com/grafana/agent/releases/download/${RELEASE_VERSION}"
 DEB_URL="${RELEASE_URL}/grafana-agent-${RELEASE_VERSION#v}-1.${ARCH}.deb"
 RPM_URL="${RELEASE_URL}/grafana-agent-${RELEASE_VERSION#v}-1.${ARCH}.rpm"


### PR DESCRIPTION
grafanacloud-install.sh is the only place which doesn't refer to the version with the `v` prefix, so it tends to be missed when bumping the version references.

```
$ RELEASE_VERSION=v0.26.1 
$ echo "${RELEASE_VERSION#v}" 
0.26.1
```