### PR TITLE
grafana-agent-operator: fix typo in Dockerfile

### DIFF
--- a/cmd/grafana-agent-operator/Dockerfile
+++ b/cmd/grafana-agent-operator/Dockerfile
@@ -31,6 +31,6 @@ RUN <<EOF
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 EOF
 
-COPY --from=build /src/agent/build/agent-operator /bin/grafana-agent-operator
+COPY --from=build /src/agent/build/grafana-agent-operator /bin/grafana-agent-operator
 RUN ln -sv /bin/grafana-agent-operator /bin/agent-operator
 ENTRYPOINT ["/bin/grafana-agent-operator"]


### PR DESCRIPTION
The source binary wasn't updated from #2677.