### PR TITLE
ci: have crosscompile jobs build with journald support

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -343,8 +343,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agent
+  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -360,8 +359,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agent
+  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="builtinassets" make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -377,8 +375,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="builtinassets promtail_journal_enabled"
-    make agent
+  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="builtinassets" make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -394,8 +391,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="builtinassets promtail_journal_enabled"
-    make agent
+  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="builtinassets" make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -411,8 +407,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agent
+  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="builtinassets" make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -428,8 +423,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agent
+  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -445,8 +439,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agent
+  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="builtinassets" make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -462,8 +455,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agent
+  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -479,8 +471,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agent
+  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -496,8 +487,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agentctl
+  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -513,8 +503,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agentctl
+  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="builtinassets" make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -530,8 +519,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="builtinassets promtail_journal_enabled"
-    make agentctl
+  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="builtinassets" make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -547,8 +535,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="builtinassets promtail_journal_enabled"
-    make agentctl
+  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="builtinassets" make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -564,8 +551,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agentctl
+  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="builtinassets" make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -581,8 +567,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agentctl
+  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -598,8 +583,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agentctl
+  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="builtinassets" make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -615,8 +599,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agentctl
+  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -632,8 +615,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agentctl
+  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -649,8 +631,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make operator
+  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -666,8 +647,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make operator
+  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="builtinassets" make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -683,8 +663,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="builtinassets promtail_journal_enabled"
-    make operator
+  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="builtinassets" make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -700,8 +679,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="builtinassets promtail_journal_enabled"
-    make operator
+  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="builtinassets" make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -717,8 +695,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make operator
+  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="builtinassets" make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -734,8 +711,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make operator
+  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -751,8 +727,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make operator
+  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="builtinassets" make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -768,8 +743,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make operator
+  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -785,8 +759,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make operator
+  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -1205,6 +1178,6 @@ kind: secret
 name: gpg_passphrase
 ---
 kind: signature
-hmac: 2097870865d1bf21f0f152860bb03d4fd0c55b8d0626aaf85e2902d053aad8a5
+hmac: 5ffdb7c3b55910b2d65e43d3424c8dafec446a5cd6b8d17c9b4ee784b0d80d15
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -342,7 +342,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=amd64 GOARM= make agent
+  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -357,7 +357,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=arm64 GOARM= make agent
+  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="promtail_journal_enabled" make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -372,7 +372,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=arm GOARM=6 make agent
+  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="promtail_journal_enabled" make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -387,7 +387,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=arm GOARM=7 make agent
+  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="promtail_journal_enabled" make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -402,7 +402,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=ppc64le GOARM= make agent
+  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="promtail_journal_enabled" make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -417,7 +417,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=darwin GOARCH=amd64 GOARM= make agent
+  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -432,7 +432,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=darwin GOARCH=arm64 GOARM= make agent
+  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="promtail_journal_enabled" make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -447,7 +447,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=windows GOARCH=amd64 GOARM= make agent
+  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -462,7 +462,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=freebsd GOARCH=amd64 GOARM= make agent
+  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -477,7 +477,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=amd64 GOARM= make agentctl
+  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -492,7 +492,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=arm64 GOARM= make agentctl
+  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="promtail_journal_enabled" make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -507,7 +507,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=arm GOARM=6 make agentctl
+  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="promtail_journal_enabled" make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -522,7 +522,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=arm GOARM=7 make agentctl
+  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="promtail_journal_enabled" make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -537,7 +537,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=ppc64le GOARM= make agentctl
+  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="promtail_journal_enabled" make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -552,7 +552,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=darwin GOARCH=amd64 GOARM= make agentctl
+  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -567,7 +567,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=darwin GOARCH=arm64 GOARM= make agentctl
+  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="promtail_journal_enabled" make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -582,7 +582,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=windows GOARCH=amd64 GOARM= make agentctl
+  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -597,7 +597,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=freebsd GOARCH=amd64 GOARM= make agentctl
+  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -612,7 +612,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=amd64 GOARM= make operator
+  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -627,7 +627,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=arm64 GOARM= make operator
+  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="promtail_journal_enabled" make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -642,7 +642,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=arm GOARM=6 make operator
+  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="promtail_journal_enabled" make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -657,7 +657,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=arm GOARM=7 make operator
+  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="promtail_journal_enabled" make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -672,7 +672,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=ppc64le GOARM= make operator
+  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="promtail_journal_enabled" make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -687,7 +687,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=darwin GOARCH=amd64 GOARM= make operator
+  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -702,7 +702,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=darwin GOARCH=arm64 GOARM= make operator
+  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="promtail_journal_enabled" make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -717,7 +717,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=windows GOARCH=amd64 GOARM= make operator
+  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -732,7 +732,7 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=freebsd GOARCH=amd64 GOARM= make operator
+  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -1151,6 +1151,6 @@ kind: secret
 name: gpg_passphrase
 ---
 kind: signature
-hmac: 5e85b73dd2e075bffd57cf6fd5d943abcdd72356097b0e18d9a0520d733d7ea0
+hmac: a68d39ad608628104d6ffdce7ebd9eb9b3bbcbbc202363790fe93910c9b9daf4
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -393,7 +393,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="promtail_journal_enabled" make agent
+  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="builtinassets promtail_journal_enabled"
+    make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -544,7 +545,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="promtail_journal_enabled" make agentctl
+  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="builtinassets promtail_journal_enabled"
+    make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -695,7 +697,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="promtail_journal_enabled" make operator
+  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="builtinassets promtail_journal_enabled"
+    make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -1199,6 +1202,6 @@ kind: secret
 name: gpg_passphrase
 ---
 kind: signature
-hmac: e19ee857f311b668b5f91252a4597004d64795245c01f4a0a973198b8763e01e
+hmac: 3a13fd175473adb0873959a4e67b7b2787161d9b69af0f1da3bf776671da8ce8
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -343,7 +343,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make agent
+  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -359,7 +360,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="builtinassets" make agent
+  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -375,7 +377,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="builtinassets" make agent
+  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="promtail_journal_enabled" make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -391,7 +393,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="builtinassets" make agent
+  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="promtail_journal_enabled" make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -407,7 +409,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="builtinassets" make agent
+  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -423,7 +426,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make agent
+  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -439,7 +443,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="builtinassets" make agent
+  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -455,7 +460,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make agent
+  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -471,7 +477,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make agent
+  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -487,7 +494,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make agentctl
+  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -503,7 +511,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="builtinassets" make agentctl
+  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -519,7 +528,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="builtinassets" make agentctl
+  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="promtail_journal_enabled" make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -535,7 +544,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="builtinassets" make agentctl
+  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="promtail_journal_enabled" make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -551,7 +560,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="builtinassets" make agentctl
+  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -567,7 +577,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make agentctl
+  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -583,7 +594,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="builtinassets" make agentctl
+  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -599,7 +611,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make agentctl
+  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -615,7 +628,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make agentctl
+  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -631,7 +645,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make operator
+  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -647,7 +662,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="builtinassets" make operator
+  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -663,7 +679,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="builtinassets" make operator
+  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="promtail_journal_enabled" make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -679,7 +695,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="builtinassets" make operator
+  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="promtail_journal_enabled" make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -695,7 +711,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="builtinassets" make operator
+  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -711,7 +728,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make operator
+  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -727,7 +745,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="builtinassets" make operator
+  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -743,7 +762,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make operator
+  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -759,7 +779,8 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="builtinassets" make operator
+  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -1178,6 +1199,6 @@ kind: secret
 name: gpg_passphrase
 ---
 kind: signature
-hmac: 5ffdb7c3b55910b2d65e43d3424c8dafec446a5cd6b8d17c9b4ee784b0d80d15
+hmac: e19ee857f311b668b5f91252a4597004d64795245c01f4a0a973198b8763e01e
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -342,7 +342,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make agent
+  - make generate-ui
+  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -357,7 +359,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="promtail_journal_enabled" make agent
+  - make generate-ui
+  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -372,7 +376,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="promtail_journal_enabled" make agent
+  - make generate-ui
+  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="builtinassets promtail_journal_enabled"
+    make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -387,7 +393,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="promtail_journal_enabled" make agent
+  - make generate-ui
+  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="builtinassets promtail_journal_enabled"
+    make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -402,7 +410,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="promtail_journal_enabled" make agent
+  - make generate-ui
+  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -417,7 +427,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make agent
+  - make generate-ui
+  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -432,7 +444,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="promtail_journal_enabled" make agent
+  - make generate-ui
+  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -447,7 +461,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make agent
+  - make generate-ui
+  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -462,7 +478,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make agent
+  - make generate-ui
+  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agent
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -477,7 +495,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make agentctl
+  - make generate-ui
+  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -492,7 +512,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="promtail_journal_enabled" make agentctl
+  - make generate-ui
+  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -507,7 +529,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="promtail_journal_enabled" make agentctl
+  - make generate-ui
+  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="builtinassets promtail_journal_enabled"
+    make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -522,7 +546,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="promtail_journal_enabled" make agentctl
+  - make generate-ui
+  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="builtinassets promtail_journal_enabled"
+    make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -537,7 +563,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="promtail_journal_enabled" make agentctl
+  - make generate-ui
+  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -552,7 +580,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make agentctl
+  - make generate-ui
+  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -567,7 +597,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="promtail_journal_enabled" make agentctl
+  - make generate-ui
+  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -582,7 +614,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make agentctl
+  - make generate-ui
+  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -597,7 +631,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make agentctl
+  - make generate-ui
+  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make agentctl
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -612,7 +648,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make operator
+  - make generate-ui
+  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -627,7 +665,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="promtail_journal_enabled" make operator
+  - make generate-ui
+  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -642,7 +682,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="promtail_journal_enabled" make operator
+  - make generate-ui
+  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="builtinassets promtail_journal_enabled"
+    make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -657,7 +699,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="promtail_journal_enabled" make operator
+  - make generate-ui
+  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="builtinassets promtail_journal_enabled"
+    make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -672,7 +716,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="promtail_journal_enabled" make operator
+  - make generate-ui
+  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -687,7 +733,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make operator
+  - make generate-ui
+  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -702,7 +750,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="promtail_journal_enabled" make operator
+  - make generate-ui
+  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -717,7 +767,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make operator
+  - make generate-ui
+  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -732,7 +784,9 @@ platform:
   os: linux
 steps:
 - commands:
-  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="promtail_journal_enabled" make operator
+  - make generate-ui
+  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
+    make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -1151,6 +1205,6 @@ kind: secret
 name: gpg_passphrase
 ---
 kind: signature
-hmac: a68d39ad608628104d6ffdce7ebd9eb9b3bbcbbc202363790fe93910c9b9daf4
+hmac: 2097870865d1bf21f0f152860bb03d4fd0c55b8d0626aaf85e2902d053aad8a5
 
 ...

--- a/.drone/pipelines/crosscompile.jsonnet
+++ b/.drone/pipelines/crosscompile.jsonnet
@@ -5,8 +5,8 @@ local os_arch_tuples = [
   // Linux
   { name: 'Linux amd64', os: 'linux', arch: 'amd64' },
   { name: 'Linux arm64', os: 'linux', arch: 'arm64' },
-  { name: 'Linux armv6', os: 'linux', arch: 'arm', arm: '6' },
-  { name: 'Linux armv7', os: 'linux', arch: 'arm', arm: '7' },
+  { name: 'Linux armv6', os: 'linux', arch: 'arm', arm: '6', tags: 'promtail_journal_enabled' },
+  { name: 'Linux armv7', os: 'linux', arch: 'arm', arm: '7', tags: 'promtail_journal_enabled' },
   { name: 'Linux ppc64le', os: 'linux', arch: 'ppc64le' },
 
   // Darwin
@@ -29,12 +29,18 @@ local targets = [
 std.flatMap(function(target) (
   std.map(function(platform) (
     pipelines.linux('Build %s (%s)' % [target, platform.name]) {
+      local build_tags = (
+        if 'tags' in platform then platform.tags
+        else 'builtinassets promtail_journal_enabled'
+      ),
+
       local env = {
         GOOS: platform.os,
         GOARCH: platform.arch,
         GOARM: if 'arm' in platform then platform.arm else '',
 
         target: target,
+        tags: build_tags,
       },
 
       trigger: {
@@ -45,7 +51,7 @@ std.flatMap(function(target) (
         image: build_image.linux,
         commands: [
           'make generate-ui',
-          'GOOS=%(GOOS)s GOARCH=%(GOARCH)s GOARM=%(GOARM)s GO_TAGS="builtinassets" make %(target)s' % env,
+          'GOOS=%(GOOS)s GOARCH=%(GOARCH)s GOARM=%(GOARM)s GO_TAGS="%(tags)s" make %(target)s' % env,
         ],
       }],
     }

--- a/.drone/pipelines/crosscompile.jsonnet
+++ b/.drone/pipelines/crosscompile.jsonnet
@@ -44,7 +44,8 @@ std.flatMap(function(target) (
         name: 'Build',
         image: build_image.linux,
         commands: [
-          'GOOS=%(GOOS)s GOARCH=%(GOARCH)s GOARM=%(GOARM)s GO_TAGS="promtail_journal_enabled" make %(target)s' % env,
+          'make generate-ui',
+          'GOOS=%(GOOS)s GOARCH=%(GOARCH)s GOARM=%(GOARM)s GO_TAGS="builtinassets promtail_journal_enabled" make %(target)s' % env,
         ],
       }],
     }

--- a/.drone/pipelines/crosscompile.jsonnet
+++ b/.drone/pipelines/crosscompile.jsonnet
@@ -6,7 +6,7 @@ local os_arch_tuples = [
   { name: 'Linux amd64', os: 'linux', arch: 'amd64' },
   { name: 'Linux arm64', os: 'linux', arch: 'arm64' },
   { name: 'Linux armv6', os: 'linux', arch: 'arm', arm: '6', tags: 'promtail_journal_enabled' },
-  { name: 'Linux armv7', os: 'linux', arch: 'arm', arm: '7', tags: 'promtail_journal_enabled' },
+  { name: 'Linux armv7', os: 'linux', arch: 'arm', arm: '7' },
   { name: 'Linux ppc64le', os: 'linux', arch: 'ppc64le' },
 
   // Darwin

--- a/.drone/pipelines/crosscompile.jsonnet
+++ b/.drone/pipelines/crosscompile.jsonnet
@@ -44,7 +44,7 @@ std.flatMap(function(target) (
         name: 'Build',
         image: build_image.linux,
         commands: [
-          'GOOS=%(GOOS)s GOARCH=%(GOARCH)s GOARM=%(GOARM)s make %(target)s' % env,
+          'GOOS=%(GOOS)s GOARCH=%(GOARCH)s GOARM=%(GOARM)s GO_TAGS="promtail_journal_enabled" make %(target)s' % env,
         ],
       }],
     }

--- a/.drone/pipelines/crosscompile.jsonnet
+++ b/.drone/pipelines/crosscompile.jsonnet
@@ -45,7 +45,7 @@ std.flatMap(function(target) (
         image: build_image.linux,
         commands: [
           'make generate-ui',
-          'GOOS=%(GOOS)s GOARCH=%(GOARCH)s GOARM=%(GOARM)s GO_TAGS="builtinassets promtail_journal_enabled" make %(target)s' % env,
+          'GOOS=%(GOOS)s GOARCH=%(GOARCH)s GOARM=%(GOARM)s GO_TAGS="builtinassets" make %(target)s' % env,
         ],
       }],
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,7 +148,7 @@ v0.32.0-rc.0 (2023-02-23)
 
 - Use Go 1.20 for builds. (@rfratto)
 
-- Grafana Agent Flow is now considered production ready. A subset of Flow
+- The beta label from Grafana Agent Flow has been removed. A subset of Flow
   components are still marked as beta or experimental:
 
   - `loki.echo` is explicitly marked as beta.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
+> **NOTE**: As of v0.32.0, builds for 32-bit ARMv6 currently don't support the
+> embedded Flow UI. The Flow UI will return to this target as soon as possible.
+
 Main (unreleased)
 -----------------
 
@@ -14,6 +17,9 @@ v0.32.0-rc.0 (2023-02-23)
 -------------------------
 
 ### Breaking changes
+
+- Support for the embedded Flow UI for 32-bit ARMv6 builds is temporarily
+  removed. (@rfratto)
 
 - Node Exporter configuration options changed to align with new upstream version (@Thor77):
 

--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -42,11 +42,11 @@ dist/grafana-agent-linux-arm64: GOARCH  := arm64
 dist/grafana-agent-linux-arm64: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/grafana-agent-linux-armv6: GO_TAGS += builtinassets promtail_journal_enabled
+dist/grafana-agent-linux-armv6: GO_TAGS += promtail_journal_enabled
 dist/grafana-agent-linux-armv6: GOOS    := linux
 dist/grafana-agent-linux-armv6: GOARCH  := arm
 dist/grafana-agent-linux-armv6: GOARM   := 6
-dist/grafana-agent-linux-armv6: generate-ui
+dist/grafana-agent-linux-armv6:
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
 dist/grafana-agent-linux-armv7: GO_TAGS += builtinassets promtail_journal_enabled
@@ -142,7 +142,6 @@ dist/grafana-agentctl-windows-amd64.exe: GOARCH := amd64
 dist/grafana-agentctl-windows-amd64.exe:
 	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
 
-dist/grafana-agentctl-freebsd-amd64: GO_TAGS += builtinassets
 dist/grafana-agentctl-freebsd-amd64: GOOS    := freebsd
 dist/grafana-agentctl-freebsd-amd64: GOARCH  := amd64
 dist/grafana-agentctl-freebsd-amd64:


### PR DESCRIPTION
When working on the v0.32.0-rc.0 release, we noticed the 32-bit ARMv6 build is broken and preventing us from releasing.

It seems that removing the embedded Flow UI for ARMv6 restores the builds. Since it doesn't seem like anyone on 32-bit ARM is using Flow, we are temporarily removing support while we wait for Go 1.20.2 which fixes the linker issue we're running into. 
