### PR TITLE
otelcol.exporter.otlp: fix test flakes

### DIFF
--- a/component/otelcol/exporter/otlp/otlp_test.go
+++ b/component/otelcol/exporter/otlp/otlp_test.go
@@ -33,7 +33,7 @@ func Test(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := fmt.Sprintf(`
-		timeout = "1s"
+		timeout = "250ms"
 
 		client {
 			endpoint = "%s"


### PR DESCRIPTION
I noticed some [flaky test runs](https://github.com/grafana/agent/actions/runs/3284481234/jobs/5410488587) in the otelcol.exporter.otlp tests.

I wasn't able to reproduce locally (even with `go test -count=5000 ./component/otelcol/exporter/otlp`), but the fixes here should more or less cover it. 