### PR TITLE
Fix CloudWatch integration docs template and title

### DIFF
--- a/docs/sources/configuration/integrations/cloudwatch-exporter-config.md
+++ b/docs/sources/configuration/integrations/cloudwatch-exporter-config.md
@@ -1,8 +1,5 @@
 ---
-aliases:
-
-- /docs/agent/latest/configuration/integrations/cloudwatch-exporter/ title: cloudwatch_exporter
-
+title: cloudwatch_exporter_config
 ---
 
 # cloudwatch_exporter_config

--- a/pkg/integrations/cloudwatch_exporter/docs/template.md
+++ b/pkg/integrations/cloudwatch_exporter/docs/template.md
@@ -1,6 +1,6 @@
-# Supported services in discovery jobs
+## Supported services in discovery jobs
 
 The following is a list of AWS services that are supported in `cloudwatch_exporter` discovery jobs. When configuring a
-discovery job, the `type` field of each `discovery_job` must match either one of the desired job namespace or alias.
+discovery job, the `type` field of each `discovery_job` must match either the desired job namespace or alias.
 
 {{SERVICE_LIST}}


### PR DESCRIPTION
#### PR Description
When reviewing the [PR](https://github.com/grafana/agent/pull/2740) that introduced the CW integration, some of the docs comments applied where not applied as well to the docs template, since a part of that integration's docs are generated.

This PR updates that template to make the check pass.

Also, this PR adds the missing title in the new docs header section.

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
