### PR TITLE
Add field to Operator to disable report usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Main (unreleased)
 - Introduce new configuration fields for disabling Keep-Alives and setting the
   IdleConnectionTimeout when scraping. (@tpaschalis)
 
+- Add field to Operator CRD to disable report usage functionality. (@marctc)
+
 ### Bugfixes
 
 - Tracing: Fixed issue with the PromSD processor using the `connection` method to discover the IP

--- a/docs/sources/operator/custom-resource-quickstart.md
+++ b/docs/sources/operator/custom-resource-quickstart.md
@@ -135,7 +135,7 @@ Deploying a GrafanaAgent resource on its own will not spin up any Agent Pods. Ag
 
 ### Disable feature flags reporting
 
-If you would like to disable the [reporting]({{< relref "../configuration/flags.md/#report-use-of-feature-flags" >}}) reporting usage of feature flags to Grafana, set `disableReporting` field to `true`.
+If you would like to disable the [reporting]({{< relref "../configuration/flags.md/#report-use-of-feature-flags" >}}) usage of feature flags to Grafana, set `disableReporting` field to `true`.
 
 ## Step 2: Deploy a MetricsInstance resource
 

--- a/docs/sources/operator/custom-resource-quickstart.md
+++ b/docs/sources/operator/custom-resource-quickstart.md
@@ -133,6 +133,10 @@ The full hierarchy of custom resources is as follows:
 
 Deploying a GrafanaAgent resource on its own will not spin up any Agent Pods. Agent Operator will create Agent Pods once MetricsInstance and LogsIntance resources have been created. In the next step, you'll roll out a `MetricsInstance` resource to scrape cAdvisor and Kubelet metrics and ship these to your Prometheus-compatible metrics endpoint.
 
+### Disable feature flags reporting
+
+If you would like to disable the [reporting]({{< relref "../configuration/flags.md/#report-use-of-feature-flags" >}}) reporting usage of feature flags to Grafana, set `disableReporting` field to `true`.
+
 ## Step 2: Deploy a MetricsInstance resource
 
 In this step you'll roll out a MetricsInstance resource. MetricsInstance resources define a `remote_write` sink for metrics and configure one or more selectors to watch for creation and updates to `*Monitor` objects. These objects allow you to define Agent scrape targets via K8s manifests:

--- a/pkg/operator/apis/monitoring/v1alpha1/types.go
+++ b/pkg/operator/apis/monitoring/v1alpha1/types.go
@@ -169,6 +169,9 @@ type GrafanaAgentSpec struct {
 	// config port 8080 on the agent.
 	// +kubebuilder:default=false
 	EnableConfigReadAPI bool `json:"enableConfigReadAPI,omitempty"`
+
+	// disableReporting disable reporting of enabled feature flags to Grafana.
+	DisableReporting bool `json:"disableReporting,omitempty"`
 }
 
 // +kubebuilder:object:generate=false

--- a/pkg/operator/apis/monitoring/v1alpha1/types.go
+++ b/pkg/operator/apis/monitoring/v1alpha1/types.go
@@ -171,6 +171,7 @@ type GrafanaAgentSpec struct {
 	EnableConfigReadAPI bool `json:"enableConfigReadAPI,omitempty"`
 
 	// disableReporting disable reporting of enabled feature flags to Grafana.
+	// +kubebuilder:default=false
 	DisableReporting bool `json:"disableReporting,omitempty"`
 }
 

--- a/pkg/operator/resources_pod_template.go
+++ b/pkg/operator/resources_pod_template.go
@@ -52,6 +52,11 @@ func generatePodTemplate(
 		agentArgs = append(agentArgs, "-config.enable-read-api")
 	}
 
+	disableReporting := d.Agent.Spec.DisableReporting
+	if disableReporting {
+		agentArgs = append(agentArgs, "-disable-reporting")
+	}
+
 	// NOTE(rfratto): the Prometheus Operator supports a ListenLocal to prevent a
 	// service from being created. Given the intent is that Agents can connect to
 	// each other, ListenLocal isn't currently supported and we always create a

--- a/production/operator/crds/monitoring.grafana.com_grafanaagents.yaml
+++ b/production/operator/crds/monitoring.grafana.com_grafanaagents.yaml
@@ -327,9 +327,7 @@ spec:
                                     field and the ones listed in the namespaces field.
                                     null selector and null or empty namespaces list
                                     means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces. This field is beta-level
-                                    and is only honored when PodAffinityNamespaceSelector
-                                    feature is enabled.
+                                    ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -384,7 +382,7 @@ spec:
                                     term is applied to the union of the namespaces
                                     listed in this field and the ones selected by
                                     namespaceSelector. null or empty namespaces list
-                                    and null namespaceSelector means "this pod's namespace"
+                                    and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
@@ -483,8 +481,6 @@ spec:
                                 the ones listed in the namespaces field. null selector
                                 and null or empty namespaces list means "this pod's
                                 namespace". An empty selector ({}) matches all namespaces.
-                                This field is beta-level and is only honored when
-                                PodAffinityNamespaceSelector feature is enabled.
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label
@@ -535,7 +531,7 @@ spec:
                                 to the union of the namespaces listed in this field
                                 and the ones selected by namespaceSelector. null or
                                 empty namespaces list and null namespaceSelector means
-                                "this pod's namespace"
+                                "this pod's namespace".
                               items:
                                 type: string
                               type: array
@@ -636,9 +632,7 @@ spec:
                                     field and the ones listed in the namespaces field.
                                     null selector and null or empty namespaces list
                                     means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces. This field is beta-level
-                                    and is only honored when PodAffinityNamespaceSelector
-                                    feature is enabled.
+                                    ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -693,7 +687,7 @@ spec:
                                     term is applied to the union of the namespaces
                                     listed in this field and the ones selected by
                                     namespaceSelector. null or empty namespaces list
-                                    and null namespaceSelector means "this pod's namespace"
+                                    and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
@@ -792,8 +786,6 @@ spec:
                                 the ones listed in the namespaces field. null selector
                                 and null or empty namespaces list means "this pod's
                                 namespace". An empty selector ({}) matches all namespaces.
-                                This field is beta-level and is only honored when
-                                PodAffinityNamespaceSelector feature is enabled.
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label
@@ -844,7 +836,7 @@ spec:
                                 to the union of the namespaces listed in this field
                                 and the ones selected by namespaceSelector. null or
                                 empty namespaces list and null namespaceSelector means
-                                "this pod's namespace"
+                                "this pod's namespace".
                               items:
                                 type: string
                               type: array
@@ -1107,7 +1099,7 @@ spec:
                     within a pod.
                   properties:
                     args:
-                      description: 'Arguments to the entrypoint. The docker image''s
+                      description: 'Arguments to the entrypoint. The container image''s
                         CMD is used if this is not provided. Variable references $(VAR_NAME)
                         are expanded using the container''s environment. If a variable
                         cannot be resolved, the reference in the input string will
@@ -1121,7 +1113,7 @@ spec:
                       type: array
                     command:
                       description: 'Entrypoint array. Not executed within a shell.
-                        The docker image''s ENTRYPOINT is used if this is not provided.
+                        The container image''s ENTRYPOINT is used if this is not provided.
                         Variable references $(VAR_NAME) are expanded using the container''s
                         environment. If a variable cannot be resolved, the reference
                         in the input string will be unchanged. Double $$ are reduced
@@ -1292,7 +1284,7 @@ spec:
                         type: object
                       type: array
                     image:
-                      description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                      description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
                         This field is optional to allow higher level config management
                         to default or override container images in workload controllers
                         like Deployments and StatefulSets.'
@@ -1522,7 +1514,7 @@ spec:
                           type: integer
                         grpc:
                           description: GRPC specifies an action involving a GRPC port.
-                            This is an alpha field and requires enabling GRPCContainerProbe
+                            This is a beta field and requires enabling GRPCContainerProbe
                             feature gate.
                           properties:
                             port:
@@ -1724,7 +1716,7 @@ spec:
                           type: integer
                         grpc:
                           description: GRPC specifies an action involving a GRPC port.
-                            This is an alpha field and requires enabling GRPCContainerProbe
+                            This is a beta field and requires enabling GRPCContainerProbe
                             feature gate.
                           properties:
                             port:
@@ -2084,7 +2076,7 @@ spec:
                           type: integer
                         grpc:
                           description: GRPC specifies an action involving a GRPC port.
-                            This is an alpha field and requires enabling GRPCContainerProbe
+                            This is a beta field and requires enabling GRPCContainerProbe
                             feature gate.
                           properties:
                             port:
@@ -2317,6 +2309,10 @@ spec:
                   - name
                   type: object
                 type: array
+              disableReporting:
+                description: disableReporting disable reporting of enabled feature
+                  flags to Grafana.
+                type: boolean
               enableConfigReadAPI:
                 default: false
                 description: enableConfigReadAPI enables the read API for viewing
@@ -2357,7 +2353,7 @@ spec:
                     within a pod.
                   properties:
                     args:
-                      description: 'Arguments to the entrypoint. The docker image''s
+                      description: 'Arguments to the entrypoint. The container image''s
                         CMD is used if this is not provided. Variable references $(VAR_NAME)
                         are expanded using the container''s environment. If a variable
                         cannot be resolved, the reference in the input string will
@@ -2371,7 +2367,7 @@ spec:
                       type: array
                     command:
                       description: 'Entrypoint array. Not executed within a shell.
-                        The docker image''s ENTRYPOINT is used if this is not provided.
+                        The container image''s ENTRYPOINT is used if this is not provided.
                         Variable references $(VAR_NAME) are expanded using the container''s
                         environment. If a variable cannot be resolved, the reference
                         in the input string will be unchanged. Double $$ are reduced
@@ -2542,7 +2538,7 @@ spec:
                         type: object
                       type: array
                     image:
-                      description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                      description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
                         This field is optional to allow higher level config management
                         to default or override container images in workload controllers
                         like Deployments and StatefulSets.'
@@ -2772,7 +2768,7 @@ spec:
                           type: integer
                         grpc:
                           description: GRPC specifies an action involving a GRPC port.
-                            This is an alpha field and requires enabling GRPCContainerProbe
+                            This is a beta field and requires enabling GRPCContainerProbe
                             feature gate.
                           properties:
                             port:
@@ -2974,7 +2970,7 @@ spec:
                           type: integer
                         grpc:
                           description: GRPC specifies an action involving a GRPC port.
-                            This is an alpha field and requires enabling GRPCContainerProbe
+                            This is a beta field and requires enabling GRPCContainerProbe
                             feature gate.
                           properties:
                             port:
@@ -3334,7 +3330,7 @@ spec:
                           type: integer
                         grpc:
                           description: GRPC specifies an action involving a GRPC port.
-                            This is an alpha field and requires enabling GRPCContainerProbe
+                            This is a beta field and requires enabling GRPCContainerProbe
                             feature gate.
                           properties:
                             port:
@@ -4874,22 +4870,22 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir'
                     properties:
                       medium:
-                        description: 'What type of storage medium should back this
-                          directory. The default is "" which means to use the node''s
-                          default medium. Must be an empty string (default) or Memory.
-                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        description: 'medium represents what type of storage medium
+                          should back this directory. The default is "" which means
+                          to use the node''s default medium. Must be an empty string
+                          (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                         type: string
                       sizeLimit:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Total amount of local storage required for this
-                          EmptyDir volume. The size limit is also applicable for memory
-                          medium. The maximum usage on memory medium EmptyDir would
-                          be the minimum value between the SizeLimit specified here
-                          and the sum of memory limits of all containers in a pod.
-                          The default is nil which means that the limit is undefined.
-                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                        description: 'sizeLimit is the total amount of local storage
+                          required for this EmptyDir volume. The size limit is also
+                          applicable for memory medium. The maximum usage on memory
+                          medium EmptyDir would be the minimum value between the SizeLimit
+                          specified here and the sum of memory limits of all containers
+                          in a pod. The default is nil which means that the limit
+                          is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     type: object
@@ -4931,14 +4927,14 @@ spec:
                               as in a PersistentVolumeClaim are also valid here.
                             properties:
                               accessModes:
-                                description: 'AccessModes contains the desired access
+                                description: 'accessModes contains the desired access
                                   modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                 items:
                                   type: string
                                 type: array
                               dataSource:
-                                description: 'This field can be used to specify either:
-                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                description: 'dataSource field can be used to specify
+                                  either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                   * An existing PVC (PersistentVolumeClaim) If the
                                   provisioner or an external controller can support
                                   the specified data source, it will create a new
@@ -4967,27 +4963,28 @@ spec:
                                 - name
                                 type: object
                               dataSourceRef:
-                                description: 'Specifies the object from which to populate
-                                  the volume with data, if a non-empty volume is desired.
-                                  This may be any local object from a non-empty API
-                                  group (non core object) or a PersistentVolumeClaim
-                                  object. When this field is specified, volume binding
-                                  will only succeed if the type of the specified object
-                                  matches some installed volume populator or dynamic
-                                  provisioner. This field will replace the functionality
-                                  of the DataSource field and as such if both fields
-                                  are non-empty, they must have the same value. For
-                                  backwards compatibility, both fields (DataSource
-                                  and DataSourceRef) will be set to the same value
-                                  automatically if one of them is empty and the other
-                                  is non-empty. There are two important differences
-                                  between DataSource and DataSourceRef: * While DataSource
-                                  only allows two specific types of objects, DataSourceRef
-                                  allows any non-core object, as well as PersistentVolumeClaim
+                                description: 'dataSourceRef specifies the object from
+                                  which to populate the volume with data, if a non-empty
+                                  volume is desired. This may be any local object
+                                  from a non-empty API group (non core object) or
+                                  a PersistentVolumeClaim object. When this field
+                                  is specified, volume binding will only succeed if
+                                  the type of the specified object matches some installed
+                                  volume populator or dynamic provisioner. This field
+                                  will replace the functionality of the DataSource
+                                  field and as such if both fields are non-empty,
+                                  they must have the same value. For backwards compatibility,
+                                  both fields (DataSource and DataSourceRef) will
+                                  be set to the same value automatically if one of
+                                  them is empty and the other is non-empty. There
+                                  are two important differences between DataSource
+                                  and DataSourceRef: * While DataSource only allows
+                                  two specific types of objects, DataSourceRef allows
+                                  any non-core object, as well as PersistentVolumeClaim
                                   objects. * While DataSource ignores disallowed values
                                   (dropping them), DataSourceRef preserves all values,
                                   and generates an error if a disallowed value is
-                                  specified. (Alpha) Using this field requires the
+                                  specified. (Beta) Using this field requires the
                                   AnyVolumeDataSource feature gate to be enabled.'
                                 properties:
                                   apiGroup:
@@ -5010,7 +5007,7 @@ spec:
                                 - name
                                 type: object
                               resources:
-                                description: 'Resources represents the minimum resources
+                                description: 'resources represents the minimum resources
                                   the volume should have. If RecoverVolumeExpansionFailure
                                   feature is enabled users are allowed to specify
                                   resource requirements that are lower than previous
@@ -5043,8 +5040,8 @@ spec:
                                     type: object
                                 type: object
                               selector:
-                                description: A label query over volumes to consider
-                                  for binding.
+                                description: selector is a label query over volumes
+                                  to consider for binding.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -5091,8 +5088,8 @@ spec:
                                     type: object
                                 type: object
                               storageClassName:
-                                description: 'Name of the StorageClass required by
-                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                description: 'storageClassName is the name of the
+                                  StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                 type: string
                               volumeMode:
                                 description: volumeMode defines what type of volume
@@ -5100,7 +5097,7 @@ spec:
                                   implied when not included in claim spec.
                                 type: string
                               volumeName:
-                                description: VolumeName is the binding reference to
+                                description: volumeName is the binding reference to
                                   the PersistentVolume backing this claim.
                                 type: string
                             type: object
@@ -5158,14 +5155,14 @@ spec:
                           a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                         properties:
                           accessModes:
-                            description: 'AccessModes contains the desired access
+                            description: 'accessModes contains the desired access
                               modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                             items:
                               type: string
                             type: array
                           dataSource:
-                            description: 'This field can be used to specify either:
-                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                            description: 'dataSource field can be used to specify
+                              either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                               * An existing PVC (PersistentVolumeClaim) If the provisioner
                               or an external controller can support the specified
                               data source, it will create a new volume based on the
@@ -5190,13 +5187,13 @@ spec:
                             - name
                             type: object
                           dataSourceRef:
-                            description: 'Specifies the object from which to populate
-                              the volume with data, if a non-empty volume is desired.
-                              This may be any local object from a non-empty API group
-                              (non core object) or a PersistentVolumeClaim object.
-                              When this field is specified, volume binding will only
-                              succeed if the type of the specified object matches
-                              some installed volume populator or dynamic provisioner.
+                            description: 'dataSourceRef specifies the object from
+                              which to populate the volume with data, if a non-empty
+                              volume is desired. This may be any local object from
+                              a non-empty API group (non core object) or a PersistentVolumeClaim
+                              object. When this field is specified, volume binding
+                              will only succeed if the type of the specified object
+                              matches some installed volume populator or dynamic provisioner.
                               This field will replace the functionality of the DataSource
                               field and as such if both fields are non-empty, they
                               must have the same value. For backwards compatibility,
@@ -5209,8 +5206,8 @@ spec:
                               PersistentVolumeClaim objects. * While DataSource ignores
                               disallowed values (dropping them), DataSourceRef preserves
                               all values, and generates an error if a disallowed value
-                              is specified. (Alpha) Using this field requires the
-                              AnyVolumeDataSource feature gate to be enabled.'
+                              is specified. (Beta) Using this field requires the AnyVolumeDataSource
+                              feature gate to be enabled.'
                             properties:
                               apiGroup:
                                 description: APIGroup is the group for the resource
@@ -5229,7 +5226,7 @@ spec:
                             - name
                             type: object
                           resources:
-                            description: 'Resources represents the minimum resources
+                            description: 'resources represents the minimum resources
                               the volume should have. If RecoverVolumeExpansionFailure
                               feature is enabled users are allowed to specify resource
                               requirements that are lower than previous value but
@@ -5261,8 +5258,8 @@ spec:
                                 type: object
                             type: object
                           selector:
-                            description: A label query over volumes to consider for
-                              binding.
+                            description: selector is a label query over volumes to
+                              consider for binding.
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -5307,8 +5304,8 @@ spec:
                                 type: object
                             type: object
                           storageClassName:
-                            description: 'Name of the StorageClass required by the
-                              claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                            description: 'storageClassName is the name of the StorageClass
+                              required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                             type: string
                           volumeMode:
                             description: volumeMode defines what type of volume is
@@ -5316,7 +5313,7 @@ spec:
                               when not included in claim spec.
                             type: string
                           volumeName:
-                            description: VolumeName is the binding reference to the
+                            description: volumeName is the binding reference to the
                               PersistentVolume backing this claim.
                             type: string
                         type: object
@@ -5325,7 +5322,7 @@ spec:
                           of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                         properties:
                           accessModes:
-                            description: 'AccessModes contains the actual access modes
+                            description: 'accessModes contains the actual access modes
                               the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                             items:
                               type: string
@@ -5337,19 +5334,19 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: The storage resource within AllocatedResources
-                              tracks the capacity allocated to a PVC. It may be larger
-                              than the actual capacity when a volume expansion operation
-                              is requested. For storage quota, the larger value from
-                              allocatedResources and PVC.spec.resources is used. If
-                              allocatedResources is not set, PVC.spec.resources alone
-                              is used for quota calculation. If a volume expansion
-                              capacity request is lowered, allocatedResources is only
-                              lowered if there are no expansion operations in progress
-                              and if the actual volume capacity is equal or lower
-                              than the requested capacity. This is an alpha field
-                              and requires enabling RecoverVolumeExpansionFailure
-                              feature.
+                            description: allocatedResources is the storage resource
+                              within AllocatedResources tracks the capacity allocated
+                              to a PVC. It may be larger than the actual capacity
+                              when a volume expansion operation is requested. For
+                              storage quota, the larger value from allocatedResources
+                              and PVC.spec.resources is used. If allocatedResources
+                              is not set, PVC.spec.resources alone is used for quota
+                              calculation. If a volume expansion capacity request
+                              is lowered, allocatedResources is only lowered if there
+                              are no expansion operations in progress and if the actual
+                              volume capacity is equal or lower than the requested
+                              capacity. This is an alpha field and requires enabling
+                              RecoverVolumeExpansionFailure feature.
                             type: object
                           capacity:
                             additionalProperties:
@@ -5358,36 +5355,37 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: Represents the actual resources of the underlying
-                              volume.
+                            description: capacity represents the actual resources
+                              of the underlying volume.
                             type: object
                           conditions:
-                            description: Current Condition of persistent volume claim.
-                              If underlying persistent volume is being resized then
-                              the Condition will be set to 'ResizeStarted'.
+                            description: conditions is the current Condition of persistent
+                              volume claim. If underlying persistent volume is being
+                              resized then the Condition will be set to 'ResizeStarted'.
                             items:
                               description: PersistentVolumeClaimCondition contails
                                 details about state of pvc
                               properties:
                                 lastProbeTime:
-                                  description: Last time we probed the condition.
+                                  description: lastProbeTime is the time we probed
+                                    the condition.
                                   format: date-time
                                   type: string
                                 lastTransitionTime:
-                                  description: Last time the condition transitioned
-                                    from one status to another.
+                                  description: lastTransitionTime is the time the
+                                    condition transitioned from one status to another.
                                   format: date-time
                                   type: string
                                 message:
-                                  description: Human-readable message indicating details
-                                    about last transition.
+                                  description: message is the human-readable message
+                                    indicating details about last transition.
                                   type: string
                                 reason:
-                                  description: Unique, this should be a short, machine
-                                    understandable string that gives the reason for
-                                    condition's last transition. If it reports "ResizeStarted"
-                                    that means the underlying persistent volume is
-                                    being resized.
+                                  description: reason is a unique, this should be
+                                    a short, machine understandable string that gives
+                                    the reason for condition's last transition. If
+                                    it reports "ResizeStarted" that means the underlying
+                                    persistent volume is being resized.
                                   type: string
                                 status:
                                   type: string
@@ -5401,10 +5399,10 @@ spec:
                               type: object
                             type: array
                           phase:
-                            description: Phase represents the current phase of PersistentVolumeClaim.
+                            description: phase represents the current phase of PersistentVolumeClaim.
                             type: string
                           resizeStatus:
-                            description: ResizeStatus stores status of resize operation.
+                            description: resizeStatus stores status of resize operation.
                               ResizeStatus is not set by default but when expansion
                               is complete resizeStatus is set to empty string by resize
                               controller or kubelet. This is an alpha field and requires
@@ -5511,11 +5509,14 @@ spec:
                         be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                         it is the maximum permitted difference between the number
                         of matching pods in the target topology and the global minimum.
-                        For example, in a 3-zone cluster, MaxSkew is set to 1, and
-                        pods with the same labelSelector spread as 1/1/0: | zone1
-                        | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is
-                        1, incoming pod can only be scheduled to zone3 to become 1/1/1;
-                        scheduling it onto zone1(zone2) would make the ActualSkew(2-0)
+                        The global minimum is the minimum number of matching pods
+                        in an eligible domain or zero if the number of eligible domains
+                        is less than MinDomains. For example, in a 3-zone cluster,
+                        MaxSkew is set to 1, and pods with the same labelSelector
+                        spread as 2/2/1: In this case, the global minimum is 1. |
+                        zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                        is 1, incoming pod can only be scheduled to zone3 to become
+                        2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1)
                         on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming
                         pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                         it is used to give higher precedence to topologies that satisfy
@@ -5523,12 +5524,42 @@ spec:
                         allowed.'
                       format: int32
                       type: integer
+                    minDomains:
+                      description: "MinDomains indicates a minimum number of eligible
+                        domains. When the number of eligible domains with matching
+                        topology keys is less than minDomains, Pod Topology Spread
+                        treats \"global minimum\" as 0, and then the calculation of
+                        Skew is performed. And when the number of eligible domains
+                        with matching topology keys equals or greater than minDomains,
+                        this value has no effect on scheduling. As a result, when
+                        the number of eligible domains is less than minDomains, scheduler
+                        won't schedule more than maxSkew Pods to those domains. If
+                        value is nil, the constraint behaves as if MinDomains is equal
+                        to 1. Valid values are integers greater than 0. When value
+                        is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For
+                        example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains
+                        is set to 5 and pods with the same labelSelector spread as
+                        2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  |
+                        The number of domains is less than 5(MinDomains), so \"global
+                        minimum\" is treated as 0. In this situation, new pod with
+                        the same labelSelector cannot be scheduled, because computed
+                        skew will be 3(3 - 0) if new Pod is scheduled to any of the
+                        three zones, it will violate MaxSkew. \n This is an alpha
+                        field and requires enabling MinDomainsInPodTopologySpread
+                        feature gate."
+                      format: int32
+                      type: integer
                     topologyKey:
                       description: TopologyKey is the key of node labels. Nodes that
                         have a label with this key and identical values are considered
                         to be in the same topology. We consider each <key, value>
                         as a "bucket", and try to put balanced number of pods into
-                        each bucket. It's a required field.
+                        each bucket. We define a domain as a particular instance of
+                        a topology. Also, we define an eligible domain as a domain
+                        whose nodes match the node selector. e.g. If TopologyKey is
+                        "kubernetes.io/hostname", each Node is a domain of that topology.
+                        And, if TopologyKey is "topology.kubernetes.io/zone", each
+                        zone is a domain of that topology. It's a required field.
                       type: string
                     whenUnsatisfiable:
                       description: 'WhenUnsatisfiable indicates how to deal with a
@@ -5608,117 +5639,121 @@ spec:
                     be accessed by any container in the pod.
                   properties:
                     awsElasticBlockStore:
-                      description: 'AWSElasticBlockStore represents an AWS Disk resource
+                      description: 'awsElasticBlockStore represents an AWS Disk resource
                         that is attached to a kubelet''s host machine and then exposed
                         to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                       properties:
                         fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          description: 'fsType is the filesystem type of the volume
+                            that you want to mount. Tip: Ensure that the filesystem
+                            type is supported by the host operating system. Examples:
+                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                             TODO: how do we prevent errors in the filesystem from
                             compromising the machine'
                           type: string
                         partition:
-                          description: 'The partition in the volume that you want
-                            to mount. If omitted, the default is to mount by volume
-                            name. Examples: For volume /dev/sda1, you specify the
-                            partition as "1". Similarly, the volume partition for
-                            /dev/sda is "0" (or you can leave the property empty).'
+                          description: 'partition is the partition in the volume that
+                            you want to mount. If omitted, the default is to mount
+                            by volume name. Examples: For volume /dev/sda1, you specify
+                            the partition as "1". Similarly, the volume partition
+                            for /dev/sda is "0" (or you can leave the property empty).'
                           format: int32
                           type: integer
                         readOnly:
-                          description: 'Specify "true" to force and set the ReadOnly
-                            property in VolumeMounts to "true". If omitted, the default
-                            is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          description: 'readOnly value true will force the readOnly
+                            setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                           type: boolean
                         volumeID:
-                          description: 'Unique ID of the persistent disk resource
-                            in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          description: 'volumeID is unique ID of the persistent disk
+                            resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                           type: string
                       required:
                       - volumeID
                       type: object
                     azureDisk:
-                      description: AzureDisk represents an Azure Data Disk mount on
+                      description: azureDisk represents an Azure Data Disk mount on
                         the host and bind mount to the pod.
                       properties:
                         cachingMode:
-                          description: 'Host Caching mode: None, Read Only, Read Write.'
+                          description: 'cachingMode is the Host Caching mode: None,
+                            Read Only, Read Write.'
                           type: string
                         diskName:
-                          description: The Name of the data disk in the blob storage
+                          description: diskName is the Name of the data disk in the
+                            blob storage
                           type: string
                         diskURI:
-                          description: The URI the data disk in the blob storage
+                          description: diskURI is the URI of data disk in the blob
+                            storage
                           type: string
                         fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          description: fsType is Filesystem type to mount. Must be
+                            a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
                           type: string
                         kind:
-                          description: 'Expected values Shared: multiple blob disks
-                            per storage account  Dedicated: single blob disk per storage
-                            account  Managed: azure managed data disk (only in managed
-                            availability set). defaults to shared'
+                          description: 'kind expected values are Shared: multiple
+                            blob disks per storage account  Dedicated: single blob
+                            disk per storage account  Managed: azure managed data
+                            disk (only in managed availability set). defaults to shared'
                           type: string
                         readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
+                          description: readOnly Defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                       required:
                       - diskName
                       - diskURI
                       type: object
                     azureFile:
-                      description: AzureFile represents an Azure File Service mount
+                      description: azureFile represents an Azure File Service mount
                         on the host and bind mount to the pod.
                       properties:
                         readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
+                          description: readOnly defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretName:
-                          description: the name of secret that contains Azure Storage
-                            Account Name and Key
+                          description: secretName is the  name of secret that contains
+                            Azure Storage Account Name and Key
                           type: string
                         shareName:
-                          description: Share Name
+                          description: shareName is the azure share Name
                           type: string
                       required:
                       - secretName
                       - shareName
                       type: object
                     cephfs:
-                      description: CephFS represents a Ceph FS mount on the host that
+                      description: cephFS represents a Ceph FS mount on the host that
                         shares a pod's lifetime
                       properties:
                         monitors:
-                          description: 'Required: Monitors is a collection of Ceph
-                            monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          description: 'monitors is Required: Monitors is a collection
+                            of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           items:
                             type: string
                           type: array
                         path:
-                          description: 'Optional: Used as the mounted root, rather
-                            than the full Ceph tree, default is /'
+                          description: 'path is Optional: Used as the mounted root,
+                            rather than the full Ceph tree, default is /'
                           type: string
                         readOnly:
-                          description: 'Optional: Defaults to false (read/write).
+                          description: 'readOnly is Optional: Defaults to false (read/write).
                             ReadOnly here will force the ReadOnly setting in VolumeMounts.
                             More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           type: boolean
                         secretFile:
-                          description: 'Optional: SecretFile is the path to key ring
-                            for User, default is /etc/ceph/user.secret More info:
-                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          description: 'secretFile is Optional: SecretFile is the
+                            path to key ring for User, default is /etc/ceph/user.secret
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           type: string
                         secretRef:
-                          description: 'Optional: SecretRef is reference to the authentication
-                            secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          description: 'secretRef is Optional: SecretRef is reference
+                            to the authentication secret for User, default is empty.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           properties:
                             name:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -5726,30 +5761,30 @@ spec:
                               type: string
                           type: object
                         user:
-                          description: 'Optional: User is the rados user name, default
-                            is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          description: 'user is optional: User is the rados user name,
+                            default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           type: string
                       required:
                       - monitors
                       type: object
                     cinder:
-                      description: 'Cinder represents a cinder volume attached and
+                      description: 'cinder represents a cinder volume attached and
                         mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                       properties:
                         fsType:
-                          description: 'Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          description: 'fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to
+                            be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                           type: string
                         readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                          description: 'readOnly defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
                             More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                           type: boolean
                         secretRef:
-                          description: 'Optional: points to a secret object containing
-                            parameters used to connect to OpenStack.'
+                          description: 'secretRef is optional: points to a secret
+                            object containing parameters used to connect to OpenStack.'
                           properties:
                             name:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -5757,31 +5792,31 @@ spec:
                               type: string
                           type: object
                         volumeID:
-                          description: 'volume id used to identify the volume in cinder.
+                          description: 'volumeID used to identify the volume in cinder.
                             More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                           type: string
                       required:
                       - volumeID
                       type: object
                     configMap:
-                      description: ConfigMap represents a configMap that should populate
+                      description: configMap represents a configMap that should populate
                         this volume
                       properties:
                         defaultMode:
-                          description: 'Optional: mode bits used to set permissions
-                            on created files by default. Must be an octal value between
-                            0000 and 0777 or a decimal value between 0 and 511. YAML
-                            accepts both octal and decimal values, JSON requires decimal
-                            values for mode bits. Defaults to 0644. Directories within
-                            the path are not affected by this setting. This might
-                            be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits
-                            set.'
+                          description: 'defaultMode is optional: mode bits used to
+                            set permissions on created files by default. Must be an
+                            octal value between 0000 and 0777 or a decimal value between
+                            0 and 511. YAML accepts both octal and decimal values,
+                            JSON requires decimal values for mode bits. Defaults to
+                            0644. Directories within the path are not affected by
+                            this setting. This might be in conflict with other options
+                            that affect the file mode, like fsGroup, and the result
+                            can be other mode bits set.'
                           format: int32
                           type: integer
                         items:
-                          description: If unspecified, each key-value pair in the
-                            Data field of the referenced ConfigMap will be projected
+                          description: items if unspecified, each key-value pair in
+                            the Data field of the referenced ConfigMap will be projected
                             into the volume as a file whose name is the key and content
                             is the value. If specified, the listed keys will be projected
                             into the specified paths, and unlisted keys will not be
@@ -5793,25 +5828,25 @@ spec:
                             description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: The key to project.
+                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: 'Optional: mode bits used to set permissions
-                                  on this file. Must be an octal value between 0000
-                                  and 0777 or a decimal value between 0 and 511. YAML
-                                  accepts both octal and decimal values, JSON requires
-                                  decimal values for mode bits. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
+                                description: 'mode is Optional: mode bits used to
+                                  set permissions on this file. Must be an octal value
+                                  between 0000 and 0777 or a decimal value between
+                                  0 and 511. YAML accepts both octal and decimal values,
+                                  JSON requires decimal values for mode bits. If not
+                                  specified, the volume defaultMode will be used.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
                                 format: int32
                                 type: integer
                               path:
-                                description: The relative path of the file to map
-                                  the key to. May not be an absolute path. May not
-                                  contain the path element '..'. May not start with
-                                  the string '..'.
+                                description: path is the relative path of the file
+                                  to map the key to. May not be an absolute path.
+                                  May not contain the path element '..'. May not start
+                                  with the string '..'.
                                 type: string
                             required:
                             - key
@@ -5823,28 +5858,28 @@ spec:
                             TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                         optional:
-                          description: Specify whether the ConfigMap or its keys must
-                            be defined
+                          description: optional specify whether the ConfigMap or its
+                            keys must be defined
                           type: boolean
                       type: object
                     csi:
-                      description: CSI (Container Storage Interface) represents ephemeral
+                      description: csi (Container Storage Interface) represents ephemeral
                         storage that is handled by certain external CSI drivers (Beta
                         feature).
                       properties:
                         driver:
-                          description: Driver is the name of the CSI driver that handles
+                          description: driver is the name of the CSI driver that handles
                             this volume. Consult with your admin for the correct name
                             as registered in the cluster.
                           type: string
                         fsType:
-                          description: Filesystem type to mount. Ex. "ext4", "xfs",
-                            "ntfs". If not provided, the empty value is passed to
-                            the associated CSI driver which will determine the default
-                            filesystem to apply.
+                          description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                            If not provided, the empty value is passed to the associated
+                            CSI driver which will determine the default filesystem
+                            to apply.
                           type: string
                         nodePublishSecretRef:
-                          description: NodePublishSecretRef is a reference to the
+                          description: nodePublishSecretRef is a reference to the
                             secret object containing sensitive information to pass
                             to the CSI driver to complete the CSI NodePublishVolume
                             and NodeUnpublishVolume calls. This field is optional,
@@ -5858,13 +5893,13 @@ spec:
                               type: string
                           type: object
                         readOnly:
-                          description: Specifies a read-only configuration for the
-                            volume. Defaults to false (read/write).
+                          description: readOnly specifies a read-only configuration
+                            for the volume. Defaults to false (read/write).
                           type: boolean
                         volumeAttributes:
                           additionalProperties:
                             type: string
-                          description: VolumeAttributes stores driver-specific properties
+                          description: volumeAttributes stores driver-specific properties
                             that are passed to the CSI driver. Consult your driver's
                             documentation for supported values.
                           type: object
@@ -5872,7 +5907,7 @@ spec:
                       - driver
                       type: object
                     downwardAPI:
-                      description: DownwardAPI represents downward API about the pod
+                      description: downwardAPI represents downward API about the pod
                         that should populate this volume
                       properties:
                         defaultMode:
@@ -5959,31 +5994,31 @@ spec:
                           type: array
                       type: object
                     emptyDir:
-                      description: 'EmptyDir represents a temporary directory that
+                      description: 'emptyDir represents a temporary directory that
                         shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                       properties:
                         medium:
-                          description: 'What type of storage medium should back this
-                            directory. The default is "" which means to use the node''s
-                            default medium. Must be an empty string (default) or Memory.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                          description: 'medium represents what type of storage medium
+                            should back this directory. The default is "" which means
+                            to use the node''s default medium. Must be an empty string
+                            (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: 'Total amount of local storage required for
-                            this EmptyDir volume. The size limit is also applicable
-                            for memory medium. The maximum usage on memory medium
-                            EmptyDir would be the minimum value between the SizeLimit
-                            specified here and the sum of memory limits of all containers
-                            in a pod. The default is nil which means that the limit
-                            is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                          description: 'sizeLimit is the total amount of local storage
+                            required for this EmptyDir volume. The size limit is also
+                            applicable for memory medium. The maximum usage on memory
+                            medium EmptyDir would be the minimum value between the
+                            SizeLimit specified here and the sum of memory limits
+                            of all containers in a pod. The default is nil which means
+                            that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
-                      description: "Ephemeral represents a volume that is handled
+                      description: "ephemeral represents a volume that is handled
                         by a cluster storage driver. The volume's lifecycle is tied
                         to the pod that defines it - it will be created before the
                         pod starts, and deleted when the pod is removed. \n Use this
@@ -6034,13 +6069,13 @@ spec:
                                 as in a PersistentVolumeClaim are also valid here.
                               properties:
                                 accessModes:
-                                  description: 'AccessModes contains the desired access
+                                  description: 'accessModes contains the desired access
                                     modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                   items:
                                     type: string
                                   type: array
                                 dataSource:
-                                  description: 'This field can be used to specify
+                                  description: 'dataSource field can be used to specify
                                     either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                     * An existing PVC (PersistentVolumeClaim) If the
                                     provisioner or an external controller can support
@@ -6070,14 +6105,14 @@ spec:
                                   - name
                                   type: object
                                 dataSourceRef:
-                                  description: 'Specifies the object from which to
-                                    populate the volume with data, if a non-empty
-                                    volume is desired. This may be any local object
-                                    from a non-empty API group (non core object) or
-                                    a PersistentVolumeClaim object. When this field
-                                    is specified, volume binding will only succeed
-                                    if the type of the specified object matches some
-                                    installed volume populator or dynamic provisioner.
+                                  description: 'dataSourceRef specifies the object
+                                    from which to populate the volume with data, if
+                                    a non-empty volume is desired. This may be any
+                                    local object from a non-empty API group (non core
+                                    object) or a PersistentVolumeClaim object. When
+                                    this field is specified, volume binding will only
+                                    succeed if the type of the specified object matches
+                                    some installed volume populator or dynamic provisioner.
                                     This field will replace the functionality of the
                                     DataSource field and as such if both fields are
                                     non-empty, they must have the same value. For
@@ -6091,7 +6126,7 @@ spec:
                                     as PersistentVolumeClaim objects. * While DataSource
                                     ignores disallowed values (dropping them), DataSourceRef
                                     preserves all values, and generates an error if
-                                    a disallowed value is specified. (Alpha) Using
+                                    a disallowed value is specified. (Beta) Using
                                     this field requires the AnyVolumeDataSource feature
                                     gate to be enabled.'
                                   properties:
@@ -6115,7 +6150,7 @@ spec:
                                   - name
                                   type: object
                                 resources:
-                                  description: 'Resources represents the minimum resources
+                                  description: 'resources represents the minimum resources
                                     the volume should have. If RecoverVolumeExpansionFailure
                                     feature is enabled users are allowed to specify
                                     resource requirements that are lower than previous
@@ -6148,8 +6183,8 @@ spec:
                                       type: object
                                   type: object
                                 selector:
-                                  description: A label query over volumes to consider
-                                    for binding.
+                                  description: selector is a label query over volumes
+                                    to consider for binding.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -6199,8 +6234,9 @@ spec:
                                       type: object
                                   type: object
                                 storageClassName:
-                                  description: 'Name of the StorageClass required
-                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                  description: 'storageClassName is the name of the
+                                    StorageClass required by the claim. More info:
+                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                   type: string
                                 volumeMode:
                                   description: volumeMode defines what type of volume
@@ -6208,7 +6244,7 @@ spec:
                                     is implied when not included in claim spec.
                                   type: string
                                 volumeName:
-                                  description: VolumeName is the binding reference
+                                  description: volumeName is the binding reference
                                     to the PersistentVolume backing this claim.
                                   type: string
                               type: object
@@ -6217,32 +6253,33 @@ spec:
                           type: object
                       type: object
                     fc:
-                      description: FC represents a Fibre Channel resource that is
+                      description: fc represents a Fibre Channel resource that is
                         attached to a kubelet's host machine and then exposed to the
                         pod.
                       properties:
                         fsType:
-                          description: 'Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
+                          description: 'fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified. TODO: how do we prevent errors in the
+                            filesystem from compromising the machine'
                           type: string
                         lun:
-                          description: 'Optional: FC target lun number'
+                          description: 'lun is Optional: FC target lun number'
                           format: int32
                           type: integer
                         readOnly:
-                          description: 'Optional: Defaults to false (read/write).
+                          description: 'readOnly is Optional: Defaults to false (read/write).
                             ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                           type: boolean
                         targetWWNs:
-                          description: 'Optional: FC target worldwide names (WWNs)'
+                          description: 'targetWWNs is Optional: FC target worldwide
+                            names (WWNs)'
                           items:
                             type: string
                           type: array
                         wwids:
-                          description: 'Optional: FC volume world wide identifiers
+                          description: 'wwids Optional: FC volume world wide identifiers
                             (wwids) Either wwids or combination of targetWWNs and
                             lun must be set, but not both simultaneously.'
                           items:
@@ -6250,34 +6287,36 @@ spec:
                           type: array
                       type: object
                     flexVolume:
-                      description: FlexVolume represents a generic volume resource
+                      description: flexVolume represents a generic volume resource
                         that is provisioned/attached using an exec based plugin.
                       properties:
                         driver:
-                          description: Driver is the name of the driver to use for
+                          description: driver is the name of the driver to use for
                             this volume.
                           type: string
                         fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". The default filesystem depends on FlexVolume
-                            script.
+                          description: fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends
+                            on FlexVolume script.
                           type: string
                         options:
                           additionalProperties:
                             type: string
-                          description: 'Optional: Extra command options if any.'
+                          description: 'options is Optional: this field holds extra
+                            command options if any.'
                           type: object
                         readOnly:
-                          description: 'Optional: Defaults to false (read/write).
+                          description: 'readOnly is Optional: defaults to false (read/write).
                             ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                           type: boolean
                         secretRef:
-                          description: 'Optional: SecretRef is reference to the secret
-                            object containing sensitive information to pass to the
-                            plugin scripts. This may be empty if no secret object
-                            is specified. If the secret object contains more than
-                            one secret, all secrets are passed to the plugin scripts.'
+                          description: 'secretRef is Optional: secretRef is reference
+                            to the secret object containing sensitive information
+                            to pass to the plugin scripts. This may be empty if no
+                            secret object is specified. If the secret object contains
+                            more than one secret, all secrets are passed to the plugin
+                            scripts.'
                           properties:
                             name:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -6288,90 +6327,92 @@ spec:
                       - driver
                       type: object
                     flocker:
-                      description: Flocker represents a Flocker volume attached to
+                      description: flocker represents a Flocker volume attached to
                         a kubelet's host machine. This depends on the Flocker control
                         service being running
                       properties:
                         datasetName:
-                          description: Name of the dataset stored as metadata -> name
-                            on the dataset for Flocker should be considered as deprecated
+                          description: datasetName is Name of the dataset stored as
+                            metadata -> name on the dataset for Flocker should be
+                            considered as deprecated
                           type: string
                         datasetUUID:
-                          description: UUID of the dataset. This is unique identifier
-                            of a Flocker dataset
+                          description: datasetUUID is the UUID of the dataset. This
+                            is unique identifier of a Flocker dataset
                           type: string
                       type: object
                     gcePersistentDisk:
-                      description: 'GCEPersistentDisk represents a GCE Disk resource
+                      description: 'gcePersistentDisk represents a GCE Disk resource
                         that is attached to a kubelet''s host machine and then exposed
                         to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                       properties:
                         fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          description: 'fsType is filesystem type of the volume that
+                            you want to mount. Tip: Ensure that the filesystem type
+                            is supported by the host operating system. Examples: "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                             More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                             TODO: how do we prevent errors in the filesystem from
                             compromising the machine'
                           type: string
                         partition:
-                          description: 'The partition in the volume that you want
-                            to mount. If omitted, the default is to mount by volume
-                            name. Examples: For volume /dev/sda1, you specify the
-                            partition as "1". Similarly, the volume partition for
-                            /dev/sda is "0" (or you can leave the property empty).
+                          description: 'partition is the partition in the volume that
+                            you want to mount. If omitted, the default is to mount
+                            by volume name. Examples: For volume /dev/sda1, you specify
+                            the partition as "1". Similarly, the volume partition
+                            for /dev/sda is "0" (or you can leave the property empty).
                             More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                           format: int32
                           type: integer
                         pdName:
-                          description: 'Unique name of the PD resource in GCE. Used
-                            to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          description: 'pdName is unique name of the PD resource in
+                            GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                           type: string
                         readOnly:
-                          description: 'ReadOnly here will force the ReadOnly setting
+                          description: 'readOnly here will force the ReadOnly setting
                             in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                           type: boolean
                       required:
                       - pdName
                       type: object
                     gitRepo:
-                      description: 'GitRepo represents a git repository at a particular
+                      description: 'gitRepo represents a git repository at a particular
                         revision. DEPRECATED: GitRepo is deprecated. To provision
                         a container with a git repo, mount an EmptyDir into an InitContainer
                         that clones the repo using git, then mount the EmptyDir into
                         the Pod''s container.'
                       properties:
                         directory:
-                          description: Target directory name. Must not contain or
-                            start with '..'.  If '.' is supplied, the volume directory
-                            will be the git repository.  Otherwise, if specified,
-                            the volume will contain the git repository in the subdirectory
-                            with the given name.
+                          description: directory is the target directory name. Must
+                            not contain or start with '..'.  If '.' is supplied, the
+                            volume directory will be the git repository.  Otherwise,
+                            if specified, the volume will contain the git repository
+                            in the subdirectory with the given name.
                           type: string
                         repository:
-                          description: Repository URL
+                          description: repository is the URL
                           type: string
                         revision:
-                          description: Commit hash for the specified revision.
+                          description: revision is the commit hash for the specified
+                            revision.
                           type: string
                       required:
                       - repository
                       type: object
                     glusterfs:
-                      description: 'Glusterfs represents a Glusterfs mount on the
+                      description: 'glusterfs represents a Glusterfs mount on the
                         host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                       properties:
                         endpoints:
-                          description: 'EndpointsName is the endpoint name that details
+                          description: 'endpoints is the endpoint name that details
                             Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                           type: string
                         path:
-                          description: 'Path is the Glusterfs volume path. More info:
+                          description: 'path is the Glusterfs volume path. More info:
                             https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                           type: string
                         readOnly:
-                          description: 'ReadOnly here will force the Glusterfs volume
+                          description: 'readOnly here will force the Glusterfs volume
                             to be mounted with read-only permissions. Defaults to
                             false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                           type: boolean
@@ -6380,7 +6421,7 @@ spec:
                       - path
                       type: object
                     hostPath:
-                      description: 'HostPath represents a pre-existing file or directory
+                      description: 'hostPath represents a pre-existing file or directory
                         on the host machine that is directly exposed to the container.
                         This is generally used for system agents or other privileged
                         things that are allowed to see the host machine. Most containers
@@ -6389,68 +6430,70 @@ spec:
                         mounts and who can/can not mount host directories as read/write.'
                       properties:
                         path:
-                          description: 'Path of the directory on the host. If the
+                          description: 'path of the directory on the host. If the
                             path is a symlink, it will follow the link to the real
                             path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                           type: string
                         type:
-                          description: 'Type for HostPath Volume Defaults to "" More
+                          description: 'type for HostPath Volume Defaults to "" More
                             info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                           type: string
                       required:
                       - path
                       type: object
                     iscsi:
-                      description: 'ISCSI represents an ISCSI Disk resource that is
+                      description: 'iscsi represents an ISCSI Disk resource that is
                         attached to a kubelet''s host machine and then exposed to
                         the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                       properties:
                         chapAuthDiscovery:
-                          description: whether support iSCSI Discovery CHAP authentication
+                          description: chapAuthDiscovery defines whether support iSCSI
+                            Discovery CHAP authentication
                           type: boolean
                         chapAuthSession:
-                          description: whether support iSCSI Session CHAP authentication
+                          description: chapAuthSession defines whether support iSCSI
+                            Session CHAP authentication
                           type: boolean
                         fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                          description: 'fsType is the filesystem type of the volume
+                            that you want to mount. Tip: Ensure that the filesystem
+                            type is supported by the host operating system. Examples:
+                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
                             TODO: how do we prevent errors in the filesystem from
                             compromising the machine'
                           type: string
                         initiatorName:
-                          description: Custom iSCSI Initiator Name. If initiatorName
-                            is specified with iscsiInterface simultaneously, new iSCSI
-                            interface <target portal>:<volume name> will be created
-                            for the connection.
+                          description: initiatorName is the custom iSCSI Initiator
+                            Name. If initiatorName is specified with iscsiInterface
+                            simultaneously, new iSCSI interface <target portal>:<volume
+                            name> will be created for the connection.
                           type: string
                         iqn:
-                          description: Target iSCSI Qualified Name.
+                          description: iqn is the target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
-                          description: iSCSI Interface Name that uses an iSCSI transport.
-                            Defaults to 'default' (tcp).
+                          description: iscsiInterface is the interface Name that uses
+                            an iSCSI transport. Defaults to 'default' (tcp).
                           type: string
                         lun:
-                          description: iSCSI Target Lun number.
+                          description: lun represents iSCSI Target Lun number.
                           format: int32
                           type: integer
                         portals:
-                          description: iSCSI Target Portal List. The portal is either
-                            an IP or ip_addr:port if the port is other than default
-                            (typically TCP ports 860 and 3260).
+                          description: portals is the iSCSI Target Portal List. The
+                            portal is either an IP or ip_addr:port if the port is
+                            other than default (typically TCP ports 860 and 3260).
                           items:
                             type: string
                           type: array
                         readOnly:
-                          description: ReadOnly here will force the ReadOnly setting
+                          description: readOnly here will force the ReadOnly setting
                             in VolumeMounts. Defaults to false.
                           type: boolean
                         secretRef:
-                          description: CHAP Secret for iSCSI target and initiator
-                            authentication
+                          description: secretRef is the CHAP Secret for iSCSI target
+                            and initiator authentication
                           properties:
                             name:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -6458,9 +6501,9 @@ spec:
                               type: string
                           type: object
                         targetPortal:
-                          description: iSCSI Target Portal. The Portal is either an
-                            IP or ip_addr:port if the port is other than default (typically
-                            TCP ports 860 and 3260).
+                          description: targetPortal is iSCSI Target Portal. The Portal
+                            is either an IP or ip_addr:port if the port is other than
+                            default (typically TCP ports 860 and 3260).
                           type: string
                       required:
                       - iqn
@@ -6468,24 +6511,24 @@ spec:
                       - targetPortal
                       type: object
                     name:
-                      description: 'Volume''s name. Must be a DNS_LABEL and unique
+                      description: 'name of the volume. Must be a DNS_LABEL and unique
                         within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
                     nfs:
-                      description: 'NFS represents an NFS mount on the host that shares
+                      description: 'nfs represents an NFS mount on the host that shares
                         a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                       properties:
                         path:
-                          description: 'Path that is exported by the NFS server. More
+                          description: 'path that is exported by the NFS server. More
                             info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                           type: string
                         readOnly:
-                          description: 'ReadOnly here will force the NFS export to
+                          description: 'readOnly here will force the NFS export to
                             be mounted with read-only permissions. Defaults to false.
                             More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                           type: boolean
                         server:
-                          description: 'Server is the hostname or IP address of the
+                          description: 'server is the hostname or IP address of the
                             NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                           type: string
                       required:
@@ -6493,86 +6536,87 @@ spec:
                       - server
                       type: object
                     persistentVolumeClaim:
-                      description: 'PersistentVolumeClaimVolumeSource represents a
+                      description: 'persistentVolumeClaimVolumeSource represents a
                         reference to a PersistentVolumeClaim in the same namespace.
                         More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                       properties:
                         claimName:
-                          description: 'ClaimName is the name of a PersistentVolumeClaim
+                          description: 'claimName is the name of a PersistentVolumeClaim
                             in the same namespace as the pod using this volume. More
                             info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                           type: string
                         readOnly:
-                          description: Will force the ReadOnly setting in VolumeMounts.
-                            Default false.
+                          description: readOnly Will force the ReadOnly setting in
+                            VolumeMounts. Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     photonPersistentDisk:
-                      description: PhotonPersistentDisk represents a PhotonController
+                      description: photonPersistentDisk represents a PhotonController
                         persistent disk attached and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          description: fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
                           type: string
                         pdID:
-                          description: ID that identifies Photon Controller persistent
-                            disk
+                          description: pdID is the ID that identifies Photon Controller
+                            persistent disk
                           type: string
                       required:
                       - pdID
                       type: object
                     portworxVolume:
-                      description: PortworxVolume represents a portworx volume attached
+                      description: portworxVolume represents a portworx volume attached
                         and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: FSType represents the filesystem type to mount
+                          description: fSType represents the filesystem type to mount
                             Must be a filesystem type supported by the host operating
                             system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
                             if unspecified.
                           type: string
                         readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
+                          description: readOnly defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                         volumeID:
-                          description: VolumeID uniquely identifies a Portworx volume
+                          description: volumeID uniquely identifies a Portworx volume
                           type: string
                       required:
                       - volumeID
                       type: object
                     projected:
-                      description: Items for all in one resources secrets, configmaps,
-                        and downward API
+                      description: projected items for all in one resources secrets,
+                        configmaps, and downward API
                       properties:
                         defaultMode:
-                          description: Mode bits used to set permissions on created
-                            files by default. Must be an octal value between 0000
-                            and 0777 or a decimal value between 0 and 511. YAML accepts
-                            both octal and decimal values, JSON requires decimal values
-                            for mode bits. Directories within the path are not affected
-                            by this setting. This might be in conflict with other
-                            options that affect the file mode, like fsGroup, and the
-                            result can be other mode bits set.
+                          description: defaultMode are the mode bits used to set permissions
+                            on created files by default. Must be an octal value between
+                            0000 and 0777 or a decimal value between 0 and 511. YAML
+                            accepts both octal and decimal values, JSON requires decimal
+                            values for mode bits. Directories within the path are
+                            not affected by this setting. This might be in conflict
+                            with other options that affect the file mode, like fsGroup,
+                            and the result can be other mode bits set.
                           format: int32
                           type: integer
                         sources:
-                          description: list of volume projections
+                          description: sources is the list of volume projections
                           items:
                             description: Projection that may be projected along with
                               other supported volume types
                             properties:
                               configMap:
-                                description: information about the configMap data
-                                  to project
+                                description: configMap information about the configMap
+                                  data to project
                                 properties:
                                   items:
-                                    description: If unspecified, each key-value pair
-                                      in the Data field of the referenced ConfigMap
+                                    description: items if unspecified, each key-value
+                                      pair in the Data field of the referenced ConfigMap
                                       will be projected into the volume as a file
                                       whose name is the key and content is the value.
                                       If specified, the listed keys will be projected
@@ -6587,27 +6631,28 @@ spec:
                                         a volume.
                                       properties:
                                         key:
-                                          description: The key to project.
+                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'Optional: mode bits used to
-                                            set permissions on this file. Must be
-                                            an octal value between 0000 and 0777 or
-                                            a decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. If not specified, the volume defaultMode
-                                            will be used. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511. YAML accepts both octal and decimal
+                                            values, JSON requires decimal values for
+                                            mode bits. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
                                           format: int32
                                           type: integer
                                         path:
-                                          description: The relative path of the file
-                                            to map the key to. May not be an absolute
-                                            path. May not contain the path element
-                                            '..'. May not start with the string '..'.
+                                          description: path is the relative path of
+                                            the file to map the key to. May not be
+                                            an absolute path. May not contain the
+                                            path element '..'. May not start with
+                                            the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -6621,13 +6666,13 @@ spec:
                                       uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or
-                                      its keys must be defined
+                                    description: optional specify whether the ConfigMap
+                                      or its keys must be defined
                                     type: boolean
                                 type: object
                               downwardAPI:
-                                description: information about the downwardAPI data
-                                  to project
+                                description: downwardAPI information about the downwardAPI
+                                  data to project
                                 properties:
                                   items:
                                     description: Items is a list of DownwardAPIVolume
@@ -6708,15 +6753,15 @@ spec:
                                     type: array
                                 type: object
                               secret:
-                                description: information about the secret data to
-                                  project
+                                description: secret information about the secret data
+                                  to project
                                 properties:
                                   items:
-                                    description: If unspecified, each key-value pair
-                                      in the Data field of the referenced Secret will
-                                      be projected into the volume as a file whose
-                                      name is the key and content is the value. If
-                                      specified, the listed keys will be projected
+                                    description: items if unspecified, each key-value
+                                      pair in the Data field of the referenced Secret
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
                                       into the specified paths, and unlisted keys
                                       will not be present. If a key is specified which
                                       is not present in the Secret, the volume setup
@@ -6728,27 +6773,28 @@ spec:
                                         a volume.
                                       properties:
                                         key:
-                                          description: The key to project.
+                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'Optional: mode bits used to
-                                            set permissions on this file. Must be
-                                            an octal value between 0000 and 0777 or
-                                            a decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. If not specified, the volume defaultMode
-                                            will be used. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511. YAML accepts both octal and decimal
+                                            values, JSON requires decimal values for
+                                            mode bits. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
                                           format: int32
                                           type: integer
                                         path:
-                                          description: The relative path of the file
-                                            to map the key to. May not be an absolute
-                                            path. May not contain the path element
-                                            '..'. May not start with the string '..'.
+                                          description: path is the relative path of
+                                            the file to map the key to. May not be
+                                            an absolute path. May not contain the
+                                            path element '..'. May not start with
+                                            the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -6762,16 +6808,16 @@ spec:
                                       uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
+                                    description: optional field specify whether the
+                                      Secret or its key must be defined
                                     type: boolean
                                 type: object
                               serviceAccountToken:
-                                description: information about the serviceAccountToken
-                                  data to project
+                                description: serviceAccountToken is information about
+                                  the serviceAccountToken data to project
                                 properties:
                                   audience:
-                                    description: Audience is the intended audience
+                                    description: audience is the intended audience
                                       of the token. A recipient of a token must identify
                                       itself with an identifier specified in the audience
                                       of the token, and otherwise should reject the
@@ -6779,7 +6825,7 @@ spec:
                                       of the apiserver.
                                     type: string
                                   expirationSeconds:
-                                    description: ExpirationSeconds is the requested
+                                    description: expirationSeconds is the requested
                                       duration of validity of the service account
                                       token. As the token approaches expiration, the
                                       kubelet volume plugin will proactively rotate
@@ -6791,7 +6837,7 @@ spec:
                                     format: int64
                                     type: integer
                                   path:
-                                    description: Path is the path relative to the
+                                    description: path is the path relative to the
                                       mount point of the file to project the token
                                       into.
                                     type: string
@@ -6802,35 +6848,35 @@ spec:
                           type: array
                       type: object
                     quobyte:
-                      description: Quobyte represents a Quobyte mount on the host
+                      description: quobyte represents a Quobyte mount on the host
                         that shares a pod's lifetime
                       properties:
                         group:
-                          description: Group to map volume access to Default is no
+                          description: group to map volume access to Default is no
                             group
                           type: string
                         readOnly:
-                          description: ReadOnly here will force the Quobyte volume
+                          description: readOnly here will force the Quobyte volume
                             to be mounted with read-only permissions. Defaults to
                             false.
                           type: boolean
                         registry:
-                          description: Registry represents a single or multiple Quobyte
+                          description: registry represents a single or multiple Quobyte
                             Registry services specified as a string as host:port pair
                             (multiple entries are separated with commas) which acts
                             as the central registry for volumes
                           type: string
                         tenant:
-                          description: Tenant owning the given Quobyte volume in the
+                          description: tenant owning the given Quobyte volume in the
                             Backend Used with dynamically provisioned Quobyte volumes,
                             value is set by the plugin
                           type: string
                         user:
-                          description: User to map volume access to Defaults to serivceaccount
+                          description: user to map volume access to Defaults to serivceaccount
                             user
                           type: string
                         volume:
-                          description: Volume is a string that references an already
+                          description: volume is a string that references an already
                             created Quobyte volume by name.
                           type: string
                       required:
@@ -6838,41 +6884,42 @@ spec:
                       - volume
                       type: object
                     rbd:
-                      description: 'RBD represents a Rados Block Device mount on the
+                      description: 'rbd represents a Rados Block Device mount on the
                         host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                       properties:
                         fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                          description: 'fsType is the filesystem type of the volume
+                            that you want to mount. Tip: Ensure that the filesystem
+                            type is supported by the host operating system. Examples:
+                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
                             TODO: how do we prevent errors in the filesystem from
                             compromising the machine'
                           type: string
                         image:
-                          description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          description: 'image is the rados image name. More info:
+                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: string
                         keyring:
-                          description: 'Keyring is the path to key ring for RBDUser.
+                          description: 'keyring is the path to key ring for RBDUser.
                             Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: string
                         monitors:
-                          description: 'A collection of Ceph monitors. More info:
-                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          description: 'monitors is a collection of Ceph monitors.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           items:
                             type: string
                           type: array
                         pool:
-                          description: 'The rados pool name. Default is rbd. More
-                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          description: 'pool is the rados pool name. Default is rbd.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: string
                         readOnly:
-                          description: 'ReadOnly here will force the ReadOnly setting
+                          description: 'readOnly here will force the ReadOnly setting
                             in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: boolean
                         secretRef:
-                          description: 'SecretRef is name of the authentication secret
+                          description: 'secretRef is name of the authentication secret
                             for RBDUser. If provided overrides keyring. Default is
                             nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           properties:
@@ -6882,35 +6929,36 @@ spec:
                               type: string
                           type: object
                         user:
-                          description: 'The rados user name. Default is admin. More
-                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          description: 'user is the rados user name. Default is admin.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: string
                       required:
                       - image
                       - monitors
                       type: object
                     scaleIO:
-                      description: ScaleIO represents a ScaleIO persistent volume
+                      description: scaleIO represents a ScaleIO persistent volume
                         attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Default is "xfs".
+                          description: fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                           type: string
                         gateway:
-                          description: The host address of the ScaleIO API Gateway.
+                          description: gateway is the host address of the ScaleIO
+                            API Gateway.
                           type: string
                         protectionDomain:
-                          description: The name of the ScaleIO Protection Domain for
-                            the configured storage.
+                          description: protectionDomain is the name of the ScaleIO
+                            Protection Domain for the configured storage.
                           type: string
                         readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
+                          description: readOnly Defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: SecretRef references to the secret for ScaleIO
+                          description: secretRef references to the secret for ScaleIO
                             user and other sensitive information. If this is not provided,
                             Login operation will fail.
                           properties:
@@ -6920,25 +6968,26 @@ spec:
                               type: string
                           type: object
                         sslEnabled:
-                          description: Flag to enable/disable SSL communication with
-                            Gateway, default false
+                          description: sslEnabled Flag enable/disable SSL communication
+                            with Gateway, default false
                           type: boolean
                         storageMode:
-                          description: Indicates whether the storage for a volume
-                            should be ThickProvisioned or ThinProvisioned. Default
-                            is ThinProvisioned.
+                          description: storageMode indicates whether the storage for
+                            a volume should be ThickProvisioned or ThinProvisioned.
+                            Default is ThinProvisioned.
                           type: string
                         storagePool:
-                          description: The ScaleIO Storage Pool associated with the
-                            protection domain.
+                          description: storagePool is the ScaleIO Storage Pool associated
+                            with the protection domain.
                           type: string
                         system:
-                          description: The name of the storage system as configured
-                            in ScaleIO.
+                          description: system is the name of the storage system as
+                            configured in ScaleIO.
                           type: string
                         volumeName:
-                          description: The name of a volume already created in the
-                            ScaleIO system that is associated with this volume source.
+                          description: volumeName is the name of a volume already
+                            created in the ScaleIO system that is associated with
+                            this volume source.
                           type: string
                       required:
                       - gateway
@@ -6946,24 +6995,24 @@ spec:
                       - system
                       type: object
                     secret:
-                      description: 'Secret represents a secret that should populate
+                      description: 'secret represents a secret that should populate
                         this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                       properties:
                         defaultMode:
-                          description: 'Optional: mode bits used to set permissions
-                            on created files by default. Must be an octal value between
-                            0000 and 0777 or a decimal value between 0 and 511. YAML
-                            accepts both octal and decimal values, JSON requires decimal
-                            values for mode bits. Defaults to 0644. Directories within
-                            the path are not affected by this setting. This might
-                            be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits
-                            set.'
+                          description: 'defaultMode is Optional: mode bits used to
+                            set permissions on created files by default. Must be an
+                            octal value between 0000 and 0777 or a decimal value between
+                            0 and 511. YAML accepts both octal and decimal values,
+                            JSON requires decimal values for mode bits. Defaults to
+                            0644. Directories within the path are not affected by
+                            this setting. This might be in conflict with other options
+                            that affect the file mode, like fsGroup, and the result
+                            can be other mode bits set.'
                           format: int32
                           type: integer
                         items:
-                          description: If unspecified, each key-value pair in the
-                            Data field of the referenced Secret will be projected
+                          description: items If unspecified, each key-value pair in
+                            the Data field of the referenced Secret will be projected
                             into the volume as a file whose name is the key and content
                             is the value. If specified, the listed keys will be projected
                             into the specified paths, and unlisted keys will not be
@@ -6975,25 +7024,25 @@ spec:
                             description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: The key to project.
+                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: 'Optional: mode bits used to set permissions
-                                  on this file. Must be an octal value between 0000
-                                  and 0777 or a decimal value between 0 and 511. YAML
-                                  accepts both octal and decimal values, JSON requires
-                                  decimal values for mode bits. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
+                                description: 'mode is Optional: mode bits used to
+                                  set permissions on this file. Must be an octal value
+                                  between 0000 and 0777 or a decimal value between
+                                  0 and 511. YAML accepts both octal and decimal values,
+                                  JSON requires decimal values for mode bits. If not
+                                  specified, the volume defaultMode will be used.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
                                 format: int32
                                 type: integer
                               path:
-                                description: The relative path of the file to map
-                                  the key to. May not be an absolute path. May not
-                                  contain the path element '..'. May not start with
-                                  the string '..'.
+                                description: path is the relative path of the file
+                                  to map the key to. May not be an absolute path.
+                                  May not contain the path element '..'. May not start
+                                  with the string '..'.
                                 type: string
                             required:
                             - key
@@ -7001,29 +7050,30 @@ spec:
                             type: object
                           type: array
                         optional:
-                          description: Specify whether the Secret or its keys must
-                            be defined
+                          description: optional field specify whether the Secret or
+                            its keys must be defined
                           type: boolean
                         secretName:
-                          description: 'Name of the secret in the pod''s namespace
-                            to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                          description: 'secretName is the name of the secret in the
+                            pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                           type: string
                       type: object
                     storageos:
-                      description: StorageOS represents a StorageOS volume attached
+                      description: storageOS represents a StorageOS volume attached
                         and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          description: fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
                           type: string
                         readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
+                          description: readOnly defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: SecretRef specifies the secret to use for obtaining
+                          description: secretRef specifies the secret to use for obtaining
                             the StorageOS API credentials.  If not specified, default
                             values will be attempted.
                           properties:
@@ -7033,12 +7083,12 @@ spec:
                               type: string
                           type: object
                         volumeName:
-                          description: VolumeName is the human-readable name of the
+                          description: volumeName is the human-readable name of the
                             StorageOS volume.  Volume names are only unique within
                             a namespace.
                           type: string
                         volumeNamespace:
-                          description: VolumeNamespace specifies the scope of the
+                          description: volumeNamespace specifies the scope of the
                             volume within StorageOS.  If no namespace is specified
                             then the Pod's namespace will be used.  This allows the
                             Kubernetes name scoping to be mirrored within StorageOS
@@ -7049,24 +7099,26 @@ spec:
                           type: string
                       type: object
                     vsphereVolume:
-                      description: VsphereVolume represents a vSphere volume attached
+                      description: vsphereVolume represents a vSphere volume attached
                         and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          description: fsType is filesystem type to mount. Must be
+                            a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
                           type: string
                         storagePolicyID:
-                          description: Storage Policy Based Management (SPBM) profile
-                            ID associated with the StoragePolicyName.
+                          description: storagePolicyID is the storage Policy Based
+                            Management (SPBM) profile ID associated with the StoragePolicyName.
                           type: string
                         storagePolicyName:
-                          description: Storage Policy Based Management (SPBM) profile
-                            name.
+                          description: storagePolicyName is the storage Policy Based
+                            Management (SPBM) profile name.
                           type: string
                         volumePath:
-                          description: Path that identifies vSphere volume vmdk
+                          description: volumePath is the path that identifies vSphere
+                            volume vmdk
                           type: string
                       required:
                       - volumePath

--- a/production/operator/crds/monitoring.grafana.com_grafanaagents.yaml
+++ b/production/operator/crds/monitoring.grafana.com_grafanaagents.yaml
@@ -2310,6 +2310,7 @@ spec:
                   type: object
                 type: array
               disableReporting:
+                default: false
                 description: disableReporting disable reporting of enabled feature
                   flags to Grafana.
                 type: boolean

--- a/production/operator/crds/monitoring.grafana.com_integrations.yaml
+++ b/production/operator/crds/monitoring.grafana.com_integrations.yaml
@@ -174,117 +174,121 @@ spec:
                     be accessed by any container in the pod.
                   properties:
                     awsElasticBlockStore:
-                      description: 'AWSElasticBlockStore represents an AWS Disk resource
+                      description: 'awsElasticBlockStore represents an AWS Disk resource
                         that is attached to a kubelet''s host machine and then exposed
                         to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                       properties:
                         fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          description: 'fsType is the filesystem type of the volume
+                            that you want to mount. Tip: Ensure that the filesystem
+                            type is supported by the host operating system. Examples:
+                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                             TODO: how do we prevent errors in the filesystem from
                             compromising the machine'
                           type: string
                         partition:
-                          description: 'The partition in the volume that you want
-                            to mount. If omitted, the default is to mount by volume
-                            name. Examples: For volume /dev/sda1, you specify the
-                            partition as "1". Similarly, the volume partition for
-                            /dev/sda is "0" (or you can leave the property empty).'
+                          description: 'partition is the partition in the volume that
+                            you want to mount. If omitted, the default is to mount
+                            by volume name. Examples: For volume /dev/sda1, you specify
+                            the partition as "1". Similarly, the volume partition
+                            for /dev/sda is "0" (or you can leave the property empty).'
                           format: int32
                           type: integer
                         readOnly:
-                          description: 'Specify "true" to force and set the ReadOnly
-                            property in VolumeMounts to "true". If omitted, the default
-                            is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          description: 'readOnly value true will force the readOnly
+                            setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                           type: boolean
                         volumeID:
-                          description: 'Unique ID of the persistent disk resource
-                            in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          description: 'volumeID is unique ID of the persistent disk
+                            resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                           type: string
                       required:
                       - volumeID
                       type: object
                     azureDisk:
-                      description: AzureDisk represents an Azure Data Disk mount on
+                      description: azureDisk represents an Azure Data Disk mount on
                         the host and bind mount to the pod.
                       properties:
                         cachingMode:
-                          description: 'Host Caching mode: None, Read Only, Read Write.'
+                          description: 'cachingMode is the Host Caching mode: None,
+                            Read Only, Read Write.'
                           type: string
                         diskName:
-                          description: The Name of the data disk in the blob storage
+                          description: diskName is the Name of the data disk in the
+                            blob storage
                           type: string
                         diskURI:
-                          description: The URI the data disk in the blob storage
+                          description: diskURI is the URI of data disk in the blob
+                            storage
                           type: string
                         fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          description: fsType is Filesystem type to mount. Must be
+                            a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
                           type: string
                         kind:
-                          description: 'Expected values Shared: multiple blob disks
-                            per storage account  Dedicated: single blob disk per storage
-                            account  Managed: azure managed data disk (only in managed
-                            availability set). defaults to shared'
+                          description: 'kind expected values are Shared: multiple
+                            blob disks per storage account  Dedicated: single blob
+                            disk per storage account  Managed: azure managed data
+                            disk (only in managed availability set). defaults to shared'
                           type: string
                         readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
+                          description: readOnly Defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                       required:
                       - diskName
                       - diskURI
                       type: object
                     azureFile:
-                      description: AzureFile represents an Azure File Service mount
+                      description: azureFile represents an Azure File Service mount
                         on the host and bind mount to the pod.
                       properties:
                         readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
+                          description: readOnly defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretName:
-                          description: the name of secret that contains Azure Storage
-                            Account Name and Key
+                          description: secretName is the  name of secret that contains
+                            Azure Storage Account Name and Key
                           type: string
                         shareName:
-                          description: Share Name
+                          description: shareName is the azure share Name
                           type: string
                       required:
                       - secretName
                       - shareName
                       type: object
                     cephfs:
-                      description: CephFS represents a Ceph FS mount on the host that
+                      description: cephFS represents a Ceph FS mount on the host that
                         shares a pod's lifetime
                       properties:
                         monitors:
-                          description: 'Required: Monitors is a collection of Ceph
-                            monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          description: 'monitors is Required: Monitors is a collection
+                            of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           items:
                             type: string
                           type: array
                         path:
-                          description: 'Optional: Used as the mounted root, rather
-                            than the full Ceph tree, default is /'
+                          description: 'path is Optional: Used as the mounted root,
+                            rather than the full Ceph tree, default is /'
                           type: string
                         readOnly:
-                          description: 'Optional: Defaults to false (read/write).
+                          description: 'readOnly is Optional: Defaults to false (read/write).
                             ReadOnly here will force the ReadOnly setting in VolumeMounts.
                             More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           type: boolean
                         secretFile:
-                          description: 'Optional: SecretFile is the path to key ring
-                            for User, default is /etc/ceph/user.secret More info:
-                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          description: 'secretFile is Optional: SecretFile is the
+                            path to key ring for User, default is /etc/ceph/user.secret
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           type: string
                         secretRef:
-                          description: 'Optional: SecretRef is reference to the authentication
-                            secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          description: 'secretRef is Optional: SecretRef is reference
+                            to the authentication secret for User, default is empty.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           properties:
                             name:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -292,30 +296,30 @@ spec:
                               type: string
                           type: object
                         user:
-                          description: 'Optional: User is the rados user name, default
-                            is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          description: 'user is optional: User is the rados user name,
+                            default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           type: string
                       required:
                       - monitors
                       type: object
                     cinder:
-                      description: 'Cinder represents a cinder volume attached and
+                      description: 'cinder represents a cinder volume attached and
                         mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                       properties:
                         fsType:
-                          description: 'Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          description: 'fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to
+                            be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                           type: string
                         readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                          description: 'readOnly defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
                             More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                           type: boolean
                         secretRef:
-                          description: 'Optional: points to a secret object containing
-                            parameters used to connect to OpenStack.'
+                          description: 'secretRef is optional: points to a secret
+                            object containing parameters used to connect to OpenStack.'
                           properties:
                             name:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -323,31 +327,31 @@ spec:
                               type: string
                           type: object
                         volumeID:
-                          description: 'volume id used to identify the volume in cinder.
+                          description: 'volumeID used to identify the volume in cinder.
                             More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                           type: string
                       required:
                       - volumeID
                       type: object
                     configMap:
-                      description: ConfigMap represents a configMap that should populate
+                      description: configMap represents a configMap that should populate
                         this volume
                       properties:
                         defaultMode:
-                          description: 'Optional: mode bits used to set permissions
-                            on created files by default. Must be an octal value between
-                            0000 and 0777 or a decimal value between 0 and 511. YAML
-                            accepts both octal and decimal values, JSON requires decimal
-                            values for mode bits. Defaults to 0644. Directories within
-                            the path are not affected by this setting. This might
-                            be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits
-                            set.'
+                          description: 'defaultMode is optional: mode bits used to
+                            set permissions on created files by default. Must be an
+                            octal value between 0000 and 0777 or a decimal value between
+                            0 and 511. YAML accepts both octal and decimal values,
+                            JSON requires decimal values for mode bits. Defaults to
+                            0644. Directories within the path are not affected by
+                            this setting. This might be in conflict with other options
+                            that affect the file mode, like fsGroup, and the result
+                            can be other mode bits set.'
                           format: int32
                           type: integer
                         items:
-                          description: If unspecified, each key-value pair in the
-                            Data field of the referenced ConfigMap will be projected
+                          description: items if unspecified, each key-value pair in
+                            the Data field of the referenced ConfigMap will be projected
                             into the volume as a file whose name is the key and content
                             is the value. If specified, the listed keys will be projected
                             into the specified paths, and unlisted keys will not be
@@ -359,25 +363,25 @@ spec:
                             description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: The key to project.
+                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: 'Optional: mode bits used to set permissions
-                                  on this file. Must be an octal value between 0000
-                                  and 0777 or a decimal value between 0 and 511. YAML
-                                  accepts both octal and decimal values, JSON requires
-                                  decimal values for mode bits. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
+                                description: 'mode is Optional: mode bits used to
+                                  set permissions on this file. Must be an octal value
+                                  between 0000 and 0777 or a decimal value between
+                                  0 and 511. YAML accepts both octal and decimal values,
+                                  JSON requires decimal values for mode bits. If not
+                                  specified, the volume defaultMode will be used.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
                                 format: int32
                                 type: integer
                               path:
-                                description: The relative path of the file to map
-                                  the key to. May not be an absolute path. May not
-                                  contain the path element '..'. May not start with
-                                  the string '..'.
+                                description: path is the relative path of the file
+                                  to map the key to. May not be an absolute path.
+                                  May not contain the path element '..'. May not start
+                                  with the string '..'.
                                 type: string
                             required:
                             - key
@@ -389,28 +393,28 @@ spec:
                             TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                         optional:
-                          description: Specify whether the ConfigMap or its keys must
-                            be defined
+                          description: optional specify whether the ConfigMap or its
+                            keys must be defined
                           type: boolean
                       type: object
                     csi:
-                      description: CSI (Container Storage Interface) represents ephemeral
+                      description: csi (Container Storage Interface) represents ephemeral
                         storage that is handled by certain external CSI drivers (Beta
                         feature).
                       properties:
                         driver:
-                          description: Driver is the name of the CSI driver that handles
+                          description: driver is the name of the CSI driver that handles
                             this volume. Consult with your admin for the correct name
                             as registered in the cluster.
                           type: string
                         fsType:
-                          description: Filesystem type to mount. Ex. "ext4", "xfs",
-                            "ntfs". If not provided, the empty value is passed to
-                            the associated CSI driver which will determine the default
-                            filesystem to apply.
+                          description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                            If not provided, the empty value is passed to the associated
+                            CSI driver which will determine the default filesystem
+                            to apply.
                           type: string
                         nodePublishSecretRef:
-                          description: NodePublishSecretRef is a reference to the
+                          description: nodePublishSecretRef is a reference to the
                             secret object containing sensitive information to pass
                             to the CSI driver to complete the CSI NodePublishVolume
                             and NodeUnpublishVolume calls. This field is optional,
@@ -424,13 +428,13 @@ spec:
                               type: string
                           type: object
                         readOnly:
-                          description: Specifies a read-only configuration for the
-                            volume. Defaults to false (read/write).
+                          description: readOnly specifies a read-only configuration
+                            for the volume. Defaults to false (read/write).
                           type: boolean
                         volumeAttributes:
                           additionalProperties:
                             type: string
-                          description: VolumeAttributes stores driver-specific properties
+                          description: volumeAttributes stores driver-specific properties
                             that are passed to the CSI driver. Consult your driver's
                             documentation for supported values.
                           type: object
@@ -438,7 +442,7 @@ spec:
                       - driver
                       type: object
                     downwardAPI:
-                      description: DownwardAPI represents downward API about the pod
+                      description: downwardAPI represents downward API about the pod
                         that should populate this volume
                       properties:
                         defaultMode:
@@ -525,31 +529,31 @@ spec:
                           type: array
                       type: object
                     emptyDir:
-                      description: 'EmptyDir represents a temporary directory that
+                      description: 'emptyDir represents a temporary directory that
                         shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                       properties:
                         medium:
-                          description: 'What type of storage medium should back this
-                            directory. The default is "" which means to use the node''s
-                            default medium. Must be an empty string (default) or Memory.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                          description: 'medium represents what type of storage medium
+                            should back this directory. The default is "" which means
+                            to use the node''s default medium. Must be an empty string
+                            (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: 'Total amount of local storage required for
-                            this EmptyDir volume. The size limit is also applicable
-                            for memory medium. The maximum usage on memory medium
-                            EmptyDir would be the minimum value between the SizeLimit
-                            specified here and the sum of memory limits of all containers
-                            in a pod. The default is nil which means that the limit
-                            is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                          description: 'sizeLimit is the total amount of local storage
+                            required for this EmptyDir volume. The size limit is also
+                            applicable for memory medium. The maximum usage on memory
+                            medium EmptyDir would be the minimum value between the
+                            SizeLimit specified here and the sum of memory limits
+                            of all containers in a pod. The default is nil which means
+                            that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
-                      description: "Ephemeral represents a volume that is handled
+                      description: "ephemeral represents a volume that is handled
                         by a cluster storage driver. The volume's lifecycle is tied
                         to the pod that defines it - it will be created before the
                         pod starts, and deleted when the pod is removed. \n Use this
@@ -600,13 +604,13 @@ spec:
                                 as in a PersistentVolumeClaim are also valid here.
                               properties:
                                 accessModes:
-                                  description: 'AccessModes contains the desired access
+                                  description: 'accessModes contains the desired access
                                     modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                   items:
                                     type: string
                                   type: array
                                 dataSource:
-                                  description: 'This field can be used to specify
+                                  description: 'dataSource field can be used to specify
                                     either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                     * An existing PVC (PersistentVolumeClaim) If the
                                     provisioner or an external controller can support
@@ -636,14 +640,14 @@ spec:
                                   - name
                                   type: object
                                 dataSourceRef:
-                                  description: 'Specifies the object from which to
-                                    populate the volume with data, if a non-empty
-                                    volume is desired. This may be any local object
-                                    from a non-empty API group (non core object) or
-                                    a PersistentVolumeClaim object. When this field
-                                    is specified, volume binding will only succeed
-                                    if the type of the specified object matches some
-                                    installed volume populator or dynamic provisioner.
+                                  description: 'dataSourceRef specifies the object
+                                    from which to populate the volume with data, if
+                                    a non-empty volume is desired. This may be any
+                                    local object from a non-empty API group (non core
+                                    object) or a PersistentVolumeClaim object. When
+                                    this field is specified, volume binding will only
+                                    succeed if the type of the specified object matches
+                                    some installed volume populator or dynamic provisioner.
                                     This field will replace the functionality of the
                                     DataSource field and as such if both fields are
                                     non-empty, they must have the same value. For
@@ -657,7 +661,7 @@ spec:
                                     as PersistentVolumeClaim objects. * While DataSource
                                     ignores disallowed values (dropping them), DataSourceRef
                                     preserves all values, and generates an error if
-                                    a disallowed value is specified. (Alpha) Using
+                                    a disallowed value is specified. (Beta) Using
                                     this field requires the AnyVolumeDataSource feature
                                     gate to be enabled.'
                                   properties:
@@ -681,7 +685,7 @@ spec:
                                   - name
                                   type: object
                                 resources:
-                                  description: 'Resources represents the minimum resources
+                                  description: 'resources represents the minimum resources
                                     the volume should have. If RecoverVolumeExpansionFailure
                                     feature is enabled users are allowed to specify
                                     resource requirements that are lower than previous
@@ -714,8 +718,8 @@ spec:
                                       type: object
                                   type: object
                                 selector:
-                                  description: A label query over volumes to consider
-                                    for binding.
+                                  description: selector is a label query over volumes
+                                    to consider for binding.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -765,8 +769,9 @@ spec:
                                       type: object
                                   type: object
                                 storageClassName:
-                                  description: 'Name of the StorageClass required
-                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                  description: 'storageClassName is the name of the
+                                    StorageClass required by the claim. More info:
+                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                   type: string
                                 volumeMode:
                                   description: volumeMode defines what type of volume
@@ -774,7 +779,7 @@ spec:
                                     is implied when not included in claim spec.
                                   type: string
                                 volumeName:
-                                  description: VolumeName is the binding reference
+                                  description: volumeName is the binding reference
                                     to the PersistentVolume backing this claim.
                                   type: string
                               type: object
@@ -783,32 +788,33 @@ spec:
                           type: object
                       type: object
                     fc:
-                      description: FC represents a Fibre Channel resource that is
+                      description: fc represents a Fibre Channel resource that is
                         attached to a kubelet's host machine and then exposed to the
                         pod.
                       properties:
                         fsType:
-                          description: 'Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
+                          description: 'fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified. TODO: how do we prevent errors in the
+                            filesystem from compromising the machine'
                           type: string
                         lun:
-                          description: 'Optional: FC target lun number'
+                          description: 'lun is Optional: FC target lun number'
                           format: int32
                           type: integer
                         readOnly:
-                          description: 'Optional: Defaults to false (read/write).
+                          description: 'readOnly is Optional: Defaults to false (read/write).
                             ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                           type: boolean
                         targetWWNs:
-                          description: 'Optional: FC target worldwide names (WWNs)'
+                          description: 'targetWWNs is Optional: FC target worldwide
+                            names (WWNs)'
                           items:
                             type: string
                           type: array
                         wwids:
-                          description: 'Optional: FC volume world wide identifiers
+                          description: 'wwids Optional: FC volume world wide identifiers
                             (wwids) Either wwids or combination of targetWWNs and
                             lun must be set, but not both simultaneously.'
                           items:
@@ -816,34 +822,36 @@ spec:
                           type: array
                       type: object
                     flexVolume:
-                      description: FlexVolume represents a generic volume resource
+                      description: flexVolume represents a generic volume resource
                         that is provisioned/attached using an exec based plugin.
                       properties:
                         driver:
-                          description: Driver is the name of the driver to use for
+                          description: driver is the name of the driver to use for
                             this volume.
                           type: string
                         fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". The default filesystem depends on FlexVolume
-                            script.
+                          description: fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends
+                            on FlexVolume script.
                           type: string
                         options:
                           additionalProperties:
                             type: string
-                          description: 'Optional: Extra command options if any.'
+                          description: 'options is Optional: this field holds extra
+                            command options if any.'
                           type: object
                         readOnly:
-                          description: 'Optional: Defaults to false (read/write).
+                          description: 'readOnly is Optional: defaults to false (read/write).
                             ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                           type: boolean
                         secretRef:
-                          description: 'Optional: SecretRef is reference to the secret
-                            object containing sensitive information to pass to the
-                            plugin scripts. This may be empty if no secret object
-                            is specified. If the secret object contains more than
-                            one secret, all secrets are passed to the plugin scripts.'
+                          description: 'secretRef is Optional: secretRef is reference
+                            to the secret object containing sensitive information
+                            to pass to the plugin scripts. This may be empty if no
+                            secret object is specified. If the secret object contains
+                            more than one secret, all secrets are passed to the plugin
+                            scripts.'
                           properties:
                             name:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -854,90 +862,92 @@ spec:
                       - driver
                       type: object
                     flocker:
-                      description: Flocker represents a Flocker volume attached to
+                      description: flocker represents a Flocker volume attached to
                         a kubelet's host machine. This depends on the Flocker control
                         service being running
                       properties:
                         datasetName:
-                          description: Name of the dataset stored as metadata -> name
-                            on the dataset for Flocker should be considered as deprecated
+                          description: datasetName is Name of the dataset stored as
+                            metadata -> name on the dataset for Flocker should be
+                            considered as deprecated
                           type: string
                         datasetUUID:
-                          description: UUID of the dataset. This is unique identifier
-                            of a Flocker dataset
+                          description: datasetUUID is the UUID of the dataset. This
+                            is unique identifier of a Flocker dataset
                           type: string
                       type: object
                     gcePersistentDisk:
-                      description: 'GCEPersistentDisk represents a GCE Disk resource
+                      description: 'gcePersistentDisk represents a GCE Disk resource
                         that is attached to a kubelet''s host machine and then exposed
                         to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                       properties:
                         fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          description: 'fsType is filesystem type of the volume that
+                            you want to mount. Tip: Ensure that the filesystem type
+                            is supported by the host operating system. Examples: "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                             More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                             TODO: how do we prevent errors in the filesystem from
                             compromising the machine'
                           type: string
                         partition:
-                          description: 'The partition in the volume that you want
-                            to mount. If omitted, the default is to mount by volume
-                            name. Examples: For volume /dev/sda1, you specify the
-                            partition as "1". Similarly, the volume partition for
-                            /dev/sda is "0" (or you can leave the property empty).
+                          description: 'partition is the partition in the volume that
+                            you want to mount. If omitted, the default is to mount
+                            by volume name. Examples: For volume /dev/sda1, you specify
+                            the partition as "1". Similarly, the volume partition
+                            for /dev/sda is "0" (or you can leave the property empty).
                             More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                           format: int32
                           type: integer
                         pdName:
-                          description: 'Unique name of the PD resource in GCE. Used
-                            to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          description: 'pdName is unique name of the PD resource in
+                            GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                           type: string
                         readOnly:
-                          description: 'ReadOnly here will force the ReadOnly setting
+                          description: 'readOnly here will force the ReadOnly setting
                             in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                           type: boolean
                       required:
                       - pdName
                       type: object
                     gitRepo:
-                      description: 'GitRepo represents a git repository at a particular
+                      description: 'gitRepo represents a git repository at a particular
                         revision. DEPRECATED: GitRepo is deprecated. To provision
                         a container with a git repo, mount an EmptyDir into an InitContainer
                         that clones the repo using git, then mount the EmptyDir into
                         the Pod''s container.'
                       properties:
                         directory:
-                          description: Target directory name. Must not contain or
-                            start with '..'.  If '.' is supplied, the volume directory
-                            will be the git repository.  Otherwise, if specified,
-                            the volume will contain the git repository in the subdirectory
-                            with the given name.
+                          description: directory is the target directory name. Must
+                            not contain or start with '..'.  If '.' is supplied, the
+                            volume directory will be the git repository.  Otherwise,
+                            if specified, the volume will contain the git repository
+                            in the subdirectory with the given name.
                           type: string
                         repository:
-                          description: Repository URL
+                          description: repository is the URL
                           type: string
                         revision:
-                          description: Commit hash for the specified revision.
+                          description: revision is the commit hash for the specified
+                            revision.
                           type: string
                       required:
                       - repository
                       type: object
                     glusterfs:
-                      description: 'Glusterfs represents a Glusterfs mount on the
+                      description: 'glusterfs represents a Glusterfs mount on the
                         host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                       properties:
                         endpoints:
-                          description: 'EndpointsName is the endpoint name that details
+                          description: 'endpoints is the endpoint name that details
                             Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                           type: string
                         path:
-                          description: 'Path is the Glusterfs volume path. More info:
+                          description: 'path is the Glusterfs volume path. More info:
                             https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                           type: string
                         readOnly:
-                          description: 'ReadOnly here will force the Glusterfs volume
+                          description: 'readOnly here will force the Glusterfs volume
                             to be mounted with read-only permissions. Defaults to
                             false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                           type: boolean
@@ -946,7 +956,7 @@ spec:
                       - path
                       type: object
                     hostPath:
-                      description: 'HostPath represents a pre-existing file or directory
+                      description: 'hostPath represents a pre-existing file or directory
                         on the host machine that is directly exposed to the container.
                         This is generally used for system agents or other privileged
                         things that are allowed to see the host machine. Most containers
@@ -955,68 +965,70 @@ spec:
                         mounts and who can/can not mount host directories as read/write.'
                       properties:
                         path:
-                          description: 'Path of the directory on the host. If the
+                          description: 'path of the directory on the host. If the
                             path is a symlink, it will follow the link to the real
                             path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                           type: string
                         type:
-                          description: 'Type for HostPath Volume Defaults to "" More
+                          description: 'type for HostPath Volume Defaults to "" More
                             info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                           type: string
                       required:
                       - path
                       type: object
                     iscsi:
-                      description: 'ISCSI represents an ISCSI Disk resource that is
+                      description: 'iscsi represents an ISCSI Disk resource that is
                         attached to a kubelet''s host machine and then exposed to
                         the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                       properties:
                         chapAuthDiscovery:
-                          description: whether support iSCSI Discovery CHAP authentication
+                          description: chapAuthDiscovery defines whether support iSCSI
+                            Discovery CHAP authentication
                           type: boolean
                         chapAuthSession:
-                          description: whether support iSCSI Session CHAP authentication
+                          description: chapAuthSession defines whether support iSCSI
+                            Session CHAP authentication
                           type: boolean
                         fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                          description: 'fsType is the filesystem type of the volume
+                            that you want to mount. Tip: Ensure that the filesystem
+                            type is supported by the host operating system. Examples:
+                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
                             TODO: how do we prevent errors in the filesystem from
                             compromising the machine'
                           type: string
                         initiatorName:
-                          description: Custom iSCSI Initiator Name. If initiatorName
-                            is specified with iscsiInterface simultaneously, new iSCSI
-                            interface <target portal>:<volume name> will be created
-                            for the connection.
+                          description: initiatorName is the custom iSCSI Initiator
+                            Name. If initiatorName is specified with iscsiInterface
+                            simultaneously, new iSCSI interface <target portal>:<volume
+                            name> will be created for the connection.
                           type: string
                         iqn:
-                          description: Target iSCSI Qualified Name.
+                          description: iqn is the target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
-                          description: iSCSI Interface Name that uses an iSCSI transport.
-                            Defaults to 'default' (tcp).
+                          description: iscsiInterface is the interface Name that uses
+                            an iSCSI transport. Defaults to 'default' (tcp).
                           type: string
                         lun:
-                          description: iSCSI Target Lun number.
+                          description: lun represents iSCSI Target Lun number.
                           format: int32
                           type: integer
                         portals:
-                          description: iSCSI Target Portal List. The portal is either
-                            an IP or ip_addr:port if the port is other than default
-                            (typically TCP ports 860 and 3260).
+                          description: portals is the iSCSI Target Portal List. The
+                            portal is either an IP or ip_addr:port if the port is
+                            other than default (typically TCP ports 860 and 3260).
                           items:
                             type: string
                           type: array
                         readOnly:
-                          description: ReadOnly here will force the ReadOnly setting
+                          description: readOnly here will force the ReadOnly setting
                             in VolumeMounts. Defaults to false.
                           type: boolean
                         secretRef:
-                          description: CHAP Secret for iSCSI target and initiator
-                            authentication
+                          description: secretRef is the CHAP Secret for iSCSI target
+                            and initiator authentication
                           properties:
                             name:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -1024,9 +1036,9 @@ spec:
                               type: string
                           type: object
                         targetPortal:
-                          description: iSCSI Target Portal. The Portal is either an
-                            IP or ip_addr:port if the port is other than default (typically
-                            TCP ports 860 and 3260).
+                          description: targetPortal is iSCSI Target Portal. The Portal
+                            is either an IP or ip_addr:port if the port is other than
+                            default (typically TCP ports 860 and 3260).
                           type: string
                       required:
                       - iqn
@@ -1034,24 +1046,24 @@ spec:
                       - targetPortal
                       type: object
                     name:
-                      description: 'Volume''s name. Must be a DNS_LABEL and unique
+                      description: 'name of the volume. Must be a DNS_LABEL and unique
                         within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
                     nfs:
-                      description: 'NFS represents an NFS mount on the host that shares
+                      description: 'nfs represents an NFS mount on the host that shares
                         a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                       properties:
                         path:
-                          description: 'Path that is exported by the NFS server. More
+                          description: 'path that is exported by the NFS server. More
                             info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                           type: string
                         readOnly:
-                          description: 'ReadOnly here will force the NFS export to
+                          description: 'readOnly here will force the NFS export to
                             be mounted with read-only permissions. Defaults to false.
                             More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                           type: boolean
                         server:
-                          description: 'Server is the hostname or IP address of the
+                          description: 'server is the hostname or IP address of the
                             NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                           type: string
                       required:
@@ -1059,86 +1071,87 @@ spec:
                       - server
                       type: object
                     persistentVolumeClaim:
-                      description: 'PersistentVolumeClaimVolumeSource represents a
+                      description: 'persistentVolumeClaimVolumeSource represents a
                         reference to a PersistentVolumeClaim in the same namespace.
                         More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                       properties:
                         claimName:
-                          description: 'ClaimName is the name of a PersistentVolumeClaim
+                          description: 'claimName is the name of a PersistentVolumeClaim
                             in the same namespace as the pod using this volume. More
                             info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                           type: string
                         readOnly:
-                          description: Will force the ReadOnly setting in VolumeMounts.
-                            Default false.
+                          description: readOnly Will force the ReadOnly setting in
+                            VolumeMounts. Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     photonPersistentDisk:
-                      description: PhotonPersistentDisk represents a PhotonController
+                      description: photonPersistentDisk represents a PhotonController
                         persistent disk attached and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          description: fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
                           type: string
                         pdID:
-                          description: ID that identifies Photon Controller persistent
-                            disk
+                          description: pdID is the ID that identifies Photon Controller
+                            persistent disk
                           type: string
                       required:
                       - pdID
                       type: object
                     portworxVolume:
-                      description: PortworxVolume represents a portworx volume attached
+                      description: portworxVolume represents a portworx volume attached
                         and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: FSType represents the filesystem type to mount
+                          description: fSType represents the filesystem type to mount
                             Must be a filesystem type supported by the host operating
                             system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
                             if unspecified.
                           type: string
                         readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
+                          description: readOnly defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                         volumeID:
-                          description: VolumeID uniquely identifies a Portworx volume
+                          description: volumeID uniquely identifies a Portworx volume
                           type: string
                       required:
                       - volumeID
                       type: object
                     projected:
-                      description: Items for all in one resources secrets, configmaps,
-                        and downward API
+                      description: projected items for all in one resources secrets,
+                        configmaps, and downward API
                       properties:
                         defaultMode:
-                          description: Mode bits used to set permissions on created
-                            files by default. Must be an octal value between 0000
-                            and 0777 or a decimal value between 0 and 511. YAML accepts
-                            both octal and decimal values, JSON requires decimal values
-                            for mode bits. Directories within the path are not affected
-                            by this setting. This might be in conflict with other
-                            options that affect the file mode, like fsGroup, and the
-                            result can be other mode bits set.
+                          description: defaultMode are the mode bits used to set permissions
+                            on created files by default. Must be an octal value between
+                            0000 and 0777 or a decimal value between 0 and 511. YAML
+                            accepts both octal and decimal values, JSON requires decimal
+                            values for mode bits. Directories within the path are
+                            not affected by this setting. This might be in conflict
+                            with other options that affect the file mode, like fsGroup,
+                            and the result can be other mode bits set.
                           format: int32
                           type: integer
                         sources:
-                          description: list of volume projections
+                          description: sources is the list of volume projections
                           items:
                             description: Projection that may be projected along with
                               other supported volume types
                             properties:
                               configMap:
-                                description: information about the configMap data
-                                  to project
+                                description: configMap information about the configMap
+                                  data to project
                                 properties:
                                   items:
-                                    description: If unspecified, each key-value pair
-                                      in the Data field of the referenced ConfigMap
+                                    description: items if unspecified, each key-value
+                                      pair in the Data field of the referenced ConfigMap
                                       will be projected into the volume as a file
                                       whose name is the key and content is the value.
                                       If specified, the listed keys will be projected
@@ -1153,27 +1166,28 @@ spec:
                                         a volume.
                                       properties:
                                         key:
-                                          description: The key to project.
+                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'Optional: mode bits used to
-                                            set permissions on this file. Must be
-                                            an octal value between 0000 and 0777 or
-                                            a decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. If not specified, the volume defaultMode
-                                            will be used. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511. YAML accepts both octal and decimal
+                                            values, JSON requires decimal values for
+                                            mode bits. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
                                           format: int32
                                           type: integer
                                         path:
-                                          description: The relative path of the file
-                                            to map the key to. May not be an absolute
-                                            path. May not contain the path element
-                                            '..'. May not start with the string '..'.
+                                          description: path is the relative path of
+                                            the file to map the key to. May not be
+                                            an absolute path. May not contain the
+                                            path element '..'. May not start with
+                                            the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -1187,13 +1201,13 @@ spec:
                                       uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or
-                                      its keys must be defined
+                                    description: optional specify whether the ConfigMap
+                                      or its keys must be defined
                                     type: boolean
                                 type: object
                               downwardAPI:
-                                description: information about the downwardAPI data
-                                  to project
+                                description: downwardAPI information about the downwardAPI
+                                  data to project
                                 properties:
                                   items:
                                     description: Items is a list of DownwardAPIVolume
@@ -1274,15 +1288,15 @@ spec:
                                     type: array
                                 type: object
                               secret:
-                                description: information about the secret data to
-                                  project
+                                description: secret information about the secret data
+                                  to project
                                 properties:
                                   items:
-                                    description: If unspecified, each key-value pair
-                                      in the Data field of the referenced Secret will
-                                      be projected into the volume as a file whose
-                                      name is the key and content is the value. If
-                                      specified, the listed keys will be projected
+                                    description: items if unspecified, each key-value
+                                      pair in the Data field of the referenced Secret
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
                                       into the specified paths, and unlisted keys
                                       will not be present. If a key is specified which
                                       is not present in the Secret, the volume setup
@@ -1294,27 +1308,28 @@ spec:
                                         a volume.
                                       properties:
                                         key:
-                                          description: The key to project.
+                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'Optional: mode bits used to
-                                            set permissions on this file. Must be
-                                            an octal value between 0000 and 0777 or
-                                            a decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. If not specified, the volume defaultMode
-                                            will be used. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511. YAML accepts both octal and decimal
+                                            values, JSON requires decimal values for
+                                            mode bits. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
                                           format: int32
                                           type: integer
                                         path:
-                                          description: The relative path of the file
-                                            to map the key to. May not be an absolute
-                                            path. May not contain the path element
-                                            '..'. May not start with the string '..'.
+                                          description: path is the relative path of
+                                            the file to map the key to. May not be
+                                            an absolute path. May not contain the
+                                            path element '..'. May not start with
+                                            the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -1328,16 +1343,16 @@ spec:
                                       uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
+                                    description: optional field specify whether the
+                                      Secret or its key must be defined
                                     type: boolean
                                 type: object
                               serviceAccountToken:
-                                description: information about the serviceAccountToken
-                                  data to project
+                                description: serviceAccountToken is information about
+                                  the serviceAccountToken data to project
                                 properties:
                                   audience:
-                                    description: Audience is the intended audience
+                                    description: audience is the intended audience
                                       of the token. A recipient of a token must identify
                                       itself with an identifier specified in the audience
                                       of the token, and otherwise should reject the
@@ -1345,7 +1360,7 @@ spec:
                                       of the apiserver.
                                     type: string
                                   expirationSeconds:
-                                    description: ExpirationSeconds is the requested
+                                    description: expirationSeconds is the requested
                                       duration of validity of the service account
                                       token. As the token approaches expiration, the
                                       kubelet volume plugin will proactively rotate
@@ -1357,7 +1372,7 @@ spec:
                                     format: int64
                                     type: integer
                                   path:
-                                    description: Path is the path relative to the
+                                    description: path is the path relative to the
                                       mount point of the file to project the token
                                       into.
                                     type: string
@@ -1368,35 +1383,35 @@ spec:
                           type: array
                       type: object
                     quobyte:
-                      description: Quobyte represents a Quobyte mount on the host
+                      description: quobyte represents a Quobyte mount on the host
                         that shares a pod's lifetime
                       properties:
                         group:
-                          description: Group to map volume access to Default is no
+                          description: group to map volume access to Default is no
                             group
                           type: string
                         readOnly:
-                          description: ReadOnly here will force the Quobyte volume
+                          description: readOnly here will force the Quobyte volume
                             to be mounted with read-only permissions. Defaults to
                             false.
                           type: boolean
                         registry:
-                          description: Registry represents a single or multiple Quobyte
+                          description: registry represents a single or multiple Quobyte
                             Registry services specified as a string as host:port pair
                             (multiple entries are separated with commas) which acts
                             as the central registry for volumes
                           type: string
                         tenant:
-                          description: Tenant owning the given Quobyte volume in the
+                          description: tenant owning the given Quobyte volume in the
                             Backend Used with dynamically provisioned Quobyte volumes,
                             value is set by the plugin
                           type: string
                         user:
-                          description: User to map volume access to Defaults to serivceaccount
+                          description: user to map volume access to Defaults to serivceaccount
                             user
                           type: string
                         volume:
-                          description: Volume is a string that references an already
+                          description: volume is a string that references an already
                             created Quobyte volume by name.
                           type: string
                       required:
@@ -1404,41 +1419,42 @@ spec:
                       - volume
                       type: object
                     rbd:
-                      description: 'RBD represents a Rados Block Device mount on the
+                      description: 'rbd represents a Rados Block Device mount on the
                         host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                       properties:
                         fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                          description: 'fsType is the filesystem type of the volume
+                            that you want to mount. Tip: Ensure that the filesystem
+                            type is supported by the host operating system. Examples:
+                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
                             TODO: how do we prevent errors in the filesystem from
                             compromising the machine'
                           type: string
                         image:
-                          description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          description: 'image is the rados image name. More info:
+                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: string
                         keyring:
-                          description: 'Keyring is the path to key ring for RBDUser.
+                          description: 'keyring is the path to key ring for RBDUser.
                             Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: string
                         monitors:
-                          description: 'A collection of Ceph monitors. More info:
-                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          description: 'monitors is a collection of Ceph monitors.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           items:
                             type: string
                           type: array
                         pool:
-                          description: 'The rados pool name. Default is rbd. More
-                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          description: 'pool is the rados pool name. Default is rbd.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: string
                         readOnly:
-                          description: 'ReadOnly here will force the ReadOnly setting
+                          description: 'readOnly here will force the ReadOnly setting
                             in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: boolean
                         secretRef:
-                          description: 'SecretRef is name of the authentication secret
+                          description: 'secretRef is name of the authentication secret
                             for RBDUser. If provided overrides keyring. Default is
                             nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           properties:
@@ -1448,35 +1464,36 @@ spec:
                               type: string
                           type: object
                         user:
-                          description: 'The rados user name. Default is admin. More
-                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          description: 'user is the rados user name. Default is admin.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: string
                       required:
                       - image
                       - monitors
                       type: object
                     scaleIO:
-                      description: ScaleIO represents a ScaleIO persistent volume
+                      description: scaleIO represents a ScaleIO persistent volume
                         attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Default is "xfs".
+                          description: fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                           type: string
                         gateway:
-                          description: The host address of the ScaleIO API Gateway.
+                          description: gateway is the host address of the ScaleIO
+                            API Gateway.
                           type: string
                         protectionDomain:
-                          description: The name of the ScaleIO Protection Domain for
-                            the configured storage.
+                          description: protectionDomain is the name of the ScaleIO
+                            Protection Domain for the configured storage.
                           type: string
                         readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
+                          description: readOnly Defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: SecretRef references to the secret for ScaleIO
+                          description: secretRef references to the secret for ScaleIO
                             user and other sensitive information. If this is not provided,
                             Login operation will fail.
                           properties:
@@ -1486,25 +1503,26 @@ spec:
                               type: string
                           type: object
                         sslEnabled:
-                          description: Flag to enable/disable SSL communication with
-                            Gateway, default false
+                          description: sslEnabled Flag enable/disable SSL communication
+                            with Gateway, default false
                           type: boolean
                         storageMode:
-                          description: Indicates whether the storage for a volume
-                            should be ThickProvisioned or ThinProvisioned. Default
-                            is ThinProvisioned.
+                          description: storageMode indicates whether the storage for
+                            a volume should be ThickProvisioned or ThinProvisioned.
+                            Default is ThinProvisioned.
                           type: string
                         storagePool:
-                          description: The ScaleIO Storage Pool associated with the
-                            protection domain.
+                          description: storagePool is the ScaleIO Storage Pool associated
+                            with the protection domain.
                           type: string
                         system:
-                          description: The name of the storage system as configured
-                            in ScaleIO.
+                          description: system is the name of the storage system as
+                            configured in ScaleIO.
                           type: string
                         volumeName:
-                          description: The name of a volume already created in the
-                            ScaleIO system that is associated with this volume source.
+                          description: volumeName is the name of a volume already
+                            created in the ScaleIO system that is associated with
+                            this volume source.
                           type: string
                       required:
                       - gateway
@@ -1512,24 +1530,24 @@ spec:
                       - system
                       type: object
                     secret:
-                      description: 'Secret represents a secret that should populate
+                      description: 'secret represents a secret that should populate
                         this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                       properties:
                         defaultMode:
-                          description: 'Optional: mode bits used to set permissions
-                            on created files by default. Must be an octal value between
-                            0000 and 0777 or a decimal value between 0 and 511. YAML
-                            accepts both octal and decimal values, JSON requires decimal
-                            values for mode bits. Defaults to 0644. Directories within
-                            the path are not affected by this setting. This might
-                            be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits
-                            set.'
+                          description: 'defaultMode is Optional: mode bits used to
+                            set permissions on created files by default. Must be an
+                            octal value between 0000 and 0777 or a decimal value between
+                            0 and 511. YAML accepts both octal and decimal values,
+                            JSON requires decimal values for mode bits. Defaults to
+                            0644. Directories within the path are not affected by
+                            this setting. This might be in conflict with other options
+                            that affect the file mode, like fsGroup, and the result
+                            can be other mode bits set.'
                           format: int32
                           type: integer
                         items:
-                          description: If unspecified, each key-value pair in the
-                            Data field of the referenced Secret will be projected
+                          description: items If unspecified, each key-value pair in
+                            the Data field of the referenced Secret will be projected
                             into the volume as a file whose name is the key and content
                             is the value. If specified, the listed keys will be projected
                             into the specified paths, and unlisted keys will not be
@@ -1541,25 +1559,25 @@ spec:
                             description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: The key to project.
+                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: 'Optional: mode bits used to set permissions
-                                  on this file. Must be an octal value between 0000
-                                  and 0777 or a decimal value between 0 and 511. YAML
-                                  accepts both octal and decimal values, JSON requires
-                                  decimal values for mode bits. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
+                                description: 'mode is Optional: mode bits used to
+                                  set permissions on this file. Must be an octal value
+                                  between 0000 and 0777 or a decimal value between
+                                  0 and 511. YAML accepts both octal and decimal values,
+                                  JSON requires decimal values for mode bits. If not
+                                  specified, the volume defaultMode will be used.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
                                 format: int32
                                 type: integer
                               path:
-                                description: The relative path of the file to map
-                                  the key to. May not be an absolute path. May not
-                                  contain the path element '..'. May not start with
-                                  the string '..'.
+                                description: path is the relative path of the file
+                                  to map the key to. May not be an absolute path.
+                                  May not contain the path element '..'. May not start
+                                  with the string '..'.
                                 type: string
                             required:
                             - key
@@ -1567,29 +1585,30 @@ spec:
                             type: object
                           type: array
                         optional:
-                          description: Specify whether the Secret or its keys must
-                            be defined
+                          description: optional field specify whether the Secret or
+                            its keys must be defined
                           type: boolean
                         secretName:
-                          description: 'Name of the secret in the pod''s namespace
-                            to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                          description: 'secretName is the name of the secret in the
+                            pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                           type: string
                       type: object
                     storageos:
-                      description: StorageOS represents a StorageOS volume attached
+                      description: storageOS represents a StorageOS volume attached
                         and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          description: fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
                           type: string
                         readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
+                          description: readOnly defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: SecretRef specifies the secret to use for obtaining
+                          description: secretRef specifies the secret to use for obtaining
                             the StorageOS API credentials.  If not specified, default
                             values will be attempted.
                           properties:
@@ -1599,12 +1618,12 @@ spec:
                               type: string
                           type: object
                         volumeName:
-                          description: VolumeName is the human-readable name of the
+                          description: volumeName is the human-readable name of the
                             StorageOS volume.  Volume names are only unique within
                             a namespace.
                           type: string
                         volumeNamespace:
-                          description: VolumeNamespace specifies the scope of the
+                          description: volumeNamespace specifies the scope of the
                             volume within StorageOS.  If no namespace is specified
                             then the Pod's namespace will be used.  This allows the
                             Kubernetes name scoping to be mirrored within StorageOS
@@ -1615,24 +1634,26 @@ spec:
                           type: string
                       type: object
                     vsphereVolume:
-                      description: VsphereVolume represents a vSphere volume attached
+                      description: vsphereVolume represents a vSphere volume attached
                         and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          description: fsType is filesystem type to mount. Must be
+                            a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
                           type: string
                         storagePolicyID:
-                          description: Storage Policy Based Management (SPBM) profile
-                            ID associated with the StoragePolicyName.
+                          description: storagePolicyID is the storage Policy Based
+                            Management (SPBM) profile ID associated with the StoragePolicyName.
                           type: string
                         storagePolicyName:
-                          description: Storage Policy Based Management (SPBM) profile
-                            name.
+                          description: storagePolicyName is the storage Policy Based
+                            Management (SPBM) profile name.
                           type: string
                         volumePath:
-                          description: Path that identifies vSphere volume vmdk
+                          description: volumePath is the path that identifies vSphere
+                            volume vmdk
                           type: string
                       required:
                       - volumePath


### PR DESCRIPTION
#### PR Description

This PR adds the ability to disable the reporting of usage of feature flags
to grafana when using the Agent Operator

#### Which issue(s) this PR fixes

Closes #1856 

#### Notes to the Reviewers

After running `make crd` it changed quite a lot the current CRDs.
Please, look if anything critical changed.

#### PR Checklist

- [ ] CHANGELOG updated
- [x] Documentation added
- [ ] Tests updated
