### PR TITLE
Use Go 1.19 for builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
-    - name: Set up Go 1.18
+    - name: Set up Go 1.19
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.0
+        go-version: "1.19"
         cache: true
     - name: Test
       run: make GO_TAGS="nodocker" test

--- a/.github/workflows/test_packages.yml
+++ b/.github/workflows/test_packages.yml
@@ -11,10 +11,10 @@ jobs:
     name: Test Packages
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.18
+    - name: Set up Go 1.19
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.0
+        go-version: "1.19"
       id: go
     - name: Checkout code
       uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,8 @@ Main (unreleased)
 
   - Update `github.com/prometheus-community/postgres_exporter` to `v0.11.1`. (@captncraig)
 
+- Use Go 1.19.3 for builds. (@rfratto)
+
 v0.28.0 (2022-09-29)
 --------------------
 

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ GO_LDFLAGS   := -X $(VPREFIX).Branch=$(GIT_BRANCH)                        \
                 -X $(VPREFIX).BuildDate=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 DEFAULT_FLAGS    := $(GO_FLAGS)
-DEBUG_GO_FLAGS   := -gcflags "all=-N -l" -ldflags "$(GO_LDFLAGS)" -tags "netgo $(GO_TAGS)"
+DEBUG_GO_FLAGS   := -ldflags "$(GO_LDFLAGS)" -tags "netgo $(GO_TAGS)"
 RELEASE_GO_FLAGS := -ldflags "-s -w $(GO_LDFLAGS)" -tags "netgo $(GO_TAGS)"
 
 ifeq ($(RELEASE_BUILD),1)

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -19,7 +19,7 @@ FROM alpine:3.16 as docker
 RUN apk add --no-cache docker-cli docker-cli-buildx
 
 # Dependency: Go and Go dependencies
-FROM golang:1.18-bullseye as golang
+FROM golang:1.19.3-bullseye as golang
 
 # Keep in sync with cmd/agent-operator/DEVELOPERS.md
 ENV CONTROLLER_GEN_VERSION v0.8.0

--- a/build-image/windows/Dockerfile
+++ b/build-image/windows/Dockerfile
@@ -1,3 +1,3 @@
 FROM grafana/ci-build-windows:0.3.4
 
-RUN powershell -Command choco install golang --version 1.18.3 -y
+RUN powershell -Command choco install golang --version 1.19.3 -y

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/agent
 
-go 1.18
+go 1.19
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2


### PR DESCRIPTION
This updates the GitHub Actions and build image to use Go 1.19.2 for builds. After this PR, a new build image tag will need to be cut and a follow up PR will be needed to update everything. 

We should probably wait until the [1.19.3 release](https://groups.google.com/g/golang-nuts/c/0D1HwgYge94/m/SO3Tr1zBBwAJ) is available and use that instead, but I'm still opening this in draft just to queue up the work. 

This also removes `-gcflags "all=-N -l"` from our debug flags to allow tests to pass again. Those flags, which disable optimizations and inlining, should now be the responsibility of tools like delve and GoLang to inject. Passing the flags in Go 1.19 causes issues for Macs (see issue 54291 in the Go repo).