### PR TITLE
Use ubuntu base image

### DIFF
--- a/cmd/agent-operator/Dockerfile
+++ b/cmd/agent-operator/Dockerfile
@@ -6,7 +6,7 @@ ARG IMAGE_TAG
 
 RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agent-operator
 
-FROM debian:bullseye-slim
+FROM ubuntu:focal
 
 RUN apt-get update && \
   apt-get install -qy tzdata ca-certificates && \

--- a/cmd/agent-operator/Dockerfile
+++ b/cmd/agent-operator/Dockerfile
@@ -6,7 +6,7 @@ ARG IMAGE_TAG
 
 RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agent-operator
 
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 RUN apt-get update && \
   apt-get install -qy tzdata ca-certificates && \

--- a/cmd/agent-operator/Dockerfile.buildx
+++ b/cmd/agent-operator/Dockerfile.buildx
@@ -19,7 +19,7 @@ ARG IMAGE_TAG
 
 RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false DRONE=true agent-operator
 
-FROM debian:bullseye-slim
+FROM ubuntu:jammy
 
 RUN apt-get update && \
   apt-get install -qy tzdata ca-certificates && \

--- a/cmd/agent/Dockerfile
+++ b/cmd/agent/Dockerfile
@@ -15,8 +15,6 @@ RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUI
 
 FROM ubuntu:jammy
 
-# Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
-# plus the libbpfcc library for running the eBPF integration.
 RUN apt-get update && apt-get install -qy libsystemd-dev tzdata ca-certificates && \
   if [ `uname -m` = "x86_64" ]; then apt-get install -qy libbpfcc; fi && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/cmd/agent/Dockerfile
+++ b/cmd/agent/Dockerfile
@@ -13,13 +13,11 @@ RUN apt-get update && apt-get install -qy libbpfcc-dev
 
 RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agent
 
-FROM debian:bullseye-slim
+FROM ubuntu:jammy
 
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
 # plus the libbpfcc library for running the eBPF integration.
-RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev && \
-  apt-get install -qy tzdata ca-certificates && \
+RUN apt-get update && apt-get install -qy libsystemd-dev tzdata ca-certificates && \
   if [ `uname -m` = "x86_64" ]; then apt-get install -qy libbpfcc; fi && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/cmd/agent/Dockerfile.buildx
+++ b/cmd/agent/Dockerfile.buildx
@@ -22,13 +22,11 @@ ARG IMAGE_TAG
 
 RUN make clean && IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false DRONE=true make agent
 
-FROM debian:bullseye-slim
+FROM ubuntu:jammy
 
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
 # plus the libbpfcc library for running the eBPF integration.
-RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev && \
-  apt-get install -qy tzdata ca-certificates && \
+RUN apt-get update && apt-get install -qy libsystemd-dev tzdata ca-certificates && \
   if [ `uname -m` = "x86_64" ]; then apt-get install -qy libbpfcc; fi && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/cmd/agent/Dockerfile.buildx
+++ b/cmd/agent/Dockerfile.buildx
@@ -24,8 +24,6 @@ RUN make clean && IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN
 
 FROM ubuntu:jammy
 
-# Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
-# plus the libbpfcc library for running the eBPF integration.
 RUN apt-get update && apt-get install -qy libsystemd-dev tzdata ca-certificates && \
   if [ `uname -m` = "x86_64" ]; then apt-get install -qy libbpfcc; fi && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/cmd/agentctl/Dockerfile
+++ b/cmd/agentctl/Dockerfile
@@ -15,10 +15,7 @@ RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUI
 
 FROM ubuntu:jammy
 
-# Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
-# plus the libbpfcc library for running the eBPF integration.
-RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev && \
+RUN apt-get update && apt-get install -qy libsystemd-dev && \
   apt-get install -qy tzdata ca-certificates && \
   if [ `uname -m` = "x86_64" ]; then apt-get install -qy libbpfcc; fi && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/cmd/agentctl/Dockerfile
+++ b/cmd/agentctl/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -qy libbpfcc-dev
 
 RUN make clean && make IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false agentctl
 
-FROM debian:bullseye-slim
+FROM ubuntu:jammy
 
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
 # plus the libbpfcc library for running the eBPF integration.

--- a/cmd/agentctl/Dockerfile.buildx
+++ b/cmd/agentctl/Dockerfile.buildx
@@ -23,16 +23,13 @@ ARG IMAGE_TAG
 # Makefile.
 RUN make clean && IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN_CONTAINER=false DRONE=true make agentctl
 
-FROM debian:bullseye-slim
+FROM ubuntu:jammy
 
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
 # plus the libbpfcc library for running the eBPF integration.
-RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev && \
-  apt-get install -qy tzdata ca-certificates && \
+RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev tzdata ca-certificates && \
   if [ `uname -m` = "x86_64" ]; then apt-get install -qy libbpfcc; fi && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
 COPY --from=build /src/agent/cmd/agentctl/agentctl /bin/agentctl
 
 ENTRYPOINT ["/bin/agentctl"]

--- a/cmd/agentctl/Dockerfile.buildx
+++ b/cmd/agentctl/Dockerfile.buildx
@@ -25,9 +25,7 @@ RUN make clean && IMAGE_TAG=${IMAGE_TAG} RELEASE_BUILD=${RELEASE_BUILD} BUILD_IN
 
 FROM ubuntu:jammy
 
-# Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
-# plus the libbpfcc library for running the eBPF integration.
-RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev tzdata ca-certificates && \
+RUN apt-get update && apt-get install -qy libsystemd-dev tzdata ca-certificates && \
   if [ `uname -m` = "x86_64" ]; then apt-get install -qy libbpfcc; fi && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 COPY --from=build /src/agent/cmd/agentctl/agentctl /bin/agentctl


### PR DESCRIPTION
 `ubuntu:jammy` is slightly smaller than `debian:bullseye-slim`, and has 0 high or critical vulnerabilities in trivy.

If it works, this could solve a lot of problems.

It runs for me locally, but still needs verification of the cgo bits:

- [x] test ebpf (@tpaschalis plz). I'm not even sure if that works in the current main image though.
- [x] test systemd log scraping (@captncraig )