### PR TITLE
docs/flow: fix mentions of previous component names and fields

### DIFF
--- a/docs/flow/_index.md
+++ b/docs/flow/_index.md
@@ -51,12 +51,14 @@ local.file "apikey" {
 
 // Collect and send metrics to a Prometheus remote_write endpoint.
 prometheus.remote_write "default" {
-  remote_write {
+  endpoint {
     url = "http://localhost:9009/api/prom/push"
 
-    basic_auth {
-      username = "MY_USERNAME"
-      password = local.file.apikey.content
+    http_client_config {
+      basic_auth {
+        username = "MY_USERNAME"
+        password = local.file.apikey.content
+      }
     }
   }
 }

--- a/docs/flow/concepts/components.md
+++ b/docs/flow/concepts/components.md
@@ -99,14 +99,16 @@ local.file "api_key" {
 // This component exports a "receiver" value which can be used by other
 // components to send metrics.
 prometheus.remote_write "prod" {
-  remote_write {
+  endpoint {
     url = "https://prod:9090/api/v1/write"
 
-    basic_auth {
-      username = "admin"
+    http_client_config {
+      basic_auth {
+        username = "admin"
 
-      // Use our password file for authenticating with the production database.
-      password = local.file.api_key.content
+        // Use our password file for authenticating with the production database.
+        password = local.file.api_key.content
+      }
     }
   }
 }

--- a/docs/flow/concepts/configuration_language.md
+++ b/docs/flow/concepts/configuration_language.md
@@ -21,7 +21,7 @@ prometheus.scrape "default" {
 }
 
 prometheus.remote_write "default" {
-  remote_write {
+  endpoint {
     url = "http://localhost:9009/api/prom/push"
   }
 }
@@ -79,7 +79,7 @@ can contain any number of attributes or nested blocks.
 
 ```river
 prometheus.remote_write "default" {
-  remote_write {
+  endpoint {
     url = "http://localhost:9009/api/prom/push"
   }
 }

--- a/docs/flow/config-language/expressions/referencing_exports.md
+++ b/docs/flow/config-language/expressions/referencing_exports.md
@@ -36,7 +36,7 @@ prometheus.scrape "default" {
 }
 
 prometheus.remote_write "onprem" {
-	remote_write {
+	endpoint {
 		url = "http://prometheus:9009/api/prom/push"
 	}
 }

--- a/docs/flow/config-language/expressions/types_and_values.md
+++ b/docs/flow/config-language/expressions/types_and_values.md
@@ -125,20 +125,20 @@ it can only be assigned a `capsule("prometheus.Receiver")` type. The specific
 type of capsule expected is explicitly documented for any component which uses
 or exports them.
 
-In the following example, the `metrics.remote_write` component exports a
-`receiver`, which is a `capsule("metrics.Receiver")` type. This can then be
-used in the `forward_to` attribute of `metrics.scrape`, which
-expects an array of `capsule("metrics.Receiver")`s:
+In the following example, the `prometheus.remote_write` component exports a
+`receiver`, which is a `capsule("prometheus.Receiver")` type. This can then be
+used in the `forward_to` attribute of `prometheus.scrape`, which
+expects an array of `capsule("prometheus.Receiver")`s:
 
 ```river
-metrics.remote_write "default" {
-  remote_write {
+prometheus.remote_write "default" {
+  endpoint {
     url = "http://localhost:9090/api/v1/write"
   }
 }
 
-metrics.scrape "default" {
+prometheus.scrape "default" {
   targets    = [/* ... */]
-  forward_to = [metrics.remote_write.default.receiver]
+  forward_to = [prometheus.remote_write.default.receiver]
 }
 ```

--- a/docs/flow/getting_started.md
+++ b/docs/flow/getting_started.md
@@ -35,14 +35,14 @@ EXPERIMENTAL_ENABLE_FLOW=1 agent run /path/to/my/config.river
 You can use this file as an example to get started:
 
 ```river
-metrics.scrape "default" {
+prometheus.scrape "default" {
   targets = [
     {"__address__" = "demo.robustperception.io:9090"},
   ]
-  forward_to = [metrics.remote_write.default.receiver]
+  forward_to = [prometheus.remote_write.default.receiver]
 }
 
-metrics.remote_write "default" {
+prometheus.remote_write "default" {
   // No endpoints configured; metrics will be accumulated locally in a WAL
   // and discarded.
 }

--- a/docs/flow/tutorials/assets/flow_configs/agent.flow
+++ b/docs/flow/tutorials/assets/flow_configs/agent.flow
@@ -13,7 +13,7 @@ prometheus.scrape "default" {
 }
 
 prometheus.remote_write "prom" {
-	remote_write {
+	endpoint {
 		url = "http://mimir:9009/api/v1/push"
 	}
 }

--- a/docs/flow/tutorials/assets/flow_configs/multiple-inputs.flow
+++ b/docs/flow/tutorials/assets/flow_configs/multiple-inputs.flow
@@ -29,7 +29,7 @@ prometheus.relabel "not_cool" {
 }
 
 prometheus.remote_write "prom" {
-	remote_write {
+	endpoint {
 		url = "http://mimir:9009/api/v1/push"
 	}
 }

--- a/docs/flow/tutorials/assets/flow_configs/relabel.flow
+++ b/docs/flow/tutorials/assets/flow_configs/relabel.flow
@@ -18,7 +18,7 @@ prometheus.relabel "filter" {
 }
 
 prometheus.remote_write "prom" {
-	remote_write {
+	endpoint {
 		url = "http://mimir:9009/api/v1/push"
 	}
 }

--- a/docs/flow/tutorials/chaining.md
+++ b/docs/flow/tutorials/chaining.md
@@ -60,7 +60,7 @@ prometheus.relabel "not_cool" {
 }
 
 prometheus.remote_write "prom" {
-    remote_write {
+    endpoint {
         url = "http://mimir:9009/api/v1/push"
     }
 }

--- a/docs/flow/tutorials/collecting-prometheus-metrics.md
+++ b/docs/flow/tutorials/collecting-prometheus-metrics.md
@@ -51,7 +51,7 @@ The [`prometheus.remote_write`]({{< relref "prometheus.remote_write.md" >}}) com
 
 ```river
 prometheus.remote_write "prom" {
-    remote_write {
+    endpoint {
         url = "http://mimir:9009/api/v1/push"
     }
 }

--- a/pkg/river/parser/testdata/assign_block_to_attr.river
+++ b/pkg/river/parser/testdata/assign_block_to_attr.river
@@ -1,9 +1,11 @@
 rw = prometheus/* ERROR "cannot use a block as an expression" */.remote_write "default" {
   endpoint {
     url = "some_url"
-    basic_auth {
-      username = "username"
-      password = "password"
+    http_client_config {
+      basic_auth {
+        username = "username"
+        password = "password"
+      }
     }
   }
 }

--- a/pkg/river/parser/testdata/assign_block_to_attr.river
+++ b/pkg/river/parser/testdata/assign_block_to_attr.river
@@ -1,5 +1,5 @@
-rw = metrics/* ERROR "cannot use a block as an expression" */.remote_write "default" {
-  remote_write {
+rw = prometheus/* ERROR "cannot use a block as an expression" */.remote_write "default" {
+  endpoint {
     url = "some_url"
     basic_auth {
       username = "username"
@@ -12,12 +12,14 @@ attr_1 = 15
 attr_2 = 51
 
 block {
-	rw_2 = metrics/* ERROR "cannot use a block as an expression" */.remote_write "other" {
-		remote_write {
+	rw_2 = prometheus/* ERROR "cannot use a block as an expression" */.remote_write "other" {
+		endpoint {
 			url = "other_url"
-			basic_auth {
-				username = "username_2"
-				password = "password_2"
+			http_client_config {
+				basic_auth {
+					username = "username_2"
+					password = "password_2"
+				}
 			}
 		}
 	}

--- a/web/ui/src/features/component/types.ts
+++ b/web/ui/src/features/component/types.ts
@@ -9,8 +9,9 @@ export interface ComponentInfo {
 
   /**
    * The name of the component is the name of the block used to instantiate
-   * the component. For example, the component ID metrics.remote_write.default
-   * would have a name of "metrics.remote_write".
+   * the component. For example, the component ID
+   * prometheus.remote_write.default would have a name of
+   * "prometheus.remote_write".
    */
   name: string;
 
@@ -18,8 +19,8 @@ export interface ComponentInfo {
    * Label is an optional label for a component. Not all components may have
    * labels.
    *
-   * For example, the metrics.remote_write.default component would have a label
-   * of "default".
+   * For example, the prometheus.remote_write.default component would have a
+   * label of "default".
    */
   label?: string;
 


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR cleans up some references to previous component and field names after the recent namespacing and component cleanup.

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer
Did I miss anything? Did you spot any more of those?

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
