### PR TITLE
river: support squash tags

### DIFF
--- a/pkg/river/encoding/block.go
+++ b/pkg/river/encoding/block.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/grafana/agent/pkg/river/internal/reflectutil"
 	"github.com/grafana/agent/pkg/river/internal/rivertags"
 	"github.com/grafana/agent/pkg/river/internal/value"
 )
@@ -57,7 +58,7 @@ func getBlockLabel(rv reflect.Value) string {
 	tags := rivertags.Get(rv.Type())
 	for _, tag := range tags {
 		if tag.Flags&rivertags.FlagLabel != 0 {
-			return rv.FieldByIndex(tag.Index).String()
+			return reflectutil.FieldWalk(rv, tag.Index, false).String()
 		}
 	}
 
@@ -70,7 +71,7 @@ func getFieldsForBlock(input interface{}) ([]interface{}, error) {
 	rt := rivertags.Get(reflectVal.Type())
 	var fields []interface{}
 	for _, t := range rt {
-		fieldRef := reflectVal.FieldByIndex(t.Index)
+		fieldRef := reflectutil.FieldWalk(reflectVal, t.Index, false)
 		fieldVal := value.FromRaw(fieldRef)
 
 		if t.IsBlock() && (fieldRef.Kind() == reflect.Array || fieldRef.Kind() == reflect.Slice) {

--- a/pkg/river/internal/reflectutil/walk.go
+++ b/pkg/river/internal/reflectutil/walk.go
@@ -1,0 +1,53 @@
+package reflectutil
+
+import (
+	"reflect"
+)
+
+// FieldWalk returns the nested field of value corresponding to index.
+// FieldWalk panics if not given a struct.
+//
+// It is similar to [reflect/Value.FieldByIndex] but can handle traversing
+// through nil pointers. If allocate is true, FieldWalk allocates any
+// intermediate nil pointers while traversing the struct. If allocate is false,
+// FieldWalk returns a non-settable zero value for the final field.
+func FieldWalk(value reflect.Value, index []int, allocate bool) reflect.Value {
+	if len(index) == 1 {
+		return value.Field(index[0])
+	}
+
+	if value.Kind() != reflect.Struct {
+		panic("FieldWalk must be given a Struct, but found " + value.Kind().String())
+	}
+
+	for i, next := range index {
+		for value.Kind() == reflect.Pointer {
+			if value.IsNil() {
+				if !allocate {
+					return fieldWalkZero(value, index[i:])
+				}
+				value.Set(reflect.New(value.Type().Elem()))
+			}
+
+			value = value.Elem()
+		}
+
+		value = value.Field(next)
+	}
+
+	return value
+}
+
+// fieldWalkZero returns a non-settable zero value while walking value.
+func fieldWalkZero(value reflect.Value, index []int) reflect.Value {
+	typ := value.Type()
+
+	for _, next := range index {
+		for typ.Kind() == reflect.Pointer {
+			typ = typ.Elem()
+		}
+		typ = typ.Field(next).Type
+	}
+
+	return reflect.Zero(typ)
+}

--- a/pkg/river/internal/reflectutil/walk_test.go
+++ b/pkg/river/internal/reflectutil/walk_test.go
@@ -1,0 +1,71 @@
+package reflectutil_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/grafana/agent/pkg/river/internal/reflectutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeeplyNested_Access(t *testing.T) {
+	type Struct struct {
+		Field1 struct {
+			Field2 struct {
+				Field3 struct {
+					Value string
+				}
+			}
+		}
+	}
+
+	var s Struct
+	s.Field1.Field2.Field3.Value = "Hello, world!"
+
+	rv := reflect.ValueOf(&s).Elem()
+	innerValue := reflectutil.FieldWalk(rv, []int{0, 0, 0, 0}, true)
+	assert.True(t, innerValue.CanSet())
+	assert.Equal(t, reflect.String, innerValue.Kind())
+}
+
+func TestDeeplyNested_Allocate(t *testing.T) {
+	type Struct struct {
+		Field1 *struct {
+			Field2 *struct {
+				Field3 *struct {
+					Value string
+				}
+			}
+		}
+	}
+
+	var s Struct
+
+	rv := reflect.ValueOf(&s).Elem()
+	innerValue := reflectutil.FieldWalk(rv, []int{0, 0, 0, 0}, true)
+	require.True(t, innerValue.CanSet())
+	require.Equal(t, reflect.String, innerValue.Kind())
+
+	innerValue.Set(reflect.ValueOf("Hello, world!"))
+	require.Equal(t, "Hello, world!", s.Field1.Field2.Field3.Value)
+}
+
+func TestDeeplyNested_NoAllocate(t *testing.T) {
+	type Struct struct {
+		Field1 *struct {
+			Field2 *struct {
+				Field3 *struct {
+					Value string
+				}
+			}
+		}
+	}
+
+	var s Struct
+
+	rv := reflect.ValueOf(&s).Elem()
+	innerValue := reflectutil.FieldWalk(rv, []int{0, 0, 0, 0}, false)
+	assert.False(t, innerValue.CanSet())
+	assert.Equal(t, reflect.String, innerValue.Kind())
+}

--- a/pkg/river/internal/rivertags/rivertags.go
+++ b/pkg/river/internal/rivertags/rivertags.go
@@ -148,22 +148,11 @@ func Get(ty reflect.Type) []Field {
 		}
 		usedNames[fullName] = tf.Index
 
-		switch options[1] {
-		case "attr":
-			tf.Flags |= FlagAttr
-		case "attr,optional":
-			tf.Flags |= FlagAttr | FlagOptional
-		case "block":
-			tf.Flags |= FlagBlock
-		case "block,optional":
-			tf.Flags |= FlagBlock | FlagOptional
-		case "label":
-			tf.Flags |= FlagLabel
-		case "squash":
-			tf.Flags |= FlagSquash
-		default:
+		flags, ok := parseFlags(options[1])
+		if !ok {
 			panic(fmt.Sprintf("river: unrecognized river tag format %q at %s", tag, printPathToField(ty, tf.Index)))
 		}
+		tf.Flags = flags
 
 		if len(tf.Name) > 1 && tf.Flags&FlagBlock == 0 {
 			panic(fmt.Sprintf("river: field names with `.` may only be used by blocks (found at %s)", printPathToField(ty, tf.Index)))
@@ -211,6 +200,27 @@ func Get(ty reflect.Type) []Field {
 	}
 
 	return fields
+}
+
+func parseFlags(input string) (f Flags, ok bool) {
+	switch input {
+	case "attr":
+		f |= FlagAttr
+	case "attr,optional":
+		f |= FlagAttr | FlagOptional
+	case "block":
+		f |= FlagBlock
+	case "block,optional":
+		f |= FlagBlock | FlagOptional
+	case "label":
+		f |= FlagLabel
+	case "squash":
+		f |= FlagSquash
+	default:
+		return
+	}
+
+	return f, true
 }
 
 func printPathToField(structTy reflect.Type, path []int) string {

--- a/pkg/river/internal/rivertags/rivertags.go
+++ b/pkg/river/internal/rivertags/rivertags.go
@@ -18,6 +18,7 @@ const (
 
 	FlagOptional // FlagOptional marks a field optional for decoding/encoding
 	FlagLabel    // FlagLabel will store block labels in the field
+	FlagSquash   // FlagSquash will expose inner fields from a struct as outer fields.
 )
 
 // String returns the flags as a string.
@@ -35,6 +36,9 @@ func (f Flags) String() string {
 	}
 	if f&FlagLabel != 0 {
 		attrs = append(attrs, "label")
+	}
+	if f&FlagSquash != 0 {
+		attrs = append(attrs, "squash")
 	}
 
 	return fmt.Sprintf("Flags(%s)", strings.Join(attrs, ","))
@@ -89,8 +93,11 @@ func (f Field) IsOptional() bool { return f.Flags&FlagOptional != 0 }
 //	// represents.
 //	Field string `river:",label"`
 //
-// With the exception of the `river:",label"` tag, all tagged fields must have a
-// unique name.
+//	// Attributes and blocks inside of Field are exposed as top-level fields.
+//	Field struct{} `river:",squash"`
+//
+// With the exception of the `river:",label"` and `river:",squash" tags, all
+// tagged fields must have a unique name.
 //
 // The type of tagged fields may be any Go type, with the exception of
 // `river:",label"` tags, which must be strings.
@@ -152,6 +159,8 @@ func Get(ty reflect.Type) []Field {
 			tf.Flags |= FlagBlock | FlagOptional
 		case "label":
 			tf.Flags |= FlagLabel
+		case "squash":
+			tf.Flags |= FlagSquash
 		default:
 			panic(fmt.Sprintf("river: unrecognized river tag format %q at %s", tag, printPathToField(ty, tf.Index)))
 		}
@@ -174,7 +183,27 @@ func Get(ty reflect.Type) []Field {
 			usedLabelField = tf.Index
 		}
 
-		if fullName == "" && tf.Flags&FlagLabel == 0 /* (e.g., *not* a label) */ {
+		if tf.Flags&FlagSquash != 0 {
+			if fullName != "" {
+				panic(fmt.Sprintf("river: squash field at %s must not have a name", printPathToField(ty, tf.Index)))
+			}
+
+			// Get the inner fields from the squashed struct and append each of them.
+			// The index of the squashed field is prepended to the index of the inner
+			// struct.
+			innerFields := Get(deferenceType(field.Type))
+			for _, innerField := range innerFields {
+				fields = append(fields, Field{
+					Name:  innerField.Name,
+					Index: append(field.Index, innerField.Index...),
+					Flags: innerField.Flags,
+				})
+			}
+
+			continue
+		}
+
+		if fullName == "" && tf.Flags&(FlagLabel|FlagSquash) == 0 /* (e.g., *not* a label or squash) */ {
 			panic(fmt.Sprintf("river: non-empty field name required at %s", printPathToField(ty, tf.Index)))
 		}
 
@@ -202,4 +231,11 @@ func printPathToField(structTy reflect.Type, path []int) string {
 	}
 
 	return sb.String()
+}
+
+func deferenceType(ty reflect.Type) reflect.Type {
+	for ty.Kind() == reflect.Pointer {
+		ty = ty.Elem()
+	}
+	return ty
 }

--- a/pkg/river/internal/rivertags/rivertags_test.go
+++ b/pkg/river/internal/rivertags/rivertags_test.go
@@ -95,6 +95,37 @@ func TestSquash(t *testing.T) {
 	assert.Equal(t, expect, structPointerActual)
 }
 
+func TestDeepSquash(t *testing.T) {
+	type Inner2Struct struct {
+		InnerField1 string `river:"inner_field_1,attr"`
+		InnerField2 string `river:"inner_field_2,attr"`
+	}
+
+	type InnerStruct struct {
+		Inner2Struct Inner2Struct `river:",squash"`
+	}
+
+	type Struct struct {
+		Inner InnerStruct `river:",squash"`
+	}
+
+	expect := []rivertags.Field{
+		{
+			Name:  []string{"inner_field_1"},
+			Index: []int{0, 0, 0},
+			Flags: rivertags.FlagAttr,
+		},
+		{
+			Name:  []string{"inner_field_2"},
+			Index: []int{0, 0, 1},
+			Flags: rivertags.FlagAttr,
+		},
+	}
+
+	structActual := rivertags.Get(reflect.TypeOf(Struct{}))
+	assert.Equal(t, expect, structActual)
+}
+
 func Test_Get_Panics(t *testing.T) {
 	expectPanic := func(t *testing.T, expect string, v interface{}) {
 		t.Helper()

--- a/pkg/river/internal/rivertags/rivertags_test.go
+++ b/pkg/river/internal/rivertags/rivertags_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/grafana/agent/pkg/river/internal/rivertags"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,6 +45,54 @@ func TestEmbedded(t *testing.T) {
 		Field2 string `river:"parent_field_2,attr"`
 	}
 	require.PanicsWithValue(t, "river: anonymous fields not supported rivertags_test.Struct.InnerStruct", func() { rivertags.Get(reflect.TypeOf(Struct{})) })
+}
+
+func TestSquash(t *testing.T) {
+	type InnerStruct struct {
+		InnerField1 string `river:"inner_field_1,attr"`
+		InnerField2 string `river:"inner_field_2,attr"`
+	}
+
+	type Struct struct {
+		Field1 string      `river:"parent_field_1,attr"`
+		Inner  InnerStruct `river:",squash"`
+		Field2 string      `river:"parent_field_2,attr"`
+	}
+
+	type StructWithPointer struct {
+		Field1 string       `river:"parent_field_1,attr"`
+		Inner  *InnerStruct `river:",squash"`
+		Field2 string       `river:"parent_field_2,attr"`
+	}
+
+	expect := []rivertags.Field{
+		{
+			Name:  []string{"parent_field_1"},
+			Index: []int{0},
+			Flags: rivertags.FlagAttr,
+		},
+		{
+			Name:  []string{"inner_field_1"},
+			Index: []int{1, 0},
+			Flags: rivertags.FlagAttr,
+		},
+		{
+			Name:  []string{"inner_field_2"},
+			Index: []int{1, 1},
+			Flags: rivertags.FlagAttr,
+		},
+		{
+			Name:  []string{"parent_field_2"},
+			Index: []int{2},
+			Flags: rivertags.FlagAttr,
+		},
+	}
+
+	structActual := rivertags.Get(reflect.TypeOf(Struct{}))
+	assert.Equal(t, expect, structActual)
+
+	structPointerActual := rivertags.Get(reflect.TypeOf(StructWithPointer{}))
+	assert.Equal(t, expect, structPointerActual)
 }
 
 func Test_Get_Panics(t *testing.T) {

--- a/pkg/river/internal/value/decode.go
+++ b/pkg/river/internal/value/decode.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"reflect"
 	"time"
+
+	"github.com/grafana/agent/pkg/river/internal/reflectutil"
 )
 
 // Unmarshaler is a custom type which can be used to hook into the decoder.
@@ -478,7 +480,7 @@ func (d *decoder) decodeObject(val Value, rt reflect.Value) error {
 		for i, key := range keys {
 			// First decode the key into the label.
 			elem := res.Index(i)
-			elem.FieldByIndex(labelField.Index).Set(reflect.ValueOf(key))
+			reflectutil.FieldWalk(elem, labelField.Index, true).Set(reflect.ValueOf(key))
 
 			// Now decode the inner object.
 			value, _ := val.Key(key)
@@ -550,7 +552,7 @@ func (d *decoder) decodeObjectToStruct(val Value, rt reflect.Value, fields *obje
 			}
 
 			// Decode the key into the label.
-			rt.FieldByIndex(lf.Index).Set(reflect.ValueOf(key))
+			reflectutil.FieldWalk(rt, lf.Index, true).Set(reflect.ValueOf(key))
 
 			// ...and then code the rest of the object.
 			if err := d.decodeObjectToStruct(value, rt, fields, true); err != nil {
@@ -570,30 +572,13 @@ func (d *decoder) decodeObjectToStruct(val Value, rt reflect.Value, fields *obje
 			}
 		case objectKeyTypeField:
 			targetField, _ := fields.Field(key)
-			if err := d.decodeToField(value, rt, targetField.Index); err != nil {
+			targetValue := reflectutil.FieldWalk(rt, targetField.Index, true)
+
+			if err := d.decode(value, targetValue); err != nil {
 				return FieldError{Value: val, Field: key, Inner: err}
 			}
 		}
 	}
 
 	return nil
-}
-
-// decodeToField will decode val into a field within intoStruct indexed by the
-// index slice. decodeToField will allocate pointers as necessary while
-// traversing the struct fields.
-func (d *decoder) decodeToField(val Value, intoStruct reflect.Value, index []int) error {
-	curr := intoStruct
-	for _, next := range index {
-		for curr.Kind() == reflect.Pointer {
-			if curr.IsNil() {
-				curr.Set(reflect.New(curr.Type().Elem()))
-			}
-			curr = curr.Elem()
-		}
-
-		curr = curr.Field(next)
-	}
-
-	return d.decode(val, curr)
 }

--- a/pkg/river/internal/value/decode_test.go
+++ b/pkg/river/internal/value/decode_test.go
@@ -384,3 +384,73 @@ func TestDecode_CustomConvert(t *testing.T) {
 		require.EqualError(t, err, "expected string, got capsule")
 	})
 }
+
+func TestDecode_SquashedFields(t *testing.T) {
+	type InnerStruct struct {
+		InnerField1 string `river:"inner_field_1,attr,optional"`
+		InnerField2 string `river:"inner_field_2,attr,optional"`
+	}
+
+	type OuterStruct struct {
+		OuterField1 string      `river:"outer_field_1,attr,optional"`
+		Inner       InnerStruct `river:",squash"`
+		OuterField2 string      `river:"outer_field_2,attr,optional"`
+	}
+
+	var (
+		in = map[string]string{
+			"outer_field_1": "value1",
+			"outer_field_2": "value2",
+			"inner_field_1": "value3",
+			"inner_field_2": "value4",
+		}
+		expect = OuterStruct{
+			OuterField1: "value1",
+			Inner: InnerStruct{
+				InnerField1: "value3",
+				InnerField2: "value4",
+			},
+			OuterField2: "value2",
+		}
+	)
+
+	var out OuterStruct
+	err := value.Decode(value.Encode(in), &out)
+	require.NoError(t, err)
+	require.Equal(t, expect, out)
+}
+
+func TestDecode_SquashedFields_Pointer(t *testing.T) {
+	type InnerStruct struct {
+		InnerField1 string `river:"inner_field_1,attr,optional"`
+		InnerField2 string `river:"inner_field_2,attr,optional"`
+	}
+
+	type OuterStruct struct {
+		OuterField1 string       `river:"outer_field_1,attr,optional"`
+		Inner       *InnerStruct `river:",squash"`
+		OuterField2 string       `river:"outer_field_2,attr,optional"`
+	}
+
+	var (
+		in = map[string]string{
+			"outer_field_1": "value1",
+			"outer_field_2": "value2",
+			"inner_field_1": "value3",
+			"inner_field_2": "value4",
+		}
+		expect = OuterStruct{
+			OuterField1: "value1",
+			Inner: &InnerStruct{
+				InnerField1: "value3",
+				InnerField2: "value4",
+			},
+			OuterField2: "value2",
+		}
+	)
+
+	var out OuterStruct
+	err := value.Decode(value.Encode(in), &out)
+	require.NoError(t, err)
+	require.Equal(t, expect, out)
+}

--- a/pkg/river/internal/value/value.go
+++ b/pkg/river/internal/value/value.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/grafana/agent/pkg/river/internal/reflectutil"
 )
 
 // Go types used throughout the package.
@@ -330,7 +332,7 @@ func (v Value) Keys() []string {
 
 		keys := make([]string, v.rv.Len())
 		for i := range keys {
-			keys[i] = v.rv.Index(i).FieldByIndex(labelField.Index).String()
+			keys[i] = reflectutil.FieldWalk(v.rv.Index(i), labelField.Index, false).String()
 		}
 		return keys
 
@@ -376,7 +378,7 @@ func (v Value) Key(key string) (index Value, ok bool) {
 		for i := 0; i < v.rv.Len(); i++ {
 			elem := v.rv.Index(i)
 
-			label := elem.FieldByIndex(labelField.Index).String()
+			label := reflectutil.FieldWalk(elem, labelField.Index, false).String()
 			if label == key {
 				// We discard the label since the key here represents the label value.
 				ws := wrapStruct(elem, false)

--- a/pkg/river/internal/value/value_object.go
+++ b/pkg/river/internal/value/value_object.go
@@ -1,6 +1,10 @@
 package value
 
-import "reflect"
+import (
+	"reflect"
+
+	"github.com/grafana/agent/pkg/river/internal/reflectutil"
+)
 
 // structWrapper allows for partially traversing structs which contain fields
 // representing blocks. This is required due to how block names and labels
@@ -40,7 +44,7 @@ func wrapStruct(val reflect.Value, keepLabel bool) structWrapper {
 
 	var label string
 	if f, ok := fields.LabelField(); ok && keepLabel {
-		label = val.FieldByIndex(f.Index).String()
+		label = reflectutil.FieldWalk(val, f.Index, false).String()
 	}
 
 	return structWrapper{

--- a/pkg/river/river.go
+++ b/pkg/river/river.go
@@ -82,6 +82,10 @@ import (
 //	// converted into a block. When decoding, a block label must be provided.
 //	Field string `river:",label"`
 //
+//	// The inner attributes and blocks of Field are exposed as top-level
+//	// attributes and blocks of the outer struct.
+//	Field struct{...} `river:",squash"`
+//
 // If a river tag specifies a required or optional block, the name is permitted
 // to contain period `.` characters.
 //

--- a/pkg/river/token/builder/builder.go
+++ b/pkg/river/token/builder/builder.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/grafana/agent/pkg/river/internal/reflectutil"
 	"github.com/grafana/agent/pkg/river/internal/rivertags"
 	"github.com/grafana/agent/pkg/river/token"
 )
@@ -136,7 +137,7 @@ func getBlockLabel(rv reflect.Value) string {
 	tags := rivertags.Get(rv.Type())
 	for _, tag := range tags {
 		if tag.Flags&rivertags.FlagLabel != 0 {
-			return rv.FieldByIndex(tag.Index).String()
+			return reflectutil.FieldWalk(rv, tag.Index, false).String()
 		}
 	}
 
@@ -157,7 +158,7 @@ func (b *Body) encodeFields(rv reflect.Value) {
 	fields := rivertags.Get(rv.Type())
 
 	for _, field := range fields {
-		fieldVal := rv.FieldByIndex(field.Index)
+		fieldVal := reflectutil.FieldWalk(rv, field.Index, false)
 		b.encodeField(field, fieldVal)
 	}
 }

--- a/pkg/river/types.go
+++ b/pkg/river/types.go
@@ -20,7 +20,9 @@ var (
 // decode into another type or provide pre-decoding logic.
 type Unmarshaler interface {
 	// UnmarshalRiver is invoked when decoding a River value into a Go value. f
-	// should be called with a pointer to a value to decode into.
+	// should be called with a pointer to a value to decode into. UnmarshalRiver
+	// will not be called on types which are squashed into the parent struct
+	// using `river:",squash"`.
 	UnmarshalRiver(f func(v interface{}) error) error
 }
 

--- a/pkg/river/vm/vm.go
+++ b/pkg/river/vm/vm.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/agent/pkg/river/ast"
 	"github.com/grafana/agent/pkg/river/diag"
+	"github.com/grafana/agent/pkg/river/internal/reflectutil"
 	"github.com/grafana/agent/pkg/river/internal/rivertags"
 	"github.com/grafana/agent/pkg/river/internal/stdlib"
 	"github.com/grafana/agent/pkg/river/internal/value"
@@ -195,7 +196,7 @@ func (vm *Evaluator) evaluateBlockOrBody(scope *Scope, assoc map[value.Value]ast
 			return fmt.Errorf("%q may only be used as a block or an attribute, but found both", fullName)
 		}
 
-		field := rv.FieldByIndex(tf.Index)
+		field := reflectutil.FieldWalk(rv, tf.Index, true)
 
 		// Decode.
 		switch {
@@ -338,7 +339,7 @@ func (vm *Evaluator) evaluateBlockLabel(node *ast.BlockStmt, tfs []rivertags.Fie
 	}
 
 	var (
-		field     = rv.FieldByIndex(labelField.Index)
+		field     = reflectutil.FieldWalk(rv, labelField.Index, true)
 		fieldType = field.Type()
 	)
 	if !reflect.TypeOf(node.Label).AssignableTo(fieldType) {

--- a/pkg/river/vm/vm_block_test.go
+++ b/pkg/river/vm/vm_block_test.go
@@ -151,6 +151,78 @@ func TestVM_Block_Attributes(t *testing.T) {
 		require.Equal(t, 25, **actual.NumberC)
 		require.Equal(t, 30, ***actual.NumberD)
 	})
+
+	t.Run("Supports squashed attributes", func(t *testing.T) {
+		type InnerStruct struct {
+			InnerField1 string `river:"inner_field_1,attr,optional"`
+			InnerField2 string `river:"inner_field_2,attr,optional"`
+		}
+
+		type OuterStruct struct {
+			OuterField1 string      `river:"outer_field_1,attr,optional"`
+			Inner       InnerStruct `river:",squash"`
+			OuterField2 string      `river:"outer_field_2,attr,optional"`
+		}
+
+		var (
+			input = `some_block {
+				outer_field_1 = "value1"
+				outer_field_2 = "value2"
+				inner_field_1 = "value3"
+				inner_field_2 = "value4"
+			}`
+
+			expect = OuterStruct{
+				OuterField1: "value1",
+				Inner: InnerStruct{
+					InnerField1: "value3",
+					InnerField2: "value4",
+				},
+				OuterField2: "value2",
+			}
+		)
+		eval := vm.New(parseBlock(t, input))
+
+		var actual OuterStruct
+		require.NoError(t, eval.Evaluate(nil, &actual))
+		require.Equal(t, expect, actual)
+	})
+
+	t.Run("Supports squashed attributes in pointers", func(t *testing.T) {
+		type InnerStruct struct {
+			InnerField1 string `river:"inner_field_1,attr,optional"`
+			InnerField2 string `river:"inner_field_2,attr,optional"`
+		}
+
+		type OuterStruct struct {
+			OuterField1 string       `river:"outer_field_1,attr,optional"`
+			Inner       *InnerStruct `river:",squash"`
+			OuterField2 string       `river:"outer_field_2,attr,optional"`
+		}
+
+		var (
+			input = `some_block {
+				outer_field_1 = "value1"
+				outer_field_2 = "value2"
+				inner_field_1 = "value3"
+				inner_field_2 = "value4"
+			}`
+
+			expect = OuterStruct{
+				OuterField1: "value1",
+				Inner: &InnerStruct{
+					InnerField1: "value3",
+					InnerField2: "value4",
+				},
+				OuterField2: "value2",
+			}
+		)
+		eval := vm.New(parseBlock(t, input))
+
+		var actual OuterStruct
+		require.NoError(t, eval.Evaluate(nil, &actual))
+		require.Equal(t, expect, actual)
+	})
 }
 
 func TestVM_Block_Children_Blocks(t *testing.T) {
@@ -307,6 +379,78 @@ func TestVM_Block_Children_Blocks(t *testing.T) {
 		require.Equal(t, false, (*actual.BlockB).Attr)
 		require.Equal(t, true, (**actual.BlockC).Attr)
 		require.Equal(t, false, (***actual.BlockD).Attr)
+	})
+
+	t.Run("Supports squashed blocks", func(t *testing.T) {
+		type InnerStruct struct {
+			Inner1 childBlock `river:"inner_block_1,block"`
+			Inner2 childBlock `river:"inner_block_2,block"`
+		}
+
+		type OuterStruct struct {
+			Outer1 childBlock  `river:"outer_block_1,block"`
+			Inner  InnerStruct `river:",squash"`
+			Outer2 childBlock  `river:"outer_block_2,block"`
+		}
+
+		var (
+			input = `some_block {
+				outer_block_1 { attr = true }
+				outer_block_2 { attr = false }
+				inner_block_1 { attr = true } 
+				inner_block_2 { attr = false } 
+			}`
+
+			expect = OuterStruct{
+				Outer1: childBlock{Attr: true},
+				Outer2: childBlock{Attr: false},
+				Inner: InnerStruct{
+					Inner1: childBlock{Attr: true},
+					Inner2: childBlock{Attr: false},
+				},
+			}
+		)
+		eval := vm.New(parseBlock(t, input))
+
+		var actual OuterStruct
+		require.NoError(t, eval.Evaluate(nil, &actual))
+		require.Equal(t, expect, actual)
+	})
+
+	t.Run("Supports squashed blocks in pointers", func(t *testing.T) {
+		type InnerStruct struct {
+			Inner1 *childBlock `river:"inner_block_1,block"`
+			Inner2 *childBlock `river:"inner_block_2,block"`
+		}
+
+		type OuterStruct struct {
+			Outer1 childBlock   `river:"outer_block_1,block"`
+			Inner  *InnerStruct `river:",squash"`
+			Outer2 childBlock   `river:"outer_block_2,block"`
+		}
+
+		var (
+			input = `some_block {
+				outer_block_1 { attr = true }
+				outer_block_2 { attr = false }
+				inner_block_1 { attr = true } 
+				inner_block_2 { attr = false } 
+			}`
+
+			expect = OuterStruct{
+				Outer1: childBlock{Attr: true},
+				Outer2: childBlock{Attr: false},
+				Inner: &InnerStruct{
+					Inner1: &childBlock{Attr: true},
+					Inner2: &childBlock{Attr: false},
+				},
+			}
+		)
+		eval := vm.New(parseBlock(t, input))
+
+		var actual OuterStruct
+		require.NoError(t, eval.Evaluate(nil, &actual))
+		require.Equal(t, expect, actual)
 	})
 
 	// TODO(rfratto): decode all blocks into a []*ast.BlockStmt field.

--- a/tools/agentlint/internal/rivertags/rivertags.go
+++ b/tools/agentlint/internal/rivertags/rivertags.go
@@ -32,6 +32,7 @@ var riverTagRegex = regexp.MustCompile(`river:"([^"]*)"`)
 //   - block
 //   - block,optional
 //   - label
+//   - squash
 // - Attribute and block tags must have a non-empty value NAME.
 // - Fields marked as blocks must be the appropriate type.
 // - Label tags must have an empty value for NAME.
@@ -229,6 +230,11 @@ func lintRiverTag(ty *types.Var, tag string) (diagnostics []string) {
 	case "label":
 		if name != "" {
 			diagnostics = append(diagnostics, "label field must have an empty value for name")
+		}
+
+	case "squash":
+		if name != "" {
+			diagnostics = append(diagnostics, "squash field must have an empty value for name")
 		}
 
 	default:


### PR DESCRIPTION
This PR adds support for adding a `,squash` tag to structs:

```go
type Example struct {
  Squashed OtherStruct `river:",squash"` 
}
```

Fields denoted as `,squash` will have their inner attributes and blocks squashed and exposed as top-level attributes and blocks on the parent struct. 

As part of this change, nearly every usage of `reflect.Value.FieldByIndex` has been replaced with a call to a new function, `reflectutil.FieldWalk` which supports walking through intermediate nil fields, either allocating pointers or returning a zero value as appropriate. 

Sorry for the PR size, most of it is tests. 

Closes #2373. 

No existing component is updated to make use of this new feature; that can be done follow up PRs. 