### PR TITLE
user node_exporter for chaining

### DIFF
--- a/docs/sources/flow/tutorials/assets/flow_configs/example.flow
+++ b/docs/sources/flow/tutorials/assets/flow_configs/example.flow
@@ -1,5 +1,5 @@
 prometheus.integration.node_exporter {
-set_collectors = ["cpu", "diskstats"]
+	set_collectors = ["cpu", "diskstats"]
 }
 
 prometheus.scrape "my_scrape_job" {

--- a/docs/sources/flow/tutorials/assets/flow_configs/multiple-inputs.flow
+++ b/docs/sources/flow/tutorials/assets/flow_configs/multiple-inputs.flow
@@ -1,10 +1,14 @@
-prometheus.scrape "first" {
+prometheus.scrape "agent" {
 	targets    = [{"__address__" = "localhost:12345"}]
 	forward_to = [prometheus.relabel.service.receiver]
 }
 
-prometheus.scrape "second" {
-	targets    = [{"__address__" = "localhost:12345"}]
+prometheus.integration.node_exporter {
+	set_collectors = ["cpu", "diskstats"]
+}
+
+prometheus.scrape "node" {
+	targets    = prometheus.integration.node_exporter.targets
 	forward_to = [prometheus.relabel.service.receiver]
 }
 

--- a/docs/sources/flow/tutorials/chaining.md
+++ b/docs/sources/flow/tutorials/chaining.md
@@ -25,22 +25,24 @@ The `runt.sh` script does:
 2. Downloads the docker image for Grafana Agent explicitly.
 3. Runs the docker-compose up command to bring all the services up.
 
-Allow the Grafana Agent to run for two minutes, then navigate to [Grafana](http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Mimir%22,%7B%22refId%22:%22A%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22agent_build_info%7B%7D%22%7D%5D).
-
-![](../assets/multiple.png)
+Allow the Grafana Agent to run for two minutes, then navigate to [Grafana](http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Mimir%22,%7B%22refId%22:%22A%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22agent_build_info%7B%7D%22%7D%5D) to see the Agent scrape metrics. The [node_exporter](http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Mimir%22,%7B%22refId%22:%22A%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22node_cpu_seconds_total%22%7D%5D) metrics also show up now.
 
 There are two scrapes each sending metrics to one filter. Note the `job` label lists the full name of the scrape component.
 
 ## Multiple outputs
 
 ```river
-prometheus.scrape "first" {
+prometheus.scrape "agent" {
 	targets    = [{"__address__" = "localhost:12345"}]
 	forward_to = [prometheus.relabel.service.receiver]
 }
 
-prometheus.scrape "second" {
-	targets    = [{"__address__" = "localhost:12345"}]
+prometheus.integration.node_exporter {
+	set_collectors = ["cpu", "diskstats"]
+}
+
+prometheus.scrape "node" {
+	targets    = prometheus.integration.node_exporter.targets
 	forward_to = [prometheus.relabel.service.receiver]
 }
 
@@ -48,14 +50,20 @@ prometheus.relabel "service" {
 	rule {
 		source_labels = ["__name__"]
 		regex         = "(.+)"
-		replacement   = "service"
-		target_label  = "api_server"
+		replacement   = "api_server"
+		target_label  = "service"
 	}
 	forward_to = [prometheus.remote_write.prom.receiver]
 }
+
+prometheus.remote_write "prom" {
+	endpoint {
+		url = "http://mimir:9009/api/v1/push"
+	}
+}
 ```
 
-In the above Flow block, `prometheus.relabel.service` is being forwarded metrics from two sources `prometheus.scrape.first` and `prometheus.scrape.second`. This allows for a single relabel component to be used with any number of inputs.
+In the above Flow block, `prometheus.relabel.service` is being forwarded metrics from two sources `prometheus.scrape.agent` and `prometheus.scrape.node`. This allows for a single relabel component to be used with any number of inputs.
 
 ## Adding another relabel
 


### PR DESCRIPTION
Updated to use the node_exporter for a more "real" world usage when using multiple inputs. Kept using the agent metrics to keep the flow files as small as possible for the other examples.