### PR TITLE
tools/ci: add options to print commands before building Docker containers

### DIFF
--- a/tools/ci/docker-containers
+++ b/tools/ci/docker-containers
@@ -5,6 +5,7 @@
 #
 # This script expects to be run from the repo root and has checks for running
 # from a Drone trigger.
+set -euxo pipefail
 
 export AGENT_IMAGE=grafana/agent
 export AGENTCTL_IMAGE=grafana/agentctl


### PR DESCRIPTION
It looks like not all the images are getting consistently built and pushed. We need to make sure the commands are running to help debug the problem.