### PR TITLE
Revert "Automatically assign new PRs to project board (#2349)"

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -3,9 +3,6 @@ on:
   issues:
     types:
       - opened
-  pull_request:
-    types:
-      - opened
 jobs:
   add-to-project:
     name: Add issue to project


### PR DESCRIPTION
This reverts commit bf8675a1cecc4427fe7e1ce59a1a77d9f424e12e.

PRs from forks cannot automatically be added to projects because secrets are not exposed.