### PR TITLE
Decrease the CPU profiling period to avoid cancellations

### DIFF
--- a/component/phlare/scrape/scrape_loop_test.go
+++ b/component/phlare/scrape/scrape_loop_test.go
@@ -71,7 +71,7 @@ func TestScrapePool(t *testing.T) {
 				NewTarget(
 					labels.FromStrings("instance", "localhost:8080", "foo", "bar", model.AddressLabel, "localhost:8080", model.MetricNameLabel, pprofProcessCPU, model.SchemeLabel, "http", ProfilePath, "/debug/pprof/profile"),
 					labels.FromStrings("foo", "bar", model.AddressLabel, "localhost:8080", model.MetricNameLabel, pprofProcessCPU, model.SchemeLabel, "http", ProfilePath, "/debug/pprof/profile"),
-					url.Values{"seconds": []string{"15"}},
+					url.Values{"seconds": []string{"14"}},
 				),
 				NewTarget(
 					labels.FromStrings("instance", "localhost:9090", "foo", "bar", model.AddressLabel, "localhost:9090", model.MetricNameLabel, pprofMutex, model.SchemeLabel, "http", ProfilePath, "/debug/pprof/mutex"),
@@ -81,7 +81,7 @@ func TestScrapePool(t *testing.T) {
 				NewTarget(
 					labels.FromStrings("instance", "localhost:9090", "foo", "bar", model.AddressLabel, "localhost:9090", model.MetricNameLabel, pprofProcessCPU, model.SchemeLabel, "http", ProfilePath, "/debug/pprof/profile"),
 					labels.FromStrings("foo", "bar", model.AddressLabel, "localhost:9090", model.MetricNameLabel, pprofProcessCPU, model.SchemeLabel, "http", ProfilePath, "/debug/pprof/profile"),
-					url.Values{"seconds": []string{"15"}},
+					url.Values{"seconds": []string{"14"}},
 				),
 			},
 		},
@@ -103,7 +103,7 @@ func TestScrapePool(t *testing.T) {
 				NewTarget(
 					labels.FromStrings("instance", "localhost:9090", model.AddressLabel, "localhost:9090", model.MetricNameLabel, pprofProcessCPU, model.SchemeLabel, "http", ProfilePath, "/debug/pprof/profile"),
 					labels.FromStrings(model.AddressLabel, "localhost:9090", model.MetricNameLabel, pprofProcessCPU, model.SchemeLabel, "http", ProfilePath, "/debug/pprof/profile"),
-					url.Values{"seconds": []string{"15"}},
+					url.Values{"seconds": []string{"14"}},
 				),
 			},
 		},
@@ -125,7 +125,7 @@ func TestScrapePool(t *testing.T) {
 				NewTarget(
 					labels.FromStrings("instance", "localhost:9090", model.AddressLabel, "localhost:9090", model.MetricNameLabel, pprofProcessCPU, model.SchemeLabel, "http", ProfilePath, "/debug/pprof/profile"),
 					labels.FromStrings("__type__", "foo", model.AddressLabel, "localhost:9090", model.MetricNameLabel, pprofProcessCPU, model.SchemeLabel, "http", ProfilePath, "/debug/pprof/profile"),
-					url.Values{"seconds": []string{"15"}},
+					url.Values{"seconds": []string{"14"}},
 				),
 			},
 		},

--- a/component/phlare/scrape/target.go
+++ b/component/phlare/scrape/target.go
@@ -391,7 +391,7 @@ func targetsFromGroup(group *targetgroup.Group, cfg Arguments) ([]*Target, []*Ta
 				}
 
 				if pcfg, found := cfg.ProfilingConfig.AllTargets()[profType]; found && pcfg.Delta {
-					params.Add("seconds", strconv.Itoa(int((cfg.ScrapeInterval)/time.Second)))
+					params.Add("seconds", strconv.Itoa(int((cfg.ScrapeInterval)/time.Second)-1))
 				}
 				targets = append(targets, NewTarget(lbls, origLabels, params))
 			}

--- a/component/phlare/scrape/target_test.go
+++ b/component/phlare/scrape/target_test.go
@@ -57,7 +57,7 @@ func Test_targetsFromGroup(t *testing.T) {
 				model.SchemeLabel:     "http",
 				"foo":                 "bar",
 			}),
-			url.Values{"seconds": []string{"15"}}),
+			url.Values{"seconds": []string{"14"}}),
 	}
 	require.NoError(t, err)
 	sort.Sort(Targets(active))


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR decrease the profiling CPU period to interval-1second, we've seen some timeout in the agent because of that and we made the same change in Phlare. see https://github.com/grafana/phlare/commit/c5e677293d21424a444a147b217ddb4f7c150523

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
