### PR TITLE
river/encoding: sort object keys

### DIFF
--- a/pkg/river/encoding/map.go
+++ b/pkg/river/encoding/map.go
@@ -31,7 +31,7 @@ func (mf *mapField) convertMap(val value.Value) error {
 
 	keys := val.Keys()
 
-	// If v isn't an ordered object (i.e., a go map), sort the keys so they have
+	// If v isn't an ordered object (i.e., a Go map), sort the keys so they have
 	// a deterministic print order.
 	if !val.OrderedKeys() {
 		sort.Strings(keys)

--- a/pkg/river/encoding/map.go
+++ b/pkg/river/encoding/map.go
@@ -2,6 +2,7 @@ package encoding
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/grafana/agent/pkg/river/internal/value"
 )
@@ -27,7 +28,16 @@ func (mf *mapField) hasValue() bool {
 func (mf *mapField) convertMap(val value.Value) error {
 	mf.Type = objectType
 	fields := make([]*keyField, 0)
-	for _, key := range val.Keys() {
+
+	keys := val.Keys()
+
+	// If v isn't an ordered object (i.e., a go map), sort the keys so they have
+	// a deterministic print order.
+	if !val.OrderedKeys() {
+		sort.Strings(keys)
+	}
+
+	for _, key := range keys {
 		kf := &keyField{}
 
 		kf.Key = key


### PR DESCRIPTION
Sort object keys so River objects backed by Go maps appear in a consistent order.