### PR TITLE
mimir.rules.kubernetes component: add RBAC information to the docs

### DIFF
--- a/docs/sources/flow/reference/components/mimir.rules.kubernetes.md
+++ b/docs/sources/flow/reference/components/mimir.rules.kubernetes.md
@@ -18,7 +18,7 @@ loads them into a Mimir instance.
 * This component accesses the Kubernetes REST API from [within a Pod][].
 
 > **NOTE**: This component requires [Role-based access control (RBAC)][] to be setup 
-> in Kubernetes in oder for the Agent to access it via the Kubernetes REST API.
+> in Kubernetes in order for the Agent to access it via the Kubernetes REST API.
 > For an example RBAC configuration please click [here](#example).
 
 [Kubernetes label selectors]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors

--- a/docs/sources/flow/reference/components/mimir.rules.kubernetes.md
+++ b/docs/sources/flow/reference/components/mimir.rules.kubernetes.md
@@ -218,7 +218,7 @@ mimir.rules.kubernetes "default" {
 }
 ```
 
-Below is an example RBAC configuration for Kubernetes - it authorizes the Agent to query the Kubernetes REST API:
+The following example is an RBAC configuration for Kubernetes. It authorizes the Agent to query the Kubernetes REST API:
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
Quick update to the documentation for `mimir.rules.kubernetes` following a discussion with @Logiraptor 