### PR TITLE
Separate Github Actions to avoid publishing rc documentation as stable

### DIFF
--- a/.github/workflows/publish-documentation-next.yml
+++ b/.github/workflows/publish-documentation-next.yml
@@ -1,61 +1,45 @@
-name: publish_docs
+name: "publish-technical-documentation-next"
 
 on:
   push:
     branches:
       - main
-      - 'release-*'
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
     paths:
       - 'docs/sources/**'
+  workflow_dispatch:
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
+      - name: "Check out code"
         uses: actions/checkout@v3
       - name: "Build technical documentation"
         run: |
           docker run -v ${PWD}/docs/sources:/hugo/content/docs/agent/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
+
   sync:
     runs-on: ubuntu-latest
     needs: test
     steps:
 
-    - name: Checkout Agent repo
+    - name: "Checkout Agent repo"
       uses: actions/checkout@v3
 
-    - name: Checkout Actions library
-      uses: actions/checkout@v3
-      with:
-        repository: "grafana/grafana-github-actions"
-        path: ./actions
-
-    - name: Install Actions from library
-      run: npm install --production --prefix ./actions
-
-    - name: Extract semver
-      uses: ./actions/docs-target
-      id: target
-      with:
-        ref_name: ${{ github.ref_name }}
-
-    - name: Clone website-sync Action
+    - name: "Clone website-sync Action"
       run: git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync
 
-    - name: publish-to-git
+    - name: "Publish to website repository (next)"
       uses: ./.github/actions/website-sync
-      id: publish
+      id: "publish_next"
       with:
         repository: grafana/website
         branch: master
         host: github.com
         github_pat: '${{ secrets.GH_BOT_ACCESS_TOKEN }}'
         source_folder: docs/sources
-        target_folder: 'content/docs/agent/${{ steps.target.outputs.target }}'
+        target_folder: 'content/docs/agent/next'
     - shell: bash
       run: |
-        test -n "${{ steps.publish.outputs.commit_hash }}"
-        test -n "${{ steps.publish.outputs.working_directory }}"
+        test -n "${{ steps.publish_next.outputs.commit_hash }}"
+        test -n "${{ steps.publish_next.outputs.working_directory }}"

--- a/.github/workflows/publish-documentation-versioned.yml
+++ b/.github/workflows/publish-documentation-versioned.yml
@@ -44,7 +44,7 @@ jobs:
       with:
         ref_name: "${{ github.ref_name }}"
         release_tag_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
-        release_branch_regexp: "^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
+        release_branch_regexp: "^release-v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
 
     - name: "Extract semver"
       if: "steps.has-matching-release-tag.outputs.bool == 'true'"

--- a/.github/workflows/publish-documentation-versioned.yml
+++ b/.github/workflows/publish-documentation-versioned.yml
@@ -1,0 +1,74 @@
+name: "publish-technical-documentation-version"
+
+on:
+  push:
+    branches:
+      - 'release-*'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+    paths:
+      - 'docs/sources/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check out code"
+        uses: actions/checkout@v3
+      - name: "Build technical documentation"
+        run: |
+          docker run -v ${PWD}/docs/sources:/hugo/content/docs/agent/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
+
+  sync:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+
+    - name: "Checkout Agent repo"
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: "Checkout Actions library"
+      uses: actions/checkout@v3
+      with:
+        repository: "grafana/grafana-github-actions"
+        path: ./actions
+
+    - name: "Install Actions from library"
+      run: npm install --production --prefix ./actions
+
+    - name: "Determine if there is a matching release tag"
+      id: "has-matching-release-tag"
+      uses: "./actions/has-matching-release-tag"
+      with:
+        ref_name: "${{ github.ref_name }}"
+        release_tag_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
+        release_branch_regexp: "^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
+
+    - name: "Extract semver"
+      if: "steps.has-matching-release-tag.outputs.bool == 'true'"
+      uses: ./actions/docs-target
+      id: target
+      with:
+        ref_name: ${{ github.ref_name }}
+
+    - name: "Clone website-sync Action"
+      if: "steps.has-matching-release-tag.outputs.bool == 'true'"
+      run: git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync
+
+    - name: "Publish to website repository (release)"
+      if: "steps.has-matching-release-tag.outputs.bool == 'true'"
+      uses: ./.github/actions/website-sync
+      id: "publish_release"
+      with:
+        repository: grafana/website
+        branch: master
+        host: github.com
+        github_pat: '${{ secrets.GH_BOT_ACCESS_TOKEN }}'
+        source_folder: docs/sources
+        target_folder: 'content/docs/agent/${{ steps.target.outputs.target }}'
+    - shell: bash
+      run: |
+        test -n "${{ steps.publish_release.outputs.commit_hash }}"
+        test -n "${{ steps.publish_release.outputs.working_directory }}"


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR separates the `publish.yml` GitHub action into two
a) A new, simpler one which just pushes docs whenever there's a new commit on `main`.
b) An updated version of the previous one, which uses the `has-matching-release-tag` custom action to perform a stricter check and only push documentation if there's already a published tag with the same name.

The same approach is used by Mimir's [workflows](https://github.com/grafana/mimir/tree/main/.github/workflows) and while I think we could maybe fit everything into one Action, I believe it's worth it to follow a common approach, with simpler building blocks that other projects can reuse more easily.

#### Which issue(s) this PR fixes
Fixes #1782

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
