### PR TITLE
cmd/agent: expose the Flow UI from the HTTP server

### DIFF
--- a/cmd/agent/flow_run.go
+++ b/cmd/agent/flow_run.go
@@ -50,7 +50,11 @@ run starts an HTTP server which can be used to debug Grafana Agent Flow or
 force it to reload (by sending a GET or POST request to /-/reload). The listen
 address can be changed through the --server.http.listen-addr flag.
 
-By default, the HTTP server exposes the following debug endpoints:
+By default, the HTTP server exposes a debugging UI at /. The path of the
+debugging UI can be changed by providing a different value to
+--server.http.ui-path-prefix.
+
+Additionally, the HTTP server exposes the following debug endpoints:
 
   /debug/config  Display the state of running components. Values marked as
                  secret are not shown. /debug/config?debug=1 shows extra

--- a/cmd/agent/flow_run.go
+++ b/cmd/agent/flow_run.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/grafana/agent/web/api"
+	"github.com/grafana/agent/web/ui"
 
 	"github.com/fatih/color"
 	"github.com/go-kit/log/level"
@@ -188,6 +189,10 @@ func (fr *flowRun) Run(configFile string) error {
 		// Register Routes must be the last
 		fa := api.NewFlowAPI(f, r)
 		fa.RegisterRoutes(fr.uiPrefix, r)
+
+		// NOTE(rfratto): keep this at the bottom of all other routes, otherwise it
+		// will take precedence over anything else mapped in uiPrefix.
+		ui.RegisterRoutes(fr.uiPrefix, r)
 
 		srv := &http.Server{Handler: r}
 

--- a/docs/flow/reference/cli/run.md
+++ b/docs/flow/reference/cli/run.md
@@ -32,3 +32,4 @@ The following flags are supported:
 * `--server.http.listen-addr`: Address to listen for HTTP traffic on (default `127.0.0.1:12345`).
 * `--storage.path`: Base directory where components can store data (default `data-agent/`).
 * `--debug.endpoints.enabled`: Whether to enable HTTP debug endpoints (default `true`).
+* `--server.http.ui-path-prefix`: Base path where the UI will be exposed (default `/`).

--- a/docs/flow/reference/cli/run.md
+++ b/docs/flow/reference/cli/run.md
@@ -29,7 +29,7 @@ various debugging needs.
 
 The following flags are supported:
 
-* `--server.http.listen-addr`: Address to listen for HTTP traffic on (default `127.0.0.1:12345`).
-* `--storage.path`: Base directory where components can store data (default `data-agent/`).
 * `--debug.endpoints.enabled`: Whether to enable HTTP debug endpoints (default `true`).
+* `--server.http.listen-addr`: Address to listen for HTTP traffic on (default `127.0.0.1:12345`).
 * `--server.http.ui-path-prefix`: Base path where the UI will be exposed (default `/`).
+* `--storage.path`: Base directory where components can store data (default `data-agent/`).

--- a/web/ui/assets_builtin.go
+++ b/web/ui/assets_builtin.go
@@ -1,0 +1,25 @@
+//go:build builtinassets
+// +build builtinassets
+
+package ui
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+)
+
+//go:generate yarn
+//go:generate yarn run build
+
+//go:embed build
+var builtinAssetsTarball embed.FS
+
+// Assets contains the UI's assets.
+func Assets() http.FileSystem {
+	inner, err := fs.Sub(builtinAssetsTarball, "build")
+	if err != nil {
+		panic(err)
+	}
+	return http.FS(inner)
+}

--- a/web/ui/assets_nobuiltin.go
+++ b/web/ui/assets_nobuiltin.go
@@ -1,0 +1,11 @@
+//go:build !builtinassets
+// +build !builtinassets
+
+package ui
+
+import "net/http"
+
+// Assets contains the UI's assets.
+func Assets() http.FileSystem {
+	return http.Dir("./web/ui/build")
+}

--- a/web/ui/assets_nobuiltin.go
+++ b/web/ui/assets_nobuiltin.go
@@ -3,9 +3,13 @@
 
 package ui
 
-import "net/http"
+import (
+	"net/http"
+	"path/filepath"
+)
 
 // Assets contains the UI's assets.
 func Assets() http.FileSystem {
-	return http.Dir("./web/ui/build")
+	assetsDir := filepath.Join(".", "web", "ui", "build")
+	return http.Dir(assetsDir)
 }

--- a/web/ui/src/contexts/PathPrefixContext.tsx
+++ b/web/ui/src/contexts/PathPrefixContext.tsx
@@ -10,13 +10,19 @@ const PathPrefixContext = React.createContext('');
  * usePathPrefix retrieves the current base URL where the application is
  * hosted. Links and API calls should be all relative to this path. Returns
  * `/` if there is no path prefix.
+ *
+ * The returned path prefix will always end in a `/`.
  */
 function usePathPrefix(): string {
   const prefix = React.useContext(PathPrefixContext);
   if (prefix === '') {
     return '/';
   }
-  return prefix;
+
+  if (prefix.endsWith('/')) {
+    return prefix;
+  }
+  return prefix + '/';
 }
 
 export { PathPrefixContext, usePathPrefix };

--- a/web/ui/ui.go
+++ b/web/ui/ui.go
@@ -94,6 +94,10 @@ func (tr *templateRenderer) Open(name string) (http.File, error) {
 
 	// Return the underlying file if we got a directory. Otherwise, we're going
 	// to create our own synthethic file.
+	//
+	// When we create a synthethic file, we close the original file, f, on
+	// return. Otherwise, we leave f open on return so the caller can read and
+	// close it.
 	if fi.IsDir() {
 		return f, nil
 	}

--- a/web/ui/ui.go
+++ b/web/ui/ui.go
@@ -64,6 +64,9 @@ func RegisterRoutes(pathPrefix string, router *mux.Router) {
 // templateRenderer wraps around an inner fs.FS and will use html/template to
 // render files it serves. Files will be cached after rendering to save on CPU
 // time between repeated requests.
+//
+// The templateRenderer is used to inject runtime variables into the statically
+// built UI, such as the base URL path where the UI is exposed.
 type templateRenderer struct {
 	pathPrefix string
 	inner      http.FileSystem

--- a/web/ui/ui.go
+++ b/web/ui/ui.go
@@ -1,0 +1,201 @@
+// Package ui exposes utilities to get a Handler for the Grafana Agent Flow UI.
+package ui
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"path"
+	"strings"
+	"sync"
+	"text/template"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/prometheus/common/server"
+)
+
+// RegisterRoutes registers routes to the provided mux.Router for serving the
+// Grafana Agent Flow UI. The UI will be served relative to pathPrefix. If no
+// pathPrefix is specified, the UI will be served at root.
+//
+// By default, the UI is retreived from the ./web/ui/build directory relative
+// to working directory, assuming that the Agent is run from the repo root.
+// However, if the builtinassets Go tag is present, the built UI will be
+// embedded into the binary; run go generate -tags builtinassets for this
+// package to generate the assets to embed.
+//
+// RegisterRoutes catches all requests from pathPrefix and so should only be
+// invoked after all other routes have been registered.
+//
+// RegisterRoutes is not intended for public use and will only work properly
+// when called from github.com/grafana/agent.
+func RegisterRoutes(pathPrefix string, router *mux.Router) {
+	if !strings.HasSuffix(pathPrefix, "/") {
+		pathPrefix = pathPrefix + "/"
+	}
+
+	publicPath := path.Join(pathPrefix, "public")
+
+	renderer := &templateRenderer{
+		pathPrefix: strings.TrimSuffix(pathPrefix, "/"),
+		inner:      Assets(),
+
+		contentCache:     make(map[string]string),
+		contentCacheTime: make(map[string]time.Time),
+	}
+
+	router.PathPrefix(publicPath).Handler(http.StripPrefix(publicPath, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		server.StaticFileServer(renderer).ServeHTTP(w, r)
+	})))
+
+	router.HandleFunc(strings.TrimSuffix(pathPrefix, "/"), func(w http.ResponseWriter, r *http.Request) {
+		// Redirect to form with /
+		http.Redirect(w, r, pathPrefix, http.StatusFound)
+	})
+	router.PathPrefix(pathPrefix).HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.URL.Path = "/"
+		server.StaticFileServer(renderer).ServeHTTP(w, r)
+	})
+}
+
+// templateRenderer wraps around an inner fs.FS and will use html/template to
+// render files it serves. Files will be cached after rendering to save on CPU
+// time between repeated requests.
+type templateRenderer struct {
+	pathPrefix string
+	inner      http.FileSystem
+
+	cacheMut         sync.RWMutex
+	contentCache     map[string]string
+	contentCacheTime map[string]time.Time
+}
+
+var _ http.FileSystem = (*templateRenderer)(nil)
+
+func (tr *templateRenderer) Open(name string) (http.File, error) {
+	// First, open the inner file.
+	f, err := tr.inner.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	// Get the modification time of the file. This will be used to determine if
+	// our cache is stale.
+	fi, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+
+	// Return the underlying file if we got a directory. Otherwise, we're going
+	// to create our own synthethic file.
+	if fi.IsDir() {
+		return f, nil
+	}
+	defer f.Close()
+
+	// Return the existing cache entry if one exists.
+	if ent, ok := tr.getCacheEntry(name, fi, true); ok {
+		return ent, nil
+	}
+
+	tr.cacheMut.Lock()
+	defer tr.cacheMut.Unlock()
+
+	// Check to see if another goroutine happened to cache the file while we were
+	// waiting for the lock.
+	if ent, ok := tr.getCacheEntry(name, fi, false); ok {
+		return ent, nil
+	}
+
+	rawBytes, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("reading file for template processing: %w", err)
+	}
+	tmpl, err := template.New(name).Delims("{{!", "!}}").Parse(string(rawBytes))
+	if err != nil {
+		return nil, fmt.Errorf("parsing template: %w", err)
+	}
+
+	// Render the file as an html/template.
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, struct{ PublicURL string }{PublicURL: tr.pathPrefix}); err != nil {
+		return nil, fmt.Errorf("rendering template: %w", err)
+	}
+
+	tr.contentCache[name] = buf.String()
+	tr.contentCacheTime[name] = fi.ModTime()
+
+	return &readerFile{
+		Reader: bytes.NewReader(buf.Bytes()),
+		fi: &infoWithSize{
+			FileInfo: fi,
+			size:     int64(buf.Len()),
+		},
+	}, nil
+}
+
+func (tr *templateRenderer) getCacheEntry(name string, fi fs.FileInfo, lock bool) (f http.File, ok bool) {
+	if lock {
+		tr.cacheMut.RLock()
+		defer tr.cacheMut.RUnlock()
+	}
+
+	content, ok := tr.contentCache[name]
+	if !ok {
+		return nil, false
+	}
+
+	// Before returning, make sure that that fi isn't newer than our cache time.
+	if fi.ModTime().After(tr.contentCacheTime[name]) {
+		// The file has changed since we cached it. It needs to be re-cached. This
+		// is only common to happen during development, but would rarely happen in
+		// production where the files are static.
+		return nil, false
+	}
+
+	return &readerFile{
+		Reader: strings.NewReader(content),
+		fi: &infoWithSize{
+			FileInfo: fi,
+			size:     int64(len(content)),
+		},
+	}, true
+}
+
+type readerFile struct {
+	io.Reader
+	fi fs.FileInfo
+}
+
+var _ http.File = (*readerFile)(nil)
+
+func (rf *readerFile) Stat() (fs.FileInfo, error) { return rf.fi, nil }
+
+func (rf *readerFile) Close() error {
+	// no-op: nothing to close
+	return nil
+}
+
+// http.Filesystem expects that io.Seeker and Readdir is implemented for all
+// http.File implementations.
+//
+// These don't need to do anything; http also contains an adapter for fs.FS to
+// http.FileSystem (http.FS) where these two methods can be a no-op.
+
+func (rf *readerFile) Seek(offset int64, whence int) (int64, error) {
+	return 0, fmt.Errorf("Seek not implemented")
+}
+
+func (rf *readerFile) Readdir(count int) ([]fs.FileInfo, error) {
+	return nil, fmt.Errorf("Readdir not implemented")
+}
+
+type infoWithSize struct {
+	fs.FileInfo
+	size int64
+}
+
+func (iws *infoWithSize) Size() int64 { return iws.size }


### PR DESCRIPTION
This commit exposes the Flow UI from Grafana Agent Flow's HTTP server. By default, the UI is available via the the `/` path. The path where the UI (and the UI's API) is hosted can be changed via the `--server.http.ui-path-prefix` flag.

By default, Grafana Agent Flow will look for the UI at the `./web/ui/build` path relative to the working directory from where Grafana Agent Flow is running. A built UI at `./web/ui/build` can be baked into the binary by setting a `builtinassets` build flag when building.

To build the UI, run `go generate -tags builtinassets ./web/ui` or run `yarn && yarn build` from the `./web/ui` directory. 

This change does not yet modify the Makefile or Dockerfile to include the builtin UI from release assets. This will be done in a future change.