### PR TITLE
Flow UI: skip over config nodes in the DAG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ Main (unreleased)
 - Fix issue where whitespace was being sent as part of password when using a
   password file for `redis_exporter`. (@spartan0x117)
 
+- Flow UI: Fix issue where a configuration block referencing a component would
+  cause the graph page to fail to load. (@rfratto)
+
 v0.29.0 (2022-11-08)
 --------------------
 

--- a/pkg/flow/flow.go
+++ b/pkg/flow/flow.go
@@ -265,6 +265,18 @@ func newFromNode(cn *controller.ComponentNode, edges []dag.Edge) *ComponentInfo 
 	references := make([]string, 0)
 	referencedBy := make([]string, 0)
 	for _, e := range edges {
+		// Skip over any edge which isn't between two component nodes. This is a
+		// temporary workaround needed until there's the conept of configuration
+		// blocks from the API.
+		//
+		// Without this change, the graph fails to render when a configuration
+		// block is referenced in the graph.
+		//
+		// TODO(rfratto): add support for config block nodes in the API and UI.
+		if !isComponentNode(e.From) || !isComponentNode(e.To) {
+			continue
+		}
+
 		if e.From.NodeID() == cn.NodeID() {
 			references = append(references, e.To.NodeID())
 		} else if e.To.NodeID() == cn.NodeID() {
@@ -286,6 +298,11 @@ func newFromNode(cn *controller.ComponentNode, edges []dag.Edge) *ComponentInfo 
 		},
 	}
 	return ci
+}
+
+func isComponentNode(n dag.Node) bool {
+	_, ok := n.(*controller.ComponentNode)
+	return ok
 }
 
 // ComponentInfo represents a component in flow.


### PR DESCRIPTION
If a config node appeared in the references list for a given node, the graph page would fail to load because a reference to a non-existant node would be defined.

This temporarily works around the issue by skipping over DAG edges to a config node.

A longer term fix would be to add support for config blocks in the UI so users can see how they evaluated.

This is behavior which can be observed from v0.29.0, but I'm not sure if it warrants a patch release.