### PR TITLE
kubetail: add a max lifetime for tailing logs from a container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Main (unreleased)
   where the Kubernetes API server stops responding with logs without closing
   the TCP connection. (@rfratto)
 
+- Flow: fix issue in `loki.source.kubernetes` where `__pod__uid__` meta label
+  defaulted incorrectly to the container name, causing tailers to never
+  restart.
+
 v0.32.0-rc.0 (2023-02-23)
 -------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Bugfixes
+
+- Flow: add a maximum connection lifetime of one hour when tailing logs from
+  `loki.source.kubernetes` and `loki.source.podlogs` to recover from an issue
+  where the Kubernetes API server stops responding with logs without closing
+  the TCP connection. (@rfratto)
+
 v0.32.0-rc.0 (2023-02-23)
 -------------------------
 

--- a/component/loki/source/kubernetes/kubetail/tailer.go
+++ b/component/loki/source/kubernetes/kubetail/tailer.go
@@ -79,7 +79,7 @@ func newLabelSet(l labels.Labels) model.LabelSet {
 }
 
 var retailBackoff = backoff.Config{
-	MinBackoff: time.Second,
+	MinBackoff: 0,
 	MaxBackoff: time.Minute,
 }
 
@@ -120,7 +120,10 @@ func (t *tailer) Run(ctx context.Context) {
 }
 
 func (t *tailer) tail(ctx context.Context, handler loki.EntryHandler) error {
-	ctx, cancel := context.WithCancel(ctx)
+	// Set a maximum lifetime of the tail to ensure that connections are
+	// reestablished. This avoids an issue where the Kubernetes API server stops
+	// responding with new logs while the connection is kept open.
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Hour)
 	defer cancel()
 
 	var (
@@ -155,6 +158,7 @@ func (t *tailer) tail(ctx context.Context, handler loki.EntryHandler) error {
 		SinceTime:  offsetTime,
 		Timestamps: true, // Should be forced to true so we can parse the original timestamp back out.
 	})
+
 	stream, err := req.Stream(ctx)
 	if err != nil {
 		return err
@@ -206,7 +210,7 @@ func (t *tailer) tail(ctx context.Context, handler loki.EntryHandler) error {
 		// until the tailer is shutdown; EOF being returned doesn't necessarily
 		// indicate that the logs are done, and could point to a brief network
 		// outage.
-		if err != nil && errors.Is(err, io.EOF) {
+		if err != nil && (errors.Is(err, io.EOF) || ctx.Err() != nil) {
 			return nil
 		} else if err != nil {
 			return err

--- a/component/loki/source/kubernetes/kubetail/tailer.go
+++ b/component/loki/source/kubernetes/kubetail/tailer.go
@@ -79,6 +79,10 @@ func newLabelSet(l labels.Labels) model.LabelSet {
 }
 
 var retailBackoff = backoff.Config{
+	// Since our tailers have a maximum lifetime and are expected to regularly
+	// terminate to refresh their connection to the Kubernetes API, the minimum
+	// backoff starts at zero so there's minimum delay between expected
+	// terminations.
 	MinBackoff: 0,
 	MaxBackoff: time.Minute,
 }

--- a/component/loki/source/kubernetes/kubetail/target.go
+++ b/component/loki/source/kubernetes/kubetail/target.go
@@ -208,7 +208,7 @@ func PrepareLabels(lset labels.Labels, defaultJob string) (res labels.Labels, er
 		lb.Set(LabelPodContainerName, podContainerName)
 	}
 	if !lset.Has(LabelPodUID) {
-		lb.Set(LabelPodUID, podContainerName)
+		lb.Set(LabelPodUID, podUID)
 	}
 
 	// Meta labels are deleted after relabelling. Other internal labels propagate


### PR DESCRIPTION
This adds a maximum lifetime (1 hour) for each tailing connection to a container. This fixes an issue where the connection between the agent, the Kubernetes API server, and the Kubelet can get disrupted without closing the TCP connection, leading to no logs being read.

This bug fix impacts `loki.source.kubernetes` and `loki.source.podlogs`, which both use the kubetail package. 

Closes #3093.