### PR TITLE
river: improve diagnostic for invalid object keys

### DIFF
--- a/pkg/river/parser/internal.go
+++ b/pkg/river/parser/internal.go
@@ -683,29 +683,28 @@ func (p *parser) parseFieldList(until token.Token) []*ast.ObjectField {
 //
 //    Field = ( string | identifier ) "=" Expression
 func (p *parser) parseField() *ast.ObjectField {
-	if p.tok != token.STRING && p.tok != token.IDENT {
-		p.addErrorf("expected field name (string or identifier), got %s", p.tok)
-		p.advanceAny(fieldStarter)
-		return nil
-	}
+	var field ast.ObjectField
 
-	field := &ast.ObjectField{
-		Name: &ast.Ident{
+	if p.tok == token.STRING || p.tok == token.IDENT {
+		field.Name = &ast.Ident{
 			Name:    p.lit,
 			NamePos: p.pos,
-		},
+		}
+		if p.tok == token.STRING && len(p.lit) > 2 {
+			// The field name a string literal; unwrap the quotes.
+			field.Name.Name = p.lit[1 : len(p.lit)-1]
+			field.Quoted = true
+		}
+		p.next() // Consume field name
+	} else {
+		p.addErrorf("expected field name (string or identifier), got %s", p.tok)
+		p.advance(token.ASSIGN)
 	}
-	if p.tok == token.STRING && len(p.lit) > 2 {
-		// The field name a string literal; unwrap the quotes.
-		field.Name.Name = p.lit[1 : len(p.lit)-1]
-		field.Quoted = true
-	}
-	p.next() // Consume field name
 
 	p.expect(token.ASSIGN)
 
 	field.Value = p.ParseExpression()
-	return field
+	return &field
 }
 
 var fieldStarter = map[token.Token]struct{}{

--- a/pkg/river/parser/internal.go
+++ b/pkg/river/parser/internal.go
@@ -691,7 +691,7 @@ func (p *parser) parseField() *ast.ObjectField {
 			NamePos: p.pos,
 		}
 		if p.tok == token.STRING && len(p.lit) > 2 {
-			// The field name a string literal; unwrap the quotes.
+			// The field name is a string literal; unwrap the quotes.
 			field.Name.Name = p.lit[1 : len(p.lit)-1]
 			field.Quoted = true
 		}

--- a/pkg/river/parser/internal.go
+++ b/pkg/river/parser/internal.go
@@ -707,11 +707,6 @@ func (p *parser) parseField() *ast.ObjectField {
 	return &field
 }
 
-var fieldStarter = map[token.Token]struct{}{
-	token.STRING: {},
-	token.IDENT:  {},
-}
-
 func isValidIdentifier(in string) bool {
 	s := scanner.New(nil, []byte(in), nil, 0)
 	_, tok, lit := s.Scan()

--- a/pkg/river/parser/testdata/invalid_object_key.river
+++ b/pkg/river/parser/testdata/invalid_object_key.river
@@ -3,6 +3,7 @@ obj {
     "string_field"    = "foo", 
     identifier_string = "bar", 
     1337 /* ERROR "expected field name \(string or identifier\), got NUMBER" */ = "baz", 
+    "another_field"   = "qux",
   }
 }
 

--- a/pkg/river/parser/testdata/invalid_object_key.river
+++ b/pkg/river/parser/testdata/invalid_object_key.river
@@ -1,0 +1,8 @@
+obj {
+  map = {
+    "string_field"    = "foo", 
+    identifier_string = "bar", 
+    1337 /* ERROR "expected field name \(string or identifier\), got NUMBER" */ = "baz", 
+  }
+}
+


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

#### PR Description
After a recent discussion with @rfratto about River only allowing string map keys, we noticed that the error was not terminating correctly.

This PR contains an approach for fixing the reported error by advancing directly to the assignment operator instead of attempting to simply consume any strings or identifiers in sequence.

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer
A side-effect of this change is that `parseField()` no longer returns a nil `ast.ObjectField`, but rather an empty one in case of errors. I didn't see any issues with that in any caller, but I'll look once more.

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [X] Tests updated
