### PR TITLE
Clean up caches to speed up Windows Docker container builds

### DIFF
--- a/cmd/grafana-agent/Dockerfile.windows
+++ b/cmd/grafana-agent/Dockerfile.windows
@@ -5,10 +5,12 @@ ARG RELEASE_BUILD=1
 COPY . /src/agent
 WORKDIR /src/agent
 
-SHELL ["cmd", "/C"]
+SHELL ["cmd", "/S", "/C"]
 
-RUN "C:\Program Files\git\bin\bash.exe" -c 'RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} make generate-ui'
-RUN "C:\Program Files\git\bin\bash.exe" -c 'RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} make agent'
+# Creating new layers can be really slow on Windows so we clean up any caches
+# we can before moving on to the next step.
+RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} make generate-ui && rm -rf web/ui/node_modules && yarn cache clean --all""
+RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} make agent && go clean -cache -modcache""
 
 # Use the smallest container possible for the final image
 FROM mcr.microsoft.com/windows/nanoserver:1809

--- a/cmd/grafana-agentctl/Dockerfile.windows
+++ b/cmd/grafana-agentctl/Dockerfile.windows
@@ -5,9 +5,11 @@ ARG RELEASE_BUILD=1
 COPY . /src/agent
 WORKDIR /src/agent
 
-SHELL ["cmd", "/C"]
+SHELL ["cmd", "/S", "/C"]
 
-RUN "C:\Program Files\git\bin\bash.exe" -c 'RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} make agentctl'
+# Creating new layers can be really slow on Windows so we clean up any caches
+# we can before moving on to the next step.
+RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} make agentctl && go clean -cache -modcache""
 
 # Use the smallest container possible for the final image
 FROM mcr.microsoft.com/windows/nanoserver:1809


### PR DESCRIPTION
Saving a large layer can be really slow on Windows, so here we clean up the caches after building the UI and binaries to speed up the container builds overall on Windows.