### PR TITLE
Prefer deamonless containers

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,14 +1,15 @@
+PODMAN = $(shell if command -v podman &>/dev/null; then echo podman; else echo docker; fi)
 IMAGE = grafana/docs-base:latest
 CONTENT_PATH = /hugo/content/docs/agent/latest
 PORT = 3002:3002
 
 .PHONY: pull
 pull:
-	docker pull $(IMAGE)
+	$(PODMAN) pull $(IMAGE)
 
 .PHONY: docs
 docs: pull
-	docker run --init -v $(shell pwd)/sources:$(CONTENT_PATH):Z -p $(PORT) --rm -it $(IMAGE)
+	$(PODMAN) run --init -v $(shell pwd)/sources:$(CONTENT_PATH):Z -p $(PORT) --rm -it $(IMAGE)
 
 sources/assets/hierarchy.svg: sources/operator/hierarchy.dot
-	cat $< | docker run --rm -i nshine/dot dot -Tsvg > $@
+	cat $< | $(PODMAN) run --rm -i nshine/dot dot -Tsvg > $@


### PR DESCRIPTION
Use podman (https://podman.io) for running containers without a root Docker daemon if it is installed.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
