### PR TITLE
Unregister collectors when stopping promtail instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,8 @@ Main (unreleased)
 - Flow: fix a goroutine leak when `loki.source.file` is passed more than one
   target with identical set of public labels. (@rfratto)
 
-- Fix issue where removing and re-adding log instance configurations causes an error due to double registration of metrics (@spartan0x117, @jcreixell)
+- Fix issue where removing and re-adding log instance configurations causes an
+  error due to double registration of metrics (@spartan0x117, @jcreixell)
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ Main (unreleased)
 - Flow: fix a goroutine leak when `loki.source.file` is passed more than one
   target with identical set of public labels. (@rfratto)
 
+- Fix issue where removing and re-adding log instance configurations causes an error due to double registration of metrics (@spartan0x117, @jcreixell)
+
 ### Other changes
 
 - Use Go 1.19.4 for builds. (@erikbaranowski)

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -215,4 +215,5 @@ func (i *Instance) Stop() {
 		i.promtail.Shutdown()
 		i.promtail = nil
 	}
+	i.reg.UnregisterAll()
 }

--- a/pkg/logs/logs_test.go
+++ b/pkg/logs/logs_test.go
@@ -153,9 +153,8 @@ configs:
 	t.Run("re-apply previous config", func(t *testing.T) {
 		// Applying a nil config should remove all instances.
 		l.ApplyConfig(nil, false)
-		//
+
 		// Re-Apply the previous config and write a new line.
-		//
 		var newCfg Config
 		dec = yaml.NewDecoder(strings.NewReader(cfgText))
 		dec.SetStrict(true)

--- a/pkg/logs/logs_test.go
+++ b/pkg/logs/logs_test.go
@@ -170,7 +170,6 @@ configs:
 			require.Equal(t, "Hello again!", req.Streams[0].Entries[0].Line)
 		}
 	})
-
 }
 
 func TestLogs_PositionsDirectory(t *testing.T) {

--- a/pkg/logs/logs_test.go
+++ b/pkg/logs/logs_test.go
@@ -149,6 +149,29 @@ configs:
 		require.NoError(t, err)
 		require.Len(t, l.instances, 0)
 	})
+
+	t.Run("re-apply previous config", func(t *testing.T) {
+		// Applying a nil config should remove all instances.
+		l.ApplyConfig(nil, false)
+		//
+		// Re-Apply the previous config and write a new line.
+		//
+		var newCfg Config
+		dec = yaml.NewDecoder(strings.NewReader(cfgText))
+		dec.SetStrict(true)
+		require.NoError(t, dec.Decode(&newCfg))
+
+		require.NoError(t, l.ApplyConfig(&newCfg, false))
+
+		fmt.Fprintf(tmpFile, "Hello again!\n")
+		select {
+		case <-time.After(time.Second * 30):
+			require.FailNow(t, "timed out waiting for data to be pushed")
+		case req := <-pushes:
+			require.Equal(t, "Hello again!", req.Streams[0].Entries[0].Line)
+		}
+	})
+
 }
 
 func TestLogs_PositionsDirectory(t *testing.T) {


### PR DESCRIPTION
#### PR Description

  - Adding, removing and adding again log configuration instances seems to trigger an error due to double registration of metrics. This affects dynamically reloaded configs (for example, via `/-/reload` endpoint or agent management).
  - This change makes sure that collectors are unregistered when a given instance is stopped.

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

- Any ideas on how to test potential side effects?

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [x] Tests updated

Co-authored-By: Mischa Thompson <mischabear@gmail.com>