### PR TITLE
CI: use cache option for actions/setup-go

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,20 +14,6 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: 1.18.0
-      id: go
-    - name: Determine Go cache directories
-      id: go-cache
-      run: |
-        echo "::set-output name=go-build::$(go env GOCACHE)"
-        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
-    - name: Restore Go cache
-      uses: actions/cache@v3.0.8
-      with:
-        path: |
-          ${{ steps.go-cache.outputs.go-build }}
-          ${{ steps.go-cache.outputs.go-mod }}
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        cache: true
     - name: Test
       run: make GO_TAGS="nodocker" test


### PR DESCRIPTION
I've noticed that there's some cache misses for the CI even though they should exist. I want to see if using the builtin cache option for actions/setup-go fixes our issues.