### PR TITLE
Fix TLS configuration for Probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ Main (unreleased)
 
 - Flow: add timeout to loki.source.podlogs controller setup. (@polyrain)
 
+### Bugfixes
+
+- Fixed a reconciliation error in Grafana Agent Operator when using `tlsConfig` on `Probe`. (@supergillis)
+
 ### Other changes
 
 - Use Go 1.20 for builds. Official release binaries are still produced using Go

--- a/pkg/operator/config/metrics_templates_test.go
+++ b/pkg/operator/config/metrics_templates_test.go
@@ -359,6 +359,11 @@ func TestProbe(t *testing.T) {
 								},
 							},
 						},
+						TLSConfig: &prom_v1.ProbeTLSConfig{
+							SafeTLSConfig: prom_v1.SafeTLSConfig{
+								InsecureSkipVerify: true,
+							},
+						},
 					},
 				},
 				"apiServer":                prom_v1.APIServerConfig{},
@@ -402,6 +407,8 @@ func TestProbe(t *testing.T) {
 					target_label: instance
 				- replacement: ""
 					target_label: __address__
+				tls_config:
+					insecure_skip_verify: true
 			`),
 		},
 	}

--- a/pkg/operator/config/templates/component/metrics/tls_config.libsonnet
+++ b/pkg/operator/config/templates/component/metrics/tls_config.libsonnet
@@ -10,15 +10,19 @@ function(namespace, config) new_safe_tls_config(namespace, config.SafeTLSConfig)
   // over the SafeTLSConfig. Check local settings first and then fall back
   // to the safe setings.
 
+  local has_ca_file = std.objectHasAll(config, 'CAFile'),
+  local has_cert_file = std.objectHasAll(config, 'CertFile'),
+  local has_key_file = std.objectHasAll(config, 'KeyFile'),
+
   ca_file:
-    local unsafe = optionals.string(config.CAFile);
+    local unsafe = if has_ca_file then optionals.string(config.CAFile) else null;
     if unsafe == null then super.ca_file else unsafe,
 
   cert_file:
-    local unsafe = optionals.string(config.CertFile);
+    local unsafe = if has_cert_file then optionals.string(config.CertFile) else null;
     if unsafe == null then super.cert_file else unsafe,
 
   key_file:
-    local unsafe = optionals.string(config.KeyFile);
+    local unsafe = if has_key_file then optionals.string(config.KeyFile) else null;
     if unsafe == null then super.key_file else unsafe,
 }


### PR DESCRIPTION
#### PR Description

Fixed a reconciliation error in Grafana Agent Operator when using `tlsConfig` on `Probe`.

#### Which issue(s) this PR fixes

https://github.com/grafana/agent/issues/3002

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
