### PR TITLE
Remove -config.expand-env flag from tanka library

### DIFF
--- a/production/tanka/grafana-agent/v2/internal/base.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/base.libsonnet
@@ -23,7 +23,6 @@ function(name='grafana-agent', namespace='') {
     agent_args: {
       'config.file': '/etc/agent/agent.yaml',
       'server.http.address': '0.0.0.0:80',
-      'config.expand-env': 'true',
     },
   },
 


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Recently, https://github.com/grafana/agent/commit/c2acc706d526eb58408d286294025968518116aa added the `-config.expand-env` flag in the sample kubernetes manifests.

The flag was also added in our Tanka library, which when used with Flow mode, breaks deployments since the flag is not supported.

#### Which issue(s) this PR fixes
Failed Flow deployments when using base.libsonnet

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
