### PR TITLE
Update tagging instructions for releases

### DIFF
--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -212,8 +212,8 @@ Example commands:
 ```
 git checkout release-v0.31
 git pull
-git tag v0.31.2
-git push origin --tags
+git tag -s v0.31.2
+git push origin v0.31.2
 ```
 
 After the push double check that the tag on GitHub corresponds to the tip of the release branch on GitHub.


### PR DESCRIPTION
Update tagging instructions to explicitly sign commits (to be safe) and only push the most recent tag rather than all local tags.
