### PR TITLE
Support exemplars in Prometheus component pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ Main (unreleased)
 
 - Add support for using a [password map file](https://github.com/oliver006/redis_exporter/blob/master/contrib/sample-pwd-file.json) in `redis_exporter`. (@spartan0x117)
 
+- Flow: Add support for exemplars in Prometheus component pipelines. (@rfratto)
+
 ### Bugfixes
 
 - Fix issue where whitespace was being sent as part of password when using a

--- a/component/otelcol/exporter/prometheus/internal/convert/convert.go
+++ b/component/otelcol/exporter/prometheus/internal/convert/convert.go
@@ -9,7 +9,6 @@ package convert
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -17,7 +16,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	fp "github.com/grafana/agent/component/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/metadata"
@@ -130,9 +128,7 @@ func (conv *Converter) consumeResourceMetrics(app storage.Appender, rm pmetric.R
 
 	if conv.getOpts().IncludeTargetInfo {
 		if err := resourceMD.WriteTo(app, time.Now()); err != nil {
-			if !errors.Is(err, fp.ErrMetadataNotSupported) {
-				level.Warn(conv.log).Log("msg", "failed to write target_info metadata", "err", err)
-			}
+			level.Warn(conv.log).Log("msg", "failed to write target_info metadata", "err", err)
 		}
 		if err := memResource.WriteTo(app, time.Now()); err != nil {
 			level.Error(conv.log).Log("msg", "failed to write target_info metric", "err", err)
@@ -222,9 +218,7 @@ func (conv *Converter) consumeScopeMetrics(app storage.Appender, memResource *me
 
 	if conv.getOpts().IncludeScopeInfo {
 		if err := scopeMD.WriteTo(app, time.Now()); err != nil {
-			if !errors.Is(err, fp.ErrMetadataNotSupported) {
-				level.Warn(conv.log).Log("msg", "failed to write otel_scope_info metadata", "err", err)
-			}
+			level.Warn(conv.log).Log("msg", "failed to write otel_scope_info metadata", "err", err)
 		}
 		if err := memScope.WriteTo(app, time.Now()); err != nil {
 			level.Error(conv.log).Log("msg", "failed to write otel_scope_info metric", "err", err)
@@ -291,9 +285,7 @@ func (conv *Converter) consumeGauge(app storage.Appender, memResource *memorySer
 		Help: m.Description(),
 	})
 	if err := metricMD.WriteTo(app, time.Now()); err != nil {
-		if !errors.Is(err, fp.ErrMetadataNotSupported) {
-			level.Warn(conv.log).Log("msg", "failed to write metric family metadata", "err", err)
-		}
+		level.Warn(conv.log).Log("msg", "failed to write metric family metadata", "err", err)
 	}
 
 	for dpcount := 0; dpcount < m.Gauge().DataPoints().Len(); dpcount++ {
@@ -409,9 +401,7 @@ func (conv *Converter) consumeSum(app storage.Appender, memResource *memorySerie
 		Help: m.Description(),
 	})
 	if err := metricMD.WriteTo(app, time.Now()); err != nil {
-		if !errors.Is(err, fp.ErrMetadataNotSupported) {
-			level.Warn(conv.log).Log("msg", "failed to write metric family metadata", "err", err)
-		}
+		level.Warn(conv.log).Log("msg", "failed to write metric family metadata", "err", err)
 	}
 
 	for dpcount := 0; dpcount < m.Sum().DataPoints().Len(); dpcount++ {
@@ -442,9 +432,7 @@ func (conv *Converter) consumeHistogram(app storage.Appender, memResource *memor
 		Help: m.Description(),
 	})
 	if err := metricMD.WriteTo(app, time.Now()); err != nil {
-		if !errors.Is(err, fp.ErrMetadataNotSupported) {
-			level.Warn(conv.log).Log("msg", "failed to write metric family metadata", "err", err)
-		}
+		level.Warn(conv.log).Log("msg", "failed to write metric family metadata", "err", err)
 	}
 
 	for dpcount := 0; dpcount < m.Histogram().DataPoints().Len(); dpcount++ {
@@ -516,9 +504,7 @@ func (conv *Converter) consumeSummary(app storage.Appender, memResource *memoryS
 		Help: m.Description(),
 	})
 	if err := metricMD.WriteTo(app, time.Now()); err != nil {
-		if !errors.Is(err, fp.ErrMetadataNotSupported) {
-			level.Warn(conv.log).Log("msg", "failed to write metric family metadata", "err", err)
-		}
+		level.Warn(conv.log).Log("msg", "failed to write metric family metadata", "err", err)
 	}
 
 	for dpcount := 0; dpcount < m.Summary().DataPoints().Len(); dpcount++ {

--- a/component/prometheus/interceptor.go
+++ b/component/prometheus/interceptor.go
@@ -2,8 +2,6 @@ package prometheus
 
 import (
 	"context"
-	"fmt"
-	"sync"
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
@@ -11,72 +9,48 @@ import (
 	"github.com/prometheus/prometheus/storage"
 )
 
-// Intercept func allows interceptor owners to inject custom behavior.
-type Intercept func(ref storage.SeriesRef, l labels.Labels, t int64, v float64, next storage.Appender) (storage.SeriesRef, error)
-
-// Interceptor supports the concept of an appendable/appender that you can add a func to be called before
-// the values are sent to the child appendable/append.
+// Interceptor is a storage.Appendable which invokes callback functions upon
+// getting data. Interceptor should not be modified once created. All callback
+// fields are optional.
 type Interceptor struct {
-	mut sync.RWMutex
-	// intercept allows one to intercept the series before it fans out to make any changes. If labels.Labels returns nil the series is not propagated.
-	// Intercept shouuld be thread safe and can be called across appenders.
-	intercept Intercept
-	// next is where to send the next command.
-	next storage.Appendable
+	OnAppend         func(ref storage.SeriesRef, l labels.Labels, t int64, v float64, next storage.Appender) (storage.SeriesRef, error)
+	OnAppendExemplar func(ref storage.SeriesRef, l labels.Labels, e exemplar.Exemplar, next storage.Appender) (storage.SeriesRef, error)
+	OnUpdateMetadata func(ref storage.SeriesRef, l labels.Labels, m metadata.Metadata, next storage.Appender) (storage.SeriesRef, error)
 
-	// ComponentID is what component this belongs to.
-	componentID string
+	// Next is the next appendable to pass in the chain.
+	Next storage.Appendable
 }
 
-// NewInterceptor creates a interceptor appendable.
-func NewInterceptor(inter Intercept, next storage.Appendable, componentID string) (*Interceptor, error) {
-	if inter == nil {
-		return nil, fmt.Errorf("intercept cannot be null for component %s", componentID)
-	}
-	return &Interceptor{
-		intercept:   inter,
-		next:        next,
-		componentID: componentID,
-	}, nil
-}
-
-// UpdateChild allows changing of the child of the interceptor.
-func (f *Interceptor) UpdateChild(child storage.Appendable) {
-	f.mut.Lock()
-	defer f.mut.Unlock()
-
-	f.next = child
-}
+var _ storage.Appendable = (*Interceptor)(nil)
 
 // Appender satisfies the Appendable interface.
 func (f *Interceptor) Appender(ctx context.Context) storage.Appender {
-	f.mut.RLock()
-	defer f.mut.RUnlock()
-
 	app := &interceptappender{
-		intercept:   f.intercept,
-		componentID: f.componentID,
+		interceptor: f,
 	}
-	if f.next != nil {
-		app.child = f.next.Appender(ctx)
+	if f.Next != nil {
+		app.child = f.Next.Appender(ctx)
 	}
 	return app
 }
 
-var _ storage.Appender = (*appender)(nil)
-
 type interceptappender struct {
+	interceptor *Interceptor
 	child       storage.Appender
-	componentID string
-	intercept   Intercept
 }
+
+var _ storage.Appender = (*interceptappender)(nil)
 
 // Append satisfies the Appender interface.
 func (a *interceptappender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v float64) (storage.SeriesRef, error) {
 	if ref == 0 {
 		ref = storage.SeriesRef(GlobalRefMapping.GetOrAddGlobalRefID(l))
 	}
-	return a.intercept(ref, l, t, v, a.child)
+
+	if a.interceptor.OnAppend != nil {
+		return a.interceptor.OnAppend(ref, l, t, v, a.child)
+	}
+	return a.child.Append(ref, l, t, v)
 }
 
 // Commit satisfies the Appender interface.
@@ -102,7 +76,14 @@ func (a *interceptappender) AppendExemplar(
 	e exemplar.Exemplar,
 ) (storage.SeriesRef, error) {
 
-	return 0, fmt.Errorf("appendExemplar not supported yet")
+	if ref == 0 {
+		ref = storage.SeriesRef(GlobalRefMapping.GetOrAddGlobalRefID(l))
+	}
+
+	if a.interceptor.OnAppendExemplar != nil {
+		return a.interceptor.OnAppendExemplar(ref, l, e, a.child)
+	}
+	return a.child.AppendExemplar(ref, l, e)
 }
 
 // UpdateMetadata satisifies the Appender interface.
@@ -112,5 +93,12 @@ func (a *interceptappender) UpdateMetadata(
 	m metadata.Metadata,
 ) (storage.SeriesRef, error) {
 
-	return 0, fmt.Errorf("updateMetadata not supported yet")
+	if ref == 0 {
+		ref = storage.SeriesRef(GlobalRefMapping.GetOrAddGlobalRefID(l))
+	}
+
+	if a.interceptor.OnUpdateMetadata != nil {
+		return a.interceptor.OnUpdateMetadata(ref, l, m, a.child)
+	}
+	return a.child.UpdateMetadata(ref, l, m)
 }

--- a/component/prometheus/relabel/relabel_test.go
+++ b/component/prometheus/relabel/relabel_test.go
@@ -56,12 +56,10 @@ func TestUpdateReset(t *testing.T) {
 }
 
 func TestNil(t *testing.T) {
-	fanout := &prometheus.Interceptor{
-		OnAppend: func(ref storage.SeriesRef, _ labels.Labels, _ int64, _ float64, _ storage.Appender) (storage.SeriesRef, error) {
-			require.True(t, false)
-			return ref, nil
-		},
-	}
+	fanout := prometheus.NewInterceptor(nil, prometheus.WithAppendHook(func(ref storage.SeriesRef, _ labels.Labels, _ int64, _ float64, _ storage.Appender) (storage.SeriesRef, error) {
+		require.True(t, false)
+		return ref, nil
+	}))
 	relabeller, err := New(component.Options{
 		ID:     "1",
 		Logger: util.TestLogger(t),
@@ -88,12 +86,10 @@ func TestNil(t *testing.T) {
 func BenchmarkCache(b *testing.B) {
 	l := log.NewSyncLogger(log.NewLogfmtLogger(os.Stderr))
 
-	fanout := &prometheus.Interceptor{
-		OnAppend: func(ref storage.SeriesRef, l labels.Labels, _ int64, _ float64, _ storage.Appender) (storage.SeriesRef, error) {
-			require.True(b, l.Has("new_label"))
-			return ref, nil
-		},
-	}
+	fanout := prometheus.NewInterceptor(nil, prometheus.WithAppendHook(func(ref storage.SeriesRef, l labels.Labels, _ int64, _ float64, _ storage.Appender) (storage.SeriesRef, error) {
+		require.True(b, l.Has("new_label"))
+		return ref, nil
+	}))
 	var entry storage.Appendable
 	_, _ = New(component.Options{
 		ID:     "1",
@@ -126,12 +122,10 @@ func BenchmarkCache(b *testing.B) {
 }
 
 func generateRelabel(t *testing.T) *Component {
-	fanout := &prometheus.Interceptor{
-		OnAppend: func(ref storage.SeriesRef, l labels.Labels, _ int64, _ float64, _ storage.Appender) (storage.SeriesRef, error) {
-			require.True(t, l.Has("new_label"))
-			return ref, nil
-		},
-	}
+	fanout := prometheus.NewInterceptor(nil, prometheus.WithAppendHook(func(ref storage.SeriesRef, l labels.Labels, _ int64, _ float64, _ storage.Appender) (storage.SeriesRef, error) {
+		require.True(t, l.Has("new_label"))
+		return ref, nil
+	}))
 	relabeller, err := New(component.Options{
 		ID:     "1",
 		Logger: util.TestLogger(t),

--- a/component/prometheus/relabel/relabel_test.go
+++ b/component/prometheus/relabel/relabel_test.go
@@ -56,11 +56,12 @@ func TestUpdateReset(t *testing.T) {
 }
 
 func TestNil(t *testing.T) {
-	fanout, err := prometheus.NewInterceptor(func(ref storage.SeriesRef, l labels.Labels, tt int64, v float64, next storage.Appender) (storage.SeriesRef, error) {
-		require.True(t, false)
-		return ref, nil
-	}, nil, "1")
-	require.NoError(t, err)
+	fanout := &prometheus.Interceptor{
+		OnAppend: func(ref storage.SeriesRef, _ labels.Labels, _ int64, _ float64, _ storage.Appender) (storage.SeriesRef, error) {
+			require.True(t, false)
+			return ref, nil
+		},
+	}
 	relabeller, err := New(component.Options{
 		ID:     "1",
 		Logger: util.TestLogger(t),
@@ -87,11 +88,12 @@ func TestNil(t *testing.T) {
 func BenchmarkCache(b *testing.B) {
 	l := log.NewSyncLogger(log.NewLogfmtLogger(os.Stderr))
 
-	fanout, err := prometheus.NewInterceptor(func(ref storage.SeriesRef, l labels.Labels, tt int64, v float64, next storage.Appender) (storage.SeriesRef, error) {
-		require.True(b, l.Has("new_label"))
-		return ref, nil
-	}, nil, "1")
-	require.NoError(b, err)
+	fanout := &prometheus.Interceptor{
+		OnAppend: func(ref storage.SeriesRef, l labels.Labels, _ int64, _ float64, _ storage.Appender) (storage.SeriesRef, error) {
+			require.True(b, l.Has("new_label"))
+			return ref, nil
+		},
+	}
 	var entry storage.Appendable
 	_, _ = New(component.Options{
 		ID:     "1",
@@ -124,11 +126,12 @@ func BenchmarkCache(b *testing.B) {
 }
 
 func generateRelabel(t *testing.T) *Component {
-	fanout, err := prometheus.NewInterceptor(func(ref storage.SeriesRef, l labels.Labels, tt int64, v float64, next storage.Appender) (storage.SeriesRef, error) {
-		require.True(t, l.Has("new_label"))
-		return ref, nil
-	}, nil, "1")
-	require.NoError(t, err)
+	fanout := &prometheus.Interceptor{
+		OnAppend: func(ref storage.SeriesRef, l labels.Labels, _ int64, _ float64, _ storage.Appender) (storage.SeriesRef, error) {
+			require.True(t, l.Has("new_label"))
+			return ref, nil
+		},
+	}
 	relabeller, err := New(component.Options{
 		ID:     "1",
 		Logger: util.TestLogger(t),

--- a/component/prometheus/scrape/scrape_test.go
+++ b/component/prometheus/scrape/scrape_test.go
@@ -42,15 +42,13 @@ func TestForwardingToAppendable(t *testing.T) {
 	// Update the component with a mock receiver; it should be passed along to the Appendable.
 	var receivedTs int64
 	var receivedSamples labels.Labels
-	fanout, err := prometheus.NewInterceptor(
-		func(ref storage.SeriesRef, l labels.Labels, t int64, v float64, next storage.Appender) (storage.SeriesRef, error) {
+	fanout := &prometheus.Interceptor{
+		OnAppend: func(ref storage.SeriesRef, l labels.Labels, t int64, _ float64, _ storage.Appender) (storage.SeriesRef, error) {
 			receivedTs = t
 			receivedSamples = l
 			return ref, nil
 		},
-		nil,
-		"1",
-	)
+	}
 	require.NoError(t, err)
 	args.ForwardTo = []storage.Appendable{fanout}
 	err = s.Update(args)

--- a/component/prometheus/scrape/scrape_test.go
+++ b/component/prometheus/scrape/scrape_test.go
@@ -42,13 +42,11 @@ func TestForwardingToAppendable(t *testing.T) {
 	// Update the component with a mock receiver; it should be passed along to the Appendable.
 	var receivedTs int64
 	var receivedSamples labels.Labels
-	fanout := &prometheus.Interceptor{
-		OnAppend: func(ref storage.SeriesRef, l labels.Labels, t int64, _ float64, _ storage.Appender) (storage.SeriesRef, error) {
-			receivedTs = t
-			receivedSamples = l
-			return ref, nil
-		},
-	}
+	fanout := prometheus.NewInterceptor(nil, prometheus.WithAppendHook(func(ref storage.SeriesRef, l labels.Labels, t int64, _ float64, _ storage.Appender) (storage.SeriesRef, error) {
+		receivedTs = t
+		receivedSamples = l
+		return ref, nil
+	}))
 	require.NoError(t, err)
 	args.ForwardTo = []storage.Appendable{fanout}
 	err = s.Update(args)


### PR DESCRIPTION
This commit allows exemplars to be passed around in Prometheus component pipelines. To support this change, the prometheus.Interceptor struct was extended to support intercepting any call to the Appendable interface.

Support for metadata is also added, though that code path is currently not invoked in our usage of the Prometheus scraper.

Fixes #2420.