### PR TITLE
otelcol.auth.bearer: new component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ Main (unreleased)
     drops data or forces a garbage collection if the defined limits are
     exceeded. (@tpaschalis)
 
+  - `otelcol.auth.bearer` performs bearer token authentication for `otelcol`
+    components which support authentication extensions. (@rfratto)
+
 - Flow: Allow config blocks to reference component exports. (@tpaschalis)
 
 ### Enhancements

--- a/component/otelcol/auth/bearer/bearer.go
+++ b/component/otelcol/auth/bearer/bearer.go
@@ -1,0 +1,50 @@
+// Package bearer provides an otelcol.auth.bearer component.
+package bearer
+
+import (
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otelcol"
+	"github.com/grafana/agent/component/otelcol/auth"
+	"github.com/grafana/agent/pkg/flow/rivertypes"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension"
+	otelcomponent "go.opentelemetry.io/collector/component"
+	otelconfig "go.opentelemetry.io/collector/config"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:    "otelcol.auth.bearer",
+		Args:    Arguments{},
+		Exports: otelcol.ConsumerExports{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			fact := bearertokenauthextension.NewFactory()
+			return auth.New(opts, fact, args.(Arguments))
+		},
+	})
+}
+
+// Arguments configures the otelcol.auth.bearer component.
+type Arguments struct {
+	Token rivertypes.Secret `river:"token,attr"`
+}
+
+var _ auth.Arguments = Arguments{}
+
+// Convert implements auth.Arguments.
+func (args Arguments) Convert() otelconfig.Extension {
+	return &bearertokenauthextension.Config{
+		ExtensionSettings: otelconfig.NewExtensionSettings(otelconfig.NewComponentID("bearer")),
+		BearerToken:       string(args.Token),
+	}
+}
+
+// Extensions implements auth.Arguments.
+func (args Arguments) Extensions() map[otelconfig.ComponentID]otelcomponent.Extension {
+	return nil
+}
+
+// Exporters implements auth.Arguments.
+func (args Arguments) Exporters() map[otelconfig.DataType]map[otelconfig.ComponentID]otelcomponent.Exporter {
+	return nil
+}

--- a/component/otelcol/auth/bearer/bearer_test.go
+++ b/component/otelcol/auth/bearer/bearer_test.go
@@ -1,0 +1,77 @@
+package bearer_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/component/otelcol/auth"
+	"github.com/grafana/agent/component/otelcol/auth/bearer"
+	"github.com/grafana/agent/pkg/flow/componenttest"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/grafana/agent/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configauth"
+)
+
+// Test performs a basic integration test which runs the otelcol.exporter.otlp
+// component and ensures that it can be used for authentication.
+func Test(t *testing.T) {
+	// Create an HTTP server which will assert that bearer auth has been injected
+	// into the request.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		assert.Equal(t, "Bearer foobar", authHeader, "auth header didn't match")
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := componenttest.TestContext(t)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	l := util.TestLogger(t)
+
+	// Create and run our component
+	ctrl, err := componenttest.NewControllerFromID(l, "otelcol.auth.bearer")
+	require.NoError(t, err)
+
+	cfg := `
+		token = "foobar"
+	`
+	var args bearer.Arguments
+	require.NoError(t, river.Unmarshal([]byte(cfg), &args))
+
+	go func() {
+		err := ctrl.Run(ctx, args)
+		require.NoError(t, err)
+	}()
+
+	require.NoError(t, ctrl.WaitRunning(time.Second), "component never started")
+	require.NoError(t, ctrl.WaitExports(time.Second), "component never exported anything")
+
+	// Get the authentication extension from our component and use it to make a
+	// request to our test server.
+	exports := ctrl.Exports().(auth.Exports)
+	require.NotNil(t, exports.Handler.Extension, "handler extension is nil")
+
+	clientAuth, ok := exports.Handler.Extension.(configauth.ClientAuthenticator)
+	require.True(t, ok, "handler does not implement configauth.ClientAuthenticator")
+
+	rt, err := clientAuth.RoundTripper(http.DefaultTransport)
+	require.NoError(t, err)
+	cli := &http.Client{Transport: rt}
+
+	// Wait until the request finishes. We don't assert anything else here; our
+	// HTTP handler won't write the response until it ensures that the bearer
+	// auth was found.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := cli.Do(req)
+	require.NoError(t, err, "HTTP request failed")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/docs/sources/flow/reference/components/otelcol.auth.bearer.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.bearer.md
@@ -1,0 +1,70 @@
+---
+aliases:
+- /docs/agent/latest/flow/reference/components/otelcol.auth.bearer
+title: otelcol.auth.bearer
+---
+
+# otelcol.auth.bearer
+
+`otelcol.auth.bearer` exposes a `handler` that can be used by other `otelcol`
+components to authenticate requests using bearer token authentication.
+
+> **NOTE**: `otelcol.auth.bearer` is a wrapper over the upstream OpenTelemetry
+> Collector `bearertokenauth` extension. Bug reports or feature requests will
+> be redirected to the upstream repository, if necessary.
+
+Multiple `otelcol.auth.bearer` components can be specified by giving them
+different labels.
+
+## Usage
+
+```river
+otelcol.auth.bearer "LABEL" {
+  token = "TOKEN"
+}
+```
+
+## Arguments
+
+`otelcol.auth.bearer` supports the following arguments:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`token` | `secret` | Bearer token to use for authenticating requests. | | yes
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+Name | Type | Description
+---- | ---- | -----------
+`handler` | `capsule(otelcol.Handler)` | A value that other components can use to authenticate requests.
+
+## Component health
+
+`otelcol.auth.bearer` is only reported as unhealthy if given an invalid
+configuration.
+
+## Debug information
+
+`otelcol.auth.bearer` does not expose any component-specific debug information.
+
+## Example
+
+This example configures [otelcol.exporter.otlp][] to use bearer token
+authentication:
+
+```river
+otelcol.exporter.otlp "example" {
+  client {
+    endpoint = "my-otlp-grpc-server:4317"
+    auth     = otelcol.auth.bearer.creds.handler
+  }
+}
+
+otelcol.auth.bearer "creds" {
+  token = env("API_KEY")
+}
+```
+
+[otelcol.exporter.otlp]: {{< relref "./otelcol.exporter.otlp.md" >}}

--- a/go.mod
+++ b/go.mod
@@ -384,6 +384,7 @@ require (
 	github.com/nicolai86/scaleway-sdk v1.10.2-0.20180628010248-798f60e20bb2 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.61.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.61.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.61.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.61.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.61.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2049,6 +2049,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexp
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.61.0/go.mod h1:GtzfeHEYI2XcD9rs79UlgDT6A+WYJv8o5GWL5k20kg4=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.61.0 h1:O02J3B6hkVtftbtXCbkEyaQm1mDu5k6VoVOghJgN95o=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.61.0/go.mod h1:lSpO0oRJvNEbAdKbKIqJ7Lb+Tfj6XI9N415E0ATAMYE=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.61.0 h1:s3Xc8ncFd8E4va9xDIXoEYzoBILSe2bdGwxMuS6MVBE=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.61.0/go.mod h1:AlW4Z/pvtLqP0PtLzuh1I5ifJXEsSWTTj0g194BEsQA=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension v0.61.0 h1:USlB+ZO5VxvoLU1iE3bToDaS9xBTcqD6J5ooYBu8fUk=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension v0.61.0/go.mod h1:kY/a+e4Yl3cTEWp3m8eFxmNU60yYvoWledSKjLKrip4=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.61.0 h1:z+MA5MWVNh9n6w9+npb4Cb7/Ycgfa/jqJFnkSCSYhb0=


### PR DESCRIPTION
Introduce an `otelcol.auth.bearer` component which wraps around the upstream bearertokenauth extension and allows other components to use it.

Closes #2355.