### PR TITLE
otelcol.exporter.otlp: new component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ Main (unreleased)
   `otelcol` components before forwarding it to other `otelcol` components.
   (@rfratto)
 
+- Flow: add `otelcol.exporter.otlp` component which accepts data from `otelcol`
+  components and sends it a gRPC server using the OTLP protocol. (@rfratto)
+
 ### Features
 
 - Add `agentctl test-logs` command to allow testing log configurations by redirecting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Main (unreleased)
   (@rfratto)
 
 - Flow: add `otelcol.exporter.otlp` component which accepts data from `otelcol`
-  components and sends it a gRPC server using the OTLP protocol. (@rfratto)
+  components and sends it to a gRPC server using the OTLP protocol. (@rfratto)
 
 ### Features
 

--- a/component/all/all.go
+++ b/component/all/all.go
@@ -5,6 +5,7 @@ import (
 	_ "github.com/grafana/agent/component/discovery/kubernetes"                 // Import discovery.kubernetes
 	_ "github.com/grafana/agent/component/discovery/relabel"                    // Import discovery.relabel
 	_ "github.com/grafana/agent/component/local/file"                           // Import local.file
+	_ "github.com/grafana/agent/component/otelcol/exporter/otlp"                // Import otelcol.exporter.otlp
 	_ "github.com/grafana/agent/component/otelcol/processor/batch"              // Import otelcol.processor.batch
 	_ "github.com/grafana/agent/component/otelcol/receiver/otlp"                // Import otelcol.receiver.otlp
 	_ "github.com/grafana/agent/component/prometheus/integration/node_exporter" // Import prometheus.integration.node_exporter

--- a/component/otelcol/config_compression.go
+++ b/component/otelcol/config_compression.go
@@ -1,0 +1,59 @@
+package otelcol
+
+import (
+	"encoding"
+	"fmt"
+
+	"go.opentelemetry.io/collector/config/configcompression"
+)
+
+// CompressionType represents a mechanism used to compress data.
+type CompressionType string
+
+// Supported values for compression
+const (
+	CompressionTypeGzip    CompressionType = "gzip"
+	CompressionTypeZlib    CompressionType = "zlib"
+	CompressionTypeDeflate CompressionType = "deflate"
+	CompressionTypeSnappy  CompressionType = "snappy"
+	CompressionTypeZstd    CompressionType = "zstd"
+	CompressionTypeNone    CompressionType = "none"
+	CompressionTypeEmpty   CompressionType = ""
+)
+
+var _ encoding.TextUnmarshaler = (*CompressionType)(nil)
+
+// UnmarshalText converts a string into a CompressionType. Returns an error if
+// the string is invalid.
+func (ct *CompressionType) UnmarshalText(in []byte) error {
+	switch typ := CompressionType(in); typ {
+	case CompressionTypeGzip, CompressionTypeZlib, CompressionTypeDeflate,
+		CompressionTypeSnappy, CompressionTypeZstd, CompressionTypeNone, CompressionTypeEmpty:
+
+		*ct = typ
+		return nil
+	default:
+		return fmt.Errorf("unrecognized compression type %q", typ)
+	}
+}
+
+var compressionMappings = map[CompressionType]configcompression.CompressionType{
+	CompressionTypeGzip:    configcompression.Gzip,
+	CompressionTypeZlib:    configcompression.Zlib,
+	CompressionTypeDeflate: configcompression.Deflate,
+	CompressionTypeSnappy:  configcompression.Snappy,
+	CompressionTypeZstd:    configcompression.Zstd,
+	CompressionTypeNone:    configcompression.CompressionType("none"),
+	CompressionTypeEmpty:   configcompression.CompressionType(""),
+}
+
+// Convert converts ct into the upstream type.
+func (ct CompressionType) Convert() configcompression.CompressionType {
+	upstream, ok := compressionMappings[ct]
+	if !ok {
+		// This line should never hit unless compressionMappings wasn't updated
+		// when the list of valid options was extended.
+		panic("missing entry in compressionMappings table for " + string(ct))
+	}
+	return upstream
+}

--- a/component/otelcol/config_grpc.go
+++ b/component/otelcol/config_grpc.go
@@ -172,9 +172,9 @@ func (args *GRPCClientArguments) Convert() *otelconfiggrpc.GRPCClientSettings {
 // KeepaliveClientArguments holds shared keepalive settings for components
 // which launch clients.
 type KeepaliveClientArguments struct {
-	Time                time.Duration `river:"time,attr,optional"`
-	Timeout             time.Duration `river:"timeout,attr,optional"`
-	PermitWithoutStream bool          `river:"permit_without_stream,attr,optional"`
+	PingWait            time.Duration `river:"ping_wait,attr,optional"`
+	PingResponseTimeout time.Duration `river:"ping_response_timeout,attr,optional"`
+	PingWithoutStream   bool          `river:"ping_without_stream,attr,optional"`
 }
 
 // Convert converts args into the upstream type.
@@ -184,8 +184,8 @@ func (args *KeepaliveClientArguments) Convert() *otelconfiggrpc.KeepaliveClientC
 	}
 
 	return &otelconfiggrpc.KeepaliveClientConfig{
-		Time:                args.Time,
-		Timeout:             args.Timeout,
-		PermitWithoutStream: args.PermitWithoutStream,
+		Time:                args.PingWait,
+		Timeout:             args.PingResponseTimeout,
+		PermitWithoutStream: args.PingWithoutStream,
 	}
 }

--- a/component/otelcol/config_grpc.go
+++ b/component/otelcol/config_grpc.go
@@ -121,3 +121,71 @@ func (args *KeepaliveEnforcementPolicy) Convert() *otelconfiggrpc.KeepaliveEnfor
 		PermitWithoutStream: args.PermitWithoutStream,
 	}
 }
+
+// GRPCClientArguments holds shared gRPC settings for components which launch
+// gRPC clients.
+type GRPCClientArguments struct {
+	Endpoint string `river:"endpoint,attr"`
+
+	Compression CompressionType `river:"compression,attr,optional"`
+
+	TLS       TLSClientArguments        `river:"tls,block,optional"`
+	Keepalive *KeepaliveClientArguments `river:"keepalive,block,optional"`
+
+	ReadBufferSize  units.Base2Bytes  `river:"read_buffer_size,attr,optional"`
+	WriteBufferSize units.Base2Bytes  `river:"write_buffer_size,attr,optional"`
+	WaitForReady    bool              `river:"wait_for_ready,attr,optional"`
+	Headers         map[string]string `river:"headers,attr,optional"`
+	BalancerName    string            `river:"balancer_name,attr,optional"`
+
+	// TODO(rfratto): auth
+	//
+	// Figuring out how to do authentication isn't very straightforward here. The
+	// auth section links to an authenticator extension.
+	//
+	// We will need to generally figure out how we want to provide common
+	// authentication extensions to all of our components.
+}
+
+// Convert converts args into the upstream type.
+func (args *GRPCClientArguments) Convert() *otelconfiggrpc.GRPCClientSettings {
+	if args == nil {
+		return nil
+	}
+
+	return &otelconfiggrpc.GRPCClientSettings{
+		Endpoint: args.Endpoint,
+
+		Compression: args.Compression.Convert(),
+
+		TLSSetting: *args.TLS.Convert(),
+		Keepalive:  args.Keepalive.Convert(),
+
+		ReadBufferSize:  int(args.ReadBufferSize),
+		WriteBufferSize: int(args.WriteBufferSize),
+		WaitForReady:    args.WaitForReady,
+		Headers:         args.Headers,
+		BalancerName:    args.BalancerName,
+	}
+}
+
+// KeepaliveClientArguments holds shared keepalive settings for components
+// which launch clients.
+type KeepaliveClientArguments struct {
+	Time                time.Duration `river:"time,attr,optional"`
+	Timeout             time.Duration `river:"timeout,attr,optional"`
+	PermitWithoutStream bool          `river:"permit_without_stream,attr,optional"`
+}
+
+// Convert converts args into the upstream type.
+func (args *KeepaliveClientArguments) Convert() *otelconfiggrpc.KeepaliveClientConfig {
+	if args == nil {
+		return nil
+	}
+
+	return &otelconfiggrpc.KeepaliveClientConfig{
+		Time:                args.Time,
+		Timeout:             args.Timeout,
+		PermitWithoutStream: args.PermitWithoutStream,
+	}
+}

--- a/component/otelcol/config_queue.go
+++ b/component/otelcol/config_queue.go
@@ -1,0 +1,70 @@
+package otelcol
+
+import (
+	"fmt"
+
+	"github.com/grafana/agent/pkg/river"
+	otelexporterhelper "go.opentelemetry.io/collector/exporter/exporterhelper"
+)
+
+// QueueArguments holds shared settings for components which can queue
+// requests.
+type QueueArguments struct {
+	Enabled      bool `river:"enabled,attr,optional"`
+	NumConsumers int  `river:"num_consumers,attr,optional"`
+	QueueSize    int  `river:"queue_size,attr,optional"`
+
+	// TODO(rfratto): queues can send to persistent storage through an extension.
+}
+
+var _ river.Unmarshaler = (*QueueArguments)(nil)
+
+// DefaultQueueArguments holds default settings for QueueArguments.
+var DefaultQueueArguments = QueueArguments{
+	Enabled:      true,
+	NumConsumers: 10,
+
+	// Copied from [upstream]:
+	//
+	// 5000 queue elements at 100 requests/sec gives about 50 seconds of survival
+	// of destination outage. This is a pretty decent value for production. Users
+	// should calculate this from the perspective of how many seconds to buffer
+	// in case of a backend outage and multiply that by the number of requests
+	// per second.
+	//
+	// [upstream]: https://github.com/open-telemetry/opentelemetry-collector/blob/ff73e49f74d8fd8c57a849aa3ff23ae1940cc16a/exporter/exporterhelper/queued_retry.go#L62-L65
+	QueueSize: 5000,
+}
+
+// UnmarshalRiver implements river.Unmarshaler.
+func (args *QueueArguments) UnmarshalRiver(f func(interface{}) error) error {
+	*args = DefaultQueueArguments
+	type arguments QueueArguments
+	return f((*arguments)(args))
+}
+
+// Convert converts args into the upstream type.
+func (args *QueueArguments) Convert() *otelexporterhelper.QueueSettings {
+	if args == nil {
+		return nil
+	}
+
+	return &otelexporterhelper.QueueSettings{
+		Enabled:      args.Enabled,
+		NumConsumers: args.NumConsumers,
+		QueueSize:    args.QueueSize,
+	}
+}
+
+// Validate returns an error if args is invalid.
+func (args *QueueArguments) Validate() error {
+	if args == nil || !args.Enabled {
+		return nil
+	}
+
+	if args.QueueSize <= 0 {
+		return fmt.Errorf("queue_size must be greater than zero")
+	}
+
+	return nil
+}

--- a/component/otelcol/config_retry.go
+++ b/component/otelcol/config_retry.go
@@ -1,0 +1,48 @@
+package otelcol
+
+import (
+	"time"
+
+	"github.com/grafana/agent/pkg/river"
+	otelexporterhelper "go.opentelemetry.io/collector/exporter/exporterhelper"
+)
+
+// RetryArguments holds shared settings for components which can retry
+// requests.
+type RetryArguments struct {
+	Enabled         bool          `river:"enabled,attr,optional"`
+	InitialInterval time.Duration `river:"initial_interval,attr,optional"`
+	MaxInterval     time.Duration `river:"max_interval,attr,optional"`
+	MaxElapsedTime  time.Duration `river:"max_elapsed_time,attr,optional"`
+}
+
+var _ river.Unmarshaler = (*RetryArguments)(nil)
+
+// DefaultRetryArguments holds default settings for RetryArguments.
+var DefaultRetryArguments = RetryArguments{
+	Enabled:         true,
+	InitialInterval: 5 * time.Second,
+	MaxInterval:     30 * time.Second,
+	MaxElapsedTime:  5 * time.Minute,
+}
+
+// UnmarshalRiver implements river.Unmarshaler.
+func (args *RetryArguments) UnmarshalRiver(f func(interface{}) error) error {
+	*args = DefaultRetryArguments
+	type arguments RetryArguments
+	return f((*arguments)(args))
+}
+
+// Convert converts args into the upstream type.
+func (args *RetryArguments) Convert() *otelexporterhelper.RetrySettings {
+	if args == nil {
+		return nil
+	}
+
+	return &otelexporterhelper.RetrySettings{
+		Enabled:         args.Enabled,
+		InitialInterval: args.InitialInterval,
+		MaxInterval:     args.MaxInterval,
+		MaxElapsedTime:  args.MaxElapsedTime,
+	}
+}

--- a/component/otelcol/config_timeout.go
+++ b/component/otelcol/config_timeout.go
@@ -1,0 +1,7 @@
+package otelcol
+
+import "time"
+
+// DefaultTimeout holds the default timeout used for components which can time
+// out from requests.
+var DefaultTimeout = 5 * time.Second

--- a/component/otelcol/config_tls.go
+++ b/component/otelcol/config_tls.go
@@ -36,3 +36,40 @@ func (args *TLSServerArguments) Convert() *otelconfigtls.TLSServerSetting {
 		ClientCAFile: args.ClientCAFile,
 	}
 }
+
+// TLSClientArguments holds shared TLS settings for components which launch
+// TLS clients.
+type TLSClientArguments struct {
+	CAFile         string        `river:"ca_file,attr,optional"`
+	CertFile       string        `river:"cert_file,attr,optional"`
+	KeyFile        string        `river:"key_file,attr,optional"`
+	MinVersion     string        `river:"min_version,attr,optional"`
+	MaxVersion     string        `river:"max_version,attr,optional"`
+	ReloadInterval time.Duration `river:"reload_interval,attr,optional"`
+
+	Insecure           bool   `river:"insecure,attr,optional"`
+	InsecureSkipVerify bool   `river:"insecure_skip_verify,attr,optional"`
+	ServerName         string `river:"server_name,attr,optional"`
+}
+
+// Convert converts args into the upstream type.
+func (args *TLSClientArguments) Convert() *otelconfigtls.TLSClientSetting {
+	if args == nil {
+		return nil
+	}
+
+	return &otelconfigtls.TLSClientSetting{
+		TLSSetting: otelconfigtls.TLSSetting{
+			CAFile:         args.CAFile,
+			CertFile:       args.CertFile,
+			KeyFile:        args.KeyFile,
+			MinVersion:     args.MinVersion,
+			MaxVersion:     args.MaxVersion,
+			ReloadInterval: args.ReloadInterval,
+		},
+
+		Insecure:           args.Insecure,
+		InsecureSkipVerify: args.InsecureSkipVerify,
+		ServerName:         args.ServerName,
+	}
+}

--- a/component/otelcol/exporter/otlp/otlp.go
+++ b/component/otelcol/exporter/otlp/otlp.go
@@ -1,0 +1,102 @@
+// Package otlp provides an otelcol.exporter.otlp component.
+package otlp
+
+import (
+	"time"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otelcol"
+	"github.com/grafana/agent/component/otelcol/exporter"
+	"github.com/grafana/agent/pkg/river"
+	otelcomponent "go.opentelemetry.io/collector/component"
+	otelconfig "go.opentelemetry.io/collector/config"
+	otelpexporterhelper "go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/exporter/otlpexporter"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:    "otelcol.exporter.otlp",
+		Args:    Arguments{},
+		Exports: otelcol.ConsumerExports{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			fact := otlpexporter.NewFactory()
+			return exporter.New(opts, fact, args.(Arguments))
+		},
+	})
+}
+
+// Arguments configures the otelcol.exporter.otlp component.
+type Arguments struct {
+	Timeout time.Duration `river:"timeout,attr,optional"`
+
+	Queue otelcol.QueueArguments `river:"sending_queue,block,optional"`
+	Retry otelcol.RetryArguments `river:"retry_on_failure,block,optional"`
+
+	Client GRPCClientArguments `river:"client,block"`
+}
+
+var (
+	_ river.Unmarshaler  = (*Arguments)(nil)
+	_ exporter.Arguments = Arguments{}
+)
+
+// DefaultArguments holds default values for Arguments.
+var DefaultArguments = Arguments{
+	Timeout: otelcol.DefaultTimeout,
+	Queue:   otelcol.DefaultQueueArguments,
+	Retry:   otelcol.DefaultRetryArguments,
+	Client:  DefaultGRPCClientArguments,
+}
+
+// UnmarshalRiver implements river.Unmarshaler.
+func (args *Arguments) UnmarshalRiver(f func(interface{}) error) error {
+	*args = DefaultArguments
+	type arguments Arguments
+	return f((*arguments)(args))
+}
+
+// Convert implements exporter.Arguments.
+func (args Arguments) Convert() otelconfig.Exporter {
+	return &otlpexporter.Config{
+		ExporterSettings: otelconfig.NewExporterSettings(otelconfig.NewComponentID("otlp")),
+		TimeoutSettings: otelpexporterhelper.TimeoutSettings{
+			Timeout: args.Timeout,
+		},
+		QueueSettings:      *args.Queue.Convert(),
+		RetrySettings:      *args.Retry.Convert(),
+		GRPCClientSettings: *(*otelcol.GRPCClientArguments)(&args.Client).Convert(),
+	}
+}
+
+// Extensions implements exporter.Arguments.
+func (args Arguments) Extensions() map[otelconfig.ComponentID]otelcomponent.Extension {
+	return nil
+}
+
+// Exporters implements exporter.Arguments.
+func (args Arguments) Exporters() map[otelconfig.DataType]map[otelconfig.ComponentID]otelcomponent.Exporter {
+	return nil
+}
+
+// GRPCClientArguments is used to configure otelcol.exporter.otlp with
+// component-specific defaults.
+type GRPCClientArguments otelcol.GRPCClientArguments
+
+var _ river.Unmarshaler = (*GRPCClientArguments)(nil)
+
+// DefaultGRPCClientArguments holds component-specific default settings for
+// GRPCClientArguments.
+var DefaultGRPCClientArguments = GRPCClientArguments{
+	Headers:         map[string]string{},
+	Compression:     otelcol.CompressionTypeGzip,
+	WriteBufferSize: 512 * 1024,
+}
+
+// UnmarshalRiver implements river.Unmarshaler and supplies defaults.
+func (args *GRPCClientArguments) UnmarshalRiver(f func(interface{}) error) error {
+	*args = DefaultGRPCClientArguments
+	type arguments GRPCClientArguments
+	return f((*arguments)(args))
+}

--- a/component/otelcol/exporter/otlp/otlp_test.go
+++ b/component/otelcol/exporter/otlp/otlp_test.go
@@ -1,0 +1,138 @@
+package otlp_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/component/otelcol"
+	"github.com/grafana/agent/component/otelcol/exporter/otlp"
+	"github.com/grafana/agent/pkg/flow/componenttest"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/grafana/agent/pkg/util"
+	"github.com/grafana/dskit/backoff"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"google.golang.org/grpc"
+)
+
+// Test performs a basic integration test which runs the otelcol.exporter.otlp
+// component and ensures that it can pass data to an OTLP gRPC server.
+func Test(t *testing.T) {
+	traceCh := make(chan ptrace.Traces)
+	tracesServer := makeTracesServer(t, traceCh)
+
+	ctx := componenttest.TestContext(t)
+	l := util.TestLogger(t)
+
+	ctrl, err := componenttest.NewControllerFromID(l, "otelcol.exporter.otlp")
+	require.NoError(t, err)
+
+	cfg := fmt.Sprintf(`
+		timeout = "1s"
+
+		client {
+			endpoint = "%s"
+
+			compression = "none"
+
+			tls {
+				insecure             = true
+				insecure_skip_verify = true
+			}
+		}
+	`, tracesServer)
+	var args otlp.Arguments
+	require.NoError(t, river.Unmarshal([]byte(cfg), &args))
+
+	go func() {
+		err := ctrl.Run(ctx, args)
+		require.NoError(t, err)
+	}()
+
+	require.NoError(t, ctrl.WaitRunning(time.Second), "component never started")
+	require.NoError(t, ctrl.WaitExports(time.Second), "component never exported anything")
+
+	// Send traces in the background to our exporter.
+	go func() {
+		exports := ctrl.Exports().(otelcol.ConsumerExports)
+
+		bo := backoff.New(ctx, backoff.Config{
+			MinBackoff: 10 * time.Millisecond,
+			MaxBackoff: 100 * time.Millisecond,
+		})
+		for bo.Ongoing() {
+			err := exports.Input.ConsumeTraces(ctx, createTestTraces())
+			if err != nil {
+				level.Error(l).Log("msg", "failed to send traces", "err", err)
+				bo.Wait()
+				continue
+			}
+
+			return
+		}
+	}()
+
+	// Wait for our exporter to finish and pass data to our HTTP server.
+	select {
+	case <-time.After(time.Second):
+		require.FailNow(t, "failed waiting for traces")
+	case tr := <-traceCh:
+		require.Equal(t, 1, tr.SpanCount())
+	}
+}
+
+// makeTracesServer returns a host:port which will accept traces over insecure
+// gRPC.
+func makeTracesServer(t *testing.T, ch chan ptrace.Traces) string {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := grpc.NewServer()
+	ptraceotlp.RegisterServer(srv, &mockTracesReceiver{ch: ch})
+
+	go func() {
+		err := srv.Serve(lis)
+		require.NoError(t, err)
+	}()
+	t.Cleanup(srv.Stop)
+
+	return lis.Addr().String()
+}
+
+type mockTracesReceiver struct {
+	ch chan ptrace.Traces
+}
+
+var _ ptraceotlp.GRPCServer = (*mockTracesReceiver)(nil)
+
+func (ms *mockTracesReceiver) Export(_ context.Context, req ptraceotlp.Request) (ptraceotlp.Response, error) {
+	ms.ch <- req.Traces()
+	return ptraceotlp.NewResponse(), nil
+}
+
+func createTestTraces() ptrace.Traces {
+	// Matches format from the protobuf definition:
+	// https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/trace/v1/trace.proto
+	var bb = `{
+		"resource_spans": [{
+			"scope_spans": [{
+				"spans": [{
+					"name": "TestSpan"
+				}]
+			}]
+		}]
+	}`
+
+	data, err := ptrace.NewJSONUnmarshaler().UnmarshalTraces([]byte(bb))
+	if err != nil {
+		panic(err)
+	}
+	return data
+}

--- a/component/otelcol/processor/batch/batch.go
+++ b/component/otelcol/processor/batch/batch.go
@@ -16,8 +16,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "otelcol.processor.batch",
-		Args: Arguments{},
+		Name:    "otelcol.processor.batch",
+		Args:    Arguments{},
+		Exports: otelcol.ConsumerExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := batchprocessor.NewFactory()

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
@@ -41,7 +41,7 @@ The following blocks are supported inside the definition of
 
 Hierarchy | Block | Description | Required
 --------- | ----- | ----------- | --------
-client | [client][] | Configures the gRPC server to send telemetry data to. | **yes**
+client | [client][] | Configures the gRPC server to send telemetry data to. | yes
 client > tls | [tls][] | Configures TLS for the gRPC client. | no
 client > keepalive | [keepalive][] | Configures keepalive settings for the gRPC client. | no
 queue | [queue][] | Configures batching of data before sending. | no
@@ -64,15 +64,15 @@ The following arguments are supported:
 
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`endpoint` | `string` | `host:port` to send telemetry data to. | | **yes**
+`endpoint` | `string` | `host:port` to send telemetry data to. | | yes
 `compression` | `string` | Compression mechanism to use for requests. | `"gzip"` | no
-`read_buffer_size` | `string` | Size of the read buffer the gRPC client will use for reading server responses. | | no
-`write_buffer_size` | `string` | Size of the write buffer the gRPC client will use for writing requests. | `"512KiB"` | no
+`read_buffer_size` | `string` | Size of the read buffer the gRPC client to use for reading server responses. | | no
+`write_buffer_size` | `string` | Size of the write buffer the gRPC client to use for writing requests. | `"512KiB"` | no
 `wait_for_ready` | `boolean` | Waits for gRPC connection to be in the `READY` state before sending data. | `false` | no
 `headers` | `map(string)` | Additional headers to send with the request. | `{}` | no
 `balancer_name` | `string` | Which gRPC client-side load balancer to use for requests. | | no
 
-By default, requests will be compressed with gzip. The `compression` argument
+By default, requests are compressed with gzip. The `compression` argument
 controls which compression mechanism to use. Supported strings are:
 
 * `"gzip"`
@@ -81,8 +81,8 @@ controls which compression mechanism to use. Supported strings are:
 * `"snappy"`
 * `"zstd"`
 
-If `compression` is set to `"none"` or an empty string `""`, no compression
-will be used.
+If `compression` is set to `"none"` or an empty string `""`, no compression is
+used.
 
 The `balancer_name` argument controls what client-side load balancing mechanism
 to use. See the gRPC documentation on [Load balancing][] for more information.
@@ -135,13 +135,13 @@ The following arguments are supported:
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `enabled` | `boolean` | Enables an in-memory buffer before sending data to the client. | `true` | no
-`num_consumers` | `number` | Number of readers which will send batches written to the queue in parallel. | `10` | no
+`num_consumers` | `number` | Number of readers to send batches written to the queue in parallel. | `10` | no
 `queue_size` | `number` | Maximum number of unwritten batches allowed in the queue at once. | `5000` | no
 
-When `enabled` is `true`, data will first be written to an in-memory buffer
-before sending it to the configured gRPC server. Batches sent to the
-component's `input` exported field will be added to the buffer as long as the
-number of unsent batches does not exceed the configured `queue_size`.
+When `enabled` is `true`, data is first written to an in-memory buffer before
+sending it to the configured gRPC server. Batches sent to the component's
+`input` exported field are added to the buffer as long as the number of unsent
+batches does not exceed the configured `queue_size`.
 
 `queue_size` is used to determine how long an endpoint outage is tolerated for.
 Assuming 100 requests/second, the default queue size `5000` provides about 50
@@ -149,13 +149,13 @@ seconds of outage tolerance. To calculate the correct value for `queue_size`,
 multiply the average number of outgoing requests per second by the amount of
 time in seconds outages should be tolerated for.
 
-The `num_consumers` argument controls how many readers will read from the
-buffer and send data in parallel. Larger values of `num_consumers` will allow
-to send data more quickly at the expense of increased network traffic.
+The `num_consumers` argument controls how many readers read from the buffer and
+send data in parallel. Larger values of `num_consumers` allow data to be sent
+more quickly at the expense of increased network traffic.
 
 ### retry block
 
-The `retry` block configures how failed requests to the gRPC server will be
+The `retry` block configures how failed requests to the gRPC server are
 retried.
 
 The following arguments are supported:
@@ -167,11 +167,11 @@ Name | Type | Description | Default | Required
 `max_interval` | `duration` | Maximum time to wait between retries. | `"30s"` | no
 `max_elapsed_time` | `duration` | Maximum amount of time to wait before discarding a failed batch. | `"5m"` | no
 
-When `enabled` is `true`, failed batches will be retried after a given
-interval. The `initial_interval` argument specifies how long to wait before the
-first retry attempt. If requests continue to fail, the time to wait before
-retrying will exponentially increase. The `max_interval` argument specifies the
-upper bound of how long to wait in between retries.
+When `enabled` is `true`, failed batches are retried after a given interval.
+The `initial_interval` argument specifies how long to wait before the first
+retry attempt. If requests continue to fail, the time to wait before retrying
+increases exponentially. The `max_interval` argument specifies the upper bound
+of how long to wait between retries.
 
 If a batch has not sent successfully, it is discarded after the time specified
 by `max_elapsed_time` elapses. If `max_elapsed_time` is set to `"0s"`, failed

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
@@ -121,9 +121,9 @@ The following arguments are supported:
 
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`time` | `duration` | How often to ping the server after no activity. | | no
-`timeout` | `duration` | Time to wait before closing inactive connections if the server does not respond to a ping. | | no
-`permit_without_stream` | `boolean` | Send pings even if there is no active stream request. | | no
+`ping_wait` | `duration` | How often to ping the server after no activity. | | no
+`ping_response_timeout` | `duration` | Time to wait before closing inactive connections if the server does not respond to a ping. | | no
+`ping_without_stream` | `boolean` | Send pings even if there is no active stream request. | | no
 
 ### queue block
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
@@ -1,0 +1,199 @@
+---
+aliases:
+- /docs/agent/latest/flow/reference/components/otelcol.exporter.otlp
+title: otelcol.exporter.otlp
+---
+
+# otelcol.exporter.otlp
+
+`otelcol.exporter.otlp` accepts telemetry data from other `otelcol` components
+and writes them over the network using the OTLP gRPC protocol.
+
+> **NOTE**: `otelcol.exporter.otlp` is a wrapper over the upstream
+> OpenTelemetry Collector `otlp` exporter. Bug reports or feature requests may
+> be redirected to the upstream repository.
+
+Multiple `otelcol.exporter.otlp` components can be specified by giving them
+different labels.
+
+## Usage
+
+```river
+otelcol.exporter.otlp "LABEL" {
+  client {
+    endpoint = "HOST:PORT"
+  }
+}
+```
+
+## Arguments
+
+`otelcol.exporter.otlp` supports the following arguments:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`timeout` | `duration` | Time to wait before marking a request as failed. | `"5s"` | no
+
+## Blocks
+
+The following blocks are supported inside the definition of
+`otelcol.exporter.otlp`:
+
+Hierarchy | Block | Description | Required
+--------- | ----- | ----------- | --------
+client | [client][] | Configures the gRPC server to send telemetry data to. | **yes**
+client > tls | [tls][] | Configures TLS for the gRPC client. | no
+client > keepalive | [keepalive][] | Configures keepalive settings for the gRPC client. | no
+queue | [queue][] | Configures batching of data before sending. | no
+retry | [retry][] | Configures retry mechanism for failed requests. | no
+
+The `>` symbol indicates deeper levels of nesting. For example, `client > tls`
+refers to a `tls` block defined inside a `client` block.
+
+[client]: #client-block
+[tls]: #tls-block
+[keepalive]: #keepalive-block
+[queue]: #queue-block
+[retry]: #retry-block
+
+### client block
+
+The `client` block configures the gRPC client used by the component.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`endpoint` | `string` | `host:port` to send telemetry data to. | | **yes**
+`compression` | `string` | Compression mechanism to use for requests. | `"gzip"` | no
+`read_buffer_size` | `string` | Size of the read buffer the gRPC client will use for reading server responses. | | no
+`write_buffer_size` | `string` | Size of the write buffer the gRPC client will use for writing requests. | `"512KiB"` | no
+`wait_for_ready` | `boolean` | Waits for gRPC connection to be in the `READY` state before sending data. | `false` | no
+`headers` | `map(string)` | Additional headers to send with the request. | `{}` | no
+`balancer_name` | `string` | Which gRPC client-side load balancer to use for requests. | | no
+
+By default, requests will be compressed with gzip. The `compression` argument
+controls which compression mechanism to use. Supported strings are:
+
+* `"gzip"`
+* `"zlib"`
+* `"deflate"`
+* `"snappy"`
+* `"zstd"`
+
+If `compression` is set to `"none"` or an empty string `""`, no compression
+will be used.
+
+The `balancer_name` argument controls what client-side load balancing mechanism
+to use. See the gRPC documentation on [Load balancing][] for more information.
+When unspecified, `pick_first` is used.
+
+[Load balancing]: https://github.com/grpc/grpc-go/blob/master/examples/features/load_balancing/README.md#pick_first
+
+### tls block
+
+The `tls` block configures TLS settings used for the connection to the gRPC
+server.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`ca_file` | `string` | Path to the CA file. | | no
+`cert_file` | `string` | Path to the TLS certificate. | | no
+`key_file` | `string` | Path to the TLS certificate key. | | no
+`min_version` | `string` | Minimum acceptable TLS version for connections. | `"TLS 1.2"` | no
+`max_version` | `string` | Maximum acceptable TLS version for connections. | `"TLS 1.3"` | no
+`insecure` | `boolean` | Disables TLS when connecting to the gRPC server. | | no
+`insecure_skip_verify` | `boolean` | Ignores insecure server TLS sertificates. | | no
+`server_name` | `string` | Verifies the hostname of server certificates when set. | | no
+
+The `tls` block should always be provided, even if the server doesn't support
+TLS. To disable `tls` for connections to the gRPC server, set the `insecure`
+argument to `true`.
+
+### keepalive block
+
+The `keepalive` block configures keepalive settings for gRPC client
+connections.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`time` | `duration` | How often to ping the server after no activity. | | no
+`timeout` | `duration` | Time to wait before closing inactive connections if the server does not respond to a ping. | | no
+`permit_without_stream` | `boolean` | Send pings even if there is no active stream request. | | no
+
+### queue block
+
+The `queue` block configures an in-memory buffer of batches before data is sent
+to the gRPC server.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`enabled` | `boolean` | Enables an in-memory buffer before sending data to the client. | `true` | no
+`num_consumers` | `number` | Number of readers which will send batches written to the queue in parallel. | `10` | no
+`queue_size` | `number` | Maximum number of unwritten batches allowed in the queue at once. | `5000` | no
+
+When `enabled` is `true`, data will first be written to an in-memory buffer
+before sending it to the configured gRPC server. Batches sent to the
+component's `input` exported field will be added to the buffer as long as the
+number of unsent batches does not exceed the configured `queue_size`.
+
+`queue_size` is used to determine how long an endpoint outage is tolerated for.
+Assuming 100 requests/second, the default queue size `5000` provides about 50
+seconds of outage tolerance. To calculate the correct value for `queue_size`,
+multiply the average number of outgoing requests per second by the amount of
+time in seconds outages should be tolerated for.
+
+The `num_consumers` argument controls how many readers will read from the
+buffer and send data in parallel. Larger values of `num_consumers` will allow
+to send data more quickly at the expense of increased network traffic.
+
+### retry block
+
+The `retry` block configures how failed requests to the gRPC server will be
+retried.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`enabled` | `boolean` | Enables retrying failed requests. | `true` | no
+`initial_interval` | `duration` | Initial time to wait before retrying a failed request. | `"5s"` | no
+`max_interval` | `duration` | Maximum time to wait between retries. | `"30s"` | no
+`max_elapsed_time` | `duration` | Maximum amount of time to wait before discarding a failed batch. | `"5m"` | no
+
+When `enabled` is `true`, failed batches will be retried after a given
+interval. The `initial_interval` argument specifies how long to wait before the
+first retry attempt. If requests continue to fail, the time to wait before
+retrying will exponentially increase. The `max_interval` argument specifies the
+upper bound of how long to wait in between retries.
+
+If a batch has not sent successfully, it is discarded after the time specified
+by `max_elapsed_time` elapses. If `max_elapsed_time` is set to `"0s"`, failed
+requests are retried forever until they succeed.
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+Name | Type | Description
+---- | ---- | -----------
+`input` | `otelcol.Consumer` | A value that other components can use to send telemetry data to.
+
+`input` accepts `otelcol.Consumer` data for any telemetry signal (metrics,
+logs, or traces).
+
+## Component health
+
+`otelcol.exporter.otlp` is only reported as unhealthy if given an invalid
+configuration.
+
+## Debug information
+
+`otelcol.exporter.otlp` does not expose any component-specific debug
+information.

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
@@ -10,8 +10,8 @@ title: otelcol.exporter.otlp
 and writes them over the network using the OTLP gRPC protocol.
 
 > **NOTE**: `otelcol.exporter.otlp` is a wrapper over the upstream
-> OpenTelemetry Collector `otlp` exporter. Bug reports or feature requests may
-> be redirected to the upstream repository.
+> OpenTelemetry Collector `otlp` exporter. Bug reports or feature requests will
+> be redirected to the upstream repository, if necessary.
 
 Multiple `otelcol.exporter.otlp` components can be specified by giving them
 different labels.

--- a/docs/sources/flow/reference/components/otelcol.processor.batch.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.batch.md
@@ -13,7 +13,7 @@ data.
 
 > **NOTE**: `otelcol.processor.batch` is a wrapper over the upstream
 > OpenTelemetry Collector `batch` processor. Bug reports or feature requests
-> may be redirected to the upstream repository.
+> will be redirected to the upstream repository, if necessary.
 
 Multiple `otelcol.processor.batch` components can be specified by giving them
 different labels.

--- a/docs/sources/flow/reference/components/otelcol.receiver.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.otlp.md
@@ -79,7 +79,7 @@ Name | Type | Description | Default | Required
 `max_recv_msg_size` | `string` | Maximum size of messages the server will accept. 0 disables a limit. | | no
 `max_concurrent_streams` | `number` | Limit the number of concurrent streaming RPC calls. | | no
 `read_buffer_size` | `string` | Size of the read buffer the gRPC server will use for reading from clients. | `"512KiB"` | no
-`write_buffer_size` | `string` | Size of the write buffer the gRPC will use for writing to clients. | | no
+`write_buffer_size` | `string` | Size of the write buffer the gRPC server will use for writing to clients. | | no
 `include_metadata` | `boolean` | Propagate incoming connection metadata to downstream consumers. | | no
 
 ### tls block

--- a/docs/sources/flow/reference/components/otelcol.receiver.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.otlp.md
@@ -10,8 +10,8 @@ title: otelcol.receiver.otlp
 forwards it to other `otelcol.*` components.
 
 > **NOTE**: `otelcol.receiver.otlp` is a wrapper over the upstream
-> OpenTelemetry Collector `otlp` receiver. Bug reports or feature requests may
-> be redirected to the upstream repository.
+> OpenTelemetry Collector `otlp` receiver. Bug reports or feature requests will
+> be redirected to the upstream repository, if necessary.
 
 Multiple `otelcol.receiver.otlp` components can be specified by giving them
 different labels.


### PR DESCRIPTION
Introduce an `otelcol.exporter.otlp` component which wraps around the upstream otlp (gRPC) exporter.

I've left two pieces of work to be done in future PRs:

* `otelcol.exporter.otlp` doesn't support authentication yet.
* #2345 

Closes #2288.
