### PR TITLE
Remove latest from grafana cloud links

### DIFF
--- a/docs/sources/about-agent/_index.md
+++ b/docs/sources/about-agent/_index.md
@@ -21,10 +21,10 @@ There are different ways for you to set up Grafana Agent to scrape data&mdash;th
 
 | Topic | Description |
 |---|---|
-| [Get started with monitoring using an integration](/docs/grafana-cloud/latest/data-configuration/get-started-integration/) | Walk through installing a Linux integration using Grafana Agent in the Grafana Cloud interface. |
-| [Install and manage integrations](/docs/grafana-cloud/latest/data-configuration/integrations/install-and-manage-integrations/)  | View general steps for using Grafana Cloud integrations to install Grafana Agent to collect data. See [supported integrations](/docs/grafana-cloud/latest/data-configuration/integrations/integration-reference/).  
-| [Ship your metrics to Grafana Cloud without an integration](/docs/grafana-cloud/latest/data-configuration/metrics/agent-config-exporter/) | If you want to ship your Prometheus metrics to Grafana Cloud but there isn’t an integration available, you can use a Prometheus exporter and deploy Grafana Agent to scrape your local machine or service. |
-| [Change your metrics scrape interval](/docs/grafana-cloud/latest/billing-and-usage/control-prometheus-metrics-usage/changing-scrape-interval/) | Learn about reducing your total data points per minute (DPM) by adjusting your scrape interval. |
+| [Get started with monitoring using an integration](/docs/grafana-cloud/data-configuration/get-started-integration/) | Walk through installing a Linux integration using Grafana Agent in the Grafana Cloud interface. |
+| [Install and manage integrations](/docs/grafana-cloud/data-configuration/integrations/install-and-manage-integrations/)  | View general steps for using Grafana Cloud integrations to install Grafana Agent to collect data. See [supported integrations](/docs/grafana-cloud/data-configuration/integrations/integration-reference/).  
+| [Ship your metrics to Grafana Cloud without an integration](/docs/grafana-cloud/data-configuration/metrics/agent-config-exporter/) | If you want to ship your Prometheus metrics to Grafana Cloud but there isn’t an integration available, you can use a Prometheus exporter and deploy Grafana Agent to scrape your local machine or service. |
+| [Change your metrics scrape interval](/docs/grafana-cloud/billing-and-usage/control-prometheus-metrics-usage/changing-scrape-interval/) | Learn about reducing your total data points per minute (DPM) by adjusting your scrape interval. |
 
 ## Grafana Agent for Kubernetes Monitoring
 
@@ -32,18 +32,18 @@ Grafana Kubernetes Monitoring provides a simplified approach to monitoring your 
 
 | Topic | Description |
 |---|---|
-| [Configure Kubernetes Monitoring using Agent](/docs/grafana-cloud/latest/kubernetes-monitoring/configuration/config-k8s-agent-guide/) | Use the Kubernetes Monitoring solution to set up monitoring of your Kubernetes cluster and to install preconfigured dashboards and alerts. |
-| [Ship Kubernetes metrics using Grafana Agent directly](/docs/grafana-cloud/latest/kubernetes-monitoring/other-methods/k8s-agent-metrics/) |  Take a more hands-on approach and directly deploy Grafana Agent into a Kubernetes cluster without using the Kubernetes Monitoring interface. Use this guide to configure Agent to scrape the kubelet and cadvisor endpoints on your cluster Nodes. If you use this method, you still have access to the Kubernetes Monitoring preconfigured dashboards and alerts. |
-| [Ship Kubernetes logs using Grafana Agent directly](/docs/grafana-cloud/latest/kubernetes-monitoring/other-methods/k8s-agent-logs/) | Deploy Grafana Agent into your Kubernetes cluster as a DaemonSet and configure it to collect logs for your Kubernetes workloads.  |
-| [Ship Kubernetes traces using Grafana Agent directly](/docs/grafana-cloud/latest/kubernetes-monitoring/other-methods/k8s-agent-traces/) | Deploy Grafana Agent into your Kubernetes cluster as a deployment and configure it to collect traces for your Kubernetes workloads.  |
+| [Configure Kubernetes Monitoring using Agent](/docs/grafana-cloud/kubernetes-monitoring/configuration/config-k8s-agent-guide/) | Use the Kubernetes Monitoring solution to set up monitoring of your Kubernetes cluster and to install preconfigured dashboards and alerts. |
+| [Ship Kubernetes metrics using Grafana Agent directly](/docs/grafana-cloud/kubernetes-monitoring/other-methods/k8s-agent-metrics/) |  Take a more hands-on approach and directly deploy Grafana Agent into a Kubernetes cluster without using the Kubernetes Monitoring interface. Use this guide to configure Agent to scrape the kubelet and cadvisor endpoints on your cluster Nodes. If you use this method, you still have access to the Kubernetes Monitoring preconfigured dashboards and alerts. |
+| [Ship Kubernetes logs using Grafana Agent directly](/docs/grafana-cloud/kubernetes-monitoring/other-methods/k8s-agent-logs/) | Deploy Grafana Agent into your Kubernetes cluster as a DaemonSet and configure it to collect logs for your Kubernetes workloads.  |
+| [Ship Kubernetes traces using Grafana Agent directly](/docs/grafana-cloud/kubernetes-monitoring/other-methods/k8s-agent-traces/) | Deploy Grafana Agent into your Kubernetes cluster as a deployment and configure it to collect traces for your Kubernetes workloads.  |
 
 ## Grafana Agent Operator for Kubernetes Monitoring
 
-You can use Kubernetes Monitoring with Grafana Agent or with Grafana Agent Operator. Use Grafana Agent Operator if you prefer to use a Kubernetes-style operator rather than an agent. See [Grafana Agent versus Grafana Agent Operator](/docs/grafana-cloud/latest/kubernetes-monitoring/#grafana-agent-versus-grafana-agent-operator) to understand the differences.
+You can use Kubernetes Monitoring with Grafana Agent or with Grafana Agent Operator. Use Grafana Agent Operator if you prefer to use a Kubernetes-style operator rather than an agent. See [Grafana Agent versus Grafana Agent Operator](/docs/grafana-cloud/kubernetes-monitoring/#grafana-agent-versus-grafana-agent-operator) to understand the differences.
 
 | Topic | Description |
 |---|---|
-| [Configure Kubernetes Monitoring using Agent Operator](/docs/grafana-cloud/latest/kubernetes-monitoring/configuration/config-k8s-agent-operator-guide/) | Use the Kubernetes Monitoring solution to set up monitoring of your Kubernetes cluster and to install preconfigured dashboards and alerts. |
+| [Configure Kubernetes Monitoring using Agent Operator](/docs/grafana-cloud/kubernetes-monitoring/configuration/config-k8s-agent-operator-guide/) | Use the Kubernetes Monitoring solution to set up monitoring of your Kubernetes cluster and to install preconfigured dashboards and alerts. |
 | [Ship Kubernetes metrics directly using Agent Operator]({{< relref "../operator/getting-started/" >}}) |  Take a hands-on approach and directly deploy Grafana Agent Operator into your Kubernetes cluster. After you deploy Agent Operator, you then [deploy the Agent Operator resources]({{< relref "../operator/deploy-agent-operator-resources/" >}}) to begin collecting telemetry data.|
 | [Ship Kubernetes metrics directly using Agent Operator with Helm]({{< relref "../operator/helm-getting-started/" >}}) |  Take a hands-on approach and directly deploy Grafana Agent Operator into your Kubernetes cluster using the [grafana-agent-operator Helm chart](https://github.com/grafana/helm-charts/tree/main/charts/agent-operator). After you deploy Agent Operator, you then [deploy the Agent Operator resources]({{< relref "../operator/deploy-agent-operator-resources/" >}}) and begin collecting telemetry data. |
 
@@ -53,23 +53,23 @@ Grafana Cloud integration workflows and the Kubernetes Monitoring solution are t
 
 | Topic | Description |
 |---|---|
-| [Install Grafana Agent](/docs/grafana-cloud/latest/data-configuration/agent/install_agent/) | Install Grafana Agent using a script for Debian- and Red Hat-based systems. |
-| [Manage Grafana Agent with systemd](/docs/grafana-cloud/latest/data-configuration/agent/agent_as_service/) |  Run Grafana Agent as a [systemd](https://www.freedesktop.org/wiki/Software/systemd/) service to create a long-living process that can automatically restart when killed or when the host is rebooted. |
-| [Monitor Grafana Agent](/docs/grafana-cloud/latest/data-configuration/agent/agent_monitoring/) |  Grafana Agent lets you monitor services but you can also monitor Grafana Agent itself. Learn how to use PromQL to set up an alert for an Agent integration, as well as other methods to monitor Agent. |
-| [Uninstall Grafana Agent](/docs/grafana-cloud/latest/data-configuration/agent/install_agent/#uninstall-grafana-agent) | Uninstalling an integration doesn't automatically stop Agent from scraping data. Learn how to uninstall Agent. |
-| [Troubleshoot Grafana Agent](/docs/grafana-cloud/latest/data-configuration/agent/troubleshooting/) | Learn what to check when you are having trouble collecting data using Grafana Agent, and find solutions to common issues.  |
+| [Install Grafana Agent](/docs/grafana-cloud/data-configuration/agent/install_agent/) | Install Grafana Agent using a script for Debian- and Red Hat-based systems. |
+| [Manage Grafana Agent with systemd](/docs/grafana-cloud/data-configuration/agent/agent_as_service/) |  Run Grafana Agent as a [systemd](https://www.freedesktop.org/wiki/Software/systemd/) service to create a long-living process that can automatically restart when killed or when the host is rebooted. |
+| [Monitor Grafana Agent](/docs/grafana-cloud/data-configuration/agent/agent_monitoring/) |  Grafana Agent lets you monitor services but you can also monitor Grafana Agent itself. Learn how to use PromQL to set up an alert for an Agent integration, as well as other methods to monitor Agent. |
+| [Uninstall Grafana Agent](/docs/grafana-cloud/data-configuration/agent/install_agent/#uninstall-grafana-agent) | Uninstalling an integration doesn't automatically stop Agent from scraping data. Learn how to uninstall Agent. |
+| [Troubleshoot Grafana Agent](/docs/grafana-cloud/data-configuration/agent/troubleshooting/) | Learn what to check when you are having trouble collecting data using Grafana Agent, and find solutions to common issues.  |
 
 ## Use Grafana Agent to send logs to Grafana Loki
 
-Logs are included when you [set up a Cloud integration](/docs/grafana-cloud/latest/data-configuration/integrations/install-and-manage-integrations) but you can take a more hands-on approach with the following guide.
+Logs are included when you [set up a Cloud integration](/docs/grafana-cloud/data-configuration/integrations/install-and-manage-integrations) but you can take a more hands-on approach with the following guide.
 
 | Topic | Description |
 |---|---|
-| [Collect logs with Grafana Agent](/docs/grafana-cloud/latest/data-configuration/logs/collect-logs-with-agent/) |  Install Grafana Agent to collect logs for use with Grafana Loki, included with your [Grafana Cloud account](/docs/grafana-cloud/latest/account-management/cloud-portal/). | 
+| [Collect logs with Grafana Agent](/docs/grafana-cloud/data-configuration/logs/collect-logs-with-agent/) |  Install Grafana Agent to collect logs for use with Grafana Loki, included with your [Grafana Cloud account](/docs/grafana-cloud/account-management/cloud-portal/). | 
 
 ## Use Grafana Agent to send traces to Grafana Tempo
 
 | Topic | Description |
 |---|---|
-| [Set up and use tracing](/docs/grafana-cloud/latest/data-configuration/traces/set-up-and-use-tempo/) |  Install Grafana Agent to collect traces for use with Grafana Tempo, included with your [Grafana Cloud account](/docs/grafana-cloud/latest/account-management/cloud-portal/). |
+| [Set up and use tracing](/docs/grafana-cloud/data-configuration/traces/set-up-and-use-tempo/) |  Install Grafana Agent to collect traces for use with Grafana Tempo, included with your [Grafana Cloud account](/docs/grafana-cloud/account-management/cloud-portal/). |
 | [Use Grafana Agent as a tracing pipeline](/docs/tempo/latest/grafana-agent/) | Grafana Agent can be configured to run a set of tracing pipelines to collect data from your applications and write it to Grafana Tempo. Pipelines are built using OpenTelemetry, and consist of receivers, processors, and exporters. |


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Couldn't test the links that start with /docs until after building website, for example: [Get started with monitoring using an integration](/docs/grafana-cloud/data-configuration/get-started-integration/). We're supposed to use /docs/ links rather than "http" links but they can't be tested without a full website build. See [Links and cross references in the Writers' Toolkit ](https://grafana.com/docs/writers-toolkit/writing-guide/references/)for details.

#### Which issue(s) this PR fixes

https://github.com/grafana/agent/issues/2981

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
