### PR TITLE
flow: Add support for filtering stages to loki.process component

### DIFF
--- a/component/loki/process/internal/stages/drop.go
+++ b/component/loki/process/internal/stages/drop.go
@@ -1,5 +1,9 @@
 package stages
 
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
 import (
 	"errors"
 	"fmt"

--- a/component/loki/process/internal/stages/drop.go
+++ b/component/loki/process/internal/stages/drop.go
@@ -1,0 +1,184 @@
+package stages
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"time"
+
+	"github.com/alecthomas/units"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Configuration errors.
+var (
+	ErrDropStageEmptyConfig   = errors.New("drop stage config must contain at least one of `source`, `expression`, `older_than` or `longer_than`")
+	ErrDropStageInvalidConfig = errors.New("drop stage config error, `value` and `expression` cannot both be defined at the same time")
+	ErrDropStageInvalidRegex  = errors.New("drop stage regex compilation error")
+)
+
+var defaultDropReason = "drop_stage"
+
+var emptyDuration time.Duration
+
+// DropConfig contains the configuration for a dropStage
+type DropConfig struct {
+	DropReason string           `river:"drop_counter_reason,attr,optional"`
+	Source     string           `river:"source,attr,optional"`
+	Value      string           `river:"value,attr,optional"`
+	Expression string           `river:"expression,attr,optional"`
+	OlderThan  time.Duration    `river:"older_than,attr,optional"`
+	LongerThan units.Base2Bytes `river:"longer_than,attr,optional"`
+	regex      *regexp.Regexp
+}
+
+// validateDropConfig validates the DropConfig for the dropStage
+func validateDropConfig(cfg *DropConfig) error {
+	if cfg.Source == "" && cfg.Expression == "" && cfg.OlderThan == emptyDuration && cfg.LongerThan == 0 {
+		return ErrDropStageEmptyConfig
+	}
+	if cfg.DropReason == "" {
+		cfg.DropReason = defaultDropReason
+	}
+	if cfg.Value != "" && cfg.Expression != "" {
+		return ErrDropStageInvalidConfig
+	}
+	if cfg.Expression != "" {
+		expr, err := regexp.Compile(cfg.Expression)
+		if err != nil {
+			return fmt.Errorf("%v: %w", ErrDropStageInvalidRegex, err)
+		}
+		cfg.regex = expr
+	}
+	return nil
+}
+
+// newDropStage creates a DropStage from config
+func newDropStage(logger log.Logger, config DropConfig, registerer prometheus.Registerer) (Stage, error) {
+	err := validateDropConfig(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dropStage{
+		logger:    log.With(logger, "component", "stage", "type", "drop"),
+		cfg:       &config,
+		dropCount: getDropCountMetric(registerer),
+	}, nil
+}
+
+// dropStage applies Label matchers to determine if the include stages should be run
+type dropStage struct {
+	logger    log.Logger
+	cfg       *DropConfig
+	dropCount *prometheus.CounterVec
+}
+
+func (m *dropStage) Run(in chan Entry) chan Entry {
+	out := make(chan Entry)
+	go func() {
+		defer close(out)
+		for e := range in {
+			if !m.shouldDrop(e) {
+				out <- e
+				continue
+			}
+			m.dropCount.WithLabelValues(m.cfg.DropReason).Inc()
+		}
+	}()
+	return out
+}
+
+func (m *dropStage) shouldDrop(e Entry) bool {
+	// There are many options for dropping a log and if multiple are defined it's treated like an AND condition
+	// where all drop conditions must be met to drop the log.
+	// Therefore if at any point there is a condition which does not match we can return.
+	// The order is what I roughly think would be fastest check to slowest check to try to quit early whenever possible
+
+	if m.cfg.LongerThan != 0 {
+		if len(e.Line) > int(m.cfg.LongerThan) {
+			// Too long, drop
+			level.Debug(m.logger).Log("msg", fmt.Sprintf("line met drop criteria for length %v > %v bytes", len(e.Line), int(m.cfg.LongerThan)))
+		} else {
+			level.Debug(m.logger).Log("msg", fmt.Sprintf("line will not be dropped, it did not meet criteria for drop length %v is not greater than %v", len(e.Line), int(m.cfg.LongerThan)))
+			return false
+		}
+	}
+
+	if m.cfg.OlderThan != emptyDuration {
+		ct := time.Now()
+		if e.Timestamp.Before(ct.Add(-m.cfg.OlderThan)) {
+			// Too old, drop
+			level.Debug(m.logger).Log("msg", fmt.Sprintf("line met drop criteria for age; current time=%v, drop before=%v, log timestamp=%v", ct, ct.Add(-m.cfg.OlderThan), e.Timestamp))
+		} else {
+			level.Debug(m.logger).Log("msg", fmt.Sprintf("line will not be dropped, it did not meet drop criteria for age; current time=%v, drop before=%v, log timestamp=%v", ct, ct.Add(-m.cfg.OlderThan), e.Timestamp))
+			return false
+		}
+	}
+
+	if m.cfg.Source != "" && m.cfg.Expression == "" {
+		if v, ok := e.Extracted[m.cfg.Source]; ok {
+			if m.cfg.Value == "" {
+				// Found in map, no value set meaning drop if found in map
+				level.Debug(m.logger).Log("msg", "line met drop criteria for finding source key in extracted map")
+			} else {
+				if m.cfg.Value == v {
+					// Found in map with value set for drop
+					level.Debug(m.logger).Log("msg", "line met drop criteria for finding source key in extracted map with value matching desired drop value")
+				} else {
+					// Value doesn't match, don't drop
+					level.Debug(m.logger).Log("msg", fmt.Sprintf("line will not be dropped, source key was found in extracted map but value '%v' did not match desired value '%v'", v, m.cfg.Value))
+					return false
+				}
+			}
+		} else {
+			// Not found in extact map, don't drop
+			level.Debug(m.logger).Log("msg", "line will not be dropped, the provided source was not found in the extracted map")
+			return false
+		}
+	}
+
+	if m.cfg.Expression != "" {
+		if m.cfg.Source != "" {
+			if v, ok := e.Extracted[m.cfg.Source]; ok {
+				s, err := getString(v)
+				if err != nil {
+					level.Debug(m.logger).Log("msg", "Failed to convert extracted map value to string, cannot test regex line will not be dropped.", "err", err, "type", reflect.TypeOf(v))
+					return false
+				}
+				match := m.cfg.regex.FindStringSubmatch(s)
+				if match == nil {
+					// Not a match to the regex, don't drop
+					level.Debug(m.logger).Log("msg", fmt.Sprintf("line will not be dropped, the provided regular expression did not match the value found in the extracted map for source key: %v", m.cfg.Source))
+					return false
+				}
+				// regex match, will be dropped
+				level.Debug(m.logger).Log("msg", "line met drop criteria, regex matched the value in the extracted map source key")
+			} else {
+				// Not found in extact map, don't drop
+				level.Debug(m.logger).Log("msg", "line will not be dropped, the provided source was not found in the extracted map")
+				return false
+			}
+		} else {
+			match := m.cfg.regex.FindStringSubmatch(e.Line)
+			if match == nil {
+				// Not a match to the regex, don't drop
+				level.Debug(m.logger).Log("msg", "line will not be dropped, the provided regular expression did not match the log line")
+				return false
+			}
+			level.Debug(m.logger).Log("msg", "line met drop criteria, the provided regular expression matched the log line")
+		}
+	}
+
+	// Everything matched, drop the line
+	level.Debug(m.logger).Log("msg", "all criteria met, line will be dropped")
+	return true
+}
+
+// Name implements Stage
+func (m *dropStage) Name() string {
+	return StageTypeDrop
+}

--- a/component/loki/process/internal/stages/drop_test.go
+++ b/component/loki/process/internal/stages/drop_test.go
@@ -1,5 +1,9 @@
 package stages
 
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
 import (
 	"fmt"
 	"io"

--- a/component/loki/process/internal/stages/drop_test.go
+++ b/component/loki/process/internal/stages/drop_test.go
@@ -1,0 +1,360 @@
+package stages
+
+import (
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/units"
+	"github.com/grafana/agent/pkg/flow/logging"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ww "github.com/weaveworks/common/server"
+)
+
+// Not all these are tested but are here to make sure the different types marshal without error
+var testDropRiver = `
+stage {
+	json {
+		expressions = { "app" = "", "msg" = "" }
+	}
+}
+
+stage {
+	drop {
+		source      = "src"
+		expression  = ".*test.*"
+		older_than  = "24h"
+		longer_than = "8KB"
+	}
+}
+
+stage {
+	drop {
+		expression = ".*app1.*"
+	}
+}
+
+stage {
+	drop {
+		source = "app"
+		value  = "loki"
+	}
+}
+
+stage {
+	drop {
+		longer_than = "10000B"
+	}
+}
+`
+
+func TestDropStage(t *testing.T) {
+	// Enable debug logging
+	cfg := &ww.Config{}
+	require.Nil(t, cfg.LogLevel.Set("debug"))
+
+	tenBytes, _ := units.ParseBase2Bytes("10B")
+	oneHour := 1 * time.Hour
+
+	tests := []struct {
+		name       string
+		config     *DropConfig
+		labels     model.LabelSet
+		extracted  map[string]interface{}
+		t          time.Time
+		entry      string
+		shouldDrop bool
+	}{
+		{
+			name: "Longer Than Should Drop",
+			config: &DropConfig{
+				LongerThan: tenBytes,
+			},
+			labels:     model.LabelSet{},
+			extracted:  map[string]interface{}{},
+			entry:      "12345678901",
+			shouldDrop: true,
+		},
+		{
+			name: "Longer Than Should Not Drop When Equal",
+			config: &DropConfig{
+				LongerThan: tenBytes,
+			},
+			labels:     model.LabelSet{},
+			extracted:  map[string]interface{}{},
+			entry:      "1234567890",
+			shouldDrop: false,
+		},
+		{
+			name: "Longer Than Should Not Drop When Less",
+			config: &DropConfig{
+				LongerThan: tenBytes,
+			},
+			labels:     model.LabelSet{},
+			extracted:  map[string]interface{}{},
+			entry:      "123456789",
+			shouldDrop: false,
+		},
+		{
+			name: "Older than Should Drop",
+			config: &DropConfig{
+				OlderThan: oneHour,
+			},
+			labels:     model.LabelSet{},
+			extracted:  map[string]interface{}{},
+			t:          time.Now().Add(-2 * time.Hour),
+			shouldDrop: true,
+		},
+		{
+			name: "Older than Should Not Drop",
+			config: &DropConfig{
+				OlderThan: oneHour,
+			},
+			labels:     model.LabelSet{},
+			extracted:  map[string]interface{}{},
+			t:          time.Now().Add(-5 * time.Minute),
+			shouldDrop: false,
+		},
+		{
+			name: "Matched Source",
+			config: &DropConfig{
+				Source: "key",
+			},
+			labels: model.LabelSet{},
+			extracted: map[string]interface{}{
+				"key": "",
+			},
+			shouldDrop: true,
+		},
+		{
+			name: "Did not match Source",
+			config: &DropConfig{
+				Source: "key1",
+			},
+			labels: model.LabelSet{},
+			extracted: map[string]interface{}{
+				"key": "val1",
+			},
+			shouldDrop: false,
+		},
+		{
+			name: "Matched Source and Value",
+			config: &DropConfig{
+				Source: "key",
+				Value:  "val1",
+			},
+			labels: model.LabelSet{},
+			extracted: map[string]interface{}{
+				"key": "val1",
+			},
+			shouldDrop: true,
+		},
+		{
+			name: "Did not match Source and Value",
+			config: &DropConfig{
+				Source: "key",
+				Value:  "val1",
+			},
+			labels: model.LabelSet{},
+			extracted: map[string]interface{}{
+				"key": "VALRUE1",
+			},
+			shouldDrop: false,
+		},
+		{
+			name: "Regex Matched Source and Value",
+			config: &DropConfig{
+				Source:     "key",
+				Expression: ".*val.*",
+			},
+			labels: model.LabelSet{},
+			extracted: map[string]interface{}{
+				"key": "val1",
+			},
+			shouldDrop: true,
+		},
+		{
+			name: "Regex Did not match Source and Value",
+			config: &DropConfig{
+				Source:     "key",
+				Expression: ".*val.*",
+			},
+			labels: model.LabelSet{},
+			extracted: map[string]interface{}{
+				"key": "pal1",
+			},
+			shouldDrop: false,
+		},
+		{
+			name: "Regex No Matching Source",
+			config: &DropConfig{
+				Source:     "key",
+				Expression: ".*val.*",
+			},
+			labels: model.LabelSet{},
+			extracted: map[string]interface{}{
+				"pokey": "pal1",
+			},
+			shouldDrop: false,
+		},
+		{
+			name: "Regex Did Not Match Line",
+			config: &DropConfig{
+				Expression: ".*val.*",
+			},
+			labels:     model.LabelSet{},
+			entry:      "this is a line which does not match the regex",
+			extracted:  map[string]interface{}{},
+			shouldDrop: false,
+		},
+		{
+			name: "Regex Matched Line",
+			config: &DropConfig{
+				Expression: ".*val.*",
+			},
+			labels:     model.LabelSet{},
+			entry:      "this is a line with the word value in it",
+			extracted:  map[string]interface{}{},
+			shouldDrop: true,
+		},
+		{
+			name: "Match Source and Length Both Match",
+			config: &DropConfig{
+				Source:     "key",
+				LongerThan: tenBytes,
+			},
+			labels: model.LabelSet{},
+			extracted: map[string]interface{}{
+				"key": "pal1",
+			},
+			entry:      "12345678901",
+			shouldDrop: true,
+		},
+		{
+			name: "Match Source and Length Only First Matches",
+			config: &DropConfig{
+				Source:     "key",
+				LongerThan: tenBytes,
+			},
+			labels: model.LabelSet{},
+			extracted: map[string]interface{}{
+				"key": "pal1",
+			},
+			entry:      "123456789",
+			shouldDrop: false,
+		},
+		{
+			name: "Match Source and Length Only Second Matches",
+			config: &DropConfig{
+				Source:     "key",
+				LongerThan: tenBytes,
+			},
+			labels: model.LabelSet{},
+			extracted: map[string]interface{}{
+				"WOOOOOOOOOOOOOO": "pal1",
+			},
+			entry:      "123456789012",
+			shouldDrop: false,
+		},
+		{
+			name: "Everything Must Match",
+			config: &DropConfig{
+				Source:     "key",
+				Expression: ".*val.*",
+				OlderThan:  oneHour,
+				LongerThan: tenBytes,
+			},
+			labels: model.LabelSet{},
+			extracted: map[string]interface{}{
+				"key": "must contain value to match",
+			},
+			t:          time.Now().Add(-2 * time.Hour),
+			entry:      "12345678901",
+			shouldDrop: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDropConfig(tt.config)
+			if err != nil {
+				t.Error(err)
+			}
+			logger, _ := logging.New(io.Discard, logging.DefaultOptions)
+			m, err := newDropStage(logger, *tt.config, prometheus.DefaultRegisterer)
+			require.NoError(t, err)
+			out := processEntries(m, newEntry(tt.extracted, tt.labels, tt.entry, tt.t))
+			if tt.shouldDrop {
+				assert.Len(t, out, 0)
+			} else {
+				assert.Len(t, out, 1)
+			}
+		})
+	}
+}
+
+func ptrFromString(str string) *string {
+	return &str
+}
+
+// TestDropPipeline is used to verify we properly parse the yaml config and create a working pipeline
+func TestDropPipeline(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	plName := "test_pipeline"
+	logger, _ := logging.New(io.Discard, logging.DefaultOptions)
+	pl, err := NewPipeline(logger, loadConfig(testDropRiver), &plName, registry)
+	require.NoError(t, err)
+	out := processEntries(pl,
+		newEntry(nil, nil, testMatchLogLineApp1, time.Now()),
+		newEntry(nil, nil, testMatchLogLineApp2, time.Now()),
+	)
+
+	// Only the second line will go through.
+	assert.Len(t, out, 1)
+	assert.Equal(t, out[0].Line, testMatchLogLineApp2)
+}
+
+var (
+	dropVal          = "msg"
+	dropRegex        = ".*blah"
+	dropInvalidRegex = "(?P<ts[0-9]+).*"
+)
+
+func Test_validateDropConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *DropConfig
+		wantErr error
+	}{
+		{
+			name:    "ErrEmpty",
+			config:  &DropConfig{},
+			wantErr: ErrDropStageEmptyConfig,
+		},
+		{
+			name: "Invalid Config",
+			config: &DropConfig{
+				Value:      dropVal,
+				Expression: dropRegex,
+			},
+			wantErr: ErrDropStageInvalidConfig,
+		},
+		{
+			name: "Invalid Regex",
+			config: &DropConfig{
+				Expression: dropInvalidRegex,
+			},
+			wantErr: fmt.Errorf("%s: %s", ErrDropStageInvalidRegex.Error(), "error parsing regexp: invalid named capture: `(?P<ts[0-9]+).*`"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateDropConfig(tt.config); ((err != nil) && (err.Error() != tt.wantErr.Error())) || (err == nil && tt.wantErr != nil) {
+				t.Errorf("validateDropConfig() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/component/loki/process/internal/stages/drop_test.go
+++ b/component/loki/process/internal/stages/drop_test.go
@@ -300,7 +300,6 @@ func TestDropStage(t *testing.T) {
 	}
 }
 
-// TestDropPipeline is used to verify we properly parse the yaml config and create a working pipeline
 func TestDropPipeline(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	plName := "test_pipeline"

--- a/component/loki/process/internal/stages/drop_test.go
+++ b/component/loki/process/internal/stages/drop_test.go
@@ -300,10 +300,6 @@ func TestDropStage(t *testing.T) {
 	}
 }
 
-func ptrFromString(str string) *string {
-	return &str
-}
-
 // TestDropPipeline is used to verify we properly parse the yaml config and create a working pipeline
 func TestDropPipeline(t *testing.T) {
 	registry := prometheus.NewRegistry()

--- a/component/loki/process/internal/stages/match.go
+++ b/component/loki/process/internal/stages/match.go
@@ -5,11 +5,11 @@ package stages
 // new code without being able to slowly review, examine and test them.
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/loki/clients/pkg/logentry/logql"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -83,13 +83,13 @@ func newMatcherStage(logger log.Logger, jobName *string, config MatchConfig, reg
 		var err error
 		pl, err = NewPipeline(logger, config.Stages, nPtr, registerer)
 		if err != nil {
-			return nil, errors.Wrapf(err, "match stage failed to create pipeline from config: %v", config)
+			return nil, fmt.Errorf("%v: %w", err, fmt.Errorf("match stage failed to create pipeline from config: %v", config))
 		}
 	}
 
 	filter, err := selector.Filter()
 	if err != nil {
-		return nil, errors.Wrap(err, "error parsing pipeline")
+		return nil, fmt.Errorf("%v: %w", "error parsing pipeline", err)
 	}
 
 	dropReason := "match_stage"

--- a/component/loki/process/internal/stages/match.go
+++ b/component/loki/process/internal/stages/match.go
@@ -1,5 +1,9 @@
 package stages
 
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
 import (
 	"fmt"
 

--- a/component/loki/process/internal/stages/match.go
+++ b/component/loki/process/internal/stages/match.go
@@ -1,0 +1,198 @@
+package stages
+
+import (
+	"fmt"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/loki/clients/pkg/logentry/logql"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+// Configuration errors.
+var (
+	ErrEmptyMatchStageConfig = errors.New("match stage config cannot be empty")
+	ErrPipelineNameRequired  = errors.New("match stage pipeline name can be omitted but cannot be an empty string")
+	ErrSelectorRequired      = errors.New("selector statement required for match stage")
+	ErrMatchRequiresStages   = errors.New("match stage requires at least one additional stage to be defined in '- stages'")
+	ErrSelectorSyntax        = errors.New("invalid selector syntax for match stage")
+	ErrStagesWithDropLine    = errors.New("match stage configured to drop entries cannot contains stages")
+	ErrUnknownMatchAction    = errors.New("match stage action should be 'keep' or 'drop'")
+
+	MatchActionKeep = "keep"
+	MatchActionDrop = "drop"
+)
+
+// MatchConfig contains the configuration for a matcherStage
+type MatchConfig struct {
+	Selector     string        `river:"selector,attr"`
+	Stages       []StageConfig `river:"stage,block,optional"`
+	Action       string        `river:"action,attr,optional"`
+	PipelineName string        `river:"pipeline_name,attr,optional"`
+	DropReason   string        `river:"drop_counter_reason,attr,optional"`
+}
+
+// validateMatcherConfig validates the MatcherConfig for the matcherStage
+func validateMatcherConfig(cfg *MatchConfig) (logql.Expr, error) {
+	if cfg.Selector == "" {
+		return nil, ErrSelectorRequired
+	}
+	switch cfg.Action {
+	case MatchActionKeep, MatchActionDrop:
+	case "":
+		cfg.Action = MatchActionKeep
+	default:
+		return nil, ErrUnknownMatchAction
+	}
+
+	if cfg.Action == MatchActionKeep && (cfg.Stages == nil || len(cfg.Stages) == 0) {
+		return nil, ErrMatchRequiresStages
+	}
+	if cfg.Action == MatchActionDrop && (cfg.Stages != nil && len(cfg.Stages) != 0) {
+		return nil, ErrStagesWithDropLine
+	}
+
+	selector, err := logql.ParseExpr(cfg.Selector)
+	if err != nil {
+		return nil, fmt.Errorf("%v: %w", ErrSelectorSyntax, err)
+	}
+	return selector, nil
+}
+
+// newMatcherStage creates a new matcherStage from config
+func newMatcherStage(logger log.Logger, jobName *string, config MatchConfig, registerer prometheus.Registerer) (Stage, error) {
+	selector, err := validateMatcherConfig(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	var nPtr *string
+	if config.PipelineName != "" && jobName != nil {
+		name := *jobName + "_" + config.PipelineName
+		nPtr = &name
+	}
+
+	var pl *Pipeline
+	if config.Action == MatchActionKeep {
+		var err error
+		pl, err = NewPipeline(logger, config.Stages, nPtr, registerer)
+		if err != nil {
+			return nil, errors.Wrapf(err, "match stage failed to create pipeline from config: %v", config)
+		}
+	}
+
+	filter, err := selector.Filter()
+	if err != nil {
+		return nil, errors.Wrap(err, "error parsing pipeline")
+	}
+
+	dropReason := "match_stage"
+	if config.DropReason != "" {
+		dropReason = config.DropReason
+	}
+
+	return &matcherStage{
+		dropReason: dropReason,
+		dropCount:  getDropCountMetric(registerer),
+		matchers:   selector.Matchers(),
+		stage:      pl,
+		action:     config.Action,
+		filter:     filter,
+	}, nil
+}
+
+func getDropCountMetric(registerer prometheus.Registerer) *prometheus.CounterVec {
+	dropCount := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "loki_process_dropped_lines_total",
+		Help: "A count of all log lines dropped as a result of a pipeline stage",
+	}, []string{"reason"})
+	err := registerer.Register(dropCount)
+	if err != nil {
+		if existing, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			dropCount = existing.ExistingCollector.(*prometheus.CounterVec)
+		} else {
+			// Same behavior as MustRegister if the error is not for AlreadyRegistered
+			panic(err)
+		}
+	}
+	return dropCount
+}
+
+// matcherStage applies Label matchers to determine if the include stages should be run
+type matcherStage struct {
+	dropReason string
+	dropCount  *prometheus.CounterVec
+	matchers   []*labels.Matcher
+	filter     logql.Filter
+	stage      Stage
+	action     string
+}
+
+func (m *matcherStage) Run(in chan Entry) chan Entry {
+	switch m.action {
+	case MatchActionDrop:
+		return m.runDrop(in)
+	case MatchActionKeep:
+		return m.runKeep(in)
+	}
+	panic("unexpected action")
+}
+
+func (m *matcherStage) runKeep(in chan Entry) chan Entry {
+	next := make(chan Entry)
+	out := make(chan Entry)
+	outNext := m.stage.Run(next)
+	go func() {
+		defer close(out)
+		for e := range outNext {
+			out <- e
+		}
+	}()
+	go func() {
+		defer close(next)
+		for e := range in {
+			e, ok := m.processLogQL(e)
+			if !ok {
+				out <- e
+				continue
+			}
+			next <- e
+		}
+	}()
+	return out
+}
+
+func (m *matcherStage) runDrop(in chan Entry) chan Entry {
+	out := make(chan Entry)
+	go func() {
+		defer close(out)
+		for e := range in {
+			if e, ok := m.processLogQL(e); !ok {
+				out <- e
+				continue
+			}
+			m.dropCount.WithLabelValues(m.dropReason).Inc()
+		}
+	}()
+	return out
+}
+
+func (m *matcherStage) processLogQL(e Entry) (Entry, bool) {
+	for _, filter := range m.matchers {
+		if !filter.Matches(string(e.Labels[model.LabelName(filter.Name)])) {
+			return e, false
+		}
+	}
+
+	if m.filter == nil || m.filter([]byte(e.Line)) {
+		return e, true
+	}
+	return e, false
+}
+
+// Name implements Stage
+func (m *matcherStage) Name() string {
+	return StageTypeMatch
+}

--- a/component/loki/process/internal/stages/match_test.go
+++ b/component/loki/process/internal/stages/match_test.go
@@ -1,5 +1,9 @@
 package stages
 
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
 import (
 	"fmt"
 	"io"

--- a/component/loki/process/internal/stages/match_test.go
+++ b/component/loki/process/internal/stages/match_test.go
@@ -184,7 +184,6 @@ func TestMatcher(t *testing.T) {
 				return
 			}
 			if s != nil {
-
 				out := processEntries(s, newEntry(map[string]interface{}{
 					"test_label": "unimportant value",
 				}, toLabelSet(tt.labels), "foo", time.Now()))
@@ -201,7 +200,6 @@ func TestMatcher(t *testing.T) {
 						t.Error("stage ran but should have not")
 					}
 				}
-
 			}
 		})
 	}

--- a/component/loki/process/internal/stages/match_test.go
+++ b/component/loki/process/internal/stages/match_test.go
@@ -1,0 +1,233 @@
+package stages
+
+import (
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/pkg/flow/logging"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+var testMatchRiver = `
+stage {
+	json {
+		expressions = { "app" = "" }
+	}
+}
+
+stage {
+	labels {
+		values = { "app" = "" }
+	}
+}
+
+stage {
+	match {
+		selector = "{app=\"loki\"}"
+		stage {
+			json {
+				expressions = { "msg" = "message" }
+			}
+		}
+		action = "keep"
+	}
+}
+
+stage {
+	match {
+		pipeline_name = "app2"
+		selector = "{app=\"poki\"}"
+		stage {
+			json {
+				expressions = { "msg" = "msg" }
+			}
+		}
+		action = "keep"
+	}
+}
+
+stage {
+	output {
+		source = "msg"
+	}
+}
+`
+
+var testMatchLogLineApp1 = `
+{
+	"time":"2012-11-01T22:08:41+00:00",
+	"app":"loki",
+	"component": ["parser","type"],
+	"level" : "WARN",
+	"message" : "app1 log line"
+}
+`
+
+var testMatchLogLineApp2 = `
+{
+	"time":"2012-11-01T22:08:41+00:00",
+	"app":"poki",
+	"component": ["parser","type"],
+	"level" : "WARN",
+	"msg" : "app2 log line"
+}
+`
+
+func TestMatchStage(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	plName := "test_pipeline"
+	logger, _ := logging.New(io.Discard, logging.DefaultOptions)
+	pl, err := NewPipeline(logger, loadConfig(testMatchRiver), &plName, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	in := make(chan Entry)
+
+	out := pl.Run(in)
+
+	in <- newEntry(nil, nil, testMatchLogLineApp1, time.Now())
+
+	e := <-out
+
+	assert.Equal(t, "app1 log line", e.Line)
+
+	// Process the second log line which should extract the output from the `msg` field
+	e.Line = testMatchLogLineApp2
+	e.Extracted = map[string]interface{}{}
+	in <- e
+	e = <-out
+	assert.Equal(t, "app2 log line", e.Line)
+	close(in)
+}
+
+func TestMatcher(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		selector string
+		labels   map[string]string
+		action   string
+
+		shouldDrop bool
+		shouldRun  bool
+		wantErr    bool
+	}{
+		{`{foo="bar"} |= "foo"`, map[string]string{"foo": "bar"}, MatchActionKeep, false, true, false},
+		{`{foo="bar"} |~ "foo"`, map[string]string{"foo": "bar"}, MatchActionKeep, false, true, false},
+		{`{foo="bar"} |= "bar"`, map[string]string{"foo": "bar"}, MatchActionKeep, false, false, false},
+		{`{foo="bar"} |~ "bar"`, map[string]string{"foo": "bar"}, MatchActionKeep, false, false, false},
+		{`{foo="bar"} != "bar"`, map[string]string{"foo": "bar"}, MatchActionKeep, false, true, false},
+		{`{foo="bar"} !~ "bar"`, map[string]string{"foo": "bar"}, MatchActionKeep, false, true, false},
+		{`{foo="bar"} != "foo"`, map[string]string{"foo": "bar"}, MatchActionKeep, false, false, false},
+		{`{foo="bar"} |= "foo"`, map[string]string{"foo": "bar"}, MatchActionDrop, true, false, false},
+		{`{foo="bar"} |~ "foo"`, map[string]string{"foo": "bar"}, MatchActionDrop, true, false, false},
+		{`{foo="bar"} |= "bar"`, map[string]string{"foo": "bar"}, MatchActionDrop, false, false, false},
+		{`{foo="bar"} |~ "bar"`, map[string]string{"foo": "bar"}, MatchActionDrop, false, false, false},
+		{`{foo="bar"} != "bar"`, map[string]string{"foo": "bar"}, MatchActionDrop, true, false, false},
+		{`{foo="bar"} !~ "bar"`, map[string]string{"foo": "bar"}, MatchActionDrop, true, false, false},
+		{`{foo="bar"} != "foo"`, map[string]string{"foo": "bar"}, MatchActionDrop, false, false, false},
+		{`{foo="bar"} !~ "[]"`, map[string]string{"foo": "bar"}, MatchActionDrop, false, false, true},
+		{"foo", map[string]string{"foo": "bar"}, MatchActionKeep, false, false, true},
+		{"{}", map[string]string{"foo": "bar"}, MatchActionKeep, false, false, true},
+		{"{", map[string]string{"foo": "bar"}, MatchActionKeep, false, false, true},
+		{"", map[string]string{"foo": "bar"}, MatchActionKeep, false, true, true},
+		{`{foo="bar"}`, map[string]string{"foo": "bar"}, MatchActionKeep, false, true, false},
+		{`{foo=""}`, map[string]string{"foo": "bar"}, MatchActionKeep, false, false, false},
+		{`{foo=""}`, map[string]string{}, MatchActionKeep, false, true, false},
+		{`{foo!="bar"}`, map[string]string{"foo": "bar"}, MatchActionKeep, false, false, false},
+		{`{foo!="bar"}`, map[string]string{"foo": "bar"}, MatchActionDrop, false, false, false},
+		{`{foo="bar",bar!="test"}`, map[string]string{"foo": "bar"}, MatchActionKeep, false, true, false},
+		{`{foo="bar",bar!="test"}`, map[string]string{"foo": "bar"}, MatchActionDrop, true, false, false},
+		{`{foo="bar",bar!="test"}`, map[string]string{"foo": "bar", "bar": "test"}, MatchActionKeep, false, false, false},
+		{`{foo="bar",bar=~"te.*"}`, map[string]string{"foo": "bar", "bar": "test"}, MatchActionDrop, true, false, false},
+		{`{foo="bar",bar=~"te.*"}`, map[string]string{"foo": "bar", "bar": "test"}, MatchActionKeep, false, true, false},
+		{`{foo="bar",bar!~"te.*"}`, map[string]string{"foo": "bar", "bar": "test"}, MatchActionKeep, false, false, false},
+		{`{foo="bar",bar!~"te.*"}`, map[string]string{"foo": "bar", "bar": "test"}, MatchActionDrop, false, false, false},
+
+		{`{foo=""}`, map[string]string{}, MatchActionKeep, false, true, false},
+	}
+
+	for _, tt := range tests {
+		name := fmt.Sprintf("%s/%s/%s", tt.selector, tt.labels, tt.action)
+
+		t.Run(name, func(t *testing.T) {
+			// Build a match config which has a simple label stage that when matched will add the test_label to
+			// the labels in the pipeline.
+			var stages []StageConfig
+			if tt.action != MatchActionDrop {
+				stages = []StageConfig{
+					{
+						LabelsConfig: &LabelsConfig{
+							Values: map[string]*string{"test_label": nil},
+						},
+					},
+				}
+			}
+			matchConfig := MatchConfig{
+				tt.selector,
+				stages,
+				tt.action,
+				"",
+				"",
+			}
+			logger, _ := logging.New(io.Discard, logging.DefaultOptions)
+			s, err := newMatcherStage(logger, nil, matchConfig, prometheus.DefaultRegisterer)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("withMatcher() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if s != nil {
+
+				out := processEntries(s, newEntry(map[string]interface{}{
+					"test_label": "unimportant value",
+				}, toLabelSet(tt.labels), "foo", time.Now()))
+
+				if tt.shouldDrop {
+					if len(out) != 0 {
+						t.Errorf("stage should have been dropped but got %v", out)
+					}
+					return
+				}
+				// test_label should only be in the label set if the stage ran
+				if _, ok := out[0].Labels["test_label"]; ok {
+					if !tt.shouldRun {
+						t.Error("stage ran but should have not")
+					}
+				}
+
+			}
+		})
+	}
+}
+
+func TestValidateMatcherConfig(t *testing.T) {
+	emptyStages := []StageConfig{}
+	defaultStage := []StageConfig{{MatchConfig: &MatchConfig{}}}
+	tests := []struct {
+		name    string
+		cfg     *MatchConfig
+		wantErr bool
+	}{
+		{"pipeline name required", &MatchConfig{}, true},
+		{"selector required", &MatchConfig{Selector: ""}, true},
+		{"nil stages without dropping", &MatchConfig{PipelineName: "", Selector: `{app="foo"}`, Action: MatchActionKeep, Stages: nil}, true},
+		{"empty stages without dropping", &MatchConfig{Selector: `{app="foo"}`, Action: MatchActionKeep, Stages: emptyStages}, true},
+		{"stages with dropping", &MatchConfig{Selector: `{app="foo"}`, Action: MatchActionDrop, Stages: defaultStage}, true},
+		{"empty stages dropping", &MatchConfig{Selector: `{app="foo"}`, Action: MatchActionDrop, Stages: emptyStages}, false},
+		{"stages without dropping", &MatchConfig{Selector: `{app="foo"}`, Action: MatchActionKeep, Stages: defaultStage}, false},
+		{"bad selector", &MatchConfig{Selector: `{app="foo}`, Action: MatchActionKeep, Stages: defaultStage}, true},
+		{"bad action", &MatchConfig{Selector: `{app="foo}`, Action: "nope", Stages: emptyStages}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := validateMatcherConfig(tt.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateMatcherConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/component/loki/process/internal/stages/pipeline.go
+++ b/component/loki/process/internal/stages/pipeline.go
@@ -38,6 +38,8 @@ type StageConfig struct {
 	OutputConfig       *OutputConfig       `river:"output,block,optional"`
 	ReplaceConfig      *ReplaceConfig      `river:"replace,block,optional"`
 	MultilineConfig    *MultilineConfig    `river:"multiline,block,optional"`
+	MatchConfig        *MatchConfig        `river:"match,block,optional"`
+	DropConfig         *DropConfig         `river:"drop,block,optional"`
 }
 
 // UnmarshalRiver implements river.Unmarshaler.
@@ -192,24 +194,4 @@ func (p *Pipeline) Size() int {
 func SetReadLineRateLimiter(rateVal float64, burstVal int, drop bool) {
 	rateLimiter = rate.NewLimiter(rate.Limit(rateVal), burstVal)
 	rateLimiterDrop = drop
-}
-
-// TODO(@tpaschalis) This is a helper from the metrics stage. Remove this
-// copy when we port it over, or remove it entirely in favor of a central
-// metrics struct.
-func getDropCountMetric(registerer prometheus.Registerer) *prometheus.CounterVec {
-	dropCount := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "loki_process_dropped_lines_total",
-		Help: "A count of all log lines dropped as a result of a pipeline stage",
-	}, []string{"reason"})
-	err := registerer.Register(dropCount)
-	if err != nil {
-		if existing, ok := err.(prometheus.AlreadyRegisteredError); ok {
-			dropCount = existing.ExistingCollector.(*prometheus.CounterVec)
-		} else {
-			// Same behavior as MustRegister if the error is not for AlreadyRegistered
-			panic(err)
-		}
-	}
-	return dropCount
 }

--- a/component/loki/process/internal/stages/stage.go
+++ b/component/loki/process/internal/stages/stage.go
@@ -163,11 +163,11 @@ func New(logger log.Logger, jobName *string, cfg StageConfig, registerer prometh
 		if err != nil {
 			return nil, err
 		}
-	// case StageTypeMatch:
-	// 	s, err = newMatcherStage(logger, jobName, cfg, registerer)
-	// 	if err != nil {
-	// 		return nil, err
-	// 	}
+	case cfg.MatchConfig != nil:
+		s, err = newMatcherStage(logger, jobName, *cfg.MatchConfig, registerer)
+		if err != nil {
+			return nil, err
+		}
 	// case StageTypeTemplate:
 	// 	s, err = newTemplateStage(logger, cfg)
 	// 	if err != nil {
@@ -183,13 +183,18 @@ func New(logger log.Logger, jobName *string, cfg StageConfig, registerer prometh
 		if err != nil {
 			return nil, err
 		}
-	// case StageTypeDrop:
-	// 	s, err = newDropStage(logger, cfg, registerer)
+	// case StageTypeLimit:
+	// 	s, err = newLimitStage(logger, cfg, registerer)
 	// 	if err != nil {
 	// 		return nil, err
 	// 	}
-	// case cfg.LimitConfig != nil:
-	// 	s, err = newLimitStage(logger, *cfg.LimitConfig, registerer)
+	case cfg.DropConfig != nil:
+		s, err = newDropStage(logger, *cfg.DropConfig, registerer)
+		if err != nil {
+			return nil, err
+		}
+	// case StageTypeLimit:
+	// 	s, err = newLimitStage(logger, cfg, registerer)
 	// 	if err != nil {
 	// 		return nil, err
 	// 	}

--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -773,12 +773,12 @@ Name            | Type      | Description                                       
 --------------- | --------- | ------------------------------------------------------------------- | ------- | --------
 `selector`      | `string`  | The LogQL stream selector and filter expressions to use.            |         | yes
 `pipeline_name` | `string`  | A custom name to use for the nested pipeline.                       | `""`    | no
-`action`        | `string`  | The action to take when the selector matches the log line. Supported values are "keep" and "drop" | `"keep"` | no
+`action`        | `string`  | The action to take when the selector matches the log line. Supported values are `"keep"` and `"drop"` | `"keep"` | no
 `drop_counter_reason` | `string` | A custom reason to report for dropped lines.                   | `"match_stage"` | no 
 
-The `match` block supports a number of `stage` inner blocks, same as
-the top-level one. These are used to construct the  nested set of stages to run
-if the selector matches the labels and content of the log entries.
+The `match` block supports a number of `stage` inner blocks, like the top-level
+block. These are used to construct the nested set of stages to run if the
+selector matches the labels and content of the log entries.
 
 The following blocks are supported inside the definition of `stage > match`:
 
@@ -789,7 +789,7 @@ stage          | [stage][]  | Processing stage to run. | no
 
 If the specified action is `"drop"`, the metric
 `loki_process_dropped_lines_total` is incremented with every line dropped.
-By default, the reason label is `match_stage`, but a custom reason can be
+By default, the reason label is `"match_stage"`, but a custom reason can be
 provided by using the `drop_counter_reason` argument.
 
 Let's see this in action, with the following log lines and stages
@@ -855,17 +855,17 @@ lines where the `applbl="foo"`. So, for the first line, the nested JSON stage
 adds `msg="app1 log line"` into the extracted map.
 
 The fourth stage uses the LogQL selector to only execute on lines where
-`applbl="qux"`; that means it won't match on any of our input, and the nested
-json stage does not run.
+`applbl="qux"`; that means it won't match any of the input, and the nested
+JSON stage does not run.
 
-The fifth stage drops any entries from on lines where `applbl` is set to
-'bar' and the line contents that matches the regex `.*noisy error.*`. It also
-increments the `loki_process_dropped_lines_total` metric with a label
-reason="discard_noisy_errors".
+The fifth stage drops entries from lines where `applbl` is set to 'bar' and the
+line contents matches the regex `.*noisy error.*`. It also increments the
+`loki_process_dropped_lines_total` metric with a label
+`drop_counter_reason="discard_noisy_errors"`.
 
 The final output stage changes the contents of the log line to be the value of
 `msg` from the extracted map. In this case, the first log entry's content is
-is changed to `app1 log line`.
+changed to `app1 log line`.
 
 
 ### drop block
@@ -891,13 +891,13 @@ not provided, the regex attempts to match the log line itself. If source is
 provided, the regex attempts to match the corresponding value from the
 extracted map.
 
-On the other hand, the `value` field can only work with values from the
-extracted map, and must be specified together with `source`. Entries are
-dropped when there is an exact match between the two.
+The `value` field can only work with values from the extracted map, and must be
+specified together with `source`. Entries are dropped when there is an exact
+match between the two.
 
 Whenever an entry is dropped, the metric `loki_process_dropped_lines_total`
-is incremented. By default, the reason label is `drop_stage`, but a custom
-one can be provided by using the `drop_counter_reason` argument.
+is incremented. By default, the reason label is `"drop_stage"`, but you can
+provide a custom label using the `drop_counter_reason` argument.
 
 The following stage drops log entries that contain the word `debug` _and_ are
 longer than 1KB.
@@ -911,8 +911,9 @@ stage {
 }
 ```
 
-The following stages drop entries that are 24h or older, are longer than
-8KB, _or_ the extracted value of 'app' is equal to foo.
+On the following example, we define multiple `drop` blocks so `loki.process`
+will drop entries that are either 24h or older, are longer than 8KB, _or_ the
+extracted value of 'app' is equal to foo.
 
 ```
 stage {
@@ -925,7 +926,7 @@ stage {
 stage {
 	drop {
 		older_than  = "8KB"
-		longer_than = "too long"
+		drop_reason = "too long"
 	}
 }
 

--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -366,25 +366,15 @@ Name          | Type      | Description                                         
 `source`      | `string`  | Name from extracted data to parse. If empty, uses the log message.  | `""`    | no
 
 
-The `expression` field needs to be a RE2 regex string. Every capture group (re) is set into the extracted map, so it must be named like: `(?P<name>re)`. The name of the capture group is then used as the key in the extracted map.
+The `expression` field needs to be a RE2 regex string. Every capture group (re)
+is set into the extracted map, so it must be named like: `(?P<name>re)`. The
+name of the capture group is then used as the key in the extracted map.
 
-<!--
-We don't care about YAML, what does River do instead???
+Because of how River treats backslashes in double-quoted strings, all
+backslashes in an `expression` must be escaped like `"\\S+"`.
 
-Because of how YAML treats backslashes in double-quoted strings, note that all backslashes in a regex expression must be escaped when using double quotes. For example, all of these are valid:
-
-expression: \w*
-expression: '\w*'
-expression: "\\w*"
-But these are not:
-
-expression: \\w* (only escape backslashes when using double quotes)
-expression: '\\w*' (only escape backslashes when using double quotes)
-expression: "\w*" (backslash must be escaped)
--->
-
-If the `source` is empty, then the stage uses attempts to parse the log line
-itself.
+If the `source` is empty or missing, then the stage parses the log line itself.
+If it's set, the stage parses a previously extracted value with the same name.
 
 Given the following log line and regex stage, the extracted values are shown
 below:

--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -366,12 +366,13 @@ Name          | Type      | Description                                         
 `source`      | `string`  | Name from extracted data to parse. If empty, uses the log message.  | `""`    | no
 
 
-The `expression` field needs to be a RE2 regex string. Every capture group (re)
-is set into the extracted map, so it must be named like: `(?P<name>re)`. The
-name of the capture group is then used as the key in the extracted map.
+The `expression` field needs to be a RE2 regex string. Every matched capture
+group is added to the extracted map, so it must be named like: `(?P<name>re)`.
+The name of the capture group is then used as the key in the extracted map for
+the matched value.
 
-Because of how River treats backslashes in double-quoted strings, all
-backslashes in an `expression` must be escaped like `"\\S+"`.
+Because of how River strings work, any backslashes in `expression` must be
+escaped with a double backslash; for example `"\\w"` or `"\\S+"`.
 
 If the `source` is empty or missing, then the stage parses the log line itself.
 If it's set, the stage parses a previously extracted value with the same name.

--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -865,7 +865,7 @@ lines where the `applbl="foo"`. So, for the first line, the nested JSON stage
 adds `msg="app1 log line"` into the extracted map.
 
 The fourth stage uses the LogQL selector to only execute on lines where
-`applbl="qux"; that means it won't match on any of our input, and the nested
+`applbl="qux"`; that means it won't match on any of our input, and the nested
 json stage does not run.
 
 The fifth stage drops any entries from on lines where `applbl` is set to


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR updates loki.process to port the two 'filtering' stages available in Promtail, namely `match` and `drop`.

The first one can conditionally either drop, or  run a nested set of processing stages on entries that match a LogQL selector.

The second one can drop entries based on some predefined criteria, which are treated as AND clauses.
 
#### Which issue(s) this PR fixes
Updates #2515 

#### Notes to the Reviewer
We're still trying to port these over in smaller batches, so we can review the code and documentation being brought in, as well as make any obvious improvements work.

For this PR, the main change from the upstream Promtail code is not using pointers to denote optional values but letting River handle those.

Finally, the `DropConfig` struct contains both an Expression string _and_ the Regex it's used to construct. We can keep only one if we do something similar to what we're doing on `flow_relabel.Config`, but didn't know if it was worth the hassle.

#### PR Checklist

- [ ] CHANGELOG updated (will add a changelog entry when all stages are ported over)
- [X] Documentation added
- [X] Tests updated
