### PR TITLE
test: use `t.TempDir` to create temporary test directory

### DIFF
--- a/component/loki/source/file/file_test.go
+++ b/component/loki/source/file/file_test.go
@@ -22,9 +22,7 @@ func Test(t *testing.T) {
 	// Create opts for component
 	l, err := logging.New(os.Stderr, logging.DefaultOptions)
 	require.NoError(t, err)
-	dataPath, err := os.MkdirTemp("", "loki.source.file")
-	require.NoError(t, err)
-	defer os.RemoveAll(dataPath) // clean up
+	dataPath := t.TempDir()
 
 	opts := component.Options{Logger: l, DataPath: dataPath}
 
@@ -32,7 +30,6 @@ func Test(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer os.Remove(f.Name())
 	defer f.Close()
 
 	ch1, ch2 := make(chan loki.Entry), make(chan loki.Entry)
@@ -75,9 +72,7 @@ func TestTwoTargets(t *testing.T) {
 	// Create opts for component
 	l, err := logging.New(os.Stderr, logging.DefaultOptions)
 	require.NoError(t, err)
-	dataPath, err := os.MkdirTemp("", "loki.source.file")
-	require.NoError(t, err)
-	defer os.RemoveAll(dataPath) // clean up
+	dataPath := t.TempDir()
 
 	opts := component.Options{Logger: l, DataPath: dataPath}
 
@@ -89,8 +84,6 @@ func TestTwoTargets(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer os.Remove(f.Name())
-	defer os.Remove(f2.Name())
 	defer f.Close()
 	defer f2.Close()
 

--- a/component/loki/source/journal/journal_test.go
+++ b/component/loki/source/journal/journal_test.go
@@ -22,11 +22,7 @@ func TestJournal(t *testing.T) {
 	// Create opts for component
 	l, err := logging.New(os.Stderr, logging.DefaultOptions)
 	require.NoError(t, err)
-	tmp, err := os.MkdirTemp("", "testjrnl")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = os.RemoveAll(tmp)
-	})
+	tmp := t.TempDir()
 	lr := make(loki.LogsReceiver)
 	c, err := New(component.Options{
 		ID:         "loki.source.journal.test",

--- a/component/loki/source/windowsevent/component_test.go
+++ b/component/loki/source/windowsevent/component_test.go
@@ -25,9 +25,7 @@ func TestEventLogger(t *testing.T) {
 	require.NoError(t, err)
 	l, err := logging.New(os.Stdout, logging.DefaultOptions)
 	require.NoError(t, err)
-	dataPath, err := os.MkdirTemp("", "loki.source.windowsevent")
-	require.NoError(t, err)
-	defer os.RemoveAll(dataPath) // clean up
+	dataPath := t.TempDir()
 	rec := make(loki.LogsReceiver)
 	c, err := New(component.Options{
 		ID:       "loki.source.windowsevent.test",

--- a/component/loki/source/windowsevent/component_windows.go
+++ b/component/loki/source/windowsevent/component_windows.go
@@ -115,10 +115,11 @@ func (c *Component) Update(args component.Arguments) error {
 		if err != nil {
 			return err
 		}
-		_, err = os.Create(newArgs.BookmarkPath)
+		f, err := os.Create(newArgs.BookmarkPath)
 		if err != nil {
 			return err
 		}
+		_ = f.Close()
 	}
 
 	winTarget, err := windows.New(c.opts.Logger, c.handle, nil, convertConfig(newArgs))

--- a/pkg/agentctl/walstats_test.go
+++ b/pkg/agentctl/walstats_test.go
@@ -2,7 +2,6 @@ package agentctl
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -49,11 +48,7 @@ func TestWALStats(t *testing.T) {
 func setupTestWAL(t *testing.T) string {
 	l := log.NewNopLogger()
 
-	walDir, err := os.MkdirTemp(os.TempDir(), "wal")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(walDir)
-	})
+	walDir := t.TempDir()
 
 	reg := prometheus.NewRegistry()
 	w, err := wlog.NewSize(log.NewNopLogger(), reg, filepath.Join(walDir, "wal"), wlog.DefaultSegmentSize, true)

--- a/pkg/config/dynamicloader_configs_test.go
+++ b/pkg/config/dynamicloader_configs_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestConfigMaker(t *testing.T) {
 	configStr := `wal_directory: /tmp/wal`
-	tDir := generatePath(t)
+	tDir := t.TempDir()
 	writeFile(t, tDir, "metrics-1.yml", configStr)
 	fileFS := generateFilePath(tDir)
 	loaderCfg := LoaderConfig{
@@ -31,7 +31,7 @@ func TestConfigMaker(t *testing.T) {
 
 func TestConfigMakerWithFakeFiles(t *testing.T) {
 	configStr := `wal_directory: /tmp/wal`
-	tDir := generatePath(t)
+	tDir := t.TempDir()
 	writeFile(t, tDir, "metrics-1.yml", configStr)
 	writeFile(t, tDir, "fake.yml", configStr)
 	fileFS := generateFilePath(tDir)
@@ -48,7 +48,7 @@ func TestConfigMakerWithFakeFiles(t *testing.T) {
 
 func TestConfigMakerWithMultipleMetrics(t *testing.T) {
 	configStr := `wal_directory: /tmp/wal`
-	tDir := generatePath(t)
+	tDir := t.TempDir()
 	writeFile(t, tDir, "metrics-1.yml", configStr)
 	writeFile(t, tDir, "metrics-2.yml", configStr)
 
@@ -65,7 +65,7 @@ func TestConfigMakerWithMultipleMetrics(t *testing.T) {
 
 func TestConfigMakerWithMetricsAndInstances(t *testing.T) {
 	configStr := `wal_directory: /tmp/wal`
-	tDir := generatePath(t)
+	tDir := t.TempDir()
 	writeFile(t, tDir, "metrics-1.yml", configStr)
 	writeFile(t, tDir, "metrics_instances-1.yml", "name: t1")
 	writeFile(t, tDir, "metrics_instances-2.yml", "name: t2")
@@ -91,7 +91,7 @@ func TestConfigMakerWithExporter(t *testing.T) {
 windows:
   enabled_collectors: one,two,three
 `
-	tDir := generatePath(t)
+	tDir := t.TempDir()
 	writeFile(t, tDir, "integrations-1.yml", configStr)
 	fileFS := generateFilePath(tDir)
 
@@ -116,7 +116,7 @@ node_exporter:
   autoscrape:
     enable: false
 `
-	tDir := generatePath(t)
+	tDir := t.TempDir()
 	writeFile(t, tDir, "integrations-1.yml", configStr)
 	fileFS := generateFilePath(tDir)
 
@@ -176,7 +176,7 @@ redis_configs:
       replacement: "apple"
 - redis_addr: localhost:6380
 `
-	tDir := generatePath(t)
+	tDir := t.TempDir()
 	writeFile(t, tDir, "integrations-1.yml", configStr)
 	fileFS := generateFilePath(tDir)
 
@@ -208,7 +208,7 @@ integrations:
 	addIntegration := `
 windows: {}
 `
-	tDir := generatePath(t)
+	tDir := t.TempDir()
 	writeFile(t, tDir, "agent-1.yml", configStr)
 	writeFile(t, tDir, "integrations-windows.yml", addIntegration)
 	fileFS := generateFilePath(tDir)
@@ -285,7 +285,7 @@ configs:
         source: filename
         expression: '\\temp\\Logs\\(?P<log_app>.+?)\\'
 `
-	tDir := generatePath(t)
+	tDir := t.TempDir()
 	writeFile(t, tDir, "a-1.yml", agentStr)
 	writeFile(t, tDir, "s-1.yml", serverStr)
 	writeFile(t, tDir, "m-1.yml", metricsStr)

--- a/pkg/config/dynamicloader_template_test.go
+++ b/pkg/config/dynamicloader_template_test.go
@@ -30,7 +30,7 @@ windows:
   enabled_collectors: {{ (datasource "vars").value }}
   instance: testinstance
 `
-	tDir := generatePath(t)
+	tDir := t.TempDir()
 	writeFile(t, tDir, "vars.yaml", "value: banana")
 	writeFile(t, tDir, "integrations-1.yml", configStr)
 	fileFS := generateFilePath(tDir)
@@ -56,7 +56,7 @@ windows:
   enabled_collectors: {{ (datasource "vars").value }}
   instance: testinstance
 `
-	tDir := generatePath(t)
+	tDir := t.TempDir()
 	writeFile(t, tDir, "vars.yaml", "value: banana")
 	u := pushFilesToFakeS3(t, "integrations-1.yml", configStr)
 	s3Url := "s3://mybucket/?region=us-east-1&disableSSL=true&s3ForcePathStyle=true&endpoint=" + u.Host
@@ -88,7 +88,7 @@ windows:
       replacement: "{{ . }}-value"
     {{ end }}
 `
-	tDir := generatePath(t)
+	tDir := t.TempDir()
 	writeFile(t, tDir, "vars.yaml", "value: [banana,apple,pear]")
 	u := pushFilesToFakeS3(t, "integrations-1.yml", configStr)
 
@@ -140,13 +140,6 @@ func generateFilePath(directory string) string {
 		return fmt.Sprintf("file:///%s", directory)
 	}
 	return fmt.Sprintf("file://%s", directory)
-}
-
-func generatePath(t *testing.T) string {
-	tDir, err := os.MkdirTemp("", "*-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(tDir) })
-	return tDir
 }
 
 func pushFilesToFakeS3(t *testing.T, filename string, filecontents string) *url.URL {

--- a/pkg/logs/logs_test.go
+++ b/pkg/logs/logs_test.go
@@ -35,11 +35,7 @@ func TestLogs(t *testing.T) {
 	//
 	// Create a temporary file to tail
 	//
-	positionsDir, err := os.MkdirTemp(os.TempDir(), "positions-*")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = os.RemoveAll(positionsDir)
-	})
+	positionsDir := t.TempDir()
 
 	tmpFile, err := os.CreateTemp(os.TempDir(), "*.log")
 	require.NoError(t, err)
@@ -176,11 +172,7 @@ func TestLogs_PositionsDirectory(t *testing.T) {
 	//
 	// Create a temporary file to tail
 	//
-	positionsDir, err := os.MkdirTemp(os.TempDir(), "positions-*")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = os.RemoveAll(positionsDir)
-	})
+	positionsDir := t.TempDir()
 
 	//
 	// Launch Loki so it starts tailing the file and writes to our server.

--- a/pkg/metrics/cleaner_test.go
+++ b/pkg/metrics/cleaner_test.go
@@ -29,12 +29,10 @@ func TestWALCleaner_getAllStorageNoRoot(t *testing.T) {
 }
 
 func TestWALCleaner_getAllStorageSuccess(t *testing.T) {
-	walRoot, err := os.MkdirTemp(os.TempDir(), "getAllStorageSuccess")
-	require.NoError(t, err)
-	defer os.RemoveAll(walRoot)
+	walRoot := t.TempDir()
 
 	walDir := filepath.Join(walRoot, "instance-1")
-	err = os.MkdirAll(walDir, 0755)
+	err := os.MkdirAll(walDir, 0755)
 	require.NoError(t, err)
 
 	logger := log.NewLogfmtLogger(os.Stderr)
@@ -51,12 +49,10 @@ func TestWALCleaner_getAllStorageSuccess(t *testing.T) {
 }
 
 func TestWALCleaner_getAbandonedStorageBeforeCutoff(t *testing.T) {
-	walRoot, err := os.MkdirTemp(os.TempDir(), "getAbandonedStorageBeforeCutoff")
-	require.NoError(t, err)
-	defer os.RemoveAll(walRoot)
+	walRoot := t.TempDir()
 
 	walDir := filepath.Join(walRoot, "instance-1")
-	err = os.MkdirAll(walDir, 0755)
+	err := os.MkdirAll(walDir, 0755)
 	require.NoError(t, err)
 
 	all := []string{walDir}
@@ -84,12 +80,10 @@ func TestWALCleaner_getAbandonedStorageBeforeCutoff(t *testing.T) {
 }
 
 func TestWALCleaner_getAbandonedStorageAfterCutoff(t *testing.T) {
-	walRoot, err := os.MkdirTemp(os.TempDir(), "getAbandonedStorageAfterCutoff")
-	require.NoError(t, err)
-	defer os.RemoveAll(walRoot)
+	walRoot := t.TempDir()
 
 	walDir := filepath.Join(walRoot, "instance-1")
-	err = os.MkdirAll(walDir, 0755)
+	err := os.MkdirAll(walDir, 0755)
 	require.NoError(t, err)
 
 	all := []string{walDir}
@@ -117,12 +111,10 @@ func TestWALCleaner_getAbandonedStorageAfterCutoff(t *testing.T) {
 }
 
 func TestWALCleaner_cleanup(t *testing.T) {
-	walRoot, err := os.MkdirTemp(os.TempDir(), "cleanup")
-	require.NoError(t, err)
-	defer os.RemoveAll(walRoot)
+	walRoot := t.TempDir()
 
 	walDir := filepath.Join(walRoot, "instance-1")
-	err = os.MkdirAll(walDir, 0755)
+	err := os.MkdirAll(walDir, 0755)
 	require.NoError(t, err)
 
 	now := time.Now()

--- a/pkg/metrics/instance/instance_integration_test.go
+++ b/pkg/metrics/instance/instance_integration_test.go
@@ -30,9 +30,7 @@ import (
 func TestInstance_Update(t *testing.T) {
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 
-	walDir, err := os.MkdirTemp(os.TempDir(), "wal")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(walDir) })
+	walDir := t.TempDir()
 
 	var (
 		scraped = atomic.NewBool(false)
@@ -106,9 +104,7 @@ remote_write:
 func TestInstance_Update_Failed(t *testing.T) {
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 
-	walDir, err := os.MkdirTemp(os.TempDir(), "wal")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(walDir) })
+	walDir := t.TempDir()
 
 	r := mux.NewRouter()
 	r.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
@@ -173,9 +169,7 @@ remote_write:
 func TestInstance_Update_InvalidChanges(t *testing.T) {
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 
-	walDir, err := os.MkdirTemp(os.TempDir(), "wal")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(walDir) })
+	walDir := t.TempDir()
 
 	// Create a new instance where it's not scraping or writing anything by default.
 	initialConfig := loadConfig(t, `

--- a/pkg/metrics/instance/instance_test.go
+++ b/pkg/metrics/instance/instance_test.go
@@ -189,9 +189,7 @@ func TestInstance_Path(t *testing.T) {
 	scrapeAddr, closeSrv := getTestServer(t)
 	defer closeSrv()
 
-	walDir, err := os.MkdirTemp(os.TempDir(), "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	globalConfig := getTestGlobalConfig(t)
 
@@ -218,9 +216,7 @@ func TestInstance(t *testing.T) {
 	scrapeAddr, closeSrv := getTestServer(t)
 	defer closeSrv()
 
-	walDir, err := os.MkdirTemp(os.TempDir(), "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	globalConfig := getTestGlobalConfig(t)
 	cfg := getTestConfig(t, &globalConfig, scrapeAddr)
@@ -252,9 +248,7 @@ func TestInstance_Recreate(t *testing.T) {
 	scrapeAddr, closeSrv := getTestServer(t)
 	defer closeSrv()
 
-	walDir, err := os.MkdirTemp(os.TempDir(), "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	globalConfig := getTestGlobalConfig(t)
 

--- a/pkg/metrics/wal/wal_test.go
+++ b/pkg/metrics/wal/wal_test.go
@@ -3,7 +3,6 @@ package wal
 import (
 	"context"
 	"math"
-	"os"
 	"sort"
 	"testing"
 	"time"
@@ -21,9 +20,7 @@ import (
 )
 
 func TestStorage_InvalidSeries(t *testing.T) {
-	walDir, err := os.MkdirTemp(os.TempDir(), "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
 	require.NoError(t, err)
@@ -63,9 +60,7 @@ func TestStorage_InvalidSeries(t *testing.T) {
 }
 
 func TestStorage(t *testing.T) {
-	walDir, err := os.MkdirTemp(os.TempDir(), "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
 	require.NoError(t, err)
@@ -105,9 +100,7 @@ func TestStorage(t *testing.T) {
 }
 
 func TestStorage_DuplicateExemplarsIgnored(t *testing.T) {
-	walDir, err := os.MkdirTemp(os.TempDir(), "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
 	require.NoError(t, err)
@@ -146,9 +139,7 @@ func TestStorage_DuplicateExemplarsIgnored(t *testing.T) {
 }
 
 func TestStorage_ExistingWAL(t *testing.T) {
-	walDir, err := os.MkdirTemp(os.TempDir(), "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
 	require.NoError(t, err)
@@ -213,9 +204,7 @@ func TestStorage_ExistingWAL(t *testing.T) {
 func TestStorage_ExistingWAL_RefID(t *testing.T) {
 	l := util.TestLogger(t)
 
-	walDir, err := os.MkdirTemp(os.TempDir(), "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	s, err := NewStorage(l, nil, walDir)
 	require.NoError(t, err)
@@ -246,9 +235,7 @@ func TestStorage_Truncate(t *testing.T) {
 	// after writing all the data, forcefully create 4 more segments,
 	// then do a truncate of a timestamp for _some_ of the data.
 	// then read data back in. Expect to only get the latter half of data.
-	walDir, err := os.MkdirTemp(os.TempDir(), "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
 	require.NoError(t, err)
@@ -308,9 +295,7 @@ func TestStorage_Truncate(t *testing.T) {
 }
 
 func TestStorage_WriteStalenessMarkers(t *testing.T) {
-	walDir, err := os.MkdirTemp(os.TempDir(), "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
 	require.NoError(t, err)
@@ -362,9 +347,7 @@ func TestStorage_WriteStalenessMarkers(t *testing.T) {
 }
 
 func TestStorage_TruncateAfterClose(t *testing.T) {
-	walDir, err := os.MkdirTemp(os.TempDir(), "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
 	require.NoError(t, err)
@@ -374,8 +357,7 @@ func TestStorage_TruncateAfterClose(t *testing.T) {
 }
 
 func TestGlobalReferenceID_Normal(t *testing.T) {
-	walDir, _ := os.MkdirTemp(os.TempDir(), "wal")
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	s, _ := NewStorage(log.NewNopLogger(), nil, walDir)
 	defer s.Close()
@@ -402,8 +384,7 @@ func TestGlobalReferenceID_Normal(t *testing.T) {
 }
 
 func BenchmarkAppendExemplar(b *testing.B) {
-	walDir, _ := os.MkdirTemp(os.TempDir(), "wal")
-	defer os.RemoveAll(walDir)
+	walDir := b.TempDir()
 
 	s, _ := NewStorage(log.NewNopLogger(), nil, walDir)
 	defer s.Close()

--- a/pkg/metrics/wal/wal_test.go
+++ b/pkg/metrics/wal/wal_test.go
@@ -104,6 +104,9 @@ func TestStorage_DuplicateExemplarsIgnored(t *testing.T) {
 
 	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
 	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, s.Close())
+	}()
 
 	app := s.Appender(context.Background())
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `t.TempDir` function from the `testing` package to create temporary directory. The directory created by `t.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [x] Tests updated
