### PR TITLE
docs/flow: use consistent placeholders

### DIFF
--- a/docs/sources/flow/concepts/configuration_language.md
+++ b/docs/sources/flow/concepts/configuration_language.md
@@ -39,7 +39,7 @@ River was designed with the following requirements in mind:
 ## Attributes
 
 _Attributes_ are used to configure individual settings. They always take the
-form of `<ATTRIBUTE_NAME> = <ATTRIBUTE_VALUE>`.
+form of `ATTRIBUTE_NAME = ATTRIBUTE_VALUE`.
 
 ```river
 log_level = "debug"

--- a/docs/sources/flow/config-language/_index.md
+++ b/docs/sources/flow/config-language/_index.md
@@ -28,15 +28,15 @@ local.file "my_file" {
 }
 
 // Pattern for creating a labeled block, which the above block follows:
-<BLOCK NAME> "<BLOCK LABEL>" {
+BLOCK_NAME "BLOCK_LABEL" {
   // Block body
-  <IDENTIFIER> = <EXPRESSION> // Attribute
+  IDENTIFIER = EXPRESSION // Attribute
 }
 
 // Pattern for creating an unlabeled block:
-<BLOCK NAME> {
+BLOCK_NAME {
   // Block body
-  <IDENTIFIER> = <EXPRESSION> // Attribute
+  IDENTIFIER = EXPRESSION // Attribute
 }
 ```
 

--- a/docs/sources/flow/config-language/syntax.md
+++ b/docs/sources/flow/config-language/syntax.md
@@ -35,7 +35,7 @@ The following example sets the `log_level` attribute to `"debug"`.
 log_level = "debug"
 ```
 
-All `ATTRIBUTE_NAME`s must be valid River [identifiers](#identifiers).
+The `ATTRIBUTE_NAME` must be a valid River [identifier](#identifier).
 
 The `ATTRIBUTE_VALUE` can be either a constant value of a valid River
 [type]({{< relref "./expressions/types_and_values.md" >}}) (eg. string,
@@ -48,8 +48,9 @@ grouping any number of attributes or nested blocks using curly braces.
 Blocks have a _name_, an optional _label_ and a body that contains any number
 of arguments and nested unlabeled blocks.
 
-```
-// Pattern for creating an unlabeled block:
+#### Pattern for creating an unlabeled block
+
+```river
 BLOCK_NAME {
   // Block body can contain attributes and nested unlabeled blocks
   IDENTIFIER = EXPRESSION // Attribute
@@ -58,7 +59,11 @@ BLOCK_NAME {
     // Nested block body
   }
 }
+```
 
+#### Pattern for creating a labeled block
+
+```river
 // Pattern for creating a labeled block:
 BLOCK_NAME "BLOCK_LABEL" {
   // Block body can contain attributes and nested unlabeled blocks
@@ -70,8 +75,10 @@ BLOCK_NAME "BLOCK_LABEL" {
 }
 ```
 
-The `<BLOCK_NAME>` has to be recognized by Flow as either a valid component
-name or a special block for configuring global settings. If the `<BLOCK_LABEL>`
+#### Block naming rules
+
+The `BLOCK_NAME` has to be recognized by Flow as either a valid component
+name or a special block for configuring global settings. If the `BLOCK_LABEL`
 has to be set, it must be a valid River [identifier](#identifiers) wrapped in
 double quotes. In these cases the label will be used to disambiguate between
 multiple top-level blocks of the same name.

--- a/docs/sources/flow/config-language/syntax.md
+++ b/docs/sources/flow/config-language/syntax.md
@@ -26,7 +26,7 @@ letters, digits or underscores, but doesn't start with a digit.
 
 ### Attributes
 _Attributes_ are used to configure individual settings. They always take the
-form of `<ATTRIBUTE_NAME> = <ATTRIBUTE_VALUE>`. They can appear either as
+form of `ATTRIBUTE_NAME = ATTRIBUTE_VALUE`. They can appear either as
 top-level elements or nested within blocks.
 
 The following example sets the `log_level` attribute to `"debug"`.
@@ -35,9 +35,9 @@ The following example sets the `log_level` attribute to `"debug"`.
 log_level = "debug"
 ```
 
-All `<ATTRIBUTE_NAME>`s must be valid River [identifiers](#identifiers).
+All `ATTRIBUTE_NAME`s must be valid River [identifiers](#identifiers).
 
-The `<ATTRIBUTE_VALUE>` can be either a constant value of a valid River
+The `ATTRIBUTE_VALUE` can be either a constant value of a valid River
 [type]({{< relref "./expressions/types_and_values.md" >}}) (eg. string,
 boolean, number) or an [_expression_]({{< relref "./expressions/_index.md" >}})
 to represent or compute more complex attribute values.
@@ -50,21 +50,21 @@ of arguments and nested unlabeled blocks.
 
 ```
 // Pattern for creating an unlabeled block:
-<BLOCK NAME> {
+BLOCK_NAME {
   // Block body can contain attributes and nested unlabeled blocks
-  <IDENTIFIER> = <EXPRESSION> // Attribute
+  IDENTIFIER = EXPRESSION // Attribute
 
-  <NESTED_BLOCK_NAME> {
+  NESTED_BLOCK_NAME {
     // Nested block body
   }
 }
 
 // Pattern for creating a labeled block:
-<BLOCK NAME> "<BLOCK LABEL>" {
+BLOCK_NAME "BLOCK_LABEL" {
   // Block body can contain attributes and nested unlabeled blocks
-  <IDENTIFIER> = <EXPRESSION> // Attribute
+  IDENTIFIER = EXPRESSION // Attribute
 
-  <NESTED_BLOCK_NAME> {
+  NESTED_BLOCK_NAME {
     // Nested block body
   }
 }

--- a/docs/sources/flow/reference/components/prometheus.integration.node_exporter.md
+++ b/docs/sources/flow/reference/components/prometheus.integration.node_exporter.md
@@ -1,7 +1,14 @@
 ---
+# NOTE(rfratto): the title below has zero-width spaces injected into it to
+# prevent it from overflowing the sidebar on the rendered site. Be careful when
+# modifying this section to retain the spaces.
+#
+# Ideally, in the future, we can fix the overflow issue with css rather than
+# injecting special characters.
+
 aliases:
 - /docs/agent/latest/flow/reference/components/prometheus.integration.node_exporter
-title: prometheus.&#8203;integration.&#8203;node_exporter
+title: prometheus.​integration.​node_exporter
 ---
 
 # prometheus.integration.node_exporter

--- a/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
+++ b/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
@@ -15,24 +15,25 @@ Grafana Agent is a telemetry collector with the primary goal of moving telemetry
 
 ## Run the example
 
-Run the following `curl https://raw.githubusercontent.com/grafana/agent/main/docs/sources/flow/tutorials/assets/runt.sh -O && bash ./runt.sh agent.flow`. 
+Run the following `curl https://raw.githubusercontent.com/grafana/agent/main/docs/sources/flow/tutorials/assets/runt.sh -O && bash ./runt.sh agent.flow`.
 
 The `runt.sh` script does:
 
-1. Downloads the configs necessary for Mimir, Grafana and the Grafana Agent. 
+1. Downloads the configs necessary for Mimir, Grafana and the Grafana Agent.
 2. Downloads the docker image for Grafana Agent explicitly.
 3. Runs the docker-compose up command to bring all the services up.
 
-Allow the Grafana Agent to run for two minutes, then navigate to [Grafana](http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Mimir%22,%7B%22refId%22:%22A%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22agent_build_info%7B%7D%22%7D%5D). 
+Allow the Grafana Agent to run for two minutes, then navigate to [Grafana](http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Mimir%22,%7B%22refId%22:%22A%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22agent_build_info%7B%7D%22%7D%5D).
 
 ![](../assets/agent_build_info.png)
 
 This example scrapes the Grafana Agent's `http://localhost:12345/metrics` endpoint and pushes those metrics to the Mimir instance.
 
-Navigate to `http://localhost:12345/graph` to view the Grafana Agent Flow UI. 
+Navigate to `http://localhost:12345/graph` to view the Grafana Agent Flow UI.
 
 ![](../assets/graph.png)
-The Agent displays the component pipeline in a dependency graph.  See [Scraping component](#scraping-component) and [Remote Write component](#remote-write-component) for details about the components used in this configuration. 
+
+The Agent displays the component pipeline in a dependency graph.  See [Scraping component](#scraping-component) and [Remote Write component](#remote-write-component) for details about the components used in this configuration.
 Click the nodes to navigate to the associated component page. There, you can view the state, health information, and, if applicable, the debug information.
 
 ![](../assets/comp_info.png)


### PR DESCRIPTION
Placeholders should be all-uppercase SNAKE_CASE with no other special characters denoting a placeholder (such as angle brackets).