### PR TITLE
docs/flow: Add zero-width space in title to prevent overflowing in rendered docs

### DIFF
--- a/docs/sources/flow/reference/components/otelcol.processor.memory_limiter.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.memory_limiter.md
@@ -1,7 +1,14 @@
 ---
+# NOTE(tpaschalis): the title below has zero-width spaces injected into it to
+# prevent it from overflowing the sidebar on the rendered site. Be careful when
+# modifying this section to retain the spaces.
+#
+# Ideally, in the future, we can fix the overflow issue with css rather than
+# injecting special characters.
+
 aliases:
 - /docs/agent/latest/flow/reference/components/otelcol.processor.memory_limiter
-title: otelcol.processor.memory_limiter
+title: otelcol.​processor.​memory_limiter
 ---
 
 # otelcol.processor.memory_limiter


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Fix the same 

#### Which issue(s) this PR fixes
No issue filed

#### Notes to the Reviewer
Ran `make docs` to see how it looks.

![image](https://user-images.githubusercontent.com/17771679/196761680-b9af7bfe-3392-4e02-b968-6838fbf85e2f.png)

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [X] Documentation added
- [ ] Tests updated (N/A)
