### PR TITLE
fix indentation errors in metrics section

### DIFF
--- a/docs/sources/configuration/create-config-file.md
+++ b/docs/sources/configuration/create-config-file.md
@@ -79,9 +79,9 @@ metrics:
   configs:
     - name: agent
       scrape_configs:
-        # PASTE scrape_configs SECTION HERE
-      remote_write:
-        # PASTE remote_write SECTION HERE
+      # PASTE scrape_configs SECTION HERE
+    remote_write:
+    # PASTE remote_write SECTION HERE
 ```
 
 For example, this configuration file configures the Grafana Agent to
@@ -97,11 +97,11 @@ metrics:
   configs:
     - name: agent
       scrape_configs:
-        - job_name: agent
-          static_configs:
-            - targets: ['127.0.0.1:12345']
+      - job_name: agent
+        static_configs:
+          - targets: ['127.0.0.1:12345']
       remote_write:
-        - url: http://localhost:9009/api/prom/push
+      - url: http://localhost:9009/api/prom/push
 ```
 
 Like with integrations, full configuration options can be found in the
@@ -144,9 +144,9 @@ metrics:
   configs:
     - name: default
       scrape_configs:
-        - job_name: agent
-          static_configs:
-            - targets: ['127.0.0.1:12345']
+      - job_name: agent
+        static_configs:
+          - targets: ['127.0.0.1:12345']
 
 logs:
   configs:


### PR DESCRIPTION
I haven't tested the entire config but the indentation was incorrect and my agent would not start. We should prob double check these as well as the other sections mentioned in this page for proper indentation. YAML is a fickle beast.

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
