### PR TITLE
flow: polish prometheus.scrape component

### DIFF
--- a/cmd/agent/example-config.river
+++ b/cmd/agent/example-config.river
@@ -16,10 +16,6 @@ prometheus.scrape "default" {
 		"dynamic_label" = local.file.this_file.content,
 	}]
 	forward_to = [prometheus.remote_write.default.receiver]
-
-	scrape_config {
-		job_name = "default"
-	}
 }
 
 prometheus.remote_write "default" {

--- a/component/prometheus/scrape/scrape.go
+++ b/component/prometheus/scrape/scrape.go
@@ -3,12 +3,15 @@ package scrape
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"sync"
 	"time"
 
+	"github.com/alecthomas/units"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/component"
 	fa "github.com/grafana/agent/component/common/appendable"
+	component_config "github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
 	"github.com/grafana/agent/component/prometheus"
 	"github.com/grafana/agent/pkg/build"
@@ -37,10 +40,62 @@ type Arguments struct {
 	Targets   []discovery.Target     `river:"targets,attr"`
 	ForwardTo []*prometheus.Receiver `river:"forward_to,attr"`
 
-	ScrapeConfig Config `river:"scrape_config,block"`
+	// Indicator whether the scraped metrics should remain unmodified.
+	HonorLabels bool `river:"honor_labels,attr,optional"`
+	// Indicator whether the scraped timestamps should be respected.
+	HonorTimestamps bool `river:"honor_timestamps,attr,optional"`
+	// A set of query parameters with which the target is scraped.
+	Params url.Values `river:"params,attr,optional"`
+	// How frequently to scrape the targets of this scrape config.
+	ScrapeInterval time.Duration `river:"scrape_interval,attr,optional"`
+	// The timeout for scraping targets of this config.
+	ScrapeTimeout time.Duration `river:"scrape_timeout,attr,optional"`
+	// The HTTP resource path on which to fetch metrics from targets.
+	MetricsPath string `river:"metrics_path,attr,optional"`
+	// The URL scheme with which to fetch metrics from targets.
+	Scheme string `river:"scheme,attr,optional"`
+	// An uncompressed response body larger than this many bytes will cause the
+	// scrape to fail. 0 means no limit.
+	BodySizeLimit units.Base2Bytes `river:"body_size_limit,attr,optional"`
+	// More than this many samples post metric-relabeling will cause the scrape
+	// to fail.
+	SampleLimit uint `river:"sample_limit,attr,optional"`
+	// More than this many targets after the target relabeling will cause the
+	// scrapes to fail.
+	TargetLimit uint `river:"target_limit,attr,optional"`
+	// More than this many labels post metric-relabeling will cause the scrape
+	// to fail.
+	LabelLimit uint `river:"label_limit,attr,optional"`
+	// More than this label name length post metric-relabeling will cause the
+	// scrape to fail.
+	LabelNameLengthLimit uint `river:"label_name_length_limit,attr,optional"`
+	// More than this label value length post metric-relabeling will cause the
+	// scrape to fail.
+	LabelValueLengthLimit uint `river:"label_value_length_limit,attr,optional"`
+
+	HTTPClientConfig component_config.HTTPClientConfig `river:"http_client_config,block,optional"`
 
 	// Scrape Options
 	ExtraMetrics bool `river:"extra_metrics,attr,optional"`
+}
+
+// DefaultArguments defines the default settings for a scrape job.
+var DefaultArguments = Arguments{
+	MetricsPath:      "/metrics",
+	Scheme:           "http",
+	HonorLabels:      false,
+	HonorTimestamps:  true,
+	HTTPClientConfig: component_config.DefaultHTTPClientConfig,
+	ScrapeInterval:   1 * time.Minute,  // From config.DefaultGlobalConfig
+	ScrapeTimeout:    10 * time.Second, // From config.DefaultGlobalConfig
+}
+
+// UnmarshalRiver implements river.Unmarshaler.
+func (arg *Arguments) UnmarshalRiver(f func(interface{}) error) error {
+	*arg = DefaultArguments
+
+	type args Arguments
+	return f((*args)(arg))
 }
 
 // Component implements the prometheus.scrape component.
@@ -123,7 +178,7 @@ func (c *Component) Update(args component.Arguments) error {
 
 	c.appendable.SetReceivers(newArgs.ForwardTo)
 
-	sc, err := newArgs.ScrapeConfig.getPromScrapeConfigs(c.opts.ID)
+	sc, err := getPromScrapeConfigs(c.opts.ID, newArgs)
 	if err != nil {
 		return fmt.Errorf("invalid scrape_config: %w", err)
 	}

--- a/component/prometheus/scrape/scrape.go
+++ b/component/prometheus/scrape/scrape.go
@@ -40,6 +40,8 @@ type Arguments struct {
 	Targets   []discovery.Target     `river:"targets,attr"`
 	ForwardTo []*prometheus.Receiver `river:"forward_to,attr"`
 
+	// The job name to override the job label with.
+	JobName string `river:"job_name,attr,optional"`
 	// Indicator whether the scraped metrics should remain unmodified.
 	HonorLabels bool `river:"honor_labels,attr,optional"`
 	// Indicator whether the scraped timestamps should be respected.

--- a/component/prometheus/scrape/scrape_test.go
+++ b/component/prometheus/scrape/scrape_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/grafana/agent/component"
-	"github.com/grafana/agent/component/discovery"
 	"github.com/grafana/agent/component/prometheus"
 	"github.com/grafana/agent/pkg/flow/logging"
 	prometheus_client "github.com/prometheus/client_golang/prometheus"
@@ -25,11 +24,8 @@ func TestForwardingToAppendable(t *testing.T) {
 
 	nilReceivers := []*prometheus.Receiver{nil, nil}
 
-	args := Arguments{
-		Targets:      []discovery.Target{},
-		ForwardTo:    nilReceivers,
-		ScrapeConfig: DefaultConfig,
-	}
+	args := DefaultArguments
+	args.ForwardTo = nilReceivers
 
 	s, err := New(opts, args)
 	require.NoError(t, err)

--- a/component/prometheus/scrape/types.go
+++ b/component/prometheus/scrape/types.go
@@ -20,7 +20,11 @@ const bearer string = "Bearer"
 // - ServiceDiscoveryConfigs
 func getPromScrapeConfigs(jobName string, c Arguments) (*config.ScrapeConfig, error) {
 	dec := config.DefaultScrapeConfig
-	dec.JobName = jobName
+	if c.JobName != "" {
+		dec.JobName = c.JobName
+	} else {
+		dec.JobName = jobName
+	}
 	dec.HonorLabels = c.HonorLabels
 	dec.HonorTimestamps = c.HonorTimestamps
 	dec.Params = c.Params

--- a/component/prometheus/scrape/types.go
+++ b/component/prometheus/scrape/types.go
@@ -2,80 +2,14 @@ package scrape
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
-	"time"
 
-	"github.com/alecthomas/units"
-	component_config "github.com/grafana/agent/component/common/config"
 	common_config "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 )
 
 const bearer string = "Bearer"
-
-// Config holds all of the attributes that can be used to configure a scrape
-// component.
-type Config struct {
-	// The job name to which the job label is set by default.
-	JobName string `river:"job_name,attr"`
-
-	// Indicator whether the scraped metrics should remain unmodified.
-	HonorLabels bool `river:"honor_labels,attr,optional"`
-	// Indicator whether the scraped timestamps should be respected.
-	HonorTimestamps bool `river:"honor_timestamps,attr,optional"`
-	// A set of query parameters with which the target is scraped.
-	Params url.Values `river:"params,attr,optional"`
-	// How frequently to scrape the targets of this scrape config.
-	ScrapeInterval time.Duration `river:"scrape_interval,attr,optional"`
-	// The timeout for scraping targets of this config.
-	ScrapeTimeout time.Duration `river:"scrape_timeout,attr,optional"`
-	// The HTTP resource path on which to fetch metrics from targets.
-	MetricsPath string `river:"metrics_path,attr,optional"`
-	// The URL scheme with which to fetch metrics from targets.
-	Scheme string `river:"scheme,attr,optional"`
-	// An uncompressed response body larger than this many bytes will cause the
-	// scrape to fail. 0 means no limit.
-	BodySizeLimit units.Base2Bytes `river:"body_size_limit,attr,optional"`
-	// More than this many samples post metric-relabeling will cause the scrape to
-	// fail.
-	SampleLimit uint `river:"sample_limit,attr,optional"`
-	// More than this many targets after the target relabeling will cause the
-	// scrapes to fail.
-	TargetLimit uint `river:"target_limit,attr,optional"`
-	// More than this many labels post metric-relabeling will cause the scrape to
-	// fail.
-	LabelLimit uint `river:"label_limit,attr,optional"`
-	// More than this label name length post metric-relabeling will cause the
-	// scrape to fail.
-	LabelNameLengthLimit uint `river:"label_name_length_limit,attr,optional"`
-	// More than this label value length post metric-relabeling will cause the
-	// scrape to fail.
-	LabelValueLengthLimit uint `river:"label_value_length_limit,attr,optional"`
-
-	HTTPClientConfig component_config.HTTPClientConfig `river:"http_client_config,block,optional"`
-}
-
-// DefaultConfig is the set of default options applied before decoding a given
-// scrape_config block.
-var DefaultConfig = Config{
-	MetricsPath:      "/metrics",
-	Scheme:           "http",
-	HonorLabels:      false,
-	HonorTimestamps:  true,
-	HTTPClientConfig: component_config.DefaultHTTPClientConfig,
-	ScrapeInterval:   1 * time.Minute,  // From config.DefaultGlobalConfig
-	ScrapeTimeout:    10 * time.Second, // From config.DefaultGlobalConfig
-}
-
-// UnmarshalRiver implements river.Unmarshaler.
-func (c *Config) UnmarshalRiver(f func(interface{}) error) error {
-	*c = DefaultConfig
-
-	type scrapeConfig Config
-	return f((*scrapeConfig)(c))
-}
 
 // Helper function to bridge the in-house configuration with the Prometheus
 // scrape_config.
@@ -84,7 +18,7 @@ func (c *Config) UnmarshalRiver(f func(interface{}) error) error {
 // - RelabelConfigs
 // - MetricsRelabelConfigs
 // - ServiceDiscoveryConfigs
-func (c *Config) getPromScrapeConfigs(jobName string) (*config.ScrapeConfig, error) {
+func getPromScrapeConfigs(jobName string, c Arguments) (*config.ScrapeConfig, error) {
 	dec := config.DefaultScrapeConfig
 	dec.JobName = jobName
 	dec.HonorLabels = c.HonorLabels

--- a/docs/flow/reference/components/prometheus.scrape.md
+++ b/docs/flow/reference/components/prometheus.scrape.md
@@ -29,7 +29,7 @@ prometheus.scrape "blackbox_scraper" {
 	forward_to = [prometheus.remote_write.grafanacloud.receiver, prometheus.remote_write.onprem.receiver]
 	
 	scrape_interval = "10s"
-	params          = { "target" = ["grafana.com"], "module" = ["http_2xx"]}
+	params          = { "target" = ["grafana.com"], "module" = ["http_2xx"] }
 	metrics_path    = "/probe"
 }
 ```

--- a/docs/flow/reference/components/prometheus.scrape.md
+++ b/docs/flow/reference/components/prometheus.scrape.md
@@ -40,6 +40,8 @@ The component will configure and start a new scrape job to scrape all of the
 input targets. The list of arguments that can be used to configure the block is
 presented below.
 
+The scrape job name will default to the fully formed component name.
+
 Any omitted fields will take on their default values. In case that conflicting
 attributes are being passed (eg. defining both a BearerToken and
 BearerTokenFile or configuring both Basic Authorization and OAuth2 at the same
@@ -49,9 +51,10 @@ The following arguments are supported:
 
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`targets` | `list(map(string))` | Targets to scrape | | **yes**
-`forward_to` | `list(MetricsReceiver)` | List of receivers to send scraped metrics to | | **yes**
-`extra_metrics` | `bool` | Whether extra metrics should be generated for scrape targets | `false` | no
+`targets`                  | `list(map(string))`     | List of targets to scrape. | | **yes**
+`forward_to`               | `list(MetricsReceiver)` | List of receivers to send scraped metrics to. | | **yes**
+`job_name`                 | `string`   | The job name to override the job label with. | component name | no
+`extra_metrics`            | `bool`     | Whether extra metrics should be generated for scrape targets. | `false` | no
 `honor_labels`             | `bool`     | Indicator whether the scraped metrics should remain unmodified. | false | no
 `honor_timestamps`         | `bool`     | Indicator whether the scraped timestamps should be respected. | true | no
 `params`                   | `map(list(string))` | A set of query parameters with which the target is scraped. | | no

--- a/docs/flow/reference/components/prometheus.scrape.md
+++ b/docs/flow/reference/components/prometheus.scrape.md
@@ -18,7 +18,7 @@ different labels.
 The following example will set up the job with certain attributes (scrape
 intervals, query parameters) and let it scrape two instances of the blackbox
 exporter. The received metrics will be sent over to the provided list of
-remote writes, as defined by other components.
+receivers, as defined by other components.
 
 ```river
 prometheus.scrape "blackbox_scraper" {


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR aims to provide a round of polish to the `prometheus.scrape` component.

More specifically: 
* Removes the requirement to pass a `job_name`, which was a leftover from when the component could configure multiple targets at the same time. The reported job_name will be set to the component's ID (prometheus.scrape.label).
* Removes the `scrape_config` block to allow for a flatter configuration. The only nested blocks now is `http_client_config`. Note: I tried to simply embed the previously-defined Config field, but unfortunately it broke River's unmarshalling, and ended up not recognizing even the previously-present fields, so I had to widen the scope of changes.
* Made a final comparison between the fields defined in Prometheus' scrape config and the component's Arguments. The only field we're missing is the [custom HTTPClientOptions](https://github.com/prometheus/common/blob/dfbc25bd00225c70aca0d94c3c4bb7744f28ace0/config/http_config.go#L379) which are defined as functional options. We _could_ add some custom logic to hook them up if the user requires to tinker with these settings, but they are not currently configurable not even in Prometheus' YAML configuration, so I'm not sure if it makes sense for now.
* Changed the example configuration to match the new Argument structure.

#### Which issue(s) this PR fixes

#### Notes to the Reviewer
If you can, take 5' to verify; have I missed anything else? :)

We're getting close, it'd be nice to have the component as polished as possible! 🙏 
 
#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [X] Documentation added
- [X] Tests updated
