### PR TITLE
otelcol.auth.basic: new component

### DIFF
--- a/component/all/all.go
+++ b/component/all/all.go
@@ -5,6 +5,7 @@ import (
 	_ "github.com/grafana/agent/component/discovery/kubernetes"                 // Import discovery.kubernetes
 	_ "github.com/grafana/agent/component/discovery/relabel"                    // Import discovery.relabel
 	_ "github.com/grafana/agent/component/local/file"                           // Import local.file
+	_ "github.com/grafana/agent/component/otelcol/auth/basic"                   // Import otelcol.auth.basic
 	_ "github.com/grafana/agent/component/otelcol/exporter/otlp"                // Import otelcol.exporter.otlp
 	_ "github.com/grafana/agent/component/otelcol/processor/batch"              // Import otelcol.processor.batch
 	_ "github.com/grafana/agent/component/otelcol/receiver/otlp"                // Import otelcol.receiver.otlp

--- a/component/otelcol/auth/auth.go
+++ b/component/otelcol/auth/auth.go
@@ -99,26 +99,26 @@ func New(opts component.Options, f otelcomponent.ExtensionFactory, args Argument
 }
 
 // Run starts the Auth component.
-func (r *Auth) Run(ctx context.Context) error {
-	defer r.cancel()
-	return r.sched.Run(ctx)
+func (a *Auth) Run(ctx context.Context) error {
+	defer a.cancel()
+	return a.sched.Run(ctx)
 }
 
 // Update implements component.Component. It will convert the Arguments into
 // configuration for OpenTelemetry Collector authentication extension
 // configuration and manage the underlying OpenTelemetry Collector extension.
-func (r *Auth) Update(args component.Arguments) error {
+func (a *Auth) Update(args component.Arguments) error {
 	rargs := args.(Arguments)
 
 	host := scheduler.NewHost(
-		r.opts.Logger,
+		a.opts.Logger,
 		scheduler.WithHostExtensions(rargs.Extensions()),
 		scheduler.WithHostExporters(rargs.Exporters()),
 	)
 
 	settings := otelcomponent.ExtensionCreateSettings{
 		TelemetrySettings: otelcomponent.TelemetrySettings{
-			Logger: zapadapter.New(r.opts.Logger),
+			Logger: zapadapter.New(a.opts.Logger),
 
 			// TODO(rfratto): expose tracing and logging statistics.
 			//
@@ -141,7 +141,7 @@ func (r *Auth) Update(args component.Arguments) error {
 	// Create instances of the extension from our factory.
 	var components []otelcomponent.Component
 
-	ext, err := r.factory.CreateExtension(r.ctx, settings, extensionConfig)
+	ext, err := a.factory.CreateExtension(a.ctx, settings, extensionConfig)
 	if err != nil {
 		return err
 	} else if ext != nil {
@@ -149,19 +149,19 @@ func (r *Auth) Update(args component.Arguments) error {
 	}
 
 	// Inform listeners that our handler changed.
-	r.opts.OnStateChange(Exports{
+	a.opts.OnStateChange(Exports{
 		Handler: Handler{
-			ID:        otelconfig.NewComponentID(otelconfig.Type(r.opts.ID)),
+			ID:        otelconfig.NewComponentID(otelconfig.Type(a.opts.ID)),
 			Extension: ext,
 		},
 	})
 
 	// Schedule the components to run once our component is running.
-	r.sched.Schedule(host, components...)
+	a.sched.Schedule(host, components...)
 	return nil
 }
 
 // CurrentHealth implements component.HealthComponent.
-func (r *Auth) CurrentHealth() component.Health {
-	return r.sched.CurrentHealth()
+func (a *Auth) CurrentHealth() component.Health {
+	return a.sched.CurrentHealth()
 }

--- a/component/otelcol/auth/auth.go
+++ b/component/otelcol/auth/auth.go
@@ -41,8 +41,8 @@ type Arguments interface {
 // Exports is a common Exports type for Flow components which expose
 // OpenTelemetry Collector authentication extensions.
 type Exports struct {
-	// Handler is the managed compoent. Handler is updated any time the extension
-	// is updated.
+	// Handler is the managed component. Handler is updated any time the
+	// extension is updated.
 	Handler Handler `river:"handler,attr"`
 }
 

--- a/component/otelcol/auth/basic/basic.go
+++ b/component/otelcol/auth/basic/basic.go
@@ -1,0 +1,56 @@
+// Package basic provides an otelcol.auth.basic component.
+package basic
+
+import (
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otelcol"
+	"github.com/grafana/agent/component/otelcol/auth"
+	"github.com/grafana/agent/pkg/flow/rivertypes"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension"
+	otelcomponent "go.opentelemetry.io/collector/component"
+	otelconfig "go.opentelemetry.io/collector/config"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:    "otelcol.auth.basic",
+		Args:    Arguments{},
+		Exports: otelcol.ConsumerExports{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			fact := basicauthextension.NewFactory()
+			return auth.New(opts, fact, args.(Arguments))
+		},
+	})
+}
+
+// Arguments configures the otelcol.auth.basic component.
+type Arguments struct {
+	// TODO(rfratto): should we support htpasswd?
+
+	Username string            `river:"username,attr"`
+	Password rivertypes.Secret `river:"password,attr"`
+}
+
+var _ auth.Arguments = Arguments{}
+
+// Convert implements auth.Arguments.
+func (args Arguments) Convert() otelconfig.Extension {
+	return &basicauthextension.Config{
+		ExtensionSettings: otelconfig.NewExtensionSettings(otelconfig.NewComponentID("basic")),
+		ClientAuth: &basicauthextension.ClientAuthSettings{
+			Username: args.Username,
+			Password: string(args.Password),
+		},
+	}
+}
+
+// Extensions implements auth.Arguments.
+func (args Arguments) Extensions() map[otelconfig.ComponentID]otelcomponent.Extension {
+	return nil
+}
+
+// Exporters implements auth.Arguments.
+func (args Arguments) Exporters() map[otelconfig.DataType]map[otelconfig.ComponentID]otelcomponent.Exporter {
+	return nil
+}

--- a/component/otelcol/auth/basic/basic_test.go
+++ b/component/otelcol/auth/basic/basic_test.go
@@ -1,0 +1,80 @@
+package basic_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/component/otelcol/auth"
+	"github.com/grafana/agent/component/otelcol/auth/basic"
+	"github.com/grafana/agent/pkg/flow/componenttest"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/grafana/agent/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configauth"
+)
+
+// Test performs a basic integration test which runs the otelcol.exporter.otlp
+// component and ensures that it can be used for authentication.
+func Test(t *testing.T) {
+	// Create an HTTP server which will assert that basic auth has been injected
+	// into the request.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		assert.True(t, ok, "no basic auth found")
+		assert.Equal(t, "foo", username, "basic auth username didn't match")
+		assert.Equal(t, "bar", password, "basic auth password didn't match")
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := componenttest.TestContext(t)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	l := util.TestLogger(t)
+
+	// Create and run our component
+	ctrl, err := componenttest.NewControllerFromID(l, "otelcol.auth.basic")
+	require.NoError(t, err)
+
+	cfg := `
+		username = "foo"
+		password = "bar"
+	`
+	var args basic.Arguments
+	require.NoError(t, river.Unmarshal([]byte(cfg), &args))
+
+	go func() {
+		err := ctrl.Run(ctx, args)
+		require.NoError(t, err)
+	}()
+
+	require.NoError(t, ctrl.WaitRunning(time.Second), "component never started")
+	require.NoError(t, ctrl.WaitExports(time.Second), "component never exported anything")
+
+	// Get the authentication extension from our component and use it to make a
+	// request to our test server.
+	exports := ctrl.Exports().(auth.Exports)
+	require.NotNil(t, exports.Handler.Extension, "handler extension is nil")
+
+	clientAuth, ok := exports.Handler.Extension.(configauth.ClientAuthenticator)
+	require.True(t, ok, "handler does not implement configauth.ClientAuthenticator")
+
+	rt, err := clientAuth.RoundTripper(http.DefaultTransport)
+	require.NoError(t, err)
+	cli := &http.Client{Transport: rt}
+
+	// Wait until the request finishes. We don't assert anything else here; our
+	// HTTP handler won't write the response until it ensures that the basic auth
+	// was found.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := cli.Do(req)
+	require.NoError(t, err, "HTTP request failed")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/component/otelcol/exporter/otlp/otlp.go
+++ b/component/otelcol/exporter/otlp/otlp.go
@@ -72,7 +72,7 @@ func (args Arguments) Convert() otelconfig.Exporter {
 
 // Extensions implements exporter.Arguments.
 func (args Arguments) Extensions() map[otelconfig.ComponentID]otelcomponent.Extension {
-	return nil
+	return (*otelcol.GRPCClientArguments)(&args.Client).Extensions()
 }
 
 // Exporters implements exporter.Arguments.

--- a/docs/sources/flow/reference/components/otelcol.auth.basic.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.basic.md
@@ -1,0 +1,72 @@
+---
+aliases:
+- /docs/agent/latest/flow/reference/components/otelcol.auth.basic
+title: otelcol.auth.basic
+---
+
+# otelcol.auth.basic
+
+`otelcol.auth.basic` exposes a `handler` that can be used by other `otelcol`
+components to authenticate requests using basic authentication.
+
+> **NOTE**: `otelcol.auth.basic` is a wrapper over the upstream OpenTelemetry
+> Collector `basicauth` extension. Bug reports or feature requests will be
+> redirected to the upstream repository, if necessary.
+
+Multiple `otelcol.auth.basic` components can be specified by giving them
+different labels.
+
+## Usage
+
+```river
+otelcol.auth.basic "LABEL" {
+  username = "USERNAME"
+  password = "PASSWORD"
+}
+```
+
+## Arguments
+
+`otelcol.auth.basic` supports the following arguments:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`username` | `string` | Username to use for basic authentication requests. | | yes
+`password` | `secret` | Password to use for basic authentication requests. | | yes
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+Name | Type | Description
+---- | ---- | -----------
+`handler` | `capsule(otelcol.Handler)` | A value that other components can use to authenticate requests.
+
+## Component health
+
+`otelcol.auth.basic` is only reported as unhealthy if given an invalid
+configuration.
+
+## Debug information
+
+`otelcol.auth.basic` does not expose any component-specific debug information.
+
+## Example
+
+This example configures [otelcol.exporter.otlp][] to use basic authentication:
+
+```river
+otelcol.exporter.otlp "example" {
+  client {
+    endpoint = "my-otlp-grpc-server:4317"
+    auth     = otelcol.auth.basic.creds.handler
+  }
+}
+
+otelcol.auth.basic "creds" {
+  username = "demo"
+  password = env("API_KEY")
+}
+```
+
+[otelcol.exporter.otlp]: {{< relref "./otelcol.exporter.otlp.md" >}}

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
@@ -71,6 +71,7 @@ Name | Type | Description | Default | Required
 `wait_for_ready` | `boolean` | Waits for gRPC connection to be in the `READY` state before sending data. | `false` | no
 `headers` | `map(string)` | Additional headers to send with the request. | `{}` | no
 `balancer_name` | `string` | Which gRPC client-side load balancer to use for requests. | | no
+`auth` | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests. | | no
 
 By default, requests are compressed with gzip. The `compression` argument
 controls which compression mechanism to use. Supported strings are:

--- a/go.mod
+++ b/go.mod
@@ -152,6 +152,7 @@ require (
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
@@ -380,6 +381,7 @@ require (
 	github.com/nicolai86/scaleway-sdk v1.10.2-0.20180628010248-798f60e20bb2 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.61.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.61.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.61.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.61.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.61.0 // indirect
@@ -439,6 +441,7 @@ require (
 	github.com/subosito/gotenv v1.3.0 // indirect
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
 	github.com/tencentcloud/tencentcloud-sdk-go v1.0.162 // indirect
+	github.com/tg123/go-htpasswd v1.2.0 // indirect
 	github.com/thanos-io/thanos v0.25.0 // indirect
 	github.com/theupdateframework/notary v0.7.0 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -186,6 +186,8 @@ github.com/DATA-DOG/go-sqlmock v1.4.1 h1:ThlnYciV1iM/V0OSF/dtkqWb6xo5qITT1TJBG1M
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v0.0.0-20160329135253-cc2f4770f4d6/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962 h1:KeNholpO2xKjgaaSyd+DyQRrsQjhbSeS7qe4nEw8aQw=
+github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962/go.mod h1:kC29dT1vFpj7py2OvG1khBdQpo3kInWP+6QipLbdngo=
 github.com/GoogleCloudPlatform/cloudsql-proxy v1.24.0/go.mod h1:3tx938GhY4FC+E1KT/jNjDw7Z5qxAEtIiERJ2sXjnII=
 github.com/HdrHistogram/hdrhistogram-go v1.1.0/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=
@@ -2043,6 +2045,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancing
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.61.0/go.mod h1:/UWRVw83NJvr3OAUxNKdFvA42ZcwJU80U6sC9Ga6rG4=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.61.0 h1:4NrUohPC7kbHracIMwNMwjjJw+RoTzGFqLcyOgChXu0=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.61.0/go.mod h1:GtzfeHEYI2XcD9rs79UlgDT6A+WYJv8o5GWL5k20kg4=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.61.0 h1:O02J3B6hkVtftbtXCbkEyaQm1mDu5k6VoVOghJgN95o=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.61.0/go.mod h1:lSpO0oRJvNEbAdKbKIqJ7Lb+Tfj6XI9N415E0ATAMYE=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension v0.61.0 h1:USlB+ZO5VxvoLU1iE3bToDaS9xBTcqD6J5ooYBu8fUk=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension v0.61.0/go.mod h1:kY/a+e4Yl3cTEWp3m8eFxmNU60yYvoWledSKjLKrip4=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.61.0 h1:z+MA5MWVNh9n6w9+npb4Cb7/Ycgfa/jqJFnkSCSYhb0=
@@ -2492,6 +2496,8 @@ github.com/tencentcloud/tencentcloud-sdk-go v1.0.162/go.mod h1:asUz5BPXxgoPGaRgZ
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/kms v1.0.194/go.mod h1:yrBKWhChnDqNz1xuXdSbWXG56XawEq0G5j1lg4VwBD4=
 github.com/tencentyun/cos-go-sdk-v5 v0.7.31/go.mod h1:4E4+bQ2gBVJcgEC9Cufwylio4mXOct2iu05WjgEBx1o=
 github.com/tent/http-link-go v0.0.0-20130702225549-ac974c61c2f9/go.mod h1:RHkNRtSLfOK7qBTHaeSX1D6BNpI3qw7NTxsmNr4RvN8=
+github.com/tg123/go-htpasswd v1.2.0 h1:UKp34m9H467/xklxUxU15wKRru7fwXoTojtxg25ITF0=
+github.com/tg123/go-htpasswd v1.2.0/go.mod h1:h7IzlfpvIWnVJhNZ0nQ9HaFxHb7pn5uFJYLlEUJa2sM=
 github.com/thanos-io/thanos v0.19.1-0.20211126105533-c5505f5eaa7d/go.mod h1:sfnKJG7cDA41ixNL4gsTJEa3w9Qt8lwAjw+dqRMSDG0=
 github.com/thanos-io/thanos v0.25.0 h1:vuEd8z8onjH8rQZ3vCdkeybdflrRm7T1qqkgboe3MHI=
 github.com/thanos-io/thanos v0.25.0/go.mod h1:7i7BAtkc5n9gADy6Fez3PCiVb9Wzc7DldhZ+JJJC0Eg=
@@ -2757,6 +2763,7 @@ golang.org/x/crypto v0.0.0-20181009213950-7c1a557ab941/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190228161510-8dd112bcdc25/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190320223903-b7391e95e576/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
Introduce an `otelcol.auth.basic` component which wraps around the upstream basicauth extension and allows other components to use it.

This also updates the `otelcol.exporter.otlp` component to accept a reference to the extension and use it for authentication.

Closes #2354.