### PR TITLE
prometheus.relabel: clone labels before relabeling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ Main (unreleased)
 
 - Flow UI: Fix the issue with long string going out of bound in the component detail page. (@xiyu95)
 
+- Flow: `prometheus.relabel` will no longer modify the labels of the original
+  metrics, which could lead to relabel rules applying incorrectly on subsequent
+  relabels. (@rfratto)
+
 ### Other changes
 
 - Use Go 1.19.4 for builds. (@erikbaranowski)

--- a/component/prometheus/relabel/relabel.go
+++ b/component/prometheus/relabel/relabel.go
@@ -173,7 +173,9 @@ func (c *Component) relabel(val float64, lbls labels.Labels) labels.Labels {
 			relabelled = newLbls.labels
 		}
 	} else {
-		relabelled = relabel.Process(lbls, c.mrc...)
+		// Relabel against a copy of the labels to prevent modifying the original
+		// slice.
+		relabelled = relabel.Process(lbls.Copy(), c.mrc...)
 		c.cacheMisses.Inc()
 		c.cacheSize.Inc()
 		c.addToCache(globalRef, relabelled)


### PR DESCRIPTION
This PR clones the label set before applying relabels. Not cloning lead to two problems:

1. It forces the computed ID of the incoming series to change (as its labels changed), which causes duplicate relabeling caching.
2. It can cause obscure bugs with relabel rules being applied, such as a `keep` action which doesn't work after modifying the original slice.