### PR TITLE
Operator: Add support for bearer token for metrics remote write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ Main (unreleased)
 
 - Tracing: fix a panic when the required `protocols` field was not set in the `otlp` receiver. (@ptodev)
 
+- Support Bearer tokens for metric remote writes in the Grafana Operator (@jcreixell, @marctc)
+
 v0.28.0 (2022-09-29)
 --------------------
 

--- a/pkg/operator/config/metrics_templates_test.go
+++ b/pkg/operator/config/metrics_templates_test.go
@@ -573,6 +573,38 @@ func TestRemoteWrite(t *testing.T) {
 			`),
 		},
 		{
+			name: "bearer_token",
+			input: map[string]interface{}{
+				"namespace": "operator",
+				"rw": gragent.RemoteWriteSpec{
+					URL:         "http://cortex/api/prom/push",
+					BearerToken: "my-token",
+				},
+			},
+			expect: util.Untab(`
+				url: http://cortex/api/prom/push
+				authorization:
+					type: Bearer
+					credentials: my-token
+			`),
+		},
+		{
+			name: "bearer_token_file",
+			input: map[string]interface{}{
+				"namespace": "operator",
+				"rw": gragent.RemoteWriteSpec{
+					URL:             "http://cortex/api/prom/push",
+					BearerTokenFile: "/path/to/file",
+				},
+			},
+			expect: util.Untab(`
+				url: http://cortex/api/prom/push
+				authorization:
+					type: Bearer
+					credentials_file: /path/to/file
+			`),
+		},
+		{
 			name: "sigv4",
 			input: map[string]interface{}{
 				"namespace": "operator",

--- a/pkg/operator/config/templates/component/metrics/remote_write.libsonnet
+++ b/pkg/operator/config/templates/component/metrics/remote_write.libsonnet
@@ -35,6 +35,15 @@ function(namespace, rw) {
     }
   ),
 
+  authorization: (
+    if rw.BearerToken != "" then {
+      type: "Bearer",
+      credentials: rw.BearerToken
+    } else if rw.BearerTokenFile != "" then {
+      type: "Bearer",
+      credentials_file: rw.BearerTokenFile
+    }
+  ),
   sigv4: (
     if rw.SigV4 != null then {
       region: optionals.string(rw.SigV4.Region),

--- a/pkg/operator/config/templates/component/metrics/remote_write.libsonnet
+++ b/pkg/operator/config/templates/component/metrics/remote_write.libsonnet
@@ -34,16 +34,15 @@ function(namespace, rw) {
       password_file: secrets.pathForSecret(namespace, rw.BasicAuth.Password),
     }
   ),
+  local bearerToken = optionals.string(rw.BearerToken),
+  local bearerTokenFile = optionals.string(rw.BearerTokenFile),
 
-  authorization: (
-    if rw.BearerToken != "" then {
-      type: "Bearer",
-      credentials: rw.BearerToken
-    } else if rw.BearerTokenFile != "" then {
-      type: "Bearer",
-      credentials_file: rw.BearerTokenFile
-    }
-  ),
+  authorization: if bearerToken != null || bearerTokenFile != null then {
+    type: 'Bearer',
+    credentials: bearerToken,
+    credentials_file: bearerTokenFile,
+  },
+
   sigv4: (
     if rw.SigV4 != null then {
       region: optionals.string(rw.SigV4.Region),


### PR DESCRIPTION
#### PR Description

  - Operator CRDs allow defining bearer tokens for remote writes, but the fields are never mapped to the final configuration.
  - Adds mapping to render them when defined.
  - See https://prometheus.io/docs/prometheus/2.34/configuration/configuration/#remote_write

#### Which issue(s) this PR fixes

- Fixes #2332 

#### PR Checklist

- [x] CHANGELOG updated
- [ ] ~Documentation added~ (already documented via CRDs)
- [x] Tests updated
