### PR TITLE
Flow: Add support for labels in loki components positions file

### DIFF
--- a/component/common/loki/positions/positions.go
+++ b/component/common/loki/positions/positions.go
@@ -51,14 +51,21 @@ type positions struct {
 	logger    log.Logger
 	cfg       Config
 	mtx       sync.Mutex
-	positions map[string]string
+	positions map[Entry]string
 	quit      chan struct{}
 	done      chan struct{}
 }
 
+// Entry desribes a positions file entry consisting of an absolute path and
+// the accompanying labels.
+type Entry struct {
+	Path   string `yaml:"path"`
+	Labels string `yaml:"labels"`
+}
+
 // File format for the positions data.
 type File struct {
-	Positions map[string]string `yaml:"positions"`
+	Positions map[Entry]string `yaml:"positions"`
 }
 
 type Positions interface {
@@ -66,18 +73,18 @@ type Positions interface {
 	// JournalTarget writes a journal cursor to the positions file, while
 	// FileTarget writes an integer offset. Use Get to read the integer
 	// offset.
-	GetString(path string) string
+	GetString(path, labels string) string
 	// Get returns how far we've read through a file. Returns an error
 	// if the value stored for the file is not an integer.
-	Get(path string) (int64, error)
+	Get(path, labels string) (int64, error)
 	// PutString records (asynchronously) how far we've read through a file.
 	// Unlike Put, it records a string offset and is only useful for
 	// JournalTargets which doesn't have integer offsets.
-	PutString(path string, pos string)
+	PutString(path, labels string, pos string)
 	// Put records (asynchronously) how far we've read through a file.
-	Put(path string, pos int64)
+	Put(path, labels string, pos int64)
 	// Remove removes the position tracking for a filepath
-	Remove(path string)
+	Remove(path, labels string)
 	// SyncPeriod returns how often the positions file gets resynced
 	SyncPeriod() time.Duration
 	// Stop the Position tracker.
@@ -108,40 +115,40 @@ func (p *positions) Stop() {
 	<-p.done
 }
 
-func (p *positions) PutString(path string, pos string) {
+func (p *positions) PutString(path, labels string, pos string) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
-	p.positions[path] = pos
+	p.positions[Entry{path, labels}] = pos
 }
 
-func (p *positions) Put(path string, pos int64) {
-	p.PutString(path, strconv.FormatInt(pos, 10))
+func (p *positions) Put(path, labels string, pos int64) {
+	p.PutString(path, labels, strconv.FormatInt(pos, 10))
 }
 
-func (p *positions) GetString(path string) string {
+func (p *positions) GetString(path, labels string) string {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
-	return p.positions[path]
+	return p.positions[Entry{path, labels}]
 }
 
-func (p *positions) Get(path string) (int64, error) {
+func (p *positions) Get(path, labels string) (int64, error) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
-	pos, ok := p.positions[path]
+	pos, ok := p.positions[Entry{path, labels}]
 	if !ok {
 		return 0, nil
 	}
 	return strconv.ParseInt(pos, 10, 64)
 }
 
-func (p *positions) Remove(path string) {
+func (p *positions) Remove(path, labels string) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
-	p.remove(path)
+	p.remove(path, labels)
 }
 
-func (p *positions) remove(path string) {
-	delete(p.positions, path)
+func (p *positions) remove(path, labels string) {
+	delete(p.positions, Entry{path, labels})
 }
 
 func (p *positions) SyncPeriod() time.Duration {
@@ -172,7 +179,7 @@ func (p *positions) save() {
 		return
 	}
 	p.mtx.Lock()
-	positions := make(map[string]string, len(p.positions))
+	positions := make(map[Entry]string, len(p.positions))
 	for k, v := range p.positions {
 		positions[k] = v
 	}
@@ -191,16 +198,16 @@ func CursorKey(key string) string {
 func (p *positions) cleanup() {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
-	toRemove := []string{}
+	toRemove := []Entry{}
 	for k := range p.positions {
 		// If the position file is prefixed with cursor, it's a
 		// cursor and not a file on disk.
 		// We still have to support journal files, so we keep the previous check to avoid breaking change.
-		if strings.HasPrefix(k, cursorKeyPrefix) || strings.HasPrefix(k, journalKeyPrefix) {
+		if strings.HasPrefix(k.Path, cursorKeyPrefix) || strings.HasPrefix(k.Path, journalKeyPrefix) {
 			continue
 		}
 
-		if _, err := os.Stat(k); err != nil {
+		if _, err := os.Stat(k.Path); err != nil {
 			if os.IsNotExist(err) {
 				// File no longer exists.
 				toRemove = append(toRemove, k)
@@ -212,16 +219,16 @@ func (p *positions) cleanup() {
 		}
 	}
 	for _, tr := range toRemove {
-		p.remove(tr)
+		p.remove(tr.Path, tr.Labels)
 	}
 }
 
-func readPositionsFile(cfg Config, logger log.Logger) (map[string]string, error) {
+func readPositionsFile(cfg Config, logger log.Logger) (map[Entry]string, error) {
 	cleanfn := filepath.Clean(cfg.PositionsFile)
 	buf, err := os.ReadFile(cleanfn)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return map[string]string{}, nil
+			return map[Entry]string{}, nil
 		}
 		return nil, err
 	}
@@ -232,7 +239,7 @@ func readPositionsFile(cfg Config, logger log.Logger) (map[string]string, error)
 		// return empty if cfg option enabled
 		if cfg.IgnoreInvalidYaml {
 			level.Debug(logger).Log("msg", "ignoring invalid positions file", "file", cleanfn, "error", err)
-			return map[string]string{}, nil
+			return map[Entry]string{}, nil
 		}
 
 		return nil, fmt.Errorf("invalid yaml positions file [%s]: %v", cleanfn, err)
@@ -240,7 +247,7 @@ func readPositionsFile(cfg Config, logger log.Logger) (map[string]string, error)
 
 	// p.Positions will be nil if the file exists but is empty
 	if p.Positions == nil {
-		p.Positions = map[string]string{}
+		p.Positions = map[Entry]string{}
 	}
 
 	return p.Positions, nil

--- a/component/common/loki/positions/positions.go
+++ b/component/common/loki/positions/positions.go
@@ -56,8 +56,13 @@ type positions struct {
 	done      chan struct{}
 }
 
-// Entry desribes a positions file entry consisting of an absolute path and
-// the accompanying labels.
+// Entry desribes a positions file entry consisting of an absolute file path and
+// the matching label set.
+// An entry expects the string representation of a LabelSet or a Labels slice
+// so that it can be utilized as a YAML key. The caller should make sure that
+// the order and structure of the passed string representation is reproducible,
+// and maintains the same format for both reading and writing from/to the
+// positions file.
 type Entry struct {
 	Path   string `yaml:"path"`
 	Labels string `yaml:"labels"`

--- a/component/common/loki/positions/positions_test.go
+++ b/component/common/loki/positions/positions_test.go
@@ -43,7 +43,8 @@ func TestReadPositionsOK(t *testing.T) {
 		_ = os.Remove(temp)
 	}()
 
-	yaml := []byte(`positions:
+	yaml := []byte(`
+positions:
   ? path: /tmp/random.log
     labels: '{job="tmp"}'
   : "17623"
@@ -109,7 +110,8 @@ func TestReadPositionsFromBadYaml(t *testing.T) {
 		_ = os.Remove(temp)
 	}()
 
-	badYaml := []byte(`positions:
+	badYaml := []byte(`
+positions:
   ? path: /tmp/random.log
     labels: "{}"
   : "176
@@ -133,7 +135,8 @@ func TestReadPositionsFromBadYamlIgnoreCorruption(t *testing.T) {
 		_ = os.Remove(temp)
 	}()
 
-	badYaml := []byte(`positions:
+	badYaml := []byte(`
+positions:
   ? path: /tmp/random.log
     labels: "{}"
   : "176
@@ -157,7 +160,8 @@ func Test_ReadOnly(t *testing.T) {
 	defer func() {
 		_ = os.Remove(temp)
 	}()
-	yaml := []byte(`positions:
+	yaml := []byte(`
+positions:
   ? path: /tmp/random.log
     labels: '{job="tmp"}'
   : "17623"
@@ -193,4 +197,94 @@ func Test_ReadOnly(t *testing.T) {
 	require.Equal(t, map[Entry]string{
 		{Path: "/tmp/random.log", Labels: `{job="tmp"}`}: "17623",
 	}, out)
+}
+
+func TestWriteEmptyLabels(t *testing.T) {
+	temp := tempFilename(t)
+	defer func() {
+		_ = os.Remove(temp)
+	}()
+	yaml := []byte(`
+positions:
+  ? path: /tmp/initial.log
+    labels: '{job="tmp"}'
+  : "10030"
+`)
+	err := os.WriteFile(temp, yaml, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, err := New(util_log.Logger, Config{
+		SyncPeriod:    20 * time.Nanosecond,
+		PositionsFile: temp,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Stop()
+	p.Put("/tmp/foo/nolabels.log", "", 10040)
+	p.Put("/tmp/foo/emptylabels.log", "{}", 10050)
+	p.PutString("/tmp/bar/nolabels.log", "", "10060")
+	p.PutString("/tmp/bar/emptylabels.log", "{}", "10070")
+	pos, err := p.Get("/tmp/initial.log", `{job="tmp"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, int64(10030), pos)
+	p.(*positions).save()
+	out, err := readPositionsFile(Config{
+		PositionsFile:     temp,
+		IgnoreInvalidYaml: true,
+		ReadOnly:          false,
+	}, log.NewNopLogger())
+
+	require.NoError(t, err)
+	require.Equal(t, map[Entry]string{
+		{Path: "/tmp/initial.log", Labels: `{job="tmp"}`}: "10030",
+		{Path: "/tmp/bar/emptylabels.log", Labels: `{}`}:  "10070",
+		{Path: "/tmp/bar/nolabels.log", Labels: ""}:       "10060",
+		{Path: "/tmp/foo/emptylabels.log", Labels: `{}`}:  "10050",
+		{Path: "/tmp/foo/nolabels.log", Labels: ""}:       "10040",
+	}, out)
+}
+
+func TestReadEmptyLabels(t *testing.T) {
+	temp := tempFilename(t)
+	defer func() {
+		_ = os.Remove(temp)
+	}()
+
+	yaml := []byte(`
+positions:
+  ? path: /tmp/nolabels.log
+    labels: ''
+  : "10020"
+  ? path: /tmp/emptylabels.log
+    labels: '{}'
+  : "10030"
+  ? path: /tmp/missinglabels.log
+  : "10040"
+`)
+	err := os.WriteFile(temp, yaml, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pos, err := readPositionsFile(Config{
+		PositionsFile: temp,
+	}, log.NewNopLogger())
+
+	require.NoError(t, err)
+	require.Equal(t, "10020", pos[Entry{
+		Path:   "/tmp/nolabels.log",
+		Labels: ``,
+	}])
+	require.Equal(t, "10030", pos[Entry{
+		Path:   "/tmp/emptylabels.log",
+		Labels: `{}`,
+	}])
+	require.Equal(t, "10040", pos[Entry{
+		Path:   "/tmp/missinglabels.log",
+		Labels: ``,
+	}])
 }

--- a/component/common/loki/positions/write_positions_unix.go
+++ b/component/common/loki/positions/write_positions_unix.go
@@ -15,7 +15,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-func writePositionFile(filename string, positions map[string]string) error {
+func writePositionFile(filename string, positions map[Entry]string) error {
 	buf, err := yaml.Marshal(File{
 		Positions: positions,
 	})

--- a/component/common/loki/positions/write_positions_windows.go
+++ b/component/common/loki/positions/write_positions_windows.go
@@ -16,7 +16,7 @@ import (
 
 // writePositionFile is a fall back for Windows because renameio does not support Windows.
 // See https://github.com/google/renameio#windows-support
-func writePositionFile(filename string, positions map[string]string) error {
+func writePositionFile(filename string, positions map[Entry]string) error {
 	buf, err := yaml.Marshal(File{
 		Positions: positions,
 	})

--- a/component/loki/source/file/file.go
+++ b/component/loki/source/file/file.go
@@ -35,6 +35,7 @@ const (
 
 // Arguments holds values which are used to configure the loki.source.file
 // component.
+// TODO(@tpaschalis) Allow users to configure the encoding of the tailed files.
 type Arguments struct {
 	Targets   []discovery.Target  `river:"targets,attr"`
 	ForwardTo []loki.LogsReceiver `river:"forward_to,attr"`
@@ -184,13 +185,14 @@ func (c *Component) Update(args component.Arguments) error {
 
 // DebugInfo returns information about the status of tailed targets.
 // TODO(@tpaschalis) Decorate with more debug information once it's made
-// available, such as the label set and the last time a log line was read.
+// available, such as the last time a log line was read.
 func (c *Component) DebugInfo() interface{} {
 	var res readerDebugInfo
 	for e, reader := range c.readers {
 		offset, _ := c.posFile.Get(e.Path, e.Labels)
 		res.TargetsInfo = append(res.TargetsInfo, targetInfo{
 			Path:       e.Path,
+			Labels:     e.Labels,
 			IsRunning:  reader.IsRunning(),
 			ReadOffset: offset,
 		})


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

#### PR Description
In #2503 we introduced a new `loki.source.file` component, which tails files from disk and sends scraped log entries to other loki.* components.

There are a few omissions with the component current component implementation.

* On Update() it stops and re-creates all readers, even if it's not required
* It does not support tailing multiple files with the same path but different label sets (last one currently wins)
* It cannot expose target labels in DebugInfo

Some of this behavior stems from Promtail's positions file implementation which indexes _only by path_.

This PR updates the `positions` package to index files by both path _and_ the label set.
This will allow for smarter handling when updating the status of targets, better insight on the current status of active readers, and finer-grained handling of targets in future PRs.

Since this is a breaking change for the Positions file format (rendering previously-used positions files useless) this would be a breaking change if it were to be included in a future release, so I'd like to try and include this with v0.30.

The new positions file format looks like this
```
--- positions.yml ---
$ cat data-agent/loki.source.file.default/positions.yml
positions:
  ? path: /Users/tpaschalis/GitRepos/agent/test/foo.txt
    labels: '{color="pink"}'
  : "1472"
  ? path: /Users/tpaschalis/GitRepos/agent/test/bar.txt
    labels: '{color="blue"}'
  : "22"
  ? path: /Users/tpaschalis/GitRepos/agent/test/baz.txt
    labels: '{}'
  : "29"
```

The question mark character makes use of YAML's 'complex key mapping' feature ([1](https://stackoverflow.com/questions/33987316/what-is-a-complex-mapping-key-in-yaml) [2](https://yaml.org/spec/1.2.2/#:~:text=Example%202.11%20Mapping%20between%20Sequences)) which allows to index a key using a _structure_ and not a single string.

An alternative would be to use a separator like `filename~~~labels` or `filename|labels`, but since we want the format to be portable between *nix-like and Windows machines _and_  be able to parse back and forth from it without any ambiguous meaning; I couldn't find a good way to do that (eg. a character that cannot be a part of a path in any Windows _or_ Linux filesystems).

#### Which issue(s) this PR fixes
Follow-up to #2503.


#### Notes to the Reviewer
This is still a WIP. At a first glance, it works locally, but I'd like to verify its behavior and increase our confidence with a test suite.

Also, will have to verify the positions file structure.


#### PR Checklist

- [ ] CHANGELOG updated (N/A, not a user-facing change)
- [ ] Documentation added
- [X] Tests updated
