### PR TITLE
agent-flow-mixin: Add annotation about deployments

### DIFF
--- a/operations/agent-flow-mixin/dashboards/resources.libsonnet
+++ b/operations/agent-flow-mixin/dashboards/resources.libsonnet
@@ -42,6 +42,9 @@ local stackedPanelMixin = {
         label_values(agent_component_controller_running_components_total{cluster="$cluster", namespace="$namespace"}, instance)
       |||),
     ]) +
+    dashboard.withAnnotations([
+      dashboard.newLokiAnnotation('Deployments', 'loki-dev', '{cluster="$cluster", container="kube-diff-logger"} | json | namespace_extracted="grafana-agent" | name_extracted=~"grafana-agent.*"', 'rgba(0, 211, 255, 1)'),
+    ]) +
     dashboard.withPanelsMixin([
       // CPU usage
       (

--- a/operations/agent-flow-mixin/dashboards/utils/dashboard.jsonnet
+++ b/operations/agent-flow-mixin/dashboards/utils/dashboard.jsonnet
@@ -71,6 +71,19 @@
     sort: 2,
   },
 
+  newLokiAnnotation(name, source, expression, color):: {
+    name: name,
+    datasource: {
+      type: 'loki',
+      uid: source,
+    },
+    enable: true,
+    expr: expression,
+    iconColor: color,
+    instant: false,
+    titleFormat: '{{cluster}}/{{namespace}}',
+  },
+
   newMultiTemplateVariable(name, query):: $.newTemplateVariable(name, query) {
     allValue: '.*',
     includeAll: true,
@@ -78,6 +91,12 @@
   },
 
   withPanelsMixin(panels):: { panels+: panels },
+
+  withAnnotations(annotations):: {
+    annotations+: {
+      list+: annotations,
+    },
+  },
 
   withDocsLink(url, desc):: {
     links+: [{


### PR DESCRIPTION
The Grafana Cloud JSON with the new Annotation, looks like this

```
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "target": {
          "limit": 100,
          "matchAny": false,
          "tags": [],
          "type": "dashboard"
        },
        "type": "dashboard"
      },
      {
        "datasource": {
          "type": "loki",
          "uid": "loki-dev"
        },
        "enable": false,
        "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"grafana-agent\" | name_extracted=~\"grafana-agent.*\"",
        "hide": true,
        "iconColor": "#b5d0f8",
        "instant": false,
        "name": "Deployments",
        "titleFormat": "{{cluster}}/{{namespace}}"
      }
    ]
  },
...
}
```
When previewing the Grafana Cloud 
![image](https://user-images.githubusercontent.com/17771679/215765419-b85d01f2-7827-48b3-8920-11b75ea2744f.png)

When looking at the generated jsonnet on the resources dashboard (for example) I get the following

```
{
   "agent-flow-resources.json": {
      "annotations": {
         "list": [
            {
               "datasource": {
                  "type": "loki",
                  "uid": "loki-dev"
               },
               "enable": true,
               "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"grafana-agent\" | name_extracted=~\"grafana-agent.*\"",
               "iconColor": "rgba(0, 211, 255, 1)",
               "instant": false,
               "name": "Deployments",
               "titleFormat": "{{cluster}}/{{namespace}}"
            }
         ]
      },
```

which looks fine, except for missing the 'default' annotation.