### PR TITLE
Add timeout to loki.source.podlogs controller setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ Main (unreleased)
 - Flow: add `constants` into the standard library to expose the hostname, OS,
   and architecture of the system Grafana Agent is running on. (@rfratto)
 
+- Flow: add timeout to loki.source.podlogs controller setup. (@polyrain)
+
 ### Other changes
 
 - Use Go 1.20 for builds. Official release binaries are still produced using Go

--- a/component/loki/source/podlogs/controller.go
+++ b/component/loki/source/podlogs/controller.go
@@ -176,7 +176,7 @@ func (ctrl *controller) configureInformers(ctx context.Context, informers cache.
 		informer, err := informers.GetInformer(informerCtx, ty)
 		if err != nil {
 			if err == context.DeadlineExceeded {
-				return fmt.Errorf("Timeout exceeded while configuring informers. Check the connection to the Kubernetes API is stable and that the Agent has appropriate RBAC permissions for namespaces, pods, and PodLogs.")
+				return fmt.Errorf("Timeout exceeded while configuring informers. Check the connection to the Kubernetes API is stable and that the Agent has appropriate RBAC permissions for %v", ty)
 			}
 
 			return err

--- a/component/loki/source/podlogs/controller.go
+++ b/component/loki/source/podlogs/controller.go
@@ -175,12 +175,11 @@ func (ctrl *controller) configureInformers(ctx context.Context, informers cache.
 	for _, ty := range types {
 		informer, err := informers.GetInformer(informerCtx, ty)
 		if err != nil {
-			switch err {
-			case context.DeadlineExceeded:
+			if err == context.DeadlineExceeded {
 				return fmt.Errorf("Timeout exceeded while configuring informers. Check the connection to the Kubernetes API is stable and that the Agent has appropriate RBAC permissions for namespaces, pods, and PodLogs.")
-			default:
-				return err
 			}
+
+			return err
 		}
 		informer.AddEventHandler(onChangeEventHandler{ChangeFunc: ctrl.RequestReconcile})
 	}

--- a/component/loki/source/podlogs/controller.go
+++ b/component/loki/source/podlogs/controller.go
@@ -176,8 +176,9 @@ func (ctrl *controller) configureInformers(ctx context.Context, informers cache.
 	for _, ty := range types {
 		informer, err := informers.GetInformer(informerCtx, ty)
 		if err != nil {
-			if errors.Is(informerCtx.Err(), context.DeadlineExceeded) { // Check the context to prevent GetInformer returning a fake timeout; if GetInformer was cancelled due to timeout this is the same result
-				return fmt.Errorf("Timeout exceeded while configuring informers. Check the connection to the Kubernetes API is stable and that the Agent has appropriate RBAC permissions for %v", ty)
+			if errors.Is(informerCtx.Err(), context.DeadlineExceeded) { // Check the context to prevent GetInformer returning a fake timeout
+				return fmt.Errorf("Timeout exceeded while configuring informers. Check the connection"+
+					" to the Kubernetes API is stable and that the Agent has appropriate RBAC permissions for %v", ty)
 			}
 
 			return err

--- a/component/loki/source/podlogs/controller.go
+++ b/component/loki/source/podlogs/controller.go
@@ -175,7 +175,7 @@ func (ctrl *controller) configureInformers(ctx context.Context, informers cache.
 	for _, ty := range types {
 		informer, err := informers.GetInformer(informerCtx, ty)
 		if err != nil {
-			if err == context.DeadlineExceeded {
+			if informerCtx.Err() == context.DeadlineExceeded { // Check the context to prevent GetInformer returning a fake timeout; if GetInformer was cancelled due to timeout this is the same result
 				return fmt.Errorf("Timeout exceeded while configuring informers. Check the connection to the Kubernetes API is stable and that the Agent has appropriate RBAC permissions for %v", ty)
 			}
 

--- a/component/loki/source/podlogs/controller.go
+++ b/component/loki/source/podlogs/controller.go
@@ -2,6 +2,7 @@ package podlogs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -175,7 +176,7 @@ func (ctrl *controller) configureInformers(ctx context.Context, informers cache.
 	for _, ty := range types {
 		informer, err := informers.GetInformer(informerCtx, ty)
 		if err != nil {
-			if informerCtx.Err() == context.DeadlineExceeded { // Check the context to prevent GetInformer returning a fake timeout; if GetInformer was cancelled due to timeout this is the same result
+			if errors.Is(informerCtx.Err(), context.DeadlineExceeded) { // Check the context to prevent GetInformer returning a fake timeout; if GetInformer was cancelled due to timeout this is the same result
 				return fmt.Errorf("Timeout exceeded while configuring informers. Check the connection to the Kubernetes API is stable and that the Agent has appropriate RBAC permissions for %v", ty)
 			}
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR adds a timeout when configuring Informers in `loki.source.podlogs`, which had the potential to block forever if 
the Agent had insufficient RBAC permissions or flaky connection to the control plane. After 10 seconds the context is cancelled and if the error branch is hit due to this, a more informative error message is returned explaining possible causes.

#### Which issue(s) this PR fixes
Fixes #2866

#### Notes to the Reviewer
Golang is an area I'm not the most fluent in, apologies if some aspects aren't idiomatic; feedback appreciated :) 

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
