### PR TITLE
Flow: add `agent fmt` subcommand to format files

### DIFF
--- a/cmd/agent/flow.go
+++ b/cmd/agent/flow.go
@@ -27,7 +27,10 @@ func runFlow() {
 	}
 	cmd.SetVersionTemplate("{{ .Version }}\n")
 
-	cmd.AddCommand(runCommand())
+	cmd.AddCommand(
+		fmtCommand(),
+		runCommand(),
+	)
 
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/agent/flow_fmt.go
+++ b/cmd/agent/flow_fmt.go
@@ -104,7 +104,7 @@ func format(filename string, fi os.FileInfo, r io.Reader, write bool) error {
 		return err
 	}
 
-	// Add a newline at the endi
+	// Add a newline at the end of the file.
 	_, _ = buf.Write([]byte{'\n'})
 
 	if !write {

--- a/cmd/agent/flow_fmt.go
+++ b/cmd/agent/flow_fmt.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/grafana/agent/pkg/river/diag"
+	"github.com/grafana/agent/pkg/river/parser"
+	"github.com/grafana/agent/pkg/river/printer"
+)
+
+func fmtCommand() *cobra.Command {
+	f := &flowFmt{
+		write: false,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "fmt [flags] file",
+		Short: "Format a River file",
+		Long: `The fmt subcommand applies standard formatting rules to the specified
+River configuration file.
+
+If the file argument is not supplied or if the file argument is "-", then fmt will read from stdin.
+
+The -w flag can be used to write the formatted file back to disk. -w can not be provided when fmt is reading from stdin. When -w is not provided, fmt will write the result to stdout.`,
+		Args:         cobra.RangeArgs(0, 1),
+		SilenceUsage: true,
+
+		RunE: func(_ *cobra.Command, args []string) error {
+			var err error
+
+			if len(args) == 0 {
+				// Read from stdin when there are no args provided.
+				err = f.Run("-")
+			} else {
+				err = f.Run(args[0])
+			}
+
+			var diags diag.Diagnostics
+			if errors.As(err, &diags) {
+				for _, diag := range diags {
+					fmt.Fprintln(os.Stderr, diag)
+				}
+				return fmt.Errorf("encountered errors during formatting")
+			}
+
+			return err
+		},
+	}
+
+	cmd.Flags().BoolVarP(&f.write, "write", "w", f.write, "write result to (source) file instead of stdout")
+	return cmd
+}
+
+type flowFmt struct {
+	write bool
+}
+
+func (ff *flowFmt) Run(configFile string) error {
+	switch configFile {
+	case "-":
+		if ff.write {
+			return fmt.Errorf("cannot use -w with standard input")
+		}
+		return format("<stdin>", nil, os.Stdin, false)
+
+	default:
+		fi, err := os.Stat(configFile)
+		if err != nil {
+			return err
+		}
+		if fi.IsDir() {
+			return fmt.Errorf("cannot format a directory")
+		}
+
+		f, err := os.Open(configFile)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		return format(configFile, fi, f, ff.write)
+	}
+}
+
+func format(filename string, fi os.FileInfo, r io.Reader, write bool) error {
+	bb, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	f, err := parser.ParseFile(filename, bb)
+	if err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+	if err := printer.Fprint(&buf, f); err != nil {
+		return err
+	}
+
+	// Add a newline at the endi
+	_, _ = buf.Write([]byte{'\n'})
+
+	if !write {
+		_, err := io.Copy(os.Stdout, &buf)
+		return err
+	}
+
+	wf, err := os.OpenFile(filename, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, fi.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer wf.Close()
+
+	_, err = io.Copy(wf, &buf)
+	return err
+}

--- a/cmd/agent/flow_fmt.go
+++ b/cmd/agent/flow_fmt.go
@@ -30,6 +30,7 @@ If the file argument is not supplied or if the file argument is "-", then fmt wi
 The -w flag can be used to write the formatted file back to disk. -w can not be provided when fmt is reading from stdin. When -w is not provided, fmt will write the result to stdout.`,
 		Args:         cobra.RangeArgs(0, 1),
 		SilenceUsage: true,
+		Aliases:      []string{"format"},
 
 		RunE: func(_ *cobra.Command, args []string) error {
 			var err error

--- a/docs/flow/reference/cli/_index.md
+++ b/docs/flow/reference/cli/_index.md
@@ -15,8 +15,8 @@ starts Grafana Agent Flow.
 
 Available commands:
 
-* [`agent run`][run]: Start Grafana Agent Flow given a config file.
-* [`agent fmt`][fmt]: Format a Grafana Agent Flow configuration file.
+* [`agent run`][run]: Start Grafana Agent Flow, given a config file.
+* [`agent fmt`][fmt]: Format a Grafana Agent Flow config file.
 * `agent completion`: Generate shell completion for the `agent` CLI.
 * `agent help`: Print help for supported commands.
 

--- a/docs/flow/reference/cli/_index.md
+++ b/docs/flow/reference/cli/_index.md
@@ -15,8 +15,10 @@ starts Grafana Agent Flow.
 
 Available commands:
 
-* [`agent run`][run]: Start Grafana Agent Flow given a config file
-* `agent completion`: Generate shell completion for the `agent` CLI
-* `agent help`: Print help for supported commands
+* [`agent run`][run]: Start Grafana Agent Flow given a config file.
+* [`agent fmt`][fmt]: Format a Grafana Agent Flow configuration file.
+* `agent completion`: Generate shell completion for the `agent` CLI.
+* `agent help`: Print help for supported commands.
 
 [run]: {{< relref "./run.md" >}}
+[fmt]: {{< relref "./fmt.md" >}}

--- a/docs/flow/reference/cli/fmt.md
+++ b/docs/flow/reference/cli/fmt.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/flow/reference/cli/run
+- /docs/agent/latest/flow/reference/cli/fmt
 title: agent fmt
 weight: 100
 ---

--- a/docs/flow/reference/cli/fmt.md
+++ b/docs/flow/reference/cli/fmt.md
@@ -1,0 +1,27 @@
+---
+aliases:
+- /docs/agent/latest/flow/reference/cli/run
+title: agent run
+weight: 100
+---
+
+# `agent fmt` command
+
+The `agent fmt` command formats a given Grafana Agent Flow configuration file.
+
+## Usage
+
+Usage: `agent fmt [flags] file`
+
+If the `file` argument is not provided or if the `file` argument is equal to
+`-`, `agent fmt` formats the contents of standard input. Otherwise, `agent fmt`
+reads and formats the file from disk specified by the argument.
+
+The `--write` flag can be specified to write the formatted result back to disk.
+`--write` can only be provided when `agent fmt` is not reading from standard
+input.
+
+The following flags are supported:
+
+* `--write`, `-w`: Write the formatted file back to disk when not reading from
+  standard input.

--- a/docs/flow/reference/cli/fmt.md
+++ b/docs/flow/reference/cli/fmt.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/latest/flow/reference/cli/run
-title: agent run
+title: agent fmt
 weight: 100
 ---
 
@@ -17,9 +17,9 @@ If the `file` argument is not provided or if the `file` argument is equal to
 `-`, `agent fmt` formats the contents of standard input. Otherwise, `agent fmt`
 reads and formats the file from disk specified by the argument.
 
-The `--write` flag can be specified to write the formatted result back to disk.
-`--write` can only be provided when `agent fmt` is not reading from standard
-input.
+The `--write` flag can be specified to replace the contents of the original
+file on disk with the formatted results. `--write` can only be provided when
+`agent fmt` is not reading from standard input.
 
 The following flags are supported:
 


### PR DESCRIPTION
The `agent fmt` subcommand formats the specified River configuration file.

The `agent fmt` subcommand behaves similarly as `tools/riverfmt`, but uses Cobra instead.

Closes #2150.