### PR TITLE
otel: allow setting dimension cache size for spanmetrics processor

### DIFF
--- a/docs/sources/configuration/traces-config.md
+++ b/docs/sources/configuration/traces-config.md
@@ -234,6 +234,8 @@ spanmetrics:
   [ metrics_instance: <string> ]
   # handler_endpoint defines the endpoint where the OTel prometheus exporter will be exposed.
   [ handler_endpoint: <string> ]
+  # dimensions_cache_size defines the size of cache for storing Dimensions
+  [ dimensions_cache_size: <int> ]
 
 # tail_sampling supports tail-based sampling of traces in the agent.
 #

--- a/pkg/traces/config_test.go
+++ b/pkg/traces/config_test.go
@@ -538,6 +538,7 @@ spanmetrics:
       default: GET
     - name: http.status_code
   metrics_instance: traces
+  dimensions_cache_size: 10000
 `,
 			expectedConfig: `
 receivers:
@@ -563,6 +564,7 @@ processors:
       - name: http.method
         default: GET
       - name: http.status_code
+    dimensions_cache_size: 10000
 extensions: {}
 service:
   pipelines:


### PR DESCRIPTION
Fixes #2875 