### PR TITLE
river/stdlib: add discovery_target_decode function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Main (unreleased)
 - Grafana Agent Flow: Add tracing instrumentation and a `tracing` block to
   forward traces to `otelcol` component. (@rfratto)
 
+- Grafana Agent Flow: add a `discovery_target_decode` function to decode a JSON
+  array of discovery targets corresponding to Prometheus' HTTP and file service
+  discovery formats. (@rfratto)
+
 ### Enhancements
 
 - Update OpenTelemetry Collector dependency to v0.63.1. (@tpaschalis)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Main (unreleased)
 - Grafana Agent Flow: Add tracing instrumentation and a `tracing` block to
   forward traces to `otelcol` component. (@rfratto)
 
-- Grafana Agent Flow: add a `discovery_target_decode` function to decode a JSON
+- Grafana Agent Flow: Add a `discovery_target_decode` function to decode a JSON
   array of discovery targets corresponding to Prometheus' HTTP and file service
   discovery formats. (@rfratto)
 

--- a/docs/sources/flow/reference/stdlib/concat.md
+++ b/docs/sources/flow/reference/stdlib/concat.md
@@ -4,11 +4,11 @@ aliases:
 title: concat
 ---
 
-# `concat` Function
+# concat
 
-`concat` concatenates one or more lists of values into a single list. Each
-argument to `concat` must be a list value. Elements within the list can be any
-type.
+The `concat` function concatenates one or more lists of values into a single
+list. Each argument to `concat` must be a list value. Elements within the list
+can be any type.
 
 ## Examples
 

--- a/docs/sources/flow/reference/stdlib/discovery_target_decode.md
+++ b/docs/sources/flow/reference/stdlib/discovery_target_decode.md
@@ -31,8 +31,7 @@ Elements specified by the `targets` key are converted into a flat list of
 targets. The base set of labels for each target is retrieved from the `labels`
 key, and the `__address__` label is received from the target element.
 
-For example, the following JSON file will map to the River objects provided
-below:
+For example, the following JSON file maps to the River objects provided below:
 
 ```json
 [

--- a/docs/sources/flow/reference/stdlib/discovery_target_decode.md
+++ b/docs/sources/flow/reference/stdlib/discovery_target_decode.md
@@ -1,0 +1,88 @@
+---
+aliases:
+- /docs/agent/latest/flow/configuration-language/standard-library/discovery_target_decode
+title: discovery_target_decode
+---
+
+# discovery_target_decode
+
+The `discovery_target_decode` function decodes a string into an array of
+targets matching the exports of `discovery.*` components.
+
+The string must match the JSON format used by Prometheus' HTTP and file service
+discovery:
+
+```
+[
+  {
+    "targets": [ "<host:ip>", ... ],
+    "labels": {
+      "<label name>": "<label value>"
+    }
+  }
+]
+```
+
+If the provided string doesn't match the expected JSON format,
+`discovery_target_decode` fails to evaluate and marks the component containing
+the expression as unhealthy.
+
+Elements specified by the `targets` key are converted into a flat list of
+targets. The base set of labels for each target is retrieved from the `labels`
+key, and the `__address__` label is received from the target element.
+
+For example, the following JSON file will map to the River objects provided
+below:
+
+```json
+[
+  {
+    "targets": [ "host-a:80", "host-b:80" ],
+    "labels": {
+      "cluster": "production",
+      "region": "us-west-0"
+    }
+  },
+  {
+    "targets": [ "host-c:80" ],
+    "labels": {
+      "cluster": "development",
+      "region": "us-west-0"
+    }
+  }
+]
+```
+
+```river
+[
+  {
+    __address__ = "host-a:80",
+    cluster     = "production",
+    region      = "us-west-0",
+  },
+  {
+    __address__ = "host-b:80",
+    cluster     = "production",
+    region      = "us-west-0",
+  },
+  {
+    __address__ = "host-c:80",
+    cluster     = "development",
+    region      = "us-west-0",
+  },
+]
+```
+
+## Example pipeline
+
+```river
+local.file "example" {
+  filename = env("TARGETS_FILE")
+}
+
+prometheus.scrape "default" {
+  targets = discovery_target_decode(local.file.example.content)
+}
+```
+
+[`local.file`]: {{< relref "../components/local.file.md" >}}

--- a/docs/sources/flow/reference/stdlib/env.md
+++ b/docs/sources/flow/reference/stdlib/env.md
@@ -4,11 +4,11 @@ aliases:
 title: env
 ---
 
-# `env` Function
+# env
 
-`env` gets the value of an environment variable from the system Grafana Agent
-is running on. If the environment variable does not exist, `env` returns an
-empty string.
+The `env` function gets the value of an environment variable from the system
+Grafana Agent is running on. If the environment variable does not exist, `env`
+returns an empty string.
 
 ## Examples
 

--- a/docs/sources/flow/reference/stdlib/json_decode.md
+++ b/docs/sources/flow/reference/stdlib/json_decode.md
@@ -4,10 +4,10 @@ aliases:
 title: json_decode
 ---
 
-# `json_decode` Function
+# json_decode
 
-`json_decode` decodes a string representing JSON into a River value.
-`json_decode` will fail if the string argument provided cannot be parsed as
+The `json_decode` function decodes a string representing JSON into a River
+value. `json_decode` fails if the string argument provided cannot be parsed as
 JSON.
 
 A common use case of `json_decode` is to decode the output of a

--- a/pkg/river/vm/vm_stdlib_test.go
+++ b/pkg/river/vm/vm_stdlib_test.go
@@ -2,10 +2,13 @@ package vm_test
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
+	"github.com/grafana/agent/component/discovery"
 	"github.com/grafana/agent/pkg/river/parser"
 	"github.com/grafana/agent/pkg/river/vm"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,9 +35,72 @@ func TestVM_Stdlib(t *testing.T) {
 
 			eval := vm.New(expr)
 
-			var v interface{}
-			require.NoError(t, eval.Evaluate(nil, &v))
-			require.Equal(t, tc.expect, v)
+			rv := reflect.New(reflect.TypeOf(tc.expect))
+			require.NoError(t, eval.Evaluate(nil, rv.Interface()))
+			require.Equal(t, tc.expect, rv.Elem().Interface())
+		})
+	}
+}
+
+func TestVM_Stdlib_Scoped(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  string
+		scope  *vm.Scope
+		expect interface{}
+	}{
+		{
+			name:  "discovery_target_decode",
+			input: `discovery_target_decode(input)`,
+			scope: &vm.Scope{
+				Variables: map[string]interface{}{
+					"input": `[
+						{
+							"targets": ["host-a:12345", "host-a:12346"],
+							"labels": {
+								"foo": "bar"
+							}
+						},
+						{
+							"targets": ["host-b:12345", "host-b:12346"],
+							"labels": {
+								"hello": "world"
+							}
+						}
+					]`,
+				},
+			},
+			expect: []discovery.Target{
+				{
+					model.AddressLabel: "host-a:12345",
+					"foo":              "bar",
+				},
+				{
+					model.AddressLabel: "host-a:12346",
+					"foo":              "bar",
+				},
+				{
+					model.AddressLabel: "host-b:12345",
+					"hello":            "world",
+				},
+				{
+					model.AddressLabel: "host-b:12346",
+					"hello":            "world",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := parser.ParseExpression(tc.input)
+			require.NoError(t, err)
+
+			eval := vm.New(expr)
+
+			rv := reflect.New(reflect.TypeOf(tc.expect))
+			require.NoError(t, eval.Evaluate(tc.scope, rv.Interface()))
+			require.Equal(t, tc.expect, rv.Elem().Interface())
 		})
 	}
 }


### PR DESCRIPTION
`discovery_target_decode` decodes a target list in the style of Prometheus HTTP or file service discovery into a list of `discovery.*`-compatible targets.

Because there currently aren't any `discovery.file` or `discovery.http` components, `discovery_target_decode` acts as a replacement so that `local.file` or `remote.http` (#2495) can be used. This also enables HTTP SD-formatted files to be sourced from `remote.s3`.

Related to #2270.