### PR TITLE
Flow: add otelcol.exporter.loki component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ Main (unreleased)
   - `loki.source.windowsevent` reads logs from Windows Event Log. (@mattdurham)
   - `loki.source.syslog` listens for Syslog messages over TCP and UDP
     connections and forwards them to other `loki` components. (@tpaschalis)
+  - `otelcol.exporter.loki` forwards OTLP-formatted data to compatible `loki`
+    receivers. (@tpaschalis)
+
 
 - Flow components which work with relabeling rules (`discovery.relabel`,
   `prometheus.relabel` and `loki.relabel`) now export a new value named Rules.

--- a/component/all/all.go
+++ b/component/all/all.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/grafana/agent/component/otelcol/auth/basic"                   // Import otelcol.auth.basic
 	_ "github.com/grafana/agent/component/otelcol/auth/bearer"                  // Import otelcol.auth.bearer
 	_ "github.com/grafana/agent/component/otelcol/auth/headers"                 // Import otelcol.auth.headers
+	_ "github.com/grafana/agent/component/otelcol/exporter/loki"                // Import otelcol.exporter.loki
 	_ "github.com/grafana/agent/component/otelcol/exporter/otlp"                // Import otelcol.exporter.otlp
 	_ "github.com/grafana/agent/component/otelcol/exporter/otlphttp"            // Import otelcol.exporter.otlphttp
 	_ "github.com/grafana/agent/component/otelcol/exporter/prometheus"          // Import otelcol.exporter.prometheus

--- a/component/otelcol/exporter/loki/internal/convert/convert.go
+++ b/component/otelcol/exporter/loki/internal/convert/convert.go
@@ -1,0 +1,189 @@
+// Package convert implements conversion utilities to convert between
+// OpenTelemetry Collector and Loki data.
+//
+// It follows the [OpenTelemetry Logs Data Model] and the [loki translator]
+// package for implementing the conversion.
+//
+// [OpenTelemetry Logs Data Model]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md
+// [loki translator]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/translator/loki
+package convert
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+// Converter implements consumer.Logs and converts received OTel logs into
+// Loki-compatible log entries.
+type Converter struct {
+	log     log.Logger
+	metrics *metrics
+
+	mut  sync.RWMutex
+	next []loki.LogsReceiver // Location to write converted logs.
+}
+
+var _ consumer.Logs = (*Converter)(nil)
+
+// New returns a new Converter. Converted logs are passed to the provided list
+// of LogsReceivers.
+func New(l log.Logger, r prometheus.Registerer, next []loki.LogsReceiver) *Converter {
+	if l == nil {
+		l = log.NewNopLogger()
+	}
+	m := newMetrics(r)
+	return &Converter{log: l, metrics: m, next: next}
+}
+
+// Capabilities implements consumer.Logs.
+func (conv *Converter) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{
+		MutatesData: false,
+	}
+}
+
+// ConsumeLogs converts the provided OpenTelemetry Collector-formatted logs
+// into Loki-compatible entries. Each call to ConsumeLogs will forward
+// converted entries to the list of channels in the `next` field.
+// This is reusing the logic from the OpenTelemetry Collector "contrib"
+// distribution and its LogsToLokiRequests function.
+func (conv *Converter) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
+	var entries []loki.Entry
+
+	rls := ld.ResourceLogs()
+	for i := 0; i < rls.Len(); i++ {
+		ills := rls.At(i).ScopeLogs()
+		for j := 0; j < ills.Len(); j++ {
+			logs := ills.At(j).LogRecords()
+			for k := 0; k < logs.Len(); k++ {
+				conv.metrics.entriesTotal.Inc()
+
+				log := plog.NewLogRecord()
+				logs.At(k).CopyTo(log)
+
+				// we may remove resources, so we make a copy and change our version
+				resource := pcommon.NewResource()
+				rls.At(i).Resource().CopyTo(resource)
+
+				// adds level attribute from log.severityNumber
+				addLogLevelAttributeAndHint(log)
+
+				// TODO (@tpaschalis) If we want to pre-populate a tenant
+				// label from the OTel hint, it should happen here. with the
+				// upstream getTenantFromTenantHint helper.
+
+				format := getFormatFromFormatHint(log.Attributes(), resource.Attributes())
+
+				mergedLabels := convertAttributesAndMerge(log.Attributes(), resource.Attributes())
+				// remove the attributes that were promoted to labels
+				removeAttributes(log.Attributes(), mergedLabels)
+				removeAttributes(resource.Attributes(), mergedLabels)
+
+				entry, err := convertLogToLokiEntry(log, resource, format)
+				if err != nil {
+					level.Error(conv.log).Log("msg", "failed to convert log to loki entry", "err", err)
+					conv.metrics.entriesFailed.Inc()
+					continue
+				}
+
+				conv.metrics.entriesProcessed.Inc()
+				entries = append(entries, loki.Entry{
+					Labels: mergedLabels,
+					Entry:  *entry,
+				})
+			}
+		}
+	}
+
+	for _, entry := range entries {
+		conv.mut.RLock()
+		for _, receiver := range conv.next {
+			select {
+			case <-ctx.Done():
+				return nil
+			case receiver <- entry:
+				// no-op, send the entry along
+			}
+		}
+		conv.mut.RUnlock()
+	}
+	return nil
+}
+
+// UpdateFanout sets the locations the converter forwards log entries to.
+func (conv *Converter) UpdateFanout(fanout []loki.LogsReceiver) {
+	conv.mut.Lock()
+	defer conv.mut.Unlock()
+
+	conv.next = fanout
+}
+
+func addLogLevelAttributeAndHint(log plog.LogRecord) {
+	if log.SeverityNumber() == plog.SeverityNumberUnspecified {
+		return
+	}
+	addHint(log)
+	if _, found := log.Attributes().Get(levelAttributeName); !found {
+		level := severityNumberToLevel[log.SeverityNumber().String()]
+		log.Attributes().PutStr(levelAttributeName, level)
+	}
+}
+
+func addHint(log plog.LogRecord) {
+	if value, found := log.Attributes().Get(hintAttributes); found && !strings.Contains(value.AsString(), levelAttributeName) {
+		log.Attributes().PutStr(hintAttributes, fmt.Sprintf("%s,%s", value.AsString(), levelAttributeName))
+	} else {
+		log.Attributes().PutStr(hintAttributes, levelAttributeName)
+	}
+}
+
+var severityNumberToLevel = map[string]string{
+	plog.SeverityNumberUnspecified.String(): "UNSPECIFIED",
+	plog.SeverityNumberTrace.String():       "TRACE",
+	plog.SeverityNumberTrace2.String():      "TRACE2",
+	plog.SeverityNumberTrace3.String():      "TRACE3",
+	plog.SeverityNumberTrace4.String():      "TRACE4",
+	plog.SeverityNumberDebug.String():       "DEBUG",
+	plog.SeverityNumberDebug2.String():      "DEBUG2",
+	plog.SeverityNumberDebug3.String():      "DEBUG3",
+	plog.SeverityNumberDebug4.String():      "DEBUG4",
+	plog.SeverityNumberInfo.String():        "INFO",
+	plog.SeverityNumberInfo2.String():       "INFO2",
+	plog.SeverityNumberInfo3.String():       "INFO3",
+	plog.SeverityNumberInfo4.String():       "INFO4",
+	plog.SeverityNumberWarn.String():        "WARN",
+	plog.SeverityNumberWarn2.String():       "WARN2",
+	plog.SeverityNumberWarn3.String():       "WARN3",
+	plog.SeverityNumberWarn4.String():       "WARN4",
+	plog.SeverityNumberError.String():       "ERROR",
+	plog.SeverityNumberError2.String():      "ERROR2",
+	plog.SeverityNumberError3.String():      "ERROR3",
+	plog.SeverityNumberError4.String():      "ERROR4",
+	plog.SeverityNumberFatal.String():       "FATAL",
+	plog.SeverityNumberFatal2.String():      "FATAL2",
+	plog.SeverityNumberFatal3.String():      "FATAL3",
+	plog.SeverityNumberFatal4.String():      "FATAL4",
+}
+
+func getFormatFromFormatHint(logAttr pcommon.Map, resourceAttr pcommon.Map) string {
+	format := formatJSON
+	formatVal, found := resourceAttr.Get(hintFormat)
+	if !found {
+		formatVal, found = logAttr.Get(hintFormat)
+	}
+
+	if found {
+		format = formatVal.AsString()
+	}
+	return format
+}

--- a/component/otelcol/exporter/loki/internal/convert/convert.go
+++ b/component/otelcol/exporter/loki/internal/convert/convert.go
@@ -68,10 +68,13 @@ func (conv *Converter) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 			for k := 0; k < logs.Len(); k++ {
 				conv.metrics.entriesTotal.Inc()
 
+				// we may remove attributes, so to avoid mutating the original
+				// log entry, we make our own copy and change that instead.
 				log := plog.NewLogRecord()
 				logs.At(k).CopyTo(log)
 
-				// we may remove resources, so we make a copy and change our version
+				// similarly, we may remove resources, so to avoid mutating the
+				// original log entry, we make and use our own copy instead.
 				resource := pcommon.NewResource()
 				rls.At(i).Resource().CopyTo(resource)
 

--- a/component/otelcol/exporter/loki/internal/convert/convert_loki.go
+++ b/component/otelcol/exporter/loki/internal/convert/convert_loki.go
@@ -1,0 +1,175 @@
+package convert
+
+// This file is a near copy of
+// https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.63.0/pkg/translator/loki/convert.go
+//
+// A copy was made because the upstream package contains some unexported
+// definitions. If they're ever made public, our copy can be removed.
+//
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki"
+	"github.com/prometheus/common/model"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+const (
+	hintAttributes     = "loki.attribute.labels"
+	hintResources      = "loki.resource.labels"
+	hintTenant         = "loki.tenant"
+	hintFormat         = "loki.format"
+	levelAttributeName = "level"
+)
+
+const (
+	formatJSON   string = "json"
+	formatLogfmt string = "logfmt"
+)
+
+var defaultExporterLabels = model.LabelSet{"exporter": "OTLP"}
+var timeNow = time.Now
+
+func convertAttributesAndMerge(logAttrs pcommon.Map, resAttrs pcommon.Map) model.LabelSet {
+	out := defaultExporterLabels
+
+	if resourcesToLabel, found := resAttrs.Get(hintResources); found {
+		labels := convertAttributesToLabels(resAttrs, resourcesToLabel)
+		out = out.Merge(labels)
+	}
+
+	// get the hint from the log attributes, not from the resource
+	// the value can be a single resource name to use as label
+	// or a slice of string values
+	if resourcesToLabel, found := logAttrs.Get(hintResources); found {
+		labels := convertAttributesToLabels(resAttrs, resourcesToLabel)
+		out = out.Merge(labels)
+	}
+
+	if attributesToLabel, found := logAttrs.Get(hintAttributes); found {
+		labels := convertAttributesToLabels(logAttrs, attributesToLabel)
+		out = out.Merge(labels)
+	}
+
+	// get tenant hint from resource attributes, fallback to record attributes
+	// if it is not found
+	if resourcesToLabel, found := resAttrs.Get(hintTenant); !found {
+		if attributesToLabel, found := logAttrs.Get(hintTenant); found {
+			labels := convertAttributesToLabels(logAttrs, attributesToLabel)
+			out = out.Merge(labels)
+		}
+	} else {
+		labels := convertAttributesToLabels(resAttrs, resourcesToLabel)
+		out = out.Merge(labels)
+	}
+
+	return out
+}
+
+func convertAttributesToLabels(attributes pcommon.Map, attrsToSelect pcommon.Value) model.LabelSet {
+	out := model.LabelSet{}
+
+	attrs := parseAttributeNames(attrsToSelect)
+	for _, attr := range attrs {
+		attr = strings.TrimSpace(attr)
+		av, ok := attributes.Get(attr) // do we need to trim this?
+		if ok {
+			out[model.LabelName(attr)] = model.LabelValue(av.AsString())
+		}
+	}
+
+	return out
+}
+
+func parseAttributeNames(attrsToSelect pcommon.Value) []string {
+	var out []string
+
+	switch attrsToSelect.Type() {
+	case pcommon.ValueTypeStr:
+		out = strings.Split(attrsToSelect.AsString(), ",")
+	case pcommon.ValueTypeSlice:
+		as := attrsToSelect.Slice().AsRaw()
+		for _, a := range as {
+			out = append(out, fmt.Sprintf("%v", a))
+		}
+	default:
+		// trying to make the most of bad data
+		out = append(out, attrsToSelect.AsString())
+	}
+
+	return out
+}
+
+func removeAttributes(attrs pcommon.Map, labels model.LabelSet) {
+	attrs.RemoveIf(func(s string, v pcommon.Value) bool {
+		if s == hintAttributes || s == hintResources || s == hintTenant || s == hintFormat {
+			return true
+		}
+
+		_, exists := labels[model.LabelName(s)]
+		return exists
+	})
+}
+
+func convertLogToJSONEntry(lr plog.LogRecord, res pcommon.Resource) (*logproto.Entry, error) {
+	line, err := loki.Encode(lr, res)
+	if err != nil {
+		return nil, err
+	}
+	return &logproto.Entry{
+		Timestamp: timestampFromLogRecord(lr),
+		Line:      line,
+	}, nil
+}
+
+func convertLogToLogfmtEntry(lr plog.LogRecord, res pcommon.Resource) (*logproto.Entry, error) {
+	line, err := loki.EncodeLogfmt(lr, res)
+	if err != nil {
+		return nil, err
+	}
+	return &logproto.Entry{
+		Timestamp: timestampFromLogRecord(lr),
+		Line:      line,
+	}, nil
+}
+
+func convertLogToLokiEntry(lr plog.LogRecord, res pcommon.Resource, format string) (*logproto.Entry, error) {
+	switch format {
+	case formatJSON:
+		return convertLogToJSONEntry(lr, res)
+	case formatLogfmt:
+		return convertLogToLogfmtEntry(lr, res)
+	default:
+		return nil, fmt.Errorf("invalid format %s. Expected one of: %s, %s", format, formatJSON, formatLogfmt)
+	}
+}
+
+func timestampFromLogRecord(lr plog.LogRecord) time.Time {
+	if lr.Timestamp() != 0 {
+		return time.Unix(0, int64(lr.Timestamp()))
+	}
+
+	if lr.ObservedTimestamp() != 0 {
+		return time.Unix(0, int64(lr.ObservedTimestamp()))
+	}
+
+	return time.Unix(0, int64(pcommon.NewTimestampFromTime(timeNow())))
+}

--- a/component/otelcol/exporter/loki/internal/convert/convert_test.go
+++ b/component/otelcol/exporter/loki/internal/convert/convert_test.go
@@ -1,0 +1,481 @@
+package convert_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/agent/component/otelcol/exporter/loki/internal/convert"
+	"github.com/grafana/agent/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func TestConverter(t *testing.T) {
+	tt := []struct {
+		name            string
+		input           string
+		expectLine      string
+		expectLabels    string
+		expectTimestamp time.Time
+	}{
+		{
+			name: "log line without format hint",
+			input: `{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "testHost"
+            }
+          }
+        ],
+        "droppedAttributesCount": 1
+      },
+      "scopeLogs": [
+        {
+          "scope": {
+            "name": "name",
+            "version": "version",
+            "droppedAttributesCount": 1
+          },
+          "logRecords": [
+            {
+              "timeUnixNano": "1672827031972869000",
+              "observedTimeUnixNano": "1672827031972869000",
+              "severityNumber": 17,
+              "severityText": "Error",
+              "body": {
+                "stringValue": "hello world"
+              },
+              "attributes": [
+                {
+                  "key": "sdkVersion",
+                  "value": {
+                    "stringValue": "1.0.1"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 1,
+              "traceId": "0102030405060708090a0b0c0d0e0f10",
+              "spanId": "1112131415161718"
+            }
+          ],
+          "schemaUrl": "ScopeLogsSchemaURL"
+        }
+      ],
+      "schemaUrl": "testSchemaURL"
+    }
+  ]
+}`,
+			expectLine:      `{"body":"hello world","traceid":"0102030405060708090a0b0c0d0e0f10","spanid":"1112131415161718","severity":"Error","attributes":{"sdkVersion":"1.0.1"},"resources":{"host.name":"testHost"}}`,
+			expectLabels:    `{exporter="OTLP", level="ERROR"}`,
+			expectTimestamp: time.Date(2023, time.January, 4, 12, 10, 31, 972869000, time.Local),
+		},
+		{
+			name: "log line with logfmt format hint in resource attributes",
+			input: `{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "testHost"
+            }
+          },
+          {
+            "key": "loki.format",
+            "value": {
+              "stringValue": "logfmt"
+            }
+          }
+        ],
+        "droppedAttributesCount": 1
+      },
+      "scopeLogs": [
+        {
+          "scope": {
+            "name": "name",
+            "version": "version",
+            "droppedAttributesCount": 1
+          },
+          "logRecords": [
+            {
+              "timeUnixNano": "1672827031972869000",
+              "observedTimeUnixNano": "1672827031972869000",
+              "severityNumber": 17,
+              "severityText": "Error",
+              "body": {
+                "stringValue": "msg=\"hello world\""
+              },
+              "attributes": [
+                {
+                  "key": "sdkVersion",
+                  "value": {
+                    "stringValue": "1.0.1"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 1,
+              "traceId": "0102030405060708090a0b0c0d0e0f10",
+              "spanId": "1112131415161718"
+            }
+          ],
+          "schemaUrl": "ScopeLogsSchemaURL"
+        }
+      ],
+      "schemaUrl": "testSchemaURL"
+    }
+  ]
+}`,
+			expectLine:      `msg="hello world" traceID=0102030405060708090a0b0c0d0e0f10 spanID=1112131415161718 severity=Error attribute_sdkVersion=1.0.1 resource_host.name=testHost`,
+			expectLabels:    `{exporter="OTLP", level="ERROR"}`,
+			expectTimestamp: time.Date(2023, time.January, 4, 12, 10, 31, 972869000, time.Local),
+		},
+		{
+			name: "log line with logfmt format hint in log attributes",
+			input: `{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "testHost"
+            }
+          }
+        ],
+        "droppedAttributesCount": 1
+      },
+      "scopeLogs": [
+        {
+          "scope": {
+            "name": "name",
+            "version": "version",
+            "droppedAttributesCount": 1
+          },
+          "logRecords": [
+            {
+              "timeUnixNano": "1672827031972869000",
+              "observedTimeUnixNano": "1672827031972869000",
+              "severityNumber": 17,
+              "severityText": "Error",
+              "body": {
+                "stringValue": "msg=\"hello world\""
+              },
+              "attributes": [
+                {
+                  "key": "sdkVersion",
+                  "value": {
+                    "stringValue": "1.0.1"
+                  }
+                },
+                {
+                  "key": "loki.format",
+                  "value": {
+                    "stringValue": "logfmt"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 1,
+              "traceId": "0102030405060708090a0b0c0d0e0f10",
+              "spanId": "1112131415161718"
+            }
+          ],
+          "schemaUrl": "ScopeLogsSchemaURL"
+        }
+      ],
+      "schemaUrl": "testSchemaURL"
+    }
+  ]
+}`,
+			expectLine:      `msg="hello world" traceID=0102030405060708090a0b0c0d0e0f10 spanID=1112131415161718 severity=Error attribute_sdkVersion=1.0.1 resource_host.name=testHost`,
+			expectLabels:    `{exporter="OTLP", level="ERROR"}`,
+			expectTimestamp: time.Date(2023, time.January, 4, 12, 10, 31, 972869000, time.Local),
+		},
+		{
+			name: "resource attributes converted to labels",
+			input: `{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "testHost"
+            }
+          },
+		  {
+		    "key": "loki.resource.labels",
+			"value": {
+			  "stringValue": "mylabel_1,mylabel_2"
+			}
+		  },
+		  {
+		    "key": "mylabel_1",
+			"value": {
+			  "stringValue": "value_1"
+			}
+		  },
+		  {
+		    "key": "mylabel_2",
+			"value": {
+			  "intValue": "42"
+			}
+		  },
+		  {
+		    "key": "mylabel_3",
+			"value": {
+			  "stringValue": "value_3"
+			}
+		  }
+        ],
+        "droppedAttributesCount": 1
+      },
+      "scopeLogs": [
+        {
+          "scope": {
+            "name": "name",
+            "version": "version",
+            "droppedAttributesCount": 1
+          },
+          "logRecords": [
+            {
+              "timeUnixNano": "1672827031972869000",
+              "observedTimeUnixNano": "1672827031972869000",
+              "severityNumber": 17,
+              "severityText": "Error",
+              "body": {
+                "stringValue": "msg=\"hello world\""
+              },
+              "attributes": [
+                {
+                  "key": "sdkVersion",
+                  "value": {
+                    "stringValue": "1.0.1"
+                  }
+                },
+                {
+                  "key": "loki.format",
+                  "value": {
+                    "stringValue": "logfmt"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 1,
+              "traceId": "0102030405060708090a0b0c0d0e0f10",
+              "spanId": "1112131415161718"
+            }
+          ],
+          "schemaUrl": "ScopeLogsSchemaURL"
+        }
+      ],
+      "schemaUrl": "testSchemaURL"
+    }
+  ]
+}`,
+			expectLine:      `msg="hello world" traceID=0102030405060708090a0b0c0d0e0f10 spanID=1112131415161718 severity=Error attribute_sdkVersion=1.0.1 resource_host.name=testHost resource_mylabel_3=value_3`,
+			expectLabels:    `{exporter="OTLP", level="ERROR", mylabel_1="value_1", mylabel_2="42"}`,
+			expectTimestamp: time.Date(2023, time.January, 4, 12, 10, 31, 972869000, time.Local),
+		},
+		{
+			name: "log attributes converted to labels",
+			input: `{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "testHost"
+            }
+          }
+        ],
+        "droppedAttributesCount": 1
+      },
+      "scopeLogs": [
+        {
+          "scope": {
+            "name": "name",
+            "version": "version",
+            "droppedAttributesCount": 1
+          },
+          "logRecords": [
+            {
+              "timeUnixNano": "1672827031972869000",
+              "observedTimeUnixNano": "1672827031972869000",
+              "severityNumber": 17,
+              "severityText": "Error",
+              "body": {
+                "stringValue": "msg=\"hello world\""
+              },
+              "attributes": [
+                {
+                  "key": "sdkVersion",
+                  "value": {
+                    "stringValue": "1.0.1"
+                  }
+                },
+                {
+                  "key": "loki.format",
+                  "value": {
+                    "stringValue": "logfmt"
+                  }
+                },
+		        {
+		          "key": "loki.attribute.labels",
+		          "value": {
+		            "stringValue": "mylabel_1,mylabel_2"
+		          }
+		        },
+		        {
+		          "key": "mylabel_1",
+		          "value": {
+		            "stringValue": "value_1"
+		          }
+		        },
+		        {
+		          "key": "mylabel_2",
+		          "value": {
+		            "intValue": "42"
+		          }
+		        },
+		        {
+		          "key": "mylabel_3",
+		          "value": {
+		            "stringValue": "value_3"
+		          }
+		        }
+              ],
+              "droppedAttributesCount": 1,
+              "traceId": "0102030405060708090a0b0c0d0e0f10",
+              "spanId": "1112131415161718"
+            }
+          ],
+          "schemaUrl": "ScopeLogsSchemaURL"
+        }
+      ],
+      "schemaUrl": "testSchemaURL"
+    }
+  ]
+}`,
+			expectLine:      `msg="hello world" traceID=0102030405060708090a0b0c0d0e0f10 spanID=1112131415161718 severity=Error attribute_sdkVersion=1.0.1 attribute_mylabel_3=value_3 resource_host.name=testHost`,
+			expectLabels:    `{exporter="OTLP", level="ERROR", mylabel_1="value_1", mylabel_2="42"}`,
+			expectTimestamp: time.Date(2023, time.January, 4, 12, 10, 31, 972869000, time.Local),
+		},
+		{
+			name: "tenant resource attribute converted to label",
+			input: `{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "testHost"
+            }
+          }
+        ],
+        "droppedAttributesCount": 1
+      },
+      "scopeLogs": [
+        {
+          "scope": {
+            "name": "name",
+            "version": "version",
+            "droppedAttributesCount": 1
+          },
+          "logRecords": [
+            {
+              "timeUnixNano": "1672827031972869000",
+              "observedTimeUnixNano": "1672827031972869000",
+              "severityNumber": 17,
+              "severityText": "Error",
+              "body": {
+                "stringValue": "hello world"
+              },
+              "attributes": [
+                {
+                  "key": "sdkVersion",
+                  "value": {
+                    "stringValue": "1.0.1"
+                  }
+                },
+                {
+                  "key": "loki.format",
+                  "value": {
+                    "stringValue": "json"
+                  }
+                },
+                {
+                  "key": "loki.tenant",
+                  "value": {
+                    "stringValue": "tenant.id"
+                  }
+                },
+                {
+                  "key": "tenant.id",
+                  "value": {
+                    "stringValue": "tenant_2"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 1,
+              "traceId": "0102030405060708090a0b0c0d0e0f10",
+              "spanId": "1112131415161718"
+            }
+          ],
+          "schemaUrl": "ScopeLogsSchemaURL"
+        }
+      ],
+      "schemaUrl": "testSchemaURL"
+    }
+  ]
+}`,
+			expectLine:      `{"body":"hello world","traceid":"0102030405060708090a0b0c0d0e0f10","spanid":"1112131415161718","severity":"Error","attributes":{"sdkVersion":"1.0.1"},"resources":{"host.name":"testHost"}}`,
+			expectLabels:    `{exporter="OTLP", level="ERROR", tenant.id="tenant_2"}`,
+			expectTimestamp: time.Date(2023, time.January, 4, 12, 10, 31, 972869000, time.Local),
+		},
+	}
+
+	decoder := &plog.JSONUnmarshaler{}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			payload, err := decoder.UnmarshalLogs([]byte(tc.input))
+			require.NoError(t, err)
+
+			l := util.TestLogger(t)
+			ch1, ch2 := make(loki.LogsReceiver), make(loki.LogsReceiver)
+			conv := convert.New(l, prometheus.NewRegistry(), []loki.LogsReceiver{ch1, ch2})
+			go func() {
+				require.NoError(t, conv.ConsumeLogs(context.Background(), payload))
+			}()
+
+			for i := 0; i < 2; i++ {
+				select {
+				case l := <-ch1:
+					require.Equal(t, tc.expectLine, l.Line)
+					require.Equal(t, tc.expectLabels, l.Labels.String())
+					require.Equal(t, tc.expectTimestamp, l.Timestamp)
+				case l := <-ch2:
+					require.Equal(t, tc.expectLine, l.Line)
+					require.Equal(t, tc.expectLabels, l.Labels.String())
+					require.Equal(t, tc.expectTimestamp, l.Timestamp)
+				case <-time.After(time.Second):
+					require.FailNow(t, "failed waiting for logs")
+				}
+			}
+		})
+	}
+}

--- a/component/otelcol/exporter/loki/internal/convert/convert_test.go
+++ b/component/otelcol/exporter/loki/internal/convert/convert_test.go
@@ -75,7 +75,7 @@ func TestConverter(t *testing.T) {
 }`,
 			expectLine:      `{"body":"hello world","traceid":"0102030405060708090a0b0c0d0e0f10","spanid":"1112131415161718","severity":"Error","attributes":{"sdkVersion":"1.0.1"},"resources":{"host.name":"testHost"}}`,
 			expectLabels:    `{exporter="OTLP", level="ERROR"}`,
-			expectTimestamp: time.Date(2023, time.January, 4, 12, 10, 31, 972869000, time.Local),
+			expectTimestamp: time.Date(2023, time.January, 4, 10, 10, 31, 972869000, time.UTC),
 		},
 		{
 			name: "log line with logfmt format hint in resource attributes",
@@ -137,7 +137,7 @@ func TestConverter(t *testing.T) {
 }`,
 			expectLine:      `msg="hello world" traceID=0102030405060708090a0b0c0d0e0f10 spanID=1112131415161718 severity=Error attribute_sdkVersion=1.0.1 resource_host.name=testHost`,
 			expectLabels:    `{exporter="OTLP", level="ERROR"}`,
-			expectTimestamp: time.Date(2023, time.January, 4, 12, 10, 31, 972869000, time.Local),
+			expectTimestamp: time.Date(2023, time.January, 4, 10, 10, 31, 972869000, time.UTC),
 		},
 		{
 			name: "log line with logfmt format hint in log attributes",
@@ -199,7 +199,7 @@ func TestConverter(t *testing.T) {
 }`,
 			expectLine:      `msg="hello world" traceID=0102030405060708090a0b0c0d0e0f10 spanID=1112131415161718 severity=Error attribute_sdkVersion=1.0.1 resource_host.name=testHost`,
 			expectLabels:    `{exporter="OTLP", level="ERROR"}`,
-			expectTimestamp: time.Date(2023, time.January, 4, 12, 10, 31, 972869000, time.Local),
+			expectTimestamp: time.Date(2023, time.January, 4, 10, 10, 31, 972869000, time.UTC),
 		},
 		{
 			name: "resource attributes converted to labels",
@@ -285,7 +285,7 @@ func TestConverter(t *testing.T) {
 }`,
 			expectLine:      `msg="hello world" traceID=0102030405060708090a0b0c0d0e0f10 spanID=1112131415161718 severity=Error attribute_sdkVersion=1.0.1 resource_host.name=testHost resource_mylabel_3=value_3`,
 			expectLabels:    `{exporter="OTLP", level="ERROR", mylabel_1="value_1", mylabel_2="42"}`,
-			expectTimestamp: time.Date(2023, time.January, 4, 12, 10, 31, 972869000, time.Local),
+			expectTimestamp: time.Date(2023, time.January, 4, 10, 10, 31, 972869000, time.UTC),
 		},
 		{
 			name: "log attributes converted to labels",
@@ -371,7 +371,7 @@ func TestConverter(t *testing.T) {
 }`,
 			expectLine:      `msg="hello world" traceID=0102030405060708090a0b0c0d0e0f10 spanID=1112131415161718 severity=Error attribute_sdkVersion=1.0.1 attribute_mylabel_3=value_3 resource_host.name=testHost`,
 			expectLabels:    `{exporter="OTLP", level="ERROR", mylabel_1="value_1", mylabel_2="42"}`,
-			expectTimestamp: time.Date(2023, time.January, 4, 12, 10, 31, 972869000, time.Local),
+			expectTimestamp: time.Date(2023, time.January, 4, 10, 10, 31, 972869000, time.UTC),
 		},
 		{
 			name: "tenant resource attribute converted to label",
@@ -445,7 +445,7 @@ func TestConverter(t *testing.T) {
 }`,
 			expectLine:      `{"body":"hello world","traceid":"0102030405060708090a0b0c0d0e0f10","spanid":"1112131415161718","severity":"Error","attributes":{"sdkVersion":"1.0.1"},"resources":{"host.name":"testHost"}}`,
 			expectLabels:    `{exporter="OTLP", level="ERROR", tenant.id="tenant_2"}`,
-			expectTimestamp: time.Date(2023, time.January, 4, 12, 10, 31, 972869000, time.Local),
+			expectTimestamp: time.Date(2023, time.January, 4, 10, 10, 31, 972869000, time.UTC),
 		},
 	}
 
@@ -467,11 +467,11 @@ func TestConverter(t *testing.T) {
 				case l := <-ch1:
 					require.Equal(t, tc.expectLine, l.Line)
 					require.Equal(t, tc.expectLabels, l.Labels.String())
-					require.Equal(t, tc.expectTimestamp, l.Timestamp)
+					require.Equal(t, tc.expectTimestamp, l.Timestamp.UTC())
 				case l := <-ch2:
 					require.Equal(t, tc.expectLine, l.Line)
 					require.Equal(t, tc.expectLabels, l.Labels.String())
-					require.Equal(t, tc.expectTimestamp, l.Timestamp)
+					require.Equal(t, tc.expectTimestamp, l.Timestamp.UTC())
 				case <-time.After(time.Second):
 					require.FailNow(t, "failed waiting for logs")
 				}

--- a/component/otelcol/exporter/loki/internal/convert/metrics.go
+++ b/component/otelcol/exporter/loki/internal/convert/metrics.go
@@ -1,0 +1,39 @@
+package convert
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	prometheus_client "github.com/prometheus/client_golang/prometheus"
+)
+
+type metrics struct {
+	entriesTotal     prometheus_client.Counter
+	entriesFailed    prometheus_client.Counter
+	entriesProcessed prometheus_client.Counter
+}
+
+func newMetrics(reg prometheus.Registerer) *metrics {
+	var m metrics
+
+	m.entriesTotal = prometheus_client.NewCounter(prometheus_client.CounterOpts{
+		Name: "otelcol_exporter_loki_entries_total",
+		Help: "Total number of log entries passed through the converter",
+	})
+	m.entriesFailed = prometheus_client.NewCounter(prometheus_client.CounterOpts{
+		Name: "otelcol_exporter_loki_entries_failed",
+		Help: "Total number of log entries failed to convert",
+	})
+	m.entriesProcessed = prometheus_client.NewCounter(prometheus_client.CounterOpts{
+		Name: "otelcol_exporter_loki_entries_processed",
+		Help: "Total number of log entries successfully converted",
+	})
+
+	if reg != nil {
+		reg.MustRegister(
+			m.entriesTotal,
+			m.entriesFailed,
+			m.entriesProcessed,
+		)
+	}
+
+	return &m
+}

--- a/component/otelcol/exporter/loki/loki.go
+++ b/component/otelcol/exporter/loki/loki.go
@@ -1,0 +1,77 @@
+// Package loki provides an otelcol.exporter.loki component.
+package loki
+
+import (
+	"context"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/agent/component/otelcol"
+	"github.com/grafana/agent/component/otelcol/exporter/loki/internal/convert"
+	"github.com/grafana/agent/component/otelcol/internal/lazyconsumer"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:    "otelcol.exporter.loki",
+		Args:    Arguments{},
+		Exports: otelcol.ConsumerExports{},
+
+		Build: func(o component.Options, a component.Arguments) (component.Component, error) {
+			return New(o, a.(Arguments))
+		},
+	})
+}
+
+// Arguments configures the otelcol.exporter.loki component.
+type Arguments struct {
+	ForwardTo []loki.LogsReceiver `river:"forward_to,attr"`
+}
+
+// Component is the otelcol.exporter.loki component.
+type Component struct {
+	log  log.Logger
+	opts component.Options
+
+	converter *convert.Converter
+}
+
+var _ component.Component = (*Component)(nil)
+
+// New creates a new otelcol.exporter.loki component.
+func New(o component.Options, c Arguments) (*Component, error) {
+	converter := convert.New(o.Logger, o.Registerer, c.ForwardTo)
+
+	res := &Component{
+		log:  o.Logger,
+		opts: o,
+
+		converter: converter,
+	}
+	if err := res.Update(c); err != nil {
+		return nil, err
+	}
+
+	// Construct a consumer based on our converter and export it. This will
+	// remain the same throughout the component's lifetime, so we do this
+	// during component construction.
+	export := lazyconsumer.New(context.Background())
+	export.SetConsumers(nil, nil, converter)
+	o.OnStateChange(otelcol.ConsumerExports{Input: export})
+
+	return res, nil
+}
+
+// Run implements Component.
+func (c *Component) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+// Update implements Component.
+func (c *Component) Update(newConfig component.Arguments) error {
+	cfg := newConfig.(Arguments)
+	c.converter.UpdateFanout(cfg.ForwardTo)
+	return nil
+}

--- a/docs/sources/flow/reference/components/loki.write.md
+++ b/docs/sources/flow/reference/components/loki.write.md
@@ -147,7 +147,7 @@ local Loki instance:
 
 ```river
 loki.write "local" {
-    client {
+    endpoint {
         url = "loki:3100"
     }
 }

--- a/docs/sources/flow/reference/components/otelcol.exporter.loki.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.loki.md
@@ -81,7 +81,7 @@ otelcol.exporter.loki "default" {
 }
 
 loki.write "local" {
-    client {
+    endpoint {
         url = "loki:3100"
     }
 }

--- a/docs/sources/flow/reference/components/otelcol.exporter.loki.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.loki.md
@@ -1,0 +1,88 @@
+---
+aliases:
+- /docs/agent/latest/flow/reference/components/otelcol.exporter.loki
+title: otelcol.exporter.loki
+---
+
+# otelcol.exporter.loki
+
+`otelcol.exporter.loki` accepts OTLP-formatted logs from other `otelcol`
+components, converts them to Loki-formatted log entries, and forwards them
+to `loki` components.
+
+> **NOTE**: `otelcol.exporter.loki` is a custom component unrelated to the
+> `lokiexporter` from the OpenTelemetry Collector.
+>
+> Conversion of logs are done according to the OpenTelemetry
+> [Logs Data Model][] specification.
+
+Multiple `otelcol.exporter.loki` components can be specified by giving them
+different labels.
+
+[Logs Data Model]: https://opentelemetry.io/docs/reference/specification/logs/data-model/
+
+## Usage
+
+```river
+otelcol.exporter.loki "LABEL" {
+  forward_to = [...]
+}
+```
+
+## Arguments
+
+`otelcol.exporter.loki` supports the following arguments:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`forward_to` | `list(receiver)` | Where to forward converted Loki logs. | | yes
+
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+Name | Type | Description
+---- | ---- | -----------
+`input` | `otelcol.Consumer` | A value that other components can use to send telemetry data to.
+
+`input` accepts `otelcol.Consumer` data for logs. Other telemetry signals are ignored.
+
+Logs sent to `input` are converted to Loki-compatible log entries and are
+forwarded to the `forward_to` argument in sequence.
+
+
+## Component health
+
+`otelcol.exporter.loki` is only reported as unhealthy if given an invalid
+configuration.
+
+## Debug information
+
+`otelcol.exporter.loki` does not expose any component-specific debug
+information.
+
+## Example
+
+This example accepts OTLP logs over gRPC, transforms them and forwards
+the converted log entries to `loki.write`:
+
+```river
+otelcol.receiver.otlp "default" {
+  grpc {}
+
+  output {
+    logs = [otelcol.exporter.loki.default.input]
+  }
+}
+
+otelcol.exporter.loki "default" {
+  forward_to = [loki.write.local.receiver]
+}
+
+loki.write "local" {
+    client {
+        url = "loki:3100"
+    }
+}
+```

--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,6 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.17.2
 	github.com/aws/aws-sdk-go-v2/config v1.17.8
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.11
-	github.com/beevik/ntp v0.3.0
 	github.com/bmatcuk/doublestar v1.2.2
 	github.com/bufbuild/connect-go v1.4.1
 	github.com/fatih/color v1.13.0
@@ -132,9 +131,11 @@ require (
 	github.com/grafana/vmware_exporter v0.0.4-beta
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/hpcloud/tail v1.0.0
+	github.com/influxdata/go-syslog/v3 v3.0.1-0.20201128200927-a1889d947b48
 	github.com/jaegertracing/jaeger v1.38.1
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/mackerelio/go-osstat v0.2.3
+	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.63.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.61.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.61.0
@@ -225,6 +226,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.19 // indirect
 	github.com/aws/smithy-go v1.13.5 // indirect
+	github.com/beevik/ntp v0.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.2-0.20180723201105-3c1074078d32+incompatible // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
@@ -363,7 +365,6 @@ require (
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/infinityworks/go-common v0.0.0-20170820165359-7f20a140fd37 // indirect
-	github.com/influxdata/go-syslog/v3 v3.0.1-0.20201128200927-a1889d947b48 // indirect
 	github.com/influxdata/telegraf v1.16.3 // indirect
 	github.com/ionos-cloud/sdk-go/v6 v6.1.3 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
@@ -420,7 +421,6 @@ require (
 	github.com/mrunalp/fileutils v0.5.0 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/ncabatoff/go-seq v0.0.0-20180805175032-b08ef85ed833 // indirect
 	github.com/nicolai86/scaleway-sdk v1.10.2-0.20180628010248-798f60e20bb2 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -120,9 +120,11 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.17.2
 	github.com/aws/aws-sdk-go-v2/config v1.17.8
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.11
+	github.com/beevik/ntp v0.3.0
 	github.com/bmatcuk/doublestar v1.2.2
 	github.com/bufbuild/connect-go v1.4.1
 	github.com/fatih/color v1.13.0
+	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/google/go-cmp v0.5.9
 	github.com/google/renameio/v2 v2.0.0
 	github.com/grafana/phlare/api v0.1.2
@@ -137,9 +139,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.61.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.61.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.61.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki v0.63.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.63.0
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
+	github.com/prometheus-operator/prometheus-operator/pkg/client v0.61.1
 	github.com/prometheus/blackbox_exporter v0.22.1-0.20220920154026-3446984d6a6e
 	github.com/prometheus/client_model v0.3.0
 	github.com/shirou/gopsutil/v3 v3.22.9
@@ -158,6 +162,7 @@ require (
 	golang.org/x/exp v0.0.0-20221031165847-c99f073a8326
 	golang.org/x/text v0.5.0
 	google.golang.org/protobuf v1.28.1
+	k8s.io/component-base v0.25.4
 )
 
 require (
@@ -220,7 +225,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.19 // indirect
 	github.com/aws/smithy-go v1.13.5 // indirect
-	github.com/beevik/ntp v0.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.2-0.20180723201105-3c1074078d32+incompatible // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
@@ -280,7 +284,6 @@ require (
 	github.com/form3tech-oss/jwt-go v3.2.5+incompatible // indirect
 	github.com/fvbommel/sortorder v1.0.2 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.1 // indirect
-	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
 	github.com/go-git/go-git/v5 v5.4.2 // indirect
@@ -445,7 +448,6 @@ require (
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/power-devops/perfstat v0.0.0-20220216144756-c35f1ee13d7c // indirect
-	github.com/prometheus-operator/prometheus-operator/pkg/client v0.61.1 // indirect
 	github.com/prometheus/alertmanager v0.24.0 // indirect
 	github.com/prometheus/common/sigv4 v0.1.0 // indirect
 	github.com/prometheus/exporter-toolkit v0.8.2 // indirect
@@ -538,7 +540,6 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6 // indirect
-	k8s.io/component-base v0.25.4 // indirect
 	k8s.io/kube-openapi v0.0.0-20221123214604-86e75ddd809a // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2369,6 +2369,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetr
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.63.0/go.mod h1:UDUauqPQgqflOJVnOD3Ut4iVuTaGg1Y9G6yA+mRCXF8=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.63.0 h1:XzKVij0Zmwei9a3ktwWk11GMX0FX+WGDg3cw9/tytmw=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.63.0/go.mod h1:w5rHiSvZJ110BJE/xLQxtlCGEELhfJ46dPR7XAHBXHE=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki v0.63.0 h1:I8F8AEPyXeAMNLVaajKvO2mB7u1bTA/LqdDlfJCYGcY=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki v0.63.0/go.mod h1:abIg0b0KukLnR6owOmUsJRlhy12/x2DhwKmjWNTueCY=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.63.0 h1:8BZjkVilBkS7SdrwF+u/ZdE6T6Xy9tuFx+dqhn7d+Nc=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.63.0/go.mod h1:5dGHcdbTljgvIX05yeobiBQEDqVaLWRxJ8FfaHH0sXw=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.63.0 h1:dtk8VTTTLozsrvNcOryh0s2XxrpqiInxSvIRCnRrKgo=


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The PR adds an `otelol.exporter.loki` component that received OTel-formatted log entries, transforms them to Loki log entries and forwards them to other loki comoonents.

The conversion is based on the OTel [loki translator](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/translator/loki) package that is also used by the opentelemetry-collector-contrib's [lokiexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/lokiexporter), but is applied per-entry instead of per-request.

The conversion format defaults to json, but uses the OTel format hints (i.e. the `loki.format` resource or log attribute) to decide whether to use json or logfmt.

#### Which issue(s) this PR fixes
Fixes #2666, Updates #2501 

#### Notes to the Reviewer
The Grafana OTLP Gateway uses the same upstream code for transforming OTLP -> Loki log entries. We will be in sync with them if we decide to always include a certain set of labels extracted from OTel attributes.

If you want to play around with this

* Save the following in a file eg. `/tmp/log.json`

<details>

```
{
  "resourceLogs": [
    {
      "resource": {
        "attributes": [
          {
            "key": "host.name",
            "value": {
              "stringValue": "testHost"
            }
          }
        ],
        "droppedAttributesCount": 1
      },
      "scopeLogs": [
        {
          "scope": {
            "name": "name",
            "version": "version",
            "droppedAttributesCount": 1
          },
          "logRecords": [
            {
              "timeUnixNano": "1673451765000000000",
              "observedTimeUnixNano": "1673451765000000000",
              "severityNumber": 17,
              "severityText": "Error",
              "body": {
                "stringValue": "hello world"
              },
              "attributes": [
                {
                  "key": "sdkVersion",
                  "value": {
                    "stringValue": "1.0.1"
                  }
                }
              ],
              "droppedAttributesCount": 1,
              "traceId": "0102030405060708090a0b0c0d0e0f10",
              "spanId": "1112131415161718"
            }
          ],
          "schemaUrl": "ScopeLogsSchemaURL"
        }
      ],
      "schemaUrl": "testSchemaURL"
    }
  ]
}
```

</details

* Run the Agent with a config like this

```
otelcol.receiver.otlp "default" {
  http {}

  output {
    logs = [otelcol.exporter.loki.default.input]
  }
}

otelcol.exporter.loki "default" {
  forward_to = [loki.write.cloud.receiver]
}

loki.write "cloud" {
  endpoint {
    url = <loki_url>
    http_client_config {
      basic_auth {
        username = <user>
        password = <pass>
      }
    }
  }
}

```

* Send the log entry to the OTLP receiver's http endpoint

```
$ curl -vi http://localhost:4318/v1/logs -X POST -H "Content-Type: application/json" -d '@/tmp/log.json' --output -
```

#### PR Checklist

- [X] CHANGELOG updated
- [X] Documentation added
- [X] Tests updated
