### PR TITLE
 Flow: add loki.relabel component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ Main (unreleased)
   - `loki.write` receives log entries from other `loki` components and sends
     them over to a Loki instance. (@tpaschalis)
 
+  - `loki.relabel` receives log entries from other `loki` components and
+    rewrites their label set. (@tpaschalis)
+
 ### Enhancements
 
 - Update OpenTelemetry Collector dependency to v0.63.1. (@tpaschalis)

--- a/component/all/all.go
+++ b/component/all/all.go
@@ -6,6 +6,7 @@ import (
 	_ "github.com/grafana/agent/component/discovery/kubernetes"                 // Import discovery.kubernetes
 	_ "github.com/grafana/agent/component/discovery/relabel"                    // Import discovery.relabel
 	_ "github.com/grafana/agent/component/local/file"                           // Import local.file
+	_ "github.com/grafana/agent/component/loki/relabel"                         // Import loki.relabel
 	_ "github.com/grafana/agent/component/loki/source/file"                     // Import loki.source.file
 	_ "github.com/grafana/agent/component/loki/write"                           // Import loki.write
 	_ "github.com/grafana/agent/component/otelcol/auth/basic"                   // Import otelcol.auth.basic

--- a/component/loki/relabel/metrics.go
+++ b/component/loki/relabel/metrics.go
@@ -1,0 +1,53 @@
+package relabel
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	prometheus_client "github.com/prometheus/client_golang/prometheus"
+)
+
+type metrics struct {
+	entriesProcessed prometheus_client.Counter
+	entriesOutgoing  prometheus_client.Counter
+	cacheHits        prometheus_client.Counter
+	cacheMisses      prometheus_client.Counter
+	cacheSize        prometheus_client.Gauge
+}
+
+// newMetrics creates a new set of metrics. If reg is non-nil, the metrics
+// will also be registered.
+func newMetrics(reg prometheus.Registerer) *metrics {
+	var m metrics
+
+	m.entriesProcessed = prometheus_client.NewCounter(prometheus_client.CounterOpts{
+		Name: "loki_relabel_entries_processed",
+		Help: "Total number of log entries processed",
+	})
+	m.entriesOutgoing = prometheus_client.NewCounter(prometheus_client.CounterOpts{
+		Name: "loki_relabel_entries_written",
+		Help: "Total number of log entries forwarded",
+	})
+	m.cacheMisses = prometheus_client.NewCounter(prometheus_client.CounterOpts{
+		Name: "loki_relabel_cache_misses",
+		Help: "Total number of cache misses",
+	})
+	m.cacheHits = prometheus_client.NewCounter(prometheus_client.CounterOpts{
+		Name: "loki_relabel_cache_hits",
+		Help: "Total number of cache hits",
+	})
+	m.cacheSize = prometheus_client.NewGauge(prometheus_client.GaugeOpts{
+		Name: "loki_relabel_cache_size",
+		Help: "Total size of relabel cache",
+	})
+
+	if reg != nil {
+		reg.MustRegister(
+			m.entriesProcessed,
+			m.entriesOutgoing,
+			m.cacheMisses,
+			m.cacheHits,
+			m.cacheSize,
+		)
+	}
+
+	return &m
+}

--- a/component/loki/relabel/relabel.go
+++ b/component/loki/relabel/relabel.go
@@ -1,0 +1,214 @@
+package relabel
+
+import (
+	"context"
+	"reflect"
+	"sync"
+
+	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/common/loki"
+	flow_relabel "github.com/grafana/agent/component/common/relabel"
+	lru "github.com/hashicorp/golang-lru"
+	prometheus_client "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/relabel"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:    "loki.relabel",
+		Args:    Arguments{},
+		Exports: Exports{},
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			return New(opts, args.(Arguments))
+		},
+	})
+}
+
+// Arguments holds values which are used to configure the loki.relabel
+// component.
+type Arguments struct {
+	// Where the relabelled metrics should be forwarded to.
+	ForwardTo []loki.LogsReceiver `river:"forward_to,attr"`
+
+	// The relabelling rules to apply to each log entry before it's forwarded.
+	RelabelConfigs []*flow_relabel.Config `river:"rule,block,optional"`
+}
+
+// Exports holds values which are exported by the loki.relabel component.
+type Exports struct {
+	Receiver loki.LogsReceiver `river:"receiver,attr"`
+}
+
+// Component implements the loki.relabel component.
+type Component struct {
+	mut      sync.RWMutex
+	opts     component.Options
+	rcs      []*relabel.Config
+	receiver loki.LogsReceiver
+	fanout   []loki.LogsReceiver
+
+	entriesProcessed prometheus_client.Counter
+	entriesOutgoing  prometheus_client.Counter
+	cacheHits        prometheus_client.Counter
+	cacheMisses      prometheus_client.Counter
+	cacheSize        prometheus_client.Gauge
+
+	cache *lru.Cache
+}
+
+var (
+	_ component.Component = (*Component)(nil)
+
+	maxCacheSize = 10_000 // TODO(@tpaschalis) Do we make this configurable?
+)
+
+// New creates a new loki.relabel component.
+func New(o component.Options, args Arguments) (*Component, error) {
+	cache, err := lru.New(maxCacheSize)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Component{
+		opts:  o,
+		cache: cache,
+	}
+	c.entriesProcessed = prometheus_client.NewCounter(prometheus_client.CounterOpts{
+		Name: "loki_relabel_entries_processed",
+		Help: "Total number of log entries processed",
+	})
+	c.entriesOutgoing = prometheus_client.NewCounter(prometheus_client.CounterOpts{
+		Name: "loki_relabel_entries_written",
+		Help: "Total number of log entries forwarded",
+	})
+	c.cacheMisses = prometheus_client.NewCounter(prometheus_client.CounterOpts{
+		Name: "loki_relabel_cache_misses",
+		Help: "Total number of cache misses",
+	})
+	c.cacheHits = prometheus_client.NewCounter(prometheus_client.CounterOpts{
+		Name: "loki_relabel_cache_hits",
+		Help: "Total number of cache hits",
+	})
+	c.cacheSize = prometheus_client.NewGauge(prometheus_client.GaugeOpts{
+		Name: "loki_relabel_cache_size",
+		Help: "Total size of relabel cache",
+	})
+
+	for _, metric := range []prometheus_client.Collector{c.entriesProcessed, c.entriesOutgoing, c.cacheMisses, c.cacheHits, c.cacheSize} {
+		err := o.Registerer.Register(metric)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Create and immediately export the receiver which remains the same for
+	// the component's lifetime.
+	c.receiver = make(loki.LogsReceiver)
+	o.OnStateChange(Exports{Receiver: c.receiver})
+
+	// Call to Update() to set the relabelling rules once at the start.
+	if err := c.Update(args); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// Run implements component.Component.
+func (c *Component) Run(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case entry := <-c.receiver:
+			lbls := c.relabel(entry)
+			if len(lbls) == 0 {
+				level.Debug(c.opts.Logger).Log("msg", "dropping entry after relabeling", "labels", entry.Labels.String())
+				continue
+			}
+
+			c.entriesOutgoing.Inc()
+			entry.Labels = lbls
+			for _, f := range c.fanout {
+				select {
+				case <-ctx.Done():
+					return nil
+				case f <- entry:
+				}
+			}
+		}
+	}
+}
+
+func (c *Component) relabel(e loki.Entry) model.LabelSet {
+	c.entriesProcessed.Inc()
+	hash := e.Labels.Fingerprint().String()
+	found, ok := c.cache.Get(hash)
+	if ok {
+		c.cacheHits.Inc()
+		return found.(model.LabelSet)
+	}
+
+	c.cacheMisses.Inc()
+
+	// TODO(@tpaschalis) It's unfortunate how we have to cast back and forth
+	// between model.LabelSet (map) and labels.Labels (slice). Promtail does
+	// not have this issue as relabel config rules are only applied to targets.
+	// Do we want to use labels.Labels in loki.Entry instead?
+	var lbls labels.Labels
+	for k, v := range e.Labels {
+		lbls = append(lbls, labels.Label{
+			Name:  string(k),
+			Value: string(v),
+		})
+	}
+	lbls = relabel.Process(lbls, c.rcs...)
+
+	relabelled := make(model.LabelSet, len(lbls))
+	for i := range lbls {
+		relabelled[model.LabelName(lbls[i].Name)] = model.LabelValue(lbls[i].Value)
+	}
+
+	c.cache.Add(hash, relabelled)
+	c.cacheSize.Set(float64(c.cache.Len()))
+
+	return relabelled
+}
+
+// Update implements component.Component.
+func (c *Component) Update(args component.Arguments) error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	newArgs := args.(Arguments)
+	newRCS := flow_relabel.ComponentToPromRelabelConfigs(newArgs.RelabelConfigs)
+	if relabelingChanged(c.rcs, newRCS) {
+		level.Debug(c.opts.Logger).Log("msg", "received new relabel configs, purging cache")
+		c.cache.Purge()
+		c.cacheSize.Set(0)
+	}
+	c.rcs = newRCS
+	c.cache.Purge()
+	c.fanout = newArgs.ForwardTo
+
+	return nil
+}
+
+// TODO(@tpaschalis) This is an attempt to not purge the cache if the
+// relabeling rules are the same. One way to go about it would be to use the
+// fingerprinting idea on Flow's relabel structs, but this seemed more
+// straightforward. Are we okay with importing reflect here?
+func relabelingChanged(prev, next []*relabel.Config) bool {
+	if len(prev) != len(next) {
+		return true
+	}
+	for i := range prev {
+		if !reflect.DeepEqual(prev[i], next[i]) {
+			return true
+		}
+	}
+	return false
+}

--- a/component/loki/relabel/relabel.go
+++ b/component/loki/relabel/relabel.go
@@ -179,7 +179,7 @@ type cacheItem struct {
 // not have this issue as relabel config rules are only applied to targets.
 // Do we want to use labels.Labels in loki.Entry instead?
 func (c *Component) relabel(e loki.Entry) model.LabelSet {
-	hash := e.Labels.Fingerprint().String()
+	hash := e.Labels.Fingerprint()
 
 	// Let's look in the cache for the hash of the entry's labels.
 	val, found := c.cache.Get(hash)

--- a/component/loki/relabel/relabel_test.go
+++ b/component/loki/relabel/relabel_test.go
@@ -1,0 +1,100 @@
+package relabel
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/common/loki"
+	flow_relabel "github.com/grafana/agent/component/common/relabel"
+	"github.com/grafana/agent/pkg/flow/logging"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test(t *testing.T) {
+	// Rename the kubernetes_(.*) labels without the suffix and remove them,
+	// then set the `environment` label to the value of the namespace.
+	rc := `rule {
+         regex        = "kubernetes_(.*)"
+         replacement  = "$1"
+         action       = "labelmap"
+       }
+       rule {
+         regex  = "kubernetes_(.*)"
+         action = "labeldrop"
+       }
+       rule {
+         source_labels = ["namespace"]
+         target_label  = "environment"
+         action        = "replace"
+       }`
+
+	// Unmarshal the River relabel rules into a custom struct, as we don't have
+	// an easy way to refer to a loki.LogsReceiver value for the forward_to
+	// argument.
+	type cfg struct {
+		Rcs []*flow_relabel.Config `river:"rule,block,optional"`
+	}
+	var relabelConfigs cfg
+	err := river.Unmarshal([]byte(rc), &relabelConfigs)
+	require.NoError(t, err)
+
+	ch1, ch2 := make(loki.LogsReceiver), make(loki.LogsReceiver)
+
+	// Create and run the component, so that it relabels and forwards logs.
+	l, err := logging.New(os.Stderr, logging.DefaultOptions)
+	require.NoError(t, err)
+	opts := component.Options{Logger: l, Registerer: prometheus.NewRegistry(), OnStateChange: func(e component.Exports) {}}
+	args := Arguments{
+		ForwardTo:      []loki.LogsReceiver{ch1, ch2},
+		RelabelConfigs: relabelConfigs.Rcs,
+	}
+
+	c, err := New(opts, args)
+	require.NoError(t, err)
+	go c.Run(context.Background())
+
+	// Send a log entry to the component's receiver.
+	logEntry := loki.Entry{
+		Labels: model.LabelSet{"filename": "/var/log/pods/agent/agent/1.log", "kubernetes_namespace": "dev", "kubernetes_pod_name": "agent", "foo": "bar"},
+		Entry: logproto.Entry{
+			Timestamp: time.Now(),
+			Line:      "very important log",
+		},
+	}
+
+	c.receiver <- logEntry
+
+	wantLabelSet := model.LabelSet{
+		"filename":    "/var/log/pods/agent/agent/1.log",
+		"namespace":   "dev",
+		"pod_name":    "agent",
+		"environment": "dev",
+		"foo":         "bar",
+	}
+
+	// The log entry should be received in both channels, with the relabeling
+	// rules correctly applied.
+	for i := 0; i < 2; i++ {
+		select {
+		case logEntry := <-ch1:
+			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
+			require.Equal(t, "very important log", logEntry.Line)
+			require.Equal(t, wantLabelSet, logEntry.Labels)
+		case logEntry := <-ch2:
+			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
+			require.Equal(t, "very important log", logEntry.Line)
+			require.Equal(t, wantLabelSet, logEntry.Labels)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "failed waiting for log line")
+		}
+	}
+
+}

--- a/component/loki/relabel/relabel_test.go
+++ b/component/loki/relabel/relabel_test.go
@@ -2,6 +2,7 @@ package relabel
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -14,14 +15,14 @@ import (
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/relabel"
 
 	"github.com/stretchr/testify/require"
 )
 
-func Test(t *testing.T) {
-	// Rename the kubernetes_(.*) labels without the suffix and remove them,
-	// then set the `environment` label to the value of the namespace.
-	rc := `rule {
+// Rename the kubernetes_(.*) labels without the suffix and remove them,
+// then set the `environment` label to the value of the namespace.
+var rc = `rule {
          regex        = "kubernetes_(.*)"
          replacement  = "$1"
          action       = "labelmap"
@@ -36,6 +37,7 @@ func Test(t *testing.T) {
          action        = "replace"
        }`
 
+func TestRelabeling(t *testing.T) {
 	// Unmarshal the River relabel rules into a custom struct, as we don't have
 	// an easy way to refer to a loki.LogsReceiver value for the forward_to
 	// argument.
@@ -99,6 +101,189 @@ func Test(t *testing.T) {
 	}
 }
 
-// TODO(@tpaschalis) Benchmark relabeling with new component.
-// TODO(@tpaschalis) Test new cache implementation.
-// TODO(@tpaschalis) Test graceful shutdown.
+func BenchmarkRelabelComponent(b *testing.B) {
+	type cfg struct {
+		Rcs []*flow_relabel.Config `river:"rule,block,optional"`
+	}
+	var relabelConfigs cfg
+	_ = river.Unmarshal([]byte(rc), &relabelConfigs)
+	ch1 := make(loki.LogsReceiver)
+
+	// Create and run the component, so that it relabels and forwards logs.
+	l, _ := logging.New(os.Stderr, logging.DefaultOptions)
+	opts := component.Options{Logger: l, Registerer: prometheus.NewRegistry(), OnStateChange: func(e component.Exports) {}}
+	args := Arguments{
+		ForwardTo:      []loki.LogsReceiver{ch1},
+		RelabelConfigs: relabelConfigs.Rcs,
+		MaxCacheSize:   500_000,
+	}
+
+	c, _ := New(opts, args)
+	ctx, cancel := context.WithCancel(context.Background())
+	go c.Run(ctx)
+
+	var entry loki.Entry
+	go func() {
+		for e := range ch1 {
+			entry = e
+		}
+	}()
+
+	now := time.Now()
+	for i := 0; i < b.N; i++ {
+		c.receiver <- loki.Entry{
+			Labels: model.LabelSet{"filename": "/var/log/pods/agent/agent/%d.log", "kubernetes_namespace": "dev", "kubernetes_pod_name": model.LabelValue(fmt.Sprintf("agent-%d", i)), "foo": "bar"},
+			Entry: logproto.Entry{
+				Timestamp: now,
+				Line:      "very important log",
+			},
+		}
+	}
+
+	_ = entry
+	cancel()
+}
+
+func TestCache(t *testing.T) {
+	type cfg struct {
+		Rcs []*flow_relabel.Config `river:"rule,block,optional"`
+	}
+	var relabelConfigs cfg
+	err := river.Unmarshal([]byte(rc), &relabelConfigs)
+	require.NoError(t, err)
+
+	ch1 := make(loki.LogsReceiver)
+
+	// Create and run the component, so that it relabels and forwards logs.
+	l, err := logging.New(os.Stderr, logging.DefaultOptions)
+	require.NoError(t, err)
+	opts := component.Options{Logger: l, Registerer: prometheus.NewRegistry(), OnStateChange: func(e component.Exports) {}}
+	args := Arguments{
+		ForwardTo: []loki.LogsReceiver{ch1},
+		RelabelConfigs: []*flow_relabel.Config{
+			{
+				SourceLabels: []string{"name", "A"},
+				Regex:        flow_relabel.Regexp(relabel.MustNewRegexp("(.+)")),
+
+				Action:      "replace",
+				TargetLabel: "env",
+				Replacement: "staging",
+			}},
+		MaxCacheSize: 4,
+	}
+
+	c, err := New(opts, args)
+	require.NoError(t, err)
+	go c.Run(context.Background())
+
+	go func() {
+		for e := range ch1 {
+			require.Equal(t, "very important log", e.Line)
+		}
+	}()
+
+	e := getEntry()
+
+	lsets := []model.LabelSet{
+		{"name": "foo"},
+		{"name": "bar"},
+		{"name": "baz"},
+		{"name": "qux"},
+		{"name": "xyz"},
+	}
+	rlsets := []model.LabelSet{
+		{"env": "staging", "name": "foo"},
+		{"env": "staging", "name": "bar"},
+		{"env": "staging", "name": "baz"},
+		{"env": "staging", "name": "qux"},
+		{"env": "staging", "name": "xyz"},
+	}
+	// Send three entries with different label sets along the receiver.
+	e.Labels = lsets[0]
+	c.receiver <- e
+	e.Labels = lsets[1]
+	c.receiver <- e
+	e.Labels = lsets[2]
+	c.receiver <- e
+
+	time.Sleep(100 * time.Millisecond)
+	// Let's look into the cache's structure now!
+	// The cache should have stored each label set by its fingerprint.
+	for i := 0; i < 3; i++ {
+		val, ok := c.cache.Get(lsets[i].Fingerprint())
+		require.True(t, ok)
+		cached, ok := val.([]cacheItem)
+		require.True(t, ok)
+
+		// Each cache value should be a 1-item slice, with the correct initial
+		// and relabeled values applied to it.
+		require.Len(t, cached, 1)
+		require.Equal(t, cached[0].original, lsets[i])
+		require.Equal(t, cached[0].relabeled, rlsets[i])
+	}
+
+	// Let's send over an entry we've seen before.
+	// We should've hit the cached path, with no changes to the cache's length
+	// or the underlying stored value.
+	e.Labels = lsets[0]
+	c.receiver <- e
+	require.Equal(t, c.cache.Len(), 3)
+	val, _ := c.cache.Get(lsets[0].Fingerprint())
+	cachedVal := val.([]cacheItem)
+	require.Len(t, cachedVal, 1)
+	require.Equal(t, cachedVal[0].original, lsets[0])
+	require.Equal(t, cachedVal[0].relabeled, rlsets[0])
+
+	// Now, let's try to hit a collision.
+	// These LabelSets are known to collide (string: 8746e5b6c5f0fb60)
+	// https://github.com/pstibrany/fnv-1a-64bit-collisions
+	ls1 := model.LabelSet{"A": "K6sjsNNczPl"}
+	ls2 := model.LabelSet{"A": "cswpLMIZpwt"}
+	envls := model.LabelSet{"env": "staging"}
+	require.Equal(t, ls1.Fingerprint(), ls2.Fingerprint(), "expected labelset fingerpints to collide; have we changed the hashing algorithm?")
+
+	e.Labels = ls1
+	c.receiver <- e
+
+	e.Labels = ls2
+	c.receiver <- e
+
+	time.Sleep(100 * time.Millisecond)
+	// Both of these should be under a single, new cache key which will contain
+	// both entries.
+	require.Equal(t, c.cache.Len(), 4)
+	val, ok := c.cache.Get(ls1.Fingerprint())
+	require.True(t, ok)
+	cachedVal = val.([]cacheItem)
+	require.Len(t, cachedVal, 2)
+
+	require.Equal(t, cachedVal[0].original, ls1)
+	require.Equal(t, cachedVal[1].original, ls2)
+	require.Equal(t, cachedVal[0].relabeled, ls1.Merge(envls))
+	require.Equal(t, cachedVal[1].relabeled, ls2.Merge(envls))
+
+	// Finally, send two more entries, which should fill up the cache and evict
+	// the Least Recently Used items (lsets[1], and lsets[2]).
+	e.Labels = lsets[3]
+	c.receiver <- e
+	e.Labels = lsets[4]
+	c.receiver <- e
+
+	require.Equal(t, c.cache.Len(), 4)
+	wantKeys := []model.Fingerprint{lsets[0].Fingerprint(), ls1.Fingerprint(), lsets[3].Fingerprint(), lsets[4].Fingerprint()}
+	for i, k := range c.cache.Keys() { // Returns the cache keys in LRU order.
+		f, ok := k.(model.Fingerprint)
+		require.True(t, ok)
+		require.Equal(t, f, wantKeys[i])
+	}
+}
+
+func getEntry() loki.Entry {
+	return loki.Entry{
+		Labels: model.LabelSet{},
+		Entry: logproto.Entry{
+			Timestamp: time.Now(),
+			Line:      "very important log",
+		},
+	}
+}

--- a/component/loki/relabel/relabel_test.go
+++ b/component/loki/relabel/relabel_test.go
@@ -240,7 +240,7 @@ func TestCache(t *testing.T) {
 	ls1 := model.LabelSet{"A": "K6sjsNNczPl"}
 	ls2 := model.LabelSet{"A": "cswpLMIZpwt"}
 	envls := model.LabelSet{"env": "staging"}
-	require.Equal(t, ls1.Fingerprint(), ls2.Fingerprint(), "expected labelset fingerpints to collide; have we changed the hashing algorithm?")
+	require.Equal(t, ls1.Fingerprint(), ls2.Fingerprint(), "expected labelset fingerprints to collide; have we changed the hashing algorithm?")
 
 	e.Labels = ls1
 	c.receiver <- e

--- a/component/loki/relabel/relabel_test.go
+++ b/component/loki/relabel/relabel_test.go
@@ -97,5 +97,8 @@ func Test(t *testing.T) {
 			require.FailNow(t, "failed waiting for log line")
 		}
 	}
-
 }
+
+// TODO(@tpaschalis) Benchmark relabeling with new component.
+// TODO(@tpaschalis) Test new cache implementation.
+// TODO(@tpaschalis) Test graceful shutdown.

--- a/component/loki/relabel/relabel_test.go
+++ b/component/loki/relabel/relabel_test.go
@@ -55,6 +55,7 @@ func Test(t *testing.T) {
 	args := Arguments{
 		ForwardTo:      []loki.LogsReceiver{ch1, ch2},
 		RelabelConfigs: relabelConfigs.Rcs,
+		MaxCacheSize:   10,
 	}
 
 	c, err := New(opts, args)

--- a/docs/sources/flow/reference/components/loki.relabel.md
+++ b/docs/sources/flow/reference/components/loki.relabel.md
@@ -15,8 +15,8 @@ results to the list of receivers in the component's arguments.
   component which allows you to run one or more 'stages' on the log entries.
  -->
 
-If no labels remain after the relabeling rules are applied, then the log entry
-are dropped.
+If no labels remain after the relabeling rules are applied, then the log
+entries are dropped.
 
 The most common use of `loki.relabel` is to filter log entries or standardize
 the label set that is passed to one or more downstream receivers. The `rule`
@@ -46,7 +46,8 @@ The following arguments are supported:
 
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`forward_to` | `list(receiver)` | Where the log entries should be forwarded to, after relabeling takes place. | | yes
+`forward_to` | `list(receiver)` | Where to forward log entries after relabeling. | | yes
+`max_cache_size` | `int` | The maximum number of elements to hold in the relabeling cache | 10,000 | no
 
 ## Blocks
 
@@ -81,7 +82,6 @@ In those cases, exported fields are kept at their last healthy values.
 
 ## Debug metrics
 
-
 * `loki_relabel_entries_processed` (counter): Total number of log entries processed.
 * `loki_relabel_entries_written` (counter): Total number of log entries forwarded.
 * `loki_relabel_cache_misses` (counter): Total number of cache misses.
@@ -90,21 +90,8 @@ In those cases, exported fields are kept at their last healthy values.
 
 ## Example
 
-One of Loki's core features is that, unlike other logging systems, it does not
-index the log message itself, but works off indexing metadata about the
-received log streams. These metadata are stored as key-value pairs called
-_labels_, much like Prometheus metric labels. Having a small and efficient
-index, along being able to store the log data itself in highly compressed
-chunks, simplifies the operation and lowers the cost of running Loki.
-
-All Loki log entries that pass through a Flow pipeline carry two pieces of
-information: the log itself (the logged line and a timestamp), as well as the
-labels associated with it.
-
-Let's create an instance of a `loki.relabel` component and see how it acts on
-some incoming log entries. We can see the component definition, as well as some
-log entries coming from different files, environments, jobs, and on varying log
-levels.
+The following example creates a `loki.relabel` component that only forwards
+entries whose 'level' value is set to 'error'.
 
 ```river
 loki.relabel "keep_error_only" {
@@ -115,68 +102,6 @@ loki.relabel "keep_error_only" {
     source_labels = ["level"]
     regex         = "error"
   }
-  rule {
-    action        = "replace"
-    source_labels = ["env", "job"]
-    separator     = "/"
-    target_label  = "instance"
-  }
-  rule {
-    action = "labeldrop"
-    regex  = "env|job"
-  }
 }
 ```
 
-```
-Log line     |    Labels
-------------------------------
-"entry1"     | "filename" = "/tmp/foo.txt", "env" = "dev",  "job" = "web", "level" = "info"
-"error foo!" | "filename" = "/tmp/foo.txt", "env" = "dev",  "job" = "web", "level" = "error"
-"entry2"     | "filename" = "/tmp/bar.txt", "env" = "dev",  "job" = "web", "level" = "info"
-"entry3"     | "filename" = "/tmp/bar.txt", "env" = "dev",  "job" = "web", "level" = "debug"
-"error bar!  | "filename" = "/tmp/bar.txt", "env" = "dev",  "job" = "sql", "level" = "error"
-"error baz!  | "filename" = "/tmp/baz.txt", "env" = "prod", "job" = "sql", "level" = "error"
-```
-
-After applying the first relabeling rule, the component would only keep the entries whose level is 'error'.
-
-```
-Log line     |    Labels
-------------------------------
-"error foo!" | "filename" = "/tmp/foo.txt", "env" = "dev",  "job" = "web", "level" = "error"
-"error bar!  | "filename" = "/tmp/bar.txt", "env" = "dev",  "job" = "sql", "level" = "error"
-"error baz!  | "filename" = "/tmp/baz.txt", "env" = "prod", "job" = "sql", "level" = "error"
-```
-
-The second relabeling rule concatenates the values in the 'env' and 'jobs'
-labels using a slash, and populates the instance label.
-
-```
-Log line     |    Labels
-------------------------------
-"error foo!" | "filename" = "/tmp/foo.txt", "env" = "dev",  "job" = "web", "level" = "error", "instance" = "dev/web"
-"error bar!  | "filename" = "/tmp/bar.txt", "env" = "dev",  "job" = "sql", "level" = "error", "instance" = "dev/sql"
-"error baz!  | "filename" = "/tmp/baz.txt", "env" = "prod", "job" = "sql", "level" = "error", "instance" = "prod/sql"
-```
-
-The third relabeling rule would drop the 'env' and 'job' labels, as they're no
-longer needed.
-
-```
-Log line     |    Labels
-------------------------------
-"error foo!" | "filename" = "/tmp/foo.txt", "level" = "error", "instance" = "dev/web"
-"error bar!  | "filename" = "/tmp/bar.txt", "level" = "error", "instance" = "dev/sql"
-"error baz!  | "filename" = "/tmp/baz.txt", "level" = "error", "instance" = "prod/sql"
-```
-
-The log entries are processed and sent to the list of receivers in `forward_to`
-in succession. This means that if a receiver is bottlenecked, it may impact the
-rest.
-
-Since relabeling can be a resource-intensive process, the component utilizes
-an LRU cache to store the results of the relabling process on previously-seen
-log label streams. The cache is purged whenever the component is updated with
-a new relabeling configuration. You can use the component's debug metrics to
-see how the cache is performing in terms of hits/misses and its current size.

--- a/docs/sources/flow/reference/components/loki.relabel.md
+++ b/docs/sources/flow/reference/components/loki.relabel.md
@@ -1,0 +1,182 @@
+---
+aliases:
+- /docs/agent/latest/flow/reference/components/loki.relabel
+title: loki.relabel
+---
+
+# loki.relabel
+
+The `loki.relabel` component rewrites the label set of each log entry passed to
+its receiver by applying one or more relabeling `rule`s and forwards the
+results to the list of receivers in the component's arguments.
+
+<!-- TODO(@tpaschalis) Add note about loki.transform
+  To manipulate the log entry itself, you can look at the loki.transform
+  component which allows you to run one or more 'stages' on the log entries.
+ -->
+
+If no labels remain after the relabeling rules are applied, then the log entry
+are dropped.
+
+The most common use of `loki.relabel` is to filter log entries or standardize
+the label set that is passed to one or more downstream receivers. The `rule`
+blocks are applied to the label set of each log entry in order of their
+appearance in the configuration file.
+
+Multiple `loki.relabel` components can be specified by giving them
+different labels.
+
+## Usage
+
+```river
+loki.relabel "LABEL" {
+  forward_to = RECEIVER_LIST
+
+  rule {
+    ...
+  }
+
+  ...
+}
+```
+
+## Arguments
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`forward_to` | `list(receiver)` | Where the log entries should be forwarded to, after relabeling takes place. | | yes
+
+## Blocks
+
+The following blocks are supported inside the definition of `loki.relabel`:
+
+Hierarchy | Name | Description | Required
+--------- | ---- | ----------- | --------
+rule | [rule][] | Relabeling rules to apply to received log entries. | no
+
+[rule]: #rule-block
+
+### rule block
+
+{{< docs/shared lookup="flow/reference/components/rule-block.md" source="agent" >}}
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+Name | Type | Description
+---- | ---- | -----------
+`receiver` | `receiver` | The input receiver where log lines are sent to be relabeled.
+
+## Component health
+
+`loki.relabel` is only reported as unhealthy if given an invalid configuration.
+In those cases, exported fields are kept at their last healthy values.
+
+## Debug information
+
+`loki.relabel` does not expose any component-specific debug information.
+
+## Debug metrics
+
+
+* `loki_relabel_entries_processed` (counter): Total number of log entries processed.
+* `loki_relabel_entries_written` (counter): Total number of log entries forwarded.
+* `loki_relabel_cache_misses` (counter): Total number of cache misses.
+* `loki_relabel_cache_hits` (counter): Total number of cache hits.
+* `loki_relabel_cache_size` (gauge): Total size of relabel cache.
+
+## Example
+
+One of Loki's core features is that, unlike other logging systems, it does not
+index the log message itself, but works off indexing metadata about the
+received log streams. These metadata are stored as key-value pairs called
+_labels_, much like Prometheus metric labels. Having a small and efficient
+index, along being able to store the log data itself in highly compressed
+chunks, simplifies the operation and lowers the cost of running Loki.
+
+All Loki log entries that pass through a Flow pipeline carry two pieces of
+information: the log itself (the logged line and a timestamp), as well as the
+labels associated with it.
+
+Let's create an instance of a `loki.relabel` component and see how it acts on
+some incoming log entries. We can see the component definition, as well as some
+log entries coming from different files, environments, jobs, and on varying log
+levels.
+
+```river
+loki.relabel "keep_error_only" {
+  forward_to = [loki.write.onprem.receiver]
+
+  rule {
+    action        = "keep"
+    source_labels = ["level"]
+    regex         = "error"
+  }
+  rule {
+    action        = "replace"
+    source_labels = ["env", "job"]
+    separator     = "/"
+    target_label  = "instance"
+  }
+  rule {
+    action = "labeldrop"
+    regex  = "env|job"
+  }
+}
+```
+
+```
+Log line     |    Labels
+------------------------------
+"entry1"     | "filename" = "/tmp/foo.txt", "env" = "dev",  "job" = "web", "level" = "info"
+"error foo!" | "filename" = "/tmp/foo.txt", "env" = "dev",  "job" = "web", "level" = "error"
+"entry2"     | "filename" = "/tmp/bar.txt", "env" = "dev",  "job" = "web", "level" = "info"
+"entry3"     | "filename" = "/tmp/bar.txt", "env" = "dev",  "job" = "web", "level" = "debug"
+"error bar!  | "filename" = "/tmp/bar.txt", "env" = "dev",  "job" = "sql", "level" = "error"
+"error baz!  | "filename" = "/tmp/baz.txt", "env" = "prod", "job" = "sql", "level" = "error"
+```
+
+After applying the first relabeling rule, the component would only keep the entries whose level is 'error'.
+
+```
+Log line     |    Labels
+------------------------------
+"error foo!" | "filename" = "/tmp/foo.txt", "env" = "dev",  "job" = "web", "level" = "error"
+"error bar!  | "filename" = "/tmp/bar.txt", "env" = "dev",  "job" = "sql", "level" = "error"
+"error baz!  | "filename" = "/tmp/baz.txt", "env" = "prod", "job" = "sql", "level" = "error"
+```
+
+The second relabeling rule concatenates the values in the 'env' and 'jobs'
+labels using a slash, and populates the instance label.
+
+```
+Log line     |    Labels
+------------------------------
+"error foo!" | "filename" = "/tmp/foo.txt", "env" = "dev",  "job" = "web", "level" = "error", "instance" = "dev/web"
+"error bar!  | "filename" = "/tmp/bar.txt", "env" = "dev",  "job" = "sql", "level" = "error", "instance" = "dev/sql"
+"error baz!  | "filename" = "/tmp/baz.txt", "env" = "prod", "job" = "sql", "level" = "error", "instance" = "prod/sql"
+```
+
+The third relabeling rule would drop the 'env' and 'job' labels, as they're no
+longer needed.
+
+```
+Log line     |    Labels
+------------------------------
+"error foo!" | "filename" = "/tmp/foo.txt", "level" = "error", "instance" = "dev/web"
+"error bar!  | "filename" = "/tmp/bar.txt", "level" = "error", "instance" = "dev/sql"
+"error baz!  | "filename" = "/tmp/baz.txt", "level" = "error", "instance" = "prod/sql"
+```
+
+The log entries are processed and sent to the list of receivers in `forward_to`
+in succession. This means that if a receiver is bottlenecked, it may impact the
+rest.
+
+Since relabeling can be a resource-intensive process, the component utilizes
+an LRU cache to store the results of the relabling process on previously-seen
+log label streams. The cache is purged whenever the component is updated with
+a new relabeling configuration. You can use the component's debug metrics to
+see how the cache is performing in terms of hits/misses and its current size.


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The PR adds a `loki.relabel` component that receives log entries and rewrites their label set using relabeling rules. This functionality was not available in Promtail, where relabeling would only happen for targets, and any label manipulation after the log had been scraped had to be done with stages pipelines, so it needs some back-and-forth.

We didn't have to bring any new Promtail code for this one, for now.

#### Which issue(s) this PR fixes
Fixes #2514 

#### Notes to the Reviewer
* Since relabeling can be resource-intensive, I've introduced a cache field in the Component struct. Since the relabeling happens only on the same goroutine as the component is running, there was no need to protect it with a mutex.
* As the log entries do not provide any indication of 'staleness', like Prometheus metric do, we'd have to choose another way to evict items from the cache, so it doesn't keep growing forever. I've opted to use [hashicorp/golang-lru](https://github.com/hashicorp/golang-lru) which is already on our dependencies list, and comes with an [MPL-2.0 license](https://github.com/hashicorp/golang-lru/blob/master/LICENSE).

#### Open Questions
* Do we want the allow the user to configure the cache size? If we take Loki's default label limits (30 labels, up to 1024 chars for name and 2048 chars for value), the current `maxCacheSize = 10_000` value,  caps to ~1GB of memory in use.
* Is it okay to `import "reflect"` in order to detect when new relabel configs are passed? Should we use the fingerprinting idea on Flow's relabel structs to make the comparison that way?
* Should we document anything about the 'footgun' factor here? Like changing labels may result in logs being present in different 'streams'?
 
#### PR Checklist

- [X] CHANGELOG updated
- [X] Documentation added
- [X] Tests updated
