### PR TITLE
[Agent Management] Add Test for Effective Config Merging

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -268,9 +268,7 @@ func mergeEffectiveConfig(initialConfig *Config, remoteConfig *Config) {
 	initialConfig.Metrics = remoteConfig.Metrics
 	initialConfig.Integrations = remoteConfig.Integrations
 	initialConfig.Traces = remoteConfig.Traces
-	if remoteConfig.Logs != nil {
-		initialConfig.Logs = remoteConfig.Logs
-	}
+	initialConfig.Logs = remoteConfig.Logs
 }
 
 // LoadRemote reads a config from url

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -471,6 +471,7 @@ agent_management:
   remote_config_cache_location: "/etc"
   remote_configuration:
     namespace: "new_namespace"`
+
 	remoteCfg := `
 server:
   log_level: debug
@@ -496,9 +497,19 @@ agent_management:
 	assert.NoError(t, err)
 	err = LoadBytes([]byte(remoteCfg), false, &rc)
 	assert.NoError(t, err)
+
+	// keep a copy of the initial config's agent management block to ensure it isn't
+	// overwritten by the remote config's
 	initialAgentManagement := ic.AgentManagement
 	mergeEffectiveConfig(&ic, &rc)
+
 	// agent_management configuration should not be overwritten by the remote config
 	assert.Equal(t, initialAgentManagement, ic.AgentManagement)
-	// TODO: everything else should be what is in the remote config
+
+	// since these elements are purposefully different for the previous portion of the test,
+	// unset them before comparing the rest of the config
+	ic.AgentManagement = AgentManagement{}
+	rc.AgentManagement = AgentManagement{}
+
+	assert.True(t, util.CompareYAML(ic, rc))
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -462,6 +462,10 @@ func TestAgent_OmmitEmptyFields(t *testing.T) {
 
 func TestAgentManagement_MergeEffectiveConfig(t *testing.T) {
 	initialCfg := `
+server:
+  log_level: info
+logs:
+  positions_directory: /tmp
 agent_management:
   api_url: "http://localhost"
   basic_auth:


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Removes an inconsistency where if the remote config did not have a `logs` config element, but the initial config _did_, the logs config would remain.

Adds a test that checks two things for merging the initial and remote configs for agent management:

1. That the `agent_management` block of the initial config is _not_ overwritten by anything in the remote config.
2. That all other values of the initial config are overwritten by what is in the remote config.

- [ ] CHANGELOG updated
- [ ] Documentation added
- [x] Tests updated
