### PR TITLE
flow: Add support for remaining parsing stages to `loki.process` component

### DIFF
--- a/component/loki/process/internal/stages/json.go
+++ b/component/loki/process/internal/stages/json.go
@@ -70,13 +70,13 @@ type jsonStage struct {
 }
 
 // newJSONStage creates a new json pipeline stage from a config.
-func newJSONStage(logger log.Logger, cfg *JSONConfig) (Stage, error) {
-	expressions, err := validateJSONConfig(cfg)
+func newJSONStage(logger log.Logger, cfg JSONConfig) (Stage, error) {
+	expressions, err := validateJSONConfig(&cfg)
 	if err != nil {
 		return nil, err
 	}
 	return &jsonStage{
-		cfg:         cfg,
+		cfg:         &cfg,
 		expressions: expressions,
 		logger:      log.With(logger, "component", "stage", "type", "json"),
 	}, nil

--- a/component/loki/process/internal/stages/logfmt.go
+++ b/component/loki/process/internal/stages/logfmt.go
@@ -1,0 +1,131 @@
+package stages
+
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/go-logfmt/logfmt"
+	"github.com/prometheus/common/model"
+)
+
+// Config Errors
+var (
+	ErrMappingRequired        = errors.New("logfmt mapping is required")
+	ErrEmptyLogfmtStageConfig = errors.New("empty logfmt stage configuration")
+	ErrEmptyLogfmtStageSource = errors.New("empty source")
+)
+
+// LogfmtConfig represents a logfmt Stage configuration
+type LogfmtConfig struct {
+	Mapping map[string]string `river:"mapping,attr"`
+	Source  string            `river:"source,attr,optional"`
+}
+
+// validateLogfmtConfig validates a logfmt stage config and returns an inverse mapping of configured mapping.
+// Mapping inverse is done to make lookup easier. The key would be the key from parsed logfmt and
+// value would be the key with which the data in extracted map would be set.
+func validateLogfmtConfig(c *LogfmtConfig) (map[string]string, error) {
+	if c == nil {
+		return nil, ErrEmptyLogfmtStageConfig
+	}
+
+	if len(c.Mapping) == 0 {
+		return nil, ErrMappingRequired
+	}
+
+	inverseMapping := make(map[string]string)
+	for k, v := range c.Mapping {
+		// if value is not set, use the key for setting data in extracted map.
+		if v == "" {
+			v = k
+		}
+		inverseMapping[v] = k
+	}
+
+	return inverseMapping, nil
+}
+
+// logfmtStage sets extracted data using logfmt parser
+type logfmtStage struct {
+	cfg            *LogfmtConfig
+	inverseMapping map[string]string
+	logger         log.Logger
+}
+
+// newLogfmtStage creates a new logfmt pipeline stage from a config.
+func newLogfmtStage(logger log.Logger, config LogfmtConfig) (Stage, error) {
+	// inverseMapping would hold the mapping in inverse which would make lookup easier.
+	// To explain it simply, the key would be the key from parsed logfmt and value would be the key with which the data in extracted map would be set.
+	inverseMapping, err := validateLogfmtConfig(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	return toStage(&logfmtStage{
+		cfg:            &config,
+		inverseMapping: inverseMapping,
+		logger:         log.With(logger, "component", "stage", "type", "logfmt"),
+	}), nil
+}
+
+// Process implements Stage
+func (j *logfmtStage) Process(labels model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
+	// If a source key is provided, the logfmt stage should process it
+	// from the extracted map, otherwise should fallback to the entry
+	input := entry
+
+	if j.cfg.Source != "" {
+		if _, ok := extracted[j.cfg.Source]; !ok {
+			level.Debug(j.logger).Log("msg", "source does not exist in the set of extracted values", "source", j.cfg.Source)
+			return
+		}
+
+		value, err := getString(extracted[j.cfg.Source])
+		if err != nil {
+			level.Debug(j.logger).Log("msg", "failed to convert source value to string", "source", j.cfg.Source, "err", err, "type", reflect.TypeOf(extracted[j.cfg.Source]))
+			return
+		}
+
+		input = &value
+	}
+
+	if input == nil {
+		level.Debug(j.logger).Log("msg", "cannot parse a nil entry")
+		return
+	}
+	decoder := logfmt.NewDecoder(strings.NewReader(*input))
+	extractedEntriesCount := 0
+	for decoder.ScanRecord() {
+		for decoder.ScanKeyval() {
+			mapKey, ok := j.inverseMapping[string(decoder.Key())]
+			if ok {
+				extracted[mapKey] = string(decoder.Value())
+				extractedEntriesCount++
+			}
+		}
+	}
+
+	if decoder.Err() != nil {
+		level.Error(j.logger).Log("msg", "failed to decode logfmt", "err", decoder.Err())
+		return
+	}
+
+	if extractedEntriesCount != len(j.inverseMapping) {
+		level.Debug(j.logger).Log("msg", fmt.Sprintf("found only %d out of %d configured mappings in logfmt stage", extractedEntriesCount, len(j.inverseMapping)))
+	}
+	level.Debug(j.logger).Log("msg", "extracted data debug in logfmt stage", "extracted data", fmt.Sprintf("%v", extracted))
+}
+
+// Name implements Stage
+func (j *logfmtStage) Name() string {
+	return StageTypeLogfmt
+}

--- a/component/loki/process/internal/stages/logfmt_test.go
+++ b/component/loki/process/internal/stages/logfmt_test.go
@@ -1,0 +1,256 @@
+package stages
+
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/agent/pkg/flow/logging"
+	util_log "github.com/grafana/loki/pkg/util/log"
+)
+
+var testLogfmtRiverSingleStageWithoutSource = `
+stage {
+	logfmt {
+		mapping = { "out" = "message", "app" = "", "duration" = "", "unknown" = "" }
+	}
+}`
+
+var testLogfmtRiverMultiStageWithSource = `
+stage {
+	logfmt {
+		mapping = { "extra" = "" }
+	}
+}
+stage {
+	logfmt {
+		mapping = { "user" = "" }
+		source  = "extra"
+	}
+}`
+
+func TestLogfmt(t *testing.T) {
+	var testLogfmtLogLine = `
+		time=2012-11-01T22:08:41+00:00 app=loki	level=WARN duration=125 message="this is a log line" extra="user=foo""
+	`
+	t.Parallel()
+
+	tests := map[string]struct {
+		config          string
+		entry           string
+		expectedExtract map[string]interface{}
+	}{
+		"successfully run a pipeline with 1 logfmt stage without source": {
+			testLogfmtRiverSingleStageWithoutSource,
+			testLogfmtLogLine,
+			map[string]interface{}{
+				"out":      "this is a log line",
+				"app":      "loki",
+				"duration": "125",
+			},
+		},
+		"successfully run a pipeline with 2 logfmt stages with source": {
+			testLogfmtRiverMultiStageWithSource,
+			testLogfmtLogLine,
+			map[string]interface{}{
+				"extra": "user=foo",
+				"user":  "foo",
+			},
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			pl, err := NewPipeline(util_log.Logger, loadConfig(testData.config), nil, prometheus.DefaultRegisterer)
+			assert.NoError(t, err)
+			out := processEntries(pl, newEntry(nil, nil, testData.entry, time.Now()))[0]
+			assert.Equal(t, testData.expectedExtract, out.Extracted)
+		})
+	}
+}
+
+func TestLogfmtConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		config           LogfmtConfig
+		wantMappingCount int
+		err              error
+	}{
+		"no mapping": {
+			LogfmtConfig{},
+			0,
+			ErrMappingRequired,
+		},
+		"valid without source": {
+			LogfmtConfig{
+				Mapping: map[string]string{
+					"foo1": "foo",
+					"foo2": "",
+				},
+			},
+			2,
+			nil,
+		},
+		"valid with source": {
+			LogfmtConfig{
+				Mapping: map[string]string{
+					"foo1": "foo",
+					"foo2": "",
+				},
+				Source: "log",
+			},
+			2,
+			nil,
+		},
+	}
+	for tName, tt := range tests {
+		tt := tt
+		t.Run(tName, func(t *testing.T) {
+			got, err := validateLogfmtConfig(&tt.config)
+			if tt.err != nil {
+				assert.EqualError(t, err, tt.err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantMappingCount, len(got))
+		})
+	}
+}
+
+var testLogfmtLogFixture = `
+	time=2012-11-01T22:08:41+00:00
+	app=loki
+	level=WARN
+	nested="child=value"
+	message="this is a log line"
+`
+
+func TestLogfmtParser_Parse(t *testing.T) {
+	t.Parallel()
+	logger, _ := logging.New(io.Discard, logging.DefaultOptions)
+	tests := map[string]struct {
+		config          LogfmtConfig
+		extracted       map[string]interface{}
+		entry           string
+		expectedExtract map[string]interface{}
+	}{
+		"successfully decode logfmt on entry": {
+			LogfmtConfig{
+				Mapping: map[string]string{
+					"time":    "",
+					"app":     "",
+					"level":   "",
+					"nested":  "",
+					"message": "",
+				},
+			},
+			map[string]interface{}{},
+			testLogfmtLogFixture,
+			map[string]interface{}{
+				"time":    "2012-11-01T22:08:41+00:00",
+				"app":     "loki",
+				"level":   "WARN",
+				"nested":  "child=value",
+				"message": "this is a log line",
+			},
+		},
+		"successfully decode logfmt on extracted[source]": {
+			LogfmtConfig{
+				Mapping: map[string]string{
+					"time":    "",
+					"app":     "",
+					"level":   "",
+					"nested":  "",
+					"message": "",
+				},
+				Source: "log",
+			},
+			map[string]interface{}{
+				"log": testLogfmtLogFixture,
+			},
+			"{}",
+			map[string]interface{}{
+				"time":    "2012-11-01T22:08:41+00:00",
+				"app":     "loki",
+				"level":   "WARN",
+				"nested":  "child=value",
+				"message": "this is a log line",
+				"log":     testLogfmtLogFixture,
+			},
+		},
+		"missing extracted[source]": {
+			LogfmtConfig{
+				Mapping: map[string]string{
+					"app": "",
+				},
+				Source: "log",
+			},
+			map[string]interface{}{},
+			testLogfmtLogFixture,
+			map[string]interface{}{},
+		},
+		"invalid logfmt on entry": {
+			LogfmtConfig{
+				Mapping: map[string]string{
+					"expr1": "",
+				},
+			},
+			map[string]interface{}{},
+			"{\"invalid\":\"logfmt\"}",
+			map[string]interface{}{},
+		},
+		"invalid logfmt on extracted[source]": {
+			LogfmtConfig{
+				Mapping: map[string]string{
+					"app": "",
+				},
+				Source: "log",
+			},
+			map[string]interface{}{
+				"log": "not logfmt",
+			},
+			testLogfmtLogFixture,
+			map[string]interface{}{
+				"log": "not logfmt",
+			},
+		},
+		"nil source": {
+			LogfmtConfig{
+				Mapping: map[string]string{
+					"app": "",
+				},
+				Source: "log",
+			},
+			map[string]interface{}{
+				"log": nil,
+			},
+			testLogfmtLogFixture,
+			map[string]interface{}{
+				"log": nil,
+			},
+		},
+	}
+	for tName, tt := range tests {
+		tt := tt
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+			p, err := New(logger, nil, StageConfig{LogfmtConfig: &tt.config}, nil)
+			assert.NoError(t, err)
+			out := processEntries(p, newEntry(tt.extracted, nil, tt.entry, time.Now()))[0]
+
+			assert.Equal(t, tt.expectedExtract, out.Extracted)
+		})
+	}
+}

--- a/component/loki/process/internal/stages/multiline.go
+++ b/component/loki/process/internal/stages/multiline.go
@@ -1,0 +1,222 @@
+package stages
+
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/prometheus/common/model"
+)
+
+// Configuration errors.
+var (
+	ErrMultilineStageEmptyConfig        = errors.New("multiline stage config must define `firstline` regular expression")
+	ErrMultilineStageInvalidRegex       = errors.New("multiline stage first line regex compilation error")
+	ErrMultilineStageInvalidMaxWaitTime = errors.New("multiline stage `max_wait_time` parse error")
+)
+
+const (
+	maxLineDefault uint64 = 128
+	maxWaitDefault        = 3 * time.Second
+)
+
+// MultilineConfig contains the configuration for a Multiline stage.
+type MultilineConfig struct {
+	Expression  string        `river:"firstline,attr"`
+	MaxLines    uint64        `river:"max_lines,attr,optional"`
+	MaxWaitTime time.Duration `river:"max_wait_time,attr,optional"`
+	regex       *regexp.Regexp
+}
+
+// DefaultMultilineConfig applies the default values on
+var DefaultMultilineConfig = MultilineConfig{
+	MaxLines:    128,
+	MaxWaitTime: 3 * time.Second,
+}
+
+var _ river.Unmarshaler = (*MultilineConfig)(nil)
+
+// UnmarshalRiver implements river.Unmarshaler, applying defaults and
+// validating the provided config.
+func (args *MultilineConfig) UnmarshalRiver(f func(interface{}) error) error {
+	*args = DefaultMultilineConfig
+
+	type arguments MultilineConfig
+	if err := f((*arguments)(args)); err != nil {
+		return err
+	}
+
+	if args.MaxWaitTime <= 0 {
+		return fmt.Errorf("max_wait_time must be greater than 0")
+	}
+
+	return nil
+}
+
+func validateMultilineConfig(cfg *MultilineConfig) error {
+	if cfg.Expression == "" {
+		return ErrMultilineStageEmptyConfig
+	}
+
+	expr, err := regexp.Compile(cfg.Expression)
+	if err != nil {
+		return fmt.Errorf("%v: %w", ErrMultilineStageInvalidRegex, err)
+	}
+	cfg.regex = expr
+
+	return nil
+}
+
+// multilineStage matches lines to determine whether the following lines belong to a block and should be collapsed
+type multilineStage struct {
+	logger log.Logger
+	cfg    MultilineConfig
+}
+
+// multilineState captures the internal state of a running multiline stage.
+type multilineState struct {
+	buffer         *bytes.Buffer // The lines of the current multiline block.
+	startLineEntry Entry         // The entry of the start line of a multiline block.
+	currentLines   uint64        // The number of lines of the current multiline block.
+}
+
+// newMulitlineStage creates a MulitlineStage from config
+func newMultilineStage(logger log.Logger, config MultilineConfig) (Stage, error) {
+	err := validateMultilineConfig(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &multilineStage{
+		logger: log.With(logger, "component", "stage", "type", "multiline"),
+		cfg:    config,
+	}, nil
+}
+
+func (m *multilineStage) Run(in chan Entry) chan Entry {
+	out := make(chan Entry)
+	go func() {
+		defer close(out)
+
+		streams := make(map[model.Fingerprint](chan Entry))
+		wg := new(sync.WaitGroup)
+
+		for e := range in {
+			key := e.Labels.FastFingerprint()
+			s, ok := streams[key]
+			if !ok {
+				// Pass through entries until we hit first start line.
+				if !m.cfg.regex.MatchString(e.Line) {
+					level.Debug(m.logger).Log("msg", "pass through entry", "stream", key)
+					out <- e
+					continue
+				}
+
+				level.Debug(m.logger).Log("msg", "creating new stream", "stream", key)
+				s = make(chan Entry)
+				streams[key] = s
+
+				wg.Add(1)
+				go m.runMultiline(s, out, wg)
+			}
+			level.Debug(m.logger).Log("msg", "pass entry", "stream", key, "line", e.Line)
+			s <- e
+		}
+
+		// Close all streams and wait for them to finish being processed.
+		for _, s := range streams {
+			close(s)
+		}
+		wg.Wait()
+	}()
+	return out
+}
+
+func (m *multilineStage) runMultiline(in chan Entry, out chan Entry, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	state := &multilineState{
+		buffer:       new(bytes.Buffer),
+		currentLines: 0,
+	}
+
+	for {
+		select {
+		case <-time.After(m.cfg.MaxWaitTime):
+			level.Debug(m.logger).Log("msg", fmt.Sprintf("flush multiline block due to %v timeout", m.cfg.MaxWaitTime), "block", state.buffer.String())
+			m.flush(out, state)
+		case e, ok := <-in:
+			level.Debug(m.logger).Log("msg", "processing line", "line", e.Line, "stream", e.Labels.FastFingerprint())
+
+			if !ok {
+				level.Debug(m.logger).Log("msg", "flush multiline block because inbound closed", "block", state.buffer.String(), "stream", e.Labels.FastFingerprint())
+				m.flush(out, state)
+				return
+			}
+
+			isFirstLine := m.cfg.regex.MatchString(e.Line)
+			if isFirstLine {
+				level.Debug(m.logger).Log("msg", "flush multiline block because new start line", "block", state.buffer.String(), "stream", e.Labels.FastFingerprint())
+				m.flush(out, state)
+
+				// The start line entry is used to set timestamp and labels in the flush method.
+				// The timestamps for following lines are ignored for now.
+				state.startLineEntry = e
+			}
+
+			// Append block line
+			if state.buffer.Len() > 0 {
+				state.buffer.WriteRune('\n')
+			}
+			state.buffer.WriteString(e.Line)
+			state.currentLines++
+
+			if state.currentLines == m.cfg.MaxLines {
+				m.flush(out, state)
+			}
+		}
+	}
+}
+
+func (m *multilineStage) flush(out chan Entry, s *multilineState) {
+	if s.buffer.Len() == 0 {
+		level.Debug(m.logger).Log("msg", "nothing to flush", "buffer_len", s.buffer.Len())
+		return
+	}
+	// copy extracted data.
+	extracted := make(map[string]interface{}, len(s.startLineEntry.Extracted))
+	for k, v := range s.startLineEntry.Extracted {
+		extracted[k] = v
+	}
+	collapsed := Entry{
+		Extracted: extracted,
+		Entry: loki.Entry{
+			Labels: s.startLineEntry.Entry.Labels.Clone(),
+			Entry: logproto.Entry{
+				Timestamp: s.startLineEntry.Entry.Entry.Timestamp,
+				Line:      s.buffer.String(),
+			},
+		},
+	}
+	s.buffer.Reset()
+	s.currentLines = 0
+
+	out <- collapsed
+}
+
+// Name implements Stage
+func (m *multilineStage) Name() string {
+	return StageTypeMultiline
+}

--- a/component/loki/process/internal/stages/multiline_test.go
+++ b/component/loki/process/internal/stages/multiline_test.go
@@ -1,0 +1,143 @@
+package stages
+
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
+import (
+	"io"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/agent/pkg/flow/logging"
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultilineStageProcess(t *testing.T) {
+	logger, _ := logging.New(io.Discard, logging.DefaultOptions)
+	mcfg := MultilineConfig{Expression: "^START", MaxWaitTime: 3 * time.Second}
+	err := validateMultilineConfig(&mcfg)
+	require.NoError(t, err)
+
+	stage := &multilineStage{
+		cfg:    mcfg,
+		logger: logger,
+	}
+
+	out := processEntries(stage,
+		simpleEntry("not a start line before 1", "label"),
+		simpleEntry("not a start line before 2", "label"),
+		simpleEntry("START line 1", "label"),
+		simpleEntry("not a start line", "label"),
+		simpleEntry("START line 2", "label"),
+		simpleEntry("START line 3", "label"))
+
+	require.Len(t, out, 5)
+	require.Equal(t, "not a start line before 1", out[0].Line)
+	require.Equal(t, "not a start line before 2", out[1].Line)
+	require.Equal(t, "START line 1\nnot a start line", out[2].Line)
+	require.Equal(t, "START line 2", out[3].Line)
+	require.Equal(t, "START line 3", out[4].Line)
+}
+
+func TestMultilineStageMultiStreams(t *testing.T) {
+	logger, _ := logging.New(io.Discard, logging.DefaultOptions)
+	mcfg := MultilineConfig{Expression: "^START", MaxWaitTime: 3 * time.Second}
+	err := validateMultilineConfig(&mcfg)
+	require.NoError(t, err)
+
+	stage := &multilineStage{
+		cfg:    mcfg,
+		logger: logger,
+	}
+
+	out := processEntries(stage,
+		simpleEntry("START line 1", "one"),
+		simpleEntry("not a start line 1", "one"),
+		simpleEntry("START line 1", "two"),
+		simpleEntry("not a start line 2", "one"),
+		simpleEntry("START line 2", "two"),
+		simpleEntry("START line 2", "one"),
+		simpleEntry("not a start line 1", "one"),
+	)
+
+	sort.Slice(out, func(l, r int) bool {
+		return out[l].Timestamp.Before(out[r].Timestamp)
+	})
+
+	require.Len(t, out, 4)
+
+	require.Equal(t, "START line 1\nnot a start line 1\nnot a start line 2", out[0].Line)
+	require.Equal(t, model.LabelValue("one"), out[0].Labels["value"])
+
+	require.Equal(t, "START line 1", out[1].Line)
+	require.Equal(t, model.LabelValue("two"), out[1].Labels["value"])
+
+	require.Equal(t, "START line 2", out[2].Line)
+	require.Equal(t, model.LabelValue("two"), out[2].Labels["value"])
+
+	require.Equal(t, "START line 2\nnot a start line 1", out[3].Line)
+	require.Equal(t, model.LabelValue("one"), out[3].Labels["value"])
+}
+
+func TestMultilineStageMaxWaitTime(t *testing.T) {
+	logger, _ := logging.New(io.Discard, logging.DefaultOptions)
+	mcfg := MultilineConfig{Expression: "^START", MaxWaitTime: 2 * time.Second}
+	err := validateMultilineConfig(&mcfg)
+	require.NoError(t, err)
+
+	stage := &multilineStage{
+		cfg:    mcfg,
+		logger: logger,
+	}
+
+	in := make(chan Entry, 2)
+	out := stage.Run(in)
+
+	// Accumulate result
+	mu := new(sync.Mutex)
+	var res []Entry
+	go func() {
+		for e := range out {
+			mu.Lock()
+			t.Logf("appending %s", e.Line)
+			res = append(res, e)
+			mu.Unlock()
+		}
+	}()
+
+	// Write input with a delay
+	go func() {
+		in <- simpleEntry("START line", "label")
+
+		// Trigger flush due to max wait timeout
+		time.Sleep(4 * time.Second)
+
+		in <- simpleEntry("not a start line hitting timeout", "label")
+
+		// Signal pipeline we are done.
+		close(in)
+	}()
+
+	require.Eventually(t, func() bool { mu.Lock(); defer mu.Unlock(); return len(res) == 2 }, 6*time.Second, time.Second)
+	require.Equal(t, "START line", res[0].Line)
+	require.Equal(t, "not a start line hitting timeout", res[1].Line)
+}
+
+func simpleEntry(line, label string) Entry {
+	return Entry{
+		Extracted: map[string]interface{}{},
+		Entry: loki.Entry{
+			Labels: model.LabelSet{"value": model.LabelValue(label)},
+			Entry: logproto.Entry{
+				Timestamp: time.Now(),
+				Line:      line,
+			},
+		},
+	}
+}

--- a/component/loki/process/internal/stages/pipeline.go
+++ b/component/loki/process/internal/stages/pipeline.go
@@ -26,6 +26,7 @@ type StageConfig struct {
 	// hand. This will be fixed once we've gained confidence in the ported
 	// processing stages and the package is made non-internal.
 	JSONConfig         *JSONConfig         `river:"json,block,optional"`
+	LogfmtConfig       *LogfmtConfig       `river:"logfmt,block,optional"`
 	LabelsConfig       *LabelsConfig       `river:"labels,block,optional"`
 	LabelAllowConfig   *LabelAllowConfig   `river:"label_keep,block,optional"`
 	LabelDropConfig    *LabelDropConfig    `river:"label_drop,block,optional"`
@@ -35,6 +36,8 @@ type StageConfig struct {
 	RegexConfig        *RegexConfig        `river:"regex,block,optional"`
 	TimestampConfig    *TimestampConfig    `river:"timestamp,block,optional"`
 	OutputConfig       *OutputConfig       `river:"output,block,optional"`
+	ReplaceConfig      *ReplaceConfig      `river:"replace,block,optional"`
+	MultilineConfig    *MultilineConfig    `river:"multiline,block,optional"`
 }
 
 // UnmarshalRiver implements river.Unmarshaler.

--- a/component/loki/process/internal/stages/replace.go
+++ b/component/loki/process/internal/stages/replace.go
@@ -1,0 +1,226 @@
+package stages
+
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/Masterminds/sprig/v3"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/common/model"
+	"golang.org/x/crypto/sha3"
+)
+
+// Config Errors
+var (
+	ErrEmptyReplaceStageConfig = errors.New("empty replace stage configuration")
+	ErrEmptyReplaceStageSource = errors.New("empty source in replace stage")
+)
+
+var extraFunctionMap = template.FuncMap{
+	"ToLower":    strings.ToLower,
+	"ToUpper":    strings.ToUpper,
+	"Replace":    strings.Replace,
+	"Trim":       strings.Trim,
+	"TrimLeft":   strings.TrimLeft,
+	"TrimRight":  strings.TrimRight,
+	"TrimPrefix": strings.TrimPrefix,
+	"TrimSuffix": strings.TrimSuffix,
+	"TrimSpace":  strings.TrimSpace,
+	"Hash": func(salt string, input string) string {
+		hash := sha3.Sum256([]byte(salt + input))
+		return hex.EncodeToString(hash[:])
+	},
+	"Sha2Hash": func(salt string, input string) string {
+		hash := sha256.Sum256([]byte(salt + input))
+		return hex.EncodeToString(hash[:])
+	},
+	"regexReplaceAll": func(regex string, s string, repl string) string {
+		r := regexp.MustCompile(regex)
+		return r.ReplaceAllString(s, repl)
+	},
+	"regexReplaceAllLiteral": func(regex string, s string, repl string) string {
+		r := regexp.MustCompile(regex)
+		return r.ReplaceAllLiteralString(s, repl)
+	},
+}
+
+var functionMap = sprig.TxtFuncMap()
+
+func init() {
+	for k, v := range extraFunctionMap {
+		functionMap[k] = v
+	}
+}
+
+// ReplaceConfig contains a regexStage configuration
+type ReplaceConfig struct {
+	Expression string `river:"expression,attr"`
+	Source     string `river:"source,attr,optional"`
+	Replace    string `river:"replace,attr,optional"`
+}
+
+func getExpressionRegex(c ReplaceConfig) (*regexp.Regexp, error) {
+	if c.Expression == "" {
+		return nil, ErrExpressionRequired
+	}
+
+	expr, err := regexp.Compile(c.Expression)
+	if err != nil {
+		return nil, fmt.Errorf("%v: %w", ErrCouldNotCompileRegex, err)
+	}
+	return expr, nil
+}
+
+// replaceStage sets extracted data using regular expressions
+type replaceStage struct {
+	cfg        ReplaceConfig
+	expression *regexp.Regexp
+	logger     log.Logger
+}
+
+// newReplaceStage creates a newReplaceStage
+func newReplaceStage(logger log.Logger, config ReplaceConfig) (Stage, error) {
+	expression, err := getExpressionRegex(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return toStage(&replaceStage{
+		cfg:        config,
+		expression: expression,
+		logger:     log.With(logger, "component", "stage", "type", "replace"),
+	}), nil
+}
+
+// Process implements Stage
+func (r *replaceStage) Process(labels model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
+	// If a source key is provided, the replace stage should process it
+	// from the extracted map, otherwise should fallback to the entry
+	input := entry
+
+	if r.cfg.Source != "" {
+		if _, ok := extracted[r.cfg.Source]; !ok {
+			level.Debug(r.logger).Log("msg", "source does not exist in the set of extracted values", "source", r.cfg.Source)
+			return
+		}
+
+		value, err := getString(extracted[r.cfg.Source])
+		if err != nil {
+			level.Debug(r.logger).Log("msg", "failed to convert source value to string", "source", r.cfg.Source, "err", err, "type", reflect.TypeOf(extracted[r.cfg.Source]))
+			return
+		}
+
+		input = &value
+	}
+
+	if input == nil {
+		level.Debug(r.logger).Log("msg", "cannot parse a nil entry")
+		return
+	}
+
+	// Get string of matched captured groups. We will use this to extract all named captured groups
+	match := r.expression.FindStringSubmatch(*input)
+	matchAllIndex := r.expression.FindAllStringSubmatchIndex(*input, -1)
+
+	if matchAllIndex == nil {
+		level.Debug(r.logger).Log("msg", "regex did not match", "input", *input, "regex", r.expression)
+		return
+	}
+
+	// All extracted values will be available for templating
+	td := r.getTemplateData(extracted)
+
+	// Initialize the template with the "replace" string defined by user
+	templ, err := template.New("pipeline_template").Funcs(functionMap).Parse(r.cfg.Replace)
+	if err != nil {
+		level.Debug(r.logger).Log("msg", "template initialization error", "err", err)
+		return
+	}
+
+	result, capturedMap, err := r.getReplacedEntry(matchAllIndex, *input, td, templ)
+	if err != nil {
+		level.Debug(r.logger).Log("msg", "failed to execute template on extracted value", "err", err)
+		return
+	}
+
+	if r.cfg.Source != "" {
+		extracted[r.cfg.Source] = result
+	} else {
+		*entry = result
+	}
+
+	// All the named captured group will be extracted
+	for i, name := range r.expression.SubexpNames() {
+		if i != 0 && name != "" {
+			if v, ok := capturedMap[match[i]]; ok {
+				extracted[name] = v
+			}
+		}
+	}
+	level.Debug(r.logger).Log("msg", "extracted data debug in replace stage", "extracted data", fmt.Sprintf("%v", extracted))
+}
+
+func (r *replaceStage) getReplacedEntry(matchAllIndex [][]int, input string, td map[string]string, templ *template.Template) (string, map[string]string, error) {
+	var result string
+	previousInputEndIndex := 0
+	capturedMap := make(map[string]string)
+	// For a simple string like `11.11.11.11 - frank 12.12.12.12 - frank`
+	// if the regex is "(\\d{2}.\\d{2}.\\d{2}.\\d{2}) - (\\S+)"
+	// FindAllStringSubmatchIndex would return [[0 19 0 11 14 19] [20 37 20 31 34 37]].
+	// Each inner array's first two values will be the start and end index of the entire
+	// matched string and the next values will be start and end index of the matched
+	// captured group. Here 0-19 is "11.11.11.11 - frank",  0-11 is "11.11.11.11" and
+	// 14-19 is "frank". So, we advance by 2 index to get the next match
+	for _, matchIndex := range matchAllIndex {
+		for i := 2; i < len(matchIndex); i += 2 {
+			if matchIndex[i] == -1 {
+				continue
+			}
+			capturedString := input[matchIndex[i]:matchIndex[i+1]]
+			buf := &bytes.Buffer{}
+			td["Value"] = capturedString
+			err := templ.Execute(buf, td)
+			if err != nil {
+				return "", nil, err
+			}
+			st := buf.String()
+			if previousInputEndIndex == 0 || previousInputEndIndex <= matchIndex[i] {
+				result += input[previousInputEndIndex:matchIndex[i]] + st
+				previousInputEndIndex = matchIndex[i+1]
+			}
+			capturedMap[capturedString] = st
+		}
+	}
+	return result + input[previousInputEndIndex:], capturedMap, nil
+}
+
+func (r *replaceStage) getTemplateData(extracted map[string]interface{}) map[string]string {
+	td := make(map[string]string)
+	for k, v := range extracted {
+		s, err := getString(v)
+		if err != nil {
+			level.Debug(r.logger).Log("msg", "extracted template could not be converted to a string", "err", err, "type", reflect.TypeOf(v))
+			continue
+		}
+		td[k] = s
+	}
+	return td
+}
+
+// Name implements Stage
+func (r *replaceStage) Name() string {
+	return StageTypeReplace
+}

--- a/component/loki/process/internal/stages/replace_test.go
+++ b/component/loki/process/internal/stages/replace_test.go
@@ -1,0 +1,237 @@
+package stages
+
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/pkg/flow/logging"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+var testReplaceRiverSingleStageWithoutSource = `
+stage {
+	replace {
+		expression = "11.11.11.11 - (\\S+) .*"
+		replace    = "dummy"
+	}
+}
+`
+var testReplaceRiverMultiStageWithSource = `
+stage {
+	json {
+		expressions = { "level" = "", "msg" = "" }
+	}
+}
+
+stage {
+	replace {
+		expression = "\\S+ - \"POST (\\S+) .*"
+    	source     = "msg"
+    	replace    = "/loki/api/v1/push/"
+	}
+}
+`
+
+var testReplaceRiverWithNamedCaputedGroupWithTemplate = `
+stage {
+	replace {
+		expression = "^(?P<ip>\\S+) (?P<identd>\\S+) (?P<user>\\S+) \\[(?P<timestamp>[\\w:/]+\\s[+\\-]\\d{4})\\] \"(?P<action>\\S+)\\s?(?P<path>\\S+)?\\s?(?P<protocol>\\S+)?\" (?P<status>\\d{3}|-) (\\d+|-)\\s?\"?(?P<referer>[^\"]*)\"?\\s?\"?(?P<useragent>[^\"]*)?\"?$"
+		replace    = "{{ if eq .Value \"200\" }}{{ Replace .Value \"200\" \"HttpStatusOk\" -1 }}{{ else }}{{ .Value | ToUpper }}{{ end }}"
+	}
+}
+`
+
+var testReplaceRiverWithNestedCapturedGroups = `
+stage {
+	replace {
+		expression = "(?P<ip_user>^(?P<ip>\\S+) (?P<identd>\\S+) (?P<user>\\S+)) \\[(?P<timestamp>[\\w:/]+\\s[+\\-]\\d{4})\\] \"(?P<action_path>(?P<action>\\S+)\\s?(?P<path>\\S+)?)\\s?(?P<protocol>\\S+)?\" (?P<status>\\d{3}|-) (\\d+|-)\\s?\"?(?P<referer>[^\"]*)\"?\\s?\"?(?P<useragent>[^\"]*)?\"?$"
+		replace    = "{{ if eq .Value \"200\" }}{{ Replace .Value \"200\" \"HttpStatusOk\" -1 }}{{ else }}{{ .Value | ToUpper }}{{ end }}"
+	}
+}
+`
+
+var testReplaceRiverWithTemplate = `
+stage {
+	replace {
+		expression = "^(\\S+) (\\S+) (\\S+) \\[([\\w:/]+\\s[+\\-]\\d{4})\\] \"(\\S+)\\s?(\\S+)?\\s?(\\S+)?\" (\\d{3}|-) (\\d+|-)\\s?\"?([^\"]*)\"?\\s?\"?([^\"]*)?\"?$"
+		replace    = "{{ if eq .Value \"200\" }}{{ Replace .Value \"200\" \"HttpStatusOk\" -1 }}{{ else }}{{ .Value | ToUpper }}{{ end }}"
+	}
+}
+`
+
+var testReplaceRiverWithEmptyReplace = `
+stage {
+	replace {
+		expression = "11.11.11.11 - (\\S+\\s)"
+		replace    = ""
+	}
+}
+`
+
+var testReplaceAdjacentCaptureGroups = `
+stage {
+	replace {
+		expression = "(a|b|c)"
+		replace    = ""
+	}
+}
+`
+
+var testReplaceLogLine = `11.11.11.11 - frank [25/Jan/2000:14:00:01 -0500] "GET /1986.js HTTP/1.1" 200 932 "-" "Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6"`
+var testReplaceLogJSONLine = `{"time":"2019-01-01T01:00:00.000000001Z", "level": "info", "msg": "11.11.11.11 - \"POST /loki/api/push/ HTTP/1.1\" 200 932 \"-\" \"Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6\""}`
+var testReplaceLogLineAdjacentCaptureGroups = `abc`
+
+func TestReplace(t *testing.T) {
+	t.Parallel()
+	logger, _ := logging.New(io.Discard, logging.DefaultOptions)
+
+	tests := map[string]struct {
+		config        string
+		entry         string
+		extracted     map[string]interface{}
+		expectedEntry string
+	}{
+		"successfully run a pipeline with 1 regex stage without source": {
+			testReplaceRiverSingleStageWithoutSource,
+			testReplaceLogLine,
+			map[string]interface{}{},
+			`11.11.11.11 - dummy [25/Jan/2000:14:00:01 -0500] "GET /1986.js HTTP/1.1" 200 932 "-" "Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6"`,
+		},
+		"successfully run a pipeline with multi stage with": {
+			testReplaceRiverMultiStageWithSource,
+			testReplaceLogJSONLine,
+			map[string]interface{}{
+				"level": "info",
+				"msg":   `11.11.11.11 - "POST /loki/api/v1/push/ HTTP/1.1" 200 932 "-" "Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6"`,
+			},
+			`{"time":"2019-01-01T01:00:00.000000001Z", "level": "info", "msg": "11.11.11.11 - \"POST /loki/api/push/ HTTP/1.1\" 200 932 \"-\" \"Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6\""}`,
+		},
+		"successfully run a pipeline with 1 regex stage with named captured group and with template and without source": {
+			testReplaceRiverWithNamedCaputedGroupWithTemplate,
+			testReplaceLogLine,
+			map[string]interface{}{
+				"ip":        "11.11.11.11",
+				"identd":    "-",
+				"user":      "FRANK",
+				"timestamp": "25/JAN/2000:14:00:01 -0500",
+				"action":    "GET",
+				"path":      "/1986.JS",
+				"protocol":  "HTTP/1.1",
+				"status":    "HttpStatusOk",
+				"referer":   "-",
+				"useragent": "MOZILLA/5.0 (WINDOWS; U; WINDOWS NT 5.1; DE; RV:1.9.1.7) GECKO/20091221 FIREFOX/3.5.7 GTB6",
+			},
+			`11.11.11.11 - FRANK [25/JAN/2000:14:00:01 -0500] "GET /1986.JS HTTP/1.1" HttpStatusOk 932 "-" "MOZILLA/5.0 (WINDOWS; U; WINDOWS NT 5.1; DE; RV:1.9.1.7) GECKO/20091221 FIREFOX/3.5.7 GTB6"`,
+		},
+		"successfully run a pipeline with 1 regex stage with nested captured groups and with template and without source": {
+			testReplaceRiverWithNestedCapturedGroups,
+			testReplaceLogLine,
+			map[string]interface{}{
+				"ip_user":     "11.11.11.11 - FRANK",
+				"action_path": "GET /1986.JS",
+				"ip":          "11.11.11.11",
+				"identd":      "-",
+				"user":        "FRANK",
+				"timestamp":   "25/JAN/2000:14:00:01 -0500",
+				"action":      "GET",
+				"path":        "/1986.JS",
+				"protocol":    "HTTP/1.1",
+				"status":      "HttpStatusOk",
+				"referer":     "-",
+				"useragent":   "MOZILLA/5.0 (WINDOWS; U; WINDOWS NT 5.1; DE; RV:1.9.1.7) GECKO/20091221 FIREFOX/3.5.7 GTB6",
+			},
+			`11.11.11.11 - FRANK [25/JAN/2000:14:00:01 -0500] "GET /1986.JS HTTP/1.1" HttpStatusOk 932 "-" "MOZILLA/5.0 (WINDOWS; U; WINDOWS NT 5.1; DE; RV:1.9.1.7) GECKO/20091221 FIREFOX/3.5.7 GTB6"`,
+		},
+		"successfully run a pipeline with 1 regex stage with template and without source": {
+			testReplaceRiverWithTemplate,
+			testReplaceLogLine,
+			map[string]interface{}{},
+			`11.11.11.11 - FRANK [25/JAN/2000:14:00:01 -0500] "GET /1986.JS HTTP/1.1" HttpStatusOk 932 "-" "MOZILLA/5.0 (WINDOWS; U; WINDOWS NT 5.1; DE; RV:1.9.1.7) GECKO/20091221 FIREFOX/3.5.7 GTB6"`,
+		},
+		"successfully run a pipeline with empty replace value": {
+			testReplaceRiverWithEmptyReplace,
+			testReplaceLogLine,
+			map[string]interface{}{},
+			`11.11.11.11 - [25/Jan/2000:14:00:01 -0500] "GET /1986.js HTTP/1.1" 200 932 "-" "Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6"`,
+		},
+		"successfully run a pipeline with adjacent capture groups": {
+			testReplaceAdjacentCaptureGroups,
+			testReplaceLogLineAdjacentCaptureGroups,
+			map[string]interface{}{},
+			``,
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			pl, err := NewPipeline(logger, loadConfig(testData.config), nil, prometheus.DefaultRegisterer)
+			if err != nil {
+				t.Fatal(err)
+			}
+			out := processEntries(pl, newEntry(nil, nil, testData.entry, time.Now()))[0]
+			assert.Equal(t, testData.expectedEntry, out.Line)
+			assert.Equal(t, testData.extracted, out.Extracted)
+		})
+	}
+}
+
+func TestReplaceConfigValidation(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		config ReplaceConfig
+		err    error
+	}{
+		"missing regex_expression": {
+			ReplaceConfig{},
+			ErrExpressionRequired,
+		},
+		"invalid regex_expression": {
+			ReplaceConfig{
+				Expression: "(?P<ts[0-9]+).*",
+				Replace:    "test",
+			},
+			fmt.Errorf("%v: %w", ErrCouldNotCompileRegex, errors.New("error parsing regexp: invalid named capture: `(?P<ts[0-9]+).*`")),
+		},
+		"valid without source": {
+			ReplaceConfig{
+				Expression: "(?P<ts>[0-9]+).*",
+				Replace:    "test",
+			},
+			nil,
+		},
+		"valid with source": {
+			ReplaceConfig{
+				Expression: "(?P<ts>[0-9]+).*",
+				Source:     "log",
+				Replace:    "test",
+			},
+			nil,
+		},
+	}
+	for tName, tt := range tests {
+		tt := tt
+		t.Run(tName, func(t *testing.T) {
+			_, err := getExpressionRegex(tt.config)
+			if (err != nil) != (tt.err != nil) {
+				t.Errorf("ReplaceConfig.validate() expected error = %v, actual error = %v", tt.err, err)
+				return
+			}
+			if (err != nil) && (err.Error() != tt.err.Error()) {
+				t.Errorf("ReplaceConfig.validate() expected error = %v, actual error = %v", tt.err, err)
+				return
+			}
+		})
+	}
+}

--- a/component/loki/process/internal/stages/stage.go
+++ b/component/loki/process/internal/stages/stage.go
@@ -124,15 +124,15 @@ func New(logger log.Logger, jobName *string, cfg StageConfig, registerer prometh
 			return nil, err
 		}
 	case cfg.JSONConfig != nil:
-		s, err = newJSONStage(logger, cfg.JSONConfig)
+		s, err = newJSONStage(logger, *cfg.JSONConfig)
 		if err != nil {
 			return nil, err
 		}
-	// case StageTypeLogfmt:
-	// 	s, err = newLogfmtStage(logger, cfg)
-	// 	if err != nil {
-	// 		return nil, err
-	// 	}
+	case cfg.LogfmtConfig != nil:
+		s, err = newLogfmtStage(logger, *cfg.LogfmtConfig)
+		if err != nil {
+			return nil, err
+		}
 	// case StageTypeMetric:
 	// 	s, err = newMetricStage(logger, cfg, registerer)
 	// 	if err != nil {
@@ -174,30 +174,30 @@ func New(logger log.Logger, jobName *string, cfg StageConfig, registerer prometh
 	// 		return nil, err
 	// 	}
 	// case StageTypeTenant:
-	// 	s, err = newTenantStage(logger, cfg)
+	// 	s, err = newTenantStage(logger, cfg.TenantConfig)
 	// 	if err != nil {
 	// 		return nil, err
 	// 	}
-	// case StageTypeReplace:
-	// 	s, err = newReplaceStage(logger, cfg)
-	// 	if err != nil {
-	// 		return nil, err
-	// 	}
+	case cfg.ReplaceConfig != nil:
+		s, err = newReplaceStage(logger, *cfg.ReplaceConfig)
+		if err != nil {
+			return nil, err
+		}
 	// case StageTypeDrop:
 	// 	s, err = newDropStage(logger, cfg, registerer)
 	// 	if err != nil {
 	// 		return nil, err
 	// 	}
-	// case StageTypeLimit:
-	// 	s, err = newLimitStage(logger, cfg, registerer)
+	// case cfg.LimitConfig != nil:
+	// 	s, err = newLimitStage(logger, *cfg.LimitConfig, registerer)
 	// 	if err != nil {
 	// 		return nil, err
 	// 	}
-	// case StageTypeMultiline:
-	// 	s, err = newMultilineStage(logger, cfg)
-	// 	if err != nil {
-	// 		return nil, err
-	// 	}
+	case cfg.MultilineConfig != nil:
+		s, err = newMultilineStage(logger, *cfg.MultilineConfig)
+		if err != nil {
+			return nil, err
+		}
 	// case StageTypePack:
 	// 	s, err = newPackStage(logger, cfg, registerer)
 	// 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR updates `loki.process` to port the three remaining 'parsing' stages available in Promtail, namely logfmt, replace and multiline.

The first one parses log lines or extracted values as logfmt. The `replace` stage parses log lines using regular expression and replaces or runs templating commands on them, while `multiline` collapses multiple lines into a single log entry.

#### Which issue(s) this PR fixes
Updates #2515 

#### Notes to the Reviewer
We're still trying to port these over in smaller batches, so we can review the code and documentation being brought in, as well as make any obvious improvements work.

For this PR, the main change from the upstream Promtail code is not using pointers to denote optional values but letting River handle those.


#### PR Checklist

- [ ] CHANGELOG updated
- [X] Documentation added
- [X] Tests updated
