### PR TITLE
flow: add `constants` to stdlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,12 @@ Main (unreleased)
 
 ### Features
 
-- Integrations: Introduce the `oracledb` integration. (@schmikei)
+- New integrations: introduce the `oracledb` integration. (@schmikei)
 
-- New metric for prometheus.scrape - `agent_prometheus_scrape_targets_gauge`. (@ptodev)
-
-- New metric for prometheus.scrape and prometheus.relabel - `agent_prometheus_forwarded_samples_total`. (@ptodev)
-
-- Integrations: Introduce the `mssql` integration. (@binaryfissiongames)
-
-- Integrations: Introduce `cloudwatch metrics` integration. (@thepalbi)
-
-- Integrations: Introduce an `azure` integration. (@kgeckhart)
+  - `oracledb` (@schmikei)
+  - `mssql` (@binaryfissiongames)
+  - `cloudwatch metrics` (@thepalbi)
+  - `azure` (@kgeckhart)
 
 ### Enhancements
 
@@ -40,8 +35,15 @@ Main (unreleased)
   `systemctl reload grafana-agent` will now reload the configuration file.
   (@rfratto)
 
-- Flow: The `loki.process` component now implements all the same processing
+- Flow: the `loki.process` component now implements all the same processing
   stages as Promtail's pipelines. (@tpaschalis)
+
+- Flow: new metric for `prometheus.scrape` - `agent_prometheus_scrape_targets_gauge`. (@ptodev)
+
+- Flow: new metric for `prometheus.scrape` and `prometheus.relabel` - `agent_prometheus_forwarded_samples_total`. (@ptodev)
+
+- Flow: add `constants` into the standard library to expose the hostname, OS,
+  and architecture of the system Grafana Agent is running on. (@rfratto)
 
 ### Other changes
 

--- a/docs/sources/flow/reference/stdlib/constants.md
+++ b/docs/sources/flow/reference/stdlib/constants.md
@@ -1,0 +1,28 @@
+---
+aliases:
+- ../../configuration-language/standard-library/constants/
+title: constants
+---
+
+# constants
+
+The `constants` object exposes a list of constant values about the system
+Grafana Agent is running on:
+
+* `constants.hostname`: The hostname of the machine Grafana Agent is running
+  on.
+* `constants.os`: The operating system Grafana Agent is running on.
+* `constants.arch`: The architecture of the system Grafana Agent is running on.
+
+## Examples
+
+```
+> constants.hostname
+"my-hostaname"
+
+> constants.os
+"linux"
+
+> constants.arch
+"amd64"
+```

--- a/docs/sources/flow/reference/stdlib/constants.md
+++ b/docs/sources/flow/reference/stdlib/constants.md
@@ -18,7 +18,7 @@ Grafana Agent is running on:
 
 ```
 > constants.hostname
-"my-hostaname"
+"my-hostname"
 
 > constants.os
 "linux"

--- a/pkg/flow/internal/controller/component_references.go
+++ b/pkg/flow/internal/controller/component_references.go
@@ -48,7 +48,7 @@ func ComponentReferences(cn dag.Node, g *dag.Graph) ([]Reference, diag.Diagnosti
 		//
 		// Any call to an stdlib function is ignored.
 		var emptyScope vm.Scope
-		if _, ok := emptyScope.Lookup(t[0].Name); ok && len(t) == 1 {
+		if _, ok := emptyScope.Lookup(t[0].Name); ok {
 			continue
 		}
 

--- a/pkg/river/internal/stdlib/constants.go
+++ b/pkg/river/internal/stdlib/constants.go
@@ -1,0 +1,19 @@
+package stdlib
+
+import (
+	"os"
+	"runtime"
+)
+
+var constants = map[string]string{
+	"hostname": "", // Initialized via init function
+	"os":       runtime.GOOS,
+	"arch":     runtime.GOARCH,
+}
+
+func init() {
+	hostname, err := os.Hostname()
+	if err == nil {
+		constants["hostname"] = hostname
+	}
+}

--- a/pkg/river/internal/stdlib/stdlib.go
+++ b/pkg/river/internal/stdlib/stdlib.go
@@ -15,6 +15,9 @@ import (
 // least one non-error return value, with an optionally supported error return
 // value as the second return value.
 var Functions = map[string]interface{}{
+	// See constants.go for the definition.
+	"constants": constants,
+
 	"env": os.Getenv,
 
 	// concat is implemented as a raw function so it can bypass allocations

--- a/pkg/river/internal/stdlib/stdlib.go
+++ b/pkg/river/internal/stdlib/stdlib.go
@@ -10,11 +10,13 @@ import (
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 )
 
-// Functions returns the list of stdlib functions by name. The interface{}
-// value is always a River-compatible function value, where functions have at
-// least one non-error return value, with an optionally supported error return
-// value as the second return value.
-var Functions = map[string]interface{}{
+// Identifiers holds a list of stdlib identifiers by name. All interface{}
+// values are River-compatible values.
+//
+// Function identifiers are Go functions with exactly one one non-error return
+// value, with an optionally supported error return value as the second return
+// value.
+var Identifiers = map[string]interface{}{
 	// See constants.go for the definition.
 	"constants": constants,
 

--- a/pkg/river/vm/vm.go
+++ b/pkg/river/vm/vm.go
@@ -552,8 +552,8 @@ func (s *Scope) Lookup(name string) (interface{}, bool) {
 		}
 		s = s.Parent
 	}
-	if fn, ok := stdlib.Functions[name]; ok {
-		return fn, true
+	if ident, ok := stdlib.Identifiers[name]; ok {
+		return ident, true
 	}
 	return nil, false
 }


### PR DESCRIPTION
Add `constants` identifier to stdlib which returns an object of various constants exposing information about the system that Grafana Agent is running on. The initial set of constants is:

* `constants.hostname`: The hostname of the system that Grafana Agent is running on.
* `constants.os`: The operating system that Grafana Agent is running on. 
* `constants.arch`: The architecture of the system that Grafana Agent is running on.

Closes #2703.