### PR TITLE
build-image: update to Go 1.20

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -19,7 +19,7 @@ FROM alpine:3.16 as docker
 RUN apk add --no-cache docker-cli docker-cli-buildx
 
 # Dependency: Go and Go dependencies
-FROM golang:1.19.4-bullseye as golang
+FROM golang:1.20.0-bullseye as golang
 
 # Keep in sync with cmd/grafana-agent-operator/DEVELOPERS.md
 ENV CONTROLLER_GEN_VERSION v0.9.2

--- a/build-image/windows/Dockerfile
+++ b/build-image/windows/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/golang:1.19.4-windowsservercore-1809
+FROM library/golang:1.20.0-windowsservercore-1809
 
 SHELL ["powershell", "-command"]
 


### PR DESCRIPTION
Updates the build image to Go 1.20. I didn't update the changelog; I'll update that once we update the CI to use the new release.