### PR TITLE
Add option to disable reporting in the config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ Main (unreleased)
 
 - Flow: the targets in debug info from `loki.source.file` are now individual blocks. (@rfratto)
 
+- Add option to disable usage stats reporting in config file via `enable_usage_report` field. (@marctc)
+
 ### Bugfixes
 
 - Flow UI: Fix the issue with messy layout on the component list page while browser window resize. (@xiyu95)

--- a/docs/sources/configuration/flags.md
+++ b/docs/sources/configuration/flags.md
@@ -56,7 +56,7 @@ The usage information includes the following details:
 This list may change over time. All newly reported data will also be documented in the CHANGELOG.
 
 If you would like to disable the reporting, Grafana Agent provides the flag `-disable-reporting`
-to stop the reporting.
+to stop the reporting or set `enable_usage_report` to false in the config.
 
 ## Support bundles
 Grafana Agent allows the exporting of 'support bundles' on the `/-/support`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -84,7 +84,7 @@ type Config struct {
 	DisableSupportBundle bool `yaml:"-"`
 
 	// Report enabled features options
-	EnableUsageReport bool     `yaml:"-"`
+	EnableUsageReport bool     `yaml:"enable_usage_report,omitempty"`
 	EnabledFeatures   []string `yaml:"-"`
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -459,3 +459,26 @@ func TestAgent_OmmitEmptyFields(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "{}\n", string(yml))
 }
+
+func TestConfig_DisableReporting(t *testing.T) {
+	cfg := `
+enable_usage_report: false
+`
+
+	var c Config
+	err := LoadBytes([]byte(cfg), false, &c)
+	require.NoError(t, err)
+	require.False(t, c.EnableUsageReport)
+}
+
+func TestConfig_ReportingEnableDefault(t *testing.T) {
+	cfg := `
+server:
+  log_level: info
+`
+
+	var c Config
+	err := LoadBytes([]byte(cfg), false, &c)
+	require.NoError(t, err)
+	require.True(t, c.EnableUsageReport)
+}


### PR DESCRIPTION
#### PR Description
This PR adds the ability to enable agent to send usage stats to Grafana using
a field in the config file.

#### Which issue(s) this PR fixes

Fixes #2540 

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
