### PR TITLE
fix(helm): add rbac for eventhandler

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased
 ----------
 ### Enhancements
 - Helm chart: Add support for templates inside of configMap.content (@ts-mini)
+- Add the necessary rbac to support eventhandler integration (@nvanheuverzwijn)
 
 
 0.6.0 (2023-02-13)

--- a/operations/helm/charts/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/charts/grafana-agent/templates/rbac.yaml
@@ -54,6 +54,15 @@ rules:
       - /metrics
     verbs:
       - get
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
 
 ---
 

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/rbac.yaml
@@ -59,6 +59,15 @@ rules:
       - /metrics
     verbs:
       - get
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: grafana-agent/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/rbac.yaml
@@ -59,6 +59,15 @@ rules:
       - /metrics
     verbs:
       - get
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: grafana-agent/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/rbac.yaml
@@ -59,6 +59,15 @@ rules:
       - /metrics
     verbs:
       - get
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: grafana-agent/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/operations/helm/tests/custom-config/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/rbac.yaml
@@ -59,6 +59,15 @@ rules:
       - /metrics
     verbs:
       - get
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: grafana-agent/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/operations/helm/tests/default-values/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/rbac.yaml
@@ -59,6 +59,15 @@ rules:
       - /metrics
     verbs:
       - get
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: grafana-agent/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/operations/helm/tests/existing-config/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/rbac.yaml
@@ -59,6 +59,15 @@ rules:
       - /metrics
     verbs:
       - get
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: grafana-agent/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
@@ -59,6 +59,15 @@ rules:
       - /metrics
     verbs:
       - get
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: grafana-agent/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/operations/helm/tests/faro-ingress/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/faro-ingress/grafana-agent/templates/rbac.yaml
@@ -59,6 +59,15 @@ rules:
       - /metrics
     verbs:
       - get
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: grafana-agent/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/operations/helm/tests/static-mode/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/rbac.yaml
@@ -59,6 +59,15 @@ rules:
       - /metrics
     verbs:
       - get
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: grafana-agent/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
#### PR Description
Add rbac value in order for eventhandler to read kubernets events. According to https://grafana.com/docs/agent/latest/configuration/integrations/integrations-next/eventhandler-config/, grafana-agent need to be able to read the `events` resources.
