### PR TITLE
docs/flow: fix typo in json_decode examples

### DIFF
--- a/docs/flow/reference/stdlib/json_decode.md
+++ b/docs/flow/reference/stdlib/json_decode.md
@@ -35,7 +35,7 @@ null
   key = "value",
 }
 
-> json_decode(local.file.some_file.contents)
+> json_decode(local.file.some_file.content)
 "Hello, world!"
 ```
 


### PR DESCRIPTION
The export of local.file is called `content`, not `contents`:

https://github.com/grafana/agent/blob/fa4e86ede73c320849476ff384f8dd7632bd4061/component/local/file/file.go#L72