### PR TITLE
drone: only rebuild containers when Dockerfiles change

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -189,6 +189,8 @@ steps:
 trigger:
   event:
   - pull_request
+  paths:
+  - cmd/grafana-agent/Dockerfile
 type: docker
 volumes:
 - host:
@@ -211,6 +213,8 @@ steps:
 trigger:
   event:
   - pull_request
+  paths:
+  - cmd/grafana-agentctl/Dockerfile
 type: docker
 volumes:
 - host:
@@ -233,6 +237,8 @@ steps:
 trigger:
   event:
   - pull_request
+  paths:
+  - cmd/grafana-agent-operator/Dockerfile
 type: docker
 volumes:
 - host:
@@ -257,6 +263,8 @@ steps:
 trigger:
   event:
   - pull_request
+  paths:
+  - '**/Dockerfile.windows'
 type: docker
 volumes:
 - host:
@@ -457,6 +465,6 @@ kind: secret
 name: gpg_passphrase
 ---
 kind: signature
-hmac: 9012ab3c553d2488901d9266471a6e04dcded1a9b36b9c822efed1e654c66151
+hmac: c9d0152efc10b7ac63abd427c798edeaf72e8f013dd28e968977c9bb89e9c80d
 
 ...

--- a/.drone/pipelines/check_containers.jsonnet
+++ b/.drone/pipelines/check_containers.jsonnet
@@ -2,15 +2,16 @@ local build_image = import '../util/build_image.jsonnet';
 local pipelines = import '../util/pipelines.jsonnet';
 
 local linux_containers = [
-  { name: 'grafana/agent', make: 'make agent-image' },
-  { name: 'grafana/agentctl', make: 'make agentctl-image' },
-  { name: 'grafana/agent-operator', make: 'make operator-image' },
+  { name: 'grafana/agent', make: 'make agent-image', path: 'cmd/grafana-agent/Dockerfile' },
+  { name: 'grafana/agentctl', make: 'make agentctl-image', path: 'cmd/grafana-agentctl/Dockerfile' },
+  { name: 'grafana/agent-operator', make: 'make operator-image', path: 'cmd/grafana-agent-operator/Dockerfile' },
 ];
 
 (
   std.map(function(container) pipelines.linux('Check Linux container (%s)' % container.name) {
     trigger: {
       event: ['pull_request'],
+      paths: [container.path],
     },
     steps: [{
       name: 'Build container',
@@ -32,6 +33,7 @@ local linux_containers = [
   pipelines.windows('Check Windows containers') {
     trigger: {
       event: ['pull_request'],
+      paths: ['**/Dockerfile.windows'],
     },
     steps: [{
       name: 'Build container',


### PR DESCRIPTION
Currently, it takes upwards of 40 minutes to run the "Check Windows containers" drone job for every push to a PR.

This change only runs jobs to check containers if the Dockerfile itself has changed, which should reduce the turnaround time on PRs.

Note that these rules come from a [Drone plugin which is being used on our runners](https://github.com/meltwater/drone-convert-pathschanged), so the specific syntax can't be seen in Drone's docs.