### PR TITLE
Ensure no empty fields are marshaled in YAML

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -452,3 +452,10 @@ func TestLoadDynamicConfigurationExpandError(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "expand var is not supported when using dynamic configuration, use gomplate env instead"))
 }
+
+func TestAgent_OmmitEmptyFields(t *testing.T) {
+	var cfg Config
+	yml, err := yaml.Marshal(&cfg)
+	require.NoError(t, err)
+	require.Equal(t, "{}\n", string(yml))
+}

--- a/pkg/metrics/cluster/cluster.go
+++ b/pkg/metrics/cluster/cluster.go
@@ -71,7 +71,7 @@ func New(
 		return nil, fmt.Errorf("failed to initialize node membership: %w", err)
 	}
 
-	c.store, err = configstore.NewRemote(l, reg, cfg.KVStore, cfg.Enabled)
+	c.store, err = configstore.NewRemote(l, reg, cfg.KVStore.Config, cfg.Enabled)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize configstore: %w", err)
 	}

--- a/pkg/metrics/cluster/config.go
+++ b/pkg/metrics/cluster/config.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"flag"
+	"reflect"
 	"strings"
 	"time"
 
@@ -15,16 +16,34 @@ import (
 // DefaultConfig provides default values for the config
 var DefaultConfig = *flagutil.DefaultConfigFromFlags(&Config{}).(*Config)
 
+// KVConfig wraps the kv.Config type to allow defining IsZero, which is required to make omitempty work when marshalling YAML.
+type KVConfig struct {
+	kv.Config
+}
+
+func (k KVConfig) IsZero() bool {
+	return reflect.DeepEqual(k, KVConfig{})
+}
+
+// LifecyclerConfig wraps the ring.LifecyclerConfig type to allow defining IsZero, which is required to make omitempty work when marshalling YAML.
+type LifecyclerConfig struct {
+	ring.LifecyclerConfig
+}
+
+func (l LifecyclerConfig) IsZero() bool {
+	return reflect.DeepEqual(l, LifecyclerConfig{})
+}
+
 // Config describes how to instantiate a scraping service Server instance.
 type Config struct {
-	Enabled                    bool                  `yaml:"enabled"`
-	ReshardInterval            time.Duration         `yaml:"reshard_interval"`
-	ReshardTimeout             time.Duration         `yaml:"reshard_timeout"`
-	ClusterReshardEventTimeout time.Duration         `yaml:"cluster_reshard_event_timeout"`
-	KVStore                    kv.Config             `yaml:"kvstore"`
-	Lifecycler                 ring.LifecyclerConfig `yaml:"lifecycler"`
+	Enabled                    bool             `yaml:"enabled,omitempty"`
+	ReshardInterval            time.Duration    `yaml:"reshard_interval,omitempty"`
+	ReshardTimeout             time.Duration    `yaml:"reshard_timeout,omitempty"`
+	ClusterReshardEventTimeout time.Duration    `yaml:"cluster_reshard_event_timeout,omitempty"`
+	KVStore                    KVConfig         `yaml:"kvstore,omitempty"`
+	Lifecycler                 LifecyclerConfig `yaml:"lifecycler,omitempty"`
 
-	DangerousAllowReadingFiles bool `yaml:"dangerous_allow_reading_files"`
+	DangerousAllowReadingFiles bool `yaml:"dangerous_allow_reading_files,omitempty"`
 
 	// TODO(rfratto): deprecate scraping_service_client in Agent and replace with this.
 	Client                    client.Config `yaml:"-"`

--- a/pkg/metrics/cluster/config_test.go
+++ b/pkg/metrics/cluster/config_test.go
@@ -1,0 +1,15 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestAgent_OmmitEmptyFields(t *testing.T) {
+	var cfg Config
+	yml, err := yaml.Marshal(&cfg)
+	require.NoError(t, err)
+	require.Equal(t, "{}\n", string(yml))
+}

--- a/pkg/metrics/cluster/node.go
+++ b/pkg/metrics/cluster/node.go
@@ -120,7 +120,7 @@ func (n *node) ApplyConfig(cfg Config) error {
 	}
 	n.ring = r
 
-	lc, err := ring.NewLifecycler(cfg.Lifecycler, n, "agent", agentKey, false, n.log, prometheus.WrapRegistererWithPrefix("agent_dskit_", n.reg))
+	lc, err := ring.NewLifecycler(cfg.Lifecycler.LifecyclerConfig, n, "agent", agentKey, false, n.log, prometheus.WrapRegistererWithPrefix("agent_dskit_", n.reg))
 	if err != nil {
 		return fmt.Errorf("failed to create lifecycler: %w", err)
 	}

--- a/pkg/metrics/cluster/node_test.go
+++ b/pkg/metrics/cluster/node_test.go
@@ -49,7 +49,7 @@ func Test_node_Join(t *testing.T) {
 
 	nodeConfig := DefaultConfig
 	nodeConfig.Enabled = true
-	nodeConfig.Lifecycler = testLifecyclerConfig(t)
+	nodeConfig.Lifecycler.LifecyclerConfig = testLifecyclerConfig(t)
 
 	n, err := newNode(reg, logger, nodeConfig, local)
 	require.NoError(t, err)
@@ -99,7 +99,7 @@ func Test_node_Leave(t *testing.T) {
 
 	nodeConfig := DefaultConfig
 	nodeConfig.Enabled = true
-	nodeConfig.Lifecycler = testLifecyclerConfig(t)
+	nodeConfig.Lifecycler.LifecyclerConfig = testLifecyclerConfig(t)
 
 	n, err := newNode(reg, logger, nodeConfig, local)
 	require.NoError(t, err)
@@ -132,7 +132,7 @@ func Test_node_ApplyConfig(t *testing.T) {
 
 	nodeConfig := DefaultConfig
 	nodeConfig.Enabled = true
-	nodeConfig.Lifecycler = testLifecyclerConfig(t)
+	nodeConfig.Lifecycler.LifecyclerConfig = testLifecyclerConfig(t)
 
 	n, err := newNode(reg, logger, nodeConfig, local)
 	require.NoError(t, err)

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -6,10 +6,19 @@ import (
 	"github.com/weaveworks/common/logging"
 )
 
+// LogLevel wraps the logging.Level type to allow defining IsZero, which is required to make omitempty work when marshalling YAML.
+type LogLevel struct {
+	logging.Level
+}
+
+func (l LogLevel) IsZero() bool {
+	return l.Level.String() == ""
+}
+
 // Config holds dynamic configuration options for a Server.
 type Config struct {
-	LogLevel  logging.Level  `yaml:"log_level"`
-	LogFormat logging.Format `yaml:"log_format"`
+	LogLevel  LogLevel       `yaml:"log_level,omitempty"`
+	LogFormat logging.Format `yaml:"log_format,omitempty"`
 
 	GRPC GRPCConfig `yaml:",inline"`
 	HTTP HTTPConfig `yaml:",inline"`
@@ -25,12 +34,12 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // HTTPConfig holds dynamic configuration options for the HTTP server.
 type HTTPConfig struct {
-	TLSConfig TLSConfig `yaml:"http_tls_config"`
+	TLSConfig TLSConfig `yaml:"http_tls_config,omitempty"`
 }
 
 // GRPCConfig holds dynamic configuration options for the gRPC server.
 type GRPCConfig struct {
-	TLSConfig TLSConfig `yaml:"grpc_tls_config"`
+	TLSConfig TLSConfig `yaml:"grpc_tls_config,omitempty"`
 }
 
 // Default configuration structs.
@@ -51,8 +60,8 @@ var (
 	}
 
 	emptyFlagSet    = flag.NewFlagSet("", flag.ExitOnError)
-	DefaultLogLevel = func() logging.Level {
-		var lvl logging.Level
+	DefaultLogLevel = func() LogLevel {
+		var lvl LogLevel
 		lvl.RegisterFlags(emptyFlagSet)
 		return lvl
 	}()

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -1,0 +1,15 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestConfig_OmmitEmptyFields(t *testing.T) {
+	var cfg Config
+	yml, err := yaml.Marshal(&cfg)
+	require.NoError(t, err)
+	require.Equal(t, "{}\n", string(yml))
+}

--- a/pkg/server/logger.go
+++ b/pkg/server/logger.go
@@ -72,7 +72,7 @@ func (l *Logger) ApplyConfig(cfg *Config) error {
 }
 
 func defaultLogger(cfg *Config) (log.Logger, error) {
-	return makeDefaultLogger(cfg.LogLevel, cfg.LogFormat)
+	return makeDefaultLogger(cfg.LogLevel.Level, cfg.LogFormat)
 }
 
 func makeDefaultLogger(lvl logging.Level, fmt logging.Format) (log.Logger, error) {


### PR DESCRIPTION
#### PR Description

  - Remote config merging requires marshaling valid but minimal configurations to avoid returning more fields than necessary, which may lead to unwanted overrides in the local and default configurations. 
  - This change makes sure no empty fields are marshaled.

#### Notes to the Reviewer

  - Although we omit most of the empty fields already, some types (especially imported ones) require implementing the IsZeroer interface for `omitempty` to properly work.
  - Since we cannot extend an external type with this interface, we need to define wrapper types.
  - Although this is relatively intrusive, it is probably safer than replacing the existing fields with pointers.
  - See https://pkg.go.dev/gopkg.in/yaml.v2#IsZeroer
  - See https://sentry.io/answers/alias-type-definitions/#the-solution

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
