### PR TITLE
Small riverfmt enhancements

### DIFF
--- a/pkg/river/printer/testdata/example.expect
+++ b/pkg/river/printer/testdata/example.expect
@@ -12,11 +12,9 @@ attr_2 = 30 * 2 + 5
 attr_3 = field.access * 2
 
 // Blocks with nothing inside of them should be truncated.
-empty.block {
-}
+empty.block { }
 
-empty.block "labeled" {
-}
+empty.block "labeled" { }
 
 //
 // Alignment tests

--- a/pkg/river/printer/testdata/func_call.expect
+++ b/pkg/river/printer/testdata/func_call.expect
@@ -1,0 +1,17 @@
+one_line = some_func(1, 2, 3, 4)
+
+multi_line = some_func(1,
+	2, 3,
+	4)
+
+multi_line_pretty = some_func(
+	1,
+	2,
+	3,
+	4,
+)
+
+func_with_obj = some_func({
+	key1 = "value1",
+	key2 = "value2",
+})

--- a/pkg/river/printer/testdata/func_call.in
+++ b/pkg/river/printer/testdata/func_call.in
@@ -1,0 +1,17 @@
+one_line = some_func(1, 2, 3, 4)
+
+multi_line = some_func(1,
+2, 3,
+4)
+
+multi_line_pretty = some_func(
+1,
+2,
+3,
+4,
+)
+
+func_with_obj = some_func({
+	key1 = "value1",
+	key2 = "value2",
+})

--- a/pkg/river/printer/testdata/oneline_block.expect
+++ b/pkg/river/printer/testdata/oneline_block.expect
@@ -1,0 +1,11 @@
+block { }
+
+block { }
+
+block { }
+
+block { }
+
+block {
+	// Comments should be kept.
+}

--- a/pkg/river/printer/testdata/oneline_block.in
+++ b/pkg/river/printer/testdata/oneline_block.in
@@ -1,0 +1,14 @@
+block {}
+
+block { }
+
+block {
+}
+
+block {
+
+}
+
+block {
+	// Comments should be kept.
+}

--- a/pkg/river/printer/walker.go
+++ b/pkg/river/printer/walker.go
@@ -100,9 +100,6 @@ func (w *walker) walkAttributeStmt(s *ast.AttributeStmt) {
 func (w *walker) walkBlockStmt(s *ast.BlockStmt) {
 	joined := strings.Join(s.Name, ".")
 
-	// TODO(rfratto): Should blocks have a oneline format if they're short or
-	// empty? e.g.: `empty_block { attr = 5 }`, `empty_block {}`
-
 	w.p.Write(
 		s.NamePos,
 		&ast.Ident{Name: joined, NamePos: s.NamePos},
@@ -120,10 +117,17 @@ func (w *walker) walkBlockStmt(s *ast.BlockStmt) {
 	w.p.Write(
 		wsBlank,
 		s.LCurlyPos, token.LCURLY, wsIndent,
-		wsNewline,
 	)
 
-	w.walkStmts(s.Body)
+	if len(s.Body) > 0 {
+		// Add a newline before writing any statements.
+		w.p.Write(wsNewline)
+		w.walkStmts(s.Body)
+	} else {
+		// There's no statements, but add a blank line between the left and right
+		// curly anyway.
+		w.p.Write(wsBlank)
+	}
 
 	w.p.Write(wsUnindent, s.RCurlyPos, token.RCURLY)
 }


### PR DESCRIPTION
This PR makes two small changes to riverfmt: 

* Permit empty blocks with both curly braces on the same line
* Allow function arguments to persist across different lines

Closes #2399 
Closes #2331 