### PR TITLE
Introduce global configuration for logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ Main (unreleased)
 
 - New experimental feature: agent-management. Polls configured remote API to fetch new configs. (@spartan0x117)
 
+- Introduce global configuration for logs. (@jcreixell)
+
 ### Enhancements
 
 - Handle faro-web-sdk `View` meta in app_agent_receiver. (@rlankfo)

--- a/docs/sources/configuration/logs-config.md
+++ b/docs/sources/configuration/logs-config.md
@@ -28,10 +28,28 @@ for the supported values for these fields.
 # This directory will be automatically created if it doesn't exist.
 [positions_directory: <string>]
 
+# Configure values for all Loki Promtail instances.
+[global: <global_config>]
+
 # Loki Promtail instances to run for log collection.
 configs:
   - [<logs_instance_config>]
 ```
+
+## global_config
+
+The `global_config` block configures global values for all launched Loki Promtail
+instances.
+
+```yaml
+clients:
+  - [<promtail.client_config>]
+```
+
+> **Note:** More information on the following types can be found on the
+> documentation for Promtail:
+>
+> * [`promtail.client_config`](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#clients)
 
 ## logs_instance_config
 

--- a/pkg/logs/config.go
+++ b/pkg/logs/config.go
@@ -14,6 +14,7 @@ import (
 // Config controls the configuration of the Loki log scraper.
 type Config struct {
 	PositionsDirectory string            `yaml:"positions_directory,omitempty"`
+	Global             GlobalConfig      `yaml:"global,omitempty"`
 	Configs            []*InstanceConfig `yaml:"configs,omitempty"`
 }
 
@@ -42,6 +43,8 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 //
 //  1. If a positions config is empty, it will be generated based on
 //     the InstanceConfig name and Config.PositionsDirectory.
+//  2. If an InstanceConfigs's ClientConfigs is empty, it will be generated based on
+//     the Config.GlobalConfig.ClientConfigs.
 func (c *Config) ApplyDefaults() error {
 	var (
 		names     = map[string]struct{}{}
@@ -67,6 +70,10 @@ func (c *Config) ApplyDefaults() error {
 			return fmt.Errorf("Loki configs %s and %s must have different positions file paths", orig, ic.Name)
 		}
 		positions[ic.PositionsConfig.PositionsFile] = ic.Name
+
+		if len(ic.ClientConfigs) == 0 {
+			ic.ClientConfigs = c.Global.ClientConfigs
+		}
 	}
 
 	return nil

--- a/pkg/logs/gobal.go
+++ b/pkg/logs/gobal.go
@@ -1,0 +1,29 @@
+package logs
+
+import (
+	"reflect"
+
+	"github.com/grafana/loki/clients/pkg/promtail/client"
+)
+
+// DefaultGlobalConfig holds default global settings to be used across all instances.
+var DefaultGlobalConfig = GlobalConfig{
+	ClientConfigs: []client.Config{},
+}
+
+// GlobalConfig holds global settings that apply to all instances by default.
+type GlobalConfig struct {
+	ClientConfigs []client.Config `yaml:"clients,omitempty"`
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler.
+func (c *GlobalConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultGlobalConfig
+
+	type plain GlobalConfig
+	return unmarshal((*plain)(c))
+}
+
+func (c GlobalConfig) IsZero() bool {
+	return reflect.DeepEqual(c, GlobalConfig{}) || reflect.DeepEqual(c, DefaultGlobalConfig)
+}


### PR DESCRIPTION
#### PR Description

  - Similarly to how we allow setting default configurations for metrics (e.g. remote_writes), this change introduces a global field under the logs section of the config.
  - It allows defining default clients for promtail.
  - This is useful for agent management, where we only allow defining scrape_configs in the configuration snippets.

Example config:

```yaml
logs:
  global:
    clients:
      - basic_auth:
          password: password_default
          username: username_default
        url: https://default.com
  configs:
  - name: config1
    clients:
    - basic_auth:
        password: password_override
        username: username_override
      url: https://override.com
```

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
