### PR TITLE
packaging: set WorkingDirectory for systemd services

### DIFF
--- a/packaging/deb/grafana-agent.service
+++ b/packaging/deb/grafana-agent.service
@@ -9,6 +9,7 @@ Restart=always
 User=grafana-agent
 Environment=HOSTNAME=%H
 EnvironmentFile=/etc/default/grafana-agent
+WorkingDirectory=/var/lib/grafana-agent
 ExecStart=/usr/bin/grafana-agent --config.file $CONFIG_FILE $CUSTOM_ARGS
 # If running the Agent in scraping service mode, you will want to override this value with
 # something larger to allow the Agent to gracefully leave the cluster. 4800s is recommend.

--- a/packaging/rpm/grafana-agent.service
+++ b/packaging/rpm/grafana-agent.service
@@ -9,6 +9,7 @@ Restart=always
 User=grafana-agent
 Environment=HOSTNAME=%H
 EnvironmentFile=/etc/sysconfig/grafana-agent
+WorkingDirectory=/var/lib/grafana-agent
 ExecStart=/usr/bin/grafana-agent --config.file $CONFIG_FILE $CUSTOM_ARGS
 # If running the Agent in scraping service mode, you will want to override this value with
 # something larger to allow the Agent to gracefully leave the cluster. 4800s is recommend.


### PR DESCRIPTION
Setting the WorkingDirectory allows the grafana-agent service to run relative to /var/lib/grafana-agent. This means that the default storage location will be relative to a path which is writable by the grafana-agent user.

Fixes #2217.
