### PR TITLE
Fix k3d examples

### DIFF
--- a/example/k3d/environment/main.jsonnet
+++ b/example/k3d/environment/main.jsonnet
@@ -94,7 +94,7 @@ local images = {
     ]) +
     grafana_agent.withTracesTailSamplingConfig({
       policies: [{
-        always_sample: null,
+        type: 'always_sample',
       }],
     }) +
     grafana_agent.withTracesLoadBalancingConfig({

--- a/production/tanka/grafana-agent/grafana-agent.libsonnet
+++ b/production/tanka/grafana-agent/grafana-agent.libsonnet
@@ -31,7 +31,7 @@ k + config {
 
   agent_args:: {
     'config.file': '/etc/agent/agent.yml',
-    'prometheus.wal-directory': '/tmp/agent/data',
+    'metrics.wal-directory': '/tmp/agent/data',
   },
 
   agent_container::

--- a/production/tanka/grafana-agent/scraping-svc/main.libsonnet
+++ b/production/tanka/grafana-agent/scraping-svc/main.libsonnet
@@ -72,7 +72,7 @@ local policyRule = k.rbac.v1.policyRule;
       container.withPorts(containerPort.new(name='http-metrics', port=80)) +
       container.withArgsMixin(k.util.mapToFlags({
         'config.file': '/etc/agent/agent.yml',
-        'prometheus.wal-directory': '/tmp/agent/data',
+        'metrics.wal-directory': '/tmp/agent/data',
       })) +
       container.withEnv([
         k.core.v1.envVar.fromFieldPath('HOSTNAME', 'spec.nodeName'),


### PR DESCRIPTION
#### PR Description

  - Agent pods were crashlooping due to outdated configuration format and flags
