### PR TITLE
docs/sources/flow: various documentation tweaks

### DIFF
--- a/docs/sources/flow/_index.md
+++ b/docs/sources/flow/_index.md
@@ -24,9 +24,10 @@ needs of power users.
 ## Features
 
 * Write declarative configurations with a Terraform-inspired configuration
-  language
-* Declare components to configure parts of a pipeline
-* Use expressions to bind components together to build a programmable pipeline
+  language.
+* Declare components to configure parts of a pipeline.
+* Use expressions to bind components together to build a programmable pipeline.
+* Includes a UI for debugging the state of a pipeline.
 
 ## Example
 

--- a/docs/sources/flow/concepts/component_controller.md
+++ b/docs/sources/flow/concepts/component_controller.md
@@ -12,16 +12,16 @@ components at runtime.
 
 It is responsible for:
 
-* Reading and validating the config file
-* Managing the lifecycle of defined components
-* Evaluating the arguments used to configure components
-* Reporting the health of defined components
+* Reading and validating the config file.
+* Managing the lifecycle of defined components.
+* Evaluating the arguments used to configure components.
+* Reporting the health of defined components.
 
 ## Component graph
 
 As discussed in [Components][], a relationship between components is created
-when an expression is used to set the argument of one component to an export of
-another component.
+when an expression is used to set the argument of one component to an exported
+field of another component.
 
 The set of all components and the relationships between them define a [directed
 acyclic graph][DAG] (DAG), which informs the component controller which
@@ -31,7 +31,7 @@ For a config file to be valid, components must not reference themselves or
 contain a cyclic reference:
 
 ```river
-// INVALID: local.file.some_file may not reference itself:
+// INVALID: local.file.some_file can not reference itself:
 local.file "self_reference" {
   filename = local.file.self_reference.content
 }
@@ -50,48 +50,48 @@ local.file "b" {
 ## Component evaluation
 
 A component is _evaluated_ when its expressions are computed into concrete
-values and used to configure the component. The component controller is
-finished loading once all components have been evaluated and are running.
+values. The computed values are then used to configure the component's runtime
+behavior. The component controller is finished loading once all components are
+evaluated, configured, and running.
 
-The component controller is guaranteed to only evaluate a given component after
-evaluating all of the components the given component references. Components
-which do not reference other components may be evaluated at any time during the
-evaluation process.
+The component controller only evaluates a given component after evaluating all
+of that component's dependencies. Component which do not depend on another
+components can be evaluated at any time during the evaluation process.
 
 ## Component reevaluation
 
-As mentioned in [Components][], a component is dynamic: a component may update
+As mentioned in [Components][], a component is dynamic: a component can update
 its exports any number of times throughout its lifetime.
 
 When a component updates its exports, a _controller reevaluation_ is triggered:
-the component controller will reevaluate any component which references the
-changed component, any components which reference those components, and so on,
-until all affected components have been reevaluated.
+the component controller reevaluates any component which references the changed
+component, any components which reference those components, and so on, until
+all affected components are reevaluated.
 
 ## Component health
 
-At any given time, a component may have one of the following health states:
+At any given time, a component can have one of the following health states:
 
-1. Unknown: default state, the component isn't running yet
-2. Healthy: the component is working as expected
-3. Unhealthy: the component is not working as expected
-4. Exited: the component has stopped and is no longer running
+1. Unknown: default state, the component isn't running yet.
+2. Healthy: the component is working as expected.
+3. Unhealthy: the component is not working as expected.
+4. Exited: the component has stopped and is no longer running.
 
 By default, the component controller determines the health of a component. The
-component controller will mark a component has healthy as long as that
-component is running and its most recent evaluation was successful.
+component controller marks a component as healthy as long as that component is
+running and its most recent evaluation succeeded.
 
-Some components may report their own component-specific health information. For
-example, the `local.file` component will report itself unhealthy if the file it
+Some components can report their own component-specific health information. For
+example, the `local.file` component reports itself as unhealthy if the file it
 was watching gets deleted.
 
-The overall health of a component is reported by combining the
+The overall health of a component is determined by combining the
 controller-reported health of the component with the component-specific health
 information.
 
 An individual component's health is independent from the health of any other
-components it references: a component may be marked as healthy even if it
-references the exports of an unhealthy component.
+components it references: a component can be marked as healthy even if it
+references an exported field of an unhealthy component.
 
 ## Handling evaluation failures
 
@@ -99,11 +99,11 @@ When a component fails to evaluate, it is marked as unhealthy with the reason
 for why the evaluation failed.
 
 When an evaluation fails, the component continues operating as normal: it
-continues using its previous set of evaluated arguments, and it may continue
+continues using its previous set of evaluated arguments, and it can continue
 exporting new values.
 
 This prevents failure propagation: if your `local.file` component which watches
-API keys suddenly stops working, other components will continue using the last
+API keys suddenly stops working, other components continues using the last
 valid API key until the component returns to a healthy state.
 
 ## Updating the config file

--- a/docs/sources/flow/concepts/components.md
+++ b/docs/sources/flow/concepts/components.md
@@ -13,16 +13,16 @@ collecting Prometheus metrics.
 
 Components are composed of two parts:
 
-* Arguments: settings which configure a component
-* Exports: named values which a component exposes to other components
+* Arguments: settings which configure a component.
+* Exports: named values which a component exposes to other components.
 
 Each component has a name which describes what that component is responsible
 for. For example, the `local.file` component is responsible for retrieving the
 contents of files on disk.
 
-Components are specified by users by first providing the component's name with
-a user-specified label, and then by providing arguments to configure the
-component:
+Components are specified in the config file by first providing the component's
+name with a user-specified label, and then by providing arguments to configure
+the component:
 
 ```
 discovery.kubernetes "pods" {
@@ -44,18 +44,20 @@ discovery.kubernetes "nodes" {
 
 ## Pipelines
 
-Most arguments a user specifies for a component will be some constant value,
-such setting a `log_level` attribute to the quoted string `"debug"` (`log_level
-= "debug"`).
+Most arguments for a component in a config file are constant values, such
+setting a `log_level` attribute to the quoted string `"debug"`:
 
-Users may also use _expressions_ to dynamically compute the value of an
-argument at runtime. Among other things, expressions may be used to retrieving
-the value of an environment variable (`log_level = env("LOG_LEVEL")`) or
-referencing the export of another component (`log_level =
-local.file.log_level.content`).
+```river
+log_level = "debug"
+```
 
-When a user configures a component's argument to reference an export of another
-component, a relationship is created: a component's input (arguments) now
+_Expressions_ can be used to dynamically compute the value of an argument at
+runtime. Among other things, expressions may be used to retrieving the value of
+an environment variable (`log_level = env("LOG_LEVEL")`) or referencing the
+export of another component (`log_level = local.file.log_level.content`).
+
+When a component's argument references an exported field of another component,
+a dependant relationship is created: a component's input (arguments) now
 depends on another component's output (exports). The input of the component
 will now be re-evaluated any time the exports of the components it references
 get updated.
@@ -75,12 +77,12 @@ An example pipeline may look like this:
    component, and sends collected metrics to the `prometheus.remote_write`
    component.
 
-A user would use this config file to represent the above pipeline:
+The following config file reprsents the above pipeline:
 
 ```river
 // Get our API key from disk.
 //
-// This component has an exported value called "content", holding the content
+// This component has an exported field called "content", holding the content
 // of the file.
 //
 // local.file.api_key will watch the file and update its exports any time the
@@ -88,8 +90,8 @@ A user would use this config file to represent the above pipeline:
 local.file "api_key" {
   filename  = "/var/data/secrets/api-key"
 
-  // Mark this file as sensitive to prevent its value from being shown to
-  // users.
+  // Mark this file as sensitive to prevent its value from being shown from the
+  // UI.
   is_secret = true
 }
 

--- a/docs/sources/flow/config-language/_index.md
+++ b/docs/sources/flow/config-language/_index.md
@@ -7,7 +7,7 @@ weight: 400
 
 # Configuration language
 
-Grafana Agent Flow uses a custom configuration language called River to
+Grafana Agent Flow contains a custom configuration language called River to
 dynamically configure and connect components.
 
 River aims to reduce errors in configuration files by making configurations

--- a/docs/sources/flow/config-language/components.md
+++ b/docs/sources/flow/config-language/components.md
@@ -49,17 +49,17 @@ as well as whether its contents are sensitive or not.
 
 ```river
 local.file "targets" {
-	// Required argument
-	filename = "/etc/agent/targets" 
+  // Required argument
+  filename = "/etc/agent/targets"
 
-	// Optional arguments: Components may have some optional arguments that
-	// do not need to be defined.
-	// 
-	// The optional arguments for local.file are is_secret, detector, and
-	// poll_frequency. 
+  // Optional arguments: Components may have some optional arguments that
+  // do not need to be defined.
+  //
+  // The optional arguments for local.file are is_secret, detector, and
+  // poll_frequency.
 
-	// Exports: a single field named `content`
-	// It can be referred to as `local.file.targets.content`
+  // Exports: a single field named `content`
+  // It can be referred to as `local.file.targets.content`
 }
 ```
 
@@ -74,22 +74,22 @@ an expression that ties the target to the value of
 
 ```river
 prometheus.scrape "default" {
-	targets = [
-		{ "__address__" = local.file.targets.content }, // tada!
-		{ "__address__" = "localhost:9001" },
-	] 
+  targets = [
+    { "__address__" = local.file.targets.content }, // tada!
+    { "__address__" = "localhost:9001" },
+  ]
 
-	forward_to = [prometheus.remote_write.default.receiver]
-	scrape_config {
-		job_name = "default"
-	}
+  forward_to = [prometheus.remote_write.default.receiver]
+  scrape_config {
+    job_name = "default"
+  }
 }
 ```
 
 Every time the file contents change, the `local.file` will update its exports,
 so the new value will provided to `prometheus.scrape` targets field.
 
-All arguments and exports have an underlying [type]({{< relref "./expressions/types_and_values.md" >}}).
+Each argument and exported field has an underlying [type]({{< relref "./expressions/types_and_values.md" >}}).
 River will type-check expressions before assigning a value to an attribute; the
 documentation of each component will have more information about the ways that
 you can wire components together.

--- a/docs/sources/flow/config-language/expressions/operators.md
+++ b/docs/sources/flow/config-language/expressions/operators.md
@@ -11,26 +11,28 @@ follow the standard [PEMDAS](https://en.wikipedia.org/wiki/Order_of_operations)
 rule for operator precedence.
 
 ## Arithmetic operators
-```
-+    for addition: 3+5
--    for subtraction: 10-3
-*    for multiplication: 13*7
-/    for division: 15/3
-%    for remainder: 7%2
-^    for exponentiation: 2^8
-```
+
+Operator | Description
+-------- | -----------
+`+`      | Adds two numbers.
+`-`      | Subtracts two numbers.
+`*`      | Multiplies two numbers.
+`/`      | Divides two numbers.
+`%`      | Computes the remainder after dividing two numbers.
+`^`      | Raises the number to the specified power.
 
 The `+` operator can also be used for string concatenation.
 
 ## Comparison operators
-```
-==    equal
-!=    not equal
-<     less
-<=    less or equal
->     greater
->=    greater or equal
-```
+
+Operator | Description
+-------- | -----------
+`==`     | `true` when two values are equal.
+`!=`     | `true` when two values are not equal.
+`<`      | `true` when the left value is less than the right value.
+`<=`     | `true` when the left value is less than or equal to the right value.
+`>`      | `true` when the left value is greater than the right value.
+`>=`     | `true` when the left value is greater or equal to the right value.
 
 The equality operators `==` and `!=` can be applied to any operands.
 
@@ -46,11 +48,12 @@ comparisons are defined as follows:
 * Array values are equal if their corresponding elements are equal.
 
 ## Logical operators
-```
-&&    conditional AND
-||    conditional OR 
-!     NOT            
-```
+
+Operator | Description
+-------- | -----------
+`&&`     | `true` when the both left _and_ right value are `true`.
+`||`     | `true` when the either left _or_ right value are `true`.
+`!`      | Negates a boolean value.
 
 Logical operators apply to boolean values and yield a boolean result.
 
@@ -69,12 +72,13 @@ to which it is being assigned.
   a number.
 * Blocks are not assignable.
 
-## Brackets 
-```
-{ }    used for defining blocks and objects
-( )    used to group and prioritize expressions
-[ ]    used for defining arrays
-```
+## Brackets
+
+Brackets | Description
+-------- | -----------
+`{ }`    | Defines blocks and objects.
+`( )`    | Groups and prioritizes expressions.
+`[ ]`    | Defines arrays.
 
 In the following example we can see the use of curly braces and square brackets
 to define an object and an array.
@@ -84,10 +88,11 @@ arr = [1, true, 7 * (1+1), 3]
 ```
 
 ## Access operators
-```
-[ ]    used for access operations on arrays and objects
- .     used for access operations on objects and components
-```
+
+Operator | Description
+-------- | -----------
+`[ ]`    | Access a member of an array or object.
+`.`      | Access a named member of an object or an exported field of a component.
 
 River's access operators support accessing of arbitrarily nested values.
 Square brackets can be used to access zero-indexed array indices as well as

--- a/docs/sources/flow/config-language/files.md
+++ b/docs/sources/flow/config-language/files.md
@@ -7,7 +7,7 @@ weight: 100
 
 # Files
 River files are plaintext files with the `.river` file extension. Each River
-file may be referred to as a 'configuration file', or a 'River configuration'.
+file may be referred to as a "configuration file," or a "River configuration."
 
 River files are required to be UTF-8 encoded, and are permitted to contain
 Unicode characters. River files can use both Unix-style line endings (LF) and

--- a/docs/sources/flow/config-language/syntax.md
+++ b/docs/sources/flow/config-language/syntax.md
@@ -7,12 +7,20 @@ weight: 200
 
 # Syntax
 The River syntax is designed to be easy to read and write. Essentially, there
-are just two high-level elements to it: _Attributes_ and _Blocks_. 
+are just two high-level elements to it: _Attributes_ and _Blocks_.
 
 River is a _declarative_ language used to build programmable pipelines.
 As such, the ordering of blocks and attributes within the River configuration
 file is not important; the language will consider all direct and indirect
 dependencies between elements to determine their relationships.
+
+## Comments
+River configuration files support single-line `//` as well as block `/* */`
+comments.
+
+## Identifiers
+River considers an identifier as valid if it consists of one or more UTF-8
+letters, digits or underscores, but doesn't start with a digit.
 
 ## Attributes and Blocks
 
@@ -43,22 +51,22 @@ of arguments and nested unlabeled blocks.
 ```
 // Pattern for creating an unlabeled block:
 <BLOCK NAME> {
-	// Block body can contain attributes and nested unlabeled blocks
-	<IDENTIFIER> = <EXPRESSION> // Attribute
+  // Block body can contain attributes and nested unlabeled blocks
+  <IDENTIFIER> = <EXPRESSION> // Attribute
 
-	<NESTED_BLOCK_NAME> {
-		// Nested block body
-	}
+  <NESTED_BLOCK_NAME> {
+    // Nested block body
+  }
 }
 
 // Pattern for creating a labeled block:
 <BLOCK NAME> "<BLOCK LABEL>" {
-	// Block body can contain attributes and nested unlabeled blocks
-	<IDENTIFIER> = <EXPRESSION> // Attribute
+  // Block body can contain attributes and nested unlabeled blocks
+  <IDENTIFIER> = <EXPRESSION> // Attribute
 
-	<NESTED_BLOCK_NAME> {
-		// Nested block body
-	}
+  <NESTED_BLOCK_NAME> {
+    // Nested block body
+  }
 }
 ```
 
@@ -74,18 +82,10 @@ environment variable by using an expression and the `is_secret` attribute is
 set to the boolean `true`, marking the file content as sensitive.
 ```river
 local.file "token" {
-	filename  = env("TOKEN_FILE_PATH") // Use an expression to read from an env var.
-	is_secret = true
+  filename  = env("TOKEN_FILE_PATH") // Use an expression to read from an env var.
+  is_secret = true
 }
 ```
-
-## Comments
-River configuration files support single-line `//` as well as block `/* */` 
-comments.
-
-## Identifiers
-River considers an identifier as valid if it consists of one or more UTF-8
-letters, digits or underscores, but doesn't start with a digit.
 
 ## Terminators
 All block and attribute definitions are followed by a newline, which River

--- a/docs/sources/flow/getting_started.md
+++ b/docs/sources/flow/getting_started.md
@@ -18,11 +18,11 @@ release.
 Grafana Agent Flow can be enabled by setting the `EXPERIMENTAL_ENABLE_FLOW`
 environment variable to `true`.
 
-Then, use the `agent run` command to start Grafana Agent Flow, passing the
-config file to use.
+Then, use the `agent run` command to start Grafana Agent Flow, replacing
+`FILE_PATH` with the path of a config file to use:
 
 ```
-EXPERIMENTAL_ENABLE_FLOW=1 agent run /path/to/my/config.river
+EXPERIMENTAL_ENABLE_FLOW=1 agent run FILE_PATH
 ```
 
 > Grafana Agent Flow uses a different command-line interface and command line

--- a/docs/sources/flow/monitoring/component_metrics.md
+++ b/docs/sources/flow/monitoring/component_metrics.md
@@ -32,6 +32,6 @@ The [reference documentation][] for each component will describe the list of
 component-specific metrics that component exposes. Not all components will
 expose metrics.
 
-[component]: {{< relref "../concepts/components.md" >}}
+[components]: {{< relref "../concepts/components.md" >}}
 [agent run]: {{< relref "../reference/cli/run.md" >}}
 [reference documentation]: {{< relref "../reference/components/_index.md" >}}

--- a/docs/sources/flow/monitoring/controller_metrics.md
+++ b/docs/sources/flow/monitoring/controller_metrics.md
@@ -30,5 +30,5 @@ The controller exposes the following metrics:
   graph evaluations performed by the component controller with how long they
   took.
 
-[controller]: {{< relref "../concepts/component_controller.md" >}}
+[component controller]: {{< relref "../concepts/component_controller.md" >}}
 [agent run]: {{< relref "../reference/cli/run.md" >}}

--- a/docs/sources/flow/reference/cli/fmt.md
+++ b/docs/sources/flow/reference/cli/fmt.md
@@ -11,11 +11,11 @@ The `agent fmt` command formats a given Grafana Agent Flow configuration file.
 
 ## Usage
 
-Usage: `agent fmt [flags] file`
+Usage: `agent fmt [FLAG ...] FILE_NAME`
 
-If the `file` argument is not provided or if the `file` argument is equal to
-`-`, `agent fmt` formats the contents of standard input. Otherwise, `agent fmt`
-reads and formats the file from disk specified by the argument.
+If the `FILE_NAME` argument is not provided or if the `FILE_NAME` argument is
+equal to `-`, `agent fmt` formats the contents of standard input. Otherwise,
+`agent fmt` reads and formats the file from disk specified by the argument.
 
 The `--write` flag can be specified to replace the contents of the original
 file on disk with the formatted results. `--write` can only be provided when

--- a/docs/sources/flow/reference/cli/run.md
+++ b/docs/sources/flow/reference/cli/run.md
@@ -12,7 +12,7 @@ interrupt is received.
 
 ## Usage
 
-Usage: `agent run [flags] file`
+Usage: `agent run [FLAG ...] FILE_NAME`
 
 `agent run` must be provided an argument which points at the River config file
 to use. `agent run` will immediately exit with an error if the River file
@@ -36,3 +36,21 @@ The following flags are supported:
 
 [usage reporting]: {{< relref "../../../configuration/flags.md/#report-information-usage" >}}
 [components]: {{< relref "../../concepts/components.md" >}}
+
+## Updating the config file
+
+The config file can be reloaded from disk by either:
+
+* Sending an HTTP POST request to the `/-/reload` endpoint.
+* Sending a `SIGHUP` signal to the Grafana Agent process.
+
+When this happens, the [component controller][] will synchronize the set of
+running components with the latest set of components specified in the config
+file. Components which are no longer defined in the config file after reloading
+will be shut down, and components which have been added to the config file
+since the previous reload will be created.
+
+All components managed by the component controller are reevaluated after
+reloading.
+
+[component controller]: {{< relref "../../concepts/component_controller.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.integration.node_exporter.md
+++ b/docs/sources/flow/reference/components/prometheus.integration.node_exporter.md
@@ -5,8 +5,8 @@ title: prometheus.integration.node_exporter
 ---
 
 # prometheus.integration.node_exporter
-The `prometheus.integration.node_exporter` component embeds 
-[node_exporter](https://github.com/prometheus/node_exporter) which exposes a 
+The `prometheus.integration.node_exporter` component embeds
+[node_exporter](https://github.com/prometheus/node_exporter) which exposes a
 wide variety of hardware and OS metrics for \*nix-based systems.
 
 The `node_exporter` itself is comprised of various _collectors_, which can be
@@ -37,7 +37,7 @@ Name | Type | Description | Default | Required
 `set_collectors`           | `list(string)` | Overrides the default set of enabled collectors with the collectors listed. | | no
 `enable_collectors`        | `list(string)` | Collectors to mark as enabled.  | | no
 `disable_collectors`       | `list(string)` | Collectors to mark as disabled. | | no
-`include_exporter_metrics` | `boolean`      | Whether metrics about the exporter itself should be reported. | false | no 
+`include_exporter_metrics` | `boolean`      | Whether metrics about the exporter itself should be reported. | false | no
 `procfs_path`              | `string`       | The procfs mountpoint. | `/proc` | no
 `sysfs_path`               | `string`       | The sysfs mountpoint.  | `/sys`   | no
 `rootfs_path`              | `string`       | Specify a prefix for accessing the host filesystem. | `/` | no
@@ -166,8 +166,7 @@ name | type | description | default | required
 `url` | `string` | XML RPC endpoint for the supervisord collector. | `"http://localhost:9001/RPC2"` | no
 
 Setting `SUPERVISORD_URL` in the environment overrides the default value.
-An explicit value in the YAML config takes precedence over the environment
-variable.
+An explicit value in the block takes precedence over the environment variable.
 
 
 ### `systemd` block
@@ -194,12 +193,11 @@ name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
 `fields` | `string` | Regexp of fields to return for the vmstat collector. | `"^(oom_kill\|pgpg\|pswp\|pg.*fault).*"` | no
 
-
 ## Exported fields
 The following fields are exported and can be referenced by other components.
 
-Name      | Type                | Description 
---------- | ------------------- | ----------- 
+Name      | Type                | Description
+--------- | ------------------- | -----------
 `targets` | `list(map(string))` | The targets that can be used to collect `node_exporter` metrics.
 
 For example, the `targets` could either be passed to a `prometheus.relabel`

--- a/docs/sources/flow/tutorials/assets/flow_configs/agent.flow
+++ b/docs/sources/flow/tutorials/assets/flow_configs/agent.flow
@@ -1,19 +1,19 @@
 // Create a prometheus.scrape component labeled "default."
 prometheus.scrape "default" {
-	// Collect metrics from `http://localhost:12345/metrics`. 
-	// The http:// protocol and /metrics path are implied by default 
-	// but can be overridden.
-	targets = [{"__address__" = "localhost:12345"}]
+  // Collect metrics from `http://localhost:12345/metrics`.
+  // The http:// protocol and /metrics path are implied by default
+  // but can be overridden.
+  targets = [{"__address__" = "localhost:12345"}]
 
-	// Forward collected metrics to the receiver. forward_to 
-	// is a common argument name used for forwarding Prometheus metrics.
-	// Receiver is an export of prometheus.remote_write.prom which 
-	// can accept metrics.
-	forward_to = [prometheus.remote_write.prom.receiver]
+  // Forward collected metrics to the receiver. forward_to
+  // is a common argument name used for forwarding Prometheus metrics.
+  // Receiver is an exported field of prometheus.remote_write.prom which
+  // can accept metrics.
+  forward_to = [prometheus.remote_write.prom.receiver]
 }
 
 prometheus.remote_write "prom" {
-	endpoint {
-		url = "http://mimir:9009/api/v1/push"
-	}
+  endpoint {
+    url = "http://mimir:9009/api/v1/push"
+  }
 }

--- a/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
+++ b/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
@@ -5,7 +5,7 @@ title: Collecting Prometheus metrics
 weight: 200
 ---
 
-Grafana Agent is a telemetry collector with the primary goal of moving telemetry data from one location to another. In this tutorial, you'll set up a Grafana Agent in Flow mode.  
+Grafana Agent is a telemetry collector with the primary goal of moving telemetry data from one location to another. In this tutorial, you'll set up a Grafana Agent in Flow mode.
 
 # Prerequisites
 
@@ -14,11 +14,11 @@ Grafana Agent is a telemetry collector with the primary goal of moving telemetry
 
 # Scraping the Agent
 
-To quickly spin up an example environment, run the following: `CONFIG_FILE=agent.flow docker-compose -f ./assets/docker-compose.yaml up` with the [flow file](../assets/flow_configs/agent.flow). Allow the service to run for a few minutes, then navigate to the [metrics browser](http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Mimir%22,%7B%22refId%22:%22A%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22agent_build_info%7B%7D%22%7D%5D). 
+To quickly spin up an example environment, run the following: `CONFIG_FILE=agent.flow docker-compose -f ./assets/docker-compose.yaml up` with the [flow file](../assets/flow_configs/agent.flow). Allow the service to run for a few minutes, then navigate to the [metrics browser](http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Mimir%22,%7B%22refId%22:%22A%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22agent_build_info%7B%7D%22%7D%5D).
 
 ![](../assets/agent_build_info.png)
 
-This example scrapes the Grafana Agent's `http://localhost:12345/metrics` endpoint and pushes those metrics to the Mimir instance. 
+This example scrapes the Grafana Agent's `http://localhost:12345/metrics` endpoint and pushes those metrics to the Mimir instance.
 
 
 ## Scraping component
@@ -29,17 +29,17 @@ The [`prometheus.scrape`]({{< relref "prometheus.scrape.md" >}}) component is re
 // prometheus.scrape is the name of the component and "default" is its label.
 prometheus.scrape "default" {
     // Tell the scraper to scrape at http://localhost:12345/metrics.
-    // The http:// and metrics are implied but able to be overwritten. 
+    // The http:// and metrics are implied but able to be overwritten.
     targets = [{"__address__" = "localhost:12345"}]
-    // Forward the scrape results to the receiver. In general, 
-    // Flow uses forward_to to tell which receiver to send results to. 
-    // The forward_to is an argument of prometheus.scrape.default and 
-    // the receiver is an export prometheus.remote_write.prom.
+    // Forward the scrape results to the receiver. In general,
+    // Flow uses forward_to to tell which receiver to send results to.
+    // The forward_to is an argument of prometheus.scrape.default and
+    // the receiver is an exported field of prometheus.remote_write.prom.
     forward_to = [prometheus.remote_write.prom.receiver]
 }
 ```
 
-The `prometheus.scrape "default"` annotation indicates the name of the component, `prometheus.scrape`, and its label, `default`. All components must have a unique combination of name and if applicable label. 
+The `prometheus.scrape "default"` annotation indicates the name of the component, `prometheus.scrape`, and its label, `default`. All components must have a unique combination of name and if applicable label.
 
 The `targets` [attribute]({{< relref "configuration_language.md#Attributes" >}}) is an [argument]({{< relref "../concepts/components.md">}}). `targets` is a list of labels that specify the target via the special key `__address__`. The scraper is targeting the Agent's `/metrics` endpoint. Both `http` and `/metrics` are implied but can be overridden.
 


### PR DESCRIPTION
* Try to use present tense more consistently 
* Use the [recommended style][cli-style] for placeholders and command-line arguments.
* Use "exported field" terminology consistently instead of "an export."
* Use double quotes over single quotes. 
* Try to make some sections easier to understand. 


[cli-style]: https://developers.google.com/style/placeholders