### PR TITLE
Use go install to install binaries in drone 

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -303,7 +303,8 @@ steps:
       - tar -C /usr/local -xzf go1.18.linux-amd64.tar.gz
       - rm go1.18.linux-amd64.tar.gz
       - export PATH=$PATH:/usr/local/go/bin
-      - GO111MODULE=on go get -u github.com/mitchellh/gox github.com/tcnksm/ghr
+      - go install github.com/mitchellh/gox@latest
+      - go install github.com/tcnksm/ghr@latest
       - export PATH="$(go env GOPATH)/bin:$PATH"
       - make -j4 DOCKER_OPTS="" BUILD_IN_CONTAINER=false RELEASE_BUILD=true RELEASE_TAG=${DRONE_TAG} publish
 depends_on:

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -365,6 +365,6 @@ get:
 
 ---
 kind: signature
-hmac: 2cf5a5ca48b13a35f2f609985ab81e5cf21bf5f31a1543fde16a74ce3ff60c13
+hmac: e0f7d15a7b573f8b29d9f115eed16f237b9dccfa6b4eb168c8c84770660c15b1
 
 ...


### PR DESCRIPTION
go get for installing binaries is deprecated in go 1.18.

Trying to see if this fixes the release.

https://go.dev/doc/go-get-install-deprecation