### PR TITLE
Support arm64 variant of grafana/agent-build-image

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -22,8 +22,9 @@ steps:
     commands:
     - export IMAGE_TAG=${DRONE_TAG##build-image/v}
     - docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
-    - docker build -t grafana/agent-build-image:$IMAGE_TAG ./build-image
-    - docker push grafana/agent-build-image:$IMAGE_TAG
+    - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    - docker buildx create --name multiarch --driver docker-container --use
+    - docker buildx build --push --platform linux/amd64,linux/arm64 -t grafana/agent-build-image:$IMAGE_TAG ./build-image
 volumes:
   - name: docker
     host:

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -366,6 +366,6 @@ get:
 
 ---
 kind: signature
-hmac: e0f7d15a7b573f8b29d9f115eed16f237b9dccfa6b4eb168c8c84770660c15b1
+hmac: 1ba848fa0abbbeeb5a9c222a68fdd53e06b9bbc889a4847b006821ff764bc3cd
 
 ...

--- a/Makefile-v2.mk
+++ b/Makefile-v2.mk
@@ -57,6 +57,7 @@
 ##
 ##   build-container-cache  Create a cache for the build container to speed up
 ##                          subsequent proxied builds
+##   drone                  Sign Drone CI config (maintainers only)
 ##   clean                  Clean caches and built binaries
 ##   help                   Displays this message
 ##   info                   Print Makefile-specific environment variables
@@ -262,7 +263,15 @@ endif
 #
 # build-container-cache and clean-build-container-cache are defined in
 # Makefile.build-container.
+
+# Drone signs the yaml, you will need to specify DRONE_TOKEN, which can be
+# found by logging into your profile in Drone.
 #
+# This will only work for maintainers.
+.PHONY: drone
+drone:
+	drone lint .drone/drone.yml --trusted
+	drone --server https://drone.grafana.net sign --save grafana/agent .drone/drone.yml
 
 .PHONY: clean
 clean: clean-dist clean-build-container-cache

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -38,12 +38,12 @@ FROM rfratto/viceroy:v0.2.1
 
 # NOTE(rfratto): musl is installed so the Docker binaries from alpine work
 # properly.
-RUN apt-get update                               \
- && apt-get install -qy                          \
-      build-essential file zip unzip gettext git \
-      musl libsystemd-dev nsis libbpfcc-dev nsis \
-      rpm ruby ruby-dev rubygems                 \
-      protobuf-compiler libprotobuf-dev          \
+RUN apt-get update                                \
+ && apt-get install -qy                           \
+      build-essential file zip unzip gettext git  \
+      musl libsystemd-dev nsis libbpfcc-dev:amd64 \
+      rpm ruby ruby-dev rubygems                  \
+      protobuf-compiler libprotobuf-dev           \
  && gem install --no-document fpm                \
  && rm -rf /var/lib/apt/lists/*
 

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update                                \
       musl libsystemd-dev nsis libbpfcc-dev:amd64 \
       rpm ruby ruby-dev rubygems                  \
       protobuf-compiler libprotobuf-dev           \
- && gem install --no-document fpm                \
+ && gem install --no-document fpm                 \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=golangci /bin/golangci-lint              /usr/local/bin


### PR DESCRIPTION
Updates Drone to build arm64 variants of grafana/agent-build-image, primarily for Apple Silicon users. 

Also ensures that `libbpfcc-dev` is always installed for amd64, which is the only architecture that eBPF works on right now. 

This will tag 0.15.1 of the build image.