### PR TITLE
river: add documentation for language concepts

### DIFF
--- a/docs/flow/config-language/components.md
+++ b/docs/flow/config-language/components.md
@@ -16,6 +16,8 @@ controller_]({{< relref "../concepts/component_controller.md" >}}), who is
 responsible for scheduling them, reporting their health and debug status, and
 continuously re-evaluating their inputs and outputs.
 
+
+## Configuring components
 Each top-level River _block_ will instantiate a new component. All components
 are identified by their name, describing what the component is responsible for,
 while some allow or require to provide an extra user-specified _label_.
@@ -62,6 +64,7 @@ local.file "targets" {
 }
 ```
 
+## Referencing components
 To wire components together, one can use the Exports of one as the Arguments
 to another.
 
@@ -96,10 +99,4 @@ you can wire components together.
 In the previous example, the contents of the `local.file.target.content`
 expression must first be evaluated in a concrete value then type-checked and
 substituted into `prometheus.scrape.default` for it to be configured in turn.
-
-River attributes that appear as Arguments and Exports can carry around more
-than the basic types you'd expect such as strings, numbers or booleans; they
-are able to natively wrap any Go value (eg. channels or interfaces), as well as
-pass around and invoke Go functions which makes for powerful tooling when
-building more complex pipelines.
 

--- a/docs/flow/config-language/components.md
+++ b/docs/flow/config-language/components.md
@@ -45,9 +45,8 @@ file `content` as a string in its Exports.
 
 The `filename` attribute is a _required_ argument; the user can also define a
 number of _optional_ ones, in this case `detector`, `poll_frequency` and
-`is_sensitive`, which configure how and how often the file should be polled
-as well as whether its contents are safe to be presented as plaintext back to
-the user.
+`is_secret`, which configure how and how often the file should be polled
+as well as whether its contents are sensitive or not.
 
 ```river
 local.file "targets" {
@@ -55,7 +54,7 @@ local.file "targets" {
 	filename = "/etc/agent/targets" 
 
 	// Optional Arguments
-	//   is_sensitive   = <boolean>
+	//   is_secret      = <boolean>
 	//   detector       = < "fsnotify" | "poll" >
 	//   poll_frequency = <duration> 
 

--- a/docs/flow/config-language/components.md
+++ b/docs/flow/config-language/components.md
@@ -8,7 +8,7 @@ weight: 300
 # Components
 Components are the defining feature of Grafana Agent Flow. They are autonomous
 pieces of business logic that perform a single task (like retrieving secrets or
-collecting Prometheus metrics) and are wired together to form programmable
+collecting Prometheus metrics) and can be wired together to form programmable
 pipelines of telemetry data.
 
 Under the hood, components are orchestrated via the [_component
@@ -33,11 +33,11 @@ _Arguments_ and _Exports_.
 
 * _Arguments_ are settings which modify the behavior of a component. They can
  be any number of attributes or nested unlabeled blocks, some of them being
-required for the component to work and some being optional. Any optional
-arguments that are not overriden, will take on their default values.
+required and some being optional. Any optional arguments that are not
+overriden, will take on their default values.
 
-* _Exports_ are zero or more named return values that can be referred to by
- other components and can be any River value.
+* _Exports_ are zero or more output values that can be referred to by other
+  components, and can be any River type.
 
 Here's a quick example; the following block defines a `local.file` component
 labelled "targets". The `local.file.targets` component will then expose the
@@ -70,7 +70,7 @@ to another.
 
 For example, here's a component that scrapes Prometheus metrics. The `targets`
 field is populated with two scrape targets; a constant one `localhost:9001` and
-an expression that ties the target to the contents of
+an expression that ties the target to the value of
 `local.file.target.content`.
 
 ```river

--- a/docs/flow/config-language/components.md
+++ b/docs/flow/config-language/components.md
@@ -39,6 +39,12 @@ take on their default values.
  other components. There is no limit to what an export might be; it can take on
 any River value or Go type (eg. channels, interfaces).
 
+Each component's documentation page contains the list of all available
+Arguments and resulting Exports, along their underlying type. Users can
+configure Arguments either using a constant value or an
+[_expression_]({{< relref "./expressions/_index.md" >}}) to continuously
+re-evaluate values who are dynamic in nature.
+
 Here's a quick example; the following block defines a `local.file` component
 labelled "targets". The `local.file.targets` component will then expose the
 file `content` as a string in its Exports.
@@ -87,6 +93,10 @@ prometheus.scrape "default" {
 }
 ```
 
+Every time the file contents change and the `local.file` component re-evaluates
+its Exports, the value will propagated to `prometheus.scrape` so it can start
+scraping the new target.
+
 All Arguments and Exports have an underlying [type]({{< relref "./expressions/types_and_values.md" >}}).
 River will type-check expressions before assigning a value to an attribute; the
 documentation of each component will have more information about the ways that
@@ -110,6 +120,18 @@ invalid references in expressions.
 In the previous example, the contents of the `local.file.target.content`
 expression must first be evaluated in a concrete value then type-checked and
 substituted into `prometheus.scrape.default` for it to be configured in turn.
+
+## Component Lifecycle
+Each time a River configuration file is reloaded or re-evaluated, Flow will:
+
+- Parse the provided configuration file. In case any errors are found, the
+  Agent will continue using the last valid River configuration.
+- Parse and apply settings for predefined global blocks (like `logging`).
+- Create a graph of component relationships and validate it.
+- Create new components that weren't present in the last loaded configuration
+  file.
+- Drop components that no longer exist in the new configuration file.
+- Update any pre-existing components whose arguments have changed.
 
 ## Error reporting
 Like in the case of syntax errors, River will also enrich component-related

--- a/docs/flow/config-language/components.md
+++ b/docs/flow/config-language/components.md
@@ -33,14 +33,14 @@ _Arguments_ and _Exports_.
 
 * _Arguments_ are settings which modify the behavior of a component. They can
  be any number of attributes or nested unlabeled blocks, some of them being
-required and some being optional. Any optional arguments that are not
-overriden, will take on their default values.
+required and some being optional. Any optional arguments that are not set, will
+take on their default values.
 
 * _Exports_ are zero or more output values that can be referred to by other
-  components, and can be any River type.
+  components, and can be of any River type.
 
 Here's a quick example; the following block defines a `local.file` component
-labelled "targets". The `local.file.targets` component will then expose the
+labeled "targets". The `local.file.targets` component will then expose the
 file `content` as a string in its Exports.
 
 The `filename` attribute is a _required_ argument; the user can also define a

--- a/docs/flow/config-language/components.md
+++ b/docs/flow/config-language/components.md
@@ -12,7 +12,7 @@ collecting Prometheus metrics) and can be wired together to form programmable
 pipelines of telemetry data.
 
 Under the hood, components are orchestrated via the [_component
-controller_]({{< relref "../concepts/component_controller.md" >}}), who is
+controller_]({{< relref "../concepts/component_controller.md" >}}), which is
 responsible for scheduling them, reporting their health and debug status, and
 continuously re-evaluating their inputs and outputs.
 
@@ -22,10 +22,10 @@ Each top-level River _block_ will instantiate a new component. All components
 are identified by their name, describing what the component is responsible for,
 while some allow or require to provide an extra user-specified _label_.
 
-You can see a list of all available components [here]({{< relref "../components/_index.md" >}}).
-Each one features a complete reference page, so getting a component to work for
-you should be as easy as reading its documentation and copy/pasting from an
-example.
+The [components docs]({{< relref "../components/_index.md" >}}) contain a list
+of all available components. Each one has a complete reference page, so getting
+a component to work for you should be as easy as reading its documentation and
+copy/pasting from an example.
 
 ## Arguments and Exports
 Most user interactions with components will center around two basic concepts;
@@ -33,7 +33,7 @@ _Arguments_ and _Exports_.
 
 * _Arguments_ are settings which modify the behavior of a component. They can
  be any number of attributes or nested unlabeled blocks, some of them being
-required and some being optional. Any optional arguments that are not set, will
+required and some being optional. Any optional arguments that are not set will
 take on their default values.
 
 * _Exports_ are zero or more output values that can be referred to by other
@@ -53,29 +53,30 @@ local.file "targets" {
 	// Required Argument
 	filename = "/etc/agent/targets" 
 
-	// Optional Arguments
-	//   is_secret      = <boolean>
-	//   detector       = < "fsnotify" | "poll" >
-	//   poll_frequency = <duration> 
+	// Optional Arguments: Components may have some optional arguments that
+	// do not need to be defined.
+	// 
+	// The optional arguments for local.file are is_secret, detector, and
+	// poll_frequency. 
 
 	// Exports: a single field named `content`
-	// It can be referred to as `local.file.token.content`
+	// It can be referred to as `local.file.targets.content`
 }
 ```
 
 ## Referencing components
 To wire components together, one can use the Exports of one as the Arguments
-to another.
+to another by using references. References can only appear in components.
 
 For example, here's a component that scrapes Prometheus metrics. The `targets`
 field is populated with two scrape targets; a constant one `localhost:9001` and
 an expression that ties the target to the value of
-`local.file.target.content`.
+`local.file.targets.content`.
 
 ```river
 prometheus.scrape "default" {
 	targets = [
-		{ "__address__" = local.file.target.content }, // tada!
+		{ "__address__" = local.file.targets.content }, // tada!
 		{ "__address__" = "localhost:9001" },
 	] 
 
@@ -95,7 +96,7 @@ River will type-check expressions before assigning a value to an attribute; the
 documentation of each component will have more information about the ways that
 you can wire components together.
 
-In the previous example, the contents of the `local.file.target.content`
+In the previous example, the contents of the `local.file.targets.content`
 expression must first be evaluated in a concrete value then type-checked and
 substituted into `prometheus.scrape.default` for it to be configured in turn.
 

--- a/docs/flow/config-language/components.md
+++ b/docs/flow/config-language/components.md
@@ -20,38 +20,38 @@ Each top-level River _block_ will instantiate a new component. A component
 consists of its name (which describes what the component is responsible for) as
 well as an optional user-specified label.
 
-You can see a list of all available components [here]({{< relref
-"../components/_index.md" >}}). Each component features a complete reference
-pages, so getting a component to work should be as easy as reading its
-documentation and copy/pasting from an example.
+You can see a list of all available components [here]({{< relref "../components/_index.md" >}}).
+Each component features a complete reference page, so getting a component to
+work for you should be as easy as reading its documentation and copy/pasting
+from an example.
 
 ## Arguments and Outputs
 Most user interactions with components will center around two basic concepts;
 _Arguments_ and _Exports_.
 
 * _Arguments_ work much like function arguments in your favorite programming
- language. They can be any number of attributes or nested blocks and they're
-used to configure the component's behavior. Most components will feature both
-required and optional arguments. Any arguments that are not provided will take
-on their default values.
+ language. They can be any number of attributes or nested unlabeled blocks and
+are used to configure the component's behavior. Most components will feature
+both required and optional arguments. Any arguments that are not provided will
+take on their default values.
 
-* _Exports_ are zero or more named return values, that can be referred to by
- other components. There is no limit to what an export might be; it can be any
-River value, or Go type (eg. channels, interfaces).
+* _Exports_ are zero or more named return values that can be referred to by
+ other components. There is no limit to what an export might be; it can take on
+any River value or Go type (eg. channels, interfaces).
 
 Here's a quick example; the following block defines a `local.file` component
 labelled "targets". The `local.file.targets` component will then expose the
-file `content` in its Exports.
+file `content` as a string in its Exports.
 
 The `filename` attribute is a _required_ argument; the user can also define a
-number of _optional_ ones (in this case `is_sensitive`, `detector` and
-`poll_frequency`), which configure how and how often the file should be polled
+number of _optional_ ones (in this case  `detector`, `poll_frequency` and
+`is_sensitive`), which configure how and how often the file should be polled
 as well as whether its contents are safe to be presented as plaintext back to
 the user.
 
 ```river
 local.file "targets" {
-	// Mandatory Argument
+	// Required Argument
 	filename = "/etc/agent/targets" 
 
 	/* Optional Arguments
@@ -60,7 +60,7 @@ local.file "targets" {
 	poll_frequency = <duration> 
 	*/
 
-	// Export: a field named `content`
+	// Exports: a single field named `content`
 	// It can be referred to as `local.file.token.content`
 }
 ```
@@ -70,7 +70,7 @@ of another.
 
 For example, here's a component that scrapes Prometheus metrics. The `targets`
 field is populated with two scrape targets; a constant one `localhost:9001` and
-an expression that ties the target to the contents of the
+an expression that ties the target to the contents of
 `local.file.target.content`.
 
 ```river
@@ -87,23 +87,29 @@ prometheus.scrape "default" {
 }
 ```
 
-All Arguments and Exports have an underlying [type]({{< relref
-"./expressions/types_and_values.md" >}}). River will type-check expressions
-before assigning a value to an attribute; the documentation of each component
-will have more information about the ways that you can wire components
-together.
+All Arguments and Exports have an underlying [type]({{< relref "./expressions/types_and_values.md" >}}).
+River will type-check expressions before assigning a value to an attribute; the
+documentation of each component will have more information about the ways that
+you can wire components together.
 
 River attributes that appear as Arguments and Exports can carry around more
 than the basic types you'd expect such as strings, numbers or booleans; they
-are able to wrap any Go value (eg. channels or interfaces), which makes for
-powerful tooling when building more complex pipelines.
+are able to natively wrap any Go value (eg. channels or interfaces), as well as
+pass around and invoke Go functions which makes for powerful tooling when
+building more complex pipelines.
 
 ## DAG
 The relationships between components form a [Directed Acyclic Graph](https://en.wikipedia.org/wiki/Directed_acyclic_graph).
 
-This graph is used by River to resolve dependencies between components, set the correct order for component evaluation, and ensure the validity of references. River does not allow components that reference themselves, or other relationship that end up in cyclical references, or invalid references.
+This graph is used by River to resolve dependencies between components, set the
+correct order for component evaluation, and ensure the validity of references.
+River does not allow components that reference themselves, any other
+relationship that might end up in cyclical references, and will reject outright
+invalid references in expressions.
 
-In the previous example, the contents of the `local.file.target.content` expression must first be evaluated in a concrete value then type-checked and substituted into `prometheus.scrape.default` for it to be configured in turn.
+In the previous example, the contents of the `local.file.target.content`
+expression must first be evaluated in a concrete value then type-checked and
+substituted into `prometheus.scrape.default` for it to be configured in turn.
 
 ## Error reporting
 Like in the case of syntax errors, River will also enrich component-related

--- a/docs/flow/config-language/components.md
+++ b/docs/flow/config-language/components.md
@@ -6,3 +6,129 @@ weight: 300
 ---
 
 # Components
+Components are the defining feature of Grafana Agent Flow. They are autonomous
+pieces of business logic that perform a single task (like retrieving secrets or
+collecting Prometheus metrics) and are wired together to form programmable
+pipelines of telemetry data.
+
+Under the hood, components are orchestrated via the [_component
+controller_]({{< relref "../concepts/component_controller.md" >}}), who is
+responsible for scheduling them, reporting their health and debug status, and
+continuously re-evaluating their inputs and outputs.
+
+Each top-level River _block_ will instantiate a new component. A component
+consists of its name (which describes what the component is responsible for) as
+well as an optional user-specified label.
+
+You can see a list of all available components [here]({{< relref
+"../components/_index.md" >}}). Each component features a complete reference
+pages, so getting a component to work should be as easy as reading its
+documentation and copy/pasting from an example.
+
+## Arguments and Outputs
+Most user interactions with components will center around two basic concepts;
+_Arguments_ and _Exports_.
+
+* _Arguments_ work much like function arguments in your favorite programming
+ language. They can be any number of attributes or nested blocks and they're
+used to configure the component's behavior. Most components will feature both
+required and optional arguments. Any arguments that are not provided will take
+on their default values.
+
+* _Exports_ are zero or more named return values, that can be referred to by
+ other components. There is no limit to what an export might be; it can be any
+River value, or Go type (eg. channels, interfaces).
+
+Here's a quick example; the following block defines a `local.file` component
+labelled "targets". The `local.file.targets` component will then expose the
+file `content` in its Exports.
+
+The `filename` attribute is a _required_ argument; the user can also define a
+number of _optional_ ones (in this case `is_sensitive`, `detector` and
+`poll_frequency`), which configure how and how often the file should be polled
+as well as whether its contents are safe to be presented as plaintext back to
+the user.
+
+```river
+local.file "targets" {
+	// Mandatory Argument
+	filename = "/etc/agent/targets" 
+
+	/* Optional Arguments
+	is_sensitive   = <boolean>
+	detector       = < "fsnotify" | "poll" >
+	poll_frequency = <duration> 
+	*/
+
+	// Export: a field named `content`
+	// It can be referred to as `local.file.token.content`
+}
+```
+
+To wire components together, you just use the Exports of one as the Arguments
+of another.
+
+For example, here's a component that scrapes Prometheus metrics. The `targets`
+field is populated with two scrape targets; a constant one `localhost:9001` and
+an expression that ties the target to the contents of the
+`local.file.target.content`.
+
+```river
+prometheus.scrape "default" {
+	targets = [
+		{ "__address__" = local.file.target.content }, // tada!
+		{ "__address__" = "localhost:9001" },
+	] 
+
+	forward_to = [prometheus.remote_write.default.receiver]
+	scrape_config {
+		job_name = "default"
+	}
+}
+```
+
+All Arguments and Exports have an underlying [type]({{< relref
+"./expressions/types_and_values.md" >}}). River will type-check expressions
+before assigning a value to an attribute; the documentation of each component
+will have more information about the ways that you can wire components
+together.
+
+River attributes that appear as Arguments and Exports can carry around more
+than the basic types you'd expect such as strings, numbers or booleans; they
+are able to wrap any Go value (eg. channels or interfaces), which makes for
+powerful tooling when building more complex pipelines.
+
+## DAG
+The relationships between components form a [Directed Acyclic Graph](https://en.wikipedia.org/wiki/Directed_acyclic_graph).
+
+This graph is used by River to resolve dependencies between components, set the correct order for component evaluation, and ensure the validity of references. River does not allow components that reference themselves, or other relationship that end up in cyclical references, or invalid references.
+
+In the previous example, the contents of the `local.file.target.content` expression must first be evaluated in a concrete value then type-checked and substituted into `prometheus.scrape.default` for it to be configured in turn.
+
+## Error reporting
+Like in the case of syntax errors, River will also enrich component-related
+errors with useful information to help with debugging.
+
+```
+Error: ./cmd/agent/example-config.river:16:21: component "local.file.this_files.content" does not exist
+
+15 |         "__address__"   = "localhost:12345",
+16 |         "dynamic_label" = local.file.this_files.content,
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^
+17 |     }]
+
+Error: ./cmd/agent/example-config.river:25:1: Failed to build component: building component: duplicate remote write configs are not allowed, found duplicate for URL: http://localhost:9009/api/prom/push
+
+24 |
+25 | | prometheus.remote_write "default" {
+   |  _^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+26 | |     remote_write {
+27 | |         url = "http://localhost:9009/api/prom/push"
+28 | |     }
+29 | |     remote_write {
+30 | |         url = "http://localhost:9009/api/prom/push"
+31 | |     }
+32 | | }
+   | |_^
+33 |
+```

--- a/docs/flow/config-language/components.md
+++ b/docs/flow/config-language/components.md
@@ -25,7 +25,7 @@ Each component features a complete reference page, so getting a component to
 work for you should be as easy as reading its documentation and copy/pasting
 from an example.
 
-## Arguments and Outputs
+## Arguments and Exports
 Most user interactions with components will center around two basic concepts;
 _Arguments_ and _Exports_.
 

--- a/docs/flow/config-language/components.md
+++ b/docs/flow/config-language/components.md
@@ -6,30 +6,29 @@ weight: 300
 ---
 
 # Components
-Components are the defining feature of Grafana Agent Flow. They are autonomous
-pieces of business logic that perform a single task (like retrieving secrets or
-collecting Prometheus metrics) and can be wired together to form programmable
-pipelines of telemetry data.
+Components are the defining feature of Grafana Agent Flow. They are small,
+reusable pieces of business logic that perform a single task (like retrieving
+secrets or collecting Prometheus metrics) and can be wired together to form
+programmable pipelines of telemetry data.
 
 Under the hood, components are orchestrated via the [_component
 controller_]({{< relref "../concepts/component_controller.md" >}}), which is
-responsible for scheduling them, reporting their health and debug status, and
-continuously re-evaluating their inputs and outputs.
-
+responsible for scheduling them, reporting their health and debug status,
+re-evaluating their arguments and providing their exports.
 
 ## Configuring components
-Each top-level River _block_ will instantiate a new component. All components
+Components are created by defining a top-level River block. All components
 are identified by their name, describing what the component is responsible for,
 while some allow or require to provide an extra user-specified _label_.
 
-The [components docs]({{< relref "../components/_index.md" >}}) contain a list
+The [components docs]({{< relref "../reference/components/_index.md" >}}) contain a list
 of all available components. Each one has a complete reference page, so getting
 a component to work for you should be as easy as reading its documentation and
 copy/pasting from an example.
 
-## Arguments and Exports
+## Arguments and exports
 Most user interactions with components will center around two basic concepts;
-_Arguments_ and _Exports_.
+_arguments_ and _exports_.
 
 * _Arguments_ are settings which modify the behavior of a component. They can
  be any number of attributes or nested unlabeled blocks, some of them being
@@ -41,7 +40,7 @@ take on their default values.
 
 Here's a quick example; the following block defines a `local.file` component
 labeled "targets". The `local.file.targets` component will then expose the
-file `content` as a string in its Exports.
+file `content` as a string in its exports.
 
 The `filename` attribute is a _required_ argument; the user can also define a
 number of _optional_ ones, in this case `detector`, `poll_frequency` and
@@ -50,10 +49,10 @@ as well as whether its contents are sensitive or not.
 
 ```river
 local.file "targets" {
-	// Required Argument
+	// Required argument
 	filename = "/etc/agent/targets" 
 
-	// Optional Arguments: Components may have some optional arguments that
+	// Optional arguments: Components may have some optional arguments that
 	// do not need to be defined.
 	// 
 	// The optional arguments for local.file are is_secret, detector, and
@@ -65,7 +64,7 @@ local.file "targets" {
 ```
 
 ## Referencing components
-To wire components together, one can use the Exports of one as the Arguments
+To wire components together, one can use the exports of one as the arguments
 to another by using references. References can only appear in components.
 
 For example, here's a component that scrapes Prometheus metrics. The `targets`
@@ -87,11 +86,10 @@ prometheus.scrape "default" {
 }
 ```
 
-Every time the file contents change and the `local.file` component re-evaluates
-its Exports, the value will propagated to `prometheus.scrape` so it can start
-scraping the new target.
+Every time the file contents change, the `local.file` will update its exports,
+so the new value will provided to `prometheus.scrape` targets field.
 
-All Arguments and Exports have an underlying [type]({{< relref "./expressions/types_and_values.md" >}}).
+All arguments and exports have an underlying [type]({{< relref "./expressions/types_and_values.md" >}}).
 River will type-check expressions before assigning a value to an attribute; the
 documentation of each component will have more information about the ways that
 you can wire components together.

--- a/docs/flow/config-language/files.md
+++ b/docs/flow/config-language/files.md
@@ -6,7 +6,6 @@ weight: 100
 ---
 
 # Files
-
 River files are plaintext files with the `.river` file extension. Each River
 file may be referred to as a 'configuration file', or a 'River configuration'.
 

--- a/docs/flow/config-language/files.md
+++ b/docs/flow/config-language/files.md
@@ -14,10 +14,8 @@ Unicode characters. River files can use both Unix-style line endings (LF) and
 Windows-style line endings (CRLF), but formatters may replace all line endings
 with Unix-style ones.
 
+## Community tooling
 There is experimental support for River in
 [vim](https://github.com/rfratto/vim-river) and in
 [VSCode](https://github.com/rfratto/vscode-river).
 
-To learn more about the basic elements that form a River configuration file,
-check out the [Syntax]({{< relref "../../controller-config/logging.md" >}})
-guide next.

--- a/docs/flow/config-language/files.md
+++ b/docs/flow/config-language/files.md
@@ -6,3 +6,19 @@ weight: 100
 ---
 
 # Files
+
+River files are plaintext files with the `.river` file extension. Each River
+file may be referred to as a 'configuration file', or a 'River configuration'.
+
+River files are required to be UTF-8 encoded, and are permitted to contain
+Unicode characters. River files can use both Unix-style line endings (LF) and
+Windows-style line endings (CRLF), but formatters may replace all line endings
+with Unix-style ones.
+
+There is experimental support for River in
+[vim](https://github.com/rfratto/vim-river) and in
+[VSCode](https://github.com/rfratto/vscode-river).
+
+To learn more about the basic elements that form a River configuration file,
+check out the [Syntax]({{< relref "../../controller-config/logging.md" >}})
+guide next.

--- a/docs/flow/config-language/syntax.md
+++ b/docs/flow/config-language/syntax.md
@@ -90,7 +90,7 @@ letters, digits or underscores, but doesn't start with a digit.
 ## Terminators
 All block and attribute definitions are followed by a newline, which River
 calls a _terminator_, as it terminates the current statement.
-A terminator is found when there's a newline following any expression, `]`,
-`)` or `}`. Other newlines are effectively ignored and a user can enter as many
-cosmetic newlines as they want.
+A newline is treated as terminator when it follows any expression, `]`,
+`)` or `}`. Other newlines are ignored by River and and a user can enter as many
+newlines as they want.
 

--- a/docs/flow/config-language/syntax.md
+++ b/docs/flow/config-language/syntax.md
@@ -32,16 +32,15 @@ All `<ATTRIBUTE_NAME>`s must be valid River identifiers.
 The `<ATTRIBUTE_VALUE>` can be either a constant value of a valid River
 [type]({{< relref "./expressions/types_and_values.md" >}}) (eg. string,
 boolean, number) or an [_expression_]({{< relref "./expressions/_index.md" >}})
-that computes and continuously re-evaluates more complex attribute values.
+to represent or compute more complex attribute values.
 
 ### Blocks
 _Blocks_ are used to configure components by grouping any number of attributes
 or nested blocks using curly braces.
 
-Blocks have a _name_ (the type of the component it defines), an
-optional _label_ and a body that contains any number of arguments or nested
-unlabeled blocks. Labels are used to disambiguate between multiple top-level
-blocks of the same name.
+Blocks have a _name_ (the type of the component it defines), an optional
+_label_ (depending on the component type) and a body that contains any number
+of arguments or nested unlabeled blocks.
 
 ```
 // Pattern for creating an unlabeled block:
@@ -70,8 +69,8 @@ The `<BLOCK_NAME>` must correspond to a registered Flow [component]({{< relref "
 If the optional `<BLOCK_LABEL>` is set, it has to be a valid River identifier
 wrapped in double quotes.
 
-River does not allow multiple unlabelled blocks with the same name to co-exist,
-so `<BLOCK_LABEL>`s are used to create multiple blocks and distinguish them.
+In case the component allows or requires a label to be set, it will be used to
+disambiguate between multiple top-level blocks of the same name.
 
 The following snippet defines a block named `local.file` with its label set to
 "token". The block's body sets the to the contents of the `TOKEN_FILE_PATH`

--- a/docs/flow/config-language/syntax.md
+++ b/docs/flow/config-language/syntax.md
@@ -35,12 +35,10 @@ boolean, number) or an [_expression_]({{< relref "./expressions/_index.md" >}})
 to represent or compute more complex attribute values.
 
 ### Blocks
-_Blocks_ are used to configure components by grouping any number of attributes
-or nested blocks using curly braces.
-
-Blocks have a _name_ (the type of the component it defines), an optional
-_label_ (depending on the component type) and a body that contains any number
-of arguments or nested unlabeled blocks.
+_Blocks_ are used to configure the Agent behavior as well as Flow components by
+grouping any number of attributes or nested blocks using curly braces.
+Blocks have a _name_, an optional _label_ and a body that contains any number
+of arguments and nested unlabeled blocks.
 
 ```
 // Pattern for creating an unlabeled block:
@@ -64,13 +62,11 @@ of arguments or nested unlabeled blocks.
 }
 ```
 
-The `<BLOCK_NAME>` must correspond to a registered Flow [component]({{< relref "./components.md" >}}).
-
-If the optional `<BLOCK_LABEL>` is set, it has to be a valid River [identifier](#identifiers)
-wrapped in double quotes.
-
-In case the component allows or requires a label to be set, it will be used to
-disambiguate between multiple top-level blocks of the same name.
+The `<BLOCK_NAME>` has to be recognized by Flow as either a valid component
+name or a special block for configuring global settings. If the `<BLOCK_LABEL>`
+has to be set, it must be a valid River [identifier](#identifiers) wrapped in
+double quotes. In these cases the label will be used to disambiguate between
+multiple top-level blocks of the same name.
 
 The following snippet defines a block named `local.file` with its label set to
 "token". The block's body sets the to the contents of the `TOKEN_FILE_PATH`
@@ -96,5 +92,5 @@ All block and attribute definitions are followed by a newline, which River
 calls a _terminator_, as it terminates the current statement.
 A terminator is found when there's a newline following any expression, `]`,
 `)` or `}`. Other newlines are effectively ignored and a user can enter as many
-newlines as they want.
+cosmetic newlines as they want.
 

--- a/docs/flow/config-language/syntax.md
+++ b/docs/flow/config-language/syntax.md
@@ -91,3 +91,10 @@ comments.
 River considers an identifier as valid if it consists of one or more UTF-8
 letters, digits or underscores, but doesn't start with a digit.
 
+## Terminators
+All block and attribute definitions are followed by a newline, which River
+calls a _terminator_, as it terminates the current statement.
+A terminator is found when there's a newline following any expression, `]`,
+`)` or `}`. Other newlines are effectively ignored and a user can enter as many
+newlines as they want.
+

--- a/docs/flow/config-language/syntax.md
+++ b/docs/flow/config-language/syntax.md
@@ -7,15 +7,12 @@ weight: 200
 
 # Syntax
 The River syntax is designed to be easy to read and write. Essentially, there
-are just two high-level elements to it; _Attributes_ and  _Blocks_. 
+are just two high-level elements to it: _Attributes_ and  _Blocks_. 
 
-The main purpose of River is to define components for the Grafana Agent Flow
-mode, so that they can be wired together to form programmable telemetry
-pipelines.
+River is a _declarative_ language used to build programmable pipelines.
 As such, the ordering of blocks and attributes within the River configuration
 file is not important; the language will consider all direct and indirect
-dependencies between elements to determine the order which must be used for the
-evaluation.
+dependencies between elements to determine their relationships.
 
 ## Attributes and Blocks
 
@@ -24,15 +21,13 @@ _Attributes_ are used to configure individual settings. They always take the
 form of `<ATTRIBUTE_NAME> = <ATTRIBUTE_VALUE>`. They can appear either as
 top-level elements or nested within blocks.
 
-The following sets the `log_level` attribute to `"debug"`.
+The following example  sets the `log_level` attribute to `"debug"`.
 
 ```river
 log_level = "debug"
 ```
 
-All `<ATTRIBUTE_NAME>`s must be valid River identifiers: they must be made up
-of one or more UTF-8 letters, digits or underscores, but cannot start with a
-digit.
+All `<ATTRIBUTE_NAME>`s must be valid River identifiers.
 
 The `<ATTRIBUTE_VALUE>` can be either a constant value of a valid River
 [type]({{< relref "./expressions/types_and_values.md" >}}) (eg. string,
@@ -49,8 +44,18 @@ unlabeled blocks. Labels are used to disambiguate between multiple top-level
 blocks of the same name.
 
 ```
-// Pattern for creating a block with an optional user-label:
-<BLOCK NAME> ["<BLOCK LABEL>"] {
+// Pattern for creating an unlabeled block:
+<BLOCK NAME> {
+	// Block body can contain attributes and nested unlabeled blocks
+	<IDENTIFIER> = <EXPRESSION> // Attribute
+
+	<NESTED_BLOCK_NAME> {
+		// Nested block body
+	}
+}
+
+// Pattern for creating a labeled block:
+<BLOCK NAME> "<BLOCK LABEL>" {
 	// Block body can contain attributes and nested unlabeled blocks
 	<IDENTIFIER> = <EXPRESSION> // Attribute
 
@@ -62,79 +67,28 @@ blocks of the same name.
 
 The `<BLOCK_NAME>` must correspond to a registered Flow [component]({{< relref "./components.md" >}}).
 
-If the optional `<BLOCK_LABEL>` is set, it has to be a valid River identifier:
-consisting of one or more UTF-8 letters, digits or underscores, but it cannot
-begin with a digit.
+If the optional `<BLOCK_LABEL>` is set, it has to be a valid River identifier
+wrapped in double quotes.
 
 River does not allow multiple unlabelled blocks with the same name to co-exist,
 so `<BLOCK_LABEL>`s are used to create multiple blocks and distinguish them.
-Once a block is created, it can be referred to by combining the name and label
-in a dot-delimited string like `remote.s3.production`.
 
 The following snippet defines a block named `local.file` with its label set to
-"token". The block's body sets the `filename` and `is_secret` attributes.
-
+"token". The block's body sets the to the contents of the `TOKEN_FILE_PATH`
+environment variable by using an expression and the `is_secret` attribute is
+set to the boolean `true`, marking the file content as sensitive.
 ```river
 local.file "token" {
-	filename  = "/etc/agent/service-account-token"
+	filename  = env("TOKEN_FILE_PATH") // Use an expression to read from an env var.
 	is_secret = true
 }
 ```
 
 ## Comments
-River configuration files support single-line `//` as well as `/* */` multiline
+River configuration files support single-line `//` as well as `/* */` block
 comments.
 
-## Error reporting
-One of the main improvements River brings to the table is its error reporting.
-Whenever a syntax error is emitted, River will decorate it with information
-about the position of the error, some surrounding context as well as a possible
-solution.
-
-```
-Error: ./cmd/agent/example-config.river:13:1: unrecognized attribute foo
-
-12 |
-13 | foo = bar
-   | ^^^
-14 |
-
-Error: ./cmd/agent/example-config.river:16:11: expected block label to be a valid identifier
-
-15 |
-16 | remote.s3 "instance-one" {
-   |            ^
-17 |     poll_frequency = "5m"
-
-Error: ./cmd/agent/example-config.river:33:1: expected }, got EOF
-
-32 | }
-33 |
-   |
-```
-
-## Examples
-The following example showcases River's syntax primitives.
-
-```river
-// `logging` is a special block that sets up some global attributes
-logging {
-	level  = "debug"
-	format = "logfmt"
-}
-
-/*
-The following block defines a `remote.s3` component labelled "token".
-The `path` attribute is set to the contents of the S3_TOKEN_PATH environment variable by using an expression.
-The `is_secret` attribute is set to the boolean true; the file contents will not be exposed as plaintext.
-*/
-remote.s3 "token" {
-	path      = env("S3_TOKEN_PATH") // Use an expression to read from an env var.
-	is_secret = true
-}
-```
-
-Feel free to move on to the [components]({{< relref "./components.md" >}}) docs
-to learn about the available component types, as well as how to configure,
-debug, and connect them to form a pipeline.
+## Identifiers
+River considers an identifier as valid if it consists of one or more UTF-8
+letters, digits or underscores, but it doesn't start with a digit.
 

--- a/docs/flow/config-language/syntax.md
+++ b/docs/flow/config-language/syntax.md
@@ -85,10 +85,10 @@ local.file "token" {
 ```
 
 ## Comments
-River configuration files support single-line `//` as well as `/* */` block
+River configuration files support single-line `//` as well as block `/* */` 
 comments.
 
 ## Identifiers
 River considers an identifier as valid if it consists of one or more UTF-8
-letters, digits or underscores, but it doesn't start with a digit.
+letters, digits or underscores, but doesn't start with a digit.
 

--- a/docs/flow/config-language/syntax.md
+++ b/docs/flow/config-language/syntax.md
@@ -7,7 +7,7 @@ weight: 200
 
 # Syntax
 The River syntax is designed to be easy to read and write. Essentially, there
-are just two high-level elements to it: _Attributes_ and  _Blocks_. 
+are just two high-level elements to it: _Attributes_ and _Blocks_. 
 
 River is a _declarative_ language used to build programmable pipelines.
 As such, the ordering of blocks and attributes within the River configuration
@@ -21,13 +21,13 @@ _Attributes_ are used to configure individual settings. They always take the
 form of `<ATTRIBUTE_NAME> = <ATTRIBUTE_VALUE>`. They can appear either as
 top-level elements or nested within blocks.
 
-The following example  sets the `log_level` attribute to `"debug"`.
+The following example sets the `log_level` attribute to `"debug"`.
 
 ```river
 log_level = "debug"
 ```
 
-All `<ATTRIBUTE_NAME>`s must be valid River identifiers.
+All `<ATTRIBUTE_NAME>`s must be valid River [identifiers](#identifiers).
 
 The `<ATTRIBUTE_VALUE>` can be either a constant value of a valid River
 [type]({{< relref "./expressions/types_and_values.md" >}}) (eg. string,
@@ -66,7 +66,7 @@ of arguments or nested unlabeled blocks.
 
 The `<BLOCK_NAME>` must correspond to a registered Flow [component]({{< relref "./components.md" >}}).
 
-If the optional `<BLOCK_LABEL>` is set, it has to be a valid River identifier
+If the optional `<BLOCK_LABEL>` is set, it has to be a valid River [identifier](#identifiers)
 wrapped in double quotes.
 
 In case the component allows or requires a label to be set, it will be used to

--- a/docs/flow/config-language/syntax.md
+++ b/docs/flow/config-language/syntax.md
@@ -6,3 +6,138 @@ weight: 200
 ---
 
 # Syntax
+The River syntax is designed to be easy to read and write. Essentially, there
+are just two high-level elements to it; _Attributes_ and  _Blocks_. 
+
+The main purpose of River is to define components for the Grafana Agent Flow
+mode, so that they can be wired together to form programmable telemetry
+pipelines.
+As such, the ordering of blocks and attributes within the River configuration
+file is not important; the language will consider all direct and indirect
+dependencies between elements to determine the order which must be used for the
+evaluation.
+
+## Attributes and Blocks
+
+### Attributes
+_Attributes_ are used to configure individual settings. They always take the
+form of `<ATTRIBUTE_NAME> = <ATTRIBUTE_VALUE>`. They can appear either as
+top-level elements or nested within blocks.
+
+The following sets the `log_level` attribute to `"debug"`.
+
+```river
+log_level = "debug"
+```
+
+All `<ATTRIBUTE_NAME>`s must be valid River identifiers: they must be made up
+of one or more UTF-8 letters, digits or underscores, but cannot start with a
+digit.
+
+The `<ATTRIBUTE_VALUE>` can be either a constant value of a valid River
+[type]({{< relref "./expressions/types_and_values.md" >}}) (eg. string,
+boolean, number), or an [_expression_]({{< relref "./expressions/_index.md"
+>}}) that computes and continuously re-evaluates more complex attribute
+values.
+
+### Blocks
+_Blocks_ are used to configure components by grouping any number of attributes
+or nested blocks using curly braces.
+
+Blocks have a _name_ (the type of the component it defines), an
+optional _label_ and a body that contains any number of arguments or nested
+unlabeled blocks. Labels are used to disambiguate between multiple top-level
+blocks of the same name.
+
+```
+// Pattern for creating a block with an optional user-label:
+<BLOCK NAME> ["<BLOCK LABEL>"] {
+	// Block body can contain attributes and nested unlabeled blocks
+	<IDENTIFIER> = <EXPRESSION> // Attribute
+
+	<NESTED_BLOCK_NAME> {
+		// Nested block body
+	}
+}
+```
+
+The `<BLOCK_NAME>` must correspond to a registered Flow [component]({{< relref "./components.md" >}}).
+
+If the optional `<BLOCK_LABEL>` is set, it has to be a valid River identifier:
+consisting of one or more UTF-8 letters, digits or underscores, but it cannot
+begin with a digit.
+
+River does not allow multiple unlabelled blocks with the same name to co-exist,
+so `<BLOCK_LABEL>`s are used to create multiple blocks and distinguish them.
+Once a block is created, it can be referred to by combining the name and label
+in a dot-delimited string like `remote.s3.production`.
+
+The following snippet defines a block named `local.file` with its label set to
+"token". The block's body sets the `filename` and `is_secret` attributes.
+
+```river
+local.file "token" {
+	filename  = "/etc/agent/service-account-token"
+	is_secret = true
+}
+```
+
+## Comments
+River configuration files support single-line `//` as well as `/* */` multiline
+comments.
+
+## Error reporting
+One of the main improvements River brings to the table is its error reporting.
+Whenever a syntax error is emitted, River will decorate it with information
+about the position of the error, some surrounding context as well as a possible
+solution.
+
+```
+Error: ./cmd/agent/example-config.river:13:1: unrecognized attribute foo
+
+12 |
+13 | foo = bar
+   | ^^^
+14 |
+
+Error: ./cmd/agent/example-config.river:16:11: expected block label to be a valid identifier
+
+15 |
+16 | remote.s3 "instance-one" {
+   |            ^
+17 |     poll_frequency = "5m"
+
+Error: ./cmd/agent/example-config.river:33:1: expected }, got EOF
+
+32 | }
+33 |
+   |
+```
+
+## Examples
+Here's an example of a simple River configuration file to showcase the
+language's syntax primitives.
+
+```river
+
+// `logging` is a special block that sets up some global attributes
+logging {
+	level  = "debug"
+	format = "logfmt"
+}
+
+/*
+The following block defines a `remote.s3` component labelled "token".
+The `path` attribute is set to the contents of the S3_TOKEN_PATH environment variable by using an expression.
+The `is_secret` attribute is set to the boolean true; the file contents will not be exposed as plaintext.
+*/
+remote.s3 "token" {
+	path      = env("S3_TOKEN_PATH") // Use an expression to read from an env var.
+	is_secret = true
+}
+```
+
+Feel free to move on to the [components]({{< relref "./components.md" >}}) docs
+to learn about the available component types, as well as how to configure,
+debug, and connect them to form a pipeline.
+

--- a/docs/flow/config-language/syntax.md
+++ b/docs/flow/config-language/syntax.md
@@ -36,9 +36,8 @@ digit.
 
 The `<ATTRIBUTE_VALUE>` can be either a constant value of a valid River
 [type]({{< relref "./expressions/types_and_values.md" >}}) (eg. string,
-boolean, number), or an [_expression_]({{< relref "./expressions/_index.md"
->}}) that computes and continuously re-evaluates more complex attribute
-values.
+boolean, number) or an [_expression_]({{< relref "./expressions/_index.md" >}})
+that computes and continuously re-evaluates more complex attribute values.
 
 ### Blocks
 _Blocks_ are used to configure components by grouping any number of attributes
@@ -115,11 +114,9 @@ Error: ./cmd/agent/example-config.river:33:1: expected }, got EOF
 ```
 
 ## Examples
-Here's an example of a simple River configuration file to showcase the
-language's syntax primitives.
+The following example showcases River's syntax primitives.
 
 ```river
-
 // `logging` is a special block that sets up some global attributes
 logging {
 	level  = "debug"


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This is an initial stab at adding slightly more detailed documentation for River's files, the language syntax and handling of components.

#### Which issue(s) this PR fixes

#### Notes to the Reviewer
I think that there's significant overlap with what we thought would go under `config-language/_index.md` in #2093 which leads me to think that we should have something more or different here? 

I'm not entirely sure _what_ that would be though right now, looking forward to your feedback

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [X] Documentation added
- [ ] Tests updated (N/A)
