### PR TITLE
build-image: add NodeJS and Yarn for building the UI

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -61,7 +61,7 @@ EOF
 # See https://yarnpkg.com/getting-started/install#nodejs-1610
 RUN corepack enable
 
-#  Install other dependencies.
+# Install other dependencies.
 #
 # NOTE(rfratto): musl is installed so the Docker binaries from alpine work
 # properly.

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,9 +1,8 @@
 # syntax=docker/dockerfile:1.4
 
-# NOTE: This Dockerfile can only be built using BuildKit.
-# BuildKit is used by default when running `docker buildx
-# build` or when DOCKER_BUILDKIT=1 is set in environment
-# variables.
+# NOTE: This Dockerfile can only be built using BuildKit. BuildKit is used by
+# default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
+# in environment variables.
 
 #
 # Dependencies

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,3 +1,10 @@
+# syntax=docker/dockerfile:1.4
+
+# NOTE: This Dockerfile can only be built using BuildKit.
+# BuildKit is used by default when running `docker buildx
+# build` or when DOCKER_BUILDKIT=1 is set in environment
+# variables.
+
 #
 # Dependencies
 #
@@ -36,6 +43,27 @@ RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@$CONTROLLER_GEN_V
 # dependencies.
 FROM rfratto/viceroy:v0.2.1
 
+# Install NodeJS LTS. This is needed because the most recent version of NodeJS
+# from official Debian packages is v12, and we need LTS version v16.
+#
+# This must be done before installing other dependencies, otherwise nodesource
+# will fail on installing NodeJS for all platforms instead of just our host
+# platform.
+RUN <<EOF
+  apt-get update && apt-get install -qy curl
+  curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+
+  apt-get update && apt-get install -qy nodejs
+  rm -rf /var/lib/apt/lists/*
+EOF
+
+# Install Yarn.
+#
+# See https://yarnpkg.com/getting-started/install#nodejs-1610
+RUN corepack enable
+
+#  Install other dependencies.
+#
 # NOTE(rfratto): musl is installed so the Docker binaries from alpine work
 # properly.
 RUN apt-get update                                \


### PR DESCRIPTION
This commit adds NodeJS LTS (v16) and Yarn for building the UI. This has been tested to work through the following steps:

```
$ docker build -t grafana/agent-build-image:0.16.0 ./build-image
$ docker run --rm -it -v `pwd`:/src -w /src grafana/agent-build-image:0.16.0

$ cd web/ui
$ yarn
$ yarn run build
```

Once this is merged into main, build-image/v0.16.0 will be tagged.