### PR TITLE
Mention zip executable breaking change and update the upgrade guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,12 +53,8 @@ v0.31.0 (2023-01-31)
   - `agentctl` is now `grafana-agentctl`.
   - `agent-operator` is now `grafana-agent-operator`.
 
-- Some release executables which used to be a `zip` archive are now published 
-  unzipped (@rfratto):
-
-  - `grafana-agent-installer.exe`
-  - `grafana-agent-windows-amd64.exe`
-  - `grafana-agentctl-windows-amd64.exe`
+- All release Windows `.exe` files are now published as a zip archive.
+  Previously, `grafana-agent-installer.exe` was unzipped. (@rfratto)
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,13 @@ v0.31.0 (2023-01-31)
   - `agentctl` is now `grafana-agentctl`.
   - `agent-operator` is now `grafana-agent-operator`.
 
+- Some release executables which used to be a `zip` archive are now published 
+  unzipped (@rfratto):
+
+  - `grafana-agent-installer.exe`
+  - `grafana-agent-windows-amd64.exe`
+  - `grafana-agentctl-windows-amd64.exe`
+
 ### Deprecations
 
 - A symbolic link in Docker containers from the old binary name to the new

--- a/docs/sources/upgrade-guide/_index.md
+++ b/docs/sources/upgrade-guide/_index.md
@@ -21,12 +21,8 @@ As first announced in v0.29, release binary names are now prefixed with
 - `agentctl` is now `grafana-agentctl`.
 - `agent-operator` is now `grafana-agent-operator`.
 
-In addition, some release executables which used to be a `zip` archive 
-are now published unzipped:
-
-- `grafana-agent-installer.exe`
-- `grafana-agent-windows-amd64.exe`
-- `grafana-agentctl-windows-amd64.exe`
+Additionally, all release Windows `.exe` files are now published as a zip
+archive. Previously, `grafana-agent-installer.exe` was unzipped.
 
 For the `grafana/agent` Docker container, the entrypoint is now
 `/bin/grafana-agent`. A symbolic link from `/bin/agent` to the new binary has

--- a/docs/sources/upgrade-guide/_index.md
+++ b/docs/sources/upgrade-guide/_index.md
@@ -8,7 +8,7 @@ weight: 800
 This guide describes all breaking changes that have happened in prior
 releases and how to migrate to newer versions.
 
-## Unreleased changes
+## v0.31.0
 
 These changes will come in a future version.
 
@@ -20,6 +20,13 @@ As first announced in v0.29, release binary names are now prefixed with
 - `agent` is now `grafana-agent`.
 - `agentctl` is now `grafana-agentctl`.
 - `agent-operator` is now `grafana-agent-operator`.
+
+In addition, some release executables which used to be a `zip` archive 
+are now published unzipped:
+
+- `grafana-agent-installer.exe`
+- `grafana-agent-windows-amd64.exe`
+- `grafana-agentctl-windows-amd64.exe`
 
 For the `grafana/agent` Docker container, the entrypoint is now
 `/bin/grafana-agent`. A symbolic link from `/bin/agent` to the new binary has

--- a/production/grafanacloud-install.ps1
+++ b/production/grafanacloud-install.ps1
@@ -4,24 +4,24 @@ param ($GCLOUD_STACK_ID, $GCLOUD_API_KEY, $GCLOUD_API_URL)
 Write-Host "Setting up Grafana agent"
 
 if ( -Not [bool](([System.Security.Principal.WindowsIdentity]::GetCurrent()).groups -match "S-1-5-32-544") ) {
-	Write-Host "ERROR: The script needs to be run with Administrator privileges"
-	exit
+  Write-Host "ERROR: The script needs to be run with Administrator privileges"
+  exit
 }
 
 # Check if required parameters are present
 if ($GCLOUD_STACK_ID -eq "") {
-	Write-Host "ERROR: Required argument GCLOUD_STACK_ID missing"
-	exit
+  Write-Host "ERROR: Required argument GCLOUD_STACK_ID missing"
+  exit
 }
 
 if ($GCLOUD_API_KEY -eq "") {
-	Write-Host "ERROR:  Required argument GCLOUD_API_KEY missing"
-	exit
+  Write-Host "ERROR:  Required argument GCLOUD_API_KEY missing"
+  exit
 }
 
 if ($GCLOUD_API_URL -eq "") {
-	Write-Host "ERROR: Required argument GCLOUD_API_URL missing"
-	exit
+  Write-Host "ERROR: Required argument GCLOUD_API_URL missing"
+  exit
 }
 
 Write-Host "GCLOUD_STACK_ID:" $GCLOUD_STACK_ID
@@ -33,9 +33,11 @@ Write-Host "Checking and installing required Powershell-yaml module"
 Install-Module PowerShell-yaml
 
 Write-Host "Downloading Grafana agent Windows Installer"
-$DOWLOAD_URL = "https://github.com/grafana/agent/releases/latest/download/grafana-agent-installer.exe"
+$DOWLOAD_URL = "https://github.com/grafana/agent/releases/latest/download/grafana-agent-installer.exe.zip"
+$OUTPUT_ZIP_FILE = ".\grafana-agent-installer.exe.zip"
 $OUTPUT_FILE = ".\grafana-agent-installer.exe"
-Invoke-WebRequest -Uri $DOWLOAD_URL -OutFile $OUTPUT_FILE
+Invoke-WebRequest -Uri $DOWLOAD_URL -OutFile $OUTPUT_ZIP_FILE
+Expand-Archive -LiteralPath $OUTPUT_ZIP_FILE -DestinationPath $OUTPUT_FILE
 
 # Install Grafana agent in silent mode
 Write-Host "Installing Grafana agent for Windows"
@@ -53,15 +55,15 @@ $response = Invoke-WebRequest $CONFIG_URI -Method 'GET' -Headers $headers -UseBa
 
 $jsonObj = $response | ConvertFrom-Json
 if ($jsonObj.status -eq "success") {
-	$config_file = ".\agent-config.yaml"
-	Write-Host "Saving and updating agent configuration file"
-	$yamlConfig = $jsonObj.data | ConvertTo-Yaml
-	Set-Content -Path $config_file -Value ($yamlConfig)
+  $config_file = ".\agent-config.yaml"
+  Write-Host "Saving and updating agent configuration file"
+  $yamlConfig = $jsonObj.data | ConvertTo-Yaml
+  Set-Content -Path $config_file -Value ($yamlConfig)
     # Append APPDATA path to bookmark files
     $line = Get-Content $config_file | Select-String bookmark_path | Select-Object -ExpandProperty Line
     if ($line -ne $null) {
         $content = Get-Content $config_file
-        $line | ForEach-Object {  
+        $line | ForEach-Object {
             $split_line = $_ -split ": "
             $prefix = $split_line[0]
             $bookmark_filename = $split_line[1] -replace "./",""
@@ -71,21 +73,21 @@ if ($jsonObj.status -eq "success") {
     }
     Move-Item $config_file "C:\Program Files\Grafana Agent\agent-config.yaml" -force
 
-	# Wait for service to initialize after first install
-	Write-Host "Wait for Grafana service to initialize"
-	Start-Sleep -s 5
+  # Wait for service to initialize after first install
+  Write-Host "Wait for Grafana service to initialize"
+  Start-Sleep -s 5
 
-	# Restart Grafana agent to load new configuration
-	Write-Host "Restarting Grafana agent service"
-	Stop-Service "Grafana Agent"
-	Start-Service "Grafana Agent"
+  # Restart Grafana agent to load new configuration
+  Write-Host "Restarting Grafana agent service"
+  Stop-Service "Grafana Agent"
+  Start-Service "Grafana Agent"
 
-	# Wait for service to startup after restart
-	Write-Host "Wait for Grafana service to initialize after restart"
-	Start-Sleep -s 10
+  # Wait for service to startup after restart
+  Write-Host "Wait for Grafana service to initialize after restart"
+  Start-Sleep -s 10
 
-	# Show Grafana agent service status
-	Get-Service "Grafana Agent"
+  # Show Grafana agent service status
+  Get-Service "Grafana Agent"
 } else {
-	Write-Host "Failed to retrieve config"
+  Write-Host "Failed to retrieve config"
 }

--- a/tools/release
+++ b/tools/release
@@ -3,10 +3,10 @@
 # This script should be run from the root of the repository.
 set -x
 
-# Zip up all the agent binaries to reduce the download size. DEBs, RPMs, and
-# Windows installers aren't included to be easier to work with.
+# Zip up all the agent binaries to reduce the download size. DEBs and RPMs
+# aren't included to be easier to work with.
 find dist/ -type f \
-  -name 'grafana-agent*' -not -name '*.deb' -not -name '*.rpm' -not -name '*.exe' \
+  -name 'grafana-agent*' -not -name '*.deb' -not -name '*.rpm' \
   -exec zip -j -m "{}.zip" "{}" \;
 
 # Sign the RPM packages. DEB packages aren't signed.


### PR DESCRIPTION
There are two problems with the documentation on the 0.31 branch:

* The upgrade guide was not updated to point to the latest version
* A change to not zip some release artifacts was not mentioned as a breaking change

Fixes #2887