### PR TITLE
Add clarification in PR template about closing issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,9 @@ contributors around things like how to update the changelog.
 
 #### Which issue(s) this PR fixes
 
+<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
+<!-- Fixes #issue_id -->
+
 #### Notes to the Reviewer
 
 #### PR Checklist


### PR DESCRIPTION
Many contributors (specially new ones) only add the issue id in `Which issue(s) this PR fixes`
and hoping that this will be close automatically. Hopefully, with this comment contributors will be
aware that they need to add Close or Fixes before the issue id.