### PR TITLE
Add Default Cache Directory for Agent Management

### DIFF
--- a/pkg/config/agentmanagement.go
+++ b/pkg/config/agentmanagement.go
@@ -21,7 +21,7 @@ var defaultConfig = AgentManagement{
 
 type labelMap map[string]string
 
-type remoteConfiguration struct {
+type RemoteConfiguration struct {
 	Labels    labelMap `yaml:"labels"`
 	Namespace string   `yaml:"namespace"`
 }
@@ -34,7 +34,7 @@ type AgentManagement struct {
 	PollingInterval string           `yaml:"polling_interval"`
 	CacheLocation   string           `yaml:"remote_config_cache_location"`
 
-	RemoteConfiguration remoteConfiguration `yaml:"remote_configuration"`
+	RemoteConfiguration RemoteConfiguration `yaml:"remote_configuration"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.

--- a/pkg/config/agentmanagement.go
+++ b/pkg/config/agentmanagement.go
@@ -15,9 +15,13 @@ import (
 
 const cacheFilename = "remote-config-cache.yaml"
 
+var defaultConfig = AgentManagement{
+	CacheLocation: "data-agent/",
+}
+
 type labelMap map[string]string
 
-type RemoteConfiguration struct {
+type remoteConfiguration struct {
 	Labels    labelMap `yaml:"labels"`
 	Namespace string   `yaml:"namespace"`
 }
@@ -30,7 +34,14 @@ type AgentManagement struct {
 	PollingInterval string           `yaml:"polling_interval"`
 	CacheLocation   string           `yaml:"remote_config_cache_location"`
 
-	RemoteConfiguration RemoteConfiguration `yaml:"remote_configuration"`
+	RemoteConfiguration remoteConfiguration `yaml:"remote_configuration"`
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler.
+func (am *AgentManagement) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*am = defaultConfig
+	type plain AgentManagement
+	return unmarshal((*plain)(am))
 }
 
 // getRemoteConfig gets the remote config specified in the initial config, falling back to a local, cached copy

--- a/pkg/config/agentmanagement_test.go
+++ b/pkg/config/agentmanagement_test.go
@@ -158,6 +158,7 @@ basic_auth:
   password_file: /tmp/test/passfile
 protocol: http
 polling_interval: 1m
+remote_config_cache_location: /tmp/agent-management/
 remote_configuration:
   namespace: test_namespace
   labels:
@@ -174,7 +175,7 @@ remote_configuration:
 		},
 		Protocol:        "http",
 		PollingInterval: "1m",
-		CacheLocation:   defaultConfig.CacheLocation,
+		CacheLocation:   "/tmp/agent-management/",
 		RemoteConfiguration: RemoteConfiguration{
 			Labels:    labelMap{"l1": "label1"},
 			Namespace: "test_namespace",

--- a/pkg/config/agentmanagement_test.go
+++ b/pkg/config/agentmanagement_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/prometheus/common/config"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
 )
 
 func TestValidateValidConfig(t *testing.T) {
@@ -20,7 +21,7 @@ func TestValidateValidConfig(t *testing.T) {
 		Protocol:        "https",
 		PollingInterval: "1m",
 		CacheLocation:   "/test/path/",
-		RemoteConfiguration: RemoteConfiguration{
+		RemoteConfiguration: remoteConfiguration{
 			Namespace: "test_namespace",
 		},
 	}
@@ -35,7 +36,7 @@ func TestValidateInvalidBasicAuth(t *testing.T) {
 		Protocol:        "https",
 		PollingInterval: "1m",
 		CacheLocation:   "/test/path/",
-		RemoteConfiguration: RemoteConfiguration{
+		RemoteConfiguration: remoteConfiguration{
 			Namespace: "test_namespace",
 		},
 	}
@@ -60,7 +61,7 @@ func TestValidateInvalidPollingInterval(t *testing.T) {
 		Protocol:        "https",
 		PollingInterval: "1?",
 		CacheLocation:   "/test/path/",
-		RemoteConfiguration: RemoteConfiguration{
+		RemoteConfiguration: remoteConfiguration{
 			Namespace: "test_namespace",
 		},
 	}
@@ -80,7 +81,7 @@ func TestMissingCacheLocation(t *testing.T) {
 		},
 		Protocol:        "https",
 		PollingInterval: "1?",
-		RemoteConfiguration: RemoteConfiguration{
+		RemoteConfiguration: remoteConfiguration{
 			Namespace: "test_namespace",
 		},
 	}
@@ -104,7 +105,7 @@ func TestSleepTime(t *testing.T) {
 		Protocol:        "https",
 		PollingInterval: "1m",
 		CacheLocation:   "/test/path/",
-		RemoteConfiguration: RemoteConfiguration{
+		RemoteConfiguration: remoteConfiguration{
 			Namespace: "test_namespace",
 		},
 	}
@@ -129,7 +130,7 @@ func TestFullUrl(t *testing.T) {
 		Protocol:        "https",
 		PollingInterval: "1m",
 		CacheLocation:   "/test/path/",
-		RemoteConfiguration: RemoteConfiguration{
+		RemoteConfiguration: remoteConfiguration{
 			Labels:    labelMap{"b": "B", "a": "A"},
 			Namespace: "test_namespace",
 		},
@@ -137,4 +138,11 @@ func TestFullUrl(t *testing.T) {
 	actual, err := c.fullUrl()
 	assert.NoError(t, err)
 	assert.Equal(t, "https://localhost:1234/example/api/namespace/test_namespace/remote_config?a=A&b=B", actual)
+}
+
+func TestDefaultConfig(t *testing.T) {
+	empty := `agent_management:`
+	var am AgentManagement
+	yaml.Unmarshal([]byte(empty), &am)
+	assert.Equal(t, "data-agent/", am.CacheLocation)
 }

--- a/pkg/config/agentmanagement_test.go
+++ b/pkg/config/agentmanagement_test.go
@@ -21,7 +21,7 @@ func TestValidateValidConfig(t *testing.T) {
 		Protocol:        "https",
 		PollingInterval: "1m",
 		CacheLocation:   "/test/path/",
-		RemoteConfiguration: remoteConfiguration{
+		RemoteConfiguration: RemoteConfiguration{
 			Namespace: "test_namespace",
 		},
 	}
@@ -36,7 +36,7 @@ func TestValidateInvalidBasicAuth(t *testing.T) {
 		Protocol:        "https",
 		PollingInterval: "1m",
 		CacheLocation:   "/test/path/",
-		RemoteConfiguration: remoteConfiguration{
+		RemoteConfiguration: RemoteConfiguration{
 			Namespace: "test_namespace",
 		},
 	}
@@ -61,7 +61,7 @@ func TestValidateInvalidPollingInterval(t *testing.T) {
 		Protocol:        "https",
 		PollingInterval: "1?",
 		CacheLocation:   "/test/path/",
-		RemoteConfiguration: remoteConfiguration{
+		RemoteConfiguration: RemoteConfiguration{
 			Namespace: "test_namespace",
 		},
 	}
@@ -81,7 +81,7 @@ func TestMissingCacheLocation(t *testing.T) {
 		},
 		Protocol:        "https",
 		PollingInterval: "1?",
-		RemoteConfiguration: remoteConfiguration{
+		RemoteConfiguration: RemoteConfiguration{
 			Namespace: "test_namespace",
 		},
 	}
@@ -105,7 +105,7 @@ func TestSleepTime(t *testing.T) {
 		Protocol:        "https",
 		PollingInterval: "1m",
 		CacheLocation:   "/test/path/",
-		RemoteConfiguration: remoteConfiguration{
+		RemoteConfiguration: RemoteConfiguration{
 			Namespace: "test_namespace",
 		},
 	}
@@ -130,7 +130,7 @@ func TestFullUrl(t *testing.T) {
 		Protocol:        "https",
 		PollingInterval: "1m",
 		CacheLocation:   "/test/path/",
-		RemoteConfiguration: remoteConfiguration{
+		RemoteConfiguration: RemoteConfiguration{
 			Labels:    labelMap{"b": "B", "a": "A"},
 			Namespace: "test_namespace",
 		},
@@ -175,7 +175,7 @@ remote_configuration:
 		Protocol:        "http",
 		PollingInterval: "1m",
 		CacheLocation:   defaultConfig.CacheLocation,
-		RemoteConfiguration: remoteConfiguration{
+		RemoteConfiguration: RemoteConfiguration{
 			Labels:    labelMap{"l1": "label1"},
 			Namespace: "test_namespace",
 		},


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Adds `data-agent/` as the default location for caching remote configs, along with tests.

Also removes the unnecessary export of the `RemoteConfiguration` struct.


- [ ] CHANGELOG updated
- [ ] Documentation added
- [X] Tests updated
