### PR TITLE
Operator: Update prometheus-config-reloader to v0.62.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ Main (unreleased)
 - Use Go 1.20 for builds. Official release binaries are still produced using Go
   1.19. (@rfratto)
 
+- In the Agent Operator, upgrade the `prometheus-config-reloader` dependency
+  from version 0.47.0 to version 0.62.0. (@ptodev)
+
 v0.31.1 (2023-02-06)
 --------------------
 

--- a/pkg/operator/resources_pod_template.go
+++ b/pkg/operator/resources_pod_template.go
@@ -199,7 +199,7 @@ func generatePodTemplate(
 	operatorContainers := []core_v1.Container{
 		{
 			Name:         "config-reloader",
-			Image:        "quay.io/prometheus-operator/prometheus-config-reloader:v0.47.0",
+			Image:        "quay.io/prometheus-operator/prometheus-config-reloader:v0.62.0",
 			VolumeMounts: volumeMounts,
 			Env:          envVars,
 			SecurityContext: &core_v1.SecurityContext{


### PR DESCRIPTION
#### PR Description
The Agent Operator currently uses version 0.47.0 of prometheus-config-reloader. This PR will upgrade it to version 0.62.0.

#### Notes to the Reviewer
This upgrade was requested by a customer via a support escalation.

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
