### PR TITLE
Fix Rules export of relabeling components to directly expose the rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,12 +45,9 @@ Main (unreleased)
     receivers. (@tpaschalis)
   - `loki.source.gelf` listens for Graylog logs. (@mattdurham)
 
-
-
 - Flow components which work with relabeling rules (`discovery.relabel`,
   `prometheus.relabel` and `loki.relabel`) now export a new value named Rules.
-  This value is a function that returns the currently configured rules.
-  (@tpaschalis)
+  This value returns a copy of the currently configured rules. (@tpaschalis)
 
 - New experimental feature: agent-management. Polls configured remote API to fetch new configs. (@spartan0x117)
 

--- a/component/common/relabel/relabel.go
+++ b/component/common/relabel/relabel.go
@@ -186,9 +186,7 @@ func ComponentToPromRelabelConfigs(rcs []*Config) []*relabel.Config {
 }
 
 // Rules returns the relabel configs in use for a relabeling component.
-type Rules struct {
-	GetAll func() []*Config
-}
+type Rules []*Config
 
 // RiverCapsule marks the alias defined above as a "capsule type" so that it
 // cannot be invoked by River code.

--- a/component/discovery/relabel/relabel.go
+++ b/component/discovery/relabel/relabel.go
@@ -2,7 +2,6 @@ package relabel
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/grafana/agent/component"
@@ -86,7 +85,6 @@ func (c *Component) Update(args component.Arguments) error {
 		}
 	}
 
-	fmt.Println("calling OnStateChange!")
 	c.opts.OnStateChange(Exports{
 		Output: targets,
 		Rules:  newArgs.RelabelConfigs,

--- a/component/discovery/relabel/relabel.go
+++ b/component/discovery/relabel/relabel.go
@@ -2,6 +2,7 @@ package relabel
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/grafana/agent/component"
@@ -34,8 +35,8 @@ type Arguments struct {
 
 // Exports holds values which are exported by the discovery.relabel component.
 type Exports struct {
-	Output []discovery.Target  `river:"output,attr"`
-	Rules  *flow_relabel.Rules `river:"rules,attr"`
+	Output []discovery.Target `river:"output,attr"`
+	Rules  flow_relabel.Rules `river:"rules,attr"`
 }
 
 // Component implements the discovery.relabel component.
@@ -87,23 +88,13 @@ func (c *Component) Update(args component.Arguments) error {
 		}
 	}
 
+	fmt.Println("calling OnStateChange!")
 	c.opts.OnStateChange(Exports{
 		Output: targets,
-		Rules:  getRules(c),
+		Rules:  c.rcsFlow,
 	})
 
 	return nil
-}
-
-func getRules(c *Component) *flow_relabel.Rules {
-	return &flow_relabel.Rules{
-		GetAll: func() []*flow_relabel.Config {
-			c.mut.RLock()
-			defer c.mut.RUnlock()
-
-			return c.rcsFlow
-		},
-	}
 }
 
 func componentMapToPromLabels(ls discovery.Target) labels.Labels {

--- a/component/discovery/relabel/relabel.go
+++ b/component/discovery/relabel/relabel.go
@@ -43,9 +43,8 @@ type Exports struct {
 type Component struct {
 	opts component.Options
 
-	mut     sync.RWMutex
-	rcs     []*relabel.Config
-	rcsFlow []*flow_relabel.Config
+	mut sync.RWMutex
+	rcs []*relabel.Config
 }
 
 var _ component.Component = (*Component)(nil)
@@ -78,7 +77,6 @@ func (c *Component) Update(args component.Arguments) error {
 	targets := make([]discovery.Target, 0, len(newArgs.Targets))
 	relabelConfigs := flow_relabel.ComponentToPromRelabelConfigs(newArgs.RelabelConfigs)
 	c.rcs = relabelConfigs
-	c.rcsFlow = newArgs.RelabelConfigs
 
 	for _, t := range newArgs.Targets {
 		lset := componentMapToPromLabels(t)
@@ -91,7 +89,7 @@ func (c *Component) Update(args component.Arguments) error {
 	fmt.Println("calling OnStateChange!")
 	c.opts.OnStateChange(Exports{
 		Output: targets,
-		Rules:  c.rcsFlow,
+		Rules:  newArgs.RelabelConfigs,
 	})
 
 	return nil

--- a/component/discovery/relabel/relabel_test.go
+++ b/component/discovery/relabel/relabel_test.go
@@ -97,7 +97,7 @@ rule {
 
 	// Use the getter to retrieve the original relabeling rules.
 	exports := tc.Exports().(relabel.Exports)
-	gotOriginal := exports.Rules.GetAll()
+	gotOriginal := exports.Rules
 
 	// Update the component with new relabeling rules and retrieve them.
 	updatedCfg := `
@@ -111,7 +111,8 @@ rule {
 	require.NoError(t, river.Unmarshal([]byte(updatedCfg), &args))
 
 	require.NoError(t, tc.Update(args))
-	gotUpdated := exports.Rules.GetAll()
+	exports = tc.Exports().(relabel.Exports)
+	gotUpdated := exports.Rules
 
 	require.NotEqual(t, gotOriginal, gotUpdated)
 	require.Len(t, gotOriginal, 1)

--- a/component/loki/relabel/relabel.go
+++ b/component/loki/relabel/relabel.go
@@ -69,7 +69,6 @@ type Component struct {
 
 	mut      sync.RWMutex
 	rcs      []*relabel.Config
-	rcsFlow  []*flow_relabel.Config
 	receiver loki.LogsReceiver
 	fanout   []loki.LogsReceiver
 
@@ -154,7 +153,6 @@ func (c *Component) Update(args component.Arguments) error {
 		}
 	}
 	c.rcs = newRCS
-	c.rcsFlow = newArgs.RelabelConfigs
 	c.fanout = newArgs.ForwardTo
 
 	c.opts.OnStateChange(Exports{Receiver: c.receiver, Rules: newArgs.RelabelConfigs})

--- a/component/loki/relabel/relabel.go
+++ b/component/loki/relabel/relabel.go
@@ -58,8 +58,8 @@ func (a *Arguments) UnmarshalRiver(f func(interface{}) error) error {
 
 // Exports holds values which are exported by the loki.relabel component.
 type Exports struct {
-	Receiver loki.LogsReceiver   `river:"receiver,attr"`
-	Rules    *flow_relabel.Rules `river:"rules,attr"`
+	Receiver loki.LogsReceiver  `river:"receiver,attr"`
+	Rules    flow_relabel.Rules `river:"rules,attr"`
 }
 
 // Component implements the loki.relabel component.
@@ -98,7 +98,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 	// Create and immediately export the receiver which remains the same for
 	// the component's lifetime.
 	c.receiver = make(loki.LogsReceiver)
-	o.OnStateChange(Exports{Receiver: c.receiver, Rules: getRules(c)})
+	o.OnStateChange(Exports{Receiver: c.receiver, Rules: args.RelabelConfigs})
 
 	// Call to Update() to set the relabelling rules once at the start.
 	if err := c.Update(args); err != nil {
@@ -156,6 +156,8 @@ func (c *Component) Update(args component.Arguments) error {
 	c.rcs = newRCS
 	c.rcsFlow = newArgs.RelabelConfigs
 	c.fanout = newArgs.ForwardTo
+
+	c.opts.OnStateChange(Exports{Receiver: c.receiver, Rules: newArgs.RelabelConfigs})
 
 	return nil
 }
@@ -231,15 +233,4 @@ func (c *Component) process(e loki.Entry) model.LabelSet {
 		relabeled[model.LabelName(lbls[i].Name)] = model.LabelValue(lbls[i].Value)
 	}
 	return relabeled
-}
-
-func getRules(c *Component) *flow_relabel.Rules {
-	return &flow_relabel.Rules{
-		GetAll: func() []*flow_relabel.Config {
-			c.mut.RLock()
-			defer c.mut.RUnlock()
-
-			return c.rcsFlow
-		},
-	}
 }

--- a/component/loki/relabel/relabel_test.go
+++ b/component/loki/relabel/relabel_test.go
@@ -302,7 +302,7 @@ func TestRuleGetter(t *testing.T) {
 
 	// Use the getter to retrieve the original relabeling rules.
 	exports := tc.Exports().(Exports)
-	gotOriginal := exports.Rules.GetAll()
+	gotOriginal := exports.Rules
 
 	// Update the component with new relabeling rules and retrieve them.
 	updatedCfg := `rule {
@@ -314,7 +314,8 @@ func TestRuleGetter(t *testing.T) {
 	require.NoError(t, river.Unmarshal([]byte(updatedCfg), &args))
 
 	require.NoError(t, tc.Update(args))
-	gotUpdated := exports.Rules.GetAll()
+	exports = tc.Exports().(Exports)
+	gotUpdated := exports.Rules
 
 	require.NotEqual(t, gotOriginal, gotUpdated)
 	require.Len(t, gotOriginal, 1)

--- a/component/loki/source/syslog/syslog.go
+++ b/component/loki/source/syslog/syslog.go
@@ -29,7 +29,7 @@ func init() {
 type Arguments struct {
 	SyslogListeners []ListenerConfig    `river:"listener,block"`
 	ForwardTo       []loki.LogsReceiver `river:"forward_to,attr"`
-	RelabelRules    *flow_relabel.Rules `river:"relabel_rules,attr,optional"`
+	RelabelRules    flow_relabel.Rules  `river:"relabel_rules,attr,optional"`
 }
 
 // Component implements the loki.source.syslog component.
@@ -99,8 +99,8 @@ func (c *Component) Update(args component.Arguments) error {
 	c.fanout = newArgs.ForwardTo
 
 	var rcs []*relabel.Config
-	if newArgs.RelabelRules != nil && len(newArgs.RelabelRules.GetAll()) > 0 {
-		rcs = flow_relabel.ComponentToPromRelabelConfigs(newArgs.RelabelRules.GetAll())
+	if newArgs.RelabelRules != nil && len(newArgs.RelabelRules) > 0 {
+		rcs = flow_relabel.ComponentToPromRelabelConfigs(newArgs.RelabelRules)
 	}
 
 	if configsChanged(c.lc, newArgs.SyslogListeners) {

--- a/component/loki/source/syslog/syslog_test.go
+++ b/component/loki/source/syslog/syslog_test.go
@@ -121,20 +121,16 @@ func TestWithRelabelRules(t *testing.T) {
 	args.ForwardTo = []loki.LogsReceiver{ch1}
 
 	// Create a handler which will be used to retrieve relabeling rules.
-	args.RelabelRules = &flow_relabel.Rules{
-		GetAll: func() []*flow_relabel.Config {
-			return []*flow_relabel.Config{
-				{
-					SourceLabels: []string{"__name__"},
-					Regex:        mustNewRegexp("__syslog_(.*)"),
-					Action:       flow_relabel.LabelMap,
-					Replacement:  "syslog_${1}",
-				},
-				{
-					Regex:  mustNewRegexp("syslog_connection_hostname"),
-					Action: flow_relabel.LabelDrop,
-				},
-			}
+	args.RelabelRules = []*flow_relabel.Config{
+		{
+			SourceLabels: []string{"__name__"},
+			Regex:        mustNewRegexp("__syslog_(.*)"),
+			Action:       flow_relabel.LabelMap,
+			Replacement:  "syslog_${1}",
+		},
+		{
+			Regex:  mustNewRegexp("syslog_connection_hostname"),
+			Action: flow_relabel.LabelDrop,
 		},
 	}
 

--- a/component/prometheus/relabel/relabel.go
+++ b/component/prometheus/relabel/relabel.go
@@ -52,7 +52,6 @@ type Exports struct {
 type Component struct {
 	mut              sync.RWMutex
 	opts             component.Options
-	mrcFlow          []*flow_relabel.Config
 	mrc              []*relabel.Config
 	receiver         *prometheus.Interceptor
 	metricsProcessed prometheus_client.Counter
@@ -173,7 +172,6 @@ func (c *Component) Update(args component.Arguments) error {
 	newArgs := args.(Arguments)
 	c.clearCache()
 	c.mrc = flow_relabel.ComponentToPromRelabelConfigs(newArgs.MetricRelabelConfigs)
-	c.mrcFlow = newArgs.MetricRelabelConfigs
 	c.fanout.UpdateChildren(newArgs.ForwardTo)
 
 	c.opts.OnStateChange(Exports{Receiver: c.receiver, Rules: newArgs.MetricRelabelConfigs})

--- a/component/prometheus/relabel/relabel_test.go
+++ b/component/prometheus/relabel/relabel_test.go
@@ -173,7 +173,7 @@ func TestRuleGetter(t *testing.T) {
 
 	// Use the getter to retrieve the original relabeling rules.
 	exports := tc.Exports().(Exports)
-	gotOriginal := exports.Rules.GetAll()
+	gotOriginal := exports.Rules
 
 	// Update the component with new relabeling rules and retrieve them.
 	updatedCfg := `rule {
@@ -185,7 +185,8 @@ func TestRuleGetter(t *testing.T) {
 	require.NoError(t, river.Unmarshal([]byte(updatedCfg), &args))
 
 	require.NoError(t, tc.Update(args))
-	gotUpdated := exports.Rules.GetAll()
+	exports = tc.Exports().(Exports)
+	gotUpdated := exports.Rules
 
 	require.NotEqual(t, gotOriginal, gotUpdated)
 	require.Len(t, gotOriginal, 1)

--- a/docs/sources/flow/reference/components/discovery.relabel.md
+++ b/docs/sources/flow/reference/components/discovery.relabel.md
@@ -76,7 +76,7 @@ The following fields are exported and can be referenced by other components:
 Name | Type | Description
 ---- | ---- | -----------
 `output` | `list(map(string))` | The set of targets after applying relabeling.
-`rules`    | `RelabelRules` | A function that returns the currently configured relabeling rules.
+`rules`    | `RelabelRules` | The currently configured relabeling rules.
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/loki.relabel.md
+++ b/docs/sources/flow/reference/components/loki.relabel.md
@@ -71,7 +71,7 @@ The following fields are exported and can be referenced by other components:
 Name | Type | Description
 ---- | ---- | -----------
 `receiver` | `receiver` | The input receiver where log lines are sent to be relabeled.
-`rules`    | `RelabelRules` | A function that returns the currently configured relabeling rules.
+`rules`    | `RelabelRules` | The currently configured relabeling rules.
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/loki.source.gelf.md
+++ b/docs/sources/flow/reference/components/loki.source.gelf.md
@@ -30,25 +30,11 @@ Name         | Type                 | Description                               
 ------------ |----------------------|--------------------------------------------------------------------------------|----------------------------| --------
 `listen_address`    | `string`             | UDP address and port to listen for Graylog messages.                    | `0.0.0.0:12201` | no
 `use_incoming_timestamp`    | `bool`             | When false, assigns the current timestamp to the log when it was processed | `false`                            | no
+`relabel_rules` | `RelabelRules`         | Relabeling rules to apply on log entries. | "{}" | no
 
 
 > **NOTE**: GELF logs can be sent uncompressed or compressed with GZIP or ZLIB. 
 > A `job` label is added with the full name of the component `loki.source.gelf.LABEL`. 
-
-
-## Blocks
-
-The following blocks are supported inside the definition of `loki.source.gelf`:
-
-Hierarchy | Name | Description | Required
---------- | ---- | ----------- | --------
-rule | [rule][] | Relabeling rules to apply to received log entries. | no
-
-[rule]: #rule-block
-
-### rule block
-
-{{< docs/shared lookup="flow/reference/components/rule-block.md" source="agent" >}}
 
 Incoming messages have the following labels available:
 * `__gelf_message_level`: The GELF level as a string.
@@ -56,8 +42,9 @@ Incoming messages have the following labels available:
 * `__gelf_message_host`: The GELF level message version sent by the client.
 * `__gelf_message_facility`: The GELF facility.
 
-These labels are stripped unless a rule is created to retain the labels. An example rule is 
-below.
+These labels are stripped unless relabeling is used to retain the labels with a
+`loki.relabel` component and its Rules export as the `relabel_rules` argument.
+An example rule is presented below.
 
 ```river
 rule {

--- a/docs/sources/flow/reference/components/prometheus.relabel.md
+++ b/docs/sources/flow/reference/components/prometheus.relabel.md
@@ -73,7 +73,7 @@ The following fields are exported and can be referenced by other components:
 Name | Type | Description
 ---- | ---- | -----------
 `receiver` | `receiver` | The input receiver where samples are sent to be relabeled.
-`rules`    | `RelabelRules` | A function that returns the currently configured relabeling rules.
+`rules`    | `RelabelRules` | The currently configured relabeling rules.
 
 ## Component health
 


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR changes the common Rules export of relabeling components to expose a copy of the slice of configured rules directly. This fixes the propagating of updates to components that use this value.

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer
cc @mattdurham I've also changed the way that we wire relabeling rules in the GELF source component for uniformity, and also updated its docs. Let me know how it works!

#### PR Checklist

- [X] CHANGELOG updated
- [ ] Documentation added (N/A)
- [X] Tests updated
