### PR TITLE
agent-flow-mixin: Add annotation about deployments

### DIFF
--- a/operations/agent-flow-mixin/dashboards/resources.libsonnet
+++ b/operations/agent-flow-mixin/dashboards/resources.libsonnet
@@ -42,6 +42,9 @@ local stackedPanelMixin = {
         label_values(agent_component_controller_running_components_total{cluster="$cluster", namespace="$namespace"}, instance)
       |||),
     ]) +
+    dashboard.withAnnotations([
+      dashboard.newLokiAnnotation('Deployments', '{cluster="$cluster", container="kube-diff-logger"} | json | namespace_extracted="grafana-agent" | name_extracted=~"grafana-agent.*"', 'rgba(0, 211, 255, 1)'),
+    ]) +
     dashboard.withPanelsMixin([
       // CPU usage
       (

--- a/operations/agent-flow-mixin/dashboards/utils/dashboard.jsonnet
+++ b/operations/agent-flow-mixin/dashboards/utils/dashboard.jsonnet
@@ -16,6 +16,13 @@
         query: 'prometheus',
         refresh: 1,
         sort: 2,
+      }, {
+        name: 'loki_datasource',
+        label: 'Loki Data Source',
+        type: 'datasource',
+        query: 'loki',
+        refresh: 1,
+        sort: 2,
       }],
     },
     time: {
@@ -71,6 +78,16 @@
     sort: 2,
   },
 
+  newLokiAnnotation(name, expression, color):: {
+    name: name,
+    datasource: '$loki_datasource',
+    enable: true,
+    expr: expression,
+    iconColor: color,
+    instant: false,
+    titleFormat: '{{cluster}}/{{namespace}}',
+  },
+
   newMultiTemplateVariable(name, query):: $.newTemplateVariable(name, query) {
     allValue: '.*',
     includeAll: true,
@@ -78,6 +95,12 @@
   },
 
   withPanelsMixin(panels):: { panels+: panels },
+
+  withAnnotations(annotations):: {
+    annotations+: {
+      list+: annotations,
+    },
+  },
 
   withDocsLink(url, desc):: {
     links+: [{


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR updates the Flow mixin to include an annotation of recent deployments. To achieve that, it introduces a new variable to choose from a Loki datasource and makes use of Grafana's [kube-diff-logger](https://github.com/grafana/kubernetes-diff-logger) to detect changes, although the query can be changed to fit your needs.

If this approach looks reasonable, I can use the same annotation for the other Flow dashboards as well.


#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer
Still not super familiar with jsonnet, so any advise is appreciated

The Grafana Cloud JSON with the new Annotation, looks like this

```
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "target": {
          "limit": 100,
          "matchAny": false,
          "tags": [],
          "type": "dashboard"
        },
        "type": "dashboard"
      },
      {
        "datasource": {
          "type": "loki",
          "uid": "loki-dev"
        },
        "enable": false,
        "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"grafana-agent\" | name_extracted=~\"grafana-agent.*\"",
        "hide": true,
        "iconColor": "#b5d0f8",
        "instant": false,
        "name": "Deployments",
        "titleFormat": "{{cluster}}/{{namespace}}"
      }
    ]
  },
...
}
```


When looking at the generated jsonnet on the resources dashboard (for example) I get the following

```
{
   "agent-flow-resources.json": {
      "annotations": {
         "list": [
            {
               "datasource": "$loki_datasource",
               "enable": true,
               "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"grafana-agent\" | name_extracted=~\"grafana-agent.*\"",
               "iconColor": "rgba(0, 211, 255, 1)",
               "instant": false,
               "name": "Deployments",
               "titleFormat": "{{cluster}}/{{namespace}}"
            }
         ]
      },
```

I've verified that it works by importing the output JSON as a new dashboard and seeing the new variable and annotations work.

#### PR Checklist

- [ ] CHANGELOG updated (N/A) AFAIK
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
