### PR TITLE
docs: Use consistent structure for Flow component references

### DIFF
--- a/docs/sources/flow/reference/components/discovery.kubernetes.md
+++ b/docs/sources/flow/reference/components/discovery.kubernetes.md
@@ -413,7 +413,7 @@ This example uses a kubeconfig file to authenticate to the Kubernetes API:
 ```river
 discovery.kubernetes "k8s_pods" {
   role = "pod"
-  kubeconfig_file = "/path/to/kubeconfig"
+  kubeconfig_file = "/etc/k8s/kubeconfig.yaml"
 }
 ```
 

--- a/docs/sources/flow/reference/components/discovery.kubernetes.md
+++ b/docs/sources/flow/reference/components/discovery.kubernetes.md
@@ -14,25 +14,11 @@ If you supply no connection information, this component defaults to an
 in-cluster config. A kubeconfig file or manual connection settings can be used
 to override the defaults.
 
-## Example
-
-This example shows a simple in-cluster discovery of all pods:
+## Usage
 
 ```river
-discovery.kubernetes "k8s_pods" {
-  role = "pod"
-}
-```
-
-This example provides a custom namespace and kubeconfig file:
-
-```river
-discovery.kubernetes "k8s_pods" {
-  role = "pod"
-  kubeconfig_file = "/path/to/kubeconfig"
-  namespaces {
-    names = ["myapp"]
-  }
+discovery.kubernetes "LABEL" {
+  role = "DISCOVERY_ROLE"
 }
 ```
 
@@ -407,3 +393,39 @@ values.
 ### Debug metrics
 
 `discovery.kubernetes` does not expose any component-specific debug metrics.
+
+## Examples
+
+### In-cluster discovery
+
+This example uses in-cluster authentication to discover all pods:
+
+```river
+discovery.kubernetes "k8s_pods" {
+  role = "pod"
+}
+```
+
+### Kubeconfig authentication
+
+This example uses a kubeconfig file to authenticate to the Kubernetes API:
+
+```river
+discovery.kubernetes "k8s_pods" {
+  role = "pod"
+  kubeconfig_file = "/path/to/kubeconfig"
+}
+```
+
+### Limit searched namespaces
+
+This example limits the namespaces where pods are discovered using the `namespaces` block:
+
+```river
+discovery.kubernetes "k8s_pods" {
+  role = "pod"
+  namespaces {
+    names = ["myapp"]
+  }
+}
+```

--- a/docs/sources/flow/reference/components/discovery.kubernetes.md
+++ b/docs/sources/flow/reference/components/discovery.kubernetes.md
@@ -36,7 +36,7 @@ The `role` argument is required to specify what type of targets to discover.
 `role` must be one of `node`, `pod`, `service`, `endpoints`, `endpointslice`,
 or `ingress`.
 
-### `node` role
+### node role
 
 The `node` role discovers one target per cluster node with the address
 defaulting to the HTTP port of the Kubelet daemon. The target address defaults
@@ -59,7 +59,7 @@ The following labels are included for discovered nodes:
 In addition, the `instance` label for the node will be set to the node name as
 retrieved from the API server.
 
-### `service` role
+### service role
 
 The `service` role discovers a target for each service port for each service.
 This is generally useful for externally monitoring a service. The address will
@@ -89,7 +89,7 @@ The following labels are included for discovered services:
   the target.
 * `__meta_kubernetes_service_type`: The type of the service.
 
-### `pod` role
+### pod role
 
 The `pod` role discovers all pods and exposes their containers as targets. For
 each declared port of a container, a single target is generated.
@@ -131,7 +131,7 @@ The following labels are included for discovered pods:
 * `__meta_kubernetes_pod_controller_kind`: Object kind of the pod controller.
 * `__meta_kubernetes_pod_controller_name`: Name of the pod controller.
 
-### `endpoints` role
+### endpoints role
 
 The `endpoints` role discovers targets from listed endpoints of a service. For
 each endpoint address one target is discovered per port. If the endpoint is
@@ -164,7 +164,7 @@ The following labels are included for discovered endpoints:
 * For all targets backed by a pod, all labels of the `pod` role discovery are
   attached.
 
-### `endpointslice` role
+### endpointslice role
 
 The endpointslice role discovers targets from existing Kubernetes endpoint
 slices. For each endpoint address referenced in the `EndpointSlice` object, one
@@ -200,7 +200,7 @@ The following labels are included for discovered endpoint slices:
 * For all targets backed by a pod, all labels of the `pod` role discovery are
   attached.
 
-### `ingress` role
+### ingress role
 
 The `ingress` role discovers a target for each path of each ingress. This is
 generally useful for externally monitoring an ingress. The address will be set

--- a/docs/sources/flow/reference/components/discovery.kubernetes.md
+++ b/docs/sources/flow/reference/components/discovery.kubernetes.md
@@ -50,14 +50,6 @@ The `role` argument is required to specify what type of targets to discover.
 `role` must be one of `node`, `pod`, `service`, `endpoints`, `endpointslice`,
 or `ingress`.
 
-The following sub-blocks are supported:
-
-Name | Description | Required
----- | ----------- | --------
-[`namespaces`](#namespaces-block) | Information about which Kubernetes namespaces to search. | no
-[`selectors`](#selectors-block) | Selectors to limit objects selected. | no
-[`http_client_config`](#http_client_config-block) | HTTP client configuration for Kubernetes requests. | no
-
 ### `node` role
 
 The `node` role discovers one target per cluster node with the address
@@ -246,7 +238,34 @@ The following labels are included for discovered ingress objects:
   config is set. Defaults to `http`.
 * `__meta_kubernetes_ingress_path`: Path from ingress spec. Defaults to /.
 
-### `namespaces` block
+## Blocks
+
+The following blocks are supported inside the definition of
+`discovery.kubernetes`:
+
+Hierarchy | Block | Description | Required
+--------- | ----- | ----------- | --------
+namespaces | [namespaces][] | Information about which Kubernetes namespaces to search. | no
+selectors | [selectors][] | Information about which Kubernetes namespaces to search. | no
+http_client_config | [http_client_config][] | HTTP client configuration for Kubernetes requests. | no
+http_client_config > basic_auth | [basic_auth][] | Configure basic_auth for authenticating to the endpoint. | no
+http_client_config > authorization | [authorization][] | Configure generic authorization to the endpoint. | no
+http_client_config > oauth2 | [oauth2][] | Configure OAuth2 for authenticating to the endpoint. | no
+http_client_config > oauth2 > tls_config | [tls_config][] | Configure TLS settings for connecting to the endpoint. | no
+
+The `>` symbol indicates deeper levels of nesting. For example,
+`http_client_config > basic_auth` refers to a `basic_auth` block defined inside
+an `http_client_config` block.
+
+[namespaces]: #namespaces-block
+[selectors]: #selectors-block
+[http_client_config]: #http_client_config-block
+[basic_auth]: #basic_auth-block
+[authorization]: #authorization-block
+[oauth2]: #oauth2-block
+[tls_config]: #tls_config-block
+
+### namespaces block
 
 The `namespaces` block limits the namespaces to discover resources in. If
 omitted, all namespaces are searched.
@@ -256,7 +275,7 @@ Name | Type | Description | Default | Required
 `own_namespace` | `bool`   | Include the namespace the agent is running in. | | no
 `names` | `[]string` | List of namespaces to search. | | no
 
-### `selectors` block
+### selectors block
 
 The `selectors` block contains optional label and field selectors to limit the
 discovery process to a subset of resources.
@@ -282,7 +301,7 @@ selectors][] to learn more about the possible filters that can be used.
 [Labels and selectros]: https://Kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 [discovery.relabel]: {{< relref "./discovery.relabel.md" >}}
 
-### `http_client_config` block
+### http_client_config block
 
 The `http_client_config` block configures settings used to connect to the
 Kubernetes API server.

--- a/docs/sources/flow/reference/components/discovery.relabel.md
+++ b/docs/sources/flow/reference/components/discovery.relabel.md
@@ -31,28 +31,11 @@ guaranteed to never be used.
 Multiple `discovery.relabel` components can be specified by giving them
 different labels.
 
-## Example
+## Usage
 
-```river
-discovery.relabel "keep_backend_only" {
-  targets = [
-    { "__meta_foo" = "foo", "__address__" = "localhost", "instance" = "one",   "app" = "backend"  },
-    { "__meta_bar" = "bar", "__address__" = "localhost", "instance" = "two",   "app" = "database" },
-    { "__meta_baz" = "baz", "__address__" = "localhost", "instance" = "three", "app" = "frontend" },
-  ]
-
-  rule {
-    source_labels = ["__address__", "instance"]
-    separator     = "/"
-    target_label  = "destination"
-    action        = "replace"
-  }
-
-  rule {
-    source_labels = ["app"]
-    action        = "keep"
-    regex         = "backend"
-  }
+```
+discovery.relabel "LABEL" {
+  targets = TARGET_LIST
 }
 ```
 
@@ -129,3 +112,30 @@ values.
 ### Debug metrics
 
 `discovery.relabel` does not expose any component-specific debug metrics.
+
+## Example
+
+```river
+discovery.relabel "keep_backend_only" {
+  targets = [
+    { "__meta_foo" = "foo", "__address__" = "localhost", "instance" = "one",   "app" = "backend"  },
+    { "__meta_bar" = "bar", "__address__" = "localhost", "instance" = "two",   "app" = "database" },
+    { "__meta_baz" = "baz", "__address__" = "localhost", "instance" = "three", "app" = "frontend" },
+  ]
+
+  rule {
+    source_labels = ["__address__", "instance"]
+    separator     = "/"
+    target_label  = "destination"
+    action        = "replace"
+  }
+
+  rule {
+    source_labels = ["app"]
+    action        = "keep"
+    regex         = "backend"
+  }
+}
+```
+
+

--- a/docs/sources/flow/reference/components/discovery.relabel.md
+++ b/docs/sources/flow/reference/components/discovery.relabel.md
@@ -36,6 +36,12 @@ different labels.
 ```
 discovery.relabel "LABEL" {
   targets = TARGET_LIST
+
+  rule {
+    ...
+  }
+
+  ...
 }
 ```
 

--- a/docs/sources/flow/reference/components/discovery.relabel.md
+++ b/docs/sources/flow/reference/components/discovery.relabel.md
@@ -64,13 +64,18 @@ Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `targets` | `list(map(string))` | Targets to relabel | | **yes**
 
-The following subblocks are supported:
+## Blocks
 
-Name | Description | Required
----- | ----------- | --------
-[`rule`](#rule-block) | Relabeling rules to apply to targets | no
+The following blocks are supported inside the definition of
+`discovery.relabel`:
 
-### `rule` block
+Hierarchy | Block | Description | Required
+--------- | ----- | ----------- | --------
+rule | [rule][] | Relabeling rules to apply to targets. | no
+
+[rule]: #rule-block
+
+### rule block
 
 The `rule` block contains the definition of any relabeling rules that
 can be applied to an input target. If more than one `rule` block is

--- a/docs/sources/flow/reference/components/local.file.md
+++ b/docs/sources/flow/reference/components/local.file.md
@@ -15,11 +15,11 @@ files.
 Multiple `local.file` components can be specified by giving them different
 labels.
 
-## Example
+## Usage
 
 ```river
-local.file "my-file" {
-  filename = "path/to/my/file"
+local.file "LABEL" {
+  filename = FILE_NAME
 }
 ```
 
@@ -94,3 +94,11 @@ component.
   timestamp, in Unix seconds, that the file was last sucessfully accessed.
 
 [secret]: ../secrets.md#is_secret-argument-in-components
+
+## Example
+
+```river
+local.file "my_file" {
+  filename = "path/to/my/file"
+}
+```

--- a/docs/sources/flow/reference/components/local.file.md
+++ b/docs/sources/flow/reference/components/local.file.md
@@ -98,7 +98,8 @@ component.
 ## Example
 
 ```river
-local.file "my_file" {
-  filename = "path/to/my/file"
+local.file "secret_key" {
+  filename  = "/var/secrets/password.txt"
+  is_secret = true
 }
 ```

--- a/docs/sources/flow/reference/components/prometheus.integration.node_exporter.md
+++ b/docs/sources/flow/reference/components/prometheus.integration.node_exporter.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/latest/flow/reference/components/prometheus.integration.node_exporter
-title: prometheus.integration.node_exporter
+title: prometheus.&#8203;integration.&#8203;node_exporter
 ---
 
 # prometheus.integration.node_exporter

--- a/docs/sources/flow/reference/components/prometheus.integration.node_exporter.md
+++ b/docs/sources/flow/reference/components/prometheus.integration.node_exporter.md
@@ -16,15 +16,10 @@ enabled and disabled at will. For more information on collectors, refer to the
 The `prometheus.integration.node_exporter` component can only appear once per
 configuration file, and a block label must not be passed to it.
 
-## Example
+## Usage
+
 ```river
 prometheus.integration.node_exporter {
-}
-
-// Configure a prometheus.scrape component to collect node_exporter metrics.
-prometheus.scrape "demo" {
-  targets    = prometheus.integration.node_exporter.targets
-  forward_to = [ /* ... */ ]
 }
 ```
 
@@ -328,3 +323,21 @@ arguments for the component to work.
 You may also need to add capabilities such as `SYS_TIME` and make sure that the
 Agent is running with elevated privileges for some of the collectors to work
 properly.
+
+## Example
+
+This example uses a [`prometheus.scrape` component][scrape] to collect metrics
+from `prometheus.integration.node_exporter`:
+
+```river
+prometheus.integration.node_exporter {
+}
+
+// Configure a prometheus.scrape component to collect node_exporter metrics.
+prometheus.scrape "demo" {
+  targets    = prometheus.integration.node_exporter.targets
+  forward_to = [ /* ... */ ]
+}
+```
+
+[scrape]: {{< relref "./prometheus.scrape.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.integration.node_exporter.md
+++ b/docs/sources/flow/reference/components/prometheus.integration.node_exporter.md
@@ -53,36 +53,57 @@ of the ones provided in `set_collectors`.
 `disable_collectors` extends the default set of disabled collectors. In case
 of conflicts, it takes precedence over `enable_collectors`.
 
-Additionally, the following subblocks are supported for configuring
-collector-specific options.
+## Blocks
 
-Name | Description | Required
----- | ----------- | --------
-[`bcache`](#bcache-block) | Configures the bcache collector. | no
-[`cpu`](#cpu-block) | Configures the cpu collector. | no
-[`disk`](#disk-block) | Configures the diskstats collector. | no
-[`ethtool`](#ethtool-block) | Configures the ethtool collector. | no
-[`filesystem`](#filesystem-block) | Configures the filesystem collector. | no
-[`ipvs`](#ipvs-block) | Configures the ipvs collector. | no
-[`ntp`](#ntp-block) | Configures the ntp collector. | no
-[`netclass`](#netclass-block) | Configures the netclass collector. | no
-[`netdev`](#netdev-block) | Configures the netdev collector. | no
-[`netstat`](#netstat-block) | Configures the netstat collector. | no
-[`perf`](#perf-block) | Configures the perf collector. | no
-[`powersupply`](#powersupply-block) | Configures the powersupply collector. | no
-[`runit`](#runit-block) | Configures the runit collector. | no
-[`supervisord`](#supervisord-block) | Configures the supervisord collector. | no
-[`systemd`](#systemd-block) | Configures the systemd collector. | no
-[`tapestats`](#tapestats-block) | Configures the tapestats collector. | no
-[`textfile`](#textfile-block) | Configures the textfile collector. | no
-[`vmstat`](#vmstat-block) | Configures the vmstat collector. | no
+The following blocks are supported inside the definiton of
+`prometheus.integration.node_exporter` to configure collector-specific options:
 
-### `bcache` block
+Hierarchy | Name | Description | Required
+--------- | ---- | ----------- | --------
+bcache | [bcache][] | Configures the bcache collector. | no
+cpu | [cpu][] | Configures the cpu collector. | no
+disk | [disk][] | Configures the diskstats collector. | no
+ethtool | [ethtool][] | Configures the ethtool collector. | no
+filesystem | [filesystem][] | Configures the filesystem collector. | no
+ipvs | [ipvs][] | Configures the ipvs collector. | no
+ntp | [ntp][] | Configures the ntp collector. | no
+netclass | [netclass][] | Configures the netclass collector. | no
+netdev | [netdev][] | Configures the netdev collector. | no
+netstat | [netstat][] | Configures the netstat collector. | no
+perf | [perf][] | Configures the perf collector. | no
+powersupply | [powersupply][] | Configures the powersupply collector. | no
+runit | [runit][] | Configures the runit collector. | no
+supervisord | [supervisord][] | Configures the supervisord collector. | no
+systemd | [systemd][] | Configures the systemd collector. | no
+tapestats | [tapestats][] | Configures the tapestats collector. | no
+textfile | [textfile][] | Configures the textfile collector. | no
+vmstat | [vmstat][] | Configures the vmstat collector. | no
+
+[bcache]: #bcache-block
+[cpu]: #cpu-block
+[disk]: #disk-block
+[ethtool]: #ethtool-block
+[filesystem]: #filesystem-block
+[ipvs]: #ipvs-block
+[ntp]: #ntp-block
+[netclass]: #netclass-block
+[netdev]: #netdev-block
+[netstat]: #netstat-block
+[perf]: #perf-block
+[powersupply]: #powersupply-block
+[runit]: #runit-block
+[supervisord]: #supervisord-block
+[systemd]: #systemd-block
+[tapestats]: #tapestats-block
+[textfile]: #textfile-block
+[vmstat]: #vmstat-block
+
+### bcache block
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `priority_stats` | `boolean` |  Enable exposing of expensive bcache priority stats. | false | no
 
-### `cpu` block
+### cpu block
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `guest`         | `boolean` | Enable the `node_cpu_guest_seconds_total` metric. | true | no
@@ -90,31 +111,31 @@ Name | Type | Description | Default | Required
 `bugs_include`  | `string`  | Regexp of `bugs` field in cpu info to filter. | | no
 `flags_include` | `string`  | Regexp of `flags` field in cpu info to filter. | | no
 
-### `disk` block
+### disk block
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `ignored_devices` | `string` | Regexp of devices to ignore for diskstats. | `"^(ram\|loop\|fd\|(h\|s\|v\|xv)d[a-z]\|nvme\\d+n\\d+p)\\d+$"` | no
 
-### `ethtool` block
+### ethtool block
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `device_exclude` | `string` | Regexp of ethtool devices to exclude (mutually exclusive with `device_include`). | | no
 `device_include` | `string` | Regexp of ethtool devices to include (mutually exclusive with `device_exclude`). | | no
 `metrics_include`| `string` | Regexp of ethtool stats to include. | `.*` | no
 
-### `filesystem` block
+### filesystem block
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `fs_types_exclude`     | `string`   | Regexp of filesystem types to ignore for filesystem collector.| `"^(autofs\|binfmt_misc\|bpf\|cgroup2?\|configfs\|debugfs\|devpts\|devtmpfs\|fusectl\|hugetlbfs\|iso9660\|mqueue\|nsfs\|overlay\|proc\|procfs\|pstore\|rpc_pipefs\|securityfs\|selinuxfs\|squashfs\|sysfs\|tracefs)$"` | no
 `mount_points_exclude` | `string`   | Regexp of mount points to ignore for filesystem collector. | `"^/(dev\|proc\|sys\|var/lib/docker/.+)($\|/)"` | no
 `mount_timeout`        | `duration` | How long to wait for a mount to respond before marking it as stale. | `"5s"` | no
 
-### `ipvs` block
+### ipvs block
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `backend_labels` | `list(string)` | Array of IPVS backend stats labels. | `[local_address, local_port, remote_address, remote_port, proto, local_mark]` | no
 
-### `ntp` block
+### ntp block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
 `server`                 | `string`   | NTP server to use for the collector. | `"127.0.0.1"` | no
@@ -124,43 +145,41 @@ name | type | description | default | required
 `max_distance`           | `duration` | Max accumulated distance to the root. | `"3466080us"` | no
 `protocol_version`       | `int`      | NTP protocol version. | 4 | no
 
-### `netclass` block
+### netclass block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
 `ignore_invalid_speed_device` | `boolean` | Ignore net devices with invalid speed values. | false | no
 `ignored_devices`             | `string`  | Regexp of net devices to ignore for netclass collector. | `"^$"` | no
 
-### `netdev` block
+### netdev block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
 `address_info`   | `boolean` | Enable collecting address-info for every device. | false | no
 `device_exclude` | `string`  | Regexp of net devices to exclude (mutually exclusive with `device_include`). |  | no
 `device_include` | `string`  | Regexp of net devices to include (mutually exclusive with `device_exclude`). |  | no
 
-### `netstat` block
+### netstat block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
 `fields` | `string` | Regexp of fields to return for netstat collector. | `"^(.*_(InErrors\|InErrs)\|Ip_Forwarding\|Ip(6\|Ext)_(InOctets\|OutOctets)\|Icmp6?_(InMsgs\|OutMsgs)\|TcpExt_(Listen.*\|Syncookies.*\|TCPSynRetrans\|TCPTimeouts)\|Tcp_(ActiveOpens\|InSegs\|OutSegs\|OutRsts\|PassiveOpens\|RetransSegs\|CurrEstab)\|Udp6?_(InDatagrams\|OutDatagrams\|NoPorts\|RcvbufErrors\|SndbufErrors))$"` | no
 
-
-
-### `perf` block
+### perf block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
 `cpus`       | `string`       | List of CPUs from which perf metrics should be collected. | | no
 `tracepoint` | `list(string)` | Array of perf tracepoints that should be collected. | | no
 
-### `powersupply` block
+### powersupply block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
 `ignored_supplies` | `string` | Regexp of power supplies to ignore for the powersupplyclass collector. | `"^$"` | no
 
-### `runit` block
+### runit block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
 `service_dir` | `string` | Path to runit service directory. | `"/etc/service"` | no
 
-### `supervisord` block
+### supervisord block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
 `url` | `string` | XML RPC endpoint for the supervisord collector. | `"http://localhost:9001/RPC2"` | no
@@ -168,8 +187,7 @@ name | type | description | default | required
 Setting `SUPERVISORD_URL` in the environment overrides the default value.
 An explicit value in the block takes precedence over the environment variable.
 
-
-### `systemd` block
+### systemd block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
 `enable_restarts` | `boolean` | Enables service unit metric `service_restart_total` | false | no
@@ -178,17 +196,17 @@ name | type | description | default | required
 `unit_exclude`    | `string`  | Regexp of systemd units to exclude. Units must both match include and not match exclude to be collected. | `".+\\.(automount\|device\|mount\|scope\|slice)"` | no
 `unit_include`    | `string`  | Regexp of systemd units to include. Units must both match include and not match exclude to be collected. | `".+"` | no
 
-### `tapestats` block
+### tapestats block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
 `ignored_devices` | `string` | Regexp of tapestats devices to ignore. | `"^$"` | no
 
-### `textfile` block
+### textfile block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
 `textfile_directory` | `string` | Directory to read `*.prom` files from for the textfile collector. |  | no
 
-### `vmstat` block
+### vmstat block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
 `fields` | `string` | Regexp of fields to return for the vmstat collector. | `"^(oom_kill\|pgpg\|pswp\|pg.*fault).*"` | no
@@ -310,4 +328,3 @@ arguments for the component to work.
 You may also need to add capabilities such as `SYS_TIME` and make sure that the
 Agent is running with elevated privileges for some of the collectors to work
 properly.
-

--- a/docs/sources/flow/reference/components/prometheus.relabel.md
+++ b/docs/sources/flow/reference/components/prometheus.relabel.md
@@ -116,9 +116,11 @@ values.
 
 `prometheus.relabel` does not expose any component-specific debug metrics.
 
-## Metric relabeling in action
+## Example
+
 Let's create an instance of a see `prometheus.relabel` component and see how
 it acts on the following metrics.
+
 ```river
 prometheus.relabel "keep_backend_only" {
   forward_to = [prometheus.remote_write.onprem.receiver]
@@ -181,26 +183,3 @@ metric_a{host = "cluster_a/production",  __address__ = "cluster_a", app = "backe
 
 The two resulting metrics are then propagated to each receiver defined in the
 `forward_to` argument.
-
-## Example
-
-```river
-prometheus.relabel "keep_backend_only" {
-  forward_to = [prometheus.remote_write.onprem.receiver]
-
-  rule {
-    action        = "replace"
-    source_labels = ["__address__", "instance"]
-    separator     = "/"
-    target_label  = "host"
-  }
-
-  rule {
-    action        = "keep"
-    source_labels = ["app"]
-    regex         = "backend"
-  }
-}
-```
-
-

--- a/docs/sources/flow/reference/components/prometheus.relabel.md
+++ b/docs/sources/flow/reference/components/prometheus.relabel.md
@@ -29,23 +29,17 @@ each metric in order of their appearance in the configuration file.
 Multiple `prometheus.relabel` components can be specified by giving them
 different labels.
 
-## Example
+## Usage
+
 ```river
-prometheus.relabel "keep_backend_only" {
-  forward_to = [prometheus.remote_write.onprem.receiver]
+prometheus.relabel "LABEL" {
+  forward_to = RECEIVER_LIST
 
   rule {
-    action        = "replace"
-    source_labels = ["__address__", "instance"]
-    separator     = "/"
-    target_label  = "host"
+    ...
   }
 
-  rule {
-    action        = "keep"
-    source_labels = ["app"]
-    regex         = "backend"
-  }
+  ...
 }
 ```
 
@@ -187,4 +181,26 @@ metric_a{host = "cluster_a/production",  __address__ = "cluster_a", app = "backe
 
 The two resulting metrics are then propagated to each receiver defined in the
 `forward_to` argument.
+
+## Example
+
+```river
+prometheus.relabel "keep_backend_only" {
+  forward_to = [prometheus.remote_write.onprem.receiver]
+
+  rule {
+    action        = "replace"
+    source_labels = ["__address__", "instance"]
+    separator     = "/"
+    target_label  = "host"
+  }
+
+  rule {
+    action        = "keep"
+    source_labels = ["app"]
+    regex         = "backend"
+  }
+}
+```
+
 

--- a/docs/sources/flow/reference/components/prometheus.relabel.md
+++ b/docs/sources/flow/reference/components/prometheus.relabel.md
@@ -32,20 +32,20 @@ different labels.
 ## Example
 ```river
 prometheus.relabel "keep_backend_only" {
-	forward_to = [prometheus.remote_write.onprem.receiver]
+  forward_to = [prometheus.remote_write.onprem.receiver]
 
-	rule {
-		action        = "replace"
-		source_labels = ["__address__", "instance"]
-		separator     = "/"
-		target_label  = "host"
-	}
+  rule {
+    action        = "replace"
+    source_labels = ["__address__", "instance"]
+    separator     = "/"
+    target_label  = "host"
+  }
 
-	rule {
-		action        = "keep"
-		source_labels = ["app"]
-		regex         = "backend"
-	}
+  rule {
+    action        = "keep"
+    source_labels = ["app"]
+    regex         = "backend"
+  }
 }
 ```
 
@@ -55,15 +55,19 @@ The following arguments are supported:
 
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`forward_to` | `list(receiver)` | Where the metrics should be forwarded to, after relabeling takes place | | **yes**
+`forward_to` | `list(receiver)` | Where the metrics should be forwarded to, after relabeling takes place. | | **yes**
 
-The following subblocks are supported:
+## Blocks
 
-Name | Description | Required
----- | ----------- | --------
-[`rule`](#rule-block) | Relabeling rules to apply to received metrics | no
+The following blocks are supported inside the definition of `prometheus.relabel`:
 
-### `rule` block
+Hierarchy | Name | Description | Required
+--------- | ---- | ----------- | --------
+rule | [rule][] | Relabeling rules to apply to received metrics. | no
+
+[rule]: #rule-block
+
+### rule block
 
 The `rule` block contains the definition of any relabeling
 rules that can be applied to an input metric. If more than one
@@ -123,32 +127,32 @@ Let's create an instance of a see `prometheus.relabel` component and see how
 it acts on the following metrics.
 ```river
 prometheus.relabel "keep_backend_only" {
-	forward_to = [prometheus.remote_write.onprem.receiver]
+  forward_to = [prometheus.remote_write.onprem.receiver]
 
-	rule {
-		action        = "replace"
-		source_labels = ["__address__", "instance"]
-		separator     = "/"
-		target_label  = "host"
-	}
-	rule {
-		action        = "keep"
-		source_labels = ["app"]
-		regex         = "backend"
-	}
-	rule {
-		action = "labeldrop"
-		regex  = "instance"
-	}
+  rule {
+    action        = "replace"
+    source_labels = ["__address__", "instance"]
+    separator     = "/"
+    target_label  = "host"
+  }
+  rule {
+    action        = "keep"
+    source_labels = ["app"]
+    regex         = "backend"
+  }
+  rule {
+    action = "labeldrop"
+    regex  = "instance"
+  }
 }
 ```
 
 ```
 metric_a{__address__ = "localhost", instance = "development", app = "frontend"} 10
-metric_a{__address__ = "localhost", instance = "development", app = "backend"}	2
+metric_a{__address__ = "localhost", instance = "development", app = "backend"}  2
 metric_a{__address__ = "cluster_a", instance = "production",  app = "frontend"} 7
-metric_a{__address__ = "cluster_a", instance = "production",  app = "backend"}	9
-metric_a{__address__ = "cluster_b", instance = "production",  app = "database"}	4
+metric_a{__address__ = "cluster_a", instance = "production",  app = "backend"}  9
+metric_a{__address__ = "cluster_b", instance = "production",  app = "database"} 4
 ```
 
 After applying the first `rule`, the `replace` action populates a new label
@@ -157,10 +161,10 @@ labels, separated by a slash `/`.
 
 ```
 metric_a{host = "localhost/development", __address__ = "localhost", instance = "development", app = "frontend"} 10
-metric_a{host = "localhost/development", __address__ = "localhost", instance = "development", app = "backend"}	2
+metric_a{host = "localhost/development", __address__ = "localhost", instance = "development", app = "backend"}  2
 metric_a{host = "cluster_a/production",  __address__ = "cluster_a", instance = "production",  app = "frontend"} 7
-metric_a{host = "cluster_a/production",  __address__ = "cluster_a", instance = "production",  app = "backend"}	9
-metric_a{host = "cluster_b/production",  __address__ = "cluster_a", instance = "production",  app = "database"}	4
+metric_a{host = "cluster_a/production",  __address__ = "cluster_a", instance = "production",  app = "backend"}  9
+metric_a{host = "cluster_b/production",  __address__ = "cluster_a", instance = "production",  app = "database"} 4
 ```
 
 On the second relabeling rule, the `keep` action only keeps the metrics whose
@@ -168,8 +172,8 @@ On the second relabeling rule, the `keep` action only keeps the metrics whose
 is be trimmed down to:
 
 ```
-metric_a{host = "localhost/development", __address__ = "localhost", instance = "development", app = "backend"}	2
-metric_a{host = "cluster_a/production",  __address__ = "cluster_a", instance = "production",  app = "backend"}	9
+metric_a{host = "localhost/development", __address__ = "localhost", instance = "development", app = "backend"}  2
+metric_a{host = "cluster_a/production",  __address__ = "cluster_a", instance = "production",  app = "backend"}  9
 ```
 
 The third and final relabeling rule which uses the `labeldrop` action removes
@@ -177,8 +181,8 @@ the `instance` label from the set of labels.
 
 So in this case, the initial set of metrics passed to the exported receiver is:
 ```
-metric_a{host = "localhost/development", __address__ = "localhost", app = "backend"}	2
-metric_a{host = "cluster_a/production",  __address__ = "cluster_a", app = "backend"}	9
+metric_a{host = "localhost/development", __address__ = "localhost", app = "backend"}  2
+metric_a{host = "cluster_a/production",  __address__ = "cluster_a", app = "backend"}  9
 ```
 
 The two resulting metrics are then propagated to each receiver defined in the

--- a/docs/sources/flow/reference/components/prometheus.remote_write.md
+++ b/docs/sources/flow/reference/components/prometheus.remote_write.md
@@ -175,7 +175,7 @@ Name | Type | Description | Default | Required
 `insecure_skip_verify` | `bool` | Disables validation of the server certificate. | | no
 `min_version` | `string` | Minimum acceptable TLS version. | | no
 
-When `min_version` is not provided, the minumum acceptable TLS version is
+When `min_version` is not provided, the minimum acceptable TLS version is
 inherited from Go's default minimum version, TLS 1.2. If `min_version` is
 provided, it must be set to one of the following strings:
 

--- a/docs/sources/flow/reference/components/prometheus.remote_write.md
+++ b/docs/sources/flow/reference/components/prometheus.remote_write.md
@@ -16,31 +16,17 @@ different labels.
 
 [remote_write-spec]: https://docs.google.com/document/d/1LPhVRSFkGNSuU1fBd81ulhsCPR4hkSZyyBj1SZ8fWOM/edit
 
-## Example
+## Usage
 
 ```river
-prometheus.remote_write "staging" {
-  // Send metrics to a locally running Mimir.
+prometheus.remote_write "LABEL" {
   endpoint {
-    url = "http://mimir:9009/api/v1/push"
+    url = REMOTE_WRITE_URL
 
-    http_client_config {
-      basic_auth {
-        username = "example-user"
-        password = "example-password"
-      }
-    }
+    ...
   }
-}
 
-// Configure a prometheus.scrape component to send metrics to
-// prometheus.remote_write component.
-prometheus.scrape "demo" {
-  targets = [
-    // Collect metrics from Grafana Agent's default HTTP listen address.
-    {"__address__" = "127.0.0.1:12345"},
-  ]
-  forward_to = [prometheus.remote_write.staging.receiver]
+  ...
 }
 ```
 
@@ -354,3 +340,31 @@ information.
   remote storage.
 * `prometheus_remote_storage_exemplars_in_total` (counter): Exemplars read into
   remote storage.
+
+## Example
+
+```river
+prometheus.remote_write "staging" {
+  // Send metrics to a locally running Mimir.
+  endpoint {
+    url = "http://mimir:9009/api/v1/push"
+
+    http_client_config {
+      basic_auth {
+        username = "example-user"
+        password = "example-password"
+      }
+    }
+  }
+}
+
+// Configure a prometheus.scrape component to send metrics to
+// prometheus.remote_write component.
+prometheus.scrape "demo" {
+  targets = [
+    // Collect metrics from Grafana Agent's default HTTP listen address.
+    {"__address__" = "127.0.0.1:12345"},
+  ]
+  forward_to = [prometheus.remote_write.staging.receiver]
+}
+```

--- a/docs/sources/flow/reference/components/prometheus.scrape.md
+++ b/docs/sources/flow/reference/components/prometheus.scrape.md
@@ -23,16 +23,16 @@ defined by other components.
 
 ```river
 prometheus.scrape "blackbox_scraper" {
-	targets = [
-		{"__address__" = "blackbox-exporter:9115", "instance" = "one"},
-		{"__address__" = "blackbox-exporter:9116", "instance" = "two"},
-	]
+  targets = [
+    {"__address__" = "blackbox-exporter:9115", "instance" = "one"},
+    {"__address__" = "blackbox-exporter:9116", "instance" = "two"},
+  ]
 
-	forward_to = [prometheus.remote_write.grafanacloud.receiver, prometheus.remote_write.onprem.receiver]
-	
-	scrape_interval = "10s"
-	params          = { "target" = ["grafana.com"], "module" = ["http_2xx"] }
-	metrics_path    = "/probe"
+  forward_to = [prometheus.remote_write.grafanacloud.receiver, prometheus.remote_write.onprem.receiver]
+
+  scrape_interval = "10s"
+  params          = { "target" = ["grafana.com"], "module" = ["http_2xx"] }
+  metrics_path    = "/probe"
 }
 ```
 
@@ -77,67 +77,105 @@ Name | Type | Description | Default | Required
 `label_name_length_limit`  | `uint`     | More than this label name length post metric-relabeling causes the scrape to fail. | | no
 `label_value_length_limit` | `uint`     | More than this label value length post metric-relabeling causes the scrape to fail. | | no
 
-The components also supports the `http_client_config` sub-block for configuring
-the behavior of the HTTP client used for the scraping.
+## Blocks
 
-### `http_client_config` block
+The following blocks are supported inside the definition of `prometheus.remote_write`:
+
+Hierarchy | Block | Description | Required
+--------- | ----- | ----------- | --------
+http_client_config | [http_client_config][] | HTTP client settings when connecting to targets. | no
+http_client_config > basic_auth | [basic_auth][] | Configure basic_auth for authenticating to targets. | no
+http_client_config > authorization | [authorization][] | Configure generic authorization to targets. | no
+http_client_config > oauth2 | [oauth2][] | Configure OAuth2 for authenticating to targets. | no
+http_client_config > oauth2 > tls_config | [tls_config][] | Configure TLS settings for connecting to targets via OAuth2. | no
+http_client_config > tls_config | [tls_config][] | Configure TLS settings for connecting to targets. | no
+
+The `>` symbol indicates deeper levels of nesting. For example,
+`http_client_config > basic_auth` refers to a `basic_auth` block defined inside
+an `http_client_config` block.
+
+
+[http_client_config]: #http_client_config-block
+[basic_auth]: #basic_auth-block
+[authorization]: #authorization-block
+[oauth2]: #oauth2-block
+[tls_config]: #tls_config-block
+
+### http_client_config block
+
+The `http_client_config` block configures the HTTP client used to connect to an
+endpoint.
+
+The following arguments are supported:
 
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`bearer_token`             | `secret`   | Use to set up the Bearer Token. | | no
-`bearer_token_file`        | `string`   | Use to set up the Bearer Token file. | | no
-`proxy_url`                | `string`   | Use to set up a proxy URL. | | no
-`follow_redirects`         | `bool`     | Whether the scraper should follow redirects. | `true` | no
-`enable_http_2`            | `bool`     | Whether the scraper should use HTTP2. | `true` | no
+`bearer_token` | `secret` | Bearer token to authenticate with. | | no
+`bearer_token_file` | `string` | File containing a bearer token to authenticate with. | | no
+`proxy_url` | `string` | HTTP proxy to proxy requests through. | | no
+`follow_redirects` | `bool` | Whether redirects returned by the server should be followed. | `true` | no
+`enable_http_2` | `bool` | Whether HTTP2 is supported for requests. | `true` | no
 
-The following sub-blocks are supported for `http_client_config`:
+`bearer_token`, `bearer_token_file`, `basic_auth`, `authorization`, and
+`oauth2` are mutually exclusive and only one can be provided inside of a
+`http_client_config` block.
 
-Name | Description | Required
----- | ----------- | --------
-[`basic_auth`](#basic_auth-block) | Configure basic_auth for authenticating against targets | no
-[`authorization`](#authorization-block) | Configure generic authorization against targets | no
-[`oauth2`](#oauth2-block) | Configure OAuth2 for authenticating against targets | no
-[`tls_config`](#tls_config-block) | Configure TLS settings for connecting to targets | no
+### basic_auth block
 
-#### `basic_auth` block
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`username` | `string` | Basic auth username. | | no
+`password` | `secret` | Basic auth password. | | no
+`password_file` | `string` | File containing the basic auth password. | | no
 
-Name          | Type     | Description                                     | Default | Required
-------------- | -------- | ----------------------------------------------- | ------- | -------
-`username`      | `string`   | Setup of Basic HTTP authentication credentials. |         | no
-`password`      | `secret`   | Setup of Basic HTTP authentication credentials. |         | no
-`password_file` | `string`   | Setup of Basic HTTP authentication credentials. |         | no
+`password` and `password_file` are mututally exclusive and only one can be
+provided inside of a `basic_auth` block.
 
-#### `authorization` block
+### authorization block
 
-Name                  | Type       | Description                              | Default | Required
---------------------- | ---------- | ---------------------------------------- | ------- | --------
-`type`                | `string`   | Setup of HTTP Authorization credentials. |         | no
-`credential`          | `secret`   | Setup of HTTP Authorization credentials. |         | no
-`credentials_file`    | `string`   | Setup of HTTP Authorization credentials. |         | no
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`type` | `string` | Authorization type, for example, "Bearer". | | no
+`credential` | `secret` | Secret value. | | no
+`credentials_file` | `string` | File containing the secret value. | | no
 
-#### `oauth2` block
+`credential` and `credentials_file` are mututally exclusive and only one can be
+provided inside of an `authorization` block.
 
-Name                 | Type                 | Description                              | Default | Required
--------------------- | -------------------- | ---------------------------------------- | ------- | --------
-`client_id`          | `string`             | Setup of the OAuth2 client.              |         | no
-`client_secret`      | `secret`             | Setup of the OAuth2 client.              |         | no
-`client_secret_file` | `string`             | Setup of the OAuth2 client.              |         | no
-`scopes`             | `list(string)`       | Setup of the OAuth2 client.              |         | no
-`token_url`          | `string`             | Setup of the OAuth2 client.              |         | no
-`endpoint_params`    | `map(string)`        | Setup of the OAuth2 client.              |         | no
-`proxy_url`          | `string`             | Setup of the OAuth2 client.              |         | no
+### oauth2 block
 
-The `oauth2` block may also contain its own separate `tls_config` sub-block.
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`client_id` | `string` | OAuth2 client ID. | | no
+`client_secret` | `secret` | OAuth2 client secret. | | no
+`client_secret_file` | `string` | File containing the OAuth2 client secret. | | no
+`scopes` | `list(string)` | List of scopes to authenticate with. | | no
+`token_url` | `string` | URL to fetch the token from. | | no
+`endpoint_params` | `map(string)` | Optional parameters to append to the token URL. | | no
+`proxy_url` | `string` | Optional proxy URL for OAuth2 requests. | | no
 
-#### `tls_config` block
+`client_secret` and `client_secret_file` are mututally exclusive and only one
+can be provided inside of an `oauth2` block.
 
-Name                              | Type       | Description                                | Default | Required
---------------------------------- | ---------- | ------------------------------------------ | ------- | --------
-`tls_config_ca_file`              | `string`   | Configuration options for TLS connections. |         | no
-`tls_config_cert_file`            | `string`   | Configuration options for TLS connections. |         | no
-`tls_config_key_file`             | `string`   | Configuration options for TLS connections. |         | no
-`tls_config_server_name`          | `string`   | Configuration options for TLS connections. |         | no
-`tls_config_insecure_skip_verify` | `bool`     | Configuration options for TLS connections. |         | no
+### tls_config block
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`ca_file` | `string` | CA certificate to validate the server with. | | no
+`cert_file` | `string` | Certificate file for client authentication. | | no
+`key_file` | `string` | Key file for client authentication. | | no
+`server_name` | `string` | ServerName extension to indicate the name of the server. | | no
+`insecure_skip_verify` | `bool` | Disables validation of the server certificate. | | no
+`min_version` | `string` | Minimum acceptable TLS version. | | no
+
+When `min_version` is not provided, the minimum acceptable TLS version is
+inherited from Go's default minimum version, TLS 1.2. If `min_version` is
+provided, it must be set to one of the following strings:
+
+* `"TLS10"` (TLS 1.0)
+* `"TLS11"` (TLS 1.1)
+* `"TLS12"` (TLS 1.2)
+* `"TLS13"` (TLS 1.3)
 
 ## Exported fields
 
@@ -164,7 +202,7 @@ Prometheus, and by extent this component, uses a pull model for scraping
 metrics from a given set of _targets_.
 Each scrape target is defined as a set of key-value pairs called _labels_.
 The set of targets can either be _static_, or dynamically provided periodically
-by a service disovery component such as `discovery.kubernetes`. The special
+by a service discovery component such as `discovery.kubernetes`. The special
 label `__address__` _must always_ be present and corresponds to the
 `<host>:<port>` that is used for the scrape request.
 
@@ -193,7 +231,7 @@ The following labels are automatically injected to the scraped time series and
 can help pin down a scrape target.
 
 Label                 | Description
---------------------- | ---------- 
+--------------------- | ----------
 job                   | The configured job name that the target belongs to. Defaults to the fully formed component name.
 instance              | The `__address__` or `<host>:<port>` of the scrape target's URL.
 

--- a/docs/sources/flow/reference/components/prometheus.scrape.md
+++ b/docs/sources/flow/reference/components/prometheus.scrape.md
@@ -13,33 +13,13 @@ title: prometheus.scrape
 Multiple `prometheus.scrape` components can be specified by giving them
 different labels.
 
-## Example
+## Usage
 
-The following example sets up the scrape job with certain attributes (scrape
-endpoint, scrape interval, query parameters) and lets it scrape two instances
-of the [blackbox exporter](https://github.com/prometheus/blackbox_exporter/).
-The exposed metrics are sent over to the provided list of receivers, as
-defined by other components.
-
-```river
-prometheus.scrape "blackbox_scraper" {
-  targets = [
-    {"__address__" = "blackbox-exporter:9115", "instance" = "one"},
-    {"__address__" = "blackbox-exporter:9116", "instance" = "two"},
-  ]
-
-  forward_to = [prometheus.remote_write.grafanacloud.receiver, prometheus.remote_write.onprem.receiver]
-
-  scrape_interval = "10s"
-  params          = { "target" = ["grafana.com"], "module" = ["http_2xx"] }
-  metrics_path    = "/probe"
+```
+prometheus.scrape "LABEL" {
+  targets    = TARGET_LIST
+  forward_to = RECEIVER_LIST
 }
-```
-
-Here's the the endpoints that are being scraped every 10 seconds:
-```
-http://blackbox-exporter:9115/probe?target=grafana.com&module=http_2xx
-http://blackbox-exporter:9116/probe?target=grafana.com&module=http_2xx
 ```
 
 ## Arguments
@@ -255,4 +235,34 @@ scrape target, either because it is not reachable, because the connection
 times out while scraping, or because the samples from the target could not be
 processed. When the target is behaving normally, the `up` metric is set to
 `1`.
+
+## Example
+
+The following example sets up the scrape job with certain attributes (scrape
+endpoint, scrape interval, query parameters) and lets it scrape two instances
+of the [blackbox exporter](https://github.com/prometheus/blackbox_exporter/).
+The exposed metrics are sent over to the provided list of receivers, as
+defined by other components.
+
+```river
+prometheus.scrape "blackbox_scraper" {
+  targets = [
+    {"__address__" = "blackbox-exporter:9115", "instance" = "one"},
+    {"__address__" = "blackbox-exporter:9116", "instance" = "two"},
+  ]
+
+  forward_to = [prometheus.remote_write.grafanacloud.receiver, prometheus.remote_write.onprem.receiver]
+
+  scrape_interval = "10s"
+  params          = { "target" = ["grafana.com"], "module" = ["http_2xx"] }
+  metrics_path    = "/probe"
+}
+```
+
+Here's the the endpoints that are being scraped every 10 seconds:
+```
+http://blackbox-exporter:9115/probe?target=grafana.com&module=http_2xx
+http://blackbox-exporter:9116/probe?target=grafana.com&module=http_2xx
+```
+
 

--- a/docs/sources/flow/reference/components/remote.s3.md
+++ b/docs/sources/flow/reference/components/remote.s3.md
@@ -19,11 +19,11 @@ labels. By default, [AWS environment variables](https://docs.aws.amazon.com/cli/
 > authentication environment variables. There is no  guarantee that `remote.s3` will work with non-AWS S3
 > systems.
 
-## Example
+## Usage
 
 ```river
-remote.s3 "data" {
-  path = "s3://test-bucket/file.txt"
+remote.s3 "LABEL" {
+  path = S3_FILE_PATH
 }
 ```
 
@@ -84,3 +84,11 @@ the watched file was successful.
 ### Debug metrics
 
 `remote.s3` does not expose any component-specific debug metrics.
+
+## Example
+
+```river
+remote.s3 "data" {
+  path = "s3://test-bucket/file.txt"
+}
+```

--- a/docs/sources/flow/reference/components/remote.s3.md
+++ b/docs/sources/flow/reference/components/remote.s3.md
@@ -6,17 +6,17 @@ title: remote.s3
 
 # remote.s3
 
-`remote.s3` exposes the string contents of a file located in [AWS S3](https://aws.amazon.com/s3/)  
+`remote.s3` exposes the string contents of a file located in [AWS S3](https://aws.amazon.com/s3/)
 to other components. The file will be polled for changes so that the most
 recent content is always available.
 
-The most common use of `remote.s3` is to load secrets from files. 
+The most common use of `remote.s3` is to load secrets from files.
 
 Multiple `remote.s3` components can be specified using different name
-labels. By default, [AWS environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) are used to authenticate against S3. The `key` and `secret` arguments inside `client_options` blocks can be used to provide custom authentication. 
+labels. By default, [AWS environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) are used to authenticate against S3. The `key` and `secret` arguments inside `client_options` blocks can be used to provide custom authentication.
 
-> **NOTE**: Other S3-compatible systems can be read  with `remote.s3` but may require specific 
-> authentication environment variables. There is no  guarantee that `remote.s3` will work with non-AWS S3 
+> **NOTE**: Other S3-compatible systems can be read  with `remote.s3` but may require specific
+> authentication environment variables. There is no  guarantee that `remote.s3` will work with non-AWS S3
 > systems.
 
 ## Example
@@ -31,8 +31,8 @@ remote.s3 "data" {
 
 The following arguments are supported:
 
-Name | Type | Description                                                             | Default | Required
----- | ---- |-------------------------------------------------------------------------| ------- | --------
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
 `path` | `string` | Path in the format of `"s3://bucket/file"`. | | **yes**
 `poll_frequency` | `duration` | How often to poll the file for changes. Must be greater than 30 seconds. | `"10m"` | no
 `is_secret` | `bool` | Marks the file as containing a [secret][]. | `false` | no
@@ -43,10 +43,11 @@ Name | Type | Description                                                       
 
 ## Blocks
 
-Name | Description | Required
----- | ----------- | --------
-[`client_options`](#client_options-block) | Additional options for configuring the S3 client. | no
+Hierarchy | Name | Description | Required
+--------- | ---- | ----------- | --------
+client_options | [client_options][] | Additional options for configuring the S3 client. | no
 
+[client_options]: #client_options-block
 
 ### client_options block
 


### PR DESCRIPTION
This PR changes the component references to use a consistent structure:

* Examples have been moved to the bottom of the page, and a Usage section has been moved to where Examples used to be. 
* Components that have blocks now have a h2 for `Blocks` and one h3 per defined block. 