### PR TITLE
CHANGELOG: group new Flow components under a single bulletpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,24 +23,23 @@ Main (unreleased)
 - Add `agentctl test-logs` command to allow testing log configurations by redirecting
 collected logs to standard output. This can be useful for debugging. (@jcreixell)
 
-- Flow: add an `otelcol.receiver.otlp` component which receives OTLP-formatted
-  traces, metrics, and logs. Data can then be forwarded to other `otelcol`
-  components. (@rfratto)
+- New Grafana Agent Flow components:
 
-- Flow: add an `otelcol.processor.batch` component which batches data from
-  `otelcol` components before forwarding it to other `otelcol` components.
-  (@rfratto)
+  - `otelcol.receiver.otlp` receives OTLP-formatted traces, metrics, and logs.
+    Data can then be forwarded to other `otelcol` components. (@rfratto)
 
-- Flow: add an `otelcol.exporter.otlp` component which accepts data from `otelcol`
-  components and sends it to a gRPC server using the OTLP protocol. (@rfratto)
+  - `otelcol.processor.batch` batches data from `otelcol` components before
+    forwarding it to other `otelcol` components. (@rfratto)
 
-- Flow: add an `otelcol.auth.basic` component which can perform basic
-  authentication for `otelcol` components which support authentication
-  extensions. (@rfratto)
+  - `otelcol.exporter.otlp` accepts data from `otelcol` components and sends
+    it to a gRPC server using the OTLP protocol. (@rfratto)
 
-- Flow: add an `otelcol.receiver.jeager` component which receives Jaeger-formatted
-  traces. Data can then be forwarded to other `otelcol` components. (@rfratto)
-  
+  - `otelcol.auth.basic` performs basic authentication for `otelcol`
+    components which support authentication extensions. (@rfratto)
+
+  - `otelcol.receiver.jeager` receives Jaeger-formatted traces. Data can then
+    be forwarded to other `otelcol` components. (@rfratto)
+
 ### Enhancements
 
 - Update OpenTelemetry Collector dependency to v0.61.0. (@rfratto)


### PR DESCRIPTION
Since there's a lot of new Flow components in the upcoming release, it might make sense to group them under a single bullet point instead of listing them out individually at the top level of the features header.