### PR TITLE
podAnnotations and service IP fixes

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -12,8 +12,8 @@ Unreleased
 
 ### Bugfixes
 
-- Fix `podAnnotations` values reference in pod template (should be `controller.podAnnotations`)
-- Ensure the service gets a clusterIP assigned by default
+- Fix `podAnnotations` values reference in pod template (should be `controller.podAnnotations`).
+- Ensure the service gets a clusterIP assigned by default.
 
 0.3.0 (2023-01-23)
 ------------------

--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -13,7 +13,7 @@ Unreleased
 ### Bugfixes
 
 - Fix `podAnnotations` values reference in pod template (should be `controller.podAnnotations`)
-- Ensure the service gets a clusterIP assigned
+- Ensure the service gets a clusterIP assigned by default
 
 0.3.0 (2023-01-23)
 ------------------

--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -10,6 +10,10 @@ internal API changes are not present.
 Unreleased
 ----------
 
+### Bugfixes
+
+- Fix `podAnnotations` values reference in pod template (should be `controller.podAnnotations`)
+
 0.3.0 (2023-01-23)
 ------------------
 

--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -13,6 +13,7 @@ Unreleased
 ### Bugfixes
 
 - Fix `podAnnotations` values reference in pod template (should be `controller.podAnnotations`)
+- Ensure the service gets a clusterIP assigned
 
 0.3.0 (2023-01-23)
 ------------------

--- a/operations/helm/charts/grafana-agent/Chart.yaml
+++ b/operations/helm/charts/grafana-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: grafana-agent
 description: "Grafana Agent"
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "v0.30.2"

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -1,6 +1,6 @@
 # Grafana Agent Helm chart
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![AppVersion: v0.30.2](https://img.shields.io/badge/AppVersion-v0.30.2-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![AppVersion: v0.30.2](https://img.shields.io/badge/AppVersion-v0.30.2-informational?style=flat-square)
 
 Helm chart for deploying [Grafana Agent][] to Kubernetes.
 
@@ -63,6 +63,8 @@ use the older mode (called "static mode"), set the `agent.mode` value to
 | image.tag | string | `nil` | Grafana Agent image tag. When empty, the Chart's appVersion is used. |
 | nameOverride | string | `nil` | Overrides the chart's name. Used to change the infix in the resource names. |
 | rbac.create | bool | `true` | Whether to create RBAC resources for the agent. |
+| service.clusterIP | string | `""` | Cluster IP, can be set to None, empty "" or an IP address |
+| service.type | string | `"ClusterIP"` | Service type |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the created service account. |
 | serviceAccount.create | bool | `true` | Whether to create a service account for the Grafana Agent deployment. |
 | serviceAccount.name | string | `nil` | The name of the existing service account to use when serviceAccount.create is false. |

--- a/operations/helm/charts/grafana-agent/templates/controllers/_pod.yaml
+++ b/operations/helm/charts/grafana-agent/templates/controllers/_pod.yaml
@@ -1,6 +1,6 @@
 {{- define "grafana-agent.pod-template" -}}
 metadata:
-  {{- with .Values.podAnnotations }}
+  {{- with .Values.controller.podAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/operations/helm/charts/grafana-agent/templates/service.yaml
+++ b/operations/helm/charts/grafana-agent/templates/service.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     {{- include "grafana-agent.labels" . | nindent 4 }}
 spec:
-  type: ClusterIP
-  clusterIP: None
+  type: {{ .Values.service.type }}
+  clusterIP: {{ .Values.service.clusterIP }}
   selector:
     {{- include "grafana-agent.selectorLabels" . | nindent 4 }}
   ports:

--- a/operations/helm/charts/grafana-agent/values.yaml
+++ b/operations/helm/charts/grafana-agent/values.yaml
@@ -124,5 +124,5 @@ controller:
 service:
   # -- Service type
   type: ClusterIP
-  # -- Cluster IP, can be set to None
-  clusterIP: null
+  # -- Cluster IP, can be set to None, empty "" or an IP address
+  clusterIP: ""

--- a/operations/helm/charts/grafana-agent/values.yaml
+++ b/operations/helm/charts/grafana-agent/values.yaml
@@ -120,3 +120,9 @@ controller:
 
   # -- volumeClaimTemplates to add when controller.type is 'statefulset'.
   volumeClaimTemplates: []
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Cluster IP, can be set to None
+  clusterIP: null

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/service.yaml
@@ -5,14 +5,14 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
-  clusterIP: None
+  clusterIP: 
   selector:
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/service.yaml
@@ -5,14 +5,14 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
-  clusterIP: None
+  clusterIP: 
   selector:
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/service.yaml
@@ -5,14 +5,14 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
-  clusterIP: None
+  clusterIP: 
   selector:
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/custom-config/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/custom-config/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/custom-config/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/service.yaml
@@ -5,14 +5,14 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
-  clusterIP: None
+  clusterIP: 
   selector:
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/custom-config/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/default-values/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/service.yaml
@@ -5,14 +5,14 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
-  clusterIP: None
+  clusterIP: 
   selector:
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/default-values/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/service.yaml
@@ -5,14 +5,14 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
-  clusterIP: None
+  clusterIP: 
   selector:
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/existing-config/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
@@ -5,14 +5,14 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
-  clusterIP: None
+  clusterIP: 
   selector:
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/service.yaml
@@ -5,14 +5,14 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
-  clusterIP: None
+  clusterIP: 
   selector:
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/static-mode/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.0
+    helm.sh/chart: grafana-agent-0.3.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.30.2"


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Fix erroneous reference to podAnnotations instead of controller.podAnnotations 
Fix missing service ClusterIP by adding values support, default to assigning cluster IP

#### Which issue(s) this PR fixes
An issue with some services not reporting traces as when the service has no cluster IP, the DNS name for the service provides only the IPs of the pods. This breaks some applications that don't periodically re-query DNS for the service name.

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
