### PR TITLE
ci: automatically add new issues to Grafana Agent project board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,14 @@
+name: add-to-project
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/grafana/projects/269
+          github-token: ${{ secrets.ADD_TO_PROJECT_GH_TOKEN }}

--- a/component/otelcol/receiver/otlp/otlp_test.go
+++ b/component/otelcol/receiver/otlp/otlp_test.go
@@ -60,7 +60,7 @@ func Test(t *testing.T) {
 		request := func() error {
 			f, err := os.Open("testdata/payload.json")
 			require.NoError(t, err)
-			defer func() { _ = f.Close() }()
+			defer f.Close()
 
 			tracesURL := fmt.Sprintf("http://%s/v1/traces", httpAddr)
 			_, err = http.DefaultClient.Post(tracesURL, "application/json", f)


### PR DESCRIPTION
This PR adds a GitHub Action where new issues will automatically get added to the Grafana Agent project board. It uses [actions/add-to-project](https://github.com/actions/add-to-project) to work.