### PR TITLE
Switch from nanoseconds to seconds.

### DIFF
--- a/component/common/loki/positions/positions_test.go
+++ b/component/common/loki/positions/positions_test.go
@@ -171,7 +171,7 @@ positions:
 		t.Fatal(err)
 	}
 	p, err := New(util_log.Logger, Config{
-		SyncPeriod:    20 * time.Nanosecond,
+		SyncPeriod:    20 * time.Second,
 		PositionsFile: temp,
 		ReadOnly:      true,
 	})
@@ -215,7 +215,7 @@ positions:
 		t.Fatal(err)
 	}
 	p, err := New(util_log.Logger, Config{
-		SyncPeriod:    20 * time.Nanosecond,
+		SyncPeriod:    20 * time.Second,
 		PositionsFile: temp,
 	})
 	if err != nil {


### PR DESCRIPTION
#### PR Description

This fixes an issue where Windows runs would fail with the nanosecond sync period

- [X] Tests updated
