### PR TITLE
loki.source.file: put individual targets into blocks (debuginfo)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,16 +34,18 @@ Main (unreleased)
   - `otelcol.receiver.kafka` receives telemetry data from Kafka. (@rfratto)
   - `phlare.scrape` collects application performance profiles. (@cyriltovena)
   - `phlare.write` sends application performance profiles to Grafana Phlare. (@cyriltovena)
-
   - `otelcol.receiver.zipkin` receives Zipkin-formatted traces. (@rfratto)
 
 ### Enhancements
 
 - Handle faro-web-sdk `View` meta in app_agent_receiver. (@rlankfo)
 
+- Flow: the targets in debug info from `loki.source.file` are now individual blocks. (@rfratto)
+
 ### Bugfixes
 
 - Flow UI: Fix the issue with messy layout on the component list page while browser window resize. (@xiyu95)
+
 - Flow UI: Fix the issue with long string going out of bound in the component detail page. (@xiyu95)
 
 ### Other changes

--- a/component/loki/source/file/file.go
+++ b/component/loki/source/file/file.go
@@ -201,7 +201,7 @@ func (c *Component) DebugInfo() interface{} {
 }
 
 type readerDebugInfo struct {
-	TargetsInfo []targetInfo `river:"targets_info,attr"`
+	TargetsInfo []targetInfo `river:"targets_info,block"`
 }
 
 type targetInfo struct {


### PR DESCRIPTION
This commit changes the debug info for loki.source.file to list the targts in their own blocks instead of as a massive attribute. This aligns how targets are shown to how they are shown in prometheus.scrape, and I (personally) find it generally easier to read.