### PR TITLE
flow: Fix bad merge; improve conditions under which heroku and syslog listeners are recreated

### DIFF
--- a/component/loki/source/heroku/heroku.go
+++ b/component/loki/source/heroku/heroku.go
@@ -137,7 +137,7 @@ func (c *Component) Update(args component.Arguments) error {
 		rcs = flow_relabel.ComponentToPromRelabelConfigs(newArgs.RelabelRules)
 	}
 
-	if configsChanged(c.args, newArgs) {
+	if listenerChanged(c.args.HerokuListener, newArgs.HerokuListener) || relabelRulesChanged(c.args.RelabelRules, newArgs.RelabelRules) {
 		if c.target != nil {
 			err := c.target.Stop()
 			if err != nil {
@@ -194,6 +194,9 @@ type readerDebugInfo struct {
 	Address string `river:"address,attr"`
 }
 
-func configsChanged(prev, next Arguments) bool {
+func listenerChanged(prev, next ListenerConfig) bool {
+	return !reflect.DeepEqual(prev, next)
+}
+func relabelRulesChanged(prev, next flow_relabel.Rules) bool {
 	return !reflect.DeepEqual(prev, next)
 }

--- a/component/loki/source/syslog/syslog.go
+++ b/component/loki/source/syslog/syslog.go
@@ -103,7 +103,7 @@ func (c *Component) Update(args component.Arguments) error {
 		rcs = flow_relabel.ComponentToPromRelabelConfigs(newArgs.RelabelRules)
 	}
 
-	if configsChanged(c.args, newArgs) {
+	if listenersChanged(c.args.SyslogListeners, newArgs.SyslogListeners) || relabelRulesChanged(c.args.RelabelRules, newArgs.RelabelRules) {
 		for _, l := range c.targets {
 			err := l.Stop()
 			if err != nil {
@@ -124,7 +124,6 @@ func (c *Component) Update(args component.Arguments) error {
 
 		c.args = newArgs
 	}
-	c.lc = newArgs.SyslogListeners
 
 	return nil
 }
@@ -155,6 +154,9 @@ type listenerInfo struct {
 	Labels        string `river:"labels,attr"`
 }
 
-func configsChanged(prev, next Arguments) bool {
+func listenersChanged(prev, next []ListenerConfig) bool {
+	return !reflect.DeepEqual(prev, next)
+}
+func relabelRulesChanged(prev, next flow_relabel.Rules) bool {
 	return !reflect.DeepEqual(prev, next)
 }


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The previous condition would always be true, as Update would never get called if the Arguments weren't equal. We only want to restart the listeners if their config, or the relabel config we'd like to pass on to them change. 

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
