### PR TITLE
integrations: add missing setting to override eventhandler instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@ Main (unreleased)
   now export receivers immediately, removing the need for dependant components
   to be evaluated twice at process startup. (@rfratto)
 
+- Add missing setting to configure instance key, extra labels and autoscrape for
+  Eventhandler integration. (@marctc)
+
 ### Bugfixes
 
 - Remove empty port from the `apache_http` integration's instance label. (@katepangLiu)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,8 +74,7 @@ Main (unreleased)
   now export receivers immediately, removing the need for dependant components
   to be evaluated twice at process startup. (@rfratto)
 
-- Add missing setting to configure instance key, extra labels and autoscrape for
-  Eventhandler integration. (@marctc)
+- Add missing setting to configure instance key for Eventhandler integration. (@marctc)
 
 ### Bugfixes
 

--- a/docs/sources/configuration/integrations/integrations-next/eventhandler-config.md
+++ b/docs/sources/configuration/integrations/integrations-next/eventhandler-config.md
@@ -80,6 +80,10 @@ Configuration reference:
 
   ## If you would like to limit events to a given namespace, use this parameter.
   [namespace: <string>]
+
+  ## Configure extra labels to add to log lines
+  extra_labels:
+    { <string>: <string> }  
 ```
 
 Sample agent config:

--- a/docs/sources/configuration/integrations/integrations-next/eventhandler-config.md
+++ b/docs/sources/configuration/integrations/integrations-next/eventhandler-config.md
@@ -47,6 +47,36 @@ below.
 Configuration reference:
 
 ```yaml
+  # Provide an explicit value to uniquely identify this instance of the
+  # integration. If not provided, a reasonable default will be inferred based
+  # on the integration.
+  #
+  # The value here must be unique across all instances of the same integration.
+  [instance: <string>]
+
+  # Override autoscrape defaults for this integration.
+  autoscrape:
+    # Enables autoscrape of integrations.
+    [enable: <boolean> | default = <integrations.metrics.autoscrape.enable>]
+
+    # Specifies the metrics instance name to send metrics to.
+    [metrics_instance: <string> | default = <integrations.metrics.autoscrape.metrics_instance>]
+
+    # Autoscrape interval and timeout.
+    [scrape_interval: <duration> | default = <integrations.metrics.autoscrape.scrape_interval>]
+    [scrape_timeout: <duration> | default = <integrations.metrics.autoscrape.scrape_timeout>]
+
+  # An optional extra set of labels to add to metrics from the integration target. These
+  # labels are only exposed via the integration service discovery HTTP API and
+  # added when autoscrape is used. They will not be found directly on the metrics
+  # page for an integration.
+  extra_labels:
+    [ <labelname>: <labelvalue> ... ]
+
+  #
+  # Exporter-specific configuration options
+  #
+
   ## Eventhandler hands watched events off to promtail using a promtail
   ## client channel. This parameter configures how long to wait (in seconds) on the channel
   ## before abandoning and moving on.
@@ -73,10 +103,6 @@ Configuration reference:
 
   ## If you would like to limit events to a given namespace, use this parameter.
   [namespace: <string>]
-
-  ## Configure extra labels to add to log lines
-  extra_labels:
-    { <string>: <string> }
 ```
 
 Sample agent config:

--- a/docs/sources/configuration/integrations/integrations-next/eventhandler-config.md
+++ b/docs/sources/configuration/integrations/integrations-next/eventhandler-config.md
@@ -54,29 +54,6 @@ Configuration reference:
   # The value here must be unique across all instances of the same integration.
   [instance: <string>]
 
-  # Override autoscrape defaults for this integration.
-  autoscrape:
-    # Enables autoscrape of integrations.
-    [enable: <boolean> | default = <integrations.metrics.autoscrape.enable>]
-
-    # Specifies the metrics instance name to send metrics to.
-    [metrics_instance: <string> | default = <integrations.metrics.autoscrape.metrics_instance>]
-
-    # Autoscrape interval and timeout.
-    [scrape_interval: <duration> | default = <integrations.metrics.autoscrape.scrape_interval>]
-    [scrape_timeout: <duration> | default = <integrations.metrics.autoscrape.scrape_timeout>]
-
-  # An optional extra set of labels to add to metrics from the integration target. These
-  # labels are only exposed via the integration service discovery HTTP API and
-  # added when autoscrape is used. They will not be found directly on the metrics
-  # page for an integration.
-  extra_labels:
-    [ <labelname>: <labelvalue> ... ]
-
-  #
-  # Exporter-specific configuration options
-  #
-
   ## Eventhandler hands watched events off to promtail using a promtail
   ## client channel. This parameter configures how long to wait (in seconds) on the channel
   ## before abandoning and moving on.

--- a/docs/sources/configuration/integrations/integrations-next/eventhandler-config.md
+++ b/docs/sources/configuration/integrations/integrations-next/eventhandler-config.md
@@ -83,7 +83,7 @@ Configuration reference:
 
   ## Configure extra labels to add to log lines
   extra_labels:
-    { <string>: <string> }  
+    { <string>: <string> }
 ```
 
 Sample agent config:

--- a/pkg/integrations/v2/eventhandler/integration.go
+++ b/pkg/integrations/v2/eventhandler/integration.go
@@ -3,7 +3,6 @@ package eventhandler
 import (
 	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/integrations/v2"
-	"github.com/grafana/agent/pkg/integrations/v2/common"
 	"github.com/prometheus/prometheus/model/labels"
 )
 
@@ -39,8 +38,8 @@ type Config struct {
 	// If you would like to limit events to a given namespace, use this parameter.
 	Namespace string `yaml:"namespace,omitempty"`
 	// Extra labels to append to log lines
-	ExtraLabels labels.Labels        `yaml:"extra_labels,omitempty"`
-	Common      common.MetricsConfig `yaml:",inline"`
+	ExtraLabels labels.Labels `yaml:"extra_labels,omitempty"`
+	InstanceKey *string       `yaml:"instance,omitempty"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler for Config
@@ -61,8 +60,8 @@ func (c *Config) ApplyDefaults(globals integrations.Globals) error {
 
 // Identifier uniquely identifies this instance of Config
 func (c *Config) Identifier(globals integrations.Globals) (string, error) {
-	if c.Common.InstanceKey != nil {
-		return *c.Common.InstanceKey, nil
+	if c.InstanceKey != nil {
+		return *c.InstanceKey, nil
 	}
 	return c.Name(), nil
 }

--- a/pkg/integrations/v2/eventhandler/integration.go
+++ b/pkg/integrations/v2/eventhandler/integration.go
@@ -3,6 +3,7 @@ package eventhandler
 import (
 	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/integrations/v2"
+	"github.com/grafana/agent/pkg/integrations/v2/common"
 	"github.com/prometheus/prometheus/model/labels"
 )
 
@@ -38,7 +39,8 @@ type Config struct {
 	// If you would like to limit events to a given namespace, use this parameter.
 	Namespace string `yaml:"namespace,omitempty"`
 	// Extra labels to append to log lines
-	ExtraLabels labels.Labels `yaml:"extra_labels,omitempty"`
+	ExtraLabels labels.Labels        `yaml:"extra_labels,omitempty"`
+	Common      common.MetricsConfig `yaml:",inline"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler for Config
@@ -59,7 +61,10 @@ func (c *Config) ApplyDefaults(globals integrations.Globals) error {
 
 // Identifier uniquely identifies this instance of Config
 func (c *Config) Identifier(globals integrations.Globals) (string, error) {
-	return globals.AgentIdentifier, nil
+	if c.Common.InstanceKey != nil {
+		return *c.Common.InstanceKey, nil
+	}
+	return c.Name(), nil
 }
 
 // NewIntegration converts this config into an instance of an integration.


### PR DESCRIPTION
#### PR Description

As part of the effort of completing #2017 we realized that eventhandler integration
didn't include `instance` into the config which allows also to override the instance
key for that integration.

#### Which issue(s) this PR fixes

#2366


#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [ ] Tests updated
