### PR TITLE
otelcol.receiver.jaeger: new component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,22 +24,22 @@ Main (unreleased)
 
 - Update Prometheus dependency to v2.38.0. (@rfratto)
 
-- Flow: add `otelcol.receiver.otlp` component which receives OTLP-formatted
+- Flow: add an `otelcol.receiver.otlp` component which receives OTLP-formatted
   traces, metrics, and logs. Data can then be forwarded to other `otelcol`
   components. (@rfratto)
 
-- Flow: add `otelcol.processor.batch` component which batches data from
+- Flow: add an `otelcol.processor.batch` component which batches data from
   `otelcol` components before forwarding it to other `otelcol` components.
   (@rfratto)
 
-- Flow: add `otelcol.exporter.otlp` component which accepts data from `otelcol`
+- Flow: add an `otelcol.exporter.otlp` component which accepts data from `otelcol`
   components and sends it to a gRPC server using the OTLP protocol. (@rfratto)
 
-- Flow: add `otelcol.auth.basic` component which can perform basic
+- Flow: add an `otelcol.auth.basic` component which can perform basic
   authentication for `otelcol` components which support authentication
   extensions. (@rfratto)
 
-- Flow: add `otelcol.receiver.jeager` component which receives Jaeger-formatted
+- Flow: add an `otelcol.receiver.jeager` component which receives Jaeger-formatted
   traces. Data can then be forwarded to other `otelcol` components. (@rfratto)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ Main (unreleased)
 - Flow: add `otelcol.exporter.otlp` component which accepts data from `otelcol`
   components and sends it to a gRPC server using the OTLP protocol. (@rfratto)
 
+- Flow: add `otelcol.auth.basic` component which can perform basic
+  authentication for `otelcol` components which support authentication
+  extensions. (@rfratto)
+
+- Flow: add `otelcol.receiver.jeager` component which receives Jaeger-formatted
+  traces. Data can then be forwarded to other `otelcol` components. (@rfratto)
+
 ### Features
 
 - Add `agentctl test-logs` command to allow testing log configurations by redirecting

--- a/component/all/all.go
+++ b/component/all/all.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/grafana/agent/component/otelcol/auth/basic"                   // Import otelcol.auth.basic
 	_ "github.com/grafana/agent/component/otelcol/exporter/otlp"                // Import otelcol.exporter.otlp
 	_ "github.com/grafana/agent/component/otelcol/processor/batch"              // Import otelcol.processor.batch
+	_ "github.com/grafana/agent/component/otelcol/receiver/jaeger"              // Import otelcol.receiver.jaeger
 	_ "github.com/grafana/agent/component/otelcol/receiver/otlp"                // Import otelcol.receiver.otlp
 	_ "github.com/grafana/agent/component/prometheus/integration/node_exporter" // Import prometheus.integration.node_exporter
 	_ "github.com/grafana/agent/component/prometheus/relabel"                   // Import prometheus.relabel

--- a/component/otelcol/receiver/jaeger/jaeger.go
+++ b/component/otelcol/receiver/jaeger/jaeger.go
@@ -184,6 +184,12 @@ func (proto *ProtocolUDP) Convert() *jaegerreceiver.ProtocolUDP {
 
 // RemoteSamplingArguments configures remote sampling settings.
 type RemoteSamplingArguments struct {
+	// TODO(rfratto): can we work with upstream to provide a hook to provide a
+	// custom strategy file and bypass the reload interval?
+	//
+	// That would let users connect a local.file to otelcol.receiver.jaeger for
+	// the remote sampling.
+
 	HostEndpoint               string                      `river:"host_endpoint,attr"`
 	StrategyFile               string                      `river:"strategy_file,attr"`
 	StrategyFileReloadInterval time.Duration               `river:"strategy_file_reload_interval,attr"`

--- a/component/otelcol/receiver/jaeger/jaeger.go
+++ b/component/otelcol/receiver/jaeger/jaeger.go
@@ -1,0 +1,205 @@
+// Package jaeger provides an otelcol.receiver.jaeger component.
+package jaeger
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/alecthomas/units"
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otelcol"
+	"github.com/grafana/agent/component/otelcol/receiver"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver"
+	otelcomponent "go.opentelemetry.io/collector/component"
+	otelconfig "go.opentelemetry.io/collector/config"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name: "otelcol.receiver.jaeger",
+		Args: Arguments{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			fact := jaegerreceiver.NewFactory()
+			return receiver.New(opts, fact, args.(Arguments))
+		},
+	})
+}
+
+// Arguments configures the otelcol.receiver.jaeger component.
+type Arguments struct {
+	Protocols      ProtocolsArguments       `river:"protocols,block"`
+	RemoteSampling *RemoteSamplingArguments `river:"remote_sampling,block,optional"`
+
+	// Output configures where to send received data. Required.
+	Output *otelcol.ConsumerArguments `river:"output,block"`
+}
+
+var (
+	_ river.Unmarshaler  = (*Arguments)(nil)
+	_ receiver.Arguments = Arguments{}
+)
+
+// DefaultArguments provides default settings for Arguments. All protocols are
+// configured with defaults and then set to nil in UnmarshalRiver if they were
+// not defined in the source config.
+var DefaultArguments = Arguments{
+	Protocols: ProtocolsArguments{
+		GRPC: &otelcol.GRPCServerArguments{
+			Endpoint:  "0.0.0.0:14250",
+			Transport: "tcp",
+		},
+		ThriftHTTP: &otelcol.HTTPServerArguments{
+			Endpoint: "0.0.0.0:14268",
+		},
+		ThriftBinary: &ProtocolUDP{
+			Endpoint:      "0.0.0.0:6831",
+			QueueSize:     1_000,
+			MaxPacketSize: 65 * units.KiB,
+			Workers:       10,
+		},
+		ThriftCompact: &ProtocolUDP{
+			Endpoint:      "0.0.0.0:6832",
+			QueueSize:     1_000,
+			MaxPacketSize: 65 * units.KiB,
+			Workers:       10,
+		},
+	},
+}
+
+// UnmarshalRiver implements river.Unmarshaler.
+func (args *Arguments) UnmarshalRiver(f func(interface{}) error) error {
+	*args = DefaultArguments
+
+	type arguments Arguments
+
+	// Unmarshal into a temporary struct so we can detect which protocols were
+	// actually enabled by the user.
+	var temp arguments
+	if err := f(&temp); err != nil {
+		return err
+	}
+
+	// Remove protocols from args if they weren't provided by the user.
+	if temp.Protocols.GRPC == nil {
+		args.Protocols.GRPC = nil
+	}
+	if temp.Protocols.ThriftHTTP == nil {
+		args.Protocols.ThriftHTTP = nil
+	}
+	if temp.Protocols.ThriftBinary == nil {
+		args.Protocols.ThriftBinary = nil
+	}
+	if temp.Protocols.ThriftCompact == nil {
+		args.Protocols.ThriftCompact = nil
+	}
+
+	// Finally, unmarshal into the real struct.
+	if err := f((*arguments)(args)); err != nil {
+		return err
+	}
+	return args.Validate()
+}
+
+// Validate returns an error if args is invalid.
+func (args *Arguments) Validate() error {
+	if args.Protocols.GRPC == nil &&
+		args.Protocols.ThriftHTTP == nil &&
+		args.Protocols.ThriftBinary == nil &&
+		args.Protocols.ThriftCompact == nil {
+
+		return fmt.Errorf("at least one protocol must be enabled")
+	}
+
+	return nil
+}
+
+// Convert implements receiver.Arguments.
+func (args Arguments) Convert() otelconfig.Receiver {
+	return &jaegerreceiver.Config{
+		ReceiverSettings: otelconfig.NewReceiverSettings(otelconfig.NewComponentID("jaeger")),
+		Protocols: jaegerreceiver.Protocols{
+			GRPC:          args.Protocols.GRPC.Convert(),
+			ThriftHTTP:    args.Protocols.ThriftHTTP.Convert(),
+			ThriftBinary:  args.Protocols.ThriftBinary.Convert(),
+			ThriftCompact: args.Protocols.ThriftCompact.Convert(),
+		},
+		RemoteSampling: args.RemoteSampling.Convert(),
+	}
+}
+
+// Extensions implements receiver.Arguments.
+func (args Arguments) Extensions() map[otelconfig.ComponentID]otelcomponent.Extension {
+	if args.RemoteSampling == nil {
+		return nil
+	}
+	return args.RemoteSampling.Client.Extensions()
+}
+
+// Exporters implements receiver.Arguments.
+func (args Arguments) Exporters() map[otelconfig.DataType]map[otelconfig.ComponentID]otelcomponent.Exporter {
+	return nil
+}
+
+// NextConsumers implements receiver.Arguments.
+func (args Arguments) NextConsumers() *otelcol.ConsumerArguments {
+	return args.Output
+}
+
+// ProtocolsArguments configures protocols for otelcol.receiver.jaeger to
+// listen on.
+type ProtocolsArguments struct {
+	GRPC          *otelcol.GRPCServerArguments `river:"grpc,block,optional"`
+	ThriftHTTP    *otelcol.HTTPServerArguments `river:"thrift_http,block,optional"`
+	ThriftBinary  *ProtocolUDP                 `river:"thrift_binary,block,optional"`
+	ThriftCompact *ProtocolUDP                 `river:"thrift_compact,block,optional"`
+}
+
+// ProtocolUDP configures a UDP server.
+type ProtocolUDP struct {
+	Endpoint         string           `river:"endpoint,attr,optional"`
+	QueueSize        int              `river:"queue_size,attr,optional"`
+	MaxPacketSize    units.Base2Bytes `river:"max_packet_size,attr,optional"`
+	Workers          int              `river:"workers,attr,optional"`
+	SocketBufferSize units.Base2Bytes `river:"socket_buffer_size,attr,optional"`
+}
+
+// Convert converts proto into the upstream type.
+func (proto *ProtocolUDP) Convert() *jaegerreceiver.ProtocolUDP {
+	if proto == nil {
+		return nil
+	}
+
+	return &jaegerreceiver.ProtocolUDP{
+		Endpoint: proto.Endpoint,
+		ServerConfigUDP: jaegerreceiver.ServerConfigUDP{
+			QueueSize:        proto.QueueSize,
+			MaxPacketSize:    int(proto.MaxPacketSize),
+			Workers:          proto.Workers,
+			SocketBufferSize: int(proto.SocketBufferSize),
+		},
+	}
+}
+
+// RemoteSamplingArguments configures remote sampling settings.
+type RemoteSamplingArguments struct {
+	HostEndpoint               string                      `river:"host_endpoint,attr"`
+	StrategyFile               string                      `river:"strategy_file,attr"`
+	StrategyFileReloadInterval time.Duration               `river:"strategy_file_reload_interval,attr"`
+	Client                     otelcol.GRPCClientArguments `river:"client,block"`
+}
+
+// Convert converts args into the upstream type.
+func (args *RemoteSamplingArguments) Convert() *jaegerreceiver.RemoteSamplingConfig {
+	if args == nil {
+		return nil
+	}
+
+	return &jaegerreceiver.RemoteSamplingConfig{
+		HostEndpoint:               args.HostEndpoint,
+		StrategyFile:               args.StrategyFile,
+		StrategyFileReloadInterval: args.StrategyFileReloadInterval,
+		GRPCClientSettings:         *args.Client.Convert(),
+	}
+}

--- a/component/otelcol/receiver/jaeger/jaeger_test.go
+++ b/component/otelcol/receiver/jaeger/jaeger_test.go
@@ -1,0 +1,120 @@
+package jaeger_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/component/otelcol/receiver/jaeger"
+	"github.com/grafana/agent/pkg/flow/componenttest"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/grafana/agent/pkg/util"
+	"github.com/phayes/freeport"
+	"github.com/stretchr/testify/require"
+)
+
+// Test ensures that otelcol.receiver.jaeger can start successfully.
+func Test(t *testing.T) {
+	httpAddr := getFreeAddr(t)
+
+	ctx := componenttest.TestContext(t)
+	l := util.TestLogger(t)
+
+	ctrl, err := componenttest.NewControllerFromID(l, "otelcol.receiver.jaeger")
+	require.NoError(t, err)
+
+	cfg := fmt.Sprintf(`
+		protocols {
+			grpc {
+				endpoint = "%s"
+			}
+		}
+
+		output { /* no-op */ }
+	`, httpAddr)
+	var args jaeger.Arguments
+	require.NoError(t, river.Unmarshal([]byte(cfg), &args))
+
+	go func() {
+		err := ctrl.Run(ctx, args)
+		require.NoError(t, err)
+	}()
+
+	require.NoError(t, ctrl.WaitRunning(time.Second))
+
+	// TODO(rfratto): is it worthwhile trying to make sure we can send data over
+	// the client or can we trust that getting the component to run successfully
+	// is enough?
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestArguments_UnmarshalRiver(t *testing.T) {
+	t.Run("grpc", func(t *testing.T) {
+		in := `
+			protocols { grpc {} }
+			output {}
+		`
+
+		var args jaeger.Arguments
+		require.NoError(t, river.Unmarshal([]byte(in), &args))
+
+		require.Equal(t, jaeger.DefaultArguments.Protocols.GRPC, args.Protocols.GRPC)
+		require.Nil(t, args.Protocols.ThriftHTTP)
+		require.Nil(t, args.Protocols.ThriftBinary)
+		require.Nil(t, args.Protocols.ThriftCompact)
+	})
+
+	t.Run("thrift_http", func(t *testing.T) {
+		in := `
+			protocols { thrift_http {} }
+			output {} 
+		`
+
+		var args jaeger.Arguments
+		require.NoError(t, river.Unmarshal([]byte(in), &args))
+
+		require.Nil(t, args.Protocols.GRPC)
+		require.Equal(t, jaeger.DefaultArguments.Protocols.ThriftHTTP, args.Protocols.ThriftHTTP)
+		require.Nil(t, args.Protocols.ThriftBinary)
+		require.Nil(t, args.Protocols.ThriftCompact)
+	})
+
+	t.Run("thrift_binary", func(t *testing.T) {
+		in := `
+			protocols { thrift_binary {} }
+			output {}
+		`
+
+		var args jaeger.Arguments
+		require.NoError(t, river.Unmarshal([]byte(in), &args))
+
+		require.Nil(t, args.Protocols.GRPC)
+		require.Nil(t, args.Protocols.ThriftHTTP)
+		require.Equal(t, jaeger.DefaultArguments.Protocols.ThriftBinary, args.Protocols.ThriftBinary)
+		require.Nil(t, args.Protocols.ThriftCompact)
+	})
+
+	t.Run("thrift_compact", func(t *testing.T) {
+		in := `
+			protocols { thrift_compact {} }
+			output {}
+		`
+
+		var args jaeger.Arguments
+		require.NoError(t, river.Unmarshal([]byte(in), &args))
+
+		require.Nil(t, args.Protocols.GRPC)
+		require.Nil(t, args.Protocols.ThriftHTTP)
+		require.Nil(t, args.Protocols.ThriftBinary)
+		require.Equal(t, jaeger.DefaultArguments.Protocols.ThriftCompact, args.Protocols.ThriftCompact)
+	})
+}
+
+func getFreeAddr(t *testing.T) string {
+	t.Helper()
+
+	portNumber, err := freeport.GetFreePort()
+	require.NoError(t, err)
+
+	return fmt.Sprintf("localhost:%d", portNumber)
+}

--- a/docs/sources/flow/reference/components/otelcol.receiver.jaeger.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.jaeger.md
@@ -1,0 +1,289 @@
+---
+aliases:
+- /docs/agent/latest/flow/reference/components/otelcol.receiver.jaeger
+title: otelcol.receiver.jaeger
+---
+
+# otelcol.receiver.jaeger
+
+`otelcol.receiver.jaeger` accepts Jaeger-formatted data over the network and
+forwards it to other `otelcol.*` components.
+
+> **NOTE**: `otelcol.receiver.jaeger` is a wrapper over the upstream
+> OpenTelemetry Collector `jaeger` receiver. Bug reports or feature requests
+> will be redirected to the upstream repository, if necessary.
+
+Multiple `otelcol.receiver.jaeger` components can be specified by giving them
+different labels.
+
+## Usage
+
+```river
+otelcol.receiver.jaeger "LABEL" {
+  protocols {
+    grpc {}
+    thrift_http {}
+    thrift_binary {}
+    thrift_compact {}
+  }
+
+  output {
+    metrics = [...]
+    logs    = [...]
+    traces  = [...]
+  }
+}
+```
+
+## Arguments
+
+`otelcol.receiver.jaeger` doesn't support any arguments and is configured fully
+through inner blocks.
+
+## Blocks
+
+The following blocks are supported inside the definition of
+`otelcol.receiver.jaeger`:
+
+Hierarchy | Block | Description | Required
+--------- | ----- | ----------- | --------
+protocols | [protocols][] | Configures the protocols the component can accept traffic over. | yes
+protocols > grpc | [grpc][] | Configures a Jaeger gRPC server to receive traces. | no
+protocols > grpc > tls | [tls][] | Configures TLS for the gRPC server. | no
+protocols > grpc > keepalive | [keepalive][] | Configures keepalive settings for the configured server. | no
+protocols > grpc > keepalive > server_parameters | [server_parameters][] | Server parameters used to configure keepalive settings. | no
+protocols > grpc > keepalive > enforcement_policy | [enforcement_policy][] | Enforcement policy for keepalive settings. | no
+protocols > thrift_http | [thrift_http][] | Configures a Thrift HTTP server to receive traces. | no
+protocols > thrift_http > tls | [tls][] | Configures TLS for the Thrift HTTP server. | no
+protocols > thrift_http > cors | [cors][] | Configures CORS for the Thrift HTTP server. | no
+protocols > thrift_binary | [thrift_binary][] | Configures a Thrift binary UDP server to receive traces. | no
+protocols > thrift_compact | [thrift_compact][] | Configures a Thrift compact UDP server to receive traces. | no
+output | [output][] | Configures where to send received telemetry data. | yes
+
+The `>` symbol indicates deeper levels of nesting. For example, `protocols >
+grpc` refers to a `grpc` block defined inside a `protocols` block.
+
+[protocols]: #protocols-block
+[grpc]: #grpc-block
+[tls]: #tls-block
+[keepalive]: #keepalive-block
+[server_parameters]: #server_parameters-block
+[enforcement_policy]: #enforcement_policy-block
+[thrift_http]: #thrift_http-block
+[cors]: #cors-block
+[thrift_binary]: #thrift_binary-block
+[thrift_compact]: #thrift_compact-block
+[output]: #output-block
+
+### protocols block
+
+The `protocols` block defines a set of protocols that will be used to accept
+traces over the network.
+
+`protocols` doesn't support any arguments and is configured fully through inner
+blocks.
+
+`otelcol.receiver.jeager` requires at least one protocol block (`grpc`,
+`thrift_http`, `thrift_binary`, or `thrift_compact`) to be provided.
+
+### grpc block
+
+The `grpc` block configures a gRPC server which can accept Jaeger traces. If
+the `grpc` block isn't provided, a gRPC server isn't started.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`endpoint` | `string` | `host:port` to listen for traffic on. | `"0.0.0.0:14250"` | no
+`transport` | `string` | Transport to use for the gRPC server. | `"tcp"` | no
+`max_recv_msg_size` | `string` | Maximum size of messages the server will accept. 0 disables a limit. | | no
+`max_concurrent_streams` | `number` | Limit the number of concurrent streaming RPC calls. | | no
+`read_buffer_size` | `string` | Size of the read buffer the gRPC server will use for reading from clients. | `"512KiB"` | no
+`write_buffer_size` | `string` | Size of the write buffer the gRPC server will use for writing to clients. | | no
+`include_metadata` | `boolean` | Propagate incoming connection metadata to downstream consumers. | | no
+
+### tls block
+
+The `tls` block configures TLS settings used for a server. If the `tls` block
+isn't provided, TLS won't be used for connections to the server.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`ca_file` | `string` | Path to the CA file. | | no
+`cert_file` | `string` | Path to the TLS certificate. | | no
+`key_file` | `string` | Path to the TLS certificate key. | | no
+`min_version` | `string` | Minimum acceptable TLS version for connections. | `"TLS 1.2"` | no
+`max_version` | `string` | Maximum acceptable TLS version for connections. | `"TLS 1.3"` | no
+`reload_interval` | `duration` | Frequency to reload the certificates. | | no
+`client_ca_file` | `string` | Path to the CA file used to authenticate client certificates. | | no
+
+### keepalive block
+
+The `keepalive` block configures keepalive settings for connections to a gRPC
+server.
+
+`keepalive` doesn't support any arguments and is configured fully through inner
+blocks.
+
+### server_parameters block
+
+The `server_parameters` block controls keepalive and maximum age settings for gRPC
+servers.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`max_connection_idle` | `duration` | Maximum age for idle connections. | `"infinity"` | no
+`max_connection_age` | `duration` | Maximum age for non-idle connections. | `"infinity"` | no
+`max_connection_age_grace` | `duration` | Time to wait before forcibly closing connections. | `"infinity"` | no
+`time` | `duration` | How often to ping inactive clients to check for liveness. | `"2h"` | no
+`timeout` | `duration` | Time to wait before closing inactive clients that do not respond to liveness checks. | `"20s"` | no
+
+### enforcement_policy block
+
+The `enforcement_policy` block configures the keepalive enforcement policy for
+gRPC servers. The server will close connections from clients that violate the
+configured policy.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`min_time` | `duration` | Minimum time clients should wait before sending a keepalive ping. | `"5m"` | no
+`permit_without_stream` | `boolean` | Allow clients to send keepalive pings when there are no active streams. | `false` | no
+
+### thrift_http block
+
+The `http` block configures an HTTP server which can accept Thrift-formatted
+traces. If the `thrift_http` block isn't specified, an HTTP server isn't
+started.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`endpoint` | `string` | `host:port` to listen for traffic on. | `"0.0.0.0:14268"` | no
+`max_request_body_size` | `string` | Maximum request body size the server will allow. No limit when unset. | | no
+`include_metadata` | `boolean` | Propagate incoming connection metadata to downstream consumers. | | no
+
+### cors block
+
+The `cors` block configures CORS settings for an HTTP server.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`allowed_origins` | `list(string)` | Allowed values for the `Origin` header. | | no
+`allowed_headers` | `list(string)` | Accepted headers from CORS requests. | `["X-Requested-With"]` | no
+`max_age` | `number` | Configures the `Access-Control-Max-Age` response header. | | no
+
+The `allowed_headers` specifies which headers are acceptable from a CORS
+request. The following headers are always implicitly allowed:
+
+* `Accept`
+* `Accept-Language`
+* `Content-Type`
+* `Content-Language`
+
+If `allowed_headers` includes `"*"`, all headers will be permitted.
+
+### thrift_binary block
+
+The `thrift_binary` block configures a UDP server which can accept traces
+formatted to the Thrift binary protocol. If the `thrift_binary` block isn't
+provided, a UDP server isn't started.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`endpoint` | `string` | `host:port` to listen for traffic on. | `"0.0.0.0:6831"` | no
+`queue_size` | `number` | Maximum number of UDP messages that can be queued at once. | `1000` | no
+`max_packet_size` | `string` | Maximum UDP message size. | `"65KiB"` | no
+`workers` | `number` | Number of workers to concurrently read from the message queue. | `10` | no
+`socket_buffer_size` | `string` | Buffer to allocate for the UDP socket. | | no
+
+### thrift_compact block
+
+The `thrift_compact` block configures a UDP server which can accept traces
+formatted to the Thrift compact protocol. If the `thrift_compact` block isn't
+provided, a UDP server isn't started.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`endpoint` | `string` | `host:port` to listen for traffic on. | `"0.0.0.0:6832"` | no
+`queue_size` | `number` | Maximum number of UDP messages that can be queued at once. | `1000` | no
+`max_packet_size` | `string` | Maximum UDP message size. | `"65KiB"` | no
+`workers` | `number` | Number of workers to concurrently read from the message queue. | `10` | no
+`socket_buffer_size` | `string` | Buffer to allocate for the UDP socket. | | no
+
+### output block
+
+The `output` block configures a set of components to send received telemetry
+data to.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`metrics` | `list(otelcol.Consumer)` | List of consumers to send metrics to. | `[]` | no
+`logs` | `list(otelcol.Consumer)` | List of consumers to send logs to. | `[]` | no
+`traces` | `list(otelcol.Consumer)` | List of consumers to send traces to. | `[]` | no
+
+The `output` block must be specified, but all of its arguments are optional. By
+default, telemetry data will be dropped. To send telemetry data to other
+components, configure the `metrics`, `logs`, and `traces` arguments
+accordingly.
+
+## Exported fields
+
+`otelcol.receiver.jaeger` does not export any fields.
+
+## Component health
+
+`otelcol.receiver.jaeger` is only reported as unhealthy if given an invalid
+configuration.
+
+## Debug information
+
+`otelcol.receiver.jaeger` does not expose any component-specific debug
+information.
+
+## Examples
+
+This example creates a pipeline which accepts Jaeger-formatted traces and
+writes them to a OTLP server:
+
+```river
+otelcol.receiver.jaeger "default" {
+  protocols {
+    grpc {}
+    thrift_http {}
+    thrift_binary {}
+    thrift_compact {}
+  }
+
+  output {
+    traces = [otelcol.processor.batch.default.input]
+  }
+}
+
+otelcol.processor.batch "default" {
+  output {
+    traces = [otelcol.exporter.otlp.default.input]
+  }
+}
+
+otelcol.exporter.otlp "default" {
+  client {
+    endpoint = "my-otlp-server:4317"
+  }
+}
+```

--- a/docs/sources/flow/reference/components/otelcol.receiver.jaeger.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.jaeger.md
@@ -259,7 +259,7 @@ information.
 ## Examples
 
 This example creates a pipeline which accepts Jaeger-formatted traces and
-writes them to a OTLP server:
+writes them to an OTLP server:
 
 ```river
 otelcol.receiver.jaeger "default" {


### PR DESCRIPTION
Introduce an `otelcol.receiver.jaeger` component which wraps around the otelcol-contrib jaeger reciever.

Closes #2290.