### PR TITLE
CI: run macOS tests on commits to main again

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
 name: Test
 on:
+  # Run tests on main just so the module and build cache can be saved and used
+  # in PRs. This speeds up the time it takes to test PRs dramatically.
+  push:
+    branches:
+      - main
   pull_request:
 jobs:
   test:


### PR DESCRIPTION
I removed running macOS tests on commits to main because I thought it wasn't necessary, but it turns out commits to main are responsible for storing the module and build cache which speed up CI runs on PRs.