### PR TITLE
Flow: add loki.source.gcplog component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@ Main (unreleased)
     connections and forwards them to other `loki` components. (@tpaschalis)
   - `loki.source.cloudflare` reads logs from Cloudflare's Logpull API and
     forwards them to other `loki` components. (@tpaschalis)
-  - `loki.source.gcplog` reads logs from GCP cloud resources. (@tpaschalis)
+  - `loki.source.gcplog` reads logs from GCP cloud resources using Pub/Sub
+    subscriptions and forwards them to other `loki` components. (@tpaschalis)
   - `otelcol.exporter.loki` forwards OTLP-formatted data to compatible `loki`
     receivers. (@tpaschalis)
   - `loki.source.gelf` listens for Graylog logs. (@mattdurham)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Main (unreleased)
     connections and forwards them to other `loki` components. (@tpaschalis)
   - `loki.source.cloudflare` reads logs from Cloudflare's Logpull API and
     forwards them to other `loki` components. (@tpaschalis)
+  - `loki.source.gcplog` reads logs from GCP cloud resources. (@tpaschalis)
   - `otelcol.exporter.loki` forwards OTLP-formatted data to compatible `loki`
     receivers. (@tpaschalis)
   - `loki.source.gelf` listens for Graylog logs. (@mattdurham)

--- a/component/all/all.go
+++ b/component/all/all.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/grafana/agent/component/loki/relabel"                         // Import loki.relabel
 	_ "github.com/grafana/agent/component/loki/source/cloudflare"               // Import loki.source.cloudflare
 	_ "github.com/grafana/agent/component/loki/source/file"                     // Import loki.source.file
+	_ "github.com/grafana/agent/component/loki/source/gcplog"                   // Import loki.source.gcplog
 	_ "github.com/grafana/agent/component/loki/source/gelf"                     // Import loki.source.gelf
 	_ "github.com/grafana/agent/component/loki/source/syslog"                   // Import loki.source.syslog
 	_ "github.com/grafana/agent/component/loki/source/windowsevent"             // Import loki.source.windowsevent

--- a/component/loki/source/gcplog/gcplog.go
+++ b/component/loki/source/gcplog/gcplog.go
@@ -34,7 +34,7 @@ type Arguments struct {
 	PullTarget   *gt.PullConfig      `river:"pull,block,optional"`
 	PushTarget   *gt.PushConfig      `river:"push,block,optional"`
 	ForwardTo    []loki.LogsReceiver `river:"forward_to,attr"`
-	RelabelRules *flow_relabel.Rules `river:"relabel_rules,attr,optional"`
+	RelabelRules flow_relabel.Rules  `river:"relabel_rules,attr,optional"`
 }
 
 // UnmarshalRiver implements the unmarshaller
@@ -116,8 +116,8 @@ func (c *Component) Update(args component.Arguments) error {
 	c.fanout = newArgs.ForwardTo
 
 	var rcs []*relabel.Config
-	if newArgs.RelabelRules != nil && len(newArgs.RelabelRules.GetAll()) > 0 {
-		rcs = flow_relabel.ComponentToPromRelabelConfigs(newArgs.RelabelRules.GetAll())
+	if newArgs.RelabelRules != nil && len(newArgs.RelabelRules) > 0 {
+		rcs = flow_relabel.ComponentToPromRelabelConfigs(newArgs.RelabelRules)
 	}
 
 	if c.target != nil {

--- a/component/loki/source/gcplog/gcplog.go
+++ b/component/loki/source/gcplog/gcplog.go
@@ -138,7 +138,7 @@ func (c *Component) Update(args component.Arguments) error {
 		c.target = t
 	}
 	if newArgs.PushTarget != nil {
-		t, err := gt.NewPushTarget(c.metrics, c.opts.Logger, entryHandler, jobName, newArgs.PushTarget, rcs)
+		t, err := gt.NewPushTarget(c.metrics, c.opts.Logger, entryHandler, jobName, newArgs.PushTarget, rcs, c.opts.Registerer)
 		if err != nil {
 			level.Error(c.opts.Logger).Log("msg", "failed to create gcplog target with provided config", "err", err)
 			return err

--- a/component/loki/source/gcplog/gcplog.go
+++ b/component/loki/source/gcplog/gcplog.go
@@ -1,0 +1,161 @@
+package gcplog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/common/loki"
+	flow_relabel "github.com/grafana/agent/component/common/relabel"
+	gt "github.com/grafana/agent/component/loki/source/gcplog/internal/gcplogtarget"
+	"github.com/prometheus/prometheus/model/relabel"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name: "loki.source.gcplog",
+		Args: Arguments{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			return New(opts, args.(Arguments))
+		},
+	})
+}
+
+// Arguments holds values which are used to configure the loki.source.gcplog
+// component.
+type Arguments struct {
+	// TODO(@tpaschalis) Having these types defined in an internal package
+	// means that an external caller cannot build this component's Arguments
+	// by hand for now.
+	PullTarget   *gt.PullConfig      `river:"pull,block,optional"`
+	PushTarget   *gt.PushConfig      `river:"push,block,optional"`
+	ForwardTo    []loki.LogsReceiver `river:"forward_to,attr"`
+	RelabelRules *flow_relabel.Rules `river:"relabel_rules,attr,optional"`
+}
+
+// UnmarshalRiver implements the unmarshaller
+func (a *Arguments) UnmarshalRiver(f func(v interface{}) error) error {
+	*a = Arguments{}
+	type arguments Arguments
+	err := f((*arguments)(a))
+	if err != nil {
+		return err
+	}
+
+	if (a.PullTarget != nil) == (a.PushTarget != nil) {
+		return fmt.Errorf("exactly one of 'push' or 'pull' must be provided")
+	}
+	return nil
+}
+
+// Component implements the loki.source.gcplog component.
+type Component struct {
+	opts    component.Options
+	metrics *gt.Metrics
+
+	mut    sync.RWMutex
+	fanout []loki.LogsReceiver
+	target gt.Target
+
+	handler loki.LogsReceiver
+}
+
+// New creates a new loki.source.gcplog component.
+func New(o component.Options, args Arguments) (*Component, error) {
+	c := &Component{
+		opts:    o,
+		metrics: gt.NewMetrics(o.Registerer),
+		handler: make(loki.LogsReceiver),
+		fanout:  args.ForwardTo,
+	}
+
+	// Call to Update() to start readers and set receivers once at the start.
+	if err := c.Update(args); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// Run implements component.Component.
+func (c *Component) Run(ctx context.Context) error {
+	defer func() {
+		level.Info(c.opts.Logger).Log("msg", "loki.source.gcplog component shutting down, stopping the targets")
+		err := c.target.Stop()
+		if err != nil {
+			level.Error(c.opts.Logger).Log("msg", "error while stopping gcplog target", "err", err)
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case entry := <-c.handler:
+			c.mut.RLock()
+			for _, receiver := range c.fanout {
+				receiver <- entry
+			}
+			c.mut.RUnlock()
+		}
+	}
+}
+
+// Update implements component.Component.
+func (c *Component) Update(args component.Arguments) error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	newArgs := args.(Arguments)
+	c.fanout = newArgs.ForwardTo
+
+	var rcs []*relabel.Config
+	if newArgs.RelabelRules != nil && len(newArgs.RelabelRules.GetAll()) > 0 {
+		rcs = flow_relabel.ComponentToPromRelabelConfigs(newArgs.RelabelRules.GetAll())
+	}
+
+	if c.target != nil {
+		err := c.target.Stop()
+		if err != nil {
+			level.Error(c.opts.Logger).Log("msg", "error while stopping gcplog target", "err", err)
+		}
+	}
+	entryHandler := loki.NewEntryHandler(c.handler, func() {})
+	jobName := strings.Replace(c.opts.ID, ".", "_", -1)
+
+	if newArgs.PullTarget != nil {
+		// TODO(@tpaschalis) Are there any options from "google.golang.org/api/option"
+		// we should expose as configuration and pass here?
+		t, err := gt.NewPullTarget(c.metrics, c.opts.Logger, entryHandler, jobName, newArgs.PullTarget, rcs)
+		if err != nil {
+			level.Error(c.opts.Logger).Log("msg", "failed to create gcplog target with provided config", "err", err)
+			return err
+		}
+		c.target = t
+	}
+	if newArgs.PushTarget != nil {
+		t, err := gt.NewPushTarget(c.metrics, c.opts.Logger, entryHandler, jobName, newArgs.PushTarget, rcs)
+		if err != nil {
+			level.Error(c.opts.Logger).Log("msg", "failed to create gcplog target with provided config", "err", err)
+			return err
+		}
+		c.target = t
+	}
+
+	return nil
+}
+
+// DebugInfo returns information about the status of targets.
+func (c *Component) DebugInfo() interface{} {
+	var res targetDebugInfo
+	res.Details = c.target.Details()
+	return res
+}
+
+type targetDebugInfo struct {
+	Details map[string]string `river:"target_info,attr"`
+}

--- a/component/loki/source/gcplog/gcplog_test.go
+++ b/component/loki/source/gcplog/gcplog_test.go
@@ -1,0 +1,122 @@
+package gcplog
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/common/loki"
+	flow_relabel "github.com/grafana/agent/component/common/relabel"
+	gt "github.com/grafana/agent/component/loki/source/gcplog/internal/gcplogtarget"
+	"github.com/grafana/agent/pkg/flow/logging"
+	"github.com/grafana/regexp"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+// TODO (@tpaschalis) We can't test this easily as there's no way to inject
+// the mock PubSub client inside the component, but we'll find a workaround.
+func TestPull(t *testing.T) {}
+
+func TestPush(t *testing.T) {
+	l, err := logging.New(os.Stderr, logging.DefaultOptions)
+	require.NoError(t, err)
+
+	opts := component.Options{Logger: l, Registerer: prometheus.NewRegistry()}
+
+	ch1, ch2 := make(chan loki.Entry), make(chan loki.Entry)
+	args := Arguments{}
+
+	args.PushTarget = &gt.PushConfig{
+		HTTPListenAddress: "localhost",
+		HTTPListenPort:    42421,
+		Labels: map[string]string{
+			"foo": "bar",
+		},
+	}
+	args.ForwardTo = []loki.LogsReceiver{ch1, ch2}
+	args.RelabelRules = rulesExport
+
+	// Create and run the component.
+	c, err := New(opts, args)
+	require.NoError(t, err)
+
+	go c.Run(context.Background())
+	time.Sleep(200 * time.Millisecond)
+
+	// Create a GCP PushRequest and send it to the launched server.
+	req, err := http.NewRequest(http.MethodPost, "http://localhost:42421/gcp/api/v1/push", strings.NewReader(testPushPayload))
+	require.NoError(t, err)
+
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, res.StatusCode)
+
+	// Check the received log entries
+	wantLabelSet := model.LabelSet{"foo": "bar", "message_id": "5187581549398349", "resource_type": "k8s_cluster"}
+	wantLogLine := "{\"insertId\":\"4affa858-e5f2-47f7-9254-e609b5c014d0\",\"labels\":{},\"logName\":\"projects/test-project/logs/cloudaudit.googleapis.com%2Fdata_access\",\"receiveTimestamp\":\"2022-09-06T18:07:43.417714046Z\",\"resource\":{\"labels\":{\"cluster_name\":\"dev-us-central-42\",\"location\":\"us-central1\",\"project_id\":\"test-project\"},\"type\":\"k8s_cluster\"},\"timestamp\":\"2022-09-06T18:07:42.363113Z\"}\n"
+
+	for i := 0; i < 2; i++ {
+		select {
+		case logEntry := <-ch1:
+			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
+			require.Equal(t, wantLogLine, logEntry.Line)
+			require.Equal(t, wantLabelSet, logEntry.Labels)
+		case logEntry := <-ch2:
+			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
+			require.Equal(t, wantLogLine, logEntry.Line)
+			require.Equal(t, wantLabelSet, logEntry.Labels)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "failed waiting for log line")
+		}
+	}
+}
+
+const testPushPayload = `
+{
+	"message": {
+		"attributes": {
+			"logging.googleapis.com/timestamp": "2022-07-25T22:19:09.903683708Z"
+		},
+		"data": "eyJpbnNlcnRJZCI6IjRhZmZhODU4LWU1ZjItNDdmNy05MjU0LWU2MDliNWMwMTRkMCIsImxhYmVscyI6e30sImxvZ05hbWUiOiJwcm9qZWN0cy90ZXN0LXByb2plY3QvbG9ncy9jbG91ZGF1ZGl0Lmdvb2dsZWFwaXMuY29tJTJGZGF0YV9hY2Nlc3MiLCJyZWNlaXZlVGltZXN0YW1wIjoiMjAyMi0wOS0wNlQxODowNzo0My40MTc3MTQwNDZaIiwicmVzb3VyY2UiOnsibGFiZWxzIjp7ImNsdXN0ZXJfbmFtZSI6ImRldi11cy1jZW50cmFsLTQyIiwibG9jYXRpb24iOiJ1cy1jZW50cmFsMSIsInByb2plY3RfaWQiOiJ0ZXN0LXByb2plY3QifSwidHlwZSI6Ims4c19jbHVzdGVyIn0sInRpbWVzdGFtcCI6IjIwMjItMDktMDZUMTg6MDc6NDIuMzYzMTEzWiJ9Cg==",
+		"messageId": "5187581549398349",
+		"message_id": "5187581549398349",
+		"publishTime": "2022-07-25T22:19:15.56Z",
+		"publish_time": "2022-07-25T22:19:15.56Z"
+	},
+	"subscription": "projects/test-project/subscriptions/test"
+}`
+
+var rulesExport = &flow_relabel.Rules{
+	GetAll: func() []*flow_relabel.Config {
+		return []*flow_relabel.Config{
+			{
+				SourceLabels: []string{"__gcp_message_id"},
+				Regex:        mustNewRegexp("(.*)"),
+				Action:       flow_relabel.Replace,
+				Replacement:  "$1",
+				TargetLabel:  "message_id",
+			},
+			{
+				SourceLabels: []string{"__gcp_resource_type"},
+				Regex:        mustNewRegexp("(.*)"),
+				Action:       flow_relabel.Replace,
+				Replacement:  "$1",
+				TargetLabel:  "resource_type",
+			},
+		}
+	},
+}
+
+func mustNewRegexp(s string) flow_relabel.Regexp {
+	re, err := regexp.Compile("^(?:" + s + ")$")
+	if err != nil {
+		panic(err)
+	}
+	return flow_relabel.Regexp{Regexp: re}
+}

--- a/component/loki/source/gcplog/gcplog_test.go
+++ b/component/loki/source/gcplog/gcplog_test.go
@@ -40,7 +40,7 @@ func TestPush(t *testing.T) {
 		},
 	}
 	args.ForwardTo = []loki.LogsReceiver{ch1, ch2}
-	args.RelabelRules = rulesExport
+	args.RelabelRules = exportedRules
 
 	// Create and run the component.
 	c, err := New(opts, args)
@@ -92,7 +92,7 @@ const testPushPayload = `
 	"subscription": "projects/test-project/subscriptions/test"
 }`
 
-var rulesExport = flow_relabel.Rules{
+var exportedRules = flow_relabel.Rules{
 	{
 		SourceLabels: []string{"__gcp_message_id"},
 		Regex:        mustNewRegexp("(.*)"),

--- a/component/loki/source/gcplog/gcplog_test.go
+++ b/component/loki/source/gcplog/gcplog_test.go
@@ -92,24 +92,20 @@ const testPushPayload = `
 	"subscription": "projects/test-project/subscriptions/test"
 }`
 
-var rulesExport = &flow_relabel.Rules{
-	GetAll: func() []*flow_relabel.Config {
-		return []*flow_relabel.Config{
-			{
-				SourceLabels: []string{"__gcp_message_id"},
-				Regex:        mustNewRegexp("(.*)"),
-				Action:       flow_relabel.Replace,
-				Replacement:  "$1",
-				TargetLabel:  "message_id",
-			},
-			{
-				SourceLabels: []string{"__gcp_resource_type"},
-				Regex:        mustNewRegexp("(.*)"),
-				Action:       flow_relabel.Replace,
-				Replacement:  "$1",
-				TargetLabel:  "resource_type",
-			},
-		}
+var rulesExport = flow_relabel.Rules{
+	{
+		SourceLabels: []string{"__gcp_message_id"},
+		Regex:        mustNewRegexp("(.*)"),
+		Action:       flow_relabel.Replace,
+		Replacement:  "$1",
+		TargetLabel:  "message_id",
+	},
+	{
+		SourceLabels: []string{"__gcp_resource_type"},
+		Regex:        mustNewRegexp("(.*)"),
+		Action:       flow_relabel.Replace,
+		Replacement:  "$1",
+		TargetLabel:  "resource_type",
 	},
 }
 

--- a/component/loki/source/gcplog/internal/fake/client.go
+++ b/component/loki/source/gcplog/internal/fake/client.go
@@ -1,0 +1,73 @@
+package fake
+
+// This code is copied from Promtail. The fake package is used to configure
+// fake client that can be used in testing.
+
+import (
+	"sync"
+
+	"github.com/grafana/agent/component/common/loki"
+)
+
+// Client is a fake client used for testing.
+type Client struct {
+	entries  loki.LogsReceiver
+	received []loki.Entry
+	once     sync.Once
+	mtx      sync.Mutex
+	wg       sync.WaitGroup
+	OnStop   func()
+}
+
+func New(stop func()) *Client {
+	c := &Client{
+		OnStop:  stop,
+		entries: make(loki.LogsReceiver),
+	}
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		for e := range c.entries {
+			c.mtx.Lock()
+			c.received = append(c.received, e)
+			c.mtx.Unlock()
+		}
+	}()
+	return c
+}
+
+// Stop implements client.Client
+func (c *Client) Stop() {
+	c.once.Do(func() { close(c.entries) })
+	c.wg.Wait()
+	c.OnStop()
+}
+
+func (c *Client) Chan() chan<- loki.Entry {
+	return c.entries
+}
+
+func (c *Client) Received() []loki.Entry {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	cpy := make([]loki.Entry, len(c.received))
+	copy(cpy, c.received)
+	return cpy
+}
+
+// StopNow implements client.Client
+func (c *Client) StopNow() {
+	c.Stop()
+}
+
+func (c *Client) Name() string {
+	return "fake"
+}
+
+// Clear is used to cleanup the buffered received entries, so the same client can be re-used between
+// test cases.
+func (c *Client) Clear() {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	c.received = []loki.Entry{}
+}

--- a/component/loki/source/gcplog/internal/gcplogtarget/formatter.go
+++ b/component/loki/source/gcplog/internal/gcplogtarget/formatter.go
@@ -1,0 +1,117 @@
+package gcplogtarget
+
+// This code is copied from Promtail. The gcplogtarget package is used to
+// configure and run the targets that can read log entries from cloud resource
+// logs like bucket logs, load balancer logs, and Kubernetes cluster logs
+// from GCP.
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/util"
+	json "github.com/json-iterator/go"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/relabel"
+)
+
+// GCPLogEntry that will be written to the pubsub topic according to the following spec.
+// https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
+type GCPLogEntry struct {
+	// why was this here?? nolint:revive
+	LogName  string `json:"logName"`
+	Resource struct {
+		Type   string            `json:"type"`
+		Labels map[string]string `json:"labels"`
+	} `json:"resource"`
+	Timestamp string `json:"timestamp"`
+
+	// The time the log entry was received by Logging.
+	// Its important that `Timestamp` is optional in GCE log entry.
+	ReceiveTimestamp string `json:"receiveTimestamp"`
+
+	TextPayload string `json:"textPayload"`
+
+	// NOTE(kavi): There are other fields on GCPLogEntry. but we need only need
+	// above fields for now anyway we will be sending the entire entry to Loki.
+}
+
+func parseGCPLogsEntry(data []byte, other model.LabelSet, otherInternal labels.Labels, useIncomingTimestamp bool, relabelConfig []*relabel.Config) (loki.Entry, error) {
+	var ge GCPLogEntry
+
+	if err := json.Unmarshal(data, &ge); err != nil {
+		return loki.Entry{}, err
+	}
+
+	// Adding mandatory labels for gcplog
+	lbs := labels.NewBuilder(otherInternal)
+	lbs.Set("__gcp_logname", ge.LogName)
+	lbs.Set("__gcp_resource_type", ge.Resource.Type)
+
+	// labels from gcp log entry. Add it as internal labels
+	for k, v := range ge.Resource.Labels {
+		lbs.Set("__gcp_resource_labels_"+util.SnakeCase(k), v)
+	}
+
+	var processed labels.Labels
+
+	// apply relabeling
+	if len(relabelConfig) > 0 {
+		processed = relabel.Process(lbs.Labels(nil), relabelConfig...)
+	} else {
+		processed = lbs.Labels(nil)
+	}
+
+	// final labelset that will be sent to loki
+	labels := make(model.LabelSet)
+	for _, lbl := range processed {
+		// ignore internal labels
+		if strings.HasPrefix(lbl.Name, "__") {
+			continue
+		}
+		// ignore invalid labels
+		if !model.LabelName(lbl.Name).IsValid() || !model.LabelValue(lbl.Value).IsValid() {
+			continue
+		}
+		labels[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
+	}
+
+	// add labels coming from scrapeconfig
+	labels = labels.Merge(other)
+
+	ts := time.Now()
+	line := string(data)
+
+	if useIncomingTimestamp {
+		tt := ge.Timestamp
+		if tt == "" {
+			tt = ge.ReceiveTimestamp
+		}
+		var err error
+		ts, err = time.Parse(time.RFC3339, tt)
+		if err != nil {
+			return loki.Entry{}, fmt.Errorf("invalid timestamp format: %w", err)
+		}
+
+		if ts.IsZero() {
+			return loki.Entry{}, fmt.Errorf("no timestamp found in the log entry")
+		}
+	}
+
+	// Send only `ge.textPayload` as log line if its present.
+	if strings.TrimSpace(ge.TextPayload) != "" {
+		line = ge.TextPayload
+	}
+
+	return loki.Entry{
+		Labels: labels,
+		Entry: logproto.Entry{
+			Timestamp: ts,
+			Line:      line,
+		},
+	}, nil
+}

--- a/component/loki/source/gcplog/internal/gcplogtarget/formatter_test.go
+++ b/component/loki/source/gcplog/internal/gcplogtarget/formatter_test.go
@@ -1,0 +1,131 @@
+package gcplogtarget
+
+import (
+	"testing"
+	"time"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/grafana/loki/clients/pkg/promtail/api"
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormat(t *testing.T) {
+	cases := []struct {
+		name                 string
+		msg                  *pubsub.Message
+		labels               model.LabelSet
+		relabel              []*relabel.Config
+		useIncomingTimestamp bool
+		expected             api.Entry
+	}{
+		{
+			name: "relabelling",
+			msg: &pubsub.Message{
+				Data: []byte(withAllFields),
+			},
+			labels: model.LabelSet{
+				"jobname": "pubsub-test",
+			},
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"__gcp_resource_labels_backend_service_name"},
+					Separator:    ";",
+					Regex:        relabel.MustNewRegexp("(.*)"),
+					TargetLabel:  "backend_service_name",
+					Action:       "replace",
+					Replacement:  "$1",
+				},
+				{
+					SourceLabels: model.LabelNames{"__gcp_resource_labels_bucket_name"},
+					Separator:    ";",
+					Regex:        relabel.MustNewRegexp("(.*)"),
+					TargetLabel:  "bucket_name",
+					Action:       "replace",
+					Replacement:  "$1",
+				},
+			},
+			useIncomingTimestamp: true,
+			expected: api.Entry{
+				Labels: model.LabelSet{
+					"jobname":              "pubsub-test",
+					"backend_service_name": "http-loki",
+					"bucket_name":          "loki-bucket",
+				},
+				Entry: logproto.Entry{
+					Timestamp: mustTime(t, "2020-12-22T15:01:23.045123456Z"),
+					Line:      withAllFields,
+				},
+			},
+		},
+		{
+			name: "use-original-timestamp",
+			msg: &pubsub.Message{
+				Data: []byte(withAllFields),
+			},
+			labels: model.LabelSet{
+				"jobname": "pubsub-test",
+			},
+			useIncomingTimestamp: true,
+			expected: api.Entry{
+				Labels: model.LabelSet{
+					"jobname": "pubsub-test",
+				},
+				Entry: logproto.Entry{
+					Timestamp: mustTime(t, "2020-12-22T15:01:23.045123456Z"),
+					Line:      withAllFields,
+				},
+			},
+		},
+		{
+			name: "rewrite-timestamp",
+			msg: &pubsub.Message{
+				Data: []byte(withAllFields),
+			},
+			labels: model.LabelSet{
+				"jobname": "pubsub-test",
+			},
+			expected: api.Entry{
+				Labels: model.LabelSet{
+					"jobname": "pubsub-test",
+				},
+				Entry: logproto.Entry{
+					Timestamp: time.Now(),
+					Line:      withAllFields,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := parseGCPLogsEntry(c.msg.Data, c.labels, nil, c.useIncomingTimestamp, c.relabel)
+
+			require.NoError(t, err)
+
+			require.Equal(t, c.expected.Labels, got.Labels)
+			require.Equal(t, c.expected.Line, got.Line)
+			if c.useIncomingTimestamp {
+				require.Equal(t, c.expected.Entry.Timestamp, got.Timestamp)
+			} else {
+				if got.Timestamp.Sub(c.expected.Timestamp).Seconds() > 1 {
+					require.Fail(t, "timestamp shouldn't differ much when rewriting log entry timestamp.")
+				}
+			}
+		})
+	}
+}
+
+func mustTime(t *testing.T, v string) time.Time {
+	t.Helper()
+
+	ts, err := time.Parse(time.RFC3339, v)
+	require.NoError(t, err)
+	return ts
+}
+
+const (
+	withAllFields = `{"logName": "https://project/gcs", "resource": {"type": "gcs", "labels": {"backendServiceName": "http-loki", "bucketName": "loki-bucket", "instanceId": "344555"}}, "timestamp": "2020-12-22T15:01:23.045123456Z"}`
+)

--- a/component/loki/source/gcplog/internal/gcplogtarget/metrics.go
+++ b/component/loki/source/gcplog/internal/gcplogtarget/metrics.go
@@ -1,0 +1,63 @@
+package gcplogtarget
+
+// This code is copied from Promtail. The gcplogtarget package is used to
+// configure and run the targets that can read log entries from cloud resource
+// logs like bucket logs, load balancer logs, and Kubernetes cluster logs
+// from GCP.
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Metrics stores gcplog entry metrics.
+type Metrics struct {
+	// reg is the Registerer used to create this set of metrics.
+	reg prometheus.Registerer
+
+	gcplogEntries                 *prometheus.CounterVec
+	gcplogErrors                  *prometheus.CounterVec
+	gcplogTargetLastSuccessScrape *prometheus.GaugeVec
+
+	gcpPushEntries *prometheus.CounterVec
+	gcpPushErrors  *prometheus.CounterVec
+}
+
+// NewMetrics creates a new set of metrics. Metrics will be registered to reg.
+func NewMetrics(reg prometheus.Registerer) *Metrics {
+	var m Metrics
+	m.reg = reg
+
+	// Pull subscription metrics
+	m.gcplogEntries = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "loki_source_gcplog_pull_entries_total",
+		Help: "Number of entries received by the gcplog target",
+	}, []string{"project"})
+
+	m.gcplogErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "loki_source_gcplog_pull_parsing_errors_total",
+		Help: "Total number of parsing errors while receiving gcplog messages",
+	}, []string{"project"})
+
+	m.gcplogTargetLastSuccessScrape = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "loki_source_gcplog_pull_last_success_scrape",
+		Help: "Timestamp of target's last successful poll",
+	}, []string{"project", "target"})
+
+	// Push subscription metrics
+	m.gcpPushEntries = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "loki_source_gcplog_push_entries_total",
+		Help: "Number of entries received by the gcplog target",
+	}, []string{})
+
+	m.gcpPushErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "loki_source_gcplog_push_parsing_errors_total",
+		Help: "Number of parsing errors while receiving gcplog messages",
+	}, []string{"reason"})
+
+	reg.MustRegister(
+		m.gcplogEntries,
+		m.gcplogErrors,
+		m.gcplogTargetLastSuccessScrape,
+		m.gcpPushEntries,
+		m.gcpPushErrors,
+	)
+	return &m
+}

--- a/component/loki/source/gcplog/internal/gcplogtarget/pull_target.go
+++ b/component/loki/source/gcplog/internal/gcplogtarget/pull_target.go
@@ -1,0 +1,150 @@
+package gcplogtarget
+
+// This code is copied from Promtail. The gcplogtarget package is used to
+// configure and run the targets that can read log entries from cloud resource
+// logs like bucket logs, load balancer logs, and Kubernetes cluster logs
+// from GCP.
+
+import (
+	"context"
+	"sync"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/relabel"
+	"google.golang.org/api/option"
+)
+
+// PullTarget represents a target that scrapes logs from a GCP project id and
+// subscription and converts them to Loki log entries.
+type PullTarget struct {
+	// why was this here above?? nolint:revive
+	metrics       *Metrics
+	logger        log.Logger
+	handler       loki.EntryHandler
+	config        *PullConfig
+	relabelConfig []*relabel.Config
+	jobName       string
+
+	// lifecycle management
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	// pubsub
+	ps   *pubsub.Client
+	msgs chan *pubsub.Message
+}
+
+// NewPullTarget returns the new instance of PullTarget.
+func NewPullTarget(metrics *Metrics, logger log.Logger, handler loki.EntryHandler, jobName string, config *PullConfig, relabel []*relabel.Config, clientOptions ...option.ClientOption) (*PullTarget, error) {
+	// why was this here above?? nolint:revive,govet
+	ctx, cancel := context.WithCancel(context.Background())
+
+	ps, err := pubsub.NewClient(ctx, config.ProjectID, clientOptions...)
+	if err != nil {
+		return nil, err
+	}
+
+	target := &PullTarget{
+		metrics:       metrics,
+		logger:        logger,
+		handler:       handler,
+		relabelConfig: relabel,
+		config:        config,
+		jobName:       jobName,
+		ctx:           ctx,
+		cancel:        cancel,
+		ps:            ps,
+		msgs:          make(chan *pubsub.Message),
+	}
+
+	go func() {
+		err := target.run()
+		if err != nil {
+			level.Error(logger).Log("msg", "loki.source.gcplog pull target shutdown with error", "err", err)
+		}
+	}()
+
+	return target, nil
+}
+
+func (t *PullTarget) run() error {
+	t.wg.Add(1)
+	defer t.wg.Done()
+
+	send := t.handler.Chan()
+
+	sub := t.ps.SubscriptionInProject(t.config.Subscription, t.config.ProjectID)
+	go func() {
+		// NOTE(kavi): `cancel` the context as exiting from this goroutine should stop main `run` loop
+		// It makesense as no more messages will be received.
+		defer t.cancel()
+
+		err := sub.Receive(t.ctx, func(ctx context.Context, m *pubsub.Message) {
+			t.msgs <- m
+		})
+		if err != nil {
+			level.Error(t.logger).Log("msg", "failed to receive pubsub messages", "error", err)
+			t.metrics.gcplogErrors.WithLabelValues(t.config.ProjectID).Inc()
+			t.metrics.gcplogTargetLastSuccessScrape.WithLabelValues(t.config.ProjectID, t.config.Subscription).SetToCurrentTime()
+		}
+	}()
+
+	lbls := make(model.LabelSet, len(t.config.Labels))
+	for k, v := range t.config.Labels {
+		lbls[model.LabelName(k)] = model.LabelValue(v)
+	}
+
+	for {
+		select {
+		case <-t.ctx.Done():
+			return t.ctx.Err()
+		case m := <-t.msgs:
+			entry, err := parseGCPLogsEntry(m.Data, lbls, nil, t.config.UseIncomingTimestamp, t.relabelConfig)
+			if err != nil {
+				level.Error(t.logger).Log("event", "error formating log entry", "cause", err)
+				m.Ack()
+				break
+			}
+			send <- entry
+			m.Ack() // Ack only after log is sent.
+			t.metrics.gcplogEntries.WithLabelValues(t.config.ProjectID).Inc()
+		}
+	}
+}
+
+// Labels return the model.LabelSet that the target applies to log entries.
+func (t *PullTarget) Labels() model.LabelSet {
+	lbls := make(model.LabelSet, len(t.config.Labels))
+	for k, v := range t.config.Labels {
+		lbls[model.LabelName(k)] = model.LabelValue(v)
+	}
+	return lbls
+}
+
+// Details returns some debug information about the target.
+func (t *PullTarget) Details() map[string]string {
+	return map[string]string{
+		"strategy": "pull",
+		"labels":   t.Labels().String(),
+	}
+}
+
+// Stop shuts the target down.
+func (t *PullTarget) Stop() error {
+	t.cancel()
+	t.wg.Wait()
+	t.handler.Stop()
+	t.ps.Close()
+	return nil
+}
+
+// Used to add a mock pubsub clients for testing.
+func (t *PullTarget) setPubSubClientAndMessageChan(cl *pubsub.Client, ch chan *pubsub.Message) {
+	t.ps = cl
+	t.msgs = ch
+}

--- a/component/loki/source/gcplog/internal/gcplogtarget/pull_target.go
+++ b/component/loki/source/gcplog/internal/gcplogtarget/pull_target.go
@@ -141,9 +141,3 @@ func (t *PullTarget) Stop() error {
 	t.ps.Close()
 	return nil
 }
-
-// Used to add a mock pubsub clients for testing.
-func (t *PullTarget) setPubSubClientAndMessageChan(cl *pubsub.Client, ch chan *pubsub.Message) {
-	t.ps = cl
-	t.msgs = ch
-}

--- a/component/loki/source/gcplog/internal/gcplogtarget/pull_target.go
+++ b/component/loki/source/gcplog/internal/gcplogtarget/pull_target.go
@@ -21,7 +21,6 @@ import (
 // PullTarget represents a target that scrapes logs from a GCP project id and
 // subscription and converts them to Loki log entries.
 type PullTarget struct {
-	// why was this here above?? nolint:revive
 	metrics       *Metrics
 	logger        log.Logger
 	handler       loki.EntryHandler
@@ -41,11 +40,11 @@ type PullTarget struct {
 
 // NewPullTarget returns the new instance of PullTarget.
 func NewPullTarget(metrics *Metrics, logger log.Logger, handler loki.EntryHandler, jobName string, config *PullConfig, relabel []*relabel.Config, clientOptions ...option.ClientOption) (*PullTarget, error) {
-	// why was this here above?? nolint:revive,govet
 	ctx, cancel := context.WithCancel(context.Background())
 
 	ps, err := pubsub.NewClient(ctx, config.ProjectID, clientOptions...)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 

--- a/component/loki/source/gcplog/internal/gcplogtarget/pull_target_test.go
+++ b/component/loki/source/gcplog/internal/gcplogtarget/pull_target_test.go
@@ -121,8 +121,8 @@ func testPullTarget(ctx context.Context, t *testing.T) (*PullTarget, *fake.Clien
 		jobName:       t.Name() + "job-test-gcplogtarget",
 		ctx:           ctx,
 		cancel:        cancel,
-		PSClient:      mockpubsubClient,
-		Msgs:          make(chan *pubsub.Message),
+		ps:            mockpubsubClient,
+		msgs:          make(chan *pubsub.Message),
 	}
 
 	// cleanup

--- a/component/loki/source/gcplog/internal/gcplogtarget/pull_target_test.go
+++ b/component/loki/source/gcplog/internal/gcplogtarget/pull_target_test.go
@@ -1,0 +1,226 @@
+package gcplogtarget
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/pstest"
+	"github.com/go-kit/log"
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/agent/component/loki/source/gcplog/internal/fake"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"gotest.tools/assert"
+)
+
+func TestPullTarget_Run(t *testing.T) {
+	// Goal: Check message written to pubsub topic is received by the target.
+	ctx := context.Background()
+	tt, apiclient, pubsubClient, teardown := testPullTarget(ctx, t)
+	defer teardown()
+
+	// seed pubsub
+	tp, err := pubsubClient.CreateTopic(ctx, topic)
+	require.NoError(t, err)
+	defer tp.Stop()
+
+	_, err = pubsubClient.CreateSubscription(ctx, subscription, pubsub.SubscriptionConfig{
+		Topic: tp,
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		tt.run() //nolint:errcheck
+	}()
+
+	publishMessage(ctx, t, tp)
+	// Wait till message is received by the run loop.
+	// NOTE(kavi): sleep is not ideal. but not other way to confirm if loki.Handler received messages
+	time.Sleep(500 * time.Millisecond)
+
+	err = tt.Stop()
+	require.NoError(t, err)
+
+	// wait till `run` stops.
+	wg.Wait()
+
+	// Sleep one more time before reading from loki.Received.
+	time.Sleep(500 * time.Millisecond)
+	require.Equal(t, 1, len(apiclient.Received()))
+}
+
+func TestPullTarget_Stop(t *testing.T) {
+	// Goal: To test that `run()` stops when you invoke `target.Stop()`
+
+	errs := make(chan error, 1)
+
+	ctx := context.Background()
+	tt, _, _, teardown := testPullTarget(ctx, t)
+	defer teardown()
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		errs <- tt.run()
+	}()
+
+	// invoke stop
+	_ = tt.Stop()
+
+	// wait till run returns
+	wg.Wait()
+
+	// wouldn't block as 1 error is buffered into the channel.
+	err := <-errs
+
+	// returned error should be cancelled context error
+	assert.Equal(t, tt.ctx.Err(), err)
+}
+
+func TestPullTarget_Labels(t *testing.T) {
+	ctx := context.Background()
+	tt, _, _, teardown := testPullTarget(ctx, t)
+	defer teardown()
+
+	assert.Equal(t, `{job="test-gcplogtarget"}`, tt.Labels().String())
+}
+
+func testPullTarget(ctx context.Context, t *testing.T) (*PullTarget, *fake.Client, *pubsub.Client, func()) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(ctx)
+
+	mockSvr := pstest.NewServer()
+	conn, err := grpc.Dial(mockSvr.Addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	mockpubsubClient, err := pubsub.NewClient(ctx, testConfig.ProjectID, option.WithGRPCConn(conn))
+	require.NoError(t, err)
+
+	fakeClient := fake.New(func() {})
+
+	var handler loki.EntryHandler = fakeClient
+	target := &PullTarget{
+		metrics:       NewMetrics(prometheus.NewRegistry()),
+		logger:        log.NewNopLogger(),
+		handler:       handler,
+		relabelConfig: nil,
+		config:        testConfig,
+		jobName:       t.Name() + "job-test-gcplogtarget",
+		ctx:           ctx,
+		cancel:        cancel,
+		PSClient:      mockpubsubClient,
+		Msgs:          make(chan *pubsub.Message),
+	}
+
+	// cleanup
+	return target, fakeClient, mockpubsubClient, func() {
+		cancel()
+		conn.Close()
+		mockSvr.Close()
+		mockpubsubClient.Close()
+	}
+}
+
+func publishMessage(ctx context.Context, t *testing.T, topic *pubsub.Topic) {
+	t.Helper()
+
+	res := topic.Publish(ctx, &pubsub.Message{Data: []byte(gcpLogEntry)})
+
+	_, err := res.Get(ctx) // wait till message is actully published
+	require.NoError(t, err)
+}
+
+const (
+	project      = "test-project"
+	topic        = "test-topic"
+	subscription = "test-subscription"
+
+	gcpLogEntry = `
+{
+  "insertId": "ajv4d1f1ch8dr",
+  "logName": "projects/grafanalabs-dev/logs/cloudaudit.googleapis.com%2Fdata_access",
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "1040409107725-compute@developer.gserviceaccount.com",
+      "serviceAccountDelegationInfo": [
+        {
+          "firstPartyPrincipal": {
+            "principalEmail": "service-1040409107725@compute-system.iam.gserviceaccount.com"
+          }
+        }
+      ]
+    },
+    "authorizationInfo": [
+      {
+        "granted": true,
+        "permission": "storage.objects.list",
+        "resource": "projects/_/buckets/dev-us-central1-cortex-tsdb-dev",
+        "resourceAttributes": {
+        }
+      },
+      {
+        "permission": "storage.objects.get",
+        "resource": "projects/_/buckets/dev-us-central1-cortex-tsdb-dev/objects/load-generator-20/01EM34PFBC2SCV3ETBGRAQZ090/deletion-mark.json",
+        "resourceAttributes": {
+        }
+      }
+    ],
+    "methodName": "storage.objects.get",
+    "requestMetadata": {
+      "callerIp": "34.66.19.193",
+      "callerNetwork": "//compute.googleapis.com/projects/grafanalabs-dev/global/networks/__unknown__",
+      "callerSuppliedUserAgent": "thanos-store-gateway/1.5.0 (go1.14.9),gzip(gfe)",
+      "destinationAttributes": {
+      },
+      "requestAttributes": {
+        "auth": {
+        },
+        "time": "2021-01-01T02:17:10.661405637Z"
+      }
+    },
+    "resourceLocation": {
+      "currentLocations": [
+        "us-central1"
+      ]
+    },
+    "resourceName": "projects/_/buckets/dev-us-central1-cortex-tsdb-dev/objects/load-generator-20/01EM34PFBC2SCV3ETBGRAQZ090/deletion-mark.json",
+    "serviceName": "storage.googleapis.com",
+    "status": {
+    }
+  },
+  "receiveTimestamp": "2021-01-01T02:17:10.82013623Z",
+  "resource": {
+    "labels": {
+      "bucket_name": "dev-us-central1-cortex-tsdb-dev",
+      "location": "us-central1",
+      "project_id": "grafanalabs-dev"
+    },
+    "type": "gcs_bucket"
+  },
+  "severity": "INFO",
+  "timestamp": "2021-01-01T02:17:10.655982344Z"
+}
+`
+)
+
+var testConfig = &PullConfig{
+	ProjectID:    project,
+	Subscription: subscription,
+	Labels: map[string]string{
+		"job": "test-gcplogtarget",
+	},
+}

--- a/component/loki/source/gcplog/internal/gcplogtarget/push_target.go
+++ b/component/loki/source/gcplog/internal/gcplogtarget/push_target.go
@@ -1,0 +1,200 @@
+package gcplogtarget
+
+// This code is copied from Promtail. The gcplogtarget package is used to
+// configure and run the targets that can read log entries from cloud resource
+// logs like bucket logs, load balancer logs, and Kubernetes cluster logs
+// from GCP.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/loki/clients/pkg/promtail/targets/serverutils"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/weaveworks/common/logging"
+	"github.com/weaveworks/common/server"
+)
+
+// PushTarget defines a server for receiving messages from a GCP PubSub push
+// subscription.
+type PushTarget struct {
+	logger         log.Logger
+	jobName        string
+	metrics        *Metrics
+	config         *PushConfig
+	entries        chan<- loki.Entry
+	handler        loki.EntryHandler
+	relabelConfigs []*relabel.Config
+	server         *server.Server
+	serverConfig   server.Config
+}
+
+// NewPushTarget constructs a PushTarget.
+func NewPushTarget(metrics *Metrics, logger log.Logger, handler loki.EntryHandler, jobName string, config *PushConfig, relabel []*relabel.Config) (*PushTarget, error) {
+	pt := &PushTarget{
+		logger:         logger,
+		jobName:        jobName,
+		metrics:        metrics,
+		config:         config,
+		entries:        handler.Chan(),
+		handler:        handler,
+		relabelConfigs: relabel,
+	}
+
+	srvCfg := server.Config{
+		HTTPListenPort:    config.HTTPListenPort,
+		HTTPListenAddress: config.HTTPListenAddress,
+
+		// Avoid logging entire received request on failures
+		ExcludeRequestInLog: true,
+	}
+	mergedServerConfigs, err := serverutils.MergeWithDefaults(srvCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse configs and override defaults when configuring gcp push target: %w", err)
+	}
+
+	pt.serverConfig = mergedServerConfigs
+
+	err = pt.run()
+	if err != nil {
+		return nil, err
+	}
+
+	return pt, nil
+}
+
+func (p *PushTarget) run() error {
+	level.Info(p.logger).Log("msg", "starting gcp push target", "job", p.jobName)
+
+	// To prevent metric collisions registering in the global Prometheus registry.
+	tentativeServerMetricNamespace := p.jobName + "_push_target"
+	if !model.IsValidMetricName(model.LabelValue(tentativeServerMetricNamespace)) {
+		return fmt.Errorf("invalid prometheus-compatible job name: %s", p.jobName)
+	}
+	p.serverConfig.MetricsNamespace = tentativeServerMetricNamespace
+
+	// We don't want the /debug and /metrics endpoints running, since this is
+	// not the main Flow HTTP server. We want this target to expose the least
+	// surface area possible, hence disabling WeaveWorks HTTP server metrics
+	// and debugging functionality.
+	p.serverConfig.RegisterInstrumentation = false
+
+	p.serverConfig.Log = logging.GoKit(p.logger)
+
+	srv, err := server.New(p.serverConfig)
+	if err != nil {
+		return err
+	}
+	p.server = srv
+
+	p.server.HTTP.Path("/gcp/api/v1/push").Methods("POST").Handler(http.HandlerFunc(p.push))
+
+	go func() {
+		err := srv.Run()
+		if err != nil {
+			level.Error(p.logger).Log("msg", "loki.source.gcplog push target shutdown with error", "err", err)
+		}
+	}()
+
+	return nil
+}
+
+func (p *PushTarget) push(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	// Create no-op context.WithTimeout returns to simplify logic
+	ctx := r.Context()
+	cancel := context.CancelFunc(func() {})
+	if p.config.PushTimeout != 0 {
+		ctx, cancel = context.WithTimeout(r.Context(), p.config.PushTimeout)
+	}
+	defer cancel()
+
+	pushMessage := PushMessage{}
+	bs, err := io.ReadAll(r.Body)
+	if err != nil {
+		p.metrics.gcpPushErrors.WithLabelValues("read_error").Inc()
+		level.Warn(p.logger).Log("msg", "failed to read incoming gcp push request", "err", err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	err = json.Unmarshal(bs, &pushMessage)
+	if err != nil {
+		p.metrics.gcpPushErrors.WithLabelValues("format").Inc()
+		level.Warn(p.logger).Log("msg", "failed to unmarshall gcp push request", "err", err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err = pushMessage.Validate(); err != nil {
+		p.metrics.gcpPushErrors.WithLabelValues("invalid_message").Inc()
+		level.Warn(p.logger).Log("msg", "invalid gcp push request", "err", err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	entry, err := translate(pushMessage, p.Labels(), p.config.UseIncomingTimestamp, p.relabelConfigs, r.Header.Get("X-Scope-OrgID"))
+	if err != nil {
+		p.metrics.gcpPushErrors.WithLabelValues("translation").Inc()
+		level.Warn(p.logger).Log("msg", "failed to translate gcp push request", "err", err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	level.Debug(p.logger).Log("msg", fmt.Sprintf("Received line: %s", entry.Line))
+
+	if err := p.doSendEntry(ctx, entry); err != nil {
+		// NOTE: timeout errors can be tracked with from the metrics exposed by
+		// the spun weaveworks server.
+		// loki.source.gcplog.componentid_push_target_request_duration_seconds_count{status_code="503"}
+		level.Warn(p.logger).Log("msg", "error sending log entry", "err", err.Error())
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	p.metrics.gcpPushEntries.WithLabelValues().Inc()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (p *PushTarget) doSendEntry(ctx context.Context, entry loki.Entry) error {
+	select {
+	// Timeout the loki.Entry channel send operation, which is the only blocking operation in the handler
+	case <-ctx.Done():
+		return fmt.Errorf("timeout exceeded: %w", ctx.Err())
+	case p.entries <- entry:
+		return nil
+	}
+}
+
+// Labels return the model.LabelSet that the target applies to log entries.
+func (p *PushTarget) Labels() model.LabelSet {
+	lbls := make(model.LabelSet, len(p.config.Labels))
+	for k, v := range p.config.Labels {
+		lbls[model.LabelName(k)] = model.LabelValue(v)
+	}
+	return lbls
+}
+
+// Details returns some debug information about the target.
+func (p *PushTarget) Details() map[string]string {
+	return map[string]string{
+		"strategy":       "push",
+		"labels":         p.Labels().String(),
+		"server_address": p.server.HTTPListenAddr().String(),
+	}
+}
+
+// Stop shuts down the push target.
+func (p *PushTarget) Stop() error {
+	level.Info(p.logger).Log("msg", "stopping gcp push target", "job", p.jobName)
+	p.server.Stop()
+	p.server.Shutdown()
+	p.handler.Stop()
+	return nil
+}

--- a/component/loki/source/gcplog/internal/gcplogtarget/push_target_test.go
+++ b/component/loki/source/gcplog/internal/gcplogtarget/push_target_test.go
@@ -170,7 +170,7 @@ func TestPushTarget(t *testing.T) {
 
 			prometheus.DefaultRegisterer = prometheus.NewRegistry()
 			metrics := NewMetrics(prometheus.DefaultRegisterer)
-			pt, err := NewPushTarget(metrics, logger, eh, outerName+"_test_job", config, tc.args.RelabelConfigs)
+			pt, err := NewPushTarget(metrics, logger, eh, outerName+"_test_job", config, tc.args.RelabelConfigs, nil)
 			require.NoError(t, err)
 			defer func() {
 				_ = pt.Stop()
@@ -233,7 +233,7 @@ func TestPushTarget_UseIncomingTimestamp(t *testing.T) {
 
 	prometheus.DefaultRegisterer = prometheus.NewRegistry()
 	metrics := NewMetrics(prometheus.DefaultRegisterer)
-	pt, err := NewPushTarget(metrics, logger, eh, t.Name()+"_test_job", config, nil)
+	pt, err := NewPushTarget(metrics, logger, eh, t.Name()+"_test_job", config, nil, nil)
 	require.NoError(t, err)
 	defer func() {
 		_ = pt.Stop()
@@ -286,7 +286,7 @@ func TestPushTarget_UseTenantIDHeaderIfPresent(t *testing.T) {
 			Action:       relabel.Replace,
 		},
 	}
-	pt, err := NewPushTarget(metrics, logger, eh, t.Name()+"_test_job", config, tenantIDRelabelConfig)
+	pt, err := NewPushTarget(metrics, logger, eh, t.Name()+"_test_job", config, tenantIDRelabelConfig, nil)
 	require.NoError(t, err)
 	defer func() {
 		_ = pt.Stop()
@@ -306,7 +306,6 @@ func TestPushTarget_UseTenantIDHeaderIfPresent(t *testing.T) {
 
 	// Make sure we didn't timeout
 	require.Equal(t, 1, len(eh.Received()))
-	fmt.Println("~~~~", eh.Received()[0].Labels.String())
 
 	require.Equal(t, model.LabelValue("42"), eh.Received()[0].Labels[ReservedLabelTenantID])
 	require.Equal(t, model.LabelValue("42"), eh.Received()[0].Labels["tenant_id"])
@@ -330,7 +329,7 @@ func TestPushTarget_ErroneousPayloadsAreRejected(t *testing.T) {
 
 	prometheus.DefaultRegisterer = prometheus.NewRegistry()
 	metrics := NewMetrics(prometheus.DefaultRegisterer)
-	pt, err := NewPushTarget(metrics, logger, eh, t.Name()+"_test_job", config, nil)
+	pt, err := NewPushTarget(metrics, logger, eh, t.Name()+"_test_job", config, nil, nil)
 	require.NoError(t, err)
 	defer func() {
 		_ = pt.Stop()
@@ -421,7 +420,7 @@ func TestPushTarget_UsePushTimeout(t *testing.T) {
 			Action:       relabel.Replace,
 		},
 	}
-	pt, err := NewPushTarget(metrics, logger, eh, t.Name()+"_test_job", config, tenantIDRelabelConfig)
+	pt, err := NewPushTarget(metrics, logger, eh, t.Name()+"_test_job", config, tenantIDRelabelConfig, nil)
 	require.NoError(t, err)
 	defer func() {
 		_ = pt.Stop()

--- a/component/loki/source/gcplog/internal/gcplogtarget/push_target_test.go
+++ b/component/loki/source/gcplog/internal/gcplogtarget/push_target_test.go
@@ -1,0 +1,443 @@
+package gcplogtarget
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/agent/component/loki/source/gcplog/internal/fake"
+	"github.com/phayes/freeport"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/stretchr/testify/require"
+)
+
+const localhost = "127.0.0.1"
+
+const expectedMessageData = `{"insertId":"4affa858-e5f2-47f7-9254-e609b5c014d0","labels":{},"logName":"projects/test-project/logs/cloudaudit.googleapis.com%2Fdata_access","receiveTimestamp":"2022-09-06T18:07:43.417714046Z","resource":{"labels":{"cluster_name":"dev-us-central-42","location":"us-central1","project_id":"test-project"},"type":"k8s_cluster"},"timestamp":"2022-09-06T18:07:42.363113Z"}
+`
+const testPayload = `
+{
+	"message": {
+		"attributes": {
+			"logging.googleapis.com/timestamp": "2022-07-25T22:19:09.903683708Z"
+		},
+		"data": "eyJpbnNlcnRJZCI6IjRhZmZhODU4LWU1ZjItNDdmNy05MjU0LWU2MDliNWMwMTRkMCIsImxhYmVscyI6e30sImxvZ05hbWUiOiJwcm9qZWN0cy90ZXN0LXByb2plY3QvbG9ncy9jbG91ZGF1ZGl0Lmdvb2dsZWFwaXMuY29tJTJGZGF0YV9hY2Nlc3MiLCJyZWNlaXZlVGltZXN0YW1wIjoiMjAyMi0wOS0wNlQxODowNzo0My40MTc3MTQwNDZaIiwicmVzb3VyY2UiOnsibGFiZWxzIjp7ImNsdXN0ZXJfbmFtZSI6ImRldi11cy1jZW50cmFsLTQyIiwibG9jYXRpb24iOiJ1cy1jZW50cmFsMSIsInByb2plY3RfaWQiOiJ0ZXN0LXByb2plY3QifSwidHlwZSI6Ims4c19jbHVzdGVyIn0sInRpbWVzdGFtcCI6IjIwMjItMDktMDZUMTg6MDc6NDIuMzYzMTEzWiJ9Cg==",
+		"messageId": "5187581549398349",
+		"message_id": "5187581549398349",
+		"publishTime": "2022-07-25T22:19:15.56Z",
+		"publish_time": "2022-07-25T22:19:15.56Z"
+	},
+	"subscription": "projects/test-project/subscriptions/test"
+}`
+
+func makeGCPPushRequest(host string, body string) (*http.Request, error) {
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/gcp/api/v1/push", host), strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	return req, nil
+}
+
+func TestPushTarget(t *testing.T) {
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+
+	type expectedEntry struct {
+		labels model.LabelSet
+		line   string
+	}
+	type args struct {
+		RequestBody    string
+		RelabelConfigs []*relabel.Config
+		Labels         model.LabelSet
+	}
+
+	cases := map[string]struct {
+		args            args
+		expectedEntries []expectedEntry
+	}{
+		"simplified cloud functions log line": {
+			args: args{
+				RequestBody: testPayload,
+				Labels: model.LabelSet{
+					"job": "some_job_name",
+				},
+			},
+			expectedEntries: []expectedEntry{
+				{
+					labels: model.LabelSet{
+						"job": "some_job_name",
+					},
+					line: expectedMessageData,
+				},
+			},
+		},
+		"simplified cloud functions log line, with relabeling custom attribute and message id": {
+			args: args{
+				RequestBody: testPayload,
+				Labels: model.LabelSet{
+					"job": "some_job_name",
+				},
+				RelabelConfigs: []*relabel.Config{
+					{
+						SourceLabels: model.LabelNames{"__gcp_attributes_logging_googleapis_com_timestamp"},
+						Regex:        relabel.MustNewRegexp("(.*)"),
+						Replacement:  "$1",
+						TargetLabel:  "google_timestamp",
+						Action:       relabel.Replace,
+					},
+					{
+						SourceLabels: model.LabelNames{"__gcp_message_id"},
+						Regex:        relabel.MustNewRegexp("(.*)"),
+						Replacement:  "$1",
+						TargetLabel:  "message_id",
+						Action:       relabel.Replace,
+					},
+					{
+						SourceLabels: model.LabelNames{"__gcp_subscription_name"},
+						Regex:        relabel.MustNewRegexp("(.*)"),
+						Replacement:  "$1",
+						TargetLabel:  "subscription",
+						Action:       relabel.Replace,
+					},
+					// Internal GCP Log entry attributes and labels
+					{
+						SourceLabels: model.LabelNames{"__gcp_logname"},
+						Regex:        relabel.MustNewRegexp("(.*)"),
+						Replacement:  "$1",
+						TargetLabel:  "log_name",
+						Action:       relabel.Replace,
+					},
+					{
+						SourceLabels: model.LabelNames{"__gcp_resource_type"},
+						Regex:        relabel.MustNewRegexp("(.*)"),
+						Replacement:  "$1",
+						TargetLabel:  "resource_type",
+						Action:       relabel.Replace,
+					},
+					{
+						SourceLabels: model.LabelNames{"__gcp_resource_labels_cluster_name"},
+						Regex:        relabel.MustNewRegexp("(.*)"),
+						Replacement:  "$1",
+						TargetLabel:  "cluster",
+						Action:       relabel.Replace,
+					},
+				},
+			},
+			expectedEntries: []expectedEntry{
+				{
+					labels: model.LabelSet{
+						"job":              "some_job_name",
+						"google_timestamp": "2022-07-25T22:19:09.903683708Z",
+						"message_id":       "5187581549398349",
+						"subscription":     "projects/test-project/subscriptions/test",
+						"log_name":         "projects/test-project/logs/cloudaudit.googleapis.com%2Fdata_access",
+						"resource_type":    "k8s_cluster",
+						"cluster":          "dev-us-central-42",
+					},
+					line: expectedMessageData,
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		outerName := t.Name()
+		t.Run(name, func(t *testing.T) {
+			// Create fake promtail client
+			eh := fake.New(func() {})
+			defer eh.Stop()
+
+			port, err := freeport.GetFreePort()
+			require.NoError(t, err)
+			lbls := make(map[string]string, len(tc.args.Labels))
+			for k, v := range tc.args.Labels {
+				lbls[string(k)] = string(v)
+			}
+			config := &PushConfig{
+				Labels:               lbls,
+				UseIncomingTimestamp: false,
+				HTTPListenAddress:    "localhost",
+				HTTPListenPort:       port,
+			}
+
+			prometheus.DefaultRegisterer = prometheus.NewRegistry()
+			metrics := NewMetrics(prometheus.DefaultRegisterer)
+			pt, err := NewPushTarget(metrics, logger, eh, outerName+"_test_job", config, tc.args.RelabelConfigs)
+			require.NoError(t, err)
+			defer func() {
+				_ = pt.Stop()
+			}()
+
+			// Clear received lines after test case is ran
+			defer eh.Clear()
+
+			// Send some logs
+			ts := time.Now()
+
+			req, err := makeGCPPushRequest(fmt.Sprintf("http://%s:%d", localhost, port), tc.args.RequestBody)
+			require.NoError(t, err, "expected request to be created successfully")
+			res, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusNoContent, res.StatusCode, "expected no-content status code")
+
+			waitForMessages(eh)
+
+			// Make sure we didn't timeout
+			require.Equal(t, 1, len(eh.Received()))
+
+			require.Equal(t, len(eh.Received()), len(tc.expectedEntries), "expected to receive equal amount of expected label sets")
+			for i, expectedEntry := range tc.expectedEntries {
+				// TODO: Add assertion over propagated timestamp
+				actualEntry := eh.Received()[i]
+
+				require.Equal(t, expectedEntry.line, actualEntry.Line, "expected line to be equal for %d-th entry", i)
+
+				expectedLS := expectedEntry.labels
+				actualLS := actualEntry.Labels
+				for label, value := range expectedLS {
+					require.Equal(t, expectedLS[label], actualLS[label], "expected label %s to be equal to %s in %d-th entry", label, value, i)
+				}
+
+				// Timestamp is always set in the handler, we expect received timestamps to be slightly higher than the timestamp when we started sending logs.
+				require.GreaterOrEqual(t, actualEntry.Timestamp.Unix(), ts.Unix(), "expected %d-th entry to have a received timestamp greater than publish time", i)
+			}
+		})
+	}
+}
+
+func TestPushTarget_UseIncomingTimestamp(t *testing.T) {
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+
+	// Create fake promtail client
+	eh := fake.New(func() {})
+	defer eh.Stop()
+
+	port, err := freeport.GetFreePort()
+	require.NoError(t, err)
+	require.NoError(t, err, "error generating server config or finding open port")
+	config := &PushConfig{
+		Labels:               nil,
+		UseIncomingTimestamp: true,
+		HTTPListenAddress:    "localhost",
+		HTTPListenPort:       port,
+	}
+
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+	metrics := NewMetrics(prometheus.DefaultRegisterer)
+	pt, err := NewPushTarget(metrics, logger, eh, t.Name()+"_test_job", config, nil)
+	require.NoError(t, err)
+	defer func() {
+		_ = pt.Stop()
+	}()
+
+	// Clear received lines after test case is ran
+	defer eh.Clear()
+
+	req, err := makeGCPPushRequest(fmt.Sprintf("http://%s:%d", localhost, port), testPayload)
+	require.NoError(t, err, "expected request to be created successfully")
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, res.StatusCode, "expected no-content status code")
+
+	waitForMessages(eh)
+
+	// Make sure we didn't timeout
+	require.Equal(t, 1, len(eh.Received()))
+
+	expectedTs, err := time.Parse(time.RFC3339Nano, "2022-09-06T18:07:42.363113Z")
+	require.NoError(t, err, "expected expected timestamp to be parse correctly")
+	require.Equal(t, expectedTs, eh.Received()[0].Timestamp, "expected entry timestamp to be overridden by received one")
+}
+
+func TestPushTarget_UseTenantIDHeaderIfPresent(t *testing.T) {
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+
+	// Create fake promtail client
+	eh := fake.New(func() {})
+	defer eh.Stop()
+
+	port, err := freeport.GetFreePort()
+	require.NoError(t, err)
+	config := &PushConfig{
+		Labels:               nil,
+		UseIncomingTimestamp: true,
+		HTTPListenAddress:    "localhost",
+		HTTPListenPort:       port,
+	}
+
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+	metrics := NewMetrics(prometheus.DefaultRegisterer)
+	tenantIDRelabelConfig := []*relabel.Config{
+		{
+			SourceLabels: model.LabelNames{"__tenant_id__"},
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  "$1",
+			TargetLabel:  "tenant_id",
+			Action:       relabel.Replace,
+		},
+	}
+	pt, err := NewPushTarget(metrics, logger, eh, t.Name()+"_test_job", config, tenantIDRelabelConfig)
+	require.NoError(t, err)
+	defer func() {
+		_ = pt.Stop()
+	}()
+
+	// Clear received lines after test case is ran
+	defer eh.Clear()
+
+	req, err := makeGCPPushRequest(fmt.Sprintf("http://%s:%d", localhost, port), testPayload)
+	require.NoError(t, err, "expected request to be created successfully")
+	req.Header.Set("X-Scope-OrgID", "42")
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, res.StatusCode, "expected no-content status code")
+
+	waitForMessages(eh)
+
+	// Make sure we didn't timeout
+	require.Equal(t, 1, len(eh.Received()))
+	fmt.Println("~~~~", eh.Received()[0].Labels.String())
+
+	require.Equal(t, model.LabelValue("42"), eh.Received()[0].Labels[ReservedLabelTenantID])
+	require.Equal(t, model.LabelValue("42"), eh.Received()[0].Labels["tenant_id"])
+}
+
+func TestPushTarget_ErroneousPayloadsAreRejected(t *testing.T) {
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+
+	// Create fake promtail client
+	eh := fake.New(func() {})
+	defer eh.Stop()
+
+	port, err := freeport.GetFreePort()
+	require.NoError(t, err)
+	config := &PushConfig{
+		Labels:            nil,
+		HTTPListenAddress: "localhost",
+		HTTPListenPort:    port,
+	}
+
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+	metrics := NewMetrics(prometheus.DefaultRegisterer)
+	pt, err := NewPushTarget(metrics, logger, eh, t.Name()+"_test_job", config, nil)
+	require.NoError(t, err)
+	defer func() {
+		_ = pt.Stop()
+	}()
+
+	// Clear received lines after test case is ran
+	defer eh.Clear()
+
+	for caseName, testPayload := range map[string]string{
+		"invalid JSON": "{",
+		"empty":        "{}",
+		"missing subscription": `{
+			"message": {
+				"message_id": "123",
+				"data": "some data"
+			}
+		}`,
+		"missing message ID": `{
+			"subscription": "sub",
+			"message": {
+				"data": "data"
+			}
+		}`,
+		"missing data": `{
+			"subscription": "sub",
+			"message": {
+				"data": "",
+				"message_id":"123"
+			}
+		}`,
+	} {
+		t.Run(caseName, func(t *testing.T) {
+			req, err := makeGCPPushRequest(fmt.Sprintf("http://%s:%d", localhost, port), testPayload)
+			require.NoError(t, err, "expected request to be created successfully")
+			res, err := http.DefaultClient.Do(req)
+			res.Request.Body.Close()
+			require.NoError(t, err)
+			require.Equal(t, http.StatusBadRequest, res.StatusCode, "expected bad request status code")
+		})
+	}
+}
+
+// blockingEntryHandler implements an loki.EntryHandler that has no space in
+// it's receive channel, blocking when an loki.Entry is sent down the pipe.
+type blockingEntryHandler struct {
+	ch   chan loki.Entry
+	once sync.Once
+}
+
+func newBlockingEntryHandler() *blockingEntryHandler {
+	filledChannel := make(chan loki.Entry)
+	return &blockingEntryHandler{ch: filledChannel}
+}
+
+func (t *blockingEntryHandler) Chan() chan<- loki.Entry {
+	return t.ch
+}
+
+func (t *blockingEntryHandler) Stop() {
+	t.once.Do(func() { close(t.ch) })
+}
+
+func TestPushTarget_UsePushTimeout(t *testing.T) {
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+
+	eh := newBlockingEntryHandler()
+	defer eh.Stop()
+
+	port, err := freeport.GetFreePort()
+	require.NoError(t, err)
+	config := &PushConfig{
+		Labels:               nil,
+		UseIncomingTimestamp: true,
+		PushTimeout:          time.Second,
+		HTTPListenAddress:    "localhost",
+		HTTPListenPort:       port,
+	}
+
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+	metrics := NewMetrics(prometheus.DefaultRegisterer)
+	tenantIDRelabelConfig := []*relabel.Config{
+		{
+			SourceLabels: model.LabelNames{"__tenant_id__"},
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  "$1",
+			TargetLabel:  "tenant_id",
+			Action:       relabel.Replace,
+		},
+	}
+	pt, err := NewPushTarget(metrics, logger, eh, t.Name()+"_test_job", config, tenantIDRelabelConfig)
+	require.NoError(t, err)
+	defer func() {
+		_ = pt.Stop()
+	}()
+
+	req, err := makeGCPPushRequest(fmt.Sprintf("http://%s:%d", localhost, port), testPayload)
+	require.NoError(t, err, "expected request to be created successfully")
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusServiceUnavailable, res.StatusCode, "expected timeout response")
+}
+
+func waitForMessages(eh *fake.Client) {
+	countdown := 1000
+	for len(eh.Received()) != 1 && countdown > 0 {
+		time.Sleep(1 * time.Millisecond)
+		countdown--
+	}
+}

--- a/component/loki/source/gcplog/internal/gcplogtarget/push_translation.go
+++ b/component/loki/source/gcplog/internal/gcplogtarget/push_translation.go
@@ -1,0 +1,96 @@
+package gcplogtarget
+
+// This code is copied from Promtail. The gcplogtarget package is used to
+// configure and run the targets that can read log entries from cloud resource
+// logs like bucket logs, load balancer logs, and Kubernetes cluster logs
+// from GCP.
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/loki/pkg/util"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/relabel"
+)
+
+// ReservedLabelTenantID reserved to override the tenant ID while processing
+// pipeline stages
+const ReservedLabelTenantID = "__tenant_id__"
+
+// PushMessage is the POST body format sent by GCP PubSub push subscriptions.
+// See https://cloud.google.com/pubsub/docs/push for details.
+type PushMessage struct {
+	Message struct {
+		Attributes       map[string]string `json:"attributes"`
+		Data             string            `json:"data"`
+		ID               string            `json:"message_id"`
+		PublishTimestamp string            `json:"publish_time"`
+	} `json:"message"`
+	Subscription string `json:"subscription"`
+}
+
+// Validate checks that the required fields of a PushMessage are set.
+func (pm PushMessage) Validate() error {
+	if pm.Message.Data == "" {
+		return fmt.Errorf("push message has no data")
+	}
+	if pm.Message.ID == "" {
+		return fmt.Errorf("push message has no ID")
+	}
+	if pm.Subscription == "" {
+		return fmt.Errorf("push message has no subscription")
+	}
+	return nil
+}
+
+// translate converts a GCP PushMessage into a loki loki.Entry. It parses the
+// push-specific labels and delegates the rest to parseGCPLogsEntry.
+func translate(m PushMessage, other model.LabelSet, useIncomingTimestamp bool, relabelConfigs []*relabel.Config, xScopeOrgID string) (loki.Entry, error) {
+	// Collect all push-specific labels. Every one of them is first configured
+	// as optional, and the user can relabel it if needed. The relabeling and
+	// internal drop is handled in parseGCPLogsEntry.
+	lbs := labels.NewBuilder(nil)
+	lbs.Set("__gcp_message_id", m.Message.ID)
+	lbs.Set("__gcp_subscription_name", m.Subscription)
+	for k, v := range m.Message.Attributes {
+		lbs.Set(fmt.Sprintf("__gcp_attributes_%s", convertToLokiCompatibleLabel(k)), v)
+	}
+
+	// Add fixed labels coming from the target configuration
+	fixedLabels := other.Clone()
+
+	// If the incoming request carries the tenant id, inject it as the reserved
+	// label, so it's used by the remote write client.
+	if xScopeOrgID != "" {
+		// Expose tenant ID through relabel to use as logs or metrics label.
+		lbs.Set(ReservedLabelTenantID, xScopeOrgID)
+		fixedLabels[ReservedLabelTenantID] = model.LabelValue(xScopeOrgID)
+	}
+
+	decodedData, err := base64.StdEncoding.DecodeString(m.Message.Data)
+	if err != nil {
+		return loki.Entry{}, fmt.Errorf("failed to decode data: %w", err)
+	}
+
+	entry, err := parseGCPLogsEntry(decodedData, fixedLabels, lbs.Labels(nil), useIncomingTimestamp, relabelConfigs)
+	if err != nil {
+		return loki.Entry{}, fmt.Errorf("failed to parse logs entry: %w", err)
+	}
+
+	return entry, nil
+}
+
+var separatorCharacterReplacer = strings.NewReplacer(".", "_", "-", "_", "/", "_")
+
+// convertToLokiCompatibleLabel converts an incoming GCP Push message label to
+// a loki compatible format. There are labels such as
+// `logging.googleapis.com/timestamp`, which contain non-loki-compatible
+// characters, which is just alphanumeric and _. The approach taken is to
+// translate every non-alphanumeric separator character to an underscore.
+func convertToLokiCompatibleLabel(label string) string {
+	return util.SnakeCase(separatorCharacterReplacer.Replace(label))
+}

--- a/component/loki/source/gcplog/internal/gcplogtarget/push_translation_test.go
+++ b/component/loki/source/gcplog/internal/gcplogtarget/push_translation_test.go
@@ -1,0 +1,45 @@
+package gcplogtarget
+
+import (
+	"testing"
+)
+
+func TestConvertToLokiCompatibleLabel(t *testing.T) {
+	type args struct {
+		label string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Google timestamp label attribute name",
+			args: args{
+				label: "logging.googleapis.com/timestamp",
+			},
+			want: "logging_googleapis_com_timestamp",
+		},
+		{
+			name: "Label attribute name with multiple non-underscore characters",
+			args: args{
+				label: "logging.googleapis.com/Crazy-label",
+			},
+			want: "logging_googleapis_com_crazy_label",
+		},
+		{
+			name: "Label attribute name in CamelCase converted into SnakeCase",
+			args: args{
+				label: "logging.googleapis.com/CrazyLabel",
+			},
+			want: "logging_googleapis_com_crazy_label",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := convertToLokiCompatibleLabel(tt.args.label); got != tt.want {
+				t.Errorf("convertToLokiCompatibleLabel() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/component/loki/source/gcplog/internal/gcplogtarget/types.go
+++ b/component/loki/source/gcplog/internal/gcplogtarget/types.go
@@ -42,8 +42,8 @@ func (p *PushConfig) UnmarshalRiver(f func(v interface{}) error) error {
 	if err != nil {
 		return err
 	}
-	if p.PushTimeout <= 0 {
-		return fmt.Errorf("poll_frequency must be greater than 30s")
+	if p.PushTimeout < 0 {
+		return fmt.Errorf("push_timeout must be greater than zero")
 	}
 	return nil
 }

--- a/component/loki/source/gcplog/internal/gcplogtarget/types.go
+++ b/component/loki/source/gcplog/internal/gcplogtarget/types.go
@@ -1,6 +1,9 @@
 package gcplogtarget
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // Target is a common interface implemented by both GCPLog targets.
 type Target interface {
@@ -18,9 +21,29 @@ type PullConfig struct {
 
 // PushConfig configures a GCPLog target with the 'push' strategy.
 type PushConfig struct {
-	HTTPListenAddress    string            `river:"http_listen_address,attr"`
+	HTTPListenAddress    string            `river:"http_listen_address,attr,optional"`
 	HTTPListenPort       int               `river:"http_listen_port,attr,optional"`
 	PushTimeout          time.Duration     `river:"push_timeout,attr,optional"`
 	Labels               map[string]string `river:"labels,attr,optional"`
 	UseIncomingTimestamp bool              `river:"use_incoming_timestamp,attr,optional"`
+}
+
+// DefaultPushConfig sets the default listen address and port.
+var DefaultPushConfig = PushConfig{
+	HTTPListenAddress: "0.0.0.0",
+	HTTPListenPort:    8080,
+}
+
+// UnmarshalRiver implements the unmarshaller
+func (p *PushConfig) UnmarshalRiver(f func(v interface{}) error) error {
+	*p = DefaultPushConfig
+	type pushCfg PushConfig
+	err := f((*pushCfg)(p))
+	if err != nil {
+		return err
+	}
+	if p.PushTimeout <= 0 {
+		return fmt.Errorf("poll_frequency must be greater than 30s")
+	}
+	return nil
 }

--- a/component/loki/source/gcplog/internal/gcplogtarget/types.go
+++ b/component/loki/source/gcplog/internal/gcplogtarget/types.go
@@ -1,0 +1,26 @@
+package gcplogtarget
+
+import "time"
+
+// Target is a common interface implemented by both GCPLog targets.
+type Target interface {
+	Details() map[string]string
+	Stop() error
+}
+
+// PullConfig configures a GCPLog target with the 'pull' strategy.
+type PullConfig struct {
+	ProjectID            string            `river:"project_id,attr"`
+	Subscription         string            `river:"subscription,attr"`
+	Labels               map[string]string `river:"labels,attr,optional"`
+	UseIncomingTimestamp bool              `river:"use_incoming_timestamp,attr,optional"`
+}
+
+// PushConfig configures a GCPLog target with the 'push' strategy.
+type PushConfig struct {
+	HTTPListenAddress    string            `river:"http_listen_address,attr"`
+	HTTPListenPort       int               `river:"http_listen_port,attr,optional"`
+	PushTimeout          time.Duration     `river:"push_timeout,attr,optional"`
+	Labels               map[string]string `river:"labels,attr,optional"`
+	UseIncomingTimestamp bool              `river:"use_incoming_timestamp,attr,optional"`
+}

--- a/component/loki/source/syslog/syslog.go
+++ b/component/loki/source/syslog/syslog.go
@@ -122,6 +122,7 @@ func (c *Component) Update(args component.Arguments) error {
 			c.listeners = append(c.listeners, t)
 		}
 	}
+	c.lc = newArgs.SyslogListeners
 
 	return nil
 }

--- a/docs/sources/flow/reference/components/loki.source.gcplog.md
+++ b/docs/sources/flow/reference/components/loki.source.gcplog.md
@@ -1,0 +1,164 @@
+---
+aliases:
+- /docs/agent/latest/flow/reference/components/loki.source.gcplog
+title: loki.source.gcplog
+---
+
+# loki.source.gcplog
+
+`loki.source.gcplog` retrieves logs from cloud resources such as GCS buckets,
+load balancers, or Kubernetes cluster running on GCP by making use of Pub/Sub
+[subscriptions](https://cloud.google.com/pubsub/docs/subscriber).
+
+The component starts a new gcplog 'target' with either the 'push' or 'pull'
+strategy, reads log entries and forwards them to the list of receivers in
+`forward_to`.
+
+Multiple `loki.source.gcplog` components can be specified by giving them
+different labels.
+
+## Usage
+
+```river
+loki.source.gcplog "LABEL" {
+  pull {
+    project_id   = "PROJECT_ID"
+    subscription = "SUB_ID"
+  }
+
+  forward_to = RECEIVER_LIST
+}
+```
+
+## Arguments
+
+`loki.source.gcplog` supports the following arguments:
+
+Name            | Type                 | Description          | Default | Required
+--------------- | -------------------- | -------------------- | ------- | --------
+`forward_to`    | `list(LogsReceiver)` | List of receivers to send log entries to. |      | yes
+`relabel_rules` | `RelabelRules`       | Relabeling rules to apply on log entries. | "{}" | no
+
+## Blocks
+
+The following blocks are supported inside the definition of
+`loki.source.gcplog`:
+
+Hierarchy | Name | Description | Required
+--------- | ---- | ----------- | --------
+pull      | [pull][] | Configures a target to pull entries from a GCP Pub/Sub subscription. | no
+push      | [push][] | Configures a server to receive entries as GCP Pub/Sub push requests. | no
+
+The `pull` and `push` inner blocks are mutually exclusive; a component must
+contain exactly one of the two in its definition.
+
+[pull]: #pull-block
+[push]: #push-block
+
+### pull block
+
+The `pull` block defines which GCP project id and subscription ID the target
+reads log entries from.
+
+The following arguments can be used to configure the `pull` block. Any omitted
+fields take their default values.
+
+Name                     | Type          | Description | Default | Required
+------------------------ | ------------- | ----------- | ------- | --------
+`project_id`             | `string`      | The GCP project id the subscription belongs to.       |         | yes
+`subscription`           | `string`      | The subscription name to pull logs from.              |         | yes
+`labels`                 | `map(string)` | Additional labels to associate with incoming entries. | `"{}"`  | no
+`use_incoming_timestamp` | `bool`        | Whether to use the incoming entry timestamp.          | `false` | no
+
+To make use of the `pull` strategy, the GCP project must have been
+[configured](https://grafana.com/docs/loki/next/clients/promtail/gcplog-cloud/)
+to forward its cloud resource logs onto a Pub/Sub topic for
+`loki.source.gcplog` to consume.
+
+Typically, the component will also need to have its
+[credentials](https://cloud.google.com/docs/authentication/application-default-credentials)
+configured. One way to do it is to point the `GOOGLE_APPLICATION_CREDENTIALS`
+environment variable to the location of a credential configuration JSON file or
+a service account key.
+
+### push block
+
+The `push` block defines the configuration of the HTTP server to receive
+push requests from GCP's Pub/Sub servers.
+
+The following arguments can be used to configure the `push` block. Any omitted
+fields take their default values.
+
+Name                     | Type          | Description | Default | Required
+------------------------ | ------------- | ----------- | ------- | --------
+`http_listen_address`    | `string`      | The address the server listens to.  |         | yes
+`http_listen_port`       | `int`         | The port the server listens to.  |    `0`     | no
+`push_timeout`           | `duration`    | Sets a maximum processing time for each incoming GCP log entry. |  `"0s"`  | no
+`labels`                 | `map(string)` | Additional labels to associate with incoming entries. | `"{}"`  | no
+`use_incoming_timestamp` | `bool`        | Whether to use the incoming entry timestamp.          | `false` | no
+
+When using the `push` strategy, if no `http_listen_port` is defined, or the
+port is set to zero, then a random port will be allocated.
+
+The server will listen for POST requests from GCP's Push subscriptions on
+`HOST:PORT/gcp/api/v1/push`.
+
+By default, for both strategies the component assigns the log entry timestamp
+as the time it was processed, except if `use_incoming_timestamp` is set to
+true.
+
+The `labels` map is applied to every entry that passes through the component.
+
+
+## Exported fields
+
+`loki.source.gcplog` does not export any fields.
+
+## Component health
+
+`loki.source.gcplog` is only reported as unhealthy if given an invalid
+configuration.
+
+## Debug information
+
+`loki.source.gcplog` exposes some debug information per gcplog listener:
+* Whether the listener is currently running.
+* The listen address.
+* The labels that the listener applies to incoming log entries.
+
+## Debug metrics
+
+When using the `pull` strategy, the component exposes the following debug
+metrics:
+* `loki_source_gcplog_pull_entries_total` (counter): Number of entries received by the gcplog target.
+* `loki_source_gcplog_pull_parsing_errors_total` (counter): Total number of parsing errors while receiving gcplog messages.
+* `loki_source_gcplog_pull_last_success_scrape` (gauge): Timestamp of target's last successful poll.
+
+When using the `push` strategy, the component exposes the following debug
+metrics:
+* `loki_source_gcplog_push_entries_total` (counter): Number of entries received by the gcplog target.
+* `loki_source_gcplog_push_entries_total` (counter): Number of parsing errors while receiving gcplog messages.
+
+
+## Example
+
+This example listens for GCP's Pub/Sub PushRequests on `localhost:51895` and
+forwards them to a `loki.write` component.
+
+```river
+loki.source.gcplog "local" {
+  push {
+    http_listen_address = "localhost"
+    http_listen_port    = 51895
+  }
+
+  forward_to = [loki.write.local.receiver]
+}
+
+loki.write "local" {
+  endpoint {
+    url = "loki:3100/api/v1/push"
+  }
+}
+```
+

--- a/docs/sources/flow/reference/components/loki.source.gcplog.md
+++ b/docs/sources/flow/reference/components/loki.source.gcplog.md
@@ -56,7 +56,7 @@ contain exactly one of the two in its definition.
 
 ### pull block
 
-The `pull` block defines which GCP project id and subscription ID to read log
+The `pull` block defines which GCP project ID and subscription to read log
 entries from.
 
 The following arguments can be used to configure the `pull` block. Any omitted

--- a/go.mod
+++ b/go.mod
@@ -115,6 +115,7 @@ require (
 )
 
 require (
+	cloud.google.com/go/pubsub v1.27.1
 	github.com/Lusitaniae/apache_exporter v0.11.1-0.20220518131644-f9522724dab4
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
@@ -167,7 +168,9 @@ require (
 	golang.org/x/crypto v0.1.0
 	golang.org/x/exp v0.0.0-20221031165847-c99f073a8326
 	golang.org/x/text v0.5.0
+	google.golang.org/api v0.103.0
 	google.golang.org/protobuf v1.28.1
+	gotest.tools v2.2.0+incompatible
 	k8s.io/component-base v0.25.4
 )
 
@@ -176,7 +179,6 @@ require (
 	cloud.google.com/go/compute v1.13.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.1 // indirect
 	cloud.google.com/go/iam v0.8.0 // indirect
-	cloud.google.com/go/pubsub v1.27.1 // indirect
 	cloud.google.com/go/storage v1.27.0 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/99designs/keyring v1.2.1 // indirect
@@ -531,7 +533,6 @@ require (
 	golang.org/x/tools v0.4.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
-	google.golang.org/api v0.103.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20221227171554-f9683d7f8bef // indirect
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The PR adds a loki.source.gcplog component that can read logs from GCP cloud resources by making use of Pub/Sub subscriptions.

The component can define a 'pull' strategy where it scrapes a GCP Project ID and subscription given the correct credentials, or a 'pull' strategy where it starts a web server that accepts POST GCP PushRequests. Users must define exactly one strategy; if they want to use both, scrape multiple subscriptions or listen on different ports, then multiple components must be instantiated.

The log entries are then forwarded to other `loki.*` components.

Again, most of the PR size is due to bringing over Promtail's syslog package, so that we can use our own loki.Entry definition. This was also a chance to clean things up to _not_ use the Promtail Target interface and distinguish the configuration struct for each strategy.


#### Which issue(s) this PR fixes
Fixes #2692 

#### Notes to the Reviewer
I don't like the `targets` terminology, but not sure what we can use that can be consistent across different loki sources.

#### PR Checklist

- [x] CHANGELOG updated
- [X] Documentation added
- [X] Tests updated (still have to find an easy way to test the 'pull' strategy)
