### PR TITLE
helm: respect .image.pullPolicy from values

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -10,8 +10,15 @@ internal API changes are not present.
 Unreleased
 ----------
 
+0.7.1 (2023-02-24)
+------------------
+
+### Bugfixes
+
+- Fix issue where `.image.pullPolicy` was not being respected. (@rfratto)
+
 0.7.0 (2023-02-24)
-----------
+------------------
 
 ### Enhancements
 

--- a/operations/helm/charts/grafana-agent/Chart.yaml
+++ b/operations/helm/charts/grafana-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: grafana-agent
 description: 'Grafana Agent'
 type: application
-version: 0.7.0
+version: 0.7.1
 appVersion: 'v0.31.3'

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -1,6 +1,6 @@
 # Grafana Agent Helm chart
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![AppVersion: v0.31.3](https://img.shields.io/badge/AppVersion-v0.31.3-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![AppVersion: v0.31.3](https://img.shields.io/badge/AppVersion-v0.31.3-informational?style=flat-square)
 
 Helm chart for deploying [Grafana Agent][] to Kubernetes.
 
@@ -130,10 +130,13 @@ the agent is deployed in.
 
 ### Versions >= 0.31.x
 
-The recommended way for collecting container logs on Kubernetes is to make use of
-the [loki.source.kubernetes][] component introduced in 0.31.0. This component
+The [loki.source.kubernetes][] component introduced in 0.31.0 may be used to
+collect logs as an alternative to tailing files from the host. This component
 does not require mounting the hosts filesystem into the Agent, nor requires
 additional security contexts to work correctly.
+
+However, `loki.source.kubernetes` is experimental and may have issues not
+present in the file-based approach.
 
 [loki.source.kubernetes]: https://grafana.com/docs/agent/latest/flow/reference/components/loki.source.kubernetes/
 

--- a/operations/helm/charts/grafana-agent/README.md.gotmpl
+++ b/operations/helm/charts/grafana-agent/README.md.gotmpl
@@ -74,21 +74,24 @@ components like [discovery.kubernetes][] to work properly.
 ## Collecting logs from other containers
 
 There are two ways to collect logs from other containers within the cluster
-the agent is deployed in. 
+the agent is deployed in.
 
 ### Versions >= 0.31.x
 
-The recommended way for collecting container logs on Kubernetes is to make use of 
-the [loki.source.kubernetes][] component introduced in 0.31.0. This component 
+The [loki.source.kubernetes][] component introduced in 0.31.0 may be used to
+collect logs as an alternative to tailing files from the host. This component
 does not require mounting the hosts filesystem into the Agent, nor requires
 additional security contexts to work correctly.
+
+However, `loki.source.kubernetes` is experimental and may have issues not
+present in the file-based approach.
 
 [loki.source.kubernetes]: https://grafana.com/docs/agent/latest/flow/reference/components/loki.source.kubernetes/
 
 ### Versions < 0.31.x
 
-For those running the Agent on versions prior to 0.31.0, the only way to collect logs 
-from other containers is to mount `/var/lib/docker/containers` from the host and read 
+For those running the Agent on versions prior to 0.31.0, the only way to collect logs
+from other containers is to mount `/var/lib/docker/containers` from the host and read
 the log files directly.
 
 This capability is disabled by default.

--- a/operations/helm/charts/grafana-agent/templates/containers/_agent.yaml
+++ b/operations/helm/charts/grafana-agent/templates/containers/_agent.yaml
@@ -1,6 +1,7 @@
 {{- define "grafana-agent.container" -}}
 - name: grafana-agent
   image: {{ .Values.image.repository }}:{{ include "grafana-agent.imageTag" . }}
+  imagePullPolicy: {{ .Values.image.pullPolicy }}
   args:
     {{- if eq .Values.agent.mode "flow"}}
     - run

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"
@@ -26,6 +26,7 @@ spec:
       containers:
           - name: grafana-agent
             image: grafana/agent:v0.31.3
+            imagePullPolicy: IfNotPresent
             args:
               - run
               - /etc/agent/config.river

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"
@@ -75,7 +75,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"
@@ -27,6 +27,7 @@ spec:
       containers:
           - name: grafana-agent
             image: grafana/agent:v0.31.3
+            imagePullPolicy: IfNotPresent
             args:
               - run
               - /etc/agent/config.river

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"
@@ -75,7 +75,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"
@@ -28,6 +28,7 @@ spec:
       containers:
           - name: grafana-agent
             image: grafana/agent:v0.31.3
+            imagePullPolicy: IfNotPresent
             args:
               - run
               - /etc/agent/config.river

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"
@@ -75,7 +75,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/custom-config/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"
@@ -26,6 +26,7 @@ spec:
       containers:
           - name: grafana-agent
             image: grafana/agent:v0.31.3
+            imagePullPolicy: IfNotPresent
             args:
               - run
               - /etc/agent/config.river

--- a/operations/helm/tests/custom-config/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"
@@ -75,7 +75,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/custom-config/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/custom-config/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/default-values/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"
@@ -26,6 +26,7 @@ spec:
       containers:
           - name: grafana-agent
             image: grafana/agent:v0.31.3
+            imagePullPolicy: IfNotPresent
             args:
               - run
               - /etc/agent/config.river

--- a/operations/helm/tests/default-values/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"
@@ -75,7 +75,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/default-values/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/default-values/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"
@@ -26,6 +26,7 @@ spec:
       containers:
           - name: grafana-agent
             image: grafana/agent:v0.31.3
+            imagePullPolicy: IfNotPresent
             args:
               - run
               - /etc/agent/my-config.river

--- a/operations/helm/tests/existing-config/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"
@@ -75,7 +75,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"
@@ -26,6 +26,7 @@ spec:
       containers:
           - name: grafana-agent
             image: grafana/agent:v0.31.3
+            imagePullPolicy: IfNotPresent
             args:
               - run
               - /etc/agent/config.river

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"
@@ -75,7 +75,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/faro-ingress/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/faro-ingress/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/faro-ingress/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/faro-ingress/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"
@@ -26,6 +26,7 @@ spec:
       containers:
           - name: grafana-agent
             image: grafana/agent:v0.31.3
+            imagePullPolicy: IfNotPresent
             args:
               - run
               - /etc/agent/config.river

--- a/operations/helm/tests/faro-ingress/grafana-agent/templates/ingress.yaml
+++ b/operations/helm/tests/faro-ingress/grafana-agent/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-agent
   namespace: default
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/faro-ingress/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/faro-ingress/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"
@@ -75,7 +75,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/faro-ingress/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/faro-ingress/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/faro-ingress/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/faro-ingress/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"
@@ -26,6 +26,7 @@ spec:
       containers:
           - name: grafana-agent
             image: grafana/agent:v0.31.3
+            imagePullPolicy: IfNotPresent
             args:
               - -config.file=/etc/agent/config.yaml
               - -server.http.address=0.0.0.0:80

--- a/operations/helm/tests/static-mode/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"
@@ -75,7 +75,7 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"

--- a/operations/helm/tests/static-mode/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.7.0
+    helm.sh/chart: grafana-agent-0.7.1
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
     app.kubernetes.io/version: "v0.31.3"


### PR DESCRIPTION
The `.image.pullPolicy` value was not being respected. 

I've also changed the documentation to no longer recommended `loki.source.kubernetes`, given the issues discovered in #3093.