### PR TITLE
Temporarily remove support for 32-bit ARM builds

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -366,36 +366,6 @@ trigger:
 type: docker
 ---
 kind: pipeline
-name: Build agent (Linux armv6)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - GOOS=linux GOARCH=arm GOARM=6 make agent
-  image: grafana/agent-build-image:0.21.0
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
-name: Build agent (Linux armv7)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - GOOS=linux GOARCH=arm GOARM=7 make agent
-  image: grafana/agent-build-image:0.21.0
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
 name: Build agent (Linux ppc64le)
 platform:
   arch: amd64
@@ -501,36 +471,6 @@ trigger:
 type: docker
 ---
 kind: pipeline
-name: Build agentctl (Linux armv6)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - GOOS=linux GOARCH=arm GOARM=6 make agentctl
-  image: grafana/agent-build-image:0.21.0
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
-name: Build agentctl (Linux armv7)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - GOOS=linux GOARCH=arm GOARM=7 make agentctl
-  image: grafana/agent-build-image:0.21.0
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
 name: Build agentctl (Linux ppc64le)
 platform:
   arch: amd64
@@ -628,36 +568,6 @@ platform:
 steps:
 - commands:
   - GOOS=linux GOARCH=arm64 GOARM= make operator
-  image: grafana/agent-build-image:0.21.0
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
-name: Build operator (Linux armv6)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - GOOS=linux GOARCH=arm GOARM=6 make operator
-  image: grafana/agent-build-image:0.21.0
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
-name: Build operator (Linux armv7)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - GOOS=linux GOARCH=arm GOARM=7 make operator
   image: grafana/agent-build-image:0.21.0
   name: Build
 trigger:
@@ -1151,6 +1061,6 @@ kind: secret
 name: gpg_passphrase
 ---
 kind: signature
-hmac: 5e85b73dd2e075bffd57cf6fd5d943abcdd72356097b0e18d9a0520d733d7ea0
+hmac: d07ce3c2703871c8d97561742db55998aeba982721668616b88a9da4df8a81b8
 
 ...

--- a/.drone/pipelines/crosscompile.jsonnet
+++ b/.drone/pipelines/crosscompile.jsonnet
@@ -5,8 +5,6 @@ local os_arch_tuples = [
   // Linux
   { name: 'Linux amd64', os: 'linux', arch: 'amd64' },
   { name: 'Linux arm64', os: 'linux', arch: 'arm64' },
-  { name: 'Linux armv6', os: 'linux', arch: 'arm', arm: '6' },
-  { name: 'Linux armv7', os: 'linux', arch: 'arm', arm: '7' },
   { name: 'Linux ppc64le', os: 'linux', arch: 'ppc64le' },
 
   // Darwin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
+> **NOTE**: Builds for 32-bit ARM are unavailable as of v0.32.0 while we are
+> waiting for a Go patch release. 32-bit ARM builds will return when possible.
+>
+> 32-bit ARM users should continue to use the last minor release with 32-bit
+> ARM support (v0.31) until 32-bit ARM builds return.
+
 Main (unreleased)
 -----------------
 
@@ -14,6 +20,9 @@ v0.32.0-rc.0 (2023-02-23)
 -------------------------
 
 ### Breaking changes
+
+- Support for 32-bit ARM builds is temporarily removed while we await a Go
+  patch release to fix builds. (@rfratto)
 
 - Node Exporter configuration options changed to align with new upstream version (@Thor77):
 

--- a/Makefile
+++ b/Makefile
@@ -122,15 +122,6 @@ PROPAGATE_VARS := \
 
 GO_ENV := GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOARM) CGO_ENABLED=$(CGO_ENABLED)
 
-# Selectively pass -mlong-calls when building for 32-bit ARM targets (armv6,
-# armv7). This works around an issue where the text segment has gotten big
-# enough (>32MB) that "relocation truncated to fit" errors occur.
-ifeq ($(GOARCH),arm)
-ifeq ($(GOOS),linux)
-GO_ENV += CGO_CFLAGS="$(CGO_CFLAGS) -mlong-calls"
-endif
-endif
-
 VERSION      ?= $(shell ./tools/image-tag)
 GIT_REVISION := $(shell git rev-parse --short HEAD)
 GIT_BRANCH   := $(shell git rev-parse --abbrev-ref HEAD)

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -107,7 +107,7 @@ The Grafana Agent is also capable of exporting to any OpenTelemetry GRPC compati
 
 * Linux
   * Minimum version: kernel 2.6.32 or later
-  * Architectures: AMD64, ARM64, ARMv6, ARMv7
+  * Architectures: AMD64, ARM64
 * Windows
   * Minimum version: Windows Server 2012 or later, or Windows 10 or later.
   * Architectures: AMD64

--- a/docs/sources/set-up/_index.md
+++ b/docs/sources/set-up/_index.md
@@ -16,14 +16,14 @@ To get started with Grafana Agent Operator, refer to the Operator-specific
 
 ## Installation options
 
-Grafana Agent is currently distributed in plain binary form, Docker container images, a Windows installer, a Homebrew package, and a Kubernetes install script. 
+Grafana Agent is currently distributed in plain binary form, Docker container images, a Windows installer, a Homebrew package, and a Kubernetes install script.
 
 The following architectures receive active support.
 
- - macOS: Intel Mac or Apple Silicon 
- - Windows: A x64 machine 
- - Linux: AMD64, ARM64, ARMv6, or ARMv7 machines
- - FreeBSD: A AMD64 machine 
+ - macOS: Intel Mac or Apple Silicon
+ - Windows: A x64 machine
+ - Linux: AMD64 or ARM64 machines
+ - FreeBSD: A AMD64 machine
 
 In addition, best-effort support is provided for Linux: ppc64le.
 
@@ -32,7 +32,7 @@ Choose from the following platforms and installation options according to which 
 ### Kubernetes
 
 Deploy Kubernetes manifests from the [`kubernetes` directory](https://github.com/grafana/agent/tree/main/production/kubernetes).
-You can manually modify the Kubernetes manifests by downloading them. These manifests do not include Grafana Agent configuration files. 
+You can manually modify the Kubernetes manifests by downloading them. These manifests do not include Grafana Agent configuration files.
 
 For sample configuration files, refer to the Grafana Cloud Kubernetes quick start guide: https://grafana.com/docs/grafana-cloud/kubernetes/agent-k8s/.
 

--- a/tools/ci/docker-containers
+++ b/tools/ci/docker-containers
@@ -53,7 +53,7 @@ fi
 
 # Build all of our images.
 
-export BUILD_PLATFORMS=linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le
+export BUILD_PLATFORMS=linux/amd64,linux/arm64,linux/ppc64le
 
 
 case "$TARGET_CONTAINER" in

--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -22,8 +22,6 @@ PACKAGING_VARS = RELEASE_BUILD=1 GO_TAGS="$(GO_TAGS)" GOOS=$(GOOS) GOARCH=$(GOAR
 
 dist-agent-binaries: dist/grafana-agent-linux-amd64   \
                      dist/grafana-agent-linux-arm64   \
-                     dist/grafana-agent-linux-armv6   \
-                     dist/grafana-agent-linux-armv7   \
                      dist/grafana-agent-linux-ppc64le \
                      dist/grafana-agent-darwin-amd64  \
                      dist/grafana-agent-darwin-arm64  \
@@ -40,20 +38,6 @@ dist/grafana-agent-linux-arm64: GO_TAGS += builtinassets promtail_journal_enable
 dist/grafana-agent-linux-arm64: GOOS    := linux
 dist/grafana-agent-linux-arm64: GOARCH  := arm64
 dist/grafana-agent-linux-arm64: generate-ui
-	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
-
-dist/grafana-agent-linux-armv6: GO_TAGS += builtinassets promtail_journal_enabled
-dist/grafana-agent-linux-armv6: GOOS    := linux
-dist/grafana-agent-linux-armv6: GOARCH  := arm
-dist/grafana-agent-linux-armv6: GOARM   := 6
-dist/grafana-agent-linux-armv6: generate-ui
-	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
-
-dist/grafana-agent-linux-armv7: GO_TAGS += builtinassets promtail_journal_enabled
-dist/grafana-agent-linux-armv7: GOOS    := linux
-dist/grafana-agent-linux-armv7: GOARCH  := arm
-dist/grafana-agent-linux-armv7: GOARM   := 7
-dist/grafana-agent-linux-armv7: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
 dist/grafana-agent-linux-ppc64le: GO_TAGS += builtinassets promtail_journal_enabled
@@ -92,8 +76,6 @@ dist/grafana-agent-freebsd-amd64: generate-ui
 
 dist-agentctl-binaries: dist/grafana-agentctl-linux-amd64   \
                         dist/grafana-agentctl-linux-arm64   \
-                        dist/grafana-agentctl-linux-armv6   \
-                        dist/grafana-agentctl-linux-armv7   \
                         dist/grafana-agentctl-linux-ppc64le \
                         dist/grafana-agentctl-darwin-amd64  \
                         dist/grafana-agentctl-darwin-arm64  \
@@ -108,18 +90,6 @@ dist/grafana-agentctl-linux-amd64:
 dist/grafana-agentctl-linux-arm64: GOOS   := linux
 dist/grafana-agentctl-linux-arm64: GOARCH := arm64
 dist/grafana-agentctl-linux-arm64:
-	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
-
-dist/grafana-agentctl-linux-armv6: GOOS   := linux
-dist/grafana-agentctl-linux-armv6: GOARCH := arm
-dist/grafana-agentctl-linux-armv6: GOARM  := 6
-dist/grafana-agentctl-linux-armv6:
-	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
-
-dist/grafana-agentctl-linux-armv7: GOOS   := linux
-dist/grafana-agentctl-linux-armv7: GOARCH := arm
-dist/grafana-agentctl-linux-armv7: GOARM  := 7
-dist/grafana-agentctl-linux-armv7:
 	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
 
 dist/grafana-agentctl-linux-ppc64le: GOOS   := linux
@@ -183,8 +153,6 @@ PACKAGE_PREFIX  := dist/grafana-agent-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE)
 .PHONY: dist-packages
 dist-packages: dist-packages-amd64 \
                dist-packages-arm64 \
-               dist-packages-armv6 \
-               dist-packages-armv7 \
                dist-packages-arm64 \
                dist-packages-ppc64le
 
@@ -204,24 +172,6 @@ ifeq ($(USE_CONTAINER),1)
 else
 	$(call generate_fpm,deb,arm64,arm64,$(PACKAGE_PREFIX).arm64.deb)
 	$(call generate_fpm,rpm,aarch64,arm64,$(PACKAGE_PREFIX).arm64.rpm)
-endif
-
-# There's no RPM for armv6 so only debs are produced.
-.PHONY: dist-packages-armv6
-dist-packages-armv6: dist/grafana-agent-linux-armv6 dist/grafana-agentctl-linux-armv6
-ifeq ($(USE_CONTAINER),1)
-	$(RERUN_IN_CONTAINER)
-else
-	$(call generate_fpm,deb,armhf,armv6,$(PACKAGE_PREFIX).armv6.deb)
-endif
-
-.PHONY: dist-packages-armv7
-dist-packages-armv7: dist/grafana-agent-linux-armv7 dist/grafana-agentctl-linux-armv7
-ifeq ($(USE_CONTAINER),1)
-	$(RERUN_IN_CONTAINER)
-else
-	$(call generate_fpm,deb,armhf,armv7,$(PACKAGE_PREFIX).armv7.deb)
-	$(call generate_fpm,rpm,armhfp,armv7,$(PACKAGE_PREFIX).armv7.rpm)
 endif
 
 .PHONY: dist-packages-ppc64le


### PR DESCRIPTION
When working on the v0.32.0-rc.0 release, we noticed the 32-bit ARM builds are broken and preventing us from releasing. 

A fix for 32-bit ARM builds is pending the release of Go 1.20.2, so we have to temporarily pull support for these builds so we can continue releasing. 