### PR TITLE
remove specific date for v0.28 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ and the [k3d example README](./example/k3d/README.md) for more information.
 
 ## Release schedule
 
-Starting with the v0.28 release on 2022-09-27, a new minor release is planned
-to be created every 6 weeks. This includes a release for Grafana Agent, Grafana
-Agent Operator, and the `agentctl` binary.
+Starting with the v0.28 release, a new minor release is planned to be created
+every 6 weeks. This includes a release for Grafana Agent, Grafana Agent
+Operator, and the `agentctl` binary.
 
 The release schedule is best-effort, and releases may be moved forward or
 backwards if needed. The planned release dates for future minor releases are

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ and the [k3d example README](./example/k3d/README.md) for more information.
 
 ## Release schedule
 
-Starting with the v0.28 release, a new minor release is planned to be created
-every 6 weeks. This includes a release for Grafana Agent, Grafana Agent
-Operator, and the `agentctl` binary.
+Starting with the v0.28 release, a new minor release is planned for every 6
+weeks. This includes a release for Grafana Agent, Grafana Agent Operator, and
+the `agentctl` binary.
 
 The release schedule is best-effort, and releases may be moved forward or
 backwards if needed. The planned release dates for future minor releases are

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -112,9 +112,9 @@ The Grafana Agent is also capable of exporting to any OpenTelemetry GRPC compati
 
 ## Release schedule
 
-Starting with the v0.28 release on 2022-09-27, a new minor release is planned
-to be created every 6 weeks. This includes a release for Grafana Agent, Grafana
-Agent Operator, and the `agentctl` binary.
+Starting with the v0.28 release, a new minor release is planned to be created
+every 6 weeks. This includes a release for Grafana Agent, Grafana Agent
+Operator, and the `agentctl` binary.
 
 The release schedule is best-effort, and releases may be moved forward or
 backwards if needed. The planned release dates for future minor releases are

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -112,9 +112,9 @@ The Grafana Agent is also capable of exporting to any OpenTelemetry GRPC compati
 
 ## Release schedule
 
-Starting with the v0.28 release, a new minor release is planned to be created
-every 6 weeks. This includes a release for Grafana Agent, Grafana Agent
-Operator, and the `agentctl` binary.
+Starting with the v0.28 release, a new minor release is planned for every 6
+weeks. This includes a release for Grafana Agent, Grafana Agent Operator, and
+the `agentctl` binary.
 
 The release schedule is best-effort, and releases may be moved forward or
 backwards if needed. The planned release dates for future minor releases are


### PR DESCRIPTION
While v0.28 is still planned for 2022-09-27, removing the specific date gives us wiggle room for when the release gets published.