### PR TITLE
Update release instructions

### DIFF
--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -140,13 +140,13 @@ For **patch releases**, the release shepherd will:
    
 2. Cherry-pick the fixes from `main` into the release branch.
 
-3. Follow the same instructions as the ones for a stable release.
+3. Follow the same instructions as the ones for a stable release, starting from step 1.
 
 Some notes on patch releases:
 
 - When creating patch releases, there is no need for a release candidate.
 
-- Changes made to patch releases are not listed in the changelog for the next stable version.
+- Changes made to patch releases are not listed in the CHANGELOG for the next stable version.
 
 - The tag of the patch release does yet not exist at the time when we update code for the 
 main branch to reference it.
@@ -162,33 +162,33 @@ NOTE: Branches used for PRs should have a name that doesn't start with `release-
 otherwise branch protection rules apply to it. Alternatively, branches used for PRs 
 can come from forks.
 
-#### Update the changelog
+#### Update the CHANGELOG
 
 When creating a release **candidate** (i.e. an `-rc.N` version):
 
-* Add a new section in the changelog for the new release candidate and include 
+* Add a new section in the CHANGELOG for the new release candidate and include 
 today's date. E.g. "v0.31.0-rc.0 (2023-01-26)".
 * All items form the "unreleased" section will move to a new section for the upcoming release version.
 * See [here](https://github.com/grafana/agent/pull/2838/files) for an example pull request.
-* Sanity check that the changelog doesn't contain features which don't belong to it. Sometimes features get added to the wrong version in the changelog due to bad merges.
+* Sanity check that the CHANGELOG doesn't contain features which don't belong to it. Sometimes features get added to the wrong version in the CHANGELOG due to bad merges.
 
 When creating a **stable** release:
 
 * Replace the version from the release candidate section to be the stable release instead 
 of the `-rc.N` version.
-* We do not leave release candidates in the changelog once there is a stable version for them.
+* We do not leave release candidates in the CHANGELOG once there is a stable version for them.
 * Make sure to also update the **date** in the title.
 * See [here](https://github.com/grafana/agent/pull/2873/files) for an example pull request.
 
 When creating a **patch** release:
 
-* Add a new section to the changelog for the patch release.
-* In the changelog, **move** the fixes which were cherry picked onto the release branch 
+* Add a new section to the CHANGELOG for the patch release.
+* In the CHANGELOG, **move** the fixes which were cherry picked onto the release branch 
 from the "unreleased" section to the section for the new patch release.
 
 #### Update the "Upgrade guide"
 The "Upgrade guide" is located in `docs/sources/upgrade-guide/_index.md` and lists breaking changes 
-and deprecated features relevant to each release. Make sure that it is updated similarly to the changelog.
+and deprecated features relevant to each release. Make sure that it is updated similarly to the CHANGELOG.
 
 #### Search and replace the old version with the new one
 
@@ -198,7 +198,7 @@ Go through the entire repository and find references to the previous release
 NOTE: Please do not update the `operations/helm` directory. It is updated independently 
 from Agent releases for now.
 
-NOTE: There are files such as 
+NOTE: There may be files such as 
 "[pkg/operator/defaults.go](https://github.com/grafana/agent/blob/main/pkg/operator/defaults.go)", 
 where the version sometimes should not be replaced but added to a list of versions.
 At the time of this writing, `defaults.go` is the only such file.
@@ -215,12 +215,7 @@ release process.
 ### Create a tag
 Remember to **checkout** and **pull** the release branch before creating the tag!
 
-The naming conventions are:
-* For release candidates: `vX.Y.0-rc.N`. Here, `N` is the version of the release 
-candidate for this stable release.
-* For stable releases: `vX.Y.0`.
-* For patch releases: `vX.Y.N`. Here, `X` and `Y` are the versions of the stable release. 
-`N` is incremented. 
+The tag naming conventions are [described here](#release-branches)
 
 Example commands:
 ```
@@ -249,22 +244,20 @@ To publish the release:
    CHANGELOG. Add a link to the CHANGELOG, noting that the full list of changes
    can be found there. Refer to other releases for help with formatting this.
 
-3. Tick the appropriate boxes at the bottom of the release page:
+3. At the bottom of the release page, tick the check box to "add a discussion" 
+under the category for "announcements".
 
-      * For release candidates:
+4. Also tick other boxes at the bottom of the release page:
 
-         1. Tick the checkbox to "set as pre-release".
+      * For release candidates, tick the checkbox to "set as pre-release".
 
-      * For stable releases:
+      * For stable releases and patch releases to the latest release branch, 
+      tick the checkbox to "set as the latest release".
 
-         1. Tick the checkbox to "set as the latest release".
-
-         2. Tick the check box to "add a discussion" under the category for "announcements".
-
-4. Optionally, have other team members review the release draft if you wish
+5. Optionally, have other team members review the release draft if you wish
    to feel more comfortable with it.
 
-5. Publish the release!
+6. Publish the release!
 
 > **NOTE**: Release candidates should be retained on the 
 [GitHub releases page](https://github.com/grafana/agent/releases).
@@ -307,7 +300,7 @@ patch release at their own discretion.
 Note that patching an old release branch works differently from patching the latest release:
 - `main` would not be updated to reference the patch version
 - The change applied to the old release branch would have to be listed in two sections 
-in the changelog:
+in the CHANGELOG:
    1. The patch release's section
    2. The "unreleased" section
-- When publishing the release on GitHub, it should not be marked as "the latest".
+- When publishing the release on GitHub, it should **not** be marked as "the latest".

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -88,13 +88,13 @@ For a **new release candidate**, the release shepherd will:
 
 5. Create a PR to cherry pick the update from step 4 to the release branch.
 
-5. [Create a tag](#create-a-tag).
+6. [Create a tag](#create-a-tag).
 
-6. [Publish the release candidate on Github](#publishing-the-release)
+7. [Publish the release candidate on Github](#publishing-the-release)
 
-7. Announce the release candidate on the community Slack channel.
+8. Announce the release candidate on the community Slack channel.
 
-8. Run the release candidate in a testing environment for at least 48 hours. If
+9. Run the release candidate in a testing environment for at least 48 hours. If
    you do not have a testing environment, one can be spawned locally using the
    sample environments in `example/k3d`.
 

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -167,7 +167,7 @@ can come from forks.
 When creating a release **candidate** (i.e. an `-rc.N` version):
 
 * Add a new section in the CHANGELOG for the new release candidate and include 
-today's date. E.g. "v0.31.0-rc.0 (2023-01-26)".
+the date of the release, for example, "v0.31.0-rc.0 (2023-01-26)".
 * All items form the "unreleased" section will move to a new section for the upcoming release version.
 * See [here](https://github.com/grafana/agent/pull/2838/files) for an example pull request.
 * Sanity check that the CHANGELOG doesn't contain features which don't belong to it. Sometimes features get added to the wrong version in the CHANGELOG due to bad merges.

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -204,7 +204,7 @@ pushed tag. To publish the release:
 
 5. Publish the release!
 
-NOTE: Release candidates should be retained on the 
+> **NOTE**: Release candidates should be retained on the 
 [GitHub releases page](https://github.com/grafana/agent/releases).
 Please do not remove them.
 

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -291,26 +291,16 @@ will update it automatically.
 You can use this [pull-request](https://github.com/grafana/helm-charts/pull/1831) as reference.
 
 ### Updating Homebrew
-[Homebrew](https://brew.sh/) is a package manager for MacOS. It installs binaries 
-(aka "[bottles](https://docs.brew.sh/Bottles)") from either the main Homebrew repository 
-or a third-party one (aka a "[tap](https://docs.brew.sh/Taps)").
-
-For every Agent release we need to update two Brew repositories:
-* [homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core) is the main one which 
-Brew installations use by default
-* [grafana/homebrew-grafana](https://github.com/grafana/homebrew-grafana) is a "tap" - 
-a Third-Party Repository from Grafana.
+For every Agent release we need to update the [homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core) repository.
 
 When a new [release](https://github.com/grafana/agent/releases) is published, GitHub actions 
-are automatically triggered to update both of the above repositories. PRs are created automatically:
+are automatically triggered to create a PR for the above repository:
 * If there are no issues, they will be merged automatically.
-* The merges are done from these two grafanabot forks:
-    * [grafanabot/homebrew-core](https://github.com/grafanabot/homebrew-core)
-    * [grafanabot/homebrew-grafana](https://github.com/grafanabot/homebrew-grafana/tree/master)
+* The merge is done from the [grafanabot/homebrew-core](https://github.com/grafanabot/homebrew-core) fork.
 * The GitHub actions will not fail if the PRs fail to merge.
 * The release shepherd needs to manually open the GitHub actions, 
 scroll to the end to find the PR and double check that it was merged.
-* If the CI fails the PR is not able to merge, the release shepherd can push a fix to 
+* If the CI fails, the PR will not be able to merge. The release shepherd can then push a fix to 
 the same branch as the one that the PR is open for.
 
 ## Maintaining older release branches

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -207,11 +207,6 @@ At the time of this writing, `defaults.go` is the only such file.
 
 Add the new version to the "[pkg/operator/defaults.go](https://github.com/grafana/agent/blob/main/pkg/operator/defaults.go)" file. If there is a release candidate (`-rc.N`) version, remove it.
 
-#### Update manifests and dashboards
-
-Run `make generate-manifests` and `make generate-dashboards` to update
-manifests in case they are stale.
-
 ### Merge freezes
 
 Release shepherds may request a merge freeze to main for any reason during the

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -74,11 +74,11 @@ For a **new release candidate**, the release shepherd will:
 2. Create and push the release branch from the selected base commit:
 
    * The name of the release branch should be the name of the stable version we intend 
-   to release, e.g. `release-v0.31`.
-   * Release branches do not contain the `-rc.N` release candidate suffix. I.e. there 
-   is no branch called `release-v0.31-rc.0`.
-   * Release branches do not contain the patch version. I.e. there is no branch called 
-   `release-v0.31.0` or `release-v0.31.4`.
+   to release, such as `release-v0.31`.
+   * Release branches do not contain the `-rc.N` release candidate suffix. This means
+     there is no branch called `release-v0.31-rc.0`.
+   * Release branches do not contain the patch version. This means there is no 
+     branch called `release-v0.31.0` or `release-v0.31.4`.
 
 3. Create a PR to cherry-pick additional commits into the release branch as
    needed.

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -94,7 +94,7 @@ For a **new release branch**, the release shepherd will:
    fixes are available, cherry-picking the fixes into the release branch and
    starting a new release candidate.
 
-7. Create a PR to [update code](#updating-code) again - this time using the stable
+7. Create a new PR to [update code](#updating-code) using the _stable_
    release version. 
 
 8. Create the stable release tag.


### PR DESCRIPTION
Me and @tpaschalis did a release recently, and noticed that some things we normally do are not in the instructions. I hope this update will make them more complete and more clear.

To see the rendered markdown, please go to [docs/developer/releasing.md](https://github.com/grafana/agent/blob/update-rel-instructions/docs/developer/releasing.md)