### PR TITLE
river: fix an issue where negative numbers incorrectly converted to floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ Main (unreleased)
 - Flow UI: Fix the issue with long string going out of bound in the component detail page. (@xiyu95)
 
 - Flow: `prometheus.relabel` and `prometheus.remote_write` will now error if they have exited. (@ptodev)
+0
+- Flow: Fix issue where negative numbers would convert to floating-point values
+  incorrectly, treating the sign flag as part of the number. (@rfratto)
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,6 @@ Main (unreleased)
 - Flow UI: Fix the issue with long string going out of bound in the component detail page. (@xiyu95)
 
 - Flow: `prometheus.relabel` and `prometheus.remote_write` will now error if they have exited. (@ptodev)
-0
 - Flow: Fix issue where negative numbers would convert to floating-point values
   incorrectly, treating the sign flag as part of the number. (@rfratto)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Main (unreleased)
 - Flow UI: Fix the issue with long string going out of bound in the component detail page. (@xiyu95)
 
 - Flow: `prometheus.relabel` and `prometheus.remote_write` will now error if they have exited. (@ptodev)
+
 - Flow: Fix issue where negative numbers would convert to floating-point values
   incorrectly, treating the sign flag as part of the number. (@rfratto)
 

--- a/pkg/river/internal/value/number_value.go
+++ b/pkg/river/internal/value/number_value.go
@@ -110,7 +110,12 @@ func (nv Number) Uint() uint64 {
 
 // Float converts the Number into a float64.
 func (nv Number) Float() float64 {
-	if nv.k == NumberKindFloat {
+	switch nv.k {
+	case NumberKindInt:
+		// Convert nv.value to an int64 before converting to a float64 so the sign
+		// flag gets handled correctly.
+		return float64(int64(nv.value))
+	case NumberKindFloat:
 		return math.Float64frombits(nv.value)
 	}
 	return float64(nv.value)

--- a/pkg/river/vm/vm_test.go
+++ b/pkg/river/vm/vm_test.go
@@ -88,6 +88,7 @@ func TestVM_Evaluate(t *testing.T) {
 		{`5 % 3`, int(2)},
 		{`3 ^ 5`, int(243)},
 		{`3 + 5 * 2`, int(13)}, // Chain multiple binops
+		{`42.0^-2`, float64(0.0005668934240362812)},
 
 		// Identifier
 		{`foobar`, int(42)},


### PR DESCRIPTION
The Number.Float function converted the uint64 representation directly to float64 for signed numbers. This incorrectly treats the sign flag as part of the number, leading to incorrect results.

For example, `42.0^-2` coerces `-2` to a float64, but doesn't properly handle the sign flag, instead causing `42.0^9223372036854775810` to be evaluated (resulting in `+Inf`). 