### PR TITLE
(helm) Support exposing additional ports for the Grafana Agent

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -9,6 +9,10 @@ internal API changes are not present.
 
 Unreleased
 ----------
+
+0.2.0 (2023-1-12)
+----------
+
 ### Features
 
 - Introduce supporting extra ports on the Grafana Agent created by Helm Chart.

--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -9,6 +9,9 @@ internal API changes are not present.
 
 Unreleased
 ----------
+### Features
+
+- Introduce supporting extra ports on the Grafana Agent created by Helm Chart.
 
 0.1.0 (2023-01-11)
 ------------------

--- a/operations/helm/charts/grafana-agent/Chart.yaml
+++ b/operations/helm/charts/grafana-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: grafana-agent
 description: "Grafana Agent"
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "v0.30.2"

--- a/operations/helm/charts/grafana-agent/Chart.yaml
+++ b/operations/helm/charts/grafana-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: grafana-agent
 description: "Grafana Agent"
 type: application
-version: 0.1.1
+version: 0.2.0
 appVersion: "v0.30.2"

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -1,6 +1,6 @@
 # Grafana Agent Helm chart
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![AppVersion: v0.30.2](https://img.shields.io/badge/AppVersion-v0.30.2-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: v0.30.2](https://img.shields.io/badge/AppVersion-v0.30.2-informational?style=flat-square)
 
 > **EXPERIMENTAL**: This is an experimental Helm chart for Grafana Agent. It is
 > undergoing active development and it is not recommended to use this chart in

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -42,6 +42,7 @@ use the older mode (called "static mode"), set the `agent.mode` value to
 | agent.enableReporting | bool | `true` | Enables sending Grafana Labs anonymous usage stats to help improve Grafana Agent. |
 | agent.extraArgs | list | `[]` | Extra args to pass to `agent run`: https://grafana.com/docs/agent/latest/flow/reference/cli/run/ |
 | agent.extraEnv | list | `[]` | Extra environment variables to pass to the agent container. |
+| agent.extraPorts | list | `[]` | Extra container ports to expose on the agent container |
 | agent.listenAddr | string | `"0.0.0.0"` | Address to listen for traffic on. 0.0.0.0 exposes the UI to other containers. |
 | agent.listenPort | int | `80` | Port to listen for traffic on. |
 | agent.mode | string | `"flow"` | Mode to run Grafana Agent in. Can be "flow" or "static". |

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -1,6 +1,6 @@
 # Grafana Agent Helm chart
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: v0.30.2](https://img.shields.io/badge/AppVersion-v0.30.2-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![AppVersion: v0.30.2](https://img.shields.io/badge/AppVersion-v0.30.2-informational?style=flat-square)
 
 > **EXPERIMENTAL**: This is an experimental Helm chart for Grafana Agent. It is
 > undergoing active development and it is not recommended to use this chart in

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -42,7 +42,7 @@ use the older mode (called "static mode"), set the `agent.mode` value to
 | agent.enableReporting | bool | `true` | Enables sending Grafana Labs anonymous usage stats to help improve Grafana Agent. |
 | agent.extraArgs | list | `[]` | Extra args to pass to `agent run`: https://grafana.com/docs/agent/latest/flow/reference/cli/run/ |
 | agent.extraEnv | list | `[]` | Extra environment variables to pass to the agent container. |
-| agent.extraPorts | list | `[]` | Extra container ports to expose on the agent container |
+| agent.extraPorts | list | `[]` | Extra ports to expose on the Agent |
 | agent.listenAddr | string | `"0.0.0.0"` | Address to listen for traffic on. 0.0.0.0 exposes the UI to other containers. |
 | agent.listenPort | int | `80` | Port to listen for traffic on. |
 | agent.mode | string | `"flow"` | Mode to run Grafana Agent in. Can be "flow" or "static". |

--- a/operations/helm/charts/grafana-agent/templates/containers/_agent.yaml
+++ b/operations/helm/charts/grafana-agent/templates/containers/_agent.yaml
@@ -26,7 +26,7 @@
     - containerPort: {{ .Values.agent.listenPort }}
       name: http-metrics
     {{- range $portMap := .Values.agent.extraPorts }}
-    - containerPort: {{ $portMap.port }}
+    - containerPort: {{ $portMap.targetPort }}
       name: {{ $portMap.name }}
       protocol: {{ coalesce $portMap.protocol "TCP" }} 
     {{- end }}

--- a/operations/helm/charts/grafana-agent/templates/containers/_agent.yaml
+++ b/operations/helm/charts/grafana-agent/templates/containers/_agent.yaml
@@ -25,6 +25,11 @@
   ports:
     - containerPort: {{ .Values.agent.listenPort }}
       name: http-metrics
+    {{- range $portMap := .Values.agent.extraPorts }}
+    - containerPort: {{ $portMap.port }}
+      name: {{ $portMap.name }}
+      protocol: {{ coalesce $portMap.protocol "TCP" }} 
+    {{- end }}
   readinessProbe:
     httpGet:
       path: /-/ready

--- a/operations/helm/charts/grafana-agent/templates/service.yaml
+++ b/operations/helm/charts/grafana-agent/templates/service.yaml
@@ -14,3 +14,9 @@ spec:
       port: {{ .Values.agent.listenPort }}
       targetPort: {{ .Values.agent.listenPort }}
       protocol: "TCP"
+{{- range $portMap := .Values.agent.extraPorts }}
+    - name: {{ $portMap.name }}
+      port: {{ $portMap.port }}
+      targetPort: {{ $portMap.targetPort }}
+      protocol: {{ coalesce $portMap.protocol "TCP" }} 
+{{- end }}

--- a/operations/helm/charts/grafana-agent/tests/extra-ports.values.yaml
+++ b/operations/helm/charts/grafana-agent/tests/extra-ports.values.yaml
@@ -1,0 +1,7 @@
+# Specify extra ports for verifying rendering the template works
+agent:
+  extraPorts:
+    - name: jaeger-thrift
+      port: 14268
+      targetPort: 14268
+      protocol: TCP

--- a/operations/helm/charts/grafana-agent/tests/extra-ports.values.yaml
+++ b/operations/helm/charts/grafana-agent/tests/extra-ports.values.yaml
@@ -5,3 +5,4 @@ agent:
       port: 14268
       targetPort: 14268
       protocol: TCP
+      

--- a/operations/helm/charts/grafana-agent/tests/extra-ports.values.yaml
+++ b/operations/helm/charts/grafana-agent/tests/extra-ports.values.yaml
@@ -5,4 +5,3 @@ agent:
       port: 14268
       targetPort: 14268
       protocol: TCP
-      

--- a/operations/helm/charts/grafana-agent/values.yaml
+++ b/operations/helm/charts/grafana-agent/values.yaml
@@ -43,9 +43,9 @@ agent:
 
   # -- Extra ports to expose on the Agent
   # Example:  
-  # - name: authenticated
-  #     port: 8081
-  #     targetPort: 8081
+  # - name: jaeger-thrift
+  #     port: 14268
+  #     targetPort: 14268
   #     protocol: TCP
   extraPorts: []
 

--- a/operations/helm/charts/grafana-agent/values.yaml
+++ b/operations/helm/charts/grafana-agent/values.yaml
@@ -42,11 +42,6 @@ agent:
   extraArgs: []
 
   # -- Extra ports to expose on the Agent
-  # Example:  
-  # - name: jaeger-thrift
-  #     port: 14268
-  #     targetPort: 14268
-  #     protocol: TCP
   extraPorts: []
 
   mounts:

--- a/operations/helm/charts/grafana-agent/values.yaml
+++ b/operations/helm/charts/grafana-agent/values.yaml
@@ -41,6 +41,14 @@ agent:
   # -- Extra args to pass to `agent run`: https://grafana.com/docs/agent/latest/flow/reference/cli/run/
   extraArgs: []
 
+  # -- Extra ports to expose on the Agent
+  # Example:  
+  # - name: authenticated
+  #     port: 8081
+  #     targetPort: 8081
+  #     protocol: TCP
+  extraPorts: []
+
   mounts:
     # -- Mount /var/log from the host into the container for log collection.
     varlog: false

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: release-name-grafana-agent
+  name: grafana-agent
   labels:
     helm.sh/chart: grafana-agent-0.1.0
     app.kubernetes.io/name: grafana-agent
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
     app.kubernetes.io/managed-by: Helm
 data:

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
@@ -1,0 +1,42 @@
+---
+# Source: grafana-agent/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent-0.1.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.river: |- 
+    logging {
+    	level  = "info"
+    	format = "logfmt"
+    }
+    
+    discovery.kubernetes "pods" {
+    	role = "pod"
+    }
+    
+    discovery.kubernetes "nodes" {
+    	role = "node"
+    }
+    
+    discovery.kubernetes "services" {
+    	role = "service"
+    }
+    
+    discovery.kubernetes "endpoints" {
+    	role = "endpoints"
+    }
+    
+    discovery.kubernetes "endpointslices" {
+    	role = "endpointslice"
+    }
+    
+    discovery.kubernetes "ingresses" {
+    	role = "ingress"
+    }

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
@@ -40,3 +40,4 @@ data:
     discovery.kubernetes "ingresses" {
     	role = "ingress"
     }
+    

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
@@ -40,4 +40,3 @@ data:
     discovery.kubernetes "ingresses" {
     	role = "ingress"
     }
-    

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
@@ -3,11 +3,11 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: release-name-grafana-agent
+  name: grafana-agent
   labels:
     helm.sh/chart: grafana-agent-0.1.0
     app.kubernetes.io/name: grafana-agent
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -15,14 +15,14 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: grafana-agent
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
       labels:
         app.kubernetes.io/name: grafana-agent
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/instance: grafana-agent
     spec:
-      serviceAccount: release-name-grafana-agent
+      serviceAccount: grafana-agent
       containers:
           - name: grafana-agent
             image: grafana/agent:v0.30.2
@@ -72,4 +72,4 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: release-name-grafana-agent
+            name: grafana-agent

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
@@ -1,0 +1,75 @@
+---
+# Source: grafana-agent/templates/controllers/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: release-name-grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent-0.1.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  minReadySeconds: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana-agent
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana-agent
+        app.kubernetes.io/instance: release-name
+    spec:
+      serviceAccount: release-name-grafana-agent
+      containers:
+          - name: grafana-agent
+            image: grafana/agent:v0.30.2
+            args:
+              - run
+              - /etc/agent/config.river
+              - --storage.path=/tmp/agent
+              - --server.http.listen-addr=0.0.0.0:80
+            env:
+              - name: AGENT_MODE
+                value: flow
+              - name: HOSTNAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: spec.nodeName
+            ports:
+              - containerPort: 80
+                name: http-metrics
+              - containerPort: 14268
+                name: jaeger-thrift
+                protocol: TCP
+            readinessProbe:
+              httpGet:
+                path: /-/ready
+                port: 80
+              initialDelaySeconds: 10
+              timeoutSeconds: 1
+            volumeMounts:
+              - name: config
+                mountPath: /etc/agent
+          - name: config-reloader
+            image: weaveworks/watch:master-5fc29a9
+            args:
+              - -v
+              - -p=/etc/agent/config.river
+              - curl
+              - -X
+              - POST
+              - --fail
+              - -o
+              - '-'
+              - -sS
+              - http://localhost:80/-/reload
+            volumeMounts:
+              - name: config
+                mountPath: /etc/agent
+      volumes:
+        - name: config
+          configMap:
+            name: release-name-grafana-agent

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
@@ -52,3 +52,4 @@ subjects:
   - kind: ServiceAccount
     name: grafana-agent
     namespace: default
+    

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: release-name-grafana-agent
+  name: grafana-agent
   labels:
     helm.sh/chart: grafana-agent-0.1.0
     app.kubernetes.io/name: grafana-agent
@@ -37,7 +37,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: release-name-grafana-agent
+  name: grafana-agent
   labels:
     helm.sh/chart: grafana-agent-0.1.0
     app.kubernetes.io/name: grafana-agent
@@ -47,8 +47,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: release-name-grafana-agent
+  name: grafana-agent
 subjects:
   - kind: ServiceAccount
-    name: release-name-grafana-agent
+    name: grafana-agent
     namespace: default

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
@@ -1,0 +1,54 @@
+---
+# Source: grafana-agent/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-name-grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent-0.1.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  # Rules which allow discovery.kubernetes to function.
+  - apiGroups:
+      - ""
+      - "discovery.k8s.io"
+      - "networking.k8s.io"
+    resources:
+      - endpoints
+      - endpointslices
+      - ingresses
+      - nodes
+      - nodes/proxy
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+---
+# Source: grafana-agent/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent-0.1.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-grafana-agent
+subjects:
+  - kind: ServiceAccount
+    name: release-name-grafana-agent
+    namespace: default

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     helm.sh/chart: grafana-agent-0.1.0
     app.kubernetes.io/name: grafana-agent
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -41,7 +41,7 @@ metadata:
   labels:
     helm.sh/chart: grafana-agent-0.1.0
     app.kubernetes.io/name: grafana-agent
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
@@ -52,4 +52,3 @@ subjects:
   - kind: ServiceAccount
     name: grafana-agent
     namespace: default
-    

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
@@ -25,4 +25,3 @@ spec:
       port: 14268
       targetPort: 14268
       protocol: TCP
-      

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: release-name-grafana-agent
+  name: grafana-agent
   labels:
     helm.sh/chart: grafana-agent-0.1.0
     app.kubernetes.io/name: grafana-agent
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -15,7 +15,7 @@ spec:
   clusterIP: None
   selector:
     app.kubernetes.io/name: grafana-agent
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: grafana-agent
   ports:
     - name: http-metrics
       port: 80

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
@@ -1,0 +1,27 @@
+---
+# Source: grafana-agent/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent-0.1.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: release-name
+  ports:
+    - name: http-metrics
+      port: 80
+      targetPort: 80
+      protocol: "TCP"
+    - name: jaeger-thrift
+      port: 14268
+      targetPort: 14268
+      protocol: TCP

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
@@ -25,3 +25,4 @@ spec:
       port: 14268
       targetPort: 14268
       protocol: TCP
+      

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+---
+# Source: grafana-agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release-name-grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent-0.1.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
@@ -3,10 +3,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: release-name-grafana-agent
+  name: grafana-agent
   labels:
     helm.sh/chart: grafana-agent-0.1.0
     app.kubernetes.io/name: grafana-agent
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
@@ -10,4 +10,3 @@ metadata:
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
     app.kubernetes.io/managed-by: Helm
-    

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
@@ -10,3 +10,4 @@ metadata:
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
     app.kubernetes.io/managed-by: Helm
+    

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.1
+    helm.sh/chart: grafana-agent-0.2.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.1.0
+    helm.sh/chart: grafana-agent-0.1.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR adds support for specifying extra port maps to the Grafana Agent, to support exposing different ports for specific components (such as [`otelcol.receiver.jaeger`](https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.receiver.jaeger/#thrift_http-block), which defaults to listening on `14268` for http-thrift traces). By supplying the values:

```
agent:
    extraPorts:
        - name: jaeger-thrift
           port: 14268
           targetPort: 14268
           protocol: TCP
```

A new port will be exposed in both the headless service and the container itself with the provided arguments, allowing one to use the Kube DNS to send otelcol data to the Agent.


#### Which issue(s) this PR fixes
N/A

#### Notes to the Reviewer
This approach is based on the way [`kube-prom-stack`](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml#L359) adds additional ports for it's various components, but modified slightly due to the differences in how ports are specified on a container vs a service.
#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
