### PR TITLE
Remove fsnotify

### DIFF
--- a/component/discovery/file/file.go
+++ b/component/discovery/file/file.go
@@ -177,7 +177,6 @@ func (c *Component) reconcileWatchesWithWatcher() {
 			continue
 		}
 		c.addToWatchedFiles(n)
-
 	}
 	// Find all the removed paths.
 	filesToRemove := make([]string, 0)


### PR DESCRIPTION
#### PR Description

I wonder if we need fs notify, the filetarget manager code has a sync that manually syncs up items and fsnotify clutters up the codebase. We only push updates to targets on the fixed scheduled.
