### PR TITLE
flow: Report usage of enabled Components

### DIFF
--- a/docs/flow/reference/cli/run.md
+++ b/docs/flow/reference/cli/run.md
@@ -33,3 +33,7 @@ The following flags are supported:
 * `--server.http.listen-addr`: Address to listen for HTTP traffic on (default `127.0.0.1:12345`).
 * `--server.http.ui-path-prefix`: Base path where the UI will be exposed (default `/`).
 * `--storage.path`: Base directory where components can store data (default `data-agent/`).
+* `--disable-reporting`: Disable [usage reporting][] of enabled [components][] to Grafana (default `false`).
+
+[usage reporting]: {{< relref "../../../configuration/flags.md/#report-information-usage" >}}
+[components]: {{< relref "../../concepts/components.md" >}}

--- a/docs/sources/operator/custom-resource-quickstart.md
+++ b/docs/sources/operator/custom-resource-quickstart.md
@@ -135,7 +135,7 @@ Deploying a GrafanaAgent resource on its own will not spin up any Agent Pods. Ag
 
 ### Disable feature flags reporting
 
-If you would like to disable the [reporting]({{< relref "../configuration/flags.md/#report-use-of-feature-flags" >}}) usage of feature flags to Grafana, set `disableReporting` field to `true`.
+If you would like to disable the [reporting]({{< relref "../configuration/flags.md//#report-information-usage" >}}) usage of feature flags to Grafana, set `disableReporting` field to `true`.
 
 ## Step 2: Deploy a MetricsInstance resource
 

--- a/pkg/usagestats/reporter.go
+++ b/pkg/usagestats/reporter.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/google/uuid"
-	"github.com/grafana/agent/pkg/config"
 	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/multierror"
 	"github.com/prometheus/common/version"
@@ -28,7 +27,6 @@ var (
 // Reporter holds the agent seed information and sends report of usage
 type Reporter struct {
 	logger log.Logger
-	cfg    *config.Config
 
 	agentSeed  *AgentSeed
 	lastReport time.Time
@@ -42,10 +40,9 @@ type AgentSeed struct {
 }
 
 // NewReporter creates a Reporter that will send periodically reports to grafana.com
-func NewReporter(logger log.Logger, cfg *config.Config) (*Reporter, error) {
+func NewReporter(logger log.Logger) (*Reporter, error) {
 	r := &Reporter{
 		logger: logger,
-		cfg:    cfg,
 	}
 	return r, nil
 }
@@ -103,7 +100,7 @@ func agentSeedFileName() string {
 }
 
 // Start inits the reporter seed and start sending report for every interval
-func (rep *Reporter) Start(ctx context.Context) error {
+func (rep *Reporter) Start(ctx context.Context, metrics map[string]interface{}) error {
 	level.Info(rep.logger).Log("msg", "running usage stats reporter")
 	err := rep.init(ctx)
 	if err != nil {
@@ -129,7 +126,7 @@ func (rep *Reporter) Start(ctx context.Context) error {
 				continue
 			}
 			level.Info(rep.logger).Log("msg", "reporting agent stats", "date", time.Now())
-			if err := rep.reportUsage(ctx, next); err != nil {
+			if err := rep.reportUsage(ctx, next, metrics); err != nil {
 				level.Info(rep.logger).Log("msg", "failed to report usage", "err", err)
 				continue
 			}
@@ -142,7 +139,7 @@ func (rep *Reporter) Start(ctx context.Context) error {
 }
 
 // reportUsage reports the usage to grafana.com.
-func (rep *Reporter) reportUsage(ctx context.Context, interval time.Time) error {
+func (rep *Reporter) reportUsage(ctx context.Context, interval time.Time, metrics map[string]interface{}) error {
 	backoff := backoff.New(ctx, backoff.Config{
 		MinBackoff: time.Second,
 		MaxBackoff: 30 * time.Second,
@@ -150,7 +147,7 @@ func (rep *Reporter) reportUsage(ctx context.Context, interval time.Time) error 
 	})
 	var errs multierror.MultiError
 	for backoff.Ongoing() {
-		if err := sendReport(ctx, rep.agentSeed, interval, rep.getMetrics()); err != nil {
+		if err := sendReport(ctx, rep.agentSeed, interval, metrics); err != nil {
 			level.Info(rep.logger).Log("msg", "failed to send usage report", "retries", backoff.NumRetries(), "err", err)
 			errs.Add(err)
 			backoff.Wait()
@@ -160,12 +157,6 @@ func (rep *Reporter) reportUsage(ctx context.Context, interval time.Time) error 
 		return nil
 	}
 	return errs.Err()
-}
-
-func (rep *Reporter) getMetrics() map[string]interface{} {
-	return map[string]interface{}{
-		"enabled-features": rep.cfg.EnabledFeatures,
-	}
 }
 
 // nextReport compute the next report time based on the interval.

--- a/pkg/usagestats/reporter_test.go
+++ b/pkg/usagestats/reporter_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/agent/pkg/config"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
 )
@@ -40,7 +39,7 @@ func Test_ReportLoop(t *testing.T) {
 	}))
 	usageStatsURL = server.URL
 
-	r, err := NewReporter(log.NewLogfmtLogger(os.Stdout), &config.Config{EnableUsageReport: true})
+	r, err := NewReporter(log.NewLogfmtLogger(os.Stdout))
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -49,7 +48,7 @@ func Test_ReportLoop(t *testing.T) {
 		<-time.After(6 * time.Second)
 		cancel()
 	}()
-	require.Equal(t, context.Canceled, r.Start(ctx))
+	require.Equal(t, context.Canceled, r.Start(ctx, map[string]interface{}{}))
 
 	mut.Lock()
 	defer mut.Unlock()


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR enables the reporting of enabled components to grafana. This
would help us to identify which components are more used than others.

The information sent it's completely anonymous. This is the [full list](https://grafana.com/docs/agent/next/configuration/flags/#report-information-usage) of all
information sent by the reporter. The reporting can always be disabled using 
`--disable-reporting`.


#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
