### PR TITLE
otelcol.receiver.prometheus: new component

### DIFF
--- a/component/all/all.go
+++ b/component/all/all.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/grafana/agent/component/otelcol/processor/memorylimiter"      // Import otelcol.processor.memory_limiter
 	_ "github.com/grafana/agent/component/otelcol/receiver/jaeger"              // Import otelcol.receiver.jaeger
 	_ "github.com/grafana/agent/component/otelcol/receiver/otlp"                // Import otelcol.receiver.otlp
+	_ "github.com/grafana/agent/component/otelcol/receiver/prometheus"          // Import otelcol.receiver.prometheus
 	_ "github.com/grafana/agent/component/prometheus/integration/node_exporter" // Import prometheus.integration.node_exporter
 	_ "github.com/grafana/agent/component/prometheus/relabel"                   // Import prometheus.relabel
 	_ "github.com/grafana/agent/component/prometheus/remotewrite"               // Import prometheus.remote_write

--- a/component/otelcol/receiver/prometheus/internal/appendable.go
+++ b/component/otelcol/receiver/prometheus/internal/appendable.go
@@ -1,0 +1,71 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal"
+
+import (
+	"context"
+	"regexp"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/obsreport"
+)
+
+// appendable translates Prometheus scraping diffs into OpenTelemetry format.
+type appendable struct {
+	sink                 consumer.Metrics
+	metricAdjuster       MetricsAdjuster
+	useStartTimeMetric   bool
+	startTimeMetricRegex *regexp.Regexp
+	externalLabels       labels.Labels
+
+	settings component.ReceiverCreateSettings
+	obsrecv  *obsreport.Receiver
+}
+
+// NewAppendable returns a storage.Appendable instance that emits metrics to the sink.
+func NewAppendable(
+	sink consumer.Metrics,
+	set component.ReceiverCreateSettings,
+	gcInterval time.Duration,
+	useStartTimeMetric bool,
+	startTimeMetricRegex *regexp.Regexp,
+	receiverID config.ComponentID,
+	externalLabels labels.Labels) storage.Appendable {
+	var metricAdjuster MetricsAdjuster
+	if !useStartTimeMetric {
+		metricAdjuster = NewInitialPointAdjuster(set.Logger, gcInterval)
+	} else {
+		metricAdjuster = NewStartTimeMetricAdjuster(set.Logger, startTimeMetricRegex)
+	}
+
+	return &appendable{
+		sink:                 sink,
+		settings:             set,
+		metricAdjuster:       metricAdjuster,
+		useStartTimeMetric:   useStartTimeMetric,
+		startTimeMetricRegex: startTimeMetricRegex,
+		externalLabels:       externalLabels,
+		obsrecv:              obsreport.NewReceiver(obsreport.ReceiverSettings{ReceiverID: receiverID, Transport: transport, ReceiverCreateSettings: set}),
+	}
+}
+
+func (o *appendable) Appender(ctx context.Context) storage.Appender {
+	return newTransaction(ctx, o.metricAdjuster, o.sink, o.externalLabels, o.settings, o.obsrecv)
+}

--- a/component/otelcol/receiver/prometheus/internal/doc.go
+++ b/component/otelcol/receiver/prometheus/internal/doc.go
@@ -1,0 +1,20 @@
+//
+// This package is a near copy of
+// https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.61.0/receiver/prometheusreceiver/internal
+// A copy was made because the upstream package is internal. If it is ever made
+// public, our copy can be removed.
+//
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package internal

--- a/component/otelcol/receiver/prometheus/internal/logger.go
+++ b/component/otelcol/receiver/prometheus/internal/logger.go
@@ -1,0 +1,153 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal"
+
+import (
+	gokitLog "github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"go.uber.org/zap"
+)
+
+const (
+	levelKey = "level"
+	msgKey   = "msg"
+	errKey   = "err"
+)
+
+// NewZapToGokitLogAdapter create an adapter for zap.Logger to gokitLog.Logger
+func NewZapToGokitLogAdapter(logger *zap.Logger) gokitLog.Logger {
+	// need to skip two levels in order to get the correct caller
+	// one for this method, the other for gokitLog
+	logger = logger.WithOptions(zap.AddCallerSkip(2))
+	return &zapToGokitLogAdapter{l: logger.Sugar()}
+}
+
+type zapToGokitLogAdapter struct {
+	l *zap.SugaredLogger
+}
+
+type logData struct {
+	level       level.Value
+	msg         string
+	otherFields []interface{}
+}
+
+func (w *zapToGokitLogAdapter) Log(keyvals ...interface{}) error {
+	// expecting key value pairs, the number of items need to be even
+	if len(keyvals)%2 == 0 {
+		// Extract log level and message and log them using corresponding zap function
+		ld := extractLogData(keyvals)
+		logFunc := levelToFunc(w.l, ld.level)
+		logFunc(ld.msg, ld.otherFields...)
+	} else {
+		// in case something goes wrong
+		w.l.Info(keyvals...)
+	}
+	return nil
+}
+
+func extractLogData(keyvals []interface{}) logData {
+	ld := logData{
+		level: level.InfoValue(), // default
+	}
+
+	for i := 0; i < len(keyvals); i += 2 {
+		key := keyvals[i]
+		val := keyvals[i+1]
+
+		if l, ok := matchLogLevel(key, val); ok {
+			ld.level = l
+			continue
+		}
+
+		if m, ok := matchLogMessage(key, val); ok {
+			ld.msg = m
+			continue
+		}
+
+		if err, ok := matchError(key, val); ok {
+			ld.otherFields = append(ld.otherFields, zap.Error(err))
+			continue
+		}
+
+		ld.otherFields = append(ld.otherFields, key, val)
+	}
+
+	return ld
+}
+
+// check if a given key-value pair represents go-kit log message and return it
+func matchLogMessage(key interface{}, val interface{}) (string, bool) {
+	if strKey, ok := key.(string); !ok || strKey != msgKey {
+		return "", false
+	}
+
+	msg, ok := val.(string)
+	if !ok {
+		return "", false
+	}
+	return msg, true
+}
+
+// check if a given key-value pair represents go-kit log level and return it
+func matchLogLevel(key interface{}, val interface{}) (level.Value, bool) {
+	strKey, ok := key.(string)
+	if !ok || strKey != levelKey {
+		return nil, false
+	}
+
+	levelVal, ok := val.(level.Value)
+	if !ok {
+		return nil, false
+	}
+	return levelVal, true
+}
+
+//revive:disable:error-return
+
+// check if a given key-value pair represents an error and return it
+func matchError(key interface{}, val interface{}) (error, bool) {
+	strKey, ok := key.(string)
+	if !ok || strKey != errKey {
+		return nil, false
+	}
+
+	err, ok := val.(error)
+	if !ok {
+		return nil, false
+	}
+	return err, true
+}
+
+//revive:enable:error-return
+
+// find a matching zap logging function to be used for a given level
+func levelToFunc(logger *zap.SugaredLogger, lvl level.Value) func(string, ...interface{}) {
+	switch lvl {
+	case level.DebugValue():
+		return logger.Debugw
+	case level.InfoValue():
+		return logger.Infow
+	case level.WarnValue():
+		return logger.Warnw
+	case level.ErrorValue():
+		return logger.Errorw
+	}
+
+	// default
+	return logger.Infow
+}
+
+var _ gokitLog.Logger = (*zapToGokitLogAdapter)(nil)

--- a/component/otelcol/receiver/prometheus/internal/metadata.go
+++ b/component/otelcol/receiver/prometheus/internal/metadata.go
@@ -1,0 +1,78 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal"
+
+import (
+	"github.com/prometheus/prometheus/model/textparse"
+	"github.com/prometheus/prometheus/scrape"
+)
+
+type dataPoint struct {
+	value    float64
+	boundary float64
+}
+
+// internalMetricMetadata allows looking up metadata for internal scrape metrics
+var internalMetricMetadata = map[string]*scrape.MetricMetadata{
+	scrapeUpMetricName: {
+		Metric: scrapeUpMetricName,
+		Type:   textparse.MetricTypeGauge,
+		Help:   "The scraping was successful",
+	},
+	"scrape_duration_seconds": {
+		Metric: "scrape_duration_seconds",
+		Unit:   "seconds",
+		Type:   textparse.MetricTypeGauge,
+		Help:   "Duration of the scrape",
+	},
+	"scrape_samples_scraped": {
+		Metric: "scrape_samples_scraped",
+		Type:   textparse.MetricTypeGauge,
+		Help:   "The number of samples the target exposed",
+	},
+	"scrape_series_added": {
+		Metric: "scrape_series_added",
+		Type:   textparse.MetricTypeGauge,
+		Help:   "The approximate number of new series in this scrape",
+	},
+	"scrape_samples_post_metric_relabeling": {
+		Metric: "scrape_samples_post_metric_relabeling",
+		Type:   textparse.MetricTypeGauge,
+		Help:   "The number of samples remaining after metric relabeling was applied",
+	},
+}
+
+func metadataForMetric(metricName string, mc scrape.MetricMetadataStore) (*scrape.MetricMetadata, string) {
+	if metadata, ok := internalMetricMetadata[metricName]; ok {
+		return metadata, metricName
+	}
+	if metadata, ok := mc.GetMetadata(metricName); ok {
+		return &metadata, metricName
+	}
+	// If we didn't find metadata with the original name,
+	// try with suffixes trimmed, in-case it is a "merged" metric type.
+	normalizedName := normalizeMetricName(metricName)
+	if metadata, ok := mc.GetMetadata(normalizedName); ok {
+		if metadata.Type == textparse.MetricTypeCounter {
+			return &metadata, metricName
+		}
+		return &metadata, normalizedName
+	}
+	// Otherwise, the metric is unknown
+	return &scrape.MetricMetadata{
+		Metric: metricName,
+		Type:   textparse.MetricTypeUnknown,
+	}, metricName
+}

--- a/component/otelcol/receiver/prometheus/internal/metricfamily.go
+++ b/component/otelcol/receiver/prometheus/internal/metricfamily.go
@@ -1,0 +1,321 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal"
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/value"
+	"github.com/prometheus/prometheus/scrape"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+)
+
+type metricFamily struct {
+	mtype pmetric.MetricType
+	// isMonotonic only applies to sums
+	isMonotonic bool
+	groups      map[uint64]*metricGroup
+	name        string
+	metadata    *scrape.MetricMetadata
+	groupOrders []*metricGroup
+}
+
+// metricGroup, represents a single metric of a metric family. for example a histogram metric is usually represent by
+// a couple data complexValue (buckets and count/sum), a group of a metric family always share a same set of tags. for
+// simple types like counter and gauge, each data point is a group of itself
+type metricGroup struct {
+	family       *metricFamily
+	ts           int64
+	ls           labels.Labels
+	count        float64
+	hasCount     bool
+	sum          float64
+	hasSum       bool
+	value        float64
+	complexValue []*dataPoint
+}
+
+func newMetricFamily(metricName string, mc scrape.MetricMetadataStore, logger *zap.Logger) *metricFamily {
+	metadata, familyName := metadataForMetric(metricName, mc)
+	mtype, isMonotonic := convToMetricType(metadata.Type)
+	if mtype == pmetric.MetricTypeNone {
+		logger.Debug(fmt.Sprintf("Unknown-typed metric : %s %+v", metricName, metadata))
+	}
+
+	return &metricFamily{
+		mtype:       mtype,
+		isMonotonic: isMonotonic,
+		groups:      make(map[uint64]*metricGroup),
+		name:        familyName,
+		metadata:    metadata,
+	}
+}
+
+// includesMetric returns true if the metric is part of the family
+func (mf *metricFamily) includesMetric(metricName string) bool {
+	if mf.mtype != pmetric.MetricTypeGauge {
+		// If it is a merged family type, then it should match the
+		// family name when suffixes are trimmed.
+		return normalizeMetricName(metricName) == mf.name
+	}
+	// If it isn't a merged type, the metricName and family name should match
+	return metricName == mf.name
+}
+
+func (mf *metricFamily) getGroupKey(ls labels.Labels) uint64 {
+	bytes := make([]byte, 0, 2048)
+	hash, _ := ls.HashWithoutLabels(bytes, getSortedNotUsefulLabels(mf.mtype)...)
+	return hash
+}
+
+func (mg *metricGroup) sortPoints() {
+	sort.Slice(mg.complexValue, func(i, j int) bool {
+		return mg.complexValue[i].boundary < mg.complexValue[j].boundary
+	})
+}
+
+func (mg *metricGroup) toDistributionPoint(dest pmetric.HistogramDataPointSlice) {
+	if !mg.hasCount || len(mg.complexValue) == 0 {
+		return
+	}
+
+	mg.sortPoints()
+
+	// for OCAgent Proto, the bounds won't include +inf
+	// TODO: (@odeke-em) should we also check OpenTelemetry Pdata for bucket bounds?
+	bounds := make([]float64, len(mg.complexValue)-1)
+	bucketCounts := make([]uint64, len(mg.complexValue))
+
+	pointIsStale := value.IsStaleNaN(mg.sum) || value.IsStaleNaN(mg.count)
+
+	for i := 0; i < len(mg.complexValue); i++ {
+		if i != len(mg.complexValue)-1 {
+			// not need to add +inf as bound to oc proto
+			bounds[i] = mg.complexValue[i].boundary
+		}
+		adjustedCount := mg.complexValue[i].value
+		// Buckets still need to be sent to know to set them as stale,
+		// but a staleness NaN converted to uint64 would be an extremely large number.
+		// Setting to 0 instead.
+		if pointIsStale {
+			adjustedCount = 0
+		} else if i != 0 {
+			adjustedCount -= mg.complexValue[i-1].value
+		}
+		bucketCounts[i] = uint64(adjustedCount)
+	}
+
+	point := dest.AppendEmpty()
+
+	if pointIsStale {
+		point.SetFlags(pmetric.DefaultMetricDataPointFlags.WithNoRecordedValue(true))
+	} else {
+		point.SetCount(uint64(mg.count))
+		if mg.hasSum {
+			point.SetSum(mg.sum)
+		}
+	}
+
+	point.ExplicitBounds().FromRaw(bounds)
+	point.BucketCounts().FromRaw(bucketCounts)
+
+	// The timestamp MUST be in retrieved from milliseconds and converted to nanoseconds.
+	tsNanos := timestampFromMs(mg.ts)
+	point.SetStartTimestamp(tsNanos) // metrics_adjuster adjusts the startTimestamp to the initial scrape timestamp
+	point.SetTimestamp(tsNanos)
+	populateAttributes(pmetric.MetricTypeHistogram, mg.ls, point.Attributes())
+}
+
+func (mg *metricGroup) toSummaryPoint(dest pmetric.SummaryDataPointSlice) {
+	// expecting count to be provided, however, in the following two cases, they can be missed.
+	// 1. data is corrupted
+	// 2. ignored by startValue evaluation
+	if !mg.hasCount {
+		return
+	}
+
+	mg.sortPoints()
+
+	point := dest.AppendEmpty()
+	pointIsStale := value.IsStaleNaN(mg.sum) || value.IsStaleNaN(mg.count)
+	if pointIsStale {
+		point.SetFlags(pmetric.DefaultMetricDataPointFlags.WithNoRecordedValue(true))
+	} else {
+		if mg.hasSum {
+			point.SetSum(mg.sum)
+		}
+		point.SetCount(uint64(mg.count))
+	}
+
+	quantileValues := point.QuantileValues()
+	for _, p := range mg.complexValue {
+		quantile := quantileValues.AppendEmpty()
+		// Quantiles still need to be sent to know to set them as stale,
+		// but a staleness NaN converted to uint64 would be an extremely large number.
+		// By not setting the quantile value, it will default to 0.
+		if !pointIsStale {
+			quantile.SetValue(p.value)
+		}
+		quantile.SetQuantile(p.boundary)
+	}
+
+	// Based on the summary description from https://prometheus.io/docs/concepts/metric_types/#summary
+	// the quantiles are calculated over a sliding time window, however, the count is the total count of
+	// observations and the corresponding sum is a sum of all observed values, thus the sum and count used
+	// at the global level of the metricspb.SummaryValue
+	// The timestamp MUST be in retrieved from milliseconds and converted to nanoseconds.
+	tsNanos := timestampFromMs(mg.ts)
+	point.SetTimestamp(tsNanos)
+	point.SetStartTimestamp(tsNanos) // metrics_adjuster adjusts the startTimestamp to the initial scrape timestamp
+	populateAttributes(pmetric.MetricTypeSummary, mg.ls, point.Attributes())
+}
+
+func (mg *metricGroup) toNumberDataPoint(dest pmetric.NumberDataPointSlice) {
+	tsNanos := timestampFromMs(mg.ts)
+	point := dest.AppendEmpty()
+	// gauge/undefined types have no start time.
+	if mg.family.mtype == pmetric.MetricTypeSum {
+		point.SetStartTimestamp(tsNanos) // metrics_adjuster adjusts the startTimestamp to the initial scrape timestamp
+	}
+	point.SetTimestamp(tsNanos)
+	if value.IsStaleNaN(mg.value) {
+		point.SetFlags(pmetric.DefaultMetricDataPointFlags.WithNoRecordedValue(true))
+	} else {
+		point.SetDoubleValue(mg.value)
+	}
+	populateAttributes(pmetric.MetricTypeGauge, mg.ls, point.Attributes())
+}
+
+func populateAttributes(mType pmetric.MetricType, ls labels.Labels, dest pcommon.Map) {
+	dest.EnsureCapacity(ls.Len())
+	names := getSortedNotUsefulLabels(mType)
+	j := 0
+	for i := range ls {
+		for j < len(names) && names[j] < ls[i].Name {
+			j++
+		}
+		if j < len(names) && ls[i].Name == names[j] {
+			continue
+		}
+		if ls[i].Value == "" {
+			// empty label values should be omitted
+			continue
+		}
+		dest.PutString(ls[i].Name, ls[i].Value)
+	}
+}
+
+func (mf *metricFamily) loadMetricGroupOrCreate(groupKey uint64, ls labels.Labels, ts int64) *metricGroup {
+	mg, ok := mf.groups[groupKey]
+	if !ok {
+		mg = &metricGroup{
+			family: mf,
+			ts:     ts,
+			ls:     ls,
+		}
+		mf.groups[groupKey] = mg
+		// maintaining data insertion order is helpful to generate stable/reproducible metric output
+		mf.groupOrders = append(mf.groupOrders, mg)
+	}
+	return mg
+}
+
+func (mf *metricFamily) Add(metricName string, ls labels.Labels, t int64, v float64) error {
+	groupKey := mf.getGroupKey(ls)
+	mg := mf.loadMetricGroupOrCreate(groupKey, ls, t)
+	if mg.ts != t {
+		return fmt.Errorf("inconsistent timestamps on metric points for metric %v", metricName)
+	}
+	switch mf.mtype {
+	case pmetric.MetricTypeHistogram, pmetric.MetricTypeSummary:
+		switch {
+		case strings.HasSuffix(metricName, metricsSuffixSum):
+			mg.sum = v
+			mg.hasSum = true
+		case strings.HasSuffix(metricName, metricsSuffixCount):
+			// always use the timestamp from count, because is the only required field for histograms and summaries.
+			mg.ts = t
+			mg.count = v
+			mg.hasCount = true
+		default:
+			boundary, err := getBoundary(mf.mtype, ls)
+			if err != nil {
+				return err
+			}
+			mg.complexValue = append(mg.complexValue, &dataPoint{value: v, boundary: boundary})
+		}
+	default:
+		mg.value = v
+	}
+
+	return nil
+}
+
+func (mf *metricFamily) appendMetric(metrics pmetric.MetricSlice) {
+	metric := pmetric.NewMetric()
+	metric.SetName(mf.name)
+	metric.SetDescription(mf.metadata.Help)
+	metric.SetUnit(mf.metadata.Unit)
+
+	pointCount := 0
+
+	switch mf.mtype {
+	case pmetric.MetricTypeHistogram:
+		histogram := metric.SetEmptyHistogram()
+		histogram.SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+		hdpL := histogram.DataPoints()
+		for _, mg := range mf.groupOrders {
+			mg.toDistributionPoint(hdpL)
+		}
+		pointCount = hdpL.Len()
+
+	case pmetric.MetricTypeSummary:
+		summary := metric.SetEmptySummary()
+		sdpL := summary.DataPoints()
+		for _, mg := range mf.groupOrders {
+			mg.toSummaryPoint(sdpL)
+		}
+		pointCount = sdpL.Len()
+
+	case pmetric.MetricTypeSum:
+		sum := metric.SetEmptySum()
+		sum.SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+		sum.SetIsMonotonic(mf.isMonotonic)
+		sdpL := sum.DataPoints()
+		for _, mg := range mf.groupOrders {
+			mg.toNumberDataPoint(sdpL)
+		}
+		pointCount = sdpL.Len()
+
+	default: // Everything else should be set to a Gauge.
+		gauge := metric.SetEmptyGauge()
+		gdpL := gauge.DataPoints()
+		for _, mg := range mf.groupOrders {
+			mg.toNumberDataPoint(gdpL)
+		}
+		pointCount = gdpL.Len()
+	}
+
+	if pointCount == 0 {
+		return
+	}
+
+	metric.MoveTo(metrics.AppendEmpty())
+}

--- a/component/otelcol/receiver/prometheus/internal/metrics_adjuster.go
+++ b/component/otelcol/receiver/prometheus/internal/metrics_adjuster.go
@@ -1,0 +1,415 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal"
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	semconv "go.opentelemetry.io/collector/semconv/v1.6.1"
+	"go.uber.org/zap"
+)
+
+// Notes on garbage collection (gc):
+//
+// Job-level gc:
+// The Prometheus receiver will likely execute in a long running service whose lifetime may exceed
+// the lifetimes of many of the jobs that it is collecting from. In order to keep the JobsMap from
+// leaking memory for entries of no-longer existing jobs, the JobsMap needs to remove entries that
+// haven't been accessed for a long period of time.
+//
+// Timeseries-level gc:
+// Some jobs that the Prometheus receiver is collecting from may export timeseries based on metrics
+// from other jobs (e.g. cAdvisor). In order to keep the timeseriesMap from leaking memory for entries
+// of no-longer existing jobs, the timeseriesMap for each job needs to remove entries that haven't
+// been accessed for a long period of time.
+//
+// The gc strategy uses a standard mark-and-sweep approach - each time a timeseriesMap is accessed,
+// it is marked. Similarly, each time a timeseriesInfo is accessed, it is also marked.
+//
+// At the end of each JobsMap.get(), if the last time the JobsMap was gc'd exceeds the 'gcInterval',
+// the JobsMap is locked and any timeseriesMaps that are unmarked are removed from the JobsMap
+// otherwise the timeseriesMap is gc'd
+//
+// The gc for the timeseriesMap is straightforward - the map is locked and, for each timeseriesInfo
+// in the map, if it has not been marked, it is removed otherwise it is unmarked.
+//
+// Alternative Strategies
+// 1. If the job-level gc doesn't run often enough, or runs too often, a separate go routine can
+//    be spawned at JobMap creation time that gc's at periodic intervals. This approach potentially
+//    adds more contention and latency to each scrape so the current approach is used. Note that
+//    the go routine will need to be cancelled upon Shutdown().
+// 2. If the gc of each timeseriesMap during the gc of the JobsMap causes too much contention,
+//    the gc of timeseriesMaps can be moved to the end of MetricsAdjuster().AdjustMetricSlice(). This
+//    approach requires adding 'lastGC' Time and (potentially) a gcInterval duration to
+//    timeseriesMap so the current approach is used instead.
+
+// timeseriesInfo contains the information necessary to adjust from the initial point and to detect resets.
+type timeseriesInfo struct {
+	mark bool
+
+	number    numberInfo
+	histogram histogramInfo
+	summary   summaryInfo
+}
+
+type numberInfo struct {
+	startTime     pcommon.Timestamp
+	previousValue float64
+}
+
+type histogramInfo struct {
+	startTime     pcommon.Timestamp
+	previousCount uint64
+	previousSum   float64
+}
+
+type summaryInfo struct {
+	startTime     pcommon.Timestamp
+	previousCount uint64
+	previousSum   float64
+}
+
+type timeseriesKey struct {
+	name           string
+	attributes     string
+	aggTemporality pmetric.MetricAggregationTemporality
+}
+
+// timeseriesMap maps from a timeseries instance (metric * label values) to the timeseries info for
+// the instance.
+type timeseriesMap struct {
+	sync.RWMutex
+	// The mutex is used to protect access to the member fields. It is acquired for the entirety of
+	// AdjustMetricSlice() and also acquired by gc().
+
+	mark   bool
+	tsiMap map[timeseriesKey]*timeseriesInfo
+}
+
+// Get the timeseriesInfo for the timeseries associated with the metric and label values.
+func (tsm *timeseriesMap) get(metric pmetric.Metric, kv pcommon.Map) (*timeseriesInfo, bool) {
+	// This should only be invoked be functions called (directly or indirectly) by AdjustMetricSlice().
+	// The lock protecting tsm.tsiMap is acquired there.
+	name := metric.Name()
+	key := timeseriesKey{
+		name:       name,
+		attributes: getAttributesSignature(kv),
+	}
+	if metric.Type() == pmetric.MetricTypeHistogram {
+		// There are 2 types of Histograms whose aggregation temporality needs distinguishing:
+		// * CumulativeHistogram
+		// * GaugeHistogram
+		key.aggTemporality = metric.Histogram().AggregationTemporality()
+	}
+
+	tsm.mark = true
+	tsi, ok := tsm.tsiMap[key]
+	if !ok {
+		tsi = &timeseriesInfo{}
+		tsm.tsiMap[key] = tsi
+	}
+	tsi.mark = true
+	return tsi, ok
+}
+
+// Create a unique timeseries signature consisting of the metric name and label values.
+func getAttributesSignature(kv pcommon.Map) string {
+	labelValues := make([]string, 0, kv.Len())
+	kv.Sort().Range(func(_ string, attrValue pcommon.Value) bool {
+		value := attrValue.Str()
+		if value != "" {
+			labelValues = append(labelValues, value)
+		}
+		return true
+	})
+	return strings.Join(labelValues, ",")
+}
+
+// Remove timeseries that have aged out.
+func (tsm *timeseriesMap) gc() {
+	tsm.Lock()
+	defer tsm.Unlock()
+	// this shouldn't happen under the current gc() strategy
+	if !tsm.mark {
+		return
+	}
+	for ts, tsi := range tsm.tsiMap {
+		if !tsi.mark {
+			delete(tsm.tsiMap, ts)
+		} else {
+			tsi.mark = false
+		}
+	}
+	tsm.mark = false
+}
+
+func newTimeseriesMap() *timeseriesMap {
+	return &timeseriesMap{mark: true, tsiMap: map[timeseriesKey]*timeseriesInfo{}}
+}
+
+// JobsMap maps from a job instance to a map of timeseries instances for the job.
+type JobsMap struct {
+	sync.RWMutex
+	// The mutex is used to protect access to the member fields. It is acquired for most of
+	// get() and also acquired by gc().
+
+	gcInterval time.Duration
+	lastGC     time.Time
+	jobsMap    map[string]*timeseriesMap
+}
+
+// NewJobsMap creates a new (empty) JobsMap.
+func NewJobsMap(gcInterval time.Duration) *JobsMap {
+	return &JobsMap{gcInterval: gcInterval, lastGC: time.Now(), jobsMap: make(map[string]*timeseriesMap)}
+}
+
+// Remove jobs and timeseries that have aged out.
+func (jm *JobsMap) gc() {
+	jm.Lock()
+	defer jm.Unlock()
+	// once the structure is locked, confirm that gc() is still necessary
+	if time.Since(jm.lastGC) > jm.gcInterval {
+		for sig, tsm := range jm.jobsMap {
+			tsm.RLock()
+			tsmNotMarked := !tsm.mark
+			// take a read lock here, no need to get a full lock as we have a lock on the JobsMap
+			tsm.RUnlock()
+			if tsmNotMarked {
+				delete(jm.jobsMap, sig)
+			} else {
+				// a full lock will be obtained in here, if required.
+				tsm.gc()
+			}
+		}
+		jm.lastGC = time.Now()
+	}
+}
+
+func (jm *JobsMap) maybeGC() {
+	// speculatively check if gc() is necessary, recheck once the structure is locked
+	jm.RLock()
+	defer jm.RUnlock()
+	if time.Since(jm.lastGC) > jm.gcInterval {
+		go jm.gc()
+	}
+}
+
+func (jm *JobsMap) get(job, instance string) *timeseriesMap {
+	sig := job + ":" + instance
+	// a read locke is taken here as we will not need to modify jobsMap if the target timeseriesMap is available.
+	jm.RLock()
+	tsm, ok := jm.jobsMap[sig]
+	jm.RUnlock()
+	defer jm.maybeGC()
+	if ok {
+		return tsm
+	}
+	jm.Lock()
+	defer jm.Unlock()
+	// Now that we've got an exclusive lock, check once more to ensure an entry wasn't created in the interim
+	// and then create a new timeseriesMap if required.
+	tsm2, ok2 := jm.jobsMap[sig]
+	if ok2 {
+		return tsm2
+	}
+	tsm2 = newTimeseriesMap()
+	jm.jobsMap[sig] = tsm2
+	return tsm2
+}
+
+type MetricsAdjuster interface {
+	AdjustMetrics(metrics pmetric.Metrics) error
+}
+
+// initialPointAdjuster takes a map from a metric instance to the initial point in the metrics instance
+// and provides AdjustMetricSlice, which takes a sequence of metrics and adjust their start times based on
+// the initial points.
+type initialPointAdjuster struct {
+	jobsMap *JobsMap
+	logger  *zap.Logger
+}
+
+// NewInitialPointAdjuster returns a new MetricsAdjuster that adjust metrics' start times based on the initial received points.
+func NewInitialPointAdjuster(logger *zap.Logger, gcInterval time.Duration) MetricsAdjuster {
+	return &initialPointAdjuster{
+		jobsMap: NewJobsMap(gcInterval),
+		logger:  logger,
+	}
+}
+
+// AdjustMetrics takes a sequence of metrics and adjust their start times based on the initial and
+// previous points in the timeseriesMap.
+func (ma *initialPointAdjuster) AdjustMetrics(metrics pmetric.Metrics) error {
+	// By contract metrics will have at least 1 data point, so for sure will have at least one ResourceMetrics.
+
+	job, found := metrics.ResourceMetrics().At(0).Resource().Attributes().Get(semconv.AttributeServiceName)
+	if !found {
+		return errors.New("adjusting metrics without job")
+	}
+
+	instance, found := metrics.ResourceMetrics().At(0).Resource().Attributes().Get(semconv.AttributeServiceInstanceID)
+	if !found {
+		return errors.New("adjusting metrics without instance")
+	}
+	tsm := ma.jobsMap.get(job.Str(), instance.Str())
+
+	// The lock on the relevant timeseriesMap is held throughout the adjustment process to ensure that
+	// nothing else can modify the data used for adjustment.
+	tsm.Lock()
+	defer tsm.Unlock()
+	for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
+		rm := metrics.ResourceMetrics().At(i)
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			ilm := rm.ScopeMetrics().At(j)
+			for k := 0; k < ilm.Metrics().Len(); k++ {
+				metric := ilm.Metrics().At(k)
+				switch dataType := metric.Type(); dataType {
+				case pmetric.MetricTypeGauge:
+					// gauges don't need to be adjusted so no additional processing is necessary
+
+				case pmetric.MetricTypeHistogram:
+					adjustMetricHistogram(tsm, metric)
+
+				case pmetric.MetricTypeSummary:
+					adjustMetricSummary(tsm, metric)
+
+				case pmetric.MetricTypeSum:
+					adjustMetricSum(tsm, metric)
+
+				default:
+					// this shouldn't happen
+					ma.logger.Info("Adjust - skipping unexpected point", zap.String("type", dataType.String()))
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func adjustMetricHistogram(tsm *timeseriesMap, current pmetric.Metric) {
+	histogram := current.Histogram()
+	if histogram.AggregationTemporality() != pmetric.MetricAggregationTemporalityCumulative {
+		// Only dealing with CumulativeDistributions.
+		return
+	}
+
+	currentPoints := histogram.DataPoints()
+	for i := 0; i < currentPoints.Len(); i++ {
+		currentDist := currentPoints.At(i)
+		tsi, found := tsm.get(current, currentDist.Attributes())
+		if !found {
+			// initialize everything.
+			tsi.histogram.startTime = currentDist.StartTimestamp()
+			tsi.histogram.previousCount = currentDist.Count()
+			tsi.histogram.previousSum = currentDist.Sum()
+			continue
+		}
+
+		if currentDist.Flags().NoRecordedValue() {
+			// TODO: Investigate why this does not reset.
+			currentDist.SetStartTimestamp(tsi.histogram.startTime)
+			continue
+		}
+
+		if currentDist.Count() < tsi.histogram.previousCount || currentDist.Sum() < tsi.histogram.previousSum {
+			// reset re-initialize everything.
+			tsi.histogram.startTime = currentDist.StartTimestamp()
+			tsi.histogram.previousCount = currentDist.Count()
+			tsi.histogram.previousSum = currentDist.Sum()
+			continue
+		}
+
+		// Update only previous values.
+		tsi.histogram.previousCount = currentDist.Count()
+		tsi.histogram.previousSum = currentDist.Sum()
+		currentDist.SetStartTimestamp(tsi.histogram.startTime)
+	}
+}
+
+func adjustMetricSum(tsm *timeseriesMap, current pmetric.Metric) {
+	currentPoints := current.Sum().DataPoints()
+	for i := 0; i < currentPoints.Len(); i++ {
+		currentSum := currentPoints.At(i)
+		tsi, found := tsm.get(current, currentSum.Attributes())
+		if !found {
+			// initialize everything.
+			tsi.number.startTime = currentSum.StartTimestamp()
+			tsi.number.previousValue = currentSum.DoubleValue()
+			continue
+		}
+
+		if currentSum.Flags().NoRecordedValue() {
+			// TODO: Investigate why this does not reset.
+			currentSum.SetStartTimestamp(tsi.number.startTime)
+			continue
+		}
+
+		if currentSum.DoubleValue() < tsi.number.previousValue {
+			// reset re-initialize everything.
+			tsi.number.startTime = currentSum.StartTimestamp()
+			tsi.number.previousValue = currentSum.DoubleValue()
+			continue
+		}
+
+		// Update only previous values.
+		tsi.number.previousValue = currentSum.DoubleValue()
+		currentSum.SetStartTimestamp(tsi.number.startTime)
+	}
+}
+
+func adjustMetricSummary(tsm *timeseriesMap, current pmetric.Metric) {
+	currentPoints := current.Summary().DataPoints()
+
+	for i := 0; i < currentPoints.Len(); i++ {
+		currentSummary := currentPoints.At(i)
+		tsi, found := tsm.get(current, currentSummary.Attributes())
+		if !found {
+			// initialize everything.
+			tsi.summary.startTime = currentSummary.StartTimestamp()
+			tsi.summary.previousCount = currentSummary.Count()
+			tsi.summary.previousSum = currentSummary.Sum()
+			continue
+		}
+
+		if currentSummary.Flags().NoRecordedValue() {
+			// TODO: Investigate why this does not reset.
+			currentSummary.SetStartTimestamp(tsi.summary.startTime)
+			continue
+		}
+
+		if (currentSummary.Count() != 0 &&
+			tsi.summary.previousCount != 0 &&
+			currentSummary.Count() < tsi.summary.previousCount) ||
+			(currentSummary.Sum() != 0 &&
+				tsi.summary.previousSum != 0 &&
+				currentSummary.Sum() < tsi.summary.previousSum) {
+			// reset re-initialize everything.
+			tsi.summary.startTime = currentSummary.StartTimestamp()
+			tsi.summary.previousCount = currentSummary.Count()
+			tsi.summary.previousSum = currentSummary.Sum()
+			continue
+		}
+
+		// Update only previous values.
+		tsi.summary.previousCount = currentSummary.Count()
+		tsi.summary.previousSum = currentSummary.Sum()
+		currentSummary.SetStartTimestamp(tsi.summary.startTime)
+	}
+}

--- a/component/otelcol/receiver/prometheus/internal/prom_to_otlp.go
+++ b/component/otelcol/receiver/prometheus/internal/prom_to_otlp.go
@@ -1,0 +1,104 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal"
+
+import (
+	"net"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+)
+
+// isDiscernibleHost checks if a host can be used as a value for the 'host.name' key.
+// localhost-like hosts and unspecified (0.0.0.0) hosts are not discernible.
+func isDiscernibleHost(host string) bool {
+	ip := net.ParseIP(host)
+	if ip != nil {
+		// An IP is discernible if
+		//  - it's not local (e.g. belongs to 127.0.0.0/8 or ::1/128) and
+		//  - it's not unspecified (e.g. the 0.0.0.0 address).
+		return !ip.IsLoopback() && !ip.IsUnspecified()
+	}
+
+	if host == "localhost" {
+		return false
+	}
+
+	// not an IP, not 'localhost', assume it is discernible.
+	return true
+}
+
+// CreateResource creates the resource data added to OTLP payloads.
+func CreateResource(job, instance string, serviceDiscoveryLabels labels.Labels) pcommon.Resource {
+	host, port, err := net.SplitHostPort(instance)
+	if err != nil {
+		host = instance
+	}
+	resource := pcommon.NewResource()
+	attrs := resource.Attributes()
+	attrs.PutString(conventions.AttributeServiceName, job)
+	if isDiscernibleHost(host) {
+		attrs.PutString(conventions.AttributeNetHostName, host)
+	}
+	attrs.PutString(conventions.AttributeServiceInstanceID, instance)
+	attrs.PutString(conventions.AttributeNetHostPort, port)
+	attrs.PutString(conventions.AttributeHTTPScheme, serviceDiscoveryLabels.Get(model.SchemeLabel))
+
+	addKubernetesResource(attrs, serviceDiscoveryLabels)
+
+	return resource
+}
+
+// kubernetesDiscoveryToResourceAttributes maps from metadata labels discovered
+// through the kubernetes implementation of service discovery to opentelemetry
+// resource attribute keys.
+var kubernetesDiscoveryToResourceAttributes = map[string]string{
+	"__meta_kubernetes_pod_name":           conventions.AttributeK8SPodName,
+	"__meta_kubernetes_pod_uid":            conventions.AttributeK8SPodUID,
+	"__meta_kubernetes_pod_container_name": conventions.AttributeK8SContainerName,
+	"__meta_kubernetes_namespace":          conventions.AttributeK8SNamespaceName,
+	// Only one of the node name service discovery labels will be present
+	"__meta_kubernetes_pod_node_name":      conventions.AttributeK8SNodeName,
+	"__meta_kubernetes_node_name":          conventions.AttributeK8SNodeName,
+	"__meta_kubernetes_endpoint_node_name": conventions.AttributeK8SNodeName,
+}
+
+// addKubernetesResource adds resource information detected by prometheus'
+// kubernetes service discovery.
+func addKubernetesResource(attrs pcommon.Map, serviceDiscoveryLabels labels.Labels) {
+	for sdKey, attributeKey := range kubernetesDiscoveryToResourceAttributes {
+		if attr := serviceDiscoveryLabels.Get(sdKey); attr != "" {
+			attrs.PutString(attributeKey, attr)
+		}
+	}
+	controllerName := serviceDiscoveryLabels.Get("__meta_kubernetes_pod_controller_name")
+	controllerKind := serviceDiscoveryLabels.Get("__meta_kubernetes_pod_controller_kind")
+	if controllerKind != "" && controllerName != "" {
+		switch controllerKind {
+		case "ReplicaSet":
+			attrs.PutString(conventions.AttributeK8SReplicaSetName, controllerName)
+		case "DaemonSet":
+			attrs.PutString(conventions.AttributeK8SDaemonSetName, controllerName)
+		case "StatefulSet":
+			attrs.PutString(conventions.AttributeK8SStatefulSetName, controllerName)
+		case "Job":
+			attrs.PutString(conventions.AttributeK8SJobName, controllerName)
+		case "CronJob":
+			attrs.PutString(conventions.AttributeK8SCronJobName, controllerName)
+		}
+	}
+}

--- a/component/otelcol/receiver/prometheus/internal/starttimemetricadjuster.go
+++ b/component/otelcol/receiver/prometheus/internal/starttimemetricadjuster.go
@@ -1,0 +1,128 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal"
+
+import (
+	"errors"
+	"regexp"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+)
+
+var (
+	errNoStartTimeMetrics             = errors.New("start_time metric is missing")
+	errNoDataPointsStartTimeMetric    = errors.New("start time metric with no data points")
+	errUnsupportedTypeStartTimeMetric = errors.New("unsupported data type for start time metric")
+)
+
+type startTimeMetricAdjuster struct {
+	startTimeMetricRegex *regexp.Regexp
+	logger               *zap.Logger
+}
+
+// NewStartTimeMetricAdjuster returns a new MetricsAdjuster that adjust metrics' start times based on a start time metric.
+func NewStartTimeMetricAdjuster(logger *zap.Logger, startTimeMetricRegex *regexp.Regexp) MetricsAdjuster {
+	return &startTimeMetricAdjuster{
+		startTimeMetricRegex: startTimeMetricRegex,
+		logger:               logger,
+	}
+}
+
+func (stma *startTimeMetricAdjuster) AdjustMetrics(metrics pmetric.Metrics) error {
+	startTime, err := stma.getStartTime(metrics)
+	if err != nil {
+		return err
+	}
+
+	startTimeTs := timestampFromFloat64(startTime)
+	for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
+		rm := metrics.ResourceMetrics().At(i)
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			ilm := rm.ScopeMetrics().At(j)
+			for k := 0; k < ilm.Metrics().Len(); k++ {
+				metric := ilm.Metrics().At(k)
+				switch metric.Type() {
+				case pmetric.MetricTypeGauge:
+					continue
+
+				case pmetric.MetricTypeSum:
+					dataPoints := metric.Sum().DataPoints()
+					for l := 0; l < dataPoints.Len(); l++ {
+						dp := dataPoints.At(l)
+						dp.SetStartTimestamp(startTimeTs)
+					}
+
+				case pmetric.MetricTypeSummary:
+					dataPoints := metric.Summary().DataPoints()
+					for l := 0; l < dataPoints.Len(); l++ {
+						dp := dataPoints.At(l)
+						dp.SetStartTimestamp(startTimeTs)
+					}
+
+				case pmetric.MetricTypeHistogram:
+					dataPoints := metric.Histogram().DataPoints()
+					for l := 0; l < dataPoints.Len(); l++ {
+						dp := dataPoints.At(l)
+						dp.SetStartTimestamp(startTimeTs)
+					}
+
+				default:
+					stma.logger.Warn("Unknown metric type", zap.String("type", metric.Type().String()))
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (stma *startTimeMetricAdjuster) getStartTime(metrics pmetric.Metrics) (float64, error) {
+	for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
+		rm := metrics.ResourceMetrics().At(i)
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			ilm := rm.ScopeMetrics().At(j)
+			for k := 0; k < ilm.Metrics().Len(); k++ {
+				metric := ilm.Metrics().At(k)
+				if stma.matchStartTimeMetric(metric.Name()) {
+					switch metric.Type() {
+					case pmetric.MetricTypeGauge:
+						if metric.Gauge().DataPoints().Len() == 0 {
+							return 0.0, errNoDataPointsStartTimeMetric
+						}
+						return metric.Gauge().DataPoints().At(0).DoubleValue(), nil
+
+					case pmetric.MetricTypeSum:
+						if metric.Sum().DataPoints().Len() == 0 {
+							return 0.0, errNoDataPointsStartTimeMetric
+						}
+						return metric.Sum().DataPoints().At(0).DoubleValue(), nil
+
+					default:
+						return 0, errUnsupportedTypeStartTimeMetric
+					}
+				}
+			}
+		}
+	}
+	return 0.0, errNoStartTimeMetrics
+}
+func (stma *startTimeMetricAdjuster) matchStartTimeMetric(metricName string) bool {
+	if stma.startTimeMetricRegex != nil {
+		return stma.startTimeMetricRegex.MatchString(metricName)
+	}
+
+	return metricName == startTimeMetricName
+}

--- a/component/otelcol/receiver/prometheus/internal/transaction.go
+++ b/component/otelcol/receiver/prometheus/internal/transaction.go
@@ -1,0 +1,231 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal"
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/exemplar"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
+	"github.com/prometheus/prometheus/model/value"
+	"github.com/prometheus/prometheus/scrape"
+	"github.com/prometheus/prometheus/storage"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/obsreport"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+)
+
+const (
+	targetMetricName = "target_info"
+)
+
+type transaction struct {
+	isNew          bool
+	ctx            context.Context
+	families       map[string]*metricFamily
+	mc             scrape.MetricMetadataStore
+	sink           consumer.Metrics
+	externalLabels labels.Labels
+	nodeResource   pcommon.Resource
+	logger         *zap.Logger
+	metricAdjuster MetricsAdjuster
+	obsrecv        *obsreport.Receiver
+}
+
+func newTransaction(
+	ctx context.Context,
+	metricAdjuster MetricsAdjuster,
+	sink consumer.Metrics,
+	externalLabels labels.Labels,
+	settings component.ReceiverCreateSettings,
+	obsrecv *obsreport.Receiver) *transaction {
+	return &transaction{
+		ctx:            ctx,
+		families:       make(map[string]*metricFamily),
+		isNew:          true,
+		sink:           sink,
+		metricAdjuster: metricAdjuster,
+		externalLabels: externalLabels,
+		logger:         settings.Logger,
+		obsrecv:        obsrecv,
+	}
+}
+
+// Append always returns 0 to disable label caching.
+func (t *transaction) Append(ref storage.SeriesRef, ls labels.Labels, atMs int64, val float64) (storage.SeriesRef, error) {
+	select {
+	case <-t.ctx.Done():
+		return 0, errTransactionAborted
+	default:
+	}
+
+	if len(t.externalLabels) != 0 {
+		ls = append(ls, t.externalLabels...)
+		sort.Sort(ls)
+	}
+
+	if t.isNew {
+		if err := t.initTransaction(ls); err != nil {
+			return 0, err
+		}
+	}
+
+	// Any datapoint with duplicate labels MUST be rejected per:
+	// * https://github.com/open-telemetry/wg-prometheus/issues/44
+	// * https://github.com/open-telemetry/opentelemetry-collector/issues/3407
+	// as Prometheus rejects such too as of version 2.16.0, released on 2020-02-13.
+	if dupLabel, hasDup := ls.HasDuplicateLabelNames(); hasDup {
+		return 0, fmt.Errorf("invalid sample: non-unique label names: %q", dupLabel)
+	}
+
+	metricName := ls.Get(model.MetricNameLabel)
+	if metricName == "" {
+		return 0, errMetricNameNotFound
+	}
+
+	// See https://www.prometheus.io/docs/concepts/jobs_instances/#automatically-generated-labels-and-time-series
+	// up: 1 if the instance is healthy, i.e. reachable, or 0 if the scrape failed.
+	// But it can also be a staleNaN, which is inserted when the target goes away.
+	if metricName == scrapeUpMetricName && val != 1.0 && !value.IsStaleNaN(val) {
+		if val == 0.0 {
+			t.logger.Warn("Failed to scrape Prometheus endpoint",
+				zap.Int64("scrape_timestamp", atMs),
+				zap.Stringer("target_labels", ls))
+		} else {
+			t.logger.Warn("The 'up' metric contains invalid value",
+				zap.Float64("value", val),
+				zap.Int64("scrape_timestamp", atMs),
+				zap.Stringer("target_labels", ls))
+		}
+	}
+
+	// For the `target_info` metric we need to convert it to resource attributes.
+	if metricName == targetMetricName {
+		return 0, t.AddTargetInfo(ls)
+	}
+
+	curMF, ok := t.families[metricName]
+	if !ok {
+		familyName := normalizeMetricName(metricName)
+		if mf, ok := t.families[familyName]; ok && mf.includesMetric(metricName) {
+			curMF = mf
+		} else {
+			curMF = newMetricFamily(metricName, t.mc, t.logger)
+			t.families[curMF.name] = curMF
+		}
+	}
+
+	return 0, curMF.Add(metricName, ls, atMs, val)
+}
+
+func (t *transaction) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
+	return 0, nil
+}
+
+// getMetrics returns all metrics to the given slice.
+// The only error returned by this function is errNoDataToBuild.
+func (t *transaction) getMetrics(resource pcommon.Resource) (pmetric.Metrics, error) {
+	if len(t.families) == 0 {
+		return pmetric.Metrics{}, errNoDataToBuild
+	}
+
+	md := pmetric.NewMetrics()
+	rms := md.ResourceMetrics().AppendEmpty()
+	resource.CopyTo(rms.Resource())
+	metrics := rms.ScopeMetrics().AppendEmpty().Metrics()
+
+	for _, mf := range t.families {
+		mf.appendMetric(metrics)
+	}
+
+	return md, nil
+}
+
+func (t *transaction) initTransaction(labels labels.Labels) error {
+	target, ok := scrape.TargetFromContext(t.ctx)
+	if !ok {
+		return errors.New("unable to find target in context")
+	}
+	t.mc, ok = scrape.MetricMetadataStoreFromContext(t.ctx)
+	if !ok {
+		return errors.New("unable to find MetricMetadataStore in context")
+	}
+
+	job, instance := labels.Get(model.JobLabel), labels.Get(model.InstanceLabel)
+	if job == "" || instance == "" {
+		return errNoJobInstance
+	}
+	t.nodeResource = CreateResource(job, instance, target.DiscoveredLabels())
+	t.isNew = false
+	return nil
+}
+
+func (t *transaction) Commit() error {
+	if t.isNew {
+		return nil
+	}
+
+	ctx := t.obsrecv.StartMetricsOp(t.ctx)
+	md, err := t.getMetrics(t.nodeResource)
+	if err != nil {
+		t.obsrecv.EndMetricsOp(ctx, dataformat, 0, err)
+		return err
+	}
+
+	numPoints := md.DataPointCount()
+	if numPoints == 0 {
+		return nil
+	}
+
+	if err = t.metricAdjuster.AdjustMetrics(md); err != nil {
+		t.obsrecv.EndMetricsOp(ctx, dataformat, numPoints, err)
+		return err
+	}
+
+	err = t.sink.ConsumeMetrics(ctx, md)
+	t.obsrecv.EndMetricsOp(ctx, dataformat, numPoints, err)
+	return err
+}
+
+func (t *transaction) Rollback() error {
+	return nil
+}
+
+func (t *transaction) UpdateMetadata(ref storage.SeriesRef, l labels.Labels, m metadata.Metadata) (storage.SeriesRef, error) {
+	//TODO: implement this func
+	return 0, nil
+}
+
+func (t *transaction) AddTargetInfo(labels labels.Labels) error {
+	attrs := t.nodeResource.Attributes()
+
+	for _, lbl := range labels {
+		if lbl.Name == model.JobLabel || lbl.Name == model.InstanceLabel || lbl.Name == model.MetricNameLabel {
+			continue
+		}
+
+		attrs.PutString(lbl.Name, lbl.Value)
+	}
+
+	return nil
+}

--- a/component/otelcol/receiver/prometheus/internal/util.go
+++ b/component/otelcol/receiver/prometheus/internal/util.go
@@ -1,0 +1,136 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal"
+
+import (
+	"errors"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/textparse"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+const (
+	metricsSuffixCount  = "_count"
+	metricsSuffixBucket = "_bucket"
+	metricsSuffixSum    = "_sum"
+	metricSuffixTotal   = "_total"
+	metricSuffixInfo    = "_info"
+	startTimeMetricName = "process_start_time_seconds"
+	scrapeUpMetricName  = "up"
+
+	transport  = "http"
+	dataformat = "prometheus"
+)
+
+var (
+	trimmableSuffixes     = []string{metricsSuffixBucket, metricsSuffixCount, metricsSuffixSum, metricSuffixTotal, metricSuffixInfo}
+	errNoDataToBuild      = errors.New("there's no data to build")
+	errNoBoundaryLabel    = errors.New("given metricType has no 'le' or 'quantile' label")
+	errEmptyQuantileLabel = errors.New("'quantile' label on summary metric missing is empty")
+	errEmptyLeLabel       = errors.New("'le' label on histogram metric id missing or empty")
+	errMetricNameNotFound = errors.New("metricName not found from labels")
+	errTransactionAborted = errors.New("transaction aborted")
+	errNoJobInstance      = errors.New("job or instance cannot be found from labels")
+
+	notUsefulLabelsHistogram = sortString([]string{model.MetricNameLabel, model.InstanceLabel, model.SchemeLabel, model.MetricsPathLabel, model.JobLabel, model.BucketLabel})
+	notUsefulLabelsSummary   = sortString([]string{model.MetricNameLabel, model.InstanceLabel, model.SchemeLabel, model.MetricsPathLabel, model.JobLabel, model.QuantileLabel})
+	notUsefulLabelsOther     = sortString([]string{model.MetricNameLabel, model.InstanceLabel, model.SchemeLabel, model.MetricsPathLabel, model.JobLabel})
+)
+
+func sortString(strs []string) []string {
+	sort.Strings(strs)
+	return strs
+}
+
+func getSortedNotUsefulLabels(mType pmetric.MetricType) []string {
+	switch mType {
+	case pmetric.MetricTypeHistogram:
+		return notUsefulLabelsHistogram
+	case pmetric.MetricTypeSummary:
+		return notUsefulLabelsSummary
+	default:
+		return notUsefulLabelsOther
+	}
+}
+
+func timestampFromFloat64(ts float64) pcommon.Timestamp {
+	secs := int64(ts)
+	nanos := int64((ts - float64(secs)) * 1e9)
+	return pcommon.Timestamp(secs*1e9 + nanos)
+}
+
+func timestampFromMs(timeAtMs int64) pcommon.Timestamp {
+	return pcommon.Timestamp(timeAtMs * 1e6)
+}
+
+func getBoundary(metricType pmetric.MetricType, labels labels.Labels) (float64, error) {
+	val := ""
+	switch metricType {
+	case pmetric.MetricTypeHistogram:
+		val = labels.Get(model.BucketLabel)
+		if val == "" {
+			return 0, errEmptyLeLabel
+		}
+	case pmetric.MetricTypeSummary:
+		val = labels.Get(model.QuantileLabel)
+		if val == "" {
+			return 0, errEmptyQuantileLabel
+		}
+	default:
+		return 0, errNoBoundaryLabel
+	}
+
+	return strconv.ParseFloat(val, 64)
+}
+
+// convToMetricType returns the data type and if it is monotonic
+func convToMetricType(metricType textparse.MetricType) (pmetric.MetricType, bool) {
+	switch metricType {
+	case textparse.MetricTypeCounter:
+		// always use float64, as it's the internal data type used in prometheus
+		return pmetric.MetricTypeSum, true
+	// textparse.MetricTypeUnknown is converted to gauge by default to prevent Prometheus untyped metrics from being dropped
+	case textparse.MetricTypeGauge, textparse.MetricTypeUnknown:
+		return pmetric.MetricTypeGauge, false
+	case textparse.MetricTypeHistogram:
+		return pmetric.MetricTypeHistogram, true
+	// dropping support for gaugehistogram for now until we have an official spec of its implementation
+	// a draft can be found in: https://docs.google.com/document/d/1KwV0mAXwwbvvifBvDKH_LU1YjyXE_wxCkHNoCGq1GX0/edit#heading=h.1cvzqd4ksd23
+	// case textparse.MetricTypeGaugeHistogram:
+	//	return <pdata gauge histogram type>
+	case textparse.MetricTypeSummary:
+		return pmetric.MetricTypeSummary, true
+	case textparse.MetricTypeInfo, textparse.MetricTypeStateset:
+		return pmetric.MetricTypeSum, false
+	default:
+		// including: textparse.MetricTypeGaugeHistogram
+		return pmetric.MetricTypeNone, false
+	}
+}
+
+func normalizeMetricName(name string) string {
+	for _, s := range trimmableSuffixes {
+		if strings.HasSuffix(name, s) && name != s {
+			return strings.TrimSuffix(name, s)
+		}
+	}
+	return name
+}

--- a/component/otelcol/receiver/prometheus/prometheus.go
+++ b/component/otelcol/receiver/prometheus/prometheus.go
@@ -1,0 +1,173 @@
+// Package prometheus provides an otelcol.receiver.prometheus component.
+package prometheus
+
+import (
+	"context"
+	"os"
+	"regexp"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otelcol"
+	"github.com/grafana/agent/component/otelcol/internal/fanoutconsumer"
+	"github.com/grafana/agent/component/otelcol/receiver/prometheus/internal"
+	"github.com/grafana/agent/pkg/build"
+	"github.com/grafana/agent/pkg/util/zapadapter"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	otelcomponent "go.opentelemetry.io/collector/component"
+	otelconfig "go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:    "otelcol.receiver.prometheus",
+		Args:    Arguments{},
+		Exports: Exports{},
+
+		Build: func(o component.Options, a component.Arguments) (component.Component, error) {
+			return NewComponent(o, a.(Arguments))
+		},
+	})
+}
+
+// Arguments configures the otelcol.receiver.prometheus component.
+type Arguments struct {
+	ExternalLabels map[string]string `river:"external_labels,attr,optional"`
+
+	// Output configures where to send received data. Required.
+	Output *otelcol.ConsumerArguments `river:"output,block"`
+}
+
+// Exports are the set of fields exposed by the otelcol.receiver.prometheus
+// component.
+type Exports struct {
+	Receiver storage.Appendable `river:"receiver,attr"`
+}
+
+// Component is the otelcol.receiver.prometheus component.
+type Component struct {
+	log  log.Logger
+	opts component.Options
+
+	mut        sync.RWMutex
+	cfg        Arguments
+	appendable storage.Appendable
+}
+
+var _ component.Component = (*Component)(nil)
+
+// NewComponent creates a new otelcol.receiver.prometheus component.
+func NewComponent(o component.Options, c Arguments) (*Component, error) {
+	res := &Component{
+		log:  o.Logger,
+		opts: o,
+	}
+
+	if err := res.Update(c); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// Run implements Component.
+func (c *Component) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+// Update implements Component.
+func (c *Component) Update(newConfig component.Arguments) error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	cfg := newConfig.(Arguments)
+	c.cfg = cfg
+
+	// useStartTimeMetric is used to configure the 'metrics adjuster' in the
+	// prometheusreceiver which is applied whenever a Commit is called.
+	// If set to true, the receiver will utilize a `startTimeMetricAdjuster`
+	// to adjust metric start times based on a start time metric. The start
+	// time metric defaults to `process_start_time_seconds`, but can be
+	// overriden by using this regex.
+	//
+	// gcInterval should be at least as long as the longest scrape interval
+	// used by the upstream scrape configs, plus a delta to avoid race
+	// conditions so that jobs are not getting GC'ed between scrapes.
+	var (
+		useStartTimeMetric   = false
+		startTimeMetricRegex *regexp.Regexp
+
+		gcInterval = 5 * time.Minute
+	)
+	settings := otelcomponent.ReceiverCreateSettings{
+		TelemetrySettings: otelcomponent.TelemetrySettings{
+			Logger: zapadapter.New(c.opts.Logger),
+
+			// TODO(tpaschalis): expose tracing and logging statistics.
+			TracerProvider: trace.NewNoopTracerProvider(),
+			MeterProvider:  metric.NewNoopMeterProvider(),
+		},
+
+		BuildInfo: otelcomponent.BuildInfo{
+			Command:     os.Args[0],
+			Description: "Grafana Agent",
+			Version:     build.Version,
+		},
+	}
+	metricsSink := fanoutconsumer.Metrics(cfg.Output.Metrics)
+
+	appendable := internal.NewAppendable(
+		metricsSink,
+		settings,
+		gcInterval,
+		useStartTimeMetric,
+		startTimeMetricRegex,
+		otelconfig.NewComponentID(otelconfig.Type(c.opts.ID)),
+		toLabels(cfg.ExternalLabels),
+	)
+	c.appendable = appendable
+
+	// Export the receiver.
+	c.opts.OnStateChange(Exports{Receiver: c.appendable})
+
+	return nil
+}
+
+// Convert implements receiver.Arguments.
+// func (args Arguments) Convert() otelconfig.Receiver {
+// 	return &otlpreceiver.Config{
+// 		ReceiverSettings: otelconfig.NewReceiverSettings(otelconfig.NewComponentID("otelcol.receiver.prometheus")),
+// 	}
+// }
+
+// var _ receiver.Arguments = Arguments{}
+
+// Extensions implements receiver.Arguments.
+// func (args Arguments) Extensions() map[otelconfig.ComponentID]otelcomponent.Extension {
+// 	return nil
+// }
+
+// // Exporters implements receiver.Arguments.
+// func (args Arguments) Exporters() map[otelconfig.DataType]map[otelconfig.ComponentID]otelcomponent.Exporter {
+// 	return nil
+// }
+
+// // NextConsumers implements receiver.Arguments.
+// func (args Arguments) NextConsumers() *otelcol.ConsumerArguments {
+// 	return args.Output
+// }
+
+func toLabels(in map[string]string) labels.Labels {
+	res := make(labels.Labels, 0, len(in))
+	for k, v := range in {
+		res = append(res, labels.Label{Name: k, Value: v})
+	}
+	sort.Sort(res)
+	return res
+}

--- a/component/otelcol/receiver/prometheus/prometheus.go
+++ b/component/otelcol/receiver/prometheus/prometheus.go
@@ -139,30 +139,6 @@ func (c *Component) Update(newConfig component.Arguments) error {
 	return nil
 }
 
-// Convert implements receiver.Arguments.
-// func (args Arguments) Convert() otelconfig.Receiver {
-// 	return &otlpreceiver.Config{
-// 		ReceiverSettings: otelconfig.NewReceiverSettings(otelconfig.NewComponentID("otelcol.receiver.prometheus")),
-// 	}
-// }
-
-// var _ receiver.Arguments = Arguments{}
-
-// Extensions implements receiver.Arguments.
-// func (args Arguments) Extensions() map[otelconfig.ComponentID]otelcomponent.Extension {
-// 	return nil
-// }
-
-// // Exporters implements receiver.Arguments.
-// func (args Arguments) Exporters() map[otelconfig.DataType]map[otelconfig.ComponentID]otelcomponent.Exporter {
-// 	return nil
-// }
-
-// // NextConsumers implements receiver.Arguments.
-// func (args Arguments) NextConsumers() *otelcol.ConsumerArguments {
-// 	return args.Output
-// }
-
 func toLabels(in map[string]string) labels.Labels {
 	res := make(labels.Labels, 0, len(in))
 	for k, v := range in {

--- a/component/otelcol/receiver/prometheus/prometheus_test.go
+++ b/component/otelcol/receiver/prometheus/prometheus_test.go
@@ -1,0 +1,102 @@
+package prometheus_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/component/otelcol"
+	"github.com/grafana/agent/component/otelcol/internal/fakeconsumer"
+	"github.com/grafana/agent/component/otelcol/receiver/prometheus"
+	flowprometheus "github.com/grafana/agent/component/prometheus"
+	"github.com/grafana/agent/pkg/flow/componenttest"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/grafana/agent/pkg/util"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/scrape"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+// Test performs a basic integration test which runs the
+// otelcol.receiver.prometheus component and ensures that it can receive and
+// forward metric data.
+func Test(t *testing.T) {
+	ctx := componenttest.TestContext(t)
+	l := util.TestLogger(t)
+
+	ctrl, err := componenttest.NewControllerFromID(l, "otelcol.receiver.prometheus")
+	require.NoError(t, err)
+
+	cfg := `
+		output {
+			// no-op: will be overridden by test code.
+		}
+	`
+	var args prometheus.Arguments
+	require.NoError(t, river.Unmarshal([]byte(cfg), &args))
+
+	// Override our settings so metrics get forwarded to metricCh.
+	metricCh := make(chan pmetric.Metrics)
+	args.Output = makeMetricsOutput(metricCh)
+
+	go func() {
+		err := ctrl.Run(ctx, args)
+		require.NoError(t, err)
+	}()
+
+	require.NoError(t, ctrl.WaitRunning(time.Second))
+	require.NoError(t, ctrl.WaitExports(time.Second))
+
+	exports := ctrl.Exports().(prometheus.Exports)
+
+	// Use the exported Appendable to send metrics to the receiver in the
+	// background.
+	go func() {
+		l := labels.Labels{
+			{Name: model.MetricNameLabel, Value: "testMetric"},
+			{Name: model.JobLabel, Value: "testJob"},
+			{Name: model.InstanceLabel, Value: "otelcol.receiver.prometheus"},
+			{Name: "foo", Value: "bar"},
+		}
+		ts := time.Now().Unix()
+		v := 100.
+
+		ctx := context.Background()
+		ctx = scrape.ContextWithMetricMetadataStore(ctx, flowprometheus.NoopMetadataStore{})
+		ctx = scrape.ContextWithTarget(ctx, &scrape.Target{})
+		app := exports.Receiver.Appender(ctx)
+		_, err := app.Append(0, l, ts, v)
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+	}()
+
+	// Wait for our client to get the metric.
+	select {
+	case <-time.After(time.Second):
+		require.FailNow(t, "failed waiting for metrics")
+	case m := <-metricCh:
+		require.Equal(t, 1, m.MetricCount())
+		require.Equal(t, "testMetric", m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name())
+	}
+}
+
+// makeMetricsOutput returns a ConsumerArguments which will forward metrics to
+// the provided channel.
+func makeMetricsOutput(ch chan pmetric.Metrics) *otelcol.ConsumerArguments {
+	metricsConsumer := fakeconsumer.Consumer{
+		ConsumeMetricsFunc: func(ctx context.Context, m pmetric.Metrics) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case ch <- m:
+				return nil
+			}
+		},
+	}
+
+	return &otelcol.ConsumerArguments{
+		Metrics: []otelcol.Consumer{&metricsConsumer},
+	}
+}

--- a/component/prometheus/fanout.go
+++ b/component/prometheus/fanout.go
@@ -46,7 +46,9 @@ func (f *Fanout) Appender(ctx context.Context) storage.Appender {
 	f.mut.RLock()
 	defer f.mut.RUnlock()
 
-	ctx = scrape.ContextWithMetricMetadataStore(ctx, noopMetadataStore{})
+	fmt.Println("     >>> took a fanout Appender")
+
+	ctx = scrape.ContextWithMetricMetadataStore(ctx, NoopMetadataStore{})
 	ctx = scrape.ContextWithTarget(ctx, &scrape.Target{})
 
 	app := &appender{
@@ -118,11 +120,12 @@ func (a *appender) UpdateMetadata(ref storage.SeriesRef, l labels.Labels, m meta
 	return 0, fmt.Errorf("updateMetadata not supported yet")
 }
 
-type noopMetadataStore map[string]scrape.MetricMetadata
+// NoopMetadataStore implements the MetadataStore interface.
+type NoopMetadataStore map[string]scrape.MetricMetadata
 
-func (ms noopMetadataStore) GetMetadata(familyName string) (scrape.MetricMetadata, bool) {
+func (ms NoopMetadataStore) GetMetadata(familyName string) (scrape.MetricMetadata, bool) {
 	return scrape.MetricMetadata{}, false
 }
-func (ms noopMetadataStore) ListMetadata() []scrape.MetricMetadata { return nil }
-func (ms noopMetadataStore) SizeMetadata() int                     { return 0 }
-func (ms noopMetadataStore) LengthMetadata() int                   { return 0 }
+func (ms NoopMetadataStore) ListMetadata() []scrape.MetricMetadata { return nil }
+func (ms NoopMetadataStore) SizeMetadata() int                     { return 0 }
+func (ms NoopMetadataStore) LengthMetadata() int                   { return 0 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR adds a new `otelcol.receiver.prometheus` Flow component. The new component exports a Prometheus storage.Appendable, where all metrics are converted to an OTel-compatible format and then forwarded to one or more OTel metric consumers.

#### Which issue(s) this PR fixes
Fixes #2301 

#### Notes to the Reviewer

* The biggest chunk of this PR is bringing in the `internal` package from the opentelemetry-collector-contrib repo's `prometheusreceiver. I copied over the package as it existed on v0.61.0, but removed the test files.
https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.61.0/receiver/prometheusreceiver/internal
* The prometheusreceiver code expects the context passed to the Appender to have a scrape Target and a MetadataStore implementation encoded. I've amended the fanout appendable to add an empty Target and a NoopMetadataStore to the context. Unfortunately, this will be true for _every_ call of the appender, not only those tied to the otelcol bridge component. I don't _think_ this will be too much of a performance penalty though.
* There's a GC interval according to the upstream documentation, should be 'at least as long as the longest scrape interval plus a delta to avoid jobs getting GC'ed between scrapes'. We don't have that information from upstream components, so I've hardcoded to 5 minutes. We _could_ add it as an argument, not sure if it's worth it.

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [X] Tests updated
