### PR TITLE
flow: Add support for more stages to `loki.process`

### DIFF
--- a/component/loki/process/internal/stages/extensions.go
+++ b/component/loki/process/internal/stages/extensions.go
@@ -1,0 +1,135 @@
+package stages
+
+import (
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	RFC3339Nano         = "RFC3339Nano"
+	MaxPartialLinesSize = 100 // Max buffer size to hold partial lines.
+)
+
+// DockerConfig is an empty struct that is used to enable a pre-defined
+// pipeline for decoding entries that are using the Docker logs format.
+type DockerConfig struct{}
+
+// CRIConfig is an empty struct that is used to enable a pre-defined pipeline
+// for decoding entries that are using the CRI logging format.
+type CRIConfig struct{}
+
+// NewDocker creates a Docker json log format specific pipeline stage.
+func NewDocker(logger log.Logger, registerer prometheus.Registerer) (Stage, error) {
+	stages := []StageConfig{
+		{
+			JSONConfig: &JSONConfig{
+				Expressions: map[string]string{
+					"output":    "log",
+					"stream":    "stream",
+					"timestamp": "time",
+				},
+			}},
+		{
+			LabelsConfig: &LabelsConfig{
+				Values: map[string]*string{"stream": nil},
+			}},
+		{
+			TimestampConfig: &TimestampConfig{
+				Source: "timestamp",
+				Format: RFC3339Nano,
+			}},
+		{
+			OutputConfig: &OutputConfig{
+				"output",
+			},
+		}}
+	return NewPipeline(logger, stages, nil, registerer)
+}
+
+type cri struct {
+	// bounded buffer for CRI-O Partial logs lines (identified with tag `P` till we reach first `F`)
+	partialLines    []string
+	maxPartialLines int
+	base            *Pipeline
+}
+
+// implement Stage interface
+func (c *cri) Name() string {
+	return "cri"
+}
+
+// implements Stage interface
+func (c *cri) Run(entry chan Entry) chan Entry {
+	entry = c.base.Run(entry)
+
+	in := RunWithSkip(entry, func(e Entry) (Entry, bool) {
+		if e.Extracted["flags"] == "P" {
+			if len(c.partialLines) >= c.maxPartialLines {
+				// Merge existing partialLines
+				newPartialLine := e.Line
+				e.Line = strings.Join(c.partialLines, "\n")
+				level.Warn(c.base.logger).Log("msg", "cri stage: partial lines upperbound exceeded. merging it to single line", "threshold", MaxPartialLinesSize)
+				c.partialLines = c.partialLines[:0]
+				c.partialLines = append(c.partialLines, newPartialLine)
+				return e, false
+			}
+			c.partialLines = append(c.partialLines, e.Line)
+			return e, true
+		}
+		if len(c.partialLines) > 0 {
+			c.partialLines = append(c.partialLines, e.Line)
+			e.Line = strings.Join(c.partialLines, "\n")
+			c.partialLines = c.partialLines[:0]
+		}
+		return e, false
+	})
+
+	return in
+}
+
+// NewCRI creates a CRI format specific pipeline stage
+func NewCRI(logger log.Logger, registerer prometheus.Registerer) (Stage, error) {
+	base := []StageConfig{
+		{
+			RegexConfig: &RegexConfig{
+				Expression: "^(?s)(?P<time>\\S+?) (?P<stream>stdout|stderr) (?P<flags>\\S+?) (?P<content>.*)$",
+			},
+		},
+		{
+			LabelsConfig: &LabelsConfig{
+				Values: map[string]*string{"stream": nil},
+			},
+		},
+		{
+			TimestampConfig: &TimestampConfig{
+				Source: "time",
+				Format: RFC3339Nano,
+			},
+		},
+		{
+			OutputConfig: &OutputConfig{
+				"content",
+			},
+		},
+		{
+			OutputConfig: &OutputConfig{
+				"tags",
+			},
+		},
+	}
+
+	p, err := NewPipeline(logger, base, nil, registerer)
+	if err != nil {
+		return nil, err
+	}
+
+	c := cri{
+		maxPartialLines: MaxPartialLinesSize,
+		base:            p,
+	}
+	c.partialLines = make([]string, 0, c.maxPartialLines)
+	return &c, nil
+}

--- a/component/loki/process/internal/stages/extensions.go
+++ b/component/loki/process/internal/stages/extensions.go
@@ -1,5 +1,9 @@
 package stages
 
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
 import (
 	"strings"
 

--- a/component/loki/process/internal/stages/extensions_test.go
+++ b/component/loki/process/internal/stages/extensions_test.go
@@ -25,9 +25,7 @@ var (
 
 func TestNewDocker(t *testing.T) {
 	loc, err := time.LoadLocation("UTC")
-	if err != nil {
-		t.Fatal("could not parse timezone", err)
-	}
+	require.NoError(t, err, "could not parse timezone")
 
 	tests := map[string]struct {
 		entry          string
@@ -92,7 +90,7 @@ var (
 	criTestTime2   = time.Now()
 )
 
-func TestCRI_tags(t *testing.T) {
+func TestCriTags(t *testing.T) {
 	cases := []struct {
 		name            string
 		lines           []string

--- a/component/loki/process/internal/stages/extensions_test.go
+++ b/component/loki/process/internal/stages/extensions_test.go
@@ -1,5 +1,9 @@
 package stages
 
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
 import (
 	"testing"
 	"time"

--- a/component/loki/process/internal/stages/extensions_test.go
+++ b/component/loki/process/internal/stages/extensions_test.go
@@ -1,0 +1,247 @@
+package stages
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	util_log "github.com/grafana/loki/pkg/util/log"
+)
+
+var (
+	dockerRaw       = `{"log":"level=info ts=2019-04-30T02:12:41.844179Z caller=filetargetmanager.go:180 msg=\"Adding target\" key=\"{com_docker_deploy_namespace=\\\"docker\\\", com_docker_fry=\\\"compose.api\\\", com_docker_image_tag=\\\"v0.4.12\\\", container_name=\\\"compose\\\", instance=\\\"compose-api-cbff6dfc9-cqfr8\\\", job=\\\"docker/compose-api\\\", namespace=\\\"docker\\\", pod_template_hash=\\\"769928975\\\"}\"\n","stream":"stderr","time":"2019-04-30T02:12:41.8443515Z"}`
+	dockerProcessed = `level=info ts=2019-04-30T02:12:41.844179Z caller=filetargetmanager.go:180 msg="Adding target" key="{com_docker_deploy_namespace=\"docker\", com_docker_fry=\"compose.api\", com_docker_image_tag=\"v0.4.12\", container_name=\"compose\", instance=\"compose-api-cbff6dfc9-cqfr8\", job=\"docker/compose-api\", namespace=\"docker\", pod_template_hash=\"769928975\"}"
+`
+	dockerInvalidTimestampRaw = `{"log":"log message\n","stream":"stderr","time":"hi!"}`
+	dockerTestTimeNow         = time.Now()
+)
+
+func TestNewDocker(t *testing.T) {
+	loc, err := time.LoadLocation("UTC")
+	if err != nil {
+		t.Fatal("could not parse timezone", err)
+	}
+
+	tests := map[string]struct {
+		entry          string
+		expectedEntry  string
+		t              time.Time
+		expectedT      time.Time
+		labels         map[string]string
+		expectedLabels map[string]string
+	}{
+		"happy path": {
+			dockerRaw,
+			dockerProcessed,
+			time.Now(),
+			time.Date(2019, 4, 30, 02, 12, 41, 844351500, loc),
+			map[string]string{},
+			map[string]string{
+				"stream": "stderr",
+			},
+		},
+		"invalid timestamp": {
+			dockerInvalidTimestampRaw,
+			"log message\n",
+			dockerTestTimeNow,
+			dockerTestTimeNow,
+			map[string]string{},
+			map[string]string{
+				"stream": "stderr",
+			},
+		},
+		"invalid json": {
+			"i'm not json!",
+			"i'm not json!",
+			dockerTestTimeNow,
+			dockerTestTimeNow,
+			map[string]string{},
+			map[string]string{},
+		},
+	}
+
+	for tName, tt := range tests {
+		tt := tt
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+			p, err := NewDocker(util_log.Logger, prometheus.DefaultRegisterer)
+			if err != nil {
+				t.Fatalf("failed to create Docker parser: %s", err)
+			}
+			out := processEntries(p, newEntry(nil, toLabelSet(tt.labels), tt.entry, tt.t))[0]
+
+			assertLabels(t, tt.expectedLabels, out.Labels)
+			assert.Equal(t, tt.expectedEntry, out.Line, "did not receive expected log entry")
+			if out.Timestamp.Unix() != tt.expectedT.Unix() {
+				t.Fatalf("mismatch ts want: %s got:%s", tt.expectedT, tt.t)
+			}
+		})
+	}
+}
+
+var (
+	criTestTimeStr = "2019-01-01T01:00:00.000000001Z"
+	criTestTime, _ = time.Parse(time.RFC3339Nano, criTestTimeStr)
+	criTestTime2   = time.Now()
+)
+
+func TestCRI_tags(t *testing.T) {
+	cases := []struct {
+		name            string
+		lines           []string
+		expected        []string
+		maxPartialLines int
+		err             error
+	}{
+		{
+			name: "tag F",
+			lines: []string{
+				"2019-05-07T18:57:50.904275087+00:00 stdout F some full line",
+				"2019-05-07T18:57:55.904275087+00:00 stdout F log",
+			},
+			expected: []string{"some full line", "log"},
+		},
+		{
+			name: "tag P",
+			lines: []string{
+				"2019-05-07T18:57:50.904275087+00:00 stdout P partial line 1",
+				"2019-05-07T18:57:50.904275087+00:00 stdout P partial line 2",
+				"2019-05-07T18:57:55.904275087+00:00 stdout F log finished",
+				"2019-05-07T18:57:55.904275087+00:00 stdout F another full log",
+			},
+			expected: []string{
+				"partial line 1\npartial line 2\nlog finished",
+				"another full log",
+			},
+		},
+		{
+			name: "tag P exceeding MaxPartialLinesSize lines",
+			lines: []string{
+				"2019-05-07T18:57:50.904275087+00:00 stdout P partial line 1",
+				"2019-05-07T18:57:50.904275087+00:00 stdout P partial line 2",
+				"2019-05-07T18:57:50.904275087+00:00 stdout P partial line 3",
+				"2019-05-07T18:57:50.904275087+00:00 stdout P partial line 4", // this exceeds the `MaxPartialLinesSize` of 3
+				"2019-05-07T18:57:55.904275087+00:00 stdout F log finished",
+				"2019-05-07T18:57:55.904275087+00:00 stdout F another full log",
+			},
+			maxPartialLines: 3,
+			expected: []string{
+				"partial line 1\npartial line 2\npartial line 3",
+				"partial line 4\nlog finished",
+				"another full log",
+			},
+		},
+		{
+			name: "panic",
+			lines: []string{
+				"2019-05-07T18:57:50.904275087+00:00 stdout P panic: I'm pannicing",
+				"2019-05-07T18:57:50.904275087+00:00 stdout P ",
+				"2019-05-07T18:57:50.904275087+00:00 stdout P goroutine 1 [running]:",
+				"2019-05-07T18:57:55.904275087+00:00 stdout P main.main()",
+				"2019-05-07T18:57:55.904275087+00:00 stdout F 	/home/kavirajk/src/go-play/main.go:11 +0x27",
+			},
+			expected: []string{
+				`panic: I'm pannicing
+
+goroutine 1 [running]:
+main.main()
+	/home/kavirajk/src/go-play/main.go:11 +0x27`,
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := NewCRI(util_log.Logger, prometheus.DefaultRegisterer)
+			require.NoError(t, err)
+
+			got := make([]string, 0)
+
+			// tweak `maxPartialLines`
+			if tt.maxPartialLines != 0 {
+				p.(*cri).maxPartialLines = tt.maxPartialLines
+			}
+
+			for _, line := range tt.lines {
+				out := processEntries(p, newEntry(nil, nil, line, time.Now()))
+				if len(out) > 0 {
+					for _, en := range out {
+						got = append(got, en.Line)
+					}
+				}
+			}
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestNewCri(t *testing.T) {
+	tests := map[string]struct {
+		entry          string
+		expectedEntry  string
+		t              time.Time
+		expectedT      time.Time
+		labels         map[string]string
+		expectedLabels map[string]string
+	}{
+		"happy path": {
+			criTestTimeStr + " stderr F message",
+			"message",
+			time.Now(),
+			criTestTime,
+			map[string]string{},
+			map[string]string{
+				"stream": "stderr",
+			},
+		},
+		"multi line pass": {
+			criTestTimeStr + " stderr F message\nmessage2",
+			"message\nmessage2",
+			time.Now(),
+			criTestTime,
+			map[string]string{},
+			map[string]string{
+				"stream": "stderr",
+			},
+		},
+		"invalid timestamp": {
+			"3242 stderr F message",
+			"message",
+			criTestTime2,
+			criTestTime2,
+			map[string]string{},
+			map[string]string{
+				"stream": "stderr",
+			},
+		},
+		"invalid line": {
+			"i'm invalid!!!",
+			"i'm invalid!!!",
+			criTestTime2,
+			criTestTime2,
+			map[string]string{},
+			map[string]string{},
+		},
+	}
+
+	for tName, tt := range tests {
+		tt := tt
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+			p, err := NewCRI(util_log.Logger, prometheus.DefaultRegisterer)
+			if err != nil {
+				t.Fatalf("failed to create CRI parser: %s", err)
+			}
+			out := processEntries(p, newEntry(nil, toLabelSet(tt.labels), tt.entry, tt.t))[0]
+
+			assertLabels(t, tt.expectedLabels, out.Labels)
+			assert.Equal(t, tt.expectedEntry, out.Line, "did not receive expected log entry")
+			if out.Timestamp.Unix() != tt.expectedT.Unix() {
+				t.Fatalf("mismatch ts want: %s got:%s", tt.expectedT, tt.t)
+			}
+		})
+	}
+}

--- a/component/loki/process/internal/stages/output.go
+++ b/component/loki/process/internal/stages/output.go
@@ -1,0 +1,74 @@
+package stages
+
+import (
+	"errors"
+	"reflect"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/common/model"
+)
+
+// Config Errors
+const (
+	ErrEmptyOutputStageConfig = "output stage config cannot be empty"
+	ErrOutputSourceRequired   = "output source value is required if output is specified"
+)
+
+// OutputConfig represents an Output Stage configuration which sets the log
+// line to an entry of the the extracted value map.
+type OutputConfig struct {
+	Source string `river:"source,attr"`
+}
+
+// validateOutput validates the outputStage config
+func validateOutputConfig(cfg *OutputConfig) error {
+	if cfg == nil {
+		return errors.New(ErrEmptyOutputStageConfig)
+	}
+	if cfg.Source == "" {
+		return errors.New(ErrOutputSourceRequired)
+	}
+	return nil
+}
+
+// newOutputStage creates a new outputStage
+func newOutputStage(logger log.Logger, config *OutputConfig) (Stage, error) {
+	err := validateOutputConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return toStage(&outputStage{
+		config: config,
+		logger: logger,
+	}), nil
+}
+
+// outputStage will mutate the incoming entry and set it from extracted data
+type outputStage struct {
+	config *OutputConfig
+	logger log.Logger
+}
+
+// Process implements Stage
+func (o *outputStage) Process(labels model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
+	if o.config == nil {
+		return
+	}
+	if v, ok := extracted[o.config.Source]; ok {
+		s, err := getString(v)
+		if err != nil {
+			level.Debug(o.logger).Log("msg", "extracted output could not be converted to a string", "err", err, "type", reflect.TypeOf(v))
+			return
+		}
+		*entry = s
+	} else {
+		level.Debug(o.logger).Log("msg", "extracted data did not contain output source")
+	}
+}
+
+// Name implements Stage
+func (o *outputStage) Name() string {
+	return StageTypeOutput
+}

--- a/component/loki/process/internal/stages/output.go
+++ b/component/loki/process/internal/stages/output.go
@@ -1,5 +1,9 @@
 package stages
 
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
 import (
 	"errors"
 	"reflect"

--- a/component/loki/process/internal/stages/output.go
+++ b/component/loki/process/internal/stages/output.go
@@ -14,34 +14,22 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-// Config Errors
+// Config Errors.
 const (
 	ErrEmptyOutputStageConfig = "output stage config cannot be empty"
 	ErrOutputSourceRequired   = "output source value is required if output is specified"
 )
 
-// OutputConfig represents an Output Stage configuration which sets the log
-// line to an entry of the the extracted value map.
+// OutputConfig initializes a configuration stage which sets the log line to a
+// value from the extracted map.
 type OutputConfig struct {
 	Source string `river:"source,attr"`
 }
 
-// validateOutput validates the outputStage config
-func validateOutputConfig(cfg *OutputConfig) error {
-	if cfg == nil {
-		return errors.New(ErrEmptyOutputStageConfig)
-	}
-	if cfg.Source == "" {
-		return errors.New(ErrOutputSourceRequired)
-	}
-	return nil
-}
-
 // newOutputStage creates a new outputStage
-func newOutputStage(logger log.Logger, config *OutputConfig) (Stage, error) {
-	err := validateOutputConfig(config)
-	if err != nil {
-		return nil, err
+func newOutputStage(logger log.Logger, config OutputConfig) (Stage, error) {
+	if config.Source == "" {
+		return nil, errors.New(ErrOutputSourceRequired)
 	}
 	return toStage(&outputStage{
 		config: config,
@@ -51,15 +39,12 @@ func newOutputStage(logger log.Logger, config *OutputConfig) (Stage, error) {
 
 // outputStage will mutate the incoming entry and set it from extracted data
 type outputStage struct {
-	config *OutputConfig
+	config OutputConfig
 	logger log.Logger
 }
 
 // Process implements Stage
 func (o *outputStage) Process(labels model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
-	if o.config == nil {
-		return
-	}
 	if v, ok := extracted[o.config.Source]; ok {
 		s, err := getString(v)
 		if err != nil {

--- a/component/loki/process/internal/stages/output.go
+++ b/component/loki/process/internal/stages/output.go
@@ -15,9 +15,9 @@ import (
 )
 
 // Config Errors.
-const (
-	ErrEmptyOutputStageConfig = "output stage config cannot be empty"
-	ErrOutputSourceRequired   = "output source value is required if output is specified"
+var (
+	ErrEmptyOutputStageConfig = errors.New("output stage config cannot be empty")
+	ErrOutputSourceRequired   = errors.New("output source value is required if output is specified")
 )
 
 // OutputConfig initializes a configuration stage which sets the log line to a
@@ -29,7 +29,7 @@ type OutputConfig struct {
 // newOutputStage creates a new outputStage
 func newOutputStage(logger log.Logger, config OutputConfig) (Stage, error) {
 	if config.Source == "" {
-		return nil, errors.New(ErrOutputSourceRequired)
+		return nil, ErrOutputSourceRequired
 	}
 	return toStage(&outputStage{
 		config: config,

--- a/component/loki/process/internal/stages/output_test.go
+++ b/component/loki/process/internal/stages/output_test.go
@@ -1,5 +1,9 @@
 package stages
 
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
 import (
 	"bytes"
 	"errors"

--- a/component/loki/process/internal/stages/output_test.go
+++ b/component/loki/process/internal/stages/output_test.go
@@ -1,0 +1,139 @@
+package stages
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+
+	util_log "github.com/grafana/loki/pkg/util/log"
+)
+
+var testOutputRiver = `
+stage {
+  json {
+    expressions = { "out" = "message" }
+  }
+}
+stage {
+  output {
+    source = "out"
+  }
+}
+`
+
+var testOutputLogLine = `
+{
+	"time":"2012-11-01T22:08:41+00:00",
+	"app":"loki",
+	"component": ["parser","type"],
+	"level" : "WARN",
+	"nested" : {"child":"value"},
+	"message" : "this is a log line"
+}
+`
+var testOutputLogLineWithMissingKey = `
+{
+	"time":"2012-11-01T22:08:41+00:00",
+	"app":"loki",
+	"component": ["parser","type"],
+	"level" : "WARN",
+	"nested" : {"child":"value"}
+}
+`
+
+func TestPipeline_Output(t *testing.T) {
+	pl, err := NewPipeline(util_log.Logger, loadConfig(testOutputRiver), nil, prometheus.DefaultRegisterer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := processEntries(pl, newEntry(nil, nil, testOutputLogLine, time.Now()))[0]
+
+	assert.Equal(t, "this is a log line", out.Line)
+}
+
+func TestPipelineWithMissingKey_Output(t *testing.T) {
+	var buf bytes.Buffer
+	w := log.NewSyncWriter(&buf)
+	logger := log.NewLogfmtLogger(w)
+	pl, err := NewPipeline(logger, loadConfig(testOutputRiver), nil, prometheus.DefaultRegisterer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	Debug = true
+	_ = processEntries(pl, newEntry(nil, nil, testOutputLogLineWithMissingKey, time.Now()))
+	expectedLog := "level=debug msg=\"extracted output could not be converted to a string\" err=\"Can't convert <nil> to string\" type=null"
+	if !(strings.Contains(buf.String(), expectedLog)) {
+		t.Errorf("\nexpected: %s\n+actual: %s", expectedLog, buf.String())
+	}
+}
+
+func TestOutputValidation(t *testing.T) {
+	tests := map[string]struct {
+		config *OutputConfig
+		err    error
+	}{
+		"missing config": {
+			config: nil,
+			err:    errors.New(ErrEmptyOutputStageConfig),
+		},
+		"missing source": {
+			config: &OutputConfig{
+				Source: "",
+			},
+			err: errors.New(ErrOutputSourceRequired),
+		},
+	}
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			err := validateOutputConfig(test.config)
+			if (err != nil) != (test.err != nil) {
+				t.Errorf("validateOutputConfig() expected error = %v, actual error = %v", test.err, err)
+				return
+			}
+			if (err != nil) && (err.Error() != test.err.Error()) {
+				t.Errorf("validateOutputConfig() expected error = %v, actual error = %v", test.err, err)
+				return
+			}
+		})
+	}
+}
+
+func TestOutputStage_Process(t *testing.T) {
+	tests := map[string]struct {
+		config         *OutputConfig
+		extracted      map[string]interface{}
+		expectedOutput string
+	}{
+		"sets output": {
+			&OutputConfig{
+				Source: "out",
+			},
+			map[string]interface{}{
+				"something": "notimportant",
+				"out":       "outmessage",
+			},
+			"outmessage",
+		},
+	}
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			st, err := newOutputStage(util_log.Logger, test.config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			out := processEntries(st, newEntry(test.extracted, nil, "replaceme", time.Time{}))[0]
+
+			assert.Equal(t, test.expectedOutput, out.Line)
+		})
+	}
+}

--- a/component/loki/process/internal/stages/output_test.go
+++ b/component/loki/process/internal/stages/output_test.go
@@ -77,7 +77,7 @@ func TestPipelineWithMissingKey_Output(t *testing.T) {
 func TestOutputValidation(t *testing.T) {
 	emptyConfig := OutputConfig{Source: ""}
 	_, err := newOutputStage(nil, emptyConfig)
-	require.EqualError(t, err, ErrOutputSourceRequired)
+	require.Equal(t, err, ErrOutputSourceRequired)
 }
 
 func TestOutputStage_Process(t *testing.T) {

--- a/component/loki/process/internal/stages/pipeline.go
+++ b/component/loki/process/internal/stages/pipeline.go
@@ -30,6 +30,11 @@ type StageConfig struct {
 	LabelAllowConfig   *LabelAllowConfig   `river:"label_keep,block,optional"`
 	LabelDropConfig    *LabelDropConfig    `river:"label_drop,block,optional"`
 	StaticLabelsConfig *StaticLabelsConfig `river:"static_labels,block,optional"`
+	DockerConfig       *DockerConfig       `river:"docker,block,optional"`
+	CRIConfig          *CRIConfig          `river:"cri,block,optional"`
+	RegexConfig        *RegexConfig        `river:"regex,block,optional"`
+	TimestampConfig    *TimestampConfig    `river:"timestamp,block,optional"`
+	OutputConfig       *OutputConfig       `river:"output,block,optional"`
 }
 
 // UnmarshalRiver implements river.Unmarshaler.

--- a/component/loki/process/internal/stages/regex.go
+++ b/component/loki/process/internal/stages/regex.go
@@ -1,0 +1,135 @@
+package stages
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/mitchellh/mapstructure"
+	"github.com/prometheus/common/model"
+)
+
+// Config Errors
+const (
+	ErrExpressionRequired    = "expression is required"
+	ErrCouldNotCompileRegex  = "could not compile regular expression"
+	ErrEmptyRegexStageConfig = "empty regex stage configuration"
+	ErrEmptyRegexStageSource = "empty source"
+)
+
+// RegexConfig contains a regexStage configuration.
+type RegexConfig struct {
+	Expression string  `river:"expression,attr"`
+	Source     *string `river:"source,attr,optional"`
+}
+
+// validateRegexConfig validates the config and return a regex
+func validateRegexConfig(c *RegexConfig) (*regexp.Regexp, error) {
+	if c == nil {
+		return nil, errors.New(ErrEmptyRegexStageConfig)
+	}
+
+	if c.Expression == "" {
+		return nil, errors.New(ErrExpressionRequired)
+	}
+
+	if c.Source != nil && *c.Source == "" {
+		return nil, errors.New(ErrEmptyRegexStageSource)
+	}
+
+	expr, err := regexp.Compile(c.Expression)
+	if err != nil {
+		return nil, fmt.Errorf("%v: %w", ErrCouldNotCompileRegex, err)
+	}
+
+	return expr, nil
+}
+
+// regexStage sets extracted data using regular expressions
+type regexStage struct {
+	config     *RegexConfig
+	expression *regexp.Regexp
+	logger     log.Logger
+}
+
+// newRegexStage creates a newRegexStage
+func newRegexStage(logger log.Logger, config *RegexConfig) (Stage, error) {
+	expression, err := validateRegexConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return toStage(&regexStage{
+		config:     config,
+		expression: expression,
+		logger:     log.With(logger, "component", "stage", "type", "regex"),
+	}), nil
+}
+
+// parseRegexConfig processes an incoming configuration into a RegexConfig
+func parseRegexConfig(config interface{}) (*RegexConfig, error) {
+	cfg := &RegexConfig{}
+	err := mapstructure.Decode(config, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// Process implements Stage
+func (r *regexStage) Process(labels model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
+	// If a source key is provided, the regex stage should process it
+	// from the extracted map, otherwise should fallback to the entry
+	input := entry
+
+	if r.config.Source != nil {
+		if _, ok := extracted[*r.config.Source]; !ok {
+			if Debug {
+				level.Debug(r.logger).Log("msg", "source does not exist in the set of extracted values", "source", *r.config.Source)
+			}
+			return
+		}
+
+		value, err := getString(extracted[*r.config.Source])
+		if err != nil {
+			if Debug {
+				level.Debug(r.logger).Log("msg", "failed to convert source value to string", "source", *r.config.Source, "err", err, "type", reflect.TypeOf(extracted[*r.config.Source]))
+			}
+			return
+		}
+
+		input = &value
+	}
+
+	if input == nil {
+		if Debug {
+			level.Debug(r.logger).Log("msg", "cannot parse a nil entry")
+		}
+		return
+	}
+
+	match := r.expression.FindStringSubmatch(*input)
+	if match == nil {
+		if Debug {
+			level.Debug(r.logger).Log("msg", "regex did not match", "input", *input, "regex", r.expression)
+		}
+		return
+	}
+
+	for i, name := range r.expression.SubexpNames() {
+		if i != 0 && name != "" {
+			extracted[name] = match[i]
+		}
+	}
+	if Debug {
+		level.Debug(r.logger).Log("msg", "extracted data debug in regex stage", "extracted data", fmt.Sprintf("%v", extracted))
+	}
+}
+
+// Name implements Stage
+func (r *regexStage) Name() string {
+	return StageTypeRegex
+}

--- a/component/loki/process/internal/stages/regex.go
+++ b/component/loki/process/internal/stages/regex.go
@@ -1,5 +1,9 @@
 package stages
 
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
 import (
 	"errors"
 	"fmt"

--- a/component/loki/process/internal/stages/regex.go
+++ b/component/loki/process/internal/stages/regex.go
@@ -18,10 +18,10 @@ import (
 )
 
 // Config Errors.
-const (
-	ErrExpressionRequired    = "expression is required"
-	ErrCouldNotCompileRegex  = "could not compile regular expression"
-	ErrEmptyRegexStageSource = "empty source"
+var (
+	ErrExpressionRequired    = errors.New("expression is required")
+	ErrCouldNotCompileRegex  = errors.New("could not compile regular expression")
+	ErrEmptyRegexStageSource = errors.New("empty source")
 )
 
 // RegexConfig configures a processing stage uses regular expressions to
@@ -34,11 +34,11 @@ type RegexConfig struct {
 // validateRegexConfig validates the config and return a regex
 func validateRegexConfig(c RegexConfig) (*regexp.Regexp, error) {
 	if c.Expression == "" {
-		return nil, errors.New(ErrExpressionRequired)
+		return nil, ErrExpressionRequired
 	}
 
 	if c.Source != nil && *c.Source == "" {
-		return nil, errors.New(ErrEmptyRegexStageSource)
+		return nil, ErrEmptyRegexStageSource
 	}
 
 	expr, err := regexp.Compile(c.Expression)

--- a/component/loki/process/internal/stages/regex_test.go
+++ b/component/loki/process/internal/stages/regex_test.go
@@ -1,0 +1,385 @@
+package stages
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+
+	util_log "github.com/grafana/loki/pkg/util/log"
+)
+
+var protocolStr = "protocol"
+
+var testRegexRiverSingleStageWithoutSource = `
+stage {
+  regex {
+    expression =  "^(?P<ip>\\S+) (?P<identd>\\S+) (?P<user>\\S+) \\[(?P<timestamp>[\\w:/]+\\s[+\\-]\\d{4})\\] \"(?P<action>\\S+)\\s?(?P<path>\\S+)?\\s?(?P<protocol>\\S+)?\" (?P<status>\\d{3}|-) (?P<size>\\d+|-)\\s?\"?(?P<referer>[^\"]*)\"?\\s?\"?(?P<useragent>[^\"]*)?\"?$"
+  }
+}
+`
+
+var testRegexRiverMultiStageWithSource = `
+stage {
+  regex {
+    expression = "^(?P<ip>\\S+) (?P<identd>\\S+) (?P<user>\\S+) \\[(?P<timestamp>[\\w:/]+\\s[+\\-]\\d{4})\\] \"(?P<action>\\S+)\\s?(?P<path>\\S+)?\\s?(?P<protocol>\\S+)?\" (?P<status>\\d{3}|-) (?P<size>\\d+|-)\\s?\"?(?P<referer>[^\"]*)\"?\\s?\"?(?P<useragent>[^\"]*)?\"?$"
+  }
+}
+stage {
+  regex {
+    expression = "^HTTP\\/(?P<protocol_version>[0-9\\.]+)$"
+    source     = "protocol"
+  }
+}
+`
+
+var testRegexRiverSourceWithMissingKey = `
+stage {
+  json {
+    expressions = { "time" = "" }
+  }
+}
+stage {
+  regex {
+    expression = "^(?P<year>\\d+)"
+    source     = "time"
+  }
+}
+`
+
+var testRegexLogLineWithMissingKey = `
+{
+	"app":"loki",
+	"component": ["parser","type"],
+	"level": "WARN"
+}
+`
+
+var testRegexLogLine = `11.11.11.11 - frank [25/Jan/2000:14:00:01 -0500] "GET /1986.js HTTP/1.1" 200 932 "-" "Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6"`
+
+func init() {
+	Debug = true
+}
+
+func TestPipeline_Regex(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		config          string
+		entry           string
+		expectedExtract map[string]interface{}
+	}{
+		"successfully run a pipeline with 1 regex stage without source": {
+			testRegexRiverSingleStageWithoutSource,
+			testRegexLogLine,
+			map[string]interface{}{
+				"ip":        "11.11.11.11",
+				"identd":    "-",
+				"user":      "frank",
+				"timestamp": "25/Jan/2000:14:00:01 -0500",
+				"action":    "GET",
+				"path":      "/1986.js",
+				"protocol":  "HTTP/1.1",
+				"status":    "200",
+				"size":      "932",
+				"referer":   "-",
+				"useragent": "Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6",
+			},
+		},
+		"successfully run a pipeline with 2 regex stages with source": {
+			testRegexRiverMultiStageWithSource,
+			testRegexLogLine,
+			map[string]interface{}{
+				"ip":               "11.11.11.11",
+				"identd":           "-",
+				"user":             "frank",
+				"timestamp":        "25/Jan/2000:14:00:01 -0500",
+				"action":           "GET",
+				"path":             "/1986.js",
+				"protocol":         "HTTP/1.1",
+				"protocol_version": "1.1",
+				"status":           "200",
+				"size":             "932",
+				"referer":          "-",
+				"useragent":        "Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6",
+			},
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			pl, err := NewPipeline(util_log.Logger, loadConfig(testData.config), nil, prometheus.DefaultRegisterer)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			out := processEntries(pl, newEntry(nil, nil, testData.entry, time.Now()))[0]
+			assert.Equal(t, testData.expectedExtract, out.Extracted)
+		})
+	}
+}
+
+func TestPipelineWithMissingKey_Regex(t *testing.T) {
+	var buf bytes.Buffer
+	w := log.NewSyncWriter(&buf)
+	logger := log.NewLogfmtLogger(w)
+	pl, err := NewPipeline(logger, loadConfig(testRegexRiverSourceWithMissingKey), nil, prometheus.DefaultRegisterer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = processEntries(pl, newEntry(nil, nil, testRegexLogLineWithMissingKey, time.Now()))[0]
+
+	expectedLog := "level=debug component=stage type=regex msg=\"failed to convert source value to string\" source=time err=\"Can't convert <nil> to string\" type=null"
+	if !(strings.Contains(buf.String(), expectedLog)) {
+		t.Errorf("\nexpected: %s\n+actual: %s", expectedLog, buf.String())
+	}
+}
+
+var regexCfg = `regex:
+  expression: "regexexpression"`
+
+// nolint
+func TestRegexMapStructure(t *testing.T) {
+	t.Parallel()
+
+	// testing that we can use yaml data into mapstructure.
+	var mapstruct map[interface{}]interface{}
+	if err := yaml.Unmarshal([]byte(regexCfg), &mapstruct); err != nil {
+		t.Fatalf("error while un-marshalling config: %s", err)
+	}
+	p, ok := mapstruct["regex"].(map[interface{}]interface{})
+	if !ok {
+		t.Fatalf("could not read parser %+v", mapstruct["regex"])
+	}
+	got, err := parseRegexConfig(p)
+	if err != nil {
+		t.Fatalf("could not create parser from yaml: %s", err)
+	}
+	want := &RegexConfig{
+		Expression: "regexexpression",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("want: %+v got: %+v", want, got)
+	}
+}
+
+func TestRegexConfig_validate(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		config interface{}
+		err    error
+	}{
+		"empty config": {
+			nil,
+			errors.New(ErrExpressionRequired),
+		},
+		"missing regex_expression": {
+			map[string]interface{}{},
+			errors.New(ErrExpressionRequired),
+		},
+		"invalid regex_expression": {
+			map[string]interface{}{
+				"expression": "(?P<ts[0-9]+).*",
+			},
+			errors.New(ErrCouldNotCompileRegex + ": error parsing regexp: invalid named capture: `(?P<ts[0-9]+).*`"),
+		},
+		"empty source": {
+			map[string]interface{}{
+				"expression": "(?P<ts>[0-9]+).*",
+				"source":     "",
+			},
+			errors.New(ErrEmptyRegexStageSource),
+		},
+		"valid without source": {
+			map[string]interface{}{
+				"expression": "(?P<ts>[0-9]+).*",
+			},
+			nil,
+		},
+		"valid with source": {
+			map[string]interface{}{
+				"expression": "(?P<ts>[0-9]+).*",
+				"source":     "log",
+			},
+			nil,
+		},
+	}
+	for tName, tt := range tests {
+		tt := tt
+		t.Run(tName, func(t *testing.T) {
+			c, err := parseRegexConfig(tt.config)
+			if err != nil {
+				t.Fatalf("failed to create config: %s", err)
+			}
+			_, err = validateRegexConfig(c)
+			if (err != nil) != (tt.err != nil) {
+				t.Errorf("RegexConfig.validate() expected error = %v, actual error = %v", tt.err, err)
+				return
+			}
+			if (err != nil) && (err.Error() != tt.err.Error()) {
+				t.Errorf("RegexConfig.validate() expected error = %v, actual error = %v", tt.err, err)
+				return
+			}
+		})
+	}
+}
+
+var regexLogFixture = `11.11.11.11 - frank [25/Jan/2000:14:00:01 -0500] "GET /1986.js HTTP/1.1" 200 932 "-" "Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6"`
+
+func TestRegexParser_Parse(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		config          RegexConfig
+		extracted       map[string]interface{}
+		entry           string
+		expectedExtract map[string]interface{}
+	}{
+		"successfully match expression on entry": {
+			RegexConfig{
+				Expression: "^(?P<ip>\\S+) (?P<identd>\\S+) (?P<user>\\S+) \\[(?P<timestamp>[\\w:/]+\\s[+\\-]\\d{4})\\] \"(?P<action>\\S+)\\s?(?P<path>\\S+)?\\s?(?P<protocol>\\S+)?\" (?P<status>\\d{3}|-) (?P<size>\\d+|-)\\s?\"?(?P<referer>[^\"]*)\"?\\s?\"?(?P<useragent>[^\"]*)?\"?$",
+			},
+			map[string]interface{}{},
+			regexLogFixture,
+			map[string]interface{}{
+				"ip":        "11.11.11.11",
+				"identd":    "-",
+				"user":      "frank",
+				"timestamp": "25/Jan/2000:14:00:01 -0500",
+				"action":    "GET",
+				"path":      "/1986.js",
+				"protocol":  "HTTP/1.1",
+				"status":    "200",
+				"size":      "932",
+				"referer":   "-",
+				"useragent": "Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6",
+			},
+		},
+		"successfully match expression on extracted[source]": {
+			RegexConfig{
+				Expression: "^HTTP\\/(?P<protocol_version>.*)$",
+				Source:     &protocolStr,
+			},
+			map[string]interface{}{
+				"protocol": "HTTP/1.1",
+			},
+			regexLogFixture,
+			map[string]interface{}{
+				"protocol":         "HTTP/1.1",
+				"protocol_version": "1.1",
+			},
+		},
+		"failed to match expression on entry": {
+			RegexConfig{
+				Expression: "^(?s)(?P<time>\\S+?) (?P<stream>stdout|stderr) (?P<flags>\\S+?) (?P<message>.*)$",
+			},
+			map[string]interface{}{},
+			"blahblahblah",
+			map[string]interface{}{},
+		},
+		"failed to match expression on extracted[source]": {
+			RegexConfig{
+				Expression: "^HTTP\\/(?P<protocol_version>.*)$",
+				Source:     &protocolStr,
+			},
+			map[string]interface{}{
+				"protocol": "unknown",
+			},
+			"unknown/unknown",
+			map[string]interface{}{
+				"protocol": "unknown",
+			},
+		},
+		"case insensitive": {
+			RegexConfig{
+				Expression: "(?i)(?P<bad>panic:|core_dumped|failure|error|attack| bad |illegal |denied|refused|unauthorized|fatal|failed|Segmentation Fault|Corrupted)",
+			},
+			map[string]interface{}{},
+			"A Terrible Error has occurred!!!",
+			map[string]interface{}{
+				"bad": "Error",
+			},
+		},
+		"missing extracted[source]": {
+			RegexConfig{
+				Expression: "^HTTP\\/(?P<protocol_version>.*)$",
+				Source:     &protocolStr,
+			},
+			map[string]interface{}{},
+			"blahblahblah",
+			map[string]interface{}{},
+		},
+		"invalid data type in extracted[source]": {
+			RegexConfig{
+				Expression: "^HTTP\\/(?P<protocol_version>.*)$",
+				Source:     &protocolStr,
+			},
+			map[string]interface{}{
+				"protocol": true,
+			},
+			"unknown/unknown",
+			map[string]interface{}{
+				"protocol": true,
+			},
+		},
+	}
+	for tName, tt := range tests {
+		tt := tt
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+			p, err := New(util_log.Logger, nil, StageConfig{RegexConfig: &tt.config}, nil)
+			if err != nil {
+				t.Fatalf("failed to create regex parser: %s", err)
+			}
+			out := processEntries(p, newEntry(tt.extracted, nil, tt.entry, time.Now()))[0]
+			assert.Equal(t, tt.expectedExtract, out.Extracted)
+		})
+	}
+}
+
+func BenchmarkRegexStage(b *testing.B) {
+	benchmarks := []struct {
+		name   string
+		config RegexConfig
+		entry  string
+	}{
+		{"apache common log",
+			RegexConfig{
+				Expression: "^(?P<ip>\\S+) (?P<identd>\\S+) (?P<user>\\S+) \\[(?P<timestamp>[\\w:/]+\\s[+\\-]\\d{4})\\] \"(?P<action>\\S+)\\s?(?P<path>\\S+)?\\s?(?P<protocol>\\S+)?\" (?P<status>\\d{3}|-) (?P<size>\\d+|-)\\s?\"?(?P<referer>[^\"]*)\"?\\s?\"?(?P<useragent>[^\"]*)?\"?$"},
+			regexLogFixture,
+		},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			stage, err := New(util_log.Logger, nil, StageConfig{RegexConfig: &bm.config}, nil)
+			if err != nil {
+				panic(err)
+			}
+			labels := model.LabelSet{}
+			ts := time.Now()
+			extr := map[string]interface{}{}
+
+			in := make(chan Entry)
+			out := stage.Run(in)
+			go func() {
+				for range out {
+				}
+			}()
+			for i := 0; i < b.N; i++ {
+				in <- newEntry(extr, labels, bm.entry, ts)
+			}
+			close(in)
+		})
+	}
+}

--- a/component/loki/process/internal/stages/regex_test.go
+++ b/component/loki/process/internal/stages/regex_test.go
@@ -1,5 +1,9 @@
 package stages
 
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
 import (
 	"bytes"
 	"errors"

--- a/component/loki/process/internal/stages/regex_test.go
+++ b/component/loki/process/internal/stages/regex_test.go
@@ -158,24 +158,24 @@ func TestRegexConfig_validate(t *testing.T) {
 	}{
 		"empty config": {
 			nil,
-			errors.New(ErrExpressionRequired),
+			ErrExpressionRequired,
 		},
 		"missing regex_expression": {
 			map[string]interface{}{},
-			errors.New(ErrExpressionRequired),
+			ErrExpressionRequired,
 		},
 		"invalid regex_expression": {
 			map[string]interface{}{
 				"expression": "(?P<ts[0-9]+).*",
 			},
-			errors.New(ErrCouldNotCompileRegex + ": error parsing regexp: invalid named capture: `(?P<ts[0-9]+).*`"),
+			errors.New(ErrCouldNotCompileRegex.Error() + ": error parsing regexp: invalid named capture: `(?P<ts[0-9]+).*`"),
 		},
 		"empty source": {
 			map[string]interface{}{
 				"expression": "(?P<ts>[0-9]+).*",
 				"source":     "",
 			},
-			errors.New(ErrEmptyRegexStageSource),
+			ErrEmptyRegexStageSource,
 		},
 		"valid without source": {
 			map[string]interface{}{

--- a/component/loki/process/internal/stages/stage.go
+++ b/component/loki/process/internal/stages/stage.go
@@ -149,17 +149,17 @@ func New(logger log.Logger, jobName *string, cfg StageConfig, registerer prometh
 	// 		return nil, err
 	// 	}
 	case cfg.RegexConfig != nil:
-		s, err = newRegexStage(logger, cfg.RegexConfig)
+		s, err = newRegexStage(logger, *cfg.RegexConfig)
 		if err != nil {
 			return nil, err
 		}
 	case cfg.TimestampConfig != nil:
-		s, err = newTimestampStage(logger, cfg.TimestampConfig)
+		s, err = newTimestampStage(logger, *cfg.TimestampConfig)
 		if err != nil {
 			return nil, err
 		}
 	case cfg.OutputConfig != nil:
-		s, err = newOutputStage(logger, cfg.OutputConfig)
+		s, err = newOutputStage(logger, *cfg.OutputConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/component/loki/process/internal/stages/stage.go
+++ b/component/loki/process/internal/stages/stage.go
@@ -113,16 +113,16 @@ func New(logger log.Logger, jobName *string, cfg StageConfig, registerer prometh
 		err error
 	)
 	switch {
-	// case StageTypeDocker:
-	// 	s, err = NewDocker(logger, registerer)
-	// 	if err != nil {
-	// 		return nil, err
-	// 	}
-	// case StageTypeCRI:
-	// 	s, err = NewCRI(logger, registerer)
-	// 	if err != nil {
-	// 		return nil, err
-	// 	}
+	case cfg.DockerConfig != nil:
+		s, err = NewDocker(logger, registerer)
+		if err != nil {
+			return nil, err
+		}
+	case cfg.CRIConfig != nil:
+		s, err = NewCRI(logger, registerer)
+		if err != nil {
+			return nil, err
+		}
 	case cfg.JSONConfig != nil:
 		s, err = newJSONStage(logger, cfg.JSONConfig)
 		if err != nil {
@@ -130,11 +130,6 @@ func New(logger log.Logger, jobName *string, cfg StageConfig, registerer prometh
 		}
 	// case StageTypeLogfmt:
 	// 	s, err = newLogfmtStage(logger, cfg)
-	// 	if err != nil {
-	// 		return nil, err
-	// 	}
-	// case StageTypeRegex:
-	// 	s, err = newRegexStage(logger, cfg)
 	// 	if err != nil {
 	// 		return nil, err
 	// 	}
@@ -148,16 +143,26 @@ func New(logger log.Logger, jobName *string, cfg StageConfig, registerer prometh
 		if err != nil {
 			return nil, err
 		}
-	// case StageTypeTimestamp:
-	// 	s, err = newTimestampStage(logger, cfg)
+	// case StageTypeLabelDrop:
+	// 	s, err = newLabelDropStage(cfg)
 	// 	if err != nil {
 	// 		return nil, err
 	// 	}
-	// case StageTypeOutput:
-	// 	s, err = newOutputStage(logger, cfg)
-	// 	if err != nil {
-	// 		return nil, err
-	// 	}
+	case cfg.RegexConfig != nil:
+		s, err = newRegexStage(logger, cfg.RegexConfig)
+		if err != nil {
+			return nil, err
+		}
+	case cfg.TimestampConfig != nil:
+		s, err = newTimestampStage(logger, cfg.TimestampConfig)
+		if err != nil {
+			return nil, err
+		}
+	case cfg.OutputConfig != nil:
+		s, err = newOutputStage(logger, cfg.OutputConfig)
+		if err != nil {
+			return nil, err
+		}
 	// case StageTypeMatch:
 	// 	s, err = newMatcherStage(logger, jobName, cfg, registerer)
 	// 	if err != nil {

--- a/component/loki/process/internal/stages/timestamp.go
+++ b/component/loki/process/internal/stages/timestamp.go
@@ -1,0 +1,224 @@
+package stages
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/prometheus/common/model"
+
+	"github.com/grafana/loki/pkg/util"
+)
+
+// Config errors.
+const (
+	ErrEmptyTimestampStageConfig = "timestamp stage config cannot be empty"
+	ErrTimestampSourceRequired   = "timestamp source value is required if timestamp is specified"
+	ErrTimestampFormatRequired   = "timestamp format is required"
+	ErrInvalidLocation           = "invalid location specified: %v"
+	ErrInvalidActionOnFailure    = "invalid action on failure (supported values are %v)"
+	ErrTimestampSourceMissing    = "extracted data did not contain a timestamp"
+	ErrTimestampConversionFailed = "failed to convert extracted time to string"
+	ErrTimestampParsingFailed    = "failed to parse time"
+
+	Unix   = "Unix"
+	UnixMs = "UnixMs"
+	UnixUs = "UnixUs"
+	UnixNs = "UnixNs"
+
+	TimestampActionOnFailureSkip    = "skip"
+	TimestampActionOnFailureFudge   = "fudge"
+	TimestampActionOnFailureDefault = TimestampActionOnFailureFudge
+
+	// Maximum number of "streams" for which we keep the last known timestamp
+	maxLastKnownTimestampsCacheSize = 10000
+)
+
+var (
+	TimestampActionOnFailureOptions = []string{TimestampActionOnFailureSkip, TimestampActionOnFailureFudge}
+)
+
+// TimestampConfig configures timestamp extraction
+type TimestampConfig struct {
+	Source          string   `river:"source,attr"`
+	Format          string   `river:"format,attr"`
+	FallbackFormats []string `river:"fallback_formats,attr,optional"`
+	Location        *string  `river:"location,attr,optional"`
+	ActionOnFailure *string  `river:"action_on_failure,attr,optional"`
+}
+
+// parser can convert the time string into a time.Time value
+type parser func(string) (time.Time, error)
+
+// validateTimestampConfig validates a timestampStage configuration
+func validateTimestampConfig(cfg *TimestampConfig) (parser, error) {
+	if cfg == nil {
+		return nil, errors.New(ErrEmptyTimestampStageConfig)
+	}
+	if cfg.Source == "" {
+		return nil, errors.New(ErrTimestampSourceRequired)
+	}
+	if cfg.Format == "" {
+		return nil, errors.New(ErrTimestampFormatRequired)
+	}
+	var loc *time.Location
+	var err error
+	if cfg.Location != nil {
+		loc, err = time.LoadLocation(*cfg.Location)
+		if err != nil {
+			return nil, fmt.Errorf(ErrInvalidLocation, err)
+		}
+	}
+
+	// Validate the action on failure and enforce the default
+	if cfg.ActionOnFailure == nil {
+		cfg.ActionOnFailure = util.StringRef(TimestampActionOnFailureDefault)
+	} else {
+		if !util.StringsContain(TimestampActionOnFailureOptions, *cfg.ActionOnFailure) {
+			return nil, fmt.Errorf(ErrInvalidActionOnFailure, TimestampActionOnFailureOptions)
+		}
+	}
+
+	if len(cfg.FallbackFormats) > 0 {
+		multiConvertDateLayout := func(input string) (time.Time, error) {
+			orignalTime, originalErr := convertDateLayout(cfg.Format, loc)(input)
+			if originalErr == nil {
+				return orignalTime, originalErr
+			}
+			for i := 0; i < len(cfg.FallbackFormats); i++ {
+				if t, err := convertDateLayout(cfg.FallbackFormats[i], loc)(input); err == nil {
+					return t, err
+				}
+			}
+			return orignalTime, originalErr
+		}
+		return multiConvertDateLayout, nil
+	}
+
+	return convertDateLayout(cfg.Format, loc), nil
+}
+
+// newTimestampStage creates a new timestamp extraction pipeline stage.
+func newTimestampStage(logger log.Logger, config *TimestampConfig) (Stage, error) {
+	parser, err := validateTimestampConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	var lastKnownTimestamps *lru.Cache
+	if *config.ActionOnFailure == TimestampActionOnFailureFudge {
+		lastKnownTimestamps, err = lru.New(maxLastKnownTimestampsCacheSize)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return toStage(&timestampStage{
+		config:              config,
+		logger:              logger,
+		parser:              parser,
+		lastKnownTimestamps: lastKnownTimestamps,
+	}), nil
+}
+
+// timestampStage will set the timestamp using extracted data
+type timestampStage struct {
+	config *TimestampConfig
+	logger log.Logger
+	parser parser
+
+	// Stores the last known timestamp for a given "stream id" (guessed, since at this stage
+	// there's no reliable way to know it).
+	lastKnownTimestamps *lru.Cache
+}
+
+// Name implements Stage
+func (ts *timestampStage) Name() string {
+	return StageTypeTimestamp
+}
+
+// Process implements Stage
+func (ts *timestampStage) Process(labels model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
+	if ts.config == nil {
+		return
+	}
+
+	parsedTs, err := ts.parseTimestampFromSource(extracted)
+	if err != nil {
+		ts.processActionOnFailure(labels, t)
+		return
+	}
+
+	// Update the log entry timestamp with the parsed one
+	*t = *parsedTs
+
+	// The timestamp has been correctly parsed, so we should store it in the map
+	// containing the last known timestamp used by the "fudge" action on failure.
+	if *ts.config.ActionOnFailure == TimestampActionOnFailureFudge {
+		ts.lastKnownTimestamps.Add(labels.String(), *t)
+	}
+}
+
+func (ts *timestampStage) parseTimestampFromSource(extracted map[string]interface{}) (*time.Time, error) {
+	// Ensure the extracted data contains the timestamp source
+	v, ok := extracted[ts.config.Source]
+	if !ok {
+		if Debug {
+			level.Debug(ts.logger).Log("msg", ErrTimestampSourceMissing)
+		}
+
+		return nil, errors.New(ErrTimestampSourceMissing)
+	}
+
+	// Convert the timestamp source to string (if it's not a string yet)
+	s, err := getString(v)
+	if err != nil {
+		if Debug {
+			level.Debug(ts.logger).Log("msg", ErrTimestampConversionFailed, "err", err, "type", reflect.TypeOf(v))
+		}
+
+		return nil, errors.New(ErrTimestampConversionFailed)
+	}
+
+	// Parse the timestamp source according to the configured format
+	parsedTs, err := ts.parser(s)
+	if err != nil {
+		if Debug {
+			level.Debug(ts.logger).Log("msg", ErrTimestampParsingFailed, "err", err, "format", ts.config.Format, "value", s)
+		}
+
+		return nil, errors.New(ErrTimestampParsingFailed)
+	}
+
+	return &parsedTs, nil
+}
+
+func (ts *timestampStage) processActionOnFailure(labels model.LabelSet, t *time.Time) {
+	switch *ts.config.ActionOnFailure {
+	case TimestampActionOnFailureFudge:
+		ts.processActionOnFailureFudge(labels, t)
+	case TimestampActionOnFailureSkip:
+		// Nothing to do
+	}
+}
+
+func (ts *timestampStage) processActionOnFailureFudge(labels model.LabelSet, t *time.Time) {
+	labelsStr := labels.String()
+	lastTimestamp, ok := ts.lastKnownTimestamps.Get(labelsStr)
+
+	// If the last known timestamp is unknown (ie. has not been successfully parsed yet)
+	// there's nothing we can do, so we're going to keep the current timestamp
+	if !ok {
+		return
+	}
+
+	// Fudge the timestamp
+	*t = lastTimestamp.(time.Time).Add(1 * time.Nanosecond)
+
+	// Store the fudged timestamp, so that a subsequent fudged timestamp will be 1ns after it
+	ts.lastKnownTimestamps.Add(labelsStr, *t)
+}

--- a/component/loki/process/internal/stages/timestamp.go
+++ b/component/loki/process/internal/stages/timestamp.go
@@ -1,5 +1,9 @@
 package stages
 
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
 import (
 	"errors"
 	"fmt"

--- a/component/loki/process/internal/stages/timestamp.go
+++ b/component/loki/process/internal/stages/timestamp.go
@@ -76,7 +76,7 @@ func validateTimestampConfig(cfg TimestampConfig) (parser, error) {
 		cfg.ActionOnFailure = TimestampActionOnFailureDefault
 	} else {
 		if !stringsContain(TimestampActionOnFailureOptions, cfg.ActionOnFailure) {
-			return nil, fmt.Errorf("%v: %w", ErrInvalidActionOnFailure, TimestampActionOnFailureOptions)
+			return nil, fmt.Errorf(ErrInvalidActionOnFailure.Error(), TimestampActionOnFailureOptions)
 		}
 	}
 

--- a/component/loki/process/internal/stages/timestamp_test.go
+++ b/component/loki/process/internal/stages/timestamp_test.go
@@ -1,0 +1,454 @@
+package stages
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	lokiutil "github.com/grafana/loki/pkg/util"
+	util_log "github.com/grafana/loki/pkg/util/log"
+)
+
+var testTimestampRiver = `
+stage {
+  json {
+    expressions = { ts = "time" }
+  }
+}
+stage {
+  timestamp {
+    source = "ts"
+	format = "RFC3339"
+  }
+}`
+
+var testTimestampLogLine = `
+{
+	"time":"2012-11-01T22:08:41-04:00",
+	"app":"loki",
+	"component": ["parser","type"],
+	"level" : "WARN"
+}
+`
+
+var testTimestampLogLineWithMissingKey = `
+{
+	"app":"loki",
+	"component": ["parser","type"],
+	"level" : "WARN"
+}
+`
+
+func TestTimestampPipeline(t *testing.T) {
+	pl, err := NewPipeline(util_log.Logger, loadConfig(testTimestampRiver), nil, prometheus.DefaultRegisterer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := processEntries(pl, newEntry(nil, nil, testTimestampLogLine, time.Now()))[0]
+	assert.Equal(t, time.Date(2012, 11, 01, 22, 8, 41, 0, time.FixedZone("", -4*60*60)).Unix(), out.Timestamp.Unix())
+}
+
+var (
+	invalidLocationString = "America/Canada"
+	validLocationString   = "America/New_York"
+	validLocation, _      = time.LoadLocation(validLocationString)
+)
+
+func TestPipelineWithMissingKey_Timestamp(t *testing.T) {
+	var buf bytes.Buffer
+	w := log.NewSyncWriter(&buf)
+	logger := log.NewLogfmtLogger(w)
+	pl, err := NewPipeline(logger, loadConfig(testTimestampRiver), nil, prometheus.DefaultRegisterer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	Debug = true
+	_ = processEntries(pl, newEntry(nil, nil, testTimestampLogLineWithMissingKey, time.Now()))
+
+	expectedLog := fmt.Sprintf("level=debug msg=\"%s\" err=\"Can't convert <nil> to string\" type=null", ErrTimestampConversionFailed)
+	if !(strings.Contains(buf.String(), expectedLog)) {
+		t.Errorf("\nexpected: %s\n+actual: %s", expectedLog, buf.String())
+	}
+}
+
+func TestTimestampValidation(t *testing.T) {
+	tests := map[string]struct {
+		config *TimestampConfig
+		// Note the error text validation is a little loose as it only validates with strings.HasPrefix
+		// this is to work around different errors related to timezone loading on different systems
+		err          error
+		testString   string
+		expectedTime time.Time
+	}{
+		"missing config": {
+			config: nil,
+			err:    errors.New(ErrEmptyTimestampStageConfig),
+		},
+		"missing source": {
+			config: &TimestampConfig{},
+			err:    errors.New(ErrTimestampSourceRequired),
+		},
+		"missing format": {
+			config: &TimestampConfig{
+				Source: "source1",
+			},
+			err: errors.New(ErrTimestampFormatRequired),
+		},
+		"invalid location": {
+			config: &TimestampConfig{
+				Source:   "source1",
+				Format:   "2006-01-02",
+				Location: &invalidLocationString,
+			},
+			err: fmt.Errorf(ErrInvalidLocation, ""),
+		},
+		"standard format": {
+			config: &TimestampConfig{
+				Source: "source1",
+				Format: time.RFC3339,
+			},
+			err:          nil,
+			testString:   "2012-11-01T22:08:41-04:00",
+			expectedTime: time.Date(2012, 11, 01, 22, 8, 41, 0, time.FixedZone("", -4*60*60)),
+		},
+		"custom format with year": {
+			config: &TimestampConfig{
+				Source: "source1",
+				Format: "2006-01-02",
+			},
+			err:          nil,
+			testString:   "2009-01-01",
+			expectedTime: time.Date(2009, 01, 01, 00, 00, 00, 0, time.UTC),
+		},
+		"custom format without year": {
+			config: &TimestampConfig{
+				Source: "source1",
+				Format: "Jan 02 15:04:05",
+			},
+			err:          nil,
+			testString:   "Jul 15 01:02:03",
+			expectedTime: time.Date(time.Now().Year(), 7, 15, 1, 2, 3, 0, time.UTC),
+		},
+		"custom format with location": {
+			config: &TimestampConfig{
+				Source:   "source1",
+				Format:   "2006-01-02 15:04:05",
+				Location: &validLocationString,
+			},
+			err:          nil,
+			testString:   "2009-07-01 03:30:20",
+			expectedTime: time.Date(2009, 7, 1, 3, 30, 20, 0, validLocation),
+		},
+		"unix_ms": {
+			config: &TimestampConfig{
+				Source: "source1",
+				Format: "UnixMs",
+			},
+			err:          nil,
+			testString:   "1562708916919",
+			expectedTime: time.Date(2019, 7, 9, 21, 48, 36, 919*1000000, time.UTC),
+		},
+		"should fail on invalid action on failure": {
+			config: &TimestampConfig{
+				Source:          "source1",
+				Format:          time.RFC3339,
+				ActionOnFailure: lokiutil.StringRef("foo"),
+			},
+			err: fmt.Errorf(ErrInvalidActionOnFailure, TimestampActionOnFailureOptions),
+		},
+		"fallback formats contains the format": {
+			config: &TimestampConfig{
+				Source:          "source1",
+				Format:          "UnixMs",
+				FallbackFormats: []string{"2006-01-02 03:04:05.000000000 +0000 UTC", time.RFC3339},
+			},
+			err:          nil,
+			testString:   "2012-11-01T22:08:41-04:00",
+			expectedTime: time.Date(2012, 11, 01, 22, 8, 41, 0, time.FixedZone("", -4*60*60)),
+		},
+	}
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			parser, err := validateTimestampConfig(test.config)
+			if (err != nil) != (test.err != nil) {
+				t.Errorf("validateOutputConfig() expected error = %v, actual error = %v", test.err, err)
+				return
+			}
+			if (err != nil) && !strings.HasPrefix(err.Error(), test.err.Error()) {
+				t.Errorf("validateOutputConfig() expected error = %v, actual error = %v", test.err, err)
+				return
+			}
+			if test.testString != "" {
+				ts, err := parser(test.testString)
+				if err != nil {
+					t.Errorf("validateOutputConfig() unexpected error parsing test time: %v", err)
+					return
+				}
+				assert.Equal(t, test.expectedTime.UnixNano(), ts.UnixNano())
+			}
+		})
+	}
+}
+
+func TestTimestampStage_Process(t *testing.T) {
+	tests := map[string]struct {
+		config    TimestampConfig
+		extracted map[string]interface{}
+		expected  time.Time
+	}{
+		"set success": {
+			TimestampConfig{
+				Source: "ts",
+				Format: time.RFC3339,
+			},
+			map[string]interface{}{
+				"somethigelse": "notimportant",
+				"ts":           "2106-01-02T23:04:05-04:00",
+			},
+			time.Date(2106, 01, 02, 23, 04, 05, 0, time.FixedZone("", -4*60*60)),
+		},
+		"unix success": {
+			TimestampConfig{
+				Source: "ts",
+				Format: "Unix",
+			},
+			map[string]interface{}{
+				"somethigelse": "notimportant",
+				"ts":           "1562708916",
+			},
+			time.Date(2019, 7, 9, 21, 48, 36, 0, time.UTC),
+		},
+		"unix fractions ms success": {
+			TimestampConfig{
+				Source: "ts",
+				Format: "Unix",
+			},
+			map[string]interface{}{
+				"somethigelse": "notimportant",
+				"ts":           "1562708916.414123",
+			},
+			time.Date(2019, 7, 9, 21, 48, 36, 414123*1000, time.UTC),
+		},
+		"unix fractions ns success": {
+			TimestampConfig{
+				Source: "ts",
+				Format: "Unix",
+			},
+			map[string]interface{}{
+				"somethigelse": "notimportant",
+				"ts":           "1562708916.000000123",
+			},
+			time.Date(2019, 7, 9, 21, 48, 36, 123, time.UTC),
+		},
+		"unix millisecond success": {
+			TimestampConfig{
+				Source: "ts",
+				Format: "UnixMs",
+			},
+			map[string]interface{}{
+				"somethigelse": "notimportant",
+				"ts":           "1562708916414",
+			},
+			time.Date(2019, 7, 9, 21, 48, 36, 414*1000000, time.UTC),
+		},
+		"unix microsecond success": {
+			TimestampConfig{
+				Source: "ts",
+				Format: "UnixUs",
+			},
+			map[string]interface{}{
+				"somethigelse": "notimportant",
+				"ts":           "1562708916414123",
+			},
+			time.Date(2019, 7, 9, 21, 48, 36, 414123*1000, time.UTC),
+		},
+		"unix nano success": {
+			TimestampConfig{
+				Source: "ts",
+				Format: "UnixNs",
+			},
+			map[string]interface{}{
+				"somethigelse": "notimportant",
+				"ts":           "1562708916000000123",
+			},
+			time.Date(2019, 7, 9, 21, 48, 36, 123, time.UTC),
+		},
+		"with location success": {
+			TimestampConfig{
+				Source:   "ts",
+				Format:   "2006-01-02 15:04:05",
+				Location: &validLocationString,
+			},
+			map[string]interface{}{
+				"somethigelse": "notimportant",
+				"ts":           "2019-07-22 20:29:32",
+			},
+			time.Date(2019, 7, 22, 20, 29, 32, 0, validLocation),
+		},
+	}
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			st, err := newTimestampStage(util_log.Logger, &test.config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			out := processEntries(st, newEntry(test.extracted, nil, "hello world", time.Now()))[0]
+			assert.Equal(t, test.expected.UnixNano(), out.Timestamp.UnixNano())
+		})
+	}
+}
+
+func TestTimestampStage_ProcessActionOnFailure(t *testing.T) {
+	t.Parallel()
+
+	type inputEntry struct {
+		timestamp time.Time
+		labels    model.LabelSet
+		extracted map[string]interface{}
+	}
+
+	tests := map[string]struct {
+		config             TimestampConfig
+		inputEntries       []inputEntry
+		expectedTimestamps []time.Time
+	}{
+		"should keep the parsed timestamp on success": {
+			config: TimestampConfig{
+				Source:          "time",
+				Format:          time.RFC3339Nano,
+				ActionOnFailure: lokiutil.StringRef(TimestampActionOnFailureFudge),
+			},
+			inputEntries: []inputEntry{
+				{timestamp: time.Unix(1, 0), extracted: map[string]interface{}{"time": "2019-10-01T01:02:03.400000000Z"}},
+				{timestamp: time.Unix(1, 0), extracted: map[string]interface{}{"time": "2019-10-01T01:02:03.500000000Z"}},
+			},
+			expectedTimestamps: []time.Time{
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.400000000Z"),
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.500000000Z"),
+			},
+		},
+		"should fudge the timestamp based on the last known value on timestamp parsing failure": {
+			config: TimestampConfig{
+				Source:          "time",
+				Format:          time.RFC3339Nano,
+				ActionOnFailure: lokiutil.StringRef(TimestampActionOnFailureFudge),
+			},
+			inputEntries: []inputEntry{
+				{timestamp: time.Unix(1, 0), extracted: map[string]interface{}{"time": "2019-10-01T01:02:03.400000000Z"}},
+				{timestamp: time.Unix(1, 0), extracted: map[string]interface{}{}},
+				{timestamp: time.Unix(1, 0), extracted: map[string]interface{}{}},
+			},
+			expectedTimestamps: []time.Time{
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.400000000Z"),
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.400000001Z"),
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.400000002Z"),
+			},
+		},
+		"should fudge the timestamp based on the last known value for the right file target": {
+			config: TimestampConfig{
+				Source:          "time",
+				Format:          time.RFC3339Nano,
+				ActionOnFailure: lokiutil.StringRef(TimestampActionOnFailureFudge),
+			},
+			inputEntries: []inputEntry{
+				{timestamp: time.Unix(1, 0), labels: model.LabelSet{"filename": "/1.log"}, extracted: map[string]interface{}{"time": "2019-10-01T01:02:03.400000000Z"}},
+				{timestamp: time.Unix(1, 0), labels: model.LabelSet{"filename": "/2.log"}, extracted: map[string]interface{}{"time": "2019-10-01T01:02:03.800000000Z"}},
+				{timestamp: time.Unix(1, 0), labels: model.LabelSet{"filename": "/1.log"}, extracted: map[string]interface{}{}},
+				{timestamp: time.Unix(1, 0), labels: model.LabelSet{"filename": "/2.log"}, extracted: map[string]interface{}{}},
+				{timestamp: time.Unix(1, 0), labels: model.LabelSet{"filename": "/1.log"}, extracted: map[string]interface{}{}},
+			},
+			expectedTimestamps: []time.Time{
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.400000000Z"),
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.800000000Z"),
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.400000001Z"),
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.800000001Z"),
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.400000002Z"),
+			},
+		},
+		"should keep the input timestamp if unable to fudge because there's no known valid timestamp yet": {
+			config: TimestampConfig{
+				Source:          "time",
+				Format:          time.RFC3339Nano,
+				ActionOnFailure: lokiutil.StringRef(TimestampActionOnFailureFudge),
+			},
+			inputEntries: []inputEntry{
+				{timestamp: time.Unix(1, 0), labels: model.LabelSet{"filename": "/1.log"}, extracted: map[string]interface{}{"time": "2019-10-01T01:02:03.400000000Z"}},
+				{timestamp: time.Unix(1, 0), labels: model.LabelSet{"filename": "/2.log"}, extracted: map[string]interface{}{}},
+			},
+			expectedTimestamps: []time.Time{
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.400000000Z"),
+				time.Unix(1, 0),
+			},
+		},
+		"should keep the input timestamp on action_on_failure=skip": {
+			config: TimestampConfig{
+				Source:          "time",
+				Format:          time.RFC3339Nano,
+				ActionOnFailure: lokiutil.StringRef(TimestampActionOnFailureSkip),
+			},
+			inputEntries: []inputEntry{
+				{timestamp: time.Unix(1, 0), extracted: map[string]interface{}{"time": "2019-10-01T01:02:03.400000000Z"}},
+				{timestamp: time.Unix(1, 0), extracted: map[string]interface{}{}},
+			},
+			expectedTimestamps: []time.Time{
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.400000000Z"),
+				time.Unix(1, 0),
+			},
+		},
+		"labels with colliding fingerprints should have independent timestamps when fudging": {
+			config: TimestampConfig{
+				Source:          "time",
+				Format:          time.RFC3339Nano,
+				ActionOnFailure: lokiutil.StringRef(TimestampActionOnFailureFudge),
+			},
+			inputEntries: []inputEntry{
+				{timestamp: time.Unix(1, 0), labels: model.LabelSet{"app": "m", "uniq0": "1", "uniq1": "1"}, extracted: map[string]interface{}{"time": "2019-10-01T01:02:03.400000000Z"}},
+				{timestamp: time.Unix(1, 0), labels: model.LabelSet{"app": "l", "uniq0": "0", "uniq1": "1"}, extracted: map[string]interface{}{"time": "2019-10-01T01:02:03.800000000Z"}},
+				{timestamp: time.Unix(1, 0), labels: model.LabelSet{"app": "m", "uniq0": "1", "uniq1": "1"}, extracted: map[string]interface{}{}},
+				{timestamp: time.Unix(1, 0), labels: model.LabelSet{"app": "l", "uniq0": "0", "uniq1": "1"}, extracted: map[string]interface{}{}},
+				{timestamp: time.Unix(1, 0), labels: model.LabelSet{"app": "m", "uniq0": "1", "uniq1": "1"}, extracted: map[string]interface{}{}},
+				{timestamp: time.Unix(1, 0), labels: model.LabelSet{"app": "l", "uniq0": "0", "uniq1": "1"}, extracted: map[string]interface{}{}},
+			},
+			expectedTimestamps: []time.Time{
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.400000000Z"),
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.800000000Z"),
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.400000001Z"),
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.800000001Z"),
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.400000002Z"),
+				mustParseTime(time.RFC3339Nano, "2019-10-01T01:02:03.800000002Z"),
+			},
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			// Ensure the test has been correctly set
+			require.Equal(t, len(testData.inputEntries), len(testData.expectedTimestamps))
+
+			s, err := newTimestampStage(util_log.Logger, &testData.config)
+			require.NoError(t, err)
+
+			for i, inputEntry := range testData.inputEntries {
+				out := processEntries(s, newEntry(inputEntry.extracted, inputEntry.labels, "", inputEntry.timestamp))[0]
+				assert.Equal(t, testData.expectedTimestamps[i], out.Timestamp, "entry: %d", i)
+			}
+		})
+	}
+}

--- a/component/loki/process/internal/stages/timestamp_test.go
+++ b/component/loki/process/internal/stages/timestamp_test.go
@@ -1,5 +1,9 @@
 package stages
 
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
 import (
 	"bytes"
 	"errors"

--- a/component/loki/process/internal/stages/timestamp_test.go
+++ b/component/loki/process/internal/stages/timestamp_test.go
@@ -6,7 +6,6 @@ package stages
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -91,13 +90,13 @@ func TestTimestampValidation(t *testing.T) {
 	}{
 		"missing source": {
 			config: &TimestampConfig{},
-			err:    errors.New(ErrTimestampSourceRequired),
+			err:    ErrTimestampSourceRequired,
 		},
 		"missing format": {
 			config: &TimestampConfig{
 				Source: "source1",
 			},
-			err: errors.New(ErrTimestampFormatRequired),
+			err: ErrTimestampFormatRequired,
 		},
 		"invalid location": {
 			config: &TimestampConfig{
@@ -105,7 +104,7 @@ func TestTimestampValidation(t *testing.T) {
 				Format:   "2006-01-02",
 				Location: &invalidLocationString,
 			},
-			err: fmt.Errorf(ErrInvalidLocation, ""),
+			err: fmt.Errorf(ErrInvalidLocation.Error(), ""),
 		},
 		"standard format": {
 			config: &TimestampConfig{
@@ -159,7 +158,7 @@ func TestTimestampValidation(t *testing.T) {
 				Format:          time.RFC3339,
 				ActionOnFailure: "foo",
 			},
-			err: fmt.Errorf(ErrInvalidActionOnFailure, TimestampActionOnFailureOptions),
+			err: fmt.Errorf(ErrInvalidActionOnFailure.Error(), TimestampActionOnFailureOptions),
 		},
 		"fallback formats contains the format": {
 			config: &TimestampConfig{

--- a/component/loki/process/internal/stages/util.go
+++ b/component/loki/process/internal/stages/util.go
@@ -6,7 +6,10 @@ package stages
 
 import (
 	"fmt"
+	"math"
 	"strconv"
+	"strings"
+	"time"
 )
 
 var (
@@ -20,150 +23,148 @@ var (
 	Inspect = false
 )
 
-// TODO(@tpaschalis) Comment these out for now, until we bring over the
-// timestamp stage.
-//
-// const (
-// 	ErrTimestampContainsYear = "timestamp '%s' is expected to not contain the year date component"
-// )
-// // convertDateLayout converts pre-defined date format layout into date format
-// func convertDateLayout(predef string, location *time.Location) parser {
-// 	switch predef {
-// 	case "ANSIC":
-// 		return func(t string) (time.Time, error) {
-// 			return time.Parse(time.ANSIC, t)
-// 		}
-// 	case "UnixDate":
-// 		return func(t string) (time.Time, error) {
-// 			return time.Parse(time.UnixDate, t)
-// 		}
-// 	case "RubyDate":
-// 		return func(t string) (time.Time, error) {
-// 			return time.Parse(time.RubyDate, t)
-// 		}
-// 	case "RFC822":
-// 		return func(t string) (time.Time, error) {
-// 			return time.Parse(time.RFC822, t)
-// 		}
-// 	case "RFC822Z":
-// 		return func(t string) (time.Time, error) {
-// 			return time.Parse(time.RFC822Z, t)
-// 		}
-// 	case "RFC850":
-// 		return func(t string) (time.Time, error) {
-// 			return time.Parse(time.RFC850, t)
-// 		}
-// 	case "RFC1123":
-// 		return func(t string) (time.Time, error) {
-// 			return time.Parse(time.RFC1123, t)
-// 		}
-// 	case "RFC1123Z":
-// 		return func(t string) (time.Time, error) {
-// 			return time.Parse(time.RFC1123Z, t)
-// 		}
-// 	case "RFC3339":
-// 		return func(t string) (time.Time, error) {
-// 			return time.Parse(time.RFC3339, t)
-// 		}
-// 	case "RFC3339Nano":
-// 		return func(t string) (time.Time, error) {
-// 			return time.Parse(time.RFC3339Nano, t)
-// 		}
-// 	case "Unix":
-// 		return func(t string) (time.Time, error) {
-// 			if strings.Count(t, ".") == 1 {
-// 				split := strings.Split(t, ".")
-// 				if len(split) != 2 {
-// 					return time.Time{}, fmt.Errorf("can't split %v into two parts", t)
-// 				}
-// 				sec, err := strconv.ParseInt(split[0], 10, 64)
-// 				if err != nil {
-// 					return time.Time{}, err
-// 				}
-// 				frac, err := strconv.ParseInt(split[1], 10, 64)
-// 				if err != nil {
-// 					return time.Time{}, err
-// 				}
-// 				nsec := int64(float64(frac) * math.Pow(10, float64(9-len(split[1]))))
-// 				return time.Unix(sec, nsec), nil
-// 			}
-// 			i, err := strconv.ParseInt(t, 10, 64)
-// 			if err != nil {
-// 				return time.Time{}, err
-// 			}
-// 			return time.Unix(i, 0), nil
-// 		}
-// 	case "UnixMs":
-// 		return func(t string) (time.Time, error) {
-// 			i, err := strconv.ParseInt(t, 10, 64)
-// 			if err != nil {
-// 				return time.Time{}, err
-// 			}
-// 			return time.Unix(0, i*int64(time.Millisecond)), nil
-// 		}
-// 	case "UnixUs":
-// 		return func(t string) (time.Time, error) {
-// 			i, err := strconv.ParseInt(t, 10, 64)
-// 			if err != nil {
-// 				return time.Time{}, err
-// 			}
-// 			return time.Unix(0, i*int64(time.Microsecond)), nil
-// 		}
-// 	case "UnixNs":
-// 		return func(t string) (time.Time, error) {
-// 			i, err := strconv.ParseInt(t, 10, 64)
-// 			if err != nil {
-// 				return time.Time{}, err
-// 			}
-// 			return time.Unix(0, i), nil
-// 		}
-// 	default:
-// 		if !strings.Contains(predef, "06") && !strings.Contains(predef, "2006") {
-// 			return func(t string) (time.Time, error) {
-// 				return parseTimestampWithoutYear(predef, location, t, time.Now())
-// 			}
-// 		}
-// 		return func(t string) (time.Time, error) {
-// 			if location != nil {
-// 				return time.ParseInLocation(predef, t, location)
-// 			}
-// 			return time.Parse(predef, t)
-// 		}
-// 	}
-// }
-//
+const (
+	ErrTimestampContainsYear = "timestamp '%s' is expected to not contain the year date component"
+)
+
+// convertDateLayout converts pre-defined date format layout into date format
+func convertDateLayout(predef string, location *time.Location) parser {
+	switch predef {
+	case "ANSIC":
+		return func(t string) (time.Time, error) {
+			return time.Parse(time.ANSIC, t)
+		}
+	case "UnixDate":
+		return func(t string) (time.Time, error) {
+			return time.Parse(time.UnixDate, t)
+		}
+	case "RubyDate":
+		return func(t string) (time.Time, error) {
+			return time.Parse(time.RubyDate, t)
+		}
+	case "RFC822":
+		return func(t string) (time.Time, error) {
+			return time.Parse(time.RFC822, t)
+		}
+	case "RFC822Z":
+		return func(t string) (time.Time, error) {
+			return time.Parse(time.RFC822Z, t)
+		}
+	case "RFC850":
+		return func(t string) (time.Time, error) {
+			return time.Parse(time.RFC850, t)
+		}
+	case "RFC1123":
+		return func(t string) (time.Time, error) {
+			return time.Parse(time.RFC1123, t)
+		}
+	case "RFC1123Z":
+		return func(t string) (time.Time, error) {
+			return time.Parse(time.RFC1123Z, t)
+		}
+	case "RFC3339":
+		return func(t string) (time.Time, error) {
+			return time.Parse(time.RFC3339, t)
+		}
+	case "RFC3339Nano":
+		return func(t string) (time.Time, error) {
+			return time.Parse(time.RFC3339Nano, t)
+		}
+	case "Unix":
+		return func(t string) (time.Time, error) {
+			if strings.Count(t, ".") == 1 {
+				split := strings.Split(t, ".")
+				if len(split) != 2 {
+					return time.Time{}, fmt.Errorf("can't split %v into two parts", t)
+				}
+				sec, err := strconv.ParseInt(split[0], 10, 64)
+				if err != nil {
+					return time.Time{}, err
+				}
+				frac, err := strconv.ParseInt(split[1], 10, 64)
+				if err != nil {
+					return time.Time{}, err
+				}
+				nsec := int64(float64(frac) * math.Pow(10, float64(9-len(split[1]))))
+				return time.Unix(sec, nsec), nil
+			}
+			i, err := strconv.ParseInt(t, 10, 64)
+			if err != nil {
+				return time.Time{}, err
+			}
+			return time.Unix(i, 0), nil
+		}
+	case "UnixMs":
+		return func(t string) (time.Time, error) {
+			i, err := strconv.ParseInt(t, 10, 64)
+			if err != nil {
+				return time.Time{}, err
+			}
+			return time.Unix(0, i*int64(time.Millisecond)), nil
+		}
+	case "UnixUs":
+		return func(t string) (time.Time, error) {
+			i, err := strconv.ParseInt(t, 10, 64)
+			if err != nil {
+				return time.Time{}, err
+			}
+			return time.Unix(0, i*int64(time.Microsecond)), nil
+		}
+	case "UnixNs":
+		return func(t string) (time.Time, error) {
+			i, err := strconv.ParseInt(t, 10, 64)
+			if err != nil {
+				return time.Time{}, err
+			}
+			return time.Unix(0, i), nil
+		}
+	default:
+		if !strings.Contains(predef, "06") && !strings.Contains(predef, "2006") {
+			return func(t string) (time.Time, error) {
+				return parseTimestampWithoutYear(predef, location, t, time.Now())
+			}
+		}
+		return func(t string) (time.Time, error) {
+			if location != nil {
+				return time.ParseInLocation(predef, t, location)
+			}
+			return time.Parse(predef, t)
+		}
+	}
+}
+
 // parseTimestampWithoutYear parses the input timestamp without the year component,
 // assuming the timestamp is related to a point in time close to "now", and correctly
 // handling the edge cases around new year's eve
-// func parseTimestampWithoutYear(layout string, location *time.Location, timestamp string, now time.Time) (time.Time, error) {
-// 	var parsedTime time.Time
-// 	var err error
-// 	if location != nil {
-// 		parsedTime, err = time.ParseInLocation(layout, timestamp, location)
-// 	} else {
-// 		parsedTime, err = time.Parse(layout, timestamp)
-// 	}
-// 	if err != nil {
-// 		return parsedTime, err
-// 	}
+func parseTimestampWithoutYear(layout string, location *time.Location, timestamp string, now time.Time) (time.Time, error) {
+	var parsedTime time.Time
+	var err error
+	if location != nil {
+		parsedTime, err = time.ParseInLocation(layout, timestamp, location)
+	} else {
+		parsedTime, err = time.Parse(layout, timestamp)
+	}
+	if err != nil {
+		return parsedTime, err
+	}
 
-// 	// Ensure the year component of the input date string has not been
-// 	// parsed for real
-// 	if parsedTime.Year() != 0 {
-// 		return parsedTime, fmt.Errorf(ErrTimestampContainsYear, timestamp)
-// 	}
+	// Ensure the year component of the input date string has not been
+	// parsed for real
+	if parsedTime.Year() != 0 {
+		return parsedTime, fmt.Errorf(ErrTimestampContainsYear, timestamp)
+	}
 
-// 	// Handle the case we're crossing the new year's eve midnight
-// 	if parsedTime.Month() == 12 && now.Month() == 1 {
-// 		parsedTime = parsedTime.AddDate(now.Year()-1, 0, 0)
-// 	} else if parsedTime.Month() == 1 && now.Month() == 12 {
-// 		parsedTime = parsedTime.AddDate(now.Year()+1, 0, 0)
-// 	} else {
-// 		parsedTime = parsedTime.AddDate(now.Year(), 0, 0)
-// 	}
+	// Handle the case we're crossing the new year's eve midnight
+	if parsedTime.Month() == 12 && now.Month() == 1 {
+		parsedTime = parsedTime.AddDate(now.Year()-1, 0, 0)
+	} else if parsedTime.Month() == 1 && now.Month() == 12 {
+		parsedTime = parsedTime.AddDate(now.Year()+1, 0, 0)
+	} else {
+		parsedTime = parsedTime.AddDate(now.Year(), 0, 0)
+	}
 
-// 	return parsedTime, nil
-// }
+	return parsedTime, nil
+}
 
 // getString will convert the input variable to a string if possible
 func getString(unk interface{}) (string, error) {

--- a/component/loki/process/internal/stages/util.go
+++ b/component/loki/process/internal/stages/util.go
@@ -196,3 +196,13 @@ func getString(unk interface{}) (string, error) {
 		return "", fmt.Errorf("Can't convert %v to string", unk)
 	}
 }
+
+func stringsContain(values []string, search string) bool {
+	for _, v := range values {
+		if search == v {
+			return true
+		}
+	}
+
+	return false
+}

--- a/component/loki/process/internal/stages/util_test.go
+++ b/component/loki/process/internal/stages/util_test.go
@@ -5,6 +5,7 @@ package stages
 // new code without being able to slowly review, examine and test them.
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -51,18 +52,18 @@ func toLabelSet(lbs map[string]string) model.LabelSet {
 	return res
 }
 
-// func assertLabels(t *testing.T, expect map[string]string, got model.LabelSet) {
-// 	if len(expect) != len(got) {
-// 		t.Fatalf("labels are not equal in size want: %s got: %s", expect, got)
-// 	}
-// 	for k, v := range expect {
-// 		gotV, ok := got[model.LabelName(k)]
-// 		if !ok {
-// 			t.Fatalf("missing expected label key: %s", k)
-// 		}
-// 		assert.Equal(t, model.LabelValue(v), gotV, "mismatch label value")
-// 	}
-// }
+func assertLabels(t *testing.T, expect map[string]string, got model.LabelSet) {
+	if len(expect) != len(got) {
+		t.Fatalf("labels are not equal in size want: %s got: %s", expect, got)
+	}
+	for k, v := range expect {
+		gotV, ok := got[model.LabelName(k)]
+		if !ok {
+			t.Fatalf("missing expected label key: %s", k)
+		}
+		assert.Equal(t, model.LabelValue(v), gotV, "mismatch label value")
+	}
+}
 
 // Verify the formatting of float conversion to make sure there are not any trailing zeros,
 // and also make sure unix timestamps are converted properly
@@ -97,150 +98,149 @@ func TestGetString(t *testing.T) {
 
 // TODO(@tpaschalis) Comment these out until we port over the remaining
 // stages and use these tests to verify their behavior.
-//
-// var (
-// 	location, _ = time.LoadLocation("America/New_York")
-// )
+var (
+	location, _ = time.LoadLocation("America/New_York")
+)
 
-// func TestConvertDateLayout(t *testing.T) {
-// 	t.Parallel()
+func TestConvertDateLayout(t *testing.T) {
+	t.Parallel()
 
-// 	tests := map[string]struct {
-// 		layout    string
-// 		location  *time.Location
-// 		timestamp string
-// 		expected  time.Time
-// 	}{
-// 		"custom layout with short year": {
-// 			"06 Jan 02 15:04:05",
-// 			nil,
-// 			"19 Jul 15 01:02:03",
-// 			time.Date(2019, 7, 15, 1, 2, 3, 0, time.UTC),
-// 		},
-// 		"custom layout with long year": {
-// 			"2006 Jan 02 15:04:05",
-// 			nil,
-// 			"2019 Jul 15 01:02:03",
-// 			time.Date(2019, 7, 15, 1, 2, 3, 0, time.UTC),
-// 		},
-// 		"custom layout with short year and location": {
-// 			"06 Jan 02 15:04:05",
-// 			location,
-// 			"19 Jul 15 01:02:03",
-// 			time.Date(2019, 7, 15, 1, 2, 3, 0, location),
-// 		},
-// 		"custom layout with long year and location": {
-// 			"2006 Jan 02 15:04:05",
-// 			location,
-// 			"2019 Jul 15 01:02:03",
-// 			time.Date(2019, 7, 15, 1, 2, 3, 0, location),
-// 		},
-// 		"custom layout without year": {
-// 			"Jan 02 15:04:05",
-// 			nil,
-// 			"Jul 15 01:02:03",
-// 			time.Date(time.Now().Year(), 7, 15, 1, 2, 3, 0, time.UTC),
-// 		},
-// 		"custom layout without year and location": {
-// 			"Jan 02 15:04:05",
-// 			location,
-// 			"Jul 15 01:02:03",
-// 			time.Date(time.Now().Year(), 7, 15, 1, 2, 3, 0, location),
-// 		},
-// 	}
+	tests := map[string]struct {
+		layout    string
+		location  *time.Location
+		timestamp string
+		expected  time.Time
+	}{
+		"custom layout with short year": {
+			"06 Jan 02 15:04:05",
+			nil,
+			"19 Jul 15 01:02:03",
+			time.Date(2019, 7, 15, 1, 2, 3, 0, time.UTC),
+		},
+		"custom layout with long year": {
+			"2006 Jan 02 15:04:05",
+			nil,
+			"2019 Jul 15 01:02:03",
+			time.Date(2019, 7, 15, 1, 2, 3, 0, time.UTC),
+		},
+		"custom layout with short year and location": {
+			"06 Jan 02 15:04:05",
+			location,
+			"19 Jul 15 01:02:03",
+			time.Date(2019, 7, 15, 1, 2, 3, 0, location),
+		},
+		"custom layout with long year and location": {
+			"2006 Jan 02 15:04:05",
+			location,
+			"2019 Jul 15 01:02:03",
+			time.Date(2019, 7, 15, 1, 2, 3, 0, location),
+		},
+		"custom layout without year": {
+			"Jan 02 15:04:05",
+			nil,
+			"Jul 15 01:02:03",
+			time.Date(time.Now().Year(), 7, 15, 1, 2, 3, 0, time.UTC),
+		},
+		"custom layout without year and location": {
+			"Jan 02 15:04:05",
+			location,
+			"Jul 15 01:02:03",
+			time.Date(time.Now().Year(), 7, 15, 1, 2, 3, 0, location),
+		},
+	}
 
-// 	for testName, testData := range tests {
-// 		testData := testData
+	for testName, testData := range tests {
+		testData := testData
 
-// 		t.Run(testName, func(t *testing.T) {
-// 			t.Parallel()
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 
-// 			parser := convertDateLayout(testData.layout, testData.location)
-// 			parsed, err := parser(testData.timestamp)
-// 			if err != nil {
-// 				t.Errorf("convertDateLayout() parser returned an unexpected error = %v", err)
-// 				return
-// 			}
+			parser := convertDateLayout(testData.layout, testData.location)
+			parsed, err := parser(testData.timestamp)
+			if err != nil {
+				t.Errorf("convertDateLayout() parser returned an unexpected error = %v", err)
+				return
+			}
 
-// 			assert.Equal(t, testData.expected, parsed)
-// 		})
-// 	}
-// }
+			assert.Equal(t, testData.expected, parsed)
+		})
+	}
+}
 
-// func TestParseTimestampWithoutYear(t *testing.T) {
-// 	t.Parallel()
+func TestParseTimestampWithoutYear(t *testing.T) {
+	t.Parallel()
 
-// 	tests := map[string]struct {
-// 		layout    string
-// 		location  *time.Location
-// 		timestamp string
-// 		now       time.Time
-// 		expected  time.Time
-// 		err       error
-// 	}{
-// 		"parse timestamp within current year": {
-// 			"Jan 02 15:04:05",
-// 			nil,
-// 			"Jul 15 01:02:03",
-// 			time.Date(2019, 7, 14, 0, 0, 0, 0, time.UTC),
-// 			time.Date(2019, 7, 15, 1, 2, 3, 0, time.UTC),
-// 			nil,
-// 		},
-// 		"parse timestamp with location DST": {
-// 			"Jan 02 15:04:05",
-// 			location,
-// 			"Jul 15 01:02:03",
-// 			time.Date(2019, 7, 14, 0, 0, 0, 0, time.UTC),
-// 			time.Date(2019, 7, 15, 1, 2, 3, 0, location),
-// 			nil,
-// 		},
-// 		"parse timestamp with location non DST": {
-// 			"Jan 02 15:04:05",
-// 			location,
-// 			"Jan 15 01:02:03",
-// 			time.Date(2019, 7, 14, 0, 0, 0, 0, time.UTC),
-// 			time.Date(2019, 1, 15, 1, 2, 3, 0, location),
-// 			nil,
-// 		},
-// 		"parse timestamp on 31th Dec and today is 1st Jan": {
-// 			"Jan 02 15:04:05",
-// 			nil,
-// 			"Dec 31 23:59:59",
-// 			time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
-// 			time.Date(2018, 12, 31, 23, 59, 59, 0, time.UTC),
-// 			nil,
-// 		},
-// 		"parse timestamp on 1st Jan and today is 31st Dec": {
-// 			"Jan 02 15:04:05",
-// 			nil,
-// 			"Jan 01 01:02:03",
-// 			time.Date(2018, 12, 31, 23, 59, 59, 0, time.UTC),
-// 			time.Date(2019, 1, 1, 1, 2, 3, 0, time.UTC),
-// 			nil,
-// 		},
-// 		"error if the input layout actually includes the year component": {
-// 			"2006 Jan 02 15:04:05",
-// 			nil,
-// 			"2019 Jan 01 01:02:03",
-// 			time.Date(2019, 1, 1, 1, 2, 3, 0, time.UTC),
-// 			time.Date(2019, 1, 1, 1, 2, 3, 0, time.UTC),
-// 			fmt.Errorf(ErrTimestampContainsYear, "2019 Jan 01 01:02:03"),
-// 		},
-// 	}
+	tests := map[string]struct {
+		layout    string
+		location  *time.Location
+		timestamp string
+		now       time.Time
+		expected  time.Time
+		err       error
+	}{
+		"parse timestamp within current year": {
+			"Jan 02 15:04:05",
+			nil,
+			"Jul 15 01:02:03",
+			time.Date(2019, 7, 14, 0, 0, 0, 0, time.UTC),
+			time.Date(2019, 7, 15, 1, 2, 3, 0, time.UTC),
+			nil,
+		},
+		"parse timestamp with location DST": {
+			"Jan 02 15:04:05",
+			location,
+			"Jul 15 01:02:03",
+			time.Date(2019, 7, 14, 0, 0, 0, 0, time.UTC),
+			time.Date(2019, 7, 15, 1, 2, 3, 0, location),
+			nil,
+		},
+		"parse timestamp with location non DST": {
+			"Jan 02 15:04:05",
+			location,
+			"Jan 15 01:02:03",
+			time.Date(2019, 7, 14, 0, 0, 0, 0, time.UTC),
+			time.Date(2019, 1, 15, 1, 2, 3, 0, location),
+			nil,
+		},
+		"parse timestamp on 31th Dec and today is 1st Jan": {
+			"Jan 02 15:04:05",
+			nil,
+			"Dec 31 23:59:59",
+			time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2018, 12, 31, 23, 59, 59, 0, time.UTC),
+			nil,
+		},
+		"parse timestamp on 1st Jan and today is 31st Dec": {
+			"Jan 02 15:04:05",
+			nil,
+			"Jan 01 01:02:03",
+			time.Date(2018, 12, 31, 23, 59, 59, 0, time.UTC),
+			time.Date(2019, 1, 1, 1, 2, 3, 0, time.UTC),
+			nil,
+		},
+		"error if the input layout actually includes the year component": {
+			"2006 Jan 02 15:04:05",
+			nil,
+			"2019 Jan 01 01:02:03",
+			time.Date(2019, 1, 1, 1, 2, 3, 0, time.UTC),
+			time.Date(2019, 1, 1, 1, 2, 3, 0, time.UTC),
+			fmt.Errorf(ErrTimestampContainsYear, "2019 Jan 01 01:02:03"),
+		},
+	}
 
-// 	for testName, testData := range tests {
-// 		testData := testData
+	for testName, testData := range tests {
+		testData := testData
 
-// 		t.Run(testName, func(t *testing.T) {
-// 			t.Parallel()
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 
-// 			parsed, err := parseTimestampWithoutYear(testData.layout, testData.location, testData.timestamp, testData.now)
-// 			if ((err != nil) != (testData.err != nil)) || (err != nil && testData.err != nil && err.Error() != testData.err.Error()) {
-// 				t.Errorf("parseTimestampWithoutYear() expected error = %v, actual error = %v", testData.err, err)
-// 				return
-// 			}
+			parsed, err := parseTimestampWithoutYear(testData.layout, testData.location, testData.timestamp, testData.now)
+			if ((err != nil) != (testData.err != nil)) || (err != nil && testData.err != nil && err.Error() != testData.err.Error()) {
+				t.Errorf("parseTimestampWithoutYear() expected error = %v, actual error = %v", testData.err, err)
+				return
+			}
 
-// 			assert.Equal(t, testData.expected, parsed)
-// 		})
-// 	}
-// }
+			assert.Equal(t, testData.expected, parsed)
+		})
+	}
+}

--- a/component/loki/process/process_test.go
+++ b/component/loki/process/process_test.go
@@ -204,3 +204,104 @@ stage {
 		}
 	}
 }
+
+func TestRegexTimestampOutput(t *testing.T) {
+	// The first stage will attempt to parse the input line using a regular
+	// expression with named capture groups. The three capture groups (time,
+	// stream and content) will be extracted in the shared map of values.
+	// Since 'source' is empty, it implies that we want to parse the log line
+	// itself.
+	//
+	// The second stage will parse the extracted `time` value as Unix epoch
+	// time and set it to the log entry timestamp.
+	//
+	// The third stage will set the `content` value as the message value.
+	//
+	// The fourth and final stage will set the `stream` value as the label.
+	stg := `
+stage {
+	regex {
+		expression = "^(?s)(?P<time>\\S+?) (?P<stream>stdout|stderr) (?P<content>.*)$"
+	}
+}
+stage {
+	timestamp {
+		source = "time"
+		format = "RFC3339"
+	}
+}
+stage {
+	output {
+		source = "content"
+	}
+}
+stage {
+	labels {
+		values = { src = "stream" }
+	}
+}`
+
+	// Unmarshal the River relabel rules into a custom struct, as we don't have
+	// an easy way to refer to a loki.LogsReceiver value for the forward_to
+	// argument.
+	type cfg struct {
+		Stages []stages.StageConfig `river:"stage,block"`
+	}
+	var stagesCfg cfg
+	err := river.Unmarshal([]byte(stg), &stagesCfg)
+	require.NoError(t, err)
+
+	ch1, ch2 := make(loki.LogsReceiver), make(loki.LogsReceiver)
+
+	// Create and run the component, so that it can process and forwards logs.
+	l, err := logging.New(os.Stderr, logging.DefaultOptions)
+	require.NoError(t, err)
+	opts := component.Options{Logger: l, Registerer: prometheus.NewRegistry(), OnStateChange: func(e component.Exports) {}}
+	args := Arguments{
+		ForwardTo: []loki.LogsReceiver{ch1, ch2},
+		Stages:    stagesCfg.Stages,
+	}
+
+	c, err := New(opts, args)
+	require.NoError(t, err)
+	go c.Run(context.Background())
+
+	// Send a log entry to the component's receiver.
+	ts := time.Now()
+	logline := `2022-01-17T08:17:42-07:00 stderr somewhere, somehow, an error occurred`
+	logEntry := loki.Entry{
+		Labels: model.LabelSet{"filename": "/var/log/pods/agent/agent/1.log", "foo": "bar"},
+		Entry: logproto.Entry{
+			Timestamp: ts,
+			Line:      logline,
+		},
+	}
+
+	c.receiver <- logEntry
+
+	wantLabelSet := model.LabelSet{
+		"filename": "/var/log/pods/agent/agent/1.log",
+		"foo":      "bar",
+		"src":      "stderr",
+	}
+	wantTimestamp, err := time.Parse(time.RFC3339, "2022-01-17T08:17:42-07:00")
+	wantLogline := `somewhere, somehow, an error occurred`
+	require.NoError(t, err)
+
+	// The log entry should be received in both channels, with the processing
+	// stages correctly applied.
+	for i := 0; i < 2; i++ {
+		select {
+		case logEntry := <-ch1:
+			require.Equal(t, wantLogline, logEntry.Line)
+			require.Equal(t, wantTimestamp, logEntry.Timestamp)
+			require.Equal(t, wantLabelSet, logEntry.Labels)
+		case logEntry := <-ch2:
+			require.Equal(t, wantLogline, logEntry.Line)
+			require.Equal(t, wantTimestamp, logEntry.Timestamp)
+			require.Equal(t, wantLabelSet, logEntry.Labels)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "failed waiting for log line")
+		}
+	}
+}

--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -101,9 +101,9 @@ stage {
 
 Docker log entries are formatted as JSON with the following keys:
 
-1) `log`: The content of log line
-2) `stream`: Either `stdout` or `stderr`
-3) `time`: The timestamp string of the log line
+* `log`: The content of log line
+* `stream`: Either `stdout` or `stderr`
+* `time`: The timestamp string of the log line
 
 Then, given the following log line, the following key-value pairs would be
 created in the shared map of extracted data:
@@ -133,10 +133,10 @@ stage {
 CRI specifies log lines as single space-delimited values with the following
 components:
 
-1) `time`: The timestamp string of the log
-2) `stream`: Either `stdout` or `stderr`
-3) `flags`: CRI flags including `F` or `P`
-4) `log`: The contents of the log line
+* `time`: The timestamp string of the log
+* `stream`: Either `stdout` or `stderr`
+* `flags`: CRI flags including `F` or `P`
+* `log`: The contents of the log line
 
 Given the following log line, the following key-value pairs would be created in
 the shared map of extracted data:

--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -56,6 +56,9 @@ stage > labels | [labels][] | Configures a labels processing stage. | no
 stage > label_keep   | [label_keep][]    | Configures a `label_keep` processing stage. | no
 stage > label_drop   | [label_drop][]    | Configures a `label_drop` processing stage. | no
 stage > static_labels | [static_labels][] | Configures a `static_labels` processing stage. | no
+stage > regex        | [regex][]         | Configures a `regex` processing stage. | no
+stage > timestamp    | [timestamp][]     | Configures a `timestamp` processing stage. | no
+stage > output       | [output][]        | Configures an `output` processing stage. | no
 
 The `>` symbol indicates deeper levels of nesting. For example, `stage > json`
 refers to a `json` block defined inside of a `stage` block.

--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -49,6 +49,8 @@ The following blocks are supported inside the definition of `loki.process`:
 Hierarchy        | Block      | Description | Required
 ---------------- | ---------- | ----------- | --------
 stage          | [stage][]  | Processing stage to run. | no
+stage > docker | [docker][] | Configures a pre-defined Docker log format pipeline. | no
+stage > cri    | [cri][]    | Configures a pre-defined CRI-format pipeline. | no
 stage > json   | [json][]   | Configures a JSON processing stage.  | no
 stage > labels | [labels][] | Configures a labels processing stage. | no
 stage > label_keep   | [label_keep][]    | Configures a `label_keep` processing stage. | no
@@ -59,11 +61,16 @@ The `>` symbol indicates deeper levels of nesting. For example, `stage > json`
 refers to a `json` block defined inside of a `stage` block.
 
 [stage]: #stage-block
+[docker]: #docker-block
+[cri]: #cri-block
 [json]: #json-block
 [labels]: #labels-block
 [label_keep]: #label_keep-block
 [label_drop]: #label_drop-block
 [static_labels]: #static_labels-block
+[regex]: #regex-block
+[timestamp]: #timestamp-block
+[output]: #output-block
 
 ### stage block
 
@@ -74,6 +81,69 @@ different blocks and are applied on the incoming log entries in top-down order.
 
 The `stage` block does not support any arguments and is configured only via
 inner blocks.
+
+### docker block
+
+The `docker` inner block enables a predefined pipeline which reads log lines in
+the standard format of Docker log files.
+
+The `docker` block does not support any arguments or inner blocks, but is
+always empty.
+
+```river
+stage {
+	docker {}
+}
+```
+
+Docker log entries are formatted as JSON with the following keys:
+
+1) `log`: The content of log line
+2) `stream`: Either `stdout` or `stderr`
+3) `time`: The timestamp string of the log line
+
+Then, given the following log line, the following key-value pairs would be
+created in the shared map of extracted data:
+
+```
+{"log":"log message\n","stream":"stderr","time":"2019-04-30T02:12:41.8443515Z"}
+
+output: log message\n
+stream: stderr
+timestamp: 2019-04-30T02:12:41.8443515
+```
+
+### cri block
+
+The `cri` inner block enables a predefined pipeline which reads log lines using
+the CRI logging format.
+
+The `cri` block does not support any arguments or inner blocks, but is always
+empty.
+
+```river
+stage {
+	cri {}
+}
+```
+
+CRI specifies log lines as single space-delimited values with the following
+components:
+
+1) `time`: The timestamp string of the log
+2) `stream`: Either `stdout` or `stderr`
+3) `flags`: CRI flags including `F` or `P`
+4) `log`: The contents of the log line
+
+Given the following log line, the following key-value pairs would be created in
+the shared map of extracted data:
+```
+"2019-04-30T02:12:41.8443515Z stdout F message"
+
+content: message
+stream: stdout
+timestamp: 2019-04-30T02:12:41.8443515
+```
 
 ### json block
 
@@ -220,6 +290,224 @@ stage {
 	}
 }
 ```
+
+### regex block
+
+The `regex` inner block configures a processing stage that parses log lines
+using regular expressions and uses named capture groups for adding data into
+the shared extracted map of values.
+
+The following arguments are supported:
+
+Name          | Type      | Description                                                         | Default | Required
+------------- | --------- | ------------------------------------------------------------------- | ------- | --------
+`expression`  | `string`  | A valid RE2 regular expression. Each capture group must be named.   |         | yes
+`source`      | `string`  | Name from extracted data to parse. If empty, uses the log message.  | `""`    | no
+
+
+The `expression` field needs to be a Go RE2 regex string. Every capture group (re) is set into the extracted map, so it must be named like: `(?P<name>re)`. The name of the capture group is then used as the key in the extracted map.
+
+<!--
+We don't care about YAML, what does River do instead???
+
+Because of how YAML treats backslashes in double-quoted strings, note that all backslashes in a regex expression must be escaped when using double quotes. For example, all of these are valid:
+
+expression: \w*
+expression: '\w*'
+expression: "\\w*"
+But these are not:
+
+expression: \\w* (only escape backslashes when using double quotes)
+expression: '\\w*' (only escape backslashes when using double quotes)
+expression: "\w*" (backslash must be escaped)
+-->
+
+If the `source` is empty, then the stage uses attempts to parse the log line
+itself.
+
+Given the following log line and regex stage, the extracted values are:
+
+```
+2019-01-01T01:00:00.000000001Z stderr P i'm a log message!
+stage {
+  regex {
+    expression = "^(?s)(?P<time>\\S+?) (?P<stream>stdout|stderr) (?P<flags>\\S+?) (?P<content>.*)$"
+  }
+}
+
+
+time: 2019-01-01T01:00:00.000000001Z,
+stream: stderr,
+flags: P,
+content: i'm a log message
+```
+
+On the other hand, if the `source` value is set, then the regex is applied to
+the value stored in the shared map under that name.
+
+Let's see what happens when the following log line is put through this
+two-stage pipeline:
+```
+{"timestamp":"2022-01-01T01:00:00.000000001Z"}
+
+stage {
+  json {
+    expressions = { time = "timestamp" }
+  }
+}
+stage {
+  regex {
+    expression = "^(?P<year>\\d+)"
+    source     = "time"
+  }
+}
+```
+
+The first stage would add the following key-value pairs into the extracted map:
+```
+time: 2022-01-01T01:00:00.000000001Z
+```
+
+Then, the regex stage would parse the value for time from the shared values and
+append the following key-value pairs back into the extracted values map:
+```
+year: 2022
+```
+
+
+### timestamp block
+
+The `timestamp` inner block configures a processing stage that sets the
+timestamp of log entries before they're forwarded to the next component. When
+no timestamp stage is set, the log entry timestamp defaults to the time when
+the log entry was scraped.
+
+The following arguments are supported:
+
+Name                | Type           | Description                                                 | Default   | Required
+------------------- | -------------- | ----------------------------------------------------------- | --------- | --------
+`source`            | `string`       | Name from extracted values map to use for the timestamp.    |           | yes
+`format`            | `string`       | Determines how to parse the time string.                    | `""`      | yes
+`fallback_formats`  | `list(string)` | Fallback formats to try if the `format` field fails.        | `[]`      | no
+`location`          | `string`       | IANA Timezone Database location to use when parsing.        | `""`      | no
+`action_on_failure` | `string`       | What to do when the timestamp can't be extracted or parsed. | `"fudge"` | no
+
+The `source` field defines which value from the shared map of extracted values
+the stage should attempt to parse as a timestamp.
+
+The `format` field defines _how_ that source should be parsed.
+
+First off, the `format` can be set to one of the following shorthand values for
+commonly-used forms:
+```
+ANSIC: Mon Jan _2 15:04:05 2006
+UnixDate: Mon Jan _2 15:04:05 MST 2006
+RubyDate: Mon Jan 02 15:04:05 -0700 2006
+RFC822: 02 Jan 06 15:04 MST
+RFC822Z: 02 Jan 06 15:04 -0700
+RFC850: Monday, 02-Jan-06 15:04:05 MST
+RFC1123: Mon, 02 Jan 2006 15:04:05 MST
+RFC1123Z: Mon, 02 Jan 2006 15:04:05 -0700
+RFC3339: 2006-01-02T15:04:05-07:00
+RFC3339Nano: 2006-01-02T15:04:05.999999999-07:00
+
+Additionally, support for common Unix timestamps is supported with the following format values:
+Unix: 1562708916 or with fractions 1562708916.000000123
+UnixMs: 1562708916414
+UnixUs: 1562708916414123
+UnixNs: 1562708916000000123
+```
+
+Otherwise, the field accepts a custom format string that defines how an
+arbitrary reference point in history (Mon Jan 2 15:04:05 -0700 MST 2006) should
+be interpreted by the stage.
+
+The string value of the field is passed directly to the layout parameter in
+Go's [`time.Parse`](https://pkg.go.dev/time#Parse) function.
+
+If the custom format has no year component the stage uses the current year,
+according to the system's clock.
+
+The following table shows the supported reference values which should be used
+when defining a custom format.
+
+Timestamp Component | Format value 
+------------------- | --------------
+Year                | 06, 2006
+Month               | 1, 01, Jan, January
+Day                 | 2, 02, _2 (two digits right justified)
+Day of the week     | Mon, Monday
+Hour                | 3 (12-hour), 03 (12-hour zero prefixed), 15 (24-hour)
+Minute              | 4, 04
+Second              | 5, 05
+Fraction of second  | .000 (ms zero prefixed), .000000 (μs), .000000000 (ns), .999 (ms without trailing zeroes), .999999 (μs), .999999999 (ns)
+12-hour period      | pm, PM
+Timezone name       | MST
+Timezone offset     | -0700, -070000 (with seconds), -07, 07:00, -07:00:00 (with seconds)
+Timezone ISO-8601   | Z0700 (Z for UTC or time offset), Z070000, Z07, Z07:00, Z07:00:00
+
+The `fallback_formats` field allows to define one or more format fields to try
+and parse the timestamp with, if parsing with `format` fails.
+
+The `location` field must be a valid IANA Timezone Database location and
+determines in which timezone the timestamp value will be interpreted to be in.
+
+The `action_on_failure` field defines what should happen when the source field
+doesn't exist in the shared extracted map, or if the timestamp parsing fails.
+
+The supported actions are:
+
+* fudge (default): change the timestamp to the last known timestamp, summing up 1 nanosecond (to guarantee log entries ordering)
+* skip: do not change the timestamp and keep the time when the log entry has been scraped
+
+
+### output block
+
+The `output` inner block configures a processing stage that reads from the
+extracted map and changes the content of the log line that will be forwarded
+to the next component.
+
+The following arguments are supported:
+
+Name                | Type           | Description                                           | Default   | Required
+------------------- | -------------- | ----------------------------------------------------- | --------- | --------
+`source`            | `string`       | Name from extracted data to use for the log entry.    |           | yes
+
+
+Let's see how this would work for the following log line and three-stage
+pipeline
+```
+{"user": "John Doe", "message": "hello, world!"}
+
+stage {
+	json {
+		expressions = { "user" = "user", "message" = "message" }
+	}
+}
+
+stage {
+	labels {
+		values = { "user" = "user" }
+	}
+}
+
+stage {
+	output {
+		source = "message"
+	}
+}
+```
+
+The first stage will extract the following key-value pairs into the shared map:
+```
+user: John Doe
+message: hello, world!
+```
+
+Then, the second stage will add `user="John Doe"` to the label set of the log
+entry, and the final output stage will change the log line from the original
+JSON to `hello, world!`.
+
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -90,7 +90,7 @@ inner blocks.
 The `docker` inner block enables a predefined pipeline which reads log lines in
 the standard format of Docker log files.
 
-The `docker` block does not support any arguments or inner blocks, but is
+The `docker` block does not support any arguments or inner blocks, so it is
 always empty.
 
 ```river
@@ -105,8 +105,8 @@ Docker log entries are formatted as JSON with the following keys:
 * `stream`: Either `stdout` or `stderr`
 * `time`: The timestamp string of the log line
 
-Then, given the following log line, the following key-value pairs would be
-created in the shared map of extracted data:
+Given the following log line, the subsequent key-value pairs are created in the
+shared map of extracted data:
 
 ```
 {"log":"log message\n","stream":"stderr","time":"2019-04-30T02:12:41.8443515Z"}
@@ -121,7 +121,7 @@ timestamp: 2019-04-30T02:12:41.8443515
 The `cri` inner block enables a predefined pipeline which reads log lines using
 the CRI logging format.
 
-The `cri` block does not support any arguments or inner blocks, but is always
+The `cri` block does not support any arguments or inner blocks, so it is always
 empty.
 
 ```river
@@ -138,8 +138,8 @@ components:
 * `flags`: CRI flags including `F` or `P`
 * `log`: The contents of the log line
 
-Given the following log line, the following key-value pairs would be created in
-the shared map of extracted data:
+Given the following log line, the subsequent key-value pairs are created in the
+shared map of extracted data:
 ```
 "2019-04-30T02:12:41.8443515Z stdout F message"
 
@@ -328,10 +328,12 @@ expression: "\w*" (backslash must be escaped)
 If the `source` is empty, then the stage uses attempts to parse the log line
 itself.
 
-Given the following log line and regex stage, the extracted values are:
+Given the following log line and regex stage, the extracted values are shown
+below:
 
 ```
 2019-01-01T01:00:00.000000001Z stderr P i'm a log message!
+
 stage {
   regex {
     expression = "^(?s)(?P<time>\\S+?) (?P<stream>stdout|stderr) (?P<flags>\\S+?) (?P<content>.*)$"
@@ -366,13 +368,13 @@ stage {
 }
 ```
 
-The first stage would add the following key-value pairs into the extracted map:
+The first stage adds the following key-value pair into the extracted map:
 ```
 time: 2022-01-01T01:00:00.000000001Z
 ```
 
-Then, the regex stage would parse the value for time from the shared values and
-append the following key-value pairs back into the extracted values map:
+Then, the regex stage parses the value for time from the shared values and
+appends the subsequent key-value pair back into the extracted values map:
 ```
 year: 2022
 ```
@@ -413,8 +415,11 @@ RFC1123: Mon, 02 Jan 2006 15:04:05 MST
 RFC1123Z: Mon, 02 Jan 2006 15:04:05 -0700
 RFC3339: 2006-01-02T15:04:05-07:00
 RFC3339Nano: 2006-01-02T15:04:05.999999999-07:00
+```
 
-Additionally, support for common Unix timestamps is supported with the following format values:
+Additionally, support for common Unix timestamps is supported with the
+following format values:
+```
 Unix: 1562708916 or with fractions 1562708916.000000123
 UnixMs: 1562708916414
 UnixUs: 1562708916414123
@@ -428,11 +433,11 @@ be interpreted by the stage.
 The string value of the field is passed directly to the layout parameter in
 Go's [`time.Parse`](https://pkg.go.dev/time#Parse) function.
 
-If the custom format has no year component the stage uses the current year,
+If the custom format has no year component, the stage uses the current year,
 according to the system's clock.
 
-The following table shows the supported reference values which should be used
-when defining a custom format.
+The following table shows the supported reference values to use when defining a
+custom format.
 
 Timestamp Component | Format value 
 ------------------- | --------------
@@ -449,8 +454,8 @@ Timezone name       | MST
 Timezone offset     | -0700, -070000 (with seconds), -07, 07:00, -07:00:00 (with seconds)
 Timezone ISO-8601   | Z0700 (Z for UTC or time offset), Z070000, Z07, Z07:00, Z07:00:00
 
-The `fallback_formats` field allows to define one or more format fields to try
-and parse the timestamp with, if parsing with `format` fails.
+The `fallback_formats` field defines one or more format fields to try and parse
+the timestamp with, if parsing with `format` fails.
 
 The `location` field must be a valid IANA Timezone Database location and
 determines in which timezone the timestamp value is interpreted to be in.
@@ -460,11 +465,13 @@ doesn't exist in the shared extracted map, or if the timestamp parsing fails.
 
 The supported actions are:
 
-* fudge (default): change the timestamp to the last known timestamp, summing up 1 nanosecond (to guarantee log entries ordering)
-* skip: do not change the timestamp and keep the time when the log entry has been scraped
+* fudge (default): Change the timestamp to the last known timestamp, summing up
+  1 nanosecond (to guarantee log entries ordering).
+* skip: Do not change the timestamp and keep the time when the log entry was
+  scraped.
 
 The following stage fetches the `time` value from the shared values map, parses
-it as a RFC3339 format and set is as the log entry's timestamp.
+it as a RFC3339 format, and sets it as the log entry's timestamp.
 
 ```
 stage {
@@ -489,8 +496,8 @@ Name                | Type           | Description                              
 `source`            | `string`       | Name from extracted data to use for the log entry.    |           | yes
 
 
-Let's see how this would work for the following log line and three-stage
-pipeline
+Let's see how this works for the following log line and three-stage pipeline:
+
 ```
 {"user": "John Doe", "message": "hello, world!"}
 

--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -387,7 +387,7 @@ The following arguments are supported:
 Name                | Type           | Description                                                 | Default   | Required
 ------------------- | -------------- | ----------------------------------------------------------- | --------- | --------
 `source`            | `string`       | Name from extracted values map to use for the timestamp.    |           | yes
-`format`            | `string`       | Determines how to parse the time string.                    | `""`      | yes
+`format`            | `string`       | Determines how to parse the source string.                  |           | yes
 `fallback_formats`  | `list(string)` | Fallback formats to try if the `format` field fails.        | `[]`      | no
 `location`          | `string`       | IANA Timezone Database location to use when parsing.        | `""`      | no
 `action_on_failure` | `string`       | What to do when the timestamp can't be extracted or parsed. | `"fudge"` | no
@@ -450,7 +450,7 @@ The `fallback_formats` field allows to define one or more format fields to try
 and parse the timestamp with, if parsing with `format` fails.
 
 The `location` field must be a valid IANA Timezone Database location and
-determines in which timezone the timestamp value will be interpreted to be in.
+determines in which timezone the timestamp value is interpreted to be in.
 
 The `action_on_failure` field defines what should happen when the source field
 doesn't exist in the shared extracted map, or if the timestamp parsing fails.
@@ -460,11 +460,23 @@ The supported actions are:
 * fudge (default): change the timestamp to the last known timestamp, summing up 1 nanosecond (to guarantee log entries ordering)
 * skip: do not change the timestamp and keep the time when the log entry has been scraped
 
+The following stage fetches the `time` value from the shared values map, parses
+it as a RFC3339 format and set is as the log entry's timestamp.
+
+```
+stage {
+	timestamp {
+		source = "time"
+		format = "RFC3339"
+	}
+}
+```
+
 
 ### output block
 
 The `output` inner block configures a processing stage that reads from the
-extracted map and changes the content of the log line that will be forwarded
+extracted map and changes the content of the log entry that is forwarded
 to the next component.
 
 The following arguments are supported:
@@ -498,14 +510,14 @@ stage {
 }
 ```
 
-The first stage will extract the following key-value pairs into the shared map:
+The first stage extracts the following key-value pairs into the shared map:
 ```
 user: John Doe
 message: hello, world!
 ```
 
-Then, the second stage will add `user="John Doe"` to the label set of the log
-entry, and the final output stage will change the log line from the original
+Then, the second stage adds `user="John Doe"` to the label set of the log
+entry, and the final output stage changes the log line from the original
 JSON to `hello, world!`.
 
 

--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -427,8 +427,8 @@ UnixNs: 1562708916000000123
 ```
 
 Otherwise, the field accepts a custom format string that defines how an
-arbitrary reference point in history (Mon Jan 2 15:04:05 -0700 MST 2006) should
-be interpreted by the stage.
+arbitrary reference point in history should
+be interpreted by the stage. The arbitrary reference point is Mon Jan 2 15:04:05 -0700 MST 2006.
 
 The string value of the field is passed directly to the layout parameter in
 Go's [`time.Parse`](https://pkg.go.dev/time#Parse) function.


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR updates `loki.process` to port over some more Promtail stages, namely the `regex`, `timestamp` and `output` processing stages.

These stages are used to construct the pre-defined `docker` and `cri` stages which are syntactic sugar for pre-defined pipelines around the two formats.

#### Which issue(s) this PR fixes
Updates #2515

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated (add a changelog entry when all stages are ported over?)
- [X] Documentation added
- [X] Tests updated
