### PR TITLE
production/tanka: stop explicitly setting command

### DIFF
--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -78,8 +78,6 @@ spec:
         - -config.file=/etc/agent/agent.yaml
         - -enable-features=integrations-next
         - -server.http.address=0.0.0.0:80
-        command:
-        - /bin/grafana-agent
         env:
         - name: HOSTNAME
           valueFrom:

--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -60,8 +60,6 @@ spec:
         - -config.expand-env=true
         - -config.file=/etc/agent/agent.yaml
         - -server.http.address=0.0.0.0:80
-        command:
-        - /bin/grafana-agent
         env:
         - name: HOSTNAME
           valueFrom:

--- a/production/kubernetes/agent-traces.yaml
+++ b/production/kubernetes/agent-traces.yaml
@@ -109,8 +109,6 @@ spec:
         - -config.expand-env=true
         - -config.file=/etc/agent/agent.yaml
         - -server.http.address=0.0.0.0:80
-        command:
-        - /bin/grafana-agent
         env:
         - name: HOSTNAME
           valueFrom:

--- a/production/tanka/grafana-agent/grafana-agent.libsonnet
+++ b/production/tanka/grafana-agent/grafana-agent.libsonnet
@@ -37,7 +37,6 @@ k + config {
   agent_container::
     container.new('agent', $._images.agent) +
     container.withPorts($.core.v1.containerPort.new('http-metrics', 80)) +
-    container.withCommand('/bin/grafana-agent') +
     container.withArgsMixin($.util.mapToFlags($.agent_args)) +
     container.withEnv([
       $.core.v1.envVar.fromFieldPath('HOSTNAME', 'spec.nodeName'),

--- a/production/tanka/grafana-agent/smoke/main.libsonnet
+++ b/production/tanka/grafana-agent/smoke/main.libsonnet
@@ -41,7 +41,6 @@ local util = k.util;
 
     container::
       container.new('agent-smoke', this._config.image) +
-      container.withCommand('/bin/grafana-agent-smoke') +
       container.withPorts([
         containerPort.newNamed(name='remote-write', containerPort=19090),
       ]) +

--- a/production/tanka/grafana-agent/v1/internal/agent.libsonnet
+++ b/production/tanka/grafana-agent/v1/internal/agent.libsonnet
@@ -43,7 +43,6 @@ local serviceAccount = k.core.v1.serviceAccount;
     container::
       container.new('agent', image) +
       container.withPorts(k.core.v1.containerPort.new('http-metrics', self.listen_port)) +
-      container.withCommand('/bin/grafana-agent') +
       container.withArgsMixin(k.util.mapToFlags({
         'config.file': '/etc/agent/agent.yaml',
         'server.http.address': '0.0.0.0:' + this.listen_port,

--- a/production/tanka/grafana-agent/v2/internal/base.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/base.libsonnet
@@ -48,7 +48,6 @@ function(name='grafana-agent', namespace='') {
   container::
     container.new(name, this._images.agent) +
     container.withPorts(containerPort.new('http-metrics', this._config.agent_port)) +
-    container.withCommand('/bin/grafana-agent') +
     container.withArgsMixin(k.util.mapToFlags(this._config.agent_args)) +
     // `HOSTNAME` is required for promtail (logs) otherwise it will silently do nothing
     container.withEnvMixin([


### PR DESCRIPTION
Explicitly setting the command is not neccesary, but also currently won't work in the Jsonnet because the prefix name change (#2677) for the binaries hasn't been released yet, and the Jsonnet uses a stable release.

Removing an explicit setting of the command allows containers to use the Dockerfile default.