### PR TITLE
Add agent_ prefix to remote config metrics

### DIFF
--- a/pkg/config/instrumentation/remote_config_metrics.go
+++ b/pkg/config/instrumentation/remote_config_metrics.go
@@ -25,14 +25,14 @@ func newRemoteConfigMetrics() *remoteConfigMetrics {
 
 	remoteConfigMetrics.fetchStatusCodes = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "remote_config_fetches_total",
+			Name: "agent_remote_config_fetches_total",
 			Help: "Number of fetch requests for the remote config by HTTP status code",
 		},
 		[]string{"status_code"},
 	)
 	remoteConfigMetrics.fetchErrors = promauto.NewCounter(
 		prometheus.CounterOpts{
-			Name: "remote_config_fetch_errors_total",
+			Name: "agent_remote_config_fetch_errors_total",
 			Help: "Number of errors attempting to fetch remote config",
 		},
 	)


### PR DESCRIPTION
#### PR Description

Add missing `agent_` as prefix for remote config metrics.

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
