### PR TITLE
Flow API: Display the values of all River attributes unless they are nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ Main (unreleased)
 
 - Flow UI: Fix the issue with long string going out of bound in the component detail page. (@xiyu95)
 
+- Flow UI: Display the values of all attributes unless they are nil. (@ptodev)
+
 - Flow: `prometheus.relabel` and `prometheus.remote_write` will now error if they have exited. (@ptodev)
 
 - Flow: Fix issue where negative numbers would convert to floating-point values

--- a/pkg/river/encoding/attribute.go
+++ b/pkg/river/encoding/attribute.go
@@ -29,6 +29,10 @@ func (af *attributeField) hasValue() bool {
 
 // MarshalJSON implements json marshaller.
 func (af *attributeField) MarshalJSON() ([]byte, error) {
+	if af.valField == nil {
+		return nil, fmt.Errorf("the value of the attribute field is nil")
+	}
+
 	if af.valField.hasValue() {
 		af.field.Value = af.valField
 	} else {
@@ -43,7 +47,7 @@ func (af *attributeField) convertAttribute(val value.Value, f rivertags.Field) e
 	if !f.IsAttr() {
 		return fmt.Errorf("convertAttribute requires a field that is an attribute got %T", val.Interface())
 	}
-	if !val.Reflect().IsValid() || val.Reflect().IsZero() {
+	if !val.Reflect().IsValid() {
 		return nil
 	}
 	af.Type = attrType

--- a/pkg/river/encoding/attribute_test.go
+++ b/pkg/river/encoding/attribute_test.go
@@ -29,6 +29,25 @@ func TestSimple(t *testing.T) {
 	require.JSONEq(t, reqString, string(bb))
 }
 
+func TestSimpleZeroVal(t *testing.T) {
+	type t1 struct {
+		Age int `river:"age,attr"`
+	}
+	obj := &t1{
+		Age: 0,
+	}
+	reqString := `{"name":"age","type":"attr","value":{"type":"number","value":0}}`
+	val := value.Encode(obj)
+	tags := rivertags.Get(val.Reflect().Type())
+	require.Len(t, tags, 1)
+
+	af, err := newAttribute(value.Encode(obj.Age), tags[0])
+	require.NoError(t, err)
+	bb, err := json.Marshal(af)
+	require.NoError(t, err)
+	require.JSONEq(t, reqString, string(bb))
+}
+
 func TestNested(t *testing.T) {
 	type t1 struct {
 		Age int `river:"age,attr"`
@@ -39,6 +58,27 @@ func TestNested(t *testing.T) {
 	reqString := `{"name":"person","type":"attr","value":{"type":"object","value":[{"value":{"type":"number","value":1},"key":"age"}]}}`
 
 	obj := &parent{Person: &t1{Age: 1}}
+	val := value.Encode(obj)
+	tags := rivertags.Get(val.Reflect().Type())
+	require.Len(t, tags, 1)
+
+	af, err := newAttribute(value.Encode(obj.Person), tags[0])
+	require.NoError(t, err)
+	bb, err := json.Marshal(af)
+	require.NoError(t, err)
+	require.JSONEq(t, reqString, string(bb))
+}
+
+func TestNestedZeroVal(t *testing.T) {
+	type t1 struct {
+		Age int `river:"age,attr"`
+	}
+	type parent struct {
+		Person *t1 `river:"person,attr"`
+	}
+	reqString := `{"name":"person","type":"attr","value":{"type":"object","value":[{"value":{"type":"number","value":0},"key":"age"}]}}`
+
+	obj := &parent{Person: &t1{Age: 0}}
 	val := value.Encode(obj)
 	tags := rivertags.Get(val.Reflect().Type())
 	require.Len(t, tags, 1)

--- a/pkg/river/encoding/encoding_test.go
+++ b/pkg/river/encoding/encoding_test.go
@@ -29,3 +29,30 @@ func TestConvertRiverBodyToJSON_CapsuleValue(t *testing.T) {
 
 	require.JSONEq(t, expect, string(out))
 }
+
+func TestConvertRiverBodyToJSON_BlockWithZeroValue(t *testing.T) {
+	type t1 struct {
+		Age int `river:"age,attr"`
+	}
+	type parent struct {
+		Person *t1 `river:"person,block"`
+	}
+
+	out, err := encoding.ConvertRiverBodyToJSON(parent{Person: &t1{Age: 0}})
+	require.NoError(t, err)
+
+	expect := `[{
+		"name": "person",
+		"type": "block",
+		"body": [{
+			"name": "age",
+			"type": "attr",
+			"value": {
+				"type": "number",
+				"value": 0
+			}
+		}]
+	}]`
+
+	require.JSONEq(t, expect, string(out))
+}


### PR DESCRIPTION

#### PR Description
The UI will now display the values of all River attributes unless they are nil.

Example UI screenshots:

<details>
<summary>remote_write exports</summary>
<img src="https://user-images.githubusercontent.com/5834788/214120241-7dfcdf31-bba3-4b5a-8072-efeb840fc3da.png" >
</details>

<details>
<summary>local_file exports</summary>
<img src="https://user-images.githubusercontent.com/5834788/214120248-ba554844-e6f9-4079-8cd7-9a687bc427e0.png" >
</details>

<details>
<summary>node_exporter exports</summary>
<img src="https://user-images.githubusercontent.com/5834788/214120250-30115b80-de25-4fad-a860-a6abbf6f6ced.png" >
</details>

<details>
<summary>node_exporter arguments</summary>
<img src="https://user-images.githubusercontent.com/5834788/214120254-44eba7c0-e1ee-409f-b87f-4b6cb002c68e.png" >
</details>

#### Which issue(s) this PR fixes
Fixes #2205
Fixes #2206

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [x] Tests updated
