### PR TITLE
river: fix error message about allowed operands

### DIFF
--- a/pkg/river/vm/op_binary.go
+++ b/pkg/river/vm/op_binary.go
@@ -25,12 +25,12 @@ func evalBinop(lhs value.Value, op token.Token, rhs value.Value) (value.Value, e
 	if !acceptableBinopType(lhs, op) {
 		return value.Null, value.Error{
 			Value: lhs,
-			Inner: fmt.Errorf("should be one of %s for binop %s, got %s", binopAllowedTypes[op], op, lhs.Type()),
+			Inner: fmt.Errorf("should be one of %v for binop %s, got %s", binopAllowedTypes[op], op, lhs.Type()),
 		}
 	} else if !acceptableBinopType(rhs, op) {
 		return value.Null, value.Error{
 			Value: rhs,
-			Inner: fmt.Errorf("should be one of %s for binop %s, got %s", binopAllowedTypes[op], op, rhs.Type()),
+			Inner: fmt.Errorf("should be one of %v for binop %s, got %s", binopAllowedTypes[op], op, rhs.Type()),
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR allows us to side-step an edge case in Go's string formatting described in #2107 where `%s` in uint8 (byte) slices doesn't recurse each element to call its String() but treats the whole slice as a string.

#### Which issue(s) this PR fixes
Fixes #2107

#### Notes to the Reviewer
The allowed operands are now reported correctly.
```
ts=2022-09-02T14:14:25.417997Z level=error msg="failed to evaluate component" component=local.file.this_file err="decoding River: ./cmd/agent/example-config.river:11:18: true should be one of [number string] for binop <, got bool"
ts=2022-09-02T14:14:25.418241Z component=prometheus.remote_write.default subcomponent=rw level=info remote_name=618d80 url=http://localhost:9009/api/prom/push msg="Replaying WAL" queue=618d80
Error: ./cmd/agent/example-config.river:11:18: true should be one of [number string] for binop <, got bool

10 |     detector = "fsnotify"
11 |     is_secret = 3 < true
   |                     ^^^^
12 | }
```
#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
