### PR TITLE
tools/agentlint: introduce custom linting

### DIFF
--- a/component/all/all.go
+++ b/component/all/all.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/grafana/agent/component/otelcol/processor/batch"              // Import otelcol.processor.batch
 	_ "github.com/grafana/agent/component/otelcol/processor/memorylimiter"      // Import otelcol.processor.memory_limiter
 	_ "github.com/grafana/agent/component/otelcol/receiver/jaeger"              // Import otelcol.receiver.jaeger
+	_ "github.com/grafana/agent/component/otelcol/receiver/kafka"               // Import otelcol.receiver.kafka
 	_ "github.com/grafana/agent/component/otelcol/receiver/otlp"                // Import otelcol.receiver.otlp
 	_ "github.com/grafana/agent/component/otelcol/receiver/prometheus"          // Import otelcol.receiver.prometheus
 	_ "github.com/grafana/agent/component/prometheus/integration/node_exporter" // Import prometheus.integration.node_exporter

--- a/pkg/util/eventually.go
+++ b/pkg/util/eventually.go
@@ -1,0 +1,90 @@
+package util
+
+import (
+	"context"
+
+	"github.com/grafana/dskit/backoff"
+	"github.com/stretchr/testify/require"
+)
+
+// Eventually calls the check function several times until it doesn't report an
+// error. Failing the test in the t provided to check does not fail the test
+// until the provided backoff.Config is out of retries.
+func Eventually(t require.TestingT, check func(t require.TestingT), bc backoff.Config) {
+	bo := backoff.New(context.Background(), bc)
+
+	var (
+		lastErrors  []testError
+		shouldAbort bool
+	)
+
+	for bo.Ongoing() {
+		ev := invokeCheck(check)
+
+		lastErrors = ev.errors
+		shouldAbort = ev.aborted
+
+		if len(ev.errors) == 0 {
+			break
+		}
+
+		bo.Wait()
+	}
+
+	if bo.Err() != nil {
+		// Forward the last set of received errors back to our real test.
+		for _, err := range lastErrors {
+			t.Errorf(err.format, err.args...)
+		}
+
+		if shouldAbort {
+			t.FailNow()
+		}
+	}
+}
+
+func invokeCheck(check func(t require.TestingT)) (result eventuallyT) {
+	defer func() {
+		if err := recover(); err != nil {
+			if _, ok := err.(testAbort); ok {
+				return
+			}
+			// Unexpected panic; raise it back.
+			panic(err)
+		}
+	}()
+
+	check(&result)
+	return
+}
+
+type eventuallyT struct {
+	// Populated by calls to Errorf.
+	errors  []testError
+	aborted bool
+}
+
+// Helper types for eventuallyT,.
+type (
+	testError struct {
+		format string
+		args   []interface{}
+	}
+
+	// testAbort is sent when FailNow is called.
+	testAbort struct{}
+)
+
+var _ require.TestingT = (*eventuallyT)(nil)
+
+func (et *eventuallyT) Errorf(format string, args ...interface{}) {
+	et.errors = append(et.errors, testError{
+		format: format,
+		args:   args,
+	})
+}
+
+func (et *eventuallyT) FailNow() {
+	et.aborted = true
+	panic(testAbort{})
+}

--- a/pkg/util/eventually_test.go
+++ b/pkg/util/eventually_test.go
@@ -1,0 +1,58 @@
+package util
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/dskit/backoff"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventually(t *testing.T) {
+	var bcfg = backoff.Config{
+		MinBackoff: 10 * time.Millisecond,
+		MaxBackoff: 10 * time.Millisecond,
+		MaxRetries: 5,
+	}
+
+	t.Run("No errors", func(t *testing.T) {
+		Eventually(t, func(t require.TestingT) {
+			require.True(t, true)
+		}, bcfg)
+	})
+
+	t.Run("Fails once", func(t *testing.T) {
+		var runs int
+
+		Eventually(t, func(t require.TestingT) {
+			if runs > 0 {
+				return
+			}
+			runs++
+
+			require.True(t, false)
+		}, bcfg)
+	})
+
+	t.Run("Always fails", func(t *testing.T) {
+		var et eventuallyT
+
+		defer func() {
+			err := recover()
+			if err == nil {
+				require.Fail(t, "expected panic")
+			}
+
+			_, aborted := err.(testAbort)
+			if !aborted {
+				require.Fail(t, "expected test abort")
+			}
+
+			require.Len(t, et.errors, 1)
+		}()
+
+		Eventually(&et, func(t require.TestingT) {
+			require.True(t, false)
+		}, bcfg)
+	})
+}

--- a/tools/agentlint/go.mod
+++ b/tools/agentlint/go.mod
@@ -1,0 +1,10 @@
+module github.com/grafana/agent/tools/agentlint
+
+go 1.19
+
+require golang.org/x/tools v0.4.0
+
+require (
+	golang.org/x/mod v0.7.0 // indirect
+	golang.org/x/sys v0.3.0 // indirect
+)

--- a/tools/agentlint/go.sum
+++ b/tools/agentlint/go.sum
@@ -1,0 +1,7 @@
+golang.org/x/mod v0.7.0 h1:LapD9S96VoQRhi/GrNTqeBJFrUjs5UHCAtTlgwA5oZA=
+golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
+golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/tools v0.4.0 h1:7mTAgkunk3fr4GAloyyCasadO6h9zSsQZbwvcaIciV4=
+golang.org/x/tools v0.4.0/go.mod h1:UE5sM2OK9E/d67R0ANs2xJizIymRP5gJU295PvKXxjQ=

--- a/tools/agentlint/internal/findcomponents/findcomponents.go
+++ b/tools/agentlint/internal/findcomponents/findcomponents.go
@@ -1,0 +1,142 @@
+// Package findcomponents exposes an Analyzer which will set a fact about
+// whether a package declares a Flow component.
+package findcomponents
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/packages"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name: "findcomponents",
+	Doc:  "ensure Flow components are imported",
+	Run:  run,
+}
+
+var componentPattern string = "./component/..."
+
+func init() {
+	Analyzer.Flags.StringVar(&componentPattern, "components", componentPattern, "Pattern where components are defined")
+}
+
+func run(p *analysis.Pass) (interface{}, error) {
+	// Our linter works as follows:
+	//
+	// 1. Retrieve the list of direct imports of the package we are performing
+	//    analysis on.
+	// 2. Find component packages across the module as defined by the -components
+	//    flag.
+	// 3. Report a diagnostic for any component package which is not being
+	//    imported.
+	//
+	// This linter should only be run against a single package to check for
+	// imports.
+
+	imports := make(map[string]struct{})
+	for _, dep := range p.Pkg.Imports() {
+		imports[dep.Path()] = struct{}{}
+	}
+
+	componentPackages, err := findComponentPackages(componentPattern)
+	if err != nil {
+		return nil, err
+	}
+	for componentPackage := range componentPackages {
+		if _, imported := imports[componentPackage]; !imported {
+			p.Report(analysis.Diagnostic{
+				Pos:     p.Files[0].Pos(),
+				Message: fmt.Sprintf("package does not import component %s", componentPackage),
+			})
+		}
+	}
+
+	return nil, nil
+}
+
+// findComponentPackages returns a map of discovered packages which declare
+// Flow components. The pattern argument controls the full list of patterns
+// which are searched (e.g., "./..." or "./component/...").
+func findComponentPackages(pattern string) (map[string]struct{}, error) {
+	pkgs, err := packages.Load(&packages.Config{
+		Mode: packages.NeedName | packages.NeedTypes | packages.NeedSyntax | packages.NeedTypesInfo,
+	}, "pattern="+pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	componentPackages := map[string]struct{}{}
+
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Syntax {
+			if declaresComponent(pkg, file) {
+				componentPackages[pkg.ID] = struct{}{}
+			}
+		}
+	}
+
+	return componentPackages, nil
+}
+
+// declaresComponent inspects a file to see if it has something matching the
+// following:
+//
+//	func init() {
+//		component.Register(component.Registration{ ... })
+//	}
+func declaresComponent(pkg *packages.Package, file *ast.File) bool {
+	// Look for an init function in the file.
+	for _, decl := range file.Decls {
+		funcDecl, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+
+		if funcDecl.Name.Name != "init" || funcDecl.Recv != nil {
+			continue
+		}
+
+		var foundComponentDecl bool
+
+		// Given an init function, check to see if there's a function call to
+		// component.Register.
+		ast.Inspect(funcDecl.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+
+			ident, ok := sel.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+
+			// Check to see if the ident refers to
+			// github.com/grafana/agent/component.
+			if pkgName, ok := pkg.TypesInfo.Uses[ident].(*types.PkgName); ok {
+				if pkgName.Imported().Path() == "github.com/grafana/agent/component" &&
+					sel.Sel.Name == "Register" {
+
+					foundComponentDecl = true
+					return false
+				}
+			}
+
+			return true
+		})
+
+		if foundComponentDecl {
+			return true
+		}
+	}
+
+	return false
+}

--- a/tools/agentlint/internal/findcomponents/findcomponents.go
+++ b/tools/agentlint/internal/findcomponents/findcomponents.go
@@ -1,5 +1,5 @@
-// Package findcomponents exposes an Analyzer which will set a fact about
-// whether a package declares a Flow component.
+// Package findcomponents exposes an Analyzer which ensures that created Flow
+// components are imported by a registry package.
 package findcomponents
 
 import (

--- a/tools/agentlint/internal/findcomponents/findcomponents.go
+++ b/tools/agentlint/internal/findcomponents/findcomponents.go
@@ -17,10 +17,14 @@ var Analyzer = &analysis.Analyzer{
 	Run:  run,
 }
 
-var componentPattern string = "./component/..."
+var (
+	componentPattern = "./component/..."
+	checkPackage     = "github.com/grafana/agent/component/all"
+)
 
 func init() {
 	Analyzer.Flags.StringVar(&componentPattern, "components", componentPattern, "Pattern where components are defined")
+	Analyzer.Flags.StringVar(&checkPackage, "import-package", checkPackage, "Package that should import components")
 }
 
 func run(p *analysis.Pass) (interface{}, error) {
@@ -34,7 +38,12 @@ func run(p *analysis.Pass) (interface{}, error) {
 	//    imported.
 	//
 	// This linter should only be run against a single package to check for
-	// imports.
+	// imports. The import-package flag is checked and all other packages are
+	// ignored.
+
+	if p.Pkg.Path() != checkPackage {
+		return nil, nil
+	}
 
 	imports := make(map[string]struct{})
 	for _, dep := range p.Pkg.Imports() {

--- a/tools/agentlint/main.go
+++ b/tools/agentlint/main.go
@@ -1,0 +1,12 @@
+// Command agentlint provides custom linting utilities for the grafana/agent
+// repo.
+package main
+
+import (
+	"github.com/grafana/agent/tools/agentlint/internal/findcomponents"
+	"golang.org/x/tools/go/analysis/multichecker"
+)
+
+func main() {
+	multichecker.Main(findcomponents.Analyzer)
+}


### PR DESCRIPTION
This PR introduces a custom linter as `tools/agentlint`. Initially, it only has one pass: ensure that Flow components are imported.

It will investigate `./component/all`, doing the following:

1. Retrieve the list of direct imports of `./component/all`.
2. Examine packages in `./component/...` to determine which declare a Flow component.
   1. A package declares a Flow component if it has an `init` function which calls `component.Register`.
3. Ensure that `./component/all` imports all of the discovered component packages.

Run `make agentlint` to build the linter at `./build/agentlint`. 

To run it locally, run the following, and observe that no errors are reported:

```
agentlint ./...
```

You can remove an entry from `./component/all` and rerun to observe errors being reported. 

The linter is hooked up to the `make lint` target, and we will be able to add more custom linter passes in the future to agentlint as needed.