### PR TITLE
app-agent-receiver: add Event kind to payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Main (unreleased)
 ### Features
 
 - Integrations: (beta) Add vmware_exporter integration (@rlankfo)
+- App agent receiver: add Event kind to payload (@domasx2)
 
 ### Enhancements
 

--- a/pkg/integrations/v2/app_agent_receiver/logs_exporter.go
+++ b/pkg/integrations/v2/app_agent_receiver/logs_exporter.go
@@ -83,6 +83,13 @@ func (le *LogsExporter) Export(ctx context.Context, payload Payload) error {
 		err = le.sendKeyValsToLogsPipeline(kv)
 	}
 
+	// events
+	for _, event := range payload.Events {
+		kv := event.KeyVal()
+		MergeKeyVal(kv, meta)
+		err = le.sendKeyValsToLogsPipeline(kv)
+	}
+
 	return err
 }
 

--- a/pkg/integrations/v2/app_agent_receiver/logs_exporter_test.go
+++ b/pkg/integrations/v2/app_agent_receiver/logs_exporter_test.go
@@ -107,7 +107,7 @@ func TestExportLogs(t *testing.T) {
 		prommodel.LabelName("app"):  prommodel.LabelValue("frontend"),
 		prommodel.LabelName("kind"): prommodel.LabelValue("event"),
 	}, inst.Entries[4].Labels)
-	expectedLine = "timestamp=\"2021-09-30 10:46:17.68 +0000 UTC\" kind=event name=click_login_button domain=frontend foo=bar one=two traceID=abcd spanID=def sdk_name=grafana-frontend-agent sdk_version=1.0.0 app_name=testapp app_release=0.8.2 app_version=abcdefg app_environment=production user_email=geralt@kaermorhen.org user_id=123 user_username=domasx2 user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false"
+	expectedLine = "timestamp=\"2021-09-30 10:46:17.68 +0000 UTC\" kind=event event.name=click_login_button event.domain=frontend event.data.foo=bar event.data.one=two traceID=abcd spanID=def sdk_name=grafana-frontend-agent sdk_version=1.0.0 app_name=testapp app_release=0.8.2 app_version=abcdefg app_environment=production user_email=geralt@kaermorhen.org user_id=123 user_username=domasx2 user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false"
 	require.Equal(t, expectedLine, inst.Entries[4].Line)
 
 	// event 2
@@ -115,6 +115,6 @@ func TestExportLogs(t *testing.T) {
 		prommodel.LabelName("app"):  prommodel.LabelValue("frontend"),
 		prommodel.LabelName("kind"): prommodel.LabelValue("event"),
 	}, inst.Entries[5].Labels)
-	expectedLine = "timestamp=\"2021-09-30 10:46:17.68 +0000 UTC\" kind=event name=click_reset_password_button sdk_name=grafana-frontend-agent sdk_version=1.0.0 app_name=testapp app_release=0.8.2 app_version=abcdefg app_environment=production user_email=geralt@kaermorhen.org user_id=123 user_username=domasx2 user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false"
+	expectedLine = "timestamp=\"2021-09-30 10:46:17.68 +0000 UTC\" kind=event event.name=click_reset_password_button sdk_name=grafana-frontend-agent sdk_version=1.0.0 app_name=testapp app_release=0.8.2 app_version=abcdefg app_environment=production user_email=geralt@kaermorhen.org user_id=123 user_username=domasx2 user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false"
 	require.Equal(t, expectedLine, inst.Entries[5].Line)
 }

--- a/pkg/integrations/v2/app_agent_receiver/logs_exporter_test.go
+++ b/pkg/integrations/v2/app_agent_receiver/logs_exporter_test.go
@@ -107,7 +107,7 @@ func TestExportLogs(t *testing.T) {
 		prommodel.LabelName("app"):  prommodel.LabelValue("frontend"),
 		prommodel.LabelName("kind"): prommodel.LabelValue("event"),
 	}, inst.Entries[4].Labels)
-	expectedLine = "timestamp=\"2021-09-30 10:46:17.68 +0000 UTC\" kind=event event.name=click_login_button event.domain=frontend event.data.foo=bar event.data.one=two traceID=abcd spanID=def sdk_name=grafana-frontend-agent sdk_version=1.0.0 app_name=testapp app_release=0.8.2 app_version=abcdefg app_environment=production user_email=geralt@kaermorhen.org user_id=123 user_username=domasx2 user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false"
+	expectedLine = "timestamp=\"2021-09-30 10:46:17.68 +0000 UTC\" kind=event event_name=click_login_button event_domain=frontend event_data_foo=bar event_data_one=two traceID=abcd spanID=def sdk_name=grafana-frontend-agent sdk_version=1.0.0 app_name=testapp app_release=0.8.2 app_version=abcdefg app_environment=production user_email=geralt@kaermorhen.org user_id=123 user_username=domasx2 user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false"
 	require.Equal(t, expectedLine, inst.Entries[4].Line)
 
 	// event 2
@@ -115,6 +115,6 @@ func TestExportLogs(t *testing.T) {
 		prommodel.LabelName("app"):  prommodel.LabelValue("frontend"),
 		prommodel.LabelName("kind"): prommodel.LabelValue("event"),
 	}, inst.Entries[5].Labels)
-	expectedLine = "timestamp=\"2021-09-30 10:46:17.68 +0000 UTC\" kind=event event.name=click_reset_password_button sdk_name=grafana-frontend-agent sdk_version=1.0.0 app_name=testapp app_release=0.8.2 app_version=abcdefg app_environment=production user_email=geralt@kaermorhen.org user_id=123 user_username=domasx2 user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false"
+	expectedLine = "timestamp=\"2021-09-30 10:46:17.68 +0000 UTC\" kind=event event_name=click_reset_password_button sdk_name=grafana-frontend-agent sdk_version=1.0.0 app_name=testapp app_release=0.8.2 app_version=abcdefg app_environment=production user_email=geralt@kaermorhen.org user_id=123 user_username=domasx2 user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false"
 	require.Equal(t, expectedLine, inst.Entries[5].Line)
 }

--- a/pkg/integrations/v2/app_agent_receiver/logs_exporter_test.go
+++ b/pkg/integrations/v2/app_agent_receiver/logs_exporter_test.go
@@ -68,7 +68,7 @@ func TestExportLogs(t *testing.T) {
 	err := logsExporter.Export(ctx, payload)
 	require.NoError(t, err)
 
-	require.Len(t, inst.Entries, 4)
+	require.Len(t, inst.Entries, 6)
 
 	// log1
 	require.Equal(t, prommodel.LabelSet{
@@ -101,4 +101,20 @@ func TestExportLogs(t *testing.T) {
 	}, inst.Entries[3].Labels)
 	expectedLine = "timestamp=\"2021-09-30 10:46:17.68 +0000 UTC\" kind=measurement ttfb=14.000000 ttfcp=22.120000 ttfp=20.120000 traceID=abcd spanID=def sdk_name=grafana-frontend-agent sdk_version=1.0.0 app_name=testapp app_release=0.8.2 app_version=abcdefg app_environment=production user_email=geralt@kaermorhen.org user_id=123 user_username=domasx2 user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false"
 	require.Equal(t, expectedLine, inst.Entries[3].Line)
+
+	// event 1
+	require.Equal(t, prommodel.LabelSet{
+		prommodel.LabelName("app"):  prommodel.LabelValue("frontend"),
+		prommodel.LabelName("kind"): prommodel.LabelValue("event"),
+	}, inst.Entries[4].Labels)
+	expectedLine = "timestamp=\"2021-09-30 10:46:17.68 +0000 UTC\" kind=event name=click_login_button domain=frontend foo=bar one=two traceID=abcd spanID=def sdk_name=grafana-frontend-agent sdk_version=1.0.0 app_name=testapp app_release=0.8.2 app_version=abcdefg app_environment=production user_email=geralt@kaermorhen.org user_id=123 user_username=domasx2 user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false"
+	require.Equal(t, expectedLine, inst.Entries[4].Line)
+
+	// event 2
+	require.Equal(t, prommodel.LabelSet{
+		prommodel.LabelName("app"):  prommodel.LabelValue("frontend"),
+		prommodel.LabelName("kind"): prommodel.LabelValue("event"),
+	}, inst.Entries[5].Labels)
+	expectedLine = "timestamp=\"2021-09-30 10:46:17.68 +0000 UTC\" kind=event name=click_reset_password_button sdk_name=grafana-frontend-agent sdk_version=1.0.0 app_name=testapp app_release=0.8.2 app_version=abcdefg app_environment=production user_email=geralt@kaermorhen.org user_id=123 user_username=domasx2 user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false"
+	require.Equal(t, expectedLine, inst.Entries[5].Line)
 }

--- a/pkg/integrations/v2/app_agent_receiver/payload.go
+++ b/pkg/integrations/v2/app_agent_receiver/payload.go
@@ -337,6 +337,7 @@ type App struct {
 	Environment string `json:"environment,omitempty"`
 }
 
+// Event holds RUM event data
 type Event struct {
 	Name       string            `json:"name"`
 	Domain     string            `json:"domain,omitempty"`
@@ -350,10 +351,10 @@ func (e Event) KeyVal() *KeyVal {
 	kv := NewKeyVal()
 	KeyValAdd(kv, "timestamp", e.Timestamp.String())
 	KeyValAdd(kv, "kind", "event")
-	KeyValAdd(kv, "name", e.Name)
-	KeyValAdd(kv, "domain", e.Domain)
+	KeyValAdd(kv, "event.name", e.Name)
+	KeyValAdd(kv, "event.domain", e.Domain)
 	if e.Attributes != nil {
-		MergeKeyVal(kv, KeyValFromMap(e.Attributes))
+		MergeKeyValWithPrefix(kv, KeyValFromMap(e.Attributes), "event.data.")
 	}
 	MergeKeyVal(kv, e.Trace.KeyVal())
 	return kv

--- a/pkg/integrations/v2/app_agent_receiver/payload.go
+++ b/pkg/integrations/v2/app_agent_receiver/payload.go
@@ -351,10 +351,10 @@ func (e Event) KeyVal() *KeyVal {
 	kv := NewKeyVal()
 	KeyValAdd(kv, "timestamp", e.Timestamp.String())
 	KeyValAdd(kv, "kind", "event")
-	KeyValAdd(kv, "event.name", e.Name)
-	KeyValAdd(kv, "event.domain", e.Domain)
+	KeyValAdd(kv, "event_name", e.Name)
+	KeyValAdd(kv, "event_domain", e.Domain)
 	if e.Attributes != nil {
-		MergeKeyValWithPrefix(kv, KeyValFromMap(e.Attributes), "event.data.")
+		MergeKeyValWithPrefix(kv, KeyValFromMap(e.Attributes), "event_data_")
 	}
 	MergeKeyVal(kv, e.Trace.KeyVal())
 	return kv

--- a/pkg/integrations/v2/app_agent_receiver/payload.go
+++ b/pkg/integrations/v2/app_agent_receiver/payload.go
@@ -15,6 +15,7 @@ type Payload struct {
 	Exceptions   []Exception   `json:"exceptions,omitempty"`
 	Logs         []Log         `json:"logs,omitempty"`
 	Measurements []Measurement `json:"measurements,omitempty"`
+	Events       []Event       `json:"events,omitempty"`
 	Meta         Meta          `json:"meta,omitempty"`
 	Traces       *Traces       `json:"traces,omitempty"`
 }
@@ -334,6 +335,28 @@ type App struct {
 	Release     string `json:"release,omitempty"`
 	Version     string `json:"version,omitempty"`
 	Environment string `json:"environment,omitempty"`
+}
+
+type Event struct {
+	Name       string            `json:"name"`
+	Domain     string            `json:"domain,omitempty"`
+	Attributes map[string]string `json:"attributes,omitempty"`
+	Timestamp  time.Time         `json:"timestamp,omitempty"`
+	Trace      TraceContext      `json:"trace,omitempty"`
+}
+
+// KeyVal produces key -> value representation of Event metadata
+func (e Event) KeyVal() *KeyVal {
+	kv := NewKeyVal()
+	KeyValAdd(kv, "timestamp", e.Timestamp.String())
+	KeyValAdd(kv, "kind", "event")
+	KeyValAdd(kv, "name", e.Name)
+	KeyValAdd(kv, "domain", e.Domain)
+	if e.Attributes != nil {
+		MergeKeyVal(kv, KeyValFromMap(e.Attributes))
+	}
+	MergeKeyVal(kv, e.Trace.KeyVal())
+	return kv
 }
 
 // KeyVal produces key-> value representation of App metadata

--- a/pkg/integrations/v2/app_agent_receiver/payload_test.go
+++ b/pkg/integrations/v2/app_agent_receiver/payload_test.go
@@ -94,4 +94,24 @@ func TestUnmarshalPayloadJSON(t *testing.T) {
 			},
 		},
 	}, payload.Logs)
+
+	require.Equal(t, []Event{
+		{
+			Name:      "click_login_button",
+			Domain:    "frontend",
+			Timestamp: now,
+			Attributes: map[string]string{
+				"foo": "bar",
+				"one": "two",
+			},
+			Trace: TraceContext{
+				TraceID: "abcd",
+				SpanID:  "def",
+			},
+		},
+		{
+			Name:      "click_reset_password_button",
+			Timestamp: now,
+		},
+	}, payload.Events)
 }

--- a/pkg/integrations/v2/app_agent_receiver/receiver_metrics_exporter.go
+++ b/pkg/integrations/v2/app_agent_receiver/receiver_metrics_exporter.go
@@ -12,6 +12,7 @@ type ReceiverMetricsExporter struct {
 	totalLogs         prometheus.Counter
 	totalMeasurements prometheus.Counter
 	totalExceptions   prometheus.Counter
+	totalEvents       prometheus.Counter
 }
 
 // NewReceiverMetricsExporter creates a new ReceiverMetricsExporter
@@ -29,9 +30,13 @@ func NewReceiverMetricsExporter(reg prometheus.Registerer) appAgentReceiverExpor
 			Name: "app_agent_receiver_exceptions_total",
 			Help: "Total number of ingested exceptions",
 		}),
+		totalEvents: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "app_agent_receiver_events_total",
+			Help: "Total number of ingested events",
+		}),
 	}
 
-	reg.MustRegister(exp.totalLogs, exp.totalExceptions, exp.totalMeasurements)
+	reg.MustRegister(exp.totalLogs, exp.totalExceptions, exp.totalMeasurements, exp.totalEvents)
 
 	return exp
 }
@@ -46,5 +51,6 @@ func (re *ReceiverMetricsExporter) Export(ctx context.Context, payload Payload) 
 	re.totalExceptions.Add(float64(len(payload.Exceptions)))
 	re.totalLogs.Add(float64(len(payload.Logs)))
 	re.totalMeasurements.Add(float64(len(payload.Measurements)))
+	re.totalEvents.Add(float64(len(payload.Events)))
 	return nil
 }

--- a/pkg/integrations/v2/app_agent_receiver/receiver_metrics_test.go
+++ b/pkg/integrations/v2/app_agent_receiver/receiver_metrics_test.go
@@ -50,6 +50,7 @@ func TestReceiverMetricsExport(t *testing.T) {
 	payload.Logs = make([]Log, 2)
 	payload.Measurements = make([]Measurement, 3)
 	payload.Exceptions = make([]Exception, 4)
+	payload.Events = make([]Event, 5)
 	testcase(t, payload, []metricAssertion{
 		{
 			name:  "app_agent_receiver_logs_total",
@@ -62,6 +63,10 @@ func TestReceiverMetricsExport(t *testing.T) {
 		{
 			name:  "app_agent_receiver_exceptions_total",
 			value: 4,
+		},
+		{
+			name:  "app_agent_receiver_events_total",
+			value: 5,
 		},
 	})
 }

--- a/pkg/integrations/v2/app_agent_receiver/testdata/payload.json
+++ b/pkg/integrations/v2/app_agent_receiver/testdata/payload.json
@@ -223,6 +223,25 @@
           }
       }
   ],
+  "events": [
+    {
+        "name": "click_login_button",
+        "domain": "frontend",
+        "attributes": {
+            "foo": "bar",
+            "one": "two"
+        },
+        "timestamp": "2021-09-30T10:46:17.680Z",
+        "trace": {
+            "trace_id": "abcd",
+            "span_id": "def"
+        }
+    },
+    {
+        "name": "click_reset_password_button",
+        "timestamp": "2021-09-30T10:46:17.680Z"
+    }
+  ],
   "meta": {
       "sdk": {
           "name": "grafana-frontend-agent",


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Adds Event kind to app-agent-receiver payload, modeled after [OTEP for Events API](https://github.com/open-telemetry/oteps/blob/main/text/0202-events-and-logs-api.md). [Issue to add Events API support on the grafana javascript agent side](https://github.com/grafana/grafana-javascript-agent/issues/48).

#### Which issue(s) this PR fixes

Fixes #2062 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [x] Tests updated
