### PR TITLE
Change config reloader image used in Helm chart

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -10,16 +10,25 @@ internal API changes are not present.
 Unreleased
 ----------
 
+0.3.0 (2023-01-23)
+------------------
+
+### Security
+
+- Change config reloader image to `jimmidyson/configmap-reload:v0.8.0` to resolve security scanner report. (@rfratto)
+
 0.2.3 (2023-01-17)
 ------------------
 
 ### Bugfixes
+
 - Sets correct arguments for starting the agent when static mode is selected.
 
 0.2.2 (2023-01-17)
 ------------------
 
 ### Bugfixes
+
 - Updated configmap template to use correct variable for populating configmap content
 
 0.2.1 (2023-01-12)

--- a/operations/helm/charts/grafana-agent/Chart.yaml
+++ b/operations/helm/charts/grafana-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: grafana-agent
 description: "Grafana Agent"
 type: application
-version: 0.2.3
+version: 0.3.0
 appVersion: "v0.30.2"

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -1,6 +1,6 @@
 # Grafana Agent Helm chart
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![AppVersion: v0.30.2](https://img.shields.io/badge/AppVersion-v0.30.2-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![AppVersion: v0.30.2](https://img.shields.io/badge/AppVersion-v0.30.2-informational?style=flat-square)
 
 Helm chart for deploying [Grafana Agent][] to Kubernetes.
 
@@ -47,8 +47,8 @@ use the older mode (called "static mode"), set the `agent.mode` value to
 | agent.storagePath | string | `"/tmp/agent"` | Path to where Grafana Agent stores data (for example, the Write-Ahead Log). By default, data is lost between reboots. |
 | configReloader.customArgs | list | `[]` | Override the args passed to the container. |
 | configReloader.enabled | bool | `true` | Enables automatically reloading when the agent config changes. |
-| configReloader.image.repository | string | `"weaveworks/watch"` | Repository to get config reloader image from. |
-| configReloader.image.tag | string | `"master-5fc29a9"` | Tag of image to use for config reloading. |
+| configReloader.image.repository | string | `"jimmidyson/configmap-reload"` | Repository to get config reloader image from. |
+| configReloader.image.tag | string | `"v0.8.0"` | Tag of image to use for config reloading. |
 | controller.podAnnotations | object | `{}` | Extra pod annotations to add. |
 | controller.replicas | int | `1` | Number of pods to deploy. Ignored when controller.type is 'daemonset'. |
 | controller.tolerations | list | `[]` | Tolerations to apply to Grafana Agent pods. |

--- a/operations/helm/charts/grafana-agent/templates/containers/_watch.yaml
+++ b/operations/helm/charts/grafana-agent/templates/containers/_watch.yaml
@@ -7,16 +7,8 @@
     {{- toYaml .Values.configReloader.customArgs | nindent 4 }}
   {{- else }}
   args:
-    - -v
-    - -p=/etc/agent/{{ include "grafana-agent.config-map.key" . }}
-    - curl
-    - -X
-    - POST
-    - --fail
-    - -o
-    - '-'
-    - -sS
-    - http://localhost:{{ .Values.agent.listenPort }}/-/reload
+    - --volume-dir=/etc/agent
+    - --webhook-url=http://localhost:{{ .Values.agent.listenPort }}/-/reload
   {{- end }}
   volumeMounts:
     - name: config

--- a/operations/helm/charts/grafana-agent/values.yaml
+++ b/operations/helm/charts/grafana-agent/values.yaml
@@ -91,9 +91,9 @@ configReloader:
   enabled: true
   image:
     # -- Repository to get config reloader image from.
-    repository: weaveworks/watch
+    repository: jimmidyson/configmap-reload
     # -- Tag of image to use for config reloading.
-    tag: master-5fc29a9
+    tag: v0.8.0
   # -- Override the args passed to the container.
   customArgs: []
 

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -51,18 +51,10 @@ spec:
               - name: config
                 mountPath: /etc/agent
           - name: config-reloader
-            image: weaveworks/watch:master-5fc29a9
+            image: jimmidyson/configmap-reload:v0.8.0
             args:
-              - -v
-              - -p=/etc/agent/config.river
-              - curl
-              - -X
-              - POST
-              - --fail
-              - -o
-              - '-'
-              - -sS
-              - http://localhost:80/-/reload
+              - --volume-dir=/etc/agent
+              - --webhook-url=http://localhost:80/-/reload
             volumeMounts:
               - name: config
                 mountPath: /etc/agent

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -52,18 +52,10 @@ spec:
               - name: config
                 mountPath: /etc/agent
           - name: config-reloader
-            image: weaveworks/watch:master-5fc29a9
+            image: jimmidyson/configmap-reload:v0.8.0
             args:
-              - -v
-              - -p=/etc/agent/config.river
-              - curl
-              - -X
-              - POST
-              - --fail
-              - -o
-              - '-'
-              - -sS
-              - http://localhost:80/-/reload
+              - --volume-dir=/etc/agent
+              - --webhook-url=http://localhost:80/-/reload
             volumeMounts:
               - name: config
                 mountPath: /etc/agent

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -53,18 +53,10 @@ spec:
               - name: config
                 mountPath: /etc/agent
           - name: config-reloader
-            image: weaveworks/watch:master-5fc29a9
+            image: jimmidyson/configmap-reload:v0.8.0
             args:
-              - -v
-              - -p=/etc/agent/config.river
-              - curl
-              - -X
-              - POST
-              - --fail
-              - -o
-              - '-'
-              - -sS
-              - http://localhost:80/-/reload
+              - --volume-dir=/etc/agent
+              - --webhook-url=http://localhost:80/-/reload
             volumeMounts:
               - name: config
                 mountPath: /etc/agent

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/custom-config/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -51,18 +51,10 @@ spec:
               - name: config
                 mountPath: /etc/agent
           - name: config-reloader
-            image: weaveworks/watch:master-5fc29a9
+            image: jimmidyson/configmap-reload:v0.8.0
             args:
-              - -v
-              - -p=/etc/agent/config.river
-              - curl
-              - -X
-              - POST
-              - --fail
-              - -o
-              - '-'
-              - -sS
-              - http://localhost:80/-/reload
+              - --volume-dir=/etc/agent
+              - --webhook-url=http://localhost:80/-/reload
             volumeMounts:
               - name: config
                 mountPath: /etc/agent

--- a/operations/helm/tests/custom-config/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/custom-config/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/custom-config/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -51,18 +51,10 @@ spec:
               - name: config
                 mountPath: /etc/agent
           - name: config-reloader
-            image: weaveworks/watch:master-5fc29a9
+            image: jimmidyson/configmap-reload:v0.8.0
             args:
-              - -v
-              - -p=/etc/agent/config.river
-              - curl
-              - -X
-              - POST
-              - --fail
-              - -o
-              - '-'
-              - -sS
-              - http://localhost:80/-/reload
+              - --volume-dir=/etc/agent
+              - --webhook-url=http://localhost:80/-/reload
             volumeMounts:
               - name: config
                 mountPath: /etc/agent

--- a/operations/helm/tests/default-values/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -51,18 +51,10 @@ spec:
               - name: config
                 mountPath: /etc/agent
           - name: config-reloader
-            image: weaveworks/watch:master-5fc29a9
+            image: jimmidyson/configmap-reload:v0.8.0
             args:
-              - -v
-              - -p=/etc/agent/my-config.river
-              - curl
-              - -X
-              - POST
-              - --fail
-              - -o
-              - '-'
-              - -sS
-              - http://localhost:80/-/reload
+              - --volume-dir=/etc/agent
+              - --webhook-url=http://localhost:80/-/reload
             volumeMounts:
               - name: config
                 mountPath: /etc/agent

--- a/operations/helm/tests/existing-config/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -54,18 +54,10 @@ spec:
               - name: config
                 mountPath: /etc/agent
           - name: config-reloader
-            image: weaveworks/watch:master-5fc29a9
+            image: jimmidyson/configmap-reload:v0.8.0
             args:
-              - -v
-              - -p=/etc/agent/config.river
-              - curl
-              - -X
-              - POST
-              - --fail
-              - -o
-              - '-'
-              - -sS
-              - http://localhost:80/-/reload
+              - --volume-dir=/etc/agent
+              - --webhook-url=http://localhost:80/-/reload
             volumeMounts:
               - name: config
                 mountPath: /etc/agent

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -49,18 +49,10 @@ spec:
               - name: config
                 mountPath: /etc/agent
           - name: config-reloader
-            image: weaveworks/watch:master-5fc29a9
+            image: jimmidyson/configmap-reload:v0.8.0
             args:
-              - -v
-              - -p=/etc/agent/config.yaml
-              - curl
-              - -X
-              - POST
-              - --fail
-              - -o
-              - '-'
-              - -sS
-              - http://localhost:80/-/reload
+              - --volume-dir=/etc/agent
+              - --webhook-url=http://localhost:80/-/reload
             volumeMounts:
               - name: config
                 mountPath: /etc/agent

--- a/operations/helm/tests/static-mode/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.2.3
+    helm.sh/chart: grafana-agent-0.3.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"


### PR DESCRIPTION
#### PR Description
Changes the config reloader image to `jimmidyson/configmap-reload:v0.8.0` ([link to repo](https://github.com/jimmidyson/configmap-reload)) which doesn't have any reported security vulnerabilities, as opposed to `weaveworks/watch`.

#### Which issue(s) this PR fixes
Fixes #2805 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
