### PR TITLE
Flow: add otelcol.receiver.loki component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Main (unreleased)
   - `otelcol.exporter.loki` forwards OTLP-formatted data to compatible `loki`
     receivers. (@tpaschalis)
   - `loki.source.gelf` listens for Graylog logs. (@mattdurham)
+  - `otelcol.receiver.loki` receives Loki logs, converts them to the OTLP log
+    format and forwards them to other `otelcol` components. (@tpaschalis)
 
 - Flow components which work with relabeling rules (`discovery.relabel`,
   `prometheus.relabel` and `loki.relabel`) now export a new value named Rules.

--- a/component/all/all.go
+++ b/component/all/all.go
@@ -28,6 +28,7 @@ import (
 	_ "github.com/grafana/agent/component/otelcol/processor/memorylimiter"      // Import otelcol.processor.memory_limiter
 	_ "github.com/grafana/agent/component/otelcol/receiver/jaeger"              // Import otelcol.receiver.jaeger
 	_ "github.com/grafana/agent/component/otelcol/receiver/kafka"               // Import otelcol.receiver.kafka
+	_ "github.com/grafana/agent/component/otelcol/receiver/loki"                // Import otelcol.receiver.loki
 	_ "github.com/grafana/agent/component/otelcol/receiver/opencensus"          // Import otelcol.receiver.opencensus
 	_ "github.com/grafana/agent/component/otelcol/receiver/otlp"                // Import otelcol.receiver.otlp
 	_ "github.com/grafana/agent/component/otelcol/receiver/prometheus"          // Import otelcol.receiver.prometheus

--- a/component/otelcol/receiver/loki/loki.go
+++ b/component/otelcol/receiver/loki/loki.go
@@ -146,11 +146,3 @@ func parsePromtailEntry(inputEntry loki.Entry) *entry.Entry {
 	}
 	return outputEntry
 }
-
-// NewEntry will create a new entry.
-func NewEntry(value interface{}) (*entry.Entry, error) {
-	entry := entry.New()
-	entry.Body = value
-
-	return entry, nil
-}

--- a/component/otelcol/receiver/loki/loki.go
+++ b/component/otelcol/receiver/loki/loki.go
@@ -84,13 +84,17 @@ func (c *Component) Run(ctx context.Context) error {
 			return nil
 		case entry := <-c.receiver:
 			stanzaEntry, err := parsePromtailEntry(entry)
+			// TODO(@tpaschalis) Is there any more handling to be done for the
+			// errors here?
 			if err != nil {
-				// TODO(@tpaschalis) Is there any more handling to be done here?
 				level.Error(c.opts.Logger).Log("msg", "failed to parse loki entry", "err", err)
 				continue
 			}
 			plogEntry := adapter.Convert(stanzaEntry)
-			c.logsSink.ConsumeLogs(ctx, plogEntry)
+			err = c.logsSink.ConsumeLogs(ctx, plogEntry)
+			if err != nil {
+				level.Error(c.opts.Logger).Log("msg", "failed to consume log entries", "err", err)
+			}
 		}
 	}
 }

--- a/component/otelcol/receiver/loki/loki.go
+++ b/component/otelcol/receiver/loki/loki.go
@@ -1,0 +1,156 @@
+// Package loki provides an otelcol.receiver.loki component.
+package loki
+
+import (
+	"context"
+	"path"
+	"strings"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/agent/component/otelcol"
+	"github.com/grafana/agent/component/otelcol/internal/fanoutconsumer"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"go.opentelemetry.io/collector/consumer"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:    "otelcol.receiver.loki",
+		Args:    Arguments{},
+		Exports: Exports{},
+
+		Build: func(o component.Options, a component.Arguments) (component.Component, error) {
+			return NewComponent(o, a.(Arguments))
+		},
+	})
+}
+
+var hintAttributes = "loki.attribute.labels"
+
+// Arguments configures the otelcol.receiver.loki component.
+type Arguments struct {
+	// Output configures where to send received data. Required.
+	Output *otelcol.ConsumerArguments `river:"output,block"`
+}
+
+// Exports holds the receiver that is used to send log entries to the
+// loki.write component.
+type Exports struct {
+	Receiver loki.LogsReceiver `river:"receiver,attr"`
+}
+
+// Component is the otelcol.receiver.loki component.
+type Component struct {
+	log  log.Logger
+	opts component.Options
+
+	mut      sync.RWMutex
+	receiver loki.LogsReceiver
+	logsSink consumer.Logs
+}
+
+var _ component.Component = (*Component)(nil)
+
+// NewComponent creates a new otelcol.receiver.loki component.
+func NewComponent(o component.Options, c Arguments) (*Component, error) {
+	// TODO(@tpaschalis) Create a metrics struct to count
+	// total/succcessful/errored log entries?
+	res := &Component{
+		log:  o.Logger,
+		opts: o,
+	}
+
+	// Create and immediately export the receiver which remains the same for
+	// the component's lifetime.
+	res.receiver = make(loki.LogsReceiver)
+	o.OnStateChange(Exports{Receiver: res.receiver})
+
+	if err := res.Update(c); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// Run implements Component.
+func (c *Component) Run(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case entry := <-c.receiver:
+			stanzaEntry, err := parsePromtailEntry(entry)
+			if err != nil {
+				// TODO(@tpaschalis) Is there any more handling to be done here?
+				level.Error(c.opts.Logger).Log("msg", "failed to parse loki entry", "err", err)
+				continue
+			}
+			plogEntry := adapter.Convert(stanzaEntry)
+			c.logsSink.ConsumeLogs(ctx, plogEntry)
+		}
+	}
+}
+
+// Update implements Component.
+func (c *Component) Update(newConfig component.Arguments) error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	cfg := newConfig.(Arguments)
+	c.logsSink = fanoutconsumer.Logs(cfg.Output.Logs)
+
+	return nil
+}
+
+// parsePromtailEntry creates new stanza.Entry from promtail entry
+func parsePromtailEntry(inputEntry loki.Entry) (*entry.Entry, error) {
+	outputEntry := entry.New()
+	outputEntry.Body = inputEntry.Entry.Line
+	outputEntry.Timestamp = inputEntry.Entry.Timestamp
+
+	var lbls []string
+	for key, val := range inputEntry.Labels {
+		valStr := string(val)
+		keyStr := string(key)
+		switch key {
+		case "filename":
+			outputEntry.AddAttribute("filename", valStr)
+			lbls = append(lbls, "filename")
+			// The `promtailreceiver` from the opentelemetry-collector-contrib
+			// repo adds these two labels based on these "semantic conventions
+			// for log media".
+			// https://opentelemetry.io/docs/reference/specification/logs/semantic_conventions/media/
+			// We're keeping them as well, but we're also adding the `filename`
+			// attribute so that it can be used from the
+			// `loki.attribute.labels` hint for when the opposite OTel -> Loki
+			// transformation happens.
+			outputEntry.AddAttribute("log.file.path", valStr)
+			outputEntry.AddAttribute("log.file.name", path.Base(valStr))
+		default:
+			lbls = append(lbls, keyStr)
+			outputEntry.AddAttribute(keyStr, valStr)
+		}
+	}
+
+	if len(lbls) > 0 {
+		// This hint is defined in the pkg/translator/loki package and the
+		// opentelemetry-collector-contrib repo, but is not exported so we
+		// re-define it.
+		// It is used to detect which attributes should be promoted to labels
+		// when transforming back from OTel -> Loki.
+		outputEntry.AddAttribute(hintAttributes, strings.Join(lbls, ","))
+	}
+	return outputEntry, nil
+}
+
+// NewEntry will create a new entry.
+func NewEntry(value interface{}) (*entry.Entry, error) {
+	entry := entry.New()
+	entry.Body = value
+
+	return entry, nil
+}

--- a/component/otelcol/receiver/loki/loki_test.go
+++ b/component/otelcol/receiver/loki/loki_test.go
@@ -77,7 +77,12 @@ func Test(t *testing.T) {
 	case otelLogs = <-logCh:
 		require.Equal(t, 1, otelLogs.LogRecordCount())
 		require.Equal(t, "It's super effective!", otelLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().AsString())
-		require.Equal(t, wantAttributes, otelLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw())
+		require.Equal(t, wantAttributes["env"], otelLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw()["env"])
+		require.Equal(t, wantAttributes["filename"], otelLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw()["filename"])
+		require.Equal(t, wantAttributes["log.file.name"], otelLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw()["log.file.name"])
+		require.Equal(t, wantAttributes["log.file.path"], otelLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw()["log.file.path"])
+		require.Contains(t, otelLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw()["loki.attribute.labels"], "env")
+		require.Contains(t, otelLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw()["loki.attribute.labels"], "filename")
 	}
 }
 

--- a/component/otelcol/receiver/loki/loki_test.go
+++ b/component/otelcol/receiver/loki/loki_test.go
@@ -66,7 +66,7 @@ func Test(t *testing.T) {
 		"filename":              "/var/log/app/errors.log",
 		"log.file.name":         "errors.log",
 		"log.file.path":         "/var/log/app/errors.log",
-		"loki.attribute.labels": "filename,filename,log.file.path,log.file.name,env",
+		"loki.attribute.labels": "filename,env",
 	}
 
 	// Wait for our client to get the log.

--- a/component/otelcol/receiver/loki/loki_test.go
+++ b/component/otelcol/receiver/loki/loki_test.go
@@ -1,0 +1,101 @@
+package loki
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	lokiapi "github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/agent/component/otelcol"
+	"github.com/grafana/agent/component/otelcol/internal/fakeconsumer"
+	"github.com/grafana/agent/pkg/flow/componenttest"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/grafana/agent/pkg/util"
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func Test(t *testing.T) {
+	ctx := componenttest.TestContext(t)
+	l := util.TestLogger(t)
+
+	ctrl, err := componenttest.NewControllerFromID(l, "otelcol.receiver.loki")
+	require.NoError(t, err)
+
+	cfg := `
+		output {
+			// no-op: will be overridden by test code.
+		}
+	`
+	var args Arguments
+	require.NoError(t, river.Unmarshal([]byte(cfg), &args))
+
+	// Override our settings so logs get forwarded to logCh.
+	logCh := make(chan plog.Logs)
+	args.Output = makeLogsOutput(logCh)
+
+	go func() {
+		err := ctrl.Run(ctx, args)
+		require.NoError(t, err)
+	}()
+
+	require.NoError(t, ctrl.WaitRunning(time.Second))
+	require.NoError(t, ctrl.WaitExports(time.Second))
+
+	exports := ctrl.Exports().(Exports)
+
+	// Use the exported receiver to send log entries in the background.
+	go func() {
+		entry := lokiapi.Entry{
+			Labels: map[model.LabelName]model.LabelValue{
+				"filename": "/var/log/app/errors.log",
+				"env":      "dev",
+			},
+			Entry: logproto.Entry{
+				Timestamp: time.Now(),
+				Line:      "It's super effective!",
+			},
+		}
+		exports.Receiver <- entry
+	}()
+
+	wantAttributes := map[string]interface{}{
+		"env":                   "dev",
+		"filename":              "/var/log/app/errors.log",
+		"log.file.name":         "errors.log",
+		"log.file.path":         "/var/log/app/errors.log",
+		"loki.attribute.labels": "filename,filename,log.file.path,log.file.name,env",
+	}
+
+	// Wait for our client to get the log.
+	var otelLogs plog.Logs
+	select {
+	case <-time.After(time.Second):
+		require.FailNow(t, "failed waiting for log entry")
+	case otelLogs = <-logCh:
+		require.Equal(t, 1, otelLogs.LogRecordCount())
+		require.Equal(t, "It's super effective!", otelLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().AsString())
+		require.Equal(t, wantAttributes, otelLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw())
+	}
+}
+
+// makeLogsOutput returns a ConsumerArguments which will forward logs to
+// the provided channel.
+func makeLogsOutput(ch chan plog.Logs) *otelcol.ConsumerArguments {
+	logsConsumer := fakeconsumer.Consumer{
+		ConsumeLogsFunc: func(ctx context.Context, l plog.Logs) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case ch <- l:
+				return nil
+			}
+		},
+	}
+
+	return &otelcol.ConsumerArguments{
+		Logs: []otelcol.Consumer{&logsConsumer},
+	}
+}

--- a/docs/sources/flow/reference/components/otelcol.receiver.loki.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.loki.md
@@ -1,0 +1,92 @@
+---
+aliases:
+- /docs/agent/latest/flow/reference/components/otelcol.receiver.loki
+title: otelcol.receiver.loki
+---
+
+# otelcol.receiver.loki
+
+`otelcol.receiver.loki` receives Loki log entries, converts them to the
+OpenTelemetry logs format, and forwards them to other `otelcol.*` components.
+
+Multiple `otelcol.receiver.loki` components can be specified by giving them
+different labels.
+
+## Usage
+
+```river
+otelcol.receiver.loki "LABEL" {
+  output {
+    logs = [...]
+  }
+}
+```
+
+## Arguments
+
+`otelcol.receiver.loki` doesn't support any arguments and is configured fully
+through inner blocks.
+
+## Blocks
+
+The following blocks are supported inside the definition of
+`otelcol.receiver.loki`:
+
+Hierarchy | Block | Description | Required
+--------- | ----- | ----------- | --------
+output | [output][] | Configures where to send converted telemetry data. | yes
+
+[output]: #output-block
+
+### output block
+
+{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" >}}
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+Name | Type | Description
+---- | ---- | -----------
+`receiver` | `LogsReceiver` | A value that other components can use to send Loki logs to.
+
+## Component health
+
+`otelcol.receiver.loki` is only reported as unhealthy if given an invalid
+configuration.
+
+## Debug information
+
+`otelcol.receiver.loki` does not expose any component-specific debug
+information.
+
+## Example
+
+This example uses the `otelcol.receiver.loki` component as a bridge
+between the Loki and OpenTelemetry ecosystems. The component exposes a
+receiver which the `loki.source.file` component uses to send Loki log entries
+to. The logs are converted to the OTLP format before they are forwarded
+to the `otelcol.exporter.otlp` component to be sent to an OTLP-capable
+endpoint:
+
+```river
+loki.source.file "default" {
+  targets = [
+    {__path__ = "/tmp/foo.txt", "loki.format" = "logfmt"},
+    {__path__ = "/tmp/bar.txt", "loki.format" = "json"},
+  ]
+  forward_to = [otelcol.receiver.loki.default.receiver]
+}
+
+otelcol.receiver.loki "default" {
+  output {
+    logs = [otelcol.exporter.otlp.default.input] 
+  } 
+}
+
+otelcol.exporter.otlp "default" {
+  client {
+    endpoint = env("OTLP_ENDPOINT")
+  }
+}
+```

--- a/go.mod
+++ b/go.mod
@@ -136,7 +136,7 @@ require (
 	github.com/grafana/vmware_exporter v0.0.4-beta
 	github.com/hashicorp/golang-lru v0.6.0
 	github.com/hpcloud/tail v1.0.0
-	github.com/influxdata/go-syslog/v3 v3.0.1-0.20201128200927-a1889d947b48
+	github.com/influxdata/go-syslog/v3 v3.0.1-0.20210608084020-ac565dc76ba6
 	github.com/jaegertracing/jaeger v1.38.1
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/mackerelio/go-osstat v0.2.3
@@ -145,6 +145,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.61.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.61.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.61.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.63.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki v0.63.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.63.0
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
@@ -428,6 +429,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncabatoff/go-seq v0.0.0-20180805175032-b08ef85ed833 // indirect
 	github.com/nicolai86/scaleway-sdk v1.10.2-0.20180628010248-798f60e20bb2 // indirect
+	github.com/observiq/ctimefmt v1.0.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.63.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.63.0 // indirect
@@ -533,6 +535,8 @@ require (
 	golang.org/x/tools v0.4.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
+	gonum.org/v1/gonum v0.12.0 // indirect
+	google.golang.org/api v0.103.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20221227171554-f9683d7f8bef // indirect
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -457,6 +457,7 @@ github.com/Microsoft/hcsshim v0.9.3 h1:k371PzBuRrz2b+ebGuI2nVgVhgsVX60jMfSw80NEC
 github.com/Microsoft/hcsshim v0.9.3/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
 github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5hlzMzRKMLyo42nCZ9oml8AdTlq/0cvIaBv6tK1RehU=
 github.com/Microsoft/hcsshim/test v0.0.0-20210227013316-43a75bb4edd3/go.mod h1:mw7qgWloBUl75W/gVH3cQszUg1+gUITj7D6NY7ywVnY=
+github.com/Mottl/ctimefmt v0.0.0-20190803144728-fd2ac23a585a/go.mod h1:eyj2WSIdoPMPs2eNTLpSmM6Nzqo4V80/d6jHpnJ1SAI=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.0.1/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
@@ -1894,8 +1895,8 @@ github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLf
 github.com/infinityworks/go-common v0.0.0-20170820165359-7f20a140fd37 h1:Lm6kyC3JBiJQvJrus66He0E4viqDc/m5BdiFNSkIFfU=
 github.com/infinityworks/go-common v0.0.0-20170820165359-7f20a140fd37/go.mod h1:+OaHNKQvQ9oOCr+DgkF95PkiDx20fLHpzMp8SmRPQTg=
 github.com/influxdata/go-syslog/v2 v2.0.1/go.mod h1:hjvie1UTaD5E1fTnDmxaCw8RRDrT4Ve+XHr5O2dKSCo=
-github.com/influxdata/go-syslog/v3 v3.0.1-0.20201128200927-a1889d947b48 h1:0WbZ+ZVg74wbyQoRx1TD4D1Xoz8MsXJSTwdP9F7RMeQ=
-github.com/influxdata/go-syslog/v3 v3.0.1-0.20201128200927-a1889d947b48/go.mod h1:aXdIdfn2OcGnMhOTojXmwZqXKgC3MU5riiNvzwwG9OY=
+github.com/influxdata/go-syslog/v3 v3.0.1-0.20210608084020-ac565dc76ba6 h1:s9ZL6ZhFF8y6ebnm1FLvobkzoIu5xwDQUcRPk/IEhpM=
+github.com/influxdata/go-syslog/v3 v3.0.1-0.20210608084020-ac565dc76ba6/go.mod h1:aXdIdfn2OcGnMhOTojXmwZqXKgC3MU5riiNvzwwG9OY=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/influxdata/tail v1.0.1-0.20200707181643-03a791b270e4/go.mod h1:VeiWgI3qaGdJWust2fP27a6J+koITo/1c/UhxeOxgaM=
@@ -2313,6 +2314,8 @@ github.com/nsqio/go-nsq v1.0.7/go.mod h1:XP5zaUs3pqf+Q71EqUJs3HYfBIqfK6G83WQMdNN
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+github.com/observiq/ctimefmt v1.0.0 h1:r7vTJ+Slkrt9fZ67mkf+mA6zAdR5nGIJRMTzkUyvilk=
+github.com/observiq/ctimefmt v1.0.0/go.mod h1:mxi62//WbSpG/roCO1c6MqZ7zQTvjVtYheqHN3eOjvc=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v0.0.0-20180308005104-6934b124db28/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
@@ -2380,6 +2383,7 @@ github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssette
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.61.0/go.mod h1:+Yjsoz9iiXiPPChQnGCW710kkrMNwApF6s3AwIFVby0=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension v0.63.0 h1:rF8UuIGWZMi0LugBGrPzQCpQiwi96AA0xY5beCEskVA=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension v0.63.0/go.mod h1:cKToSzuvHNDTPH94Y24z3LsNP/f9adbzobUOpfAJ4CI=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.63.0 h1:/VP8ntb3Kjx2v2+vmrZTNAAnJOwCIfHpcPaFem3+NCY=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.63.0 h1:NsaYjgHJVTkjef8ZTkuYWATDFvBZU7wfVcMQsXUHbVM=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.63.0 h1:2jXMdfJ36Hs7QuzlhvC9wi9xFCJ9q0a40qjPaFEsDI8=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.63.0/go.mod h1:Vo92E1v3sPewq/74L573iW9dCJl40na+Heum93YGbPQ=
@@ -2389,6 +2393,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.63.0/go.mod h1:5ZKBQ9B/qM4XmJLHC1B5H5KdVVbTgnEZp9EAzIsm+/w=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.63.0 h1:17Bw6z1FOtHeK446eAHHt6TBzmpYaufCMuEDpbZAAyA=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.63.0/go.mod h1:UDUauqPQgqflOJVnOD3Ut4iVuTaGg1Y9G6yA+mRCXF8=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.63.0 h1:2/DBbtCcEFOg2h64UkO2cMFrDFD5CzhYizUxm7dLOEY=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.63.0/go.mod h1:wiWJHLJlVUk5yOmhZvyk9XqoPcVWnFHZzQkEHamA8CE=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.63.0 h1:XzKVij0Zmwei9a3ktwWk11GMX0FX+WGDg3cw9/tytmw=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.63.0/go.mod h1:w5rHiSvZJ110BJE/xLQxtlCGEELhfJ46dPR7XAHBXHE=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki v0.63.0 h1:I8F8AEPyXeAMNLVaajKvO2mB7u1bTA/LqdDlfJCYGcY=
@@ -3780,6 +3786,7 @@ gonum.org/v1/gonum v0.6.2/go.mod h1:9mxDZsDKxgMAuccQkewq682L+0eCu4dCN2yonUJTCLU=
 gonum.org/v1/gonum v0.8.2/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
 gonum.org/v1/gonum v0.9.3/go.mod h1:TZumC3NeyVQskjXqmyWt4S3bINhy7B4eYwW69EbyX+0=
 gonum.org/v1/gonum v0.12.0 h1:xKuo6hzt+gMav00meVPUlXwSdoEJP46BR+wdxQEFK2o=
+gonum.org/v1/gonum v0.12.0/go.mod h1:73TDxJfAAHeA8Mk9mf8NlIppyhQNo5GLTcYeqgo2lvY=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b/go.mod h1:Wt8AAjI+ypCyYX3nZBvf6cAIx93T+c/OS2HFAYskSZc=
 gonum.org/v1/plot v0.9.0/go.mod h1:3Pcqqmp6RHvJI72kgb8fThyUnav364FOsdDo2aGW5lY=


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The PR adds an otelol.receiver.loki component that receives Loki log entries, transforms them to the OTLP format and forwards them to other `otelcol` components.

The conversion is straightforward and is what the `promtailreceiver` from the opentelemetry-collector-contrib repo [does](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/promtailreceiver/promtail.go) as well; basically just create a new OTLP Logs entry, add the log content and timestamp, append all labels as attributes and send it over.

We're adding one more attribute that keeps track of which attributes came from Loki labels, so it can be used when the opposite conversion happens, to promote this subset of resources back into labels.

The conversion format defaults to json, but uses the OTel format hints (i.e. the loki.format resource or log attribute) to decide whether to use json or logfmt.

#### Which issue(s) this PR fixes
Fixes #2665 
Updates #2501

#### Notes to the Reviewer

To play with this, you can use the following!

#### Loki -> OTel -> Loki pipeline

Agent config:
<details> 

```river
logging {
  level  = "debug"
  format = "logfmt"
}

loki.source.file "default" {
  targets = [
    {__path__ = "/tmp/foo.txt", "color" = "pink", "loki.format" = "logfmt"},
    {__path__ = "/tmp/bar.txt", "color" = "pink", "loki.format" = "json"},
  ]
  forward_to = [otelcol.receiver.loki.r.receiver, loki.stdout.a.receiver]
}

// Read loki -> Create OTLP
otelcol.receiver.loki "r" {
	output {
	    logs    = [otelcol.exporter.loki.e.input]
	}
}

// Receive OTLP -> Send Loki
otelcol.exporter.loki "e" {
	forward_to = [loki.stdout.a.receiver, loki.process.json.receiver]
}

loki.process "json" {
	stage {
		json {
			expressions = { body = "body" }
		}
	}
	
	stage {
		output {
			source = "body"
		}
	}

	forward_to = [loki.stdout.a.receiver]
}

// Outputs
loki.stdout "a" {}
```

</details>

Send logfmt and json entries to the corresponding files.
```
echo 'msg="hello world" level=info' >> /tmp/foo.txt
echo '{"msg":"hello world!","level"="info"}' >> /tmp/bar.txt
```

The `otelcol.exporter.loki` component reuses upstream code from `pkg/translator/loki` where the JSON Encode method puts the log entry as a "body" key on the output JSON.

Open question: To get the same result, you have to reuse a loki.process stage like the one above. Should this be included by default, or simply documented? I'd say the second.

#### OTel -> Loki -> OTel pipeline

Agent config: 
<details>

```river
logging {
  level  = "debug"
  format = "logfmt"
}

// Receive OTLP Logs
otelcol.receiver.otlp "default" {
  http {}

  output {
    logs = [otelcol.exporter.loki.e.input]
  }
}

// Get OTLP Logs -> Transform to Loki
otelcol.exporter.loki "e" {
  forward_to = [loki.stdout.a.receiver, otelcol.receiver.loki.r.receiver]
}

// Read Loki -> Re-create OTLP message
otelcol.receiver.loki "r" {
	output {
	    logs    = [otelcol.exporter.otlphttp.local.input]
	}
}

loki.stdout "a" {}

otelcol.exporter.otlphttp "local" {
  client {
    endpoint = "http://localhost:4320"
  }
}
```

</details>

The intermediate Loki entry
```
"{\"body\":\"hello world\",\"traceid\":\"0102030405060708090a0b0c0d0e0f10\",\"spanid\":\"1112131415161718\",\"severity\":\"Error\",\"attributes\":{\"sdkVersion\":\"1.0.1\"},\"resources\":{\"host.name\":\"testHost\"}}" labels="{exporter=\"OTLP\", level=\"ERROR\", source=\"opentelemetry\"}"
```

To see the resulting logs back in the OTLP format, use the OTel Collector with the logging exporter and a config like the following:

<details>

```yaml
receivers:
  otlp:
    protocols:
      http:
        endpoint: "0.0.0.0:4320"

exporters:
  logging:
    verbosity: detailed

service:
  pipelines:
    logs:
      receivers: [otlp]
      exporters: [logging]
```

</details>

When you send a log entry to the Agent's OTLP receiver port:

```
curl --http0.9 -vi http://localhost:4318/v1/logs -X POST -H "Content-Type: application/json" -d '@/tmp/log.json' --output -
```

You can see it being printed out by the OTel Collector's logging exporter
```
2023-01-13T13:39:57.632+0200	info	LogsExporter	{"kind": "exporter", "data_type": "logs", "name": "logging", "#logs": 1}
2023-01-13T13:39:57.633+0200	info	ResourceLog #0
ObservedTimestamp: 2023-01-13 11:39:57.628165 +0000 UTC
Timestamp: 2023-01-12 12:37:51 +0000 UTC
SeverityText:
SeverityNumber: Unspecified(0)
Body: Str({"body":"hello world","traceid":"0102030405060708090a0b0c0d0e0f10","spanid":"1112131415161718","severity":"Error","attributes":{"sdkVersion":"1.0.1"},"resources":{"host.name":"testHost"}})
Attributes:
     -> exporter: Str(OTLP)
     -> source: Str(opentelemetry)
     -> level: Str(ERROR)
     -> loki.attribute.labels: Str(exporter,source,level)
Trace ID:
Span ID:
Flags: 0
	{"kind": "exporter", "data_type": "logs", "name": "logging"}
```

You can use a log like the following

<details>

```
--- /tmp/log.json ---

{
  "resourceLogs": [
    {
      "resource": {
        "attributes": [
          {
            "key": "host.name",
            "value": {
              "stringValue": "testHost"
            }
          }
        ],
        "droppedAttributesCount": 1
      },
      "scopeLogs": [
        {
          "scope": {
            "name": "name",
            "version": "version",
            "droppedAttributesCount": 1
          },
          "logRecords": [
            {
              "timeUnixNano": "1673527071000000000",
              "observedTimeUnixNano": "1673527071000000000",
              "severityNumber": 17,
              "severityText": "Error",
              "body": {
                "stringValue": "hello world"
              },
              "attributes": [
                {
                  "key": "sdkVersion",
                  "value": {
                    "stringValue": "1.0.1"
                  }
                },
                {
                  "key": "loki.attribute.labels",
                  "value": {
                    "stringValue": "source"
                  }
                },
                {
                  "key": "source",
                  "value": {
                    "stringValue": "opentelemetry"
                  }
                }
              ],
              "droppedAttributesCount": 1,
              "traceId": "0102030405060708090a0b0c0d0e0f10",
              "spanId": "1112131415161718"
            }
          ],
          "schemaUrl": "ScopeLogsSchemaURL"
        }
      ],
      "schemaUrl": "testSchemaURL"
    }
  ]
}
```

</details>


#### PR Checklist

- [X] CHANGELOG updated
- [X] Documentation added
- [X] Tests updated
