### PR TITLE
Flow: add loki.source.kubernetes component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,24 +31,29 @@ Main (unreleased)
 
 - New Grafana Agent Flow components:
 
-  - `otelcol.receiver.kafka` receives telemetry data from Kafka. (@rfratto)
-  - `phlare.scrape` collects application performance profiles. (@cyriltovena)
-  - `phlare.write` sends application performance profiles to Grafana Phlare. (@cyriltovena)
-  - `otelcol.receiver.zipkin` receives Zipkin-formatted traces. (@rfratto)
-  - `otelcol.receiver.opencensus` receives OpenConsensus-formatted traces or metrics. (@ptodev)
-  - `loki.source.heroku` listens for Heroku messages over TCP a connection and forwards them to other `loki` components. (@erikbaranowski)
-  - `loki.source.windowsevent` reads logs from Windows Event Log. (@mattdurham)
-  - `loki.source.syslog` listens for Syslog messages over TCP and UDP
-    connections and forwards them to other `loki` components. (@tpaschalis)
   - `loki.source.cloudflare` reads logs from Cloudflare's Logpull API and
     forwards them to other `loki` components. (@tpaschalis)
   - `loki.source.gcplog` reads logs from GCP cloud resources using Pub/Sub
     subscriptions and forwards them to other `loki` components. (@tpaschalis)
+  - `loki.source.gelf` listens for Graylog logs. (@mattdurham)
+  - `loki.source.heroku` listens for Heroku messages over TCP a connection and
+    forwards them to other `loki` components. (@erikbaranowski)
+  - `loki.source.kubernetes` collects logs from Kubernetes pods using the
+    Kubernetes API. (@rfratto)
+  - `loki.source.syslog` listens for Syslog messages over TCP and UDP
+    connections and forwards them to other `loki` components. (@tpaschalis)
+  - `loki.source.windowsevent` reads logs from Windows Event Log. (@mattdurham)
   - `otelcol.exporter.loki` forwards OTLP-formatted data to compatible `loki`
     receivers. (@tpaschalis)
-  - `loki.source.gelf` listens for Graylog logs. (@mattdurham)
+  - `otelcol.receiver.kafka` receives telemetry data from Kafka. (@rfratto)
   - `otelcol.receiver.loki` receives Loki logs, converts them to the OTLP log
     format and forwards them to other `otelcol` components. (@tpaschalis)
+  - `otelcol.receiver.opencensus` receives OpenConsensus-formatted traces or
+    metrics. (@ptodev)
+  - `otelcol.receiver.zipkin` receives Zipkin-formatted traces. (@rfratto)
+  - `phlare.scrape` collects application performance profiles. (@cyriltovena)
+  - `phlare.write` sends application performance profiles to Grafana Phlare.
+    (@cyriltovena)
 
 - Flow components which work with relabeling rules (`discovery.relabel`,
   `prometheus.relabel` and `loki.relabel`) now export a new value named Rules.

--- a/component/all/all.go
+++ b/component/all/all.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/grafana/agent/component/loki/source/gcplog"                   // Import loki.source.gcplog
 	_ "github.com/grafana/agent/component/loki/source/gelf"                     // Import loki.source.gelf
 	_ "github.com/grafana/agent/component/loki/source/heroku"                   // Import loki.source.heroku
+	_ "github.com/grafana/agent/component/loki/source/kubernetes"               // Import loki.source.kubernetes
 	_ "github.com/grafana/agent/component/loki/source/syslog"                   // Import loki.source.syslog
 	_ "github.com/grafana/agent/component/loki/source/windowsevent"             // Import loki.source.windowsevent
 	_ "github.com/grafana/agent/component/loki/write"                           // Import loki.write

--- a/component/discovery/discovery.go
+++ b/component/discovery/discovery.go
@@ -2,17 +2,29 @@ package discovery
 
 import (
 	"context"
+	"sort"
 	"sync"
 	"time"
 
 	"github.com/grafana/agent/component"
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/model/labels"
 )
 
 // Target refers to a singular discovered endpoint found by a discovery
 // component.
 type Target map[string]string
+
+// Labels converts Target into a set of sorted labels.
+func (t Target) Labels() labels.Labels {
+	var lset labels.Labels
+	for k, v := range t {
+		lset = append(lset, labels.Label{Name: k, Value: v})
+	}
+	sort.Sort(lset)
+	return lset
+}
 
 // Exports holds values which are exported by all discovery components.
 type Exports struct {

--- a/component/loki/source/kubernetes/kubernetes.go
+++ b/component/loki/source/kubernetes/kubernetes.go
@@ -1,0 +1,311 @@
+// Package kubernetes implements the loki.source.kubernetes component.
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/common/config"
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/agent/component/common/loki/positions"
+	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/component/loki/source/kubernetes/kubetail"
+	"github.com/grafana/agent/pkg/build"
+	"github.com/grafana/agent/pkg/river"
+	promconfig "github.com/prometheus/common/config"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name: "loki.source.kubernetes",
+		Args: Arguments{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			return New(opts, args.(Arguments))
+		},
+	})
+}
+
+// Arguments holds values which are used to configure the loki.source.kubernetes
+// component.
+type Arguments struct {
+	Targets   []discovery.Target  `river:"targets,attr"`
+	ForwardTo []loki.LogsReceiver `river:"forward_to,attr"`
+
+	// Client settings to connect to Kubernetes.
+	Client ClientArguments `river:"client,block,optional"`
+}
+
+var _ river.Unmarshaler = (*Arguments)(nil)
+
+// DefaultArguments holds default settings for loki.source.kubernetes.
+var DefaultArguments = Arguments{
+	Client: ClientArguments{
+		HTTPClientConfig: config.DefaultHTTPClientConfig,
+	},
+}
+
+// UnmarshalRiver implements river.Unmarshaler and applies defaults.
+func (args *Arguments) UnmarshalRiver(f func(interface{}) error) error {
+	*args = DefaultArguments
+
+	type arguments Arguments
+	return f((*arguments)(args))
+}
+
+// ClientArguments controls how loki.source.kubernetes connects to Kubernetes.
+type ClientArguments struct {
+	APIServer        config.URL              `river:"api_server,attr,optional"`
+	KubeConfig       string                  `river:"kubeconfig_file,attr,optional"`
+	HTTPClientConfig config.HTTPClientConfig `river:"http_client_config,block,optional"`
+}
+
+// UnmarshalRiver unmarshals ClientArguments and performs validations.
+func (args *ClientArguments) UnmarshalRiver(f func(interface{}) error) error {
+	type arguments ClientArguments
+	if err := f((*arguments)(args)); err != nil {
+		return err
+	}
+
+	if args.APIServer.URL != nil && args.KubeConfig != "" {
+		return fmt.Errorf("only one of api_server and kubeconfig_file can be set")
+	}
+	if args.KubeConfig != "" && !reflect.DeepEqual(args.HTTPClientConfig, config.DefaultHTTPClientConfig) {
+		return fmt.Errorf("http_client_config can not be configured when kubeconfig_file is set")
+	}
+	if args.APIServer.URL == nil && !reflect.DeepEqual(args.HTTPClientConfig, config.DefaultHTTPClientConfig) {
+		return fmt.Errorf("api_server must be set when http_client_config is provided")
+	}
+
+	return nil
+}
+
+func (args *ClientArguments) buildClient(l log.Logger) (*kubernetes.Clientset, error) {
+	var (
+		cfg *rest.Config
+		err error
+	)
+
+	switch {
+	case args.KubeConfig != "":
+		cfg, err = clientcmd.BuildConfigFromFlags("", args.KubeConfig)
+		if err != nil {
+			return nil, err
+		}
+
+	case args.APIServer.URL == nil:
+		// Use in-cluster config.
+		cfg, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+		level.Info(l).Log("msg", "Using pod service account via in-cluster config")
+
+	default:
+		rt, err := promconfig.NewRoundTripperFromConfig(*args.HTTPClientConfig.Convert(), "loki.source.kubernetes")
+		if err != nil {
+			return nil, err
+		}
+		cfg = &rest.Config{
+			Host:      args.APIServer.String(),
+			Transport: rt,
+		}
+	}
+
+	cfg.UserAgent = fmt.Sprintf("GrafanaAgent/%s", build.Version)
+	cfg.ContentType = "application/vnd.kubernetes.protobuf"
+
+	return kubernetes.NewForConfig(cfg)
+}
+
+// Component implements the loki.source.kubernetes component.
+type Component struct {
+	log       log.Logger
+	opts      component.Options
+	positions positions.Positions
+
+	mut         sync.Mutex
+	args        Arguments
+	tailer      *kubetail.Manager
+	lastOptions *kubetail.Options
+
+	handler loki.LogsReceiver
+
+	receiversMut sync.RWMutex
+	receivers    []loki.LogsReceiver
+}
+
+var (
+	_ component.Component      = (*Component)(nil)
+	_ component.DebugComponent = (*Component)(nil)
+)
+
+// New creates a new loki.source.kubernetes component.
+func New(o component.Options, args Arguments) (*Component, error) {
+	err := os.MkdirAll(o.DataPath, 0750)
+	if err != nil && !os.IsExist(err) {
+		return nil, err
+	}
+	positionsFile, err := positions.New(o.Logger, positions.Config{
+		SyncPeriod:    10 * time.Second,
+		PositionsFile: filepath.Join(o.DataPath, "positions.yml"),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Component{
+		log:       o.Logger,
+		opts:      o,
+		handler:   make(loki.LogsReceiver),
+		positions: positionsFile,
+	}
+	if err := c.Update(args); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// Run implements component.Component.
+func (c *Component) Run(ctx context.Context) error {
+	defer c.positions.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case entry := <-c.handler:
+			c.receiversMut.RLock()
+			receivers := c.receivers
+			c.receiversMut.RUnlock()
+
+			for _, receiver := range receivers {
+				receiver <- entry
+			}
+		}
+	}
+}
+
+// Update implements component.Component.
+func (c *Component) Update(args component.Arguments) error {
+	newArgs := args.(Arguments)
+
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	// Update the receivers before anything else, just in case something fails.
+	c.receivers = newArgs.ForwardTo
+
+	managerOpts, err := c.getTailerOptions(newArgs)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case c.tailer == nil:
+		// First call to Update; build the tailer.
+		c.tailer = kubetail.NewManager(c.log, managerOpts)
+
+	case managerOpts != c.lastOptions:
+		// Options changed; pass it to the tailer.
+		//
+		// This will never fail because it only fails if the context gets canceled.
+		//
+		// TODO(rfratto): should we have a generous update timeout to prevent this
+		// from potentially hanging forever?
+		_ = c.tailer.UpdateOptions(context.Background(), managerOpts)
+		c.lastOptions = managerOpts
+
+	default:
+		// No-op: manager already exists and options didn't change.
+	}
+
+	// Convert input targets into targets to give to tailer.
+	targets := make([]*kubetail.Target, 0, len(newArgs.Targets))
+
+	for _, inTarget := range newArgs.Targets {
+		lset := inTarget.Labels()
+		processed, err := kubetail.PrepareLabels(lset, c.opts.ID)
+		if err != nil {
+			// TODO(rfratto): should this set the health of the component?
+			level.Error(c.log).Log("msg", "failed to process input target", "target", lset.String(), "err", err)
+		}
+		targets = append(targets, kubetail.NewTarget(lset, processed))
+	}
+
+	// This will never fail because it only fails if the context gets canceled.
+	//
+	// TODO(rfratto): should we have a generous update timeout to prevent this
+	// from potentially hanging forever?
+	_ = c.tailer.SyncTargets(context.Background(), targets)
+	return nil
+}
+
+// getTailerOptions gets tailer options from arguments. If args hasn't changed
+// from the last call to getTailerOptions, c.lastOptions is returned.
+// c.lastOptions must be updated by the caller.
+//
+// getTailerOptions must only be called when c.mut is held.
+func (c *Component) getTailerOptions(args Arguments) (*kubetail.Options, error) {
+	if reflect.DeepEqual(c.args.Client, args.Client) {
+		return c.lastOptions, nil
+	}
+
+	clientSet, err := args.Client.buildClient(c.log)
+	if err != nil {
+		return c.lastOptions, fmt.Errorf("building Kubernetes client: %w", err)
+	}
+
+	return &kubetail.Options{
+		Client:    clientSet,
+		Handler:   loki.NewEntryHandler(c.handler, func() {}),
+		Positions: c.positions,
+	}, nil
+}
+
+// DebugInfo returns debug information for loki.source.kubernetes.
+func (c *Component) DebugInfo() interface{} {
+	var info DebugInfo
+
+	for _, target := range c.tailer.Targets() {
+		var lastError string
+		if err := target.LastError(); err != nil {
+			lastError = err.Error()
+		}
+
+		info.Targets = append(info.Targets, DebugInfoTarget{
+			Labels:          target.Labels().Map(),
+			DiscoveryLabels: target.DiscoveryLabels().Map(),
+			LastError:       lastError,
+			UpdateTime:      target.LastEntry().Local(),
+		})
+	}
+
+	return info
+}
+
+// DebugInfo represents debug information for loki.source.kubernets.
+type DebugInfo struct {
+	Targets []DebugInfoTarget `river:"target,block,optional"`
+}
+
+// DebugInfoTarget is debug information for an individual target being tailed
+// for logs.
+type DebugInfoTarget struct {
+	Labels          map[string]string `river:"labels,attr,optional"`
+	DiscoveryLabels map[string]string `river:"discovery_labels,attr,optional"`
+	LastError       string            `river:"last_error,attr,optional"`
+	UpdateTime      time.Time         `river:"update_time,attr,optional"`
+}

--- a/component/loki/source/kubernetes/kubernetes.go
+++ b/component/loki/source/kubernetes/kubernetes.go
@@ -241,6 +241,7 @@ func (c *Component) Update(args component.Arguments) error {
 		if err != nil {
 			// TODO(rfratto): should this set the health of the component?
 			level.Error(c.log).Log("msg", "failed to process input target", "target", lset.String(), "err", err)
+			continue
 		}
 		targets = append(targets, kubetail.NewTarget(lset, processed))
 	}

--- a/component/loki/source/kubernetes/kubetail/container_utils.go
+++ b/component/loki/source/kubernetes/kubetail/container_utils.go
@@ -1,0 +1,31 @@
+package kubetail
+
+import corev1 "k8s.io/api/core/v1"
+
+type containerType uint8
+
+const (
+	containerTypeNone containerType = iota
+	containerTypeApp
+	containerTypeInit
+	containerTypeEphemeral
+)
+
+func findContainerStatus(pod *corev1.Pod, containerName string) (status corev1.ContainerStatus, typ containerType, ok bool) {
+	for _, container := range pod.Status.ContainerStatuses {
+		if container.Name == containerName {
+			return container, containerTypeApp, true
+		}
+	}
+	for _, container := range pod.Status.InitContainerStatuses {
+		if container.Name == containerName {
+			return container, containerTypeInit, true
+		}
+	}
+	for _, container := range pod.Status.EphemeralContainerStatuses {
+		if container.Name == containerName {
+			return container, containerTypeEphemeral, true
+		}
+	}
+	return corev1.ContainerStatus{}, containerTypeNone, false
+}

--- a/component/loki/source/kubernetes/kubetail/kubetail.go
+++ b/component/loki/source/kubernetes/kubetail/kubetail.go
@@ -90,11 +90,19 @@ func (m *Manager) SyncTargets(ctx context.Context, targets []*Target) error {
 }
 
 func entryForTarget(t *Target) positions.Entry {
+	// The positions entry is keyed by UID to ensure that positions from
+	// completely distinct "namespace/name:container" instances don't interfere
+	// with each other.
+	//
+	// While it's still technically possible for two containers to have the same
+	// "namespace/name:container" string and UID, it's so wildly unlikely that
+	// it's probably not worth handling.
+	//
 	// The path is fed into positions.CursorKey to treat it as a "cursor";
 	// otherise positions.Positions will try to read the path as a file and
 	// delete the entry when it can't find it.
 	return positions.Entry{
-		Path:   positions.CursorKey(t.String()),
+		Path:   positions.CursorKey(t.String() + ":" + t.UID()),
 		Labels: t.Labels().String(),
 	}
 }

--- a/component/loki/source/kubernetes/kubetail/kubetail.go
+++ b/component/loki/source/kubernetes/kubetail/kubetail.go
@@ -1,0 +1,144 @@
+// Package kubetail implements a log file tailer using the Kubernetes API.
+package kubetail
+
+import (
+	"context"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/agent/component/common/loki/positions"
+	"github.com/grafana/agent/pkg/runner"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Options passed to all tailers.
+type Options struct {
+	// Client to use to request logs from Kubernetes.
+	Client *kubernetes.Clientset
+
+	// Handler to send discovered logs to.
+	Handler loki.EntryHandler
+
+	// Positions interface so tailers can save/restore offsets in log files.
+	Positions positions.Positions
+}
+
+// A Manager manages a set of running Tailers.
+type Manager struct {
+	log log.Logger
+
+	mut   sync.Mutex
+	opts  *Options
+	tasks []*tailerTask
+
+	runner *runner.Runner[*tailerTask]
+}
+
+// NewManager returns a new Manager which manages a set of running tailers.
+// Options must not be modified after passing it to a Manager.
+func NewManager(l log.Logger, opts *Options) *Manager {
+	return &Manager{
+		log: l,
+		runner: runner.New(func(t *tailerTask) runner.Worker {
+			return newTailer(l, t)
+		}),
+	}
+}
+
+// SyncTargets synchronizes the set of running tailers to the set specified by
+// targets.
+func (m *Manager) SyncTargets(ctx context.Context, targets []*Target) error {
+	m.mut.Lock()
+	defer m.mut.Unlock()
+
+	// Convert targets into tasks to give to the runner.
+	tasks := make([]*tailerTask, 0, len(targets))
+	for _, target := range targets {
+		tasks = append(tasks, &tailerTask{
+			Options: m.opts,
+			Target:  target,
+		})
+	}
+
+	if err := m.runner.ApplyTasks(ctx, tasks); err != nil {
+		return err
+	}
+
+	// Delete positions for targets which have gone away.
+	newEntries := make(map[positions.Entry]struct{}, len(targets))
+	for _, target := range targets {
+		newEntries[entryForTarget(target)] = struct{}{}
+	}
+
+	for _, task := range m.tasks {
+		ent := entryForTarget(task.Target)
+
+		// The task from the last call to SyncTargets is no longer in newEntries;
+		// remove it from the positions file. We do this _after_ calling ApplyTasks
+		// to ensure that the old tailers have shut down, otherwise the tailer
+		// might write its position again during shutdown after we removed it.
+		if _, found := newEntries[ent]; !found {
+			level.Info(m.log).Log("msg", "removing entry from positions file", "path", ent.Path, "labels", ent.Labels)
+			m.opts.Positions.Remove(ent.Path, ent.Labels)
+		}
+	}
+
+	m.tasks = tasks
+	return nil
+}
+
+func entryForTarget(t *Target) positions.Entry {
+	// Prefix the path with "cursor-" so it doesn't get automatically deleted by
+	// positions.Positions, which otherwise will try to read the path as a file.
+	return positions.Entry{
+		Path:   "cursor-" + t.String(),
+		Labels: t.Labels().String(),
+	}
+}
+
+// UpdateOptions updates the Options shared with all Tailers. All Tailers will
+// be updated with the new set of Options. Options should not be modified after
+// passing to UpdateOptions.
+func (m *Manager) UpdateOptions(ctx context.Context, newOptions *Options) error {
+	m.mut.Lock()
+	defer m.mut.Unlock()
+
+	// Iterate through the previous set of tasks and create a new task with the
+	// new set of options.
+	tasks := make([]*tailerTask, 0, len(m.tasks))
+	for _, oldTask := range m.tasks {
+		tasks = append(tasks, &tailerTask{
+			Options: newOptions,
+			Target:  oldTask.Target,
+		})
+	}
+
+	if err := m.runner.ApplyTasks(ctx, tasks); err != nil {
+		return err
+	}
+
+	m.opts = newOptions
+	m.tasks = tasks
+	return nil
+}
+
+// Targets returns the set of targets which are actively being tailed. Targets
+// for tailers which have terminated are not included. The returned set of
+// targets are deduplicated.
+func (m *Manager) Targets() []*Target {
+	tasks := m.runner.Tasks()
+
+	targets := make([]*Target, 0, len(tasks))
+	for _, task := range tasks {
+		targets = append(targets, task.Target)
+	}
+	return targets
+}
+
+// Stop stops the manager and all running Tailers. It blocks until all Tailers
+// have exited.
+func (m *Manager) Stop() {
+	m.runner.Stop()
+}

--- a/component/loki/source/kubernetes/kubetail/kubetail.go
+++ b/component/loki/source/kubernetes/kubetail/kubetail.go
@@ -90,10 +90,11 @@ func (m *Manager) SyncTargets(ctx context.Context, targets []*Target) error {
 }
 
 func entryForTarget(t *Target) positions.Entry {
-	// Prefix the path with "cursor-" so it doesn't get automatically deleted by
-	// positions.Positions, which otherwise will try to read the path as a file.
+	// The path is fed into positions.CursorKey to treat it as a "cursor";
+	// otherise positions.Positions will try to read the path as a file and
+	// delete the entry when it can't find it.
 	return positions.Entry{
-		Path:   "cursor-" + t.String(),
+		Path:   positions.CursorKey(t.String()),
 		Labels: t.Labels().String(),
 	}
 }

--- a/component/loki/source/kubernetes/kubetail/tailer.go
+++ b/component/loki/source/kubernetes/kubetail/tailer.go
@@ -1,0 +1,323 @@
+package kubetail
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/agent/pkg/runner"
+	"github.com/grafana/dskit/backoff"
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubetypes "k8s.io/apimachinery/pkg/types"
+)
+
+// tailerTask is the payload used to create tailers. It implements runner.Task.
+type tailerTask struct {
+	Options *Options
+	Target  *Target
+}
+
+var _ runner.Task = (*tailerTask)(nil)
+
+func (tt *tailerTask) Hash() uint64 { return tt.Target.Hash() }
+
+func (tt *tailerTask) Equals(other runner.Task) bool {
+	otherTask := other.(*tailerTask)
+
+	// Quick path: pointers are exactly the same.
+	if tt == otherTask {
+		return true
+	}
+
+	// Slow path: check individual fields which are part of the task.
+	return tt.Options == otherTask.Options &&
+		tt.Target.UID() == otherTask.Target.UID() &&
+		labels.Equal(tt.Target.Labels(), otherTask.Target.Labels())
+}
+
+// A tailer tails the logs of a Kubernetes container. It is created by a
+// [Manager].
+type tailer struct {
+	log    log.Logger
+	opts   *Options
+	target *Target
+
+	lset model.LabelSet
+}
+
+var _ runner.Worker = (*tailer)(nil)
+
+// newTailer returns a new Tailer which tails logs from the target specified by
+// the task.
+func newTailer(l log.Logger, task *tailerTask) *tailer {
+	return &tailer{
+		log:    log.WithPrefix(l, "target", task.Target.String()),
+		opts:   task.Options,
+		target: task.Target,
+
+		lset: newLabelSet(task.Target.Labels()),
+	}
+}
+
+func newLabelSet(l labels.Labels) model.LabelSet {
+	res := make(model.LabelSet, len(l))
+	for _, pair := range l {
+		res[model.LabelName(pair.Name)] = model.LabelValue(pair.Value)
+	}
+	return res
+}
+
+var retailBackoff = backoff.Config{
+	MinBackoff: time.Second,
+	MaxBackoff: time.Minute,
+}
+
+func (t *tailer) Run(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	level.Info(t.log).Log("msg", "tailer running")
+	defer level.Info(t.log).Log("msg", "tailer exited")
+
+	bo := backoff.New(ctx, retailBackoff)
+
+	handler := loki.NewEntryMutatorHandler(t.opts.Handler, func(e loki.Entry) loki.Entry {
+		// A log line got read, we can reset the backoff period now.
+		bo.Reset()
+		return e
+	})
+	defer handler.Stop()
+
+	for bo.Ongoing() {
+		err := t.tail(ctx, handler)
+		if err == nil {
+			terminated, err := t.containerTerminated(ctx)
+			if terminated {
+				// The container shut down and won't come back; we can stop tailing it.
+				return
+			} else if err != nil {
+				level.Warn(t.log).Log("msg", "could not determine if container terminated; will retry tailing", "err", err)
+			}
+		}
+
+		if err != nil {
+			t.target.Report(time.Now().UTC(), err)
+			level.Warn(t.log).Log("msg", "tailer stopped; will retry", "err", err)
+		}
+		bo.Wait()
+	}
+}
+
+func (t *tailer) tail(ctx context.Context, handler loki.EntryHandler) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var (
+		key           = t.target.NamespacedName()
+		containerName = t.target.ContainerName()
+
+		positionsEnt = entryForTarget(t.target)
+	)
+
+	var lastReadTime time.Time
+
+	if offset, err := t.opts.Positions.Get(positionsEnt.Path, positionsEnt.Labels); err != nil {
+		level.Warn(t.log).Log("msg", "failed to load last read offset", "err", err)
+	} else {
+		lastReadTime = time.UnixMicro(offset)
+	}
+
+	// If the last entry for our target is after the positions cache, use that
+	// instead.
+	if lastEntry := t.target.LastEntry(); lastEntry.After(lastReadTime) {
+		lastReadTime = lastEntry
+	}
+
+	var offsetTime *metav1.Time
+	if !lastReadTime.IsZero() {
+		offsetTime = &metav1.Time{Time: lastReadTime}
+	}
+
+	req := t.opts.Client.CoreV1().Pods(key.Namespace).GetLogs(key.Name, &corev1.PodLogOptions{
+		Follow:     true,
+		Container:  containerName,
+		SinceTime:  offsetTime,
+		Timestamps: true, // Should be forced to true so we can parse the original timestamp back out.
+	})
+	stream, err := req.Stream(ctx)
+	if err != nil {
+		return err
+	}
+	go func() {
+		<-ctx.Done()
+		_ = stream.Close()
+	}()
+
+	level.Info(t.log).Log("msg", "opened log stream", "start time", lastReadTime)
+
+	ch := handler.Chan()
+	reader := bufio.NewReader(stream)
+
+	for {
+		line, err := reader.ReadString('\n')
+
+		// Try processing the line before handling the error, since data may still
+		// be returned alongside an EOF.
+		if len(line) != 0 {
+			entryTimestamp, entryLine := parseKubernetesLog(line)
+			if !entryTimestamp.After(lastReadTime) {
+				continue
+			}
+			lastReadTime = entryTimestamp
+
+			entry := loki.Entry{
+				Labels: t.lset,
+				Entry: logproto.Entry{
+					Timestamp: entryTimestamp,
+					Line:      entryLine,
+				},
+			}
+
+			select {
+			case <-ctx.Done():
+				return nil
+			case ch <- entry:
+				// Save position after it's been sent over the channel.
+				t.opts.Positions.Put(positionsEnt.Path, positionsEnt.Labels, entryTimestamp.UnixMicro())
+				t.target.Report(entryTimestamp, nil)
+			}
+		}
+
+		// Return an error if our stream closed. The caller will reopen the tailer
+		// forever until our tailer is closed.
+		//
+		// Even if EOF is returned, we still want to allow the tailer to retry
+		// until the tailer is shutdown; EOF being returned doesn't necessarily
+		// indicate that the logs are done, and could point to a brief network
+		// outage.
+		if err != nil && errors.Is(err, io.EOF) {
+			return nil
+		} else if err != nil {
+			return err
+		}
+	}
+}
+
+// containerTerminated determines whether the container this tailer was
+// watching has terminated and won't restart. If containerTerminated returns
+// true, it means that no more logs will appear for the watched target.
+func (t *tailer) containerTerminated(ctx context.Context) (terminated bool, err error) {
+	var (
+		key           = t.target.NamespacedName()
+		containerName = t.target.ContainerName()
+	)
+
+	podInfo, err := t.opts.Client.CoreV1().Pods(key.Namespace).Get(ctx, key.Name, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	// The pod UID is different than the one we were tailing; our UID has
+	// terminated.
+	if podInfo.GetUID() != kubetypes.UID(t.target.UID()) {
+		return true, nil
+	}
+
+	containerInfo, containerType, found := findContainerStatus(podInfo, containerName)
+	if !found {
+		return false, fmt.Errorf("could not find container %q in pod status", containerName)
+	}
+
+	restartPolicy := podInfo.Spec.RestartPolicy
+
+	switch containerType {
+	case containerTypeApp:
+		// An app container will only restart if:
+		//
+		// * It is in a waiting (meaning it's waiting to run) or running state
+		//   (meaning it already restarted before we had a chance to check)
+		// * It terminated with any exit code and restartPolicy is Always
+		// * It terminated with non-zero exit code and restartPolicy is not Never
+		//
+		// https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+		switch {
+		case containerInfo.State.Waiting != nil || containerInfo.State.Running != nil:
+			return false, nil // Container will restart
+		case restartPolicy == corev1.RestartPolicyAlways:
+			return false, nil // Container will restart
+		case containerInfo.State.Terminated != nil && restartPolicy == corev1.RestartPolicyOnFailure && containerInfo.State.Terminated.ExitCode != 0:
+			return false, nil // Container will restart
+		default:
+			return true, nil // Container will *not* restart
+		}
+
+	case containerTypeInit:
+		// An init container will only restart if:
+		//
+		// * It is in a waiting (meaning it's waiting to run) or running state
+		//   (meaning it already restarted before we had a chance to check)
+		// * It terminated with an exit code of non-zero and restartPolicy is not
+		//   Never.
+		//
+		// https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#understanding-init-containers
+		switch {
+		case containerInfo.State.Waiting != nil || containerInfo.State.Running != nil:
+			return false, nil // Container will restart
+		case containerInfo.State.Terminated != nil && containerInfo.State.Terminated.ExitCode != 0 && restartPolicy != corev1.RestartPolicyNever:
+			return false, nil // Container will restart
+		default:
+			return true, nil // Container will *not* restart
+		}
+
+	case containerTypeEphemeral:
+		// Ephemeral containers never restart.
+		//
+		// https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// parseKubernetesLog parses a log line returned from the Kubernetes API,
+// splitting out the timestamp and the log line. If the timestamp cannot be
+// parsed, time.Now() is returned with the original log line intact.
+//
+// If the timestamp was parsed, it is stripped out of the resulting line of
+// text.
+func parseKubernetesLog(input string) (timestamp time.Time, line string) {
+	timestampOffset := strings.IndexByte(input, ' ')
+	if timestampOffset == -1 {
+		return time.Now().UTC(), input
+	}
+
+	var remain string
+	if timestampOffset < len(input) {
+		remain = input[timestampOffset+1:]
+	}
+
+	// Kubernetes can return timestamps in either RFC3339Nano or RFC3339, so we
+	// try both.
+	timestampString := input[:timestampOffset]
+
+	if timestamp, err := time.Parse(time.RFC3339Nano, timestampString); err == nil {
+		return timestamp.UTC(), remain
+	}
+
+	if timestamp, err := time.Parse(time.RFC3339, timestampString); err == nil {
+		return timestamp.UTC(), remain
+	}
+
+	return time.Now().UTC(), input
+}

--- a/component/loki/source/kubernetes/kubetail/tailer_test.go
+++ b/component/loki/source/kubernetes/kubetail/tailer_test.go
@@ -1,0 +1,44 @@
+package kubetail
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_parseKubernetesLog(t *testing.T) {
+	tt := []struct {
+		inputLine  string
+		expectTS   time.Time
+		expectLine string
+	}{
+		{
+			// Test normal RFC3339Nano log line.
+			inputLine:  `2023-01-23T17:00:10.000000001Z hello, world!`,
+			expectTS:   time.Date(2023, time.January, 23, 17, 0, 10, 1, time.UTC),
+			expectLine: "hello, world!",
+		},
+		{
+			// Test normal RFC3339 log line.
+			inputLine:  `2023-01-23T17:00:10Z hello, world!`,
+			expectTS:   time.Date(2023, time.January, 23, 17, 0, 10, 0, time.UTC),
+			expectLine: "hello, world!",
+		},
+		{
+			// Test empty log line. There will always be a space prepended by
+			// Kubernetes.
+			inputLine:  `2023-01-23T17:00:10.000000001Z `,
+			expectTS:   time.Date(2023, time.January, 23, 17, 0, 10, 1, time.UTC),
+			expectLine: "",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.inputLine, func(t *testing.T) {
+			actualTS, actualLine := parseKubernetesLog(tc.inputLine)
+			require.Equal(t, tc.expectTS, actualTS)
+			require.Equal(t, tc.expectLine, actualLine)
+		})
+	}
+}

--- a/component/loki/source/kubernetes/kubetail/target.go
+++ b/component/loki/source/kubernetes/kubetail/target.go
@@ -1,0 +1,236 @@
+package kubetail
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Internal labels which indicate what container to tail logs from.
+const (
+	LabelPodNamespace     = "__pod_namespace__"
+	LabelPodName          = "__pod_name__"
+	LabelPodContainerName = "__pod_container_name__"
+	LabelPodUID           = "__pod_uid__"
+
+	kubePodNamespace     = "__meta_kubernetes_namespace"
+	kubePodName          = "__meta_kubernetes_pod_name"
+	kubePodContainerName = "__meta_kubernetes_pod_container_name"
+	kubePodUID           = "__meta_kubernetes_pod_uid"
+)
+
+// Target represents an individual container being tailed for logs.
+type Target struct {
+	origLabels   labels.Labels // Original discovery labels
+	publicLabels labels.Labels // Labels with private labels omitted
+
+	namespacedName types.NamespacedName
+	containerName  string
+	id             string // String representation of "namespace/pod:container"; not fully unique
+	uid            string // UID from pod
+	hash           uint64 // Hash of public labels and id
+
+	mut       sync.RWMutex
+	lastError error
+	lastEntry time.Time
+}
+
+// NewTarget creates a new Target which can be passed to a tailer.
+func NewTarget(origLabels labels.Labels, lset labels.Labels) *Target {
+	// Precompute some values based on labels so we don't have to continually
+	// search them.
+	var (
+		namespacedName = types.NamespacedName{
+			Namespace: lset.Get(LabelPodNamespace),
+			Name:      lset.Get(LabelPodName),
+		}
+
+		containerName = lset.Get(LabelPodContainerName)
+		uid           = lset.Get(LabelPodUID)
+
+		id           = fmt.Sprintf("%s:%s", namespacedName, containerName)
+		publicLabels = publicLabels(lset)
+	)
+
+	// Precompute the hash of the target from the public labels and the ID of the
+	// target.
+	hasher := xxhash.New()
+	fmt.Fprintf(hasher, "%016d", publicLabels.Hash())
+	fmt.Fprint(hasher, id)
+	fmt.Fprint(hasher, uid)
+	hash := hasher.Sum64()
+
+	return &Target{
+		origLabels:   origLabels,
+		publicLabels: publicLabels,
+
+		namespacedName: namespacedName,
+		containerName:  containerName,
+		id:             id,
+		uid:            uid,
+		hash:           hash,
+	}
+}
+
+func publicLabels(lset labels.Labels) labels.Labels {
+	lb := labels.NewBuilder(lset)
+
+	for _, l := range lset {
+		if strings.HasPrefix(l.Name, model.ReservedLabelPrefix) {
+			lb.Del(l.Name)
+		}
+	}
+
+	return lb.Labels(nil)
+}
+
+// NamespacedName returns the key of the Pod being targeted.
+func (t *Target) NamespacedName() types.NamespacedName { return t.namespacedName }
+
+// ContainerName returns the container name being targeted.
+func (t *Target) ContainerName() string { return t.containerName }
+
+// String returns a string representing the target in the form
+// "namespace/name:container".
+func (t *Target) String() string { return t.id }
+
+// DiscoveryLabels returns the set of original labels prior to processing or
+// relabeling.
+func (t *Target) DiscoveryLabels() labels.Labels { return t.origLabels }
+
+// Labels returns the set of public labels for the target.
+func (t *Target) Labels() labels.Labels { return t.publicLabels }
+
+// Hash returns an identifying hash for the target.
+func (t *Target) Hash() uint64 { return t.hash }
+
+// UID returns the UID for this target, based on the pod's UID.
+func (t *Target) UID() string { return t.uid }
+
+// Report reports information about the target.
+func (t *Target) Report(time time.Time, err error) {
+	t.mut.Lock()
+	defer t.mut.Unlock()
+
+	t.lastError = err
+	t.lastEntry = time
+}
+
+// LastError returns the most recent error if the target is unhealthy.
+func (t *Target) LastError() error {
+	t.mut.RLock()
+	defer t.mut.RUnlock()
+
+	return t.lastError
+}
+
+// LastEntry returns the time the most recent log line was read or when the
+// most recent error occurred.
+func (t *Target) LastEntry() time.Time {
+	t.mut.RLock()
+	defer t.mut.RUnlock()
+
+	return t.lastEntry
+}
+
+// PrepareLabels builds a label set with default labels applied from the
+// default label set. It validates that the input label set is valid.
+//
+// The namespace of the pod to tail logs from is determined by the
+// [LabelPodNamespace] label. If this label isn't present, PrepareLabels falls
+// back to __meta_kubernetes_namespace.
+//
+// The name of the pod to tail logs from is determined by the [LabelPodName]
+// label. If this label isn't present, PrepareLabels falls back to
+// __meta_kubernetes_pod_name.
+//
+// The name of the container to tail logs from is determined by the
+// [LabelPodContainerName] label. If this label isn't present, PrepareLabels
+// falls back to __meta_kubernetes_pod_container_name.
+//
+// Validation of lset fails if there is no label indicating the pod namespace,
+// pod name, or container name.
+func PrepareLabels(lset labels.Labels, defaultJob string) (res labels.Labels, err error) {
+	tailLabels := []labels.Label{
+		{Name: model.JobLabel, Value: defaultJob},
+	}
+	lb := labels.NewBuilder(lset)
+
+	// Add default labels to lb if they're not in lset.
+	for _, l := range tailLabels {
+		if !lset.Has(l.Name) {
+			lb.Set(l.Name, l.Value)
+		}
+	}
+
+	firstLabelValue := func(labelNames ...string) string {
+		for _, labelName := range labelNames {
+			if lv := lset.Get(labelName); lv != "" {
+				return lv
+			}
+		}
+		return ""
+	}
+
+	var (
+		podNamespace     = firstLabelValue(LabelPodNamespace, kubePodNamespace)
+		podName          = firstLabelValue(LabelPodName, kubePodName)
+		podContainerName = firstLabelValue(LabelPodContainerName, kubePodContainerName)
+		podUID           = firstLabelValue(LabelPodUID, kubePodUID)
+	)
+
+	switch {
+	case podNamespace == "":
+		return nil, fmt.Errorf("missing pod namespace label")
+	case podName == "":
+		return nil, fmt.Errorf("missing pod name label")
+	case podContainerName == "":
+		return nil, fmt.Errorf("missing pod container name label")
+	case podUID == "":
+		return nil, fmt.Errorf("missing pod UID label")
+	}
+
+	// Make sure that LabelPodNamespace, LabelPodName, LabelPodContainerName, and
+	// LabelPodUID are set on the final target.
+	if !lset.Has(LabelPodNamespace) {
+		lb.Set(LabelPodNamespace, podNamespace)
+	}
+	if !lset.Has(LabelPodName) {
+		lb.Set(LabelPodName, podName)
+	}
+	if !lset.Has(LabelPodContainerName) {
+		lb.Set(LabelPodContainerName, podContainerName)
+	}
+	if !lset.Has(LabelPodUID) {
+		lb.Set(LabelPodUID, podContainerName)
+	}
+
+	// Meta labels are deleted after relabelling. Other internal labels propagate
+	// to the target which decides whether they will be part of their label set.
+	for _, l := range lset {
+		if strings.HasPrefix(l.Name, model.MetaLabelPrefix) {
+			lb.Del(l.Name)
+		}
+	}
+
+	// Default the instance label to the target address.
+	if !lset.Has(model.InstanceLabel) {
+		defaultInstance := fmt.Sprintf("%s/%s:%s", podNamespace, podName, podContainerName)
+		lb.Set(model.InstanceLabel, defaultInstance)
+	}
+
+	res = lb.Labels(nil)
+	for _, l := range res {
+		// Check label values are valid, drop the target if not.
+		if !model.LabelValue(l.Value).IsValid() {
+			return nil, fmt.Errorf("invalid label value for %q: %q", l.Name, l.Value)
+		}
+	}
+	return res, nil
+}

--- a/docs/sources/flow/reference/components/loki.source.kubernetes.md
+++ b/docs/sources/flow/reference/components/loki.source.kubernetes.md
@@ -7,12 +7,17 @@ title: loki.source.kubernetes
 # loki.source.kubernetes
 
 `loki.source.kubernetes` tails logs from Kubernetes containers using the
-Kubernetes API.
+Kubernetes API. It has the following benefits over `loki.source.file`:
 
-Unlike `loki.source.file`, `loki.source.kubernetes` can collect container logs
-without needing a privileged container, a root user, or a `hostPath` volume
-mount. However, it leads to more network traffic and may increase CPU
-consumption of Kubelets.
+* It works without a privileged container
+* It works without a root user
+* It works without needing access to the filesystem of the Kubernetes node
+* It doesn't require a DaemonSet to collect logs, so one agent could collect
+  logs for the whole cluster.
+
+> **NOTE**: Because `loki.source.kubernetes` uses the Kubernetes API to tail
+> logs, it uses more network traffic and CPU consumption of Kubelets than
+> `loki.source.file`.
 
 Multiple `loki.source.kubernetes` components can be specified by giving them
 different labels.

--- a/docs/sources/flow/reference/components/loki.source.kubernetes.md
+++ b/docs/sources/flow/reference/components/loki.source.kubernetes.md
@@ -1,0 +1,141 @@
+---
+aliases:
+- /docs/agent/latest/flow/reference/components/loki.source.kubernetes
+title: loki.source.kubernetes
+---
+
+# loki.source.kubernetes
+
+`loki.source.kubernetes` tails logs from Kubernetes containers using the
+Kubernetes API.
+
+Unlike `loki.source.file`, `loki.source.kubernetes` can collect container logs
+without needing a privileged container, a root user, or a `hostPath` volume
+mount. However, it leads to more network traffic and may increase CPU
+consumption of Kubelets.
+
+Multiple `loki.source.kubernetes` components can be specified by giving them
+different labels.
+
+## Usage
+
+```river
+loki.source.kubernetes "LABEL" {
+  targets    = TARGET_LIST
+  forward_to = RECEIVER_LIST
+}
+```
+
+## Arguments
+
+The component starts a new reader for each of the given `targets` and fans out
+log entries to the list of receivers passed in `forward_to`.
+
+`loki.source.kubernetes` supports the following arguments:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`targets` | `list(map(string))` | List of files to read from. | | yes
+`forward_to` | `list(LogsReceiver)` | List of receivers to send log entries to. | | yes
+
+Each target in `targets` must have the following labels:
+
+* `__meta_kubernetes_namespace` or `__pod_namespace__` to specify the namespace
+  of the pod to tail.
+* `__meta_kubernetes_pod_name` or `__pod_name__` to specify the name of the pod
+  to tail.
+* `__meta_kubernetes_pod_container_name` or `__pod_container_name__` to specify
+  the container within the pod to tail.
+* `__meta_kubernetes_pod_uid` or `__pod_uid__` to specify the UID of the pod to
+  tail.
+
+By default, all of these labels are present when the output
+`discovery.kubernetes` is used.
+
+A log tailer is started for each unique target in `targets`. Log tailers will
+reconnect with exponential backoff to Kubernetes if the log stream returns
+before the container has permanently terminated.
+
+## Blocks
+
+The following blocks are supported inside the definition of
+`loki.source.kubernetes`:
+
+Hierarchy | Block | Description | Required
+--------- | ----- | ----------- | --------
+client | [client][] | Configures Kubernetes client used to tail logs. | no
+client > http_client_config | [http_client_config][] | HTTP client configuration for Kubernetes requests. | no
+
+The `>` symbol indicates deeper levels of nesting. For example, `client >
+http_client_config` refers to an `http_client_config` block defined
+inside a `client` block.
+
+[client]: #client-block
+[http_client_config]: #http_client_config-block
+
+### client block
+
+The `client` block configures the Kubernetes client used to tail logs from
+containers. If the `client` block isn't provided, default in-cluster
+configuration with the service account of the running Grafana Agent pod is
+used.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`api_server` | `string` | URL of Kubernetes API server. | | no
+`kubeconfig_file` | `string` | Path of kubeconfig file to use for connecting to Kubernetes. | | no
+
+### http_client_config block
+
+The `http_client_config` block configures settings used to connect to the
+Kubernetes API server.
+
+{{< docs/shared lookup="flow/reference/components/http-client-config-block.md" source="agent" >}}
+
+## Exported fields
+
+`loki.source.kubernetes` does not export any fields.
+
+## Component health
+
+`loki.source.kubernetes` is only reported as unhealthy if given an invalid
+configuration.
+
+## Debug information
+
+`loki.source.kubernetes` exposes some target-level debug information per
+target:
+
+* The labels associated with the target.
+* The full set of labels which were found during service discovery.
+* The most recent time a log line was read and forwarded to the next components
+  in the pipeline.
+* The most recent error from tailing, if any.
+
+## Debug metrics
+
+`loki.source.kubernetes` does not exist any component-specific debug metrics.
+
+## Example
+
+This example collects logs from all Kubernetes pods and forwards them to a
+`loki.write` component so they are can be written to Loki.
+
+```river
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+
+loki.source.kubernetes "tmpfiles" {
+  targets    = discovery.kubernetes.pods.targets
+  forward_to = [loki.write.local.receiver]
+}
+
+loki.write "local" {
+  endpoint {
+    url = env("LOKI_URL")
+  }
+}
+```

--- a/docs/sources/flow/reference/components/loki.source.kubernetes.md
+++ b/docs/sources/flow/reference/components/loki.source.kubernetes.md
@@ -9,9 +9,9 @@ title: loki.source.kubernetes
 `loki.source.kubernetes` tails logs from Kubernetes containers using the
 Kubernetes API. It has the following benefits over `loki.source.file`:
 
-* It works without a privileged container
-* It works without a root user
-* It works without needing access to the filesystem of the Kubernetes node
+* It works without a privileged container.
+* It works without a root user.
+* It works without needing access to the filesystem of the Kubernetes node.
 * It doesn't require a DaemonSet to collect logs, so one agent could collect
   logs for the whole cluster.
 
@@ -81,7 +81,7 @@ inside a `client` block.
 ### client block
 
 The `client` block configures the Kubernetes client used to tail logs from
-containers. If the `client` block isn't provided, default in-cluster
+containers. If the `client` block isn't provided, the default in-cluster
 configuration with the service account of the running Grafana Agent pod is
 used.
 
@@ -89,8 +89,8 @@ The following arguments are supported:
 
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`api_server` | `string` | URL of Kubernetes API server. | | no
-`kubeconfig_file` | `string` | Path of kubeconfig file to use for connecting to Kubernetes. | | no
+`api_server` | `string` | URL of the Kubernetes API server. | | no
+`kubeconfig_file` | `string` | Path of the `kubeconfig` file to use for connecting to Kubernetes. | | no
 
 ### http_client_config block
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -118,19 +118,22 @@ func (s *Runner[TaskType]) ApplyTasks(ctx context.Context, tt []TaskType) error 
 	var stopping sync.WaitGroup
 	for w := range s.workers.Iterate() {
 		if newTasks.Has(w.(*workerTask).Task) {
+			// Task still exists.
 			continue
 		}
 
+		// Stop and remove the task from s.workers.
 		stopping.Add(1)
-		go func(w *scheduledWorker) {
+		go func(w *workerTask) {
 			defer stopping.Done()
-			w.Cancel()
+			defer s.workers.Delete(w)
+			w.Worker.Cancel()
 
 			select {
 			case <-ctx.Done():
-			case <-w.Exited:
+			case <-w.Worker.Exited:
 			}
-		}(w.(*workerTask).Worker)
+		}(w.(*workerTask))
 	}
 
 	// Ensure that every defined task in newTasks has a worker associated with
@@ -161,7 +164,6 @@ func (s *Runner[TaskType]) ApplyTasks(ctx context.Context, tt []TaskType) error 
 			defer s.running.Done()
 			defer close(newWorker.Exited)
 			newWorker.Worker.Run(workerCtx)
-			s.workers.Delete(newTask)
 		}()
 
 		_ = s.workers.Add(newTask)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -173,6 +173,17 @@ func (s *Runner[TaskType]) ApplyTasks(ctx context.Context, tt []TaskType) error 
 	return ctx.Err()
 }
 
+// Tasks returns the current set of running Tasks. Tasks are included even if
+// their associated runner has terminated.
+func (s *Runner[TaskType]) Tasks() []TaskType {
+	var res []TaskType
+	for task := range s.workers.Iterate() {
+		workerTask := task.(*workerTask)
+		res = append(res, workerTask.Task.(TaskType))
+	}
+	return res
+}
+
 // Stop the Schduler and all running Workers. Close blocks until all running
 // Workers exit.
 func (s *Runner[TaskType]) Stop() {


### PR DESCRIPTION
The `loki.source.kubernetes` component, when given a set of targets from `discovery.kubernetes`, tails logs from containers using the Kubernetes API.

One tailer is launched for each unique container. Tailers will reconnect to Kubernetes with exponential backoff if their connection to the Kubernetes API is closed. Tailers only exit if the target is removed from the input or if the tailer determines that the terminated container will not restart.

Closes #2504.