### PR TITLE
Force directconnect for mongodb_exporter

### DIFF
--- a/pkg/integrations/mongodb_exporter/mongodb_exporter.go
+++ b/pkg/integrations/mongodb_exporter/mongodb_exporter.go
@@ -63,6 +63,7 @@ func New(logger log.Logger, c *Config) (integrations.Integration, error) {
 		// configurable in the future.
 		CompatibleMode: true,
 		CollectAll:     true,
+		DirectConnect:  true,
 	})
 
 	return integrations.NewHandlerIntegration(c.Name(), exp.Handler()), nil


### PR DESCRIPTION
#### PR Description
By default, `mongodb_exporter` enforce [DirectConnect](https://www.mongodb.com/docs/drivers/go/current/fundamentals/connection/#direct-connection) to mongodb replicaset node:
https://github.com/percona/mongodb_exporter/blob/main/main.go#L42

But AFAIK, `mongodb_exporter` integration set DirectConnect to `false` by default. In this case, even if you point mongodb mongodb_uri to secondary node, it will actually use it only to discover primary node's URI and connect to it instead. 

Such approach (DirectConnect: false) results in situation, where secondary nodes return primary node metrics (including replset state) instead of their own, messing up Replication state picture on dashboards.

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
