### PR TITLE
flow: rename targets.mutate component to discovery.relabel

### DIFF
--- a/component/all/all.go
+++ b/component/all/all.go
@@ -3,10 +3,10 @@ package all
 
 import (
 	_ "github.com/grafana/agent/component/discovery/kubernetes" // Import discovery.k8s
+	_ "github.com/grafana/agent/component/discovery/relabel"    // Import discovery.relabel
 	_ "github.com/grafana/agent/component/local/file"           // Import local.file
 	_ "github.com/grafana/agent/component/metrics/mutate"       // Import metrics.mutate
 	_ "github.com/grafana/agent/component/metrics/remotewrite"  // Import metrics.remotewrite
 	_ "github.com/grafana/agent/component/metrics/scrape"       // Import metrics.scrape
 	_ "github.com/grafana/agent/component/remote/s3"            // Import s3.file
-	_ "github.com/grafana/agent/component/targets/mutate"       // Import targets.mutate
 )

--- a/component/discovery/relabel/relabel.go
+++ b/component/discovery/relabel/relabel.go
@@ -1,4 +1,4 @@
-package mutate
+package relabel
 
 import (
 	"context"
@@ -12,7 +12,7 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "targets.mutate",
+		Name:    "discovery.relabel",
 		Args:    Arguments{},
 		Exports: Exports{},
 
@@ -22,7 +22,7 @@ func init() {
 	})
 }
 
-// Arguments holds values which are used to configure the targets.mutate component.
+// Arguments holds values which are used to configure the discovery.relabel component.
 type Arguments struct {
 	// Targets contains the input 'targets' passed by a service discovery component.
 	Targets []discovery.Target `river:"targets,attr"`
@@ -31,21 +31,19 @@ type Arguments struct {
 	RelabelConfigs []*flow_relabel.Config `river:"relabel_config,block,optional"`
 }
 
-// Exports holds values which are exported by the targets.mutate component.
+// Exports holds values which are exported by the discovery.relabel component.
 type Exports struct {
 	Output []discovery.Target `river:"output,attr"`
 }
 
-// Component implements the targets.mutate component.
+// Component implements the discovery.relabel component.
 type Component struct {
 	opts component.Options
 }
 
-var (
-	_ component.Component = (*Component)(nil)
-)
+var _ component.Component = (*Component)(nil)
 
-// New creates a new targets.mutate component.
+// New creates a new discovery.relabel component.
 func New(o component.Options, args Arguments) (*Component, error) {
 	c := &Component{opts: o}
 

--- a/component/discovery/relabel/relabel_test.go
+++ b/component/discovery/relabel/relabel_test.go
@@ -1,11 +1,11 @@
-package mutate_test
+package relabel_test
 
 import (
 	"testing"
 	"time"
 
 	"github.com/grafana/agent/component/discovery"
-	"github.com/grafana/agent/component/targets/mutate"
+	"github.com/grafana/agent/component/discovery/relabel"
 	"github.com/grafana/agent/pkg/flow/componenttest"
 	"github.com/grafana/agent/pkg/river/parser"
 	"github.com/grafana/agent/pkg/river/vm"
@@ -15,8 +15,8 @@ import (
 func TestRelabelConfigApplication(t *testing.T) {
 	riverArguments := `
 targets = [ 
-	{ "__meta_foo" = "foo", "__meta_bar" = "bar", "__address__" = "localhost", "instance" = "one", "app" = "backend", __tmp_a = "tmp" },
-	{ "__meta_foo" = "foo", "__meta_bar" = "bar", "__address__" = "localhost", "instance" = "two", "app" = "db", "__tmp_b" = "tmp" },
+	{ "__meta_foo" = "foo", "__meta_bar" = "bar", "__address__" = "localhost", "instance" = "one",   "app" = "backend",  "__tmp_a" = "tmp" },
+	{ "__meta_foo" = "foo", "__meta_bar" = "bar", "__address__" = "localhost", "instance" = "two",   "app" = "db",       "__tmp_b" = "tmp" },
 	{ "__meta_baz" = "baz", "__meta_qux" = "qux", "__address__" = "localhost", "instance" = "three", "app" = "frontend", "__tmp_c" = "tmp" },
 ]
 
@@ -55,7 +55,7 @@ relabel_config {
 	regex  = "__meta(.*)|__tmp(.*)|instance"
 }
 `
-	expectedExports := mutate.Exports{
+	expectedExports := relabel.Exports{
 		Output: []discovery.Target{
 			map[string]string{"__address__": "localhost", "app": "backend", "destination": "localhost/one", "meta_bar": "bar", "meta_foo": "foo", "name": "one"},
 		},
@@ -64,11 +64,11 @@ relabel_config {
 	file, err := parser.ParseFile("agent-config.river", []byte(riverArguments))
 	require.NoError(t, err)
 
-	var args mutate.Arguments
+	var args relabel.Arguments
 	err = vm.New(file).Evaluate(nil, &args)
 	require.NoError(t, err)
 
-	tc, err := componenttest.NewControllerFromID(nil, "targets.mutate")
+	tc, err := componenttest.NewControllerFromID(nil, "discovery.relabel")
 	require.NoError(t, err)
 	go func() {
 		err = tc.Run(componenttest.TestContext(t), args)

--- a/docs/flow/reference/components/discovery.relabel.md
+++ b/docs/flow/reference/components/discovery.relabel.md
@@ -6,17 +6,17 @@ title: discovery.relabel
 
 # discovery.relabel
 
-`discovery.relabel` rewrites the label set of the input targets by applying one or
-more `relabel_config` steps. If no relabeling steps are defined, then the input
-targets will be exported as-is.
+`discovery.relabel` rewrites the label set of the input targets by applying one
+or more `relabel_config` steps. If no relabeling steps are defined, then the
+input targets will be exported as-is.
 
 The most common use of `discovery.relabel` is to filter Prometheus targets or
 standardize the label set that will be passed to a downstream component. The
 `relabel_config` blocks will be applied to the label set of each target in
 order of their appearance in the configuration file.
 
-Multiple `discovery.relabel` components can be specified by giving them different
-labels.
+Multiple `discovery.relabel` components can be specified by giving them
+different labels.
 
 ## Example
 
@@ -55,14 +55,14 @@ The following subblocks are supported:
 
 Name | Description | Required
 ---- | ----------- | --------
-[`relabel_config`](#relabel_config-block) | Mutations to apply to targets | no
+[`relabel_config`](#relabel_config-block) | Relabeling steps to apply to targets | no
 
 ### `relabel_config` block
 
 The `relabel_config` block contains the definition of any relabeling rules that
 can be applied to an input target. If more than one `relabel_config` block is
-defined within `discovery.relabel`, the transformations will be applied in-order
-from top down.
+defined within `discovery.relabel`, the transformations will be applied
+in top-down order.
 
 The following arguments can be used to configure a `relabel_config` block.
 All arguments are optional and any omitted fields will take on their default

--- a/docs/flow/reference/components/discovery.relabel.md
+++ b/docs/flow/reference/components/discovery.relabel.md
@@ -1,31 +1,31 @@
 ---
 aliases:
-- /docs/agent/latest/flow/reference/components/targets.mutate
-title: targets.mutate
+- /docs/agent/latest/flow/reference/components/discovery.relabel
+title: discovery.relabel
 ---
 
-# targets.mutate
+# discovery.relabel
 
-`targets.mutate` rewrites the label set of the input targets by applying one or
+`discovery.relabel` rewrites the label set of the input targets by applying one or
 more `relabel_config` steps. If no relabeling steps are defined, then the input
 targets will be exported as-is.
 
-The most common use of `targets.mutate` is to filter Prometheus targets or
+The most common use of `discovery.relabel` is to filter Prometheus targets or
 standardize the label set that will be passed to a downstream component. The
 `relabel_config` blocks will be applied to the label set of each target in
 order of their appearance in the configuration file.
 
-Multiple `targets.mutate` components can be specified by giving them different
+Multiple `discovery.relabel` components can be specified by giving them different
 labels.
 
 ## Example
 
 ```river
-targets.mutate "keep-backend-only" {
+discovery.relabel "keep_backend_only" {
   targets = [
     { "__meta_foo" = "foo", "__address__" = "localhost", "instance" = "one",   "app" = "backend"  },
     { "__meta_bar" = "bar", "__address__" = "localhost", "instance" = "two",   "app" = "database" },
-    { "__meta_baz" = "baz", "__address__" = "localhost", "instance" = "three", "app" = "frontend" }
+    { "__meta_baz" = "baz", "__address__" = "localhost", "instance" = "three", "app" = "frontend" },
   ]
 
   relabel_config {
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-targets | list(map(string)) | Targets to mutate | | **yes**
+targets | list(map(string)) | Targets to relabel | | **yes**
 
 The following subblocks are supported:
 
@@ -61,7 +61,7 @@ Name | Description | Required
 
 The `relabel_config` block contains the definition of any relabeling rules that
 can be applied to an input target. If more than one `relabel_config` block is
-defined within `targets.mutate`, the transformations will be applied in-order
+defined within `discovery.relabel`, the transformations will be applied in-order
 from top down.
 
 The following arguments can be used to configure a `relabel_config` block.
@@ -100,14 +100,14 @@ output | list(map(string)) | The set of targets after applying relabeling.
 
 ## Component health
 
-`targets.mutate` will only be reported as unhealthy when given an invalid
+`discovery.relabel` will only be reported as unhealthy when given an invalid
 configuration. In those cases, exported fields will be kept at their last
 healthy values.
 
 ## Debug information
 
-`targets.mutate` does not expose any component-specific debug information.
+`discovery.relabel` does not expose any component-specific debug information.
 
 ### Debug metrics
 
-`targets.mutate` does not expose any component-specific debug metrics.
+`discovery.relabel` does not expose any component-specific debug metrics.


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
As described in #2059, we would like to set up some conventions in the naming of Flow component.

This PR renames the `targets.mutate` component and adds it under the discovery namespace as `discovery.relabel`.

#### Which issue(s) this PR fixes
No issue filed

#### Notes to the Reviewer
None, for now. 

#### PR Checklist
- [ ] CHANGELOG updated (N/A until Flow PoC is announced, I think)
- [X] Documentation added
- [X] Tests updated
