### PR TITLE
helm: support Grafana Agent v0.31

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -10,6 +10,18 @@ internal API changes are not present.
 Unreleased
 ----------
 
+0.4.0 (2023-01-31)
+------------------
+
+### Enhancements
+
+- Update Grafana Agent version to v0.31.0. (@rfratto)
+- Install PodLogs CRD for the `loki.source.podlogs` Flow component. (@rfratto)
+- Update RBAC rules to permit `loki.source.podlogs` and `mimir.rules.kubernetes` to work by default. (@rfratto)
+
+0.3.1 (2023-01-31)
+------------------
+
 ### Bugfixes
 
 - Fix `podAnnotations` values reference in pod template (should be `controller.podAnnotations`).

--- a/operations/helm/charts/grafana-agent/Chart.yaml
+++ b/operations/helm/charts/grafana-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: grafana-agent
 description: "Grafana Agent"
 type: application
-version: 0.3.1
-appVersion: "v0.30.2"
+version: 0.4.0
+appVersion: "v0.31.0"

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -1,6 +1,6 @@
 # Grafana Agent Helm chart
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![AppVersion: v0.30.2](https://img.shields.io/badge/AppVersion-v0.30.2-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![AppVersion: v0.31.0](https://img.shields.io/badge/AppVersion-v0.31.0-informational?style=flat-square)
 
 Helm chart for deploying [Grafana Agent][] to Kubernetes.
 

--- a/operations/helm/charts/grafana-agent/crds/monitoring.grafana.com_podlogs.yaml
+++ b/operations/helm/charts/grafana-agent/crds/monitoring.grafana.com_podlogs.yaml
@@ -1,0 +1,204 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: podlogs.monitoring.grafana.com
+spec:
+  group: monitoring.grafana.com
+  names:
+    categories:
+    - grafana-agent
+    kind: PodLogs
+    listKind: PodLogsList
+    plural: podlogs
+    singular: podlogs
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: PodLogs defines how to collect logs for a Pod.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PodLogsSpec defines how to collect logs for a Pod.
+            properties:
+              namespaceSelector:
+                description: Selector to select which namespaces the Pod objects are
+                  discovered from.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              relabelings:
+                description: RelabelConfigs to apply to logs before delivering.
+                items:
+                  description: 'RelabelConfig allows dynamic rewriting of the label
+                    set, being applied to samples before ingestion. It defines `<metric_relabel_configs>`-section
+                    of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                  properties:
+                    action:
+                      default: replace
+                      description: Action to perform based on regex matching. Default
+                        is 'replace'. uppercase and lowercase actions require Prometheus
+                        >= 2.36.
+                      enum:
+                      - replace
+                      - Replace
+                      - keep
+                      - Keep
+                      - drop
+                      - Drop
+                      - hashmod
+                      - HashMod
+                      - labelmap
+                      - LabelMap
+                      - labeldrop
+                      - LabelDrop
+                      - labelkeep
+                      - LabelKeep
+                      - lowercase
+                      - Lowercase
+                      - uppercase
+                      - Uppercase
+                      type: string
+                    modulus:
+                      description: Modulus to take of the hash of the source label
+                        values.
+                      format: int64
+                      type: integer
+                    regex:
+                      description: Regular expression against which the extracted
+                        value is matched. Default is '(.*)'
+                      type: string
+                    replacement:
+                      description: Replacement value against which a regex replace
+                        is performed if the regular expression matches. Regex capture
+                        groups are available. Default is '$1'
+                      type: string
+                    separator:
+                      description: Separator placed between concatenated source label
+                        values. default is ';'.
+                      type: string
+                    sourceLabels:
+                      description: The source labels select values from existing labels.
+                        Their content is concatenated using the configured separator
+                        and matched against the configured regular expression for
+                        the replace, keep, and drop actions.
+                      items:
+                        description: LabelName is a valid Prometheus label name which
+                          may only contain ASCII letters, numbers, as well as underscores.
+                        pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                        type: string
+                      type: array
+                    targetLabel:
+                      description: Label to which the resulting value is written in
+                        a replace action. It is mandatory for replace actions. Regex
+                        capture groups are available.
+                      type: string
+                  type: object
+                type: array
+              selector:
+                description: Selector to select Pod objects. Required.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - selector
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/operations/helm/charts/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/charts/grafana-agent/templates/rbac.yaml
@@ -23,6 +23,33 @@ rules:
       - get
       - list
       - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
   - nonResourceURLs:
       - /metrics
     verbs:

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.river: |- 

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -25,7 +25,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
           - name: grafana-agent
-            image: grafana/agent:v0.30.2
+            image: grafana/agent:v0.31.0
             args:
               - run
               - /etc/agent/config.river

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/rbac.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Rules which allow discovery.kubernetes to function.
@@ -28,6 +28,33 @@ rules:
       - get
       - list
       - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
   - nonResourceURLs:
       - /metrics
     verbs:
@@ -39,10 +66,10 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.river: |- 

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,7 +26,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
           - name: grafana-agent
-            image: grafana/agent:v0.30.2
+            image: grafana/agent:v0.31.0
             args:
               - run
               - /etc/agent/config.river

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/rbac.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Rules which allow discovery.kubernetes to function.
@@ -28,6 +28,33 @@ rules:
       - get
       - list
       - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
   - nonResourceURLs:
       - /metrics
     verbs:
@@ -39,10 +66,10 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.river: |- 

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
@@ -5,10 +5,10 @@ kind: StatefulSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -27,7 +27,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
           - name: grafana-agent
-            image: grafana/agent:v0.30.2
+            image: grafana/agent:v0.31.0
             args:
               - run
               - /etc/agent/config.river

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/rbac.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Rules which allow discovery.kubernetes to function.
@@ -28,6 +28,33 @@ rules:
       - get
       - list
       - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
   - nonResourceURLs:
       - /metrics
     verbs:
@@ -39,10 +66,10 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/custom-config/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.river:   |-

--- a/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -25,7 +25,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
           - name: grafana-agent
-            image: grafana/agent:v0.30.2
+            image: grafana/agent:v0.31.0
             args:
               - run
               - /etc/agent/config.river

--- a/operations/helm/tests/custom-config/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/rbac.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Rules which allow discovery.kubernetes to function.
@@ -28,6 +28,33 @@ rules:
       - get
       - list
       - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
   - nonResourceURLs:
       - /metrics
     verbs:
@@ -39,10 +66,10 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/custom-config/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/custom-config/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/default-values/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.river: |- 

--- a/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -25,7 +25,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
           - name: grafana-agent
-            image: grafana/agent:v0.30.2
+            image: grafana/agent:v0.31.0
             args:
               - run
               - /etc/agent/config.river

--- a/operations/helm/tests/default-values/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/rbac.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Rules which allow discovery.kubernetes to function.
@@ -28,6 +28,33 @@ rules:
       - get
       - list
       - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
   - nonResourceURLs:
       - /metrics
     verbs:
@@ -39,10 +66,10 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/default-values/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/default-values/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -25,7 +25,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
           - name: grafana-agent
-            image: grafana/agent:v0.30.2
+            image: grafana/agent:v0.31.0
             args:
               - run
               - /etc/agent/my-config.river

--- a/operations/helm/tests/existing-config/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/rbac.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Rules which allow discovery.kubernetes to function.
@@ -28,6 +28,33 @@ rules:
       - get
       - list
       - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
   - nonResourceURLs:
       - /metrics
     verbs:
@@ -39,10 +66,10 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/existing-config/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/existing-config/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.river: |- 

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -25,7 +25,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
           - name: grafana-agent
-            image: grafana/agent:v0.30.2
+            image: grafana/agent:v0.31.0
             args:
               - run
               - /etc/agent/config.river

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Rules which allow discovery.kubernetes to function.
@@ -28,6 +28,33 @@ rules:
       - get
       - list
       - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
   - nonResourceURLs:
       - /metrics
     verbs:
@@ -39,10 +66,10 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/static-mode/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |- 

--- a/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -25,7 +25,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
           - name: grafana-agent
-            image: grafana/agent:v0.30.2
+            image: grafana/agent:v0.31.0
             args:
               - -config.file=/etc/agent/config.yaml
               - -server.http.address=0.0.0.0:80

--- a/operations/helm/tests/static-mode/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/rbac.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Rules which allow discovery.kubernetes to function.
@@ -28,6 +28,33 @@ rules:
       - get
       - list
       - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
   - nonResourceURLs:
       - /metrics
     verbs:
@@ -39,10 +66,10 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/static-mode/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/static-mode/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.3.1
+    helm.sh/chart: grafana-agent-0.4.0
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.30.2"
+    app.kubernetes.io/version: "v0.31.0"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
Adds support for Grafana Agent v0.31 to the Helm chart:

* Installs the PodLogs CRD used by `loki.source.podlogs`. 
* Adds RBAC rules to allow `loki.source.podlogs` and `mimir.rules.kubernetes` to function. 

I chose to only include CRDs which we own, so the PrometheusRule CRD is not included and will have to be installed separately for mimir.rules.kubernetes to be able to discover resources. 

I tested this with a k3d cluster locally; everything works.
