### PR TITLE
Flow: rework Rules export of relabeling components into a struct

### DIFF
--- a/component/common/relabel/relabel.go
+++ b/component/common/relabel/relabel.go
@@ -186,7 +186,9 @@ func ComponentToPromRelabelConfigs(rcs []*Config) []*relabel.Config {
 }
 
 // Rules returns the relabel configs in use for a relabeling component.
-type Rules func() []*Config
+type Rules struct {
+	GetAll func() []*Config
+}
 
 // RiverCapsule marks the alias defined above as a "capsule type" so that it
 // cannot be invoked by River code.

--- a/component/discovery/relabel/relabel.go
+++ b/component/discovery/relabel/relabel.go
@@ -34,8 +34,8 @@ type Arguments struct {
 
 // Exports holds values which are exported by the discovery.relabel component.
 type Exports struct {
-	Output []discovery.Target `river:"output,attr"`
-	Rules  flow_relabel.Rules `river:"rules,attr"`
+	Output []discovery.Target  `river:"output,attr"`
+	Rules  *flow_relabel.Rules `river:"rules,attr"`
 }
 
 // Component implements the discovery.relabel component.
@@ -89,17 +89,21 @@ func (c *Component) Update(args component.Arguments) error {
 
 	c.opts.OnStateChange(Exports{
 		Output: targets,
-		Rules:  c.getRules,
+		Rules:  getRules(c),
 	})
 
 	return nil
 }
 
-func (c *Component) getRules() []*flow_relabel.Config {
-	c.mut.RLock()
-	defer c.mut.RUnlock()
+func getRules(c *Component) *flow_relabel.Rules {
+	return &flow_relabel.Rules{
+		GetAll: func() []*flow_relabel.Config {
+			c.mut.RLock()
+			defer c.mut.RUnlock()
 
-	return c.rcsFlow
+			return c.rcsFlow
+		},
+	}
 }
 
 func componentMapToPromLabels(ls discovery.Target) labels.Labels {

--- a/component/discovery/relabel/relabel_test.go
+++ b/component/discovery/relabel/relabel_test.go
@@ -97,7 +97,7 @@ rule {
 
 	// Use the getter to retrieve the original relabeling rules.
 	exports := tc.Exports().(relabel.Exports)
-	gotOriginal := exports.Rules()
+	gotOriginal := exports.Rules.GetAll()
 
 	// Update the component with new relabeling rules and retrieve them.
 	updatedCfg := `
@@ -111,7 +111,7 @@ rule {
 	require.NoError(t, river.Unmarshal([]byte(updatedCfg), &args))
 
 	require.NoError(t, tc.Update(args))
-	gotUpdated := exports.Rules()
+	gotUpdated := exports.Rules.GetAll()
 
 	require.NotEqual(t, gotOriginal, gotUpdated)
 	require.Len(t, gotOriginal, 1)

--- a/component/loki/relabel/relabel_test.go
+++ b/component/loki/relabel/relabel_test.go
@@ -302,7 +302,7 @@ func TestRuleGetter(t *testing.T) {
 
 	// Use the getter to retrieve the original relabeling rules.
 	exports := tc.Exports().(Exports)
-	gotOriginal := exports.Rules()
+	gotOriginal := exports.Rules.GetAll()
 
 	// Update the component with new relabeling rules and retrieve them.
 	updatedCfg := `rule {
@@ -314,7 +314,7 @@ func TestRuleGetter(t *testing.T) {
 	require.NoError(t, river.Unmarshal([]byte(updatedCfg), &args))
 
 	require.NoError(t, tc.Update(args))
-	gotUpdated := exports.Rules()
+	gotUpdated := exports.Rules.GetAll()
 
 	require.NotEqual(t, gotOriginal, gotUpdated)
 	require.Len(t, gotOriginal, 1)

--- a/component/loki/source/syslog/syslog.go
+++ b/component/loki/source/syslog/syslog.go
@@ -99,7 +99,7 @@ func (c *Component) Update(args component.Arguments) error {
 	c.fanout = newArgs.ForwardTo
 
 	var rcs []*relabel.Config
-	if len(newArgs.RelabelRules.GetAll()) > 0 {
+	if newArgs.RelabelRules != nil && len(newArgs.RelabelRules.GetAll()) > 0 {
 		rcs = flow_relabel.ComponentToPromRelabelConfigs(newArgs.RelabelRules.GetAll())
 	}
 

--- a/component/loki/source/syslog/syslog.go
+++ b/component/loki/source/syslog/syslog.go
@@ -29,7 +29,7 @@ func init() {
 type Arguments struct {
 	SyslogListeners []ListenerConfig    `river:"listener,block"`
 	ForwardTo       []loki.LogsReceiver `river:"forward_to,attr"`
-	RelabelRules    flow_relabel.Rules  `river:"relabel_rules,attr,optional"`
+	RelabelRules    *flow_relabel.Rules `river:"relabel_rules,attr,optional"`
 }
 
 // Component implements the loki.source.syslog component.
@@ -99,8 +99,8 @@ func (c *Component) Update(args component.Arguments) error {
 	c.fanout = newArgs.ForwardTo
 
 	var rcs []*relabel.Config
-	if newArgs.RelabelRules != nil {
-		rcs = flow_relabel.ComponentToPromRelabelConfigs(newArgs.RelabelRules())
+	if len(newArgs.RelabelRules.GetAll()) > 0 {
+		rcs = flow_relabel.ComponentToPromRelabelConfigs(newArgs.RelabelRules.GetAll())
 	}
 
 	if configsChanged(c.lc, newArgs.SyslogListeners) {

--- a/component/loki/source/syslog/syslog_test.go
+++ b/component/loki/source/syslog/syslog_test.go
@@ -121,19 +121,21 @@ func TestWithRelabelRules(t *testing.T) {
 	args.ForwardTo = []loki.LogsReceiver{ch1}
 
 	// Create a handler which will be used to retrieve relabeling rules.
-	args.RelabelRules = func() []*flow_relabel.Config {
-		return []*flow_relabel.Config{
-			{
-				SourceLabels: []string{"__name__"},
-				Regex:        mustNewRegexp("__syslog_(.*)"),
-				Action:       flow_relabel.LabelMap,
-				Replacement:  "syslog_${1}",
-			},
-			{
-				Regex:  mustNewRegexp("syslog_connection_hostname"),
-				Action: flow_relabel.LabelDrop,
-			},
-		}
+	args.RelabelRules = &flow_relabel.Rules{
+		GetAll: func() []*flow_relabel.Config {
+			return []*flow_relabel.Config{
+				{
+					SourceLabels: []string{"__name__"},
+					Regex:        mustNewRegexp("__syslog_(.*)"),
+					Action:       flow_relabel.LabelMap,
+					Replacement:  "syslog_${1}",
+				},
+				{
+					Regex:  mustNewRegexp("syslog_connection_hostname"),
+					Action: flow_relabel.LabelDrop,
+				},
+			}
+		},
 	}
 
 	// Create and run the component.

--- a/component/prometheus/relabel/relabel.go
+++ b/component/prometheus/relabel/relabel.go
@@ -44,8 +44,8 @@ type Arguments struct {
 
 // Exports holds values which are exported by the prometheus.relabel component.
 type Exports struct {
-	Receiver storage.Appendable `river:"receiver,attr"`
-	Rules    flow_relabel.Rules `river:"rules,attr"`
+	Receiver storage.Appendable  `river:"receiver,attr"`
+	Rules    *flow_relabel.Rules `river:"rules,attr"`
 }
 
 // Component implements the prometheus.relabel component.
@@ -147,7 +147,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 
 	// Immediately export the receiver which remains the same for the component
 	// lifetime.
-	o.OnStateChange(Exports{Rules: c.getRules})
+	o.OnStateChange(Exports{Rules: getRules(c)})
 
 	// Call to Update() to set the relabelling rules once at the start.
 	if err = c.Update(args); err != nil {
@@ -258,9 +258,13 @@ type labelAndID struct {
 	id     uint64
 }
 
-func (c *Component) getRules() []*flow_relabel.Config {
-	c.mut.RLock()
-	defer c.mut.RUnlock()
+func getRules(c *Component) *flow_relabel.Rules {
+	return &flow_relabel.Rules{
+		GetAll: func() []*flow_relabel.Config {
+			c.mut.RLock()
+			defer c.mut.RUnlock()
 
-	return c.mrcFlow
+			return c.mrcFlow
+		},
+	}
 }

--- a/component/prometheus/relabel/relabel.go
+++ b/component/prometheus/relabel/relabel.go
@@ -147,7 +147,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 
 	// Immediately export the receiver which remains the same for the component
 	// lifetime.
-	o.OnStateChange(Exports{Rules: getRules(c)})
+	o.OnStateChange(Exports{Receiver: c.receiver, Rules: getRules(c)})
 
 	// Call to Update() to set the relabelling rules once at the start.
 	if err = c.Update(args); err != nil {

--- a/component/prometheus/relabel/relabel_test.go
+++ b/component/prometheus/relabel/relabel_test.go
@@ -175,7 +175,7 @@ func TestRuleGetter(t *testing.T) {
 	// Use the getter to retrieve the original relabeling rules.
 	exports := tc.Exports().(Exports)
 	fmt.Println("exports:", exports.Receiver, "exports.rules", exports.Rules)
-	gotOriginal := exports.Rules()
+	gotOriginal := exports.Rules.GetAll()
 
 	// Update the component with new relabeling rules and retrieve them.
 	updatedCfg := `rule {
@@ -187,7 +187,7 @@ func TestRuleGetter(t *testing.T) {
 	require.NoError(t, river.Unmarshal([]byte(updatedCfg), &args))
 
 	require.NoError(t, tc.Update(args))
-	gotUpdated := exports.Rules()
+	gotUpdated := exports.Rules.GetAll()
 
 	require.NotEqual(t, gotOriginal, gotUpdated)
 	require.Len(t, gotOriginal, 1)

--- a/component/prometheus/relabel/relabel_test.go
+++ b/component/prometheus/relabel/relabel_test.go
@@ -1,7 +1,6 @@
 package relabel
 
 import (
-	"fmt"
 	"math"
 	"os"
 	"testing"
@@ -174,7 +173,6 @@ func TestRuleGetter(t *testing.T) {
 
 	// Use the getter to retrieve the original relabeling rules.
 	exports := tc.Exports().(Exports)
-	fmt.Println("exports:", exports.Receiver, "exports.rules", exports.Rules)
 	gotOriginal := exports.Rules.GetAll()
 
 	// Update the component with new relabeling rules and retrieve them.


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
After we witnessed the recent introduction of the `Rules` export field for relabeling components drop the entire Agent's throughput, this PR makes it into a struct so it can be comparable and handled by things like `reflect.IsEqual` more gracefully.

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer
I'm still looking into what caused the original issue, let me know if you have any ideas or objections to this.

#### PR Checklist

- [ ] CHANGELOG updated (N/A) 
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
