### PR TITLE
docs/flow: flesh out basic docs files

### DIFF
--- a/docs/flow/_index.md
+++ b/docs/flow/_index.md
@@ -6,3 +6,78 @@ weight: 900
 ---
 
 # Grafana Agent Flow (Experimental)
+
+Grafana Agent Flow is a _component-based_ experimental revision of Grafana
+Agent with a focus on ease-of-use, debuggability, and ability to adapt to the
+needs of power users.
+
+> **EXPERIMENTAL**: Grafana Agent Flow is an [experimental][] feature.
+> Experimental features are subject to frequent breaking changes and are
+> subject for removal if the experiment doesn't work out.
+>
+> You should only use Grafana Agent Flow if you are okay with bleeding edge
+> functionality and want to provide feedback to the developers. It is not
+> recommended to use Grafana Agent Flow in production.
+
+[experimental]: {{< relref "../operation-guide#stability" >}}
+
+## Features
+
+* Write declarative configurations with a Terraform-inspired configuration
+  language
+* Declare components to configure parts of a pipeline
+* Use expressions to bind components together to build a programmable pipeline
+
+## Example
+
+```river
+// Discover Kubernetes pods to collect metrics from.
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+
+// Scrape metrics from Kubernetes pods and send to a metrics.remote_write
+// component.
+metrics.scrape "default" {
+  targets    = discovery.kubernetes.pods.targets
+  forward_to = [metrics.remote_write.default.receiver]
+}
+
+// Get an API key from disk.
+local.file "apikey" {
+  filename  = "/var/data/my-api-key.txt"
+  is_secret = true
+}
+
+// Collect and send metrics to a Prometheus remote_write endpoint.
+metrics.remote_write "default" {
+  remote_write {
+    url = "http://localhost:9009/api/prom/push"
+
+    basic_auth {
+      username = "MY_USERNAME"
+      password = local.file.apikey.content
+    }
+  }
+}
+```
+
+## Next steps
+
+* Learn about the [core concepts][] of Grafana Agent Flow.
+* Follow our [tutorials][] to get started with Grafana Agent Flow.
+* Learn how to use Grafana Agent Flow's [configuration language][].
+* Check out our [reference documentation][] to find specific information you
+  might be looking for.
+
+[core concepts]: {{< relref "./concepts/" >}}
+[tutorials]: {{< relref "./tutorials/ ">}}
+[configuration language]: {{< relref "./config-language/" >}}
+[reference documentation]: {{< relref "./reference" >}}
+
+## Provide feedback
+
+Feedback about Grafana Agent Flow and its configuration language can be
+provided in our dedicated [GitHub discussion for feedback][feedback].
+
+[feedback]: https://github.com/grafana/agent/discussions/1969

--- a/docs/flow/_index.md
+++ b/docs/flow/_index.md
@@ -36,11 +36,11 @@ discovery.kubernetes "pods" {
   role = "pod"
 }
 
-// Scrape metrics from Kubernetes pods and send to a metrics.remote_write
+// Scrape metrics from Kubernetes pods and send to a prometheus.remote_write
 // component.
-metrics.scrape "default" {
+prometheus.scrape "default" {
   targets    = discovery.kubernetes.pods.targets
-  forward_to = [metrics.remote_write.default.receiver]
+  forward_to = [prometheus.remote_write.default.receiver]
 }
 
 // Get an API key from disk.
@@ -50,7 +50,7 @@ local.file "apikey" {
 }
 
 // Collect and send metrics to a Prometheus remote_write endpoint.
-metrics.remote_write "default" {
+prometheus.remote_write "default" {
   remote_write {
     url = "http://localhost:9009/api/prom/push"
 

--- a/docs/flow/concepts/_index.md
+++ b/docs/flow/concepts/_index.md
@@ -7,6 +7,6 @@ weight: 100
 
 # Concepts
 
-This explain explains primary concepts of Grafana Agent Flow.
+This section explains primary concepts of Grafana Agent Flow.
 
 {{< section >}}

--- a/docs/flow/concepts/_index.md
+++ b/docs/flow/concepts/_index.md
@@ -7,17 +7,6 @@ weight: 100
 
 # Concepts
 
-Grafana Agent Flow has three primary concepts:
+This explain explains primary concepts of Grafana Agent Flow.
 
-1. [Components][]: The building blocks of Grafana Agent Flow which can be wired
-   together to construct a pipeline.
-
-2. [Component controller][]: The system within Grafana Agent Flow which manages
-   and updates components.
-
-3. [Configuration language][]: The language used to configure and wire together
-   components.
-
-[Components]: {{< relref "./components.md" >}}
-[Component controller]: {{< relref "./component_controller.md" >}}
-[Configuration language]: {{< relref "./configuration_language.md" >}}
+{{< section >}}

--- a/docs/flow/getting_started.md
+++ b/docs/flow/getting_started.md
@@ -9,8 +9,8 @@ weight: 200
 
 ## Install Grafana Agent
 
-To install Grafana Agent Flow, first [install Grafana Agent][]. Grafana Agent
-Flow is an operating mode which will be available in an upcoming Grafana Agent
+To use Grafana Agent Flow, first [install Grafana Agent][]. Grafana Agent Flow
+is an operating mode which will be available in an upcoming Grafana Agent
 release.
 
 ## Running Grafana Agent Flow

--- a/docs/flow/getting_started.md
+++ b/docs/flow/getting_started.md
@@ -6,3 +6,46 @@ weight: 200
 ---
 
 # Getting Started
+
+## Install Grafana Agent
+
+To install Grafana Agent Flow, first [install Grafana Agent][]. Grafana Agent
+Flow is an operating mode which will be available in an upcoming Grafana Agent
+release.
+
+## Running Grafana Agent Flow
+
+Grafana Agent Flow can be enabled by setting the `EXPERIMENTAL_ENABLE_FLOW`
+environment variable to `true`.
+
+Then, use the `agent run` command to start Grafana Agent Flow, passing the
+config file to use.
+
+```
+EXPERIMENTAL_ENABLE_FLOW=1 agent run /path/to/my/config.river
+```
+
+> Grafana Agent Flow uses a different command-line interface and command line
+> flags than the normal Grafana Agent. You can see the supported commands and
+> the flags they support in the reference documentation for the [command-line
+> interface][].
+
+[command-line interface]: {{< relref "./reference/cli/" >}}
+
+You can use this file as an example to get started:
+
+```river
+metrics.scrape "default" {
+  targets = [
+    {"__address__" = "demo.robustperception.io:9090"},
+  ]
+  forward_to = [metrics.remote_write.default.receiver]
+}
+
+metrics.remote_write "default" {
+  // No endpoints configured; metrics will be accumulated locally in a WAL
+  // and discarded.
+}
+```
+
+[install Grafana Agent]: {{< relref "../set-up" >}}

--- a/docs/flow/reference/_index.md
+++ b/docs/flow/reference/_index.md
@@ -7,16 +7,7 @@ weight: 600
 
 # Grafana Agent Flow Reference
 
-The reference documentation section provides reference-level information on:
+This section provides reference-level documentation for the various parts of
+Grafana Agent Flow:
 
-* The [subcommands][CLI] used by the Grafana Agent Flow `agent` binary
-* The [global blocks][config-blocks] which can be used to customize Grafana
-  Agent Flow behavior
-* The list of [components][components] and detailed information on each
-* The list of [standard library functions][stdlib] which can be used in River
-  expressions
-
-[CLI]: {{< relref "./cli" >}}
-[config-blocks]: {{< relref "./config-blocks" >}}
-[components]: {{< relref "./components" >}}
-[stdlib]: {{< relref "./stdlib" >}}
+{{< section >}}

--- a/docs/flow/reference/_index.md
+++ b/docs/flow/reference/_index.md
@@ -4,3 +4,19 @@ aliases:
 title: Reference
 weight: 600
 ---
+
+# Grafana Agent Flow Reference
+
+The reference documentation section provides reference-level information on:
+
+* The [subcommands][CLI] used by the Grafana Agent Flow `agent` binary
+* The [global blocks][config-blocks] which can be used to customize Grafana
+  Agent Flow behavior
+* The list of [components][components] and detailed information on each
+* The list of [standard library functions][stdlib] which can be used in River
+  expressions
+
+[CLI]: {{< relref "./cli" >}}
+[config-blocks]: {{< relref "./config-blocks" >}}
+[components]: {{< relref "./components" >}}
+[stdlib]: {{< relref "./stdlib" >}}

--- a/docs/flow/reference/cli/_index.md
+++ b/docs/flow/reference/cli/_index.md
@@ -4,3 +4,19 @@ aliases:
 title: Command-line interface
 weight: 100
 ---
+
+# Command-line interface
+
+When in Flow mode, the `agent` binary exposes a command-line interface with
+subcommands to perform various operations.
+
+The most common subcommand is [`run`][run] which accepts a config file and
+starts Grafana Agent Flow.
+
+Available commands:
+
+* [`agent run`][run]: Start Grafana Agent Flow given a config file
+* `agent completion`: Generate shell completion for the `agent` CLI
+* `agent help`: Print help for supported commands
+
+[run]: {{< relref "./run.md" >}}

--- a/docs/flow/reference/stdlib/_index.md
+++ b/docs/flow/reference/stdlib/_index.md
@@ -18,8 +18,6 @@ when assigning values to attributes.
 All standard library functions are idempotent: they will always return the same
 output if given the same input.
 
-* [`concat`]({{< relref "./concat.md" >}})
-* [`env`]({{< relref "./env.md" >}})
-* [`json_decode`]({{< relref "./json_decode.md" >}})
+{{< section >}}
 
 [feedback]: https://github.com/grafana/agent/discussions/1969

--- a/docs/flow/reference/stdlib/json_decode.md
+++ b/docs/flow/reference/stdlib/json_decode.md
@@ -39,4 +39,4 @@ null
 "Hello, world!"
 ```
 
-[`local.file`]: {{< relref "../../components/local.file.md" >}}
+[`local.file`]: {{< relref "../components/local.file.md" >}}


### PR DESCRIPTION
Adds content to:

* docs/flow/_index.md
* docs/flow/getting_started.md
* docs/flow/reference/_index.md
* docs/flow/reference/cli/_index.md

The information presented in `docs/flow/reference/_index.md` and `docs/flow/reference/cli/_index.md` is pretty minimal. I'd appreciate any feedback on if there's more information we should add there or if it's good for now. 