### PR TITLE
flow: Allow relabeling components to expose configured rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,12 @@ Main (unreleased)
   - `otelcol.receiver.kafka` receives telemetry data from Kafka. (@rfratto)
   - `phlare.scrape` collects application performance profiles. (@cyriltovena)
   - `phlare.write` sends application performance profiles to Grafana Phlare. (@cyriltovena)
-
   - `otelcol.receiver.zipkin` receives Zipkin-formatted traces. (@rfratto)
+
+- Flow components which work with relabeling rules (`discovery.relabel`,
+  `prometheus.relabel` and `loki.relabel`) now export a new field named Rules.
+  The exported value is a method that returns the currently configured rules.
+  (@tpaschalis)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,8 @@ Main (unreleased)
   - `otelcol.receiver.zipkin` receives Zipkin-formatted traces. (@rfratto)
 
 - Flow components which work with relabeling rules (`discovery.relabel`,
-  `prometheus.relabel` and `loki.relabel`) now export a new field named Rules.
-  The exported value is a method that returns the currently configured rules.
+  `prometheus.relabel` and `loki.relabel`) now export a new value named Rules.
+  This value is a function that returns the currently configured rules.
   (@tpaschalis)
 
 ### Enhancements

--- a/component/common/loki/types.go
+++ b/component/common/loki/types.go
@@ -14,7 +14,7 @@ import (
 )
 
 // LogsReceiver is an alias for chan Entry which will be used for component
-// communication
+// communication.
 type LogsReceiver chan Entry
 
 // Entry is a log entry with labels.

--- a/component/common/loki/types.go
+++ b/component/common/loki/types.go
@@ -13,7 +13,7 @@ import (
 	"github.com/grafana/loki/pkg/logproto"
 )
 
-// LogsReceiver is an alias for chan Entry which will be used for component
+// LogsReceiver is an alias for chan Entry which is used for component
 // communication.
 type LogsReceiver chan Entry
 

--- a/component/common/relabel/relabel.go
+++ b/component/common/relabel/relabel.go
@@ -184,3 +184,6 @@ func ComponentToPromRelabelConfigs(rcs []*Config) []*relabel.Config {
 
 	return res
 }
+
+// Rules returns the relabel configs in use for a relabeling component.
+type Rules func() []*relabel.Config

--- a/component/common/relabel/relabel.go
+++ b/component/common/relabel/relabel.go
@@ -187,3 +187,7 @@ func ComponentToPromRelabelConfigs(rcs []*Config) []*relabel.Config {
 
 // Rules returns the relabel configs in use for a relabeling component.
 type Rules func() []*relabel.Config
+
+// RiverCapsule marks the alias defined above as a "capsule type" so that it
+// cannot be invoked by River code.
+func (r Rules) RiverCapsule() {}

--- a/component/common/relabel/relabel.go
+++ b/component/common/relabel/relabel.go
@@ -186,7 +186,7 @@ func ComponentToPromRelabelConfigs(rcs []*Config) []*relabel.Config {
 }
 
 // Rules returns the relabel configs in use for a relabeling component.
-type Rules func() []*relabel.Config
+type Rules func() []*Config
 
 // RiverCapsule marks the alias defined above as a "capsule type" so that it
 // cannot be invoked by River code.

--- a/component/discovery/relabel/relabel.go
+++ b/component/discovery/relabel/relabel.go
@@ -77,6 +77,7 @@ func (c *Component) Update(args component.Arguments) error {
 	targets := make([]discovery.Target, 0, len(newArgs.Targets))
 	relabelConfigs := flow_relabel.ComponentToPromRelabelConfigs(newArgs.RelabelConfigs)
 	c.rcs = relabelConfigs
+	c.rcsFlow = newArgs.RelabelConfigs
 
 	for _, t := range newArgs.Targets {
 		lset := componentMapToPromLabels(t)

--- a/component/discovery/relabel/relabel.go
+++ b/component/discovery/relabel/relabel.go
@@ -42,8 +42,9 @@ type Exports struct {
 type Component struct {
 	opts component.Options
 
-	mut sync.RWMutex
-	rcs []*relabel.Config
+	mut     sync.RWMutex
+	rcs     []*relabel.Config
+	rcsFlow []*flow_relabel.Config
 }
 
 var _ component.Component = (*Component)(nil)
@@ -93,11 +94,11 @@ func (c *Component) Update(args component.Arguments) error {
 	return nil
 }
 
-func (c *Component) getRules() []*relabel.Config {
+func (c *Component) getRules() []*flow_relabel.Config {
 	c.mut.RLock()
 	defer c.mut.RUnlock()
 
-	return c.rcs
+	return c.rcsFlow
 }
 
 func componentMapToPromLabels(ls discovery.Target) labels.Labels {

--- a/component/discovery/relabel/relabel_test.go
+++ b/component/discovery/relabel/relabel_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 	"time"
 
+	flow_relabel "github.com/grafana/agent/component/common/relabel"
 	"github.com/grafana/agent/component/discovery"
 	"github.com/grafana/agent/component/discovery/relabel"
 	"github.com/grafana/agent/pkg/flow/componenttest"
 	"github.com/grafana/agent/pkg/river"
-	prom_relabel "github.com/prometheus/prometheus/model/relabel"
 	"github.com/stretchr/testify/require"
 )
 
@@ -117,8 +117,8 @@ rule {
 	require.Len(t, gotOriginal, 1)
 	require.Len(t, gotUpdated, 1)
 
-	require.Equal(t, gotOriginal[0].Action, prom_relabel.Keep)
-	require.Equal(t, gotUpdated[0].Action, prom_relabel.Drop)
+	require.Equal(t, gotOriginal[0].Action, flow_relabel.Keep)
+	require.Equal(t, gotUpdated[0].Action, flow_relabel.Drop)
 	require.Equal(t, gotUpdated[0].SourceLabels, gotOriginal[0].SourceLabels)
 	require.Equal(t, gotUpdated[0].Regex, gotOriginal[0].Regex)
 }

--- a/component/loki/relabel/relabel.go
+++ b/component/loki/relabel/relabel.go
@@ -69,6 +69,7 @@ type Component struct {
 
 	mut      sync.RWMutex
 	rcs      []*relabel.Config
+	rcsFlow  []*flow_relabel.Config
 	receiver loki.LogsReceiver
 	fanout   []loki.LogsReceiver
 
@@ -153,6 +154,7 @@ func (c *Component) Update(args component.Arguments) error {
 		}
 	}
 	c.rcs = newRCS
+	c.rcsFlow = newArgs.RelabelConfigs
 	c.fanout = newArgs.ForwardTo
 
 	return nil
@@ -231,9 +233,9 @@ func (c *Component) process(e loki.Entry) model.LabelSet {
 	return relabeled
 }
 
-func (c *Component) getRules() []*relabel.Config {
+func (c *Component) getRules() []*flow_relabel.Config {
 	c.mut.RLock()
 	defer c.mut.RUnlock()
 
-	return c.rcs
+	return c.rcsFlow
 }

--- a/component/loki/relabel/relabel_test.go
+++ b/component/loki/relabel/relabel_test.go
@@ -320,8 +320,8 @@ func TestRuleGetter(t *testing.T) {
 	require.Len(t, gotOriginal, 1)
 	require.Len(t, gotUpdated, 1)
 
-	require.Equal(t, gotOriginal[0].Action, relabel.Keep)
-	require.Equal(t, gotUpdated[0].Action, relabel.Drop)
+	require.Equal(t, gotOriginal[0].Action, flow_relabel.Keep)
+	require.Equal(t, gotUpdated[0].Action, flow_relabel.Drop)
 	require.Equal(t, gotUpdated[0].SourceLabels, gotOriginal[0].SourceLabels)
 	require.Equal(t, gotUpdated[0].Regex, gotOriginal[0].Regex)
 }

--- a/component/prometheus/relabel/relabel.go
+++ b/component/prometheus/relabel/relabel.go
@@ -42,6 +42,7 @@ type Arguments struct {
 // Exports holds values which are exported by the prometheus.relabel component.
 type Exports struct {
 	Receiver storage.Appendable `river:"receiver,attr"`
+	Rules    flow_relabel.Rules `river:"rules,attr"`
 }
 
 // Component implements the prometheus.relabel component.
@@ -129,7 +130,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 
 	// Immediately export the receiver which remains the same for the component
 	// lifetime.
-	o.OnStateChange(Exports{Receiver: c.receiver})
+	o.OnStateChange(Exports{Rules: c.getRules})
 
 	// Call to Update() to set the relabelling rules once at the start.
 	if err = c.Update(args); err != nil {
@@ -154,7 +155,6 @@ func (c *Component) Update(args component.Arguments) error {
 	c.clearCache()
 	c.mrc = flow_relabel.ComponentToPromRelabelConfigs(newArgs.MetricRelabelConfigs)
 	c.fanout.UpdateChildren(newArgs.ForwardTo)
-	c.opts.OnStateChange(Exports{Receiver: c.receiver})
 
 	return nil
 }
@@ -234,4 +234,11 @@ func (c *Component) addToCache(originalID uint64, lbls labels.Labels) {
 type labelAndID struct {
 	labels labels.Labels
 	id     uint64
+}
+
+func (c *Component) getRules() []*relabel.Config {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+
+	return c.mrc
 }

--- a/component/prometheus/relabel/relabel.go
+++ b/component/prometheus/relabel/relabel.go
@@ -49,6 +49,7 @@ type Exports struct {
 type Component struct {
 	mut              sync.RWMutex
 	opts             component.Options
+	mrcFlow          []*flow_relabel.Config
 	mrc              []*relabel.Config
 	receiver         *prometheus.Interceptor
 	metricsProcessed prometheus_client.Counter
@@ -236,9 +237,9 @@ type labelAndID struct {
 	id     uint64
 }
 
-func (c *Component) getRules() []*relabel.Config {
+func (c *Component) getRules() []*flow_relabel.Config {
 	c.mut.RLock()
 	defer c.mut.RUnlock()
 
-	return c.mrc
+	return c.mrcFlow
 }

--- a/component/prometheus/relabel/relabel.go
+++ b/component/prometheus/relabel/relabel.go
@@ -155,6 +155,7 @@ func (c *Component) Update(args component.Arguments) error {
 	newArgs := args.(Arguments)
 	c.clearCache()
 	c.mrc = flow_relabel.ComponentToPromRelabelConfigs(newArgs.MetricRelabelConfigs)
+	c.mrcFlow = newArgs.MetricRelabelConfigs
 	c.fanout.UpdateChildren(newArgs.ForwardTo)
 
 	return nil

--- a/component/prometheus/relabel/relabel_test.go
+++ b/component/prometheus/relabel/relabel_test.go
@@ -193,8 +193,8 @@ func TestRuleGetter(t *testing.T) {
 	require.Len(t, gotOriginal, 1)
 	require.Len(t, gotUpdated, 1)
 
-	require.Equal(t, gotOriginal[0].Action, relabel.Keep)
-	require.Equal(t, gotUpdated[0].Action, relabel.Drop)
+	require.Equal(t, gotOriginal[0].Action, flow_relabel.Keep)
+	require.Equal(t, gotUpdated[0].Action, flow_relabel.Drop)
 	require.Equal(t, gotUpdated[0].SourceLabels, gotOriginal[0].SourceLabels)
 	require.Equal(t, gotUpdated[0].Regex, gotOriginal[0].Regex)
 }

--- a/docs/sources/flow/reference/components/discovery.relabel.md
+++ b/docs/sources/flow/reference/components/discovery.relabel.md
@@ -75,6 +75,7 @@ The following fields are exported and can be referenced by other components:
 Name | Type | Description
 ---- | ---- | -----------
 `output` | `list(map(string))` | The set of targets after applying relabeling.
+`rules`    | `relabel.Rules` | A function that returns the currently configured relabeling rules.
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/discovery.relabel.md
+++ b/docs/sources/flow/reference/components/discovery.relabel.md
@@ -76,7 +76,7 @@ The following fields are exported and can be referenced by other components:
 Name | Type | Description
 ---- | ---- | -----------
 `output` | `list(map(string))` | The set of targets after applying relabeling.
-`rules`    | `relabel.Rules` | A function that returns the currently configured relabeling rules.
+`rules`    | `RelabelRules` | A function that returns the currently configured relabeling rules.
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/discovery.relabel.md
+++ b/docs/sources/flow/reference/components/discovery.relabel.md
@@ -15,7 +15,8 @@ exported as-is.
 The most common use of `discovery.relabel` is to filter targets or standardize
 the target label set that is passed to a downstream component. The `rule`
 blocks are applied to the label set of each target in order of their appearance
-in the configuration file.
+in the configuration file. The configured rules can be retrieved by calling the
+function in the `rules` export field.
 
 Target labels which start with a double underscore `__` are considered
 internal, and may be removed by other Flow components prior to telemetry

--- a/docs/sources/flow/reference/components/loki.relabel.md
+++ b/docs/sources/flow/reference/components/loki.relabel.md
@@ -70,6 +70,7 @@ The following fields are exported and can be referenced by other components:
 Name | Type | Description
 ---- | ---- | -----------
 `receiver` | `receiver` | The input receiver where log lines are sent to be relabeled.
+`rules`    | `relabel.Rules` | A function that returns the currently configured relabeling rules.
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/loki.relabel.md
+++ b/docs/sources/flow/reference/components/loki.relabel.md
@@ -71,7 +71,7 @@ The following fields are exported and can be referenced by other components:
 Name | Type | Description
 ---- | ---- | -----------
 `receiver` | `receiver` | The input receiver where log lines are sent to be relabeled.
-`rules`    | `relabel.Rules` | A function that returns the currently configured relabeling rules.
+`rules`    | `RelabelRules` | A function that returns the currently configured relabeling rules.
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/loki.relabel.md
+++ b/docs/sources/flow/reference/components/loki.relabel.md
@@ -16,7 +16,8 @@ entries are dropped.
 The most common use of `loki.relabel` is to filter log entries or standardize
 the label set that is passed to one or more downstream receivers. The `rule`
 blocks are applied to the label set of each log entry in order of their
-appearance in the configuration file.
+appearance in the configuration file. The configured rules can be retrieved by
+calling the function in the `rules` export field.
 
 If you're looking for a way to process the log entry contents, take a look at
 [the `loki.process` component][loki.process] instead.

--- a/docs/sources/flow/reference/components/prometheus.relabel.md
+++ b/docs/sources/flow/reference/components/prometheus.relabel.md
@@ -72,6 +72,7 @@ The following fields are exported and can be referenced by other components:
 Name | Type | Description
 ---- | ---- | -----------
 `receiver` | `receiver` | The input receiver where samples are sent to be relabeled.
+`rules`    | `relabel.Rules` | A function that returns the currently configured relabeling rules.
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.relabel.md
+++ b/docs/sources/flow/reference/components/prometheus.relabel.md
@@ -73,7 +73,7 @@ The following fields are exported and can be referenced by other components:
 Name | Type | Description
 ---- | ---- | -----------
 `receiver` | `receiver` | The input receiver where samples are sent to be relabeled.
-`rules`    | `relabel.Rules` | A function that returns the currently configured relabeling rules.
+`rules`    | `RelabelRules` | A function that returns the currently configured relabeling rules.
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.relabel.md
+++ b/docs/sources/flow/reference/components/prometheus.relabel.md
@@ -22,7 +22,7 @@ labels remain after the relabeling rules are applied, then the metric is
 dropped.
 
 The most common use of `prometheus.relabel` is to filter Prometheus metrics or
-standardize the label set that will be passed to one or more downstream
+standardize the label set that is passed to one or more downstream
 receivers. The `rule` blocks are applied to the label set of each metric in
 order of their appearance in the configuration file. The configured rules can
 be retrieved by calling the function in the `rules` export field.

--- a/docs/sources/flow/reference/components/prometheus.relabel.md
+++ b/docs/sources/flow/reference/components/prometheus.relabel.md
@@ -23,8 +23,9 @@ dropped.
 
 The most common use of `prometheus.relabel` is to filter Prometheus metrics or
 standardize the label set that will be passed to one or more downstream
-receivers. The `rule` blocks are applied to the label set of
-each metric in order of their appearance in the configuration file.
+receivers. The `rule` blocks are applied to the label set of each metric in
+order of their appearance in the configuration file. The configured rules can
+be retrieved by calling the function in the `rules` export field.
 
 Multiple `prometheus.relabel` components can be specified by giving them
 different labels.


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR expands on the three relabeling components (`discovery.relabel`, `prometheus.relabel`, `loki.relabel`) to add a new Export field named Rules. The field value is a function that when it's called, it returns the currently-configured relabeling rules in place.

This will be useful for components that generate telemetry themselves instead of scraping it from a third-party source (such as the upcoming `loki.source.*` components), so that they can call into relabeling rules and process any 'internal' labels before discarding them.

To see this in action, here's how it would look as River configuration and component implementation for the upcoming `loki.source.syslog` component.

Wiring in the new field in another component: https://github.com/tpaschalis/agent/commit/a4d105bc68e237a49f6fa61eb8a2ccf633800cc1

```
loki.relabel "keep_internal" {
	rule {
		action      = "labelmap"
		regex       = "__syslog_(.*)"
		replacement = "syslog_${1}"
	}
	forward_to = []
}

loki.source.syslog "local" {
	listener {
		address  = "127.0.0.1:51893"
	}

	relabel_configs = loki.relabel.keep_internal.rules
	forward_to      = [loki.write.grafanacloud.receiver]
}

loki.write "grafanacloud" {
  endpoint {
...
  }
}
```

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer
- I'm not sure if such a small change warrants the tests, let me know if you'd like to remove them.
- This approach allows the relabeling components to be used in two separate ways (both with their receiver/forward_to attributes and by refering to the rules themselves). Are we okay with that?
- The current implementation means that a `loki.source.syslog` component might be able to use the exports of a `prometheus.relabel` block. Should we define separate types for the three namespaces to limit accidental reuse?
- After marking the Rules alias with the capsule interface, here's how it shows up on the Flow UI page
![image](https://user-images.githubusercontent.com/17771679/211375373-0ba5919d-ee4f-4295-83a5-ae4576ab6613.png)


#### TODO
- Expand the documentation on this usecase.

#### PR Checklist

- [X] CHANGELOG updated
- [X] Documentation added
- [X] Tests updated
