### PR TITLE
flow: Allow config blocks to reference component exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ Main (unreleased)
     drops data or forces a garbage collection if the defined limits are
     exceeded. (@tpaschalis)
 
+- Flow: Allow config blocks to reference component exports. (@tpaschalis)
+
 ### Enhancements
 
 - Update OpenTelemetry Collector dependency to v0.61.0. (@rfratto)

--- a/docs/sources/flow/config-language/expressions/referencing_exports.md
+++ b/docs/sources/flow/config-language/expressions/referencing_exports.md
@@ -11,8 +11,8 @@ components using expressions. While components can work in isolation, they're
 more useful when one component's behavior and data flow is bound to the exports
 of another, building a dependency relationship between the two.
 
-Such references can only appear as part of another component's or config block
-arguments. That means that components cannot reference themselves.
+Such references can only appear as part of another component's arguments or a
+config block's fields. That means that components cannot reference themselves.
 
 ## Using references
 These references are built by combining the component's name, label and named

--- a/docs/sources/flow/config-language/expressions/referencing_exports.md
+++ b/docs/sources/flow/config-language/expressions/referencing_exports.md
@@ -11,9 +11,8 @@ components using expressions. While components can work in isolation, they're
 more useful when one component's behavior and data flow is bound to the exports
 of another, building a dependency relationship between the two.
 
-Such references can only appear as part of another component's arguments.
-That means that components cannot reference themselves, and references cannot
-appear in non-component blocks like `logging`.
+Such references can only appear as part of another component's or config block
+arguments. That means that components cannot reference themselves.
 
 ## Using references
 These references are built by combining the component's name, label and named

--- a/docs/sources/flow/reference/config-blocks/_index.md
+++ b/docs/sources/flow/reference/config-blocks/_index.md
@@ -11,8 +11,6 @@ Configuration blocks are optional top-level blocks that can be used to
 configure various parts of the Grafana Agent process. Each config block can
 only be defined once.
 
-Configuration blocks are _not_ components, so expressions that reference
-components are invalid. Expressions that do not reference components (e.g.,
-`env("LOG_LEVEL")`) are permitted.
+Configuration blocks are _not_ components, so they have no exports.
 
 {{< section >}}

--- a/docs/sources/flow/reference/config-blocks/logging.md
+++ b/docs/sources/flow/reference/config-blocks/logging.md
@@ -11,9 +11,6 @@ weight: 100
 Agent produces log messages. `logging` is specified without a label and can
 only be provided once per configuration file.
 
-> **NOTE**: Configuration blocks are not components, so expressions that
-> reference the exports of components cannot be used.
-
 ## Example
 
 ```river

--- a/pkg/flow/config.go
+++ b/pkg/flow/config.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/grafana/agent/pkg/flow/logging"
 	"github.com/grafana/agent/pkg/river/ast"
 	"github.com/grafana/agent/pkg/river/diag"
 	"github.com/grafana/agent/pkg/river/parser"
@@ -14,8 +13,6 @@ import (
 type File struct {
 	Name string    // File name given to ReadFile.
 	Node *ast.File // Raw File node.
-
-	Logging logging.Options
 
 	// Components holds the list of raw River AST blocks describing components.
 	// The Flow controller can interpret them.
@@ -70,12 +67,9 @@ func ReadFile(name string, bb []byte) (*File, error) {
 		}
 	}
 
-	loggingOpts := logging.DefaultOptions
-
 	return &File{
 		Name:         name,
 		Node:         node,
-		Logging:      loggingOpts,
 		Components:   components,
 		ConfigBlocks: configs,
 	}, nil

--- a/pkg/flow/config.go
+++ b/pkg/flow/config.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/agent/pkg/river/ast"
 	"github.com/grafana/agent/pkg/river/diag"
 	"github.com/grafana/agent/pkg/river/parser"
-	"github.com/grafana/agent/pkg/river/vm"
 )
 
 // File holds the contents of a parsed Flow file.
@@ -20,7 +19,8 @@ type File struct {
 
 	// Components holds the list of raw River AST blocks describing components.
 	// The Flow controller can interpret them.
-	Components []*ast.BlockStmt
+	Components   []*ast.BlockStmt
+	ConfigBlocks []*ast.BlockStmt
 }
 
 // ReadFile parses the River file specified by bb into a File. name should be
@@ -37,8 +37,8 @@ func ReadFile(name string, bb []byte) (*File, error) {
 	// TODO(rfratto): should this code be brought into a helper somewhere? Maybe
 	// in ast?
 	var (
-		loggerBlock *ast.BlockStmt
-		components  []*ast.BlockStmt
+		components []*ast.BlockStmt
+		configs    []*ast.BlockStmt
 	)
 
 	for _, stmt := range node.Body {
@@ -55,7 +55,7 @@ func ReadFile(name string, bb []byte) (*File, error) {
 			fullName := strings.Join(stmt.Name, ".")
 			switch fullName {
 			case "logging":
-				loggerBlock = stmt
+				configs = append(configs, stmt)
 			default:
 				components = append(components, stmt)
 			}
@@ -71,16 +71,12 @@ func ReadFile(name string, bb []byte) (*File, error) {
 	}
 
 	loggingOpts := logging.DefaultOptions
-	if loggerBlock != nil {
-		if err := vm.New(loggerBlock.Body).Evaluate(nil, &loggingOpts); err != nil {
-			return nil, err
-		}
-	}
 
 	return &File{
-		Name:       name,
-		Node:       node,
-		Logging:    loggingOpts,
-		Components: components,
+		Name:         name,
+		Node:         node,
+		Logging:      loggingOpts,
+		Components:   components,
+		ConfigBlocks: configs,
 	}, nil
 }

--- a/pkg/flow/config_test.go
+++ b/pkg/flow/config_test.go
@@ -31,6 +31,27 @@ func TestReadFile(t *testing.T) {
 	require.Equal(t, "testcomponents.passthrough.static", getBlockID(f.Components[1]))
 }
 
+func TestReadFileWithConfigBlock(t *testing.T) {
+	content := `
+        logging {
+		    log_format = "json"
+		}
+
+		testcomponents.tick "ticker_a" {
+			frequency = "1s"
+		}
+	`
+
+	f, err := flow.ReadFile(t.Name(), []byte(content))
+	require.NoError(t, err)
+	require.NotNil(t, f)
+
+	require.Len(t, f.Components, 1)
+	require.Equal(t, "testcomponents.tick.ticker_a", getBlockID(f.Components[0]))
+	require.Len(t, f.ConfigBlocks, 1)
+	require.Equal(t, "logging", getBlockID(f.ConfigBlocks[0]))
+}
+
 func TestReadFile_Defaults(t *testing.T) {
 	f, err := flow.ReadFile(t.Name(), []byte(``))
 	require.NotNil(t, f)

--- a/pkg/flow/flow.go
+++ b/pkg/flow/flow.go
@@ -48,7 +48,6 @@ package flow
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"sync"
 	"time"
@@ -196,11 +195,6 @@ func (c *Flow) run(ctx context.Context) {
 func (c *Flow) LoadFile(file *File) error {
 	c.loadMut.Lock()
 	defer c.loadMut.Unlock()
-
-	err := c.log.Update(file.Logging)
-	if err != nil {
-		return fmt.Errorf("error updating logger: %w", err)
-	}
 
 	diags := c.loader.Apply(nil, file.Components, file.ConfigBlocks)
 	if !c.loadedOnce && diags.HasErrors() {

--- a/pkg/flow/flow.go
+++ b/pkg/flow/flow.go
@@ -202,7 +202,7 @@ func (c *Flow) LoadFile(file *File) error {
 		return fmt.Errorf("error updating logger: %w", err)
 	}
 
-	diags := c.loader.Apply(nil, file.Components)
+	diags := c.loader.Apply(nil, file.Components, file.ConfigBlocks)
 	if !c.loadedOnce && diags.HasErrors() {
 		// The first call to Load should not run any components if there were
 		// errors in the configuration file.

--- a/pkg/flow/flow_test.go
+++ b/pkg/flow/flow_test.go
@@ -47,6 +47,10 @@ func TestController_LoadFile_Evaluation(t *testing.T) {
 	in, out := getFields(t, ctrl.loader.Graph(), "testcomponents.passthrough.static")
 	require.Equal(t, "hello, world!", in.(testcomponents.PassthroughConfig).Input)
 	require.Equal(t, "hello, world!", out.(testcomponents.PassthroughExports).Output)
+
+	// Check the config node is present and has the default values applied.
+	opts := getConfigOpts(t, ctrl.loader.Graph())
+	require.Equal(t, logging.DefaultOptions, opts)
 }
 
 func getFields(t *testing.T, g *dag.Graph, nodeID string) (component.Arguments, component.Exports) {
@@ -57,6 +61,15 @@ func getFields(t *testing.T, g *dag.Graph, nodeID string) (component.Arguments, 
 
 	uc := n.(*controller.ComponentNode)
 	return uc.Arguments(), uc.Exports()
+}
+
+func getConfigOpts(t *testing.T, g *dag.Graph) logging.Options {
+	t.Helper()
+	n := g.GetByID("configNode")
+	require.NotNil(t, n, "couldn't find config node in graph")
+
+	cn := n.(*controller.ConfigNode)
+	return cn.LoggingArgs()
 }
 
 func testOptions(t *testing.T) Options {

--- a/pkg/flow/internal/controller/component_references.go
+++ b/pkg/flow/internal/controller/component_references.go
@@ -33,11 +33,11 @@ func ComponentReferences(cn dag.Node, g *dag.Graph) ([]Reference, diag.Diagnosti
 		diags diag.Diagnostics
 	)
 
-	switch cn.(type) {
+	switch cn := cn.(type) {
 	case *ConfigNode:
-		traversals = configTraversals(cn.(*ConfigNode))
+		traversals = configTraversals(cn)
 	case *ComponentNode:
-		traversals = componentTraversals(cn.(*ComponentNode))
+		traversals = componentTraversals(cn)
 	}
 
 	refs := make([]Reference, 0, len(traversals))

--- a/pkg/flow/internal/controller/config.go
+++ b/pkg/flow/internal/controller/config.go
@@ -1,0 +1,107 @@
+package controller
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/agent/pkg/flow/logging"
+	"github.com/grafana/agent/pkg/river/ast"
+	"github.com/grafana/agent/pkg/river/diag"
+	"github.com/grafana/agent/pkg/river/vm"
+)
+
+const (
+	configNodeID = "configNode"
+
+	loggingBlockID = "logging"
+)
+
+// ConfigNode is a controller node which manages agent configuration.
+type ConfigNode struct {
+	mut          sync.RWMutex
+	blocks       []*ast.BlockStmt // Current River blocks to derive config from
+	logger       log.Logger
+	loggingArgs  logging.Options // Evaluated logging arguments for the config
+	loggingBlock *ast.BlockStmt
+	loggingEval  *vm.Evaluator
+}
+
+// ConfigBlockID returns the string name for a config block.
+func ConfigBlockID(block *ast.BlockStmt) string {
+	return strings.Join(block.Name, ".")
+}
+
+// NewConfigNode creates a new ConfigNode from an initial ast.BlockStmt.
+// The underlying config isn't applied until Evaluate is called.
+func NewConfigNode(blocks []*ast.BlockStmt, l log.Logger) (*ConfigNode, diag.Diagnostics) {
+	var (
+		blockMap = make(map[string]*ast.BlockStmt, len(blocks))
+		diags    diag.Diagnostics
+
+		loggingBlock ast.BlockStmt
+	)
+
+	for _, b := range blocks {
+		id := ConfigBlockID(b)
+		if orig, redefined := blockMap[id]; redefined {
+			diags.Add(diag.Diagnostic{
+				Severity: diag.SeverityLevelError,
+				Message:  fmt.Sprintf("Config block %s already declared at %s", id, ast.StartPos(orig).Position()),
+				StartPos: b.NamePos.Position(),
+				EndPos:   b.NamePos.Add(len(id) - 1).Position(),
+			})
+			continue
+		}
+
+		switch id {
+		case loggingBlockID:
+			loggingBlock = *b
+		}
+
+		blockMap[id] = b
+	}
+
+	loggerOptions := logging.DefaultOptions // Pre-populate arguments with their zero values.
+	return &ConfigNode{
+		blocks:       blocks,
+		logger:       l,
+		loggingArgs:  loggerOptions,
+		loggingBlock: &loggingBlock,
+		loggingEval:  vm.New(loggingBlock.Body),
+	}, diags
+}
+
+// NodeID implements dag.Node and returns the unique ID for the config node.
+func (cn *ConfigNode) NodeID() string { return configNodeID }
+
+// Evaluate updates the config block by re-evaluating its River block with the
+// provided scope. The config will be built the first time Evaluate is called.
+//
+// Evaluate will return an error if the River block cannot be evaluated or if
+// decoding to arguments fails.
+func (cn *ConfigNode) Evaluate(scope *vm.Scope) (*ast.BlockStmt, error) {
+	cn.mut.Lock()
+	defer cn.mut.Unlock()
+
+	// Evaluate logging block fields and store a copy.
+	args := logging.DefaultOptions
+	if err := cn.loggingEval.Evaluate(scope, &args); err != nil {
+		return cn.loggingBlock, fmt.Errorf("decoding River: %w", err)
+	}
+	cn.loggingArgs = args
+
+	l, ok := cn.logger.(*logging.Logger)
+	if ok {
+		l.Update(cn.loggingArgs)
+	}
+	return nil, nil
+}
+
+// LoggingArgs returns the arguments used to configure the logger.
+func (cn *ConfigNode) LoggingArgs() logging.Options {
+	cn.mut.RLock()
+	cn.mut.RUnlock()
+	return cn.loggingArgs
+}

--- a/pkg/flow/internal/controller/config.go
+++ b/pkg/flow/internal/controller/config.go
@@ -94,7 +94,10 @@ func (cn *ConfigNode) Evaluate(scope *vm.Scope) (*ast.BlockStmt, error) {
 
 	l, ok := cn.logger.(*logging.Logger)
 	if ok {
-		l.Update(cn.loggingArgs)
+		err := l.Update(cn.loggingArgs)
+		if err != nil {
+			return cn.loggingBlock, fmt.Errorf("could not update logger: %v", err)
+		}
 	}
 	return nil, nil
 }
@@ -102,6 +105,6 @@ func (cn *ConfigNode) Evaluate(scope *vm.Scope) (*ast.BlockStmt, error) {
 // LoggingArgs returns the arguments used to configure the logger.
 func (cn *ConfigNode) LoggingArgs() logging.Options {
 	cn.mut.RLock()
-	cn.mut.RUnlock()
+	defer cn.mut.RUnlock()
 	return cn.loggingArgs
 }

--- a/pkg/flow/internal/controller/config.go
+++ b/pkg/flow/internal/controller/config.go
@@ -19,6 +19,8 @@ const (
 )
 
 // ConfigNode is a controller node which manages agent configuration.
+// The graph will always have _exactly one_ instance of ConfigNode, which will
+// be used to contain the state of all config blocks.
 type ConfigNode struct {
 	mut          sync.RWMutex
 	blocks       []*ast.BlockStmt // Current River blocks to derive config from

--- a/pkg/flow/internal/controller/config.go
+++ b/pkg/flow/internal/controller/config.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/agent/pkg/flow/internal/dag"
 	"github.com/grafana/agent/pkg/flow/logging"
 	"github.com/grafana/agent/pkg/river/ast"
 	"github.com/grafana/agent/pkg/river/diag"
@@ -34,6 +35,8 @@ type ConfigNode struct {
 func ConfigBlockID(block *ast.BlockStmt) string {
 	return strings.Join(block.Name, ".")
 }
+
+var _ dag.Node = (*ConfigNode)(nil)
 
 // NewConfigNode creates a new ConfigNode from an initial ast.BlockStmt.
 // The underlying config isn't applied until Evaluate is called.

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -109,14 +109,12 @@ func (l *Loader) Apply(parentScope *vm.Scope, blocks []*ast.BlockStmt, configBlo
 
 	// Evaluate all of the components.
 	_ = dag.WalkTopological(&newGraph, newGraph.Leaves(), func(n dag.Node) error {
-		switch n.(type) {
+		switch c := n.(type) {
 		case *ComponentNode:
-			c := n.(*ComponentNode)
-
 			components = append(components, c)
 			componentIDs = append(componentIDs, c.ID())
 
-			if err := l.evaluate(parentScope, n.(*ComponentNode)); err != nil {
+			if err := l.evaluate(parentScope, c); err != nil {
 				var evalDiags diag.Diagnostics
 				if errors.As(err, &evalDiags) {
 					diags = append(diags, evalDiags...)
@@ -130,7 +128,7 @@ func (l *Loader) Apply(parentScope *vm.Scope, blocks []*ast.BlockStmt, configBlo
 				}
 			}
 		case *ConfigNode:
-			if errBlock, err := l.evaluateConfig(parentScope, n.(*ConfigNode)); err != nil {
+			if errBlock, err := l.evaluateConfig(parentScope, c); err != nil {
 				diags.Add(diag.Diagnostic{
 					Severity: diag.SeverityLevelError,
 					Message:  fmt.Sprintf("Failed to build node from config blocks: %s", err),

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -128,7 +128,7 @@ func (l *Loader) Apply(parentScope *vm.Scope, blocks []*ast.BlockStmt, configBlo
 			if errBlock, err := l.evaluateConfig(parentScope, c); err != nil {
 				diags.Add(diag.Diagnostic{
 					Severity: diag.SeverityLevelError,
-					Message:  fmt.Sprintf("Failed to build node from config blocks: %s", err),
+					Message:  fmt.Sprintf("Failed to evaluate node for config blocks: %s", err),
 					StartPos: ast.StartPos(errBlock).Position(),
 					EndPos:   ast.EndPos(errBlock).Position(),
 				})
@@ -280,7 +280,12 @@ func (l *Loader) EvaluateDependencies(parentScope *vm.Scope, c *ComponentNode) {
 			// arguments will need re-evaluation.
 			return nil
 		}
-		_ = l.evaluate(parentScope, n.(*ComponentNode))
+		switch n := n.(type) {
+		case *ComponentNode:
+			_ = l.evaluate(parentScope, n)
+		case *ConfigNode:
+			_, _ = l.evaluateConfig(parentScope, n)
+		}
 		return nil
 	})
 

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -76,9 +76,6 @@ func (l *Loader) Apply(parentScope *vm.Scope, blocks []*ast.BlockStmt, configBlo
 	)
 
 	// Pre-populate graph with a ConfigNode.
-	// TODO (@tpaschalis) Are we okay with recreating the config node on each
-	// Apply? Should we check if it already exists and just update its blocks
-	// instead? if exist := l.graph.GetByID(configNodeID); exist == nil { ...
 	c, configBlockDiags := NewConfigNode(configBlocks, l.log)
 	diags = append(diags, configBlockDiags...)
 	newGraph.Add(c)

--- a/pkg/flow/internal/controller/loader_test.go
+++ b/pkg/flow/internal/controller/loader_test.go
@@ -37,6 +37,7 @@ func TestLoader(t *testing.T) {
 	// corresponds to testFile
 	testGraphDefinition := graphDefinition{
 		Nodes: []string{
+			"configNode", // The config node is always present
 			"testcomponents.tick.ticker",
 			"testcomponents.passthrough.static",
 			"testcomponents.passthrough.ticker",
@@ -120,6 +121,7 @@ func TestLoader(t *testing.T) {
 
 		requireGraph(t, l.Graph(), graphDefinition{
 			Nodes: []string{
+				"configNode", // The config node is always present
 				"testcomponents.tick.ticker",
 				"testcomponents.passthrough.valid",
 				"testcomponents.passthrough.invalid",
@@ -233,7 +235,7 @@ func applyFromContent(t *testing.T, l *controller.Loader, bb []byte) diag.Diagno
 		return diags
 	}
 
-	applyDiags := l.Apply(nil, blocks)
+	applyDiags := l.Apply(nil, blocks, nil)
 	diags = append(diags, applyDiags...)
 
 	return diags


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This is a first approach for allowing Flow's special [config blocks](https://grafana.com/docs/agent/latest/flow/reference/config-blocks/) to reference other components, that can be extended to allow for more config blocks in the future.

One way to achieve this is to pre-populate the DAG with a new type of ConfigNode.

This approach gathers all config blocks (just logging for now) when `Apply`ing a configuration file, and uses them to build a NewConfigNode before adding the rest of the components to the graph. The ConfigNode is then wired along all other ComponentNodes, to detect references to components.

The ConfigNode is prepopulated with the default argument options for the various config blocks, and uses the passed blocks to Evaluate the river expressions that were given.

#### Which issue(s) this PR fixes
Fixes #2214

#### Notes to the Reviewer
The ConfigNode works a little different than the other ComponentNodes. It does not produce exports, does not report health data, so might be more difficult to debug issues with it.

I'm divided on how we want to handle configuration issues with config blocks after reporting the error; do we act like other components do and keep on with the previous working config, or do we fall back to the defaults?

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
