### PR TITLE
Fix flaky TestScrapeLoop in phlare.scrape

### DIFF
--- a/component/phlare/scrape/scrape_loop_test.go
+++ b/component/phlare/scrape/scrape_loop_test.go
@@ -155,6 +155,12 @@ func TestScrapeLoop(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	down := atomic.NewBool(false)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The test was failing on Windows, as the scrape loop was too fast for
+		// the Windows timer resolution.
+		// This used to lead the `t.lastScrapeDuration = time.Since(start)` to
+		// be recorded as zero. The small delay here allows the timer to record
+		// the time since the last scrape properly.
+		time.Sleep(2 * time.Millisecond)
 		if down.Load() {
 			w.WriteHeader(http.StatusInternalServerError)
 		}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR adds a small delay in the httptest server in use by the scrape loop in `TestScrapeLoop` to fix a test that is flaky on Windows.

I've added a new Drone step to run this test 1000 times to verify this fixes the flakiness; I'll remove it if it works.

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer
Nothing for now.

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [X] Tests updated
