### PR TITLE
Add relabel metrics and fanout

### DIFF
--- a/component/otelcol/exporter/prometheus/prometheus.go
+++ b/component/otelcol/exporter/prometheus/prometheus.go
@@ -78,7 +78,7 @@ var _ component.Component = (*Component)(nil)
 
 // New creates a new otelcol.exporter.prometheus component.
 func New(o component.Options, c Arguments) (*Component, error) {
-	fanout := prometheus.NewFanout(nil, o.ID)
+	fanout := prometheus.NewFanout(nil, o.ID, o.Registerer)
 
 	converter := convert.New(o.Logger, fanout, convert.Options{
 		IncludeTargetInfo: true,

--- a/component/prometheus/fanout.go
+++ b/component/prometheus/fanout.go
@@ -34,7 +34,7 @@ type Fanout struct {
 func NewFanout(children []storage.Appendable, componentID string, register prometheus.Registerer) *Fanout {
 	wl := prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name: "agent_prometheus_fanout_latency",
-		Help: "Write latency writing to direct and indirect components",
+		Help: "Write latency for sending to direct and indirect components",
 	})
 	_ = register.Register(wl)
 	return &Fanout{

--- a/component/prometheus/fanout.go
+++ b/component/prometheus/fanout.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/hashicorp/go-multierror"
 
@@ -23,14 +26,21 @@ type Fanout struct {
 	// children is where to fan out.
 	children []storage.Appendable
 	// ComponentID is what component this belongs to.
-	componentID string
+	componentID  string
+	writeLatency prometheus.Histogram
 }
 
 // NewFanout creates a fanout appendable.
-func NewFanout(children []storage.Appendable, componentID string) *Fanout {
+func NewFanout(children []storage.Appendable, componentID string, register prometheus.Registerer) *Fanout {
+	wl := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "agent_prometheus_fanout_latency",
+		Help: "Write latency for fanout to write to child tree",
+	})
+	_ = register.Register(wl)
 	return &Fanout{
-		children:    children,
-		componentID: componentID,
+		children:     children,
+		componentID:  componentID,
+		writeLatency: wl,
 	}
 }
 
@@ -55,8 +65,9 @@ func (f *Fanout) Appender(ctx context.Context) storage.Appender {
 	ctx = scrape.ContextWithMetricMetadataStore(ctx, NoopMetadataStore{})
 
 	app := &appender{
-		children:    make([]storage.Appender, 0),
-		componentID: f.componentID,
+		children:     make([]storage.Appender, 0),
+		componentID:  f.componentID,
+		writeLatency: f.writeLatency,
 	}
 	for _, x := range f.children {
 		if x == nil {
@@ -70,12 +81,17 @@ func (f *Fanout) Appender(ctx context.Context) storage.Appender {
 var _ storage.Appender = (*appender)(nil)
 
 type appender struct {
-	children    []storage.Appender
-	componentID string
+	children     []storage.Appender
+	componentID  string
+	writeLatency prometheus.Histogram
+	start        time.Time
 }
 
 // Append satisfies the Appender interface.
 func (a *appender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v float64) (storage.SeriesRef, error) {
+	if a.start.IsZero() {
+		a.start = time.Now()
+	}
 	if ref == 0 {
 		ref = storage.SeriesRef(GlobalRefMapping.GetOrAddGlobalRefID(l))
 	}
@@ -91,6 +107,13 @@ func (a *appender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v flo
 
 // Commit satisfies the Appender interface.
 func (a *appender) Commit() error {
+	defer func() {
+		if a.start.IsZero() {
+			return
+		}
+		duration := time.Since(a.start)
+		a.writeLatency.Observe(duration.Seconds())
+	}()
 	var multiErr error
 	for _, x := range a.children {
 		err := x.Commit()
@@ -103,6 +126,13 @@ func (a *appender) Commit() error {
 
 // Rollback satisifies the Appender interface.
 func (a *appender) Rollback() error {
+	defer func() {
+		if a.start.IsZero() {
+			return
+		}
+		duration := time.Since(a.start)
+		a.writeLatency.Observe(duration.Seconds())
+	}()
 	var multiErr error
 	for _, x := range a.children {
 		err := x.Rollback()

--- a/component/prometheus/fanout.go
+++ b/component/prometheus/fanout.go
@@ -34,7 +34,7 @@ type Fanout struct {
 func NewFanout(children []storage.Appendable, componentID string, register prometheus.Registerer) *Fanout {
 	wl := prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name: "agent_prometheus_fanout_latency",
-		Help: "Write latency for fanout to write to child tree",
+		Help: "Write latency writing to direct and indirect components",
 	})
 	_ = register.Register(wl)
 	return &Fanout{

--- a/component/prometheus/fanout_test.go
+++ b/component/prometheus/fanout_test.go
@@ -3,6 +3,8 @@ package prometheus
 import (
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/prometheus/prometheus/storage"
 
 	"github.com/stretchr/testify/require"
@@ -10,14 +12,14 @@ import (
 )
 
 func TestRollback(t *testing.T) {
-	fanout := NewFanout([]storage.Appendable{NewFanout(nil, "1")}, "")
+	fanout := NewFanout([]storage.Appendable{NewFanout(nil, "1", prometheus.DefaultRegisterer)}, "", prometheus.DefaultRegisterer)
 	app := fanout.Appender(context.Background())
 	err := app.Rollback()
 	require.NoError(t, err)
 }
 
 func TestCommit(t *testing.T) {
-	fanout := NewFanout([]storage.Appendable{NewFanout(nil, "1")}, "")
+	fanout := NewFanout([]storage.Appendable{NewFanout(nil, "1", prometheus.DefaultRegisterer)}, "", prometheus.DefaultRegisterer)
 	app := fanout.Appender(context.Background())
 	err := app.Commit()
 	require.NoError(t, err)

--- a/component/prometheus/relabel/relabel.go
+++ b/component/prometheus/relabel/relabel.go
@@ -90,25 +90,12 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		Help: "Total size of relabel cache",
 	})
 
-	err := o.Registerer.Register(c.metricsProcessed)
-	if err != nil {
-		return nil, err
-	}
-	err = o.Registerer.Register(c.metricsOutgoing)
-	if err != nil {
-		return nil, err
-	}
-	err = o.Registerer.Register(c.cacheHits)
-	if err != nil {
-		return nil, err
-	}
-	err = o.Registerer.Register(c.cacheMisses)
-	if err != nil {
-		return nil, err
-	}
-	err = o.Registerer.Register(c.cacheSize)
-	if err != nil {
-		return nil, err
+	var err error
+	for _, metric := range []prometheus_client.Collector{c.metricsProcessed, c.metricsOutgoing, c.cacheMisses, c.cacheHits, c.cacheSize} {
+		err = o.Registerer.Register(metric)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	c.fanout = prometheus.NewFanout(args.ForwardTo, o.ID, o.Registerer)

--- a/component/prometheus/relabel/relabel.go
+++ b/component/prometheus/relabel/relabel.go
@@ -78,7 +78,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		Help: "Total number of metrics written",
 	})
 	c.cacheMisses = prometheus_client.NewCounter(prometheus_client.CounterOpts{
-		Name: "agent_prometheus_relabel_metrics_misses",
+		Name: "agent_prometheus_relabel_cache_misses",
 		Help: "Total number of cache misses",
 	})
 	c.cacheHits = prometheus_client.NewCounter(prometheus_client.CounterOpts{

--- a/component/prometheus/scrape/scrape.go
+++ b/component/prometheus/scrape/scrape.go
@@ -119,7 +119,7 @@ var (
 
 // New creates a new prometheus.scrape component.
 func New(o component.Options, args Arguments) (*Component, error) {
-	flowAppendable := prometheus.NewFanout(args.ForwardTo, o.ID)
+	flowAppendable := prometheus.NewFanout(args.ForwardTo, o.ID, o.Registerer)
 	scrapeOptions := &scrape.Options{ExtraMetrics: args.ExtraMetrics}
 	scraper := scrape.NewManager(scrapeOptions, o.Logger, flowAppendable)
 	c := &Component{

--- a/docs/sources/flow/reference/components/prometheus.relabel.md
+++ b/docs/sources/flow/reference/components/prometheus.relabel.md
@@ -91,7 +91,7 @@ values.
 * `agent_prometheus_relabel_cache_misses` (counter): Total number of cache misses.
 * `agent_prometheus_relabel_cache_hits` (counter): Total number of cache hits.
 * `agent_prometheus_relabel_cache_size` (gauge): Total size of relabel cache.
-* `agent_prometheus_fanout_latency` (histogram): Write latency for fanout to write to child tree.
+* `agent_prometheus_fanout_latency` (histogram): Write latency for sending to direct and indirect components.
 
 ## Example
 

--- a/docs/sources/flow/reference/components/prometheus.relabel.md
+++ b/docs/sources/flow/reference/components/prometheus.relabel.md
@@ -85,7 +85,13 @@ values.
 
 ## Debug metrics
 
-`prometheus.relabel` does not expose any component-specific debug metrics.
+
+* `agent_prometheus_relabel_metrics_processed` (counter): Total number of metrics processed.
+* `agent_prometheus_relabel_metrics_written` (counter): Total number of metrics written.
+* `agent_prometheus_relabel_cache_misses` (counter): Total number of cache misses.
+* `agent_prometheus_relabel_cache_hits` (counter): Total number of cache hits.
+* `agent_prometheus_relabel_cache_size` (gauge): Total size of relabel cache.
+* `agent_prometheus_fanout_latency` (histogram): Write latency for fanout to write to child tree.
 
 ## Example
 

--- a/docs/sources/flow/reference/components/prometheus.scrape.md
+++ b/docs/sources/flow/reference/components/prometheus.scrape.md
@@ -118,7 +118,7 @@ scrape job on the component's debug endpoint.
 
 ## Debug metrics
 
-* `agent_prometheus_fanout_latency` (histogram): Write latency for fanout to write to child tree.
+* `agent_prometheus_fanout_latency` (histogram): Write latency for sending to direct and indirect components.
 
 ## Scraping behavior
 

--- a/docs/sources/flow/reference/components/prometheus.scrape.md
+++ b/docs/sources/flow/reference/components/prometheus.scrape.md
@@ -118,9 +118,10 @@ scrape job on the component's debug endpoint.
 
 ## Debug metrics
 
-`prometheus.scrape` does not expose any component-specific debug metrics.
+* `agent_prometheus_fanout_latency` (histogram): Write latency for fanout to write to child tree.
 
 ## Scraping behavior
+
 The `prometheus.scrape` component borrows the scraping behavior of Prometheus.
 Prometheus, and by extent this component, uses a pull model for scraping
 metrics from a given set of _targets_.


### PR DESCRIPTION
#### PR Description

Add metrics on relabeling and fanout. Fanout will appear on anything using the fanout appended so added that metric to the individual component doc metrics. 

#### Which issue(s) this PR fixes

Closes #2408

#### Notes to the Reviewer

Moved the write latency to the fanout appender to track how long a total transaction takes. 
