### PR TITLE
agent-flow-mixin: add Resources dashboard

### DIFF
--- a/operations/agent-flow-mixin/dashboards.libsonnet
+++ b/operations/agent-flow-mixin/dashboards.libsonnet
@@ -1,4 +1,5 @@
 {
   grafanaDashboards+:
-    (import './dashboards/controller.libsonnet'),
+    (import './dashboards/controller.libsonnet') +
+    (import './dashboards/resources.libsonnet'),
 }

--- a/operations/agent-flow-mixin/dashboards/controller.libsonnet
+++ b/operations/agent-flow-mixin/dashboards/controller.libsonnet
@@ -5,6 +5,11 @@ local filename = 'agent-flow-controller.json';
 {
   [filename]:
     dashboard.new(name='Grafana Agent Flow / Controller') +
+    dashboard.withDocsLink(
+      url='https://grafana.com/docs/agent/latest/flow/concepts/component_controller/',
+      desc='Component controller documentation',
+    ) +
+    dashboard.withDashboardsLink() +
     dashboard.withUID(std.md5(filename)) +
     dashboard.withTemplateVariablesMixin([
       dashboard.newTemplateVariable('cluster', |||

--- a/operations/agent-flow-mixin/dashboards/resources.libsonnet
+++ b/operations/agent-flow-mixin/dashboards/resources.libsonnet
@@ -1,0 +1,197 @@
+local dashboard = import './utils/dashboard.jsonnet';
+local panel = import './utils/panel.jsonnet';
+local filename = 'agent-flow-resources.json';
+
+local pointsMixin = {
+  fieldConfig+: {
+    defaults+: {
+      custom: {
+        drawStyle: 'points',
+        pointSize: 3,
+      },
+    },
+  },
+
+};
+
+local stackedPanelMixin = {
+  fieldConfig+: {
+    defaults+: {
+      custom+: {
+        fillOpacity: 30,
+        gradientMode: 'none',
+        stacking: { mode: 'normal' },
+      },
+    },
+  },
+};
+
+{
+  [filename]:
+    dashboard.new(name='Grafana Agent Flow / Resources') +
+    dashboard.withDashboardsLink() +
+    dashboard.withUID(std.md5(filename)) +
+    dashboard.withTemplateVariablesMixin([
+      dashboard.newTemplateVariable('cluster', |||
+        label_values(agent_component_controller_running_components_total, cluster)
+      |||),
+      dashboard.newTemplateVariable('namespace', |||
+        label_values(agent_component_controller_running_components_total{cluster="$cluster"}, namespace)
+      |||),
+      dashboard.newMultiTemplateVariable('instance', |||
+        label_values(agent_component_controller_running_components_total{cluster="$cluster", namespace="$namespace"}, instance)
+      |||),
+    ]) +
+    dashboard.withPanelsMixin([
+      // CPU usage
+      (
+        panel.new(title='CPU usage', type='timeseries') +
+        panel.withUnit('percentunit') +
+        panel.withDescription(|||
+          CPU usage of the Grafana Agent process relative to 1 CPU core.
+
+          For example, 100% means using one entire CPU core.
+        |||) +
+        panel.withPosition({ x: 0, y: 0, w: 12, h: 8 }) +
+        panel.withQueries([
+          panel.newQuery(
+            expr='rate(agent_resources_process_cpu_seconds_total{cluster="$cluster",namespace="$namespace",instance=~"$instance"}[$__rate_interval])',
+            legendFormat='{{instance}}'
+          ),
+        ])
+      ),
+
+      // Memory (RSS)
+      (
+        panel.new(title='Memory (RSS)', type='timeseries') +
+        panel.withUnit('decbytes') +
+        panel.withDescription(|||
+          Resident memory size of the Grafana Agent process.
+        |||) +
+        panel.withPosition({ x: 12, y: 0, w: 12, h: 8 }) +
+        panel.withQueries([
+          panel.newQuery(
+            expr='agent_resources_process_resident_memory_bytes{cluster="$cluster",namespace="$namespace",instance=~"$instance"}',
+            legendFormat='{{instance}}'
+          ),
+        ])
+      ),
+
+      // GCs
+      (
+        panel.new(title='Garbage collections', type='timeseries') +
+        pointsMixin +
+        panel.withUnit('ops') +
+        panel.withDescription(|||
+          Rate at which the Grafana Agent process performs garbage collections.
+        |||) +
+        panel.withPosition({ x: 0, y: 8, w: 8, h: 8 }) +
+        panel.withQueries([
+          panel.newQuery(
+            // Lots of programs export go_goroutines so we ignore anything that
+            // doesn't also have a Grafana Agent-specific metric (i.e.,
+            // agent_build_info).
+            expr=|||
+              rate(go_gc_duration_seconds_count{cluster="$cluster",namespace="$namespace",instance=~"$instance"}[5m])
+              and on(instance)
+              agent_build_info{cluster="$cluster",namespace="$namespace",instance=~"$instance"}
+            |||,
+            legendFormat='{{instance}}'
+          ),
+        ])
+      ),
+
+      // Goroutines
+      (
+        panel.new(title='Goroutines', type='timeseries') +
+        panel.withUnit('none') +
+        panel.withDescription(|||
+          Number of goroutines which are running in parallel. An infinitely
+          growing number of these indicates a goroutine leak.
+        |||) +
+        panel.withPosition({ x: 8, y: 8, w: 8, h: 8 }) +
+        panel.withQueries([
+          panel.newQuery(
+            // Lots of programs export go_goroutines so we ignore anything that
+            // doesn't also have a Grafana Agent-specific metric (i.e.,
+            // agent_build_info).
+            expr=|||
+              go_goroutines{cluster="$cluster",namespace="$namespace",instance=~"$instance"}
+              and on(instance)
+              agent_build_info{cluster="$cluster",namespace="$namespace",instance=~"$instance"}
+            |||,
+            legendFormat='{{instance}}'
+          ),
+        ])
+      ),
+
+      // Memory (Go heap inuse)
+      (
+        panel.new(title='Memory (heap inuse)', type='timeseries') +
+        panel.withUnit('decbytes') +
+        panel.withDescription(|||
+          Heap memory currently in use by the Grafana Agent process.
+        |||) +
+        panel.withPosition({ x: 16, y: 8, w: 8, h: 8 }) +
+        panel.withQueries([
+          panel.newQuery(
+            // Lots of programs export go_memstats_heap_inuse_bytes so we ignore
+            // anything that doesn't also have a Grafana Agent-specific metric
+            // (i.e., agent_build_info).
+            expr=|||
+              go_memstats_heap_inuse_bytes{cluster="$cluster",namespace="$namespace",instance=~"$instance"}
+              and on(instance)
+              agent_build_info{cluster="$cluster",namespace="$namespace",instance=~"$instance"}
+            |||,
+            legendFormat='{{instance}}'
+          ),
+        ])
+      ),
+
+      // Network RX
+      (
+        panel.new(title='Network receive bandwidth', type='timeseries') +
+        stackedPanelMixin +
+        panel.withUnit('Bps') +
+        panel.withDescription(|||
+          Rate of data received across all network interfaces for the machine
+          Grafana Agent is running on.
+
+          Data shown here is across all running processes and not exclusive to
+          the running Grafana Agent process.
+        |||) +
+        panel.withPosition({ x: 0, y: 16, w: 12, h: 8 }) +
+        panel.withQueries([
+          panel.newQuery(
+            expr=|||
+              rate(agent_resources_machine_rx_bytes_total{cluster="$cluster",namespace="$namespace",instance=~"$instance"}[$__rate_interval])
+            |||,
+            legendFormat='{{instance}}'
+          ),
+        ])
+      ),
+
+      // Network RX
+      (
+        panel.new(title='Network send bandwidth', type='timeseries') +
+        stackedPanelMixin +
+        panel.withUnit('Bps') +
+        panel.withDescription(|||
+          Rate of data sent across all network interfaces for the machine
+          Grafana Agent is running on.
+
+          Data shown here is across all running processes and not exclusive to
+          the running Grafana Agent process.
+        |||) +
+        panel.withPosition({ x: 12, y: 16, w: 12, h: 8 }) +
+        panel.withQueries([
+          panel.newQuery(
+            expr=|||
+              rate(agent_resources_machine_tx_bytes_total{cluster="$cluster",namespace="$namespace",instance=~"$instance"}[$__rate_interval])
+            |||,
+            legendFormat='{{instance}}'
+          ),
+        ])
+      ),
+    ]),
+}

--- a/operations/agent-flow-mixin/dashboards/utils/dashboard.jsonnet
+++ b/operations/agent-flow-mixin/dashboards/utils/dashboard.jsonnet
@@ -72,4 +72,28 @@
   },
 
   withPanelsMixin(panels):: { panels+: panels },
+
+  withDocsLink(url, desc):: {
+    links+: [{
+      title: 'Documentation',
+      icon: 'doc',
+      targetBlank: true,
+      tooltip: desc,
+      type: 'link',
+      url: url,
+    }],
+  },
+
+  withDashboardsLink():: {
+    links+: [{
+      title: 'Dashboards',
+      type: 'dashboards',
+      asDropdown: true,
+      icon: 'external link',
+      includeVars: true,
+      keepTime: true,
+      tags: ['grafana-agent-flow-mixin'],
+      targetBlank: false,
+    }],
+  },
 }

--- a/operations/agent-flow-mixin/dashboards/utils/dashboard.jsonnet
+++ b/operations/agent-flow-mixin/dashboards/utils/dashboard.jsonnet
@@ -71,6 +71,12 @@
     sort: 2,
   },
 
+  newMultiTemplateVariable(name, query):: $.newTemplateVariable(name, query) {
+    allValue: '.*',
+    includeAll: true,
+    multi: true,
+  },
+
   withPanelsMixin(panels):: { panels+: panels },
 
   withDocsLink(url, desc):: {


### PR DESCRIPTION
Add a Resources dashboard which shows, at a high level, the current resource consumption of Grafana Agent. 

This dashboard is intended to be platform-agnostic so it functions regardless of how Grafana Agent is deployed. 

There are three rows:

* High level resource consumption (CPU + memory)
* Application level resource consumption (GC + goroutines + Go heap memory) 
* Network consumption (machine-wide, not agent process-specific)

The network row might be confusing to people as it shows network usage for the whole machine. However, the info tooltip for the two panels explains this. 

The changelog isn't updated since we're currently not treating the mixin as a release asset.

![image](https://user-images.githubusercontent.com/630212/197067241-81cad4bd-6af7-45b2-bda9-aea7f04899ce.png)
