### PR TITLE
Switch Drone to be built with Jsonnet

### DIFF
--- a/.drone/README.md
+++ b/.drone/README.md
@@ -6,7 +6,8 @@
 
 # Release Preperation
 
-When updating the drone.yml file the file must be re-signed using `make drone`. This is limited to Grafana employees for security reasons.
+When updating the `drone.yml` file the file must be re-signed using `make
+drone`. This is limited to Grafana employees for security reasons.
 
 Drone environment variables will need to be setup beforehand.
 
@@ -19,35 +20,46 @@ export DRONE_TOKEN=<token>
 
 **IMPORTANT: IT MAY NOT BE SAFE TO RUN ALL PIPELINES LOCALLY WITHOUT MODIFICATION**
 
-For validating your setup, the `Lint` or `Windows-Test` pipelines are safe to run depending on which architecture you are working on.
+For validating your setup, the `Lint` or `Windows-Test` pipelines are safe to
+run depending on which architecture you are working on.
 
 ## **EASIER** (recommended)
 
 Run the drone CLI locally following the drone documentation [here](https://docs.drone.io/cli/install/)
 
 1. Install the CLI in a compatible container environment to the pipelines you want to test
-1. Create a copy of .drone/drone.yml at the repo root called .drone.yml and copy the pipeline[s] you want to test in there
-2. Example command from the repo root `drone exec --secret-file=secrets.txt --trusted --pipeline=Lint`
+2. If editing the pipeline, run `make generate-drone` to generate the updated
+   `.drone/drone.yml from Jsonnet without signing.
+3. Run a command like the following the repo root:
+  `drone exec --secret-file=secrets.txt --trusted --pipeline=Lint .drone/drone.yml`
 
 Pros
-- Works with linux or windows containers depending on which environment it is installed on
+- Works with Linux or Windows containers depending on which environment it is
+  installed on.
 
 Cons
-- Doesn't exactly mirror running the pipeline on a drone server setup. For example some [environment](https://docs.drone.io/pipeline/environment/reference/) variables may not get set
+- Doesn't mirror running the pipeline on a Drone server setup. For example,
+  some [environment](https://docs.drone.io/pipeline/environment/reference/)
+  variables may not get set.
 
 ## **HARDER** (not recommended)
 
-Run the drone stack locally following the drone documentation [here](https://docs.drone.io/server/ha/developer-setup/)
+Run the Drone stack locally following the drone documentation
+[here](https://docs.drone.io/server/ha/developer-setup/).
 
-1. Fork the repo
-2. Start ngrok to get the public endpoint
-3. Create and update the drone config files with the public endpoint
-4. Configure an oath2 app in github with the public endpoint
-5. Activate the repo in the drone server and configure it to point to .drone/drone.yml
+1. Fork the repo.
+2. Start ngrok to get the public endpoint.
+3. Create and update the drone config files with the public endpoint.
+4. Configure an oath2 app in github with the public endpoint.
+5. Activate the repo in the drone server and configure it to point to `.drone/drone.yml`.
 
 Pros
-- This will allow you to run the whole drone stack and test it end to end
+- This allows you to run the whole drone stack and test it end to end.
 
 Cons
-- This doesn't include a windows drone agent so windows pipelines will not execute
-- Every time you restart ngrok (getting a new public url) you will need to delete the containers, update the drone config, delete the webhook they made in github, update the oath2 app in github, recreat the containers, reactivate the repo in the drone server, etc
+- This doesn't include a Windows Drone agent so Windows pipelines will not
+  execute.
+- Every time you restart ngrok (getting a new public url) you will need to
+  delete the containers, update the drone config, delete the webhook they made
+  in GitHub, update the oath2 app in GitHub, recreat the containers, reactivate
+  the repo in the Drone server, etc.

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -1,0 +1,7 @@
+local pipelines = import './pipelines.jsonnet';
+
+(import 'pipelines/build_images.jsonnet') +
+(import 'pipelines/test.jsonnet') +
+(import 'pipelines/check_containers.jsonnet') +
+(import 'pipelines/publish.jsonnet') +
+(import 'secrets.jsonnet')

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -196,6 +196,7 @@ steps:
 - commands:
   - git config --global --add safe.directory C:/drone/src/
   - '& "C:/Program Files/git/bin/bash.exe" -c ./tools/ci/docker-containers-windows'
+  failure: ignore
   image: grafana/agent-build-image:0.19.0-windows
   name: Build container
   volumes:
@@ -404,6 +405,6 @@ kind: secret
 name: gpg_passphrase
 ---
 kind: signature
-hmac: efdd8fe910a5f4671583c46ed3b7dc48ff2b0490ae6718b23ac6dd046619624f
+hmac: 0ad8688e80c70151916926d92a9624a9bc476b896b3a0a15e134b1a612352a20
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -149,6 +149,96 @@ steps:
 ---
 kind: pipeline
 type: docker
+name: Verify Container (grafana/agent)
+platform:
+  os: linux
+  arch: amd64
+trigger:
+  event: [pull_request]
+steps:
+  - name: Build container
+    image: grafana/agent-build-image:0.19.0
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    commands:
+      - make agent-image
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+---
+kind: pipeline
+type: docker
+name: Verify Container (grafana/agentctl)
+platform:
+  os: linux
+  arch: amd64
+trigger:
+  event: [pull_request]
+steps:
+  - name: Build container
+    image: grafana/agent-build-image:0.19.0
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    commands:
+      - make agentctl-image
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+---
+kind: pipeline
+type: docker
+name: Verify Container (grafana/agent-operator)
+platform:
+  os: linux
+  arch: amd64
+trigger:
+  event: [pull_request]
+steps:
+  - name: Build container
+    image: grafana/agent-build-image:0.19.0
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    commands:
+      - make operator-image
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+---
+kind: pipeline
+type: docker
+name: Verify Windows Containers
+platform:
+  os: windows
+  arch: amd64
+  version: "1809"
+trigger:
+  event: [pull_request]
+steps:
+  - name: Build container
+    image: grafana/agent-build-image:0.19.0-windows
+    volumes:
+      - name: docker
+        path: //./pipe/docker_engine/
+    commands:
+      - git config --global --add safe.directory C:/drone/src/
+      - '& "C:/Program Files/git/bin/bash.exe" -c ./tools/ci/docker-containers-windows'
+volumes:
+- name: docker
+  host:
+    path: //./pipe/docker_engine/
+
+---
+kind: pipeline
+type: docker
 name: Containerize
 platform:
   os: linux
@@ -377,6 +467,6 @@ get:
 
 ---
 kind: signature
-hmac: 8880e687afcbe8c6db514963c36dc48e69780082669bc190732d2e042871dcae
+hmac: 61489753c517810cccce9c906d2d2350f5dc4e2e72415b73ca19b3d593ad99c7
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1,5 +1,28 @@
 ---
 kind: pipeline
+name: Check Linux build image
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - docker buildx build -t grafana/agent-build-image:latest ./build-image
+  image: docker
+  name: Build
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+trigger:
+  event:
+    include:
+    - pull_request
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+kind: pipeline
 name: Create Linux build image
 platform:
   arch: amd64
@@ -34,6 +57,30 @@ volumes:
   name: docker
 ---
 kind: pipeline
+name: Check Windows build image
+platform:
+  arch: amd64
+  os: windows
+  version: "1809"
+steps:
+- commands:
+  - docker build -t grafana/agent-build-image:latest ./build-image/windows
+  image: docker:windowsservercore-1809
+  name: Build
+  volumes:
+  - name: docker
+    path: //./pipe/docker_engine/
+trigger:
+  event:
+    include:
+    - pull_request
+type: docker
+volumes:
+- host:
+    path: //./pipe/docker_engine/
+  name: docker
+---
+kind: pipeline
 name: Create Windows build image
 platform:
   arch: amd64
@@ -50,7 +97,7 @@ steps:
       from_secret: DOCKER_LOGIN
     DOCKER_PASSWORD:
       from_secret: DOCKER_PASSWORD
-  image: docker
+  image: docker:windowsservercore-1809
   name: Build
   volumes:
   - name: docker
@@ -405,6 +452,6 @@ kind: secret
 name: gpg_passphrase
 ---
 kind: signature
-hmac: 0ad8688e80c70151916926d92a9624a9bc476b896b3a0a15e134b1a612352a20
+hmac: f222515d9297e752c558d25eb7395a3aa275f26c9445a69dcea1069280c66f41
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1,472 +1,409 @@
 ---
 kind: pipeline
-type: docker
 name: Create Linux build image
 platform:
-  os: linux
   arch: amd64
-trigger:
-  event: [tag]
-  ref: [refs/tags/build-image/v*]
+  os: linux
 steps:
-  - name: Build
-    image: docker
-    volumes:
-      - name: docker
-        path: /var/run/docker.sock
-    environment:
-      DOCKER_LOGIN:
-        from_secret: DOCKER_LOGIN
-      DOCKER_PASSWORD:
-        from_secret: DOCKER_PASSWORD
-    commands:
-    - export IMAGE_TAG=${DRONE_TAG##build-image/v}
-    - docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
-    - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-    - docker buildx create --name multiarch --driver docker-container --use
-    - docker buildx build --push --platform linux/amd64,linux/arm64 -t grafana/agent-build-image:$IMAGE_TAG ./build-image
-volumes:
+- commands:
+  - export IMAGE_TAG=${DRONE_TAG##build-image/v}
+  - docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
+  - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  - docker buildx create --name multiarch --driver docker-container --use
+  - docker buildx build --push --platform linux/amd64,linux/arm64 -t grafana/agent-build-image:$IMAGE_TAG
+    ./build-image
+  environment:
+    DOCKER_LOGIN:
+      from_secret: DOCKER_LOGIN
+    DOCKER_PASSWORD:
+      from_secret: DOCKER_PASSWORD
+  image: docker
+  name: Build
+  volumes:
   - name: docker
-    host:
-      path: /var/run/docker.sock
-
+    path: /var/run/docker.sock
+trigger:
+  event:
+  - tag
+  ref:
+  - refs/tags/build-image/v*
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 kind: pipeline
-type: docker
 name: Create Windows build image
 platform:
-  os: windows
   arch: amd64
+  os: windows
   version: "1809"
-trigger:
-  event: [tag]
-  ref: [refs/tags/build-image/v*]
 steps:
-  - name: Build
-    image: docker:windowsservercore-1809
-    volumes:
-      - name: docker
-        path: //./pipe/docker_engine/
-    environment:
-      DOCKER_LOGIN:
-        from_secret: DOCKER_LOGIN
-      DOCKER_PASSWORD:
-        from_secret: DOCKER_PASSWORD
-    commands:
-      # NOTE(rfratto): the variable syntax is parsed ahead of time by Drone,
-      # and not by Windows (where the syntax obviously wouldn't work).
-      - $IMAGE_TAG="${DRONE_TAG##build-image/v}-windows"
-      - docker login -u $Env:DOCKER_LOGIN -p $Env:DOCKER_PASSWORD
-      - docker build -t grafana/agent-build-image:$IMAGE_TAG ./build-image/windows
-      - docker push grafana/agent-build-image:$IMAGE_TAG
-volumes:
-- name: docker
-  host:
+- commands:
+  - $IMAGE_TAG="${DRONE_TAG##build-image/v}-windows"
+  - docker login -u $Env:DOCKER_LOGIN -p $Env:DOCKER_PASSWORD
+  - docker build -t grafana/agent-build-image:$IMAGE_TAG ./build-image/windows
+  - docker push grafana/agent-build-image:$IMAGE_TAG
+  environment:
+    DOCKER_LOGIN:
+      from_secret: DOCKER_LOGIN
+    DOCKER_PASSWORD:
+      from_secret: DOCKER_PASSWORD
+  image: docker
+  name: Build
+  volumes:
+  - name: docker
     path: //./pipe/docker_engine/
-
+trigger:
+  event:
+  - tag
+  ref:
+  - refs/tags/build-image/v*
+type: docker
+volumes:
+- host:
+    path: //./pipe/docker_engine/
+  name: docker
 ---
 kind: pipeline
 name: Lint
 platform:
-  os: linux
   arch: amd64
+  os: linux
+steps:
+- commands:
+  - make lint
+  image: grafana/agent-build-image:0.19.0
+  name: Lint
 trigger:
   event:
-    - push
-    - pull_request
-    - tag
-  ref:
-    - refs/heads/main
-    - refs/pull/*/head
-    - refs/tags/v*
-
-steps:
-  - name: lint
-    image: grafana/agent-build-image:0.19.0
-    commands:
-      - make lint
-
+  - pull_request
+type: docker
 ---
 kind: pipeline
-type: docker
 name: Test
 platform:
-  os: linux
   arch: amd64
+  os: linux
+steps:
+- commands:
+  - make binaries
+  - K8S_USE_DOCKER_NETWORK=1 make test
+  image: grafana/agent-build-image:0.19.0
+  name: Run Go tests
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 trigger:
   event:
-    - push
-    - pull_request
-    - tag
-  ref:
-    - refs/heads/main
-    - refs/pull/*/head
-    - refs/tags/v*
-
-steps:
-  - name: test
-    image: grafana/agent-build-image:0.19.0
-    volumes:
-      - name: docker
-        path: /var/run/docker.sock
-    commands:
-      # Ensure the binaries can build and also run Go tests.
-      #
-      # The operator tests require K8S_USE_DOCKER_NETWORK=1 to be set when
-      # tests are being run inside of a Docker container so it can access the
-      # created k3d cluster properly.
-      - make binaries
-      - K8S_USE_DOCKER_NETWORK=1 make test
-
+  - pull_request
+type: docker
 volumes:
- - name: docker
-   host:
-     path: /var/run/docker.sock
-
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 kind: pipeline
-type: docker
-name: Windows-Test
+name: Test (Windows)
 platform:
   arch: amd64
   os: windows
   version: "1809"
+steps:
+- commands:
+  - go test -tags="nodocker,nonetwork" ./...
+  image: grafana/agent-build-image:0.19.0-windows
+  name: Run Go tests
 trigger:
   event:
-    - push
-    - pull_request
-    - tag
-  ref:
-    - refs/heads/main
-    - refs/pull/*/head
-    - refs/tags/v*
-steps:
-  - name: test
-    image: grafana/agent-build-image:0.19.0-windows
-    commands:
-      - go test -tags="nodocker,nonetwork" ./...
-
+  - pull_request
+type: docker
 ---
 kind: pipeline
-type: docker
-name: Verify Container (grafana/agent)
+name: Check Linux container (grafana/agent)
 platform:
-  os: linux
   arch: amd64
-trigger:
-  event: [pull_request]
-steps:
-  - name: Build container
-    image: grafana/agent-build-image:0.19.0
-    volumes:
-      - name: docker
-        path: /var/run/docker.sock
-    commands:
-      - make agent-image
-volumes:
-  - name: docker
-    host:
-      path: /var/run/docker.sock
-
----
-kind: pipeline
-type: docker
-name: Verify Container (grafana/agentctl)
-platform:
   os: linux
-  arch: amd64
-trigger:
-  event: [pull_request]
 steps:
-  - name: Build container
-    image: grafana/agent-build-image:0.19.0
-    volumes:
-      - name: docker
-        path: /var/run/docker.sock
-    commands:
-      - make agentctl-image
-volumes:
+- commands:
+  - make agent-image
+  image: grafana/agent-build-image:0.19.0
+  name: Build container
+  volumes:
   - name: docker
-    host:
-      path: /var/run/docker.sock
-
+    path: /var/run/docker.sock
+trigger:
+  event:
+  - pull_request
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 kind: pipeline
-type: docker
-name: Verify Container (grafana/agent-operator)
+name: Check Linux container (grafana/agentctl)
 platform:
+  arch: amd64
   os: linux
-  arch: amd64
-trigger:
-  event: [pull_request]
 steps:
-  - name: Build container
-    image: grafana/agent-build-image:0.19.0
-    volumes:
-      - name: docker
-        path: /var/run/docker.sock
-    commands:
-      - make operator-image
-volumes:
+- commands:
+  - make agentctl-image
+  image: grafana/agent-build-image:0.19.0
+  name: Build container
+  volumes:
   - name: docker
-    host:
-      path: /var/run/docker.sock
-
+    path: /var/run/docker.sock
+trigger:
+  event:
+  - pull_request
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 kind: pipeline
-type: docker
-name: Verify Windows Containers
+name: Check Linux container (grafana/agent-operator)
 platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - make operator-image
+  image: grafana/agent-build-image:0.19.0
+  name: Build container
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+trigger:
+  event:
+  - pull_request
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+kind: pipeline
+name: Check Windows containers
+platform:
+  arch: amd64
   os: windows
-  arch: amd64
   version: "1809"
-trigger:
-  event: [pull_request]
 steps:
-  - name: Build container
-    image: grafana/agent-build-image:0.19.0-windows
-    volumes:
-      - name: docker
-        path: //./pipe/docker_engine/
-    commands:
-      - git config --global --add safe.directory C:/drone/src/
-      - '& "C:/Program Files/git/bin/bash.exe" -c ./tools/ci/docker-containers-windows'
-volumes:
-- name: docker
-  host:
-    path: //./pipe/docker_engine/
-
----
-kind: pipeline
-type: docker
-name: Containerize
-platform:
-  os: linux
-  arch: amd64
-trigger:
-  ref:
-    - refs/heads/main
-    - refs/tags/v*
-    - refs/heads/dev.*
-steps:
-  - name: Build Containers
-    image: grafana/agent-build-image:0.19.0
-    volumes:
-      - name: docker
-        path: /var/run/docker.sock
-    environment:
-      DOCKER_LOGIN:
-        from_secret: DOCKER_LOGIN
-      DOCKER_PASSWORD:
-        from_secret: DOCKER_PASSWORD
-      GCR_CREDS:
-        from_secret: gcr_admin
-    commands:
-      - mkdir -p $HOME/.docker
-      - printenv GCR_CREDS > $HOME/.docker/config.json
-      - docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
-
-      # Create a buildx worker container for multiplatform builds.
-      - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-      - docker buildx create --name multiarch --driver docker-container --use
-
-      - ./tools/ci/docker-containers
-
-      # Remove the buildx worker container.
-      - docker buildx rm multiarch
-
-depends_on:
-  - Test
-
-volumes:
+- commands:
+  - git config --global --add safe.directory C:/drone/src/
+  - '& "C:/Program Files/git/bin/bash.exe" -c ./tools/ci/docker-containers-windows'
+  image: grafana/agent-build-image:0.19.0-windows
+  name: Build container
+  volumes:
   - name: docker
-    host:
-      path: /var/run/docker.sock
-
----
-kind: pipeline
-type: docker
-name: Windows-Containerize
-platform:
-  os: windows
-  arch: amd64
-  version: "1809"
-trigger:
-  ref:
-    - refs/heads/main
-    - refs/tags/v*
-    - refs/heads/dev.*
-steps:
-  - name: Build Containers
-    image: grafana/agent-build-image:0.19.0-windows
-    volumes:
-      - name: docker
-        path: //./pipe/docker_engine/
-    environment:
-      DOCKER_LOGIN:
-        from_secret: DOCKER_LOGIN
-      DOCKER_PASSWORD:
-        from_secret: DOCKER_PASSWORD
-    commands:
-      - git config --global --add safe.directory C:/drone/src/
-      - 'Invoke-Expression "C:\''Program Files''\git\bin\bash.exe -c ''.\\\\tools\\\\ci\\\\docker-containers-windows''"'
-depends_on:
-  - Windows-Test
-
-volumes:
-- name: docker
-  host:
     path: //./pipe/docker_engine/
-
+trigger:
+  event:
+  - pull_request
+type: docker
+volumes:
+- host:
+    path: //./pipe/docker_engine/
+  name: docker
 ---
 kind: pipeline
-type: docker
-name: Deploy-To-Deployment-Tools
+name: Publish Linux Docker containers
 platform:
-  os: linux
   arch: amd64
+  os: linux
+steps:
+- commands:
+  - mkdir -p $HOME/.docker
+  - printenv GCR_CREDS > $HOME/.docker/config.json
+  - docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
+  - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  - docker buildx create --name multiarch --driver docker-container --use
+  - ./tools/ci/docker-containers
+  - docker buildx rm multiarch
+  environment:
+    DOCKER_LOGIN:
+      from_secret: DOCKER_LOGIN
+    DOCKER_PASSWORD:
+      from_secret: DOCKER_PASSWORD
+    GCR_CREDS:
+      from_secret: gcr_admin
+  image: grafana/agent-build-image:0.19.0
+  name: Build containers
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 trigger:
   ref:
-    - refs/heads/main
-
+  - refs/heads/main
+  - refs/tags/v*
+  - refs/heads/dev.*
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+depends_on:
+- Publish Linux Docker containers
 image_pull_secrets:
-  - dockerconfigjson
-
-steps:
-  - name: put image tag in a file
-    image: alpine
-    commands:
-      - apk update && apk add git
-      - echo "$(sh ./tools/image-tag)" > .tag-only
-      - echo "grafana/agent:$(sh ./tools/image-tag)" > .image-tag
-  - name: Update Deployment Tools
-    image: us.gcr.io/kubernetes-dev/drone/plugins/updater
-    settings:
-      config_json: |-
-        {
-          "destination_branch": "master",
-          "pull_request_branch_prefix": "cd-agent",
-          "pull_request_enabled": false,
-          "pull_request_team_reviewers": [
-            "agent-squad"
-          ],
-          "repo_name": "deployment_tools",
-          "update_jsonnet_attribute_configs": [
-            {
-              "file_path": "ksonnet/environments/kowalski/dev-us-central-0.kowalski-dev/main.jsonnet",
-              "jsonnet_key": "agent_image",
-              "jsonnet_value_file": ".image-tag"
-            },
-            {
-              "file_path": "ksonnet/environments/grafana-agent/waves/agent.libsonnet",
-              "jsonnet_key": "dev_canary",
-              "jsonnet_value_file": ".image-tag"
-            }
-          ]
-        }
-      github_token:
-        from_secret: gh_token
-
-depends_on:
-  - Containerize
-
-volumes:
-  - name: docker
-    host:
-      path: /var/run/docker.sock
-
----
+- dockerconfigjson
 kind: pipeline
-type: docker
-name: Release
+name: Deploy to deployment_tools
 platform:
-  os: linux
   arch: amd64
+  os: linux
+steps:
+- commands:
+  - apk update && apk add git
+  - echo "$(sh ./tools/image-tag)" > .tag-only
+  - echo "grafana/agent:$(sh ./tools/image-tag)" > .image-tag
+  image: alpine
+  name: Create .image-tag
+- image: us.gcr.io/kubernetes-dev/drone/plugins/updater
+  name: Update deployment_tools
+  settings:
+    config_json: |
+      {
+        "destination_branch": "master",
+        "pull_request_branch_prefix": "cd-agent",
+        "pull_request_enabled": false,
+        "pull_request_team_reviewers": [
+          "agent-squad"
+        ],
+        "repo_name": "deployment_tools",
+        "update_jsonnet_attribute_configs": [
+          {
+            "file_path": "ksonnet/environments/kowalski/dev-us-central-0.kowalski-dev/main.jsonnet",
+            "jsonnet_key": "agent_image",
+            "jsonnet_value_file": ".image-tag"
+          },
+          {
+            "file_path": "ksonnet/environments/grafana-agent/waves/agent.libsonnet",
+            "jsonnet_key": "dev_canary",
+            "jsonnet_value_file": ".image-tag"
+          }
+        ]
+      }
+    github_token:
+      from_secret: gh_token
 trigger:
   ref:
-    - refs/tags/v*
-
-steps:
-  - name: create-release
-    image: grafana/agent-build-image:0.19.0
-    volumes:
-      - name: docker
-        path: /var/run/docker.sock
-    environment:
-      DOCKER_LOGIN:
-        from_secret: DOCKER_LOGIN
-      DOCKER_PASSWORD:
-        from_secret: DOCKER_PASSWORD
-      GITHUB_TOKEN:
-        from_secret: GITHUB_KEY
-      GPG_PRIVATE_KEY:
-        from_secret: gpg_private_key
-      GPG_PUBLIC_KEY:
-        from_secret: gpg_public_key
-      GPG_PASSPHRASE:
-        from_secret: gpg_passphrase
-    commands:
-      - docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
-      - make -j4 RELEASE_BUILD=1 VERSION=${DRONE_TAG} dist
-      - VERSION=${DRONE_TAG} RELEASE_DOC_TAG=$(echo ${DRONE_TAG} | awk -F '.' '{print $1"."$2}') ./tools/release
-depends_on:
-  - Test
-
-volumes:
-  - name: docker
-    host:
-      path: /var/run/docker.sock
-
+  - refs/heads/main
+type: docker
 ---
+kind: pipeline
+name: Publish Windows Docker containers
+platform:
+  arch: amd64
+  os: windows
+  version: "1809"
+steps:
+- commands:
+  - git config --global --add safe.directory C:/drone/src/
+  - '& "C:/Program Files/git/bin/bash.exe" -c ./tools/ci/docker-containers-windows'
+  environment:
+    DOCKER_LOGIN:
+      from_secret: DOCKER_LOGIN
+    DOCKER_PASSWORD:
+      from_secret: DOCKER_PASSWORD
+  image: grafana/agent-build-image:0.19.0-windows
+  name: Build containers
+  volumes:
+  - name: docker
+    path: //./pipe/docker_engine/
+trigger:
+  ref:
+  - refs/heads/main
+  - refs/tags/v*
+  - refs/heads/dev.*
+type: docker
+volumes:
+- host:
+    path: //./pipe/docker_engine/
+  name: docker
+---
+depends_on:
+- Publish Linux Docker containers
+- Publish Windows Docker containers
+kind: pipeline
+name: Publish release
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
+  - make -j4 RELEASE_BUILD=1 VERSION=${DRONE_TAG} dist
+  - |
+    VERSION ${DRONE_TAG} RELEASE_DOC_TAG=$(echo ${DRONE_TAG} | awk -F '.' '{print $1"."$2}') ./tools/release
+  environment:
+    DOCKER_LOGIN:
+      from_secret: DOCKER_LOGIN
+    DOCKER_PASSWORD:
+      from_secret: DOCKER_PASSWORD
+    GITHUB_TOKEN:
+      from_secret: GITHUB_KEY
+    GPG_PASSPHRASE:
+      from_secret: gpg_passphrase
+    GPG_PRIVATE_KEY:
+      from_secret: gpg_private_key
+    GPG_PUBLIC_KEY:
+      from_secret: gpg_public_key
+  image: grafana/agent-build-image:0.19.0
+  name: Publish release
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+trigger:
+  ref:
+  - refs/tags/v*
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+get:
+  name: .dockerconfigjson
+  path: secret/data/common/gcr
 kind: secret
 name: dockerconfigjson
-
-get:
-  path: secret/data/common/gcr
-  name: .dockerconfigjson
-
 ---
-kind: secret
-name: gcr_admin
-
 get:
   name: .dockerconfigjson
   path: infra/data/ci/gcr-admin
-
+kind: secret
+name: gcr_admin
 ---
+get:
+  name: pat
+  path: infra/data/ci/github/grafanabot
 kind: secret
 name: gh_token
-
-get:
-  path: infra/data/ci/github/grafanabot
-  name: pat
-
 ---
-kind: secret
-name: gpg_public_key
-
 get:
   name: public-key
   path: infra/data/ci/packages-publish/gpg
-
----
 kind: secret
-name: gpg_private_key
-
+name: gpg_public_key
+---
 get:
   name: private-key
   path: infra/data/ci/packages-publish/gpg
-
----
 kind: secret
-name: gpg_passphrase
-
+name: gpg_private_key
+---
 get:
   name: passphrase
   path: infra/data/ci/packages-publish/gpg
-
+kind: secret
+name: gpg_passphrase
 ---
 kind: signature
-hmac: 61489753c517810cccce9c906d2d2350f5dc4e2e72415b73ca19b3d593ad99c7
+hmac: efdd8fe910a5f4671583c46ed3b7dc48ff2b0490ae6718b23ac6dd046619624f
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -16,6 +16,9 @@ trigger:
   event:
     include:
     - pull_request
+  paths:
+    include:
+    - build-image/**
 type: docker
 volumes:
 - host:
@@ -74,6 +77,9 @@ trigger:
   event:
     include:
     - pull_request
+  paths:
+    include:
+    - build-image/**
 type: docker
 volumes:
 - host:
@@ -452,6 +458,6 @@ kind: secret
 name: gpg_passphrase
 ---
 kind: signature
-hmac: f222515d9297e752c558d25eb7395a3aa275f26c9445a69dcea1069280c66f41
+hmac: 116c22bc56a3f0542e95b4136ba14229f87085417f4bd003220a5e6318343486
 
 ...

--- a/.drone/pipelines/build_images.jsonnet
+++ b/.drone/pipelines/build_images.jsonnet
@@ -1,0 +1,63 @@
+local pipelines = import '../util/pipelines.jsonnet';
+
+local locals = {
+  on_build_image_tag: {
+    event: ['tag'],
+    ref: ['refs/tags/build-image/v*'],
+  },
+  docker_environment: {
+    DOCKER_LOGIN: { from_secret: 'DOCKER_LOGIN' },
+    DOCKER_PASSWORD: { from_secret: 'DOCKER_PASSWORD' },
+  },
+};
+
+[
+  pipelines.linux('Create Linux build image') {
+    trigger: locals.on_build_image_tag,
+    steps: [{
+      name: 'Build',
+      image: 'docker',
+      volumes: [{
+        name: 'docker',
+        path: '/var/run/docker.sock',
+      }],
+      environment: locals.docker_environment,
+      commands: [
+        'export IMAGE_TAG=${DRONE_TAG##build-image/v}',
+        'docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD',
+        'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes',
+        'docker buildx create --name multiarch --driver docker-container --use',
+        'docker buildx build --push --platform linux/amd64,linux/arm64 -t grafana/agent-build-image:$IMAGE_TAG ./build-image',
+      ],
+    }],
+    volumes: [{
+      name: 'docker',
+      host: { path: '/var/run/docker.sock' },
+    }],
+  },
+
+  pipelines.windows('Create Windows build image') {
+    trigger: locals.on_build_image_tag,
+    steps: [{
+      name: 'Build',
+      image: 'docker',
+      volumes: [{
+        name: 'docker',
+        path: '//./pipe/docker_engine/',
+      }],
+      environment: locals.docker_environment,
+      commands: [
+        // NOTE(rfratto): the variable syntax is parsed ahead of time by Drone,
+        // and not by Windows (where the syntax obviously wouldn't work).
+        '$IMAGE_TAG="${DRONE_TAG##build-image/v}-windows"',
+        'docker login -u $Env:DOCKER_LOGIN -p $Env:DOCKER_PASSWORD',
+        'docker build -t grafana/agent-build-image:$IMAGE_TAG ./build-image/windows',
+        'docker push grafana/agent-build-image:$IMAGE_TAG',
+      ],
+    }],
+    volumes: [{
+      name: 'docker',
+      host: { path: '//./pipe/docker_engine/' },
+    }],
+  },
+]

--- a/.drone/pipelines/build_images.jsonnet
+++ b/.drone/pipelines/build_images.jsonnet
@@ -3,7 +3,7 @@ local pipelines = import '../util/pipelines.jsonnet';
 local locals = {
   on_pr: {
     event: { include: ['pull_request'] },
-    // paths: { include: ['build-image/**'] },
+    paths: { include: ['build-image/**'] },
   },
   on_build_image_tag: {
     event: ['tag'],

--- a/.drone/pipelines/check_containers.jsonnet
+++ b/.drone/pipelines/check_containers.jsonnet
@@ -7,7 +7,6 @@ local linux_containers = [
   { name: 'grafana/agent-operator', make: 'make operator-image' },
 ];
 
-
 (
   std.map(function(container) pipelines.linux('Check Linux container (%s)' % container.name) {
     trigger: {

--- a/.drone/pipelines/check_containers.jsonnet
+++ b/.drone/pipelines/check_containers.jsonnet
@@ -1,0 +1,56 @@
+local build_image = import '../util/build_image.jsonnet';
+local pipelines = import '../util/pipelines.jsonnet';
+
+local linux_containers = [
+  { name: 'grafana/agent', make: 'make agent-image' },
+  { name: 'grafana/agentctl', make: 'make agentctl-image' },
+  { name: 'grafana/agent-operator', make: 'make operator-image' },
+];
+
+
+(
+  std.map(function(container) pipelines.linux('Check Linux container (%s)' % container.name) {
+    trigger: {
+      event: ['pull_request'],
+    },
+    steps: [{
+      name: 'Build container',
+      image: build_image.linux,
+      volumes: [{
+        name: 'docker',
+        path: '/var/run/docker.sock',
+      }],
+      commands: [container.make],
+    }],
+    volumes: [{
+      name: 'docker',
+      host: {
+        path: '/var/run/docker.sock',
+      },
+    }],
+  }, linux_containers)
+) + [
+  pipelines.windows('Check Windows containers') {
+    trigger: {
+      event: ['pull_request'],
+    },
+    steps: [{
+      name: 'Build container',
+      image: build_image.windows,
+      volumes: [{
+        name: 'docker',
+        path: '//./pipe/docker_engine/',
+      }],
+      commands: [
+        'git config --global --add safe.directory C:/drone/src/',
+        '& "C:/Program Files/git/bin/bash.exe" -c ./tools/ci/docker-containers-windows',
+      ],
+    }],
+    volumes: [{
+      name: 'docker',
+      host: {
+        path: '//./pipe/docker_engine/',
+      },
+    }],
+  },
+]

--- a/.drone/pipelines/check_containers.jsonnet
+++ b/.drone/pipelines/check_containers.jsonnet
@@ -45,6 +45,10 @@ local linux_containers = [
         'git config --global --add safe.directory C:/drone/src/',
         '& "C:/Program Files/git/bin/bash.exe" -c ./tools/ci/docker-containers-windows',
       ],
+
+      // TODO(rfratto): remove me once Windows containers are building
+      // properly.
+      failure: 'ignore',
     }],
     volumes: [{
       name: 'docker',

--- a/.drone/pipelines/publish.jsonnet
+++ b/.drone/pipelines/publish.jsonnet
@@ -1,0 +1,163 @@
+local build_image = import '../util/build_image.jsonnet';
+local pipelines = import '../util/pipelines.jsonnet';
+
+[
+  pipelines.linux('Publish Linux Docker containers') {
+    trigger: {
+      ref: [
+        'refs/heads/main',
+        'refs/tags/v*',
+        'refs/heads/dev.*',
+      ],
+    },
+    steps: [{
+      name: 'Build containers',
+      image: build_image.linux,
+      volumes: [{
+        name: 'docker',
+        path: '/var/run/docker.sock',
+      }],
+      environment: {
+        DOCKER_LOGIN: { from_secret: 'DOCKER_LOGIN' },
+        DOCKER_PASSWORD: { from_secret: 'DOCKER_PASSWORD' },
+        GCR_CREDS: { from_secret: 'gcr_admin' },
+      },
+      commands: [
+        'mkdir -p $HOME/.docker',
+        'printenv GCR_CREDS > $HOME/.docker/config.json',
+        'docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD',
+
+        // Create a buildx worker container for multiplatform builds.
+        'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes',
+        'docker buildx create --name multiarch --driver docker-container --use',
+
+        './tools/ci/docker-containers',
+
+        // Remove the buildx worker container.
+        'docker buildx rm multiarch',
+      ],
+    }],
+    volumes: [{
+      name: 'docker',
+      host: { path: '/var/run/docker.sock' },
+    }],
+  },
+
+  pipelines.linux('Deploy to deployment_tools') {
+    trigger: {
+      ref: ['refs/heads/main'],
+    },
+    image_pull_secrets: ['dockerconfigjson'],
+    steps: [
+      {
+        name: 'Create .image-tag',
+        image: 'alpine',
+        commands: [
+          'apk update && apk add git',
+          'echo "$(sh ./tools/image-tag)" > .tag-only',
+          'echo "grafana/agent:$(sh ./tools/image-tag)" > .image-tag',
+        ],
+      },
+      {
+        name: 'Update deployment_tools',
+        image: 'us.gcr.io/kubernetes-dev/drone/plugins/updater',
+        settings: {
+          config_json: |||
+            {
+              "destination_branch": "master",
+              "pull_request_branch_prefix": "cd-agent",
+              "pull_request_enabled": false,
+              "pull_request_team_reviewers": [
+                "agent-squad"
+              ],
+              "repo_name": "deployment_tools",
+              "update_jsonnet_attribute_configs": [
+                {
+                  "file_path": "ksonnet/environments/kowalski/dev-us-central-0.kowalski-dev/main.jsonnet",
+                  "jsonnet_key": "agent_image",
+                  "jsonnet_value_file": ".image-tag"
+                },
+                {
+                  "file_path": "ksonnet/environments/grafana-agent/waves/agent.libsonnet",
+                  "jsonnet_key": "dev_canary",
+                  "jsonnet_value_file": ".image-tag"
+                }
+              ]
+            }
+          |||,
+          github_token: {
+            from_secret: 'gh_token',
+          },
+        },
+      },
+    ],
+    depends_on: ['Publish Linux Docker containers'],
+  },
+
+  pipelines.windows('Publish Windows Docker containers') {
+    trigger: {
+      ref: [
+        'refs/heads/main',
+        'refs/tags/v*',
+        'refs/heads/dev.*',
+      ],
+    },
+    steps: [{
+      name: 'Build containers',
+      image: build_image.windows,
+      volumes: [{
+        name: 'docker',
+        path: '//./pipe/docker_engine/',
+      }],
+      environment: {
+        DOCKER_LOGIN: { from_secret: 'DOCKER_LOGIN' },
+        DOCKER_PASSWORD: { from_secret: 'DOCKER_PASSWORD' },
+      },
+      commands: [
+        'git config --global --add safe.directory C:/drone/src/',
+        '& "C:/Program Files/git/bin/bash.exe" -c ./tools/ci/docker-containers-windows',
+      ],
+    }],
+    volumes: [{
+      name: 'docker',
+      host: { path: '//./pipe/docker_engine/' },
+    }],
+  },
+
+  pipelines.linux('Publish release') {
+    trigger: {
+      ref: ['refs/tags/v*'],
+    },
+    depends_on: [
+      'Publish Linux Docker containers',
+      'Publish Windows Docker containers',
+    ],
+    steps: [{
+      name: 'Publish release',
+      image: build_image.linux,
+      volumes: [{
+        name: 'docker',
+        path: '/var/run/docker.sock',
+      }],
+      environment: {
+        DOCKER_LOGIN: { from_secret: 'DOCKER_LOGIN' },
+        DOCKER_PASSWORD: { from_secret: 'DOCKER_PASSWORD' },
+        GITHUB_TOKEN: { from_secret: 'GITHUB_KEY' },
+        GPG_PRIVATE_KEY: { from_secret: 'gpg_private_key' },
+        GPG_PUBLIC_KEY: { from_secret: 'gpg_public_key' },
+        GPG_PASSPHRASE: { from_secret: 'gpg_passphrase' },
+      },
+      commands: [
+        'docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD',
+        'make -j4 RELEASE_BUILD=1 VERSION=${DRONE_TAG} dist',
+        |||
+          VERSION ${DRONE_TAG} RELEASE_DOC_TAG=$(echo ${DRONE_TAG} | awk -F '.' '{print $1"."$2}') ./tools/release
+        |||,
+      ],
+    }],
+    volumes: [{
+      name: 'docker',
+      host: { path: '/var/run/docker.sock' },
+    }],
+  },
+]

--- a/.drone/pipelines/test.jsonnet
+++ b/.drone/pipelines/test.jsonnet
@@ -1,0 +1,58 @@
+local build_image = import '../util/build_image.jsonnet';
+local pipelines = import '../util/pipelines.jsonnet';
+
+[
+  pipelines.linux('Lint') {
+    trigger: {
+      event: ['pull_request'],
+    },
+    steps: [{
+      name: 'Lint',
+      image: build_image.linux,
+      commands: ['make lint'],
+    }],
+  },
+
+  pipelines.linux('Test') {
+    trigger: {
+      event: ['pull_request'],
+    },
+    steps: [{
+      name: 'Run Go tests',
+      image: build_image.linux,
+      volumes: [{
+        name: 'docker',
+        path: '/var/run/docker.sock',
+      }],
+
+      commands: [
+        // Make sure all the binaries can be built. We do this in the same
+        // step as running tests just to avoid having to redownload and
+        // rebuild the dependencies twice.
+        'make binaries',
+
+        // The operator tests require K8S_USE_DOCKER_NETWORK=1 to be set when
+        // tests are being run inside of a Docker container so it can access the
+        // created k3d cluster properly.
+        'K8S_USE_DOCKER_NETWORK=1 make test',
+      ],
+    }],
+    volumes: [{
+      name: 'docker',
+      host: {
+        path: '/var/run/docker.sock',
+      },
+    }],
+  },
+
+  pipelines.windows('Test (Windows)') {
+    trigger: {
+      event: ['pull_request'],
+    },
+    steps: [{
+      name: 'Run Go tests',
+      image: build_image.windows,
+      commands: ['go test -tags="nodocker,nonetwork" ./...'],
+    }],
+  },
+]

--- a/.drone/secrets.jsonnet
+++ b/.drone/secrets.jsonnet
@@ -1,0 +1,17 @@
+local new_secret(name) = {
+  kind: 'secret',
+  name: name,
+
+  getFrom(path, name):: self {
+    get: { path: path, name: name },
+  },
+};
+
+[
+  new_secret('dockerconfigjson').getFrom(path='secret/data/common/gcr', name='.dockerconfigjson'),
+  new_secret('gcr_admin').getFrom(path='infra/data/ci/gcr-admin', name='.dockerconfigjson'),
+  new_secret('gh_token').getFrom(path='infra/data/ci/github/grafanabot', name='pat'),
+  new_secret('gpg_public_key').getFrom(path='infra/data/ci/packages-publish/gpg', name='public-key'),
+  new_secret('gpg_private_key').getFrom(path='infra/data/ci/packages-publish/gpg', name='private-key'),
+  new_secret('gpg_passphrase').getFrom(path='infra/data/ci/packages-publish/gpg', name='passphrase'),
+]

--- a/.drone/util/build_image.jsonnet
+++ b/.drone/util/build_image.jsonnet
@@ -1,0 +1,6 @@
+{
+  local version = std.extVar('BUILD_IMAGE_VERSION'),
+
+  linux: 'grafana/agent-build-image:%s' % version,
+  windows: 'grafana/agent-build-image:%s-windows' % version,
+}

--- a/.drone/util/pipelines.jsonnet
+++ b/.drone/util/pipelines.jsonnet
@@ -1,0 +1,22 @@
+{
+  linux(name):: {
+    kind: 'pipeline',
+    type: 'docker',
+    name: name,
+    platform: {
+      os: 'linux',
+      arch: 'amd64',
+    },
+  },
+
+  windows(name):: {
+    kind: 'pipeline',
+    type: 'docker',
+    name: name,
+    platform: {
+      arch: 'amd64',
+      os: 'windows',
+      version: '1809',
+    },
+  },
+}

--- a/Makefile
+++ b/Makefile
@@ -307,6 +307,7 @@ endif
 # This will only work for maintainers.
 .PHONY: drone
 drone:
+	drone jsonnet -V BUILD_IMAGE_VERSION=$(BUILD_IMAGE_VERSION) --stream --format --source .drone/drone.jsonnet --target .drone/drone.yml
 	drone lint .drone/drone.yml --trusted
 	drone --server https://drone.grafana.net sign --save grafana/agent .drone/drone.yml
 

--- a/tools/make/build-container.mk
+++ b/tools/make/build-container.mk
@@ -33,9 +33,10 @@
 # Callers should set the PROPAGATE_VARS global variable to specify which
 # variable names should be passed through to the container.
 
-USE_CONTAINER ?= 0
-BUILD_IMAGE   ?= grafana/agent-build-image:0.19.0
-DOCKER_OPTS   ?= -it
+USE_CONTAINER       ?= 0
+BUILD_IMAGE_VERSION ?= 0.19.0
+BUILD_IMAGE         ?= grafana/agent-build-image:$(BUILD_IMAGE_VERSION)
+DOCKER_OPTS         ?= -it
 
 #
 # Build container cache. `make build-container-cache` will create two Docker


### PR DESCRIPTION
This changes our Drone file to be generated from Jsonnet. This has some benefits, primarily around code-reuse (such as not having to keep the build image version up to date in many places at once).

The resulting Drone config has some differences from today:

* There are extra pipelines for checking that Docker containers can be built in PRs 
* Test and Lint no longer run commit to main (since they run against merged code in the PR anyway)
* The Release pipeline now waits for the Docker containers to be published first.
* There are extra pipelines for checking that the build images can be built in PRs which modify the build images (otherwise these pipelines are skipped).

The `make drone` target is extended to include converting the Jsonnet to YAML before linting and signing. 