### PR TITLE
Add utilities for testing code which send data to storage.Appenders

### DIFF
--- a/pkg/util/testappender/compare.go
+++ b/pkg/util/testappender/compare.go
@@ -1,0 +1,97 @@
+package testappender
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/pmezard/go-difflib/difflib"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+// NOTE(rfratto): this file is only needed because client_golang's testutil
+// package currently enforces the Prometheus text exposition format, due to
+// there not being a OpenMetrics parser in prometheus/common yet.
+//
+// This means that, unlike with testutil, callers are forced to compare line
+// order of comments and metrics. This can be a good thing, in some cases, but
+// is fairly tedious if you don't care about the order.
+
+// Comparer can compare a slice of dto.MetricFamily to an expected list of
+// metrics.
+type Comparer struct {
+	// OpenMetrics indicates that the Comparer should test the OpenMetrics
+	// representation instead of the Prometheus text exposition format.
+	OpenMetrics bool
+}
+
+// Compare compares the text representation of families to an expected input
+// string. If the OpenMetrics field of the Comparerer is true, families is
+// converted into the OpenMetrics text exposition format. Otherwise, families
+// is converted into the Prometheus text exposition format.
+//
+// To make testing less error prone, expect is cleaned by removing leading
+// whitespace, trailing whitespace, and empty lines. The cleaned version of
+// expect is then compared directly against the text representation of
+// families.
+func (c Comparer) Compare(families []*dto.MetricFamily, expect string) error {
+	expect = cleanExpositionString(expect)
+
+	var (
+		enc expfmt.Encoder
+		buf bytes.Buffer
+	)
+	if c.OpenMetrics {
+		enc = expfmt.NewEncoder(&buf, expfmt.FmtOpenMetrics)
+	} else {
+		enc = expfmt.NewEncoder(&buf, expfmt.FmtText)
+	}
+	for _, f := range families {
+		if err := enc.Encode(f); err != nil {
+			return fmt.Errorf("error encoding family %s: %w", f.GetName(), err)
+		}
+	}
+
+	if expect != buf.String() {
+		diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+			A:        difflib.SplitLines(expect),
+			B:        difflib.SplitLines(buf.String()),
+			FromFile: "Expected",
+			ToFile:   "Actual",
+			Context:  1,
+		})
+		return fmt.Errorf("metric data does not match:\n\n%s", diff)
+	}
+
+	return nil
+}
+
+func cleanExpositionString(s string) string {
+	scanner := bufio.NewScanner(strings.NewReader(s))
+
+	var res strings.Builder
+	for scanner.Scan() {
+		line := scanner.Text()
+		line = strings.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		fmt.Fprint(&res, line, "\n")
+	}
+
+	return res.String()
+}
+
+// Compare compares the text representation of families to an expected input
+// string. Families is converted into the Prometheus text exposition format.
+//
+// To make testing less error prone, expect is cleaned by removing leading
+// whitespace, trailing whitespace, and empty lines. The cleaned version of
+// expect is then compared directly against the text representation of
+// families.
+func Compare(families []*dto.MetricFamily, expect string) error {
+	var c Comparer
+	return c.Compare(families, expect)
+}

--- a/pkg/util/testappender/dto_sort.go
+++ b/pkg/util/testappender/dto_sort.go
@@ -1,0 +1,73 @@
+package testappender
+
+import (
+	"sort"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// sortMetricFamilies sorts metric families, the metrics inside them, and the
+// summaries and histograms inside the individual metrics.
+func sortMetricFamilies(mf []*dto.MetricFamily) {
+	sort.Slice(mf, func(i, j int) bool {
+		return mf[i].GetName() < mf[j].GetName()
+	})
+
+	// Sort the met
+	for _, family := range mf {
+		sortMetrics(family.Metric)
+	}
+}
+
+// sortMetrics sorts a slice of metrics, followed by the quantiles and
+// histogram buckets (if present) inside each metric.
+func sortMetrics(mm []*dto.Metric) {
+	sort.Slice(mm, func(i, j int) bool {
+		return labelsLess(mm[i].GetLabel(), mm[j].GetLabel())
+	})
+
+	for _, m := range mm {
+		if m.Summary != nil {
+			sortQuantiles(m.Summary.GetQuantile())
+		}
+
+		if m.Histogram != nil {
+			sortBuckets(m.Histogram.GetBucket())
+		}
+	}
+}
+
+func labelsLess(a, b []*dto.LabelPair) bool {
+	for i := 0; i < len(a); i++ {
+		// If all labels have matched but we've gone past the length
+		// of b, that means that a > b.
+		// If we've gone past the length of b, then a has more labels
+		if i >= len(b) {
+			return false
+		}
+
+		switch {
+		case a[i].GetName() != b[i].GetName():
+			return a[i].GetName() < b[i].GetName()
+		case a[i].GetValue() != b[i].GetValue():
+			return a[i].GetValue() < b[i].GetValue()
+		}
+	}
+
+	// Either they're fully equal or a < b, so we return true either way..
+	return true
+}
+
+// sortQuantiles sorts a slice of quantiles.
+func sortQuantiles(qq []*dto.Quantile) {
+	sort.Slice(qq, func(i, j int) bool {
+		return qq[i].GetQuantile() < qq[j].GetQuantile()
+	})
+}
+
+// sortBuckets sorts a slice of buckets.
+func sortBuckets(bb []*dto.Bucket) {
+	sort.Slice(bb, func(i, j int) bool {
+		return bb[i].GetUpperBound() < bb[j].GetUpperBound()
+	})
+}

--- a/pkg/util/testappender/internal/dtobuilder/dtobuilder.go
+++ b/pkg/util/testappender/internal/dtobuilder/dtobuilder.go
@@ -110,7 +110,7 @@ func (b *builder) buildFamiliesFromMetadata() {
 			Type: &mt,
 		}
 		if m.Help != "" {
-			mf.Help = &m.Help
+			mf.Help = pointer.String(m.Help)
 		}
 
 		b.families = append(b.families, mf)

--- a/pkg/util/testappender/internal/dtobuilder/dtobuilder.go
+++ b/pkg/util/testappender/internal/dtobuilder/dtobuilder.go
@@ -44,6 +44,8 @@ func Build(
 		Samples:   samples,
 		Exemplars: exemplars,
 		Metadata:  metadata,
+
+		familyLookup: make(map[string]*dto.MetricFamily),
 	}
 	return b.Build()
 }
@@ -60,10 +62,6 @@ type builder struct {
 // Build converts the dtoBuilder's Samples, Exemplars, and Metadata into a set
 // of []*dto.MetricFamily.
 func (b *builder) Build() []*dto.MetricFamily {
-	// Reset state in case Build has already been called.
-	b.families = nil
-	b.familyLookup = make(map[string]*dto.MetricFamily)
-
 	// We *must* do things in the following order:
 	//
 	// 1. Populate the families from metadata so we know what fields in
@@ -76,7 +74,6 @@ func (b *builder) Build() []*dto.MetricFamily {
 
 	// Sort all the data before returning.
 	sortMetricFamilies(b.families)
-
 	return b.families
 }
 

--- a/pkg/util/testappender/internal/dtobuilder/dtobuilder.go
+++ b/pkg/util/testappender/internal/dtobuilder/dtobuilder.go
@@ -1,0 +1,386 @@
+package dtobuilder
+
+import (
+	"math"
+	"sort"
+	"strconv"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/exemplar"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
+	"github.com/prometheus/prometheus/model/textparse"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"k8s.io/utils/pointer"
+)
+
+// Sample represents an individually written sample to a storage.Appender.
+type Sample struct {
+	Labels    labels.Labels
+	Timestamp int64
+	Value     float64
+}
+
+// SeriesExemplar represents an individually written exemplar to a
+// storage.Appender.
+type SeriesExemplar struct {
+	// Labels is the labels of the series exposing the exemplar, not the labels
+	// on the exemplar itself.
+	Labels   labels.Labels
+	Exemplar exemplar.Exemplar
+}
+
+// Build converts a series of written samples, exemplars, and metadata into a
+// slice of *dto.MetricFamily.
+func Build(
+	samples map[string]Sample,
+	exemplars map[string]SeriesExemplar,
+	metadata map[string]metadata.Metadata,
+) []*dto.MetricFamily {
+
+	b := builder{
+		Samples:   samples,
+		Exemplars: exemplars,
+		Metadata:  metadata,
+	}
+	return b.Build()
+}
+
+type builder struct {
+	Samples   map[string]Sample
+	Exemplars map[string]SeriesExemplar
+	Metadata  map[string]metadata.Metadata
+
+	families     []*dto.MetricFamily
+	familyLookup map[string]*dto.MetricFamily
+}
+
+// Build converts the dtoBuilder's Samples, Exemplars, and Metadata into a set
+// of []*dto.MetricFamily.
+func (b *builder) Build() []*dto.MetricFamily {
+	// Reset state in case Build has already been called.
+	b.families = nil
+	b.familyLookup = make(map[string]*dto.MetricFamily)
+
+	// We *must* do things in the following order:
+	//
+	// 1. Populate the families from metadata so we know what fields in
+	//    *dto.Metric to set.
+	// 2. Populate *dto.Metric values from provided samples.
+	// 3. Assign exemplars to *dto.Metrics as appropriate.
+	b.buildFamiliesFromMetadata()
+	b.buildMetricsFromSamples()
+	b.injectExemplars()
+
+	// Sort all the data before returning.
+	sortMetricFamilies(b.families)
+
+	return b.families
+}
+
+// buildFamiliesFromMetadata populates the list of families based on the
+// metadata known to the dtoBuilder.
+func (b *builder) buildFamiliesFromMetadata() {
+	for familyName, m := range b.Metadata {
+		mt := textParseToMetricType(m.Type)
+		mf := &dto.MetricFamily{
+			Name: pointer.String(familyName),
+			Type: &mt,
+		}
+		if m.Help != "" {
+			mf.Help = &m.Help
+		}
+
+		b.families = append(b.families, mf)
+
+		// Determine how to populate the lookup table.
+		switch mt {
+		case dto.MetricType_SUMMARY:
+			// Summaries include metrics with the family name (for quantiles),
+			// followed by _sum and _count suffixes.
+			b.familyLookup[familyName] = mf
+			b.familyLookup[familyName+"_sum"] = mf
+			b.familyLookup[familyName+"_count"] = mf
+		case dto.MetricType_HISTOGRAM:
+			// Histograms include metrics for _bucket, _sum, and _count suffixes.
+			b.familyLookup[familyName+"_bucket"] = mf
+			b.familyLookup[familyName+"_sum"] = mf
+			b.familyLookup[familyName+"_count"] = mf
+		default:
+			// Everything else matches the family name exactly.
+			b.familyLookup[familyName] = mf
+		}
+	}
+}
+
+func textParseToMetricType(tp textparse.MetricType) dto.MetricType {
+	switch tp {
+	case textparse.MetricTypeCounter:
+		return dto.MetricType_COUNTER
+	case textparse.MetricTypeGauge:
+		return dto.MetricType_GAUGE
+	case textparse.MetricTypeHistogram:
+		return dto.MetricType_HISTOGRAM
+	case textparse.MetricTypeSummary:
+		return dto.MetricType_SUMMARY
+	default:
+		// There are other values for m.Type, but they're all
+		// OpenMetrics-specific and we're only converting into the Prometheus
+		// exposition format.
+		return dto.MetricType_UNTYPED
+	}
+}
+
+// buildMetricsFromSamples populates *dto.Metrics. If the MetricFamily doesn't
+// exist for a given sample, a new one is created.
+func (b *builder) buildMetricsFromSamples() {
+	for _, sample := range b.Samples {
+		// Get or create the metric family.
+		metricName := sample.Labels.Get(model.MetricNameLabel)
+		mf := b.getOrCreateMetricFamily(metricName)
+
+		// Retrieve the *dto.Metric based on labels.
+		m := getOrCreateMetric(mf, sample.Labels)
+		m.TimestampMs = pointer.Int64(sample.Timestamp)
+
+		switch familyType(mf) {
+		case dto.MetricType_COUNTER:
+			m.Counter = &dto.Counter{
+				Value: pointer.Float64(sample.Value),
+			}
+
+		case dto.MetricType_GAUGE:
+			m.Gauge = &dto.Gauge{
+				Value: pointer.Float64(sample.Value),
+			}
+
+		case dto.MetricType_SUMMARY:
+			if m.Summary == nil {
+				m.Summary = &dto.Summary{}
+			}
+
+			switch {
+			case metricName == mf.GetName()+"_count":
+				val := uint64(sample.Value)
+				m.Summary.SampleCount = &val
+			case metricName == mf.GetName()+"_sum":
+				m.Summary.SampleSum = pointer.Float64(sample.Value)
+			case metricName == mf.GetName():
+				quantile, err := strconv.ParseFloat(sample.Labels.Get(model.QuantileLabel), 64)
+				if err != nil {
+					continue
+				}
+
+				m.Summary.Quantile = append(m.Summary.Quantile, &dto.Quantile{
+					Quantile: &quantile,
+					Value:    pointer.Float64(sample.Value),
+				})
+			}
+
+		case dto.MetricType_UNTYPED:
+			m.Untyped = &dto.Untyped{
+				Value: pointer.Float64(sample.Value),
+			}
+
+		case dto.MetricType_HISTOGRAM:
+			if m.Histogram == nil {
+				m.Histogram = &dto.Histogram{}
+			}
+
+			switch {
+			case metricName == mf.GetName()+"_count":
+				val := uint64(sample.Value)
+				m.Histogram.SampleCount = &val
+			case metricName == mf.GetName()+"_sum":
+				m.Histogram.SampleSum = pointer.Float64(sample.Value)
+			case metricName == mf.GetName()+"_bucket":
+				boundary, err := strconv.ParseFloat(sample.Labels.Get(model.BucketLabel), 64)
+				if err != nil {
+					continue
+				}
+
+				count := uint64(sample.Value)
+
+				m.Histogram.Bucket = append(m.Histogram.Bucket, &dto.Bucket{
+					UpperBound:      &boundary,
+					CumulativeCount: &count,
+				})
+			}
+		}
+	}
+}
+
+func (b *builder) getOrCreateMetricFamily(familyName string) *dto.MetricFamily {
+	mf, ok := b.familyLookup[familyName]
+	if ok {
+		return mf
+	}
+
+	mt := dto.MetricType_UNTYPED
+	mf = &dto.MetricFamily{
+		Name: &familyName,
+		Type: &mt,
+	}
+	b.families = append(b.families, mf)
+	b.familyLookup[familyName] = mf
+	return mf
+}
+
+func getOrCreateMetric(mf *dto.MetricFamily, l labels.Labels) *dto.Metric {
+	metricLabels := toLabelPairs(familyType(mf), l)
+
+	for _, check := range mf.Metric {
+		if labelPairsEqual(check.Label, metricLabels) {
+			return check
+		}
+	}
+
+	m := &dto.Metric{
+		Label: metricLabels,
+	}
+	mf.Metric = append(mf.Metric, m)
+	return m
+}
+
+// toLabelPairs converts labels.Labels into []*dto.LabelPair. The __name__
+// label is always dropped, since the metric name is retrieved from the family
+// name instead.
+//
+// The quantile label is dropped for summaries, and the le label is dropped for
+// histograms.
+func toLabelPairs(mt dto.MetricType, ls labels.Labels) []*dto.LabelPair {
+	res := make([]*dto.LabelPair, 0, len(ls))
+	for _, l := range ls {
+		if l.Name == model.MetricNameLabel {
+			continue
+		} else if l.Name == model.QuantileLabel && mt == dto.MetricType_SUMMARY {
+			continue
+		} else if l.Name == model.BucketLabel && mt == dto.MetricType_HISTOGRAM {
+			continue
+		}
+
+		res = append(res, &dto.LabelPair{
+			Name:  pointer.String(l.Name),
+			Value: pointer.String(l.Value),
+		})
+	}
+
+	sort.Slice(res, func(i, j int) bool {
+		switch {
+		case *res[i].Name < *res[j].Name:
+			return true
+		case *res[i].Value < *res[j].Value:
+			return true
+		default:
+			return false
+		}
+	})
+	return res
+}
+
+func labelPairsEqual(a, b []*dto.LabelPair) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := 0; i < len(a); i++ {
+		if *a[i].Name != *b[i].Name || *a[i].Value != *b[i].Value {
+			return false
+		}
+	}
+
+	return true
+}
+
+func familyType(mf *dto.MetricFamily) dto.MetricType {
+	ty := mf.Type
+	if ty == nil {
+		return dto.MetricType_UNTYPED
+	}
+	return *ty
+}
+
+// injectExemplars populates the exemplars in the various *dto.Metric
+// instances. Exemplars are ignored if the parent *dto.MetricFamily doesn't
+// support exeplars based on metric type.
+func (b *builder) injectExemplars() {
+	for _, e := range b.Exemplars {
+		// Get or create the metric family.
+		exemplarName := e.Labels.Get(model.MetricNameLabel)
+
+		mf, ok := b.familyLookup[exemplarName]
+		if !ok {
+			// No metric family, which means no corresponding sample; ignore.
+			continue
+		}
+
+		m := getMetric(mf, e.Labels)
+		if m == nil {
+			continue
+		}
+
+		// Only counters and histograms support exemplars.
+		switch familyType(mf) {
+		case dto.MetricType_COUNTER:
+			if m.Counter == nil {
+				// Sample never added; ignore.
+				continue
+			}
+			m.Counter.Exemplar = convertExemplar(dto.MetricType_COUNTER, e.Exemplar)
+		case dto.MetricType_HISTOGRAM:
+			if m.Histogram == nil {
+				// Sample never added; ignore.
+				continue
+			}
+
+			switch {
+			case exemplarName == mf.GetName()+"_bucket":
+				boundary, err := strconv.ParseFloat(e.Labels.Get(model.BucketLabel), 64)
+				if err != nil {
+					continue
+				}
+				bucket := findBucket(m.Histogram, boundary)
+				if bucket == nil {
+					continue
+				}
+				bucket.Exemplar = convertExemplar(dto.MetricType_HISTOGRAM, e.Exemplar)
+			}
+		}
+	}
+}
+
+func getMetric(mf *dto.MetricFamily, l labels.Labels) *dto.Metric {
+	metricLabels := toLabelPairs(familyType(mf), l)
+
+	for _, check := range mf.Metric {
+		if labelPairsEqual(check.Label, metricLabels) {
+			return check
+		}
+	}
+
+	return nil
+}
+
+func convertExemplar(mt dto.MetricType, e exemplar.Exemplar) *dto.Exemplar {
+	res := &dto.Exemplar{
+		Label: toLabelPairs(mt, e.Labels),
+		Value: &e.Value,
+	}
+	if e.HasTs {
+		res.Timestamp = timestamppb.New(time.UnixMilli(e.Ts))
+	}
+	return res
+}
+
+func findBucket(h *dto.Histogram, bound float64) *dto.Bucket {
+	for _, b := range h.GetBucket() {
+		// If it's close enough, use the bucket.
+		if math.Abs(b.GetUpperBound()-bound) < 1e-9 {
+			return b
+		}
+	}
+
+	return nil
+}

--- a/pkg/util/testappender/internal/dtobuilder/dtobuilder.go
+++ b/pkg/util/testappender/internal/dtobuilder/dtobuilder.go
@@ -18,9 +18,10 @@ import (
 
 // Sample represents an individually written sample to a storage.Appender.
 type Sample struct {
-	Labels    labels.Labels
-	Timestamp int64
-	Value     float64
+	Labels         labels.Labels
+	Timestamp      int64
+	Value          float64
+	PrintTimestamp bool
 }
 
 // SeriesExemplar represents an individually written exemplar to a
@@ -162,7 +163,9 @@ func (b *builder) buildMetricsFromSamples() {
 
 		// Retrieve the *dto.Metric based on labels.
 		m := getOrCreateMetric(mf, sample.Labels)
-		m.TimestampMs = pointer.Int64(sample.Timestamp)
+		if sample.PrintTimestamp {
+			m.TimestampMs = pointer.Int64(sample.Timestamp)
+		}
 
 		switch familyType(mf) {
 		case dto.MetricType_COUNTER:

--- a/pkg/util/testappender/internal/dtobuilder/sort.go
+++ b/pkg/util/testappender/internal/dtobuilder/sort.go
@@ -1,4 +1,4 @@
-package testappender
+package dtobuilder
 
 import (
 	"sort"

--- a/pkg/util/testappender/internal/dtobuilder/sort.go
+++ b/pkg/util/testappender/internal/dtobuilder/sort.go
@@ -13,7 +13,6 @@ func sortMetricFamilies(mf []*dto.MetricFamily) {
 		return mf[i].GetName() < mf[j].GetName()
 	})
 
-	// Sort the met
 	for _, family := range mf {
 		sortMetrics(family.Metric)
 	}
@@ -37,6 +36,8 @@ func sortMetrics(mm []*dto.Metric) {
 	}
 }
 
+// labelsLess implements the sort.Slice "less" function, returning true if a
+// should appear before b in a list of sorted labels.
 func labelsLess(a, b []*dto.LabelPair) bool {
 	for i := 0; i < len(a); i++ {
 		// If all labels have matched but we've gone past the length

--- a/pkg/util/testappender/testappender.go
+++ b/pkg/util/testappender/testappender.go
@@ -4,21 +4,15 @@ package testappender
 
 import (
 	"fmt"
-	"math"
-	"sort"
-	"strconv"
-	"time"
 
+	"github.com/grafana/agent/pkg/util/testappender/internal/dtobuilder"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/metadata"
-	"github.com/prometheus/prometheus/model/textparse"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
-	"google.golang.org/protobuf/types/known/timestamppb"
-	"k8s.io/utils/pointer"
 )
 
 // Appender implements storage.Appender. It keeps track of samples, metadata,
@@ -35,34 +29,21 @@ import (
 type Appender struct {
 	commitCalled, rollbackCalled bool
 
-	samples   map[string]sample            // metric labels -> sample
-	exemplars map[string]seriesExemplar    // metric labels -> series exemplar
-	metadata  map[string]metadata.Metadata // metric family name -> metadata
+	samples   map[string]dtobuilder.Sample         // metric labels -> sample
+	exemplars map[string]dtobuilder.SeriesExemplar // metric labels -> series exemplar
+	metadata  map[string]metadata.Metadata         // metric family name -> metadata
 
 	families []*dto.MetricFamily
-}
-
-type seriesExemplar struct {
-	// Labels is the labels of the series exposing the exemplar, not the labels
-	// on the exemplar itself.
-	Labels   labels.Labels
-	Exemplar exemplar.Exemplar
-}
-
-type sample struct {
-	Labels    labels.Labels
-	Timestamp int64
-	Value     float64
 }
 
 var _ storage.Appender = (*Appender)(nil)
 
 func (app *Appender) init() {
 	if app.samples == nil {
-		app.samples = make(map[string]sample)
+		app.samples = make(map[string]dtobuilder.Sample)
 	}
 	if app.exemplars == nil {
-		app.exemplars = make(map[string]seriesExemplar)
+		app.exemplars = make(map[string]dtobuilder.SeriesExemplar)
 	}
 	if app.metadata == nil {
 		app.metadata = make(map[string]metadata.Metadata)
@@ -94,7 +75,7 @@ func (app *Appender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v f
 		return 0, fmt.Errorf("label name %q is not unique: %w", lbl, tsdb.ErrInvalidSample)
 	}
 
-	app.samples[l.String()] = sample{
+	app.samples[l.String()] = dtobuilder.Sample{
 		Labels:    l,
 		Timestamp: t,
 		Value:     v,
@@ -124,7 +105,7 @@ func (app *Appender) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e ex
 		return 0, fmt.Errorf("label name %q is not unique: %w", lbl, tsdb.ErrInvalidSample)
 	}
 
-	app.exemplars[l.String()] = seriesExemplar{
+	app.exemplars[l.String()] = dtobuilder.SeriesExemplar{
 		Labels:   l,
 		Exemplar: e,
 	}
@@ -173,303 +154,13 @@ func (app *Appender) Commit() error {
 		return fmt.Errorf("appender is closed")
 	}
 
-	var (
-		families     []*dto.MetricFamily
-		familyLookup = make(map[string]*dto.MetricFamily)
-	)
-
-	// First, iterate over the metadata to prepopulate the MetricFamily list.
-	// This will help us determine what inner types to create for samples.
-	for familyName, m := range app.metadata {
-		var mt dto.MetricType
-		switch m.Type {
-		case textparse.MetricTypeCounter:
-			mt = dto.MetricType_COUNTER
-		case textparse.MetricTypeGauge:
-			mt = dto.MetricType_GAUGE
-		case textparse.MetricTypeHistogram:
-			mt = dto.MetricType_HISTOGRAM
-		case textparse.MetricTypeSummary:
-			mt = dto.MetricType_SUMMARY
-		default:
-			// There are other values for m.Type, but they're all
-			// OpenMetrics-specific and we're only converting into the Prometheus
-			// exposition format.
-			mt = dto.MetricType_UNTYPED
-		}
-
-		mf := &dto.MetricFamily{
-			Name: pointer.String(familyName),
-			Type: &mt,
-		}
-
-		if m.Help != "" {
-			mf.Help = &m.Help
-		}
-
-		families = append(families, mf)
-
-		// Determine how to populate the lookup table.
-		switch mt {
-		case dto.MetricType_SUMMARY:
-			// Summaries include metrics with the family name (for quantiles),
-			// followed by _sum and _count suffixes.
-			familyLookup[familyName] = mf
-			familyLookup[familyName+"_sum"] = mf
-			familyLookup[familyName+"_count"] = mf
-		case dto.MetricType_HISTOGRAM:
-			// Histograms include metrics for _bucket, _sum, and _count suffixes.
-			familyLookup[familyName+"_bucket"] = mf
-			familyLookup[familyName+"_sum"] = mf
-			familyLookup[familyName+"_count"] = mf
-		default:
-			// Everything else matches the family name exactly.
-			familyLookup[familyName] = mf
-		}
-	}
-
-	// Next, iterate over all samples and add them to metrics in the appropriate
-	// MetricFamily. A new MetricFamily is created if one doesn't exist.
-	for _, sample := range app.samples {
-		// Get or create the metric family.
-		metricName := sample.Labels.Get(model.MetricNameLabel)
-
-		mf, ok := familyLookup[metricName]
-		if !ok {
-			mt := dto.MetricType_UNTYPED
-			mf = &dto.MetricFamily{
-				Name: &metricName,
-				Type: &mt,
-			}
-			families = append(families, mf)
-			familyLookup[metricName] = mf
-		}
-
-		// Retrieve the sample based on labels.
-		m := getOrCreateMetric(mf, sample.Labels)
-		m.TimestampMs = pointer.Int64(sample.Timestamp)
-
-		switch familyType(mf) {
-		case dto.MetricType_COUNTER:
-			m.Counter = &dto.Counter{
-				Value: pointer.Float64(sample.Value),
-			}
-
-		case dto.MetricType_GAUGE:
-			m.Gauge = &dto.Gauge{
-				Value: pointer.Float64(sample.Value),
-			}
-
-		case dto.MetricType_SUMMARY:
-			if m.Summary == nil {
-				m.Summary = &dto.Summary{}
-			}
-
-			switch {
-			case metricName == mf.GetName()+"_count":
-				val := uint64(sample.Value)
-				m.Summary.SampleCount = &val
-			case metricName == mf.GetName()+"_sum":
-				m.Summary.SampleSum = pointer.Float64(sample.Value)
-			case metricName == mf.GetName():
-				quantile, err := strconv.ParseFloat(sample.Labels.Get(model.QuantileLabel), 64)
-				if err != nil {
-					continue
-				}
-
-				m.Summary.Quantile = append(m.Summary.Quantile, &dto.Quantile{
-					Quantile: &quantile,
-					Value:    pointer.Float64(sample.Value),
-				})
-			}
-
-		case dto.MetricType_UNTYPED:
-			m.Untyped = &dto.Untyped{
-				Value: pointer.Float64(sample.Value),
-			}
-
-		case dto.MetricType_HISTOGRAM:
-			if m.Histogram == nil {
-				m.Histogram = &dto.Histogram{}
-			}
-
-			switch {
-			case metricName == mf.GetName()+"_count":
-				val := uint64(sample.Value)
-				m.Histogram.SampleCount = &val
-			case metricName == mf.GetName()+"_sum":
-				m.Histogram.SampleSum = pointer.Float64(sample.Value)
-			case metricName == mf.GetName()+"_bucket":
-				boundary, err := strconv.ParseFloat(sample.Labels.Get(model.BucketLabel), 64)
-				if err != nil {
-					continue
-				}
-
-				count := uint64(sample.Value)
-
-				m.Histogram.Bucket = append(m.Histogram.Bucket, &dto.Bucket{
-					UpperBound:      &boundary,
-					CumulativeCount: &count,
-				})
-			}
-		}
-	}
-
-	// Finally, iterate through exemplars and attach them where appropriate.
-	for _, e := range app.exemplars {
-		// Get or create the metric family.
-		exemplarName := e.Labels.Get(model.MetricNameLabel)
-
-		mf, ok := familyLookup[exemplarName]
-		if !ok {
-			// No metric family (which means no corresponding sample; ignore)
-			continue
-		}
-
-		m := getMetric(mf, e.Labels)
-		if m == nil {
-			continue
-		}
-
-		switch familyType(mf) {
-		case dto.MetricType_COUNTER:
-			if m.Counter == nil {
-				// Sample never added?
-				continue
-			}
-			m.Counter.Exemplar = convertExemplar(dto.MetricType_COUNTER, e.Exemplar)
-		case dto.MetricType_HISTOGRAM:
-			if m.Histogram == nil {
-				// Sample never added?
-				continue
-			}
-
-			switch {
-			case exemplarName == mf.GetName()+"_bucket":
-				boundary, err := strconv.ParseFloat(e.Labels.Get(model.BucketLabel), 64)
-				if err != nil {
-					continue
-				}
-
-				bucket := findBucket(m.Histogram, boundary)
-				if bucket == nil {
-					continue
-				}
-				bucket.Exemplar = convertExemplar(dto.MetricType_HISTOGRAM, e.Exemplar)
-			default:
-				// Exemplars only supported on buckets
-				continue
-			}
-
-		default:
-			// Exemplars not supported for other types; ignore.
-			continue
-		}
-	}
-
-	// Finally, sort all the DTO data.
-	sortMetricFamilies(families)
-
 	app.commitCalled = true
-	app.families = families
+	app.families = dtobuilder.Build(
+		app.samples,
+		app.exemplars,
+		app.metadata,
+	)
 	return nil
-}
-
-func familyType(mf *dto.MetricFamily) dto.MetricType {
-	ty := mf.Type
-	if ty == nil {
-		return dto.MetricType_UNTYPED
-	}
-	return *ty
-}
-
-func getMetric(mf *dto.MetricFamily, l labels.Labels) *dto.Metric {
-	metricLabels := toLabelPairs(familyType(mf), l)
-
-	for _, check := range mf.Metric {
-		if labelPairsEqual(check.Label, metricLabels) {
-			return check
-		}
-	}
-
-	return nil
-}
-
-func getOrCreateMetric(mf *dto.MetricFamily, l labels.Labels) *dto.Metric {
-	metricLabels := toLabelPairs(familyType(mf), l)
-
-	for _, check := range mf.Metric {
-		if labelPairsEqual(check.Label, metricLabels) {
-			return check
-		}
-	}
-
-	m := &dto.Metric{
-		Label: metricLabels,
-	}
-	mf.Metric = append(mf.Metric, m)
-	return m
-}
-
-func convertExemplar(mt dto.MetricType, e exemplar.Exemplar) *dto.Exemplar {
-	res := &dto.Exemplar{
-		Label: toLabelPairs(mt, e.Labels),
-		Value: &e.Value,
-	}
-	if e.HasTs {
-		res.Timestamp = timestamppb.New(time.UnixMilli(e.Ts))
-	}
-	return res
-}
-
-// toLabelPairs converts labels.Labels into []*dto.LabelPair. The __name__
-// label is always dropped, since the metric name is retrieved from the family
-// name instead.
-//
-// The quantile label is dropped for summaries, and the le label is dropped for
-// histograms.
-func toLabelPairs(mt dto.MetricType, ls labels.Labels) []*dto.LabelPair {
-	res := make([]*dto.LabelPair, 0, len(ls))
-	for _, l := range ls {
-		if l.Name == model.MetricNameLabel {
-			continue
-		} else if l.Name == model.QuantileLabel && mt == dto.MetricType_SUMMARY {
-			continue
-		} else if l.Name == model.BucketLabel && mt == dto.MetricType_HISTOGRAM {
-			continue
-		}
-
-		res = append(res, &dto.LabelPair{
-			Name:  pointer.String(l.Name),
-			Value: pointer.String(l.Value),
-		})
-	}
-
-	sort.Slice(res, func(i, j int) bool {
-		switch {
-		case *res[i].Name < *res[j].Name:
-			return true
-		case *res[i].Value < *res[j].Value:
-			return true
-		default:
-			return false
-		}
-	})
-	return res
-}
-
-func labelPairsEqual(a, b []*dto.LabelPair) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	for i := 0; i < len(a); i++ {
-		if *a[i].Name != *b[i].Name || *a[i].Value != *b[i].Value {
-			return false
-		}
-	}
-
-	return true
 }
 
 // Rollback discards pending samples, exemplars, and metadata.
@@ -498,15 +189,4 @@ func (app *Appender) MetricFamilies() ([]*dto.MetricFamily, error) {
 	}
 
 	return app.families, nil
-}
-
-func findBucket(h *dto.Histogram, bound float64) *dto.Bucket {
-	for _, b := range h.GetBucket() {
-		// If it's close enough, use the bucket.
-		if math.Abs(b.GetUpperBound()-bound) < 1e-9 {
-			return b
-		}
-	}
-
-	return nil
 }

--- a/pkg/util/testappender/testappender.go
+++ b/pkg/util/testappender/testappender.go
@@ -1,0 +1,512 @@
+// Package testappender exposes utilities to test code which writes to
+// Prometheus storage.Appenders.
+package testappender
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/exemplar"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
+	"github.com/prometheus/prometheus/model/textparse"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"k8s.io/utils/pointer"
+)
+
+// Appender implements storage.Appender. It keeps track of samples, metadata,
+// and exemplars written to it.
+//
+// When Commit is called, the written data will be converted into a slice of
+// *dto.MetricFamily, when can then be used for asserting against expectations
+// in tests.
+//
+// The zero value of Appender is ready for use. Appender is only intended for
+// test code, and is not optimized for production.
+//
+// Appender is not safe for concurrent use.
+type Appender struct {
+	commitCalled, rollbackCalled bool
+
+	samples   map[string]sample            // metric labels -> sample
+	exemplars map[string]seriesExemplar    // metric labels -> series exemplar
+	metadata  map[string]metadata.Metadata // metric family name -> metadata
+
+	families []*dto.MetricFamily
+}
+
+type seriesExemplar struct {
+	// Labels is the labels of the series exposing the exemplar, not the labels
+	// on the exemplar itself.
+	Labels   labels.Labels
+	Exemplar exemplar.Exemplar
+}
+
+type sample struct {
+	Labels    labels.Labels
+	Timestamp int64
+	Value     float64
+}
+
+var _ storage.Appender = (*Appender)(nil)
+
+func (app *Appender) init() {
+	if app.samples == nil {
+		app.samples = make(map[string]sample)
+	}
+	if app.exemplars == nil {
+		app.exemplars = make(map[string]seriesExemplar)
+	}
+	if app.metadata == nil {
+		app.metadata = make(map[string]metadata.Metadata)
+	}
+}
+
+// Append adds or updates a sample for a given metric, identified by labels. l
+// must not be empty. If Append is called twice for the same metric, older
+// samples are discarded.
+//
+// Upon calling Commit, a MetricFamily is created for each unique `__name__`
+// label. If UpdateMetadata is not called for the named series, the series will
+// be treated as untyped. The timestamp of the metric will be reported with the
+// value denoted by t.
+//
+// The ref field is ignored, and Append always returns 0 for the resulting
+// storage.SeriesRef.
+func (app *Appender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v float64) (storage.SeriesRef, error) {
+	if app.commitCalled || app.rollbackCalled {
+		return 0, fmt.Errorf("appender is closed")
+	}
+	app.init()
+
+	l = l.WithoutEmpty()
+	if len(l) == 0 {
+		return 0, fmt.Errorf("empty labelset: %w", tsdb.ErrInvalidSample)
+	}
+	if lbl, dup := l.HasDuplicateLabelNames(); dup {
+		return 0, fmt.Errorf("label name %q is not unique: %w", lbl, tsdb.ErrInvalidSample)
+	}
+
+	app.samples[l.String()] = sample{
+		Labels:    l,
+		Timestamp: t,
+		Value:     v,
+	}
+	return 0, nil
+}
+
+// AppendExemplar adds an exemplar for a given metric, identified by lablels. l
+// must not be empty.
+//
+// Upon calling Commit, exemplars are injected into the resulting Metrics for
+// any Counter or Histogram.
+//
+// The ref field is ignored, and AppendExemplar always returns 0 for the
+// resulting storage.SeriesRef.
+func (app *Appender) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
+	if app.commitCalled || app.rollbackCalled {
+		return 0, fmt.Errorf("appender is closed")
+	}
+	app.init()
+
+	l = l.WithoutEmpty()
+	if len(l) == 0 {
+		return 0, fmt.Errorf("empty labelset: %w", tsdb.ErrInvalidSample)
+	}
+	if lbl, dup := l.HasDuplicateLabelNames(); dup {
+		return 0, fmt.Errorf("label name %q is not unique: %w", lbl, tsdb.ErrInvalidSample)
+	}
+
+	app.exemplars[l.String()] = seriesExemplar{
+		Labels:   l,
+		Exemplar: e,
+	}
+	return 0, nil
+}
+
+// UpdateMetadata associates metadata for a given named metric. l must not be
+// empty. Only the `__name__` label is used from the label set; other labels
+// are ignored.
+//
+// Upon calling Commit, the metadata will be injected into the associated
+// MetricFamily. If m represents a histogram, metrics suffixed with `_bucket`,
+// `_sum`, and `_count` will be brought into the same MetricFamily.
+func (app *Appender) UpdateMetadata(ref storage.SeriesRef, l labels.Labels, m metadata.Metadata) (storage.SeriesRef, error) {
+	if app.commitCalled || app.rollbackCalled {
+		return 0, fmt.Errorf("appender is closed")
+	}
+	app.init()
+
+	l = l.WithoutEmpty()
+	if len(l) == 0 {
+		return 0, fmt.Errorf("empty labelset: %w", tsdb.ErrInvalidSample)
+	}
+	if lbl, dup := l.HasDuplicateLabelNames(); dup {
+		return 0, fmt.Errorf("label name %q is not unique: %w", lbl, tsdb.ErrInvalidSample)
+	}
+
+	// Metadata is associated with just the metric family, retrieved by the
+	// __name__ label. All metrics for that same name always have the same
+	// metadata.
+	familyName := l.Get(model.MetricNameLabel)
+	if familyName == "" {
+		return 0, fmt.Errorf("__name__ label missing: %w", tsdb.ErrInvalidSample)
+	}
+	app.metadata[familyName] = m
+	return 0, nil
+}
+
+// Commit commits pending samples, exemplars, and metadata, converting them
+// into a slice of *dto.MetricsFamily. Call MetricFamlies to get the resulting
+// data.
+//
+// After calling Commit, no other methods except MetricFamlies may be called.
+func (app *Appender) Commit() error {
+	if app.commitCalled || app.rollbackCalled {
+		return fmt.Errorf("appender is closed")
+	}
+
+	var (
+		families     []*dto.MetricFamily
+		familyLookup = make(map[string]*dto.MetricFamily)
+	)
+
+	// First, iterate over the metadata to prepopulate the MetricFamily list.
+	// This will help us determine what inner types to create for samples.
+	for familyName, m := range app.metadata {
+		var mt dto.MetricType
+		switch m.Type {
+		case textparse.MetricTypeCounter:
+			mt = dto.MetricType_COUNTER
+		case textparse.MetricTypeGauge:
+			mt = dto.MetricType_GAUGE
+		case textparse.MetricTypeHistogram:
+			mt = dto.MetricType_HISTOGRAM
+		case textparse.MetricTypeSummary:
+			mt = dto.MetricType_SUMMARY
+		default:
+			// There are other values for m.Type, but they're all
+			// OpenMetrics-specific and we're only converting into the Prometheus
+			// exposition format.
+			mt = dto.MetricType_UNTYPED
+		}
+
+		mf := &dto.MetricFamily{
+			Name: pointer.String(familyName),
+			Type: &mt,
+		}
+
+		if m.Help != "" {
+			mf.Help = &m.Help
+		}
+
+		families = append(families, mf)
+
+		// Determine how to populate the lookup table.
+		switch mt {
+		case dto.MetricType_SUMMARY:
+			// Summaries include metrics with the family name (for quantiles),
+			// followed by _sum and _count suffixes.
+			familyLookup[familyName] = mf
+			familyLookup[familyName+"_sum"] = mf
+			familyLookup[familyName+"_count"] = mf
+		case dto.MetricType_HISTOGRAM:
+			// Histograms include metrics for _bucket, _sum, and _count suffixes.
+			familyLookup[familyName+"_bucket"] = mf
+			familyLookup[familyName+"_sum"] = mf
+			familyLookup[familyName+"_count"] = mf
+		default:
+			// Everything else matches the family name exactly.
+			familyLookup[familyName] = mf
+		}
+	}
+
+	// Next, iterate over all samples and add them to metrics in the appropriate
+	// MetricFamily. A new MetricFamily is created if one doesn't exist.
+	for _, sample := range app.samples {
+		// Get or create the metric family.
+		metricName := sample.Labels.Get(model.MetricNameLabel)
+
+		mf, ok := familyLookup[metricName]
+		if !ok {
+			mt := dto.MetricType_UNTYPED
+			mf = &dto.MetricFamily{
+				Name: &metricName,
+				Type: &mt,
+			}
+			families = append(families, mf)
+			familyLookup[metricName] = mf
+		}
+
+		// Retrieve the sample based on labels.
+		m := getOrCreateMetric(mf, sample.Labels)
+		m.TimestampMs = pointer.Int64(sample.Timestamp)
+
+		switch familyType(mf) {
+		case dto.MetricType_COUNTER:
+			m.Counter = &dto.Counter{
+				Value: pointer.Float64(sample.Value),
+			}
+
+		case dto.MetricType_GAUGE:
+			m.Gauge = &dto.Gauge{
+				Value: pointer.Float64(sample.Value),
+			}
+
+		case dto.MetricType_SUMMARY:
+			if m.Summary == nil {
+				m.Summary = &dto.Summary{}
+			}
+
+			switch {
+			case metricName == mf.GetName()+"_count":
+				val := uint64(sample.Value)
+				m.Summary.SampleCount = &val
+			case metricName == mf.GetName()+"_sum":
+				m.Summary.SampleSum = pointer.Float64(sample.Value)
+			case metricName == mf.GetName():
+				quantile, err := strconv.ParseFloat(sample.Labels.Get(model.QuantileLabel), 64)
+				if err != nil {
+					continue
+				}
+
+				m.Summary.Quantile = append(m.Summary.Quantile, &dto.Quantile{
+					Quantile: &quantile,
+					Value:    pointer.Float64(sample.Value),
+				})
+			}
+
+		case dto.MetricType_UNTYPED:
+			m.Untyped = &dto.Untyped{
+				Value: pointer.Float64(sample.Value),
+			}
+
+		case dto.MetricType_HISTOGRAM:
+			if m.Histogram == nil {
+				m.Histogram = &dto.Histogram{}
+			}
+
+			switch {
+			case metricName == mf.GetName()+"_count":
+				val := uint64(sample.Value)
+				m.Histogram.SampleCount = &val
+			case metricName == mf.GetName()+"_sum":
+				m.Histogram.SampleSum = pointer.Float64(sample.Value)
+			case metricName == mf.GetName()+"_bucket":
+				boundary, err := strconv.ParseFloat(sample.Labels.Get(model.BucketLabel), 64)
+				if err != nil {
+					continue
+				}
+
+				count := uint64(sample.Value)
+
+				m.Histogram.Bucket = append(m.Histogram.Bucket, &dto.Bucket{
+					UpperBound:      &boundary,
+					CumulativeCount: &count,
+				})
+			}
+		}
+	}
+
+	// Finally, iterate through exemplars and attach them where appropriate.
+	for _, e := range app.exemplars {
+		// Get or create the metric family.
+		exemplarName := e.Labels.Get(model.MetricNameLabel)
+
+		mf, ok := familyLookup[exemplarName]
+		if !ok {
+			// No metric family (which means no corresponding sample; ignore)
+			continue
+		}
+
+		m := getMetric(mf, e.Labels)
+		if m == nil {
+			continue
+		}
+
+		switch familyType(mf) {
+		case dto.MetricType_COUNTER:
+			if m.Counter == nil {
+				// Sample never added?
+				continue
+			}
+			m.Counter.Exemplar = convertExemplar(dto.MetricType_COUNTER, e.Exemplar)
+		case dto.MetricType_HISTOGRAM:
+			if m.Histogram == nil {
+				// Sample never added?
+				continue
+			}
+
+			switch {
+			case exemplarName == mf.GetName()+"_bucket":
+				boundary, err := strconv.ParseFloat(e.Labels.Get(model.BucketLabel), 64)
+				if err != nil {
+					continue
+				}
+
+				bucket := findBucket(m.Histogram, boundary)
+				if bucket == nil {
+					continue
+				}
+				bucket.Exemplar = convertExemplar(dto.MetricType_HISTOGRAM, e.Exemplar)
+			default:
+				// Exemplars only supported on buckets
+				continue
+			}
+
+		default:
+			// Exemplars not supported for other types; ignore.
+			continue
+		}
+	}
+
+	// Finally, sort all the DTO data.
+	sortMetricFamilies(families)
+
+	app.commitCalled = true
+	app.families = families
+	return nil
+}
+
+func familyType(mf *dto.MetricFamily) dto.MetricType {
+	ty := mf.Type
+	if ty == nil {
+		return dto.MetricType_UNTYPED
+	}
+	return *ty
+}
+
+func getMetric(mf *dto.MetricFamily, l labels.Labels) *dto.Metric {
+	metricLabels := toLabelPairs(familyType(mf), l)
+
+	for _, check := range mf.Metric {
+		if labelPairsEqual(check.Label, metricLabels) {
+			return check
+		}
+	}
+
+	return nil
+}
+
+func getOrCreateMetric(mf *dto.MetricFamily, l labels.Labels) *dto.Metric {
+	metricLabels := toLabelPairs(familyType(mf), l)
+
+	for _, check := range mf.Metric {
+		if labelPairsEqual(check.Label, metricLabels) {
+			return check
+		}
+	}
+
+	m := &dto.Metric{
+		Label: metricLabels,
+	}
+	mf.Metric = append(mf.Metric, m)
+	return m
+}
+
+func convertExemplar(mt dto.MetricType, e exemplar.Exemplar) *dto.Exemplar {
+	res := &dto.Exemplar{
+		Label: toLabelPairs(mt, e.Labels),
+		Value: &e.Value,
+	}
+	if e.HasTs {
+		res.Timestamp = timestamppb.New(time.UnixMilli(e.Ts))
+	}
+	return res
+}
+
+// toLabelPairs converts labels.Labels into []*dto.LabelPair. The __name__
+// label is always dropped, since the metric name is retrieved from the family
+// name instead.
+//
+// The quantile label is dropped for summaries, and the le label is dropped for
+// histograms.
+func toLabelPairs(mt dto.MetricType, ls labels.Labels) []*dto.LabelPair {
+	res := make([]*dto.LabelPair, 0, len(ls))
+	for _, l := range ls {
+		if l.Name == model.MetricNameLabel {
+			continue
+		} else if l.Name == model.QuantileLabel && mt == dto.MetricType_SUMMARY {
+			continue
+		} else if l.Name == model.BucketLabel && mt == dto.MetricType_HISTOGRAM {
+			continue
+		}
+
+		res = append(res, &dto.LabelPair{
+			Name:  pointer.String(l.Name),
+			Value: pointer.String(l.Value),
+		})
+	}
+
+	sort.Slice(res, func(i, j int) bool {
+		switch {
+		case *res[i].Name < *res[j].Name:
+			return true
+		case *res[i].Value < *res[j].Value:
+			return true
+		default:
+			return false
+		}
+	})
+	return res
+}
+
+func labelPairsEqual(a, b []*dto.LabelPair) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := 0; i < len(a); i++ {
+		if *a[i].Name != *b[i].Name || *a[i].Value != *b[i].Value {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Rollback discards pending samples, exemplars, and metadata.
+//
+// After calling Rollback, no other methods may be called and the Appender must
+// be discarded.
+func (app *Appender) Rollback() error {
+	if app.commitCalled || app.rollbackCalled {
+		return fmt.Errorf("appender is closed")
+	}
+
+	app.rollbackCalled = true
+	return nil
+}
+
+// MetricFamilies returns the generated slice of *dto.MetricsFamily.
+// MetricFamilies returns an error unless Commit was called.
+//
+// MetricFamilies always returns a non-nil slice. If no data was appended, the
+// resulting slice has a length of zero.
+func (app *Appender) MetricFamilies() ([]*dto.MetricFamily, error) {
+	if !app.commitCalled {
+		return nil, fmt.Errorf("MetricFamilies is not ready")
+	} else if app.rollbackCalled {
+		return nil, fmt.Errorf("appender is closed")
+	}
+
+	return app.families, nil
+}
+
+func findBucket(h *dto.Histogram, bound float64) *dto.Bucket {
+	for _, b := range h.GetBucket() {
+		// If it's close enough, use the bucket.
+		if math.Abs(b.GetUpperBound()-bound) < 1e-9 {
+			return b
+		}
+	}
+
+	return nil
+}

--- a/pkg/util/testappender/testappender.go
+++ b/pkg/util/testappender/testappender.go
@@ -27,6 +27,9 @@ import (
 //
 // Appender is not safe for concurrent use.
 type Appender struct {
+	// HideTimestamps, when true, will omit timestamps from results.
+	HideTimestamps bool
+
 	commitCalled, rollbackCalled bool
 
 	samples   map[string]dtobuilder.Sample         // metric labels -> sample
@@ -76,9 +79,10 @@ func (app *Appender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v f
 	}
 
 	app.samples[l.String()] = dtobuilder.Sample{
-		Labels:    l,
-		Timestamp: t,
-		Value:     v,
+		Labels:         l,
+		Timestamp:      t,
+		Value:          v,
+		PrintTimestamp: !app.HideTimestamps,
 	}
 	return 0, nil
 }

--- a/pkg/util/testappender/testappender_test.go
+++ b/pkg/util/testappender/testappender_test.go
@@ -1,0 +1,273 @@
+package testappender_test
+
+import (
+	"testing"
+
+	"github.com/grafana/agent/pkg/util/testappender"
+	"github.com/prometheus/prometheus/model/exemplar"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
+	"github.com/prometheus/prometheus/model/textparse"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAppender_NoOp asserts that not doing anything results in no data.
+func TestAppender_NoOp(t *testing.T) {
+	var app testappender.Appender
+	requireAppenderData(t, &app, "", false)
+}
+
+func TestAppender_Metadata(t *testing.T) {
+	t.Run("No metadata", func(t *testing.T) {
+		var app testappender.Appender
+		app.Append(0, labels.FromStrings("__name__", "example_metric", "foo", "bar"), 60, 1234)
+
+		expect := `
+		# TYPE example_metric untyped
+		example_metric{foo="bar"} 1234 60
+	`
+		requireAppenderData(t, &app, expect, false)
+	})
+
+	t.Run("Has metadata", func(t *testing.T) {
+		var app testappender.Appender
+		app.Append(0, labels.FromStrings("__name__", "example_metric", "foo", "bar"), 60, 1234)
+		app.UpdateMetadata(0, labels.FromStrings("__name__", "example_metric"), metadata.Metadata{
+			Type: textparse.MetricTypeGauge,
+			Help: "example metric",
+		})
+
+		expect := `
+		# HELP example_metric example metric
+		# TYPE example_metric gauge
+		example_metric{foo="bar"} 1234 60
+		`
+		requireAppenderData(t, &app, expect, false)
+	})
+
+	t.Run("No help field", func(t *testing.T) {
+		var app testappender.Appender
+		app.Append(0, labels.FromStrings("__name__", "example_metric", "foo", "bar"), 60, 1234)
+		app.UpdateMetadata(0, labels.FromStrings("__name__", "example_metric"), metadata.Metadata{
+			Type: textparse.MetricTypeGauge,
+		})
+
+		expect := `
+		# TYPE example_metric gauge
+		example_metric{foo="bar"} 1234 60
+		`
+		requireAppenderData(t, &app, expect, false)
+	})
+}
+
+func TestAppender_Types(t *testing.T) {
+	t.Run("Untyped", func(t *testing.T) {
+		var app testappender.Appender
+		app.Append(0, labels.FromStrings("__name__", "example_metric", "foo", "bar"), 60, 1234)
+		app.UpdateMetadata(0, labels.FromStrings("__name__", "example_metric"), metadata.Metadata{
+			Type: textparse.MetricTypeUnknown,
+		})
+
+		expect := `
+		# TYPE example_metric untyped
+		example_metric{foo="bar"} 1234 60
+	`
+		requireAppenderData(t, &app, expect, false)
+	})
+
+	t.Run("Counter", func(t *testing.T) {
+		var app testappender.Appender
+		app.Append(0, labels.FromStrings("__name__", "example_metric", "foo", "bar"), 60, 1234)
+		app.UpdateMetadata(0, labels.FromStrings("__name__", "example_metric"), metadata.Metadata{
+			Type: textparse.MetricTypeCounter,
+		})
+
+		expect := `
+		# TYPE example_metric counter
+		example_metric{foo="bar"} 1234 60
+	`
+		requireAppenderData(t, &app, expect, false)
+	})
+
+	t.Run("Gauge", func(t *testing.T) {
+		var app testappender.Appender
+		app.Append(0, labels.FromStrings("__name__", "example_metric", "foo", "bar"), 60, 1234)
+		app.UpdateMetadata(0, labels.FromStrings("__name__", "example_metric"), metadata.Metadata{
+			Type: textparse.MetricTypeGauge,
+		})
+
+		expect := `
+		# TYPE example_metric gauge
+		example_metric{foo="bar"} 1234 60
+	`
+		requireAppenderData(t, &app, expect, false)
+	})
+
+	t.Run("Summary", func(t *testing.T) {
+		var app testappender.Appender
+
+		// Summaries have quantilies from 0 to 1, counts, and sums. Append the
+		// metadata first and then append all the various samples.
+		app.UpdateMetadata(0, labels.FromStrings("__name__", "example_metric"), metadata.Metadata{
+			Type: textparse.MetricTypeSummary,
+		})
+
+		app.Append(0, labels.FromStrings("__name__", "example_metric", "foo", "bar", "quantile", "0"), 10, 10)
+		app.Append(0, labels.FromStrings("__name__", "example_metric", "foo", "bar", "quantile", "0.25"), 10, 10)
+		app.Append(0, labels.FromStrings("__name__", "example_metric", "foo", "bar", "quantile", "0.50"), 10, 10)
+		app.Append(0, labels.FromStrings("__name__", "example_metric", "foo", "bar", "quantile", "0.75"), 10, 10)
+		app.Append(0, labels.FromStrings("__name__", "example_metric", "foo", "bar", "quantile", "1"), 10, 10)
+		app.Append(0, labels.FromStrings("__name__", "example_metric_count", "foo", "bar"), 10, 5)
+		app.Append(0, labels.FromStrings("__name__", "example_metric_sum", "foo", "bar"), 10, 50)
+
+		expect := `
+		# TYPE example_metric summary
+		example_metric{foo="bar",quantile="0"} 10 10
+		example_metric{foo="bar",quantile="0.25"} 10 10
+		example_metric{foo="bar",quantile="0.5"} 10 10
+		example_metric{foo="bar",quantile="0.75"} 10 10
+		example_metric{foo="bar",quantile="1"} 10 10
+		example_metric_sum{foo="bar"} 50 10
+		example_metric_count{foo="bar"} 5 10
+	`
+		requireAppenderData(t, &app, expect, false)
+	})
+
+	t.Run("Histogram", func(t *testing.T) {
+		var app testappender.Appender
+
+		// Histograms have buckets, counts, and sums. Append the metadata first and
+		// then append all the various samples.
+		app.UpdateMetadata(0, labels.FromStrings("__name__", "example_metric"), metadata.Metadata{
+			Type: textparse.MetricTypeHistogram,
+		})
+
+		app.Append(0, labels.FromStrings("__name__", "example_metric_bucket", "foo", "bar", "le", "0.5"), 10, 10)
+		app.Append(0, labels.FromStrings("__name__", "example_metric_bucket", "foo", "bar", "le", "0.75"), 10, 20)
+		app.Append(0, labels.FromStrings("__name__", "example_metric_bucket", "foo", "bar", "le", "1"), 10, 30)
+		app.Append(0, labels.FromStrings("__name__", "example_metric_bucket", "foo", "bar", "le", "+Inf"), 10, 40)
+		app.Append(0, labels.FromStrings("__name__", "example_metric_count", "foo", "bar"), 10, 4)
+		app.Append(0, labels.FromStrings("__name__", "example_metric_sum", "foo", "bar"), 10, 100)
+
+		expect := `
+		# TYPE example_metric histogram
+		example_metric_bucket{foo="bar",le="0.5"} 10 10
+		example_metric_bucket{foo="bar",le="0.75"} 20 10
+		example_metric_bucket{foo="bar",le="1"} 30 10
+		example_metric_bucket{foo="bar",le="+Inf"} 40 10
+		example_metric_sum{foo="bar"} 100 10
+		example_metric_count{foo="bar"} 4 10
+	`
+		requireAppenderData(t, &app, expect, false)
+	})
+}
+
+func TestAppender_Exemplars(t *testing.T) {
+	// These tests are the only tests where we expliclty test the OpenMetrics
+	// exposition format since OpenMetrics is the only text exposition format
+	// that supports exemplars.
+
+	t.Run("Counter", func(t *testing.T) {
+		var app testappender.Appender
+		app.Append(0, labels.FromStrings("__name__", "example_metric_total", "foo", "bar"), 60, 1234)
+		app.UpdateMetadata(0, labels.FromStrings("__name__", "example_metric_total"), metadata.Metadata{
+			Type: textparse.MetricTypeCounter,
+		})
+		app.AppendExemplar(0, labels.FromStrings("__name__", "example_metric_total", "foo", "bar"), exemplar.Exemplar{
+			Labels: labels.FromStrings("hello", "world"),
+			Value:  1337,
+			Ts:     30,
+			HasTs:  true,
+		})
+
+		expect := `
+		# TYPE example_metric counter
+		example_metric_total{foo="bar"} 1234.0 0.06 # {hello="world"} 1337.0 0.03
+		`
+		requireAppenderData(t, &app, expect, true)
+	})
+
+	t.Run("Histogram", func(t *testing.T) {
+		var app testappender.Appender
+
+		// Histograms have buckets, counts, and sums. Append the metadata first and
+		// then append all the various samples.
+		app.UpdateMetadata(0, labels.FromStrings("__name__", "example_metric"), metadata.Metadata{
+			Type: textparse.MetricTypeHistogram,
+		})
+
+		app.Append(0, labels.FromStrings("__name__", "example_metric_bucket", "foo", "bar", "le", "0.5"), 10, 10)
+		app.Append(0, labels.FromStrings("__name__", "example_metric_bucket", "foo", "bar", "le", "0.75"), 10, 20)
+		app.Append(0, labels.FromStrings("__name__", "example_metric_bucket", "foo", "bar", "le", "1"), 10, 30)
+		app.Append(0, labels.FromStrings("__name__", "example_metric_bucket", "foo", "bar", "le", "+Inf"), 10, 40)
+		app.Append(0, labels.FromStrings("__name__", "example_metric_count", "foo", "bar"), 10, 4)
+		app.Append(0, labels.FromStrings("__name__", "example_metric_sum", "foo", "bar"), 10, 100)
+
+		// Examplars must be attached to a specific bucket.
+		app.AppendExemplar(0, labels.FromStrings("__name__", "example_metric_bucket", "foo", "bar", "le", "0.75"), exemplar.Exemplar{
+			Labels: labels.FromStrings("hello", "world"),
+			Value:  1337,
+			Ts:     30,
+			HasTs:  true,
+		})
+
+		expect := `
+		# TYPE example_metric histogram
+		example_metric_bucket{foo="bar",le="0.5"} 10 0.01
+		example_metric_bucket{foo="bar",le="0.75"} 20 0.01 # {hello="world"} 1337.0 0.03
+		example_metric_bucket{foo="bar",le="1.0"} 30 0.01
+		example_metric_bucket{foo="bar",le="+Inf"} 40 0.01
+		example_metric_sum{foo="bar"} 100.0 0.01
+		example_metric_count{foo="bar"} 4 0.01
+	`
+		requireAppenderData(t, &app, expect, true)
+	})
+}
+
+// TestAppender_MultipleMetrics tests that multiple metrics, where some have
+// metadata and others don't, works as expected.
+func TestAppender_MultipleMetrics(t *testing.T) {
+	var app testappender.Appender
+
+	app.UpdateMetadata(0, labels.FromStrings("__name__", "example_metric_a"), metadata.Metadata{
+		Type: textparse.MetricTypeCounter,
+	})
+	app.UpdateMetadata(0, labels.FromStrings("__name__", "example_metric_b"), metadata.Metadata{
+		Type: textparse.MetricTypeGauge,
+	})
+
+	app.Append(0, labels.FromStrings("__name__", "example_metric_a", "foo", "bar"), 10, 10)
+	app.Append(0, labels.FromStrings("__name__", "example_metric_a", "foo", "rab"), 10, 20)
+	app.Append(0, labels.FromStrings("__name__", "example_metric_b", "fizz", "buzz"), 10, 30)
+	app.Append(0, labels.FromStrings("__name__", "example_metric_b", "fizz", "zzub"), 10, 40)
+	app.Append(0, labels.FromStrings("__name__", "example_metric_c", "hello", "world"), 10, 50)
+	app.Append(0, labels.FromStrings("__name__", "example_metric_c", "hello", "dlrow"), 10, 60)
+
+	expect := `
+		# TYPE example_metric_a counter
+		example_metric_a{foo="bar"} 10 10
+		example_metric_a{foo="rab"} 20 10
+		# TYPE example_metric_b gauge
+		example_metric_b{fizz="buzz"} 30 10
+		example_metric_b{fizz="zzub"} 40 10
+		# TYPE example_metric_c untyped
+		example_metric_c{hello="dlrow"} 60 10
+		example_metric_c{hello="world"} 50 10
+	`
+	requireAppenderData(t, &app, expect, false)
+}
+
+// requireAppenderData commits the appender and asserts that its resulting data
+// matches the Prometheus Exposition Format string specified by expect.
+func requireAppenderData(t *testing.T, app *testappender.Appender, expect string, openMetrics bool) {
+	t.Helper()
+
+	require.NoError(t, app.Commit(), "commit should not have failed")
+
+	families, err := app.MetricFamilies()
+	require.NoError(t, err, "failed to get metric families")
+
+	var c testappender.Comparer
+	c.OpenMetrics = openMetrics
+	require.NoError(t, c.Compare(families, expect))
+}


### PR DESCRIPTION

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
`util/testappender` is a new package which introduces utilities for testing code which write metrics to storage.Appender implementations.

`testappender.Appender` implements the `storage.Appender` interface and generates a slice of Prometheus `*dto.MetricFamily` upon calling Commit. The resulting slice of families can be retrieved through the MetricFamilies method.

Then, `testappender.Compare` introduces a utility method to compare a set of metric families against an expected string. The string can be reprsenting either Prometheus' or OpenMetrics' text exposition format.

#### Which issue(s) this PR fixes
N/A

#### Notes to the Reviewer
I have to clean up the code a little more, so this is being opened in draft for now. 

#### PR Checklist

- [x] CHANGELOG updated (N/A)
- [x] Documentation added (N/A)
- [x] Tests updated
