### PR TITLE
(build) fix quoting in dockerfile for 0.30.1

### DIFF
--- a/cmd/agent/Dockerfile
+++ b/cmd/agent/Dockerfile
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=${TARGETVARIANT#v} \
     RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} \
-    GO_TAGS=builtinassets promtail_journal_enabled \
+    GO_TAGS="builtinassets promtail_journal_enabled" \
     make agent
 
 FROM ubuntu:jammy


### PR DESCRIPTION
I am pretty sure the quotes here are needed for the dockerfile build.

I don't think this is worth another patch release. We should be able to force-update the existing 0.30.1 tag and re-trigger the build. Unless we really think this needs a 0.30.2.