### PR TITLE
flow: Register remaining otelcol.auth.* components and fix their export types

### DIFF
--- a/component/all/all.go
+++ b/component/all/all.go
@@ -6,6 +6,8 @@ import (
 	_ "github.com/grafana/agent/component/discovery/relabel"                    // Import discovery.relabel
 	_ "github.com/grafana/agent/component/local/file"                           // Import local.file
 	_ "github.com/grafana/agent/component/otelcol/auth/basic"                   // Import otelcol.auth.basic
+	_ "github.com/grafana/agent/component/otelcol/auth/bearer"                  // Import otelcol.auth.bearer
+	_ "github.com/grafana/agent/component/otelcol/auth/headers"                 // Import otelcol.auth.headers
 	_ "github.com/grafana/agent/component/otelcol/exporter/otlp"                // Import otelcol.exporter.otlp
 	_ "github.com/grafana/agent/component/otelcol/exporter/otlphttp"            // Import otelcol.exporter.otlphttp
 	_ "github.com/grafana/agent/component/otelcol/processor/batch"              // Import otelcol.processor.batch

--- a/component/otelcol/auth/basic/basic.go
+++ b/component/otelcol/auth/basic/basic.go
@@ -3,7 +3,6 @@ package basic
 
 import (
 	"github.com/grafana/agent/component"
-	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/auth"
 	"github.com/grafana/agent/pkg/flow/rivertypes"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension"
@@ -15,7 +14,7 @@ func init() {
 	component.Register(component.Registration{
 		Name:    "otelcol.auth.basic",
 		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Exports: auth.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := basicauthextension.NewFactory()

--- a/component/otelcol/auth/bearer/bearer.go
+++ b/component/otelcol/auth/bearer/bearer.go
@@ -3,7 +3,6 @@ package bearer
 
 import (
 	"github.com/grafana/agent/component"
-	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/auth"
 	"github.com/grafana/agent/pkg/flow/rivertypes"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension"
@@ -15,7 +14,7 @@ func init() {
 	component.Register(component.Registration{
 		Name:    "otelcol.auth.bearer",
 		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Exports: auth.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := bearertokenauthextension.NewFactory()

--- a/component/otelcol/auth/headers/headers.go
+++ b/component/otelcol/auth/headers/headers.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/grafana/agent/component"
-	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/auth"
 	"github.com/grafana/agent/pkg/flow/rivertypes"
 	"github.com/grafana/agent/pkg/river"
@@ -18,7 +17,7 @@ func init() {
 	component.Register(component.Registration{
 		Name:    "otelcol.auth.headers",
 		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Exports: auth.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := headerssetterextension.NewFactory()


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR registers the missing `otelcol.auth.headers` and `otelcol.auth.bearer` components from the all.go file.

It also fixes their export types, as it produced a panic. For future grepping purposes, the resulting error was like
```
panic: Component otelcol.auth.bearer.creds changed Exports types from otelcol.ConsumerExports to auth.Exports
```

#### Which issue(s) this PR fixes
No issue filed

#### Notes to the Reviewer
We barely test these components as-is, should we add a check maybe there?

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
