### PR TITLE
Add extra metrics for prometheus.scrape and prometheus.relabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Main (unreleased)
 
 - New metric for prometheus.scrape - `agent_prometheus_scrape_targets_gauge`. (@ptodev)
 
-- New metric for prometheus.scrape and prometheus.relabel - `agent_prometheus_fanout_samples_count`. (@ptodev)
+- New metric for prometheus.scrape and prometheus.relabel - `agent_prometheus_forwarded_samples_total`. (@ptodev)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ Main (unreleased)
 
 - Introduce global configuration for logs. (@jcreixell)
 
+- New metric for prometheus.scrape - `agent_prometheus_scrape_targets_gauge`. (@ptodev)
+
+- New metric for prometheus.scrape and prometheus.relabel - `agent_prometheus_fanout_samples_count`. (@ptodev)
+
 ### Enhancements
 
 - Handle faro-web-sdk `View` meta in app_agent_receiver. (@rlankfo)

--- a/component/prometheus/scrape/scrape.go
+++ b/component/prometheus/scrape/scrape.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/agent/component/discovery"
 	"github.com/grafana/agent/component/prometheus"
 	"github.com/grafana/agent/pkg/build"
+	client_prometheus "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -107,10 +108,11 @@ type Component struct {
 
 	reloadTargets chan struct{}
 
-	mut        sync.RWMutex
-	args       Arguments
-	scraper    *scrape.Manager
-	appendable *prometheus.Fanout
+	mut          sync.RWMutex
+	args         Arguments
+	scraper      *scrape.Manager
+	appendable   *prometheus.Fanout
+	targetsGauge *client_prometheus.GaugeVec
 }
 
 var (
@@ -127,6 +129,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		reloadTargets: make(chan struct{}, 1),
 		scraper:       scraper,
 		appendable:    flowAppendable,
+		targetsGauge:  getTargetsGaugeMetric(o.Registerer),
 	}
 
 	// Call to Update() to set the receivers and targets once at the start.
@@ -200,6 +203,7 @@ func (c *Component) Update(args component.Arguments) error {
 	default:
 	}
 
+	c.targetsGauge.WithLabelValues().Set(float64(len(c.args.Targets)))
 	return nil
 }
 
@@ -294,4 +298,21 @@ func convertLabelSet(tg discovery.Target) model.LabelSet {
 		lset[model.LabelName(k)] = model.LabelValue(v)
 	}
 	return lset
+}
+
+func getTargetsGaugeMetric(registerer client_prometheus.Registerer) *client_prometheus.GaugeVec {
+	targetsGauge := client_prometheus.NewGaugeVec(client_prometheus.GaugeOpts{
+		Name: "agent_prometheus_scrape_targets_gauge",
+		Help: "A gauge of all scrape targets this component is configured to scrape",
+	}, []string{})
+	err := registerer.Register(targetsGauge)
+	if err != nil {
+		if existing, ok := err.(client_prometheus.AlreadyRegisteredError); ok {
+			targetsGauge = existing.ExistingCollector.(*client_prometheus.GaugeVec)
+		} else {
+			// Same behavior as MustRegister if the error is not for AlreadyRegistered
+			panic(err)
+		}
+	}
+	return targetsGauge
 }

--- a/docs/sources/flow/reference/components/prometheus.relabel.md
+++ b/docs/sources/flow/reference/components/prometheus.relabel.md
@@ -94,6 +94,7 @@ values.
 * `agent_prometheus_relabel_cache_hits` (counter): Total number of cache hits.
 * `agent_prometheus_relabel_cache_size` (gauge): Total size of relabel cache.
 * `agent_prometheus_fanout_latency` (histogram): Write latency for sending to direct and indirect components.
+* `agent_prometheus_forwarded_samples_total` (counter): Total number of samples sent to downstream components.
 
 ## Example
 

--- a/docs/sources/flow/reference/components/prometheus.scrape.md
+++ b/docs/sources/flow/reference/components/prometheus.scrape.md
@@ -122,6 +122,8 @@ scrape job on the component's debug endpoint.
 ## Debug metrics
 
 * `agent_prometheus_fanout_latency` (histogram): Write latency for sending to direct and indirect components.
+* `agent_prometheus_scrape_targets_gauge` (gauge): Number of targets this component is configured to scrape.
+* `agent_prometheus_forwarded_samples_total` (counter): Total number of samples sent to downstream components.
 
 ## Scraping behavior
 


### PR DESCRIPTION
#### PR Description
Adding new metrics for prometheus components:
* `agent_prometheus_scrape_targets_gauge`
* `agent_prometheus_forwarded_samples_total`

I tested this locally by using a config file with a scrape -> relabel -> remote_write. The `/metrics` endpoint reported these new metrics:
```
# HELP agent_prometheus_scrape_targets_gauge Number of targets this component is configured to scrape
# TYPE agent_prometheus_scrape_targets_gauge gauge
agent_prometheus_scrape_targets_gauge{component_id="prometheus.scrape.default"} 1
# HELP agent_prometheus_forwarded_samples_total Total number of samples sent to downstream components.
# TYPE agent_prometheus_forwarded_samples_total counter
agent_prometheus_forwarded_samples_total{component_id="prometheus.relabel.default"} 5368
agent_prometheus_forwarded_samples_total{component_id="prometheus.scrape.default"} 5368
```

#### Which issue(s) this PR fixes
Fixes #2407

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [ ] Tests updated
