### PR TITLE
flow: handle singleton components

### DIFF
--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -168,9 +168,9 @@ func (l *Loader) populateGraph(g *dag.Graph, blocks []*ast.BlockStmt) diag.Diagn
 			if registration.Singleton && block.Label != "" {
 				diags.Add(diag.Diagnostic{
 					Severity: diag.SeverityLevelError,
-					Message:  fmt.Sprintf("Singleton component %q must not have a label", componentName),
-					StartPos: block.NamePos.Position(),
-					EndPos:   block.NamePos.Add(len(componentName) - 1).Position(),
+					Message:  fmt.Sprintf("Component %q does not support labels", componentName),
+					StartPos: block.NamePos.Add(len(componentName) + 1).Position(),
+					EndPos:   block.NamePos.Add(len(componentName) + 1).Add(len(block.Label) + 1).Position(),
 				})
 				continue
 			}

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -178,7 +178,7 @@ func (l *Loader) populateGraph(g *dag.Graph, blocks []*ast.BlockStmt) diag.Diagn
 			if !registration.Singleton && block.Label == "" {
 				diags.Add(diag.Diagnostic{
 					Severity: diag.SeverityLevelError,
-					Message:  fmt.Sprintf("Component %q is missing its label", componentName),
+					Message:  fmt.Sprintf("Component %q must have a label", componentName),
 					StartPos: block.NamePos.Position(),
 					EndPos:   block.NamePos.Add(len(componentName) - 1).Position(),
 				})

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -169,8 +169,8 @@ func (l *Loader) populateGraph(g *dag.Graph, blocks []*ast.BlockStmt) diag.Diagn
 				diags.Add(diag.Diagnostic{
 					Severity: diag.SeverityLevelError,
 					Message:  fmt.Sprintf("Component %q does not support labels", componentName),
-					StartPos: block.NamePos.Add(len(componentName) + 1).Position(),
-					EndPos:   block.NamePos.Add(len(componentName) + 1).Add(len(block.Label) + 1).Position(),
+					StartPos: block.LabelPos.Position(),
+					EndPos:   block.LabelPos.Add(len(block.Label) + 1).Position(),
 				})
 				continue
 			}

--- a/pkg/flow/internal/controller/loader_test.go
+++ b/pkg/flow/internal/controller/loader_test.go
@@ -163,7 +163,7 @@ func TestLoader(t *testing.T) {
 		l := controller.NewLoader(newGlobals())
 		diags := applyFromContent(t, l, []byte(invalidFile))
 		require.ErrorContains(t, diags[0], `Component "testcomponents.tick" must have a label`)
-		require.ErrorContains(t, diags[1], `Singleton component "testcomponents.singleton" must not have a label`)
+		require.ErrorContains(t, diags[1], `Component "testcomponents.singleton" does not support labels`)
 	})
 }
 

--- a/pkg/flow/internal/controller/loader_test.go
+++ b/pkg/flow/internal/controller/loader_test.go
@@ -152,6 +152,19 @@ func TestLoader(t *testing.T) {
 		diags := applyFromContent(t, l, []byte(invalidFile))
 		require.Error(t, diags.ErrorOrNil())
 	})
+
+	t.Run("Handling of singleton component labels", func(t *testing.T) {
+		invalidFile := `
+			testcomponents.tick {
+			}
+			testcomponents.singleton "first" {
+			}
+		`
+		l := controller.NewLoader(newGlobals())
+		diags := applyFromContent(t, l, []byte(invalidFile))
+		require.ErrorContains(t, diags[0], `Component "testcomponents.tick" must have a label`)
+		require.ErrorContains(t, diags[1], `Singleton component "testcomponents.singleton" must not have a label`)
+	})
 }
 
 // TestScopeWithFailingComponent is used to ensure that the scope is filled out, even if the component

--- a/pkg/flow/internal/testcomponents/singleton.go
+++ b/pkg/flow/internal/testcomponents/singleton.go
@@ -1,0 +1,59 @@
+package testcomponents
+
+import (
+	"context"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/agent/component"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:      "testcomponents.singleton",
+		Args:      SingletonArguments{},
+		Exports:   SingletonExports{},
+		Singleton: true,
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			return NewSingleton(opts, args.(SingletonArguments))
+		},
+	})
+}
+
+// SingletonArguments configures the testcomponents.singleton component.
+type SingletonArguments struct{}
+
+// SingletonExports describes exported fields for the
+// testcomponents.singleton component.
+type SingletonExports struct{}
+
+// Singleton implements the testcomponents.singleton component, which is a
+// no-op component.
+type Singleton struct {
+	opts component.Options
+	log  log.Logger
+}
+
+// NewSingleton creates a new singleton component.
+func NewSingleton(o component.Options, cfg SingletonArguments) (*Singleton, error) {
+	t := &Singleton{opts: o, log: o.Logger}
+	if err := t.Update(cfg); err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+var (
+	_ component.Component = (*Passthrough)(nil)
+)
+
+// Run implements Component.
+func (t *Singleton) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+// Update implements Component.
+func (t *Singleton) Update(args component.Arguments) error {
+	return nil
+}

--- a/pkg/river/ast/ast.go
+++ b/pkg/river/ast/ast.go
@@ -61,10 +61,11 @@ type AttributeStmt struct {
 
 // BlockStmt declares a block.
 type BlockStmt struct {
-	Name    []string
-	NamePos token.Pos
-	Label   string
-	Body    Body
+	Name     []string
+	NamePos  token.Pos
+	Label    string
+	LabelPos token.Pos
+	Body     Body
 
 	LCurlyPos, RCurlyPos token.Pos
 }

--- a/pkg/river/parser/internal.go
+++ b/pkg/river/parser/internal.go
@@ -280,9 +280,10 @@ func (p *parser) parseStatement() ast.Stmt {
 
 	case token.LCURLY: // Block
 		block := &ast.BlockStmt{
-			Name:    blockName.Fragments,
-			NamePos: blockName.Start,
-			Label:   blockName.Label,
+			Name:     blockName.Fragments,
+			NamePos:  blockName.Start,
+			Label:    blockName.Label,
+			LabelPos: blockName.LabelPos,
 		}
 
 		block.LCurlyPos, _, _ = p.expect(token.LCURLY)


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

#### PR Description
This PR enforces that singleton components _must_ have a label and that non-singleton components _must not_ have one. 

The error reporting looks like this

```
Error: ./example-config.river:13:1: Component "local.file" must have a label

12 |
13 | local.file {
   | ^^^^^^^^^^
14 | }

Error: ./example-config.river:16:1: Singleton component "prometheus.integration.node_exporter" must not have a label

15 |
16 | prometheus.integration.node_exporter "foo" {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17 | }
```

#### Which issue(s) this PR fixes
No issue filed specifically for the handling of singleton components, but should deal with #2095.

#### Notes to the Reviewer
* We could add this check in an earlier point eg. in `flow.ReadFile()`, but that would stop at the first error and not allow us to report all offending components.
* The error reporting here reads a little repetitive, but I would prefer we don't get too smart about it yet with a helper
* The `singleton` concept is not explained in the docs, and might even be on its way out as per #1861. In any case, we might want to update our docs to be more explicit on which components _must_ have a label and which components must not.


#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added
- [X] Tests updated
