### PR TITLE
Lazy Initialize Remote Config Metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ Main (unreleased)
 
 - Flow: `prometheus.relabel` and `prometheus.remote_write` will now error if they have exited. (@ptodev)
 
+- Agent Management: Fix `remote_config_fetch_errors_total` metric being registered even when `remote-configs` and `agent-management` features were not enabled. (@spartan0x117)
+
 ### Other changes
 
 - Use Go 1.19.4 for builds. (@erikbaranowski)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,8 +66,6 @@ Main (unreleased)
 
 - Flow: `prometheus.relabel` and `prometheus.remote_write` will now error if they have exited. (@ptodev)
 
-- Agent Management: Fix `remote_config_fetch_errors_total` metric being registered even when `remote-configs` and `agent-management` features were not enabled. (@spartan0x117)
-
 ### Other changes
 
 - Use Go 1.19.4 for builds. (@erikbaranowski)

--- a/pkg/config/instrumentation/remote_config_metrics.go
+++ b/pkg/config/instrumentation/remote_config_metrics.go
@@ -28,7 +28,7 @@ func newRemoteConfigMetrics() *remoteConfigMetrics {
 			Name: "remote_config_fetches_total",
 			Help: "Number of fetch requests for the remote config by HTTP status code",
 		},
-		[]string{"code"},
+		[]string{"status_code"},
 	)
 	remoteConfigMetrics.fetchErrors = promauto.NewCounter(
 		prometheus.CounterOpts{

--- a/pkg/config/instrumentation/remote_config_metrics.go
+++ b/pkg/config/instrumentation/remote_config_metrics.go
@@ -40,9 +40,9 @@ func newRemoteConfigMetrics() *remoteConfigMetrics {
 	return &remoteConfigMetrics
 }
 
-func InstrumentRemoteConfigFetch(code int) {
+func InstrumentRemoteConfigFetch(statusCode int) {
 	metricsInitializer.Do(initializeRemoteConfigMetrics)
-	metrics.fetchStatusCodes.WithLabelValues(fmt.Sprintf("%d", code)).Inc()
+	metrics.fetchStatusCodes.WithLabelValues(fmt.Sprintf("%d", statusCode)).Inc()
 }
 
 func InstrumentRemoteConfigFetchError() {

--- a/pkg/config/remote_config.go
+++ b/pkg/config/remote_config.go
@@ -86,12 +86,12 @@ func newHTTPProvider(opts *remoteOpts) (*httpProvider, error) {
 func (p httpProvider) retrieve() ([]byte, error) {
 	response, err := p.httpClient.Get(p.myURL.String())
 	if err != nil {
-		instrumentation.RemoteConfigMetrics.InstrumentRemoteConfigFetchError()
+		instrumentation.InstrumentRemoteConfigFetchError()
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
 	defer response.Body.Close()
 
-	instrumentation.RemoteConfigMetrics.InstrumentRemoteConfigFetch(response.StatusCode)
+	instrumentation.InstrumentRemoteConfigFetch(response.StatusCode)
 
 	if response.StatusCode/100 != 2 {
 		return nil, fmt.Errorf("error fetching config: status code: %d", response.StatusCode)


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Lazily registers `remote_config` metrics to avoid adding metrics unnecessarily when `remote-configs` and `agent-management` features are not enabled.

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
