### PR TITLE
remove armv6 container image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ seego = docker run --init --rm $(DOCKER_OPTS) $(MOD_MOUNT) -v "$(CURDIR):$(CURDI
 docker-build = docker build $(DOCKER_BUILD_FLAGS)
 ifeq ($(CROSS_BUILD),true)
 DOCKERFILE = Dockerfile.buildx
-docker-build = docker buildx build --push --platform linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7,linux/ppc64le $(DOCKER_BUILD_FLAGS)
+docker-build = docker buildx build --push --platform linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le $(DOCKER_BUILD_FLAGS)
 endif
 
 # we want to override the default seego behavior. Drone always builds locally inside seego and if build in container is false then use


### PR DESCRIPTION
After switching to [ubuntu base images](#2078), we noticed that there isn't support for armv6 in the base image anymore.

This leaves us with a few options:

1. Switch back to debian for armv6 support. This would continue supporting rpis under 3. But debian has more security issues than ubuntu.
2. Discontinue armv6 docker images. We still publish binaries and packages, and we can close some of the cves for other platforms.

This PR is for the second one. If we want to go that route.