### PR TITLE
Flow: reload when SIGHUP is sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ Main (unreleased)
 
 - Update Prometheus Node Exporter integration to v1.5.0. (@Thor77)
 
+- Grafana Agent Flow will now reload the config file when `SIGHUP` is sent to
+  the process. (@rfratto)
+
+- If using the official RPM and DEB packages for Grafana Agent, invoking
+  `systemctl reload grafana-agent` will now reload the configuration file.
+  (@rfratto)
+
 v0.31.0 (2023-01-31)
 --------------------
 

--- a/component/prometheus/integration/node_exporter/config.go
+++ b/component/prometheus/integration/node_exporter/config.go
@@ -92,7 +92,7 @@ type Config struct {
 	Powersupply PowersupplyConfig `river:"powersupply,block,optional"`
 	Runit       RunitConfig       `river:"runit,block,optional"`
 	Supervisord SupervisordConfig `river:"supervisord,block,optional"`
-	Sysctl      SysctlConfig      `river:"sysctl,block,option"`
+	Sysctl      SysctlConfig      `river:"sysctl,block,optional"`
 	Systemd     SystemdConfig     `river:"systemd,block,optional"`
 	Tapestats   TapestatsConfig   `river:"tapestats,block,optional"`
 	Textfile    TextfileConfig    `river:"textfile,block,optional"`

--- a/packaging/deb/grafana-agent.service
+++ b/packaging/deb/grafana-agent.service
@@ -11,6 +11,7 @@ Environment=HOSTNAME=%H
 EnvironmentFile=/etc/default/grafana-agent
 WorkingDirectory=/var/lib/grafana-agent
 ExecStart=/usr/bin/grafana-agent --config.file $CONFIG_FILE $CUSTOM_ARGS
+ExecReload=/usr/bin/kill -HUP $MAINPID
 # If running the Agent in scraping service mode, you will want to override this value with
 # something larger to allow the Agent to gracefully leave the cluster. 4800s is recommend.
 TimeoutStopSec=20s

--- a/packaging/rpm/grafana-agent.service
+++ b/packaging/rpm/grafana-agent.service
@@ -11,6 +11,7 @@ Environment=HOSTNAME=%H
 EnvironmentFile=/etc/sysconfig/grafana-agent
 WorkingDirectory=/var/lib/grafana-agent
 ExecStart=/usr/bin/grafana-agent --config.file $CONFIG_FILE $CUSTOM_ARGS
+ExecReload=/usr/bin/kill -HUP $MAINPID
 # If running the Agent in scraping service mode, you will want to override this value with
 # something larger to allow the Agent to gracefully leave the cluster. 4800s is recommend.
 TimeoutStopSec=20s


### PR DESCRIPTION
Three small changes:

* Flow will now reload when a SIGHUP is sent, matching the behavior of static mode.
* Update the deb and rpms to respond to `systemctl reload grafana-agent.service` by sending a SIHGUP to the agent process.
* Fix a broken River stanza introduced in #2629.