### PR TITLE
Spartan0x117/update build image versions

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -342,6 +342,6 @@ get:
 
 ---
 kind: signature
-hmac: bc08fc1da9ef0f0f5c88519ec5cfcb352657cc876a52ebbe748c5f3429f613f2
+hmac: 775235d2ab8a1ff11990f693c0f3dd528728a23bb9a598481113362d686dad2b
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -82,7 +82,7 @@ trigger:
 
 steps:
   - name: lint
-    image: grafana/agent-build-image:0.17.0
+    image: grafana/agent-build-image:0.19.0
     commands:
       - make lint
 
@@ -105,7 +105,7 @@ trigger:
 
 steps:
   - name: test
-    image: grafana/agent-build-image:0.17.0
+    image: grafana/agent-build-image:0.19.0
     volumes:
       - name: docker
         path: /var/run/docker.sock
@@ -142,7 +142,7 @@ trigger:
     - refs/tags/v*
 steps:
   - name: test
-    image: grafana/agent-build-image:0.17.0-windows
+    image: grafana/agent-build-image:0.19.0-windows
     commands:
       - go test -tags="nodocker,nonetwork" ./...
 
@@ -160,7 +160,7 @@ trigger:
     - refs/heads/dev.*
 steps:
   - name: Build Containers
-    image: grafana/agent-build-image:0.17.0
+    image: grafana/agent-build-image:0.19.0
     volumes:
       - name: docker
         path: /var/run/docker.sock
@@ -263,7 +263,7 @@ trigger:
 
 steps:
   - name: create-release
-    image: grafana/agent-build-image:0.17.0
+    image: grafana/agent-build-image:0.19.0
     volumes:
       - name: docker
         path: /var/run/docker.sock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,6 @@ Main (unreleased)
 
 - Use Go 1.19.4 for builds. (@erikbaranowski)
 
-- Update `agent-build-image` version to `0.19.0`. (@spartan0x117)
-
 v0.30.1 (2022-12-23)
 --------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ Main (unreleased)
 
 - Use Go 1.19.4 for builds. (@erikbaranowski)
 
+- Update `agent-build-image` version to `0.19.0`. (@spartan0x117)
+
 v0.30.1 (2022-12-23)
 --------------------
 

--- a/cmd/grafana-agent-operator/Dockerfile
+++ b/cmd/grafana-agent-operator/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.17.0 as build
+FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.19.0 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/cmd/grafana-agent/Dockerfile
+++ b/cmd/grafana-agent/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.17.0 as build
+FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.19.0 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/cmd/grafana-agentctl/Dockerfile
+++ b/cmd/grafana-agentctl/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.17.0 as build
+FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.19.0 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/tools/crow/Dockerfile
+++ b/tools/crow/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.17.0 as build
+FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.19.0 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/tools/make/build-container.mk
+++ b/tools/make/build-container.mk
@@ -34,7 +34,7 @@
 # variable names should be passed through to the container.
 
 USE_CONTAINER ?= 0
-BUILD_IMAGE   ?= grafana/agent-build-image:0.17.0
+BUILD_IMAGE   ?= grafana/agent-build-image:0.19.0
 DOCKER_OPTS   ?= -it
 
 #

--- a/tools/smoke/Dockerfile
+++ b/tools/smoke/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.17.0 as build
+FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.19.0 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Bumps all instances of `agent-build-image` to `0.19.0`

- [X] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
