### PR TITLE
operations/helm: remove warning about Chart not being ready for use

### DIFF
--- a/operations/helm/README.md
+++ b/operations/helm/README.md
@@ -1,12 +1,6 @@
-# agent-helm-chart
+# Helm charts
 
-This is an **experimental** repository for creating a Helm chart for Grafana
-Agent (in particular, [Grafana Agent Flow][Flow]).
-
-It is not recommended to use this Helm chart in production yet. The intent is
-to turn upstream this into grafana/agent once it's ready.
-
-[Flow]: https://grafana.com/docs/agent/latest/flow/
+This directory contains Helm charts for Grafana Agent.
 
 ## Testing
 
@@ -14,11 +8,11 @@ The `tests` contains a list of golden templates rendered from the Helm chart.
 
 These manifests are never run directly, but are instead used to validate the
 correctness of the templates emitted by the Helm chart. To regenerate this
-folder, call `make rebuild-tests`.
+folder, call `make generate-helm-tests` from the root of the repository.
 
-`make rebuild-tests` will iterate through the value.yaml files in
+`make generate-helm-tests` will iterate through the value.yaml files in
 `charts/grafana-agent/tests` and generate each one as a separate directory.
 
-When modifying the Helm charts, `make rebuild-tests` must be run before
+When modifying the Helm charts, `make generate-helm-tests` must be run before
 submitting a PR, as a linter check will ensure that this directory is up to
 date.

--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -10,8 +10,16 @@ internal API changes are not present.
 Unreleased
 ----------
 
-0.2.0 (2023-1-12)
-----------
+0.2.1 (2023-01-12)
+------------------
+
+### Other changes
+
+- Updated documentation to remove warning about the chart not being ready for
+  use.
+
+0.2.0 (2023-01-12)
+------------------
 
 ### Features
 

--- a/operations/helm/charts/grafana-agent/Chart.yaml
+++ b/operations/helm/charts/grafana-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: grafana-agent
 description: "Grafana Agent"
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "v0.30.2"

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -1,13 +1,6 @@
 # Grafana Agent Helm chart
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: v0.30.2](https://img.shields.io/badge/AppVersion-v0.30.2-informational?style=flat-square)
-
-> **EXPERIMENTAL**: This is an experimental Helm chart for Grafana Agent. It is
-> undergoing active development and it is not recommended to use this chart in
-> production.
->
-> The intent is to upstream this Helm chart into grafana/agent once it's ready
-> for adoption.
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![AppVersion: v0.30.2](https://img.shields.io/badge/AppVersion-v0.30.2-informational?style=flat-square)
 
 Helm chart for deploying [Grafana Agent][] to Kubernetes.
 

--- a/operations/helm/charts/grafana-agent/README.md.gotmpl
+++ b/operations/helm/charts/grafana-agent/README.md.gotmpl
@@ -2,13 +2,6 @@
 
 {{ template "chart.typeBadge" . }}{{ template "chart.versionBadge" . }}{{ template "chart.appVersionBadge" . }}
 
-> **EXPERIMENTAL**: This is an experimental Helm chart for Grafana Agent. It is
-> undergoing active development and it is not recommended to use this chart in
-> production.
->
-> The intent is to upstream this Helm chart into grafana/agent once it's ready
-> for adoption.
-
 Helm chart for deploying [Grafana Agent][] to Kubernetes.
 
 [Grafana Agent]: https://grafana.com/docs/agent/latest/

--- a/operations/helm/ct.yaml
+++ b/operations/helm/ct.yaml
@@ -4,3 +4,4 @@ chart-dirs:
   - operations/helm/charts
 helm-extra-args: --timeout 600s
 validate-maintainers: false
+check-version-increment: false  # Don't require every change to be released

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.0
+    helm.sh/chart: grafana-agent-0.2.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"


### PR DESCRIPTION
The warning about the chart being experimental was only meant for the prototype before it got upstreamed, and was accidentally kept in.

Additionally, change ct.yaml to no longer require every change to have a version bump. This allows us to batch changes without having to make a release for every single one.

To publish the changes to the README and remove the warning, the version has been bumped to 0.2.1.