### PR TITLE
web/ui: fix issue where clicking on navigation didn't change position

### DIFF
--- a/web/ui/public/index.html
+++ b/web/ui/public/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <base href="%REACT_APP_BASE_URL%/" />
+    <base href="%REACT_APP_BASE_URL%/" target="_top" />
 
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />

--- a/web/ui/src/features/component/ComponentView.tsx
+++ b/web/ui/src/features/component/ComponentView.tsx
@@ -27,7 +27,9 @@ export const ComponentView: FC<ComponentViewProps> = (props) => {
   function partitionTOC(partition: PartitionedBody): ReactElement {
     return (
       <li>
-        <Link to={'#' + partition.key.join('-')}>{partition.displayName[partition.displayName.length - 1]}</Link>
+        <Link to={'#' + partition.key.join('-')} target="_top">
+          {partition.displayName[partition.displayName.length - 1]}
+        </Link>
         {partition.inner.length > 0 && (
           <ul>
             {partition.inner.map((next, idx) => {
@@ -46,19 +48,25 @@ export const ComponentView: FC<ComponentViewProps> = (props) => {
         <hr />
         <ul>
           <li>
-            <Link to={'#' + props.component.id}>{props.component.id}</Link>
+            <Link to={'#' + props.component.id} target="_top">
+              {props.component.id}
+            </Link>
           </li>
           {argsPartition && partitionTOC(argsPartition)}
           {exportsPartition && partitionTOC(exportsPartition)}
           {debugPartition && partitionTOC(debugPartition)}
           {props.component.referencesTo.length > 0 && (
             <li>
-              <Link to="#dependencies">Dependencies</Link>
+              <Link to="#dependencies" target="_top">
+                Dependencies
+              </Link>
             </li>
           )}
           {props.component.referencedBy.length > 0 && (
             <li>
-              <Link to="#dependants">Dependants</Link>
+              <Link to="#dependants" target="_top">
+                Dependants
+              </Link>
             </li>
           )}
         </ul>


### PR DESCRIPTION
While #2200 fixed the links, the <base> tag and <Link> component still changed the behavior of how the page position changes when clicking on a link in the sidebar.

Adding target="_top" ensures clicking the link will change the proper browsing context to scroll the proper place in the page.