### PR TITLE
Do not store the value, only store the labels and global reference id…

### DIFF
--- a/component/prometheus/relabel/relabel.go
+++ b/component/prometheus/relabel/relabel.go
@@ -8,6 +8,8 @@ import (
 	flow_relabel "github.com/grafana/agent/component/common/relabel"
 	"github.com/grafana/agent/component/prometheus"
 	prometheus_client "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
+
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/prometheus/model/value"
 )
@@ -48,7 +50,7 @@ type Component struct {
 	metricsProcessed prometheus_client.Counter
 
 	cacheMut sync.RWMutex
-	cache    map[uint64]*prometheus.FlowMetric
+	cache    map[uint64]*labelAndID
 }
 
 var _ component.Component = (*Component)(nil)
@@ -57,7 +59,7 @@ var _ component.Component = (*Component)(nil)
 func New(o component.Options, args Arguments) (*Component, error) {
 	c := &Component{
 		opts:  o,
-		cache: make(map[uint64]*prometheus.FlowMetric),
+		cache: make(map[uint64]*labelAndID),
 	}
 	c.receiver = &prometheus.Receiver{Receive: c.Receive}
 	c.metricsProcessed = prometheus_client.NewCounter(prometheus_client.CounterOpts{
@@ -110,7 +112,10 @@ func (c *Component) Receive(ts int64, metricArr []*prometheus.FlowMetric) {
 		var relabelledFm *prometheus.FlowMetric
 		fm, found := c.getFromCache(m.GlobalRefID())
 		if found {
-			relabelledFm = fm
+			// If fm is nil but found then we want to keep the value nil, if it's not we want to reuse the labels
+			if fm.labels != nil {
+				relabelledFm = prometheus.NewFlowMetric(fm.id, fm.labels, m.Value())
+			}
 		} else {
 			relabelledFm = m.Relabel(c.mrc...)
 			c.addToCache(m.GlobalRefID(), relabelledFm)
@@ -135,7 +140,7 @@ func (c *Component) Receive(ts int64, metricArr []*prometheus.FlowMetric) {
 	}
 }
 
-func (c *Component) getFromCache(id uint64) (*prometheus.FlowMetric, bool) {
+func (c *Component) getFromCache(id uint64) (*labelAndID, bool) {
 	c.cacheMut.RLock()
 	defer c.cacheMut.RUnlock()
 
@@ -154,12 +159,26 @@ func (c *Component) clearCache() {
 	c.cacheMut.Lock()
 	defer c.cacheMut.Unlock()
 
-	c.cache = make(map[uint64]*prometheus.FlowMetric)
+	c.cache = make(map[uint64]*labelAndID)
 }
 
 func (c *Component) addToCache(originalID uint64, fm *prometheus.FlowMetric) {
 	c.cacheMut.Lock()
 	defer c.cacheMut.Unlock()
 
-	c.cache[originalID] = fm
+	if fm == nil {
+		c.cache[originalID] = nil
+		return
+	}
+	c.cache[originalID] = &labelAndID{
+		labels: fm.RawLabels(),
+		id:     fm.GlobalRefID(),
+	}
+}
+
+// labelAndID stores both the globalrefid for the label and the id itself. We store the id so that it doesnt have
+// to be recalculated again.
+type labelAndID struct {
+	labels labels.Labels
+	id     uint64
 }

--- a/component/prometheus/relabel/relabel.go
+++ b/component/prometheus/relabel/relabel.go
@@ -110,11 +110,11 @@ func (c *Component) Receive(ts int64, metricArr []*prometheus.FlowMetric) {
 	for _, m := range metricArr {
 		// Relabel may return the original flowmetric if no changes applied, nil if everything was removed or an entirely new flowmetric.
 		var relabelledFm *prometheus.FlowMetric
-		fm, found := c.getFromCache(m.GlobalRefID())
+		lbls, found := c.getFromCache(m.GlobalRefID())
 		if found {
-			// If fm is nil but found then we want to keep the value nil, if it's not we want to reuse the labels
-			if fm.labels != nil {
-				relabelledFm = prometheus.NewFlowMetric(fm.id, fm.labels, m.Value())
+			// If lbls is nil but cache entry was found then we want to keep the value nil, if it's not we want to reuse the labels
+			if lbls != nil {
+				relabelledFm = prometheus.NewFlowMetric(lbls.id, lbls.labels, m.Value())
 			}
 		} else {
 			relabelledFm = m.Relabel(c.mrc...)

--- a/component/prometheus/relabel/relabel_test.go
+++ b/component/prometheus/relabel/relabel_test.go
@@ -126,7 +126,6 @@ func TestNil(t *testing.T) {
 	newFm := prometheus.NewFlowMetric(0, labels.FromStrings("__address__", "localhost"), 20)
 	relabeller.Receive(time.Now().Unix(), []*prometheus.FlowMetric{newFm})
 	require.True(t, fm.GlobalRefID() == newFm.GlobalRefID())
-
 }
 
 func BenchmarkCache(b *testing.B) {

--- a/component/prometheus/relabel/relabel_test.go
+++ b/component/prometheus/relabel/relabel_test.go
@@ -24,10 +24,11 @@ func TestCache(t *testing.T) {
 
 	relabeller.Receive(time.Now().Unix(), []*prometheus.FlowMetric{fm})
 	require.Len(t, relabeller.cache, 1)
-	entry, found := relabeller.cache[fm.GlobalRefID()]
+	entry, found := relabeller.getFromCache(fm.GlobalRefID())
+	newFm := prometheus.NewFlowMetric(entry.id, entry.labels, 0)
 	require.True(t, found)
 	require.NotNil(t, entry)
-	require.True(t, entry.GlobalRefID() != fm.GlobalRefID())
+	require.True(t, newFm.GlobalRefID() != fm.GlobalRefID())
 }
 
 func TestEviction(t *testing.T) {
@@ -47,7 +48,7 @@ func TestUpdateReset(t *testing.T) {
 
 	relabeller.Receive(time.Now().Unix(), []*prometheus.FlowMetric{fm})
 	require.Len(t, relabeller.cache, 1)
-	relabeller.Update(Arguments{
+	_ = relabeller.Update(Arguments{
 		MetricRelabelConfigs: []*flow_relabel.Config{},
 	})
 	require.Len(t, relabeller.cache, 0)

--- a/component/prometheus/relabel/relabel_test.go
+++ b/component/prometheus/relabel/relabel_test.go
@@ -54,6 +54,81 @@ func TestUpdateReset(t *testing.T) {
 	require.Len(t, relabeller.cache, 0)
 }
 
+func TestThatValueIsNotReused(t *testing.T) {
+	// The recval is used to ensure that the value isn't also cached with the labels and id.
+	var recval float64
+	rec := &prometheus.Receiver{
+		Receive: func(timestamp int64, metrics []*prometheus.FlowMetric) {
+			require.True(t, metrics[0].LabelsCopy().Has("new_label"))
+			require.True(t, metrics[0].Value() == recval)
+		},
+	}
+	relabeller, err := New(component.Options{
+		ID:     "1",
+		Logger: util.TestLogger(t),
+		OnStateChange: func(e component.Exports) {
+		},
+		Registerer: prom.NewRegistry(),
+	}, Arguments{
+		ForwardTo: []*prometheus.Receiver{rec},
+		MetricRelabelConfigs: []*flow_relabel.Config{
+			{
+				SourceLabels: []string{"__address__"},
+				Regex:        flow_relabel.Regexp(relabel.MustNewRegexp("(.+)")),
+				TargetLabel:  "new_label",
+				Replacement:  "new_value",
+				Action:       "replace",
+			},
+		},
+	})
+	require.NotNil(t, relabeller)
+	require.NoError(t, err)
+
+	recval = 10
+	fm := prometheus.NewFlowMetric(0, labels.FromStrings("__address__", "localhost"), recval)
+	relabeller.Receive(time.Now().Unix(), []*prometheus.FlowMetric{fm})
+
+	recval = 20
+	newFm := prometheus.NewFlowMetric(0, labels.FromStrings("__address__", "localhost"), recval)
+	relabeller.Receive(time.Now().Unix(), []*prometheus.FlowMetric{newFm})
+	require.True(t, fm.GlobalRefID() == newFm.GlobalRefID())
+}
+
+func TestNil(t *testing.T) {
+	rec := &prometheus.Receiver{
+		Receive: func(timestamp int64, metrics []*prometheus.FlowMetric) {
+			// This should never run
+			require.True(t, false)
+		},
+	}
+	relabeller, err := New(component.Options{
+		ID:     "1",
+		Logger: util.TestLogger(t),
+		OnStateChange: func(e component.Exports) {
+		},
+		Registerer: prom.NewRegistry(),
+	}, Arguments{
+		ForwardTo: []*prometheus.Receiver{rec},
+		MetricRelabelConfigs: []*flow_relabel.Config{
+			{
+				SourceLabels: []string{"__address__"},
+				Regex:        flow_relabel.Regexp(relabel.MustNewRegexp("(.+)")),
+				Action:       "drop",
+			},
+		},
+	})
+	require.NotNil(t, relabeller)
+	require.NoError(t, err)
+
+	fm := prometheus.NewFlowMetric(0, labels.FromStrings("__address__", "localhost"), 10)
+	relabeller.Receive(time.Now().Unix(), []*prometheus.FlowMetric{fm})
+
+	newFm := prometheus.NewFlowMetric(0, labels.FromStrings("__address__", "localhost"), 20)
+	relabeller.Receive(time.Now().Unix(), []*prometheus.FlowMetric{newFm})
+	require.True(t, fm.GlobalRefID() == newFm.GlobalRefID())
+
+}
+
 func BenchmarkCache(b *testing.B) {
 	rec := &prometheus.Receiver{
 		Receive: func(timestamp int64, metrics []*prometheus.FlowMetric) {


### PR DESCRIPTION
#### PR Description

Instead of storing the whole flowmetric, which includes the value. We only cache the global cache id and the labels. Storing the global ref id saves a lookup and in the simple benchmark saves about 15% . This resolves the issue where the first value is locked in and always reused.
