### PR TITLE
Update publishing workflows to use PATs with fine-grained access control (#2684)

### DIFF
--- a/.github/workflows/publish-documentation-next.yml
+++ b/.github/workflows/publish-documentation-next.yml
@@ -27,7 +27,9 @@ jobs:
       uses: actions/checkout@v3
 
     - name: "Clone website-sync Action"
-      run: git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync
+      # WEBSITE_SYNC_AGENT is a fine-grained GitHub Personal Access Token that expires.
+      # It must be updated in the grafanabot GitHub account.
+      run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_AGENT }}@github.com/grafana/website-sync ./.github/actions/website-sync"
 
     - name: "Publish to website repository (next)"
       uses: ./.github/actions/website-sync
@@ -36,7 +38,9 @@ jobs:
         repository: grafana/website
         branch: master
         host: github.com
-        github_pat: '${{ secrets.GH_BOT_ACCESS_TOKEN }}'
+        # PUBLISH_TO_WEBSITE_AGENT is a fine-grained GitHub Personal Access Token that expires.
+        # It must be updated in the grafanabot GitHub account.
+        github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_AGENT }}"
         source_folder: docs/sources
         target_folder: 'content/docs/agent/next'
     - shell: bash

--- a/.github/workflows/publish-documentation-versioned.yml
+++ b/.github/workflows/publish-documentation-versioned.yml
@@ -55,7 +55,9 @@ jobs:
 
     - name: "Clone website-sync Action"
       if: "steps.has-matching-release-tag.outputs.bool == 'true'"
-      run: git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync
+      # WEBSITE_SYNC_AGENT is a fine-grained GitHub Personal Access Token that expires.
+      # It must be updated in the grafanabot GitHub account.
+      run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_AGENT }}@github.com/grafana/website-sync ./.github/actions/website-sync"
 
     - name: "Publish to website repository (release)"
       if: "steps.has-matching-release-tag.outputs.bool == 'true'"
@@ -65,7 +67,9 @@ jobs:
         repository: grafana/website
         branch: master
         host: github.com
-        github_pat: '${{ secrets.GH_BOT_ACCESS_TOKEN }}'
+        # PUBLISH_TO_WEBSITE_AGENT is a fine-grained GitHub Personal Access Token that expires.
+        # It must be updated in the grafanabot GitHub account.
+        github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_AGENT }}"
         source_folder: docs/sources
         target_folder: 'content/docs/agent/${{ steps.target.outputs.target }}'
     - shell: bash


### PR DESCRIPTION
(cherry picked from commit 68ac5a9b7f9d567f045380ff6a9b7cb0bdc60e61)
Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
