### PR TITLE
flow: rename relabeling sub-blocks to 'rule'

### DIFF
--- a/component/discovery/relabel/relabel.go
+++ b/component/discovery/relabel/relabel.go
@@ -27,8 +27,8 @@ type Arguments struct {
 	// Targets contains the input 'targets' passed by a service discovery component.
 	Targets []discovery.Target `river:"targets,attr"`
 
-	// The relabelling steps to apply to the each target's label set.
-	RelabelConfigs []*flow_relabel.Config `river:"relabel_config,block,optional"`
+	// The relabelling rules to apply to the each target's label set.
+	RelabelConfigs []*flow_relabel.Config `river:"rule,block,optional"`
 }
 
 // Exports holds values which are exported by the discovery.relabel component.

--- a/component/discovery/relabel/relabel_test.go
+++ b/component/discovery/relabel/relabel_test.go
@@ -20,37 +20,37 @@ targets = [
 	{ "__meta_baz" = "baz", "__meta_qux" = "qux", "__address__" = "localhost", "instance" = "three", "app" = "frontend", "__tmp_c" = "tmp" },
 ]
 
-relabel_config {
+rule {
 	source_labels = ["__address__", "instance"]
 	separator     = "/"
 	target_label  = "destination"
 	action        = "replace"
 } 
 
-relabel_config {
+rule {
 	source_labels = ["app"]
 	action        = "drop"
 	regex         = "frontend"
 }
 
-relabel_config {
+rule {
 	source_labels = ["app"]
 	action        = "keep"
 	regex         = "backend"
 }
 
-relabel_config {
+rule {
 	source_labels = ["instance"]
 	target_label  = "name"
 }
 
-relabel_config {
+rule {
 	action      = "labelmap"
 	regex       = "__meta_(.*)"
 	replacement = "meta_$1"
 }
 
-relabel_config {
+rule {
 	action = "labeldrop"
 	regex  = "__meta(.*)|__tmp(.*)|instance"
 }

--- a/component/prometheus/relabel/relabel.go
+++ b/component/prometheus/relabel/relabel.go
@@ -28,8 +28,8 @@ type Arguments struct {
 	// Where the relabelled metrics should be forwarded to.
 	ForwardTo []*prometheus.Receiver `river:"forward_to,attr"`
 
-	// The relabelling steps to apply to each metric before it's forwarded.
-	MetricRelabelConfigs []*flow_relabel.Config `river:"metric_relabel_config,block,optional"`
+	// The relabelling rules to apply to each metric before it's forwarded.
+	MetricRelabelConfigs []*flow_relabel.Config `river:"rule,block,optional"`
 }
 
 // Exports holds values which are exported by the prometheus.relabel component.

--- a/docs/flow/reference/components/discovery.relabel.md
+++ b/docs/flow/reference/components/discovery.relabel.md
@@ -7,7 +7,7 @@ title: discovery.relabel
 # discovery.relabel
 
 `discovery.relabel` rewrites the label set of the input targets by applying one
-or more `rule`s. If no relabeling rules are defined, then the input targets
+or more relabeling `rule`s. If no rules are defined, then the input targets
 will be exported as-is.
 
 The most common use of `discovery.relabel` is to filter Prometheus targets or
@@ -59,7 +59,7 @@ Name | Description | Required
 
 ### `rule` block
 
-The `ruke` block contains the definition of any relabeling rules that
+The `rule` block contains the definition of any relabeling rules that
 can be applied to an input target. If more than one `rule` block is defined
 within `discovery.relabel`, the transformations will be applied in top-down
 order.

--- a/docs/flow/reference/components/discovery.relabel.md
+++ b/docs/flow/reference/components/discovery.relabel.md
@@ -7,12 +7,12 @@ title: discovery.relabel
 # discovery.relabel
 
 `discovery.relabel` rewrites the label set of the input targets by applying one
-or more `relabel_config` steps. If no relabeling steps are defined, then the
-input targets will be exported as-is.
+or more `rule`s. If no relabeling rules are defined, then the input targets
+will be exported as-is.
 
 The most common use of `discovery.relabel` is to filter Prometheus targets or
 standardize the label set that will be passed to a downstream component. The
-`relabel_config` blocks will be applied to the label set of each target in
+`rule` blocks will be applied to the label set of each target in
 order of their appearance in the configuration file.
 
 Multiple `discovery.relabel` components can be specified by giving them
@@ -28,14 +28,14 @@ discovery.relabel "keep_backend_only" {
     { "__meta_baz" = "baz", "__address__" = "localhost", "instance" = "three", "app" = "frontend" },
   ]
 
-  relabel_config {
+  rule {
     source_labels = ["__address__", "instance"]
     separator     = "/"
     target_label  = "destination"
     action        = "replace"
   }
 
-  relabel_config {
+  rule {
     source_labels = ["app"]
     action        = "keep"
     regex         = "backend"
@@ -55,16 +55,16 @@ The following subblocks are supported:
 
 Name | Description | Required
 ---- | ----------- | --------
-[`relabel_config`](#relabel_config-block) | Relabeling steps to apply to targets | no
+[`rule`](#rule-block) | Relabeling rules to apply to targets | no
 
-### `relabel_config` block
+### `rule` block
 
-The `relabel_config` block contains the definition of any relabeling rules that
-can be applied to an input target. If more than one `relabel_config` block is
-defined within `discovery.relabel`, the transformations will be applied
-in top-down order.
+The `ruke` block contains the definition of any relabeling rules that
+can be applied to an input target. If more than one `rule` block is defined
+within `discovery.relabel`, the transformations will be applied in top-down
+order.
 
-The following arguments can be used to configure a `relabel_config` block.
+The following arguments can be used to configure a `rule` block.
 All arguments are optional and any omitted fields will take on their default
 values.
 

--- a/docs/flow/reference/components/prometheus.relabel.md
+++ b/docs/flow/reference/components/prometheus.relabel.md
@@ -15,10 +15,10 @@ time series and contains a value and an optional timestamp.
 ```
 
 The `prometheus.relabel` component rewrites the label set of each metric passed
-along to the exported receiver by applying one or more `rule`s. If no
-relabeling rules are defined or applicable to one of the metrics, then the
-metric is forwarded as-is to each receiver passed in the component's arguments.
-If no labels remain after the relabeling rules are applied, then the metric is
+along to the exported receiver by applying one or more relabeling `rule`s. If
+no rules are defined or applicable to some metrics, then those metrics are
+forwarded as-is to each receiver passed in the component's arguments. If no
+labels remain after the relabeling rules are applied, then the metric is
 dropped.
 
 The most common use of `prometheus.relabel` is to filter Prometheus metrics or
@@ -67,7 +67,7 @@ Name | Description | Required
 
 The `rule` block contains the definition of any relabeling
 rules that can be applied to an input metric. If more than one
-`rule`s block is defined within `prometheus.relabel`, the
+`rule` block is defined within `prometheus.relabel`, the
 transformations are applied in top-down order.
 
 The following arguments can be used to configure a `rule`.

--- a/docs/flow/tutorials/assets/flow_configs/multiple-inputs.flow
+++ b/docs/flow/tutorials/assets/flow_configs/multiple-inputs.flow
@@ -9,7 +9,7 @@ prometheus.scrape "second" {
 }
 
 prometheus.relabel "cool" {
-	metric_relabel_config {
+	rule {
 		source_labels = ["__name__"]
 		regex         = "(.+)"
 		replacement   = "${1}_cool"
@@ -19,7 +19,7 @@ prometheus.relabel "cool" {
 }
 
 prometheus.relabel "not_cool" {
-	metric_relabel_config {
+	rule {
 		source_labels = ["__name__"]
 		regex         = "(.+)"
 		replacement   = "${1}_not_cool"

--- a/docs/flow/tutorials/assets/flow_configs/relabel.flow
+++ b/docs/flow/tutorials/assets/flow_configs/relabel.flow
@@ -8,7 +8,7 @@ prometheus.scrape "default" {
 // "_cool" into a new label called "cool_label." The resulting mutated metrics
 // are then forwarded to our prometheus.remote_write component.
 prometheus.relabel "filter" {
-	metric_relabel_config {
+	rule {
 		source_labels = ["__name__"]
 		regex         = "(.+)"
 		replacement   = "${1}_cool"

--- a/docs/flow/tutorials/chaining.md
+++ b/docs/flow/tutorials/chaining.md
@@ -40,7 +40,7 @@ In the above Flow block, `forward_to` accepts an array of receivers. In previous
 
 ```river
 prometheus.relabel "cool" {
-    metric_relabel_config {
+    rule {
         source_labels = ["__name__"]
         regex = "(.+)"
         replacement = "${1}_cool"
@@ -50,7 +50,7 @@ prometheus.relabel "cool" {
 }
 
 prometheus.relabel "not_cool" {
-    metric_relabel_config {
+    rule {
         source_labels = ["__name__"]
         regex = "(.+)"
         replacement = "${1}_not_cool"


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR updates both prometheus.relabel and discovery.relabel to use `rule` as the sub-block name. This should help with the repetitiveness of typing `metrics_relabel_config` and `relabel_config` over and over again.

#### Which issue(s) this PR fixes
No issue filed

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
