### PR TITLE
Graduate Grafana Agent Flow to beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+> **DEPRECATIONS**: This release has deprecations. Please read entries
+> carefully and consult the [upgrade guide][] for specific instructions.
+
+### Deprecations
+
+- The `EXPERIMENTAL_ENABLE_FLOW` environment variable is deprecated in favor of
+  `AGENT_MODE=flow`. Support for `EXPERIMENTAL_ENABLE_FLOW` will be removed in
+  v0.32. (@rfratto)
+
 ### Features
 
 - `grafana-agent-operator` supports oauth2 as an authentication method for
@@ -77,6 +86,10 @@ Main (unreleased)
 
 - Fix issue where on checking whether to restart integrations the Integration Manager was comparing
   configs with secret values scrubbed, preventing reloads if only secrets were updated. (@spartan0x117)
+
+### Other changes
+
+- Grafana Agent Flow has graduated from experimental to beta.
 
 v0.29.0 (2022-11-08)
 --------------------

--- a/cmd/agent/flow.go
+++ b/cmd/agent/flow.go
@@ -7,14 +7,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func isFlowEnabled() bool {
-	key, found := os.LookupEnv("EXPERIMENTAL_ENABLE_FLOW")
-	if !found {
-		return false
-	}
-	return key == "true" || key == "1"
-}
-
 func runFlow() {
 	var cmd = &cobra.Command{
 		Use:     "agent [global options] <subcommand>",

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	"os"
 
@@ -42,7 +41,6 @@ func main() {
 
 	runMode, err := getRunMode()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		log.Fatalln(err)
 	}
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
 
@@ -39,9 +40,15 @@ func main() {
 		return
 	}
 
+	runMode, err := getRunMode()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		log.Fatalln(err)
+	}
+
 	// If flow is enabled go into that working mode
 	// TODO allow flow to run as a windows service
-	if isFlowEnabled() {
+	if runMode == runModeFlow {
 		runFlow()
 		return
 	}

--- a/cmd/agent/mode.go
+++ b/cmd/agent/mode.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
+type runMode int8
+
+const (
+	runModeInvalid runMode = iota
+	runModeStatic
+	runModeFlow
+)
+
+func getRunMode() (runMode, error) {
+	key, found := os.LookupEnv("AGENT_MODE")
+	if !found {
+		// Fall back to old EXPERIMENTAL_ENABLE_FLOW flag.
+		// TODO: remove support for EXPERIMENTAL_ENABLE_FLOW in v0.32.
+		if isFlowEnabled() {
+			log.Println("warning: setting EXPERIMENTAL_ENABLE_FLOW is deprecated and will be removed in v0.32, set AGENT_MODE to flow instead")
+			return runModeFlow, nil
+		}
+		return runModeStatic, nil
+	}
+
+	switch key {
+	case "flow":
+		return runModeFlow, nil
+	case "static", "":
+		return runModeStatic, nil
+	default:
+		return runModeInvalid, fmt.Errorf("unrecognized run mode %q", key)
+	}
+}
+
+func isFlowEnabled() bool {
+	key, found := os.LookupEnv("EXPERIMENTAL_ENABLE_FLOW")
+	if !found {
+		return false
+	}
+	return key == "true" || key == "1"
+}

--- a/docs/sources/flow/_index.md
+++ b/docs/sources/flow/_index.md
@@ -5,27 +5,27 @@ title: Grafana Agent Flow
 weight: 900
 ---
 
-# Grafana Agent Flow (Experimental)
+# Grafana Agent Flow (Beta)
 
-Grafana Agent Flow is a _component-based_ experimental revision of Grafana
-Agent with a focus on ease-of-use, debuggability, and ability to adapt to the
-needs of power users.
+Grafana Agent Flow is a _component-based_ revision of Grafana Agent with a
+focus on ease-of-use, debuggability, and ability to adapt to the needs of power
+users.
 
-Components allow for reusability, composability, and focus on a single task. 
+Components allow for reusability, composability, and focus on a single task.
 
 * **Reusability** allows for the output of components to be reused as the input for multiple other components.
 * **Composability** allows for components to be chained together to form a pipeline.
 * **Single task** means the scope of a component is limited to one narrow task and thus has fewer side effects.
 
-> **EXPERIMENTAL**: Grafana Agent Flow is an [experimental][] feature.
-> Experimental features are subject to frequent breaking changes and are
-> subject for removal if the experiment doesn't work out.
+> **BETA**: Grafana Agent Flow is a [beta][] feature.
+> Beta features are subject to frequent breaking changes while the feature is
+> being matured.
 >
 > You should only use Grafana Agent Flow if you are okay with bleeding edge
 > functionality and want to provide feedback to the developers. It is not
 > recommended to use Grafana Agent Flow in production.
 
-[experimental]: {{< relref "../operation-guide#stability" >}}
+[beta]: {{< relref "../operation-guide#stability" >}}
 
 ## Features
 

--- a/docs/sources/flow/config-language/files.md
+++ b/docs/sources/flow/config-language/files.md
@@ -15,7 +15,7 @@ Windows-style line endings (CRLF), but formatters may replace all line endings
 with Unix-style ones.
 
 ## Community tooling
+
 There is experimental support for River in
 [vim](https://github.com/rfratto/vim-river) and in
 [VSCode](https://github.com/rfratto/vscode-river).
-

--- a/docs/sources/flow/getting_started.md
+++ b/docs/sources/flow/getting_started.md
@@ -15,14 +15,20 @@ release.
 
 ## Running Grafana Agent Flow
 
-Grafana Agent Flow can be enabled by setting the `EXPERIMENTAL_ENABLE_FLOW`
-environment variable to `true`.
+Grafana Agent Flow can be enabled by setting the `AGENT_MODE` environment
+variable to `flow`.
+
+> **NOTE**: In previous releases, the `EXPERIMENTAL_ENABLE_FLOW` environment
+> variable was set to `1` to enable Grafana Agent Flow. This environment
+> variable is deprecated and support for it will be removed in the v0.32
+> release. It is recommended to change to `AGENT_MODE=flow` as soon as
+> possible.
 
 Then, use the `agent run` command to start Grafana Agent Flow, replacing
 `FILE_PATH` with the path of a config file to use:
 
 ```
-EXPERIMENTAL_ENABLE_FLOW=1 agent run FILE_PATH
+AGENT_MODE=flow agent run FILE_PATH
 ```
 
 > Grafana Agent Flow uses a different command-line interface and command line

--- a/docs/sources/flow/tutorials/assets/docker-compose.yaml
+++ b/docs/sources/flow/tutorials/assets/docker-compose.yaml
@@ -17,10 +17,10 @@ services:
     volumes:
       - ./flow_configs:/etc/agent-config
     environment:
-      EXPERIMENTAL_ENABLE_FLOW: "true"
+      AGENT_MODE: "flow"
     entrypoint:
-      - /bin/agent 
-      - run 
+      - /bin/agent
+      - run
       - --server.http.listen-addr=0.0.0.0:12345
       - /etc/agent-config/$CONFIG_FILE
   grafana:

--- a/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
+++ b/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
@@ -15,7 +15,7 @@ Grafana Agent is a telemetry collector with the primary goal of moving telemetry
 
 ## Run the example
 
-Run the following `curl https://raw.githubusercontent.com/grafana/agent/main/docs/sources/flow/tutorials/assets/runt.sh -O && bash ./runt.sh agent.river`. 
+Run the following `curl https://raw.githubusercontent.com/grafana/agent/main/docs/sources/flow/tutorials/assets/runt.sh -O && bash ./runt.sh agent.river`.
 
 The `runt.sh` script does:
 
@@ -78,5 +78,5 @@ prometheus.remote_write "prom" {
 
 To try out the Grafana Agent without using Docker:
 1. Download the Grafana Agent.
-1. Set the environment variable `EXPERIMENTAL_ENABLE_FLOW=true`.
+1. Set the environment variable `AGENT_MODE=flow`.
 1. Run the agent with `agent run <path_to_flow_config>`.

--- a/docs/sources/upgrade-guide/_index.md
+++ b/docs/sources/upgrade-guide/_index.md
@@ -14,6 +14,17 @@ releases and how to migrate to newer versions.
 
 These changes will come in a future version.
 
+### Deprecation: `EXPERIMENTAL_ENABLE_FLOW` environment variable changed
+
+As part of graduating Grafana Agent Flow to beta, the
+`EXPERIMENTAL_ENABLE_FLOW` environment variable is replaced by setting
+`AGENT_MODE` to `flow`.
+
+Setting `EXPERIMENTAL_ENABLE_FLOW` to `1` or `true` is now deprecated and
+support for it will be removed for the v0.32 release.
+
+## v0.29.0
+
 ### Breaking change: JSON-encoded traces from OTLP versions below 0.16.0 are no longer supported
 
 Grafana Agent's OpenTelemetry Collector dependency has been updated from


### PR DESCRIPTION
As part of Grafana Agent Flow being beta, the `AGENT_MODE=flow` environment variable is now preferred for enabling Grafna Agent Flow. Support for `EXPERIMENTAL_ENABLE_FLOW=1` continues to work but is deprecated and will be removed in v0.32.

Closes #2377.