### PR TITLE
`prometheus.*` components: immediately export receiver on component construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@ Main (unreleased)
   Grafana Agent, but are not meant to act as a replacement for fully featured
   components like `prometheus.integration.node_exporter`. (@rfratto)
 
+- Grafana Agent Flow: `prometheus.remote_write` and `prometheus.relabel` will
+  now export receivers immediately, removing the need for dependant components
+  to be evaluated twice at process startup. (@rfratto)
+
 ### Bugfixes
 
 - Remove empty port from the `apache_http` integration's instance label. (@katepangLiu)

--- a/component/prometheus/relabel/relabel.go
+++ b/component/prometheus/relabel/relabel.go
@@ -71,6 +71,11 @@ func New(o component.Options, args Arguments) (*Component, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Immediately export the receiver which remains the same for the component
+	// lifetime.
+	o.OnStateChange(Exports{Receiver: c.receiver})
+
 	// Call to Update() to set the relabelling rules once at the start.
 	if err = c.Update(args); err != nil {
 		return nil, err
@@ -95,7 +100,6 @@ func (c *Component) Update(args component.Arguments) error {
 	c.clearCache()
 	c.mrc = flow_relabel.ComponentToPromRelabelConfigs(newArgs.MetricRelabelConfigs)
 	c.forwardto = newArgs.ForwardTo
-	c.opts.OnStateChange(Exports{Receiver: c.receiver})
 
 	return nil
 }


### PR DESCRIPTION
This commit changes Flow Prometheus components which export receivers to immediately export their receivers on component construction. Receivers for these components remain the same through the process lifetime, so there's no need for them to emit exports at run or update time.

This is also a minor (but likely immeasurable) performance enhancement, where components depending on `prometheus.remote_write` or `prometheus.relabel` won't be forced to update twice in a row near the process start time. 

The CHANGELOG has been updated to reflect the performance improvement angle, since it is the only way for the changes to be observed by end users.

Closes #1946.