### PR TITLE
Enable oauth2 remote_write configuration for Grafana Agent Operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Features
+
+  - `grafana-agent-operator` supports oauth2 as an authentication method for remote_write. (@timo-42)
+
 ### Enhancements
 
 - Update OpenTelemetry Collector dependency to v0.63.1. (@tpaschalis)

--- a/docs/sources/operator/api.md
+++ b/docs/sources/operator/api.md
@@ -4248,6 +4248,19 @@ github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1.BasicA
 </tr>
 <tr>
 <td>
+<code>oauth2</code><br/>
+<em>
+<a href="https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.OAuth2">
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1.OAuth2
+</a>
+</em>
+</td>
+<td>
+<p>Oauth2 for URL</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>bearerToken</code><br/>
 <em>
 string

--- a/docs/sources/operator/custom-resource-quickstart.md
+++ b/docs/sources/operator/custom-resource-quickstart.md
@@ -170,6 +170,19 @@ spec:
         name: primary-credentials-metrics
         key: password
 
+  # As an alternative authentication method, Grafana Agent also supports OAuth2.
+  # - url: your_remote_write_URL
+  #   oauth2:
+  #     clientId:
+  #       secret:
+  #         key: username # Kubernetes Secret Key
+  #         name: primary-credentials-metrics # Kubernetes Secret Name
+  #     clientSecret:
+  #       key: password # Kubernetes Secret Key
+  #       name: primary-credentials-metrics # Kubernetes Secret Name
+  #     tokenUrl: https://auth.example.com/realms/master/protocol/openid-connect/token
+
+
   # Supply an empty namespace selector to look in all namespaces. Remove
   # this to only look in the same namespace as the MetricsInstance CR
   serviceMonitorNamespaceSelector: {}

--- a/pkg/operator/apis/monitoring/v1alpha1/types_metrics.go
+++ b/pkg/operator/apis/monitoring/v1alpha1/types_metrics.go
@@ -98,6 +98,8 @@ type RemoteWriteSpec struct {
 	WriteRelabelConfigs []prom_v1.RelabelConfig `json:"writeRelabelConfigs,omitempty"`
 	// BasicAuth for the URL.
 	BasicAuth *prom_v1.BasicAuth `json:"basicAuth,omitempty"`
+	// Oauth2 for URL
+	OAuth2 *prom_v1.OAuth2 `json:"oauth2,omitempty"`
 	// BearerToken used for remote_write.
 	BearerToken string `json:"bearerToken,omitempty"`
 	// BearerTokenFile used to read bearer token.

--- a/pkg/operator/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/operator/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
@@ -1328,6 +1328,11 @@ func (in *RemoteWriteSpec) DeepCopyInto(out *RemoteWriteSpec) {
 		*out = new(v1.BasicAuth)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.OAuth2 != nil {
+		in, out := &in.OAuth2, &out.OAuth2
+		*out = new(v1.OAuth2)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.SigV4 != nil {
 		in, out := &in.SigV4, &out.SigV4
 		*out = new(SigV4Config)

--- a/pkg/operator/config/templates/component/metrics/remote_write.libsonnet
+++ b/pkg/operator/config/templates/component/metrics/remote_write.libsonnet
@@ -34,6 +34,19 @@ function(namespace, rw) {
       password_file: secrets.pathForSecret(namespace, rw.BasicAuth.Password),
     }
   ),
+  oauth2: (
+    if rw.OAuth2 != null then {
+      // TODO: client_id can also be stored in a config map:
+      // secrets.valueForConfigMap(namespace, rw.OAuth2.ClientID.ConfigMap),
+      local client_id = secrets.valueForSecret(namespace, rw.OAuth2.ClientID.Secret),
+      
+      client_id: client_id,
+      client_secret_file: secrets.pathForSecret(namespace, rw.OAuth2.ClientSecret),
+      endpoint_params: rw.OAuth2.EndpointParams,
+      scopes: rw.OAuth2.Scopes,
+      token_url: rw.OAuth2.TokenURL,
+    }
+  ),
   local bearerToken = optionals.string(rw.BearerToken),
   local bearerTokenFile = optionals.string(rw.BearerTokenFile),
 

--- a/production/operator/crds/monitoring.grafana.com_grafanaagents.yaml
+++ b/production/operator/crds/monitoring.grafana.com_grafanaagents.yaml
@@ -4275,6 +4275,94 @@ spec:
                             if specified. The name is used in metrics and logging
                             in order to differentiate queues.
                           type: string
+                        oauth2:
+                          description: Oauth2 for URL
+                          properties:
+                            clientId:
+                              description: The secret or configmap containing the
+                                OAuth2 client id
+                              properties:
+                                configMap:
+                                  description: ConfigMap containing data to use for
+                                    the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                secret:
+                                  description: Secret containing data to use for the
+                                    targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            clientSecret:
+                              description: The secret containing the OAuth2 client
+                                secret
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            endpointParams:
+                              additionalProperties:
+                                type: string
+                              description: Parameters to append to the token URL
+                              type: object
+                            scopes:
+                              description: OAuth2 scopes used for the token request
+                              items:
+                                type: string
+                              type: array
+                            tokenUrl:
+                              description: The URL to fetch the token from
+                              minLength: 1
+                              type: string
+                          required:
+                          - clientId
+                          - clientSecret
+                          - tokenUrl
+                          type: object
                         proxyUrl:
                           description: ProxyURL to proxy requests through. Optional.
                           type: string

--- a/production/operator/crds/monitoring.grafana.com_metricsinstances.yaml
+++ b/production/operator/crds/monitoring.grafana.com_metricsinstances.yaml
@@ -266,6 +266,93 @@ spec:
                   description: RemoteWriteSpec defines the remote_write configuration
                     for Prometheus.
                   properties:
+                    oauth2:
+                      description: OAuth2 for the URL. Only valid in Prometheus versions
+                        2.27.0 and newer.
+                      properties:
+                        clientId:
+                          description: The secret or configmap containing the OAuth2
+                            client id
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        clientSecret:
+                          description: The secret containing the OAuth2 client secret
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        endpointParams:
+                          additionalProperties:
+                            type: string
+                          description: Parameters to append to the token URL
+                          type: object
+                        scopes:
+                          description: OAuth2 scopes used for the token request
+                          items:
+                            type: string
+                          type: array
+                        tokenUrl:
+                          description: The URL to fetch the token from
+                          minLength: 1
+                          type: string
+                      required:
+                      - clientId
+                      - clientSecret
+                      - tokenUrl
+                      type: object
                     basicAuth:
                       description: BasicAuth for the URL.
                       properties:

--- a/production/operator/crds/monitoring.grafana.com_metricsinstances.yaml
+++ b/production/operator/crds/monitoring.grafana.com_metricsinstances.yaml
@@ -339,6 +339,89 @@ spec:
                         if specified. The name is used in metrics and logging in order
                         to differentiate queues.
                       type: string
+                    oauth2:
+                      description: Oauth2 for URL
+                      properties:
+                        clientId:
+                          description: The secret or configmap containing the OAuth2
+                            client id
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                        clientSecret:
+                          description: The secret containing the OAuth2 client secret
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        endpointParams:
+                          additionalProperties:
+                            type: string
+                          description: Parameters to append to the token URL
+                          type: object
+                        scopes:
+                          description: OAuth2 scopes used for the token request
+                          items:
+                            type: string
+                          type: array
+                        tokenUrl:
+                          description: The URL to fetch the token from
+                          minLength: 1
+                          type: string
+                      required:
+                      - clientId
+                      - clientSecret
+                      - tokenUrl
+                      type: object
                     proxyUrl:
                       description: ProxyURL to proxy requests through. Optional.
                       type: string


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Grafana Agent already supports Oauth2 configuration, but the Grafana agent operator did not.  This PR adds the support for the agent operator as well.

#### Which issue(s) this PR fixes

Fixes #2416

#### Notes to the Reviewer

Updated the crds with `make generate-crds`, but this also lead to the oauth2 option for the Grafana agent. I'm not sure if this intended or not.

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
