### PR TITLE
Bundle UI by default in Docker images and dist assets

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -82,7 +82,7 @@ trigger:
 
 steps:
   - name: lint
-    image: grafana/agent-build-image:0.15.1
+    image: grafana/agent-build-image:0.16.0
     commands:
       - make lint
 
@@ -105,7 +105,7 @@ trigger:
 
 steps:
   - name: test
-    image: grafana/agent-build-image:0.15.1
+    image: grafana/agent-build-image:0.16.0
     volumes:
       - name: docker
         path: /var/run/docker.sock
@@ -142,7 +142,7 @@ trigger:
     - refs/tags/v*
 steps:
   - name: test
-    image: grafana/agent-build-image:0.14.0-windows
+    image: grafana/agent-build-image:0.16.0-windows
     commands:
       - go test -tags="nodocker,nonetwork" ./...
 
@@ -160,7 +160,7 @@ trigger:
     - refs/heads/dev.*
 steps:
   - name: Build Containers
-    image: grafana/agent-build-image:0.15.1
+    image: grafana/agent-build-image:0.16.0
     volumes:
       - name: docker
         path: /var/run/docker.sock
@@ -268,7 +268,7 @@ trigger:
 
 steps:
   - name: create-release
-    image: grafana/agent-build-image:0.15.1
+    image: grafana/agent-build-image:0.16.0
     volumes:
       - name: docker
         path: /var/run/docker.sock
@@ -347,6 +347,6 @@ get:
 
 ---
 kind: signature
-hmac: 30ef74d8b3810aec51486cb913df033ef6b51efa58f85e5cc33a00fa602a0ba7
+hmac: aebdad70136af378d3fa83afd38715c4919b6398772da656f9d9f1f67df3c617
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@
 ##   generate-dashboards  Generate dashboards in example/docker-compose after
 ##                        changing Jsonnet.
 ##   generate-protos      Generate protobuf files.
+##   generate-ui          Generate the UI assets.
 ##
 ## Other targets:
 ##
@@ -224,8 +225,8 @@ smoke-image:
 # Targets for generating assets
 #
 
-.PHONY: generate generate-crds generate-manifests generate-dashboards generate-protos
-generate: generate-crds generate-manifests generate-dashboards generate-protos
+.PHONY: generate generate-crds generate-manifests generate-dashboards generate-protos generate-ui
+generate: generate-crds generate-manifests generate-dashboards generate-protos generate-ui
 
 generate-crds:
 ifeq ($(USE_CONTAINER),1)
@@ -254,6 +255,13 @@ ifeq ($(USE_CONTAINER),1)
 	$(RERUN_IN_CONTAINER)
 else
 	go generate ./pkg/agentproto/
+endif
+
+generate-ui:
+ifeq ($(USE_CONTAINER),1)
+	$(RERUN_IN_CONTAINER)
+else
+	cd ./web/ui && yarn && yarn run build
 endif
 
 #

--- a/cmd/agent-operator/Dockerfile
+++ b/cmd/agent-operator/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.15.1 as build
+FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.16.0 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/cmd/agent/Dockerfile
+++ b/cmd/agent/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.15.1 as build
+FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.16.0 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS
@@ -16,10 +16,16 @@ ARG VERSION
 COPY . /src/agent
 WORKDIR /src/agent
 
+# Build the UI before building the agent, which will then bake the final UI
+# into the binary.
+RUN --mount=type=cache,target=/src/agent/web/ui/node_modules \
+   make generate-ui
+
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=${TARGETVARIANT#v} \
     RELEASE_BUILD=${RELEASE_BUILD} VERISON=${VERSION} \
+    GO_TAGS=builtinassets \
     make agent
 
 FROM ubuntu:jammy

--- a/cmd/agentctl/Dockerfile
+++ b/cmd/agentctl/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.15.1 as build
+FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.16.0 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/tools/crow/Dockerfile
+++ b/tools/crow/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.15.1 as build
+FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.16.0 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/tools/make/build-container.mk
+++ b/tools/make/build-container.mk
@@ -34,7 +34,7 @@
 # variable names should be passed through to the container.
 
 USE_CONTAINER ?= 0
-BUILD_IMAGE   ?= grafana/agent-build-image:0.15.1
+BUILD_IMAGE   ?= grafana/agent-build-image:0.16.0
 DOCKER_OPTS   ?= -it
 
 #

--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -29,47 +29,54 @@ dist-agent-binaries: dist/agent-linux-amd64   \
                      dist/agent-darwin-arm64  \
                      dist/agent-windows-amd64.exe
 
-dist/agent-linux-amd64: GO_TAGS += noebpf
+dist/agent-linux-amd64: GO_TAGS += noebpf builtinassets
 dist/agent-linux-amd64: GOOS    := linux
 dist/agent-linux-amd64: GOARCH  := amd64
-dist/agent-linux-amd64:
+dist/agent-linux-amd64: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/agent-linux-arm64: GOOS   := linux
-dist/agent-linux-arm64: GOARCH := arm64
-dist/agent-linux-arm64:
+dist/agent-linux-arm64: GO_TAGS += builtinassets
+dist/agent-linux-arm64: GOOS    := linux
+dist/agent-linux-arm64: GOARCH  := arm64
+dist/agent-linux-arm64: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/agent-linux-armv6: GOOS   := linux
-dist/agent-linux-armv6: GOARCH := arm
-dist/agent-linux-armv6: GOARM  := 6
-dist/agent-linux-armv6:
+dist/agent-linux-armv6: GO_TAGS += builtinassets
+dist/agent-linux-armv6: GOOS    := linux
+dist/agent-linux-armv6: GOARCH  := arm
+dist/agent-linux-armv6: GOARM   := 6
+dist/agent-linux-armv6: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/agent-linux-armv7: GOOS   := linux
-dist/agent-linux-armv7: GOARCH := arm
-dist/agent-linux-armv7: GOARM  := 7
-dist/agent-linux-armv7:
+dist/agent-linux-armv7: GO_TAGS += builtinassets
+dist/agent-linux-armv7: GOOS    := linux
+dist/agent-linux-armv7: GOARCH  := arm
+dist/agent-linux-armv7: GOARM   := 7
+dist/agent-linux-armv7: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/agent-linux-ppc64le: GOOS   := linux
-dist/agent-linux-ppc64le: GOARCH := ppc64le
-dist/agent-linux-ppc64le:
+dist/agent-linux-ppc64le: GO_TAGS += builtinassets
+dist/agent-linux-ppc64le: GOOS    := linux
+dist/agent-linux-ppc64le: GOARCH  := ppc64le
+dist/agent-linux-ppc64le: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/agent-darwin-amd64: GOOS   := darwin
-dist/agent-darwin-amd64: GOARCH := amd64
-dist/agent-darwin-amd64:
+dist/agent-darwin-amd64: GO_TAGS += builtinassets
+dist/agent-darwin-amd64: GOOS    := darwin
+dist/agent-darwin-amd64: GOARCH  := amd64
+dist/agent-darwin-amd64: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/agent-darwin-arm64: GOOS   := darwin
-dist/agent-darwin-arm64: GOARCH := arm64
-dist/agent-darwin-arm64:
+dist/agent-darwin-arm64: GO_TAGS += builtinassets
+dist/agent-darwin-arm64: GOOS    := darwin
+dist/agent-darwin-arm64: GOARCH  := arm64
+dist/agent-darwin-arm64: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/agent-windows-amd64.exe: GOOS   := windows
-dist/agent-windows-amd64.exe: GOARCH := amd64
-dist/agent-windows-amd64.exe:
+dist/agent-windows-amd64.exe: GO_TAGS += noebpf builtinassets
+dist/agent-windows-amd64.exe: GOOS    := windows builtinassets
+dist/agent-windows-amd64.exe: GOARCH  := amd64
+dist/agent-windows-amd64.exe: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
 #

--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -73,7 +73,7 @@ dist/agent-darwin-arm64: GOARCH  := arm64
 dist/agent-darwin-arm64: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/agent-windows-amd64.exe: GO_TAGS += noebpf builtinassets
+dist/agent-windows-amd64.exe: GO_TAGS += builtinassets
 dist/agent-windows-amd64.exe: GOOS    := windows builtinassets
 dist/agent-windows-amd64.exe: GOARCH  := amd64
 dist/agent-windows-amd64.exe: generate-ui

--- a/tools/smoke/Dockerfile
+++ b/tools/smoke/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.15.1 as build
+FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.16.0 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS


### PR DESCRIPTION
This updates the following to embed the Grafana Agent Flow UI by default:

* The grafana/agent Docker image
* Release assets produced by `make dist`

This uses the new grafana/agent-build-image:0.16.0 release which includes Node.JS and Yarn.
