### PR TITLE
docs/flow: add monitoring docs

### DIFF
--- a/docs/flow/monitoring/_index.md
+++ b/docs/flow/monitoring/_index.md
@@ -6,3 +6,7 @@ weight: 500
 ---
 
 # Monitoring Grafana Agent Flow
+
+This section details various ways to monitor and debug Grafana Agent Flow.
+
+{{< section >}}

--- a/docs/flow/monitoring/component_metrics.md
+++ b/docs/flow/monitoring/component_metrics.md
@@ -33,5 +33,5 @@ component-specific metrics that component exposes. Not all components will
 expose metrics.
 
 [component]: {{< relref "../concepts/components.md" >}}
-[agent run]: {{< relref "../reference/cli/run.md" }}
+[agent run]: {{< relref "../reference/cli/run.md" >}}
 [reference documentation]: {{< relref "../reference/components/_index.md" >}}

--- a/docs/flow/monitoring/component_metrics.md
+++ b/docs/flow/monitoring/component_metrics.md
@@ -16,8 +16,8 @@ component is running.
 > the component. Component-specific metrics are used to expose the state of a
 > component for observability, alerting, and debugging.
 
-Metrics for component-specific metrics are exposed at the `/metrics` HTTP
-endpoint of the Grafana Agent HTTP server, which defaults to listening on
+Component-specific metrics are exposed at the `/metrics` HTTP endpoint of the
+Grafana Agent HTTP server, which defaults to listening on
 `http://localhost:12345`.
 
 > The documentation for the [`agent run`][agent run] command describes how to

--- a/docs/flow/monitoring/component_metrics.md
+++ b/docs/flow/monitoring/component_metrics.md
@@ -6,3 +6,32 @@ weight: 200
 ---
 
 # Component metrics
+
+Grafana Agent Flow [components][] may optionally expose Prometheus metrics
+which can be used to investigate the behavior of that component. These
+component-specific metrics are only generated when an instance of that
+component is running.
+
+> Component-specific metrics are different than any metrics being processed by
+> the component. Component-specific metrics are used to expose the state of a
+> component for observability, alerting, and debugging.
+
+Metrics for component-specific metrics are exposed at the `/metrics` HTTP
+endpoint of the Grafana Agent HTTP server, which defaults to listening on
+`http://localhost:12345`.
+
+> The documentation for the [`agent run`][agent run] command describes how to
+> modify the address Grafana Agent listens on for HTTP traffic.
+
+Component-specific metrics will have a `component_id` label matching the
+component ID generating those metrics. For example, component-specific metrics
+for a `prometheus.remote_write` component labeled `production` will have a
+`component_id` label with the value `prometheus.remote_write.production`.
+
+The [reference documentation][] for each component will describe the list of
+component-specific metrics that component exposes. Not all components will
+expose metrics.
+
+[component]: {{< relref "../concepts/components.md" >}}
+[agent run]: {{< relref "../reference/cli/run.md" }}
+[reference documentation]: {{< relref "../reference/components/_index.md" >}}

--- a/docs/flow/monitoring/controller_metrics.md
+++ b/docs/flow/monitoring/controller_metrics.md
@@ -6,3 +6,29 @@ weight: 100
 ---
 
 # Controller metrics
+
+The Grafana Agent Flow [component controller][] exposes Prometheus metrics
+which can be used to investigate the controller state.
+
+Metrics for the controller are exposed at the `/metrics` HTTP endpoint of the
+Grafana Agent HTTP server, which defaults to listening on
+`http://localhost:12345`.
+
+> The documentation for the [`agent run`][agent run] command describes how to
+> modify the address Grafana Agent listens on for HTTP traffic.
+
+The controller exposes the following metrics:
+
+* `agent_component_controller_evaluating` (Gauge): Set to `1` whenever the
+  component controller is currently evaluating components. Note that this value
+  may be misrepresented depending on how fast evaluations complete or how often
+  evaluations occur.
+* `agent_component_controller_running_components_total` (Gauge): The current
+  number of running components by health. The health is represented in the
+  `health_type` label.
+* `agent_component_evaluation_seconds` (Histogram): The number of completed
+  graph evaluations performed by the component controller with how long they
+  took.
+
+[controller]: {{< relref "../concepts/component_controller.md" >}}
+[agent run]: {{< relref "../reference/cli/run.md" }}

--- a/docs/flow/monitoring/controller_metrics.md
+++ b/docs/flow/monitoring/controller_metrics.md
@@ -31,4 +31,4 @@ The controller exposes the following metrics:
   took.
 
 [controller]: {{< relref "../concepts/component_controller.md" >}}
-[agent run]: {{< relref "../reference/cli/run.md" }}
+[agent run]: {{< relref "../reference/cli/run.md" >}}

--- a/docs/flow/monitoring/debugging.md
+++ b/docs/flow/monitoring/debugging.md
@@ -7,10 +7,11 @@ weight: 300
 
 # Debugging
 
-There are two primary ways to debug issues with Grafana Agent Flow:
+Follow these steps to debug issues with Grafana Agent Flow:
 
-1. Through the Grafana Agent Flow UI
-2. Through examining logs
+1. Use the Grafana Agent Flow UI to debug issues.
+2. If the UI doesn't help with debugging an issue, logs can be examined
+   instead.
 
 ## Grafana Agent Flow UI
 
@@ -23,8 +24,8 @@ server, which defaults to listening at `http://localhost:12345`.
 This UI provides two views:
 
 * The home page shows a table of running components along with their health.
-  Clicking the "View" button navigates to the detail page for that component.
-* The "Graph" page shows a graph view of all running components along with
+  Clicking **View** navigates to the detail page for that component.
+* The **Graph** page shows a graph view of all running components along with
   their health. Clicking a component in the graph navigates to the detail page
   for that component.
 
@@ -46,7 +47,6 @@ To debug using the UI:
 
 [agent run]: {{< relref "../reference/cli/run.md" >}}
 [secret]: {{< relref "../config-language/expressions/types_and_values.md#secrets" >}}
-
 
 ## Examining logs
 

--- a/docs/flow/monitoring/debugging.md
+++ b/docs/flow/monitoring/debugging.md
@@ -6,3 +6,56 @@ weight: 300
 ---
 
 # Debugging
+
+There are two primary ways to debug issues with Grafana Agent Flow:
+
+1. Through the Grafana Agent Flow UI
+2. Through examining logs
+
+## Grafana Agent Flow UI
+
+Grafana Agent Flow includes an embedded UI viewable from Grafana Agent's HTTP
+server, which defaults to listening at `http://localhost:12345`.
+
+> The documentation for the [`agent run`][agent run] command describes how to
+> modify the address Grafana Agent listens on for HTTP traffic.
+
+This UI provides two views:
+
+1. The home page shows a table of running components along with their health.
+   Clicking on the "View" button will navigate to the detail page for that
+   component.
+2. The "Graph" page shows a graph view of all running components along with
+   their health. Clicking on a component in the graph will navigate to the
+   detail page for that component.
+
+The component detail page will show the following information for each
+component:
+
+1. The health of the component with a message explaining the health.
+2. The current evaluated arguments for the component.
+3. The current exports for the component.
+4. The current debug info for the component (if the component has debug info).
+
+To debug using the UI:
+
+* Ensure that no component is reported as unhealthy.
+* Ensure that the arguments and exports for misbehaving components appear
+  correct.
+
+[agent run]: {{< relref "../reference/cli/run.md" }}
+
+## Examining logs
+
+Logs may also help debug issues with Grafana Agent Flow.
+
+To reduce on logging noise, many components log hide debugging info behind
+debug-level log lines. It is recommended to configure the [`logging
+block`][logging] to emit debug-level log lines when debugging issues with
+Grafana Agent Flow.
+
+The location of Grafana Agent's logs is different based on how it is deployed.
+Refer to the [`logging block`][logging] page for how to find logs for your
+system.
+
+[logging]: {{< relref "../reference/config-blocks/logging.md" >}}

--- a/docs/flow/monitoring/debugging.md
+++ b/docs/flow/monitoring/debugging.md
@@ -22,20 +22,18 @@ server, which defaults to listening at `http://localhost:12345`.
 
 This UI provides two views:
 
-1. The home page shows a table of running components along with their health.
-   Clicking on the "View" button will navigate to the detail page for that
-   component.
-2. The "Graph" page shows a graph view of all running components along with
-   their health. Clicking on a component in the graph will navigate to the
-   detail page for that component.
+* The home page shows a table of running components along with their health.
+  Clicking the "View" button navigates to the detail page for that component.
+* The "Graph" page shows a graph view of all running components along with
+  their health. Clicking a component in the graph navigates to the detail page
+  for that component.
 
-The component detail page will show the following information for each
-component:
+The component detail page shows the following information for each component:
 
-1. The health of the component with a message explaining the health.
-2. The current evaluated arguments for the component.
-3. The current exports for the component.
-4. The current debug info for the component (if the component has debug info).
+* The health of the component with a message explaining the health.
+* The current evaluated arguments for the component.
+* The current exports for the component.
+* The current debug info for the component (if the component has debug info).
 
 To debug using the UI:
 
@@ -49,13 +47,12 @@ To debug using the UI:
 
 Logs may also help debug issues with Grafana Agent Flow.
 
-To reduce on logging noise, many components log hide debugging info behind
-debug-level log lines. It is recommended to configure the [`logging
-block`][logging] to emit debug-level log lines when debugging issues with
-Grafana Agent Flow.
+To reduce logging noise, many components hide debugging info behind debug-level
+log lines. It is recommended that you configure the [`logging block`][logging]
+to show debug-level log lines when debugging issues with Grafana Agent Flow.
 
 The location of Grafana Agent's logs is different based on how it is deployed.
-Refer to the [`logging block`][logging] page for how to find logs for your
+Refer to the [`logging block`][logging] page to see how to find logs for your
 system.
 
 [logging]: {{< relref "../reference/config-blocks/logging.md" >}}

--- a/docs/flow/monitoring/debugging.md
+++ b/docs/flow/monitoring/debugging.md
@@ -35,13 +35,18 @@ The component detail page shows the following information for each component:
 * The current exports for the component.
 * The current debug info for the component (if the component has debug info).
 
+> Values marked as a [secret][] are obfuscated and will display as the text
+> `(secret)`.
+
 To debug using the UI:
 
 * Ensure that no component is reported as unhealthy.
 * Ensure that the arguments and exports for misbehaving components appear
   correct.
 
-[agent run]: {{< relref "../reference/cli/run.md" }}
+[agent run]: {{< relref "../reference/cli/run.md" >}}
+[secret]: {{< relref "../config-language/expressions/types_and_values.md#secrets" >}}
+
 
 ## Examining logs
 


### PR DESCRIPTION
This PR adds documentation for how to monitor and debug Grafana Agent Flow. 

The UI is described here, but I've purposefully left screenshots out for the time being until the UI is merged in main (since some details may change in the meantime).