### PR TITLE
Fix typo in usagestats reporter log message.

### DIFF
--- a/pkg/usagestats/reporter.go
+++ b/pkg/usagestats/reporter.go
@@ -128,7 +128,7 @@ func (rep *Reporter) Start(ctx context.Context) error {
 			if !next.Equal(now) && now.Sub(rep.lastReport) < reportInterval {
 				continue
 			}
-			level.Info(rep.logger).Log("msg", "reporting cluster stats", "date", time.Now())
+			level.Info(rep.logger).Log("msg", "reporting agent stats", "date", time.Now())
 			if err := rep.reportUsage(ctx, next); err != nil {
 				level.Info(rep.logger).Log("msg", "failed to report usage", "err", err)
 				continue


### PR DESCRIPTION
#### PR Description
Fix typo in usagestats reporter log message.
Think the original message comes unchanged from Loki code.
