### PR TITLE
Remove support for EXPERIMENTAL_ENABLE_FLOW environment variable 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Main (unreleased)
 - `remote.s3` `client_options` block has been renamed to `client`. (@mattdurham)
 - Renamed `prometheus.integration.node_exporter` to `prometheus.exporter.unix`. (@jcreixell)
 
+- As first announced in v0.30, support for the `EXPERIMENTAL_ENABLE_FLOW`
+  environment variable has been removed in favor of `AGENT_MODE=flow`.
+  (@rfratto)
+
 ### Features
 
 - New integrations:

--- a/cmd/grafana-agent/mode.go
+++ b/cmd/grafana-agent/mode.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 )
 
@@ -17,12 +16,6 @@ const (
 func getRunMode() (runMode, error) {
 	key, found := os.LookupEnv("AGENT_MODE")
 	if !found {
-		// Fall back to old EXPERIMENTAL_ENABLE_FLOW flag.
-		// TODO: remove support for EXPERIMENTAL_ENABLE_FLOW in v0.32.
-		if isFlowEnabled() {
-			log.Println("warning: setting EXPERIMENTAL_ENABLE_FLOW is deprecated and will be removed in v0.32, set AGENT_MODE to flow instead")
-			return runModeFlow, nil
-		}
 		return runModeStatic, nil
 	}
 
@@ -34,12 +27,4 @@ func getRunMode() (runMode, error) {
 	default:
 		return runModeInvalid, fmt.Errorf("unrecognized run mode %q", key)
 	}
-}
-
-func isFlowEnabled() bool {
-	key, found := os.LookupEnv("EXPERIMENTAL_ENABLE_FLOW")
-	if !found {
-		return false
-	}
-	return key == "true" || key == "1"
 }

--- a/component/otelcol/internal/featuregate/install.go
+++ b/component/otelcol/internal/featuregate/install.go
@@ -29,18 +29,12 @@ func enableFeatureGates(reg *featuregate.Registry) error {
 }
 
 func isFlowRunning() bool {
-	key, found := os.LookupEnv("AGENT_MODE")
-	if !found {
-		key, found := os.LookupEnv("EXPERIMENTAL_ENABLE_FLOW")
-		if !found {
-			return false
-		}
-		return key == "true" || key == "1"
-	}
+	key, _ := os.LookupEnv("AGENT_MODE")
 
 	switch key {
 	case "flow":
 		return true
+	default:
+		return false
 	}
-	return false
 }

--- a/docs/sources/flow/getting_started.md
+++ b/docs/sources/flow/getting_started.md
@@ -18,12 +18,6 @@ release.
 Grafana Agent Flow can be enabled by setting the `AGENT_MODE` environment
 variable to `flow`.
 
-> **NOTE**: In previous releases, the `EXPERIMENTAL_ENABLE_FLOW` environment
-> variable was set to `1` to enable Grafana Agent Flow. This environment
-> variable is deprecated and support for it will be removed in the v0.32
-> release. It is recommended to change to `AGENT_MODE=flow` as soon as
-> possible.
-
 Then, use the `agent run` command to start Grafana Agent Flow, replacing
 `FILE_PATH` with the path of a config file to use:
 


### PR DESCRIPTION
EXPERIMENTAL_ENABLE_FLOW was first deprecated in v0.30, and scheduled for removal for v0.32. To enable Flow mode, the `AGENT_MODE` environment variable must be set to `flow`. 