### PR TITLE
river/encoding: fix issue where interface capsules were downcasted to empty objects

### DIFF
--- a/pkg/river/encoding/attribute.go
+++ b/pkg/river/encoding/attribute.go
@@ -43,7 +43,7 @@ func (af *attributeField) convertAttribute(val value.Value, f rivertags.Field) e
 	if !f.IsAttr() {
 		return fmt.Errorf("convertAttribute requires a field that is an attribute got %T", val.Interface())
 	}
-	if val.Reflect().IsZero() {
+	if !val.Reflect().IsValid() || val.Reflect().IsZero() {
 		return nil
 	}
 	af.Type = attrType

--- a/pkg/river/encoding/block.go
+++ b/pkg/river/encoding/block.go
@@ -71,11 +71,11 @@ func getFieldsForBlock(input interface{}) ([]interface{}, error) {
 	var fields []interface{}
 	for _, t := range rt {
 		fieldRef := reflectVal.FieldByIndex(t.Index)
-		fieldVal := value.Encode(fieldRef.Interface())
-		fieldReflect := fieldVal.Reflect()
-		if t.IsBlock() && (fieldReflect.Kind() == reflect.Array || fieldReflect.Kind() == reflect.Slice) {
-			for i := 0; i < fieldReflect.Len(); i++ {
-				arrEle := fieldReflect.Index(i).Interface()
+		fieldVal := value.FromRaw(fieldRef)
+
+		if t.IsBlock() && (fieldRef.Kind() == reflect.Array || fieldRef.Kind() == reflect.Slice) {
+			for i := 0; i < fieldRef.Len(); i++ {
+				arrEle := fieldRef.Index(i).Interface()
 				bf, err := newBlock(reflect.ValueOf(arrEle), t)
 				if err != nil {
 					return nil, err

--- a/pkg/river/encoding/encoding_test.go
+++ b/pkg/river/encoding/encoding_test.go
@@ -1,0 +1,31 @@
+package encoding_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/grafana/agent/pkg/river/encoding"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertRiverBodyToJSON_CapsuleValue(t *testing.T) {
+	type Content struct {
+		Field io.Closer `river:"writer,attr"`
+	}
+
+	out, err := encoding.ConvertRiverBodyToJSON(Content{Field: io.NopCloser(nil)})
+	require.NoError(t, err)
+
+	expect := `[
+		{
+			"name": "writer",
+			"type": "attr",
+			"value": {
+				"type": "capsule",
+				"value": "capsule(\"io.Closer\")"
+			}
+		}
+	]`
+
+	require.JSONEq(t, expect, string(out))
+}

--- a/pkg/river/internal/value/value.go
+++ b/pkg/river/internal/value/value.go
@@ -106,6 +106,12 @@ func Encode(v interface{}) Value {
 	return makeValue(reflect.ValueOf(v))
 }
 
+// FromRaw converts a reflect.Value into a River Value. It is useful to prevent
+// downcasting a interface into an any.
+func FromRaw(v reflect.Value) Value {
+	return makeValue(v)
+}
+
 // Type returns the River type for the value.
 func (v Value) Type() Type { return v.ty }
 


### PR DESCRIPTION
This change is similar to the fix introduced in #2369, where calling the `Interface()` method on River values forced a type change from an interface-based capsule to an any-type capsule. This caused the UI to crash when displaying an otelcol component (see #2361).

The new `value.FromRaw` method allows constructing a River value from a reflect.Value directly, avoiding the need to convert to interface{}.

As part of this change, a `!reflect.Value.IsZero()` check has been added for safety; this shouldn't happen in most circumstances unless a value.Null is trying to be encoded.

The CHANGELOG wasn't updated because this behavior only occurs when a component exports a capsule type, which was first introduced in the otelcol.* components which have yet to be released.

Fixes #2361.