### PR TITLE
docs/flow: Fix capture group reference documentation

### DIFF
--- a/docs/sources/shared/flow/reference/components/rule-block.md
+++ b/docs/sources/shared/flow/reference/components/rule-block.md
@@ -33,4 +33,4 @@ Here's a list of the available actions, along with a brief description of their 
 * `labelkeep` - Matches `regex` against all label names. Any labels that don't match are removed from the metric's label set.
 
 Finally, note that the regex capture groups can be referred to using either the
-`$1` or `${1}` notation.
+`$CAPTURE_GROUP_NUMBER` or `${CAPTURE_GROUP_NUMBER}` notation.

--- a/docs/sources/shared/flow/reference/components/rule-block.md
+++ b/docs/sources/shared/flow/reference/components/rule-block.md
@@ -33,4 +33,4 @@ Here's a list of the available actions, along with a brief description of their 
 * `labelkeep` - Matches `regex` against all label names. Any labels that don't match are removed from the metric's label set.
 
 Finally, note that the regex capture groups can be referred to using either the
-`$1` or `$${1}` notation.
+`$1` or `${1}` notation.


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR fixes the documentation of capture groups for the prometheus.relabel and discovery.relabel components. The old notation was valid when using HCL in previous Flow iterations, but is different now as we switched to River.

#### Which issue(s) this PR fixes
No issue filed

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
