### PR TITLE
Use more portable output redirection

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,7 +12,7 @@ docs: check-cloudwatch-integration pull
 	$(PODMAN) run --init -v $(shell pwd)/sources:$(CONTENT_PATH):Z -p $(PORT) --rm -it $(IMAGE)
 
 check-cloudwatch-integration:
-	docker run -v $(shell git rev-parse --show-toplevel):/repo -v $(shell pwd):/docs -w /repo golang:1.19.4-bullseye go run pkg/integrations/cloudwatch_exporter/docs/doc.go check /docs/sources/configuration/integrations/cloudwatch-exporter-config.md
+	$(PODMAN) run -v $(shell git rev-parse --show-toplevel):/repo -v $(shell pwd):/docs -w /repo golang:1.19.4-bullseye go run pkg/integrations/cloudwatch_exporter/docs/doc.go check /docs/sources/configuration/integrations/cloudwatch-exporter-config.md
 
 sources/assets/hierarchy.svg: sources/operator/hierarchy.dot
 	cat $< | $(PODMAN) run --rm -i nshine/dot dot -Tsvg > $@

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,4 +1,4 @@
-PODMAN = $(shell if command -v podman &>/dev/null; then echo podman; else echo docker; fi)
+PODMAN = $(shell if command -v podman >/dev/null 2>&1; then echo podman; else echo docker; fi)
 IMAGE = grafana/docs-base:latest
 CONTENT_PATH = /hugo/content/docs/agent/latest
 PORT = 3002:3002


### PR DESCRIPTION
`&>/dev/null` appears to be a bash-ism.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
