### PR TITLE
SNMP Exporter Scrape Configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ Main (unreleased)
 
 - Fix grafanacloud-install.ps1 web request internal server error when fetching config. (@rlankfo)
 
+- Fix snmp integration not passing module or walk_params parameters when scraping. (@rgeyer)
+
+- Fix unmarshal errors (key "<walk_param name>" already set in map) for snmp integration config when walk_params is defined, and the config is reloaded. (@rgeyer)
+
 ### Other changes
 
  - Update several go dependencies to resolve warnings from certain security scanning tools. None of the resolved vulnerabilities were known to be exploitable through the agent. (@captncraig)

--- a/pkg/integrations/snmp_exporter/snmp_exporter.go
+++ b/pkg/integrations/snmp_exporter/snmp_exporter.go
@@ -124,6 +124,12 @@ func (i *Integration) ScrapeConfigs() []config.ScrapeConfig {
 	for _, target := range i.sh.cfg.SnmpTargets {
 		queryParams := url.Values{}
 		queryParams.Add("target", target.Target)
+		if target.Module != "" {
+			queryParams.Add("module", target.Module)
+		}
+		if target.WalkParams != "" {
+			queryParams.Add("walk_params", target.WalkParams)
+		}
 		res = append(res, config.ScrapeConfig{
 			JobName:     i.sh.cfg.Name() + "/" + target.Name,
 			MetricsPath: "/metrics",

--- a/pkg/integrations/v2/snmp_exporter/snmp.go
+++ b/pkg/integrations/v2/snmp_exporter/snmp.go
@@ -53,12 +53,26 @@ func (sh *snmpHandler) Targets(ep integrations.Endpoint) []*targetgroup.Group {
 	}
 
 	for _, t := range sh.cfg.SnmpTargets {
-		group.Targets = append(group.Targets, model.LabelSet{
+		labelSet := model.LabelSet{
 			model.AddressLabel:     model.LabelValue(ep.Host),
 			model.MetricsPathLabel: model.LabelValue(path.Join(ep.Prefix, "metrics")),
 			"snmp_target":          model.LabelValue(t.Target),
 			"__param_target":       model.LabelValue(t.Target),
-		})
+		}
+
+		if t.Module != "" {
+			labelSet = labelSet.Merge(model.LabelSet{
+				"__param_module": model.LabelValue(t.Module),
+			})
+		}
+
+		if t.WalkParams != "" {
+			labelSet = labelSet.Merge(model.LabelSet{
+				"__param_walk_params": model.LabelValue(t.WalkParams),
+			})
+		}
+
+		group.Targets = append(group.Targets, labelSet)
 	}
 
 	return []*targetgroup.Group{group}

--- a/pkg/integrations/v2/snmp_exporter/snmp_exporter.go
+++ b/pkg/integrations/v2/snmp_exporter/snmp_exporter.go
@@ -77,6 +77,11 @@ func (c *Config) NewIntegration(log log.Logger, globals integrations_v2.Globals)
 func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	*c = DefaultConfig
 
+	// This should technically be accomplished by assigning DefaultConfig, right?
+	// But in the reload case the existing values in this map are not purged and
+	// an unmarshal error is thrown stating that they key already exists in the map.
+	c.WalkParams = make(map[string]snmp_config.WalkParams)
+
 	type plain Config
 	return unmarshal((*plain)(c))
 }

--- a/pkg/integrations/v2/snmp_exporter/snmp_exporter.go
+++ b/pkg/integrations/v2/snmp_exporter/snmp_exporter.go
@@ -43,6 +43,9 @@ func (c *Config) ApplyDefaults(globals integrations_v2.Globals) error {
 
 // Identifier returns a string that identifies the integration.
 func (c *Config) Identifier(globals integrations_v2.Globals) (string, error) {
+	if c.Common.InstanceKey != nil {
+		return *c.Common.InstanceKey, nil
+	}
 	return c.Name(), nil
 }
 

--- a/pkg/integrations/v2/snmp_exporter/snmp_exporter_test.go
+++ b/pkg/integrations/v2/snmp_exporter/snmp_exporter_test.go
@@ -1,0 +1,29 @@
+package snmp_exporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestSnmpConfig(t *testing.T) {
+	t.Run("reload unmarshals", func(t *testing.T) {
+		var config Config
+
+		strConfig := `---
+walk_params:
+  keyone:
+    auth:
+      community: foo
+`
+
+		// The first time should not return any errors.
+		require.NoError(t, yaml.UnmarshalStrict([]byte(strConfig), &config), "initial unmarshal")
+		require.Len(t, config.WalkParams, 1)
+
+		// A second time (executed on reload), the map will already have the specified key(s), but should still succeed
+		require.NoError(t, yaml.UnmarshalStrict([]byte(strConfig), &config), "reload unmarshal")
+		require.Len(t, config.WalkParams, 1)
+	})
+}


### PR DESCRIPTION
#### PR Description
The SNMP config was not correctly setting additional scrape params (`module`, and `walk_params` specifically) when they defined in the configuration file. This would result in incomplete service discovery, and scraping a target without those values.

#### Which issue(s) this PR fixes
Partially #2017

#### Notes to the Reviewer
I am also experiencing a yaml unmarshal error which I'm trying to track down when using the agent operator and the SNMP integration. Time will tell if I can sort it out.

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [x] Tests updated
