### PR TITLE
Fix use of incorrect label for container name

### DIFF
--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -299,7 +299,7 @@ Name        | Type           | Description                                   | D
 
 ```river
 stage.label_keep {
-		values = [ "kubernetes_pod_name", "kubernetes_container_name" ]
+		values = [ "kubernetes_pod_name", "kubernetes_pod_container_name" ]
 }
 ```
 

--- a/production/operator/templates/agent-operator.yaml
+++ b/production/operator/templates/agent-operator.yaml
@@ -549,7 +549,7 @@ spec:
     targetLabel: pod
   - action: replace
     sourceLabels:
-    - __meta_kubernetes_container_name
+    - __meta_kubernetes_pod_container_name
     targetLabel: container
   - replacement: /var/log/pods/*$1/*.log
     separator: /

--- a/production/tanka/grafana-agent-operator/util/k8slogs.libsonnet
+++ b/production/tanka/grafana-agent-operator/util/k8slogs.libsonnet
@@ -25,7 +25,7 @@ local r = pl.spec.relabelings;
         r.withTargetLabel('pod'),
 
         r.withAction('replace') +
-        r.withSourceLabels('__meta_kubernetes_container_name') +
+        r.withSourceLabels('__meta_kubernetes_pod_container_name') +
         r.withTargetLabel('container'),
 
         r.withReplacement('/var/log/pods/*$1/*.log') +


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

I noticed that using the out-of-the-box configuration that I didn't have any `container` label on logs.

From https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config
>  `__meta_kubernetes_pod_container_name`: Name of the container the target address points to.

The docs/samples in this repo were missing the `pod_` part of that.

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
