### PR TITLE
operator - remove privileged property from security context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ Main (unreleased)
 
  - Fix relabel configs in sample agent-operator manifests (@hjet)
 
+ - Operator no longer set the `SecurityContext.Privileged` flag in the `config-reloader` container. (@hsyed-dojo)
+
 v0.26.1 (2022-07-25)
 -------------------------
 

--- a/pkg/operator/resources_pod_template.go
+++ b/pkg/operator/resources_pod_template.go
@@ -193,8 +193,7 @@ func generatePodTemplate(
 			VolumeMounts: volumeMounts,
 			Env:          envVars,
 			SecurityContext: &core_v1.SecurityContext{
-				Privileged: pointer.Bool(true),
-				RunAsUser:  pointer.Int64(0),
+				RunAsUser: pointer.Int64(0),
 			},
 			Args: []string{
 				"--config-file=/var/lib/grafana-agent/config-in/agent.yml",


### PR DESCRIPTION
Signed-off-by: Hassan Syed <hassan.syed@paymentsense.com>

#### PR Description

The agent workloads cannot be scheduled on AWS Fargate as the `config-reloader` container sets `SecurityContext.Privileged` property. There is some discourse [here](https://github.com/grafana/agent/issues/1928#issuecomment-1190296733) asserting that the property is not needed.

The updated operator has been tested in:

* AWS Fargate: metrics only.
* GKE: Loki and metrics.

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added (NA?)
- [x] Tests updated
