### PR TITLE
tools/ci/docker-containers: explicitly define used environment variables

### DIFF
--- a/tools/ci/docker-containers
+++ b/tools/ci/docker-containers
@@ -8,10 +8,11 @@
 set -euxo pipefail
 
 # Environment variables used throughout this script. These must be set
-# otherwise bash will fail with an "unbound variable" error. This is because
-# we run `set -u` on the above line.
+# otherwise bash will fail with an "unbound variable" error because of the `set
+# -u` flag on the above line.
 #
-# The variables will default to the empty string when unset.
+# If the environment variables are unset, the variables below default to an
+# empty string.
 export DRONE_TAG=${DRONE_TAG:-}
 export DRONE_BRANCH=${DRONE_BRANCH:-}
 

--- a/tools/ci/docker-containers
+++ b/tools/ci/docker-containers
@@ -7,6 +7,14 @@
 # from a Drone trigger.
 set -euxo pipefail
 
+# Environment variables used throughout this script. These must be set
+# otherwise bash will fail with an "unbound variable" error. This is because
+# we run `set -u` on the above line.
+#
+# The variables will default to the empty string when unset.
+export DRONE_TAG=${DRONE_TAG:-}
+export DRONE_BRANCH=${DRONE_BRANCH:-}
+
 export AGENT_IMAGE=grafana/agent
 export AGENTCTL_IMAGE=grafana/agentctl
 export OPERATOR_IMAGE=grafana/agent-operator


### PR DESCRIPTION
This fixes an issue introduced by #2139 where adding `set -u` caused bash to fail on the first line which referenced an unbound environment variable.