### PR TITLE
Avoid a panic with an invalid traces configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ Main (unreleased)
 
 - Fix bug when specifying Blackbox's modules when using Blackbox integration. (@marctc)
 
+- Tracing: fix a panic when the required `protocols` field was not set in the `otlp` receiver. (@ptodev)
+
 v0.28.0 (2022-09-29)
 --------------------
 

--- a/pkg/traces/config.go
+++ b/pkg/traces/config.go
@@ -157,9 +157,14 @@ func (r *ReceiverMap) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	for k := range *r {
 		if strings.HasPrefix(k, otlpReceiverName) {
 			// for http and grpc receivers, include_metadata is set to true by default
-			protocolsCfg, ok := (*r)[k].(map[interface{}]interface{})["protocols"].(map[interface{}]interface{})
+			receiverCfg, ok := (*r)[k].(map[interface{}]interface{})
 			if !ok {
 				return fmt.Errorf("failed to parse OTLP receiver config: %s", k)
+			}
+
+			protocolsCfg, ok := receiverCfg["protocols"].(map[interface{}]interface{})
+			if !ok {
+				return fmt.Errorf("otlp receiver requires a \"protocols\" field which must be a YAML map: %s", k)
 			}
 
 			for _, p := range protocols {

--- a/pkg/traces/config_test.go
+++ b/pkg/traces/config_test.go
@@ -1782,6 +1782,27 @@ receivers:
 	assert.Contains(t, otel.Service.Pipelines[config.NewComponentID("traces")].Receivers, config.NewComponentID(pushreceiver.TypeStr))
 }
 
+func TestUnmarshalYAMLEmptyOTLP(t *testing.T) {
+	test := `
+receivers:
+  otlp:`
+	cfg := InstanceConfig{}
+	err := yaml.Unmarshal([]byte(test), &cfg)
+	assert.NotNil(t, err)
+	require.Contains(t, err.Error(), "failed to parse OTLP receiver config: otlp")
+}
+
+func TestUnmarshalYAMLEmptyOTLPProtocols(t *testing.T) {
+	test := `
+receivers:
+  otlp:
+    protocols:`
+	cfg := InstanceConfig{}
+	err := yaml.Unmarshal([]byte(test), &cfg)
+	assert.NotNil(t, err)
+	require.Contains(t, err.Error(), "otlp receiver requires a \"protocols\" field which must be a YAML map: otlp")
+}
+
 // sortService is a helper function to lexicographically sort all
 // the possibly unsorted elements of a given cfg.Service
 func sortService(cfg *config.Config) {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
There used to be a panic due to a configuration such as this:
```
server:
  log_level: info

traces:
  configs:
    - name: default
      receivers:
        otlp:
```
The panic message was not clear and user friendly. The new message makes it much more clear to the user why the agent failed to start.

#### Which issue(s) this PR fixes
Fixes https://github.com/grafana/agent/issues/2347

#### Notes to the Reviewer
I wrote a new "Test" function, instead of adding the test to an already existing function such as ```TestOTelConfig()```. This is because I would have had to add a 2nd ```expectedError``` field, which would only be used by this test. However, if you think there is a value in adding this test to the ```TestOTelConfig()``` function, please let me know and I will move it there.

Also, I think updating documentation is not needed., so I'll ignore that checkbox below.

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [x] Tests updated
