### PR TITLE
[Agent Management] Add Remote Config Validation

### DIFF
--- a/pkg/config/agentmanagement.go
+++ b/pkg/config/agentmanagement.go
@@ -134,10 +134,10 @@ func getRemoteConfig(expandEnvVars bool, configProvider remoteConfigProvider, lo
 
 	// this is done in order to validate the config semantically
 	if err = applyIntegrationValuesFromFlagset(fs, args, configPath, &remoteConfig); err != nil {
-		level.Error(log).Log("msg", "could not apply integration version to config", "err", err)
+		level.Error(log).Log("msg", "could not load integrations from config, falling back to cache", "err", err)
+		instrumentation.InstrumentInvalidRemoteConfig("invalid_integrations_config")
 		return configProvider.GetCachedRemoteConfig(expandEnvVars)
 	}
-
 	if err = remoteConfig.Validate(fs); err != nil {
 		level.Error(log).Log("msg", "invalid config received from the API, falling back to cache", "err", err)
 		instrumentation.InstrumentInvalidRemoteConfig("invalid_agent_config")

--- a/pkg/config/agentmanagement.go
+++ b/pkg/config/agentmanagement.go
@@ -133,7 +133,11 @@ func getRemoteConfig(expandEnvVars bool, configProvider remoteConfigProvider, lo
 	}
 
 	// this is done in order to validate the config semantically
-	applyIntegrationValuesFromFlagset(fs, args, configPath, &remoteConfig)
+	if err = applyIntegrationValuesFromFlagset(fs, args, configPath, &remoteConfig); err != nil {
+		level.Error(log).Log("msg", "could not apply integration version to config", "err", err)
+		return configProvider.GetCachedRemoteConfig(expandEnvVars)
+	}
+
 	if err = remoteConfig.Validate(fs); err != nil {
 		level.Error(log).Log("msg", "invalid config received from the API, falling back to cache", "err", err)
 		instrumentation.InstrumentInvalidRemoteConfig("invalid_agent_config")

--- a/pkg/config/agentmanagement_test.go
+++ b/pkg/config/agentmanagement_test.go
@@ -139,7 +139,7 @@ func TestFullUrl(t *testing.T) {
 	assert.Equal(t, "https://localhost:1234/example/api/namespace/test_namespace/remote_config?a=A&b=B", actual)
 }
 
-func TestGetRemoteConfig_InvalidInitialConfig(t *testing.T) {
+func TestNewRemoteConfigHTTPProvider_InvalidInitialConfig(t *testing.T) {
 	// this is invalid because it is missing the password file
 	invalidAgentManagementConfig := &AgentManagementConfig{
 		Enabled: true,
@@ -156,13 +156,11 @@ func TestGetRemoteConfig_InvalidInitialConfig(t *testing.T) {
 		},
 	}
 
-	logger := server.NewLogger(&server.DefaultConfig)
-	testProvider := testRemoteConfigProvider{InitialConfig: invalidAgentManagementConfig}
-
-	// a nil flagset is being used for testing because it should not reach flag validation
-	_, err := getRemoteConfig(true, &testProvider, logger, nil, []string{}, "test")
+	cfg := Config{
+		AgentManagement: *invalidAgentManagementConfig,
+	}
+	_, err := newRemoteConfigHTTPProvider(&cfg)
 	assert.Error(t, err)
-	assert.False(t, testProvider.didCacheRemoteConfig)
 }
 
 func TestGetRemoteConfig_UnmarshallableRemoteConfig(t *testing.T) {

--- a/pkg/config/agentmanagement_test.go
+++ b/pkg/config/agentmanagement_test.go
@@ -27,10 +27,6 @@ type testRemoteConfigProvider struct {
 	didCacheRemoteConfig      bool
 }
 
-func (t *testRemoteConfigProvider) ValidateInitialConfig() error {
-	return t.InitialConfig.Validate()
-}
-
 func (t *testRemoteConfigProvider) GetCachedRemoteConfig(expandEnvVars bool) (*Config, error) {
 	return t.cachedConfigToReturn, t.cachedConfigErrorToReturn
 }

--- a/pkg/config/agentmanagement_test.go
+++ b/pkg/config/agentmanagement_test.go
@@ -40,7 +40,7 @@ func (t *testRemoteConfigProvider) CacheRemoteConfig(r []byte) error {
 	return nil
 }
 
-var validAgentManagement = AgentManagementConfig{
+var validAgentManagementConfig = AgentManagementConfig{
 	Enabled: true,
 	Url:     "https://localhost:1234/example/api",
 	BasicAuth: config.BasicAuth{
@@ -57,7 +57,7 @@ var validAgentManagement = AgentManagementConfig{
 }
 
 func TestValidateValidConfig(t *testing.T) {
-	assert.NoError(t, validAgentManagement.Validate())
+	assert.NoError(t, validAgentManagementConfig.Validate())
 }
 
 func TestValidateInvalidBasicAuth(t *testing.T) {
@@ -121,7 +121,7 @@ func TestMissingCacheLocation(t *testing.T) {
 }
 
 func TestSleepTime(t *testing.T) {
-	c := validAgentManagement
+	c := validAgentManagementConfig
 	st, err := c.SleepTime()
 	assert.NoError(t, err)
 	assert.Equal(t, time.Minute*1, st)
@@ -133,7 +133,7 @@ func TestSleepTime(t *testing.T) {
 }
 
 func TestFullUrl(t *testing.T) {
-	c := validAgentManagement
+	c := validAgentManagementConfig
 	actual, err := c.fullUrl()
 	assert.NoError(t, err)
 	assert.Equal(t, "https://localhost:1234/example/api/namespace/test_namespace/remote_config?a=A&b=B", actual)
@@ -141,7 +141,7 @@ func TestFullUrl(t *testing.T) {
 
 func TestGetRemoteConfig_InvalidInitialConfig(t *testing.T) {
 	// this is invalid because it is missing the password file
-	invalidAgentManagement := &AgentManagementConfig{
+	invalidAgentManagementConfig := &AgentManagementConfig{
 		Enabled: true,
 		Url:     "https://localhost:1234/example/api",
 		BasicAuth: config.BasicAuth{
@@ -157,7 +157,7 @@ func TestGetRemoteConfig_InvalidInitialConfig(t *testing.T) {
 	}
 
 	logger := server.NewLogger(&server.DefaultConfig)
-	testProvider := testRemoteConfigProvider{InitialConfig: invalidAgentManagement}
+	testProvider := testRemoteConfigProvider{InitialConfig: invalidAgentManagementConfig}
 
 	// a nil flagset is being used for testing because it should not reach flag validation
 	_, err := getRemoteConfig(true, &testProvider, logger, nil, []string{}, "test")
@@ -170,7 +170,7 @@ func TestGetRemoteConfig_UnmarshallableRemoteConfig(t *testing.T) {
 
 	invalidCfgBytes := []byte(brokenCfg)
 
-	am := validAgentManagement
+	am := validAgentManagementConfig
 	logger := server.NewLogger(&server.DefaultConfig)
 	testProvider := testRemoteConfigProvider{InitialConfig: &am}
 	testProvider.fetchedConfigBytesToReturn = invalidCfgBytes
@@ -186,7 +186,7 @@ func TestGetRemoteConfig_UnmarshallableRemoteConfig(t *testing.T) {
 }
 
 func TestGetRemoteConfig_RemoteFetchFails(t *testing.T) {
-	am := validAgentManagement
+	am := validAgentManagementConfig
 	logger := server.NewLogger(&server.DefaultConfig)
 	testProvider := testRemoteConfigProvider{InitialConfig: &am}
 	testProvider.fetchedConfigErrorToReturn = errors.New("connection refused")
@@ -231,7 +231,7 @@ metrics:
           - localhost:12345`
 	invalidCfgBytes := []byte(invalidConfig)
 
-	am := validAgentManagement
+	am := validAgentManagementConfig
 	logger := server.NewLogger(&server.DefaultConfig)
 	testProvider := testRemoteConfigProvider{InitialConfig: &am}
 	testProvider.fetchedConfigBytesToReturn = invalidCfgBytes

--- a/pkg/config/agentmanagement_test.go
+++ b/pkg/config/agentmanagement_test.go
@@ -124,12 +124,6 @@ func TestMissingCacheLocation(t *testing.T) {
 	assert.Error(t, invalidConfig.Validate())
 }
 
-// func TestGetCachedRemoteConfig(t *testing.T) {
-// 	cwd := filepath.Clean("./testdata/")
-// 	_, err := getCachedRemoteConfig(cwd, false)
-// 	assert.NoError(t, err)
-// }
-
 func TestSleepTime(t *testing.T) {
 	c := validAgentManagement
 	st, err := c.SleepTime()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,7 +68,7 @@ type Config struct {
 	Integrations    VersionedIntegrations `yaml:"integrations,omitempty"`
 	Traces          traces.Config         `yaml:"traces,omitempty"`
 	Logs            *logs.Config          `yaml:"logs,omitempty"`
-	AgentManagement AgentManagement       `yaml:"agent_management,omitempty"`
+	AgentManagement AgentManagementConfig `yaml:"agent_management,omitempty"`
 
 	// Flag-only fields
 	ServerFlags server.Flags `yaml:"-"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -512,8 +512,8 @@ agent_management:
 
 	// since these elements are purposefully different for the previous portion of the test,
 	// unset them before comparing the rest of the config
-	ic.AgentManagement = AgentManagement{}
-	rc.AgentManagement = AgentManagement{}
+	ic.AgentManagement = AgentManagementConfig{}
+	rc.AgentManagement = AgentManagementConfig{}
 
 	assert.True(t, util.CompareYAML(ic, rc))
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Refactors `agentmanagement.go` so `getRemoteConfig` accepts `remoteConfigProvider`s, which allows for more testing. Adds tests for some cases.

Also splits out the code that parses the flagset (the second time) and sets integrations version in `pkg/config/config.go`, specifically `load`, into a separate function which `getRemoteConfig` also calls. `getRemoteConfig` is also modified to take the parameters needed by this function (the `flagSet`, `args`, and the config `path`).

This is done in order to allow for semantic validation of the remote config inside the agent management code. Otherwise, if the API responds with a semantically invalid config (i.e. it's valid yaml, but it's not a valid agent management config) the _invalid_ remote config will be cached and any agents attempting to use it upon startup will panic.

Finally, this adds a new metric `agent_remote_config_invalid_total`, which tracks the number of invalid configs that were returned by the API, with possible labels `invalid_yaml` and `invalid_agent_config`.

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [X] Tests updated
