### PR TITLE
docs/flow: fix rendering of 'logical or' operator

### DIFF
--- a/docs/sources/flow/config-language/expressions/operators.md
+++ b/docs/sources/flow/config-language/expressions/operators.md
@@ -52,7 +52,7 @@ comparisons are defined as follows:
 Operator | Description
 -------- | -----------
 `&&`     | `true` when the both left _and_ right value are `true`.
-`||`     | `true` when the either left _or_ right value are `true`.
+`\|\|`     | `true` when the either left _or_ right value are `true`.
 `!`      | Negates a boolean value.
 
 Logical operators apply to boolean values and yield a boolean result.


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Fixes rendering of `||` operator messing with the Markdown table.

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [X] Documentation added
- [ ] Tests updated (N/A)
