### PR TITLE
discovery.docker: new component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Main (unreleased)
   - `remote.http` polls an HTTP URL and exposes the response body as a string
     or secret to other components. (@rfratto)
 
+  - `discovery.docker` discovers Docker containers from a Docker Engine host.
+    (@rfratto)
+
 ### Enhancements
 
 - Update OpenTelemetry Collector dependency to v0.63.1. (@tpaschalis)

--- a/component/all/all.go
+++ b/component/all/all.go
@@ -2,6 +2,7 @@
 package all
 
 import (
+	_ "github.com/grafana/agent/component/discovery/docker"                     // Import discovery.docker
 	_ "github.com/grafana/agent/component/discovery/kubernetes"                 // Import discovery.kubernetes
 	_ "github.com/grafana/agent/component/discovery/relabel"                    // Import discovery.relabel
 	_ "github.com/grafana/agent/component/local/file"                           // Import local.file

--- a/component/discovery/discovery.go
+++ b/component/discovery/discovery.go
@@ -24,7 +24,7 @@ type Exports struct {
 type Discoverer discovery.Discoverer
 
 // Creator is a function provided by an implementation to create a concrete Discoverer instance.
-type Creator func(component.Arguments, component.Options) (Discoverer, error)
+type Creator func(component.Arguments) (Discoverer, error)
 
 // Component is a reusable component for any discovery implementation.
 // it will handle dynamic updates and exporting targets appropriately for a scrape implementation.
@@ -78,7 +78,7 @@ func (c *Component) Run(ctx context.Context) error {
 
 // Update implements component.Compnoent.
 func (c *Component) Update(args component.Arguments) error {
-	disc, err := c.creator(args, c.opts)
+	disc, err := c.creator(args)
 	if err != nil {
 		return err
 	}

--- a/component/discovery/docker/docker.go
+++ b/component/discovery/docker/docker.go
@@ -1,0 +1,112 @@
+// Package docker implements the discovery.docker component.
+package docker
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/common/config"
+	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/discovery/moby"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:    "discovery.docker",
+		Args:    Arguments{},
+		Exports: discovery.Exports{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			return New(opts, args.(Arguments))
+		},
+	})
+}
+
+// Arguments configures the discovery.docker component.
+type Arguments struct {
+	Host               string                  `river:"host,attr"`
+	Port               int                     `river:"port,attr,optional"`
+	HostNetworkingHost string                  `river:"host_networking_host,attr,optional"`
+	RefreshInterval    time.Duration           `river:"refresh_interval,attr,optional"`
+	Filters            []Filter                `river:"filter,block,optional"`
+	HTTPClientConfig   config.HTTPClientConfig `river:"http_client_config,block,optional"`
+}
+
+// Filter is used to limit the discovery process to a subset of available
+// resources.
+type Filter struct {
+	Name   string   `river:"name,attr"`
+	Values []string `river:"values,attr"`
+}
+
+// Convert converts a Filter to the upstream Prometheus SD type.
+func (f Filter) Convert() moby.Filter {
+	return moby.Filter{
+		Name:   f.Name,
+		Values: f.Values,
+	}
+}
+
+// DefaultArguments holds default values for Arguments.
+var DefaultArguments = Arguments{
+	Port:               80,
+	HostNetworkingHost: "localhost",
+	RefreshInterval:    time.Minute,
+	HTTPClientConfig:   config.DefaultHTTPClientConfig,
+}
+
+var _ river.Unmarshaler = (*Arguments)(nil)
+
+// UnmarshalRiver implements river.Unmarshaler, applying defaults and
+// validating the provided config.
+func (args *Arguments) UnmarshalRiver(f func(interface{}) error) error {
+	*args = DefaultArguments
+
+	type arguments Arguments
+	if err := f((*arguments)(args)); err != nil {
+		return err
+	}
+
+	if args.Host == "" {
+		return fmt.Errorf("host attribute must not be empty")
+	} else if _, err := url.Parse(args.Host); err != nil {
+		return fmt.Errorf("parsing host attribute: %w", err)
+	}
+
+	if args.RefreshInterval <= 0 {
+		return fmt.Errorf("refresh_interval must be greater than 0")
+	}
+
+	return args.HTTPClientConfig.Validate()
+}
+
+// Convert converts Arguments to the upstream Prometheus SD type.
+func (args Arguments) Convert() moby.DockerSDConfig {
+	filters := make([]moby.Filter, len(args.Filters))
+	for i, filter := range args.Filters {
+		filters[i] = filter.Convert()
+	}
+
+	return moby.DockerSDConfig{
+		HTTPClientConfig: *args.HTTPClientConfig.Convert(),
+
+		Host:               args.Host,
+		Port:               args.Port,
+		Filters:            filters,
+		HostNetworkingHost: args.HostNetworkingHost,
+
+		RefreshInterval: model.Duration(args.RefreshInterval),
+	}
+}
+
+// New returns a new instance of a discovery.docker component.
+func New(opts component.Options, args Arguments) (component.Component, error) {
+	return discovery.New(opts, args, func(args component.Arguments) (discovery.Discoverer, error) {
+		conf := args.(Arguments).Convert()
+		return moby.NewDockerDiscovery(&conf, opts.Logger)
+	})
+}

--- a/docs/sources/flow/reference/components/discovery.docker.md
+++ b/docs/sources/flow/reference/components/discovery.docker.md
@@ -1,0 +1,167 @@
+---
+aliases:
+- /docs/agent/latest/flow/reference/components/discovery.docker
+title: discovery.docker
+---
+
+# discovery.docker
+
+`discovery.docker` discovers [Docker Engine][] containers and exposes them as targets.
+
+[Docker Engine]: https://docs.docker.com/engine/
+
+## Usage
+
+```river
+discovery.docker "LABEL" {
+  host = "DOCKER_ENGINE_HOST"
+}
+```
+
+## Arguments
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`host` | `string` | Address of the Docker Daemon to connect to. | | yes
+`port` | `number` | Default port to collect metrics from when a port mapping isn't defined. | `80` | no
+`host_networking_host` | `string` | Host to use if the container is in host networking mode. | `"localhost"` | no
+`refresh_interval` | `duration` | Frequency to refresh list of containers. | `"1m"` | no
+
+## Blocks
+
+The following blocks are supported inside the definition of
+`discovery.docker`:
+
+Hierarchy | Block | Description | Required
+--------- | ----- | ----------- | --------
+filter | [filter][] | Filters discoverable resources. | no
+http_client_config | [http_client_config][] | HTTP client configuration for docker requests. | no
+http_client_config > basic_auth | [basic_auth][] | Configure basic_auth for authenticating to the endpoint. | no
+http_client_config > authorization | [authorization][] | Configure generic authorization to the endpoint. | no
+http_client_config > oauth2 | [oauth2][] | Configure OAuth2 for authenticating to the endpoint. | no
+http_client_config > oauth2 > tls_config | [tls_config][] | Configure TLS settings for connecting to the endpoint. | no
+
+The `>` symbol indicates deeper levels of nesting. For example,
+`http_client_config > basic_auth` refers to a `basic_auth` block defined inside
+an `http_client_config` block.
+
+[filter]: #filter-block
+[http_client_config]: #http_client_config-block
+[basic_auth]: #basic_auth-block
+[authorization]: #authorization-block
+[oauth2]: #oauth2-block
+[tls_config]: #tls_config-block
+
+### filter block
+
+The `filter` block configures a filter to pass to the Docker Engine to limit
+the amount of containers returned. The `filter` block can be specified multiple
+times to provide more than one filter.
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`name` | `string` | Filter name to use. | | yes
+`values` | `list(string)` | Values to pass to the filter. | | yes
+
+Refer to [List containers][List containers] from the Docker Engine API
+documentation for the list of supported filters and their meaning.
+
+[List containers]: https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerList
+
+### http_client_config block
+
+The `http_client_config` block configures settings used to connect to the
+Docker Engine API server.
+
+{{< docs/shared lookup="flow/reference/components/http-client-config-block.md" source="agent" >}}
+
+### basic_auth block
+
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+
+### authorization block
+
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+
+### oauth2 block
+
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+
+### tls_config block
+
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+Name | Type | Description
+---- | ---- | -----------
+`targets` | `list(map(string))` | The set of targets discovered from the docker API.
+
+Each target includes the following labels:
+
+* `__meta_docker_container_id`: ID of the container.
+* `__meta_docker_container_name`: Name of the container.
+* `__meta_docker_container_network_mode`: Network mode of the container.
+* `__meta_docker_container_label_<labelname>`: Each label from the container.
+* `__meta_docker_network_id`: ID of the Docker network the container is in.
+* `__meta_docker_network_name`: Name of the Docker network the container is in.
+* `__meta_docker_network_ingress`: Set to `true` if the Docker network the is
+  an ingress network.
+* `__meta_docker_network_internal`: Set to `true` if the Docker network is an
+  internal network.
+* `__meta_docker_network_label_<labelname>`: Each label from the network the
+  container is in.
+* `__meta_docker_network_scope`: The scope of the network the container is in.
+* `__meta_docker_network_ip`: The IP of the container in the network.
+* `__meta_docker_port_private`: The private port on the container.
+* `__meta_docker_port_public`: The publicly exposed port from the container,
+  if a port mapping exists.
+* `__meta_docker_port_public_ip`: The public IP of the container, if a port
+  mapping exists.
+
+Each discovered container maps into one target per each Docker network it
+belongs to and per each defined port mapping the container has.
+
+## Component health
+
+`discovery.docker` is only reported as unhealthy when given an invalid
+configuration. In those cases, exported fields retain their last healthy
+values.
+
+## Debug information
+
+`discovery.docker` does not expose any component-specific debug information.
+
+### Debug metrics
+
+`discovery.docker` does not expose any component-specific debug metrics.
+
+## Examples
+
+### Linux or macOS hosts
+
+This example discovers Docker containers when the host machine is macOS or
+Linux:
+
+```river
+discovery.docker "containers" {
+  host = "unix:///var/run/docker.sock"
+}
+```
+
+### Windows hosts
+
+This example discovers Docker containers when the host machine is Windows:
+
+```river
+discovery.docker "containers" {
+  host = "tcp://localhost:2375"
+}
+```
+
+> **NOTE**: This example requires the "Expose daemon on tcp://localhost:2375
+> without TLS" setting to be enabled in the Docker Engine settings.

--- a/docs/sources/flow/reference/components/discovery.docker.md
+++ b/docs/sources/flow/reference/components/discovery.docker.md
@@ -25,7 +25,7 @@ The following arguments are supported:
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `host` | `string` | Address of the Docker Daemon to connect to. | | yes
-`port` | `number` | Default port to collect metrics from when a port mapping isn't defined. | `80` | no
+`port` | `number` | Port to use for collecting metrics when containers don't have any port mappings. | `80` | no
 `host_networking_host` | `string` | Host to use if the container is in host networking mode. | `"localhost"` | no
 `refresh_interval` | `duration` | Frequency to refresh list of containers. | `"1m"` | no
 
@@ -109,8 +109,8 @@ Each target includes the following labels:
 * `__meta_docker_container_label_<labelname>`: Each label from the container.
 * `__meta_docker_network_id`: ID of the Docker network the container is in.
 * `__meta_docker_network_name`: Name of the Docker network the container is in.
-* `__meta_docker_network_ingress`: Set to `true` if the Docker network the is
-  an ingress network.
+* `__meta_docker_network_ingress`: Set to `true` if the Docker network is an
+  ingress network.
 * `__meta_docker_network_internal`: Set to `true` if the Docker network is an
   internal network.
 * `__meta_docker_network_label_<labelname>`: Each label from the network the
@@ -123,8 +123,8 @@ Each target includes the following labels:
 * `__meta_docker_port_public_ip`: The public IP of the container, if a port
   mapping exists.
 
-Each discovered container maps into one target per each Docker network it
-belongs to and per each defined port mapping the container has.
+Each discovered container maps to one target per unique combination of networks
+and port mappings used by the container.
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/discovery.kubernetes.md
+++ b/docs/sources/flow/reference/components/discovery.kubernetes.md
@@ -320,7 +320,7 @@ Name | Type | Description
 
 ## Component health
 
-`discovery.kubernetes` is only be reported as unhealthy when given an invalid
+`discovery.kubernetes` is reported as unhealthy when given an invalid
 configuration. In those cases, exported fields retain their last healthy
 values.
 


### PR DESCRIPTION
Introduce a `discovery.docker` component which polls a Docker Engine host for a list of containers on a set interval.

Closes #2263.