### PR TITLE
Add initial support for prometheus relabel caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
-## Main (unreleased)
+Main (unreleased)
+-----------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -49,7 +50,7 @@ internal API changes are not present.
 
 - Update Prometheus dependency to v2.38.0. (@rfratto)
 
-- Add caching to Prometheus relabel flow component. (@mattdurham)
+- Add caching to Prometheus relabel component. (@mattdurham)
 
 ### Bugfixes
 
@@ -57,7 +58,8 @@ internal API changes are not present.
 
 - Fix identifier on target creation for SNMP v2 integration. (@marctc)
 
-## v0.28.0 (2022-09-29)
+v0.28.0 (2022-09-29)
+--------------------
 
 ### Features
 
@@ -91,7 +93,8 @@ internal API changes are not present.
 
 - Add metrics for config reloads and config hash (@jcreixell)
 
-## v0.27.1 (2022-09-09)
+v0.27.1 (2022-09-09)
+--------------------
 
 > **NOTE**: ARMv6 Docker images are no longer being published.
 >
@@ -105,7 +108,8 @@ internal API changes are not present.
 
 - Switch docker image base from debian to ubuntu. (@captncraig)
 
-## v0.27.0 (2022-09-01)
+v0.27.0 (2022-09-01)
+--------------------
 
 ### Features
 
@@ -131,7 +135,7 @@ internal API changes are not present.
 ### Bugfixes
 
 - Tracing: Fixed issue with the PromSD processor using the `connection` method to discover the IP
-  address. It was failing to match because the port number was included in the address string. (@jphx)
+  address.  It was failing to match because the port number was included in the address string. (@jphx)
 
 - Register prometheus discovery metrics. (@mattdurham)
 
@@ -149,7 +153,8 @@ internal API changes are not present.
 
 - It is now possible to compile Grafana Agent using Go 1.19. (@rfratto)
 
-## v0.26.1 (2022-07-25)
+v0.26.1 (2022-07-25)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -165,7 +170,8 @@ internal API changes are not present.
 
 - Build the Linux/AMD64 artifacts using the opt-out flag for the ebpf_exporter. (@tpaschalis)
 
-## v0.26.0 (2022-07-18)
+v0.26.0 (2022-07-18)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -197,7 +203,8 @@ internal API changes are not present.
 
 - Fix mongodb exporter so that it now collects all metrics. (@mattdurham)
 
-## v0.25.1 (2022-06-16)
+v0.25.1 (2022-06-16)
+--------------------
 
 ### Bugfixes
 
@@ -205,7 +212,9 @@ internal API changes are not present.
 
 - Unwrap replayWAL error before attempting corruption repair. (@rlankfo)
 
-## v0.25.0 (2022-06-06)
+
+v0.25.0 (2022-06-06)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -251,7 +260,7 @@ internal API changes are not present.
 
 ### Bugfixes
 
-- Scraping service was not honoring the new server grpc flags `server.grpc.address`. (@mattdurham)
+- Scraping service was not honoring the new server grpc flags `server.grpc.address`.  (@mattdurham)
 
 ### Other changes
 
@@ -260,13 +269,16 @@ internal API changes are not present.
 
 - Use Go 1.18 for builds. (@rfratto)
 
-- Add `metrics` prefix to the url of list instances endpoint (`GET /agent/api/v1/instances`) and list targets endpoint (`GET /agent/api/v1/metrics/targets`). (@marctc)
+- Add `metrics` prefix to the url of list instances endpoint (`GET
+  /agent/api/v1/instances`) and list targets endpoint (`GET
+  /agent/api/v1/metrics/targets`). (@marctc)
 
 - Add extra identifying labels (`job`, `instance`, `agent_hostname`) to eventhandler integration. (@hjet)
 
 - Add `extra_labels` configuration to eventhandler integration. (@hjet)
 
-## v0.24.2 (2022-05-02)
+v0.24.2 (2022-05-02)
+--------------------
 
 ### Bugfixes
 
@@ -276,7 +288,8 @@ internal API changes are not present.
 
 - Update version of node_exporter to include additional metrics for osx. (@v-zhuravlev)
 
-## v0.24.1 (2022-04-14)
+v0.24.1 (2022-04-14)
+--------------------
 
 ### Bugfixes
 
@@ -301,7 +314,8 @@ internal API changes are not present.
 - Embed timezone data to enable Promtail pipelines using the `location` field
   on Windows machines. (@tpaschalis)
 
-## v0.24.0 (2022-04-07)
+v0.24.0 (2022-04-07)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -431,7 +445,8 @@ internal API changes are not present.
   the path name of the default secret mount. As a side effect of this bugfix,
   custom Secrets will now be mounted at
   `/var/lib/grafana-agent/extra-secrets/<secret name>` and custom ConfigMaps
-  will now be mounted at `/var/lib/grafana-agent/extra-configmaps/<configmap name>`. This is not a breaking change as it was previously impossible to
+  will now be mounted at `/var/lib/grafana-agent/extra-configmaps/<configmap
+  name>`. This is not a breaking change as it was previously impossible to
   properly provide these custom mounts. (@rfratto)
 
 - Flags accidentally prefixed with `-metrics.service..` (two `.` in a row) have
@@ -445,7 +460,8 @@ internal API changes are not present.
   will now default to `data-agent/`, the same default WAL directory as
   Prometheus Agent. (@rfratto)
 
-## v0.23.0 (2022-02-10)
+v0.23.0 (2022-02-10)
+--------------------
 
 ### Enhancements
 
@@ -490,7 +506,8 @@ internal API changes are not present.
 
 - Disable `machine-id` journal vol by default in sample logs manifest (@hjet)
 
-## v0.22.0 (2022-01-13)
+v0.22.0 (2022-01-13)
+--------------------
 
 > This release has deprecations. Please read entries carefully and consult
 > the [upgrade guide][] for specific instructions.
@@ -577,7 +594,8 @@ internal API changes are not present.
 
 - Remove log-level flag from systemd unit file (@jpkrohling)
 
-## v0.21.2 (2021-12-08)
+v0.21.2 (2021-12-08)
+--------------------
 
 ### Security fixes
 
@@ -591,7 +609,8 @@ internal API changes are not present.
   `--config.enable-read-api` flag at the command line to opt in to these
   endpoints.
 
-## v0.21.1 (2021-11-18)
+v0.21.1 (2021-11-18)
+--------------------
 
 ### Bugfixes
 
@@ -610,7 +629,8 @@ internal API changes are not present.
 - Metrics: Only run WAL cleaner when metrics are being used and a WAL is
   configured. (@rfratto)
 
-## v0.21.0 (2021-11-17)
+v0.21.0 (2021-11-17)
+--------------------
 
 ### Enhancements
 
@@ -644,9 +664,10 @@ internal API changes are not present.
 
 - Traces: Changed service graphs store implementation to improve CPU performance (@mapno)
 
-## v0.20.1 (2021-12-08)
+v0.20.1 (2021-12-08)
+--------------------
 
-> _NOTE_: The fixes in this patch are only present in v0.20.1 and >=v0.21.2.
+> *NOTE*: The fixes in this patch are only present in v0.20.1 and >=v0.21.2.
 
 ### Security fixes
 
@@ -660,7 +681,8 @@ internal API changes are not present.
   `--config.enable-read-api` flag at the command line to opt in to these
   endpoints.
 
-## v0.20.0 (2021-10-28)
+v0.20.0 (2021-10-28)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -692,7 +714,7 @@ internal API changes are not present.
 
 - Updated elasticsearch_exporter to v1.2.1 (@gaantunes)
 
-- Add remote write to silent Windows Installer (@mattdurham)
+- Add remote write to silent Windows Installer  (@mattdurham)
 
 - Updated mongodb_exporter to v0.20.7 (@rfratto)
 
@@ -733,7 +755,8 @@ internal API changes are not present.
 - The windows_exporter now disables the textfile collector by default.
   (@rfratto)
 
-## v0.19.0 (2021-09-29)
+v0.19.0 (2021-09-29)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -795,7 +818,7 @@ internal API changes are not present.
 - Allow reloading configuration using `SIGHUP` signal. (@tharun208)
 
 - Add HOSTNAME environment variable to service file to allow for expanding the
-  $HOSTNAME variable in agent config. (@dfrankel33)
+  $HOSTNAME variable in agent config.  (@dfrankel33)
 
 - Update jsonnet-libs to 1.21 for Kubernetes 1.21+ compatability. (@MurzNN)
 
@@ -835,7 +858,8 @@ internal API changes are not present.
 
 - Standardize scrape_interval to 1m in examples. (@mattdurham)
 
-## v0.18.4 (2021-09-14)
+v0.18.4 (2021-09-14)
+--------------------
 
 ### Enhancements
 
@@ -849,7 +873,8 @@ internal API changes are not present.
 - Scraping service: Ensure that a reshard is scheduled every reshard
   interval. (@rfratto)
 
-## v0.18.3 (2021-09-08)
+v0.18.3 (2021-09-08)
+--------------------
 
 ### Bugfixes
 
@@ -870,19 +895,22 @@ internal API changes are not present.
 - Scraping service: prevent more than one refresh from being queued at a time.
   (@rfratto)
 
-## v0.18.2 (2021-08-12)
+v0.18.2 (2021-08-12)
+--------------------
 
 ### Bugfixes
 
 - Honor the prefix and remove prefix from consul list results (@mattdurham)
 
-## v0.18.1 (2021-08-09)
+v0.18.1 (2021-08-09)
+--------------------
 
 ### Bugfixes
 
 - Reduce number of consul calls when ran in scrape service mode (@mattdurham)
 
-## v0.18.0 (2021-07-29)
+v0.18.0 (2021-07-29)
+--------------------
 
 ### Features
 
@@ -901,7 +929,8 @@ internal API changes are not present.
 
 - Enabled flag for integrations is not being honored. (@mattdurham)
 
-## v0.17.0 (2021-07-15)
+v0.17.0 (2021-07-15)
+--------------------
 
 ### Features
 
@@ -913,14 +942,16 @@ internal API changes are not present.
 - Fix race condition that may occur and result in a panic when initializing
   scraping service cluster. (@rfratto)
 
-## v0.16.1 (2021-06-22)
+v0.16.1 (2021-06-22)
+--------------------
 
 ### Bugfixes
 
 - Fix issue where replaying a WAL caused incorrect metrics to be sent over
   remote write. (@rfratto)
 
-## v0.16.0 (2021-06-17)
+v0.16.0 (2021-06-17)
+--------------------
 
 ### Features
 
@@ -941,7 +972,8 @@ internal API changes are not present.
   that target had gone down for long enough that its series were removed from
   the in-memory cache (2 GC cycles). (@rfratto)
 
-## v0.15.0 (2021-06-03)
+v0.15.0 (2021-06-03)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -982,7 +1014,8 @@ internal API changes are not present.
 
 - Intentionally order tracing processors. (@joe-elliott)
 
-## v0.14.0 (2021-05-24)
+v0.14.0 (2021-05-24)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -993,7 +1026,7 @@ internal API changes are not present.
 
 ### Security fixes
 
-- The Scraping service API will now reject configs that read credentials from
+* The Scraping service API will now reject configs that read credentials from
   disk by default. This prevents malicious users from reading arbitrary files
   and sending their contents over the network. The old behavior can be
   re-enabled by setting `dangerous_allow_reading_files: true` in the scraping
@@ -1001,7 +1034,7 @@ internal API changes are not present.
 
 ### Breaking changes
 
-- Configuration for SigV4 has changed. (@rfratto)
+* Configuration for SigV4 has changed. (@rfratto)
 
 ### Deprecations
 
@@ -1025,7 +1058,7 @@ internal API changes are not present.
   against the main HTTP server. Instead, two new command-line flags have been
   added: `--reload-addr` and `--reload-port`. These will launch a
   `/-/reload`-only HTTP server that can be used to safely reload the Agent's
-  state. (@rfratto)
+  state.  (@rfratto)
 
 - Add a /-/config endpoint. This endpoint will return the current configuration
   file with defaults applied that the Agent has loaded from disk. (@rfratto)
@@ -1097,7 +1130,8 @@ internal API changes are not present.
 
 - Add `tempo_spanmetrics` namespace in spanmetrics (@mapno)
 
-## v0.13.1 (2021-04-09)
+v0.13.1 (2021-04-09)
+--------------------
 
 ### Bugfixes
 
@@ -1105,7 +1139,8 @@ internal API changes are not present.
   label set with duplicate labels, mirroring the behavior of Prometheus.
   (@rfratto)
 
-## v0.13.0 (2021-02-25)
+v0.13.0 (2021-02-25)
+--------------------
 
 > The primary branch name has changed from `master` to `main`. You may have to
 > update your local checkouts of the repository to point at the new branch name.
@@ -1144,16 +1179,17 @@ internal API changes are not present.
 - Add the ability to read and serve HTTPS integration metrics when given a set
   certificates (@mattdurham)
 
-## v0.12.0 (2021-02-05)
+v0.12.0 (2021-02-05)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
 
 ### Breaking Changes
 
-- The configuration format for the `loki` block has changed. (@rfratto)
+* The configuration format for the `loki` block has changed. (@rfratto)
 
-- The configuration format for the `tempo` block has changed. (@rfratto)
+* The configuration format for the `tempo` block has changed. (@rfratto)
 
 ### Features
 
@@ -1180,7 +1216,7 @@ internal API changes are not present.
 - Scraping service: Unhealthy Agents in the ring will no longer cause job
   distribution to fail. (@rfratto)
 
-- Scraping service: Cortex ring metrics (prefixed with cortex*ring*) will now
+- Scraping service: Cortex ring metrics (prefixed with cortex_ring_) will now
   be registered for tracking the state of the hash ring. (@rfratto)
 
 - Scraping service: instance config ownership is now determined by the hash of
@@ -1198,7 +1234,8 @@ internal API changes are not present.
 - `agentctl config-check` will now work correctly when the supplied config file
   contains integrations. (@hoenn)
 
-## v0.11.0 (2021-01-20)
+v0.11.0 (2021-01-20)
+--------------------
 
 ### Features
 
@@ -1226,7 +1263,8 @@ internal API changes are not present.
 - The K8s manifests will no longer include the `default/kubernetes` job twice
   in both the DaemonSet and the Deployment. (@rfratto)
 
-## v0.10.0 (2021-01-13)
+v0.10.0 (2021-01-13)
+--------------------
 
 ### Features
 
@@ -1263,14 +1301,16 @@ internal API changes are not present.
   This was prevented by accidentally writing to a readonly volume mount.
   (@rfratto)
 
-## v0.9.1 (2021-01-04)
+v0.9.1 (2021-01-04)
+-------------------
 
 ### Enhancements
 
 - agentctl will now be installed by the rpm and deb packages as
   `grafana-agentctl`. (@rfratto)
 
-## v0.9.0 (2020-12-10)
+v0.9.0 (2020-12-10)
+-------------------
 
 ### Features
 
@@ -1319,7 +1359,8 @@ internal API changes are not present.
 - The User-Agent header sent for logs will now be `GrafanaCloudAgent/<version>`
   (@rfratto)
 
-## v0.8.0 (2020-11-06)
+v0.8.0 (2020-11-06)
+-------------------
 
 ### Features
 
@@ -1332,7 +1373,7 @@ internal API changes are not present.
 ### Enhancements
 
 - Add `<integration name>_build_info` metric to all integrations. The build
-  info displayed will match the build information of the Agent and _not_ the
+  info displayed will match the build information of the Agent and *not* the
   embedded exporter. This metric is used by community dashboards, so adding it
   to the Agent increases compatibility with existing dashboards that depend on
   it existing. (@rfratto)
@@ -1345,7 +1386,8 @@ internal API changes are not present.
   rather than just logging a generic message saying that retrieving the config
   has failed. (@rfratto)
 
-## v0.7.2 (2020-10-29)
+v0.7.2 (2020-10-29)
+-------------------
 
 ### Enhancements
 
@@ -1368,13 +1410,15 @@ internal API changes are not present.
 - Fix issue where the `push_config` for Tempo field was expected to be
   `remote_write`. `push_config` now works as expected. (@rfratto)
 
-## v0.7.1 (2020-10-23)
+v0.7.1 (2020-10-23)
+-------------------
 
 ### Bugfixes
 
 - Fix issue where ARM binaries were not published with the GitHub release.
 
-## v0.7.0 (2020-10-23)
+v0.7.0 (2020-10-23)
+-------------------
 
 ### Features
 
@@ -1416,7 +1460,8 @@ internal API changes are not present.
   computed by remote_write. This change should not negatively effect existing
   users. (@rfratto)
 
-## v0.6.1 (2020-04-11)
+v0.6.1 (2020-04-11)
+-------------------
 
 ### Bugfixes
 
@@ -1429,7 +1474,8 @@ internal API changes are not present.
 - Fix deadlock that slowly prevents the Agent from scraping targets at a high
   scrape volume. (@rfratto)
 
-## v0.6.0 (2020-09-04)
+v0.6.0 (2020-09-04)
+-------------------
 
 ### Breaking Changes
 
@@ -1478,7 +1524,7 @@ internal API changes are not present.
 - The subsystems of the Agent (`prometheus`, `loki`) are now made optional.
   Enabling integrations also implicitly enables the associated subsystem. For
   example, enabling the `agent` or `node_exporter` integration will force the
-  `prometheus` subsystem to be enabled. (@rfratto)
+  `prometheus` subsystem to be enabled.  (@rfratto)
 
 ### Bugfixes
 
@@ -1502,7 +1548,8 @@ internal API changes are not present.
 - Fix a panic that may occur during shutdown if the WAL is closed in the middle
   of the WAL being truncated. (@rfratto)
 
-## v0.5.0 (2020-08-12)
+v0.5.0 (2020-08-12)
+-------------------
 
 ### Features
 
@@ -1539,7 +1586,8 @@ internal API changes are not present.
   needing to manually set the blocklist and allowlist of filesystems.
   (@rfratto)
 
-## v0.4.0 (2020-06-18)
+v0.4.0 (2020-06-18)
+-------------------
 
 ### Features
 
@@ -1566,7 +1614,8 @@ internal API changes are not present.
 - Enable agent host_filter in the Tanka configs, which was disabled by default
   by mistake. (@rfratto)
 
-## v0.3.2 (2020-05-29)
+v0.3.2 (2020-05-29)
+-------------------
 
 ### Features
 
@@ -1606,7 +1655,8 @@ internal API changes are not present.
   correctly show the pod name of the Agent instead of the exporter name.
   (@rfratto)
 
-## v0.3.1 (2020-05-20)
+v0.3.1 (2020-05-20)
+-------------------
 
 ### Features
 
@@ -1626,7 +1676,8 @@ internal API changes are not present.
 - `agentctl` and the config API will now validate that the YAML they receive
   are valid instance configs. (@rfratto)
 
-## v0.3.0 (2020-05-13)
+v0.3.0 (2020-05-13)
+-------------------
 
 ### Features
 
@@ -1653,7 +1704,8 @@ internal API changes are not present.
 - The Grafana Agent Tanka Mixins now are placed in an "Agent" folder within
   Grafana. (@cyriltovena)
 
-## v0.2.0 (2020-04-09)
+v0.2.0 (2020-04-09)
+-------------------
 
 ### Features
 
@@ -1663,7 +1715,6 @@ internal API changes are not present.
   (@gotjosh)
 
   These metrics are available to monitor metadata being sent:
-
   - `prometheus_remote_storage_succeeded_metadata_total`
   - `prometheus_remote_storage_failed_metadata_total`
   - `prometheus_remote_storage_retried_metadata_total`
@@ -1683,7 +1734,8 @@ internal API changes are not present.
 - Enabling host_filter will now allow metrics from node role Kubernetes service
   discovery to be scraped properly (e.g., cAdvisor, Kubelet). (@rfratto)
 
-## v0.1.1 (2020-03-16)
+v0.1.1 (2020-03-16)
+-------------------
 
 ### Other changes
 
@@ -1693,13 +1745,14 @@ internal API changes are not present.
 
 - Pass through release tag to `docker build` (@rfratto)
 
-## v0.1.0 (2020-03-16)
+v0.1.0 (2020-03-16)
+-------------------
 
 > First release!
 
 ### Features
 
-- Support for scraping Prometheus metrics and sharding the agent through the
+* Support for scraping Prometheus metrics and sharding the agent through the
   presence of a `host_filter` flag within the Agent configuration file.
 
 [upgrade guide]: https://grafana.com/docs/agent/latest/upgrade-guide/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
-Main (unreleased)
------------------
+## Main (unreleased)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -21,7 +20,7 @@ Main (unreleased)
 ### Features
 
 - Add `agentctl test-logs` command to allow testing log configurations by redirecting
-collected logs to standard output. This can be useful for debugging. (@jcreixell)
+  collected logs to standard output. This can be useful for debugging. (@jcreixell)
 
 - New Grafana Agent Flow components:
 
@@ -43,12 +42,14 @@ collected logs to standard output. This can be useful for debugging. (@jcreixell
   - `otelcol.processor.memory_limiter` periodically checks memory usage and
     drops data or forces a garbage collection if the defined limits are
     exceeded. (@tpaschalis)
-  
+
 ### Enhancements
 
 - Update OpenTelemetry Collector dependency to v0.61.0. (@rfratto)
 
 - Update Prometheus dependency to v2.38.0. (@rfratto)
+
+- Add caching to Prometheus relabel flow component. (@mattdurham)
 
 ### Bugfixes
 
@@ -56,8 +57,7 @@ collected logs to standard output. This can be useful for debugging. (@jcreixell
 
 - Fix identifier on target creation for SNMP v2 integration. (@marctc)
 
-v0.28.0 (2022-09-29)
---------------------
+## v0.28.0 (2022-09-29)
 
 ### Features
 
@@ -91,8 +91,7 @@ v0.28.0 (2022-09-29)
 
 - Add metrics for config reloads and config hash (@jcreixell)
 
-v0.27.1 (2022-09-09)
---------------------
+## v0.27.1 (2022-09-09)
 
 > **NOTE**: ARMv6 Docker images are no longer being published.
 >
@@ -106,8 +105,7 @@ v0.27.1 (2022-09-09)
 
 - Switch docker image base from debian to ubuntu. (@captncraig)
 
-v0.27.0 (2022-09-01)
---------------------
+## v0.27.0 (2022-09-01)
 
 ### Features
 
@@ -133,7 +131,7 @@ v0.27.0 (2022-09-01)
 ### Bugfixes
 
 - Tracing: Fixed issue with the PromSD processor using the `connection` method to discover the IP
-  address.  It was failing to match because the port number was included in the address string. (@jphx)
+  address. It was failing to match because the port number was included in the address string. (@jphx)
 
 - Register prometheus discovery metrics. (@mattdurham)
 
@@ -147,12 +145,11 @@ v0.27.0 (2022-09-01)
 
 ### Other changes
 
- - Update several go dependencies to resolve warnings from certain security scanning tools. None of the resolved vulnerabilities were known to be exploitable through the agent. (@captncraig)
+- Update several go dependencies to resolve warnings from certain security scanning tools. None of the resolved vulnerabilities were known to be exploitable through the agent. (@captncraig)
 
- - It is now possible to compile Grafana Agent using Go 1.19. (@rfratto)
+- It is now possible to compile Grafana Agent using Go 1.19. (@rfratto)
 
-v0.26.1 (2022-07-25)
---------------------
+## v0.26.1 (2022-07-25)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -168,8 +165,7 @@ v0.26.1 (2022-07-25)
 
 - Build the Linux/AMD64 artifacts using the opt-out flag for the ebpf_exporter. (@tpaschalis)
 
-v0.26.0 (2022-07-18)
---------------------
+## v0.26.0 (2022-07-18)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -201,8 +197,7 @@ v0.26.0 (2022-07-18)
 
 - Fix mongodb exporter so that it now collects all metrics. (@mattdurham)
 
-v0.25.1 (2022-06-16)
---------------------
+## v0.25.1 (2022-06-16)
 
 ### Bugfixes
 
@@ -210,9 +205,7 @@ v0.25.1 (2022-06-16)
 
 - Unwrap replayWAL error before attempting corruption repair. (@rlankfo)
 
-
-v0.25.0 (2022-06-06)
---------------------
+## v0.25.0 (2022-06-06)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -258,7 +251,7 @@ v0.25.0 (2022-06-06)
 
 ### Bugfixes
 
-- Scraping service was not honoring the new server grpc flags `server.grpc.address`.  (@mattdurham)
+- Scraping service was not honoring the new server grpc flags `server.grpc.address`. (@mattdurham)
 
 ### Other changes
 
@@ -267,16 +260,13 @@ v0.25.0 (2022-06-06)
 
 - Use Go 1.18 for builds. (@rfratto)
 
-- Add `metrics` prefix to the url of list instances endpoint (`GET
-  /agent/api/v1/instances`) and list targets endpoint (`GET
-  /agent/api/v1/metrics/targets`). (@marctc)
+- Add `metrics` prefix to the url of list instances endpoint (`GET /agent/api/v1/instances`) and list targets endpoint (`GET /agent/api/v1/metrics/targets`). (@marctc)
 
 - Add extra identifying labels (`job`, `instance`, `agent_hostname`) to eventhandler integration. (@hjet)
 
 - Add `extra_labels` configuration to eventhandler integration. (@hjet)
 
-v0.24.2 (2022-05-02)
---------------------
+## v0.24.2 (2022-05-02)
 
 ### Bugfixes
 
@@ -286,8 +276,7 @@ v0.24.2 (2022-05-02)
 
 - Update version of node_exporter to include additional metrics for osx. (@v-zhuravlev)
 
-v0.24.1 (2022-04-14)
---------------------
+## v0.24.1 (2022-04-14)
 
 ### Bugfixes
 
@@ -312,8 +301,7 @@ v0.24.1 (2022-04-14)
 - Embed timezone data to enable Promtail pipelines using the `location` field
   on Windows machines. (@tpaschalis)
 
-v0.24.0 (2022-04-07)
---------------------
+## v0.24.0 (2022-04-07)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -443,8 +431,7 @@ v0.24.0 (2022-04-07)
   the path name of the default secret mount. As a side effect of this bugfix,
   custom Secrets will now be mounted at
   `/var/lib/grafana-agent/extra-secrets/<secret name>` and custom ConfigMaps
-  will now be mounted at `/var/lib/grafana-agent/extra-configmaps/<configmap
-  name>`. This is not a breaking change as it was previously impossible to
+  will now be mounted at `/var/lib/grafana-agent/extra-configmaps/<configmap name>`. This is not a breaking change as it was previously impossible to
   properly provide these custom mounts. (@rfratto)
 
 - Flags accidentally prefixed with `-metrics.service..` (two `.` in a row) have
@@ -458,8 +445,7 @@ v0.24.0 (2022-04-07)
   will now default to `data-agent/`, the same default WAL directory as
   Prometheus Agent. (@rfratto)
 
-v0.23.0 (2022-02-10)
---------------------
+## v0.23.0 (2022-02-10)
 
 ### Enhancements
 
@@ -504,8 +490,7 @@ v0.23.0 (2022-02-10)
 
 - Disable `machine-id` journal vol by default in sample logs manifest (@hjet)
 
-v0.22.0 (2022-01-13)
---------------------
+## v0.22.0 (2022-01-13)
 
 > This release has deprecations. Please read entries carefully and consult
 > the [upgrade guide][] for specific instructions.
@@ -592,8 +577,7 @@ v0.22.0 (2022-01-13)
 
 - Remove log-level flag from systemd unit file (@jpkrohling)
 
-v0.21.2 (2021-12-08)
---------------------
+## v0.21.2 (2021-12-08)
 
 ### Security fixes
 
@@ -607,8 +591,7 @@ v0.21.2 (2021-12-08)
   `--config.enable-read-api` flag at the command line to opt in to these
   endpoints.
 
-v0.21.1 (2021-11-18)
---------------------
+## v0.21.1 (2021-11-18)
 
 ### Bugfixes
 
@@ -627,8 +610,7 @@ v0.21.1 (2021-11-18)
 - Metrics: Only run WAL cleaner when metrics are being used and a WAL is
   configured. (@rfratto)
 
-v0.21.0 (2021-11-17)
---------------------
+## v0.21.0 (2021-11-17)
 
 ### Enhancements
 
@@ -662,10 +644,9 @@ v0.21.0 (2021-11-17)
 
 - Traces: Changed service graphs store implementation to improve CPU performance (@mapno)
 
-v0.20.1 (2021-12-08)
---------------------
+## v0.20.1 (2021-12-08)
 
-> *NOTE*: The fixes in this patch are only present in v0.20.1 and >=v0.21.2.
+> _NOTE_: The fixes in this patch are only present in v0.20.1 and >=v0.21.2.
 
 ### Security fixes
 
@@ -679,8 +660,7 @@ v0.20.1 (2021-12-08)
   `--config.enable-read-api` flag at the command line to opt in to these
   endpoints.
 
-v0.20.0 (2021-10-28)
---------------------
+## v0.20.0 (2021-10-28)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -712,7 +692,7 @@ v0.20.0 (2021-10-28)
 
 - Updated elasticsearch_exporter to v1.2.1 (@gaantunes)
 
-- Add remote write to silent Windows Installer  (@mattdurham)
+- Add remote write to silent Windows Installer (@mattdurham)
 
 - Updated mongodb_exporter to v0.20.7 (@rfratto)
 
@@ -753,8 +733,7 @@ v0.20.0 (2021-10-28)
 - The windows_exporter now disables the textfile collector by default.
   (@rfratto)
 
-v0.19.0 (2021-09-29)
---------------------
+## v0.19.0 (2021-09-29)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -816,7 +795,7 @@ v0.19.0 (2021-09-29)
 - Allow reloading configuration using `SIGHUP` signal. (@tharun208)
 
 - Add HOSTNAME environment variable to service file to allow for expanding the
-  $HOSTNAME variable in agent config.  (@dfrankel33)
+  $HOSTNAME variable in agent config. (@dfrankel33)
 
 - Update jsonnet-libs to 1.21 for Kubernetes 1.21+ compatability. (@MurzNN)
 
@@ -856,8 +835,7 @@ v0.19.0 (2021-09-29)
 
 - Standardize scrape_interval to 1m in examples. (@mattdurham)
 
-v0.18.4 (2021-09-14)
---------------------
+## v0.18.4 (2021-09-14)
 
 ### Enhancements
 
@@ -871,8 +849,7 @@ v0.18.4 (2021-09-14)
 - Scraping service: Ensure that a reshard is scheduled every reshard
   interval. (@rfratto)
 
-v0.18.3 (2021-09-08)
---------------------
+## v0.18.3 (2021-09-08)
 
 ### Bugfixes
 
@@ -893,22 +870,19 @@ v0.18.3 (2021-09-08)
 - Scraping service: prevent more than one refresh from being queued at a time.
   (@rfratto)
 
-v0.18.2 (2021-08-12)
---------------------
+## v0.18.2 (2021-08-12)
 
 ### Bugfixes
 
 - Honor the prefix and remove prefix from consul list results (@mattdurham)
 
-v0.18.1 (2021-08-09)
---------------------
+## v0.18.1 (2021-08-09)
 
 ### Bugfixes
 
 - Reduce number of consul calls when ran in scrape service mode (@mattdurham)
 
-v0.18.0 (2021-07-29)
---------------------
+## v0.18.0 (2021-07-29)
 
 ### Features
 
@@ -927,8 +901,7 @@ v0.18.0 (2021-07-29)
 
 - Enabled flag for integrations is not being honored. (@mattdurham)
 
-v0.17.0 (2021-07-15)
---------------------
+## v0.17.0 (2021-07-15)
 
 ### Features
 
@@ -940,16 +913,14 @@ v0.17.0 (2021-07-15)
 - Fix race condition that may occur and result in a panic when initializing
   scraping service cluster. (@rfratto)
 
-v0.16.1 (2021-06-22)
---------------------
+## v0.16.1 (2021-06-22)
 
 ### Bugfixes
 
 - Fix issue where replaying a WAL caused incorrect metrics to be sent over
   remote write. (@rfratto)
 
-v0.16.0 (2021-06-17)
---------------------
+## v0.16.0 (2021-06-17)
 
 ### Features
 
@@ -970,8 +941,7 @@ v0.16.0 (2021-06-17)
   that target had gone down for long enough that its series were removed from
   the in-memory cache (2 GC cycles). (@rfratto)
 
-v0.15.0 (2021-06-03)
---------------------
+## v0.15.0 (2021-06-03)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -1012,8 +982,7 @@ v0.15.0 (2021-06-03)
 
 - Intentionally order tracing processors. (@joe-elliott)
 
-v0.14.0 (2021-05-24)
---------------------
+## v0.14.0 (2021-05-24)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -1024,7 +993,7 @@ v0.14.0 (2021-05-24)
 
 ### Security fixes
 
-* The Scraping service API will now reject configs that read credentials from
+- The Scraping service API will now reject configs that read credentials from
   disk by default. This prevents malicious users from reading arbitrary files
   and sending their contents over the network. The old behavior can be
   re-enabled by setting `dangerous_allow_reading_files: true` in the scraping
@@ -1032,7 +1001,7 @@ v0.14.0 (2021-05-24)
 
 ### Breaking changes
 
-* Configuration for SigV4 has changed. (@rfratto)
+- Configuration for SigV4 has changed. (@rfratto)
 
 ### Deprecations
 
@@ -1056,7 +1025,7 @@ v0.14.0 (2021-05-24)
   against the main HTTP server. Instead, two new command-line flags have been
   added: `--reload-addr` and `--reload-port`. These will launch a
   `/-/reload`-only HTTP server that can be used to safely reload the Agent's
-  state.  (@rfratto)
+  state. (@rfratto)
 
 - Add a /-/config endpoint. This endpoint will return the current configuration
   file with defaults applied that the Agent has loaded from disk. (@rfratto)
@@ -1128,8 +1097,7 @@ v0.14.0 (2021-05-24)
 
 - Add `tempo_spanmetrics` namespace in spanmetrics (@mapno)
 
-v0.13.1 (2021-04-09)
---------------------
+## v0.13.1 (2021-04-09)
 
 ### Bugfixes
 
@@ -1137,8 +1105,7 @@ v0.13.1 (2021-04-09)
   label set with duplicate labels, mirroring the behavior of Prometheus.
   (@rfratto)
 
-v0.13.0 (2021-02-25)
---------------------
+## v0.13.0 (2021-02-25)
 
 > The primary branch name has changed from `master` to `main`. You may have to
 > update your local checkouts of the repository to point at the new branch name.
@@ -1177,17 +1144,16 @@ v0.13.0 (2021-02-25)
 - Add the ability to read and serve HTTPS integration metrics when given a set
   certificates (@mattdurham)
 
-v0.12.0 (2021-02-05)
---------------------
+## v0.12.0 (2021-02-05)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
 
 ### Breaking Changes
 
-* The configuration format for the `loki` block has changed. (@rfratto)
+- The configuration format for the `loki` block has changed. (@rfratto)
 
-* The configuration format for the `tempo` block has changed. (@rfratto)
+- The configuration format for the `tempo` block has changed. (@rfratto)
 
 ### Features
 
@@ -1214,7 +1180,7 @@ v0.12.0 (2021-02-05)
 - Scraping service: Unhealthy Agents in the ring will no longer cause job
   distribution to fail. (@rfratto)
 
-- Scraping service: Cortex ring metrics (prefixed with cortex_ring_) will now
+- Scraping service: Cortex ring metrics (prefixed with cortex*ring*) will now
   be registered for tracking the state of the hash ring. (@rfratto)
 
 - Scraping service: instance config ownership is now determined by the hash of
@@ -1232,8 +1198,7 @@ v0.12.0 (2021-02-05)
 - `agentctl config-check` will now work correctly when the supplied config file
   contains integrations. (@hoenn)
 
-v0.11.0 (2021-01-20)
---------------------
+## v0.11.0 (2021-01-20)
 
 ### Features
 
@@ -1261,8 +1226,7 @@ v0.11.0 (2021-01-20)
 - The K8s manifests will no longer include the `default/kubernetes` job twice
   in both the DaemonSet and the Deployment. (@rfratto)
 
-v0.10.0 (2021-01-13)
---------------------
+## v0.10.0 (2021-01-13)
 
 ### Features
 
@@ -1299,16 +1263,14 @@ v0.10.0 (2021-01-13)
   This was prevented by accidentally writing to a readonly volume mount.
   (@rfratto)
 
-v0.9.1 (2021-01-04)
--------------------
+## v0.9.1 (2021-01-04)
 
 ### Enhancements
 
 - agentctl will now be installed by the rpm and deb packages as
   `grafana-agentctl`. (@rfratto)
 
-v0.9.0 (2020-12-10)
--------------------
+## v0.9.0 (2020-12-10)
 
 ### Features
 
@@ -1357,8 +1319,7 @@ v0.9.0 (2020-12-10)
 - The User-Agent header sent for logs will now be `GrafanaCloudAgent/<version>`
   (@rfratto)
 
-v0.8.0 (2020-11-06)
--------------------
+## v0.8.0 (2020-11-06)
 
 ### Features
 
@@ -1371,7 +1332,7 @@ v0.8.0 (2020-11-06)
 ### Enhancements
 
 - Add `<integration name>_build_info` metric to all integrations. The build
-  info displayed will match the build information of the Agent and *not* the
+  info displayed will match the build information of the Agent and _not_ the
   embedded exporter. This metric is used by community dashboards, so adding it
   to the Agent increases compatibility with existing dashboards that depend on
   it existing. (@rfratto)
@@ -1384,8 +1345,7 @@ v0.8.0 (2020-11-06)
   rather than just logging a generic message saying that retrieving the config
   has failed. (@rfratto)
 
-v0.7.2 (2020-10-29)
--------------------
+## v0.7.2 (2020-10-29)
 
 ### Enhancements
 
@@ -1408,15 +1368,13 @@ v0.7.2 (2020-10-29)
 - Fix issue where the `push_config` for Tempo field was expected to be
   `remote_write`. `push_config` now works as expected. (@rfratto)
 
-v0.7.1 (2020-10-23)
--------------------
+## v0.7.1 (2020-10-23)
 
 ### Bugfixes
 
 - Fix issue where ARM binaries were not published with the GitHub release.
 
-v0.7.0 (2020-10-23)
--------------------
+## v0.7.0 (2020-10-23)
 
 ### Features
 
@@ -1458,8 +1416,7 @@ v0.7.0 (2020-10-23)
   computed by remote_write. This change should not negatively effect existing
   users. (@rfratto)
 
-v0.6.1 (2020-04-11)
--------------------
+## v0.6.1 (2020-04-11)
 
 ### Bugfixes
 
@@ -1472,8 +1429,7 @@ v0.6.1 (2020-04-11)
 - Fix deadlock that slowly prevents the Agent from scraping targets at a high
   scrape volume. (@rfratto)
 
-v0.6.0 (2020-09-04)
--------------------
+## v0.6.0 (2020-09-04)
 
 ### Breaking Changes
 
@@ -1522,7 +1478,7 @@ v0.6.0 (2020-09-04)
 - The subsystems of the Agent (`prometheus`, `loki`) are now made optional.
   Enabling integrations also implicitly enables the associated subsystem. For
   example, enabling the `agent` or `node_exporter` integration will force the
-  `prometheus` subsystem to be enabled.  (@rfratto)
+  `prometheus` subsystem to be enabled. (@rfratto)
 
 ### Bugfixes
 
@@ -1546,8 +1502,7 @@ v0.6.0 (2020-09-04)
 - Fix a panic that may occur during shutdown if the WAL is closed in the middle
   of the WAL being truncated. (@rfratto)
 
-v0.5.0 (2020-08-12)
--------------------
+## v0.5.0 (2020-08-12)
 
 ### Features
 
@@ -1584,8 +1539,7 @@ v0.5.0 (2020-08-12)
   needing to manually set the blocklist and allowlist of filesystems.
   (@rfratto)
 
-v0.4.0 (2020-06-18)
--------------------
+## v0.4.0 (2020-06-18)
 
 ### Features
 
@@ -1612,8 +1566,7 @@ v0.4.0 (2020-06-18)
 - Enable agent host_filter in the Tanka configs, which was disabled by default
   by mistake. (@rfratto)
 
-v0.3.2 (2020-05-29)
--------------------
+## v0.3.2 (2020-05-29)
 
 ### Features
 
@@ -1653,8 +1606,7 @@ v0.3.2 (2020-05-29)
   correctly show the pod name of the Agent instead of the exporter name.
   (@rfratto)
 
-v0.3.1 (2020-05-20)
--------------------
+## v0.3.1 (2020-05-20)
 
 ### Features
 
@@ -1674,8 +1626,7 @@ v0.3.1 (2020-05-20)
 - `agentctl` and the config API will now validate that the YAML they receive
   are valid instance configs. (@rfratto)
 
-v0.3.0 (2020-05-13)
--------------------
+## v0.3.0 (2020-05-13)
 
 ### Features
 
@@ -1702,8 +1653,7 @@ v0.3.0 (2020-05-13)
 - The Grafana Agent Tanka Mixins now are placed in an "Agent" folder within
   Grafana. (@cyriltovena)
 
-v0.2.0 (2020-04-09)
--------------------
+## v0.2.0 (2020-04-09)
 
 ### Features
 
@@ -1713,12 +1663,13 @@ v0.2.0 (2020-04-09)
   (@gotjosh)
 
   These metrics are available to monitor metadata being sent:
-    - `prometheus_remote_storage_succeeded_metadata_total`
-    - `prometheus_remote_storage_failed_metadata_total`
-    - `prometheus_remote_storage_retried_metadata_total`
-    - `prometheus_remote_storage_sent_batch_duration_seconds` and
-      `prometheus_remote_storage_sent_bytes_total` have a new label “type” with
-      the values of `metadata` or `samples`.
+
+  - `prometheus_remote_storage_succeeded_metadata_total`
+  - `prometheus_remote_storage_failed_metadata_total`
+  - `prometheus_remote_storage_retried_metadata_total`
+  - `prometheus_remote_storage_sent_batch_duration_seconds` and
+    `prometheus_remote_storage_sent_bytes_total` have a new label “type” with
+    the values of `metadata` or `samples`.
 
 ### Enhancements
 
@@ -1732,8 +1683,7 @@ v0.2.0 (2020-04-09)
 - Enabling host_filter will now allow metrics from node role Kubernetes service
   discovery to be scraped properly (e.g., cAdvisor, Kubelet). (@rfratto)
 
-v0.1.1 (2020-03-16)
--------------------
+## v0.1.1 (2020-03-16)
 
 ### Other changes
 
@@ -1743,14 +1693,13 @@ v0.1.1 (2020-03-16)
 
 - Pass through release tag to `docker build` (@rfratto)
 
-v0.1.0 (2020-03-16)
--------------------
+## v0.1.0 (2020-03-16)
 
 > First release!
 
 ### Features
 
-* Support for scraping Prometheus metrics and sharding the agent through the
+- Support for scraping Prometheus metrics and sharding the agent through the
   presence of a `host_filter` flag within the Agent configuration file.
 
 [upgrade guide]: https://grafana.com/docs/agent/latest/upgrade-guide/

--- a/component/prometheus/relabel/relabel_test.go
+++ b/component/prometheus/relabel/relabel_test.go
@@ -1,0 +1,83 @@
+package relabel
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/component"
+	flow_relabel "github.com/grafana/agent/component/common/relabel"
+	"github.com/grafana/agent/component/prometheus"
+	"github.com/grafana/agent/pkg/util"
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/prometheus/prometheus/model/value"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCache(t *testing.T) {
+	relabeller := generateRelabel(t)
+	fm := prometheus.NewFlowMetric(0, labels.FromStrings("__address__", "localhost"), 0)
+
+	relabeller.Receive(time.Now().Unix(), []*prometheus.FlowMetric{fm})
+	require.Len(t, relabeller.cache, 1)
+	entry, found := relabeller.cache[fm.GlobalRefID()]
+	require.True(t, found)
+	require.NotNil(t, entry)
+	require.True(t, entry.GlobalRefID() != fm.GlobalRefID())
+}
+
+func TestEviction(t *testing.T) {
+	relabeller := generateRelabel(t)
+	fm := prometheus.NewFlowMetric(0, labels.FromStrings("__address__", "localhost"), 0)
+
+	relabeller.Receive(time.Now().Unix(), []*prometheus.FlowMetric{fm})
+	require.Len(t, relabeller.cache, 1)
+	fmstale := prometheus.NewFlowMetric(0, labels.FromStrings("__address__", "localhost"), math.Float64frombits(value.StaleNaN))
+	relabeller.Receive(time.Now().Unix(), []*prometheus.FlowMetric{fmstale})
+	require.Len(t, relabeller.cache, 0)
+}
+
+func TestUpdateReset(t *testing.T) {
+	relabeller := generateRelabel(t)
+	fm := prometheus.NewFlowMetric(0, labels.FromStrings("__address__", "localhost"), 0)
+
+	relabeller.Receive(time.Now().Unix(), []*prometheus.FlowMetric{fm})
+	require.Len(t, relabeller.cache, 1)
+	relabeller.Update(Arguments{
+		MetricRelabelConfigs: []*flow_relabel.Config{},
+	})
+	require.Len(t, relabeller.cache, 0)
+
+}
+
+func generateRelabel(t *testing.T) *Component {
+	rec := &prometheus.Receiver{
+		Receive: func(timestamp int64, metrics []*prometheus.FlowMetric) {
+			require.True(t, metrics[0].LabelsCopy().Has("new_label"))
+		},
+	}
+	relabeller, err := New(component.Options{
+		ID:     "1",
+		Logger: util.TestLogger(t),
+		OnStateChange: func(e component.Exports) {
+		},
+		Registerer: prom.NewRegistry(),
+	}, Arguments{
+		ForwardTo: []*prometheus.Receiver{rec},
+		MetricRelabelConfigs: []*flow_relabel.Config{
+			{
+				SourceLabels: []string{"__address__"},
+				Regex:        flow_relabel.Regexp(relabel.MustNewRegexp("(.+)")),
+				TargetLabel:  "new_label",
+				Replacement:  "new_value",
+				Action:       "replace",
+			},
+		},
+	})
+	require.NotNil(t, relabeller)
+	require.NoError(t, err)
+	return relabeller
+
+}

--- a/component/prometheus/relabel/relabel_test.go
+++ b/component/prometheus/relabel/relabel_test.go
@@ -49,7 +49,6 @@ func TestUpdateReset(t *testing.T) {
 		MetricRelabelConfigs: []*flow_relabel.Config{},
 	})
 	require.Len(t, relabeller.cache, 0)
-
 }
 
 func generateRelabel(t *testing.T) *Component {
@@ -79,5 +78,4 @@ func generateRelabel(t *testing.T) *Component {
 	require.NotNil(t, relabeller)
 	require.NoError(t, err)
 	return relabeller
-
 }

--- a/component/prometheus/relabel/relabel_test.go
+++ b/component/prometheus/relabel/relabel_test.go
@@ -2,9 +2,11 @@ package relabel
 
 import (
 	"math"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/grafana/agent/component"
 	flow_relabel "github.com/grafana/agent/component/common/relabel"
 	"github.com/grafana/agent/component/prometheus"
@@ -49,6 +51,37 @@ func TestUpdateReset(t *testing.T) {
 		MetricRelabelConfigs: []*flow_relabel.Config{},
 	})
 	require.Len(t, relabeller.cache, 0)
+}
+
+func BenchmarkCache(b *testing.B) {
+	rec := &prometheus.Receiver{
+		Receive: func(timestamp int64, metrics []*prometheus.FlowMetric) {
+		},
+	}
+	l := log.NewSyncLogger(log.NewLogfmtLogger(os.Stderr))
+
+	relabeller, _ := New(component.Options{
+		ID:     "1",
+		Logger: l,
+		OnStateChange: func(e component.Exports) {
+		},
+		Registerer: prom.NewRegistry(),
+	}, Arguments{
+		ForwardTo: []*prometheus.Receiver{rec},
+		MetricRelabelConfigs: []*flow_relabel.Config{
+			{
+				SourceLabels: []string{"__address__"},
+				Regex:        flow_relabel.Regexp(relabel.MustNewRegexp("(.+)")),
+				TargetLabel:  "new_label",
+				Replacement:  "new_value",
+				Action:       "replace",
+			},
+		},
+	})
+	for i := 0; i < b.N; i++ {
+		fm := prometheus.NewFlowMetric(0, labels.FromStrings("__address__", "localhost"), float64(i))
+		relabeller.Receive(0, []*prometheus.FlowMetric{fm})
+	}
 }
 
 func generateRelabel(t *testing.T) *Component {


### PR DESCRIPTION
#### PR Description

Adds caching to prometheus relabel, it's probably not the end goal because there are cases where the cache can leak. IE if you have two relabel components in a series, the second one starts caching results from the first, and the configuration on the first changes so it never sends the value that the second was caching. 

The more complex solution would be to also add a time-based eviction notice, but that seemed to complex for an edge case. Adding it to the global cache would likely allow one component to have a timer and notify callers that the cache can be evicted. Since all metrics call back to get a global id it has the most knowledge. I think submodules complicate the global cache and am wary of adding that to global cache at the moment.

#### Which issue(s) this PR fixes

Closes #2324

#### PR Checklist

- [X] CHANGELOG updated
- [ ] Documentation added
- [X] Tests updated
