### PR TITLE
Fix usage of modules in Blackbox integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ Main (unreleased)
 
 - Fix identifier on target creation for SNMP v2 integration. (@marctc)
 
+- Fix bug when specifying Blackbox's modules when using Blackbox integration. (@marctc)
+
 v0.28.0 (2022-09-29)
 --------------------
 

--- a/pkg/integrations/blackbox_exporter/blackbox_exporter.go
+++ b/pkg/integrations/blackbox_exporter/blackbox_exporter.go
@@ -138,6 +138,9 @@ func (i *Integration) ScrapeConfigs() []config.ScrapeConfig {
 	for _, target := range i.cfg.BlackboxTargets {
 		queryParams := url.Values{}
 		queryParams.Add("target", target.Target)
+		if target.Module != "" {
+			queryParams.Add("module", target.Module)
+		}
 		res = append(res, config.ScrapeConfig{
 			JobName:     i.cfg.Name() + "/" + target.Name,
 			MetricsPath: "/metrics",

--- a/pkg/integrations/blackbox_exporter/blackbox_exporter_test.go
+++ b/pkg/integrations/blackbox_exporter/blackbox_exporter_test.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"testing"
 
-	a "github.com/grafana/agent/pkg/integrations/config"
+	integrations "github.com/grafana/agent/pkg/integrations/config"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
@@ -37,7 +37,7 @@ blackbox_config:
 
 		integration, err := New(nil, &config)
 		require.NoError(t, err)
-		expectedScrapeConfigs := []a.ScrapeConfig{
+		expectedScrapeConfigs := []integrations.ScrapeConfig{
 			{
 				JobName:     "blackbox/icmp_cloudflare",
 				MetricsPath: "/metrics",

--- a/pkg/integrations/blackbox_exporter/blackbox_exporter_test.go
+++ b/pkg/integrations/blackbox_exporter/blackbox_exporter_test.go
@@ -1,0 +1,54 @@
+package blackbox_exporter
+
+import (
+	"net/url"
+	"testing"
+
+	a "github.com/grafana/agent/pkg/integrations/config"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestBlackboxConfig(t *testing.T) {
+	t.Run("scrape configs", func(t *testing.T) {
+		var config Config
+		strConfig := `---
+blackbox_targets:
+- name: icmp_cloudflare
+  address: 1.1.1.1
+  module: icmp_ipv4
+- name: http_cloudflare
+  address: https://www.cloudflare.com
+  module: http_2xx_ipv4
+blackbox_config:
+  modules:               
+    http_2xx_ipv4:
+      prober: http
+      timeout: 5s
+      http:
+        preferred_ip_protocol: "ip4"        
+    icmp_ipv4:
+      prober: "icmp"
+      timeout: 5s
+      icmp:
+        preferred_ip_protocol: "ip4"
+`
+		require.NoError(t, yaml.UnmarshalStrict([]byte(strConfig), &config), "unmarshal config")
+
+		integration, err := New(nil, &config)
+		require.NoError(t, err)
+		expectedScrapeConfigs := []a.ScrapeConfig{
+			{
+				JobName:     "blackbox/icmp_cloudflare",
+				MetricsPath: "/metrics",
+				QueryParams: url.Values{"target": []string{"1.1.1.1"}, "module": []string{"icmp_ipv4"}},
+			},
+			{
+				JobName:     "blackbox/http_cloudflare",
+				MetricsPath: "/metrics",
+				QueryParams: url.Values{"target": []string{"https://www.cloudflare.com"}, "module": []string{"http_2xx_ipv4"}},
+			},
+		}
+		require.Equal(t, integration.ScrapeConfigs(), expectedScrapeConfigs)
+	})
+}

--- a/pkg/integrations/v2/blackbox_exporter/blackbox.go
+++ b/pkg/integrations/v2/blackbox_exporter/blackbox.go
@@ -90,17 +90,13 @@ func (bbh *blackboxHandler) Handler(prefix string) (http.Handler, error) {
 func (bbh *blackboxHandler) createHandler(targets []blackbox_exporter.BlackboxTarget) http.HandlerFunc {
 	blackboxTargets := make(map[string]blackbox_exporter.BlackboxTarget)
 	for _, target := range targets {
-		blackboxTargets[target.Name] = target
+		blackboxTargets[target.Target] = target
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		params := r.URL.Query()
 
 		targetName := params.Get("target")
-		t, ok := blackboxTargets[targetName]
-		if ok {
-			params.Set("target", t.Target)
-		}
-
+		t := blackboxTargets[targetName]
 		moduleName := params.Get("module")
 		if moduleName == "" {
 			params.Set("module", t.Module)

--- a/pkg/integrations/v2/blackbox_exporter/blackbox_test.go
+++ b/pkg/integrations/v2/blackbox_exporter/blackbox_test.go
@@ -1,0 +1,60 @@
+package blackbox_exporter_v2
+
+import (
+	"testing"
+
+	"github.com/grafana/agent/pkg/integrations/blackbox_exporter"
+	"github.com/grafana/agent/pkg/integrations/v2"
+	integrations_v2 "github.com/grafana/agent/pkg/integrations/v2"
+	autoscrape "github.com/grafana/agent/pkg/integrations/v2/autoscrape"
+	"github.com/grafana/agent/pkg/integrations/v2/common"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlackbox(t *testing.T) {
+	t.Run("targets", func(t *testing.T) {
+		key := "blackbox-test"
+		aEnabled := true
+
+		c := Config{
+			ProbeTimeoutOffset: 0.5,
+			Common: common.MetricsConfig{
+				InstanceKey: &key,
+				Autoscrape: autoscrape.Config{
+					Enable: &aEnabled,
+				},
+			},
+			BlackboxTargets: []blackbox_exporter.BlackboxTarget{{
+				Name:   "icmp_cloudflare",
+				Target: "1.1.1.1",
+				Module: "icmp_ipv4",
+			}},
+		}
+		integation, err := c.NewIntegration(nil, integrations_v2.Globals{})
+		require.NoError(t, err)
+
+		i := integation.(integrations.MetricsIntegration)
+		actual := i.Targets(integrations.Endpoint{Host: "test", Prefix: "/test/"})
+		expect := []*targetgroup.Group{{
+			Source: "blackbox/blackbox",
+			Labels: model.LabelSet{
+				"instance":       "blackbox-test",
+				"job":            "integrations/blackbox",
+				"agent_hostname": "",
+
+				"__meta_agent_integration_name":       "blackbox",
+				"__meta_agent_integration_instance":   "blackbox",
+				"__meta_agent_integration_autoscrape": "1",
+			},
+			Targets: []model.LabelSet{{
+				model.AddressLabel:     "test",
+				model.MetricsPathLabel: "/test/metrics",
+				"blackbox_target":      "1.1.1.1",
+				"__param_target":       "1.1.1.1",
+			}},
+		}}
+		require.Equal(t, expect, actual)
+	})
+}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

When using blackbox integration, either in v1 or v2, configured modules
for an specific target are not properly set and it uses `http_2xx` by default.
This PR fixes this issue.

#### Which issue(s) this PR fixes

Fixes #2400

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [x] Tests updated
