### PR TITLE
Change client_options to options in `remote.s3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Main (unreleased)
 - Some blocks in Flow components have been merged with their parent block to make the block hierarchy smaller:
   - `prometheus.scrape > client > http_client_config` is merged into the `client` block. (@erikbaranowski)
 
+- `remote.s3` `client_options` block has been renamed to `client`. (@mattdurham)
+
 ### Features
 
 - New integrations:

--- a/component/remote/s3/types.go
+++ b/component/remote/s3/types.go
@@ -20,11 +20,11 @@ type Arguments struct {
 	// IsSecret determines if the content should be displayed to the user.
 	IsSecret bool `river:"is_secret,attr,optional"`
 	// Options allows the overriding of default settings.
-	Options ClientOptions `river:"client_options,block,optional"`
+	Options Client `river:"client,block,optional"`
 }
 
-// ClientOptions implements specific AWS configuration options
-type ClientOptions struct {
+// Client implements specific AWS configuration options
+type Client struct {
 	AccessKey    string            `river:"key,attr,optional"`
 	Secret       rivertypes.Secret `river:"secret,attr,optional"`
 	Endpoint     string            `river:"endpoint,attr,optional"`

--- a/docs/sources/flow/reference/components/remote.s3.md
+++ b/docs/sources/flow/reference/components/remote.s3.md
@@ -11,7 +11,7 @@ recent content is always available.
 The most common use of `remote.s3` is to load secrets from files.
 
 Multiple `remote.s3` components can be specified using different name
-labels. By default, [AWS environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) are used to authenticate against S3. The `key` and `secret` arguments inside `client_options` blocks can be used to provide custom authentication.
+labels. By default, [AWS environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) are used to authenticate against S3. The `key` and `secret` arguments inside `client` blocks can be used to provide custom authentication.
 
 > **NOTE**: Other S3-compatible systems can be read  with `remote.s3` but may require specific
 > authentication environment variables. There is no  guarantee that `remote.s3` will work with non-AWS S3
@@ -41,15 +41,15 @@ Name | Type | Description | Default | Required
 
 ## Blocks
 
-Hierarchy | Name | Description | Required
---------- | ---- | ----------- | --------
-client_options | [client_options][] | Additional options for configuring the S3 client. | no
+Hierarchy | Name       | Description | Required
+--------- |------------| ----------- | --------
+client | [client][] | Additional options for configuring the S3 client. | no
 
-[client_options]: #client_options-block
+[client]: #client-block
 
-### client_options block
+### client block
 
-The `client_options` block customizes options to connect to the S3 server.
+The `client` block customizes options to connect to the S3 server.
 
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------


### PR DESCRIPTION
#### PR Description

Change `client_options` to `client` in code and documentation.

#### Which issue(s) this PR fixes

Closes #3001 

#### Notes to the Reviewer

#### PR Checklist

- [X] CHANGELOG updated
- [X] Documentation added
- [NA] Tests updated
