### PR TITLE
Do not marshal default or empty scraping service fields

### DIFF
--- a/pkg/metrics/agent.go
+++ b/pkg/metrics/agent.go
@@ -44,7 +44,7 @@ type Config struct {
 	WALCleanupPeriod       time.Duration         `yaml:"wal_cleanup_period,omitempty"`
 	ServiceConfig          cluster.Config        `yaml:"scraping_service,omitempty"`
 	ServiceClientConfig    client.Config         `yaml:"scraping_service_client,omitempty"`
-	Configs                []instance.Config     `yaml:"configs,omitempty,omitempty"`
+	Configs                []instance.Config     `yaml:"configs,omitempty"`
 	InstanceRestartBackoff time.Duration         `yaml:"instance_restart_backoff,omitempty"`
 	InstanceMode           instance.Mode         `yaml:"instance_mode,omitempty"`
 	DisableKeepAlives      bool                  `yaml:"http_disable_keepalives,omitempty"`

--- a/pkg/metrics/agent_test.go
+++ b/pkg/metrics/agent_test.go
@@ -333,23 +333,11 @@ func makeInstanceConfig(name string) instance.Config {
 	return cfg
 }
 
-func TestAgent_MarshalYAMLOmitDefaultServiceClientConfig(t *testing.T) {
+func TestAgent_MarshalYAMLOmitDefaultConfigFields(t *testing.T) {
 	cfg := DefaultConfig
 	yml, err := yaml.Marshal(&cfg)
 	require.NoError(t, err)
 	require.NotContains(t, string(yml), "scraping_service_client")
-}
-
-func TestAgent_MarshalYAMLOmitDefaultServiceConfig(t *testing.T) {
-	cfg := DefaultConfig
-	yml, err := yaml.Marshal(&cfg)
-	require.NoError(t, err)
 	require.NotContains(t, string(yml), "scraping_service")
-}
-
-func TestAgent_MarshalYAMLOmitGlobalConfig(t *testing.T) {
-	cfg := DefaultConfig
-	yml, err := yaml.Marshal(&cfg)
-	require.NoError(t, err)
 	require.NotContains(t, string(yml), "global")
 }

--- a/pkg/metrics/agent_test.go
+++ b/pkg/metrics/agent_test.go
@@ -346,3 +346,10 @@ func TestAgent_MarshalYAMLOmitDefaultServiceConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotContains(t, string(yml), "scraping_service")
 }
+
+func TestAgent_MarshalYAMLOmitGlobalConfig(t *testing.T) {
+	cfg := DefaultConfig
+	yml, err := yaml.Marshal(&cfg)
+	require.NoError(t, err)
+	require.NotContains(t, string(yml), "global")
+}

--- a/pkg/metrics/agent_test.go
+++ b/pkg/metrics/agent_test.go
@@ -332,3 +332,17 @@ func makeInstanceConfig(name string) instance.Config {
 	cfg.Name = name
 	return cfg
 }
+
+func TestAgent_MarshalYAMLOmitDefaultServiceClientConfig(t *testing.T) {
+	cfg := DefaultConfig
+	yml, err := yaml.Marshal(&cfg)
+	require.NoError(t, err)
+	require.NotContains(t, string(yml), "scraping_service_client")
+}
+
+func TestAgent_MarshalYAMLOmitDefaultServiceConfig(t *testing.T) {
+	cfg := DefaultConfig
+	yml, err := yaml.Marshal(&cfg)
+	require.NoError(t, err)
+	require.NotContains(t, string(yml), "scraping_service")
+}

--- a/pkg/metrics/cluster/client/client.go
+++ b/pkg/metrics/cluster/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"flag"
 	"io"
+	"reflect"
 
 	"github.com/grafana/agent/pkg/agentproto"
 	"github.com/grafana/agent/pkg/util"
@@ -36,6 +37,10 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	type plain Config
 	return unmarshal((*plain)(c))
+}
+
+func (c Config) IsZero() bool {
+	return reflect.DeepEqual(c, Config{}) || reflect.DeepEqual(c, DefaultConfig)
 }
 
 // RegisterFlags registers flags to the provided flag set.

--- a/pkg/metrics/cluster/config.go
+++ b/pkg/metrics/cluster/config.go
@@ -22,7 +22,7 @@ type KVConfig struct {
 }
 
 func (k KVConfig) IsZero() bool {
-	return reflect.DeepEqual(k, KVConfig{})
+	return reflect.DeepEqual(k, KVConfig{}) || reflect.DeepEqual(k, DefaultConfig.KVStore)
 }
 
 // LifecyclerConfig wraps the ring.LifecyclerConfig type to allow defining IsZero, which is required to make omitempty work when marshalling YAML.
@@ -31,7 +31,7 @@ type LifecyclerConfig struct {
 }
 
 func (l LifecyclerConfig) IsZero() bool {
-	return reflect.DeepEqual(l, LifecyclerConfig{})
+	return reflect.DeepEqual(l, LifecyclerConfig{}) || reflect.DeepEqual(l, DefaultConfig.Lifecycler)
 }
 
 // Config describes how to instantiate a scraping service Server instance.
@@ -61,6 +61,10 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	c.Lifecycler.RingConfig.ReplicationFactor = 1
 	return nil
+}
+
+func (c Config) IsZero() bool {
+	return reflect.DeepEqual(c, Config{}) || reflect.DeepEqual(c, DefaultConfig)
 }
 
 // RegisterFlags adds the flags required to config the Server to the given

--- a/pkg/metrics/cluster/config_test.go
+++ b/pkg/metrics/cluster/config_test.go
@@ -7,9 +7,23 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func TestAgent_OmmitEmptyFields(t *testing.T) {
+func TestConfig_MarshalYAMLOmitEmptyFields(t *testing.T) {
 	var cfg Config
 	yml, err := yaml.Marshal(&cfg)
 	require.NoError(t, err)
 	require.Equal(t, "{}\n", string(yml))
+}
+
+func TestConfig_MarshalYAMLOmitDefaultKVConfig(t *testing.T) {
+	cfg := DefaultConfig
+	yml, err := yaml.Marshal(&cfg)
+	require.NoError(t, err)
+	require.NotContains(t, string(yml), "kvstore")
+}
+
+func TestConfig_MarshalYAMLOmitDefaultLifecyclerConfig(t *testing.T) {
+	cfg := DefaultConfig
+	yml, err := yaml.Marshal(&cfg)
+	require.NoError(t, err)
+	require.NotContains(t, string(yml), "lifecycler")
 }

--- a/pkg/metrics/cluster/config_test.go
+++ b/pkg/metrics/cluster/config_test.go
@@ -14,16 +14,10 @@ func TestConfig_MarshalYAMLOmitEmptyFields(t *testing.T) {
 	require.Equal(t, "{}\n", string(yml))
 }
 
-func TestConfig_MarshalYAMLOmitDefaultKVConfig(t *testing.T) {
+func TestConfig_MarshalYAMLOmitDefaultConfigFields(t *testing.T) {
 	cfg := DefaultConfig
 	yml, err := yaml.Marshal(&cfg)
 	require.NoError(t, err)
 	require.NotContains(t, string(yml), "kvstore")
-}
-
-func TestConfig_MarshalYAMLOmitDefaultLifecyclerConfig(t *testing.T) {
-	cfg := DefaultConfig
-	yml, err := yaml.Marshal(&cfg)
-	require.NoError(t, err)
 	require.NotContains(t, string(yml), "lifecycler")
 }

--- a/pkg/metrics/instance/global.go
+++ b/pkg/metrics/instance/global.go
@@ -1,6 +1,7 @@
 package instance
 
 import (
+	"reflect"
 	"time"
 
 	"github.com/prometheus/prometheus/config"
@@ -27,4 +28,8 @@ func (c *GlobalConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	type plain GlobalConfig
 	return unmarshal((*plain)(c))
+}
+
+func (c GlobalConfig) IsZero() bool {
+	return reflect.DeepEqual(c, GlobalConfig{}) || reflect.DeepEqual(c, DefaultGlobalConfig)
 }


### PR DESCRIPTION
#### PR Description

  - Scraping service related fields produce high amounts of noise when marshaling YAML. This affects both the `/-/config` in the agent itself, as well remote agent management solutions using the Agent as a dependency.
  - This PR makes sure that configurations that do not explicitly enable scraping service or change its default configuration do not include such fields.
  - These fields include the keys `scraping_service`, `scraping_service_client` under metrics, as well as internal subkeys like `lifecycler` and `kvstore`.
  - Also excluded the `global` field under metrics, which is the only remaining top level field with nesting

Example YAML with an empty config:

```yaml
server:
  log_level: debug
  log_format: logfmt
metrics:
  wal_directory: data-agent/
  wal_cleanup_age: 12h0m0s
  wal_cleanup_period: 30m0s
  instance_restart_backoff: 5s
  instance_mode: shared
integrations:
  scrape_integrations: true
  integration_restart_backoff: 5s
  replace_instance_label: true
  use_hostname_label: true

```

#### Notes to the Reviewer

  - Unfortunately, when using `/-/config` the `scraping_service` field and most of its sub-fields are still marshaled. This is due to the way the agent applies default values *after* the Default configuration has been applied. This happens in multiple places, for example in `config.Config.Validate` (where the listen port for the lifecycler is set).
  - Some other top level fields we could clean up are less trivial (for example, `integrations` since we implement a custom marshaler using reflection. Probably not worth the hassle. 

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [x] Tests updated
