### PR TITLE
docs: add warning banner for beta/experimental components

### DIFF
--- a/docs/sources/flow/reference/components/loki.echo.md
+++ b/docs/sources/flow/reference/components/loki.echo.md
@@ -6,6 +6,8 @@ labels:
 
 # loki.echo
 
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+
 `loki.echo` receives log entries from other `loki` components and prints them
 to the process' standard output (stdout).
 

--- a/docs/sources/flow/reference/components/loki.source.kubernetes.md
+++ b/docs/sources/flow/reference/components/loki.source.kubernetes.md
@@ -6,6 +6,8 @@ labels:
 
 # loki.source.kubernetes
 
+{{< docs/shared lookup="flow/stability/experimental.md" source="agent" >}}
+
 `loki.source.kubernetes` tails logs from Kubernetes containers using the
 Kubernetes API. It has the following benefits over `loki.source.file`:
 

--- a/docs/sources/flow/reference/components/loki.source.podlogs.md
+++ b/docs/sources/flow/reference/components/loki.source.podlogs.md
@@ -6,6 +6,8 @@ labels:
 
 # loki.source.podlogs
 
+{{< docs/shared lookup="flow/stability/experimental.md" source="agent" >}}
+
 `loki.source.podlogs` discovers `PodLogs` resources on Kubernetes and, using
 the Kubernetes API, tails logs from Kubernetes containers of Pods specified by
 the discovered them.

--- a/docs/sources/flow/reference/components/mimir.rules.kubernetes.md
+++ b/docs/sources/flow/reference/components/mimir.rules.kubernetes.md
@@ -6,6 +6,8 @@ labels:
 
 # mimir.rules.kubernetes
 
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+
 `mimir.rules.kubernetes` discovers `PrometheusRule` Kubernetes resources and
 loads them into a Mimir instance.
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.loki.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.loki.md
@@ -6,6 +6,8 @@ labels:
 
 # otelcol.exporter.loki
 
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+
 `otelcol.exporter.loki` accepts OTLP-formatted logs from other `otelcol`
 components, converts them to Loki-formatted log entries, and forwards them
 to `loki` components.

--- a/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
@@ -6,6 +6,8 @@ labels:
 
 # otelcol.exporter.prometheus
 
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+
 `otelcol.exporter.prometheus` accepts OTLP-formatted metrics from other
 `otelcol` components, converts metrics to Prometheus-formatted metrics,
 and forwards the resulting metrics to `prometheus` components.

--- a/docs/sources/flow/reference/components/otelcol.receiver.loki.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.loki.md
@@ -6,6 +6,8 @@ labels:
 
 # otelcol.receiver.loki
 
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+
 `otelcol.receiver.loki` receives Loki log entries, converts them to the
 OpenTelemetry logs format, and forwards them to other `otelcol.*` components.
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.prometheus.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.prometheus.md
@@ -6,6 +6,8 @@ labels:
 
 # otelcol.receiver.prometheus
 
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+
 `otelcol.receiver.prometheus` receives Prometheus metrics, converts them to the
 OpenTelemetry metrics format, and forwards them to other `otelcol.*`
 components.

--- a/docs/sources/flow/reference/components/phlare.scrape.md
+++ b/docs/sources/flow/reference/components/phlare.scrape.md
@@ -6,6 +6,8 @@ labels:
 
 # phlare.scrape
 
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+
 `phlare.scrape` configures a [pprof] scraping job for a given set of
 `targets`. The scraped performance profiles are forwarded to the list of receivers passed in
 `forward_to`.

--- a/docs/sources/flow/reference/components/phlare.write.md
+++ b/docs/sources/flow/reference/components/phlare.write.md
@@ -6,6 +6,8 @@ labels:
 
 # phlare.write
 
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+
 `phlare.write` receives performance profiles from other components and forwards them
 to a series of user-supplied endpoints using [Phlare' Push API](https://grafana.com/oss/phlare/).
 

--- a/docs/sources/operation-guide/_index.md
+++ b/docs/sources/operation-guide/_index.md
@@ -22,8 +22,8 @@ the three categories:
 * Beta: we are working on maturing a specific feature. Beta features may be
   subject to some breaking changes. Beta features may be replaced by equivalent
   functionality that covers that same use case. Beta features can be used
-  without feature flags. Unless replaced by equivalent functionality, beta
-  features will eventually graduate to stable.
+  without a feature flag being set. Unless replaced with equivalent
+  functionality, beta features will eventually graduate to stable.
 
 * Stable: we believe this functionality is stable, and breaking changes to
   configuration will be rare and well-documented. We will communicate

--- a/docs/sources/operation-guide/_index.md
+++ b/docs/sources/operation-guide/_index.md
@@ -16,7 +16,7 @@ the three categories:
 * Experimental: we are exploring a new use case and would like feedback.
   Experimental features are subject to frequent breaking changes during
   development. Experimental features may be removed with no equivalent
-  replacement. Experimental features are always hidden behind feature flags.
+  replacement. Experimental features may be hidden behind feature flags.
   Unless removed, experimental features will eventually graduate to beta.
 
 * Beta: we are working on maturing a specific feature. Beta features may be

--- a/docs/sources/operation-guide/_index.md
+++ b/docs/sources/operation-guide/_index.md
@@ -21,7 +21,7 @@ the three categories:
 
 * Beta: we are working on maturing a specific feature. Beta features may be
   subject to some breaking changes. Beta features may be replaced by equivalent
-  functionality which covers that same use case. Beta features can be used
+  functionality that covers that same use case. Beta features can be used
   without feature flags. Unless replaced by equivalent functionality, beta
   features will eventually graduate to stable.
 

--- a/docs/sources/operation-guide/_index.md
+++ b/docs/sources/operation-guide/_index.md
@@ -14,16 +14,16 @@ Individual features of Grafana Agent may have stability falling under one of
 the three categories:
 
 * Experimental: we are exploring a new use case and would like feedback.
-  Experimental features are subject to frequent breaking changes during
-  development. Experimental features may be removed with no equivalent
-  replacement. Experimental features may be hidden behind feature flags.
-  Unless removed, experimental features will eventually graduate to beta.
+  Experimental features are subject to frequent breaking changes. Experimental
+  features may be removed with no equivalent replacement. Experimental features
+  may be hidden behind feature flags. Unless removed, experimental features
+  will eventually graduate to beta.
 
 * Beta: we are working on maturing a specific feature. Beta features may be
-  subject to some breaking changes during development. Beta features may be
-  replaced by equivalent functionality which covers that same use case. Beta
-  features can be used without feature flags. Unless replaced by equivalent
-  functionality, beta features will eventually graduate to stable.
+  subject to some breaking changes. Beta features may be replaced by equivalent
+  functionality which covers that same use case. Beta features can be used
+  without feature flags. Unless replaced by equivalent functionality, beta
+  features will eventually graduate to stable.
 
 * Stable: we believe this functionality is stable, and breaking changes to
   configuration will be rare and well-documented. We will communicate

--- a/docs/sources/shared/flow/stability/beta.md
+++ b/docs/sources/shared/flow/stability/beta.md
@@ -5,7 +5,7 @@ headless: true
 ---
 
 > **BETA**: This is a [beta][] component. Beta components are subject to breaking
-> changes, and may be replaced with equivalent functionality that covers the
+> changes, and may be replaced with equivalent functionality that cover the
 > same use case.
 
 [beta]: {{< relref "../../../operation-guide/_index.md#stability" >}}

--- a/docs/sources/shared/flow/stability/beta.md
+++ b/docs/sources/shared/flow/stability/beta.md
@@ -5,7 +5,7 @@ headless: true
 ---
 
 > **BETA**: This is a [beta][] component. Beta components are subject to breaking
-> changes, and may be replaced with equivalent functionality which covers the
+> changes, and may be replaced with equivalent functionality that covers the
 > same use case.
 
 [beta]: {{< relref "../../../operation-guide/_index.md#stability" >}}

--- a/docs/sources/shared/flow/stability/beta.md
+++ b/docs/sources/shared/flow/stability/beta.md
@@ -5,7 +5,7 @@ headless: true
 ---
 
 > **BETA**: This is a [beta][] component. Beta components are subject to breaking
-> changes changes during development, and may be replaced with equivalent
-> functionality which covers the same use case.
+> changes, and may be replaced with equivalent functionality which covers the
+> same use case.
 
 [beta]: {{< relref "../../../operation-guide/_index.md#stability" >}}

--- a/docs/sources/shared/flow/stability/beta.md
+++ b/docs/sources/shared/flow/stability/beta.md
@@ -1,0 +1,11 @@
+---
+aliases:
+- /docs/agent/shared/flow/stability/beta/
+headless: true
+---
+
+> **BETA**: This is a [beta][] component. Beta components are subject to breaking
+> changes changes during development, and may be replaced with equivalent
+> functionality which covers the same use case.
+
+[beta]: {{< relref "../../../operation-guide/_index.md#stability" >}}

--- a/docs/sources/shared/flow/stability/experimental.md
+++ b/docs/sources/shared/flow/stability/experimental.md
@@ -4,8 +4,8 @@ aliases:
 headless: true
 ---
 
-> **EXPERIMENTAL**: This is an [experimental][] component. Experimental components
-> are subject to breaking changes changes during development, and may be
-> replaced with no equivalent replacement.
+> **EXPERIMENTAL**: This is an [experimental][] component. Experimental
+> components are subject to breaking changes changes during development, and
+> may be removed with no equivalent replacement.
 
 [experimental]: {{< relref "../../../operation-guide/_index.md#stability" >}}

--- a/docs/sources/shared/flow/stability/experimental.md
+++ b/docs/sources/shared/flow/stability/experimental.md
@@ -1,0 +1,11 @@
+---
+aliases:
+- /docs/agent/shared/flow/stability/experimental/
+headless: true
+---
+
+> **EXPERIMENTAL**: This is an [experimental][] component. Experimental components
+> are subject to breaking changes changes during development, and may be
+> replaced with no equivalent replacement.
+
+[experimental]: {{< relref "../../../operation-guide/_index.md#stability" >}}

--- a/docs/sources/shared/flow/stability/experimental.md
+++ b/docs/sources/shared/flow/stability/experimental.md
@@ -5,7 +5,7 @@ headless: true
 ---
 
 > **EXPERIMENTAL**: This is an [experimental][] component. Experimental
-> components are subject to breaking changes changes during development, and
-> may be removed with no equivalent replacement.
+> components are subject to frequent breaking changes, and may be removed with
+> no equivalent replacement.
 
 [experimental]: {{< relref "../../../operation-guide/_index.md#stability" >}}


### PR DESCRIPTION
Change description of experimental components to drop requirement about feature flags.

<img width="779" alt="image" src="https://user-images.githubusercontent.com/630212/220792194-096bd7a5-842d-4651-a31c-7189284163ba.png">

<img width="779" alt="image" src="https://user-images.githubusercontent.com/630212/220792229-df01f4bf-317c-4ba8-af6c-373efa8208f5.png">
