### PR TITLE
Mention zip executable breaking change and update the upgrade guide [release branch]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ v0.31.0 (2023-01-31)
   - `agentctl` is now `grafana-agentctl`.
   - `agent-operator` is now `grafana-agent-operator`.
 
+- Some release executables which used to be a `zip` archive are now published 
+  unzipped (@rfratto):
+
+  - `grafana-agent-installer.exe`
+  - `grafana-agent-windows-amd64.exe`
+  - `grafana-agentctl-windows-amd64.exe`
+
 ### Deprecations
 
 - A symbolic link in Docker containers from the old binary name to the new

--- a/docs/sources/upgrade-guide/_index.md
+++ b/docs/sources/upgrade-guide/_index.md
@@ -10,7 +10,7 @@ weight: 800
 This guide describes all breaking changes that have happened in prior
 releases and how to migrate to newer versions.
 
-## Unreleased changes
+## v0.31.0
 
 These changes will come in a future version.
 
@@ -22,6 +22,13 @@ As first announced in v0.29, release binary names are now prefixed with
 - `agent` is now `grafana-agent`.
 - `agentctl` is now `grafana-agentctl`.
 - `agent-operator` is now `grafana-agent-operator`.
+
+In addition, some release executables which used to be a `zip` archive 
+are now published unzipped:
+
+- `grafana-agent-installer.exe`
+- `grafana-agent-windows-amd64.exe`
+- `grafana-agentctl-windows-amd64.exe`
 
 For the `grafana/agent` Docker container, the entrypoint is now
 `/bin/grafana-agent`. A symbolic link from `/bin/agent` to the new binary has


### PR DESCRIPTION
Same as #2899, but for the release branch.

There are two problems with the documentation on the 0.31 branch:

* The upgrade guide was not updated to point to the latest version
* A change to not zip some release artifacts was not mentioned as a breaking change