### PR TITLE
Avoid goroutine leaks in loki.process, loki.source.file components

### DIFF
--- a/component/loki/process/process.go
+++ b/component/loki/process/process.go
@@ -73,9 +73,11 @@ func New(o component.Options, args Arguments) (*Component, error) {
 // Run implements component.Component.
 func (c *Component) Run(ctx context.Context) error {
 	defer func() {
+		c.mut.RLock()
 		if c.entryHandler != nil {
 			c.entryHandler.Stop()
 		}
+		c.mut.RUnlock()
 	}()
 
 	for {

--- a/component/loki/process/process_test.go
+++ b/component/loki/process/process_test.go
@@ -15,9 +15,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 )
 
 func TestJSONLabelsStage(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	// The following stages will attempt to parse input lines as JSON.
 	// The first stage _extract_ any fields found with the correct names:
 	// Since 'source' is empty, it implies that we want to parse the log line
@@ -80,7 +83,9 @@ func TestJSONLabelsStage(t *testing.T) {
 
 	c, err := New(opts, args)
 	require.NoError(t, err)
-	go c.Run(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
 
 	// Send a log entry to the component's receiver.
 	ts := time.Now()
@@ -122,6 +127,8 @@ func TestJSONLabelsStage(t *testing.T) {
 }
 
 func TestStaticLabelsLabelAllowLabelDrop(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	// The following stages manipulate the label set of a log entry.
 	// The first stage will define a static set of labels (foo, bar, baz, qux)
 	// to add to the entry along the `filename` and `dev` labels.
@@ -167,7 +174,9 @@ stage {
 
 	c, err := New(opts, args)
 	require.NoError(t, err)
-	go c.Run(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
 
 	// Send a log entry to the component's receiver.
 	ts := time.Now()
@@ -206,6 +215,8 @@ stage {
 }
 
 func TestRegexTimestampOutput(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	// The first stage will attempt to parse the input line using a regular
 	// expression with named capture groups. The three capture groups (time,
 	// stream and content) will be extracted in the shared map of values.
@@ -264,7 +275,9 @@ stage {
 
 	c, err := New(opts, args)
 	require.NoError(t, err)
-	go c.Run(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
 
 	// Send a log entry to the component's receiver.
 	ts := time.Now()

--- a/component/loki/source/file/decompresser_test.go
+++ b/component/loki/source/file/decompresser_test.go
@@ -145,6 +145,7 @@ func BenchmarkReadlines(b *testing.B) {
 func TestGigantiqueGunzipFile(t *testing.T) {
 	file := "testdata/long-access.gz"
 	handler := newFakeClient(func() {})
+	defer handler.Stop()
 
 	d := &decompressor{
 		logger:  log.NewNopLogger(),
@@ -173,6 +174,7 @@ func TestOnelineFiles(t *testing.T) {
 	t.Run("gunzip file", func(t *testing.T) {
 		file := "testdata/onelinelog.log.gz"
 		handler := newFakeClient(func() {})
+		defer handler.Stop()
 
 		d := &decompressor{
 			logger:  log.NewNopLogger(),
@@ -196,6 +198,7 @@ func TestOnelineFiles(t *testing.T) {
 	t.Run("bzip2 file", func(t *testing.T) {
 		file := "testdata/onelinelog.log.bz2"
 		handler := newFakeClient(func() {})
+		defer handler.Stop()
 
 		d := &decompressor{
 			logger:  log.NewNopLogger(),
@@ -219,6 +222,7 @@ func TestOnelineFiles(t *testing.T) {
 	t.Run("tar.gz file", func(t *testing.T) {
 		file := "testdata/onelinelog.tar.gz"
 		handler := newFakeClient(func() {})
+		defer handler.Stop()
 
 		d := &decompressor{
 			logger:  log.NewNopLogger(),

--- a/component/loki/source/file/file.go
+++ b/component/loki/source/file/file.go
@@ -50,12 +50,13 @@ type Component struct {
 	opts    component.Options
 	metrics *metrics
 
-	mut       sync.RWMutex
-	args      Arguments
-	handler   loki.LogsReceiver
-	receivers []loki.LogsReceiver
-	posFile   positions.Positions
-	readers   map[positions.Entry]reader
+	mut          sync.RWMutex
+	args         Arguments
+	handler      loki.LogsReceiver
+	entryHandler loki.EntryHandler
+	receivers    []loki.LogsReceiver
+	posFile      positions.Positions
+	readers      map[positions.Entry]reader
 }
 
 // New creates a new loki.source.file component.
@@ -98,10 +99,16 @@ func New(o component.Options, args Arguments) (*Component, error) {
 // Update()? Or should it be a responsibility of the discovery component?
 func (c *Component) Run(ctx context.Context) error {
 	defer func() {
-		level.Info(c.opts.Logger).Log("msg", "loki.source.file component shutting down, stopping readers")
+		level.Info(c.opts.Logger).Log("msg", "loki.source.file component shutting down, stopping readers and positions file")
+		c.mut.RLock()
 		for _, r := range c.readers {
 			r.Stop()
 		}
+		c.posFile.Stop()
+		if c.entryHandler != nil {
+			c.entryHandler.Stop()
+		}
+		c.mut.RUnlock()
 	}()
 
 	for {
@@ -109,9 +116,11 @@ func (c *Component) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			return nil
 		case entry := <-c.handler:
+			c.mut.RLock()
 			for _, receiver := range c.receivers {
 				receiver <- entry
 			}
+			c.mut.RUnlock()
 		}
 	}
 }
@@ -146,6 +155,9 @@ func (c *Component) Update(args component.Arguments) error {
 		r.Stop()
 	}
 	c.readers = make(map[positions.Entry]reader)
+	if c.entryHandler != nil {
+		c.entryHandler.Stop()
+	}
 
 	if len(newArgs.Targets) == 0 {
 		level.Debug(c.opts.Logger).Log("msg", "no files targets were passed, nothing will be tailed")
@@ -170,9 +182,10 @@ func (c *Component) Update(args component.Arguments) error {
 		}
 
 		c.reportSize(path, labels.String())
-		handler := loki.AddLabelsMiddleware(labels).Wrap(loki.NewEntryHandler(c.handler, func() {}))
+		c.handler = make(loki.LogsReceiver)
+		c.entryHandler = loki.AddLabelsMiddleware(labels).Wrap(loki.NewEntryHandler(c.handler, func() { close(c.handler) }))
 
-		reader, err := c.startTailing(path, labels, handler)
+		reader, err := c.startTailing(path, labels, c.entryHandler)
 		if err != nil {
 			continue
 		}

--- a/component/loki/source/file/file_test.go
+++ b/component/loki/source/file/file_test.go
@@ -13,9 +13,12 @@ import (
 	"github.com/grafana/agent/pkg/flow/logging"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 )
 
 func Test(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	// Create opts for component
 	l, err := logging.New(os.Stderr, logging.DefaultOptions)
 	require.NoError(t, err)
@@ -40,7 +43,9 @@ func Test(t *testing.T) {
 	c, err := New(opts, args)
 	require.NoError(t, err)
 
-	go c.Run(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
 	time.Sleep(100 * time.Millisecond)
 
 	_, err = f.Write([]byte("writing some text\n"))


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR fixes the issue where goroutines were leaking in the loki.process and loki.source.file components due to a) not properly shutting down the channels used to Wrap around a pipeline and b) not shutting down the positions file.

I originally believed that the input/output channels for the pipeline would be simply garbage collected, but I should have read it more closely.

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer
This is a bit tedious and error prone. Should we make it easier for component authors by changing the types we ported over from Promtail in the `common/loki` package?

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [X] Tests updated
