### PR TITLE
river: sync name of stdlib function for decoding JSON

### DIFF
--- a/pkg/river/internal/stdlib/stdlib.go
+++ b/pkg/river/internal/stdlib/stdlib.go
@@ -88,7 +88,7 @@ var Functions = map[string]interface{}{
 		return value.Encode(raw.Interface()), nil
 	}),
 
-	"unmarshal_json": func(in string) (interface{}, error) {
+	"json_decode": func(in string) (interface{}, error) {
 		var res interface{}
 		err := json.Unmarshal([]byte(in), &res)
 		if err != nil {

--- a/pkg/river/vm/vm_stdlib_test.go
+++ b/pkg/river/vm/vm_stdlib_test.go
@@ -20,9 +20,9 @@ func TestVM_Stdlib(t *testing.T) {
 		{"env", `env("TEST_VAR")`, string("Hello!")},
 		{"concat", `concat([true, "foo"], [], [false, 1])`, []interface{}{true, "foo", false, 1}},
 		{"json_decode object", `json_decode("{\"foo\": \"bar\"}")`, map[string]interface{}{"foo": "bar"}},
-		{"json_decson array", `json_decode("[0, 1, 2]")`, []interface{}{float64(0), float64(1), float64(2)}},
-		{"json_decson nil field", `json_decode("{\"foo\": null}")`, map[string]interface{}{"foo": nil}},
-		{"json_decson nil array element", `json_decode("[0, null]")`, []interface{}{float64(0), nil}},
+		{"json_decode array", `json_decode("[0, 1, 2]")`, []interface{}{float64(0), float64(1), float64(2)}},
+		{"json_decode nil field", `json_decode("{\"foo\": null}")`, map[string]interface{}{"foo": nil}},
+		{"json_decode nil array element", `json_decode("[0, null]")`, []interface{}{float64(0), nil}},
 	}
 
 	for _, tc := range tt {

--- a/pkg/river/vm/vm_stdlib_test.go
+++ b/pkg/river/vm/vm_stdlib_test.go
@@ -19,10 +19,10 @@ func TestVM_Stdlib(t *testing.T) {
 	}{
 		{"env", `env("TEST_VAR")`, string("Hello!")},
 		{"concat", `concat([true, "foo"], [], [false, 1])`, []interface{}{true, "foo", false, 1}},
-		{"unmarshal_json object", `unmarshal_json("{\"foo\": \"bar\"}")`, map[string]interface{}{"foo": "bar"}},
-		{"unmarshal_json array", `unmarshal_json("[0, 1, 2]")`, []interface{}{float64(0), float64(1), float64(2)}},
-		{"unmarshal_json nil field", `unmarshal_json("{\"foo\": null}")`, map[string]interface{}{"foo": nil}},
-		{"unmarshal_json nil array element", `unmarshal_json("[0, null]")`, []interface{}{float64(0), nil}},
+		{"json_decode object", `json_decode("{\"foo\": \"bar\"}")`, map[string]interface{}{"foo": "bar"}},
+		{"json_decson array", `json_decode("[0, 1, 2]")`, []interface{}{float64(0), float64(1), float64(2)}},
+		{"json_decson nil field", `json_decode("{\"foo\": null}")`, map[string]interface{}{"foo": nil}},
+		{"json_decson nil array element", `json_decode("[0, null]")`, []interface{}{float64(0), nil}},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
In River's documentation we refer to this function as `json_decode` while its currently exposed as `unmarshal_json`.

We should sync the two; I'm not sure which of the two should be preferred but I opted to go with the first one on this PR. Let me know if you think we should go the other way around.

#### Which issue(s) this PR fixes
No PR filed.

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [X] Tests updated
