### PR TITLE
Fix agent management alert

### DIFF
--- a/production/grafana-agent-mixin/alerts.libsonnet
+++ b/production/grafana-agent-mixin/alerts.libsonnet
@@ -350,8 +350,7 @@ local _config = config._config;
           {
             alert: 'AgentManagementFailureToReload',
             expr: |||
-              agent_config_last_load_successful
-                == 0
+              avg_over_time(agent_config_last_load_successful[10m]) < 0.9
             ||| % _config,
             'for': '10m',
             labels: {
@@ -366,8 +365,7 @@ local _config = config._config;
           {
             alert: 'AgentManagementFailureToReload',
             expr: |||
-              agent_config_last_load_successful
-                == 0
+              avg_over_time(agent_config_last_load_successful[10m]) < 0.9
             ||| % _config,
             'for': '30m',
             labels: {


### PR DESCRIPTION
  - Make sure the alert does not fire as soon as an agent reports a reload failure, but only after it has been failing consistently for the specified amount of time.
  - See https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0/
