### PR TITLE
Add an `otelcol.receiver.opencensus` Flow component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Main (unreleased)
   - `phlare.scrape` collects application performance profiles. (@cyriltovena)
   - `phlare.write` sends application performance profiles to Grafana Phlare. (@cyriltovena)
   - `otelcol.receiver.zipkin` receives Zipkin-formatted traces. (@rfratto)
+  - `otelcol.receiver.opencensus` receives OpenConsensus-formatted traces or metrics. (@ptodev)
   - `loki.source.windowsevent` reads logs from Windows Event Log. (@mattdurham)
   - `loki.source.syslog` listens for Syslog messages over TCP and UDP
     connections and forwards them to other `loki` components. (@tpaschalis)

--- a/component/all/all.go
+++ b/component/all/all.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/grafana/agent/component/otelcol/processor/memorylimiter"      // Import otelcol.processor.memory_limiter
 	_ "github.com/grafana/agent/component/otelcol/receiver/jaeger"              // Import otelcol.receiver.jaeger
 	_ "github.com/grafana/agent/component/otelcol/receiver/kafka"               // Import otelcol.receiver.kafka
+	_ "github.com/grafana/agent/component/otelcol/receiver/opencensus"          // Import otelcol.receiver.opencensus
 	_ "github.com/grafana/agent/component/otelcol/receiver/otlp"                // Import otelcol.receiver.otlp
 	_ "github.com/grafana/agent/component/otelcol/receiver/prometheus"          // Import otelcol.receiver.prometheus
 	_ "github.com/grafana/agent/component/otelcol/receiver/zipkin"              // Import otelcol.receiver.zipkin

--- a/component/otelcol/receiver/opencensus/opencensus.go
+++ b/component/otelcol/receiver/opencensus/opencensus.go
@@ -1,0 +1,90 @@
+// Package opencensus provides an otelcol.receiver.opencensus component.
+package opencensus
+
+import (
+	"github.com/alecthomas/units"
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otelcol"
+	"github.com/grafana/agent/component/otelcol/receiver"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver"
+	otelcomponent "go.opentelemetry.io/collector/component"
+	otelconfig "go.opentelemetry.io/collector/config"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name: "otelcol.receiver.opencensus",
+		Args: Arguments{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			fact := opencensusreceiver.NewFactory()
+			return receiver.New(opts, fact, args.(Arguments))
+		},
+	})
+}
+
+// Arguments configures the otelcol.receiver.opencensus component.
+type Arguments struct {
+	CorsAllowedOrigins []string `river:"cors_allowed_origins,attr,optional"`
+
+	GRPC *GRPCServerArguments `river:"grpc,block,optional"`
+
+	// Output configures where to send received data. Required.
+	Output *otelcol.ConsumerArguments `river:"output,block"`
+}
+
+var _ receiver.Arguments = Arguments{}
+
+// Convert implements receiver.Arguments.
+func (args Arguments) Convert() otelconfig.Receiver {
+	return &opencensusreceiver.Config{
+		ReceiverSettings: otelconfig.NewReceiverSettings(otelconfig.NewComponentID("opencensus")),
+
+		CorsOrigins:        args.CorsAllowedOrigins,
+		GRPCServerSettings: *(*otelcol.GRPCServerArguments)(args.GRPC).Convert(),
+	}
+}
+
+// Extensions implements receiver.Arguments.
+func (args Arguments) Extensions() map[otelconfig.ComponentID]otelcomponent.Extension {
+	return nil
+}
+
+// Exporters implements receiver.Arguments.
+func (args Arguments) Exporters() map[otelconfig.DataType]map[otelconfig.ComponentID]otelcomponent.Exporter {
+	return nil
+}
+
+// NextConsumers implements receiver.Arguments.
+func (args Arguments) NextConsumers() *otelcol.ConsumerArguments {
+	return args.Output
+}
+
+type (
+	// GRPCServerArguments is used to configure otelcol.receiver.otlp with
+	// component-specific defaults.
+	GRPCServerArguments otelcol.GRPCServerArguments
+)
+
+var (
+	_ river.Unmarshaler = (*GRPCServerArguments)(nil)
+)
+
+// Default server settings.
+var (
+	DefaultGRPCServerArguments = GRPCServerArguments{
+		Endpoint:  "0.0.0.0:4317",
+		Transport: "tcp",
+
+		ReadBufferSize: 512 * units.Kibibyte,
+		// We almost write 0 bytes, so no need to tune WriteBufferSize.
+	}
+)
+
+// UnmarshalRiver implements river.Unmarshaler and supplies defaults.
+func (args *GRPCServerArguments) UnmarshalRiver(f func(interface{}) error) error {
+	*args = DefaultGRPCServerArguments
+	type arguments GRPCServerArguments
+	return f((*arguments)(args))
+}

--- a/component/otelcol/receiver/opencensus/opencensus_test.go
+++ b/component/otelcol/receiver/opencensus/opencensus_test.go
@@ -74,7 +74,6 @@ func TestArguments_UnmarshalRiver(t *testing.T) {
 		require.Equal(t, otelArgs.CorsOrigins[0], "https://*.test.com")
 		require.Equal(t, otelArgs.CorsOrigins[1], "https://test.com")
 	})
-
 }
 
 func getFreeAddr(t *testing.T) string {

--- a/component/otelcol/receiver/opencensus/opencensus_test.go
+++ b/component/otelcol/receiver/opencensus/opencensus_test.go
@@ -42,8 +42,6 @@ func Test(t *testing.T) {
 	}()
 
 	require.NoError(t, ctrl.WaitRunning(time.Second))
-
-	time.Sleep(100 * time.Millisecond)
 }
 
 func TestArguments_UnmarshalRiver(t *testing.T) {
@@ -79,7 +77,6 @@ func TestArguments_UnmarshalRiver(t *testing.T) {
 
 }
 
-// TODO: This function was copy pasted from otlp_test.go. Reuse it somehow without pasting?
 func getFreeAddr(t *testing.T) string {
 	t.Helper()
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.opencensus.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.opencensus.md
@@ -1,0 +1,234 @@
+---
+aliases:
+- /docs/agent/latest/flow/reference/components/otelcol.receiver.opencensus
+title: otelcol.receiver.opencensus
+---
+
+# otelcol.receiver.opencensus
+
+`otelcol.receiver.opencensus` accepts telemetry data via gRPC or HTTP 
+using the [OpenCensus](https://opencensus.io/) format and
+forwards it to other `otelcol.*` components.
+
+> **NOTE**: `otelcol.receiver.opencensus` is a wrapper over the upstream
+> OpenTelemetry Collector `opencensus` receiver from the `otelcol-contrib`
+> distribution. Bug reports or feature requests will be redirected to the
+> upstream repository, if necessary.
+
+Multiple `otelcol.receiver.opencensus` components can be specified by giving them
+different labels.
+
+## Usage
+
+```river
+otelcol.receiver.opencensus "LABEL" {
+  cors_allowed_origins = [ ... ]
+
+  grpc { ... }
+
+  output {
+    metrics = [...]
+    logs    = [...]
+    traces  = [...]
+  }
+}
+```
+
+In order to use plain HTTP/JSON, specify the `endpoint` attribute
+inside the `grpc` block of this component. There is no HTTP-specific block.
+The HTTP/JSON address is the same as gRPC as the protocol is recognized and processed accordingly.
+
+To write traces with HTTP/JSON, `POST` to `[address]/v1/trace`. The JSON message format parallels the gRPC protobuf format, see this [OpenApi spec for it](https://github.com/census-instrumentation/opencensus-proto/blob/master/gen-openapi/opencensus/proto/agent/trace/v1/trace_service.swagger.json).
+
+## Arguments
+
+`otelcol.receiver.opencensus` supports the following arguments:
+
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`cors_allowed_origins`     | `list(string)` | A list of allowed Cross-Origin Resource Sharing (CORS) origins. |  | no
+
+`cors_allowed_origins` are the allowed CORS origins for HTTP/JSON requests to gRPC-gateway adapter 
+for the OpenCensus receiver. See [github.com/rs/cors](github.com/rs/cors).
+An empty list means that CORS is not enabled at all. A wildcard (*) can be
+used to match any origin or one or more characters of an origin.
+
+## Blocks
+
+The following blocks are supported inside the definition of
+`otelcol.receiver.opencensus`:
+
+Hierarchy | Block | Description | Required
+--------- | ----- | ----------- | --------
+grpc | [grpc][] | Configures the gRPC/HTTP server to receive telemetry data. | no
+grpc > tls | [tls][] | Configures TLS for the gRPC server. | no
+grpc > keepalive | [keepalive][] | Configures keepalive settings for the configured server. | no
+grpc > keepalive > server_parameters | [server_parameters][] | Server parameters used to configure keepalive settings. | no
+grpc > keepalive > enforcement_policy | [enforcement_policy][] | Enforcement policy for keepalive settings. | no
+output | [output][] | Configures where to send received telemetry data. | yes
+
+The `>` symbol indicates deeper levels of nesting. For example, `grpc > tls`
+refers to a `tls` block defined inside a `grpc` block.
+
+[grpc]: #grpc-block
+[tls]: #tls-block
+[keepalive]: #keepalive-block
+[server_parameters]: #server_parameters-block
+[enforcement_policy]: #enforcement_policy-block
+[output]: #output-block
+
+### grpc block
+
+The `grpc` block configures the gRPC/HTTP server used by the component. If the
+`grpc` block isn't provided, a server will be started using default parameters.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`endpoint` | `string` | `host:port` to listen for traffic on. | `"0.0.0.0:4317"` | no
+`transport` | `string` | Transport to use for the gRPC server. | `"tcp"` | no
+`max_recv_msg_size` | `string` | Maximum size of messages the server will accept. 0 disables a limit. | | no
+`max_concurrent_streams` | `number` | Limit the number of concurrent streaming RPC calls. | | no
+`read_buffer_size` | `string` | Size of the read buffer the gRPC server will use for reading from clients. | `"512KiB"` | no
+`write_buffer_size` | `string` | Size of the write buffer the gRPC server will use for writing to clients. | | no
+`include_metadata` | `boolean` | Propagate incoming connection metadata to downstream consumers. | | no
+
+Note that `max_recv_msg_size`, `read_buffer_size` and `write_buffer_size` are formatted in a special way, 
+so that the units are included in the string - e.g. "512KiB" or "1024KB".
+
+### tls block
+
+The `tls` block configures TLS settings used for a server. If the `tls` block
+isn't provided, TLS won't be used for connections to the server.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`ca_file` | `string` | Path to the CA file. | | no
+`cert_file` | `string` | Path to the TLS certificate. | | no
+`key_file` | `string` | Path to the TLS certificate key. | | no
+`min_version` | `string` | Minimum acceptable TLS version for connections. | `"TLS 1.2"` | no
+`max_version` | `string` | Maximum acceptable TLS version for connections. | `"TLS 1.3"` | no
+`reload_interval` | `duration` | Frequency to reload the certificates. | | no
+`client_ca_file` | `string` | Path to the CA file used to authenticate client certificates. | | no
+
+### keepalive block
+
+The `keepalive` block configures keepalive settings for connections to a gRPC
+server.
+
+`keepalive` doesn't support any arguments and is configured fully through inner
+blocks.
+
+### server_parameters block
+
+The `server_parameters` block controls keepalive and maximum age settings for gRPC
+servers.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`max_connection_idle` | `duration` | Maximum age for idle connections. | `"infinity"` | no
+`max_connection_age` | `duration` | Maximum age for non-idle connections. | `"infinity"` | no
+`max_connection_age_grace` | `duration` | Time to wait before forcibly closing connections. | `"infinity"` | no
+`time` | `duration` | How often to ping inactive clients to check for liveness. | `"2h"` | no
+`timeout` | `duration` | Time to wait before closing inactive clients that do not respond to liveness checks. | `"20s"` | no
+
+### enforcement_policy block
+
+The `enforcement_policy` block configures the keepalive enforcement policy for
+gRPC servers. The server will close connections from clients that violate the
+configured policy.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`min_time` | `duration` | Minimum time clients should wait before sending a keepalive ping. | `"5m"` | no
+`permit_without_stream` | `boolean` | Allow clients to send keepalive pings when there are no active streams. | `false` | no
+
+### output block
+
+{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" >}}
+
+## Exported fields
+
+`otelcol.receiver.opencensus` does not export any fields.
+
+## Component health
+
+`otelcol.receiver.opencensus` is only reported as unhealthy if given an invalid
+configuration.
+
+## Debug information
+
+`otelcol.receiver.opencensus` does not expose any component-specific debug
+information.
+
+## Example
+
+This example forwards received telemetry data through a batch processor before
+finally sending it to an OTLP-capable endpoint:
+
+```river
+otelcol.receiver.opencensus "default" {
+  cors_allowed_origins = ["https://*.test.com", "https://test.com"]
+
+  grpc {
+    endpoint = "0.0.0.0:9090"
+    transport = "tcp"
+
+    max_recv_msg_size = "32KB"
+    max_concurrent_streams = "16"
+    read_buffer_size = "1024KB"
+    write_buffer_size = "1024KB"
+    include_metadata = true
+
+    tls {
+      cert_file = "test.crt"
+      key_file = "test.key"
+    }
+
+    keepalive {
+
+      server_parameters {
+         max_connection_idle = "11s"
+         max_connection_age = "12s"
+         max_connection_age_grace = "13s"
+         time = "30s"
+         timeout = "5s"
+      }
+
+      enforcement_policy {
+        min_time = "10s"
+        permit_without_stream = true
+      }
+
+    }
+  }
+
+  output {
+    metrics = [otelcol.processor.batch.default.input]
+    logs    = [otelcol.processor.batch.default.input]
+    traces  = [otelcol.processor.batch.default.input]
+  }
+}
+
+otelcol.processor.batch "default" {
+  output {
+    metrics = [otelcol.exporter.otlp.default.input]
+    logs    = [otelcol.exporter.otlp.default.input]
+    traces  = [otelcol.exporter.otlp.default.input]
+  }
+}
+
+otelcol.exporter.otlp "default" {
+  client {
+    endpoint = env("OTLP_ENDPOINT")
+  }
+}
+```

--- a/docs/sources/flow/reference/components/otelcol.receiver.opencensus.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.opencensus.md
@@ -39,7 +39,7 @@ Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `cors_allowed_origins`     | `list(string)` | A list of allowed Cross-Origin Resource Sharing (CORS) origins. |  | no
 
-`cors_allowed_origins` are the allowed [CORS](github.com/rs/cors) origins for HTTP/JSON requests.
+`cors_allowed_origins` are the allowed [CORS](https://github.com/rs/cors) origins for HTTP/JSON requests.
 An empty list means that CORS is not enabled at all. A wildcard (*) can be
 used to match any origin or one or more characters of an origin.
 
@@ -70,7 +70,7 @@ refers to a `tls` block defined inside a `grpc` block.
 ### grpc block
 
 The `grpc` block configures the gRPC/HTTP server used by the component. If the
-`grpc` block isn't provided, a server will be started using default parameters.
+`grpc` block isn't provided, a server using default parameters is started.
 
 The following arguments are supported:
 
@@ -85,12 +85,12 @@ Name | Type | Description | Default | Required
 `include_metadata` | `boolean` | Propagate incoming connection metadata to downstream consumers. | | no
 
 In order to use plain HTTP/JSON, specify the `endpoint` attribute. There is no HTTP-specific block.
-The HTTP/JSON address is the same as gRPC as the protocol is recognized and processed accordingly.
+The HTTP/JSON address is the same as gRPC, as the protocol is recognized and processed accordingly.
 
-To write traces with HTTP/JSON, `POST` to `[address]/v1/trace`. The JSON message format parallels the gRPC protobuf format, see this [OpenApi spec for it](https://github.com/census-instrumentation/opencensus-proto/blob/master/gen-openapi/opencensus/proto/agent/trace/v1/trace_service.swagger.json).
+To write traces with HTTP/JSON, `POST` to `[address]/v1/trace`. The JSON message format parallels the gRPC protobuf format. For details, refer to its [OpenApi specification](https://github.com/census-instrumentation/opencensus-proto/blob/master/gen-openapi/opencensus/proto/agent/trace/v1/trace_service.swagger.json).
 
 Note that `max_recv_msg_size`, `read_buffer_size` and `write_buffer_size` are formatted in a special way, 
-so that the units are included in the string - e.g. "512KiB" or "1024KB".
+so that the units are included in the string, e.g., "512KiB" or "1024KB".
 
 ### tls block
 

--- a/docs/sources/shared/flow/reference/components/authorization-block.md
+++ b/docs/sources/shared/flow/reference/components/authorization-block.md
@@ -10,5 +10,5 @@ Name | Type | Description | Default | Required
 `credential` | `secret` | Secret value. | | no
 `credentials_file` | `string` | File containing the secret value. | | no
 
-`credential` and `credentials_file` are mututally exclusive and only one can be
+`credential` and `credentials_file` are mutually exclusive and only one can be
 provided inside of an `authorization` block.


### PR DESCRIPTION
#### PR Description
This adds `otelcol.receiver.opencensus` component to flow.

#### Which issue(s) this PR fixes
Fixes #2292

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
