### PR TITLE
Remove call to 'make generate-ui' in agentctl's FreeBSD target

### DIFF
--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -146,7 +146,7 @@ dist/agentctl-windows-amd64.exe:
 dist/agentctl-freebsd-amd64: GO_TAGS += builtinassets
 dist/agentctl-freebsd-amd64: GOOS    := freebsd
 dist/agentctl-freebsd-amd64: GOARCH  := amd64
-dist/agentctl-freebsd-amd64: generate-ui
+dist/agentctl-freebsd-amd64:
 	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
 
 #


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
When I added the FreeBSD/AMD64 targets in tools/make/packaging.mk, I accidentally included a call to `make generate-ui` when building the agentctl binary. This is not required and will increase the binary size for no reason, so this PR is removing the call.

#### Which issue(s) this PR fixes
No issue filed

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
