### PR TITLE
flow/internal/controller: Trace graph evaluations

### DIFF
--- a/cmd/agent/example-config.river
+++ b/cmd/agent/example-config.river
@@ -7,7 +7,8 @@ logging {
 }
 
 tracing {
-	sampling_fraction = 0.1
+	// Sample all traces. This value should be lower for production configs!
+	sampling_fraction = 1
 
 	write_to = [otelcol.exporter.otlp.tempo.input]
 }
@@ -33,8 +34,4 @@ prometheus.remote_write "default" {
 	endpoint {
 		url = "http://localhost:9009/api/prom/push"
 	}
-}
-
-remote.http "example" {
-	url = "http://localhost:12345/metrics"
 }

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -118,6 +118,8 @@ func (l *Loader) Apply(parentScope *vm.Scope, blocks []*ast.BlockStmt, configBlo
 	logger := log.With(l.log, "trace_id", span.SpanContext().TraceID())
 	level.Info(logger).Log("msg", "starting complete graph evaluation")
 	defer func() {
+		span.SetStatus(codes.Ok, "")
+
 		duration := time.Since(start)
 		level.Info(logger).Log("msg", "finished complete graph evaluation", "duration", duration)
 		l.cm.componentEvaluationTime.Observe(duration.Seconds())
@@ -313,6 +315,8 @@ func (l *Loader) EvaluateDependencies(parentScope *vm.Scope, c *ComponentNode) {
 	logger := log.With(l.log, "trace_id", span.SpanContext().TraceID())
 	level.Info(logger).Log("msg", "starting partial graph evaluation")
 	defer func() {
+		span.SetStatus(codes.Ok, "")
+
 		duration := time.Since(start)
 		level.Info(logger).Log("msg", "finished partial graph evaluation", "duration", duration)
 		l.cm.componentEvaluationTime.Observe(duration.Seconds())

--- a/pkg/flow/internal/controller/loader_test.go
+++ b/pkg/flow/internal/controller/loader_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/agent/pkg/river/parser"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestLoader(t *testing.T) {
@@ -52,6 +53,7 @@ func TestLoader(t *testing.T) {
 	newGlobals := func() controller.ComponentGlobals {
 		return controller.ComponentGlobals{
 			Logger:          log.NewNopLogger(),
+			TraceProvider:   trace.NewNoopTracerProvider(),
 			DataPath:        t.TempDir(),
 			OnExportsChange: func(cn *controller.ComponentNode) { /* no-op */ },
 			Registerer:      prometheus.NewRegistry(),
@@ -192,6 +194,7 @@ func TestScopeWithFailingComponent(t *testing.T) {
 	newGlobals := func() controller.ComponentGlobals {
 		return controller.ComponentGlobals{
 			Logger:          log.NewNopLogger(),
+			TraceProvider:   trace.NewNoopTracerProvider(),
 			DataPath:        t.TempDir(),
 			OnExportsChange: func(cn *controller.ComponentNode) { /* no-op */ },
 			Registerer:      prometheus.NewRegistry(),


### PR DESCRIPTION
This PR adds traces to graph evaluations:

![image](https://user-images.githubusercontent.com/630212/201167978-f70bc2a4-3110-439c-8a93-7e172497d347.png)

A log line is emitted whenever a partial or full graph evaluation starts including the trace id to assist in finding traces from logs. 