### PR TITLE
New component: `otelcol.exporter.prometheus`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ Main (unreleased)
     to the OTLP metric format and forwards them to other `otelcol` components.
     (@tpaschalis)
 
+  - `otelcol.exporter.prometheus` forwards OTLP-formatted data to compatible
+    `prometheus` components. (@rfratto)
+
 - Flow: Allow config blocks to reference component exports. (@tpaschalis)
 
 - Introduce `/-/support` endpoint for generating 'support bundles' in static

--- a/component/all/all.go
+++ b/component/all/all.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/grafana/agent/component/otelcol/auth/headers"                 // Import otelcol.auth.headers
 	_ "github.com/grafana/agent/component/otelcol/exporter/otlp"                // Import otelcol.exporter.otlp
 	_ "github.com/grafana/agent/component/otelcol/exporter/otlphttp"            // Import otelcol.exporter.otlphttp
+	_ "github.com/grafana/agent/component/otelcol/exporter/prometheus"          // Import otelcol.exporter.prometheus
 	_ "github.com/grafana/agent/component/otelcol/processor/batch"              // Import otelcol.processor.batch
 	_ "github.com/grafana/agent/component/otelcol/processor/memorylimiter"      // Import otelcol.processor.memory_limiter
 	_ "github.com/grafana/agent/component/otelcol/receiver/jaeger"              // Import otelcol.receiver.jaeger

--- a/component/otelcol/exporter/prometheus/internal/convert/cache.go
+++ b/component/otelcol/exporter/prometheus/internal/convert/cache.go
@@ -1,0 +1,160 @@
+package convert
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/storage"
+)
+
+// memorySeries is an in-memory series mapped from an OpenTelemetry Collector
+// data point.
+type memorySeries struct {
+	// We shouldn't need an RWMutex here because there should only ever be
+	// exactly one goroutine for each memory series, since each series is
+	// intended to be unique.
+	sync.Mutex
+
+	labels   labels.Labels     // Labels used for writing.
+	metadata map[string]string // Extra (optional) metadata used for conversion.
+
+	id storage.SeriesRef // id returned by storage.Appender.
+
+	timestamp time.Time // Timestamp used for out-of-order detection.
+	lastSeen  time.Time // Timestamp used for garbage collection.
+
+	value float64 // Value used for writing.
+}
+
+func newMemorySeries(metadata map[string]string, labels labels.Labels) *memorySeries {
+	return &memorySeries{
+		metadata: metadata,
+		labels:   labels,
+	}
+}
+
+// Metadata returns a metadata value by key.
+func (series *memorySeries) Metadata(key string) string {
+	if series.metadata == nil {
+		return ""
+	}
+	return series.metadata[key]
+}
+
+// Timestamp returns the current timestamp of this series.
+func (series *memorySeries) Timestamp() time.Time {
+	series.Lock()
+	defer series.Unlock()
+	return series.timestamp
+}
+
+// SetTimestamp updates the current timestamp of this series.
+func (series *memorySeries) SetTimestamp(newTime time.Time) {
+	// TODO(rfratto): does this need to be a CAS-style function instead?
+	series.Lock()
+	defer series.Unlock()
+	series.timestamp = newTime
+}
+
+// LastSeen returns the timestamp when this series was last seen.
+func (series *memorySeries) LastSeen() time.Time {
+	series.Lock()
+	defer series.Unlock()
+	return series.lastSeen
+}
+
+// Ping updates the last seen timestamp of this series.
+func (series *memorySeries) Ping() {
+	series.Lock()
+	defer series.Unlock()
+	series.lastSeen = time.Now()
+}
+
+// Value gets the current value of this series.
+func (series *memorySeries) Value() float64 {
+	series.Lock()
+	defer series.Unlock()
+	return series.value
+}
+
+// SetValue updates the current value of this series.
+func (series *memorySeries) SetValue(newValue float64) {
+	// TODO(rfratto): does this need to be a CAS-style function instead?
+	series.Lock()
+	defer series.Unlock()
+	series.value = newValue
+}
+
+func (series *memorySeries) WriteTo(app storage.Appender, ts time.Time) error {
+	series.Lock()
+	defer series.Unlock()
+
+	newID, err := app.Append(series.id, series.labels, timestamp.FromTime(ts), series.value)
+	if err != nil {
+		return err
+	}
+
+	if newID != series.id {
+		series.id = newID
+	}
+	return nil
+}
+
+type memoryMetadata struct {
+	sync.Mutex
+
+	// ID returned by the underlying storage.Appender.
+	ID   storage.SeriesRef
+	Name string
+
+	lastSeen time.Time
+	metadata metadata.Metadata
+
+	// Used for determining when a write needs to occur.
+	lastWrite, lastUpdate time.Time
+}
+
+// WriteTo writes the metadata to app if the metadata has changed since the
+// last update, otherwise WriteTo is a no-op.
+func (md *memoryMetadata) WriteTo(app storage.Appender, ts time.Time) error {
+	md.Lock()
+	defer md.Unlock()
+
+	if !md.lastWrite.Before(md.lastUpdate) {
+		return nil
+	}
+
+	labels := labels.FromStrings(model.MetricNameLabel, md.Name)
+
+	ref, err := app.UpdateMetadata(md.ID, labels, md.metadata)
+	if err != nil {
+		return err
+	}
+	if ref != md.ID {
+		md.ID = ref
+	}
+
+	md.lastWrite = md.lastUpdate
+	return nil
+}
+
+// Update updates the metadata used by md. The next call to WriteTo will write
+// the new metadata only if m is different from the last metadata stored.
+func (md *memoryMetadata) Update(m metadata.Metadata) {
+	md.Lock()
+	defer md.Unlock()
+
+	md.lastSeen = time.Now()
+
+	// Metadata hasn't changed; don't do anything.
+	if m == md.metadata {
+		return
+	}
+
+	md.metadata = m
+	md.lastUpdate = time.Now()
+}

--- a/component/otelcol/exporter/prometheus/internal/convert/convert.go
+++ b/component/otelcol/exporter/prometheus/internal/convert/convert.go
@@ -9,6 +9,7 @@ package convert
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	fp "github.com/grafana/agent/component/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/metadata"
@@ -131,7 +133,9 @@ func (conv *Converter) consumeResourceMetrics(app storage.Appender, rm pmetric.R
 
 	if conv.getOpts().IncludeTargetInfo {
 		if err := resourceMD.WriteTo(app, time.Now()); err != nil {
-			level.Warn(conv.log).Log("msg", "failed to write target_info metadata", "err", err)
+			if !errors.Is(err, fp.ErrMetadataNotSupported) {
+				level.Warn(conv.log).Log("msg", "failed to write target_info metadata", "err", err)
+			}
 		}
 		if err := memResource.WriteTo(app, time.Now()); err != nil {
 			level.Error(conv.log).Log("msg", "failed to write target_info metric", "err", err)
@@ -227,7 +231,9 @@ func (conv *Converter) consumeScopeMetrics(app storage.Appender, memResource *me
 
 	if conv.getOpts().IncludeScopeInfo {
 		if err := scopeMD.WriteTo(app, time.Now()); err != nil {
-			level.Warn(conv.log).Log("msg", "failed to write otel_scope_info metadata", "err", err)
+			if !errors.Is(err, fp.ErrMetadataNotSupported) {
+				level.Warn(conv.log).Log("msg", "failed to write otel_scope_info metadata", "err", err)
+			}
 		}
 		if err := memScope.WriteTo(app, time.Now()); err != nil {
 			level.Error(conv.log).Log("msg", "failed to write otel_scope_info metric", "err", err)
@@ -301,7 +307,9 @@ func (conv *Converter) consumeGauge(app storage.Appender, memResource *memorySer
 		Help: m.Description(),
 	})
 	if err := metricMD.WriteTo(app, time.Now()); err != nil {
-		level.Warn(conv.log).Log("msg", "failed to write metric family metadata", "err", err)
+		if !errors.Is(err, fp.ErrMetadataNotSupported) {
+			level.Warn(conv.log).Log("msg", "failed to write metric family metadata", "err", err)
+		}
 	}
 
 	for dpcount := 0; dpcount < m.Gauge().DataPoints().Len(); dpcount++ {
@@ -419,7 +427,9 @@ func (conv *Converter) consumeSum(app storage.Appender, memResource *memorySerie
 		Help: m.Description(),
 	})
 	if err := metricMD.WriteTo(app, time.Now()); err != nil {
-		level.Warn(conv.log).Log("msg", "failed to write metric family metadata", "err", err)
+		if !errors.Is(err, fp.ErrMetadataNotSupported) {
+			level.Warn(conv.log).Log("msg", "failed to write metric family metadata", "err", err)
+		}
 	}
 
 	for dpcount := 0; dpcount < m.Sum().DataPoints().Len(); dpcount++ {
@@ -452,7 +462,9 @@ func (conv *Converter) consumeHistogram(app storage.Appender, memResource *memor
 		Help: m.Description(),
 	})
 	if err := metricMD.WriteTo(app, time.Now()); err != nil {
-		level.Warn(conv.log).Log("msg", "failed to write metric family metadata", "err", err)
+		if !errors.Is(err, fp.ErrMetadataNotSupported) {
+			level.Warn(conv.log).Log("msg", "failed to write metric family metadata", "err", err)
+		}
 	}
 
 	for dpcount := 0; dpcount < m.Histogram().DataPoints().Len(); dpcount++ {
@@ -526,7 +538,9 @@ func (conv *Converter) consumeSummary(app storage.Appender, memResource *memoryS
 		Help: m.Description(),
 	})
 	if err := metricMD.WriteTo(app, time.Now()); err != nil {
-		level.Warn(conv.log).Log("msg", "failed to write metric family metadata", "err", err)
+		if !errors.Is(err, fp.ErrMetadataNotSupported) {
+			level.Warn(conv.log).Log("msg", "failed to write metric family metadata", "err", err)
+		}
 	}
 
 	for dpcount := 0; dpcount < m.Summary().DataPoints().Len(); dpcount++ {

--- a/component/otelcol/exporter/prometheus/internal/convert/convert.go
+++ b/component/otelcol/exporter/prometheus/internal/convert/convert.go
@@ -1,0 +1,621 @@
+// Package convert implements conversion utilities to convert between
+// OpenTelemetry Collector data and Prometheus data.
+//
+// It follows the [OpenTelemetry Metrics Data Model] for implementing the
+// conversion.
+//
+// [OpenTelemetry Metrics Data Model]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md
+package convert
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
+	"github.com/prometheus/prometheus/model/textparse"
+	"github.com/prometheus/prometheus/model/value"
+	"github.com/prometheus/prometheus/storage"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	semconv "go.opentelemetry.io/collector/semconv/v1.6.1"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus"
+)
+
+var (
+	scopeNameLabel    = "otel_scope_name"
+	scopeVersionLabel = "otel_scope_version"
+)
+
+// TODO(rfratto): Exemplars are not currently supported.
+
+// Converter implements consumer.Metrics and converts received metrics
+// into Prometheus-compatible metrics.
+type Converter struct {
+	log log.Logger
+
+	optsMut sync.RWMutex
+	opts    Options
+
+	seriesCache   sync.Map // Cache of active series.
+	metadataCache sync.Map // Cache of active metadata entries.
+
+	next storage.Appendable // Location to write converted metrics.
+}
+
+// Options configure a Converter.
+type Options struct {
+	// IncludeTargetInfo includes the target_info metric.
+	IncludeTargetInfo bool
+	// IncludeScopeInfo includes the otel_scope_info metric and adds
+	// otel_scope_name and otel_scope_version labels to data points.
+	IncludeScopeInfo bool
+}
+
+var _ consumer.Metrics = (*Converter)(nil)
+
+// New returns a new Converter. Converted metrics are passed to the provided
+// storage.Appendable implementation.
+func New(l log.Logger, next storage.Appendable, opts Options) *Converter {
+	if l == nil {
+		l = log.NewNopLogger()
+	}
+	return &Converter{log: l, next: next, opts: opts}
+}
+
+// UpdateOptions updates the options for the Converter.
+func (conv *Converter) UpdateOptions(opts Options) {
+	conv.optsMut.Lock()
+	defer conv.optsMut.Unlock()
+	conv.opts = opts
+}
+
+// getOpts gets a copy of the current options for the Converter.
+func (conv *Converter) getOpts() Options {
+	conv.optsMut.RLock()
+	defer conv.optsMut.RUnlock()
+	return conv.opts
+}
+
+// Capabilities implements consumer.Metrics.
+func (conv *Converter) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{
+		MutatesData: false,
+	}
+}
+
+// ConsumeMetrics converts the provided OpenTelemetry Collector-formatted
+// metrics into Prometheus-compatible metrics. Each call to ConsumeMetrics
+// requests a storage.Appender and will commit generated metrics to it at the
+// end of the call.
+//
+// Metrics are tracked in memory over time. Call [*Converter.GC] to clean up
+// stale metrics.
+func (conv *Converter) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	// NOTE(rfratto): OpenTelemetry Collector doesn't have any equivalent concept
+	// of storage.SeriesRef from Prometheus. This adds some extra CPU overhead in
+	// converting pmetric.Metrics to Prometheus data, since we'll always have to
+	// build a key to uniquely represent each data point.
+	//
+	// To reduce CPU and allocations as much as possible, each datapoint is
+	// tracked as an "active series." See memorySeries for information on what is
+	// cached.
+
+	app := conv.next.Appender(ctx)
+
+	for rcount := 0; rcount < md.ResourceMetrics().Len(); rcount++ {
+		rm := md.ResourceMetrics().At(rcount)
+		if err := conv.consumeResourceMetrics(app, rm); err != nil {
+			level.Error(conv.log).Log("msg", "failed to consume resource metrics", "err", err)
+			continue
+		}
+	}
+
+	return app.Commit()
+}
+
+func (conv *Converter) consumeResourceMetrics(app storage.Appender, rm pmetric.ResourceMetrics) error {
+	resourceMD := conv.createOrUpdateMetadata("target_info", metadata.Metadata{
+		Type: textparse.MetricTypeGauge,
+		Help: "Target metadata",
+	})
+	memResource := conv.getOrCreateResource(rm.Resource())
+
+	if conv.getOpts().IncludeTargetInfo {
+		if err := resourceMD.WriteTo(app, time.Now()); err != nil {
+			level.Warn(conv.log).Log("msg", "failed to write target_info metadata", "err", err)
+		}
+		if err := memResource.WriteTo(app, time.Now()); err != nil {
+			level.Error(conv.log).Log("msg", "failed to write target_info metric", "err", err)
+		}
+	}
+
+	for smcount := 0; smcount < rm.ScopeMetrics().Len(); smcount++ {
+		sm := rm.ScopeMetrics().At(smcount)
+
+		if err := conv.consumeScopeMetrics(app, memResource, sm); err != nil {
+			level.Error(conv.log).Log("msg", "failed to write scope metrics", "err", err)
+			continue
+		}
+	}
+
+	return nil
+}
+
+func (conv *Converter) createOrUpdateMetadata(name string, md metadata.Metadata) *memoryMetadata {
+	entry := &memoryMetadata{
+		Name: name,
+	}
+	if actual, loaded := conv.metadataCache.LoadOrStore(name, entry); loaded {
+		entry = actual.(*memoryMetadata)
+	}
+
+	entry.Update(md)
+	return entry
+}
+
+// getOrCreateResource gets or creates a [*memorySeries] from the provided
+// res. The LastSeen field of the *memorySeries is updated before returning.
+func (conv *Converter) getOrCreateResource(res pcommon.Resource) *memorySeries {
+	targetInfoLabels := labels.FromStrings(model.MetricNameLabel, "target_info")
+
+	var (
+		attrs = res.Attributes().Sort()
+
+		jobLabel      string
+		instanceLabel string
+	)
+
+	if serviceName, ok := attrs.Get(semconv.AttributeServiceName); ok {
+		if serviceNamespace, ok := attrs.Get(semconv.AttributeServiceNamespace); ok {
+			jobLabel = fmt.Sprintf("%s/%s", serviceNamespace.AsString(), serviceName.AsString())
+		} else {
+			jobLabel = serviceName.AsString()
+		}
+	}
+
+	if instanceID, ok := attrs.Get(semconv.AttributeServiceInstanceID); ok {
+		instanceLabel = instanceID.AsString()
+	}
+
+	lb := labels.NewBuilder(targetInfoLabels)
+	lb.Set(model.JobLabel, jobLabel)
+	lb.Set(model.InstanceLabel, instanceLabel)
+
+	attrs.Range(func(k string, v pcommon.Value) bool {
+		// Skip attributes that we used for determining the job and instance
+		// labels.
+		if k == semconv.AttributeServiceName ||
+			k == semconv.AttributeServiceNamespace ||
+			k == semconv.AttributeServiceInstanceID {
+
+			return true
+		}
+
+		lb.Set(prometheus.NormalizeLabel(k), v.AsString())
+		return true
+	})
+
+	labels := lb.Labels(nil)
+
+	entry := newMemorySeries(map[string]string{
+		model.JobLabel:      jobLabel,
+		model.InstanceLabel: instanceLabel,
+	}, labels)
+	if actual, loaded := conv.seriesCache.LoadOrStore(labels.String(), entry); loaded {
+		entry = actual.(*memorySeries)
+	}
+
+	entry.Ping()
+	return entry
+}
+
+func (conv *Converter) consumeScopeMetrics(app storage.Appender, memResource *memorySeries, sm pmetric.ScopeMetrics) error {
+	scopeMD := conv.createOrUpdateMetadata("otel_scope_info", metadata.Metadata{
+		Type: textparse.MetricTypeGauge,
+	})
+	memScope := conv.getOrCreateScope(memResource, sm.Scope())
+
+	if conv.getOpts().IncludeScopeInfo {
+		if err := scopeMD.WriteTo(app, time.Now()); err != nil {
+			level.Warn(conv.log).Log("msg", "failed to write otel_scope_info metadata", "err", err)
+		}
+		if err := memScope.WriteTo(app, time.Now()); err != nil {
+			level.Error(conv.log).Log("msg", "failed to write otel_scope_info metric", "err", err)
+		}
+	}
+
+	for mcount := 0; mcount < sm.Metrics().Len(); mcount++ {
+		m := sm.Metrics().At(mcount)
+
+		if err := conv.consumeMetric(app, memResource, memScope, m); err != nil {
+			level.Error(conv.log).Log("msg", "failed to write metric", "err", err)
+			continue
+		}
+	}
+
+	return nil
+}
+
+// getOrCreateScope gets or creates a [*memorySeries] from the provided scope.
+// The LastSeen field of the *memorySeries is updated before returning.
+func (conv *Converter) getOrCreateScope(res *memorySeries, scope pcommon.InstrumentationScope) *memorySeries {
+	scopeInfoLabels := labels.FromStrings(
+		model.MetricNameLabel, "otel_scope_info",
+		model.JobLabel, res.metadata[model.JobLabel],
+		model.InstanceLabel, res.metadata[model.InstanceLabel],
+		"name", scope.Name(),
+		"version", scope.Version(),
+	)
+
+	lb := labels.NewBuilder(scopeInfoLabels)
+	scope.Attributes().Sort().Range(func(k string, v pcommon.Value) bool {
+		lb.Set(prometheus.NormalizeLabel(k), v.AsString())
+		return true
+	})
+
+	labels := lb.Labels(nil)
+
+	entry := newMemorySeries(map[string]string{
+		scopeNameLabel:    scope.Name(),
+		scopeVersionLabel: scope.Version(),
+	}, labels)
+	if actual, loaded := conv.seriesCache.LoadOrStore(labels.String(), entry); loaded {
+		entry = actual.(*memorySeries)
+	}
+
+	entry.Ping()
+	return entry
+}
+
+func (conv *Converter) consumeMetric(app storage.Appender, memResource *memorySeries, memScope *memorySeries, m pmetric.Metric) error {
+	switch m.Type() {
+	case pmetric.MetricTypeGauge:
+		return conv.consumeGauge(app, memResource, memScope, m)
+	case pmetric.MetricTypeSum:
+		return conv.consumeSum(app, memResource, memScope, m)
+	case pmetric.MetricTypeHistogram:
+		return conv.consumeHistogram(app, memResource, memScope, m)
+	case pmetric.MetricTypeSummary:
+		return conv.consumeSummary(app, memResource, memScope, m)
+	}
+	return nil
+}
+
+func (conv *Converter) consumeGauge(app storage.Appender, memResource *memorySeries, memScope *memorySeries, m pmetric.Metric) error {
+	metricName := prometheus.BuildPromCompliantName(m, "")
+
+	metricMD := conv.createOrUpdateMetadata(metricName, metadata.Metadata{
+		Type: textparse.MetricTypeGauge,
+		Unit: m.Unit(),
+		Help: m.Description(),
+	})
+	if err := metricMD.WriteTo(app, time.Now()); err != nil {
+		level.Warn(conv.log).Log("msg", "failed to write metric family metadata", "err", err)
+	}
+
+	for dpcount := 0; dpcount < m.Gauge().DataPoints().Len(); dpcount++ {
+		dp := m.Gauge().DataPoints().At(dpcount)
+
+		memSeries := conv.getOrCreateSeries(memResource, memScope, metricName, dp.Attributes())
+		if err := writeSeries(app, memSeries, dp, getNumberDataPointValue(dp)); err != nil {
+			level.Error(conv.log).Log("msg", "failed to write metric sample", "err", err)
+		}
+	}
+
+	return nil
+}
+
+type otelcolDataPoint interface {
+	Timestamp() pcommon.Timestamp
+	Flags() pmetric.MetricDataPointFlags
+}
+
+func writeSeries(app storage.Appender, series *memorySeries, dp otelcolDataPoint, val float64) error {
+	ts := dp.Timestamp().AsTime()
+	if ts.Before(series.Timestamp()) {
+		// Out-of-order; skip.
+		return nil
+	}
+	series.SetTimestamp(ts)
+
+	if dp.Flags().NoRecordedValue() {
+		val = float64(value.StaleNaN)
+	}
+	series.SetValue(val)
+
+	return series.WriteTo(app, ts)
+}
+
+// getOrCreateSeries gets or creates a [*memorySeries] from the provided
+// resource, scope, metric, and attributes. The LastSeen field of the
+// *memorySeries is updated before returning.
+func (conv *Converter) getOrCreateSeries(res *memorySeries, scope *memorySeries, name string, attrs pcommon.Map, extraLabels ...labels.Label) *memorySeries {
+	seriesBaseLabels := labels.FromStrings(
+		model.MetricNameLabel, name,
+		model.JobLabel, res.metadata[model.JobLabel],
+		model.InstanceLabel, res.metadata[model.InstanceLabel],
+	)
+
+	lb := labels.NewBuilder(seriesBaseLabels)
+	for _, extraLabel := range extraLabels {
+		lb.Set(extraLabel.Name, extraLabel.Value)
+	}
+
+	if conv.getOpts().IncludeScopeInfo {
+		lb.Set("otel_scope_name", scope.metadata[scopeNameLabel])
+		lb.Set("otel_scope_version", scope.metadata[scopeVersionLabel])
+	}
+
+	attrs.Sort().Range(func(k string, v pcommon.Value) bool {
+		lb.Set(prometheus.NormalizeLabel(k), v.AsString())
+		return true
+	})
+
+	labels := lb.Labels(nil)
+
+	entry := newMemorySeries(nil, labels)
+	if actual, loaded := conv.seriesCache.LoadOrStore(labels.String(), entry); loaded {
+		entry = actual.(*memorySeries)
+	}
+
+	entry.Ping()
+	return entry
+}
+
+func getNumberDataPointValue(dp pmetric.NumberDataPoint) float64 {
+	switch dp.ValueType() {
+	case pmetric.NumberDataPointValueTypeDouble:
+		return dp.DoubleValue()
+	case pmetric.NumberDataPointValueTypeInt:
+		return float64(dp.IntValue())
+	}
+
+	return 0
+}
+
+func (conv *Converter) consumeSum(app storage.Appender, memResource *memorySeries, memScope *memorySeries, m pmetric.Metric) error {
+	metricName := prometheus.BuildPromCompliantName(m, "")
+
+	// Excerpt from the spec:
+	//
+	// * If the aggregation temporarlity is cumulative and sum is monotonic, it
+	//   MUST be converted to a Prometheus Counter.
+	// * If the aggregation temporarlity is cumulative and sum is non-monotonic,
+	//   it MUST be converted to a Prometheus Gauge.
+	// * If the aggregation temporarlity is delta and the sum is monotonic, it
+	//   SHOULD be converted to a cumulative temporarlity and become a Prometheus
+	//   Sum.
+	// * Otherwise, it MUST be dropped.
+	var convType textparse.MetricType
+	switch {
+	case m.Sum().AggregationTemporality() == pmetric.MetricAggregationTemporalityCumulative && m.Sum().IsMonotonic():
+		convType = textparse.MetricTypeCounter
+	case m.Sum().AggregationTemporality() == pmetric.MetricAggregationTemporalityCumulative && !m.Sum().IsMonotonic():
+		convType = textparse.MetricTypeGauge
+	case m.Sum().AggregationTemporality() == pmetric.MetricAggregationTemporalityDelta && m.Sum().IsMonotonic():
+		// Drop non-cumulative summaries for now, which is permitted by the spec.
+		//
+		// TODO(rfratto): implement delta-to-cumulative for sums.
+		return nil
+	default:
+		// Drop the metric.
+		return nil
+	}
+
+	metricMD := conv.createOrUpdateMetadata(metricName, metadata.Metadata{
+		Type: convType,
+		Unit: m.Unit(),
+		Help: m.Description(),
+	})
+	if err := metricMD.WriteTo(app, time.Now()); err != nil {
+		level.Warn(conv.log).Log("msg", "failed to write metric family metadata", "err", err)
+	}
+
+	for dpcount := 0; dpcount < m.Sum().DataPoints().Len(); dpcount++ {
+		dp := m.Sum().DataPoints().At(dpcount)
+
+		memSeries := conv.getOrCreateSeries(memResource, memScope, metricName, dp.Attributes())
+
+		val := getNumberDataPointValue(dp)
+		if err := writeSeries(app, memSeries, dp, val); err != nil {
+			level.Error(conv.log).Log("msg", "failed to write metric sample", "err", err)
+		}
+	}
+
+	return nil
+}
+
+func (conv *Converter) consumeHistogram(app storage.Appender, memResource *memorySeries, memScope *memorySeries, m pmetric.Metric) error {
+	metricName := prometheus.BuildPromCompliantName(m, "")
+
+	if m.Histogram().AggregationTemporality() != pmetric.MetricAggregationTemporalityCumulative {
+		// Drop non-cumulative histograms for now, which is permitted by the spec.
+		//
+		// TODO(rfratto): implement delta-to-cumulative for histograms.
+		return nil
+	}
+
+	metricMD := conv.createOrUpdateMetadata(metricName, metadata.Metadata{
+		Type: textparse.MetricTypeHistogram,
+		Unit: m.Unit(),
+		Help: m.Description(),
+	})
+	if err := metricMD.WriteTo(app, time.Now()); err != nil {
+		level.Warn(conv.log).Log("msg", "failed to write metric family metadata", "err", err)
+	}
+
+	for dpcount := 0; dpcount < m.Histogram().DataPoints().Len(); dpcount++ {
+		dp := m.Histogram().DataPoints().At(dpcount)
+
+		// Sum metric
+		if dp.HasSum() {
+			sumMetric := conv.getOrCreateSeries(memResource, memScope, metricName+"_sum", dp.Attributes())
+			sumMetricVal := dp.Sum()
+
+			if err := writeSeries(app, sumMetric, dp, sumMetricVal); err != nil {
+				level.Error(conv.log).Log("msg", "failed to write histogram sum sample", "err", err)
+			}
+		}
+
+		// Count metric
+		{
+			countMetric := conv.getOrCreateSeries(memResource, memScope, metricName+"_count", dp.Attributes())
+			countMetricVal := float64(dp.Count())
+
+			if err := writeSeries(app, countMetric, dp, countMetricVal); err != nil {
+				level.Error(conv.log).Log("msg", "failed to write histogram count sample", "err", err)
+			}
+		}
+
+		// Process the boundaries. The number of buckets = number of explicit
+		// bounds + 1.
+		for i := 0; i < dp.ExplicitBounds().Len() && i < dp.BucketCounts().Len(); i++ {
+			bound := dp.ExplicitBounds().At(i)
+			count := dp.BucketCounts().At(i)
+
+			bucketLabel := labels.Label{
+				Name:  model.BucketLabel,
+				Value: strconv.FormatFloat(bound, 'f', -1, 64),
+			}
+
+			bucket := conv.getOrCreateSeries(memResource, memScope, metricName+"_bucket", dp.Attributes(), bucketLabel)
+			bucketVal := float64(count)
+
+			if err := writeSeries(app, bucket, dp, bucketVal); err != nil {
+				level.Error(conv.log).Log("msg", "failed to write histogram bucket sample", "bucket", bucketLabel.Value, "err", err)
+			}
+		}
+
+		// Add le=+Inf bucket. All values are <= +Inf, so the value is the same as
+		// the count of the datapoint.
+		{
+			bucketLabel := labels.Label{
+				Name:  model.BucketLabel,
+				Value: "+Inf",
+			}
+
+			infBucket := conv.getOrCreateSeries(memResource, memScope, metricName+"_bucket", dp.Attributes(), bucketLabel)
+			infBucketVal := float64(dp.Count())
+
+			if err := writeSeries(app, infBucket, dp, infBucketVal); err != nil {
+				level.Error(conv.log).Log("msg", "failed to write histogram bucket sample", "bucket", bucketLabel.Value, "err", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (conv *Converter) consumeSummary(app storage.Appender, memResource *memorySeries, memScope *memorySeries, m pmetric.Metric) error {
+	metricName := prometheus.BuildPromCompliantName(m, "")
+
+	metricMD := conv.createOrUpdateMetadata(metricName, metadata.Metadata{
+		Type: textparse.MetricTypeSummary,
+		Unit: m.Unit(),
+		Help: m.Description(),
+	})
+	if err := metricMD.WriteTo(app, time.Now()); err != nil {
+		level.Warn(conv.log).Log("msg", "failed to write metric family metadata", "err", err)
+	}
+
+	for dpcount := 0; dpcount < m.Summary().DataPoints().Len(); dpcount++ {
+		dp := m.Summary().DataPoints().At(dpcount)
+
+		// Sum metric
+		{
+			sumMetric := conv.getOrCreateSeries(memResource, memScope, metricName+"_sum", dp.Attributes())
+			sumMetricVal := dp.Sum()
+
+			if err := writeSeries(app, sumMetric, dp, sumMetricVal); err != nil {
+				level.Error(conv.log).Log("msg", "failed to write summary sum sample", "err", err)
+			}
+		}
+
+		// Count metric
+		{
+			countMetric := conv.getOrCreateSeries(memResource, memScope, metricName+"_count", dp.Attributes())
+			countMetricVal := float64(dp.Count())
+
+			if err := writeSeries(app, countMetric, dp, countMetricVal); err != nil {
+				level.Error(conv.log).Log("msg", "failed to write histogram count sample", "err", err)
+			}
+		}
+
+		// Quantiles
+		for i := 0; i < dp.QuantileValues().Len(); i++ {
+			qp := dp.QuantileValues().At(i)
+
+			quantileLabel := labels.Label{
+				Name:  model.QuantileLabel,
+				Value: strconv.FormatFloat(qp.Quantile(), 'f', -1, 64),
+			}
+
+			quantile := conv.getOrCreateSeries(memResource, memScope, metricName, dp.Attributes(), quantileLabel)
+			quantileVal := qp.Value()
+
+			if err := writeSeries(app, quantile, dp, quantileVal); err != nil {
+				level.Error(conv.log).Log("msg", "failed to write histogram quantile sample", "quantile", quantileLabel.Value, "err", err)
+			}
+		}
+	}
+	return nil
+}
+
+// GC cleans up stale metrics which have not been updated in the time specified
+// by staleTime.
+func (conv *Converter) GC(staleTime time.Duration) {
+	now := time.Now()
+
+	// In the code below, we use TryLock as a small performance optimization.
+	//
+	// The garbage collector doesn't bother to wait for locks for anything in the
+	// cache; the lock being unavailable implies that the cached resource is
+	// still active.
+
+	conv.seriesCache.Range(func(key, value any) bool {
+		series := value.(*memorySeries)
+		if !series.TryLock() {
+			return true
+		}
+		defer series.Unlock()
+
+		if now.Sub(series.lastSeen) > staleTime {
+			conv.seriesCache.Delete(key)
+		}
+		return true
+	})
+
+	conv.metadataCache.Range(func(key, value any) bool {
+		series := value.(*memoryMetadata)
+		if !series.TryLock() {
+			return true
+		}
+		defer series.Unlock()
+
+		if now.Sub(series.lastSeen) > staleTime {
+			conv.seriesCache.Delete(key)
+		}
+		return true
+	})
+}
+
+// FlushMetadata empties out the metadata cache, forcing metadata to get
+// rewritten.
+func (conv *Converter) FlushMetadata() {
+	// TODO(rfratto): this is fairly inefficient since it'll require rebuilding
+	// all of the metadata for every active series. However, it's the easiest
+	// thing to do for now.
+	conv.metadataCache.Range(func(key, _ any) bool {
+		conv.metadataCache.Delete(key)
+		return true
+	})
+}

--- a/component/otelcol/exporter/prometheus/internal/convert/convert.go
+++ b/component/otelcol/exporter/prometheus/internal/convert/convert.go
@@ -214,6 +214,7 @@ func (conv *Converter) getOrCreateResource(res pcommon.Resource) *memorySeries {
 		entry = actual.(*memorySeries)
 	}
 
+	entry.SetValue(1)
 	entry.Ping()
 	return entry
 }
@@ -272,6 +273,7 @@ func (conv *Converter) getOrCreateScope(res *memorySeries, scope pcommon.Instrum
 		entry = actual.(*memorySeries)
 	}
 
+	entry.SetValue(1)
 	entry.Ping()
 	return entry
 }

--- a/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
+++ b/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
@@ -1,0 +1,88 @@
+package convert_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/agent/component/otelcol/exporter/prometheus/internal/convert"
+	"github.com/grafana/agent/pkg/util"
+	"github.com/grafana/agent/pkg/util/testappender"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+func TestConverter(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name: "Gauge",
+			input: `{
+				"resource_metrics": [{
+					"resource": {
+						"attributes": [{
+							"key": "service.name",
+							"value": { "stringValue": "myservice" }
+						}, {
+							"key": "service.instance.id",
+							"value": { "stringValue": "instance" }
+						}]
+					},
+					"scope_metrics": [{
+						"metrics": [{
+							"name": "test_metric_seconds",
+							"description": "Metric for testing",
+							"unit": "seconds",
+							"gauge": {
+								"data_points": [{
+									"start_time_unix_nano": 1000000000,
+									"time_unix_nano": 1000000000,
+									"as_double": 1234.56
+								}]
+							}
+						}]
+					}]
+				}]
+			}`,
+			expect: `
+				# HELP test_metric_seconds Metric for testing
+				# TYPE test_metric_seconds gauge
+				test_metric_seconds{instance="instance",job="myservice"} 1234.56
+			`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			payload, err := pmetric.NewJSONUnmarshaler().UnmarshalMetrics([]byte(tc.input))
+			require.NoError(t, err)
+
+			var app testappender.Appender
+			app.HideTimestamps = true
+
+			l := util.TestLogger(t)
+			conv := convert.New(l, appenderAppendable{Inner: &app}, convert.Options{})
+			require.NoError(t, conv.ConsumeMetrics(context.Background(), payload))
+
+			families, err := app.MetricFamilies()
+			require.NoError(t, err)
+
+			c := testappender.Comparer{OpenMetrics: true}
+			require.NoError(t, c.Compare(families, tc.expect))
+		})
+	}
+}
+
+// appenderAppendable always returns the same Appender.
+type appenderAppendable struct {
+	Inner storage.Appender
+}
+
+var _ storage.Appendable = appenderAppendable{}
+
+func (aa appenderAppendable) Appender(context.Context) storage.Appender {
+	return aa.Inner
+}

--- a/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
+++ b/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
@@ -22,6 +22,79 @@ func TestConverter(t *testing.T) {
 			name: "Gauge",
 			input: `{
 				"resource_metrics": [{
+					"scope_metrics": [{
+						"metrics": [{
+							"name": "test_metric_seconds",
+							"gauge": {
+								"data_points": [{
+									"start_time_unix_nano": 1000000000,
+									"time_unix_nano": 1000000000,
+									"as_double": 1234.56
+								}]
+							}
+						}]
+					}]
+				}]
+			}`,
+			expect: `
+				# TYPE test_metric_seconds gauge
+				test_metric_seconds 1234.56
+			`,
+		},
+		{
+			name: "Monotonic sum",
+			input: `{
+				"resource_metrics": [{
+					"scope_metrics": [{
+						"metrics": [{
+							"name": "test_metric_seconds_total",
+							"sum": {
+								"aggregation_temporality": 2,
+								"is_monotonic": true,
+								"data_points": [{
+									"start_time_unix_nano": 1000000000,
+									"time_unix_nano": 1000000000,
+									"as_double": 15
+								}]
+							}
+						}]
+					}]
+				}]
+			}`,
+			expect: `
+				# TYPE test_metric_seconds counter
+				test_metric_seconds_total 15.0
+			`,
+		},
+		{
+			name: "Non-monotonic sum",
+			input: `{
+				"resource_metrics": [{
+					"scope_metrics": [{
+						"metrics": [{
+							"name": "test_metric_seconds",
+							"sum": {
+								"aggregation_temporality": 2,
+								"is_monotonic": false,
+								"data_points": [{
+									"start_time_unix_nano": 1000000000,
+									"time_unix_nano": 1000000000,
+									"as_double": 15
+								}]
+							}
+						}]
+					}]
+				}]
+			}`,
+			expect: `
+				# TYPE test_metric_seconds gauge
+				test_metric_seconds 15.0
+			`,
+		},
+		{
+			name: "Gauge",
+			input: `{
+				"resource_metrics": [{
 					"resource": {
 						"attributes": [{
 							"key": "service.name",

--- a/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
+++ b/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
@@ -17,6 +17,10 @@ func TestConverter(t *testing.T) {
 		name   string
 		input  string
 		expect string
+
+		showTimestamps    bool
+		includeTargetInfo bool
+		includeScopeInfo  bool
 	}{
 		{
 			name: "Gauge",
@@ -92,23 +96,82 @@ func TestConverter(t *testing.T) {
 			`,
 		},
 		{
-			name: "Gauge",
+			name: "Histogram",
 			input: `{
 				"resource_metrics": [{
-					"resource": {
-						"attributes": [{
-							"key": "service.name",
-							"value": { "stringValue": "myservice" }
-						}, {
-							"key": "service.instance.id",
-							"value": { "stringValue": "instance" }
-						}]
-					},
 					"scope_metrics": [{
 						"metrics": [{
 							"name": "test_metric_seconds",
-							"description": "Metric for testing",
-							"unit": "seconds",
+							"histogram": {
+								"aggregation_temporality": 2,
+								"data_points": [{
+									"start_time_unix_nano": 1000000000,
+									"time_unix_nano": 1000000000,
+									"count": 333,
+									"sum": 100,
+									"bucket_counts": [0, 111, 0, 222],
+									"explicit_bounds": [0.25, 0.5, 0.75, 1.0]
+								}]
+							}
+						}]
+					}]
+				}]
+			}`,
+			expect: `
+				# TYPE test_metric_seconds histogram
+				test_metric_seconds_bucket{le="0.25"} 0
+				test_metric_seconds_bucket{le="0.5"} 111
+				test_metric_seconds_bucket{le="0.75"} 0
+				test_metric_seconds_bucket{le="1.0"} 222
+				test_metric_seconds_bucket{le="+Inf"} 333
+				test_metric_seconds_sum 100.0
+				test_metric_seconds_count 333
+			`,
+		},
+		{
+			name: "Summary",
+			input: `{
+				"resource_metrics": [{
+					"scope_metrics": [{
+						"metrics": [{
+							"name": "test_metric_seconds",
+							"summary": {
+								"data_points": [{
+									"start_time_unix_nano": 1000000000,
+									"time_unix_nano": 1000000000,
+									"count": 333,
+									"sum": 100,
+									"quantile_values": [
+										{ "quantile": 0, "value": 100 },
+										{ "quantile": 0.25, "value": 200 },
+										{ "quantile": 0.5, "value": 300 },
+										{ "quantile": 0.75, "value": 400 },
+										{ "quantile": 1, "value": 500 }
+									]
+								}]
+							}
+						}]
+					}]
+				}]
+			}`,
+			expect: `
+				# TYPE test_metric_seconds summary
+				test_metric_seconds{quantile="0.0"} 100.0
+				test_metric_seconds{quantile="0.25"} 200.0
+				test_metric_seconds{quantile="0.5"} 300.0
+				test_metric_seconds{quantile="0.75"} 400.0
+				test_metric_seconds{quantile="1.0"} 500.0
+				test_metric_seconds_sum 100.0
+				test_metric_seconds_count 333
+			`,
+		},
+		{
+			name: "Timestamps",
+			input: `{
+				"resource_metrics": [{
+					"scope_metrics": [{
+						"metrics": [{
+							"name": "test_metric_seconds",
 							"gauge": {
 								"data_points": [{
 									"start_time_unix_nano": 1000000000,
@@ -120,8 +183,135 @@ func TestConverter(t *testing.T) {
 					}]
 				}]
 			}`,
+			showTimestamps: true,
 			expect: `
-				# HELP test_metric_seconds Metric for testing
+				# TYPE test_metric_seconds gauge
+				test_metric_seconds 1234.56 1.0
+			`,
+		},
+		{
+			name: "Labels from resource attributes",
+			input: `{
+				"resource_metrics": [{
+					"resource": {
+						"attributes": [{
+							"key": "service.name",
+							"value": { "stringValue": "myservice" }
+						}, {
+							"key": "service.instance.id",
+							"value": { "stringValue": "instance" }
+						}, {
+							"key": "do_not_display",
+							"value": { "stringValue": "test" }
+						}]
+					},
+					"scope_metrics": [{
+						"metrics": [{
+							"name": "test_metric_seconds",
+							"gauge": {
+								"data_points": [{
+									"as_double": 1234.56
+								}]
+							}
+						}]
+					}]
+				}]
+			}`,
+			expect: `
+				# TYPE test_metric_seconds gauge
+				test_metric_seconds{instance="instance",job="myservice"} 1234.56
+			`,
+		},
+		{
+			name: "Labels from scope name and version",
+			input: `{
+				"resource_metrics": [{
+					"scope_metrics": [{
+						"scope": {
+							"name": "a-name",
+							"version": "a-version",
+							"attributes": [{
+								"key": "something.extra",
+								"value": { "stringValue": "zzz-extra-value" }
+							}]
+						},
+						"metrics": [{
+							"name": "test_metric_seconds",
+							"gauge": {
+								"data_points": [{
+									"as_double": 1234.56
+								}]
+							}
+						}]
+					}]
+				}]
+			}`,
+			includeScopeInfo: true,
+			expect: `
+				# TYPE otel_scope_info gauge
+				otel_scope_info{name="a-name",version="a-version",something_extra="zzz-extra-value"} 1.0
+				# TYPE test_metric_seconds gauge
+				test_metric_seconds{otel_scope_name="a-name",otel_scope_version="a-version"} 1234.56
+			`,
+		},
+		{
+			name: "Labels from data point",
+			input: `{
+				"resource_metrics": [{
+					"scope_metrics": [{
+						"metrics": [{
+							"name": "test_metric_seconds",
+							"gauge": {
+								"data_points": [{
+									"attributes": [{
+										"key": "foo",
+										"value": { "stringValue": "bar" }
+									}],
+									"as_double": 1234.56
+								}]
+							}
+						}]
+					}]
+				}]
+			}`,
+			expect: `
+				# TYPE test_metric_seconds gauge
+				test_metric_seconds{foo="bar"} 1234.56
+			`,
+		},
+		{
+			name: "Target info metric",
+			input: `{
+				"resource_metrics": [{
+					"resource": {
+						"attributes": [{
+							"key": "service.name",
+							"value": { "stringValue": "myservice" }
+						}, {
+							"key": "service.instance.id",
+							"value": { "stringValue": "instance" }
+						}, {
+							"key": "custom_attr",
+							"value": { "stringValue": "test" }
+						}]
+					},
+					"scope_metrics": [{
+						"metrics": [{
+							"name": "test_metric_seconds",
+							"gauge": {
+								"data_points": [{
+									"as_double": 1234.56
+								}]
+							}
+						}]
+					}]
+				}]
+			}`,
+			includeTargetInfo: true,
+			expect: `
+				# HELP target_info Target metadata
+				# TYPE target_info gauge
+				target_info{instance="instance",job="myservice",custom_attr="test"} 1.0
 				# TYPE test_metric_seconds gauge
 				test_metric_seconds{instance="instance",job="myservice"} 1234.56
 			`,
@@ -134,10 +324,13 @@ func TestConverter(t *testing.T) {
 			require.NoError(t, err)
 
 			var app testappender.Appender
-			app.HideTimestamps = true
+			app.HideTimestamps = !tc.showTimestamps
 
 			l := util.TestLogger(t)
-			conv := convert.New(l, appenderAppendable{Inner: &app}, convert.Options{})
+			conv := convert.New(l, appenderAppendable{Inner: &app}, convert.Options{
+				IncludeTargetInfo: tc.includeTargetInfo,
+				IncludeScopeInfo:  tc.includeScopeInfo,
+			})
 			require.NoError(t, conv.ConsumeMetrics(context.Background(), payload))
 
 			families, err := app.MetricFamilies()

--- a/component/otelcol/exporter/prometheus/prometheus.go
+++ b/component/otelcol/exporter/prometheus/prometheus.go
@@ -1,0 +1,143 @@
+// Package prometheus provides an otelcol.exporter.prometheus component.
+package prometheus
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otelcol"
+	"github.com/grafana/agent/component/otelcol/exporter/prometheus/internal/convert"
+	"github.com/grafana/agent/component/prometheus"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/prometheus/prometheus/storage"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:    "otelcol.exporter.prometheus",
+		Args:    Arguments{},
+		Exports: otelcol.ConsumerExports{},
+
+		Build: func(o component.Options, a component.Arguments) (component.Component, error) {
+			return New(o, a.(Arguments))
+		},
+	})
+}
+
+// Arguments configures the otelcol.exporter.prometheus component.
+type Arguments struct {
+	IncludeTargetInfo bool                 `river:"include_target_info,attr,optional"`
+	IncludeScopeInfo  bool                 `river:"include_scope_info,attr,optional"`
+	GCFrequency       time.Duration        `river:"gc_frequency,attr,optional"`
+	ForwardTo         []storage.Appendable `river:"forward_to,attr"`
+}
+
+var _ river.Unmarshaler = (*Arguments)(nil)
+
+// DefaultArguments holds defaults values.
+var DefaultArguments = Arguments{
+	IncludeTargetInfo: true,
+	IncludeScopeInfo:  true,
+	GCFrequency:       5 * time.Minute,
+}
+
+// UnmarshalRiver implements river.Unmarshaler and applies defaults.
+func (args *Arguments) UnmarshalRiver(f func(interface{}) error) error {
+	*args = DefaultArguments
+
+	type arguments Arguments
+	if err := f((*arguments)(args)); err != nil {
+		return err
+	}
+
+	if args.GCFrequency == 0 {
+		return fmt.Errorf("gc_frequency must be greater than 0")
+	}
+
+	return nil
+}
+
+// Component is the otelcol.exporter.prometheus component.
+type Component struct {
+	log  log.Logger
+	opts component.Options
+
+	fanout    *prometheus.Fanout
+	converter *convert.Converter
+
+	mut sync.RWMutex
+	cfg Arguments
+}
+
+var _ component.Component = (*Component)(nil)
+
+// New creates a new otelcol.exporter.prometheus component.
+func New(o component.Options, c Arguments) (*Component, error) {
+	fanout := prometheus.NewFanout(nil, o.ID)
+
+	converter := convert.New(o.Logger, fanout, convert.Options{
+		IncludeTargetInfo: true,
+		IncludeScopeInfo:  true,
+	})
+
+	res := &Component{
+		log:  o.Logger,
+		opts: o,
+
+		fanout:    fanout,
+		converter: converter,
+	}
+
+	if err := res.Update(c); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// Run implements Component.
+func (c *Component) Run(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(c.nextGC()):
+			// TODO(rfratto): we may want to consider making this an option in the
+			// future, but hard-coding to 5 minutes is a reasonable default to start
+			// with.
+			c.converter.GC(5 * time.Minute)
+		}
+	}
+}
+
+func (c *Component) nextGC() time.Duration {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+	return c.cfg.GCFrequency
+}
+
+// Update implements Component.
+func (c *Component) Update(newConfig component.Arguments) error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	cfg := newConfig.(Arguments)
+	c.cfg = cfg
+
+	c.fanout.UpdateChildren(cfg.ForwardTo)
+	c.converter.UpdateOptions(convert.Options{
+		IncludeTargetInfo: cfg.IncludeTargetInfo,
+		IncludeScopeInfo:  cfg.IncludeScopeInfo,
+	})
+
+	// If our forward_to argument changed, we need to flush the metadata cache to
+	// ensure the new children have all the metadata they need.
+	//
+	// For now, we always flush whenever we update, but we could do something
+	// more intelligent here in the future.
+	c.converter.FlushMetadata()
+	return nil
+}

--- a/component/prometheus/fanout.go
+++ b/component/prometheus/fanout.go
@@ -113,14 +113,21 @@ func (a *appender) Rollback() error {
 	return multiErr
 }
 
+// Custom errors to return until we implement support for exemplars and
+// metadata.
+var (
+	ErrExemplarsNotSupported = fmt.Errorf("appendExemplar not supported yet")
+	ErrMetadataNotSupported  = fmt.Errorf("updateMetadata not supported yet")
+)
+
 // AppendExemplar satisfies the Appender interface.
 func (a *appender) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
-	return 0, fmt.Errorf("appendExemplar not supported yet")
+	return 0, ErrExemplarsNotSupported
 }
 
 // UpdateMetadata satisifies the Appender interface.
 func (a *appender) UpdateMetadata(ref storage.SeriesRef, l labels.Labels, m metadata.Metadata) (storage.SeriesRef, error) {
-	return 0, fmt.Errorf("updateMetadata not supported yet")
+	return 0, ErrMetadataNotSupported
 }
 
 // NoopMetadataStore implements the MetricMetadataStore interface.

--- a/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
@@ -1,0 +1,107 @@
+---
+aliases:
+- /docs/agent/latest/flow/reference/components/otelcol.exporter.prometheus
+title: otelcol.exporter.prometheus
+---
+
+# otelcol.exporter.prometheus
+
+`otelcol.exporter.prometheus` accepts OTLP-formatted metrics from other
+`otelcol` components, converts metrics to Prometheus-formatted metrics,
+and forwards the resulting metrics to `prometheus` components.
+
+> **NOTE**: `otelcol.exporter.prometheus` is a custom component unrelated to the
+> `prometheus` exporter from OpenTelemetry Collector.
+>
+> Conversion of metrics are done according to the OpenTelemetry
+> [Metrics Data Model][] specification.
+
+Multiple `otelcol.exporter.prometheus` components can be specified by giving them
+different labels.
+
+[Metrics Data Model]: https://opentelemetry.io/docs/reference/specification/metrics/data-model/
+
+## Usage
+
+```river
+otelcol.exporter.prometheus "LABEL" {
+  forward_to = [...]
+}
+```
+
+## Arguments
+
+`otelcol.exporter.prometheus` supports the following arguments:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`include_target_info` | `boolean` | Whether to include `target_info` metrics. | `true` | no
+`include_scope_info` | `boolean` | Whether to include `otel_scope_info` metrics. | `true` | no
+`gc_frequency` | `duration` | How often to clean up stale metrics from memory. | `"5m"` | no
+`forward_to` | `list(receiver)` | Where to forward converted Prometheus metrics. | | yes
+
+By default, OpenTelemetry resources are converted into `target_info` metrics,
+and OpenTelemetry instrumentation scopes are converted into `otel_scope_info`
+metrics. Set the `include_scope_info` and `include_target_info` arguments to
+`false`, respectively, to disable the custom metrics.
+
+When `include_scope_info` is `true`, the instrumentation scope name and version
+are added as `otel_scope_name` and `otel_scope_version` labels to every
+converted metric sample.
+
+
+When `include_scope_info` is true, OpenTelemetry Collector resources are converted into `target_info` metrics.
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+Name | Type | Description
+---- | ---- | -----------
+`input` | `otelcol.Consumer` | A value that other components can use to send telemetry data to.
+
+`input` accepts `otelcol.Consumer` data for metrics. Other telemetry signals are ignored.
+
+Metrics sent to the `input` are converted to Prometheus-compatible metrics and
+are forwarded to the `forward_to` argument.
+
+The following are dropped during the conversion process:
+
+* Metrics that use the delta aggregation temporality
+* Exemplars on OpenTelemetry cumulative sums and OpenTelemetry Histograms
+* ExponentialHistogram data points
+
+## Component health
+
+`otelcol.exporter.prometheus` is only reported as unhealthy if given an invalid
+configuration.
+
+## Debug information
+
+`otelcol.exporter.prometheus` does not expose any component-specific debug
+information.
+
+## Example
+
+This example accepts metrics over OTLP and forwards it using
+`prometheus.remote_write`:
+
+```river
+otelcol.receiver.otlp "default" {
+  grpc {}
+
+  output {
+    metrics = [otelcol.exporter.prometheus.default.input]
+  }
+}
+
+otelcol.exporter.prometheus "default" {
+  forward_to = [prometheus.remote_write.mimir.receiver]
+}
+
+prometheus.remote_write "mimir" {
+  endpoint {
+    url = "http://mimir:9009/api/v1/push"
+  }
+}
+```

--- a/go.mod
+++ b/go.mod
@@ -128,13 +128,17 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.61.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.61.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.61.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.61.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.61.0
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus/blackbox_exporter v0.22.1-0.20220920154026-3446984d6a6e
+	github.com/prometheus/client_model v0.2.0
 	github.com/shirou/gopsutil/v3 v3.22.8
 	go.opentelemetry.io/collector/pdata v0.61.0
 	go.opentelemetry.io/collector/semconv v0.61.0
 	golang.org/x/exp v0.0.0-20220916125017-b168a2c6b86b
+	google.golang.org/protobuf v1.28.1
 )
 
 require (
@@ -401,7 +405,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.61.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.61.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.61.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.61.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.61.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.61.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
@@ -418,10 +421,8 @@ require (
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/alertmanager v0.24.0 // indirect
-	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common/sigv4 v0.1.0 // indirect
 	github.com/prometheus/exporter-toolkit v0.7.2-0.20220901134540-2434b08435da // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
@@ -515,7 +516,6 @@ require (
 	google.golang.org/api v0.97.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220926220553-6981cbe3cfce // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/fsnotify/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect


### PR DESCRIPTION
#### PR Description

This PR adds a new `otelcol.exporter.prometheus` Flow component, and is the counterpart to #2462. This component: 

1. Accepts OpenTelemetry metrics from other `otelcol` components.
2. Converts metrics into the Prometheus format.
3. Forwards converted metrics to a set of provided `prometheus` components.

#### Which issue(s) this PR fixes
Closes #2302.

#### Notes to the Reviewer

The component implements the required portions of the OpenTelmemetry [Metrics Data Model][] specification.

The following optional portions of the specification are left unimplemented for this initial commit:

1. Metrics aggregated with delta temporality are dropped and no delta-to-cumulative transformation takes place.
2. Exemplars are dropped.

[Metrics Data Model]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
