### PR TITLE
 docs/flow: add reference page for prometheus.integration.node_exporter component

### DIFF
--- a/docs/flow/reference/components/prometheus.integration.node_exporter.md
+++ b/docs/flow/reference/components/prometheus.integration.node_exporter.md
@@ -4,8 +4,8 @@ aliases:
 title: prometheus.integration.node_exporter
 ---
 
-# prometheus.integrations.node_exporter
-The `prometheus.integrations.node_exporter` embeds 
+# prometheus.integration.node_exporter
+The `prometheus.integration.node_exporter` embeds 
 [node_exporter](https://github.com/prometheus/node_exporter) which exposes a 
 wide variety of hardware and OS metrics for \*nix-based systems.
 
@@ -13,18 +13,17 @@ The `node_exporter` itself is comprised of various _collectors_, which can be
 enabled and disabled at will. For more information on collectors, refer to the
 [`collectors-list`](#collectors-list) section.
 
-The `prometheus.integrations.node_exporter` component is a _singleton_
-component. That means that it can only appear once per configuration file, and
-a block label must not be passed to it.
+The `prometheus.integration.node_exporter` component can only appear once per
+configuration file, and a block label must not be passed to it.
 
 ## Example
 ```river
-prometheus.integrations.node_exporter {
+prometheus.integration.node_exporter {
 }
 
 // Configure a prometheus.scrape component to collect node_exporter metrics.
 prometheus.scrape "demo" {
-  targets    = prometheus.integrations.node_exporter.targets
+  targets    = prometheus.integration.node_exporter.targets
   forward_to = [ /* ... */ ]
 }
 ```
@@ -45,12 +44,13 @@ Name | Type | Description | Default | Required
 
 `set_collectors` defines a hand-picked list of enabled-by-default
 collectors. If set, anything not provided in that list is disabled by
-default.
+default. See the [Collectors list](#collectors-list) for the default set of
+enabled collectors for each supported operating system.
 
 `enable_collectors` enables more collectors over the default set, or on top
 of the ones provided in `set_collectors`.
 
-`disable_collector` extends the default set of disabled collectors. In case
+`disable_collectors` extends the default set of disabled collectors. In case
 of conflicts, it takes precedence over `enable_collectors`.
 
 Additionally, the following subblocks are supported for configuring
@@ -175,7 +175,7 @@ name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
 `enable_restarts` | `boolean` | Enables service unit metric `service_restart_total` | false | no
 `start_time`      | `boolean` | Enables service unit metric `unit_start_time_seconds` | false | no
-`task_metrics`    | `boolean` | Enables service unit tasks metrics `unit_tasks_current` and `unit_tasks_max.` | false | no
+`task_metrics`    | `boolean` | Enables service unit task metrics `unit_tasks_current` and `unit_tasks_max.` | false | no
 `unit_exclude`    | `string`  | Regexp of systemd units to exclude. Units must both match include and not match exclude to be collected. | `".+\\.(automount\|device\|mount\|scope\|slice)"` | no
 `unit_include`    | `string`  | Regexp of systemd units to include. Units must both match include and not match exclude to be collected. | `".+"` | no
 
@@ -200,7 +200,7 @@ The following fields are exported and can be referenced by other components.
 
 Name      | Type                | Description 
 --------- | ------------------- | ----------- 
-`targets` | `list(map(string))` | The targets where the `node_exporter` metrics are exposed to.
+`targets` | `list(map(string))` | The targets that can be used to collect `node_exporter` metrics.
 
 For example, the `targets` could either be passed to a `prometheus.relabel`
 component to rewrite the metrics' label set, or to a `prometheus.scrape`
@@ -208,28 +208,28 @@ component that collects the exposed metrics.
 
 ## Component health
 
-`prometheus.integrations.node_exporter` is only reported as unhealthy if given
-an invalid configuration. In those cases, exported fields are kept at their
-last healthy values.
+`prometheus.integration.node_exporter` is only reported as unhealthy if given
+an invalid configuration. In those cases, exported fields retain their last
+healthy values.
 
 ## Debug information
 
-`prometheus.integrations.node_exporter` does not expose any component-specific
+`prometheus.integration.node_exporter` does not expose any component-specific
 debug information.
 
 ## Debug metrics
 
-`prometheus.integrations.node_exporter` does not expose any component-specific
+`prometheus.integration.node_exporter` does not expose any component-specific
 debug metrics.
 
-## Collectors List
-The following table lists the available collectors that node_exporter brings
+## Collectors list
+The following table lists the available collectors that `node_exporter` brings
 bundled in. Some collectors only work on specific operating systems; enabling a
 collector that is not supported by the host OS where Flow is running
 is a no-op.
 
 Users can choose to enable a subset of collectors to limit the amount of
-metrics exposed by the `prometheus.integrations.node_exporter` component,
+metrics exposed by the `prometheus.integration.node_exporter` component,
 or disable collectors that are expensive to run.
 
 | Name             | Description | OS | Enabled by default |
@@ -290,7 +290,7 @@ or disable collectors that are expensive to run.
 | `supervisord`      | Exposes service status from supervisord. | any | no |
 | `systemd`          | Exposes service and system status from systemd. | Linux | no |
 | `tapestats`        | Exposes tape device stats. | Linux | yes |
-| `tcpstat`          | Exposes TCP connection status information from `/proc/net/tcp` and `/proc/net/tcp6`. (Warning: the current version has potential performance issues in high load situations). | Linux | no |
+| `tcpstat`          | Exposes TCP connection status information from `/proc/net/tcp` and `/proc/net/tcp6`. (Warning: The current version has potential performance issues in high load situations.) | Linux | no |
 | `textfile`         | Collects metrics from files in a directory matching the filename pattern `*.prom`. The files must be using the text format defined here: https://prometheus.io/docs/instrumenting/exposition_formats/. | any | yes |
 | `thermal`          | Exposes thermal statistics. | Darwin | yes |
 | `thermal_zone`     | Exposes thermal zone & cooling device statistics from `/sys/class/thermal`. | Linux | yes |

--- a/docs/flow/reference/components/prometheus.integration.node_exporter.md
+++ b/docs/flow/reference/components/prometheus.integration.node_exporter.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-- /docs/agent/latest/flow/reference/components/prometheus.integrations.node_exporter
-title: prometheus.integrations.node_exporter
+- /docs/agent/latest/flow/reference/components/prometheus.integration.node_exporter
+title: prometheus.integration.node_exporter
 ---
 
 # prometheus.integrations.node_exporter

--- a/docs/flow/reference/components/prometheus.integration.node_exporter.md
+++ b/docs/flow/reference/components/prometheus.integration.node_exporter.md
@@ -98,8 +98,8 @@ Name | Type | Description | Default | Required
 ### `ethtool` block
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`device_exclude` | `string` | Regexp of ethtool devices to exclude (mutually exclusive with ethtool_device_include). | | no
-`device_include` | `string` | Regexp of ethtool devices to include (mutually exclusive with ethtool_device_exclude). | | no
+`device_exclude` | `string` | Regexp of ethtool devices to exclude (mutually exclusive with `device_include`). | | no
+`device_include` | `string` | Regexp of ethtool devices to include (mutually exclusive with `device_exclude`). | | no
 `metrics_include`| `string` | Regexp of ethtool stats to include. | `.*` | no
 
 ### `filesystem` block
@@ -108,9 +108,6 @@ Name | Type | Description | Default | Required
 `fs_types_exclude`     | `string`   | Regexp of filesystem types to ignore for filesystem collector.| `"^(autofs\|binfmt_misc\|bpf\|cgroup2?\|configfs\|debugfs\|devpts\|devtmpfs\|fusectl\|hugetlbfs\|iso9660\|mqueue\|nsfs\|overlay\|proc\|procfs\|pstore\|rpc_pipefs\|securityfs\|selinuxfs\|squashfs\|sysfs\|tracefs)$"` | no
 `mount_points_exclude` | `string`   | Regexp of mount points to ignore for filesystem collector. | `"^/(dev\|proc\|sys\|var/lib/docker/.+)($\|/)"` | no
 `mount_timeout`        | `duration` | How long to wait for a mount to respond before marking it as stale. | `"5s"` | no
-
- 
-
 
 ### `ipvs` block
 Name | Type | Description | Default | Required
@@ -137,8 +134,8 @@ name | type | description | default | required
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
 `address_info`   | `boolean` | Enable collecting address-info for every device. | false | no
-`device_exclude` | `string`  | Regexp of net devices to exclude (mutually exclusive with include). |  | no
-`device_include` | `string`  | Regexp of net devices to include (mutually exclusive with exclude). |  | no
+`device_exclude` | `string`  | Regexp of net devices to exclude (mutually exclusive with `device_include`). |  | no
+`device_include` | `string`  | Regexp of net devices to include (mutually exclusive with `device_exclude`). |  | no
 
 ### `netstat` block
 name | type | description | default | required
@@ -190,7 +187,7 @@ name | type | description | default | required
 ### `textfile` block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-`textfile_directory` | `string` | Directory to read \*.prom files from for the textfile collector. |  | no
+`textfile_directory` | `string` | Directory to read `*.prom` files from for the textfile collector. |  | no
 
 ### `vmstat` block
 name | type | description | default | required
@@ -237,12 +234,12 @@ or disable collectors that are expensive to run.
 
 | Name             | Description | OS | Enabled by default |
 | ---------------- | ----------- | -- | ------------------ |
-| `arp`              | Exposes ARP statistics from /proc/net/arp. | Linux | yes |
-| `bcache`           | Exposes bcache statistics from /sys/fs/bcache. | Linux | yes |
+| `arp`              | Exposes ARP statistics from `/proc/net/arp`. | Linux | yes |
+| `bcache`           | Exposes bcache statistics from `/sys/fs/bcache`. | Linux | yes |
 | `bonding`          | Exposes the number of configured and active slaves of Linux bonding interfaces. | Linux | yes |
-| `boottime`         | Exposes system boot time derived from the kern.boottime sysctl. | Darwin, Dragonfly, FreeBSD, NetBSD, OpenBSD, Solaris | yes |
+| `boottime`         | Exposes system boot time derived from the `kern.boottime sysctl`. | Darwin, Dragonfly, FreeBSD, NetBSD, OpenBSD, Solaris | yes |
 | `btrfs`            | Exposes statistics on btrfs. | Linux | yes |
-| `buddyinfo`        | Exposes statistics of memory fragments as reported by /proc/buddyinfo. | Linux | no |
+| `buddyinfo`        | Exposes statistics of memory fragments as reported by `/proc/buddyinfo`. | Linux | no |
 | `conntrack`        | Shows conntrack statistics (does nothing if no /proc/sys/net/netfilter/ present). | Linux | yes |
 | `cpu`              | Exposes CPU statistics. | Darwin, Dragonfly, FreeBSD, Linux, Solaris | yes |
 | `cpufreq`          | Exposes CPU frequency statistics. | Linux, Solaris | yes |
@@ -250,27 +247,27 @@ or disable collectors that are expensive to run.
 | `diskstats`        | Exposes disk I/O statistics. | Darwin, Linux, OpenBSD | yes |
 | `dmi`              | Exposes DMI information. | Linux | yes |
 | `drbd`             | Exposes Distributed Replicated Block Device statistics (to version 8.4). | Linux | no |
-| `drm`              | Exposes GPU card info from /sys/class/drm/card?/device. | Linux | no |
+| `drm`              | Exposes GPU card info from `/sys/class/drm/card?/device`. | Linux | no |
 | `edac`             | Exposes error detection and correction statistics. | Linux | yes |
 | `entropy`          | Exposes available entropy. | Linux | yes |
 | `ethtool`          | Exposes ethtool stats. | Linux | no |
 | `exec`             | Exposes execution statistics. | Dragonfly, FreeBSD | yes |
 | `fibrechannel`     | Exposes FibreChannel statistics. | Linux | yes |
-| `filefd`           | Exposes file descriptor statistics from /proc/sys/fs/file-nr. | Linux | yes |
+| `filefd`           | Exposes file descriptor statistics from `/proc/sys/fs/file-nr`. | Linux | yes |
 | `filesystem`       | Exposes filesystem statistics, such as disk space used. | Darwin, Dragonfly, FreeBSD, Linux, OpenBSD | yes |
-| `hwmon`            | Exposes hardware monitoring and sensor data from /sys/class/hwmon. | Linux | yes |
+| `hwmon`            | Exposes hardware monitoring and sensor data from `/sys/class/hwmon`. | Linux | yes |
 | `infiniband`       | Exposes network statistics specific to InfiniBand and Intel OmniPath configurations. | Linux | yes |
 | `interrupts`       | Exposes detailed interrupts statistics. | Linux, OpenBSD | no |
 | `ipvs`             | Exposes IPVS status from `/proc/net/ip_vs` and stats from `/proc/net/ip_vs_stats`. | Linux | yes |
-| `ksmd`             | Exposes kernel and system statistics from /sys/kernel/mm/ksm. | Linux | no |
+| `ksmd`             | Exposes kernel and system statistics from `/sys/kernel/mm/ksm`. | Linux | no |
 | `lnstat`           | Exposes Linux network cache stats. | Linux | no |
 | `loadavg`          | Exposes load average. | Darwin, Dragonfly, FreeBSD, Linux, NetBSD, OpenBSD, Solaris | yes |
 | `logind`           | Exposes session counts from logind. | Linux | no |
-| `mdadm`            | Exposes statistics about devices in /proc/mdstat (does nothing if no /proc/mdstat present). | Linux | yes |
+| `mdadm`            | Exposes statistics about devices in `/proc/mdstat` (does nothing if no `/proc/mdstat` present). | Linux | yes |
 | `meminfo`          | Exposes memory statistics. | Darwin, Dragonfly, FreeBSD, Linux, OpenBSD | yes |
 | `meminfo_numa`     | Exposes memory statistics from `/proc/meminfo_numa`. | Linux | no |
 | `mountstats`       | Exposes filesystem statistics from `/proc/self/mountstats`. Exposes detailed NFS client statistics. | Linux | no |
-| `netclass`         | Exposes network interface info from `/sys/class/ne`t. | Linux | yes |
+| `netclass`         | Exposes network interface info from `/sys/class/net`. | Linux | yes |
 | `netdev`           | Exposes network interface statistics such as bytes transferred. | Darwin, Dragonfly, FreeBSD, Linux, OpenBSD | yes |
 | `netstat`          | Exposes network statistics from `/proc/net/netstat`. This is the same information as `netstat -s`. | Linux | yes |
 | `network_route`    | Exposes network route statistics. | Linux | no |
@@ -289,7 +286,7 @@ or disable collectors that are expensive to run.
 | `schedstat`        | Exposes task scheduler statistics from `/proc/schedstat`. | Linux | yes |
 | `sockstat`         | Exposes various statistics from `/proc/net/sockstat`. | Linux | yes |
 | `softnet`          | Exposes statistics from `/proc/net/softnet_stat`. | Linux | yes |
-| `stat`             | Exposes various statistics from /proc/stat. This includes boot time, forks and interrupts. | Linux | yes |
+| `stat`             | Exposes various statistics from `/proc/stat`. This includes boot time, forks and interrupts. | Linux | yes |
 | `supervisord`      | Exposes service status from supervisord. | any | no |
 | `systemd`          | Exposes service and system status from systemd. | Linux | no |
 | `tapestats`        | Exposes tape device stats. | Linux | yes |

--- a/docs/flow/reference/components/prometheus.integration.node_exporter.md
+++ b/docs/flow/reference/components/prometheus.integration.node_exporter.md
@@ -5,12 +5,12 @@ title: prometheus.integration.node_exporter
 ---
 
 # prometheus.integrations.node_exporter
-The component embeds the popular
+The `prometheus.integrations.node_exporter` embeds 
 [node_exporter](https://github.com/prometheus/node_exporter) which exposes a 
-wide variety of hardware and OS metrics from the host machine.
+wide variety of hardware and OS metrics for \*nix-based systems.
 
 The `node_exporter` itself is comprised of various _collectors_, which can be
-enabled and disabled at will. For more information on collectors refer to the
+enabled and disabled at will. For more information on collectors, refer to the
 [`collectors-list`](#collectors-list) section.
 
 The `prometheus.integrations.node_exporter` component is a _singleton_
@@ -38,61 +38,62 @@ Name | Type | Description | Default | Required
 `set_collectors`           | list(string) | Overrides the default set of enabled collectors with the collectors listed. | | no
 `enable_collectors`        | list(string) | Collectors to mark as enabled.  | | no
 `disable_collectors`       | list(string) | Collectors to mark as disabled. | | no
-`include_exporter_metrics` | boolean      | Whether metrics about the exporter itself should be reported | false | no 
+`include_exporter_metrics` | boolean      | Whether metrics about the exporter itself should be reported. | false | no 
 `procfs_path`              | string       | The procfs mountpoint. | `/proc` | no
 `sysfs_path`               | string       | The sysfs mountpoint.  | `/sys`   | no
 `rootfs_path`              | string       | Specify a prefix for accessing the host filesystem. | `/` | no
 
-The `set_collectors` argument defines a hand-picked list of enabled-by-default
+`set_collectors` defines a hand-picked list of enabled-by-default
 collectors. If set, anything not provided in that list is disabled by
 default.
 
-The `enable_collectors` enables more collectors over the default set, or on top
+`enable_collectors` enables more collectors over the default set, or on top
 of the ones provided in `set_collectors`.
 
-The `disable_collector` extends the default set of disabled collectors. In case
+`disable_collector` extends the default set of disabled collectors. In case
 of conflicts, it takes precedence over `enable_collectors`.
 
-Additionally, the following subblocks are supported for configuring collector-specific options.
+Additionally, the following subblocks are supported for configuring
+collector-specific options.
 
 Name | Description | Required
 ---- | ----------- | --------
-[`bcache`](#bcache-block) | Configures the bcache collector | no
-[`cpu`](#cpu-block) | Configures the cpu collector | no
-[`disk`](#disk-block) | Configures the diskstats collector | no
-[`ethtool`](#ethtool-block) | Configures the ethtool collector | no
-[`filesystem`](#filesystem-block) | Configures the filesystem collector | no
-[`ipvs`](#ipvs-block) | Configures the ipvs collector | no
-[`ntp`](#ntp-block) | Configures the ntp collector | no
-[`netclass`](#netclass-block) | Configures the netclass collector | no
-[`netdev`](#netdev-block) | Configures the netdev collector | no
-[`netstat`](#netstat-block) | Configures the netstat collector | no
-[`perf`](#perf-block) | Configures the perf collector | no
-[`powersupply`](#powersupply-block) | Configures the powersupply collector | no
-[`runit`](#runit-block) | Configures the runit collector | no
-[`supervisord`](#supervisord-block) | Configures the supervisord collector | no
-[`systemd`](#systemd-block) | Configures the systemd collector | no
-[`tapestats`](#tapestats-block) | Configures the tapestats collector | no
-[`textfile`](#textfile-block) | Configures the textfile collector | no
-[`vmstat`](#vmstat-block) | Configures the vmstat collector | no
+[`bcache`](#bcache-block) | Configures the bcache collector. | no
+[`cpu`](#cpu-block) | Configures the cpu collector. | no
+[`disk`](#disk-block) | Configures the diskstats collector. | no
+[`ethtool`](#ethtool-block) | Configures the ethtool collector. | no
+[`filesystem`](#filesystem-block) | Configures the filesystem collector. | no
+[`ipvs`](#ipvs-block) | Configures the ipvs collector. | no
+[`ntp`](#ntp-block) | Configures the ntp collector. | no
+[`netclass`](#netclass-block) | Configures the netclass collector. | no
+[`netdev`](#netdev-block) | Configures the netdev collector. | no
+[`netstat`](#netstat-block) | Configures the netstat collector. | no
+[`perf`](#perf-block) | Configures the perf collector. | no
+[`powersupply`](#powersupply-block) | Configures the powersupply collector. | no
+[`runit`](#runit-block) | Configures the runit collector. | no
+[`supervisord`](#supervisord-block) | Configures the supervisord collector. | no
+[`systemd`](#systemd-block) | Configures the systemd collector. | no
+[`tapestats`](#tapestats-block) | Configures the tapestats collector. | no
+[`textfile`](#textfile-block) | Configures the textfile collector. | no
+[`vmstat`](#vmstat-block) | Configures the vmstat collector. | no
 
 ### `bcache` block
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`priority_stats` | boolean |  Enable exposing of expensive bcache priority stats | false | no
+`priority_stats` | boolean |  Enable exposing of expensive bcache priority stats. | false | no
 
 ### `cpu` block
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`guest`         | boolean | Enable the node_cpu_guest_seconds_total metric. | true | no
-`info`          | boolean | Enable the cpu_info metric for the cpu collector. | true | no
+`guest`         | boolean | Enable the `node_cpu_guest_seconds_total` metric. | true | no
+`info`          | boolean | Enable the `cpu_info metric` for the cpu collector. | true | no
 `bugs_include`  | string  | Regexp of `bugs` field in cpu info to filter. | | no
 `flags_include` | string  | Regexp of `flags` field in cpu info to filter. | no
 
 ### `disk` block
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`ignored_devices` | string | Regexp of devices to ignore for diskstats | `"^(ram\|loop\|fd\|(h\|s\|v\|xv)d[a-z]\|nvme\\d+n\\d+p)\\d+$"` | no
+`ignored_devices` | string | Regexp of devices to ignore for diskstats. | `"^(ram\|loop\|fd\|(h\|s\|v\|xv)d[a-z]\|nvme\\d+n\\d+p)\\d+$"` | no
 
 ### `ethtool` block
 Name | Type | Description | Default | Required
@@ -124,20 +125,20 @@ name | type | description | default | required
 `ip_ttl`                 | int      | TTL to use while sending NTP query. | 1 | no
 `local_offset_tolerance` | duration | Offset between local clock and local ntpd time to tolerate. | "1ms" | no
 `max_distance`           | duration | Max accumulated distance to the root. | "3466080us" | no
-`protocol_version`       | int      | NTP protocol version | 4 | no
+`protocol_version`       | int      | NTP protocol version. | 4 | no
 
 ### `netclass` block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-`ignore_invalid_speed_device` | boolean | Ignore net devices with invalid speed values | false | no
+`ignore_invalid_speed_device` | boolean | Ignore net devices with invalid speed values. | false | no
 `ignored_devices`             | string  | Regexp of net devices to ignore for netclass collector. | `"^$"` | no
 
 ### `netdev` block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-`address_info`   | boolean | Enable collecting address-info for every device | false | no
-`device_exclude` | string  | Regexp of net devices to exclude (mutually exclusive with include) | `""` | no
-`device_include` | string  | Regexp of net devices to include (mutually exclusive with exclude) | `""` | no
+`address_info`   | boolean | Enable collecting address-info for every device. | false | no
+`device_exclude` | string  | Regexp of net devices to exclude (mutually exclusive with include). | `""` | no
+`device_include` | string  | Regexp of net devices to include (mutually exclusive with exclude). | `""` | no
 
 ### `netstat` block
 name | type | description | default | required
@@ -167,7 +168,7 @@ name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
 `url` | string | XML RPC endpoint for the supervisord collector. | `"http://localhost:9001/RPC2"` | no
 
-Setting SUPERVISORD_URL in the environment overrides the default value.
+Setting `SUPERVISORD_URL` in the environment overrides the default value.
 An explicit value in the YAML config takes precedence over the environment
 variable.
 
@@ -175,11 +176,11 @@ variable.
 ### `systemd` block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-enable_restarts | boolean | Enables service unit metric service_restart_total | false | no
-start_time      | boolean | Enables service unit metric unit_start_time_seconds | false | no
-task_metrics    | boolean | Enables service unit tasks metrics unit_tasks_current and unit_tasks_max.
-unit_exclude    | string  | Regexp of systemd units to exclude. Units must both match include and not match exclude to be collected. | `".+\\.(automount\|device\|mount\|scope\|slice)"` | no
-unit_include    | string  | Regexp of systemd units to include. Units must both match include and not match exclude to be collected. | `".+"` | no
+`enable_restarts` | boolean | Enables service unit metric `service_restart_total` | false | no
+`start_time`      | boolean | Enables service unit metric `unit_start_time_seconds` | false | no
+`task_metrics`    | boolean | Enables service unit tasks metrics `unit_tasks_current` and `unit_tasks_max.` | false | no
+`unit_exclude`    | string  | Regexp of systemd units to exclude. Units must both match include and not match exclude to be collected. | `".+\\.(automount\|device\|mount\|scope\|slice)"` | no
+`unit_include`    | string  | Regexp of systemd units to include. Units must both match include and not match exclude to be collected. | `".+"` | no
 
 ### `tapestats` block
 name | type | description | default | required
@@ -189,7 +190,7 @@ name | type | description | default | required
 ### `textfile` block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-`textfile_directory` | string | Directory to read *.prom files from for the textfile collector. | `""` | no
+`textfile_directory` | string | Directory to read \*.prom files from for the textfile collector. | `""` | no
 
 ### `vmstat` block
 name | type | description | default | required
@@ -216,16 +217,18 @@ last healthy values.
 
 ## Debug information
 
-`prometheus.relabel` does not expose any component-specific debug information.
+`prometheus.integrations.node_exporter` does not expose any component-specific
+debug information.
 
 ## Debug metrics
 
-`prometheus.relabel` does not expose any component-specific debug metrics.
+`prometheus.integrations.node_exporter` does not expose any component-specific
+debug metrics.
 
 ## Collectors List
 The following table lists the available collectors that node_exporter brings
-bundled in. Some collectors may only work on specific operating systems;
-enabling a collector that is not supported by the host OS where Flow is running
+bundled in. Some collectors only work on specific operating systems; enabling a
+collector that is not supported by the host OS where Flow is running
 is a no-op.
 
 Users can choose to enable a subset of collectors to limit the amount of
@@ -247,10 +250,10 @@ or disable collectors that are expensive to run.
 | diskstats        | Exposes disk I/O statistics. | Darwin, Linux, OpenBSD | yes |
 | dmi              | Exposes DMI information. | Linux | yes |
 | drbd             | Exposes Distributed Replicated Block Device statistics (to version 8.4). | Linux | no |
-| drm              | Exposes GPU card info from /sys/class/drm/card?/device | Linux | no |
+| drm              | Exposes GPU card info from /sys/class/drm/card?/device. | Linux | no |
 | edac             | Exposes error detection and correction statistics. | Linux | yes |
 | entropy          | Exposes available entropy. | Linux | yes |
-| ethtool          | Exposes ethtool stats | Linux | no |
+| ethtool          | Exposes ethtool stats. | Linux | no |
 | exec             | Exposes execution statistics. | Dragonfly, FreeBSD | yes |
 | fibrechannel     | Exposes FibreChannel statistics. | Linux | yes |
 | filefd           | Exposes file descriptor statistics from /proc/sys/fs/file-nr. | Linux | yes |
@@ -258,53 +261,58 @@ or disable collectors that are expensive to run.
 | hwmon            | Exposes hardware monitoring and sensor data from /sys/class/hwmon. | Linux | yes |
 | infiniband       | Exposes network statistics specific to InfiniBand and Intel OmniPath configurations. | Linux | yes |
 | interrupts       | Exposes detailed interrupts statistics. | Linux, OpenBSD | no |
-| ipvs             | Exposes IPVS status from /proc/net/ip_vs and stats from /proc/net/ip_vs_stats. | Linux | yes |
+| ipvs             | Exposes IPVS status from `/proc/net/ip_vs` and stats from `/proc/net/ip_vs_stats`. | Linux | yes |
 | ksmd             | Exposes kernel and system statistics from /sys/kernel/mm/ksm. | Linux | no |
-| lnstat           | Exposes Linux network cache stats | Linux | no |
+| lnstat           | Exposes Linux network cache stats. | Linux | no |
 | loadavg          | Exposes load average. | Darwin, Dragonfly, FreeBSD, Linux, NetBSD, OpenBSD, Solaris | yes |
 | logind           | Exposes session counts from logind. | Linux | no |
 | mdadm            | Exposes statistics about devices in /proc/mdstat (does nothing if no /proc/mdstat present). | Linux | yes |
 | meminfo          | Exposes memory statistics. | Darwin, Dragonfly, FreeBSD, Linux, OpenBSD | yes |
-| meminfo_numa     | Exposes memory statistics from /proc/meminfo_numa. | Linux | no |
-| mountstats       | Exposes filesystem statistics from /proc/self/mountstats. Exposes detailed NFS client statistics. | Linux | no |
-| netclass         | Exposes network interface info from /sys/class/net. | Linux | yes |
+| meminfo_numa     | Exposes memory statistics from `/proc/meminfo_numa`. | Linux | no |
+| mountstats       | Exposes filesystem statistics from `/proc/self/mountstats`. Exposes detailed NFS client statistics. | Linux | no |
+| netclass         | Exposes network interface info from `/sys/class/ne`t. | Linux | yes |
 | netdev           | Exposes network interface statistics such as bytes transferred. | Darwin, Dragonfly, FreeBSD, Linux, OpenBSD | yes |
-| netstat          | Exposes network statistics from /proc/net/netstat. This is the same information as netstat -s. | Linux | yes |
+| netstat          | Exposes network statistics from `/proc/net/netstat`. This is the same information as `netstat -s`. | Linux | yes |
 | network_route    | Exposes network route statistics. | Linux | no |
-| nfs              | Exposes NFS client statistics from /proc/net/rpc/nfs. This is the same information as nfsstat -c. | Linux | yes |
-| nfsd             | Exposes NFS kernel server statistics from /proc/net/rpc/nfsd. This is the same information as nfsstat -s. | Linux | yes |
+| nfs              | Exposes NFS client statistics from `/proc/net/rpc/nfs`. This is the same information as `nfsstat -c`. | Linux | yes |
+| nfsd             | Exposes NFS kernel server statistics from `/proc/net/rpc/nfsd`. This is the same information as `nfsstat -s`. | Linux | yes |
 | ntp              | Exposes local NTP daemon health to check time. | any | no |
 | nvme             | Exposes NVMe statistics. | Linux | yes |
 | os               | Exposes os-release information. | Linux | yes |
 | perf             | Exposes perf based metrics (Warning: Metrics are dependent on kernel configuration and settings). | Linux | no |
 | powersupplyclass | Collects information on power supplies. | any | yes |
-| pressure         | Exposes pressure stall statistics from /proc/pressure/. | Linux (kernel 4.20+ and/or CONFIG_PSI) | yes |
+| pressure         | Exposes pressure stall statistics from `/proc/pressure/`. | Linux (kernel 4.20+ and/or CONFIG_PSI) | yes |
 | processes        | Exposes aggregate process statistics from /proc. | Linux | no |
 | qdisc            | Exposes queuing discipline statistics. | Linux | no |
-| rapl             | Exposes various statistics from /sys/class/powercap. | Linux | yes |
+| rapl             | Exposes various statistics from `/sys/class/powercap`. | Linux | yes |
 | runit            | Exposes service status from runit. | any | no |
-| schedstat        | Exposes task scheduler statistics from /proc/schedstat. | Linux | yes |
-| sockstat         | Exposes various statistics from /proc/net/sockstat. | Linux | yes |
-| softnet          | Exposes statistics from /proc/net/softnet_stat. | Linux | yes |
+| schedstat        | Exposes task scheduler statistics from `/proc/schedstat`. | Linux | yes |
+| sockstat         | Exposes various statistics from `/proc/net/sockstat`. | Linux | yes |
+| softnet          | Exposes statistics from `/proc/net/softnet_stat`. | Linux | yes |
 | stat             | Exposes various statistics from /proc/stat. This includes boot time, forks and interrupts. | Linux | yes |
 | supervisord      | Exposes service status from supervisord. | any | no |
 | systemd          | Exposes service and system status from systemd. | Linux | no |
 | tapestats        | Exposes tape device stats. | Linux | yes |
-| tcpstat          | Exposes TCP connection status information from /proc/net/tcp and /proc/net/tcp6. (Warning: the current version has potential performance issues in high load situations). | Linux | no |
-| textfile         | Collects metrics from files in a directory matching the filename pattern *.prom. The files must be using the text format defined here: https://prometheus.io/docs/instrumenting/exposition_formats/ | any | yes |
+| tcpstat          | Exposes TCP connection status information from `/proc/net/tcp` and `/proc/net/tcp6`. (Warning: the current version has potential performance issues in high load situations). | Linux | no |
+| textfile         | Collects metrics from files in a directory matching the filename pattern \*.prom. The files must be using the text format defined here: https://prometheus.io/docs/instrumenting/exposition_formats/. | any | yes |
 | thermal          | Exposes thermal statistics. | Darwin | yes |
-| thermal_zone     | Exposes thermal zone & cooling device statistics from /sys/class/thermal. | Linux | yes |
+| thermal_zone     | Exposes thermal zone & cooling device statistics from `/sys/class/thermal`. | Linux | yes |
 | time             | Exposes the current system time. | any | yes |
-| timex            | Exposes selected adjtimex(2) system call stats. | Linux | yes |
-| udp_queues       | Exposes UDP total lengths of the rx_queue and tx_queue from /proc/net/udp and /proc/net/udp6. | Linux | yes |
+| timex            | Exposes selected `adjtimex(2)` system call stats. | Linux | yes |
+| udp_queues       | Exposes UDP total lengths of the `rx_queue` and `tx_queue` from `/proc/net/udp` and `/proc/net/udp6`. | Linux | yes |
 | uname            | Exposes system information as provided by the uname system call. | Darwin, FreeBSD, Linux, OpenBSD | yes |
-| vmstat           | Exposes statistics from /proc/vmstat. | Linux | yes |
+| vmstat           | Exposes statistics from `/proc/vmstat`. | Linux | yes |
 | wifi             | Exposes WiFi device and station statistics. | Linux | no |
 | xfs              | Exposes XFS runtime statistics. | Linux (kernel 4.4+) | yes |
 | zfs              | Exposes ZFS performance statistics. | Linux, Solaris | yes |
 | zoneinfo         | Exposes zone stats. | Linux | no |
 
 ## Running on Docker/Kubernetes
-When running Flow in a Docker container, you need to bind mount the filesystem, procfs and sysfs from the host machine as well as set the corresponding arguments for the component to work.
+When running Flow in a Docker container, you need to bind mount the filesystem,
+procfs, and sysfs from the host machine, as well as set the corresponding
+arguments for the component to work.
 
-You may also need to add capabilities such as `SYS_TIME` and make sure that the Agent is running with elevated privileges for some of the collectors to work properly.
+You may also need to add capabilities such as `SYS_TIME` and make sure that the
+Agent is running with elevated privileges for some of the collectors to work
+properly.
+

--- a/docs/flow/reference/components/prometheus.integration.node_exporter.md
+++ b/docs/flow/reference/components/prometheus.integration.node_exporter.md
@@ -5,7 +5,7 @@ title: prometheus.integration.node_exporter
 ---
 
 # prometheus.integration.node_exporter
-The `prometheus.integration.node_exporter` embeds 
+The `prometheus.integration.node_exporter` component embeds 
 [node_exporter](https://github.com/prometheus/node_exporter) which exposes a 
 wide variety of hardware and OS metrics for \*nix-based systems.
 

--- a/docs/flow/reference/components/prometheus.integration.node_exporter.md
+++ b/docs/flow/reference/components/prometheus.integration.node_exporter.md
@@ -107,7 +107,7 @@ Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `fs_types_exclude`     | `string`   | Regexp of filesystem types to ignore for filesystem collector.| `"^(autofs\|binfmt_misc\|bpf\|cgroup2?\|configfs\|debugfs\|devpts\|devtmpfs\|fusectl\|hugetlbfs\|iso9660\|mqueue\|nsfs\|overlay\|proc\|procfs\|pstore\|rpc_pipefs\|securityfs\|selinuxfs\|squashfs\|sysfs\|tracefs)$"` | no
 `mount_points_exclude` | `string`   | Regexp of mount points to ignore for filesystem collector. | `"^/(dev\|proc\|sys\|var/lib/docker/.+)($\|/)"` | no
-`mount_timeout`        | `duration` | How long to wait for a mount to respond before marking it as stale. | "5s" | no
+`mount_timeout`        | `duration` | How long to wait for a mount to respond before marking it as stale. | `"5s"` | no
 
  
 
@@ -120,11 +120,11 @@ Name | Type | Description | Default | Required
 ### `ntp` block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-`server`                 | `string`   | NTP server to use for the collector. | "127.0.0.1" | no
+`server`                 | `string`   | NTP server to use for the collector. | `"127.0.0.1"` | no
 `server_is_local`        | `boolean`  | Certifies that the server address is not a public ntp server. | false | no
 `ip_ttl`                 | `int`      | TTL to use while sending NTP query. | 1 | no
-`local_offset_tolerance` | `duration` | Offset between local clock and local ntpd time to tolerate. | "1ms" | no
-`max_distance`           | `duration` | Max accumulated distance to the root. | "3466080us" | no
+`local_offset_tolerance` | `duration` | Offset between local clock and local ntpd time to tolerate. | `"1ms"` | no
+`max_distance`           | `duration` | Max accumulated distance to the root. | `"3466080us"` | no
 `protocol_version`       | `int`      | NTP protocol version. | 4 | no
 
 ### `netclass` block
@@ -150,7 +150,7 @@ name | type | description | default | required
 ### `perf` block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-`cpus`       | `string`       | List of CPUs from which perf metrics should be collected. | "" | no
+`cpus`       | `string`       | List of CPUs from which perf metrics should be collected. | | no
 `tracepoint` | `list(string)` | Array of perf tracepoints that should be collected. | | no
 
 ### `powersupply` block

--- a/docs/flow/reference/components/prometheus.integration.node_exporter.md
+++ b/docs/flow/reference/components/prometheus.integration.node_exporter.md
@@ -240,7 +240,7 @@ or disable collectors that are expensive to run.
 | `boottime`         | Exposes system boot time derived from the `kern.boottime sysctl`. | Darwin, Dragonfly, FreeBSD, NetBSD, OpenBSD, Solaris | yes |
 | `btrfs`            | Exposes statistics on btrfs. | Linux | yes |
 | `buddyinfo`        | Exposes statistics of memory fragments as reported by `/proc/buddyinfo`. | Linux | no |
-| `conntrack`        | Shows conntrack statistics (does nothing if no /proc/sys/net/netfilter/ present). | Linux | yes |
+| `conntrack`        | Shows conntrack statistics (does nothing if no `/proc/sys/net/netfilter/` present). | Linux | yes |
 | `cpu`              | Exposes CPU statistics. | Darwin, Dragonfly, FreeBSD, Linux, Solaris | yes |
 | `cpufreq`          | Exposes CPU frequency statistics. | Linux, Solaris | yes |
 | `devstat`          | Exposes device statistics. | Dragonfly, FreeBSD | no |
@@ -291,7 +291,7 @@ or disable collectors that are expensive to run.
 | `systemd`          | Exposes service and system status from systemd. | Linux | no |
 | `tapestats`        | Exposes tape device stats. | Linux | yes |
 | `tcpstat`          | Exposes TCP connection status information from `/proc/net/tcp` and `/proc/net/tcp6`. (Warning: the current version has potential performance issues in high load situations). | Linux | no |
-| `textfile`         | Collects metrics from files in a directory matching the filename pattern \*.prom. The files must be using the text format defined here: https://prometheus.io/docs/instrumenting/exposition_formats/. | any | yes |
+| `textfile`         | Collects metrics from files in a directory matching the filename pattern `*.prom`. The files must be using the text format defined here: https://prometheus.io/docs/instrumenting/exposition_formats/. | any | yes |
 | `thermal`          | Exposes thermal statistics. | Darwin | yes |
 | `thermal_zone`     | Exposes thermal zone & cooling device statistics from `/sys/class/thermal`. | Linux | yes |
 | `time`             | Exposes the current system time. | any | yes |

--- a/docs/flow/reference/components/prometheus.integration.node_exporter.md
+++ b/docs/flow/reference/components/prometheus.integration.node_exporter.md
@@ -14,8 +14,8 @@ enabled and disabled at will. For more information on collectors, refer to the
 [`collectors-list`](#collectors-list) section.
 
 The `prometheus.integrations.node_exporter` component is a _singleton_
-component. That means that it can only appear _once_ per configuration file,
-and it requires that no block label is passed to it.
+component. That means that it can only appear once per configuration file, and
+a block label must not be passed to it.
 
 ## Example
 ```river
@@ -35,13 +35,13 @@ All arguments are optional. Omitted fields take their default values.
 
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`set_collectors`           | list(string) | Overrides the default set of enabled collectors with the collectors listed. | | no
-`enable_collectors`        | list(string) | Collectors to mark as enabled.  | | no
-`disable_collectors`       | list(string) | Collectors to mark as disabled. | | no
-`include_exporter_metrics` | boolean      | Whether metrics about the exporter itself should be reported. | false | no 
-`procfs_path`              | string       | The procfs mountpoint. | `/proc` | no
-`sysfs_path`               | string       | The sysfs mountpoint.  | `/sys`   | no
-`rootfs_path`              | string       | Specify a prefix for accessing the host filesystem. | `/` | no
+`set_collectors`           | `list(string)` | Overrides the default set of enabled collectors with the collectors listed. | | no
+`enable_collectors`        | `list(string)` | Collectors to mark as enabled.  | | no
+`disable_collectors`       | `list(string)` | Collectors to mark as disabled. | | no
+`include_exporter_metrics` | `boolean`      | Whether metrics about the exporter itself should be reported. | false | no 
+`procfs_path`              | `string`       | The procfs mountpoint. | `/proc` | no
+`sysfs_path`               | `string`       | The sysfs mountpoint.  | `/sys`   | no
+`rootfs_path`              | `string`       | Specify a prefix for accessing the host filesystem. | `/` | no
 
 `set_collectors` defines a hand-picked list of enabled-by-default
 collectors. If set, anything not provided in that list is disabled by
@@ -80,34 +80,34 @@ Name | Description | Required
 ### `bcache` block
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`priority_stats` | boolean |  Enable exposing of expensive bcache priority stats. | false | no
+`priority_stats` | `boolean` |  Enable exposing of expensive bcache priority stats. | false | no
 
 ### `cpu` block
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`guest`         | boolean | Enable the `node_cpu_guest_seconds_total` metric. | true | no
-`info`          | boolean | Enable the `cpu_info metric` for the cpu collector. | true | no
-`bugs_include`  | string  | Regexp of `bugs` field in cpu info to filter. | | no
-`flags_include` | string  | Regexp of `flags` field in cpu info to filter. | no
+`guest`         | `boolean` | Enable the `node_cpu_guest_seconds_total` metric. | true | no
+`info`          | `boolean` | Enable the `cpu_info metric` for the cpu collector. | true | no
+`bugs_include`  | `string`  | Regexp of `bugs` field in cpu info to filter. | | no
+`flags_include` | `string`  | Regexp of `flags` field in cpu info to filter. | | no
 
 ### `disk` block
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`ignored_devices` | string | Regexp of devices to ignore for diskstats. | `"^(ram\|loop\|fd\|(h\|s\|v\|xv)d[a-z]\|nvme\\d+n\\d+p)\\d+$"` | no
+`ignored_devices` | `string` | Regexp of devices to ignore for diskstats. | `"^(ram\|loop\|fd\|(h\|s\|v\|xv)d[a-z]\|nvme\\d+n\\d+p)\\d+$"` | no
 
 ### `ethtool` block
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`device_exclude` | string | Regexp of ethtool devices to exclude (mutually exclusive with ethtool_device_include). | | no
-`device_include` | string | Regexp of ethtool devices to include (mutually exclusive with ethtool_device_exclude). | | no
-`metrics_include`| string | Regexp of ethtool stats to include. | `.*` | no
+`device_exclude` | `string` | Regexp of ethtool devices to exclude (mutually exclusive with ethtool_device_include). | | no
+`device_include` | `string` | Regexp of ethtool devices to include (mutually exclusive with ethtool_device_exclude). | | no
+`metrics_include`| `string` | Regexp of ethtool stats to include. | `.*` | no
 
 ### `filesystem` block
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`fs_types_exclude`     | string   | Regexp of filesystem types to ignore for filesystem collector.| `"^(autofs\|binfmt_misc\|bpf\|cgroup2?\|configfs\|debugfs\|devpts\|devtmpfs\|fusectl\|hugetlbfs\|iso9660\|mqueue\|nsfs\|overlay\|proc\|procfs\|pstore\|rpc_pipefs\|securityfs\|selinuxfs\|squashfs\|sysfs\|tracefs)$"` | no
-`mount_points_exclude` | string   | Regexp of mount points to ignore for filesystem collector. | `"^/(dev\|proc\|sys\|var/lib/docker/.+)($\|/)"` | no
-`mount_timeout`        | duration | How long to wait for a mount to respond before marking it as stale. | "5s" | no
+`fs_types_exclude`     | `string`   | Regexp of filesystem types to ignore for filesystem collector.| `"^(autofs\|binfmt_misc\|bpf\|cgroup2?\|configfs\|debugfs\|devpts\|devtmpfs\|fusectl\|hugetlbfs\|iso9660\|mqueue\|nsfs\|overlay\|proc\|procfs\|pstore\|rpc_pipefs\|securityfs\|selinuxfs\|squashfs\|sysfs\|tracefs)$"` | no
+`mount_points_exclude` | `string`   | Regexp of mount points to ignore for filesystem collector. | `"^/(dev\|proc\|sys\|var/lib/docker/.+)($\|/)"` | no
+`mount_timeout`        | `duration` | How long to wait for a mount to respond before marking it as stale. | "5s" | no
 
  
 
@@ -115,58 +115,58 @@ Name | Type | Description | Default | Required
 ### `ipvs` block
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`backend_labels` | list(string) | Array of IPVS backend stats labels. | `[local_address, local_port, remote_address, remote_port, proto, local_mark]` | no
+`backend_labels` | `list(string)` | Array of IPVS backend stats labels. | `[local_address, local_port, remote_address, remote_port, proto, local_mark]` | no
 
 ### `ntp` block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-`server`                 | string   | NTP server to use for the collector. | "127.0.0.1" | no
-`server_is_local`        | boolean  | Certifies that the server address is not a public ntp server. | false | no
-`ip_ttl`                 | int      | TTL to use while sending NTP query. | 1 | no
-`local_offset_tolerance` | duration | Offset between local clock and local ntpd time to tolerate. | "1ms" | no
-`max_distance`           | duration | Max accumulated distance to the root. | "3466080us" | no
-`protocol_version`       | int      | NTP protocol version. | 4 | no
+`server`                 | `string`   | NTP server to use for the collector. | "127.0.0.1" | no
+`server_is_local`        | `boolean`  | Certifies that the server address is not a public ntp server. | false | no
+`ip_ttl`                 | `int`      | TTL to use while sending NTP query. | 1 | no
+`local_offset_tolerance` | `duration` | Offset between local clock and local ntpd time to tolerate. | "1ms" | no
+`max_distance`           | `duration` | Max accumulated distance to the root. | "3466080us" | no
+`protocol_version`       | `int`      | NTP protocol version. | 4 | no
 
 ### `netclass` block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-`ignore_invalid_speed_device` | boolean | Ignore net devices with invalid speed values. | false | no
-`ignored_devices`             | string  | Regexp of net devices to ignore for netclass collector. | `"^$"` | no
+`ignore_invalid_speed_device` | `boolean` | Ignore net devices with invalid speed values. | false | no
+`ignored_devices`             | `string`  | Regexp of net devices to ignore for netclass collector. | `"^$"` | no
 
 ### `netdev` block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-`address_info`   | boolean | Enable collecting address-info for every device. | false | no
-`device_exclude` | string  | Regexp of net devices to exclude (mutually exclusive with include). | `""` | no
-`device_include` | string  | Regexp of net devices to include (mutually exclusive with exclude). | `""` | no
+`address_info`   | `boolean` | Enable collecting address-info for every device. | false | no
+`device_exclude` | `string`  | Regexp of net devices to exclude (mutually exclusive with include). |  | no
+`device_include` | `string`  | Regexp of net devices to include (mutually exclusive with exclude). |  | no
 
 ### `netstat` block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-`fields` | string | Regexp of fields to return for netstat collector. | `"^(.*_(InErrors\|InErrs)\|Ip_Forwarding\|Ip(6\|Ext)_(InOctets\|OutOctets)\|Icmp6?_(InMsgs\|OutMsgs)\|TcpExt_(Listen.*\|Syncookies.*\|TCPSynRetrans\|TCPTimeouts)\|Tcp_(ActiveOpens\|InSegs\|OutSegs\|OutRsts\|PassiveOpens\|RetransSegs\|CurrEstab)\|Udp6?_(InDatagrams\|OutDatagrams\|NoPorts\|RcvbufErrors\|SndbufErrors))$"` | no
+`fields` | `string` | Regexp of fields to return for netstat collector. | `"^(.*_(InErrors\|InErrs)\|Ip_Forwarding\|Ip(6\|Ext)_(InOctets\|OutOctets)\|Icmp6?_(InMsgs\|OutMsgs)\|TcpExt_(Listen.*\|Syncookies.*\|TCPSynRetrans\|TCPTimeouts)\|Tcp_(ActiveOpens\|InSegs\|OutSegs\|OutRsts\|PassiveOpens\|RetransSegs\|CurrEstab)\|Udp6?_(InDatagrams\|OutDatagrams\|NoPorts\|RcvbufErrors\|SndbufErrors))$"` | no
 
 
 
 ### `perf` block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-`cpus`      | string       | List of CPUs from which perf metrics should be collected. | "" | no
-`tracepoint` | list(string) | Array of perf tracepoints that should be collected. | | no
+`cpus`       | `string`       | List of CPUs from which perf metrics should be collected. | "" | no
+`tracepoint` | `list(string)` | Array of perf tracepoints that should be collected. | | no
 
 ### `powersupply` block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-`ignored_supplies` | string | Regexp of power supplies to ignore for the powersupplyclass collector. | `"^$"` | no
+`ignored_supplies` | `string` | Regexp of power supplies to ignore for the powersupplyclass collector. | `"^$"` | no
 
 ### `runit` block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-`service_dir` | string | Path to runit service directory. | `"/etc/service"` | no
+`service_dir` | `string` | Path to runit service directory. | `"/etc/service"` | no
 
 ### `supervisord` block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-`url` | string | XML RPC endpoint for the supervisord collector. | `"http://localhost:9001/RPC2"` | no
+`url` | `string` | XML RPC endpoint for the supervisord collector. | `"http://localhost:9001/RPC2"` | no
 
 Setting `SUPERVISORD_URL` in the environment overrides the default value.
 An explicit value in the YAML config takes precedence over the environment
@@ -176,26 +176,26 @@ variable.
 ### `systemd` block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-`enable_restarts` | boolean | Enables service unit metric `service_restart_total` | false | no
-`start_time`      | boolean | Enables service unit metric `unit_start_time_seconds` | false | no
-`task_metrics`    | boolean | Enables service unit tasks metrics `unit_tasks_current` and `unit_tasks_max.` | false | no
-`unit_exclude`    | string  | Regexp of systemd units to exclude. Units must both match include and not match exclude to be collected. | `".+\\.(automount\|device\|mount\|scope\|slice)"` | no
-`unit_include`    | string  | Regexp of systemd units to include. Units must both match include and not match exclude to be collected. | `".+"` | no
+`enable_restarts` | `boolean` | Enables service unit metric `service_restart_total` | false | no
+`start_time`      | `boolean` | Enables service unit metric `unit_start_time_seconds` | false | no
+`task_metrics`    | `boolean` | Enables service unit tasks metrics `unit_tasks_current` and `unit_tasks_max.` | false | no
+`unit_exclude`    | `string`  | Regexp of systemd units to exclude. Units must both match include and not match exclude to be collected. | `".+\\.(automount\|device\|mount\|scope\|slice)"` | no
+`unit_include`    | `string`  | Regexp of systemd units to include. Units must both match include and not match exclude to be collected. | `".+"` | no
 
 ### `tapestats` block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-`ignored_devices` | string | Regexp of tapestats devices to ignore. | `"^$"` | no
+`ignored_devices` | `string` | Regexp of tapestats devices to ignore. | `"^$"` | no
 
 ### `textfile` block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-`textfile_directory` | string | Directory to read \*.prom files from for the textfile collector. | `""` | no
+`textfile_directory` | `string` | Directory to read \*.prom files from for the textfile collector. |  | no
 
 ### `vmstat` block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-`fields` | string | Regexp of fields to return for the vmstat collector. | `"^(oom_kill\|pgpg\|pswp\|pg.*fault).*"` | no
+`fields` | `string` | Regexp of fields to return for the vmstat collector. | `"^(oom_kill\|pgpg\|pswp\|pg.*fault).*"` | no
 
 
 ## Exported fields
@@ -237,75 +237,75 @@ or disable collectors that are expensive to run.
 
 | Name             | Description | OS | Enabled by default |
 | ---------------- | ----------- | -- | ------------------ |
-| arp              | Exposes ARP statistics from /proc/net/arp. | Linux | yes |
-| bcache           | Exposes bcache statistics from /sys/fs/bcache. | Linux | yes |
-| bonding          | Exposes the number of configured and active slaves of Linux bonding interfaces. | Linux | yes |
-| boottime         | Exposes system boot time derived from the kern.boottime sysctl. | Darwin, Dragonfly, FreeBSD, NetBSD, OpenBSD, Solaris | yes |
-| btrfs            | Exposes statistics on btrfs. | Linux | yes |
-| buddyinfo        | Exposes statistics of memory fragments as reported by /proc/buddyinfo. | Linux | no |
-| conntrack        | Shows conntrack statistics (does nothing if no /proc/sys/net/netfilter/ present). | Linux | yes |
-| cpu              | Exposes CPU statistics. | Darwin, Dragonfly, FreeBSD, Linux, Solaris | yes |
-| cpufreq          | Exposes CPU frequency statistics. | Linux, Solaris | yes |
-| devstat          | Exposes device statistics. | Dragonfly, FreeBSD | no |
-| diskstats        | Exposes disk I/O statistics. | Darwin, Linux, OpenBSD | yes |
-| dmi              | Exposes DMI information. | Linux | yes |
-| drbd             | Exposes Distributed Replicated Block Device statistics (to version 8.4). | Linux | no |
-| drm              | Exposes GPU card info from /sys/class/drm/card?/device. | Linux | no |
-| edac             | Exposes error detection and correction statistics. | Linux | yes |
-| entropy          | Exposes available entropy. | Linux | yes |
-| ethtool          | Exposes ethtool stats. | Linux | no |
-| exec             | Exposes execution statistics. | Dragonfly, FreeBSD | yes |
-| fibrechannel     | Exposes FibreChannel statistics. | Linux | yes |
-| filefd           | Exposes file descriptor statistics from /proc/sys/fs/file-nr. | Linux | yes |
-| filesystem       | Exposes filesystem statistics, such as disk space used. | Darwin, Dragonfly, FreeBSD, Linux, OpenBSD | yes |
-| hwmon            | Exposes hardware monitoring and sensor data from /sys/class/hwmon. | Linux | yes |
-| infiniband       | Exposes network statistics specific to InfiniBand and Intel OmniPath configurations. | Linux | yes |
-| interrupts       | Exposes detailed interrupts statistics. | Linux, OpenBSD | no |
-| ipvs             | Exposes IPVS status from `/proc/net/ip_vs` and stats from `/proc/net/ip_vs_stats`. | Linux | yes |
-| ksmd             | Exposes kernel and system statistics from /sys/kernel/mm/ksm. | Linux | no |
-| lnstat           | Exposes Linux network cache stats. | Linux | no |
-| loadavg          | Exposes load average. | Darwin, Dragonfly, FreeBSD, Linux, NetBSD, OpenBSD, Solaris | yes |
-| logind           | Exposes session counts from logind. | Linux | no |
-| mdadm            | Exposes statistics about devices in /proc/mdstat (does nothing if no /proc/mdstat present). | Linux | yes |
-| meminfo          | Exposes memory statistics. | Darwin, Dragonfly, FreeBSD, Linux, OpenBSD | yes |
-| meminfo_numa     | Exposes memory statistics from `/proc/meminfo_numa`. | Linux | no |
-| mountstats       | Exposes filesystem statistics from `/proc/self/mountstats`. Exposes detailed NFS client statistics. | Linux | no |
-| netclass         | Exposes network interface info from `/sys/class/ne`t. | Linux | yes |
-| netdev           | Exposes network interface statistics such as bytes transferred. | Darwin, Dragonfly, FreeBSD, Linux, OpenBSD | yes |
-| netstat          | Exposes network statistics from `/proc/net/netstat`. This is the same information as `netstat -s`. | Linux | yes |
-| network_route    | Exposes network route statistics. | Linux | no |
-| nfs              | Exposes NFS client statistics from `/proc/net/rpc/nfs`. This is the same information as `nfsstat -c`. | Linux | yes |
-| nfsd             | Exposes NFS kernel server statistics from `/proc/net/rpc/nfsd`. This is the same information as `nfsstat -s`. | Linux | yes |
-| ntp              | Exposes local NTP daemon health to check time. | any | no |
-| nvme             | Exposes NVMe statistics. | Linux | yes |
-| os               | Exposes os-release information. | Linux | yes |
-| perf             | Exposes perf based metrics (Warning: Metrics are dependent on kernel configuration and settings). | Linux | no |
-| powersupplyclass | Collects information on power supplies. | any | yes |
-| pressure         | Exposes pressure stall statistics from `/proc/pressure/`. | Linux (kernel 4.20+ and/or CONFIG_PSI) | yes |
-| processes        | Exposes aggregate process statistics from /proc. | Linux | no |
-| qdisc            | Exposes queuing discipline statistics. | Linux | no |
-| rapl             | Exposes various statistics from `/sys/class/powercap`. | Linux | yes |
-| runit            | Exposes service status from runit. | any | no |
-| schedstat        | Exposes task scheduler statistics from `/proc/schedstat`. | Linux | yes |
-| sockstat         | Exposes various statistics from `/proc/net/sockstat`. | Linux | yes |
-| softnet          | Exposes statistics from `/proc/net/softnet_stat`. | Linux | yes |
-| stat             | Exposes various statistics from /proc/stat. This includes boot time, forks and interrupts. | Linux | yes |
-| supervisord      | Exposes service status from supervisord. | any | no |
-| systemd          | Exposes service and system status from systemd. | Linux | no |
-| tapestats        | Exposes tape device stats. | Linux | yes |
-| tcpstat          | Exposes TCP connection status information from `/proc/net/tcp` and `/proc/net/tcp6`. (Warning: the current version has potential performance issues in high load situations). | Linux | no |
-| textfile         | Collects metrics from files in a directory matching the filename pattern \*.prom. The files must be using the text format defined here: https://prometheus.io/docs/instrumenting/exposition_formats/. | any | yes |
-| thermal          | Exposes thermal statistics. | Darwin | yes |
-| thermal_zone     | Exposes thermal zone & cooling device statistics from `/sys/class/thermal`. | Linux | yes |
-| time             | Exposes the current system time. | any | yes |
-| timex            | Exposes selected `adjtimex(2)` system call stats. | Linux | yes |
-| udp_queues       | Exposes UDP total lengths of the `rx_queue` and `tx_queue` from `/proc/net/udp` and `/proc/net/udp6`. | Linux | yes |
-| uname            | Exposes system information as provided by the uname system call. | Darwin, FreeBSD, Linux, OpenBSD | yes |
-| vmstat           | Exposes statistics from `/proc/vmstat`. | Linux | yes |
-| wifi             | Exposes WiFi device and station statistics. | Linux | no |
-| xfs              | Exposes XFS runtime statistics. | Linux (kernel 4.4+) | yes |
-| zfs              | Exposes ZFS performance statistics. | Linux, Solaris | yes |
-| zoneinfo         | Exposes zone stats. | Linux | no |
+| `arp`              | Exposes ARP statistics from /proc/net/arp. | Linux | yes |
+| `bcache`           | Exposes bcache statistics from /sys/fs/bcache. | Linux | yes |
+| `bonding`          | Exposes the number of configured and active slaves of Linux bonding interfaces. | Linux | yes |
+| `boottime`         | Exposes system boot time derived from the kern.boottime sysctl. | Darwin, Dragonfly, FreeBSD, NetBSD, OpenBSD, Solaris | yes |
+| `btrfs`            | Exposes statistics on btrfs. | Linux | yes |
+| `buddyinfo`        | Exposes statistics of memory fragments as reported by /proc/buddyinfo. | Linux | no |
+| `conntrack`        | Shows conntrack statistics (does nothing if no /proc/sys/net/netfilter/ present). | Linux | yes |
+| `cpu`              | Exposes CPU statistics. | Darwin, Dragonfly, FreeBSD, Linux, Solaris | yes |
+| `cpufreq`          | Exposes CPU frequency statistics. | Linux, Solaris | yes |
+| `devstat`          | Exposes device statistics. | Dragonfly, FreeBSD | no |
+| `diskstats`        | Exposes disk I/O statistics. | Darwin, Linux, OpenBSD | yes |
+| `dmi`              | Exposes DMI information. | Linux | yes |
+| `drbd`             | Exposes Distributed Replicated Block Device statistics (to version 8.4). | Linux | no |
+| `drm`              | Exposes GPU card info from /sys/class/drm/card?/device. | Linux | no |
+| `edac`             | Exposes error detection and correction statistics. | Linux | yes |
+| `entropy`          | Exposes available entropy. | Linux | yes |
+| `ethtool`          | Exposes ethtool stats. | Linux | no |
+| `exec`             | Exposes execution statistics. | Dragonfly, FreeBSD | yes |
+| `fibrechannel`     | Exposes FibreChannel statistics. | Linux | yes |
+| `filefd`           | Exposes file descriptor statistics from /proc/sys/fs/file-nr. | Linux | yes |
+| `filesystem`       | Exposes filesystem statistics, such as disk space used. | Darwin, Dragonfly, FreeBSD, Linux, OpenBSD | yes |
+| `hwmon`            | Exposes hardware monitoring and sensor data from /sys/class/hwmon. | Linux | yes |
+| `infiniband`       | Exposes network statistics specific to InfiniBand and Intel OmniPath configurations. | Linux | yes |
+| `interrupts`       | Exposes detailed interrupts statistics. | Linux, OpenBSD | no |
+| `ipvs`             | Exposes IPVS status from `/proc/net/ip_vs` and stats from `/proc/net/ip_vs_stats`. | Linux | yes |
+| `ksmd`             | Exposes kernel and system statistics from /sys/kernel/mm/ksm. | Linux | no |
+| `lnstat`           | Exposes Linux network cache stats. | Linux | no |
+| `loadavg`          | Exposes load average. | Darwin, Dragonfly, FreeBSD, Linux, NetBSD, OpenBSD, Solaris | yes |
+| `logind`           | Exposes session counts from logind. | Linux | no |
+| `mdadm`            | Exposes statistics about devices in /proc/mdstat (does nothing if no /proc/mdstat present). | Linux | yes |
+| `meminfo`          | Exposes memory statistics. | Darwin, Dragonfly, FreeBSD, Linux, OpenBSD | yes |
+| `meminfo_numa`     | Exposes memory statistics from `/proc/meminfo_numa`. | Linux | no |
+| `mountstats`       | Exposes filesystem statistics from `/proc/self/mountstats`. Exposes detailed NFS client statistics. | Linux | no |
+| `netclass`         | Exposes network interface info from `/sys/class/ne`t. | Linux | yes |
+| `netdev`           | Exposes network interface statistics such as bytes transferred. | Darwin, Dragonfly, FreeBSD, Linux, OpenBSD | yes |
+| `netstat`          | Exposes network statistics from `/proc/net/netstat`. This is the same information as `netstat -s`. | Linux | yes |
+| `network_route`    | Exposes network route statistics. | Linux | no |
+| `nfs`              | Exposes NFS client statistics from `/proc/net/rpc/nfs`. This is the same information as `nfsstat -c`. | Linux | yes |
+| `nfsd`             | Exposes NFS kernel server statistics from `/proc/net/rpc/nfsd`. This is the same information as `nfsstat -s`. | Linux | yes |
+| `ntp`              | Exposes local NTP daemon health to check time. | any | no |
+| `nvme`             | Exposes NVMe statistics. | Linux | yes |
+| `os`               | Exposes os-release information. | Linux | yes |
+| `perf`             | Exposes perf based metrics (Warning: Metrics are dependent on kernel configuration and settings). | Linux | no |
+| `powersupplyclass` | Collects information on power supplies. | any | yes |
+| `pressure`         | Exposes pressure stall statistics from `/proc/pressure/`. | Linux (kernel 4.20+ and/or CONFIG_PSI) | yes |
+| `processes`        | Exposes aggregate process statistics from /proc. | Linux | no |
+| `qdisc`            | Exposes queuing discipline statistics. | Linux | no |
+| `rapl`             | Exposes various statistics from `/sys/class/powercap`. | Linux | yes |
+| `runit`            | Exposes service status from runit. | any | no |
+| `schedstat`        | Exposes task scheduler statistics from `/proc/schedstat`. | Linux | yes |
+| `sockstat`         | Exposes various statistics from `/proc/net/sockstat`. | Linux | yes |
+| `softnet`          | Exposes statistics from `/proc/net/softnet_stat`. | Linux | yes |
+| `stat`             | Exposes various statistics from /proc/stat. This includes boot time, forks and interrupts. | Linux | yes |
+| `supervisord`      | Exposes service status from supervisord. | any | no |
+| `systemd`          | Exposes service and system status from systemd. | Linux | no |
+| `tapestats`        | Exposes tape device stats. | Linux | yes |
+| `tcpstat`          | Exposes TCP connection status information from `/proc/net/tcp` and `/proc/net/tcp6`. (Warning: the current version has potential performance issues in high load situations). | Linux | no |
+| `textfile`         | Collects metrics from files in a directory matching the filename pattern \*.prom. The files must be using the text format defined here: https://prometheus.io/docs/instrumenting/exposition_formats/. | any | yes |
+| `thermal`          | Exposes thermal statistics. | Darwin | yes |
+| `thermal_zone`     | Exposes thermal zone & cooling device statistics from `/sys/class/thermal`. | Linux | yes |
+| `time`             | Exposes the current system time. | any | yes |
+| `timex`            | Exposes selected `adjtimex(2)` system call stats. | Linux | yes |
+| `udp_queues`       | Exposes UDP total lengths of the `rx_queue` and `tx_queue` from `/proc/net/udp` and `/proc/net/udp6`. | Linux | yes |
+| `uname`            | Exposes system information as provided by the uname system call. | Darwin, FreeBSD, Linux, OpenBSD | yes |
+| `vmstat`           | Exposes statistics from `/proc/vmstat`. | Linux | yes |
+| `wifi`             | Exposes WiFi device and station statistics. | Linux | no |
+| `xfs`              | Exposes XFS runtime statistics. | Linux (kernel 4.4+) | yes |
+| `zfs`              | Exposes ZFS performance statistics. | Linux, Solaris | yes |
+| `zoneinfo`         | Exposes zone stats. | Linux | no |
 
 ## Running on Docker/Kubernetes
 When running Flow in a Docker container, you need to bind mount the filesystem,

--- a/docs/flow/reference/components/prometheus.integrations.node_exporter.md
+++ b/docs/flow/reference/components/prometheus.integrations.node_exporter.md
@@ -92,7 +92,7 @@ Name | Type | Description | Default | Required
 ### `disk` block
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`ignored_devices` | string | Regexp of devices to ignore for diskstats | `"^(ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\\d+n\\d+p)\\d+$"` | no
+`ignored_devices` | string | Regexp of devices to ignore for diskstats | `"^(ram\|loop\|fd\|(h\|s\|v\|xv)d[a-z]\|nvme\\d+n\\d+p)\\d+$"` | no
 
 ### `ethtool` block
 Name | Type | Description | Default | Required
@@ -150,7 +150,7 @@ name | type | description | default | required
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
 `cpus`      | string       | List of CPUs from which perf metrics should be collected. | "" | no
-`tracepoint | list(string) | Array of perf tracepoints that should be collected. | | no
+`tracepoint` | list(string) | Array of perf tracepoints that should be collected. | | no
 
 ### `powersupply` block
 name | type | description | default | required
@@ -178,7 +178,7 @@ name | type | description | default | required
 enable_restarts | boolean | Enables service unit metric service_restart_total | false | no
 start_time      | boolean | Enables service unit metric unit_start_time_seconds | false | no
 task_metrics    | boolean | Enables service unit tasks metrics unit_tasks_current and unit_tasks_max.
-unit_exclude    | string  | Regexp of systemd units to exclude. Units must both match include and not match exclude to be collected. | `".+\\.(automount|device|mount|scope|slice)"` | no
+unit_exclude    | string  | Regexp of systemd units to exclude. Units must both match include and not match exclude to be collected. | `".+\\\.(automount\|device\|mount\|scope\|slice)"` | no
 unit_include    | string  | Regexp of systemd units to include. Units must both match include and not match exclude to be collected. | `".+"` | no
 
 ### `tapestats` block
@@ -194,7 +194,7 @@ name | type | description | default | required
 ### `vmstat` block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-`fields` | string | Regexp of fields to return for the vmstat collector. | `"^(oom_kill|pgpg|pswp|pg.*fault).*"` | no
+`fields` | string | Regexp of fields to return for the vmstat collector. | `"^(oom_kill\|pgpg\|pswp\|pg.*fault).*"` | no
 
 
 ## Exported fields

--- a/docs/flow/reference/components/prometheus.integrations.node_exporter.md
+++ b/docs/flow/reference/components/prometheus.integrations.node_exporter.md
@@ -178,7 +178,7 @@ name | type | description | default | required
 enable_restarts | boolean | Enables service unit metric service_restart_total | false | no
 start_time      | boolean | Enables service unit metric unit_start_time_seconds | false | no
 task_metrics    | boolean | Enables service unit tasks metrics unit_tasks_current and unit_tasks_max.
-unit_exclude    | string  | Regexp of systemd units to exclude. Units must both match include and not match exclude to be collected. | `".+\\\.(automount\|device\|mount\|scope\|slice)"` | no
+unit_exclude    | string  | Regexp of systemd units to exclude. Units must both match include and not match exclude to be collected. | `".+\\.(automount\|device\|mount\|scope\|slice)"` | no
 unit_include    | string  | Regexp of systemd units to include. Units must both match include and not match exclude to be collected. | `".+"` | no
 
 ### `tapestats` block

--- a/docs/flow/reference/components/prometheus.integrations.node_exporter.md
+++ b/docs/flow/reference/components/prometheus.integrations.node_exporter.md
@@ -104,9 +104,13 @@ Name | Type | Description | Default | Required
 ### `filesystem` block
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`fs_types_exclude`     | string   | Regexp of filesystem types to ignore for filesystem collector.| `"^(autofs<code>&#124;</code>binfmt_misc<code>&#124;</code>bpf<code>&#124;</code>cgroup2?<code>&#124;</code>configfs<code>&#124;</code>debugfs<code>&#124;</code>devpts<code>&#124;</code>devtmpfs<code>&#124;</code>fusectl<code>&#124;</code>hugetlbfs<code>&#124;</code>iso9660<code>&#124;</code>mqueue<code>&#124;</code>nsfs<code>&#124;</code>overlay<code>&#124;</code>proc<code>&#124;</code>procfs<code>&#124;</code>pstore<code>&#124;</code>rpc_pipefs<code>&#124;</code>securityfs<code>&#124;</code>selinuxfs<code>&#124;</code>squashfs<code>&#124;</code>sysfs<code>&#124;</code>tracefs)$"` | no
+`fs_types_exclude`     | string   | Regexp of filesystem types to ignore for filesystem collector.| `"^(autofs\|binfmt_misc\|bpf\|cgroup2?\|configfs\|debugfs\|devpts\|devtmpfs\|fusectl\|hugetlbfs\|iso9660\|mqueue\|nsfs\|overlay\|proc\|procfs\|pstore\|rpc_pipefs\|securityfs\|selinuxfs\|squashfs\|sysfs\|tracefs)$"` | no
+`fs_types_exclude`     <code>|#124;</code> string   <code>|#124;</code> Regexp of filesystem types to ignore for filesystem collector.<code>|#124;</code>  <code>|#124;</code> no
 `mount_points_exclude` | string   | Regexp of mount points to ignore for filesystem collector. | `"^/(dev|proc|sys|var/lib/docker/.+)($|/)"` | no
 `mount_timeout`        | duration | How long to wait for a mount to respond before marking it as stale. | "5s" | no
+
+ 
+
 
 ### `ipvs` block
 Name | Type | Description | Default | Required

--- a/docs/flow/reference/components/prometheus.integrations.node_exporter.md
+++ b/docs/flow/reference/components/prometheus.integrations.node_exporter.md
@@ -104,7 +104,7 @@ Name | Type | Description | Default | Required
 ### `filesystem` block
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`fs_types_exclude`     | string   | Regexp of filesystem types to ignore for filesystem collector.| `"^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$"` | no
+`fs_types_exclude`     | string   | Regexp of filesystem types to ignore for filesystem collector.| `"^(autofs<code>&#124;</code>binfmt_misc<code>&#124;</code>bpf<code>&#124;</code>cgroup2?<code>&#124;</code>configfs<code>&#124;</code>debugfs<code>&#124;</code>devpts<code>&#124;</code>devtmpfs<code>&#124;</code>fusectl<code>&#124;</code>hugetlbfs<code>&#124;</code>iso9660<code>&#124;</code>mqueue<code>&#124;</code>nsfs<code>&#124;</code>overlay<code>&#124;</code>proc<code>&#124;</code>procfs<code>&#124;</code>pstore<code>&#124;</code>rpc_pipefs<code>&#124;</code>securityfs<code>&#124;</code>selinuxfs<code>&#124;</code>squashfs<code>&#124;</code>sysfs<code>&#124;</code>tracefs)$"` | no
 `mount_points_exclude` | string   | Regexp of mount points to ignore for filesystem collector. | `"^/(dev|proc|sys|var/lib/docker/.+)($|/)"` | no
 `mount_timeout`        | duration | How long to wait for a mount to respond before marking it as stale. | "5s" | no
 

--- a/docs/flow/reference/components/prometheus.integrations.node_exporter.md
+++ b/docs/flow/reference/components/prometheus.integrations.node_exporter.md
@@ -1,0 +1,146 @@
+---
+aliases:
+- /docs/agent/latest/flow/reference/components/prometheus.integrations.node_exporter
+title: prometheus.integrations.node_exporter
+---
+
+# prometheus.integrations.node_exporter
+The component embeds the popular
+[node_exporter](https://github.com/prometheus/node_exporter) which exposes a 
+wide variety of hardware and OS metrics.
+
+The `node_exporter` itself is comprised of various _collectors_, which can be enabled and disabled at will.
+
+## Example
+```river
+prometheus.integrations.node_exporter {
+}
+
+// Configure a prometheus.scrape component to collect node_exporter metrics.
+prometheus.scrape "demo" {
+  targets    = prometheus.integrations.node_exporter.targets
+  forward_to = [ /* ... */ ]
+}
+```
+
+## Arguments
+The following arguments can be used to configure the exporter's behavior.
+All arguments are optional. Omitted fields take their default values.
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`include_exporter_metrics` | boolean      | Whether metrics about the exporter itself should be reported | false | no 
+`procfs_path`              | string       | The procfs mountpoint. | `/proc` | no
+`sysfs_path`               | string       | The sysfs mountpoint.  | `sys`   | no
+`rootfs_path`              | string       | Specify a prefix for accessing the host filesystem. | `/` | no
+`enable_collectors`        | list(string) | Collectors to mark as enabled.  | | no
+`disable_collectors`       | list(string) | Collectors to mark as disabled. | | no
+`set_collectors`           | list(string) | Overrides the default set of enabled collectors with the collectors listed. | | no
+
+If running in Docker, the root filesystem of the host machine should be mounted and `rootfs_path` should be changed to the mount directory.
+
+Additionally, the following subblocks are supported for configuring collector-specific options.
+
+Name | Description | Required
+---- | ----------- | --------
+[`relabel_config`](#relabel_config-block) | Relabeling steps to apply to targets | no
+
+[`bcache`](#bcache-block) | Configures the bcache collector | no
+[`cpu`](#cpu-block) | Configures the cpu collector | no
+[`disk`](#disk-block) | Configures the diskstats collector | no
+[`ethtool`](#ethtool-block) | Configures the ethtool collector | no
+[`filesystem`](#filesystem-block) | Configures the filesystem collector | no
+[`ipvs`](#ipvs-block) | Configures the ipvs collector | no
+[`ntp`](#ntp-block) | Configures the ntp collector | no
+[`netclass`](#netclass-block) | Configures the netclass collector | no
+[`netdev`](#netdev-block) | Configures the netdev collector | no
+[`netstat`](#netstat-block) | Configures the netstat collector | no
+[`perf`](#perf-block) | Configures the perf collector | no
+[`powersupply`](#powersupply-block) | Configures the powersupply collector | no
+[`runit`](#runit-block) | Configures the runit collector | no
+[`supervisord`](#supervisord-block) | Configures the supervisord collector | no
+[`systemd`](#systemd-block) | Configures the systemd collector | no
+[`tapestats`](#tapestats-block) | Configures the tapestats collector | no
+[`textfile`](#textfile-block) | Configures the textfile collector | no
+[`vmstat`](#vmstat-block) | Configures the vmstat collector | no
+
+
+
+
+
+
+### `bcache` block
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`priority_stats` | boolean |  Enable exposing of expensive bcache priority stats | false | no
+
+### `cpu` block
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`guest`         | boolean | Enable the node_cpu_guest_seconds_total metric. | true | no
+`info`          | boolean | Enable the cpu_info metric for the cpu collector. | true | no
+`bugs_include`  | string  | Regexp of `bugs` field in cpu info to filter. | | no
+`flags_include` | string  | Regexp of `flags` field in cpu info to filter. | no
+
+### `disk` block
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`ignored_devices` | string | Regexp of devices to ignore for diskstats | `"^(ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\\d+n\\d+p)\\d+$"` | no
+
+### `ethtool` block
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`device_exclude` | string | Regexp of ethtool devices to exclude (mutually exclusive with ethtool_device_include). | | no
+`device_include` | string | Regexp of ethtool devices to include (mutually exclusive with ethtool_device_exclude). | | no
+`metrics_include`| string | Regexp of ethtool stats to include. | `.*` | no
+
+### `filesystem` block
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`fs_types_exclude`     | string   | Regexp of filesystem types to ignore for filesystem collector.| `"^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$"` | no
+`mount_points_exclude` | string   | Regexp of mount points to ignore for filesystem collector. | `"^/(dev|proc|sys|var/lib/docker/.+)($|/)"` | no
+`mount_timeout`        | duration | How long to wait for a mount to respond before marking it as stale. | "5s" | no
+
+### `ipvs` block
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`backend_labels` | list(string) | Array of IPVS backend stats labels. | `[local_address, local_port, remote_address, remote_port, proto, local_mark]` | no
+### `ntp` block
+### `netclass` block
+### `netdev` block
+### `netstat` block
+### `perf` block
+### `powersupply` block
+### `runit` block
+### `supervisord` block
+### `systemd` block
+### `tapestats` block
+### `textfile` block
+### `vmstat` block
+
+
+## Exported fields
+The following fields are exported and can be referenced by other components.
+
+Name      | Type                | Description 
+--------- | ------------------- | ----------- 
+`targets` | `list(map(string))` | The targets where the `node_exporter` metrics will be exposed to.
+
+For example, the `targets` could either be passed to a `prometheus.relabel`
+component to rewrite the metrics' label set, or to a `prometheus.scrape`
+component that collects the exposed metrics.
+
+## Component health
+
+`prometheus.integrations.node_exporter` is only reported as unhealthy if given
+an invalid configuration. In those cases, exported fields are kept at their
+last healthy values.
+
+## Debug information
+
+`prometheus.relabel` does not expose any component-specific debug information.
+
+## Debug metrics
+
+`prometheus.relabel` does not expose any component-specific debug metrics.
+

--- a/docs/flow/reference/components/prometheus.integrations.node_exporter.md
+++ b/docs/flow/reference/components/prometheus.integrations.node_exporter.md
@@ -44,7 +44,7 @@ Name | Type | Description | Default | Required
 `rootfs_path`              | string       | Specify a prefix for accessing the host filesystem. | `/` | no
 
 The `set_collectors` argument defines a hand-picked list of enabled-by-default
-collectors. If set, anything not provided in that list will be disabled by
+collectors. If set, anything not provided in that list is disabled by
 default.
 
 The `enable_collectors` enables more collectors over the default set, or on top
@@ -167,7 +167,7 @@ name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
 `url` | string | XML RPC endpoint for the supervisord collector. | `"http://localhost:9001/RPC2"` | no
 
-Setting SUPERVISORD_URL in the environment will override the default value.
+Setting SUPERVISORD_URL in the environment overrides the default value.
 An explicit value in the YAML config takes precedence over the environment
 variable.
 
@@ -202,7 +202,7 @@ The following fields are exported and can be referenced by other components.
 
 Name      | Type                | Description 
 --------- | ------------------- | ----------- 
-`targets` | `list(map(string))` | The targets where the `node_exporter` metrics will be exposed to.
+`targets` | `list(map(string))` | The targets where the `node_exporter` metrics are exposed to.
 
 For example, the `targets` could either be passed to a `prometheus.relabel`
 component to rewrite the metrics' label set, or to a `prometheus.scrape`

--- a/docs/flow/reference/components/prometheus.integrations.node_exporter.md
+++ b/docs/flow/reference/components/prometheus.integrations.node_exporter.md
@@ -105,8 +105,7 @@ Name | Type | Description | Default | Required
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `fs_types_exclude`     | string   | Regexp of filesystem types to ignore for filesystem collector.| `"^(autofs\|binfmt_misc\|bpf\|cgroup2?\|configfs\|debugfs\|devpts\|devtmpfs\|fusectl\|hugetlbfs\|iso9660\|mqueue\|nsfs\|overlay\|proc\|procfs\|pstore\|rpc_pipefs\|securityfs\|selinuxfs\|squashfs\|sysfs\|tracefs)$"` | no
-`fs_types_exclude`     <code>|#124;</code> string   <code>|#124;</code> Regexp of filesystem types to ignore for filesystem collector.<code>|#124;</code>  <code>|#124;</code> no
-`mount_points_exclude` | string   | Regexp of mount points to ignore for filesystem collector. | `"^/(dev|proc|sys|var/lib/docker/.+)($|/)"` | no
+`mount_points_exclude` | string   | Regexp of mount points to ignore for filesystem collector. | `"^/(dev\|proc\|sys\|var/lib/docker/.+)($\|/)"` | no
 `mount_timeout`        | duration | How long to wait for a mount to respond before marking it as stale. | "5s" | no
 
  
@@ -143,7 +142,9 @@ name | type | description | default | required
 ### `netstat` block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-`fields` | string | Regexp of fields to return for netstat collector. | `"^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_(Listen.*|Syncookies.*|TCPSynRetrans|TCPTimeouts)|Tcp_(ActiveOpens|InSegs|OutSegs|OutRsts|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts|RcvbufErrors|SndbufErrors))$"` | no
+`fields` | string | Regexp of fields to return for netstat collector. | `"^(.*_(InErrors\|InErrs)\|Ip_Forwarding\|Ip(6\|Ext)_(InOctets\|OutOctets)\|Icmp6?_(InMsgs\|OutMsgs)\|TcpExt_(Listen.*\|Syncookies.*\|TCPSynRetrans\|TCPTimeouts)\|Tcp_(ActiveOpens\|InSegs\|OutSegs\|OutRsts\|PassiveOpens\|RetransSegs\|CurrEstab)\|Udp6?_(InDatagrams\|OutDatagrams\|NoPorts\|RcvbufErrors\|SndbufErrors))$"` | no
+
+
 
 ### `perf` block
 name | type | description | default | required


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR adds a reference page for the `prometheus.integration.node_exporter` component.

It borrows much terminology from the existing documentation page for the node_exporter integration, so hopefully the information is not misleading on them both.

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer
Let me know if I'm missing anything important we should let users know!

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [x] Documentation added
- [ ] Tests updated (N/A)
