### PR TITLE
CI: run macOS tests when a push to main happens

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: Test
-on: [pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 jobs:
   test:
     name: Test


### PR DESCRIPTION
This makes sure macOS works against main, but more importantly it will create a reusable build cache, which is required for future PRs to be able to reuse the cache.

For details, refer to https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
