### PR TITLE
otelcol.auth.headers: new component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Main (unreleased)
     sends it to an HTTP server using the OTLP protocol. (@tpaschalis)
 
   - `otelcol.auth.basic` performs basic authentication for `otelcol`
-    components which support authentication extensions. (@rfratto)
+    components that support authentication extensions. (@rfratto)
 
   - `otelcol.receiver.jeager` receives Jaeger-formatted traces. Data can then
     be forwarded to other `otelcol` components. (@rfratto)
@@ -54,6 +54,9 @@ Main (unreleased)
     exceeded. (@tpaschalis)
 
   - `otelcol.auth.bearer` performs bearer token authentication for `otelcol`
+    components that support authentication extensions. (@rfratto)
+
+  - `otelcol.auth.headers` attaches custom request headers to `otelcol`
     components that support authentication extensions. (@rfratto)
 
 - Flow: Allow config blocks to reference component exports. (@tpaschalis)

--- a/component/otelcol/auth/headers/headers.go
+++ b/component/otelcol/auth/headers/headers.go
@@ -1,0 +1,97 @@
+// Package headers provides an otelcol.auth.headers component.
+package headers
+
+import (
+	"fmt"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otelcol"
+	"github.com/grafana/agent/component/otelcol/auth"
+	"github.com/grafana/agent/pkg/flow/rivertypes"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension"
+	otelcomponent "go.opentelemetry.io/collector/component"
+	otelconfig "go.opentelemetry.io/collector/config"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:    "otelcol.auth.headers",
+		Args:    Arguments{},
+		Exports: otelcol.ConsumerExports{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			fact := headerssetterextension.NewFactory()
+			return auth.New(opts, fact, args.(Arguments))
+		},
+	})
+}
+
+// Arguments configures the otelcol.auth.headers component.
+type Arguments struct {
+	Headers []Header `river:"header,block,optional"`
+}
+
+var _ auth.Arguments = Arguments{}
+
+// Convert implements auth.Arguments.
+func (args Arguments) Convert() otelconfig.Extension {
+	var upstreamHeaders []headerssetterextension.HeaderConfig
+	for _, h := range args.Headers {
+		upstreamHeader := headerssetterextension.HeaderConfig{
+			Key: &h.Key,
+		}
+
+		if h.Value != nil {
+			upstreamHeader.Value = &h.Value.Value
+		}
+		if h.FromContext != nil {
+			upstreamHeader.FromContext = h.FromContext
+		}
+
+		upstreamHeaders = append(upstreamHeaders, upstreamHeader)
+	}
+
+	return &headerssetterextension.Config{
+		ExtensionSettings: otelconfig.NewExtensionSettings(otelconfig.NewComponentID("headers")),
+		HeadersConfig:     upstreamHeaders,
+	}
+}
+
+// Extensions implements auth.Arguments.
+func (args Arguments) Extensions() map[otelconfig.ComponentID]otelcomponent.Extension {
+	return nil
+}
+
+// Exporters implements auth.Arguments.
+func (args Arguments) Exporters() map[otelconfig.DataType]map[otelconfig.ComponentID]otelcomponent.Exporter {
+	return nil
+}
+
+// Header is an individual Header to send along with requests.
+type Header struct {
+	Key         string                     `river:"key,attr"`
+	Value       *rivertypes.OptionalSecret `river:"value,attr,optional"`
+	FromContext *string                    `river:"from_context,attr,optional"`
+}
+
+var _ river.Unmarshaler = (*Header)(nil)
+
+// UnmarshalRiver implements river.Unmarshaler.
+func (h *Header) UnmarshalRiver(f func(interface{}) error) error {
+	type header Header
+	if err := f((*header)(h)); err != nil {
+		return err
+	}
+
+	switch {
+	case h.Key == "":
+		return fmt.Errorf("key must be set to a non-empty string")
+	case h.FromContext == nil && h.Value == nil:
+		return fmt.Errorf("either value or from_context must be provided")
+	case h.FromContext != nil && h.Value != nil:
+		return fmt.Errorf("either value or from_context must be provided, not both")
+	}
+
+	return nil
+}

--- a/component/otelcol/auth/headers/headers_test.go
+++ b/component/otelcol/auth/headers/headers_test.go
@@ -1,0 +1,80 @@
+package headers_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/component/otelcol/auth"
+	"github.com/grafana/agent/component/otelcol/auth/headers"
+	"github.com/grafana/agent/pkg/flow/componenttest"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/grafana/agent/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configauth"
+)
+
+// Test performs a basic integration test which runs the otelcol.auth.headers
+// component and ensures that it can be used for authentication.
+func Test(t *testing.T) {
+	// Create an HTTP server which will assert that headers auth has been injected
+	// into the request.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		orgID := r.Header.Get("X-Scope-Org-ID")
+		assert.Equal(t, "fake", orgID, "X-Scope-Org-ID header didn't match")
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := componenttest.TestContext(t)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	l := util.TestLogger(t)
+
+	// Create and run our component
+	ctrl, err := componenttest.NewControllerFromID(l, "otelcol.auth.headers")
+	require.NoError(t, err)
+
+	cfg := `
+		header {
+			key   = "X-Scope-Org-ID"
+			value = "fake"
+		}
+	`
+	var args headers.Arguments
+	require.NoError(t, river.Unmarshal([]byte(cfg), &args))
+
+	go func() {
+		err := ctrl.Run(ctx, args)
+		require.NoError(t, err)
+	}()
+
+	require.NoError(t, ctrl.WaitRunning(time.Second), "component never started")
+	require.NoError(t, ctrl.WaitExports(time.Second), "component never exported anything")
+
+	// Get the authentication extension from our component and use it to make a
+	// request to our test server.
+	exports := ctrl.Exports().(auth.Exports)
+	require.NotNil(t, exports.Handler.Extension, "handler extension is nil")
+
+	clientAuth, ok := exports.Handler.Extension.(configauth.ClientAuthenticator)
+	require.True(t, ok, "handler does not implement configauth.ClientAuthenticator")
+
+	rt, err := clientAuth.RoundTripper(http.DefaultTransport)
+	require.NoError(t, err)
+	cli := &http.Client{Transport: rt}
+
+	// Wait until the request finishes. We don't assert anything else here; our
+	// HTTP handler won't write the response until it ensures that the headers
+	// were set.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := cli.Do(req)
+	require.NoError(t, err, "HTTP request failed")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/docs/sources/flow/reference/components/otelcol.auth.headers.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.headers.md
@@ -89,8 +89,7 @@ configuration.
 
 ## Example
 
-This example configures [otelcol.exporter.otlp][] to use headers token
-authentication:
+This example configures [otelcol.exporter.otlp][] to use custom headers:
 
 ```river
 otelcol.exporter.otlp "example" {

--- a/docs/sources/flow/reference/components/otelcol.auth.headers.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.headers.md
@@ -30,7 +30,7 @@ otelcol.auth.headers "LABEL" {
 
 ## Arguments
 
-`otelcol.auth.headers` doesn't support any arugments and is configured fully
+`otelcol.auth.headers` doesn't support any arguments and is configured fully
 through inner blocks.
 
 ## Blocks

--- a/docs/sources/flow/reference/components/otelcol.auth.headers.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.headers.md
@@ -1,0 +1,116 @@
+---
+aliases:
+- /docs/agent/latest/flow/reference/components/otelcol.auth.headers
+title: otelcol.auth.headers
+---
+
+# otelcol.auth.headers
+
+`otelcol.auth.headers` exposes a `handler` that can be used by other `otelcol`
+components to authenticate requests using custom headers.
+
+> **NOTE**: `otelcol.auth.headers` is a wrapper over the upstream OpenTelemetry
+> Collector `headerssetter` extension. Bug reports or feature requests will be
+> redirected to the upstream repository, if necessary.
+
+Multiple `otelcol.auth.headers` components can be specified by giving them
+different labels.
+
+## Usage
+
+```river
+otelcol.auth.headers "LABEL" {
+  header {
+    key   = "HEADER_NAME"
+    value = "HEADER_VALUE"
+  }
+  token = "TOKEN"
+}
+```
+
+## Arguments
+
+`otelcol.auth.headers` doesn't support any arugments and is configured fully
+through inner blocks.
+
+## Blocks
+
+The following blocks are supported inside the definition of
+`otelcol.auth.headers`:
+
+Hierarchy | Block | Description | Required
+--------- | ----- | ----------- | --------
+header | [header][] | Custom header to attach to requests. | no
+
+[header]: #header-block
+
+### header block
+
+The `header` block defines a custom header to attach to requests. It is valid
+to provide multiple `header` blocks to set more than one header.
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`key` | `string` | Name of the header to set. | | yes
+`value` | `string` or `secret` | Value of the header. | | no
+`from_context` | `string` | Metadata name to get header value from. | | no
+
+Exactly one of `value` or `from_context` must be provided for each `header`
+block.
+
+The `value` attribute sets the value of the header directly.
+
+Alternatively, `from_context` can be used to dynamically retrieve the header
+value from request metadata.
+
+> **NOTE**: It is not possible to use `from_context` to get the header value if
+> [the `otelcol.processor.batch` component][otelcol.processor.batch] is used to
+> batch before data is sent to the component referencing
+> `otelcol.auth.headers`.
+
+[otelcol.processor.batch]: {{< relref "./otelcol.processor.batch.md" >}}
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+Name | Type | Description
+---- | ---- | -----------
+`handler` | `capsule(otelcol.Handler)` | A value that other components can use to authenticate requests.
+
+## Component health
+
+`otelcol.auth.headers` is only reported as unhealthy if given an invalid
+configuration.
+
+## Debug information
+
+`otelcol.auth.headers` does not expose any component-specific debug information.
+
+## Example
+
+This example configures [otelcol.exporter.otlp][] to use headers token
+authentication:
+
+```river
+otelcol.exporter.otlp "example" {
+  client {
+    endpoint = "my-otlp-grpc-server:4317"
+    auth     = otelcol.auth.headers.creds.handler
+  }
+}
+
+otelcol.auth.headers "creds" {
+  header {
+    key          = "X-Scope-OrgID"
+    from_context = "tenant_id"
+  }
+
+  header {
+    key   = "User-ID"
+    value = "user_id"
+  }
+}
+```
+
+[otelcol.exporter.otlp]: {{< relref "./otelcol.exporter.otlp.md" >}}

--- a/docs/sources/flow/reference/components/otelcol.auth.headers.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.headers.md
@@ -24,7 +24,6 @@ otelcol.auth.headers "LABEL" {
     key   = "HEADER_NAME"
     value = "HEADER_VALUE"
   }
-  token = "TOKEN"
 }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -385,6 +385,7 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.61.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.61.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.61.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.61.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.61.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.61.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2051,6 +2051,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthext
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.61.0/go.mod h1:lSpO0oRJvNEbAdKbKIqJ7Lb+Tfj6XI9N415E0ATAMYE=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.61.0 h1:s3Xc8ncFd8E4va9xDIXoEYzoBILSe2bdGwxMuS6MVBE=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.61.0/go.mod h1:AlW4Z/pvtLqP0PtLzuh1I5ifJXEsSWTTj0g194BEsQA=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.61.0 h1:JMkOySvXivup4MNLB8FhdxmloQlJoxEm4FqUI+fk0Tg=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.61.0/go.mod h1:+Yjsoz9iiXiPPChQnGCW710kkrMNwApF6s3AwIFVby0=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension v0.61.0 h1:USlB+ZO5VxvoLU1iE3bToDaS9xBTcqD6J5ooYBu8fUk=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension v0.61.0/go.mod h1:kY/a+e4Yl3cTEWp3m8eFxmNU60yYvoWledSKjLKrip4=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.61.0 h1:z+MA5MWVNh9n6w9+npb4Cb7/Ycgfa/jqJFnkSCSYhb0=


### PR DESCRIPTION
Introduce an `otelcol.auth.headers` component which wraps around the upstream `headerssetter` extension and allows other components to use it.

Closes #2356.