### PR TITLE
tools/agentlint: Lint for documentation on exported identifiers

### DIFF
--- a/tools/agentlint/internal/exportedcomments/exportedcomments.go
+++ b/tools/agentlint/internal/exportedcomments/exportedcomments.go
@@ -1,0 +1,146 @@
+// Package exportedcomments exposes an Analyzer which will validate that all
+// exported identifiers have comments.
+package exportedcomments
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name: "exportedcomments",
+	Doc:  "ensure eported identifiers have documentation",
+	Run:  run,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	for _, f := range pass.Files {
+		// Ignore test and generated files.
+		if strings.HasSuffix(pass.Fset.File(f.Pos()).Name(), "_test.go") {
+			continue
+		} else if isGeneratedFile(f) {
+			continue
+		}
+
+		for _, decl := range f.Decls {
+			switch decl := decl.(type) {
+			case *ast.FuncDecl:
+				lintFunction(pass, decl)
+			case *ast.GenDecl:
+				lintGenDecl(pass, decl)
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+func isGeneratedFile(file *ast.File) bool {
+	var (
+		generatedPrefix = "// Code generated"
+		generatedSuffix = " DO NOT EDIT."
+	)
+
+	for _, comment := range file.Comments {
+		for _, line := range comment.List {
+			if strings.HasPrefix(line.Text, generatedPrefix) && strings.HasSuffix(line.Text, generatedSuffix) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func lintFunction(pass *analysis.Pass, fn *ast.FuncDecl) {
+	// Ignore non-exported functions.
+	if !ast.IsExported(fn.Name.Name) {
+		return
+	}
+
+	// Ignore exported functions where the receiver is non-exported.
+	// For example:
+	//
+	//   func (a unexportedType) ExportedFunction() {}
+	if fn.Recv != nil {
+		typ := pass.TypesInfo.Types[fn.Recv.List[0].Type]
+		if !isExportedReceiverType(typ.Type) {
+			return
+		}
+
+		// golint didn't require doc comments on the implementation of
+		// sort.Interface, so we emulate the same check here.
+		switch fn.Name.Name {
+		case "Len", "Less", "Swap":
+			if types.Implements(typ.Type, sortInterface) {
+				return
+			}
+		}
+	}
+
+	if fn.Doc == nil {
+		pass.Report(analysis.Diagnostic{
+			Pos:     fn.Pos(),
+			Message: fmt.Sprintf("exported function %s should have comment or be unexported", fn.Name.Name),
+		})
+	}
+}
+
+func isExportedReceiverType(ty types.Type) bool {
+	switch ty := ty.(type) {
+	case *types.Pointer:
+		return isExportedReceiverType(ty.Elem())
+	case *types.Named:
+		return ty.Obj().Exported()
+	default:
+		// This shouldn't be possible to hit for valid functions, since valid
+		// receivers have to be to named types or pointers to named types.
+		return false
+	}
+}
+
+func lintGenDecl(pass *analysis.Pass, fn *ast.GenDecl) {
+	// Ignore any gen decl with comments
+	if fn.Doc != nil {
+		return
+	}
+
+	for _, spec := range fn.Specs {
+		res := analyzeSpec(spec)
+		if res.Exported && !res.HasDoc {
+			pass.Report(analysis.Diagnostic{
+				Pos:     spec.Pos(),
+				Message: fmt.Sprintf("exported %s %s should have comment or be unexported", res.Kind, res.Name),
+			})
+		}
+	}
+}
+
+type specAnalysis struct {
+	Name     string // Name of the specification
+	Kind     string // Kind of the specification (identifier, type)
+	HasDoc   bool   // Whether the specification has docs
+	Exported bool   // Whether the specification is exported
+}
+
+func analyzeSpec(spec ast.Spec) specAnalysis {
+	var analysis specAnalysis
+
+	switch spec := spec.(type) {
+	case *ast.ValueSpec:
+		analysis.Name = spec.Names[0].Name
+		analysis.Kind = "identifier"
+		analysis.HasDoc = (spec.Doc != nil)
+	case *ast.TypeSpec:
+		analysis.Name = spec.Name.Name
+		analysis.Kind = "type"
+		analysis.HasDoc = (spec.Doc != nil)
+	}
+
+	analysis.Exported = ast.IsExported(analysis.Name)
+	return analysis
+}

--- a/tools/agentlint/internal/exportedcomments/exportedcomments.go
+++ b/tools/agentlint/internal/exportedcomments/exportedcomments.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/tools/go/analysis"
 )
 
+// Analyzer implements the exportedcomments analyzer.
 var Analyzer = &analysis.Analyzer{
 	Name: "exportedcomments",
 	Doc:  "ensure eported identifiers have documentation",

--- a/tools/agentlint/internal/exportedcomments/sort_interface.go
+++ b/tools/agentlint/internal/exportedcomments/sort_interface.go
@@ -1,0 +1,52 @@
+package exportedcomments
+
+import "go/types"
+
+// sortInterface is the [go/types] representation of an interface identical to
+// sort.Interface.
+var sortInterface = types.NewInterfaceType([]*types.Func{
+	// Len() int
+	newBasicFuncType(
+		"Len",
+		nil,
+		[]types.BasicKind{types.Int},
+		false,
+	),
+
+	// Less(i, j int) bool
+	newBasicFuncType(
+		"Less",
+		[]types.BasicKind{types.Int, types.Int},
+		[]types.BasicKind{types.Bool},
+		false,
+	),
+
+	// Swap(i, j int)
+	newBasicFuncType(
+		"Swap",
+		[]types.BasicKind{types.Int, types.Int},
+		nil,
+		false,
+	),
+}, nil)
+
+func newBasicFuncType(name string, params []types.BasicKind, returns []types.BasicKind, variadic bool) *types.Func {
+	var convParams, convReturns []*types.Var
+	for _, param := range params {
+		convParams = append(convParams, types.NewVar(0, nil, "", types.Typ[param]))
+	}
+	for _, returnType := range returns {
+		convReturns = append(convReturns, types.NewVar(0, nil, "", types.Typ[returnType]))
+	}
+
+	var (
+		tupParams  = types.NewTuple(convParams...)
+		tupReturns = types.NewTuple(convReturns...)
+		sig        = types.NewSignatureType(nil, nil, nil, tupParams, tupReturns, variadic)
+	)
+	return types.NewFunc(0, nil, name, sig)
+}
+
+func newTypeVar(name string, typ types.Type) *types.Var {
+	return types.NewVar(0, nil, name, typ)
+}

--- a/tools/agentlint/internal/findcomponents/findcomponents.go
+++ b/tools/agentlint/internal/findcomponents/findcomponents.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
+// Analyzer implements the findcomponents analyzer.
 var Analyzer = &analysis.Analyzer{
 	Name: "findcomponents",
 	Doc:  "ensure Flow components are imported",

--- a/tools/agentlint/main.go
+++ b/tools/agentlint/main.go
@@ -3,10 +3,14 @@
 package main
 
 import (
+	"github.com/grafana/agent/tools/agentlint/internal/exportedcomments"
 	"github.com/grafana/agent/tools/agentlint/internal/findcomponents"
 	"golang.org/x/tools/go/analysis/multichecker"
 )
 
 func main() {
-	multichecker.Main(findcomponents.Analyzer)
+	multichecker.Main(
+		findcomponents.Analyzer,
+		exportedcomments.Analyzer,
+	)
 }


### PR DESCRIPTION
golint was previously used for linting, which would enforce that all exported identifiers (i.e., types, variables, functions, and methods which are part of the public API of a package) have documentation. 

Since golint is no longer maintained, we have lost this linting rule, which I personally think is important to write good APIs. While one could argue methods like `String() string` "don't need documentation," the Go standard library shows that [you can still document the method with useful information](https://pkg.go.dev/time#Duration.String). 

golint had one exception: you did not need to document the methods used for implementing `sort.Interface`. That exception has been replicated here.