### PR TITLE
Docs: reuse flow config blocks

### DIFF
--- a/docs/sources/flow/reference/components/otelcol.processor.batch.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.batch.md
@@ -72,20 +72,7 @@ output | [output][] | Configures where to send received telemetry data. | yes
 
 ### output block
 
-The `output` block configures a set of components to send batched telemetry
-data to.
-
-The following arguments are supported:
-
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`metrics` | `list(otelcol.Consumer)` | List of consumers to send metrics to. | `[]` | no
-`logs` | `list(otelcol.Consumer)` | List of consumers to send logs to. | `[]` | no
-`traces` | `list(otelcol.Consumer)` | List of consumers to send traces to. | `[]` | no
-
-The `output` block must be specified, but all of its arguments are optional. By
-default, telemetry data is dropped. To send telemetry data to other components,
-configure the `metrics`, `logs`, and `traces` arguments accordingly.
+{{< docs/shared lookup="flow/otelcol/output-block.md" source="agent" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.jaeger.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.jaeger.md
@@ -226,21 +226,7 @@ Name | Type | Description | Default | Required
 
 ### output block
 
-The `output` block configures a set of components to send received telemetry
-data to.
-
-The following arguments are supported:
-
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`metrics` | `list(otelcol.Consumer)` | List of consumers to send metrics to. | `[]` | no
-`logs` | `list(otelcol.Consumer)` | List of consumers to send logs to. | `[]` | no
-`traces` | `list(otelcol.Consumer)` | List of consumers to send traces to. | `[]` | no
-
-The `output` block must be specified, but all of its arguments are optional. By
-default, telemetry data will be dropped. To send telemetry data to other
-components, configure the `metrics`, `logs`, and `traces` arguments
-accordingly.
+{{< docs/shared lookup="flow/otelcol/output-block.md" source="agent" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.otlp.md
@@ -172,21 +172,7 @@ If `allowed_headers` includes `"*"`, all headers will be permitted.
 
 ### output block
 
-The `output` block configures a set of components to send received telemetry
-data to.
-
-The following arguments are supported:
-
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`metrics` | `list(otelcol.Consumer)` | List of consumers to send metrics to. | `[]` | no
-`logs` | `list(otelcol.Consumer)` | List of consumers to send logs to. | `[]` | no
-`traces` | `list(otelcol.Consumer)` | List of consumers to send traces to. | `[]` | no
-
-The `output` block must be specified, but all of its arguments are optional. By
-default, telemetry data will be dropped. To send telemetry data to other
-components, configure the `metrics`, `logs`, and `traces` arguments
-accordingly.
+{{< docs/shared lookup="flow/otelcol/output-block.md" source="agent" >}}
 
 ## Exported fields
 

--- a/docs/sources/shared/flow/otelcol/output-block.md
+++ b/docs/sources/shared/flow/otelcol/output-block.md
@@ -1,0 +1,20 @@
+---
+headless: true
+aliases:
+  - /docs/agent/latest/shared/flow/otelcol/output-block/
+---
+
+The `output` block configures a set of components to forward resulting
+telemetry data to.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`metrics` | `list(otelcol.Consumer)` | List of consumers to send metrics to. | `[]` | no
+`logs` | `list(otelcol.Consumer)` | List of consumers to send logs to. | `[]` | no
+`traces` | `list(otelcol.Consumer)` | List of consumers to send traces to. | `[]` | no
+
+The `output` block must be specified, but all of its arguments are optional. By
+default, telemetry data is dropped. To send telemetry data to other components,
+configure the `metrics`, `logs`, and `traces` arguments accordingly.

--- a/docs/sources/shared/index.md
+++ b/docs/sources/shared/index.md
@@ -1,0 +1,6 @@
+---
+headless: true
+aliases:
+  - /docs/agent/latest/shared/
+---
+


### PR DESCRIPTION
This PR headless pages to reuse Flow config blocks.

To view locally, run `make docs` from docs/ and look at an example page using the new shared snippet: http://localhost:3002/docs/agent/latest/flow/reference/components/otelcol.processor.batch/#output-block