### PR TITLE
CHANGELOG: fix misplaced changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,26 @@ Main (unreleased)
 
 - Support Bearer tokens for metric remote writes in the Grafana Operator (@jcreixell, @marctc)
 
+### Other changes
+
+- Update versions of embedded Prometheus exporters used for integrations:
+
+  - Update `github.com/prometheus/statsd_exporter` to `v0.22.8`. (@captncraig)
+
+  - Update `github.com/prometheus-community/postgres_exporter` to `v0.11.1`. (@captncraig)
+
+  - Update `github.com/prometheus/memcached_exporter` to `v0.10.0`. (@captncraig)
+
+  - Update `github.com/prometheus-community/elasticsearch_exporter` to `v1.5.0`. (@captncraig)
+
+  - Update `github.com/prometheus/mysqld_exporter` to `v0.14.0`. (@captncraig)
+
+  - Update `github.com/prometheus/consul_exporter` to `v0.8.0`. (@captncraig)
+
+  - Update `github.com/ncabatoff/process-exporter` to `v0.7.10`. (@captncraig)
+
+  - Update `github.com/prometheus-community/postgres_exporter` to `v0.11.1`. (@captncraig)
+
 v0.28.0 (2022-09-29)
 --------------------
 
@@ -115,15 +135,6 @@ v0.28.0 (2022-09-29)
 ### Bugfixes
 
 ### Other changes
-
-- Update embedded `github.com/prometheus/statsd_exporter` from [`v0.22.7` to `v0.22.8`](https://github.com/prometheus/statsd_exporter/releases)
-- Update embedded `github.com/prometheus-community/postgres_exporter` from [`v0.10.0` to `v0.11.1`](https://github.com/prometheus-community/postgres_exporter/releases)
-- Update embedded `github.com/prometheus/memcached_exporter` from [`v0.9.0` to `v0.10.0`](https://github.com/prometheus/memcached_exporter/releases)
-- Update embedded `github.com/prometheus-community/elasticsearch_exporter` from [`v1.2.1` to `v1.5.0`](https://github.com/prometheus-community/elasticsearch_exporter/releases)
-- Update embedded `github.com/prometheus/mysqld_exporter` from [`v0.13.0` to `v0.14.0`](https://github.com/prometheus/mysqld_exporter/releases)
-- Update embedded `github.com/prometheus/consul_exporter` from [`v0.7.2` to `v0.8.0`](https://github.com/prometheus/consul_exporter/releases)
-- Update embedded `github.com/ncabatoff/process-exporter` from [`v0.7.5` to `v0.7.10`](https://github.com/ncabatoff/process-exporter/releases)
-- Update embedded `github.com/prometheus-community/postgres_exporter` from [`v0.10.0` to `v0.11.1`](https://github.com/prometheus-community/postgres_exporter/releases)
 
 - Fix relabel configs in sample agent-operator manifests (@hjet)
 


### PR DESCRIPTION
grafana/agent#2319 updated a bunch of module dependencies, but accidentally listed them as changes for the already-released v0.28.0 release rather than in Main.

While moving the changes, I made them align with how the new Flow components are referenced and assigned authorship credit.