### PR TITLE
river: delay reporting of component traversal errors

### DIFF
--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -78,8 +78,7 @@ func (l *Loader) Apply(parentScope *vm.Scope, blocks []*ast.BlockStmt) diag.Diag
 	populateDiags := l.populateGraph(&newGraph, blocks)
 	diags = append(diags, populateDiags...)
 
-	wireDiags := l.wireGraphEdges(&newGraph)
-	diags = append(diags, wireDiags...)
+	l.wireGraphEdges(&newGraph)
 
 	// Validate graph to detect cycles
 	err := dag.Validate(&newGraph)
@@ -197,18 +196,14 @@ func (l *Loader) populateGraph(g *dag.Graph, blocks []*ast.BlockStmt) diag.Diagn
 	return diags
 }
 
-func (l *Loader) wireGraphEdges(g *dag.Graph) diag.Diagnostics {
-	var diags diag.Diagnostics
-
+func (l *Loader) wireGraphEdges(g *dag.Graph) {
 	for _, n := range g.Nodes() {
-		refs, nodeDiags := ComponentReferences(n.(*ComponentNode), g)
+		refs := ComponentReferences(n.(*ComponentNode), g)
 		for _, ref := range refs {
 			g.AddEdge(dag.Edge{From: n, To: ref.Target})
 		}
-		diags = append(diags, nodeDiags...)
 	}
-
-	return diags
+	return
 }
 
 // Variables returns the Variables the Loader exposes for other Flow components

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -203,7 +203,6 @@ func (l *Loader) wireGraphEdges(g *dag.Graph) {
 			g.AddEdge(dag.Edge{From: n, To: ref.Target})
 		}
 	}
-	return
 }
 
 // Variables returns the Variables the Loader exposes for other Flow components


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR removes the error reporting from graph traversals in the controller. Instead, these errors are reported later on by River's VM as not found identifiers.

Since there are no more errors being reported from this branch of the codebase, the diagnostics are unwired as well.

To be honest, I'm not 100% sure whether this is a good solution and if it makes sense, so maybe this will kickstart a conversation instead.

#### Which issue(s) this PR fixes
Fixes #2110

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [ ] Tests updated
