### PR TITLE
feat: adding template support into the configmap

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -9,6 +9,9 @@ internal API changes are not present.
 
 Unreleased
 ----------
+### Enhancements
+- Helm chart: Add support for templates inside of configMap.content (@ts-mini)
+
 
 0.6.0 (2023-02-13)
 ------------------

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -28,7 +28,7 @@ use the older mode (called "static mode"), set the `agent.mode` value to
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| agent.configMap.content | string | `""` | Content to assign to the new ConfigMap. |
+| agent.configMap.content | string | `""` | Content to assign to the new ConfigMap.  This is passed into `tpl` allowing for templating from values. |
 | agent.configMap.create | bool | `true` | Create a new ConfigMap for the config file. |
 | agent.configMap.key | string | `nil` | Key in ConfigMap to get config from. |
 | agent.configMap.name | string | `nil` | Name of existing ConfigMap to use. Used when create is false. |

--- a/operations/helm/charts/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/charts/grafana-agent/templates/configmap.yaml
@@ -8,13 +8,13 @@ metadata:
 data:
   {{- if eq .Values.agent.mode "flow" }}
   {{- if .Values.agent.configMap.content }}
-  config.river: {{ toYaml .Values.agent.configMap.content | indent 2 }}
+  config.river: {{ toYaml (tpl  .Values.agent.configMap.content .) | indent 2 }}
   {{- else }}
   config.river: |- {{ .Files.Get "config/example.river" | nindent 4 }}
   {{- end }}
   {{- else if eq .Values.agent.mode "static" }}
   {{- if .Values.agent.configMap.content }}
-  config.yaml: {{ toYaml .Values.agent.configMap.content | indent 2 }}
+  config.yaml: {{ toYaml (tpl .Values.agent.configMap.content .) | indent 2 }}
   {{- else }}
   config.yaml: |- {{ .Files.Get "config/example.yaml" | nindent 4 }}
   {{- end }}

--- a/operations/helm/charts/grafana-agent/values.yaml
+++ b/operations/helm/charts/grafana-agent/values.yaml
@@ -12,7 +12,7 @@ agent:
   configMap:
     # -- Create a new ConfigMap for the config file.
     create: true
-    # -- Content to assign to the new ConfigMap.
+    # -- Content to assign to the new ConfigMap.  This is passed into `tpl` allowing for templating from values.
     content: ''
 
     # -- Name of existing ConfigMap to use. Used when create is false.


### PR DESCRIPTION
#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated


## Context
[Due to previous conversations in this PR](https://github.com/grafana/agent/pull/2922) I propose the following change.  This allows us/users to provide references `{{ .Values.someAbitraryKey }}` inside their configMap string-block that will interpolate based on values provided rather than mergeOverwrite with a structured block.  

One specific use case this enables is the use of `helm secrets` whose secret values (integrations/basic, basic auth, etc) can be stored in a separate (encrypted) file but used inside the string configuration block

