### PR TITLE
Do not action if the component is not running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ Main (unreleased)
 
 - Flow UI: Fix the issue with long string going out of bound in the component detail page. (@xiyu95)
 
+- Flow: `prometheus.relabel` and `prometheus.remote_write` will now error if they have exited. (@ptodev)
+
 ### Other changes
 
 - Use Go 1.19.4 for builds. (@erikbaranowski)

--- a/component/prometheus/relabel/relabel.go
+++ b/component/prometheus/relabel/relabel.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"sync/atomic"
+
+	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/storage"
 

--- a/component/prometheus/relabel/relabel.go
+++ b/component/prometheus/relabel/relabel.go
@@ -2,7 +2,9 @@ package relabel
 
 import (
 	"context"
+	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"github.com/prometheus/prometheus/storage"
 
@@ -58,6 +60,7 @@ type Component struct {
 	cacheMisses      prometheus_client.Counter
 	cacheSize        prometheus_client.Gauge
 	fanout           *prometheus.Fanout
+	isRunning        atomic.Bool
 
 	cacheMut sync.RWMutex
 	cache    map[uint64]*labelAndID
@@ -106,6 +109,10 @@ func New(o component.Options, args Arguments) (*Component, error) {
 	c.receiver = prometheus.NewInterceptor(
 		c.fanout,
 		prometheus.WithAppendHook(func(_ storage.SeriesRef, l labels.Labels, t int64, v float64, next storage.Appender) (storage.SeriesRef, error) {
+			if !c.isRunning.Load() {
+				return 0, fmt.Errorf("%s is not running", o.ID)
+			}
+
 			newLbl := c.relabel(v, l)
 			if newLbl == nil {
 				return 0, nil
@@ -114,6 +121,10 @@ func New(o component.Options, args Arguments) (*Component, error) {
 			return next.Append(0, newLbl, t, v)
 		}),
 		prometheus.WithExemplarHook(func(_ storage.SeriesRef, l labels.Labels, e exemplar.Exemplar, next storage.Appender) (storage.SeriesRef, error) {
+			if !c.isRunning.Load() {
+				return 0, fmt.Errorf("%s is not running", o.ID)
+			}
+
 			newLbl := c.relabel(0, l)
 			if newLbl == nil {
 				return 0, nil
@@ -121,6 +132,10 @@ func New(o component.Options, args Arguments) (*Component, error) {
 			return next.AppendExemplar(0, l, e)
 		}),
 		prometheus.WithMetadataHook(func(_ storage.SeriesRef, l labels.Labels, m metadata.Metadata, next storage.Appender) (storage.SeriesRef, error) {
+			if !c.isRunning.Load() {
+				return 0, fmt.Errorf("%s is not running", o.ID)
+			}
+
 			newLbl := c.relabel(0, l)
 			if newLbl == nil {
 				return 0, nil
@@ -143,6 +158,9 @@ func New(o component.Options, args Arguments) (*Component, error) {
 
 // Run implements component.Component.
 func (c *Component) Run(ctx context.Context) error {
+	c.isRunning.Store(true)
+	defer c.isRunning.Store(false)
+
 	<-ctx.Done()
 	return nil
 }

--- a/component/prometheus/remotewrite/remote_write.go
+++ b/component/prometheus/remotewrite/remote_write.go
@@ -6,8 +6,9 @@ import (
 	"math"
 	"path/filepath"
 	"sync"
-	"sync/atomic"
 	"time"
+
+	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"

--- a/component/prometheus/remotewrite/remote_write_test.go
+++ b/component/prometheus/remotewrite/remote_write_test.go
@@ -63,7 +63,7 @@ func Test(t *testing.T) {
 	var args remotewrite.Arguments
 	require.NoError(t, river.Unmarshal([]byte(cfg), &args))
 
-	// Create our component and wait for it to generate exports so we can write
+	// Create our component and wait for it to start running so we can write
 	// metrics to the WAL.
 	tc, err := componenttest.NewControllerFromID(util.TestLogger(t), "prometheus.remote_write")
 	require.NoError(t, err)
@@ -71,7 +71,7 @@ func Test(t *testing.T) {
 		err = tc.Run(componenttest.TestContext(t), args)
 		require.NoError(t, err)
 	}()
-	require.NoError(t, tc.WaitExports(time.Second))
+	require.NoError(t, tc.WaitRunning(time.Second))
 
 	// We need to use a future timestamp since remote_write will ignore any
 	// sample which is earlier than the time when it started. Adding a minute


### PR DESCRIPTION
#### PR Description
Fixes #2216. The `prometheus.relabel` and  `prometheus.remote_write` components will now error if data is being sent to them while they are stopped. The reason they are in memory and stopped is that during a config refresh they got deleted, but a component which references them keeps a reference to them since it has to be preserved to be in the last good state (the state prior to the refresh). An issue has been raised to question this behaviour (#2709) - it may be better to preserve the last good state of the graph as a whole instead of the last good state of the individual components. If that were the case, we also would be less likely to see bugs such as this one.

#### Test evidence
1. An agent was ran locally with this river file:
```
prometheus.scrape "default" {
	targets    = [{"__address__" = "localhost:12345"}]
	forward_to = [prometheus.relabel.filter.receiver]
}

prometheus.relabel "filter" {
	rule {
		source_labels = ["__name__"]
		regex         = "(.+)"
		replacement   = "api_server"
		target_label  = "service"
	}
	forward_to = [prometheus.remote_write.prom.receiver]
}

prometheus.remote_write "prom" {
	endpoint {
		url = "http://localhost:9009/api/v1/push"
	}
}
```

2. Then the river file was changed to this:
```
prometheus.scrape "default" {
	targets    = [{"__address__" = "localhost:12345"}]
	forward_to = [prometheus.relabel.filter.receiver]
}

prometheus.remote_write "prom" {
	endpoint {
		url = "http://localhost:9009/api/v1/push"
	}
}
```

3. The config was refreshed with this command: `curl localhost:12345/-/reload`

4. The new `component is not running` warnings can be seen in the agent output:
```
% AGENT_MODE=flow ./grafana-agent run /Users/paulintodev/flow_tutorial/tutorials/flow_configs/relabel.river

ts=2023-01-10T10:31:55.289245Z level=info msg="now listening for http traffic" addr=127.0.0.1:12345
ts=2023-01-10T10:31:55.289302Z level=info msg="running usage stats reporter"
ts=2023-01-10T10:31:55.289594Z level=info trace_id=d53f49e021568fdfa2ad9a30a381566a msg="starting complete graph evaluation"
ts=2023-01-10T10:31:55.291231Z level=info component=prometheus.remote_write.prom subcomponent=wal msg="replaying WAL, this may take a while" dir=data-agent/prometheus.remote_write.prom/wal/prometheus.remote_write.prom/wal
ts=2023-01-10T10:31:55.29216Z level=info component=prometheus.remote_write.prom subcomponent=wal msg="WAL segment loaded" segment=0 maxSegment=10
ts=2023-01-10T10:31:55.293059Z level=info component=prometheus.remote_write.prom subcomponent=wal msg="WAL segment loaded" segment=1 maxSegment=10
ts=2023-01-10T10:31:55.29475Z level=info component=prometheus.remote_write.prom subcomponent=wal msg="WAL segment loaded" segment=2 maxSegment=10
ts=2023-01-10T10:31:55.296859Z level=info component=prometheus.remote_write.prom subcomponent=wal msg="WAL segment loaded" segment=3 maxSegment=10
ts=2023-01-10T10:31:55.297436Z level=info component=prometheus.remote_write.prom subcomponent=wal msg="WAL segment loaded" segment=4 maxSegment=10
ts=2023-01-10T10:31:55.298096Z level=info component=prometheus.remote_write.prom subcomponent=wal msg="WAL segment loaded" segment=5 maxSegment=10
ts=2023-01-10T10:31:55.298158Z level=info component=prometheus.remote_write.prom subcomponent=wal msg="WAL segment loaded" segment=6 maxSegment=10
ts=2023-01-10T10:31:55.299284Z level=info component=prometheus.remote_write.prom subcomponent=wal msg="WAL segment loaded" segment=7 maxSegment=10
ts=2023-01-10T10:31:55.299335Z level=info component=prometheus.remote_write.prom subcomponent=wal msg="WAL segment loaded" segment=8 maxSegment=10
ts=2023-01-10T10:31:55.299387Z level=info component=prometheus.remote_write.prom subcomponent=wal msg="WAL segment loaded" segment=9 maxSegment=10
ts=2023-01-10T10:31:55.299425Z level=info component=prometheus.remote_write.prom subcomponent=wal msg="WAL segment loaded" segment=10 maxSegment=10
ts=2023-01-10T10:31:55.299859Z component=prometheus.remote_write.prom subcomponent=rw level=info remote_name=eb37ce url=http://localhost:9009/api/v1/push msg="Starting WAL watcher" queue=eb37ce
ts=2023-01-10T10:31:55.299871Z component=prometheus.remote_write.prom subcomponent=rw level=info remote_name=eb37ce url=http://localhost:9009/api/v1/push msg="Starting scraped metadata watcher"
ts=2023-01-10T10:31:55.299979Z component=prometheus.remote_write.prom subcomponent=rw level=info remote_name=eb37ce url=http://localhost:9009/api/v1/push msg="Replaying WAL" queue=eb37ce
ts=2023-01-10T10:31:55.304789Z level=info trace_id=d53f49e021568fdfa2ad9a30a381566a msg="finished complete graph evaluation" duration=15.241083ms
ts=2023-01-10T10:31:55.304804Z level=info msg="scheduling loaded components"
ts=2023-01-10T10:32:23.737252Z component=prometheus.remote_write.prom subcomponent=rw level=info remote_name=eb37ce url=http://localhost:9009/api/v1/push msg="Done replaying WAL" duration=28.437608875s
ts=2023-01-10T10:36:53.566348Z level=info trace_id=338bf209f96350a35c92b1872c9a77f2 msg="starting complete graph evaluation"
ts=2023-01-10T10:36:53.575302Z level=info trace_id=338bf209f96350a35c92b1872c9a77f2 msg="finished complete graph evaluation" duration=9.004458ms
ts=2023-01-10T10:36:53.575352Z level=info msg="scheduling loaded components"
ts=2023-01-10T10:37:17.721105Z level=info trace_id=9288b4d0af95cb58c9965a4dbad3b599 msg="starting complete graph evaluation"
ts=2023-01-10T10:37:17.730633Z level=info trace_id=9288b4d0af95cb58c9965a4dbad3b599 msg="finished complete graph evaluation" duration=9.636292ms
ts=2023-01-10T10:37:17.730693Z level=info msg="scheduling loaded components"
ts=2023-01-10T10:37:17.730735Z level=info component=prometheus.relabel.filter msg="component exited"
ts=2023-01-10T10:37:23.714297Z level=warn component=prometheus.scrape.default scrape_pool=prometheus.scrape.default target=http://localhost:12345/metrics msg="Append failed" err="1 error occurred:\n\t* the prometheus.relabel component is not running\n\n"
ts=2023-01-10T10:37:23.714382Z level=warn component=prometheus.scrape.default scrape_pool=prometheus.scrape.default target=http://localhost:12345/metrics msg="Appending scrape report failed" err="1 error occurred:\n\t* the prometheus.relabel component is not running\n\n"
```