### PR TITLE
pkg/runner: introduce common package for goroutine scheduling

### DIFF
--- a/pkg/runner/hash_map.go
+++ b/pkg/runner/hash_map.go
@@ -1,0 +1,96 @@
+package runner
+
+import "sync"
+
+type hashMap struct {
+	mut    sync.RWMutex
+	lookup map[uint64][]Task
+}
+
+// newHashMap creates a new hashMap allocated to handle at least size unique
+// hashes.
+func newHashMap(size int) *hashMap {
+	return &hashMap{
+		lookup: make(map[uint64][]Task, size),
+	}
+}
+
+// Add adds the provided Task into the hashMap. It returns false if t
+// already exists in the hashMap.
+func (hm *hashMap) Add(t Task) bool {
+	hm.mut.Lock()
+	defer hm.mut.Unlock()
+
+	hash := t.Hash()
+	for _, compare := range hm.lookup[hash] {
+		if compare.Equals(t) {
+			return false
+		}
+	}
+
+	hm.lookup[hash] = append(hm.lookup[hash], t)
+	return true
+}
+
+// Has returns true if t exists in the hashMap.
+func (hm *hashMap) Has(t Task) bool {
+	hm.mut.RLock()
+	defer hm.mut.RUnlock()
+
+	for _, compare := range hm.lookup[t.Hash()] {
+		if compare.Equals(t) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Delete removes the provided Task from the hashMap. It returns true if the
+// Task was found and deleted.
+func (hm *hashMap) Delete(t Task) (deleted bool) {
+	hm.mut.Lock()
+	defer hm.mut.Unlock()
+
+	hash := t.Hash()
+
+	var rem []Task
+	for _, s := range hm.lookup[hash] {
+		if s.Equals(t) {
+			deleted = true
+			continue
+		}
+		rem = append(rem, s)
+	}
+	if len(rem) == 0 {
+		delete(hm.lookup, hash)
+	} else {
+		hm.lookup[hash] = rem
+	}
+
+	return deleted
+}
+
+// Iterate returns a channel which iterates through all elements in the
+// hashMap. The channel *must* be fully consumed, otherwise the hashMap will
+// deadlock.
+//
+// The iteration order is not guaranteed.
+func (hm *hashMap) Iterate() <-chan Task {
+	taskCh := make(chan Task)
+
+	go func() {
+		hm.mut.Lock()
+		defer hm.mut.Unlock()
+
+		for _, set := range hm.lookup {
+			for _, task := range set {
+				taskCh <- task
+			}
+		}
+
+		close(taskCh)
+	}()
+
+	return taskCh
+}

--- a/pkg/runner/hash_map.go
+++ b/pkg/runner/hash_map.go
@@ -54,18 +54,18 @@ func (hm *hashMap) Delete(t Task) (deleted bool) {
 
 	hash := t.Hash()
 
-	var rem []Task
+	var remaining []Task
 	for _, s := range hm.lookup[hash] {
 		if s.Equals(t) {
 			deleted = true
 			continue
 		}
-		rem = append(rem, s)
+		remaining = append(remaining, s)
 	}
-	if len(rem) == 0 {
+	if len(remaining) == 0 {
 		delete(hm.lookup, hash)
 	} else {
-		hm.lookup[hash] = rem
+		hm.lookup[hash] = remaining
 	}
 
 	return deleted

--- a/pkg/runner/hash_map_test.go
+++ b/pkg/runner/hash_map_test.go
@@ -1,0 +1,277 @@
+package runner
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_hashMap(t *testing.T) {
+	t.Run("tasks can be added", func(t *testing.T) {
+		hm := newHashMap(0)
+
+		// Try adding the task twice. The first time we add it, Add should return
+		// true, since it's brand new to the hash map. The second time we add it,
+		// Add should return false, since the task was previously added.
+		task := newBasicMockTask(1)
+		require.True(t, hm.Add(task), "Add should have returned true on the first call")
+		require.False(t, hm.Add(task), "Add should have returned false on the second call of the same task")
+
+		// Try adding a new task twice.
+		otherTask := newBasicMockTask(2)
+		require.True(t, hm.Add(otherTask), "Add should have returned true on the first call")
+		require.False(t, hm.Add(otherTask), "Add should have returned false on the second call of the same task")
+
+		// Make sure that both of our added tasks can be returned.
+		tasks := collectMockTasks(hm)
+		require.ElementsMatch(t, tasks, []*mockTask{task, otherTask})
+	})
+
+	t.Run("tasks can be searched", func(t *testing.T) {
+		hm := newHashMap(0)
+
+		var (
+			task1 = newBasicMockTask(1)
+			task2 = newBasicMockTask(2)
+		)
+
+		// Add task1 into the hashMap, but not task2.
+		require.True(t, hm.Add(task1))
+
+		require.True(t, hm.Has(task1), "task1 should be in the hashMap")
+		require.False(t, hm.Has(task2), "task2 should not be in the hashMap")
+	})
+
+	t.Run("tasks can be deleted", func(t *testing.T) {
+		hm := newHashMap(0)
+
+		// Create two sets of tasks, where each set has exactly one hash collision
+		// with the other set. This helps us test that deletes work when there's
+		// collisions too.
+		var tasks []*mockTask
+		for i := 0; i < 10; i++ {
+			tasks = append(tasks, newBasicMockTask(uint64(i)))
+		}
+		for i := 0; i < 10; i++ {
+			tasks = append(tasks, newBasicMockTask(uint64(i)))
+		}
+
+		// Add tasks all at once.
+		for _, task := range tasks {
+			require.True(t, hm.Add(task))
+		}
+
+		// Start removing every task until there's none left.
+		expectCount := 20
+		for _, task := range tasks {
+			require.Len(t, collectMockTasks(hm), expectCount)
+			expectCount--
+
+			require.True(t, hm.Delete(task))
+		}
+
+		require.Len(t, collectMockTasks(hm), 0)
+	})
+
+	t.Run("tasks are deduplicated", func(t *testing.T) {
+		hm := newHashMap(0)
+
+		// Create two tasks with the same hash and that report they're equal to
+		// each other, even though they're separate pointers.
+		//
+		// The hashMap should deduplicate these tasks and only store one.
+		var (
+			task1 = &mockTask{
+				HashFunc:   func() uint64 { return 1 },
+				EqualsFunc: func(t Task) bool { return true },
+			}
+			task2 = &mockTask{
+				HashFunc:   func() uint64 { return 1 },
+				EqualsFunc: func(t Task) bool { return true },
+			}
+		)
+
+		require.True(t, hm.Add(task1))
+		require.False(t, hm.Add(task2))
+
+		// The hashMap should say that both task1 and task2 exist because they are
+		// considered duplicates.
+		require.True(t, hm.Has(task1))
+		require.True(t, hm.Has(task2))
+
+		// Make sure that both of our added tasks can be returned.
+		tasks := collectMockTasks(hm)
+		require.ElementsMatch(t, tasks, []*mockTask{task1})
+	})
+
+	t.Run("hash collisions are handled", func(t *testing.T) {
+		hm := newHashMap(0)
+
+		// Create two tasks with the same hash but that aren't equal to each other
+		// (because mockTask.Equals will check for pointer equality).
+		//
+		// It should be possible to store both tasks in the hashMap, despite having
+		// the same hash.
+		var (
+			task1 = newBasicMockTask(1)
+			task2 = newBasicMockTask(1)
+		)
+
+		require.True(t, hm.Add(task1))
+		require.True(t, hm.Add(task2))
+
+		require.True(t, hm.Has(task1))
+		require.True(t, hm.Has(task2))
+
+		// Make sure that both of our added tasks can be returned.
+		tasks := collectMockTasks(hm)
+		require.ElementsMatch(t, tasks, []*mockTask{task1, task2})
+	})
+}
+
+func Benchmark_hashMap(b *testing.B) {
+	b.Run("Add element", func(b *testing.B) {
+		task := newBasicMockTask(0)
+
+		for i := 0; i < b.N; i++ {
+			hm := newHashMap(1)
+			hm.Add(task)
+		}
+	})
+
+	b.Run("Remove element", func(b *testing.B) {
+		task := newBasicMockTask(0)
+
+		// Precreate the hash maps to only measure deletes.
+		var hashMaps []*hashMap
+		for i := 0; i < b.N; i++ {
+			hm := newHashMap(1)
+			hm.Add(task)
+			hashMaps = append(hashMaps, hm)
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			hashMaps[i].Delete(task)
+		}
+	})
+
+	b.Run("Lookup element", func(b *testing.B) {
+		task := newBasicMockTask(0)
+
+		// Pre-add the task into the hash map so it's not counted as part of the
+		// performance benchmark.
+		hm := newHashMap(0)
+		hm.Add(task)
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			hm.Has(task)
+		}
+	})
+
+	b.Run("Add existing element", func(b *testing.B) {
+		task := newBasicMockTask(0)
+
+		// Pre-add the task into the hash map so it's not counted as part of the
+		// performance benchmark.
+		hm := newHashMap(0)
+		hm.Add(task)
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			hm.Add(task)
+		}
+	})
+}
+
+func Benchmark_hashMap_collisions(b *testing.B) {
+	collisionChecks := []int{1, 2, 5, 10, 100}
+	for _, collisions := range collisionChecks {
+		b.Run(fmt.Sprintf("%d collisions", collisions), func(b *testing.B) {
+			// Precreate the set of tasks. Each task should have the hash 0 to check
+			// for the hash collision handling performance.
+			var tasks []*mockTask
+			for i := 0; i < collisions+1; i++ {
+				tasks = append(tasks, newBasicMockTask(0))
+			}
+
+			b.Run("Add", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					hm := newHashMap(0)
+					for _, task := range tasks {
+						hm.Add(task)
+					}
+				}
+			})
+
+			b.Run("Remove", func(b *testing.B) {
+				hm := newHashMap(0)
+				for _, task := range tasks {
+					hm.Add(task)
+				}
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+					// Iterate in reverse to get worse-case performance.
+					for i := len(tasks) - 1; i >= 0; i-- {
+						hm.Delete(tasks[i])
+					}
+				}
+			})
+
+			b.Run("Lookup", func(b *testing.B) {
+				hm := newHashMap(0)
+				for _, task := range tasks {
+					hm.Add(task)
+				}
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+					for _, task := range tasks {
+						hm.Has(task)
+					}
+				}
+			})
+		})
+	}
+}
+
+func collectMockTasks(hm *hashMap) []*mockTask {
+	var res []*mockTask
+	for t := range hm.Iterate() {
+		res = append(res, t.(*mockTask))
+	}
+	return res
+}
+
+type mockTask struct {
+	HashFunc   func() uint64
+	EqualsFunc func(t Task) bool
+}
+
+func newBasicMockTask(hash uint64) *mockTask {
+	return &mockTask{
+		HashFunc: func() uint64 { return hash },
+	}
+}
+
+var _ Task = (*mockTask)(nil)
+
+func (mt *mockTask) Hash() uint64 {
+	if mt.HashFunc == nil {
+		return 0
+	}
+	return mt.HashFunc()
+}
+
+func (mt *mockTask) Equals(t Task) bool {
+	if mt.EqualsFunc == nil {
+		// Default to pointer comparison.
+		return mt == t.(*mockTask)
+	}
+	return mt.EqualsFunc(t)
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -32,7 +32,7 @@ type Worker interface {
 	// Run starts a Worker, blocking until the provided ctx is canceled or a
 	// fatal error occurs. Run is guaranteed to be called exactly once for any
 	// given Worker.
-	Run(ctx context.Context) error
+	Run(ctx context.Context)
 }
 
 // The Runner manages a set of running Workers based on an active set of tasks.
@@ -160,7 +160,7 @@ func (s *Runner[TaskType]) ApplyTasks(ctx context.Context, tt []TaskType) error 
 		go func() {
 			defer s.running.Done()
 			defer close(newWorker.Exited)
-			_ = newWorker.Worker.Run(workerCtx)
+			newWorker.Worker.Run(workerCtx)
 			s.workers.Delete(newTask)
 		}()
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1,0 +1,181 @@
+// Package runner provides an API for generic goroutine scheduling. It is
+// broken up into three concepts:
+//
+//  1. Task: a unit of work to perform
+//  2. Worker: a goroutine dedicated to doing a specific Task
+//  3. Runner: manages the set of Workers, one per unique Task
+//
+// An example of a Task and Worker pair would be a Task which describes an
+// endpoint to poll for health. The Task would then be assigned to a Worker to
+// perform the polling.
+package runner
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// A Task is a payload that determines what a Worker should do. For example,
+// a Task may be a struct including an address for a Worker to poll.
+type Task interface {
+	// Hash should return a hash which represents this Task.
+	Hash() uint64
+	// Equals should determine if two Tasks are equal. It is only called when two
+	// Tasks have the same Hash.
+	Equals(other Task) bool
+}
+
+// A Worker is a goroutine which performs business logic for a Task which is
+// assigned to it. Each Worker is responsible for a single Task.
+type Worker interface {
+	// Run starts a Worker, blocking until the provided ctx is canceled or a
+	// fatal error occurs. Run is guaranteed to be called exactly once for any
+	// given Worker.
+	Run(ctx context.Context) error
+}
+
+// The Runner manages a set of running Workers based on an active set of tasks.
+type Runner[TaskType Task] struct {
+	newWorker func(t TaskType) Worker
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	running sync.WaitGroup
+	workers *hashMap
+}
+
+// Internal types used to implement the Runner.
+type (
+	// scheduledWorker is a representation of a running worker.
+	scheduledWorker struct {
+		Worker Worker // The underlying Worker instance.
+
+		// Function to call to request the worker to stop.
+		Cancel context.CancelFunc
+
+		// Exited will close once the worker has exited.
+		Exited chan struct{}
+	}
+
+	// workerTask represents a tuple of a scheduledWorker with its assigned Task.
+	// workerTask implements Task for it to be used in a hashMap; two workerTasks
+	// are equal if their underlying Tasks are equal.
+	workerTask struct {
+		Worker *scheduledWorker
+		Task   Task
+	}
+)
+
+// Hash returns the hash of the Task the scheduledWorker owns.
+func (sw *workerTask) Hash() uint64 {
+	return sw.Task.Hash()
+}
+
+// Equals returns true if the Task owned by this workerTask equals the Task
+// owned by another workerTask.
+func (sw *workerTask) Equals(other Task) bool {
+	return sw.Task.Equals(other.(*workerTask).Task)
+}
+
+// New creates a new Runner which manages workers for a given Task type. The
+// newWorker function is called whenever a new Task is received that is not
+// managed by any existing Worker.
+func New[TaskType Task](newWorker func(t TaskType) Worker) *Runner[TaskType] {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &Runner[TaskType]{
+		newWorker: newWorker,
+
+		ctx:    ctx,
+		cancel: cancel,
+
+		workers: newHashMap(10),
+	}
+}
+
+// ApplyTasks updates the Tasks tracked by the Runner to the slice specified
+// by t. t should be the entire set of tasks that workers should be operating
+// against. ApplyTasks will launch new Workers for new tasks and terminate
+// previous Workers for tasks which are no longer found in tt.
+//
+// ApplyTasks will block until Workers for stale Tasks have terminated. If the
+// provided context is canceled, ApplyTasks will still finish synchronizing the
+// set of Workers but will not wait for stale Workers to exit.
+func (s *Runner[TaskType]) ApplyTasks(ctx context.Context, tt []TaskType) error {
+	if s.ctx.Err() != nil {
+		return fmt.Errorf("Runner is closed")
+	}
+
+	// Create a new hashMap of tasks we intend to run.
+	newTasks := newHashMap(len(tt))
+	for _, t := range tt {
+		newTasks.Add(t)
+	}
+
+	// Stop stale workers (i.e., Workers whose tasks are not in newTasks).
+	var stopping sync.WaitGroup
+	for w := range s.workers.Iterate() {
+		if newTasks.Has(w.(*workerTask).Task) {
+			continue
+		}
+
+		stopping.Add(1)
+		go func(w *scheduledWorker) {
+			defer stopping.Done()
+			w.Cancel()
+
+			select {
+			case <-ctx.Done():
+			case <-w.Exited:
+			}
+		}(w.(*workerTask).Worker)
+	}
+
+	// Ensure that every defined task in newTasks has a worker associated with
+	// it.
+	for definedTask := range newTasks.Iterate() {
+		// Ignore tasks for workers that are already running.
+		//
+		// We use a temporary workerTask here where only the task field is used
+		// for comparison. This prevent unnecessarily creating a new worker when
+		// one isn't needed.
+		if s.workers.Has(&workerTask{Task: definedTask}) {
+			continue
+		}
+
+		workerCtx, workerCancel := context.WithCancel(s.ctx)
+		newWorker := &scheduledWorker{
+			Worker: s.newWorker(definedTask.(TaskType)),
+			Cancel: workerCancel,
+			Exited: make(chan struct{}),
+		}
+		newTask := &workerTask{
+			Worker: newWorker,
+			Task:   definedTask,
+		}
+
+		s.running.Add(1)
+		go func() {
+			defer s.running.Done()
+			defer close(newWorker.Exited)
+			_ = newWorker.Worker.Run(workerCtx)
+			s.workers.Delete(newTask)
+		}()
+
+		_ = s.workers.Add(newTask)
+	}
+
+	// Wait for all stopping workers to stop (or until the context to cancel,
+	// which will stop the WaitGroup early).
+	stopping.Wait()
+	return ctx.Err()
+}
+
+// Stop the Schduler and all running Workers. Close blocks until all running
+// Workers exit.
+func (s *Runner[TaskType]) Stop() {
+	s.cancel()
+	s.running.Wait()
+}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -1,0 +1,117 @@
+package runner_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/grafana/agent/pkg/runner"
+	"github.com/grafana/agent/pkg/util"
+	"github.com/grafana/dskit/backoff"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+var backoffRetry = backoff.Config{
+	MinBackoff: 10 * time.Millisecond,
+	MaxBackoff: 1 * time.Second,
+	MaxRetries: 5,
+}
+
+func TestRunner_ApplyPayloads(t *testing.T) {
+	t.Run("new Workers get scheduled for new tasks", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+
+		workerCount := atomic.NewUint64(0)
+
+		r := runner.New(func(t stringTask) runner.Worker {
+			return &genericWorker{workerCount: workerCount}
+		})
+		defer r.Stop()
+
+		var tasks []stringTask
+
+		// Apply the first task and wait for it to run.
+		tasks = append(tasks, stringTask("task_a"))
+		require.NoError(t, r.ApplyTasks(ctx, tasks))
+		requireRunners(t, 1, workerCount)
+
+		// Append a more tasks and wait for it to run.
+		tasks = append(tasks, stringTask("task_b"), stringTask("task_c"))
+		require.NoError(t, r.ApplyTasks(ctx, tasks))
+		requireRunners(t, 3, workerCount)
+	})
+
+	t.Run("old Workers get terminated for removed tasks", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+
+		workerCount := atomic.NewUint64(0)
+
+		r := runner.New(func(t stringTask) runner.Worker {
+			return &genericWorker{workerCount: workerCount}
+		})
+		defer r.Stop()
+
+		// Apply a set of initial tasks.
+		require.NoError(t, r.ApplyTasks(ctx, []stringTask{"task_a", "task_b", "task_c"}))
+		requireRunners(t, 3, workerCount)
+
+		// Apply a new set of tasks, removing tasks that were previously defined.
+		require.NoError(t, r.ApplyTasks(ctx, []stringTask{"task_b"}))
+		requireRunners(t, 1, workerCount)
+	})
+}
+
+func TestRunner_Stop(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	workerCount := atomic.NewUint64(0)
+
+	r := runner.New(func(t stringTask) runner.Worker {
+		return &genericWorker{workerCount: workerCount}
+	})
+
+	// Apply a set of initial tasks.
+	require.NoError(t, r.ApplyTasks(ctx, []stringTask{"task_a", "task_b", "task_c"}))
+	requireRunners(t, 3, workerCount)
+
+	// Stop the runner. No tasks should be running afterwards.
+	r.Stop()
+	requireRunners(t, 0, workerCount)
+}
+
+func requireRunners(t *testing.T, expect uint64, actual *atomic.Uint64) {
+	util.Eventually(t, func(t require.TestingT) {
+		require.Equal(t, expect, actual.Load())
+	}, backoffRetry)
+}
+
+type stringTask string
+
+var _ runner.Task = stringTask("")
+
+func (st stringTask) Hash() uint64 {
+	return xxhash.Sum64String(string(st))
+}
+
+func (st stringTask) Equals(other runner.Task) bool {
+	return st == other.(stringTask)
+}
+
+type genericWorker struct {
+	workerCount *atomic.Uint64
+}
+
+var _ runner.Worker = (*genericWorker)(nil)
+
+func (w *genericWorker) Run(ctx context.Context) error {
+	w.workerCount.Inc()
+	defer w.workerCount.Dec()
+
+	<-ctx.Done()
+	return nil
+}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -108,10 +108,9 @@ type genericWorker struct {
 
 var _ runner.Worker = (*genericWorker)(nil)
 
-func (w *genericWorker) Run(ctx context.Context) error {
+func (w *genericWorker) Run(ctx context.Context) {
 	w.workerCount.Inc()
 	defer w.workerCount.Dec()
 
 	<-ctx.Done()
-	return nil
 }


### PR DESCRIPTION
Many of our Flow components share a behavior of managing goroutines, where they must synchronize the set of running goroutines with a set of tasks to perform:

* `loki.source.file` must manage tailer goroutines for each logs target.
* `phalre.scrape` must manager scraper goroutines for each profiling target.
* `prometheus.scrape` must manage scraper goroutines for each metrics target.

More components with this type of goroutine management will be added in the future (#2504, #2763). Even the Flow controller implements exactly the same goroutine management to manage the set of running components.

Throughout all of these uses, the goroutine management works the same way:

* Start new goroutines for tasks (e.g., targets) that have appeared.
* Shut down old goroutines for tasks that have gone away.
* Maintain existing goroutines as long as the task continues to exist.

This commit introduces a new utility package, `pkg/runner`, which creates an abstraction for this behavior. `pkg/runner` defines three concepts:

* Task: a unit of work that a goroutine should be performing, such as a metrics target.
* Worker: a goroutine which will act against a Task, such as scraping a metrics target on an interval.
* Runner: a mechanism that controls the set of running Workers based on Tasks given to it.

The Runner is a declarative interface; you call `ApplyTasks` with the entire set of Tasks to run, and it will synchronize the set of Workers with the given Tasks, shutting down Workers for Tasks that have gone away, creating new Workers for new Tasks, and maintaining existing Workers for Tasks which still exist.

The Task interface is defined as:

```go
type Task interface {
  Hash() uint64
  Equals(other Task) bool
}
```

Tasks are tracked internally in a hash map. The `Hash` method is invoked to figure out what bucket to put a Task in. If two Tasks happen to have the same hash, the `Equals` method is called to check if they are equal. Completely identical tasks (with the same hash and where `Equals` returns true) will be deduplicated so only one task exists.

Meanwhile, the Worker interface is defined as:

```go
type Worker interface {
  Run(ctx context.Context) error
}
```

The `Run` method is invoked when a Worker should start running. Workers should continue running until there is an error or the provided context is canceled, which is done by the Runner when a Task assigned to a Worker is removed.

There is exactly one Worker for each unique Task. Each Worker is responsible for exactly one task for its entire lifetime. A Runner is constructed with a function to map Tasks to Workers:

```go
func New[TaskType Task](newWorker func(t TaskType) Worker) *Runner[TaskType]
```

`newWorker` is only invoked when the Runner is given a Task for which no Runner is assigned to. To provide Tasks to a runner, call `ApplyTasks`.

See included test code for example of how to use the `runner` package.

Benchmarks are included to test the hashMap, where the bulk of the performance will be seen. Benchmark results show modest performance for the initial commit:

    Benchmark_hashMap/Add_element-10                                 7875709           133.3  ns/op
    Benchmark_hashMap/Remove_element-10                             30147565            48.13 ns/op
    Benchmark_hashMap/Lookup_element-10                             85129270            14.20 ns/op
    Benchmark_hashMap/Add_existing_element-10                       61546616            18.85 ns/op
    Benchmark_hashMap_collisions/1_collisions/Add-10                 5402604           215.6  ns/op
    Benchmark_hashMap_collisions/1_collisions/Remove-10             32215772            37.19 ns/op
    Benchmark_hashMap_collisions/1_collisions/Lookup-10             40548360            29.54 ns/op
    Benchmark_hashMap_collisions/2_collisions/Add-10                 4416198           270.9  ns/op
    Benchmark_hashMap_collisions/2_collisions/Remove-10             21474396            55.78 ns/op
    Benchmark_hashMap_collisions/2_collisions/Lookup-10             26042961            45.52 ns/op
    Benchmark_hashMap_collisions/5_collisions/Add-10                 3013473           396.2  ns/op
    Benchmark_hashMap_collisions/5_collisions/Remove-10             10754502           111.6  ns/op
    Benchmark_hashMap_collisions/5_collisions/Lookup-10             11606706           102.8  ns/op
    Benchmark_hashMap_collisions/10_collisions/Add-10                1863262           644.7  ns/op
    Benchmark_hashMap_collisions/10_collisions/Remove-10             5846124           204.8  ns/op
    Benchmark_hashMap_collisions/10_collisions/Lookup-10             5014551           241.2  ns/op
    Benchmark_hashMap_collisions/100_collisions/Add-10                 81848         14595    ns/op
    Benchmark_hashMap_collisions/100_collisions/Remove-10             635085          1877    ns/op
    Benchmark_hashMap_collisions/100_collisions/Lookup-10              90588         13244    ns/op

As expected, the performance steadily decreases when more hash collisions are introduced. Proper usage of pkg/runner will be to make sure that there is good hash coverage through different tasks.