### PR TITLE
build-image: add helm-docs for grafana/agent#2695

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -33,7 +33,8 @@ RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@$CONTROLLER_GEN_V
  && go install github.com/golang/protobuf/protoc-gen-go@v1.3.1                         \
  && go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0                    \
  && go install github.com/gogo/protobuf/gogoproto/...@v1.3.0                           \
- && go install github.com/ahmetb/gen-crd-api-reference-docs@v0.3.1-0.20220618162802-424739b250f5
+ && go install github.com/ahmetb/gen-crd-api-reference-docs@v0.3.1-0.20220618162802-424739b250f5 \
+ && go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.11.0
 
 #
 # Final image


### PR DESCRIPTION
Add the [helm-docs](https://github.com/norwoodj/helm-docs) tool into the Linux build image, which is needed for #2695.