### PR TITLE
feat: add logfmt stage to PodLog CRD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,8 @@ Main (unreleased)
 
 - Flow: add timeout to loki.source.podlogs controller setup. (@polyrain)
 
+- Grafana Agent Operator: `PodLog` crd now supports the `logfmt` pipeline stage. (@jzck)
+
 ### Bugfixes
 
 - Fixed a reconciliation error in Grafana Agent Operator when using `tlsConfig`

--- a/production/operator/crds/monitoring.grafana.com_podlogs.yaml
+++ b/production/operator/crds/monitoring.grafana.com_podlogs.yaml
@@ -175,6 +175,22 @@ spec:
                             will push to Loki.
                           type: integer
                       type: object
+                    logfmt:
+                      description: The logfmt stage is a parsing stage that reads the
+                        log line as logfmt and allows extraction of data into labels.
+                      properties:
+                        source:
+                          description: Name from the extracted data to parse as JSON.
+                            If empty, uses entire log message.
+                          type: string
+                        mapping:
+                          description:  Set of key/value pairs for mapping of logfmt
+                            fields to extracted labels. The YAML key will be the key
+                            in the extracted data, while the expression will be the
+                            YAML value. If the value is empty, then the logfmt field
+                            with the same name is extracted.
+                          type: object
+                      type: object
                     match:
                       description: Match is a filtering stage that conditionally applies
                         a set of stages or drop entries when a log entry matches a


### PR DESCRIPTION
#### PR Description

#### Which issue(s) this PR fixes

`PodLog` CRD doesn't support the `logfmt` pipeline stage.

#### Notes to the Reviewer

https://grafana.com/docs/loki/latest/clients/promtail/stages/logfmt/

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
