### PR TITLE
Flow: add loki.source.syslog component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,14 +36,13 @@ Main (unreleased)
   - `phlare.write` sends application performance profiles to Grafana Phlare. (@cyriltovena)
   - `otelcol.receiver.zipkin` receives Zipkin-formatted traces. (@rfratto)
   - `loki.source.windowsevent` reads logs from Windows Event Log. (@mattdurham)
+  - `loki.source.syslog` listens for Syslog messages over TCP and UDP
+    connections and forwards them to other `loki` components. (@tpaschalis)
 
 - Flow components which work with relabeling rules (`discovery.relabel`,
   `prometheus.relabel` and `loki.relabel`) now export a new value named Rules.
   This value is a function that returns the currently configured rules.
   (@tpaschalis)
-
-  - `loki.source.syslog` listens for Syslog messages over TCP and UDP
-    connections and forwards them to other `loki` components. (@tpaschalis)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Main (unreleased)
   This value is a function that returns the currently configured rules.
   (@tpaschalis)
 
+  - `loki.source.syslog` listens for Syslog messages over TCP and UDP
+    connections and forwards them to other `loki` components. (@tpaschalis)
+
 ### Enhancements
 
 - Handle faro-web-sdk `View` meta in app_agent_receiver. (@rlankfo)

--- a/component/all/all.go
+++ b/component/all/all.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/grafana/agent/component/loki/process"                         // Import loki.process
 	_ "github.com/grafana/agent/component/loki/relabel"                         // Import loki.relabel
 	_ "github.com/grafana/agent/component/loki/source/file"                     // Import loki.source.file
+	_ "github.com/grafana/agent/component/loki/source/syslog"                   // Import loki.source.syslog
 	_ "github.com/grafana/agent/component/loki/source/windowsevent"             // Import loki.source.windowsevent
 	_ "github.com/grafana/agent/component/loki/write"                           // Import loki.write
 	_ "github.com/grafana/agent/component/mimir/rules/kubernetes"               // Import mimir.rules.kubernetes

--- a/component/loki/source/syslog/internal/fake/client.go
+++ b/component/loki/source/syslog/internal/fake/client.go
@@ -1,0 +1,73 @@
+package fake
+
+// This code is copied from Promtail. The fake package is used to configure
+// fake client that can be used in testing.
+
+import (
+	"sync"
+
+	"github.com/grafana/agent/component/common/loki"
+)
+
+// Client is a fake client used for testing.
+type Client struct {
+	entries  loki.LogsReceiver
+	received []loki.Entry
+	once     sync.Once
+	mtx      sync.Mutex
+	wg       sync.WaitGroup
+	OnStop   func()
+}
+
+func New(stop func()) *Client {
+	c := &Client{
+		OnStop:  stop,
+		entries: make(loki.LogsReceiver),
+	}
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		for e := range c.entries {
+			c.mtx.Lock()
+			c.received = append(c.received, e)
+			c.mtx.Unlock()
+		}
+	}()
+	return c
+}
+
+// Stop implements client.Client
+func (c *Client) Stop() {
+	c.once.Do(func() { close(c.entries) })
+	c.wg.Wait()
+	c.OnStop()
+}
+
+func (c *Client) Chan() chan<- loki.Entry {
+	return c.entries
+}
+
+func (c *Client) Received() []loki.Entry {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	cpy := make([]loki.Entry, len(c.received))
+	copy(cpy, c.received)
+	return cpy
+}
+
+// StopNow implements client.Client
+func (c *Client) StopNow() {
+	c.Stop()
+}
+
+func (c *Client) Name() string {
+	return "fake"
+}
+
+// Clear is used to cleanup the buffered received entries, so the same client can be re-used between
+// test cases.
+func (c *Client) Clear() {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	c.received = []loki.Entry{}
+}

--- a/component/loki/source/syslog/internal/syslogtarget/metrics.go
+++ b/component/loki/source/syslog/internal/syslogtarget/metrics.go
@@ -1,0 +1,46 @@
+package syslogtarget
+
+// This code is copied from Promtail. The syslogtarget package is used to
+// configure and run the targets that can read syslog entries and forward them
+// to other loki components.
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Metrics holds a set of syslog metrics.
+type Metrics struct {
+	reg prometheus.Registerer
+
+	syslogEntries       prometheus.Counter
+	syslogParsingErrors prometheus.Counter
+	syslogEmptyMessages prometheus.Counter
+}
+
+// NewMetrics creates a new set of syslog metrics. If reg is non-nil, the
+// metrics will be registered.
+func NewMetrics(reg prometheus.Registerer) *Metrics {
+	var m Metrics
+	m.reg = reg
+
+	m.syslogEntries = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "loki_source_syslog_entries_total",
+		Help: "Total number of successful entries sent to the syslog target",
+	})
+	m.syslogParsingErrors = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "loki_source_syslog_parsing_errors_total",
+		Help: "Total number of parsing errors while receiving syslog messages",
+	})
+	m.syslogEmptyMessages = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "loki_source_syslog_empty_messages_total",
+		Help: "Total number of empty messages received from syslog",
+	})
+
+	if reg != nil {
+		reg.MustRegister(
+			m.syslogEntries,
+			m.syslogParsingErrors,
+			m.syslogEmptyMessages,
+		)
+	}
+
+	return &m
+}

--- a/component/loki/source/syslog/internal/syslogtarget/syslogtarget.go
+++ b/component/loki/source/syslog/internal/syslogtarget/syslogtarget.go
@@ -1,0 +1,242 @@
+package syslogtarget
+
+// This code is copied from Promtail. The syslogtarget package is used to
+// configure and run the targets that can read syslog entries and forward them
+// to other loki components.
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/influxdata/go-syslog/v3"
+	"github.com/influxdata/go-syslog/v3/rfc5424"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/relabel"
+
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
+	"github.com/grafana/loki/clients/pkg/promtail/targets/target"
+
+	"github.com/grafana/loki/pkg/logproto"
+)
+
+var (
+	DefaultIdleTimeout      = 120 * time.Second
+	DefaultMaxMessageLength = 8192
+	DefaultProtocol         = protocolTCP
+)
+
+// SyslogTarget listens to syslog messages.
+// nolint:revive
+type SyslogTarget struct {
+	metrics       *Metrics
+	logger        log.Logger
+	handler       loki.EntryHandler
+	config        *scrapeconfig.SyslogTargetConfig
+	relabelConfig []*relabel.Config
+
+	transport Transport
+
+	messages     chan message
+	messagesDone chan struct{}
+}
+
+type message struct {
+	labels    model.LabelSet
+	message   string
+	timestamp time.Time
+}
+
+// NewSyslogTarget configures a new SyslogTarget.
+func NewSyslogTarget(
+	metrics *Metrics,
+	logger log.Logger,
+	handler loki.EntryHandler,
+	relabel []*relabel.Config,
+	config *scrapeconfig.SyslogTargetConfig,
+) (*SyslogTarget, error) {
+
+	t := &SyslogTarget{
+		metrics:       metrics,
+		logger:        logger,
+		handler:       handler,
+		config:        config,
+		relabelConfig: relabel,
+		messagesDone:  make(chan struct{}),
+	}
+
+	switch t.transportProtocol() {
+	case protocolTCP:
+		t.transport = NewSyslogTCPTransport(
+			config,
+			t.handleMessage,
+			t.handleMessageError,
+			logger,
+		)
+	case protocolUDP:
+		t.transport = NewSyslogUDPTransport(
+			config,
+			t.handleMessage,
+			t.handleMessageError,
+			logger,
+		)
+	default:
+		return nil, fmt.Errorf("invalid transport protocol. expected 'tcp' or 'udp', got '%s'", t.transportProtocol())
+	}
+
+	t.messages = make(chan message)
+	go t.messageSender(handler.Chan())
+
+	err := t.transport.Run()
+	if err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+func (t *SyslogTarget) handleMessageError(err error) {
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		level.Debug(t.logger).Log("msg", "connection timed out", "err", ne)
+		return
+	}
+	level.Warn(t.logger).Log("msg", "error parsing syslog stream", "err", err)
+	t.metrics.syslogParsingErrors.Inc()
+}
+
+func (t *SyslogTarget) handleMessage(connLabels labels.Labels, msg syslog.Message) {
+	rfc5424Msg := msg.(*rfc5424.SyslogMessage)
+
+	if rfc5424Msg.Message == nil {
+		t.metrics.syslogEmptyMessages.Inc()
+		return
+	}
+
+	lb := labels.NewBuilder(connLabels)
+	if v := rfc5424Msg.SeverityLevel(); v != nil {
+		lb.Set("__syslog_message_severity", *v)
+	}
+	if v := rfc5424Msg.FacilityLevel(); v != nil {
+		lb.Set("__syslog_message_facility", *v)
+	}
+	if v := rfc5424Msg.Hostname; v != nil {
+		lb.Set("__syslog_message_hostname", *v)
+	}
+	if v := rfc5424Msg.Appname; v != nil {
+		lb.Set("__syslog_message_app_name", *v)
+	}
+	if v := rfc5424Msg.ProcID; v != nil {
+		lb.Set("__syslog_message_proc_id", *v)
+	}
+	if v := rfc5424Msg.MsgID; v != nil {
+		lb.Set("__syslog_message_msg_id", *v)
+	}
+
+	if t.config.LabelStructuredData && rfc5424Msg.StructuredData != nil {
+		for id, params := range *rfc5424Msg.StructuredData {
+			id = strings.ReplaceAll(id, "@", "_")
+			for name, value := range params {
+				key := "__syslog_message_sd_" + id + "_" + name
+				lb.Set(key, value)
+			}
+		}
+	}
+
+	processed := relabel.Process(lb.Labels(nil), t.relabelConfig...)
+
+	filtered := make(model.LabelSet)
+	for _, lbl := range processed {
+		if strings.HasPrefix(lbl.Name, "__") {
+			continue
+		}
+		filtered[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
+	}
+
+	var timestamp time.Time
+	if t.config.UseIncomingTimestamp && rfc5424Msg.Timestamp != nil {
+		timestamp = *rfc5424Msg.Timestamp
+	} else {
+		timestamp = time.Now()
+	}
+
+	m := *rfc5424Msg.Message
+	if t.config.UseRFC5424Message {
+		fullMsg, err := rfc5424Msg.String()
+		if err != nil {
+			level.Debug(t.logger).Log("msg", "failed to convert rfc5424 message to string; using message field instead", "err", err)
+		} else {
+			m = fullMsg
+		}
+	}
+	t.messages <- message{filtered, m, timestamp}
+}
+
+func (t *SyslogTarget) messageSender(entries chan<- loki.Entry) {
+	for msg := range t.messages {
+		entries <- loki.Entry{
+			Labels: msg.labels,
+			Entry: logproto.Entry{
+				Timestamp: msg.timestamp,
+				Line:      msg.message,
+			},
+		}
+		t.metrics.syslogEntries.Inc()
+	}
+	t.messagesDone <- struct{}{}
+}
+
+// Type returns SyslogTargetType.
+func (t *SyslogTarget) Type() target.TargetType {
+	return target.SyslogTargetType
+}
+
+// Ready indicates whether or not the syslog target is ready to be read from.
+func (t *SyslogTarget) Ready() bool {
+	return t.transport.Ready()
+}
+
+// DiscoveredLabels returns the set of labels discovered by the syslog target, which
+// is always nil. Implements Target.
+func (t *SyslogTarget) DiscoveredLabels() model.LabelSet {
+	return nil
+}
+
+// Labels returns the set of labels that statically apply to all log entries
+// produced by the SyslogTarget.
+func (t *SyslogTarget) Labels() model.LabelSet {
+	return t.config.Labels
+}
+
+// Details returns target-specific details.
+func (t *SyslogTarget) Details() interface{} {
+	return map[string]string{}
+}
+
+// Stop shuts down the SyslogTarget.
+func (t *SyslogTarget) Stop() error {
+	err := t.transport.Close()
+	t.transport.Wait()
+	close(t.messages)
+	// wait for all pending messages to be processed and sent to handler
+	<-t.messagesDone
+	t.handler.Stop()
+	return err
+}
+
+// ListenAddress returns the address SyslogTarget is listening on.
+func (t *SyslogTarget) ListenAddress() net.Addr {
+	return t.transport.Addr()
+}
+
+func (t *SyslogTarget) transportProtocol() string {
+	if t.config.ListenProtocol != "" {
+		return t.config.ListenProtocol
+	}
+	return DefaultProtocol
+}

--- a/component/loki/source/syslog/internal/syslogtarget/syslogtarget_test.go
+++ b/component/loki/source/syslog/internal/syslogtarget/syslogtarget_test.go
@@ -353,7 +353,6 @@ func Benchmark_SyslogTarget(b *testing.B) {
 			require.Eventuallyf(b, func() bool {
 				return len(client.Received()) == len(messages)*b.N
 			}, 15*time.Second, time.Second, "expected: %d got:%d", len(messages)*b.N, len(client.Received()))
-
 		})
 	}
 }

--- a/component/loki/source/syslog/internal/syslogtarget/syslogtarget_test.go
+++ b/component/loki/source/syslog/internal/syslogtarget/syslogtarget_test.go
@@ -1,0 +1,925 @@
+package syslogtarget
+
+// This code is copied from Promtail. The syslogtarget package is used to
+// configure and run the targets that can read syslog entries and forward them
+// to other loki components.
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/agent/component/loki/source/syslog/internal/fake"
+	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
+	"github.com/grafana/loki/clients/pkg/promtail/targets/syslog/syslogparser"
+	"github.com/influxdata/go-syslog/v3"
+	promconfig "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+var (
+	caCert = []byte(`
+-----BEGIN CERTIFICATE-----
+MIIFDTCCAvWgAwIBAgIRAL3YFsDcKtnEWCzE0qafwlQwDQYJKoZIhvcNAQELBQAw
+IDEeMBwGA1UEAxMVUHJvbXRhaWwgVGVzdCBSb290IENBMB4XDTIyMDYyOTA4MTQy
+MFoXDTQyMDYyOTA4MTQyMFowIDEeMBwGA1UEAxMVUHJvbXRhaWwgVGVzdCBSb290
+IENBMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA1wHnEwW3Gc1Q3v4F
+BgFL9N2rayHA7yFqViEwG8AiliaCnnN5VaAN29tpWMgr9sLpve5Ka8iCO8xnIxsM
+5rtlSvLlFW0SInXyJsBT6NyqHrk2GZBhscgT+Qb9ouSYjil4UFRADAAEhBZPVisO
+ZQiELKPS+BxyRL15QhMB7k7u1z0GRzlrG7CcopzrYM+4JLGE+2nXnoy7MSjdNduH
+w4sWwI66hD192Lpkh83HZneONXiZhJdEJOHHJ8G+rYwuZRAlnLs82y+OROIozuKV
+yFhWMk+BUGgkeftmAzIiUAneKwKugqz9QExVPo1imGAsiVHdprTTPn/34ZNpsDR7
+MXwzitVqvu/pa3BYDha7RTpeCdVPFqDs8BPFgcAleM75QQcnPtbUD/apJHUQ5D5q
+8c2U/2hTtcTMZIMCscoBBpx98bSOS9ojIJSGYKCdBj6rqnAFNYasayVCN5c5pPIw
+Mj7HUww4gKXVKMvNDnjaXqFBEgEjSv5cquZ993C8gVGHLiMnq/Bj5k9SeOD0gTKD
+/uLuLhKiMI6sOJQrYW5W0P3tTNcYGUeS0hBZW2Mo6PM+BimfzstZhsdFQnjzMEld
+I5elwqWKysEvxXIvLnGLVWXJ6s0Pyr6J0ASmxpjskQEcPgaOxkRVwNzC18eSq3Ey
+zUEWoyHiDedB4CCIq6nXY01FC5MCAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgKkMA8G
+A1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFFBj1+WwOdP8rb95R7kOmWena3RfMA0G
+CSqGSIb3DQEBCwUAA4ICAQDQtOpfNPrv+V8ObOb+pie//UfTReOwXtBZgTxMu1Bi
+uYIiFEveQ18HGAeIhbVm8wLjtfPkoJlZKzdCcMqSmLt0LZQNs13IQ8M+YuXeu5pX
+PJOu0WrbdQHW5JMnPxwKMk5T2axbrX9dYW9gvr8sh5OlnNTx88fY1vMBsnNLVZT+
+kC7Daf0zT0Go6VxBk6KRtfpoVCy/aYgwbJ1u5W61eYtXC4ezrpoLINo7zVs7Tob8
+iIxJMQ/iEk/7BbIgVh9z8lNeexdjXCqm8952pPhkGONneCESTxJjgYqXyhlV0ict
+OP+CiMHl5yf6+eklfXU78Jmkh/46XBqu7JV8lt8xbbSJ4AITWxi3csxC/Xztyu/g
+H5nS2gAmpAbTjHq7lGicFScBuR3g0o3+64KN3XhVXN1KFrTlsGSOxyPE657p2xNw
+tAAQs9IEBIPVqMInOGue6LbHTzCzW8hMClfu0CwPXiMY5DWKif7O9kzxnb9HdmAl
+gnDn+9OzTw7oAW1UyVTSbzYy0Tw1ioYR7U77Z+Gcst2+mIuWp7BFNkaX5mPaacCT
+GLnXoZk8UU0ph5/uBfZL3dNsJKeXlnCMAXACdLicnMC19g6P/dKqRZcI2w7kTPtF
+2GlKMYjeKDuAUc9VeGzDc6PAX4oqF8XPfP5Mie4nrtpYnL0zKV1RcUS1yX1TC24O
+ig==
+-----END CERTIFICATE-----
+`)
+
+	// Unused, but can be useful to (re)generate some certificates
+	// nolint:deadcode,unused,varcheck
+	caKey = []byte(`
+-----BEGIN RSA PRIVATE KEY-----
+MIIJJwIBAAKCAgEA1wHnEwW3Gc1Q3v4FBgFL9N2rayHA7yFqViEwG8AiliaCnnN5
+VaAN29tpWMgr9sLpve5Ka8iCO8xnIxsM5rtlSvLlFW0SInXyJsBT6NyqHrk2GZBh
+scgT+Qb9ouSYjil4UFRADAAEhBZPVisOZQiELKPS+BxyRL15QhMB7k7u1z0GRzlr
+G7CcopzrYM+4JLGE+2nXnoy7MSjdNduHw4sWwI66hD192Lpkh83HZneONXiZhJdE
+JOHHJ8G+rYwuZRAlnLs82y+OROIozuKVyFhWMk+BUGgkeftmAzIiUAneKwKugqz9
+QExVPo1imGAsiVHdprTTPn/34ZNpsDR7MXwzitVqvu/pa3BYDha7RTpeCdVPFqDs
+8BPFgcAleM75QQcnPtbUD/apJHUQ5D5q8c2U/2hTtcTMZIMCscoBBpx98bSOS9oj
+IJSGYKCdBj6rqnAFNYasayVCN5c5pPIwMj7HUww4gKXVKMvNDnjaXqFBEgEjSv5c
+quZ993C8gVGHLiMnq/Bj5k9SeOD0gTKD/uLuLhKiMI6sOJQrYW5W0P3tTNcYGUeS
+0hBZW2Mo6PM+BimfzstZhsdFQnjzMEldI5elwqWKysEvxXIvLnGLVWXJ6s0Pyr6J
+0ASmxpjskQEcPgaOxkRVwNzC18eSq3EyzUEWoyHiDedB4CCIq6nXY01FC5MCAwEA
+AQKCAgAeBY79cfvaJ3gWWwPajc3MWDN6VxE4ksLlWeb8yPxLWP8+HsOfeCTXQTDZ
+i8HPx/GZaq+Lk0jUDruMBFft09bV+0qPjlZM54kzbgGJb151wcjTEv0BNP3M9PPv
+jdnbZ+D73ne+9TWsN+1GC+cLpn/GN+3aZSZzgL1ww3SukOj6tvOseFEDYcrNTfnz
+361Hul3mOSY5Zk8xExKoVYoEfORlaMiUdH2hCI3HBK3GGgWKY9eT0wdZ2wjS/VOh
+qgREalfGJcLenCpSZf3qvWrKucL3bXCSCKinO7pH0fVGlcom2U4CwyLtmnsAq/9L
+ZYpydjLr9y3T+UxkfA/y4bEd/Mi5ZWdM1Dd7yP5I6RgiBaPU4RF1JZZRltD9tCc7
+D2Qw8nKCHRf455+KGxMX7f3MdJEiV0O4TW5aU5QPxKhuYcum0iMgQqTiIj+rTcTK
++nuzFcU0GRIDI2n7pW79wWMCA0mz1RQ7CSLtsgaH9gOCnetYik7Tj23FOi7NnBtW
+D0D30A3ZhdNy0Khjz4E67l1yRjzON4VO/j2zkeD39kUNpTXk+ry1Igy6EpWsGNc9
+AVycaUGqF75VWTpR8zi/qV+m9aMORM5fyviBu+vxTfDl1bzthGDWy7lJEPeC76wl
+Fs8byuK8BJT4jtrCQ6bUqeSgks8O3jNFjnrZLUo3HC2f0cA24QKCAQEA3SNlWlw5
+a2sm6bg9F3BKorG2GZdNDi8ENWBzKpQFFaDaryfeToHHwRpr4qMEsLSMSAAxbpHc
+vUDKgLvlwhrOBDZKe+KmgHH7bODzgs1x2an4KCjhBD+YJBKaL7O5bJ9o019fcWie
+DQvNoaNayl6xz3juDl8tW9l8FOfYxv3MMT1mShH6hd62OhbVPSVtNUPXKZg/Apz7
+CrsMBWDwRErH879U/IjLvOWfI0lCeNekO9fMdtKrczhCzfNmclSSZqoeRiOj/ZGo
+ZuSGgSQJF7ZyfnZ5j4gfCfyTnijW7SuKOTImVU6h2W3qlv3nWcVKg/BQwrj4eHoM
+5WjFtj+jEGIRkQKCAQEA+OcUx2wg+BU3wu3Z9LfL34wcRKgoiwpuvT0OofuI6bwz
+GQoM6K4KsNoacZvv2Bj2QydM6fmF5mvl+q60hvbxSJ0Xugi6jqwIZX/n5XKyZ9qO
+2ls/5izdETjNCT3okrdlUYxkDhI3Eqx/A5kiStBnJDoone4V834FnTXBVquJzxFP
+JG63qpcGGko7Fx/xY9Y/ZvCjwtC4qr34DOwIcT+Jtci6CHZeaSr7Jq/KC69ujJ8n
+3IByqGepNbVEHZsXYTYrKRXWzTuQw9owmcJOqkK2dYe+cEUsUHLBVvCwgv7swnb6
+3zG5KR4CE19aTCcVmIplzqMlVFxavQepH2jAuxv44wKCAQAe0uM6wCYkye/Hni2t
+ybItkVXPpV5RPs54XjRPWAiJZj11Mrpy+PYN/Y/SLGTn+JKhKp25Ss2Y96ICZa51
+6uSSg7rIH+STfM/N8mEe92IKM/3qIyCSRgb/6DPjuEp9UI78/4s/NJTrPpzwDeQG
+10IzqCiOike5SMxZ4aM+wXun1WYfpvfjlxKRcENS3ZemWAlyu8z0oUsAyOe5DDUR
+X9cVK7M97BdyAhO3iGuiinRS/xZ57Y2GZu4w5N9/yjgJ5WaI4kjmfFob1XjGIW6/
+BmhZJkx1bETfUHyHDCxBLNN8e3gKZgZ7Vy3e1A9eXPixAVtQeRXxPRn1FDCS4bXp
+/7FxAoIBADSHWCxKFp8kozMBTXlG/MC96g1XS88kMYDAjQEEe72QWVxUcar9aAYw
+0Vnepfx+MCK1/ZZ3cZnSdaO1ESZWoU9I0AQT6YNIrTD2kHMtBJfEWVed4FtsZm9H
+BIaJyTaFe918+nS5xWOsgdW5kLInT00m9QF3iKxtkTO/b4EiDKBlr8UplJts6f3M
+YrIbrK78PT81U+o+cGqgUuQvQAzecuqpZRF6IayiRITCnqpeqL8Gq7vuY8REtEJA
+chKpc4KxkuRF1qJTita6in04s69dCvK85iT9hD+qKEF35FiRAlh8Ea/e54vU6G08
+N2tQ6E7cDmZQqgUmxIOWRUv6qIoUei8CggEAGs6QILgxqN+7MLBn5Gqpur7Pe8ZC
+8aiLUDH/1OsXPQGTZ+N4AA1oe4GSJO7DqZqTp7Zy35oedNZ3uFOXCJ0aU+Q+hfey
+gp4QIipYYzC5AFCwOkxDvF5CEL3Ri+3HJM7MzEPYzGOBlxngzEtlV4RmnoaUOCZi
+N/trZVF/IEB8J/XrHvWUykS8l/3bTTEsDfm7zgGsLaviF7eSHXTBUozZrRYJH+e8
+2A3qDtgaYa0ZR7c4kVoO2tRQeJYLCVowMWZ42OsFJAKoTLB0wGBqgrDthsaOk1l7
+hN4Ta/OHuRuUu49nu9cn8T9zQm5viulglf5saeEumoahPLFQDwJCk67Yxw==
+-----END RSA PRIVATE KEY-----
+`)
+
+	serverCert = []byte(`
+-----BEGIN CERTIFICATE-----
+MIIFWDCCA0CgAwIBAgIRAMWnlYEx52Vws2b3EzexW+UwDQYJKoZIhvcNAQELBQAw
+IDEeMBwGA1UEAxMVUHJvbXRhaWwgVGVzdCBSb290IENBMB4XDTIyMDYyOTA4MTQy
+NFoXDTQyMDYyOTA4MTQyNFowKzEpMCcGA1UEAxMgUHJvbXRhaWwgVGVzdCBTZXJ2
+ZXIgQ2VydGlmaWNhdGUwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQCo
+8+m8sVjG2tvRqzFWD6XRwvWIV/7nOHhuL7ygdouTJ5MKjpKHSudOXOoxHw9aNA4u
+zmExqlSD4RVnwb2R/nXoqO1Ae5VavkNngeDw5Uk/RacqF4WFCnmFNxh523iA4ifo
+ZxmVhQoE1t3O4kMrygK2SEpSTY58PfuqLfd7ZyHDEmpu9pYfuQQCqKLOsVQS5mqY
+g7gyKQQLq0D4beCsSuih09PskMiG29uh/qCdSmDDR++j42xP/fwXVGm3nsOMLjQf
+1DFlZFqmQS42Da1KtnKzz+SVDSHihyRKiZ0KAyyDHYdKToFO/zYlCgFGw86o4VGu
+HKbolE6oPrBnqdXyIf9cON4RdnoTrChG4E6yq4LN8XoNRloePjoGQ9huoqwGie3m
+c06Pnj2eV4oCJwdLarKZqZzdJnanx+ctObAGGGjjV1ocNGFc2EMBpTFVpy20Kqd/
+E7t2yeGU6wJhzMNtvyFHhcOY+7PRTuvrUzbK1McFU/6NKBn4ioW2XBU8CjPEKGNx
+itIZWnxppqkt2EemZEB+L1QpNtNlFmSYLqPm+j1134os3I3s+kkawiSjBcpqgzDf
+stt64LiO/ULXDfPexbzE+mggQ3GsQ+b5v2O4KTQ4A4ilI48+0Qn3YxqfaVJmusGE
++Jkpo/Fnt3OCJaYBqsSzK5dIzF9TJhsOb+f5NGBJEQIDAQABo4GBMH8wDgYDVR0P
+AQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAMBgNVHRMB
+Af8EAjAAMB8GA1UdIwQYMBaAFFBj1+WwOdP8rb95R7kOmWena3RfMB8GA1UdEQQY
+MBaCFHByb210YWlsLmV4YW1wbGUuY29tMA0GCSqGSIb3DQEBCwUAA4ICAQApSDHl
+IECz4Ix+6zZqNU0DgulYTXcHKtnXEKRJVTULbKy/mWzE5ZAgVV0rpRLHbRg0fWYh
+4tjd5X/Pedf4OtnpV6ekkvBf+QCKAmDiWN9rKhjdVoTFw0+wavQv1yzz8++2HenR
+rgq7wWuwg0hB9/KKOWW09ZuBynjB7aeoWHztIbD+/cugMlzqDX8hODRl3OaEAwM3
+PBpYEqFSuPBNrCK5Y0tGgzZDdsxrDYcX5CjJdrgwtZ1kFOT8J2VE+2Sqc7KMCPFl
+LQmmtIcwjljNABf5d2L978tISFtwRoZVxrsTODqLLF8l6B7JUQdCpmoM+549E0cS
+bpTj4FVftJwEpElMFMVw/Uh5pA7hOLGAK3YYqBx6fbEGHn+WmwLA5Io7tbBSKUX/
+hNlOFupAU3Q/OawqlmSPRflqKIg4b8TgSVlafJOFmvKg0WLGVuLtl65g9eNQVht9
+KLlPPCPbpYKXpXya42eFazxEepOeaCkchOUB+x4tmAZ44NJTMR+UmiGLGCjdQTpU
+m892bbGtLA0hGhYGrMsI546Xd8PjNI117CARrDpk57E1V+CsAO6ZTOPLgI4q976L
+kWYB12V1t/BNtGyChdmfIYBqvTYAGk9hbqG80SjmcZtPu5JIEvIXCyaYXiWmEs2l
+j1ieRNjgNYyG/7wJmilCsnpjbWza85/JzxE1cA==
+-----END CERTIFICATE-----
+`)
+
+	serverKey = []byte(`
+-----BEGIN RSA PRIVATE KEY-----
+MIIJKAIBAAKCAgEAqPPpvLFYxtrb0asxVg+l0cL1iFf+5zh4bi+8oHaLkyeTCo6S
+h0rnTlzqMR8PWjQOLs5hMapUg+EVZ8G9kf516KjtQHuVWr5DZ4Hg8OVJP0WnKheF
+hQp5hTcYedt4gOIn6GcZlYUKBNbdzuJDK8oCtkhKUk2OfD37qi33e2chwxJqbvaW
+H7kEAqiizrFUEuZqmIO4MikEC6tA+G3grEroodPT7JDIhtvbof6gnUpgw0fvo+Ns
+T/38F1Rpt57DjC40H9QxZWRapkEuNg2tSrZys8/klQ0h4ockSomdCgMsgx2HSk6B
+Tv82JQoBRsPOqOFRrhym6JROqD6wZ6nV8iH/XDjeEXZ6E6woRuBOsquCzfF6DUZa
+Hj46BkPYbqKsBont5nNOj549nleKAicHS2qymamc3SZ2p8fnLTmwBhho41daHDRh
+XNhDAaUxVacttCqnfxO7dsnhlOsCYczDbb8hR4XDmPuz0U7r61M2ytTHBVP+jSgZ
++IqFtlwVPAozxChjcYrSGVp8aaapLdhHpmRAfi9UKTbTZRZkmC6j5vo9dd+KLNyN
+7PpJGsIkowXKaoMw37LbeuC4jv1C1w3z3sW8xPpoIENxrEPm+b9juCk0OAOIpSOP
+PtEJ92Man2lSZrrBhPiZKaPxZ7dzgiWmAarEsyuXSMxfUyYbDm/n+TRgSRECAwEA
+AQKCAgAIAyk+jZqMM6zhEKFSV4OhowFJ6gJorMDpWNI1Oen8nI/YnFJOoDq/+KAS
+nEp6GKXjil4JoO5JIs+FECcRWWP2GKzHthSrLQK9Ued9BSKoIYF/+YWXfZutuaMr
+hED+u7rwxpLsCFclS5tRSGGvHfFq+5qqtIrhUX8x3uQxsf5j5eeuQ3tzHa8XATBX
+ZQl7q/m6KeT+W/uZIhH+thdFlHfb1NPkECmyW5La59xuGSzlle/DcfGdCYp/AL3S
+u3DCoR5PtBxzloLGB6lNXvCs7mIaLO3GM807lPUfo88SvnvJ7AiSeY6gVHIY55SP
+6pFOaQEapLk1pnLkf7SV9fPze7FEdqOe0fZXFre15wBAg2UflMD47k4Km4kxVcob
+64e2sC+5gQbkdKy958S5PNwvxNCxDrcfHxANi0NCyEc1tx12+WHe6eCTYUfnXHA0
+CFEwlbHFj/cw2p4wiCRczEAFhnDJI2arSuRVDM3nGJ6tqb/NOeY03bhiUDOwAFEc
+NLXgBSM3xNhQ++PWHSwXxoYPwDkwHX711/oshMDuck5B+dOceB2KtrJeYApb4ZIi
+UpW9OUm5DS+9g3D7SB4Aw+6XZYaJ1Y6d+io482ysqdEtP88Z927SXoviB1Rpnt8w
+W8TeBQ/9+67GVCa+ysUNd3Ybqh6ANjZUV5Kl9AZrsrFe0sXNAQKCAQEA0wArAzzq
+cCX+9lCoCnLh6gyBxxzAEWHQ+QqTeIlnWZBq2kS7ourN6PC476EUu33+LnQe8kaX
+x8qNAlrixs/rE4tRDw9anC/iwz4EjM4ApbV563QRa5BVNzqy8m1aESHVVmtxafYY
+06V6DGVO54kyVten8Pl/1N4AL8nPj8bYqG9OxqH/Kr89UHL4ynXLHo+RbvXhyccE
+O0A7G43s4tuXjrrbM0jJLmi2qFVEVNIGBgwdy6KpZduTptro+C4GYyaYI4muPxII
+Gu5EWxH1g+cRjmHH9JcQNrTl9Ho6hWO0cpV7FavIV953rmncTiLIql7oyZmh7Gca
+ZzMsVyy2QCyKOQKCAQEAzPwXaUJYl18kG5CyXBFS/83xCLbeNcG7eKWFCYwzIVcV
+ZkRaHNS+RN5kbqIgMqCFIDXFRbfBUBt4DvkNDXbcryVrnpu0/DdPSXDOltBOdpV/
+6EyZmwThnFBWLKMG9Pk4gwvTGIa0GtN2/9Xongwogvbk5FOJduP9AlwvC+F+MkLO
+FjgwPn9llPWNd23WzQbjonZih7vyPd1DcES9Ictwn7exhJwIQHMDPeLRSdchr6O9
+tbxig+IHb/++e02kpfgUx60QGXGBbgbeXuVw2vn6GX5a7eC9/PkRKV7ke2ODAih+
+N4oLEFnceL3ZhtOvl8bK+6Ukk519tve4fcqfMcMVmQKCAQAMnhL0Y50lTbBcbGBQ
+F6SYyVytWnPF1lKXweElsRnEClXJbZjG2kGr71EvyzMhLxyXDIyZMk17PgqGnIa5
+Gs/U4FzdiK6Dbn2h7UB6Zws03ZBH2y37f6sI3XK7+nwLUDmgrFYg3v2HEnsk6J36
+TIL9HHJHf7P8N7ZNJUVLNLnaAKX2TNOka8Ev4WAtQzP9RNqOhxeUaFlBbcrbD/ad
+bkI238eh3nVhWBOsJ0UpyVFg5TKW7cgxdhrzPF34EVCCd1lbrq0DyoE/kwX1aDKF
+S7kKCaDaaHoou1KQ9wou1dKBk5zDo/0b/AquHFh3N69GONy0yYIcT+INT8sT/3F6
+ju9JAoIBACQWlcCQT6yGsYKw3NXcrvIePbs9Bq4MJ4c8DMn7htztyfSxP/QneEAD
+r0bTADwpioZ7MPnvOfdyfpaUPjoKnRuwyNupqhllW24gkB55GfdCprwtEDX8jAPL
+GQDOyuDCJ7LamBWPUZIPfLnZ3RRGK7Oy5+VS17a4uMh7lkTPNDqBDGtZBRVbtHSf
+LoLCMbjy54yorvwamLFPjRns4Cdc+70CyBwCpGlEVmPE1PfdCi8z8qhWPDnfx1Nu
+gQiQSNZ3cKEe1ODF3PWT+/5VAqNqsx9d4YBTut8Ysm7IKA2ZHW15147LnNsKFwii
+0/MqvZVJCF95WZErfwCBaFetHo3SPLECggEBAJD3MNVxgz6K9l1vqwofDvO+Lyu9
+qtBeugAnDBui2F02ho53UGBd4D2Ff81XQO6BsZu+CRrDqQqaA7WgF8a16WXHwFq5
+KTgBg4EqnvC0PgIerRL+vnt3OkHIBt2aOi1PoV8loPn+HPL85/wfds8Xtx1OhWH+
+h6jba355Zyb4LmvFVX+JTpx60zN+47cSgFuIqTwJ33rc9lX28YwHK3MTQnnZYNie
+CgB4zsbG3qeVdVjAqhxrdcALNHCTy0qf4AMk8GLO75zCFf5KbsK3R2w1wvyRGmg9
+oI3TCjSd/C09fLWdJhYsNtBtWNo8nSXZVCoR2EnrGSUZNGk7fhRSkDbm67g=
+-----END RSA PRIVATE KEY-----
+`)
+
+	clientCert = []byte(`
+-----BEGIN CERTIFICATE-----
+MIIFNTCCAx2gAwIBAgIQWzE3b7oUqYGe2UvYWJBnyDANBgkqhkiG9w0BAQsFADAg
+MR4wHAYDVQQDExVQcm9tdGFpbCBUZXN0IFJvb3QgQ0EwHhcNMjIwNjI5MDgxNDI0
+WhcNNDIwNjI5MDgxNDI0WjArMSkwJwYDVQQDEyBQcm9tdGFpbCBUZXN0IENsaWVu
+dCBDZXJ0aWZpY2F0ZTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALcQ
+KhIIL7EZLIDWPMIkT5cJdPRavs5/LO50isCVs2z+PTA4mIkj2NEk8qFqgc3+1LUh
+SV/NQ3p0LikSx9M6g1oBJbqQ7W6BcCzzUOHb4QlGoa2DXXGONPdO3AJxTTDNU6Li
+xT5ESTbuDe56JDw3x2V0pxOzCUSuTMa1mvHnIojVn/8qHOZB0l4o9c44oHGJDUGh
+o1wAc3UXGMLsd6IEYsHzLyG6kG7ayqToFftI/rkpEK8tCWMbclewh22c0OCXejEZ
+pS9mz2decoIG7NnkqrRwUj+RPNlKJgBJ2USYimbQZHmdZWNb+vP/HFXs1Eq0sin+
+5HrRnzuB6yCwQlqvR7Db3buENEXG2OcglGmO/1mBfB4nW7JKFAvIqBBtHDRmBCYr
+YS9htPiZte8Mfak3RncxLLccEzo1CNqtW9BLfryGH3l+6LR0yZkw+C95RZ9Wni4T
+e5hy5yX8SW3z4AUb3ZYbFROW4sW/sSsh8VucZoa4OXw981OB4ZGrtJnncvc1KE5Q
+BBF+bRZKdMQhzwb7pZq31kZjH0So53Ntyf4S6VHgUOTs8xorPSjnP85BKnnm7XsG
+W/zP+kGCyjOCu4WIrNvSlIguF4KcVZulWbMljVCU0TwKNbxBm5SZrTXPoJeyRtE6
+ai+fHPoMjJvwUaLYQUkzTpfdGg8OCV3NX/LvbCuVAgMBAAGjYDBeMA4GA1UdDwEB
+/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0TAQH/
+BAIwADAfBgNVHSMEGDAWgBRQY9flsDnT/K2/eUe5Dplnp2t0XzANBgkqhkiG9w0B
+AQsFAAOCAgEAxJvDifKqK6EQrN5VPL68IPORu1VK17HeSJ2xLScL3Hh7vulPs9Nf
+HLixcOhixsYhgurFZ3M3K05tT0EKy1K7WLJzJEhPccAkbz+d2oIeghksq2l75u20
+t2o1X8rgT+/7d/j+VBur/+igQdwvylo+wgGNosX8VmjyQrZBWIHvDTyzrvODFbZa
+JYf3DfgLSF5tr4e/HNLhynUD9G40CmRLQh7PkojrMXMyeqqWpBPzDBlZgvH2QMK8
+K9S8KUuaZhGUTLQmkR3NP/bx1V/Ks1/BtpmdIchQ42w+Uu2PM/pmuZsnX7bK0tzd
+zCFjgSIxifN8BKdcKMEngo+MwYy/Fj3vzy4qXxtOCbnzB+A/ziLiJV3Tsdwm+nPO
+xZFcXXfnCMoNF0ouv2/WAbUrKLTZXL712MZ14JT79TkKxWZ49AUHSiGfm1I45iky
+xgcn4FVgJpsCheRqL+gecNDyq+4VdwlWuFAuqMI4UBUbWwyAntOL1iiyENGA1ygo
+OVuQq9M0bh93d5U+Ct79CsL4LLaoRrvBGJ6WnO8PKTTLqfFC3T8ySCtVGZiLoSqn
+fJ1uhxhK8YSYhod+81/nkpJuF1xRg1t2kXgvUxPR9jzf96QaZ/94oryEH3zr59Rb
+wmOulo1MN6yRdGzWiJ8sZ8VXUuh0xBCUiwrpo++Dda2s0bF0YzJGI6E=
+-----END CERTIFICATE-----
+`)
+	clientKey = []byte(`
+-----BEGIN RSA PRIVATE KEY-----
+MIIJKQIBAAKCAgEAtxAqEggvsRksgNY8wiRPlwl09Fq+zn8s7nSKwJWzbP49MDiY
+iSPY0STyoWqBzf7UtSFJX81DenQuKRLH0zqDWgElupDtboFwLPNQ4dvhCUahrYNd
+cY40907cAnFNMM1TouLFPkRJNu4N7nokPDfHZXSnE7MJRK5MxrWa8eciiNWf/yoc
+5kHSXij1zjigcYkNQaGjXABzdRcYwux3ogRiwfMvIbqQbtrKpOgV+0j+uSkQry0J
+YxtyV7CHbZzQ4Jd6MRmlL2bPZ15yggbs2eSqtHBSP5E82UomAEnZRJiKZtBkeZ1l
+Y1v68/8cVezUSrSyKf7ketGfO4HrILBCWq9HsNvdu4Q0RcbY5yCUaY7/WYF8Hidb
+skoUC8ioEG0cNGYEJithL2G0+Jm17wx9qTdGdzEstxwTOjUI2q1b0Et+vIYfeX7o
+tHTJmTD4L3lFn1aeLhN7mHLnJfxJbfPgBRvdlhsVE5bixb+xKyHxW5xmhrg5fD3z
+U4Hhkau0medy9zUoTlAEEX5tFkp0xCHPBvulmrfWRmMfRKjnc23J/hLpUeBQ5Ozz
+Gis9KOc/zkEqeebtewZb/M/6QYLKM4K7hYis29KUiC4XgpxVm6VZsyWNUJTRPAo1
+vEGblJmtNc+gl7JG0TpqL58c+gyMm/BRothBSTNOl90aDw4JXc1f8u9sK5UCAwEA
+AQKCAgEAsnwmKLKmnUtoIq2/S6LPnvlveJfJldhVXKFwb1kGOeygiBWGU6AJ09Ds
+aAlKSih+B6ROwAOIGSqRnyZagk54pxabTI3lkWrOjmUlpTEW9k5RcLW2M/NtHPtc
+c104364yL4xet9kocVAlcTDRh4zy8q6MAB79mGNBJDUIv3aWK0ft2YGb77yZeYkC
+MHDxrgDsVeNdPWSLLcy5LcQU2HjiOSv79izKier0zVgjpn+DK9EoHUQR9PlbwLez
+M2JEHdZTIvBYKCFbcvOZPcG2yLO05HznFGdtJoavCnT2S3VW6+ufKxwVMI0L3z4K
+yJRCYBxR4bRN3JnpYMHJGHQCHhzsDZP26Hu6WRAjokcX+rSLORORuTwKGlCeQLZy
+BBe0+rsmWylAeWaCngyKCybpewwr1T1AQ9MmN7XpgMbDZ+htrz7xa/cPvJy9ebXM
+Wnwe+nGugwvdyjEHtHCHzgpSGATxMzl67p/yk/Mr/0ueuvJjL5aCzP+3rSaf8uY7
+oDQVZzWsUVItK6+sLEah34nhTZAnN757HrwcEUrmoiIcWLqFNNVi0/TJyX0E39/S
+63I7B0z8PJ3m5lzjUhNmRsccNFO0YSRh9zX2vVutvyWK8ujgEysAQEUY4okKcryf
+h15CI3thxlpT+Z3aAXP2fvMCKvXwfs4jcVd+hhgwuZdfeKnzPAECggEBANQg8Mqc
+b/Exij4HbsQDQttXIead4jX4vedJCTtKNFfGvxmYorzd2eHLF7UmUN85yIMTDtgI
+hoCJEWqZdN5NCwyWcKDbvkqRRrlN0CYGI3hQi2z+MlBShhK7kDIpybsb/G14011U
+x+R6/98Uj8BovBbM8QXV/abuOdoHAa+so5YOUOEco/6ZDIfogtBduMVMHrqOqnKK
+zdlBNeCE55Ujwq5Tm/YYgh55iXEi/nocsUjyBgz9k+fOrZ+9zzrg9AQjh+P9S86X
+o++CRiAIeDFBeH8rp7dx6wlR3ZmSGEca658LE2oIMCri9JHO1qhanJq1+SLa3+Sx
+tT4eMyuiuMawThUCggEBANzsXKan1Whv2UOoDC/A7Hdza02GRFEhMDLBBapP4xjS
+A6P8YaKrNTCKjY5GMqtWuQMgLvJgH2d5veXJSyMiOtv0FvGikb85omnsYWP9Ised
+gwGjx6e8uQHjUfUW1SF/oWhjLO0yNrlTZ90BCSsoMfj0NcLMAqIo3skR/ixsFOa2
+qu6Hihn+miek90HQd6gSWO08FPe9edHu7Zr+a3y/EEdUKX/p0S18olnnh5X9YBk2
+ZoS8oYKNtMrfWeoj97iRi6pwDhVju1AlOKVFmAwfTxX+YTyKdpycpd1kvqepaQCM
+8aXwFqrubHe8mNw8nYuM+fbqEb/rCm9QOXaJvrd5R4ECggEAc4btHKtOG+GLFHUf
+0gikpKgzglGCHTq20fto1612DEflU59ZIdsBCoN9Cd8wNCJYHWqHrwgVmHMN1Sx2
+BYuX9OcJt9F1NU8hYVILhmnZb3EOPfHCnRQUiKc1xNwVTZ3UQBqJok7F/p0uNOQR
+1gw0Q4ahzTfZyMv9HcyrEm3HObXaPn9GoSXhOTNb6vbf5jOqmJeSJIeLzEJDgV9g
+cEzlfeNzEPgQBWDThZY1WXO+6adFvFVt89UPoevRrJNO0eI34+bTHlRfp9UfM9ro
++opZgYjY8oNMKes38KcsKa1znU5+6ERFV1X7NF2dclrG50srv9vMC9TsjEQOQjmA
+wFTMcQKCAQEA0N8/8ek4Yddt6QOXEgcrCvy69L7/FF12fmX0f0OsiKj2/DH/9ZY9
+Ybl9gIhqG4iQv53MBShQSLrXicu5GGyijZbHool7lvpczhzJL4oDOgt38zLv720E
+1f4gXMLLmzJaXqF1toUFLE7pIhB6pK0KIkByG8xaqQpPKHe0gjdlw4PtNDw9m7oV
+8WmMxFLe7q76GMH3aQthg9SMHUByS60xLN8rpV5hgMoXjTzT+kFmfC/s2Y6mfRKR
+XkWxcyeybHRfQjNTfXGfhXTLi6ayzLNFSJwLPvwCjKumPh2kDEylk/mt9p96Lv3g
+24waUg+VPH17T7GaOoN0iC2nRqWRBVLLAQKCAQBpsIv0+kXJG1XsXKnclBdfgq7L
+wNIt/A0liMFEL4fb/oKEmKFfa/gek67aLYz4yS+f31uzTuZglA9jwdJu/4+P/BG/
+7idujhPpuscWJjIR/y4Ow8CjykDBk3bgicaib3ga3IYcdb7uCABwCWb7BvMYo6Yp
+9deUYOt1qNzJ57nz5675ofMruTS9Vca4SoU99T79Ei2YQ2fPFFoWYIIs6FHyvLbZ
+i8bhYBYz3F4eL6a1rrsPaaAzQadP6Aoe/zuxqiqxqEn6GLjwU9RUXH0JIm91uX6m
+c7VxCwyT3tACpQPtZoib2wCUQ+l3K3Ft3u4LFwJo/HxqjL4M1I3rI0jUXKtM
+-----END RSA PRIVATE KEY-----
+`)
+)
+
+type formatFunc func(string) string
+
+var (
+	fmtOctetCounting = func(s string) string { return fmt.Sprintf("%d %s", len(s), s) }
+	fmtNewline       = func(s string) string { return s + "\n" }
+)
+
+func Benchmark_SyslogTarget(b *testing.B) {
+	for _, tt := range []struct {
+		name       string
+		protocol   string
+		formatFunc formatFunc
+	}{
+		{"tcp", protocolTCP, fmtOctetCounting},
+		{"udp", protocolUDP, fmtOctetCounting},
+	} {
+		tt := tt
+		b.Run(tt.name, func(b *testing.B) {
+			client := fake.New(func() {})
+
+			metrics := NewMetrics(nil)
+			tgt, _ := NewSyslogTarget(metrics, log.NewNopLogger(), client, []*relabel.Config{}, &scrapeconfig.SyslogTargetConfig{
+				ListenAddress:       "127.0.0.1:0",
+				ListenProtocol:      tt.protocol,
+				LabelStructuredData: true,
+				Labels: model.LabelSet{
+					"test": "syslog_target",
+				},
+			})
+			b.Cleanup(func() {
+				require.NoError(b, tgt.Stop())
+			})
+			require.Eventually(b, tgt.Ready, time.Second, 10*time.Millisecond)
+
+			addr := tgt.ListenAddress().String()
+
+			messages := []string{
+				`<165>1 2022-04-08T22:14:10.001Z host1 app - id1 [custom@32473 exkey="1"] An application event log entry...`,
+				`<165>1 2022-04-08T22:14:11.002Z host2 app - id2 [custom@32473 exkey="1"] An application event log entry...`,
+				`<165>1 2022-04-08T22:14:12.003Z host1 app - id3 [custom@32473 exkey="1"] An application event log entry...`,
+				`<165>1 2022-04-08T22:14:13.004Z host2 app - id4 [custom@32473 exkey="1"] An application event log entry...`,
+				`<165>1 2022-04-08T22:14:14.005Z host1 app - id5 [custom@32473 exkey="1"] An application event log entry...`,
+				`<165>1 2022-04-08T22:14:15.002Z host2 app - id6 [custom@32473 exkey="1"] An application event log entry...`,
+				`<165>1 2022-04-08T22:14:16.003Z host1 app - id7 [custom@32473 exkey="1"] An application event log entry...`,
+				`<165>1 2022-04-08T22:14:17.004Z host2 app - id8 [custom@32473 exkey="1"] An application event log entry...`,
+				`<165>1 2022-04-08T22:14:18.005Z host1 app - id9 [custom@32473 exkey="1"] An application event log entry...`,
+				`<165>1 2022-04-08T22:14:19.001Z host2 app - id10 [custom@32473 exkey="1"] An application event log entry...`,
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			c, _ := net.Dial(tt.protocol, addr)
+			for n := 0; n < b.N; n++ {
+				_ = writeMessagesToStream(c, messages, tt.formatFunc)
+			}
+			c.Close()
+
+			require.Eventuallyf(b, func() bool {
+				return len(client.Received()) == len(messages)*b.N
+			}, 15*time.Second, time.Second, "expected: %d got:%d", len(messages)*b.N, len(client.Received()))
+
+		})
+	}
+}
+
+func TestSyslogTarget(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		protocol string
+		fmtFunc  formatFunc
+	}{
+		{"tpc newline separated", protocolTCP, fmtNewline},
+		{"tpc octetcounting", protocolTCP, fmtOctetCounting},
+		{"udp newline separated", protocolUDP, fmtNewline},
+		{"udp octetcounting", protocolUDP, fmtOctetCounting},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			w := log.NewSyncWriter(os.Stderr)
+			logger := log.NewLogfmtLogger(w)
+			client := fake.New(func() {})
+
+			metrics := NewMetrics(nil)
+			tgt, err := NewSyslogTarget(metrics, logger, client, relabelConfig(t), &scrapeconfig.SyslogTargetConfig{
+				MaxMessageLength:    1 << 12, // explicitly not use default value
+				ListenAddress:       "127.0.0.1:0",
+				ListenProtocol:      tt.protocol,
+				LabelStructuredData: true,
+				Labels: model.LabelSet{
+					"test": "syslog_target",
+				},
+			})
+			require.NoError(t, err)
+
+			require.Eventually(t, tgt.Ready, time.Second, 10*time.Millisecond)
+
+			addr := tgt.ListenAddress().String()
+			c, err := net.Dial(tt.protocol, addr)
+			require.NoError(t, err)
+
+			messages := []string{
+				`<165>1 2018-10-11T22:14:15.003Z host5 e - id1 [custom@32473 exkey="1"] An application event log entry...`,
+				`<165>1 2018-10-11T22:14:15.005Z host5 e - id2 [custom@32473 exkey="2"] An application event log entry...`,
+				`<165>1 2018-10-11T22:14:15.007Z host5 e - id3 [custom@32473 exkey="3"] An application event log entry...`,
+			}
+
+			err = writeMessagesToStream(c, messages, tt.fmtFunc)
+			require.NoError(t, err)
+			require.NoError(t, c.Close())
+
+			if tt.protocol == protocolUDP {
+				time.Sleep(time.Second)
+				require.NoError(t, tgt.Stop())
+			} else {
+				defer func() {
+					require.NoError(t, tgt.Stop())
+				}()
+			}
+
+			require.Eventuallyf(t, func() bool {
+				return len(client.Received()) == len(messages)
+			}, time.Second, 10*time.Millisecond, "Expected to receive %d messages.", len(messages))
+
+			labels := make([]model.LabelSet, 0, len(messages))
+			for _, entry := range client.Received() {
+				labels = append(labels, entry.Labels)
+			}
+			// we only check if one of the received entries contain the wanted label set
+			// because UDP does not guarantee the order of the messages
+			require.Contains(t, labels, model.LabelSet{
+				"test": "syslog_target",
+
+				"severity": "notice",
+				"facility": "local4",
+				"hostname": "host5",
+				"app_name": "e",
+				"msg_id":   "id1",
+
+				"sd_custom_exkey": "1",
+			})
+			require.Equal(t, "An application event log entry...", client.Received()[0].Line)
+
+			require.NotZero(t, client.Received()[0].Timestamp)
+		})
+	}
+}
+
+func relabelConfig(t *testing.T) []*relabel.Config {
+	relabelCfg := `
+- source_labels: ['__syslog_message_severity']
+  target_label: 'severity'
+- source_labels: ['__syslog_message_facility']
+  target_label: 'facility'
+- source_labels: ['__syslog_message_hostname']
+  target_label: 'hostname'
+- source_labels: ['__syslog_message_app_name']
+  target_label: 'app_name'
+- source_labels: ['__syslog_message_proc_id']
+  target_label: 'proc_id'
+- source_labels: ['__syslog_message_msg_id']
+  target_label: 'msg_id'
+- source_labels: ['__syslog_message_sd_custom_32473_exkey']
+  target_label: 'sd_custom_exkey'
+`
+
+	var relabels []*relabel.Config
+	err := yaml.Unmarshal([]byte(relabelCfg), &relabels)
+	require.NoError(t, err)
+
+	return relabels
+}
+
+func writeMessagesToStream(w io.Writer, messages []string, formatter formatFunc) error {
+	for _, msg := range messages {
+		_, err := fmt.Fprint(w, formatter(msg))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestSyslogTarget_RFC5424Messages(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		protocol string
+		fmtFunc  formatFunc
+	}{
+		{"tpc newline separated", protocolTCP, fmtNewline},
+		{"tpc octetcounting", protocolTCP, fmtOctetCounting},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			w := log.NewSyncWriter(os.Stderr)
+			logger := log.NewLogfmtLogger(w)
+			client := fake.New(func() {})
+
+			metrics := NewMetrics(nil)
+			tgt, err := NewSyslogTarget(metrics, logger, client, []*relabel.Config{}, &scrapeconfig.SyslogTargetConfig{
+				ListenAddress:       "127.0.0.1:0",
+				ListenProtocol:      tt.protocol,
+				LabelStructuredData: true,
+				Labels: model.LabelSet{
+					"test": "syslog_target",
+				},
+				UseRFC5424Message: true,
+			})
+			require.NoError(t, err)
+			require.Eventually(t, tgt.Ready, time.Second, 10*time.Millisecond)
+			defer func() {
+				require.NoError(t, tgt.Stop())
+			}()
+
+			addr := tgt.ListenAddress().String()
+			c, err := net.Dial(tt.protocol, addr)
+			require.NoError(t, err)
+
+			messages := []string{
+				`<165>1 2018-10-11T22:14:15.003Z host5 e - id1 [custom@32473 exkey="1"] An application event log entry...`,
+				`<165>1 2018-10-11T22:14:15.005Z host5 e - id2 [custom@32473 exkey="2"] An application event log entry...`,
+				`<165>1 2018-10-11T22:14:15.007Z host5 e - id3 [custom@32473 exkey="3"] An application event log entry...`,
+			}
+
+			err = writeMessagesToStream(c, messages, tt.fmtFunc)
+			require.NoError(t, err)
+			require.NoError(t, c.Close())
+
+			require.Eventuallyf(t, func() bool {
+				return len(client.Received()) == len(messages)
+			}, time.Second, time.Millisecond, "Expected to receive %d messages, got %d.", len(messages), len(client.Received()))
+
+			for i := range messages {
+				require.Equal(t, model.LabelSet{
+					"test": "syslog_target",
+				}, client.Received()[i].Labels)
+				require.Contains(t, messages, client.Received()[i].Line)
+				require.NotZero(t, client.Received()[i].Timestamp)
+			}
+		})
+	}
+}
+
+func TestSyslogTarget_TLSConfigWithoutServerCertificate(t *testing.T) {
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+	client := fake.New(func() {})
+
+	metrics := NewMetrics(nil)
+	_, err := NewSyslogTarget(metrics, logger, client, relabelConfig(t), &scrapeconfig.SyslogTargetConfig{
+		ListenAddress: "127.0.0.1:0",
+		TLSConfig: promconfig.TLSConfig{
+			KeyFile: "foo",
+		},
+	})
+	require.Error(t, err, "error setting up syslog target: certificate and key files are required")
+}
+
+func TestSyslogTarget_TLSConfigWithoutServerKey(t *testing.T) {
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+	client := fake.New(func() {})
+
+	metrics := NewMetrics(nil)
+	_, err := NewSyslogTarget(metrics, logger, client, relabelConfig(t), &scrapeconfig.SyslogTargetConfig{
+		ListenAddress: "127.0.0.1:0",
+		TLSConfig: promconfig.TLSConfig{
+			CertFile: "foo",
+		},
+	})
+	require.Error(t, err, "error setting up syslog target: certificate and key files are required")
+}
+
+func TestSyslogTarget_TLSConfig(t *testing.T) {
+	t.Run("NewlineSeparatedMessages", func(t *testing.T) {
+		testSyslogTargetWithTLS(t, fmtNewline)
+	})
+	t.Run("OctetCounting", func(t *testing.T) {
+		testSyslogTargetWithTLS(t, fmtOctetCounting)
+	})
+}
+
+func testSyslogTargetWithTLS(t *testing.T, fmtFunc formatFunc) {
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	serverCertFile, err := createTempFile(serverCert)
+	if err != nil {
+		t.Fatalf("Unable to create server certificate temporary file: %s", err)
+	}
+	defer os.Remove(serverCertFile.Name())
+
+	serverKeyFile, err := createTempFile(serverKey)
+	if err != nil {
+		t.Fatalf("Unable to create server key temporary file: %s", err)
+	}
+	defer os.Remove(serverKeyFile.Name())
+
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+	client := fake.New(func() {})
+
+	metrics := NewMetrics(nil)
+	tgt, err := NewSyslogTarget(metrics, logger, client, relabelConfig(t), &scrapeconfig.SyslogTargetConfig{
+		ListenAddress:       "127.0.0.1:0",
+		LabelStructuredData: true,
+		Labels: model.LabelSet{
+			"test": "syslog_target",
+		},
+		TLSConfig: promconfig.TLSConfig{
+			CertFile: serverCertFile.Name(),
+			KeyFile:  serverKeyFile.Name(),
+		},
+	})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, tgt.Stop())
+	}()
+
+	tlsConfig := tls.Config{
+		RootCAs:    caCertPool,
+		ServerName: "promtail.example.com",
+	}
+
+	addr := tgt.ListenAddress().String()
+	c, err := tls.Dial("tcp", addr, &tlsConfig)
+	require.NoError(t, err)
+
+	validMessages := []string{
+		`<165>1 2018-10-11T22:14:15.003Z host5 e - id1 [custom@32473 exkey="1"] An application event log entry...`,
+		`<165>1 2018-10-11T22:14:15.005Z host5 e - id2 [custom@32473 exkey="2"] An application event log entry...`,
+		`<165>1 2018-10-11T22:14:15.007Z host5 e - id3 [custom@32473 exkey="3"] An application event log entry...`,
+	}
+	// Messages that are malformed but still valid.
+	// This causes error messages being written, but the parser does not stop and close the connection.
+	malformeddMessages := []string{
+		`<165>1    -   An application event log entry...`,
+		`<165>1 2018-10-11T22:14:15.007Z host5 e -   An application event log entry...`,
+	}
+	messages := append(malformeddMessages, validMessages...)
+
+	err = writeMessagesToStream(c, messages, fmtFunc)
+	require.NoError(t, err)
+	require.NoError(t, c.Close())
+
+	require.Eventuallyf(t, func() bool {
+		return len(client.Received()) == len(validMessages)
+	}, time.Second, time.Millisecond, "Expected to receive %d messages, got %d.", len(validMessages), len(client.Received()))
+
+	require.Equal(t, model.LabelSet{
+		"test": "syslog_target",
+
+		"severity": "notice",
+		"facility": "local4",
+		"hostname": "host5",
+		"app_name": "e",
+		"msg_id":   "id1",
+
+		"sd_custom_exkey": "1",
+	}, client.Received()[0].Labels)
+	require.Equal(t, "An application event log entry...", client.Received()[0].Line)
+
+	require.NotZero(t, client.Received()[0].Timestamp)
+}
+
+func createTempFile(data []byte) (*os.File, error) {
+	tmpFile, err := os.CreateTemp("", "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary file: %s", err)
+	}
+
+	if _, err := tmpFile.Write(data); err != nil {
+		return nil, fmt.Errorf("failed to write data to temporary file: %s", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		return nil, err
+	}
+
+	return tmpFile, nil
+}
+
+func TestSyslogTarget_TLSConfigVerifyClientCertificate(t *testing.T) {
+	t.Run("NewlineSeparatedMessages", func(t *testing.T) {
+		testSyslogTargetWithTLSVerifyClientCertificate(t, fmtNewline)
+	})
+	t.Run("OctetCounting", func(t *testing.T) {
+		testSyslogTargetWithTLSVerifyClientCertificate(t, fmtOctetCounting)
+	})
+}
+
+func testSyslogTargetWithTLSVerifyClientCertificate(t *testing.T, fmtFunc formatFunc) {
+	caCertFile, err := createTempFile(caCert)
+	if err != nil {
+		t.Fatalf("Unable to create CA certificate temporary file: %s", err)
+	}
+	defer os.Remove(caCertFile.Name())
+
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	serverCertFile, err := createTempFile(serverCert)
+	if err != nil {
+		t.Fatalf("Unable to create server certificate temporary file: %s", err)
+	}
+	defer os.Remove(serverCertFile.Name())
+
+	serverKeyFile, err := createTempFile(serverKey)
+	if err != nil {
+		t.Fatalf("Unable to create server key temporary file: %s", err)
+	}
+	defer os.Remove(serverKeyFile.Name())
+
+	clientCertFile, err := createTempFile(clientCert)
+	if err != nil {
+		t.Fatalf("Unable to create client certificate temporary file: %s", err)
+	}
+	defer os.Remove(clientCertFile.Name())
+
+	clientKeyFile, err := createTempFile(clientKey)
+	if err != nil {
+		t.Fatalf("Unable to create client key temporary file: %s", err)
+	}
+	defer os.Remove(clientKeyFile.Name())
+
+	clientCerts, err := tls.LoadX509KeyPair(clientCertFile.Name(), clientKeyFile.Name())
+	if err != nil {
+		t.Fatalf("Unable to load client certificate or key: %s", err)
+	}
+
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+	client := fake.New(func() {})
+
+	metrics := NewMetrics(nil)
+	tgt, err := NewSyslogTarget(metrics, logger, client, relabelConfig(t), &scrapeconfig.SyslogTargetConfig{
+		ListenAddress:       "127.0.0.1:0",
+		LabelStructuredData: true,
+		Labels: model.LabelSet{
+			"test": "syslog_target",
+		},
+		TLSConfig: promconfig.TLSConfig{
+			CAFile:   caCertFile.Name(),
+			CertFile: serverCertFile.Name(),
+			KeyFile:  serverKeyFile.Name(),
+		},
+	})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, tgt.Stop())
+	}()
+
+	tlsConfig := tls.Config{
+		RootCAs:    caCertPool,
+		ServerName: "promtail.example.com",
+	}
+
+	addr := tgt.ListenAddress().String()
+
+	t.Run("WithoutClientCertificate", func(t *testing.T) {
+		c, err := tls.Dial("tcp", addr, &tlsConfig)
+		require.NoError(t, err)
+
+		err = c.SetDeadline(time.Now().Add(time.Second))
+		require.NoError(t, err)
+
+		buf := make([]byte, 1)
+		_, err = c.Read(buf)
+		require.EqualError(t, err, "remote error: tls: bad certificate")
+	})
+
+	t.Run("WithClientCertificate", func(t *testing.T) {
+		tlsConfig.Certificates = []tls.Certificate{clientCerts}
+		c, err := tls.Dial("tcp", addr, &tlsConfig)
+		require.NoError(t, err)
+
+		messages := []string{
+			`<165>1 2018-10-11T22:14:15.003Z host5 e - id1 [custom@32473 exkey="1"] An application event log entry...`,
+			`<165>1 2018-10-11T22:14:15.005Z host5 e - id2 [custom@32473 exkey="2"] An application event log entry...`,
+			`<165>1 2018-10-11T22:14:15.007Z host5 e - id3 [custom@32473 exkey="3"] An application event log entry...`,
+		}
+
+		err = writeMessagesToStream(c, messages, fmtFunc)
+		require.NoError(t, err)
+		require.NoError(t, c.Close())
+
+		require.Eventuallyf(t, func() bool {
+			return len(client.Received()) == len(messages)
+		}, time.Second, time.Millisecond, "Expected to receive %d messages, got %d.", len(messages), len(client.Received()))
+
+		require.Equal(t, model.LabelSet{
+			"test": "syslog_target",
+
+			"severity": "notice",
+			"facility": "local4",
+			"hostname": "host5",
+			"app_name": "e",
+			"msg_id":   "id1",
+
+			"sd_custom_exkey": "1",
+		}, client.Received()[0].Labels)
+		require.Equal(t, "An application event log entry...", client.Received()[0].Line)
+
+		require.NotZero(t, client.Received()[0].Timestamp)
+	})
+}
+
+func TestSyslogTarget_InvalidData(t *testing.T) {
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+	client := fake.New(func() {})
+	metrics := NewMetrics(nil)
+
+	tgt, err := NewSyslogTarget(metrics, logger, client, relabelConfig(t), &scrapeconfig.SyslogTargetConfig{
+		ListenAddress: "127.0.0.1:0",
+	})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, tgt.Stop())
+	}()
+
+	addr := tgt.ListenAddress().String()
+	c, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = fmt.Fprint(c, "xxx")
+	require.NoError(t, err)
+
+	// syslog target should immediately close the connection if sent invalid data
+	err = c.SetDeadline(time.Now().Add(time.Second))
+	require.NoError(t, err)
+
+	buf := make([]byte, 1)
+	_, err = c.Read(buf)
+	require.EqualError(t, err, "EOF")
+}
+
+func TestSyslogTarget_NonUTF8Message(t *testing.T) {
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+	client := fake.New(func() {})
+	metrics := NewMetrics(nil)
+
+	tgt, err := NewSyslogTarget(metrics, logger, client, relabelConfig(t), &scrapeconfig.SyslogTargetConfig{
+		ListenAddress: "127.0.0.1:0",
+	})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, tgt.Stop())
+	}()
+
+	addr := tgt.ListenAddress().String()
+	c, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+
+	msg1 := "Some non utf8 \xF8\xF7\xE3\xE4 characters"
+	require.False(t, utf8.ValidString(msg1), "msg must no be valid utf8")
+	msg2 := "\xF8 other \xF7\xE3\xE4 characters \xE3"
+	require.False(t, utf8.ValidString(msg2), "msg must no be valid utf8")
+
+	err = writeMessagesToStream(c, []string{
+		"<165>1 - - - - - - " + msg1,
+		"<123>1 - - - - - - " + msg2,
+	}, fmtOctetCounting)
+	require.NoError(t, err)
+	require.NoError(t, c.Close())
+
+	require.Eventuallyf(t, func() bool {
+		return len(client.Received()) == 2
+	}, time.Second, time.Millisecond, "Expected to receive 2 messages, got %d.", len(client.Received()))
+
+	require.Equal(t, msg1, client.Received()[0].Line)
+	require.Equal(t, msg2, client.Received()[1].Line)
+}
+
+func TestSyslogTarget_IdleTimeout(t *testing.T) {
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+	client := fake.New(func() {})
+	metrics := NewMetrics(nil)
+
+	tgt, err := NewSyslogTarget(metrics, logger, client, relabelConfig(t), &scrapeconfig.SyslogTargetConfig{
+		ListenAddress: "127.0.0.1:0",
+		IdleTimeout:   time.Millisecond,
+	})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, tgt.Stop())
+	}()
+
+	addr := tgt.ListenAddress().String()
+	c, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+	defer c.Close()
+
+	// connection should be closed before the higher timeout
+	// from SetDeadline fires
+	err = c.SetDeadline(time.Now().Add(time.Second))
+	require.NoError(t, err)
+
+	buf := make([]byte, 1)
+	_, err = c.Read(buf)
+	require.EqualError(t, err, "EOF")
+}
+
+func TestParseStream_WithAsyncPipe(t *testing.T) {
+	lines := [3]string{
+		"<165>1 2018-10-11T22:14:15.003Z host5 e - id1 [custom@32473 exkey=\"1\"] An application event log entry...\n",
+		"<165>1 2018-10-11T22:14:15.005Z host5 e - id2 [custom@32473 exkey=\"2\"] An application event log entry...\n",
+		"<165>1 2018-10-11T22:14:15.007Z host5 e - id3 [custom@32473 exkey=\"3\"] An application event log entry...\n",
+	}
+
+	addr := &net.UDPAddr{IP: net.IP{127, 0, 0, 1}, Port: 1514}
+	pipe := NewConnPipe(addr)
+	go func() {
+		for _, line := range lines {
+			_, _ = pipe.Write([]byte(line))
+		}
+		pipe.Close()
+	}()
+
+	results := make([]*syslog.Result, 0)
+	cb := func(res *syslog.Result) {
+		results = append(results, res)
+	}
+
+	err := syslogparser.ParseStream(pipe, cb, DefaultMaxMessageLength)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(results))
+}

--- a/component/loki/source/syslog/internal/syslogtarget/transport.go
+++ b/component/loki/source/syslog/internal/syslogtarget/transport.go
@@ -261,7 +261,6 @@ func (t *TCPTransport) acceptConnections() {
 		t.openConnections.Add(1)
 		go t.handleConnection(c)
 	}
-
 }
 
 func (t *TCPTransport) handleConnection(cn net.Conn) {

--- a/component/loki/source/syslog/internal/syslogtarget/transport.go
+++ b/component/loki/source/syslog/internal/syslogtarget/transport.go
@@ -1,0 +1,411 @@
+package syslogtarget
+
+// This code is copied from Promtail. The syslogtarget package is used to
+// configure and run the targets that can read syslog entries and forward them
+// to other loki components.
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/grafana/dskit/backoff"
+	"github.com/mwitkow/go-conntrack"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/influxdata/go-syslog/v3"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
+	"github.com/grafana/loki/clients/pkg/promtail/targets/syslog/syslogparser"
+)
+
+var (
+	protocolUDP = "udp"
+	protocolTCP = "tcp"
+)
+
+type Transport interface {
+	Run() error
+	Addr() net.Addr
+	Ready() bool
+	Close() error
+	Wait()
+}
+
+type handleMessage func(labels.Labels, syslog.Message)
+type handleMessageError func(error)
+
+type baseTransport struct {
+	config *scrapeconfig.SyslogTargetConfig
+	logger log.Logger
+
+	openConnections *sync.WaitGroup
+
+	handleMessage      handleMessage
+	handleMessageError handleMessageError
+
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+}
+
+func (t *baseTransport) close() {
+	t.ctxCancel()
+}
+
+// Ready implements SyslogTransport
+func (t *baseTransport) Ready() bool {
+	return t.ctx.Err() == nil
+}
+
+func (t *baseTransport) idleTimeout() time.Duration {
+	if t.config.IdleTimeout != 0 {
+		return t.config.IdleTimeout
+	}
+	return DefaultIdleTimeout
+}
+
+func (t *baseTransport) maxMessageLength() int {
+	if t.config.MaxMessageLength != 0 {
+		return t.config.MaxMessageLength
+	}
+	return DefaultMaxMessageLength
+}
+
+func (t *baseTransport) connectionLabels(ip string) labels.Labels {
+	lb := labels.NewBuilder(nil)
+	for k, v := range t.config.Labels {
+		lb.Set(string(k), string(v))
+	}
+
+	lb.Set("__syslog_connection_ip_address", ip)
+	lb.Set("__syslog_connection_hostname", lookupAddr(ip))
+
+	return lb.Labels(nil)
+}
+
+func ipFromConn(c net.Conn) net.IP {
+	switch addr := c.RemoteAddr().(type) {
+	case *net.TCPAddr:
+		return addr.IP
+	}
+
+	return nil
+}
+
+func lookupAddr(addr string) string {
+	names, _ := net.LookupAddr(addr)
+	return strings.Join(names, ",")
+}
+
+func newBaseTransport(config *scrapeconfig.SyslogTargetConfig, handleMessage handleMessage, handleError handleMessageError, logger log.Logger) *baseTransport {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &baseTransport{
+		config:             config,
+		logger:             logger,
+		openConnections:    new(sync.WaitGroup),
+		handleMessage:      handleMessage,
+		handleMessageError: handleError,
+		ctx:                ctx,
+		ctxCancel:          cancel,
+	}
+}
+
+type idleTimeoutConn struct {
+	net.Conn
+	idleTimeout time.Duration
+}
+
+func (c *idleTimeoutConn) Write(p []byte) (int, error) {
+	c.setDeadline()
+	return c.Conn.Write(p)
+}
+
+func (c *idleTimeoutConn) Read(b []byte) (int, error) {
+	c.setDeadline()
+	return c.Conn.Read(b)
+}
+
+func (c *idleTimeoutConn) setDeadline() {
+	_ = c.Conn.SetDeadline(time.Now().Add(c.idleTimeout))
+}
+
+type ConnPipe struct {
+	addr net.Addr
+	*io.PipeReader
+	*io.PipeWriter
+}
+
+func NewConnPipe(addr net.Addr) *ConnPipe {
+	pr, pw := io.Pipe()
+	return &ConnPipe{
+		addr:       addr,
+		PipeReader: pr,
+		PipeWriter: pw,
+	}
+}
+
+func (pipe *ConnPipe) Close() error {
+	if err := pipe.PipeWriter.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+type TCPTransport struct {
+	*baseTransport
+	listener net.Listener
+}
+
+func NewSyslogTCPTransport(config *scrapeconfig.SyslogTargetConfig, handleMessage handleMessage, handleError handleMessageError, logger log.Logger) Transport {
+	return &TCPTransport{
+		baseTransport: newBaseTransport(config, handleMessage, handleError, logger),
+	}
+}
+
+// Run implements SyslogTransport
+func (t *TCPTransport) Run() error {
+	l, err := net.Listen(protocolTCP, t.config.ListenAddress)
+	l = conntrack.NewListener(l, conntrack.TrackWithName("syslog_target/"+t.config.ListenAddress))
+	if err != nil {
+		return fmt.Errorf("error setting up syslog target: %w", err)
+	}
+
+	tlsEnabled := t.config.TLSConfig.CertFile != "" || t.config.TLSConfig.KeyFile != "" || t.config.TLSConfig.CAFile != ""
+	if tlsEnabled {
+		tlsConfig, err := newTLSConfig(t.config.TLSConfig.CertFile, t.config.TLSConfig.KeyFile, t.config.TLSConfig.CAFile)
+		if err != nil {
+			return fmt.Errorf("error setting up syslog target: %w", err)
+		}
+		l = tls.NewListener(l, tlsConfig)
+	}
+
+	t.listener = l
+	level.Info(t.logger).Log("msg", "syslog listening on address", "address", t.Addr().String(), "protocol", protocolTCP, "tls", tlsEnabled)
+
+	t.openConnections.Add(1)
+	go t.acceptConnections()
+
+	return nil
+}
+
+func newTLSConfig(certFile string, keyFile string, caFile string) (*tls.Config, error) {
+	if certFile == "" || keyFile == "" {
+		return nil, fmt.Errorf("certificate and key files are required")
+	}
+
+	certs, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load server certificate or key: %w", err)
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{certs},
+	}
+
+	if caFile != "" {
+		caCert, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("unable to load client CA certificate: %w", err)
+		}
+
+		caCertPool := x509.NewCertPool()
+		if ok := caCertPool.AppendCertsFromPEM(caCert); !ok {
+			return nil, fmt.Errorf("unable to parse client CA certificate")
+		}
+
+		tlsConfig.ClientCAs = caCertPool
+		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+
+	return tlsConfig, nil
+}
+
+func (t *TCPTransport) acceptConnections() {
+	defer t.openConnections.Done()
+
+	l := log.With(t.logger, "address", t.listener.Addr().String())
+
+	backoff := backoff.New(t.ctx, backoff.Config{
+		MinBackoff: 5 * time.Millisecond,
+		MaxBackoff: 1 * time.Second,
+	})
+
+	for {
+		c, err := t.listener.Accept()
+		if err != nil {
+			if !t.Ready() {
+				level.Info(l).Log("msg", "syslog server shutting down", "protocol", protocolTCP, "err", t.ctx.Err())
+				return
+			}
+
+			if _, ok := err.(net.Error); ok {
+				level.Warn(l).Log("msg", "failed to accept syslog connection", "err", err, "num_retries", backoff.NumRetries())
+				backoff.Wait()
+				continue
+			}
+
+			level.Error(l).Log("msg", "failed to accept syslog connection. quiting", "err", err)
+			return
+		}
+		backoff.Reset()
+
+		t.openConnections.Add(1)
+		go t.handleConnection(c)
+	}
+
+}
+
+func (t *TCPTransport) handleConnection(cn net.Conn) {
+	defer t.openConnections.Done()
+
+	c := &idleTimeoutConn{cn, t.idleTimeout()}
+
+	handlerCtx, cancel := context.WithCancel(t.ctx)
+	defer cancel()
+	go func() {
+		<-handlerCtx.Done()
+		_ = c.Close()
+	}()
+
+	lbs := t.connectionLabels(ipFromConn(c).String())
+
+	err := syslogparser.ParseStream(c, func(result *syslog.Result) {
+		if err := result.Error; err != nil {
+			t.handleMessageError(err)
+			return
+		}
+		t.handleMessage(lbs.Copy(), result.Message)
+	}, t.maxMessageLength())
+
+	if err != nil {
+		level.Warn(t.logger).Log("msg", "error initializing syslog stream", "err", err)
+	}
+}
+
+// Close implements SyslogTransport
+func (t *TCPTransport) Close() error {
+	t.baseTransport.close()
+	return t.listener.Close()
+}
+
+// Wait implements SyslogTransport
+func (t *TCPTransport) Wait() {
+	t.openConnections.Wait()
+}
+
+// Addr implements SyslogTransport
+func (t *TCPTransport) Addr() net.Addr {
+	return t.listener.Addr()
+}
+
+type UDPTransport struct {
+	*baseTransport
+	udpConn *net.UDPConn
+}
+
+func NewSyslogUDPTransport(config *scrapeconfig.SyslogTargetConfig, handleMessage handleMessage, handleError handleMessageError, logger log.Logger) Transport {
+	return &UDPTransport{
+		baseTransport: newBaseTransport(config, handleMessage, handleError, logger),
+	}
+}
+
+// Run implements SyslogTransport
+func (t *UDPTransport) Run() error {
+	var err error
+	addr, err := net.ResolveUDPAddr(protocolUDP, t.config.ListenAddress)
+	if err != nil {
+		return fmt.Errorf("error resolving UDP address: %w", err)
+	}
+	t.udpConn, err = net.ListenUDP(protocolUDP, addr)
+	if err != nil {
+		return fmt.Errorf("error setting up syslog target: %w", err)
+	}
+	_ = t.udpConn.SetReadBuffer(1024 * 1024)
+	level.Info(t.logger).Log("msg", "syslog listening on address", "address", t.Addr().String(), "protocol", protocolUDP)
+
+	t.openConnections.Add(1)
+	go t.acceptPackets()
+	return nil
+}
+
+// Close implements SyslogTransport
+func (t *UDPTransport) Close() error {
+	t.baseTransport.close()
+	return t.udpConn.Close()
+}
+
+func (t *UDPTransport) acceptPackets() {
+	defer t.openConnections.Done()
+
+	var (
+		n    int
+		addr net.Addr
+		err  error
+	)
+	streams := make(map[string]*ConnPipe)
+	buf := make([]byte, t.maxMessageLength())
+
+	for {
+		if !t.Ready() {
+			level.Info(t.logger).Log("msg", "syslog server shutting down", "protocol", protocolUDP, "err", t.ctx.Err())
+			for _, stream := range streams {
+				if err = stream.Close(); err != nil {
+					level.Error(t.logger).Log("msg", "failed to close pipe", "err", err)
+				}
+			}
+			return
+		}
+		n, addr, err = t.udpConn.ReadFrom(buf)
+		if n <= 0 && err != nil {
+			level.Warn(t.logger).Log("msg", "failed to read packets", "addr", addr, "err", err)
+			continue
+		}
+
+		stream, ok := streams[addr.String()]
+		if !ok {
+			stream = NewConnPipe(addr)
+			streams[addr.String()] = stream
+			t.openConnections.Add(1)
+			go t.handleRcv(stream)
+		}
+		if _, err := stream.Write(buf[:n]); err != nil {
+			level.Warn(t.logger).Log("msg", "failed to write to stream", "addr", addr, "err", err)
+		}
+	}
+}
+
+func (t *UDPTransport) handleRcv(c *ConnPipe) {
+	defer t.openConnections.Done()
+
+	lbs := t.connectionLabels(c.addr.String())
+	err := syslogparser.ParseStream(c, func(result *syslog.Result) {
+		if err := result.Error; err != nil {
+			t.handleMessageError(err)
+		} else {
+			t.handleMessage(lbs.Copy(), result.Message)
+		}
+	}, t.maxMessageLength())
+
+	if err != nil {
+		level.Warn(t.logger).Log("msg", "error parsing syslog stream", "err", err)
+	}
+}
+
+// Wait implements SyslogTransport
+func (t *UDPTransport) Wait() {
+	t.openConnections.Wait()
+}
+
+// Addr implements SyslogTransport
+func (t *UDPTransport) Addr() net.Addr {
+	return t.udpConn.LocalAddr()
+}

--- a/component/loki/source/syslog/syslog.go
+++ b/component/loki/source/syslog/syslog.go
@@ -1,0 +1,152 @@
+package syslog
+
+import (
+	"context"
+	"reflect"
+	"sync"
+
+	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/common/loki"
+	st "github.com/grafana/agent/component/loki/source/syslog/internal/syslogtarget"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name: "loki.source.syslog",
+		Args: Arguments{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			return New(opts, args.(Arguments))
+		},
+	})
+}
+
+// Arguments holds values which are used to configure the loki.source.syslog
+// component.
+type Arguments struct {
+	SyslogListeners []ListenerConfig    `river:"listener,block"`
+	ForwardTo       []loki.LogsReceiver `river:"forward_to,attr"`
+}
+
+// Component implements the loki.source.syslog component.
+type Component struct {
+	opts    component.Options
+	metrics *st.Metrics
+
+	mut     sync.RWMutex
+	lc      []ListenerConfig
+	fanout  []loki.LogsReceiver
+	targets []*st.SyslogTarget
+
+	handler loki.LogsReceiver
+}
+
+// New creates a new loki.source.syslog component.
+func New(o component.Options, args Arguments) (*Component, error) {
+
+	c := &Component{
+		opts:    o,
+		metrics: st.NewMetrics(o.Registerer),
+		handler: make(loki.LogsReceiver),
+		fanout:  args.ForwardTo,
+
+		targets: []*st.SyslogTarget{},
+	}
+
+	// Call to Update() to start readers and set receivers once at the start.
+	if err := c.Update(args); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// Run implements component.Component.
+func (c *Component) Run(ctx context.Context) error {
+	defer func() {
+		level.Info(c.opts.Logger).Log("msg", "loki.source.syslog component shutting down, stopping targets")
+		for _, r := range c.targets {
+			r.Stop()
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case entry := <-c.handler:
+			c.mut.RLock()
+			for _, receiver := range c.fanout {
+				receiver <- entry
+			}
+			c.mut.RUnlock()
+		}
+	}
+}
+
+// Update implements component.Component.
+func (c *Component) Update(args component.Arguments) error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	newArgs := args.(Arguments)
+	c.fanout = newArgs.ForwardTo
+
+	if configsChanged(c.lc, newArgs.SyslogListeners) {
+		for _, t := range c.targets {
+			t.Stop()
+		}
+		c.targets = make([]*st.SyslogTarget, 0)
+		entryHandler := loki.NewEntryHandler(c.handler, func() {})
+
+		for _, cfg := range newArgs.SyslogListeners {
+			t, err := st.NewSyslogTarget(c.metrics, c.opts.Logger, entryHandler, nil, cfg.Convert())
+			if err != nil {
+				level.Error(c.opts.Logger).Log("msg", "failed to create syslog target with provided config", "err", err)
+				continue
+			}
+			c.targets = append(c.targets, t)
+		}
+	}
+
+	return nil
+}
+
+// DebugInfo returns information about the status of tailed targets.
+func (c *Component) DebugInfo() interface{} {
+	var res readerDebugInfo
+
+	for _, t := range c.targets {
+		res.TargetsInfo = append(res.TargetsInfo, targetInfo{
+			Type:          string(t.Type()),
+			Ready:         t.Ready(),
+			ListenAddress: t.ListenAddress().String(),
+			Labels:        t.Labels().String(),
+		})
+	}
+	return res
+}
+
+type readerDebugInfo struct {
+	TargetsInfo []targetInfo `river:"targets_info,attr"`
+}
+
+type targetInfo struct {
+	Type          string `river:"type,attr"`
+	Ready         bool   `river:"ready,attr"`
+	ListenAddress string `river:"listen_address,attr"`
+	Labels        string `river:"labels,attr"`
+}
+
+func configsChanged(prev, next []ListenerConfig) bool {
+	if len(prev) != len(next) {
+		return true
+	}
+	for i := range prev {
+		if !reflect.DeepEqual(prev[i], next[i]) {
+			return true
+		}
+	}
+	return false
+}

--- a/component/loki/source/syslog/syslog.go
+++ b/component/loki/source/syslog/syslog.go
@@ -64,7 +64,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 // Run implements component.Component.
 func (c *Component) Run(ctx context.Context) error {
 	defer func() {
-		level.Info(c.opts.Logger).Log("msg", "loki.source.syslog component shutting down, stopping")
+		level.Info(c.opts.Logger).Log("msg", "loki.source.syslog component shutting down, stopping listeners")
 		for _, l := range c.listeners {
 			err := l.Stop()
 			if err != nil {
@@ -108,7 +108,7 @@ func (c *Component) Update(args component.Arguments) error {
 		for _, cfg := range newArgs.SyslogListeners {
 			t, err := st.NewSyslogTarget(c.metrics, c.opts.Logger, entryHandler, nil, cfg.Convert())
 			if err != nil {
-				level.Error(c.opts.Logger).Log("msg", "failed to create syslog target with provided config", "err", err)
+				level.Error(c.opts.Logger).Log("msg", "failed to create syslog listener with provided config", "err", err)
 				continue
 			}
 			c.listeners = append(c.listeners, t)
@@ -118,12 +118,12 @@ func (c *Component) Update(args component.Arguments) error {
 	return nil
 }
 
-// DebugInfo returns information about the status of tailed targets.
+// DebugInfo returns information about the status of listeners.
 func (c *Component) DebugInfo() interface{} {
 	var res readerDebugInfo
 
 	for _, t := range c.listeners {
-		res.TargetsInfo = append(res.TargetsInfo, targetInfo{
+		res.ListenersInfo = append(res.ListenersInfo, listenerInfo{
 			Type:          string(t.Type()),
 			Ready:         t.Ready(),
 			ListenAddress: t.ListenAddress().String(),
@@ -134,10 +134,10 @@ func (c *Component) DebugInfo() interface{} {
 }
 
 type readerDebugInfo struct {
-	TargetsInfo []targetInfo `river:"targets_info,attr"`
+	ListenersInfo []listenerInfo `river:"listeners_info,attr"`
 }
 
-type targetInfo struct {
+type listenerInfo struct {
 	Type          string `river:"type,attr"`
 	Ready         bool   `river:"ready,attr"`
 	ListenAddress string `river:"listen_address,attr"`

--- a/component/loki/source/syslog/syslog_test.go
+++ b/component/loki/source/syslog/syslog_test.go
@@ -53,7 +53,6 @@ func Test(t *testing.T) {
 	msg := `<165>1 2023-01-05T09:13:17.001Z host1 app - id1 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][examplePriority@32473 class="high"] An application event log entry...`
 	con, err := net.Dial("tcp", tcpListenerAddr)
 	require.NoError(t, err)
-
 	writeMessageToStream(con, msg, fmtNewline)
 	err = con.Close()
 	require.NoError(t, err)
@@ -75,7 +74,7 @@ func Test(t *testing.T) {
 		}
 	}
 
-	// Create and send a Syslog message over UDP to the second listener.
+	// Send a Syslog message over UDP to the second listener.
 	con, err = net.Dial("udp", udpListenerAddr)
 	require.NoError(t, err)
 	writeMessageToStream(con, msg, fmtOctetCounting)

--- a/component/loki/source/syslog/syslog_test.go
+++ b/component/loki/source/syslog/syslog_test.go
@@ -1,0 +1,1 @@
+package syslog

--- a/component/loki/source/syslog/syslog_test.go
+++ b/component/loki/source/syslog/syslog_test.go
@@ -1,1 +1,125 @@
 package syslog
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/agent/pkg/flow/logging"
+	"github.com/phayes/freeport"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func Test(t *testing.T) {
+	// Create opts for component
+	l, err := logging.New(os.Stderr, logging.DefaultOptions)
+	require.NoError(t, err)
+
+	opts := component.Options{Logger: l}
+
+	ch1, ch2 := make(chan loki.Entry), make(chan loki.Entry)
+	args := Arguments{}
+	tcpListenerAddr, udpListenerAddr := getFreeAddr(t), getFreeAddr(t)
+
+	args.SyslogListeners = []ListenerConfig{
+		{
+			ListenAddress:  tcpListenerAddr,
+			ListenProtocol: "tcp",
+			Labels:         map[string]string{"protocol": "tcp"},
+		},
+		{
+			ListenAddress:  udpListenerAddr,
+			ListenProtocol: "udp",
+			Labels:         map[string]string{"protocol": "udp"},
+		},
+	}
+	args.ForwardTo = []loki.LogsReceiver{ch1, ch2}
+
+	// Create and run the component.
+	c, err := New(opts, args)
+	require.NoError(t, err)
+
+	go c.Run(context.Background())
+	time.Sleep(200 * time.Millisecond)
+
+	// Create and send a Syslog message over TCP to the first listener.
+	msg := `<165>1 2023-01-05T09:13:17.001Z host1 app - id1 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][examplePriority@32473 class="high"] An application event log entry...`
+	con, err := net.Dial("tcp", tcpListenerAddr)
+	require.NoError(t, err)
+
+	writeMessageToStream(con, msg, fmtNewline)
+	err = con.Close()
+	require.NoError(t, err)
+
+	wantLabelSet := model.LabelSet{"protocol": "tcp"}
+
+	for i := 0; i < 2; i++ {
+		select {
+		case logEntry := <-ch1:
+			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
+			require.Equal(t, "An application event log entry...", logEntry.Line)
+			require.Equal(t, wantLabelSet, logEntry.Labels)
+		case logEntry := <-ch2:
+			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
+			require.Equal(t, "An application event log entry...", logEntry.Line)
+			require.Equal(t, wantLabelSet, logEntry.Labels)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "failed waiting for log line")
+		}
+	}
+
+	// Create and send a Syslog message over UDP to the second listener.
+	con, err = net.Dial("udp", udpListenerAddr)
+	require.NoError(t, err)
+	writeMessageToStream(con, msg, fmtOctetCounting)
+	err = con.Close()
+	require.NoError(t, err)
+
+	wantLabelSet = model.LabelSet{"protocol": "udp"}
+
+	for i := 0; i < 2; i++ {
+		select {
+		case logEntry := <-ch1:
+			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
+			require.Equal(t, "An application event log entry...", logEntry.Line)
+			require.Equal(t, wantLabelSet, logEntry.Labels)
+		case logEntry := <-ch2:
+			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
+			require.Equal(t, "An application event log entry...", logEntry.Line)
+			require.Equal(t, wantLabelSet, logEntry.Labels)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "failed waiting for log line")
+		}
+	}
+}
+
+func getFreeAddr(t *testing.T) string {
+	t.Helper()
+
+	portNumber, err := freeport.GetFreePort()
+	require.NoError(t, err)
+
+	return fmt.Sprintf("127.0.0.1:%d", portNumber)
+}
+
+func writeMessageToStream(w io.Writer, msg string, formatter formatFunc) error {
+	_, err := fmt.Fprint(w, formatter(msg))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type formatFunc func(string) string
+
+var (
+	fmtOctetCounting = func(s string) string { return fmt.Sprintf("%d %s", len(s), s) }
+	fmtNewline       = func(s string) string { return s + "\n" }
+)

--- a/component/loki/source/syslog/syslog_test.go
+++ b/component/loki/source/syslog/syslog_test.go
@@ -129,6 +129,10 @@ func TestWithRelabelRules(t *testing.T) {
 				Action:       flow_relabel.LabelMap,
 				Replacement:  "syslog_${1}",
 			},
+			{
+				Regex:  mustNewRegexp("syslog_connection_hostname"),
+				Action: flow_relabel.LabelDrop,
+			},
 		}
 	}
 
@@ -150,7 +154,6 @@ func TestWithRelabelRules(t *testing.T) {
 	// The entry should've had the relabeling rules applied to it.
 	wantLabelSet := model.LabelSet{
 		"protocol":                     "tcp",
-		"syslog_connection_hostname":   "localhost",
 		"syslog_connection_ip_address": "127.0.0.1",
 		"syslog_message_app_name":      "app",
 		"syslog_message_facility":      "local4",

--- a/component/loki/source/syslog/types.go
+++ b/component/loki/source/syslog/types.go
@@ -1,0 +1,71 @@
+package syslog
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/grafana/agent/component/common/config"
+	st "github.com/grafana/agent/component/loki/source/syslog/internal/syslogtarget"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
+	"github.com/prometheus/common/model"
+)
+
+// ListenerConfig defines a syslog listener.
+type ListenerConfig struct {
+	ListenAddress        string            `river:"address,attr"`
+	ListenProtocol       string            `river:"protocol,attr,optional"`
+	IdleTimeout          time.Duration     `river:"idle_timeout,attr,optional"`
+	LabelStructuredData  bool              `river:"label_structured_data,attr,optional"`
+	Labels               map[string]string `river:"labels,attr,optional"`
+	UseIncomingTimestamp bool              `river:"use_incoming_timestamp,attr,optional"`
+	UseRFC5424Message    bool              `river:"use_rfc5424_message,attr,optional"`
+	MaxMessageLength     int               `river:"max_message_length,attr,optional"`
+	TLSConfig            config.TLSConfig  `river:"tls_config,block,optional"`
+}
+
+// DefaultListenerConfig provides the default arguments for a syslog listener.
+var DefaultListenerConfig = ListenerConfig{
+	ListenProtocol:   st.DefaultProtocol,
+	IdleTimeout:      st.DefaultIdleTimeout,
+	MaxMessageLength: st.DefaultMaxMessageLength,
+}
+
+var _ river.Unmarshaler = (*ListenerConfig)(nil)
+
+// UnmarshalRiver implements river.Unmarshaler.
+func (sc *ListenerConfig) UnmarshalRiver(f func(interface{}) error) error {
+	*sc = DefaultListenerConfig
+
+	type syslogcfg ListenerConfig
+	err := f((*syslogcfg)(sc))
+	if err != nil {
+		return err
+	}
+
+	if sc.ListenProtocol != "tcp" && sc.ListenProtocol != "udp" {
+		return fmt.Errorf("syslog listener protocol should be either 'tcp' or 'udp', got %s", sc.ListenProtocol)
+	}
+
+	return nil
+}
+
+// Convert is used to bridge between the River and Promtail types.
+func (sc ListenerConfig) Convert() *scrapeconfig.SyslogTargetConfig {
+	lbls := make(model.LabelSet, len(sc.Labels))
+	for k, v := range sc.Labels {
+		lbls[model.LabelName(k)] = model.LabelValue(v)
+	}
+
+	return &scrapeconfig.SyslogTargetConfig{
+		ListenAddress:        sc.ListenAddress,
+		ListenProtocol:       sc.ListenProtocol,
+		IdleTimeout:          sc.IdleTimeout,
+		LabelStructuredData:  sc.LabelStructuredData,
+		Labels:               lbls,
+		UseIncomingTimestamp: sc.UseIncomingTimestamp,
+		UseRFC5424Message:    sc.UseRFC5424Message,
+		MaxMessageLength:     sc.MaxMessageLength,
+		TLSConfig:            *sc.TLSConfig.Convert(),
+	}
+}

--- a/docs/sources/flow/reference/components/loki.source.syslog.md
+++ b/docs/sources/flow/reference/components/loki.source.syslog.md
@@ -56,7 +56,7 @@ refers to a `tls_config` block defined inside a `config` block.
 ### listener block
 
 The `listener` block defines the listen address and protocol where the listener
-will expect syslog messages to, as well as its behavior when receiving
+expects syslog messages to be sent to, as well as its behavior when receiving
 messages.
 
 The following arguments can be used to configure a `listener`. Only the
@@ -65,28 +65,28 @@ values.
 
 Name                     | Type          | Description | Default | Required
 ------------------------ | ------------- | ----------- | ------- | --------
-`address`                | `string`      | The `<host:port>` address to listen on for syslog messages. | | yes
-`protocol`               | `string`      | The protocol to listen on for syslog messages. Must be either `tcp` or `udp`. | `tcp` | no
+`address`                | `string`      | The `<host:port>` address to listen to for syslog messages. | | yes
+`protocol`               | `string`      | The protocol to listen to for syslog messages. Must be either `tcp` or `udp`. | `tcp` | no
 `idle_timeout`           | `duration`    | The idle timeout for tcp connections. | `"120s"` | no
 `label_structured_data`  | `bool`        | Whether to translate syslog structured data to loki labels. | `false` | no
 `labels`                 | `map(string)` | The labels to associate with each received syslog record. | `{}` | no
 `use_incoming_timestamp` | `bool`        | Whether to set the timestamp to the incoming syslog record timestamp. | `false` | no
-`use_rfc5424_message`    | `bool`        | Whether the full RFC5424-formatted syslog message should be forwarded. | `false` | no
+`use_rfc5424_message`    | `bool`        | Whether to forward the full RFC5424-formatted syslog message. | `false` | no
 `max_message_length`     | `int`         | The maximum limit to the length of syslog messages. | `8192` | no
 
-By default, the component will assign the log entry timestamp as the time it
+By default, the component assigns the log entry timestamp as the time it
 was processed.
 
-The `labels` map will be applied to every message that the component reads.
+The `labels` map is applied to every message that the component reads.
 
-All header fields from the parsed RFC5424 messages will be brought in as
+All header fields from the parsed RFC5424 messages are brought in as
 internal labels, prefixed with `__syslog_`.
 
-If `label_structured_data` is set, structured data in the syslog header will
-also be translated to internal labels in the form of
-`__syslog_message_sd_<ID>_<KEY>`. A structured data entry of `[example@99999
-test="yes"]` would become the label `__syslog_message_sd_example_99999_test`
-with the value `"yes"`.
+If `label_structured_data` is set, structured data in the syslog header is also
+translated to internal labels in the form of
+`__syslog_message_sd_<ID>_<KEY>`. For example, a  structured data entry of
+`[example@99999 test="yes"]` becomes the label 
+`__syslog_message_sd_example_99999_test` with the value `"yes"`.
 
 ### tls_config block
 
@@ -115,9 +115,8 @@ configuration.
 
 ## Example
 
-This example collects listens for Syslog messages in valid RFC5424 format over
-TCP and UDP in the specified ports and forwards them to a `loki.write`
-component.
+This example listens for Syslog messages in valid RFC5424 format over TCP and
+UDP in the specified ports and forwards them to a `loki.write` component.
 
 ```river
 loki.source.syslog "local" {

--- a/docs/sources/flow/reference/components/loki.source.syslog.md
+++ b/docs/sources/flow/reference/components/loki.source.syslog.md
@@ -1,0 +1,144 @@
+---
+aliases:
+- /docs/agent/latest/flow/reference/components/loki.source.syslog
+title: loki.source.syslog
+---
+
+# loki.source.syslog
+
+`loki.source.syslog` listens for syslog messages over TCP or UDP connections
+and forwards them to other `loki.*` components. The messages must be compliant
+with the [RFC5424](https://www.rfc-editor.org/rfc/rfc5424) format.
+
+The component starts a new syslog listener for each of the given `config`
+blocks and fans out incoming entries to the list of receivers in `forward_to`.
+
+Multiple `loki.source.syslog` components can be specified by giving them
+different labels.
+
+## Usage
+
+```river
+loki.source.syslog "LABEL" {
+  config {
+    listen_address = "LISTEN_ADDRESS"
+  }
+  ...
+
+  forward_to = RECEIVER_LIST
+}
+```
+
+## Arguments
+
+`loki.source.syslog` supports the following arguments:
+
+Name         | Type                   | Description          | Default | Required
+------------ | ---------------------- | -------------------- | ------- | --------
+`forward_to` | `list(LogsReceiver)`   | List of receivers to send log entries to. | | yes
+
+## Blocks
+
+The following blocks are supported inside the definition of
+`loki.source.syslog`:
+
+Hierarchy | Name | Description | Required
+--------- | ---- | ----------- | --------
+listener | [config][] | Configures a listener for IETF Syslog (RFC5424) messages. | no
+listener > tls_config | [tls_config][] | Configures TLS settings for connecting to the endpoint for TCP connections. | no
+
+The `>` symbol indicates deeper levels of nesting. For example, `config > tls_config` 
+refers to a `tls_config` block defined inside a `config` block.
+
+[listener]: #listener-block
+[tls_config]: #tls_config-block
+
+### listener block
+
+The `listener` block defines the listen address and protocol where the listener
+will expect syslog messages to, as well as its behavior when receiving
+messages.
+
+The following arguments can be used to configure a `listener`. Only the
+`listen_address` field is required and any omitted fields take their default
+values.
+
+Name                     | Type          | Description | Default | Required
+------------------------ | ------------- | ----------- | ------- | --------
+`address`                | `string`      | The `<host:port>` address to listen on for syslog messages. | | yes
+`protocol`               | `string`      | The protocol to listen on for syslog messages. Must be either `tcp` or `udp`. | `tcp` | no
+`idle_timeout`           | `duration`    | The idle timeout for tcp connections. | `"120s"` | no
+`label_structured_data`  | `bool`        | Whether to translate syslog structured data to loki labels. | `false` | no
+`labels`                 | `map(string)` | The labels to associate with each received syslog record. | `{}` | no
+`use_incoming_timestamp` | `bool`        | Whether to set the timestamp to the incoming syslog record timestamp. | `false` | no
+`use_rfc5424_message`    | `bool`        | Whether the full RFC5424-formatted syslog message should be forwarded. | `false` | no
+`max_message_length`     | `int`         | The maximum limit to the length of syslog messages. | `8192` | no
+
+By default, the component will assign the log entry timestamp as the time it
+was processed.
+
+The `labels` map will be applied to every message that the component reads.
+
+All header fields from the parsed RFC5424 messages will be brought in as
+internal labels, prefixed with `__syslog_`.
+
+If `label_structured_data` is set, structured data in the syslog header will
+also be translated to internal labels in the form of
+`__syslog_message_sd_<ID>_<KEY>`. A structured data entry of `[example@99999
+test="yes"]` would become the label `__syslog_message_sd_example_99999_test`
+with the value `"yes"`.
+
+### tls_config block
+
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+
+## Exported fields
+
+`loki.source.syslog` does not export any fields.
+
+## Component health
+
+`loki.source.syslog` is only reported as unhealthy if given an invalid
+configuration.
+
+## Debug information
+
+`loki.source.syslog` exposes some debug information per syslog listener:
+* Whether the listener is currently running.
+* The listen address.
+* The labels that the listener applies to incoming log entries.
+
+## Debug metrics
+* `loki_source_syslog_entries_total` (counter): Total number of successful entries sent to the syslog component.
+* `loki_source_syslog_parsing_errors_total` (counter): Total number of parsing errors while receiving syslog messages.
+* `loki_source_syslog_empty_messages_total` (counter): Total number of empty messages received from the syslog component.
+
+## Example
+
+This example collects listens for Syslog messages in valid RFC5424 format over
+TCP and UDP in the specified ports and forwards them to a `loki.write`
+component.
+
+```river
+loki.source.syslog "local" {
+  listener {
+    address  = "127.0.0.1:51893"
+    labels   = { component = "loki.source.syslog", protocol = "tcp" } 
+  }
+
+  listener {
+    address  = "127.0.0.1:51898"
+    protocol = "udp"
+    labels   = { component = "loki.source.syslog", protocol = "udp"} 
+  }
+
+  forward_to = [loki.write.local.receiver]
+}
+
+loki.write "local" {
+  endpoint {
+    url = "loki:3100/api/v1/push"
+  }
+}
+```
+

--- a/docs/sources/flow/reference/components/loki.source.syslog.md
+++ b/docs/sources/flow/reference/components/loki.source.syslog.md
@@ -20,8 +20,8 @@ different labels.
 
 ```river
 loki.source.syslog "LABEL" {
-  config {
-    listen_address = "LISTEN_ADDRESS"
+  listener {
+    address = "LISTEN_ADDRESS"
   }
   ...
 

--- a/docs/sources/flow/reference/components/loki.source.syslog.md
+++ b/docs/sources/flow/reference/components/loki.source.syslog.md
@@ -60,7 +60,7 @@ will expect syslog messages to, as well as its behavior when receiving
 messages.
 
 The following arguments can be used to configure a `listener`. Only the
-`listen_address` field is required and any omitted fields take their default
+`address` field is required and any omitted fields take their default
 values.
 
 Name                     | Type          | Description | Default | Required

--- a/docs/sources/flow/reference/components/loki.source.syslog.md
+++ b/docs/sources/flow/reference/components/loki.source.syslog.md
@@ -33,9 +33,14 @@ loki.source.syslog "LABEL" {
 
 `loki.source.syslog` supports the following arguments:
 
-Name         | Type                   | Description          | Default | Required
------------- | ---------------------- | -------------------- | ------- | --------
-`forward_to` | `list(LogsReceiver)`   | List of receivers to send log entries to. | | yes
+Name            | Type                   | Description          | Default | Required
+--------------- | ---------------------- | -------------------- | ------- | --------
+`forward_to`    | `list(LogsReceiver)`   | List of receivers to send log entries to. |      | yes
+`relabel_rules` | `RelabelRules`         | Relabeling rules to apply on log entries. | "{}" | no
+
+The `relabel_rules` field can make use of the `rules` export value from a
+`loki.relabel` component to apply one or more relabeling rules to log entries
+before they're forwarded to the list of receivers in `forward_to`.
 
 ## Blocks
 


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The PR adds a loki.source.syslog component that spins up listeners for RFC5424-formatted syslog messages over TCP and UDP connections and forwards them to other `loki.*` components.

Each `listener` block in the component's Arguments will start a receiver. Promtail used the term `receiver`, but I chose to use a different one to avoid confusion with the receivers that tie together components. As with other cases,  entries are fanned out to each receiver passed in `ForwardTo` in succession.

Most of the PR size is due to bringing over Promtail's `syslog` package, so that we can use our own `loki.Entry` instance.

#### Which issue(s) this PR fixes
Fixes #2505.

#### Notes to the Reviewer

To test this component, I've used a configuration and a command like the ones presented below. I'm still not able to send messages over the UDP connection as I'm getting `msg="error parsing syslog stream" err="invalid or unsupported framing. first byte: 'X'"` even for valid RFC5424 entries.


```
# command for sending syslog messages
$ echo '<165>1 2022-04-08T22:14:10.001Z host1 app - id1 [custom@32473 exkey="1"] An application event log entry...' | nc 127.0.0.1 51893

# syslog.river
loki.source.syslog "local" {
	listener {
		address  = "127.0.0.1:51893"
		protocol = "tcp"

		labels = { component = "loki.source.syslog", protocol = "tcp" }
	}
	listener {
		address  = "127.0.0.1:51898"
		protocol = "udp"

		labels = { component = "loki.source.syslog", protocol = "udp"}
	}
	forward_to = [loki.write.grafanacloud.receiver]
}


loki.write "grafanacloud" {
  endpoint {
    url = "https://logs-prod-eu-west-0.grafana.net/loki/api/v1/push"
    http_client_config {
      basic_auth {
        username = "..."
        password = "eyJr="
      }
    }
  }
}
```


#### PR Checklist

- [x] CHANGELOG updated
- [X] Documentation added
- [X] Tests updated
