### PR TITLE
Add Makefile targets for FreeBSD/AMD64

### DIFF
--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -86,12 +86,6 @@ dist/agent-freebsd-amd64: GOARCH  := amd64
 dist/agent-freebsd-amd64: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/agent-linux-mipsle: GO_TAGS += builtinassets
-dist/agent-linux-mipsle: GOOS    := linux
-dist/agent-linux-mipsle: GOARCH  := mipsle
-dist/agent-linux-mipsle: generate-ui
-	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
-
 #
 # agentctl release binaries.
 #
@@ -153,12 +147,6 @@ dist/agentctl-freebsd-amd64: GO_TAGS += builtinassets
 dist/agentctl-freebsd-amd64: GOOS    := freebsd
 dist/agentctl-freebsd-amd64: GOARCH  := amd64
 dist/agentctl-freebsd-amd64: generate-ui
-	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
-
-dist/agentctl-linux-mipsle: GO_TAGS += builtinassets
-dist/agentctl-linux-mipsle: GOOS    := linux
-dist/agentctl-linux-mipsle: GOARCH  := mipsle
-dist/agentctl-linux-mipsle: generate-ui
 	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
 
 #

--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -27,7 +27,8 @@ dist-agent-binaries: dist/agent-linux-amd64   \
                      dist/agent-linux-ppc64le \
                      dist/agent-darwin-amd64  \
                      dist/agent-darwin-arm64  \
-                     dist/agent-windows-amd64.exe
+                     dist/agent-windows-amd64.exe \
+                     dist/agent-freebsd-amd64
 
 dist/agent-linux-amd64: GO_TAGS += noebpf builtinassets
 dist/agent-linux-amd64: GOOS    := linux
@@ -79,6 +80,18 @@ dist/agent-windows-amd64.exe: GOARCH  := amd64
 dist/agent-windows-amd64.exe: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
+dist/agent-freebsd-amd64: GO_TAGS += builtinassets
+dist/agent-freebsd-amd64: GOOS    := freebsd
+dist/agent-freebsd-amd64: GOARCH  := amd64
+dist/agent-freebsd-amd64: generate-ui
+	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
+
+dist/agent-linux-mipsle: GO_TAGS += builtinassets
+dist/agent-linux-mipsle: GOOS    := linux
+dist/agent-linux-mipsle: GOARCH  := mipsle
+dist/agent-linux-mipsle: generate-ui
+	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
+
 #
 # agentctl release binaries.
 #
@@ -90,7 +103,8 @@ dist-agentctl-binaries: dist/agentctl-linux-amd64   \
                         dist/agentctl-linux-ppc64le \
                         dist/agentctl-darwin-amd64  \
                         dist/agentctl-darwin-arm64  \
-                        dist/agentctl-windows-amd64.exe
+                        dist/agentctl-windows-amd64.exe \
+                        dist/agentctl-freebsd-amd64
 
 dist/agentctl-linux-amd64: GO_TAGS += noebpf
 dist/agentctl-linux-amd64: GOOS    := linux
@@ -133,6 +147,18 @@ dist/agentctl-darwin-arm64:
 dist/agentctl-windows-amd64.exe: GOOS   := windows
 dist/agentctl-windows-amd64.exe: GOARCH := amd64
 dist/agentctl-windows-amd64.exe:
+	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
+
+dist/agentctl-freebsd-amd64: GO_TAGS += builtinassets
+dist/agentctl-freebsd-amd64: GOOS    := freebsd
+dist/agentctl-freebsd-amd64: GOARCH  := amd64
+dist/agentctl-freebsd-amd64: generate-ui
+	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
+
+dist/agentctl-linux-mipsle: GO_TAGS += builtinassets
+dist/agentctl-linux-mipsle: GOOS    := linux
+dist/agentctl-linux-mipsle: GOARCH  := mipsle
+dist/agentctl-linux-mipsle: generate-ui
 	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
 
 #


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR adds Makefile targets to build FreeBSD/AMD64 images for the agent. It also adds the FreeBSD target to the list of binaries to be generated and packed with each new release.

#### Which issue(s) this PR fixes
Fixes #2415

#### Notes to the Reviewer

I'm not sure about what was the reason for the `$(error invalid flag $(1)))` that was present in the previous listing of FreeBSD, am I missing something I should add here?

https://github.com/grafana/agent/blob/9fd7d9b325f78153b7b525ddda28d2a2d3e1ccb6/Makefile#L52


#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
