### PR TITLE
[Agent Management] [WIP] Refactor Agent Management for Testing

### DIFF
--- a/pkg/config/agentmanagement.go
+++ b/pkg/config/agentmanagement.go
@@ -127,11 +127,6 @@ func getRemoteConfig(expandEnvVars bool, configProvider remoteConfigProvider, lo
 		return configProvider.GetCachedRemoteConfig(expandEnvVars)
 	}
 
-	if err = remoteConfig.Validate(nil); err != nil {
-		level.Error(log).Log("msg", "fetched remote config was invalid, falling back to cache", "err", err)
-		return configProvider.GetCachedRemoteConfig(expandEnvVars)
-	}
-
 	level.Info(log).Log("msg", "fetched and loaded remote config from API")
 
 	if err = configProvider.CacheRemoteConfig(remoteConfigBytes); err != nil {

--- a/pkg/config/agentmanagement.go
+++ b/pkg/config/agentmanagement.go
@@ -15,6 +15,80 @@ import (
 
 const cacheFilename = "remote-config-cache.yaml"
 
+type remoteConfigProvider interface {
+	AgentManagementConfig() *AgentManagement
+
+	GetCachedRemoteConfig(expandEnvVars bool) (*Config, error)
+	CacheRemoteConfig(remoteConfigBytes []byte) error
+
+	FetchRemoteConfig() ([]byte, error)
+}
+
+type remoteConfigHTTPProvider struct {
+	AgentManagement AgentManagement
+}
+
+func newRemoteConfigHTTPProvider(c *Config) remoteConfigHTTPProvider {
+	return remoteConfigHTTPProvider{
+		AgentManagement: c.AgentManagement,
+	}
+}
+
+func (r remoteConfigHTTPProvider) AgentManagementConfig() *AgentManagement {
+	return &r.AgentManagement
+}
+
+// GetCachedRemoteConfig retrieves the cached remote config from the location specified
+// in r.AgentManagement.CacheLocation
+func (r remoteConfigHTTPProvider) GetCachedRemoteConfig(expandEnvVars bool) (*Config, error) {
+	cachePath := filepath.Join(r.AgentManagement.CacheLocation, cacheFilename)
+	var cachedConfig Config
+	if err := LoadFile(cachePath, expandEnvVars, &cachedConfig); err != nil {
+		return nil, fmt.Errorf("error trying to load cached remote config from file: %w", err)
+	}
+	return &cachedConfig, nil
+}
+
+// CacheRemoteConfig caches the remote config to the location specified in
+// r.AgentManagement.CacheLocation
+func (r remoteConfigHTTPProvider) CacheRemoteConfig(remoteConfigBytes []byte) error {
+	cachePath := filepath.Join(r.AgentManagement.CacheLocation, cacheFilename)
+	return os.WriteFile(cachePath, remoteConfigBytes, 0666)
+}
+
+// FetchRemoteConfig fetches the raw bytes of the config from a remote API using
+// the values in r.AgentManagement.
+func (r remoteConfigHTTPProvider) FetchRemoteConfig() ([]byte, error) {
+	httpClientConfig := &config.HTTPClientConfig{
+		BasicAuth: &r.AgentManagement.BasicAuth,
+	}
+
+	dir, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current working directory: %w", err)
+	}
+	httpClientConfig.SetDirectory(dir)
+
+	remoteOpts := &remoteOpts{
+		HTTPClientConfig: httpClientConfig,
+	}
+
+	url, err := r.AgentManagement.fullUrl()
+	if err != nil {
+		return nil, fmt.Errorf("error trying to create full url: %w", err)
+	}
+	rc, err := newRemoteConfig(url, remoteOpts)
+	if err != nil {
+		return nil, fmt.Errorf("error reading remote config: %w", err)
+	}
+
+	bb, err := rc.retrieve()
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving remote config: %w", err)
+	}
+	return bb, nil
+}
+
 type labelMap map[string]string
 
 type RemoteConfiguration struct {
@@ -36,25 +110,31 @@ type AgentManagement struct {
 // getRemoteConfig gets the remote config specified in the initial config, falling back to a local, cached copy
 // of the remote config if the request to the remote fails. If both fail, an empty config and an
 // error will be returned.
-func getRemoteConfig(expandEnvVars bool, initialConfig *Config, log *server.Logger) (*Config, error) {
-	if err := initialConfig.AgentManagement.Validate(); err != nil {
+func getRemoteConfig(expandEnvVars bool, configProvider remoteConfigProvider, log *server.Logger) (*Config, error) {
+	if err := configProvider.AgentManagementConfig().Validate(); err != nil {
 		return nil, fmt.Errorf("invalid initial config: %w", err)
 	}
-	remoteConfigBytes, err := fetchFromApi(initialConfig)
+	remoteConfigBytes, err := configProvider.FetchRemoteConfig()
 	if err != nil {
 		level.Error(log).Log("msg", "could not fetch from API, falling back to cache", "err", err)
-		return getCachedRemoteConfig(initialConfig.AgentManagement.CacheLocation, expandEnvVars)
+		return configProvider.GetCachedRemoteConfig(expandEnvVars)
 	}
 	var remoteConfig Config
 
 	err = LoadBytes(remoteConfigBytes, expandEnvVars, &remoteConfig)
 	if err != nil {
 		level.Error(log).Log("msg", "could not load the response from the API, falling back to cache", "err", err)
-		return getCachedRemoteConfig(initialConfig.AgentManagement.CacheLocation, expandEnvVars)
+		return configProvider.GetCachedRemoteConfig(expandEnvVars)
 	}
+
+	if err = remoteConfig.Validate(nil); err != nil {
+		level.Error(log).Log("msg", "fetched remote config was invalid, falling back to cache", "err", err)
+		return configProvider.GetCachedRemoteConfig(expandEnvVars)
+	}
+
 	level.Info(log).Log("msg", "fetched and loaded remote config from API")
 
-	if err = cacheRemoteConfig(initialConfig.AgentManagement.CacheLocation, remoteConfigBytes); err != nil {
+	if err = configProvider.CacheRemoteConfig(remoteConfigBytes); err != nil {
 		level.Error(log).Log("err", fmt.Errorf("could not cache config locally: %w", err))
 	}
 	return &remoteConfig, nil
@@ -69,51 +149,15 @@ func getCachedRemoteConfig(cachePath string, expandEnvVars bool) (*Config, error
 	return &cachedConfig, nil
 }
 
-func cacheRemoteConfig(cachePath string, remoteConfigBytes []byte) error {
-	cachePath = filepath.Join(cachePath, cacheFilename)
-	return os.WriteFile(cachePath, remoteConfigBytes, 0666)
-}
-
-// fetchFromApi fetches the raw bytes from the API based on the protocol specified in c.
-func fetchFromApi(c *Config) ([]byte, error) {
+// newRemoteConfigProvider creates a remoteConfigProvider based on the protocol
+// specified in c.AgentManagement
+func newRemoteConfigProvider(c *Config) (remoteConfigHTTPProvider, error) {
 	switch p := c.AgentManagement.Protocol; {
 	case p == "http":
-		return fetchConfig(c)
+		return newRemoteConfigHTTPProvider(c), nil
 	default:
-		return nil, fmt.Errorf("unsupported protocol for agent management api: %s", p)
+		return remoteConfigHTTPProvider{}, fmt.Errorf("unsupported protocol for agent management api: %s", p)
 	}
-}
-
-// fetchConfig fetches the raw bytes of the config from the API specified in c.
-func fetchConfig(c *Config) ([]byte, error) {
-	httpClientConfig := &config.HTTPClientConfig{
-		BasicAuth: &c.AgentManagement.BasicAuth,
-	}
-
-	dir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get current working directory: %w", err)
-	}
-	httpClientConfig.SetDirectory(dir)
-
-	remoteOpts := &remoteOpts{
-		HTTPClientConfig: httpClientConfig,
-	}
-
-	url, err := c.AgentManagement.fullUrl()
-	if err != nil {
-		return nil, fmt.Errorf("error trying to create full url: %w", err)
-	}
-	rc, err := newRemoteConfig(url, remoteOpts)
-	if err != nil {
-		return nil, fmt.Errorf("error reading remote config: %w", err)
-	}
-
-	bb, err := rc.retrieve()
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving remote config: %w", err)
-	}
-	return bb, nil
 }
 
 // fullUrl creates and returns the URL that should be used when querying the Agent Management API,

--- a/pkg/config/agentmanagement_test.go
+++ b/pkg/config/agentmanagement_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/agent/pkg/util"
 	"github.com/prometheus/common/config"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
 )
 
 // testRemoteConfigProvider is an implementation of remoteConfigProvider that can be
@@ -177,8 +176,7 @@ func TestGetRemoteConfig_InvalidInitialConfig(t *testing.T) {
 func TestGetRemoteConfig_UnmarshallableRemoteConfig(t *testing.T) {
 	brokenCfg := `completely invalid config (maybe it got corrupted, maybe it was somehow set this way)`
 
-	invalidCfgBytes, err := yaml.Marshal(brokenCfg)
-	assert.NoError(t, err)
+	invalidCfgBytes := []byte(brokenCfg)
 
 	am := validAgentManagement
 	logger := server.NewLogger(&server.DefaultConfig)

--- a/pkg/config/agentmanagement_test.go
+++ b/pkg/config/agentmanagement_test.go
@@ -1,30 +1,67 @@
 package config
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/grafana/agent/pkg/server"
+	"github.com/grafana/agent/pkg/util"
 	"github.com/prometheus/common/config"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
 )
 
+// testRemoteConfigProvider is an implementation of remoteConfigProvider that can be
+// used for testing. It allows setting the values to return for both fetching the
+// remote config bytes & errors as well as the cached config & errors.
+type testRemoteConfigProvider struct {
+	AgentManagement *AgentManagement
+
+	fetchedConfigBytesToReturn []byte
+	fetchedConfigErrorToReturn error
+
+	cachedConfigToReturn      *Config
+	cachedConfigErrorToReturn error
+	didCacheRemoteConfig      bool
+}
+
+func (t *testRemoteConfigProvider) AgentManagementConfig() *AgentManagement {
+	return t.AgentManagement
+}
+
+func (t *testRemoteConfigProvider) GetCachedRemoteConfig(expandEnvVars bool) (*Config, error) {
+	return t.cachedConfigToReturn, t.cachedConfigErrorToReturn
+}
+
+func (t *testRemoteConfigProvider) FetchRemoteConfig() ([]byte, error) {
+	return t.fetchedConfigBytesToReturn, t.fetchedConfigErrorToReturn
+}
+
+func (t *testRemoteConfigProvider) CacheRemoteConfig(r []byte) error {
+	t.didCacheRemoteConfig = true
+	return nil
+}
+
+var validAgentManagement = AgentManagement{
+	Enabled: true,
+	Url:     "https://localhost:1234/example/api",
+	BasicAuth: config.BasicAuth{
+		Username:     "test",
+		PasswordFile: "/test/path",
+	},
+	Protocol:        "https",
+	PollingInterval: "1m",
+	CacheLocation:   "/test/path/",
+	RemoteConfiguration: RemoteConfiguration{
+		Labels:    labelMap{"b": "B", "a": "A"},
+		Namespace: "test_namespace",
+	},
+}
+
 func TestValidateValidConfig(t *testing.T) {
-	validConfigPolling := &AgentManagement{
-		Enabled: true,
-		Url:     "https://localhost:1234",
-		BasicAuth: config.BasicAuth{
-			Username:     "test",
-			PasswordFile: "/test/path",
-		},
-		Protocol:        "https",
-		PollingInterval: "1m",
-		CacheLocation:   "/test/path/",
-		RemoteConfiguration: RemoteConfiguration{
-			Namespace: "test_namespace",
-		},
-	}
-	assert.NoError(t, validConfigPolling.Validate())
+	assert.NoError(t, validAgentManagement.Validate())
 }
 
 func TestValidateInvalidBasicAuth(t *testing.T) {
@@ -94,20 +131,7 @@ func TestGetCachedRemoteConfig(t *testing.T) {
 }
 
 func TestSleepTime(t *testing.T) {
-	c := &AgentManagement{
-		Enabled: true,
-		Url:     "https://localhost:1234",
-		BasicAuth: config.BasicAuth{
-			Username:     "test",
-			PasswordFile: "/test/path",
-		},
-		Protocol:        "https",
-		PollingInterval: "1m",
-		CacheLocation:   "/test/path/",
-		RemoteConfiguration: RemoteConfiguration{
-			Namespace: "test_namespace",
-		},
-	}
+	c := validAgentManagement
 	st, err := c.SleepTime()
 	assert.NoError(t, err)
 	assert.Equal(t, time.Minute*1, st)
@@ -119,12 +143,19 @@ func TestSleepTime(t *testing.T) {
 }
 
 func TestFullUrl(t *testing.T) {
-	c := &AgentManagement{
+	c := validAgentManagement
+	actual, err := c.fullUrl()
+	assert.NoError(t, err)
+	assert.Equal(t, "https://localhost:1234/example/api/namespace/test_namespace/remote_config?a=A&b=B", actual)
+}
+
+func TestGetRemoteConfig_InvalidInitialConfig(t *testing.T) {
+	// this is invalid because it is missing the password file
+	invalidAgentManagement := &AgentManagement{
 		Enabled: true,
 		Url:     "https://localhost:1234/example/api",
 		BasicAuth: config.BasicAuth{
-			Username:     "test",
-			PasswordFile: "/test/path",
+			Username: "test",
 		},
 		Protocol:        "https",
 		PollingInterval: "1m",
@@ -134,7 +165,106 @@ func TestFullUrl(t *testing.T) {
 			Namespace: "test_namespace",
 		},
 	}
-	actual, err := c.fullUrl()
+
+	logger := server.NewLogger(&server.DefaultConfig)
+	testProvider := testRemoteConfigProvider{AgentManagement: invalidAgentManagement}
+
+	_, err := getRemoteConfig(true, &testProvider, logger)
+	assert.Error(t, err)
+	assert.False(t, testProvider.didCacheRemoteConfig)
+}
+
+func TestGetRemoteConfig_UnmarshallableRemoteConfig(t *testing.T) {
+	brokenCfg := `completely invalid config (maybe it got corrupted, maybe it was somehow set this way)`
+
+	invalidCfgBytes, err := yaml.Marshal(brokenCfg)
 	assert.NoError(t, err)
-	assert.Equal(t, "https://localhost:1234/example/api/namespace/test_namespace/remote_config?a=A&b=B", actual)
+
+	am := validAgentManagement
+	logger := server.NewLogger(&server.DefaultConfig)
+	testProvider := testRemoteConfigProvider{AgentManagement: &am}
+	testProvider.fetchedConfigBytesToReturn = invalidCfgBytes
+	testProvider.cachedConfigToReturn = &DefaultConfig
+
+	cfg, err := getRemoteConfig(true, &testProvider, logger)
+	assert.NoError(t, err)
+	assert.False(t, testProvider.didCacheRemoteConfig)
+
+	// check that the returned config is the cached one
+	assert.True(t, util.CompareYAML(*cfg, DefaultConfig))
+}
+
+func TestGetRemoteConfig_InvalidRemoteConfig(t *testing.T) {
+	// this is invalid because it has two scrape_configs with
+	// the same job_name
+	invalidConfig := `
+metrics:
+    configs:
+    - name: Metrics Snippets
+      scrape_configs:
+      - job_name: agent-metrics
+        honor_timestamps: true
+        scrape_interval: 15s
+        metrics_path: /metrics
+        scheme: http
+        follow_redirects: true
+        enable_http2: true
+        static_configs:
+        - targets:
+          - localhost:12345
+      - job_name: agent-metrics
+        honor_timestamps: true
+        scrape_interval: 15s
+        metrics_path: /metrics
+        scheme: http
+        follow_redirects: true
+        enable_http2: true
+        static_configs:
+        - targets:
+          - localhost:12345`
+	invalidCfgBytes := []byte(invalidConfig)
+
+	am := validAgentManagement
+	logger := server.NewLogger(&server.DefaultConfig)
+	testProvider := testRemoteConfigProvider{AgentManagement: &am}
+	testProvider.fetchedConfigBytesToReturn = invalidCfgBytes
+	testProvider.cachedConfigToReturn = &DefaultConfig
+
+	cfg, err := getRemoteConfig(true, &testProvider, logger)
+	assert.NoError(t, err)
+	assert.False(t, testProvider.didCacheRemoteConfig)
+
+	// check that the returned config is the cached one
+	assert.True(t, util.CompareYAML(*cfg, DefaultConfig))
+}
+
+func TestGetRemoteConfig_RemoteFetchFails(t *testing.T) {
+	am := validAgentManagement
+	logger := server.NewLogger(&server.DefaultConfig)
+	testProvider := testRemoteConfigProvider{AgentManagement: &am}
+	testProvider.fetchedConfigErrorToReturn = errors.New("connection refused")
+	testProvider.cachedConfigToReturn = &DefaultConfig
+
+	cfg, err := getRemoteConfig(true, &testProvider, logger)
+	assert.NoError(t, err)
+	assert.False(t, testProvider.didCacheRemoteConfig)
+
+	// check that the returned config is the cached one
+	assert.True(t, util.CompareYAML(*cfg, DefaultConfig))
+}
+
+func TestGetRemoteConfig_ValidRemoteConfig(t *testing.T) {
+	validConfig := `server:
+  log_level: info`
+
+	validConfigBytes := []byte(validConfig)
+
+	am := validAgentManagement
+	logger := server.NewLogger(&server.DefaultConfig)
+	testProvider := testRemoteConfigProvider{AgentManagement: &am}
+	testProvider.fetchedConfigBytesToReturn = validConfigBytes
+
+	_, err := getRemoteConfig(true, &testProvider, logger)
+	assert.NoError(t, err)
+	assert.True(t, testProvider.didCacheRemoteConfig)
 }

--- a/pkg/config/agentmanagement_test.go
+++ b/pkg/config/agentmanagement_test.go
@@ -194,50 +194,6 @@ func TestGetRemoteConfig_UnmarshallableRemoteConfig(t *testing.T) {
 	assert.True(t, util.CompareYAML(*cfg, DefaultConfig))
 }
 
-func TestGetRemoteConfig_InvalidRemoteConfig(t *testing.T) {
-	// this is invalid because it has two scrape_configs with
-	// the same job_name
-	invalidConfig := `
-metrics:
-    configs:
-    - name: Metrics Snippets
-      scrape_configs:
-      - job_name: agent-metrics
-        honor_timestamps: true
-        scrape_interval: 15s
-        metrics_path: /metrics
-        scheme: http
-        follow_redirects: true
-        enable_http2: true
-        static_configs:
-        - targets:
-          - localhost:12345
-      - job_name: agent-metrics
-        honor_timestamps: true
-        scrape_interval: 15s
-        metrics_path: /metrics
-        scheme: http
-        follow_redirects: true
-        enable_http2: true
-        static_configs:
-        - targets:
-          - localhost:12345`
-	invalidCfgBytes := []byte(invalidConfig)
-
-	am := validAgentManagement
-	logger := server.NewLogger(&server.DefaultConfig)
-	testProvider := testRemoteConfigProvider{AgentManagement: &am}
-	testProvider.fetchedConfigBytesToReturn = invalidCfgBytes
-	testProvider.cachedConfigToReturn = &DefaultConfig
-
-	cfg, err := getRemoteConfig(true, &testProvider, logger)
-	assert.NoError(t, err)
-	assert.False(t, testProvider.didCacheRemoteConfig)
-
-	// check that the returned config is the cached one
-	assert.True(t, util.CompareYAML(*cfg, DefaultConfig))
-}
-
 func TestGetRemoteConfig_RemoteFetchFails(t *testing.T) {
 	am := validAgentManagement
 	logger := server.NewLogger(&server.DefaultConfig)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -259,7 +259,11 @@ func loadFromAgentManagementAPI(path string, expandEnvVars bool, c *Config, log 
 		return fmt.Errorf("failed to load initial config: %w", err)
 	}
 
-	remoteConfig, err := getRemoteConfig(expandEnvVars, c, log)
+	configProvider, err := newRemoteConfigProvider(c)
+	if err != nil {
+		return err
+	}
+	remoteConfig, err := getRemoteConfig(expandEnvVars, configProvider, log)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Refactors Agent Management code to support passing a `remoteConfigProvider` interface that handles fetching and caching, in addition to adding tests for the following cases:

- An invalid _initial_ config results in an error and does not cache.
- An un-marshallable _remote_ config (i.e. invalid yaml) falls back to the cache and does not cache.
- If the remote fetch fails it falls back to the cached config and does not cache again.
- If the remote fetch succeeds and responds with a valid (note: at present `valid` means that `LoadBytes` succeeded so it is valid yaml, not necessarily that the config is a valid agent management config) there is no error and the remote config is cached.

- [ ] CHANGELOG updated
- [ ] Documentation added
- [X] Tests updated
