### PR TITLE
operator: Use enableHttp2 field as boolean in libsonnet templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ Main (unreleased)
   seconds per file to finish flushing read logs to the client, after which it
   will drop them, resulting in losing logs. (@rfratto)
 
+- Operator: Fix the handling of the enableHttp2 field as a boolean in
+  `pod_monitor` and `service_monitor` templates. (@tpaschalis)
+
 ### Other changes
 
 - Use Go 1.19.4 for builds. (@erikbaranowski)

--- a/pkg/operator/config/templates/component/metrics/pod_monitor.libsonnet
+++ b/pkg/operator/config/templates/component/metrics/pod_monitor.libsonnet
@@ -63,7 +63,7 @@ function(
   proxy_url: optionals.string(endpoint.ProxyURL),
   params: optionals.object(endpoint.Params),
   scheme: optionals.string(endpoint.Scheme),
-  enable_http2: optionals.string(endpoint.EnableHttp2),
+  enable_http2: optionals.bool(endpoint.EnableHttp2),
 
   // NOTE(rfratto): unlike ServiceMonitor, pod monitors explicitly use
   // SafeTLSConfig.

--- a/pkg/operator/config/templates/component/metrics/service_monitor.libsonnet
+++ b/pkg/operator/config/templates/component/metrics/service_monitor.libsonnet
@@ -63,7 +63,7 @@ function(
   proxy_url: optionals.string(endpoint.ProxyURL),
   params: optionals.object(endpoint.Params),
   scheme: optionals.string(endpoint.Scheme),
-  enable_http2: optionals.string(endpoint.EnableHttp2),
+  enable_http2: optionals.bool(endpoint.EnableHttp2),
 
   tls_config:
     if endpoint.TLSConfig != null then new_tls_config(meta.Namespace, endpoint.TLSConfig),


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The PR fixes the use of the enableHttp2 field from optionals.string to optional.bool

#### Which issue(s) this PR fixes
No issue filed

#### Notes to the Reviewer
Should I run anything else like `make crd` here?

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
