### PR TITLE
Grafana Agent traces Kubernetes support OTLP with HTTP protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,6 @@ Main (unreleased)
   traces, metrics, and logs. Data can then be forwarded to other `otelcol`
   components. (@rfratto)
 
-- Expose Grafana Agent traces Kubernetes with port 4318 to OTLP exporter sustain both gRPC and HTTP protocols. (@Eji4h)
-
 ### Features
 
 - Add `agentctl test-logs` command to allow testing log configurations by redirecting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Main (unreleased)
   traces, metrics, and logs. Data can then be forwarded to other `otelcol`
   components. (@rfratto)
 
+- Expose Grafana Agent traces Kubernetes with port 4318 to OTLP exporter sustain both gRPC and HTTP protocols. (@Eji4h)
+
 ### Features
 
 - Add `agentctl test-logs` command to allow testing log configurations by redirecting

--- a/production/kubernetes/agent-traces.yaml
+++ b/production/kubernetes/agent-traces.yaml
@@ -72,10 +72,14 @@ spec:
     port: 9411
     protocol: TCP
     targetPort: 9411
-  - name: grafana-agent-traces-otlp
+  - name: grafana-agent-traces-otlp-grpc
     port: 4317
     protocol: TCP
     targetPort: 4317
+  - name: grafana-agent-traces-otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
   - name: grafana-agent-traces-opencensus
     port: 55678
     protocol: TCP
@@ -133,7 +137,10 @@ spec:
           name: zipkin
           protocol: TCP
         - containerPort: 4317
-          name: otlp
+          name: otlp-grpc
+          protocol: TCP
+        - containerPort: 4318
+          name: otlp-http
           protocol: TCP
         - containerPort: 55678
           name: opencensus

--- a/production/kubernetes/build/templates/traces/main.jsonnet
+++ b/production/kubernetes/build/templates/traces/main.jsonnet
@@ -25,7 +25,8 @@ local newPort(name, portNumber, protocol='TCP') =
       newPort('zipkin', 9411, 'TCP'),
 
       // OTLP
-      newPort('otlp', 4317, 'TCP'),
+      newPort('otlp-grpc', 4317, 'TCP'),
+      newPort('otlp-http', 4318, 'TCP'),
 
       // Opencensus
       newPort('opencensus', 55678, 'TCP'),


### PR DESCRIPTION
#### PR Description
Expose Grafana Agent traces Kubernetes with port 4318 to OTLP exporter sustain both gRPC and HTTP protocols.

#### Which issue(s) this PR fixes
Fixes #2339

#### Notes to the Reviewer
I'm participating in Hactoberfest 2022 so If you Ok with the changes could you please add a "HACKTOBERFEST-ACCEPTED" label to it.

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
