### PR TITLE
river/vm: enhance error message for unrecognized attribute/block names

### DIFF
--- a/pkg/river/vm/vm.go
+++ b/pkg/river/vm/vm.go
@@ -259,20 +259,36 @@ func (vm *Evaluator) evaluateBlockOrBody(scope *Scope, assoc map[value.Value]ast
 		}
 	}
 
+	var diags diag.Diagnostics
+
 	// Make sure that all of the attributes and blocks defined in the AST node
 	// matched up with a field from our struct.
-	for attr := range foundAttrs {
-		if _, consumed := consumedAttrs[attr]; !consumed {
-			return fmt.Errorf("unrecognized attribute name %q", attr)
+	for attrName, attrs := range foundAttrs {
+		if _, consumed := consumedAttrs[attrName]; !consumed {
+			for _, attr := range attrs {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.SeverityLevelError,
+					StartPos: ast.StartPos(attr.Name).Position(),
+					EndPos:   ast.EndPos(attr.Name).Position(),
+					Message:  fmt.Sprintf("unrecognized attribute name %q", attrName),
+				})
+			}
 		}
 	}
-	for block := range foundBlocks {
-		if _, consumed := consumedBlocks[block]; !consumed {
-			return fmt.Errorf("unrecognized block name %q", block)
+	for blockName, blocks := range foundBlocks {
+		if _, consumed := consumedBlocks[blockName]; !consumed {
+			for _, block := range blocks {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.SeverityLevelError,
+					StartPos: block.NamePos.Position(),
+					EndPos:   block.NamePos.Add(len(blockName) - 1).Position(),
+					Message:  fmt.Sprintf("unrecognized block name %q", blockName),
+				})
+			}
 		}
 	}
 
-	return nil
+	return diags.ErrorOrNil()
 }
 
 func (vm *Evaluator) evaluateBlockLabel(node *ast.BlockStmt, tfs []rivertags.Field, rv reflect.Value) error {

--- a/pkg/river/vm/vm.go
+++ b/pkg/river/vm/vm.go
@@ -264,27 +264,33 @@ func (vm *Evaluator) evaluateBlockOrBody(scope *Scope, assoc map[value.Value]ast
 	// Make sure that all of the attributes and blocks defined in the AST node
 	// matched up with a field from our struct.
 	for attrName, attrs := range foundAttrs {
-		if _, consumed := consumedAttrs[attrName]; !consumed {
-			for _, attr := range attrs {
-				diags = append(diags, diag.Diagnostic{
-					Severity: diag.SeverityLevelError,
-					StartPos: ast.StartPos(attr.Name).Position(),
-					EndPos:   ast.EndPos(attr.Name).Position(),
-					Message:  fmt.Sprintf("unrecognized attribute name %q", attrName),
-				})
-			}
+		if _, consumed := consumedAttrs[attrName]; consumed {
+			// Ignore accepted attributes.
+			continue
+		}
+
+		for _, attr := range attrs {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.SeverityLevelError,
+				StartPos: ast.StartPos(attr.Name).Position(),
+				EndPos:   ast.EndPos(attr.Name).Position(),
+				Message:  fmt.Sprintf("unrecognized attribute name %q", attrName),
+			})
 		}
 	}
 	for blockName, blocks := range foundBlocks {
-		if _, consumed := consumedBlocks[blockName]; !consumed {
-			for _, block := range blocks {
-				diags = append(diags, diag.Diagnostic{
-					Severity: diag.SeverityLevelError,
-					StartPos: block.NamePos.Position(),
-					EndPos:   block.NamePos.Add(len(blockName) - 1).Position(),
-					Message:  fmt.Sprintf("unrecognized block name %q", blockName),
-				})
-			}
+		if _, consumed := consumedBlocks[blockName]; consumed {
+			// Ignore accepted blocks.
+			continue
+		}
+
+		for _, block := range blocks {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.SeverityLevelError,
+				StartPos: block.NamePos.Position(),
+				EndPos:   block.NamePos.Add(len(blockName) - 1).Position(),
+				Message:  fmt.Sprintf("unrecognized block name %q", blockName),
+			})
 		}
 	}
 

--- a/pkg/river/vm/vm_block_test.go
+++ b/pkg/river/vm/vm_block_test.go
@@ -125,7 +125,7 @@ func TestVM_Block_Attributes(t *testing.T) {
 		eval := vm.New(parseBlock(t, input))
 
 		err := eval.Evaluate(nil, &block{})
-		require.EqualError(t, err, `unrecognized attribute name "invalid"`)
+		require.EqualError(t, err, `3:4: unrecognized attribute name "invalid"`)
 	})
 
 	t.Run("Supports arbitrarily nested struct pointer fields", func(t *testing.T) {
@@ -282,7 +282,7 @@ func TestVM_Block_Children_Blocks(t *testing.T) {
 		eval := vm.New(parseBlock(t, input))
 
 		err := eval.Evaluate(nil, &block{})
-		require.EqualError(t, err, `unrecognized block name "child.block"`)
+		require.EqualError(t, err, `4:4: unrecognized block name "child.block"`)
 	})
 
 	t.Run("Supports arbitrarily nested struct pointer fields", func(t *testing.T) {


### PR DESCRIPTION
This adds a diagnostic positioned at invalid attribute and block names rather than the surrounding block, turning this error:

```
Error: ./cmd/agent/example-config.river:6:1: Failed to build component: decoding River: unrecognized block name "invalid_block"

 5 |
 6 | | local.file "this_file" {
   |  _^^^^^^^^^^^^^^^^^^^^^^^^
 7 | |     // Must be running from the root directory of the repository for this relative
 8 | |     // path to work.
 9 | |     filename = "./cmd/agent/test-local-file.txt"
10 | |     detector = "fsnotify"
11 | |
12 | |     invalid_block {
13 | |         hello = "world"
14 | |     }
15 | | }
   | |_^
16 |
```

into this:

```
Error: ./cmd/agent/example-config.river:12:2: unrecognized block name "invalid_block"

11 |
12 |     invalid_block {
   |     ^^^^^^^^^^^^^
13 |         hello = "world"
```