### PR TITLE
Flow: drop unqueued logs after 5 seconds when stopping tailer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ Main (unreleased)
   metrics, which could lead to relabel rules applying incorrectly on subsequent
   relabels. (@rfratto)
 
+- Flow: `loki.source.file` will no longer deadlock other components if log
+  lines are unable to be sent to Loki. `loki.source.file` will wait for 5
+  seconds per file to finish flushing read logs to the client, after which it
+  will drop them, resulting in losing logs. (@rfratto)
+
 ### Other changes
 
 - Use Go 1.19.4 for builds. (@erikbaranowski)

--- a/component/common/loki/types.go
+++ b/component/common/loki/types.go
@@ -5,13 +5,23 @@ package loki
 // to relabeling, stages and finally batched in a client to be written to Loki.
 
 import (
+	"context"
 	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/loki/pkg/logproto"
 )
+
+// finalEntryTimeout is how long NewEntryMutatorHandler will wait before giving
+// up on sending the final log entry. If this timeout is reached, the final log
+// entry is permanently lost.
+//
+// This timeout can only be reached if the loki.write client is backlogged due
+// to an outage or erroring (such as limits being hit).
+const finalEntryTimeout = 5 * time.Second
 
 // LogsReceiver is an alias for chan Entry which is used for component
 // communication.
@@ -77,17 +87,53 @@ func NewEntryHandler(entries chan<- Entry, stop func()) EntryHandler {
 
 // NewEntryMutatorHandler creates a EntryHandler that mutates incoming entries from another EntryHandler.
 func NewEntryMutatorHandler(next EntryHandler, f EntryMutatorFunc) EntryHandler {
-	in, wg, once := make(chan Entry), sync.WaitGroup{}, sync.Once{}
-	nextChan := next.Chan()
+	var (
+		ctx, cancel = context.WithCancel(context.Background())
+
+		in       = make(chan Entry)
+		nextChan = next.Chan()
+	)
+
+	var wg sync.WaitGroup
 	wg.Add(1)
+
 	go func() {
 		defer wg.Done()
+		defer cancel()
+
 		for e := range in {
-			nextChan <- f(e)
+			select {
+			case <-ctx.Done():
+				// This is a hard stop to the reading goroutine. Anything not forwarded
+				// to nextChan at this point will probably be permanently lost, since
+				// the positions file has likely already updated to a byte offset past
+				// the read entry.
+				//
+				// TODO(rfratto): revisit whether this logic is necessary after we have
+				// a WAL for logs.
+				return
+			case nextChan <- f(e):
+				// no-op; log entry has been queued for sending.
+			}
 		}
 	}()
+
+	var closeOnce sync.Once
 	return NewEntryHandler(in, func() {
-		once.Do(func() { close(in) })
+		closeOnce.Do(func() {
+			close(in)
+
+			select {
+			case <-ctx.Done():
+				// The goroutine above exited on its own so we don't have to wait for
+				// the timeout.
+			case <-time.After(finalEntryTimeout):
+				// We reached the timeout for sending the final entry to nextChan;
+				// request a hard stop from the reading goroutine.
+				cancel()
+			}
+		})
+
 		wg.Wait()
 	})
 }


### PR DESCRIPTION
Fix an issue where being unable to send logs to `loki.write` due to the client being permanently backlogged would deadlock the Flow controller.

The `loki.write` client may be permanently backlogged when:

* Limits are reached when sending logs to Loki, leading to endless request retries.
* Loki has an extended outage.

When an EntryHandler is stopped, it will wait for 5 seconds before forcibly stopping the goroutine which queues log entries. If this timeout is reached, any unqueued log entries are permanently lost, as the positions file will likely be updated past the point where the entry was read.

While losing logs is not ideal, it's unacceptable for any Flow component to be able to block the controller. This is a short-term solution to allow the Flow controller to continue working properly. A long term solution would be to use a Write-Ahead Log (WAL) for log entries. See grafana/loki#7993.

Fixes #2716.
Related to grafana/loki#2361.