### PR TITLE
river: support "enum" blocks

### DIFF
--- a/pkg/river/encoding/block.go
+++ b/pkg/river/encoding/block.go
@@ -58,7 +58,7 @@ func getBlockLabel(rv reflect.Value) string {
 	tags := rivertags.Get(rv.Type())
 	for _, tag := range tags {
 		if tag.Flags&rivertags.FlagLabel != 0 {
-			return reflectutil.FieldWalk(rv, tag.Index, false).String()
+			return reflectutil.Get(rv, tag).String()
 		}
 	}
 
@@ -71,7 +71,7 @@ func getFieldsForBlock(input interface{}) ([]interface{}, error) {
 	rt := rivertags.Get(reflectVal.Type())
 	var fields []interface{}
 	for _, t := range rt {
-		fieldRef := reflectutil.FieldWalk(reflectVal, t.Index, false)
+		fieldRef := reflectutil.Get(reflectVal, t)
 		fieldVal := value.FromRaw(fieldRef)
 
 		if t.IsBlock() && (fieldRef.Kind() == reflect.Array || fieldRef.Kind() == reflect.Slice) {

--- a/pkg/river/encoding/block.go
+++ b/pkg/river/encoding/block.go
@@ -104,7 +104,6 @@ func getFieldsForBlock(namePrefix []string, input interface{}) ([]interface{}, e
 				}
 				fields = append(fields, innerFields...)
 			}
-
 		} else if t.IsAttr() {
 			af, err := newAttribute(fieldVal, t)
 			if err != nil {

--- a/pkg/river/encoding/block.go
+++ b/pkg/river/encoding/block.go
@@ -18,9 +18,9 @@ type blockField struct {
 	Body  []interface{} `json:"body,omitempty"`
 }
 
-func newBlock(reflectValue reflect.Value, f rivertags.Field) (*blockField, error) {
+func newBlock(namePrefix []string, reflectValue reflect.Value, f rivertags.Field) (*blockField, error) {
 	bf := &blockField{}
-	return bf, bf.convertBlock(reflectValue, f)
+	return bf, bf.convertBlock(namePrefix, reflectValue, f)
 }
 
 func (bf *blockField) hasValue() bool {
@@ -30,7 +30,7 @@ func (bf *blockField) hasValue() bool {
 	return len(bf.Body) > 0
 }
 
-func (bf *blockField) convertBlock(reflectValue reflect.Value, f rivertags.Field) error {
+func (bf *blockField) convertBlock(namePrefix []string, reflectValue reflect.Value, f rivertags.Field) error {
 	for reflectValue.Kind() == reflect.Pointer {
 		if reflectValue.IsNil() {
 			return nil
@@ -41,11 +41,11 @@ func (bf *blockField) convertBlock(reflectValue reflect.Value, f rivertags.Field
 		return fmt.Errorf("convertBlock can only be called on struct kinds, got %s", reflectValue.Kind())
 	}
 
-	bf.Name = strings.Join(f.Name, ".")
+	bf.Name = strings.Join(mergeStringSlices(namePrefix, f.Name), ".")
 	bf.Type = "block"
 	bf.Label = getBlockLabel(reflectValue)
 
-	fields, err := getFieldsForBlock(reflectValue.Interface())
+	fields, err := getFieldsForBlock(namePrefix, reflectValue.Interface())
 	if err != nil {
 		return err
 	}
@@ -65,7 +65,7 @@ func getBlockLabel(rv reflect.Value) string {
 	return ""
 }
 
-func getFieldsForBlock(input interface{}) ([]interface{}, error) {
+func getFieldsForBlock(namePrefix []string, input interface{}) ([]interface{}, error) {
 	val := value.Encode(input)
 	reflectVal := val.Reflect()
 	rt := rivertags.Get(reflectVal.Type())
@@ -77,7 +77,7 @@ func getFieldsForBlock(input interface{}) ([]interface{}, error) {
 		if t.IsBlock() && (fieldRef.Kind() == reflect.Array || fieldRef.Kind() == reflect.Slice) {
 			for i := 0; i < fieldRef.Len(); i++ {
 				arrEle := fieldRef.Index(i).Interface()
-				bf, err := newBlock(reflect.ValueOf(arrEle), t)
+				bf, err := newBlock(namePrefix, reflect.ValueOf(arrEle), t)
 				if err != nil {
 					return nil, err
 				}
@@ -86,7 +86,7 @@ func getFieldsForBlock(input interface{}) ([]interface{}, error) {
 				}
 			}
 		} else if t.IsBlock() {
-			bf, err := newBlock(fieldRef, t)
+			bf, err := newBlock(namePrefix, fieldRef, t)
 
 			if err != nil {
 				return nil, err
@@ -94,7 +94,18 @@ func getFieldsForBlock(input interface{}) ([]interface{}, error) {
 			if bf.hasValue() {
 				fields = append(fields, bf)
 			}
-		} else {
+		} else if t.IsEnum() {
+			newPrefix := mergeStringSlices(namePrefix, t.Name)
+
+			for i := 0; i < fieldRef.Len(); i++ {
+				innerFields, err := getFieldsForEnum(newPrefix, fieldRef.Index(i))
+				if err != nil {
+					return nil, err
+				}
+				fields = append(fields, innerFields...)
+			}
+
+		} else if t.IsAttr() {
 			af, err := newAttribute(fieldVal, t)
 			if err != nil {
 				return nil, err
@@ -102,7 +113,54 @@ func getFieldsForBlock(input interface{}) ([]interface{}, error) {
 			if af.hasValue() {
 				fields = append(fields, af)
 			}
+		} else {
+			panic(fmt.Sprintf("river/encoding: unrecognized field %#v", t))
 		}
 	}
 	return fields, nil
+}
+
+func mergeStringSlices(a, b []string) []string {
+	if len(a) == 0 {
+		return b
+	} else if len(b) == 0 {
+		return a
+	}
+
+	res := make([]string, 0, len(a)+len(b))
+	res = append(res, a...)
+	res = append(res, b...)
+	return res
+}
+
+func getFieldsForEnum(name []string, enumElement reflect.Value) ([]interface{}, error) {
+	var result []interface{}
+
+	for enumElement.Kind() == reflect.Pointer {
+		if enumElement.IsNil() {
+			return nil, nil
+		}
+		enumElement = enumElement.Elem()
+	}
+
+	fields := rivertags.Get(enumElement.Type())
+
+	// Find the first non-zero field and encode it as a block.
+	for _, field := range fields {
+		fieldVal := reflectutil.Get(enumElement, field)
+		if !fieldVal.IsValid() || fieldVal.IsZero() {
+			continue
+		}
+
+		bf, err := newBlock(name, fieldVal, field)
+		if err != nil {
+			return nil, err
+		}
+		if bf.hasValue() {
+			result = append(result, bf)
+		}
+		break
+	}
+
+	return result, nil
 }

--- a/pkg/river/encoding/encoding.go
+++ b/pkg/river/encoding/encoding.go
@@ -22,7 +22,7 @@ func ConvertRiverBodyToJSON(input interface{}) ([]byte, error) {
 	if input == nil {
 		return nil, nil
 	}
-	fields, err := getFieldsForBlock(input)
+	fields, err := getFieldsForBlock(nil, input)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/river/encoding/encoding_test.go
+++ b/pkg/river/encoding/encoding_test.go
@@ -56,3 +56,68 @@ func TestConvertRiverBodyToJSON_BlockWithZeroValue(t *testing.T) {
 
 	require.JSONEq(t, expect, string(out))
 }
+
+func TestConvertRiverBodyToJSON_Enum_Block(t *testing.T) {
+	type InnerBlock struct {
+		Number int `river:"number,attr"`
+	}
+
+	type EnumBlock struct {
+		BlockA *InnerBlock `river:"a,block,optional"`
+		BlockB *InnerBlock `river:"b,block,optional"`
+		BlockC *InnerBlock `river:"c,block,optional"`
+	}
+
+	type Structure struct {
+		Field string `river:"field,attr"`
+
+		OtherBlocks []EnumBlock `river:"block,enum"`
+	}
+
+	in := Structure{
+		Field: "some_value",
+		OtherBlocks: []EnumBlock{
+			{BlockC: &InnerBlock{Number: 1}},
+			{BlockB: &InnerBlock{Number: 2}},
+			{BlockC: &InnerBlock{Number: 3}},
+		},
+	}
+
+	actual, err := encoding.ConvertRiverBodyToJSON(in)
+	require.NoError(t, err)
+
+	expect := `[{
+		"name": "field",
+		"type": "attr",
+		"value": {
+			"type": "string",
+			"value": "some_value"
+		}
+	}, {
+		"name": "block.c", 
+		"type": "block",
+		"body": [{
+			"name": "number",
+			"type": "attr",
+			"value": { "type": "number", "value": 1 }
+		}]
+	}, {
+		"name": "block.b", 
+		"type": "block",
+		"body": [{
+			"name": "number",
+			"type": "attr",
+			"value": { "type": "number", "value": 2 }
+		}]
+	}, {
+		"name": "block.c", 
+		"type": "block",
+		"body": [{
+			"name": "number",
+			"type": "attr",
+			"value": { "type": "number", "value": 3 }
+		}]
+	}]`
+
+	require.JSONEq(t, expect, string(actual))
+}

--- a/pkg/river/internal/reflectutil/walk.go
+++ b/pkg/river/internal/reflectutil/walk.go
@@ -2,33 +2,69 @@ package reflectutil
 
 import (
 	"reflect"
+
+	"github.com/grafana/agent/pkg/river/internal/rivertags"
 )
 
-// FieldWalk returns the nested field of value corresponding to index.
-// FieldWalk panics if not given a struct.
+// GetOrAlloc returns the nested field of value corresponding to index.
+// GetOrAlloc panics if not given a struct.
+func GetOrAlloc(value reflect.Value, field rivertags.Field) reflect.Value {
+	return GetOrAllocIndex(value, field.Index)
+}
+
+// GetOrAllocIndex returns the nested field of value corresponding to index.
+// GetOrAllocIndex panics if not given a struct.
 //
 // It is similar to [reflect/Value.FieldByIndex] but can handle traversing
-// through nil pointers. If allocate is true, FieldWalk allocates any
-// intermediate nil pointers while traversing the struct. If allocate is false,
-// FieldWalk returns a non-settable zero value for the final field.
-func FieldWalk(value reflect.Value, index []int, allocate bool) reflect.Value {
+// through nil pointers. If allocate is true, GetOrAllocIndex allocates any
+// intermediate nil pointers while traversing the struct.
+func GetOrAllocIndex(value reflect.Value, index []int) reflect.Value {
 	if len(index) == 1 {
 		return value.Field(index[0])
 	}
 
 	if value.Kind() != reflect.Struct {
-		panic("FieldWalk must be given a Struct, but found " + value.Kind().String())
+		panic("GetOrAlloc must be given a Struct, but found " + value.Kind().String())
 	}
 
-	for i, next := range index {
+	for _, next := range index {
+		value = deferencePointer(value).Field(next)
+	}
+
+	return value
+}
+
+func deferencePointer(value reflect.Value) reflect.Value {
+	for value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			value.Set(reflect.New(value.Type().Elem()))
+		}
+		value = value.Elem()
+	}
+
+	return value
+}
+
+// Get returns the nested field of value corresponding to index. Get panics if
+// not given a struct.
+//
+// It is similar to [reflect/Value.FieldByIndex] but can handle traversing
+// through nil pointers. If Get traverses through a nil pointer, a non-settable
+// zero value for the final field is returned.
+func Get(value reflect.Value, field rivertags.Field) reflect.Value {
+	if len(field.Index) == 1 {
+		return value.Field(field.Index[0])
+	}
+
+	if value.Kind() != reflect.Struct {
+		panic("Get must be given a Struct, but found " + value.Kind().String())
+	}
+
+	for i, next := range field.Index {
 		for value.Kind() == reflect.Pointer {
 			if value.IsNil() {
-				if !allocate {
-					return fieldWalkZero(value, index[i:])
-				}
-				value.Set(reflect.New(value.Type().Elem()))
+				return getZero(value, field.Index[i:])
 			}
-
 			value = value.Elem()
 		}
 
@@ -38,8 +74,8 @@ func FieldWalk(value reflect.Value, index []int, allocate bool) reflect.Value {
 	return value
 }
 
-// fieldWalkZero returns a non-settable zero value while walking value.
-func fieldWalkZero(value reflect.Value, index []int) reflect.Value {
+// getZero returns a non-settable zero value while walking value.
+func getZero(value reflect.Value, index []int) reflect.Value {
 	typ := value.Type()
 
 	for _, next := range index {

--- a/pkg/river/internal/reflectutil/walk_test.go
+++ b/pkg/river/internal/reflectutil/walk_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/grafana/agent/pkg/river/internal/reflectutil"
+	"github.com/grafana/agent/pkg/river/internal/rivertags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +25,7 @@ func TestDeeplyNested_Access(t *testing.T) {
 	s.Field1.Field2.Field3.Value = "Hello, world!"
 
 	rv := reflect.ValueOf(&s).Elem()
-	innerValue := reflectutil.FieldWalk(rv, []int{0, 0, 0, 0}, true)
+	innerValue := reflectutil.GetOrAlloc(rv, rivertags.Field{Index: []int{0, 0, 0, 0}})
 	assert.True(t, innerValue.CanSet())
 	assert.Equal(t, reflect.String, innerValue.Kind())
 }
@@ -43,7 +44,7 @@ func TestDeeplyNested_Allocate(t *testing.T) {
 	var s Struct
 
 	rv := reflect.ValueOf(&s).Elem()
-	innerValue := reflectutil.FieldWalk(rv, []int{0, 0, 0, 0}, true)
+	innerValue := reflectutil.GetOrAlloc(rv, rivertags.Field{Index: []int{0, 0, 0, 0}})
 	require.True(t, innerValue.CanSet())
 	require.Equal(t, reflect.String, innerValue.Kind())
 
@@ -65,7 +66,7 @@ func TestDeeplyNested_NoAllocate(t *testing.T) {
 	var s Struct
 
 	rv := reflect.ValueOf(&s).Elem()
-	innerValue := reflectutil.FieldWalk(rv, []int{0, 0, 0, 0}, false)
+	innerValue := reflectutil.Get(rv, rivertags.Field{Index: []int{0, 0, 0, 0}})
 	assert.False(t, innerValue.CanSet())
 	assert.Equal(t, reflect.String, innerValue.Kind())
 }

--- a/pkg/river/internal/rivertags/rivertags.go
+++ b/pkg/river/internal/rivertags/rivertags.go
@@ -15,6 +15,7 @@ type Flags uint
 const (
 	FlagAttr  Flags = 1 << iota // FlagAttr treats a field as attribute
 	FlagBlock                   // FlagBlock treats a field as a block
+	FlagEnum                    // FlagEnum treats a field as an enum of blocks
 
 	FlagOptional // FlagOptional marks a field optional for decoding/encoding
 	FlagLabel    // FlagLabel will store block labels in the field
@@ -30,6 +31,9 @@ func (f Flags) String() string {
 	}
 	if f&FlagBlock != 0 {
 		attrs = append(attrs, "block")
+	}
+	if f&FlagEnum != 0 {
+		attrs = append(attrs, "enum")
 	}
 	if f&FlagOptional != 0 {
 		attrs = append(attrs, "optional")
@@ -49,9 +53,41 @@ func (f Flags) GoString() string { return f.String() }
 
 // Field is a tagged field within a struct.
 type Field struct {
-	Name  []string // Name of tagged field
-	Index []int    // Index into field (reflect.Value.FieldByIndex)
-	Flags Flags    // Flags assigned to field
+	Name  []string // Name of tagged field.
+	Index []int    // Index into field. Use [reflectutil.GetOrAlloc] to retrieve a Value.
+	Flags Flags    // Flags assigned to field.
+}
+
+// Equals returns true if two fields are equal.
+func (f Field) Equals(other Field) bool {
+	// Compare names
+	{
+		if len(f.Name) != len(other.Name) {
+			return false
+		}
+
+		for i := 0; i < len(f.Name); i++ {
+			if f.Name[i] != other.Name[i] {
+				return false
+			}
+		}
+	}
+
+	// Compare index.
+	{
+		if len(f.Index) != len(other.Index) {
+			return false
+		}
+
+		for i := 0; i < len(f.Index); i++ {
+			if f.Index[i] != other.Index[i] {
+				return false
+			}
+		}
+	}
+
+	// Finally, compare flags.
+	return f.Flags == other.Flags
 }
 
 // IsAttr returns whether f is for an attribute.
@@ -59,6 +95,10 @@ func (f Field) IsAttr() bool { return f.Flags&FlagAttr != 0 }
 
 // IsBlock returns whether f is for a block.
 func (f Field) IsBlock() bool { return f.Flags&FlagBlock != 0 }
+
+// IsEnum returns whether f represents an enum of blocks, where only one block
+// is set at a time.
+func (f Field) IsEnum() bool { return f.Flags&FlagEnum != 0 }
 
 // IsOptional returns whether f is optional.
 func (f Field) IsOptional() bool { return f.Flags&FlagOptional != 0 }
@@ -95,6 +135,8 @@ func (f Field) IsOptional() bool { return f.Flags&FlagOptional != 0 }
 //
 //	// Attributes and blocks inside of Field are exposed as top-level fields.
 //	Field struct{} `river:",squash"`
+//
+//	Blocks []struct{} `river:"my_block_prefix,enum"`
 //
 // With the exception of the `river:",label"` and `river:",squash" tags, all
 // tagged fields must have a unique name.
@@ -154,8 +196,14 @@ func Get(ty reflect.Type) []Field {
 		}
 		tf.Flags = flags
 
-		if len(tf.Name) > 1 && tf.Flags&FlagBlock == 0 {
-			panic(fmt.Sprintf("river: field names with `.` may only be used by blocks (found at %s)", printPathToField(ty, tf.Index)))
+		if len(tf.Name) > 1 && tf.Flags&(FlagBlock|FlagEnum) == 0 {
+			panic(fmt.Sprintf("river: field names with `.` may only be used by blocks or enums (found at %s)", printPathToField(ty, tf.Index)))
+		}
+
+		if tf.Flags&FlagEnum != 0 {
+			if err := validateEnum(field); err != nil {
+				panic(err)
+			}
 		}
 
 		if tf.Flags&FlagLabel != 0 {
@@ -177,16 +225,24 @@ func Get(ty reflect.Type) []Field {
 				panic(fmt.Sprintf("river: squash field at %s must not have a name", printPathToField(ty, tf.Index)))
 			}
 
-			// Get the inner fields from the squashed struct and append each of them.
-			// The index of the squashed field is prepended to the index of the inner
-			// struct.
-			innerFields := Get(deferenceType(field.Type))
-			for _, innerField := range innerFields {
-				fields = append(fields, Field{
-					Name:  innerField.Name,
-					Index: append(field.Index, innerField.Index...),
-					Flags: innerField.Flags,
-				})
+			innerType := deferenceType(field.Type)
+
+			switch {
+			case isStructType(innerType): // Squashed struct
+				// Get the inner fields from the squashed struct and append each of them.
+				// The index of the squashed field is prepended to the index of the inner
+				// struct.
+				innerFields := Get(deferenceType(field.Type))
+				for _, innerField := range innerFields {
+					fields = append(fields, Field{
+						Name:  innerField.Name,
+						Index: append(field.Index, innerField.Index...),
+						Flags: innerField.Flags,
+					})
+				}
+
+			default:
+				panic(fmt.Sprintf("rivertags: squash field requires struct, got %s", innerType))
 			}
 
 			continue
@@ -212,6 +268,10 @@ func parseFlags(input string) (f Flags, ok bool) {
 		f |= FlagBlock
 	case "block,optional":
 		f |= FlagBlock | FlagOptional
+	case "enum":
+		f |= FlagEnum
+	case "enum,optional":
+		f |= FlagEnum | FlagOptional
 	case "label":
 		f |= FlagLabel
 	case "squash":
@@ -248,4 +308,43 @@ func deferenceType(ty reflect.Type) reflect.Type {
 		ty = ty.Elem()
 	}
 	return ty
+}
+
+func isStructType(ty reflect.Type) bool {
+	return ty.Kind() == reflect.Struct
+}
+
+func isStructSliceType(ty reflect.Type) bool {
+	if ty.Kind() != reflect.Slice {
+		return false
+	}
+	return isStructType(deferenceType(ty.Elem()))
+}
+
+// validateEnum ensures that an enum field is valid. Valid enum fields are
+// slices of structs containing nothing but non-slice blocks.
+func validateEnum(field reflect.StructField) error {
+	kind := field.Type.Kind()
+	if kind != reflect.Slice && kind != reflect.Array {
+		return fmt.Errorf("enum fields can only be slices or arrays")
+	}
+
+	elementType := deferenceType(field.Type.Elem())
+	if elementType.Kind() != reflect.Struct {
+		return fmt.Errorf("enum fields can only be a slice or array of structs")
+	}
+
+	enumElementFields := Get(elementType)
+	for _, field := range enumElementFields {
+		if !field.IsBlock() {
+			return fmt.Errorf("fields in an enum element may only be blocks, got " + field.Flags.String())
+		}
+
+		fieldType := deferenceType(elementType.FieldByIndex(field.Index).Type)
+		if fieldType.Kind() != reflect.Struct {
+			return fmt.Errorf("blocks in an enum element may only be structs, got " + fieldType.Kind().String())
+		}
+	}
+
+	return nil
 }

--- a/pkg/river/internal/rivertags/rivertags.go
+++ b/pkg/river/internal/rivertags/rivertags.go
@@ -314,13 +314,6 @@ func isStructType(ty reflect.Type) bool {
 	return ty.Kind() == reflect.Struct
 }
 
-func isStructSliceType(ty reflect.Type) bool {
-	if ty.Kind() != reflect.Slice {
-		return false
-	}
-	return isStructType(deferenceType(ty.Elem()))
-}
-
 // validateEnum ensures that an enum field is valid. Valid enum fields are
 // slices of structs containing nothing but non-slice blocks.
 func validateEnum(field reflect.StructField) error {

--- a/pkg/river/internal/rivertags/rivertags_test.go
+++ b/pkg/river/internal/rivertags/rivertags_test.go
@@ -13,11 +13,13 @@ func Test_Get(t *testing.T) {
 	type Struct struct {
 		IgnoreMe bool
 
-		ReqAttr  string   `river:"req_attr,attr"`
-		OptAttr  string   `river:"opt_attr,attr,optional"`
-		ReqBlock struct{} `river:"req_block,block"`
-		OptBlock struct{} `river:"opt_block,block,optional"`
-		Label    string   `river:",label"`
+		ReqAttr  string     `river:"req_attr,attr"`
+		OptAttr  string     `river:"opt_attr,attr,optional"`
+		ReqBlock struct{}   `river:"req_block,block"`
+		OptBlock struct{}   `river:"opt_block,block,optional"`
+		ReqEnum  []struct{} `river:"req_enum,enum"`
+		OptEnum  []struct{} `river:"opt_enum,enum,optional"`
+		Label    string     `river:",label"`
 	}
 
 	fs := rivertags.Get(reflect.TypeOf(Struct{}))
@@ -27,7 +29,9 @@ func Test_Get(t *testing.T) {
 		{[]string{"opt_attr"}, []int{2}, rivertags.FlagAttr | rivertags.FlagOptional},
 		{[]string{"req_block"}, []int{3}, rivertags.FlagBlock},
 		{[]string{"opt_block"}, []int{4}, rivertags.FlagBlock | rivertags.FlagOptional},
-		{[]string{""}, []int{5}, rivertags.FlagLabel},
+		{[]string{"req_enum"}, []int{5}, rivertags.FlagEnum},
+		{[]string{"opt_enum"}, []int{6}, rivertags.FlagEnum | rivertags.FlagOptional},
+		{[]string{""}, []int{7}, rivertags.FlagLabel},
 	}
 
 	require.Equal(t, expect, fs)

--- a/pkg/river/internal/value/decode.go
+++ b/pkg/river/internal/value/decode.go
@@ -564,13 +564,13 @@ func (d *decoder) decodeObjectToStruct(val Value, rt reflect.Value, fields *obje
 		switch fields.Has(key) {
 		case objectKeyTypeInvalid:
 			return MissingKeyError{Value: value, Missing: key}
-		case objectKeyTypeNestedField:
+		case objectKeyTypeNestedField: // Block with multiple name fragments
 			next, _ := fields.NestedField(key)
-			// Recruse the call with the inner value.
+			// Recurse the call with the inner value.
 			if err := d.decodeObjectToStruct(value, rt, next, decodedLabel); err != nil {
 				return err
 			}
-		case objectKeyTypeField:
+		case objectKeyTypeField: // Single-name fragment
 			targetField, _ := fields.Field(key)
 			targetValue := reflectutil.GetOrAlloc(rt, targetField)
 

--- a/pkg/river/internal/value/decode.go
+++ b/pkg/river/internal/value/decode.go
@@ -480,7 +480,7 @@ func (d *decoder) decodeObject(val Value, rt reflect.Value) error {
 		for i, key := range keys {
 			// First decode the key into the label.
 			elem := res.Index(i)
-			reflectutil.FieldWalk(elem, labelField.Index, true).Set(reflect.ValueOf(key))
+			reflectutil.GetOrAlloc(elem, labelField).Set(reflect.ValueOf(key))
 
 			// Now decode the inner object.
 			value, _ := val.Key(key)
@@ -552,7 +552,7 @@ func (d *decoder) decodeObjectToStruct(val Value, rt reflect.Value, fields *obje
 			}
 
 			// Decode the key into the label.
-			reflectutil.FieldWalk(rt, lf.Index, true).Set(reflect.ValueOf(key))
+			reflectutil.GetOrAlloc(rt, lf).Set(reflect.ValueOf(key))
 
 			// ...and then code the rest of the object.
 			if err := d.decodeObjectToStruct(value, rt, fields, true); err != nil {
@@ -572,7 +572,7 @@ func (d *decoder) decodeObjectToStruct(val Value, rt reflect.Value, fields *obje
 			}
 		case objectKeyTypeField:
 			targetField, _ := fields.Field(key)
-			targetValue := reflectutil.FieldWalk(rt, targetField.Index, true)
+			targetValue := reflectutil.GetOrAlloc(rt, targetField)
 
 			if err := d.decode(value, targetValue); err != nil {
 				return FieldError{Value: val, Field: key, Inner: err}

--- a/pkg/river/internal/value/decode_test.go
+++ b/pkg/river/internal/value/decode_test.go
@@ -454,3 +454,135 @@ func TestDecode_SquashedFields_Pointer(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expect, out)
 }
+
+func TestDecode_Slice(t *testing.T) {
+	type Block struct {
+		Attr int `river:"attr,attr"`
+	}
+
+	type Struct struct {
+		Blocks []Block `river:"block.a,block,optional"`
+	}
+
+	var (
+		in = map[string]interface{}{
+			"block": map[string]interface{}{
+				"a": []map[string]interface{}{
+					{"attr": 1},
+					{"attr": 2},
+					{"attr": 3},
+					{"attr": 4},
+				},
+			},
+		}
+		expect = Struct{
+			Blocks: []Block{
+				{Attr: 1},
+				{Attr: 2},
+				{Attr: 3},
+				{Attr: 4},
+			},
+		}
+	)
+
+	var out Struct
+	err := value.Decode(value.Encode(in), &out)
+	require.NoError(t, err)
+	require.Equal(t, expect, out)
+}
+
+func TestDecode_SquashedSlice(t *testing.T) {
+	type Block struct {
+		Attr int `river:"attr,attr"`
+	}
+
+	type InnerStruct struct {
+		BlockA Block `river:"a,block,optional"`
+		BlockB Block `river:"b,block,optional"`
+		BlockC Block `river:"c,block,optional"`
+	}
+
+	type OuterStruct struct {
+		OuterField1 string        `river:"outer_field_1,attr,optional"`
+		Inner       []InnerStruct `river:"block,enum"`
+		OuterField2 string        `river:"outer_field_2,attr,optional"`
+	}
+
+	var (
+		in = map[string]interface{}{
+			"outer_field_1": "value1",
+			"outer_field_2": "value2",
+
+			"block": []map[string]interface{}{
+				{"a": map[string]interface{}{"attr": 1}},
+				{"b": map[string]interface{}{"attr": 2}},
+				{"c": map[string]interface{}{"attr": 3}},
+				{"a": map[string]interface{}{"attr": 4}},
+			},
+		}
+		expect = OuterStruct{
+			OuterField1: "value1",
+			OuterField2: "value2",
+
+			Inner: []InnerStruct{
+				{BlockA: Block{Attr: 1}},
+				{BlockB: Block{Attr: 2}},
+				{BlockC: Block{Attr: 3}},
+				{BlockA: Block{Attr: 4}},
+			},
+		}
+	)
+
+	var out OuterStruct
+	err := value.Decode(value.Encode(in), &out)
+	require.NoError(t, err)
+	require.Equal(t, expect, out)
+}
+
+func TestDecode_SquashedSlice_Pointer(t *testing.T) {
+	type Block struct {
+		Attr int `river:"attr,attr"`
+	}
+
+	type InnerStruct struct {
+		BlockA *Block `river:"a,block,optional"`
+		BlockB *Block `river:"b,block,optional"`
+		BlockC *Block `river:"c,block,optional"`
+	}
+
+	type OuterStruct struct {
+		OuterField1 string        `river:"outer_field_1,attr,optional"`
+		Inner       []InnerStruct `river:"block,enum"`
+		OuterField2 string        `river:"outer_field_2,attr,optional"`
+	}
+
+	var (
+		in = map[string]interface{}{
+			"outer_field_1": "value1",
+			"outer_field_2": "value2",
+
+			"block": []map[string]interface{}{
+				{"a": map[string]interface{}{"attr": 1}},
+				{"b": map[string]interface{}{"attr": 2}},
+				{"c": map[string]interface{}{"attr": 3}},
+				{"a": map[string]interface{}{"attr": 4}},
+			},
+		}
+		expect = OuterStruct{
+			OuterField1: "value1",
+			OuterField2: "value2",
+
+			Inner: []InnerStruct{
+				{BlockA: &Block{Attr: 1}},
+				{BlockB: &Block{Attr: 2}},
+				{BlockC: &Block{Attr: 3}},
+				{BlockA: &Block{Attr: 4}},
+			},
+		}
+	)
+
+	var out OuterStruct
+	err := value.Decode(value.Encode(in), &out)
+	require.NoError(t, err)
+	require.Equal(t, expect, out)
+}

--- a/pkg/river/internal/value/value.go
+++ b/pkg/river/internal/value/value.go
@@ -332,7 +332,7 @@ func (v Value) Keys() []string {
 
 		keys := make([]string, v.rv.Len())
 		for i := range keys {
-			keys[i] = reflectutil.FieldWalk(v.rv.Index(i), labelField.Index, false).String()
+			keys[i] = reflectutil.Get(v.rv.Index(i), labelField).String()
 		}
 		return keys
 
@@ -378,7 +378,7 @@ func (v Value) Key(key string) (index Value, ok bool) {
 		for i := 0; i < v.rv.Len(); i++ {
 			elem := v.rv.Index(i)
 
-			label := reflectutil.FieldWalk(elem, labelField.Index, false).String()
+			label := reflectutil.Get(elem, labelField).String()
 			if label == key {
 				// We discard the label since the key here represents the label value.
 				ws := wrapStruct(elem, false)

--- a/pkg/river/internal/value/value_object.go
+++ b/pkg/river/internal/value/value_object.go
@@ -44,7 +44,7 @@ func wrapStruct(val reflect.Value, keepLabel bool) structWrapper {
 
 	var label string
 	if f, ok := fields.LabelField(); ok && keepLabel {
-		label = reflectutil.FieldWalk(val, f.Index, false).String()
+		label = reflectutil.Get(val, f).String()
 	}
 
 	return structWrapper{

--- a/pkg/river/river.go
+++ b/pkg/river/river.go
@@ -86,6 +86,14 @@ import (
 //	// attributes and blocks of the outer struct.
 //	Field struct{...} `river:",squash"`
 //
+//	// Field appears as a set of blocks starting with "example.". Only the
+//	// first set element in the struct will be encoded. Each field in struct
+//	// must be a block. The name of the block is prepended to the enum name.
+//	Field []struct{...} `river:"example,enum"`
+//
+//	// Field is equivalent to `river:"example,enum"`.
+//	Field []struct{...} `river:"example,enum,optional"`
+//
 // If a river tag specifies a required or optional block, the name is permitted
 // to contain period `.` characters.
 //

--- a/pkg/river/river.go
+++ b/pkg/river/river.go
@@ -89,6 +89,8 @@ import (
 //	// Field appears as a set of blocks starting with "example.". Only the
 //	// first set element in the struct will be encoded. Each field in struct
 //	// must be a block. The name of the block is prepended to the enum name.
+//	// When decoding, enum blocks are treated as optional blocks and can be
+//	// omitted from the source text.
 //	Field []struct{...} `river:"example,enum"`
 //
 //	// Field is equivalent to `river:"example,enum"`.

--- a/pkg/river/token/builder/builder.go
+++ b/pkg/river/token/builder/builder.go
@@ -159,11 +159,11 @@ func (b *Body) encodeFields(rv reflect.Value) {
 
 	for _, field := range fields {
 		fieldVal := reflectutil.Get(rv, field)
-		b.encodeField(field, fieldVal)
+		b.encodeField(nil, field, fieldVal)
 	}
 }
 
-func (b *Body) encodeField(field rivertags.Field, fieldValue reflect.Value) {
+func (b *Body) encodeField(prefix []string, field rivertags.Field, fieldValue reflect.Value) {
 	fieldName := strings.Join(field.Name, ".")
 
 	for fieldValue.Kind() == reflect.Pointer {
@@ -177,15 +177,17 @@ func (b *Body) encodeField(field rivertags.Field, fieldValue reflect.Value) {
 	}
 
 	switch {
-	case field.Flags&rivertags.FlagAttr != 0:
+	case field.IsAttr():
 		b.SetAttributeValue(fieldName, fieldValue.Interface())
 
-	case field.Flags&rivertags.FlagBlock != 0:
+	case field.IsBlock():
+		fullName := mergeStringSlice(prefix, field.Name)
+
 		switch {
 		case fieldValue.IsZero():
 			// It shouldn't be possible to have a required block which is unset, but
 			// we'll encode something anyway.
-			inner := NewBlock(field.Name, "")
+			inner := NewBlock(fullName, "")
 			b.AppendBlock(inner)
 
 		case fieldValue.Kind() == reflect.Slice, fieldValue.Kind() == reflect.Array:
@@ -195,14 +197,63 @@ func (b *Body) encodeField(field rivertags.Field, fieldValue reflect.Value) {
 				// Recursively call encodeField for each element in the slice/array.
 				// The recurisve call will hit the case below and add a new block for
 				// each field encountered.
-				b.encodeField(field, elem)
+				b.encodeField(prefix, field, elem)
 			}
 
 		case fieldValue.Kind() == reflect.Struct:
-			inner := NewBlock(field.Name, getBlockLabel(fieldValue))
+			inner := NewBlock(fullName, getBlockLabel(fieldValue))
 			inner.Body().encodeFields(fieldValue)
 			b.AppendBlock(inner)
 		}
+
+	case field.IsEnum():
+		// Blocks within an enum have a prefix set.
+		newPrefix := mergeStringSlice(prefix, field.Name)
+
+		switch {
+		case fieldValue.Kind() == reflect.Slice, fieldValue.Kind() == reflect.Array:
+			for i := 0; i < fieldValue.Len(); i++ {
+				b.encodeEnumElement(newPrefix, fieldValue.Index(i))
+			}
+
+		default:
+			panic(fmt.Sprintf("river/token/builder: unrecognized enum kind %s", fieldValue.Kind()))
+		}
+	}
+}
+
+func mergeStringSlice(a, b []string) []string {
+	if len(a) == 0 {
+		return b
+	} else if len(b) == 0 {
+		return a
+	}
+
+	res := make([]string, 0, len(a)+len(b))
+	res = append(res, a...)
+	res = append(res, b...)
+	return res
+}
+
+func (b *Body) encodeEnumElement(prefix []string, enumElement reflect.Value) {
+	for enumElement.Kind() == reflect.Pointer {
+		if enumElement.IsNil() {
+			return
+		}
+		enumElement = enumElement.Elem()
+	}
+
+	fields := rivertags.Get(enumElement.Type())
+
+	// Find the first non-zero field and encode it.
+	for _, field := range fields {
+		fieldVal := reflectutil.Get(enumElement, field)
+		if !fieldVal.IsValid() || fieldVal.IsZero() {
+			continue
+		}
+
+		b.encodeField(prefix, field, fieldVal)
+		break
 	}
 }
 

--- a/pkg/river/token/builder/builder.go
+++ b/pkg/river/token/builder/builder.go
@@ -137,7 +137,7 @@ func getBlockLabel(rv reflect.Value) string {
 	tags := rivertags.Get(rv.Type())
 	for _, tag := range tags {
 		if tag.Flags&rivertags.FlagLabel != 0 {
-			return reflectutil.FieldWalk(rv, tag.Index, false).String()
+			return reflectutil.Get(rv, tag).String()
 		}
 	}
 
@@ -158,7 +158,7 @@ func (b *Body) encodeFields(rv reflect.Value) {
 	fields := rivertags.Get(rv.Type())
 
 	for _, field := range fields {
-		fieldVal := reflectutil.FieldWalk(rv, field.Index, false)
+		fieldVal := reflectutil.Get(rv, field)
 		b.encodeField(field, fieldVal)
 	}
 }

--- a/pkg/river/token/builder/builder_test.go
+++ b/pkg/river/token/builder/builder_test.go
@@ -175,6 +175,98 @@ func TestBuilder_AppendFrom(t *testing.T) {
 	require.Equal(t, expect, string(f.Bytes()))
 }
 
+func TestBuilder_AppendFrom_EnumSlice(t *testing.T) {
+	type InnerBlock struct {
+		Number int `river:"number,attr"`
+	}
+
+	type EnumBlock struct {
+		BlockA InnerBlock `river:"a,block,optional"`
+		BlockB InnerBlock `river:"b,block,optional"`
+		BlockC InnerBlock `river:"c,block,optional"`
+	}
+
+	type Structure struct {
+		Field string `river:"field,attr"`
+
+		OtherBlocks []EnumBlock `river:"block,enum"`
+	}
+
+	f := builder.NewFile()
+	f.Body().AppendFrom(Structure{
+		Field: "some_value",
+		OtherBlocks: []EnumBlock{
+			{BlockC: InnerBlock{Number: 1}},
+			{BlockB: InnerBlock{Number: 2}},
+			{BlockC: InnerBlock{Number: 3}},
+		},
+	})
+
+	expect := format(t, `
+		field = "some_value"
+	
+		block.c {
+			number = 1
+		}
+
+		block.b {
+			number = 2
+		}
+
+		block.c {
+			number = 3
+		}
+	`)
+
+	require.Equal(t, expect, string(f.Bytes()))
+}
+
+func TestBuilder_AppendFrom_EnumSlice_Pointer(t *testing.T) {
+	type InnerBlock struct {
+		Number int `river:"number,attr"`
+	}
+
+	type EnumBlock struct {
+		BlockA *InnerBlock `river:"a,block,optional"`
+		BlockB *InnerBlock `river:"b,block,optional"`
+		BlockC *InnerBlock `river:"c,block,optional"`
+	}
+
+	type Structure struct {
+		Field string `river:"field,attr"`
+
+		OtherBlocks []EnumBlock `river:"block,enum"`
+	}
+
+	f := builder.NewFile()
+	f.Body().AppendFrom(Structure{
+		Field: "some_value",
+		OtherBlocks: []EnumBlock{
+			{BlockC: &InnerBlock{Number: 1}},
+			{BlockB: &InnerBlock{Number: 2}},
+			{BlockC: &InnerBlock{Number: 3}},
+		},
+	})
+
+	expect := format(t, `
+		field = "some_value"
+	
+		block.c {
+			number = 1
+		}
+
+		block.b {
+			number = 2
+		}
+
+		block.c {
+			number = 3
+		}
+	`)
+
+	require.Equal(t, expect, string(f.Bytes()))
+}
+
 func TestBuilder_SkipOptional(t *testing.T) {
 	type Structure struct {
 		OptFieldA string `river:"opt_field_a,attr,optional"`

--- a/pkg/river/vm/struct_decoder.go
+++ b/pkg/river/vm/struct_decoder.go
@@ -154,7 +154,7 @@ func (st *structDecoder) decodeAttr(attr *ast.AttributeStmt, rv reflect.Value, s
 
 	// We're reconverting our reflect.Value back into an interface{}, so we
 	// need to also turn it back into a pointer for decoding.
-	field := reflectutil.FieldWalk(rv, tf.Index, true)
+	field := reflectutil.GetOrAlloc(rv, tf)
 	if err := value.Decode(val, field.Addr().Interface()); err != nil {
 		// TODO(rfratto): get error as diagnostics.
 		return err
@@ -182,7 +182,7 @@ func (st *structDecoder) decodeBlock(block *ast.BlockStmt, rv reflect.Value, sta
 		}}
 	}
 
-	field := reflectutil.FieldWalk(rv, tf.Index, true)
+	field := reflectutil.GetOrAlloc(rv, tf)
 	decodeField := prepareDecodeValue(field)
 
 	switch decodeField.Kind() {

--- a/pkg/river/vm/tag_cache.go
+++ b/pkg/river/vm/tag_cache.go
@@ -24,20 +24,57 @@ func getCachedTagInfo(t reflect.Type) *tagInfo {
 
 	tfs := rivertags.Get(t)
 	ti := &tagInfo{
-		Tags:      tfs,
-		TagLookup: make(map[string]rivertags.Field, len(tfs)),
+		Tags:       tfs,
+		TagLookup:  make(map[string]rivertags.Field, len(tfs)),
+		EnumLookup: make(map[string]enumBlock), // The length is not known ahead of time
 	}
 
 	for _, tf := range tfs {
-		fullName := strings.Join(tf.Name, ".")
-		ti.TagLookup[fullName] = tf
+		switch {
+		case tf.IsAttr(), tf.IsBlock():
+			fullName := strings.Join(tf.Name, ".")
+			ti.TagLookup[fullName] = tf
+
+		case tf.IsEnum():
+			fullName := strings.Join(tf.Name, ".")
+
+			// Find all the blocks that match to the enum, and inject them into the
+			// EnumLookup table.
+			enumFieldType := t.FieldByIndex(tf.Index).Type
+			enumBlocksInfo := getCachedTagInfo(deferenceType(enumFieldType.Elem()))
+			for _, blockField := range enumBlocksInfo.TagLookup {
+				// The full name of the enum block is the name of the enum plus the
+				// name of the block, separated by '.'
+				enumBlockName := fullName + "." + strings.Join(blockField.Name, ".")
+				ti.EnumLookup[enumBlockName] = enumBlock{
+					EnumField:  tf,
+					BlockField: blockField,
+				}
+			}
+		}
 	}
 
 	tagsCache.Store(t, ti)
 	return ti
 }
 
+func deferenceType(ty reflect.Type) reflect.Type {
+	for ty.Kind() == reflect.Pointer {
+		ty = ty.Elem()
+	}
+	return ty
+}
+
 type tagInfo struct {
 	Tags      []rivertags.Field
 	TagLookup map[string]rivertags.Field
+
+	// EnumLookup maps enum blocks to the enum field. For example, an enum block
+	// called "foo.foo" and "foo.bar" will both map to the "foo" enum field.
+	EnumLookup map[string]enumBlock
+}
+
+type enumBlock struct {
+	EnumField  rivertags.Field // Field in the parent struct of the enum slice
+	BlockField rivertags.Field // Field in the enum struct for the enum block
 }

--- a/pkg/river/vm/vm.go
+++ b/pkg/river/vm/vm.go
@@ -175,7 +175,7 @@ func (vm *Evaluator) evaluateBlockLabel(node *ast.BlockStmt, tfs []rivertags.Fie
 	}
 
 	var (
-		field     = reflectutil.FieldWalk(rv, labelField.Index, true)
+		field     = reflectutil.GetOrAlloc(rv, labelField)
 		fieldType = field.Type()
 	)
 	if !reflect.TypeOf(node.Label).AssignableTo(fieldType) {

--- a/pkg/river/vm/vm_block_test.go
+++ b/pkg/river/vm/vm_block_test.go
@@ -456,6 +456,104 @@ func TestVM_Block_Children_Blocks(t *testing.T) {
 	// TODO(rfratto): decode all blocks into a []*ast.BlockStmt field.
 }
 
+func TestVM_Block_Enum_Block(t *testing.T) {
+	type childBlock struct {
+		Attr int `river:"attr,attr"`
+	}
+
+	type enumBlock struct {
+		BlockA *childBlock `river:"a,block,optional"`
+		BlockB *childBlock `river:"b,block,optional"`
+		BlockC *childBlock `river:"c,block,optional"`
+		BlockD *childBlock `river:"d,block,optional"`
+	}
+
+	t.Run("Decodes enum blocks", func(t *testing.T) {
+		type block struct {
+			Value  int          `river:"value,attr"`
+			Blocks []*enumBlock `river:"child,enum,optional"`
+		}
+
+		input := `some_block {
+			value = 15
+
+			child.a { attr = 1 }
+		}`
+		eval := vm.New(parseBlock(t, input))
+
+		expect := block{
+			Value: 15,
+			Blocks: []*enumBlock{
+				{BlockA: &childBlock{Attr: 1}},
+			},
+		}
+
+		var actual block
+		require.NoError(t, eval.Evaluate(nil, &actual))
+		require.Equal(t, expect, actual)
+	})
+
+	t.Run("Decodes multiple enum blocks", func(t *testing.T) {
+		type block struct {
+			Value  int          `river:"value,attr"`
+			Blocks []*enumBlock `river:"child,enum,optional"`
+		}
+
+		input := `some_block {
+			value = 15
+
+			child.b { attr = 1 }
+			child.a { attr = 2 }
+			child.c { attr = 3 }
+		}`
+		eval := vm.New(parseBlock(t, input))
+
+		expect := block{
+			Value: 15,
+			Blocks: []*enumBlock{
+				{BlockB: &childBlock{Attr: 1}},
+				{BlockA: &childBlock{Attr: 2}},
+				{BlockC: &childBlock{Attr: 3}},
+			},
+		}
+
+		var actual block
+		require.NoError(t, eval.Evaluate(nil, &actual))
+		require.Equal(t, expect, actual)
+	})
+
+	t.Run("Decodes multiple enum blocks with repeating blocks", func(t *testing.T) {
+		type block struct {
+			Value  int          `river:"value,attr"`
+			Blocks []*enumBlock `river:"child,enum,optional"`
+		}
+
+		input := `some_block {
+			value = 15
+
+			child.a { attr = 1 }
+			child.b { attr = 2 }
+			child.c { attr = 3 }
+			child.a { attr = 4 }
+		}`
+		eval := vm.New(parseBlock(t, input))
+
+		expect := block{
+			Value: 15,
+			Blocks: []*enumBlock{
+				{BlockA: &childBlock{Attr: 1}},
+				{BlockB: &childBlock{Attr: 2}},
+				{BlockC: &childBlock{Attr: 3}},
+				{BlockA: &childBlock{Attr: 4}},
+			},
+		}
+
+		var actual block
+		require.NoError(t, eval.Evaluate(nil, &actual))
+		require.Equal(t, expect, actual)
+	})
+}
+
 func TestVM_Block_Label(t *testing.T) {
 	t.Run("Decodes label into string field", func(t *testing.T) {
 		type block struct {

--- a/tools/agentlint/internal/rivertags/rivertags.go
+++ b/tools/agentlint/internal/rivertags/rivertags.go
@@ -31,6 +31,8 @@ var riverTagRegex = regexp.MustCompile(`river:"([^"]*)"`)
 //   - attr,optional
 //   - block
 //   - block,optional
+//   - enum
+//   - enum,optional
 //   - label
 //   - squash
 // - Attribute and block tags must have a non-empty value NAME.
@@ -225,6 +227,26 @@ func lintRiverTag(ty *types.Var, tag string) (diagnostics []string) {
 		innerTy := getInnermostType(ty.Type())
 		if _, ok := innerTy.(*types.Struct); !ok {
 			diagnostics = append(diagnostics, "block fields must be a struct or a slice of structs")
+		}
+
+	case "enum", "enum,optional":
+		if len(nameParts) == 0 {
+			diagnostics = append(diagnostics, "block field must have a name")
+		}
+		for _, name := range nameParts {
+			diagnostics = append(diagnostics, validateFieldName(name)...)
+		}
+
+		_, isArray := ty.Type().(*types.Array)
+		_, isSlice := ty.Type().(*types.Slice)
+
+		if !isArray && !isSlice {
+			diagnostics = append(diagnostics, "enum fields must be a slice or array of structs")
+		} else {
+			innerTy := getInnermostType(ty.Type())
+			if _, ok := innerTy.(*types.Struct); !ok {
+				diagnostics = append(diagnostics, "enum fields must be a slice or array of structs")
+			}
 		}
 
 	case "label":


### PR DESCRIPTION
#2602 originally proposed the idea of squashing structs into slices to support a slice where each element had exactly one field set to a non-zero value. 

I tried implementing it as originally suggested in #2602, but found it unintuitive and hard to follow in the code. 

This PR implements an alternative approach to #2602, supporting a new field type called "enum." Enum fields behave as described above: they're slices of a set of blocks, where each element in the slice will have exactly one inner block set. 

Enum fields must be given a name which will be prepended to the set of all blocks in the enum slice. 

For example, given the following two types:

```go 
type Arguments struct {
  Blocks []EnumBlock `river:"example,enum,optional"`  
}

type EnumBlock struct {
  BlockA struct{...} `river:"a,block,optional"`
  BlockB struct{...} `river:"b,block,optional"`
  BlockC struct{...} `river:"c,block,optional"`
}
```

Then the valid block names are `example.a`, `example.b`, and `example.c`. Any number of these blocks may be decoded from River, with the original order retained in the Blocks slice. 

This is a somewhat large PR, and I've tried to split up the work reasonably across multiple commits. I recommend reviewing commit-by-commit to make it easier. 

Closes #2602. 