### PR TITLE
modules: Initial support for loading subgraphs.

### DIFF
--- a/cmd/grafana-agent/flow_run.go
+++ b/cmd/grafana-agent/flow_run.go
@@ -151,7 +151,7 @@ func (fr *flowRun) Run(configFile string) error {
 		if err != nil {
 			return fmt.Errorf("reading config file %q: %w", configFile, err)
 		}
-		if err := f.LoadFile(flowCfg); err != nil {
+		if err := f.LoadFile(flowCfg, configFile); err != nil {
 			return fmt.Errorf("error during the initial gragent load: %w", err)
 		}
 

--- a/cmd/grafana-agent/flow_run.go
+++ b/cmd/grafana-agent/flow_run.go
@@ -287,7 +287,7 @@ func getEnabledComponentsFunc(f *flow.Flow) func() map[string]interface{} {
 	}
 }
 
-func loadFlowFile(filename string) (*flow.File, error) {
+func loadFlowFile(filename string) ([]byte, error) {
 	bb, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
@@ -295,7 +295,7 @@ func loadFlowFile(filename string) (*flow.File, error) {
 
 	instrumentation.InstrumentConfig(bb)
 
-	return flow.ReadFile(filename, bb)
+	return bb, nil
 }
 
 func interruptContext() (context.Context, context.CancelFunc) {

--- a/component/component.go
+++ b/component/component.go
@@ -128,6 +128,8 @@ type HTTPComponent interface {
 
 // SubgraphOwner is the component calling the SubgraphHandler.
 type SubgraphOwner interface {
+	// ID is the concatenated IDs of the owner, "module.string.mod1"
 	ID() string
+	// IDs is the separated IDs of the owner, []string{"module","string","mod1"}
 	IDs() []string
 }

--- a/component/component.go
+++ b/component/component.go
@@ -125,3 +125,9 @@ type HTTPComponent interface {
 	// will receive a request to just `/metrics`.
 	Handler() http.Handler
 }
+
+// SubgraphOwner is the component calling the SubgraphHandler.
+type SubgraphOwner interface {
+	ID() string
+	IDs() []string
+}

--- a/component/loki/source/file/file_test.go
+++ b/component/loki/source/file/file_test.go
@@ -84,8 +84,11 @@ func TestTwoTargets(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	defer f.Close()
+	defer os.Remove(f.Name())
 	defer f2.Close()
+	defer os.Remove(f2.Name())
 
 	ch1 := make(chan loki.Entry)
 	args := Arguments{}

--- a/component/registry.go
+++ b/component/registry.go
@@ -77,6 +77,7 @@ type Options struct {
 // subgraphs. Modules are the most common use case of this system.
 type SubgraphHandler interface {
 	LoadSubgraph(parent SubgraphOwner, config []byte) ([]Component, diag.Diagnostics, error)
+	UnloadSubgraph(parent SubgraphOwner) error
 }
 
 // Registration describes a single component.

--- a/component/registry.go
+++ b/component/registry.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/agent/pkg/river/diag"
 	"github.com/grafana/regexp"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/trace"
@@ -67,6 +68,15 @@ type Options struct {
 	// HTTPPath is the base path that requests need in order to route to this component.
 	// Requests received by a component handler will have this already trimmed off.
 	HTTPPath string
+
+	// Subgraph allows a component to load components dynamically and should be treated with extreme care.
+	Subgraph SubgraphHandler
+}
+
+// SubgraphHandler allows the creation of subgraphs, it is used by components that need to instantiate
+// subgraphs. Modules are the most common use case of this system.
+type SubgraphHandler interface {
+	LoadSubgraph(parent SubgraphOwner, config []byte) ([]Component, diag.Diagnostics, error)
 }
 
 // Registration describes a single component.

--- a/pkg/flow/flow.go
+++ b/pkg/flow/flow.go
@@ -158,11 +158,11 @@ func newFlow(o Options) (*Flow, context.Context) {
 //
 // The controller will only start running components after Load is called once
 // without any configuration errors.
-func (c *Flow) LoadFile(config []byte) error {
+func (c *Flow) LoadFile(config []byte, filename string) error {
 	c.loadMut.Lock()
 	defer c.loadMut.Unlock()
 
-	_, diags, err := c.graph.loadInitialSubgraph(c, config)
+	_, diags, err := c.graph.loadInitialSubgraph(c, config, filename)
 	if err != nil {
 		return err
 	}

--- a/pkg/flow/flow.go
+++ b/pkg/flow/flow.go
@@ -52,7 +52,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/pkg/flow/internal/controller"
 	"github.com/grafana/agent/pkg/flow/internal/dag"
 	"github.com/grafana/agent/pkg/flow/logging"
@@ -97,30 +96,12 @@ type Flow struct {
 	cancel     context.CancelFunc
 }
 
-// Run starts the component, blocking until ctx is canceled or the component
-// suffers a fatal error. Run is guaranteed to be called exactly once per
-// Component.
-//
-// Implementations of Component should perform any necessary cleanup before
-// returning from Run.
-func (f *Flow) Run(_ context.Context) error {
-	panic("not implemented") // TODO: Implement
-}
-
-// Update provides a new Config to the component. The type of newConfig will
-// always match the struct type which the component registers.
-//
-// Update will be called concurrently with Run. The component must be able to
-// gracefully handle updating its config will still running.
-//
-// An error may be returned if the provided config is invalid.
-func (f *Flow) Update(_ component.Arguments) error {
-	// This is a noop since this is the top level component.
-	return nil
-}
+// ID is necessary for calling the subgraph
 func (f *Flow) ID() string {
 	return ""
 }
+
+// IDs is necessary for calling the subgraph
 func (f *Flow) IDs() []string {
 	return []string{}
 }

--- a/pkg/flow/flow_http.go
+++ b/pkg/flow/flow_http.go
@@ -22,7 +22,7 @@ func (f *Flow) ComponentHandler() http.HandlerFunc {
 
 		// find node with ID
 		var node *controller.ComponentNode
-		for _, n := range f.loader.Components() {
+		for _, n := range f.graph.loader.Components() {
 			if n.ID().String() == id {
 				node = n
 				break
@@ -50,8 +50,8 @@ func (f *Flow) ComponentJSON(w io.Writer, ci *ComponentInfo) error {
 	defer f.loadMut.RUnlock()
 
 	var foundComponent *controller.ComponentNode
-	for _, c := range f.loader.Components() {
-		if c.ID().String() == ci.ID {
+	for _, c := range f.graph.loader.Components() {
+		if c.NamespaceID() == ci.ID {
 			foundComponent = c
 			break
 		}

--- a/pkg/flow/flow_test.go
+++ b/pkg/flow/flow_test.go
@@ -35,7 +35,7 @@ var testFile = `
 func TestController_LoadFile_Evaluation(t *testing.T) {
 	ctrl, _ := newFlow(testOptions(t))
 
-	err := ctrl.LoadFile([]byte(testFile))
+	err := ctrl.LoadFile([]byte(testFile), "")
 	require.NoError(t, err)
 	require.Len(t, ctrl.graph.Components(), 4)
 

--- a/pkg/flow/internal/controller/component.go
+++ b/pkg/flow/internal/controller/component.go
@@ -87,9 +87,8 @@ type ComponentNode struct {
 	mut     sync.RWMutex
 	block   *ast.BlockStmt // Current River block to derive args from
 	eval    *vm.Evaluator
-	managed component.Component     // Inner managed component
-	args    component.Arguments     // Evaluated arguments for the managed component
-	parent  component.SubgraphOwner // ComponentNode might have a parent node, for instance modules
+	managed component.Component // Inner managed component
+	args    component.Arguments // Evaluated arguments for the managed component
 
 	doingEval atomic.Bool
 
@@ -144,7 +143,6 @@ func NewComponentNode(delegate component.SubgraphHandler, parent component.Subgr
 		reg:               reg,
 		exportsType:       getExportsType(reg),
 		onExportsChange:   globals.OnExportsChange,
-		parent:            parent,
 
 		block: b,
 		eval:  vm.New(b.Body),

--- a/pkg/flow/internal/controller/component.go
+++ b/pkg/flow/internal/controller/component.go
@@ -29,7 +29,7 @@ type ComponentID []string
 
 // BlockComponentID returns the ComponentID specified by an River block.
 func BlockComponentID(b *ast.BlockStmt) ComponentID {
-	id := make(ComponentID, 0, len(b.Name)+1) // add 1 for the optional label
+	id := make(ComponentID, 0)
 	id = append(id, b.Name...)
 	if b.Label != "" {
 		id = append(id, b.Label)
@@ -72,21 +72,24 @@ type ComponentGlobals struct {
 // arguments and exports. ComponentNode manages the arguments for the component
 // from a River block.
 type ComponentNode struct {
-	id              ComponentID
-	label           string
-	componentName   string
-	nodeID          string // Cached from id.String() to avoid allocating new strings every time NodeID is called.
-	reg             component.Registration
-	managedOpts     component.Options
-	register        *wrappedRegisterer
-	exportsType     reflect.Type
-	onExportsChange func(cn *ComponentNode) // Informs controller that we changed our exports
+	id                ComponentID
+	label             string
+	componentName     string
+	nodeID            string // Cached from id.String() to avoid allocating new strings every time NodeID is called.
+	namespaceID       ComponentID
+	namespaceCachedID string
+	reg               component.Registration
+	managedOpts       component.Options
+	register          *wrappedRegisterer
+	exportsType       reflect.Type
+	onExportsChange   func(cn *ComponentNode) // Informs controller that we changed our exports
 
 	mut     sync.RWMutex
 	block   *ast.BlockStmt // Current River block to derive args from
 	eval    *vm.Evaluator
-	managed component.Component // Inner managed component
-	args    component.Arguments // Evaluated arguments for the managed component
+	managed component.Component     // Inner managed component
+	args    component.Arguments     // Evaluated arguments for the managed component
+	parent  component.SubgraphOwner // ComponentNode might have a parent node, for instance modules
 
 	doingEval atomic.Bool
 
@@ -106,11 +109,16 @@ var _ dag.Node = (*ComponentNode)(nil)
 
 // NewComponentNode creates a new ComponentNode from an initial ast.BlockStmt.
 // The underlying managed component isn't created until Evaluate is called.
-func NewComponentNode(globals ComponentGlobals, b *ast.BlockStmt) *ComponentNode {
+func NewComponentNode(delegate component.SubgraphHandler, parent component.SubgraphOwner, globals ComponentGlobals, b *ast.BlockStmt) *ComponentNode {
 	var (
-		id     = BlockComponentID(b)
-		nodeID = id.String()
+		id          = BlockComponentID(b)
+		nodeID      = id.String()
+		namespaceID = make([]string, 0)
 	)
+	if parent != nil {
+		namespaceID = append(namespaceID, parent.IDs()...)
+	}
+	namespaceID = append(namespaceID, id...)
 
 	reg, ok := component.Get(ComponentID(b.Name).String())
 	if !ok {
@@ -127,13 +135,16 @@ func NewComponentNode(globals ComponentGlobals, b *ast.BlockStmt) *ComponentNode
 	}
 
 	cn := &ComponentNode{
-		id:              id,
-		label:           b.Label,
-		nodeID:          nodeID,
-		componentName:   strings.Join(b.Name, "."),
-		reg:             reg,
-		exportsType:     getExportsType(reg),
-		onExportsChange: globals.OnExportsChange,
+		id:                id,
+		label:             b.Label,
+		nodeID:            nodeID,
+		namespaceID:       namespaceID,
+		namespaceCachedID: strings.Join(namespaceID, "."),
+		componentName:     strings.Join(b.Name, "."),
+		reg:               reg,
+		exportsType:       getExportsType(reg),
+		onExportsChange:   globals.OnExportsChange,
+		parent:            parent,
 
 		block: b,
 		eval:  vm.New(b.Body),
@@ -145,25 +156,26 @@ func NewComponentNode(globals ComponentGlobals, b *ast.BlockStmt) *ComponentNode
 		evalHealth: initHealth,
 		runHealth:  initHealth,
 	}
-	cn.managedOpts = getManagedOptions(globals, cn)
+	cn.managedOpts = getManagedOptions(globals, cn, delegate)
 
 	return cn
 }
 
-func getManagedOptions(globals ComponentGlobals, cn *ComponentNode) component.Options {
+func getManagedOptions(globals ComponentGlobals, cn *ComponentNode, delegate component.SubgraphHandler) component.Options {
 	wrapped := newWrappedRegisterer()
 	cn.register = wrapped
 	return component.Options{
 		ID:            cn.nodeID,
-		Logger:        log.With(globals.Logger, "component", cn.nodeID),
-		DataPath:      filepath.Join(globals.DataPath, cn.nodeID),
+		Logger:        log.With(globals.Logger, "component", cn.namespaceCachedID),
+		DataPath:      filepath.Join(globals.DataPath, cn.namespaceCachedID),
 		OnStateChange: cn.setExports,
 		Registerer: prometheus.WrapRegistererWith(prometheus.Labels{
-			"component_id": cn.nodeID,
+			"component_id": cn.namespaceCachedID,
 		}, wrapped),
-		Tracer:         wrapTracer(globals.TraceProvider, cn.nodeID),
+		Tracer:         WrapTracer(globals.TraceProvider, cn.namespaceCachedID),
 		HTTPListenAddr: globals.HTTPListenAddr,
-		HTTPPath:       fmt.Sprintf("/component/%s/", cn.nodeID),
+		HTTPPath:       fmt.Sprintf("/component/%s/", cn.namespaceCachedID),
+		Subgraph:       delegate,
 	}
 }
 
@@ -176,6 +188,9 @@ func getExportsType(reg component.Registration) reflect.Type {
 
 // ID returns the component ID of the managed component from its River block.
 func (cn *ComponentNode) ID() ComponentID { return cn.id }
+
+// NamespaceID returns the fully pathed name of the component.
+func (cn *ComponentNode) NamespaceID() string { return cn.namespaceCachedID }
 
 // Label returns the label for the block or "" if none was specified.
 func (cn *ComponentNode) Label() string { return cn.label }

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -319,7 +319,7 @@ func (l *Loader) EvaluateDependencies(parentScope *vm.Scope, c *ComponentNode) {
 		span.SetStatus(codes.Ok, "")
 
 		duration := time.Since(start)
-		_ = level.Info(logger).Log("msg", "finished partial graph evaluation", "duration", duration)
+		level.Info(logger).Log("msg", "finished partial graph evaluation", "duration", duration)
 		l.cm.componentEvaluationTime.Observe(duration.Seconds())
 	}()
 

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -35,12 +35,12 @@ type Loader struct {
 	components    []*ComponentNode
 	cache         *valueCache
 	blocks        []*ast.BlockStmt // Most recently loaded blocks, used for writing
-	cm            *controllerMetrics
+	cm            *ControllerMetrics
 }
 
 // NewLoader creates a new Loader. Components built by the Loader will be built
 // with co for their options.
-func NewLoader(globals ComponentGlobals) *Loader {
+func NewLoader(globals ComponentGlobals, cm *ControllerMetrics) *Loader {
 	l := &Loader{
 		log:     globals.Logger,
 		tracer:  globals.TraceProvider,
@@ -49,11 +49,7 @@ func NewLoader(globals ComponentGlobals) *Loader {
 		graph:         &dag.Graph{},
 		originalGraph: &dag.Graph{},
 		cache:         newValueCache(),
-		cm:            newControllerMetrics(globals.Registerer),
-	}
-	cc := newControllerCollector(l)
-	if globals.Registerer != nil {
-		globals.Registerer.MustRegister(cc)
+		cm:            cm,
 	}
 	return l
 }
@@ -70,7 +66,7 @@ func NewLoader(globals ComponentGlobals) *Loader {
 // The provided parentContext can be used to provide global variables and
 // functions to components. A child context will be constructed from the parent
 // to expose values of other components.
-func (l *Loader) Apply(parentScope *vm.Scope, blocks []*ast.BlockStmt, configBlocks []*ast.BlockStmt) diag.Diagnostics {
+func (l *Loader) Apply(delegate component.SubgraphHandler, parent component.SubgraphOwner, parentScope *vm.Scope, blocks []*ast.BlockStmt, configBlocks []*ast.BlockStmt) (diag.Diagnostics, []component.Component) {
 	start := time.Now()
 	l.mut.Lock()
 	defer l.mut.Unlock()
@@ -88,7 +84,7 @@ func (l *Loader) Apply(parentScope *vm.Scope, blocks []*ast.BlockStmt, configBlo
 	newGraph.Add(c)
 
 	// Handle the rest of the graph as ComponentNodes.
-	populateDiags := l.populateGraph(&newGraph, blocks)
+	populateDiags := l.populateGraph(delegate, parent, &newGraph, blocks)
 	diags = append(diags, populateDiags...)
 
 	wireDiags := l.wireGraphEdges(&newGraph)
@@ -98,7 +94,7 @@ func (l *Loader) Apply(parentScope *vm.Scope, blocks []*ast.BlockStmt, configBlo
 	err := dag.Validate(&newGraph)
 	if err != nil {
 		diags = append(diags, multierrToDiags(err)...)
-		return diags
+		return diags, nil
 	}
 	// Copy the original graph, this is so we can have access to the original graph for things like displaying a UI or
 	// debug information.
@@ -178,10 +174,15 @@ func (l *Loader) Apply(parentScope *vm.Scope, blocks []*ast.BlockStmt, configBlo
 	l.cache.SyncIDs(componentIDs)
 	l.blocks = blocks
 	l.cm.componentEvaluationTime.Observe(time.Since(start).Seconds())
-	return diags
+	returnComponents := make([]component.Component, 0, len(components))
+	for _, cmp := range components {
+		returnComponents = append(returnComponents, cmp.managed)
+	}
+
+	return diags, returnComponents
 }
 
-func (l *Loader) populateGraph(g *dag.Graph, blocks []*ast.BlockStmt) diag.Diagnostics {
+func (l *Loader) populateGraph(delegate component.SubgraphHandler, parent component.SubgraphOwner, g *dag.Graph, blocks []*ast.BlockStmt) diag.Diagnostics {
 	// Fill our graph with components.
 	var (
 		diags    diag.Diagnostics
@@ -240,7 +241,7 @@ func (l *Loader) populateGraph(g *dag.Graph, blocks []*ast.BlockStmt) diag.Diagn
 			}
 
 			// Create a new component
-			c = NewComponentNode(l.globals, block)
+			c = NewComponentNode(delegate, parent, l.globals, block)
 		}
 
 		g.Add(c)
@@ -318,7 +319,7 @@ func (l *Loader) EvaluateDependencies(parentScope *vm.Scope, c *ComponentNode) {
 		span.SetStatus(codes.Ok, "")
 
 		duration := time.Since(start)
-		level.Info(logger).Log("msg", "finished partial graph evaluation", "duration", duration)
+		_ = level.Info(logger).Log("msg", "finished partial graph evaluation", "duration", duration)
 		l.cm.componentEvaluationTime.Observe(duration.Seconds())
 	}()
 

--- a/pkg/flow/internal/controller/wrap_tracer.go
+++ b/pkg/flow/internal/controller/wrap_tracer.go
@@ -11,9 +11,9 @@ var (
 	componentIDAttributeKey = "grafana_agent.component_id"
 )
 
-// wrapTracer returns a new trace.TracerProvider which will inject the provided
+// WrapTracer returns a new trace.TracerProvider which will inject the provided
 // componentID as an attribute to each span.
-func wrapTracer(inner trace.TracerProvider, componentID string) trace.TracerProvider {
+func WrapTracer(inner trace.TracerProvider, componentID string) trace.TracerProvider {
 	return &wrappedProvider{
 		inner: inner,
 		id:    componentID,

--- a/pkg/flow/subgraph.go
+++ b/pkg/flow/subgraph.go
@@ -175,6 +175,7 @@ func (s *subgraph) close() error {
 
 func (s *subgraph) run(ctx context.Context) {
 	defer level.Debug(s.log).Log("msg", "subgraph exiting")
+	defer close(s.exited)
 
 	ctx, cancel := context.WithCancel(ctx)
 	s.cancel = cancel

--- a/pkg/flow/subgraph.go
+++ b/pkg/flow/subgraph.go
@@ -2,6 +2,7 @@ package flow
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -141,6 +142,22 @@ func (s *subgraph) LoadSubgraph(parent component.SubgraphOwner, config []byte) (
 	}
 	go sg.run(ctx)
 	return comps, diags, nil
+}
+
+// UnloadSubgraph is used when you no longer need to load the graph
+func (s *subgraph) UnloadSubgraph(parent component.SubgraphOwner) error {
+	foundsg, found := s.children[parent]
+	if !found {
+		return fmt.Errorf("unable to find subgraph with parent id %s", parent.ID())
+	}
+
+	// TODO figure out if we want to apply the old one back, we probably do
+	err := foundsg.graph.close()
+	if err != nil {
+		return err
+	}
+	delete(s.children, parent)
+	return nil
 }
 
 func (s *subgraph) Components() []*controller.ComponentNode {

--- a/pkg/flow/subgraph.go
+++ b/pkg/flow/subgraph.go
@@ -1,0 +1,200 @@
+package flow
+
+import (
+	"context"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/pkg/flow/internal/controller"
+	"github.com/grafana/agent/pkg/flow/logging"
+	"github.com/grafana/agent/pkg/river/diag"
+	"github.com/grafana/agent/pkg/river/vm"
+	"github.com/hashicorp/go-multierror"
+)
+
+// subgraph represents a namespace in the flow subsystem. The namespace is defined by the calling
+// delegate. In the case of normal operation that is the flow component with a namespace of "".
+// A parent delegate has a unique id that will propagate to child components to create a unique
+// namespace id that is parent.id + component.id.
+type subgraph struct {
+	mut          sync.Mutex
+	log          *logging.Logger
+	parent       component.SubgraphOwner
+	parentGraph  *subgraph
+	scope        *vm.Scope
+	loader       *controller.Loader
+	updateQueue  *controller.Queue
+	sched        *controller.Scheduler
+	globals      controller.ComponentGlobals
+	children     map[component.SubgraphOwner]child
+	exited       chan struct{}
+	loadFinished chan struct{}
+	cancel       func()
+	cm           *controller.ControllerMetrics
+}
+
+// child represents a child subgraph with the created context and cancel func.
+// This is used when we need to stop the child for shutting down or reloading.
+type child struct {
+	graph  *subgraph
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// newSubgraph creates a subgraph for use with modules, either main or child.
+func newSubgraph(
+	parent component.SubgraphOwner,
+	parentGraph *subgraph,
+	log *logging.Logger,
+	trace trace.TracerProvider,
+	datapath string,
+	register prometheus.Registerer,
+	httplistener string,
+	cm *controller.ControllerMetrics,
+) *subgraph {
+
+	sg := &subgraph{
+		parent:       parent,
+		sched:        controller.NewScheduler(),
+		updateQueue:  controller.NewQueue(),
+		children:     make(map[component.SubgraphOwner]child),
+		parentGraph:  parentGraph,
+		exited:       make(chan struct{}, 1),
+		loadFinished: make(chan struct{}, 1),
+		log:          log,
+		cm:           cm,
+	}
+	globals := controller.ComponentGlobals{
+		Logger:        log,
+		TraceProvider: controller.WrapTracer(trace, parent.ID()),
+		DataPath:      datapath,
+		OnExportsChange: func(cn *controller.ComponentNode) {
+			// Changed components should be queued for reevaluation.
+			sg.updateQueue.Enqueue(cn)
+		},
+		Registerer:     register,
+		HTTPListenAddr: httplistener,
+	}
+	sg.globals = globals
+	sg.loader = controller.NewLoader(globals, cm)
+	return sg
+}
+
+// loadInitialSubgraph is a special case used for the main subpgraph, instead of using the delegate we
+// force passing in flow so only it can call this.
+func (s *subgraph) loadInitialSubgraph(flow *Flow, config []byte) ([]component.Component, diag.Diagnostics, error) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	file, err := ReadFile("", config)
+	if err != nil {
+		return nil, nil, err
+	}
+	diags, comps := s.loader.Apply(s, flow, s.scope, file.Components, file.ConfigBlocks)
+	if diags.HasErrors() {
+		return nil, diags, diags.ErrorOrNil()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = cancel
+	go s.run(ctx)
+	return comps, diags, nil
+}
+
+// LoadSubgraph allows a component to load a subgraph with the calling component as the parent.
+// This returns all the components both new and old. EXTREME care should be taken by the caller
+// since the component is shared.
+func (s *subgraph) LoadSubgraph(parent component.SubgraphOwner, config []byte) ([]component.Component, diag.Diagnostics, error) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	file, err := ReadFile(parent.ID(), config)
+	if err != nil {
+		return nil, nil, err
+	}
+	sg := newSubgraph(parent, s, s.log, s.globals.TraceProvider, s.globals.DataPath, s.globals.Registerer, s.globals.HTTPListenAddr, s.cm)
+	diags, comps := sg.loader.Apply(s, parent, s.scope, file.Components, file.ConfigBlocks)
+	if diags.HasErrors() {
+		return nil, diags, diags.ErrorOrNil()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	s.children[parent] = child{
+		graph:  sg,
+		ctx:    ctx,
+		cancel: cancel,
+	}
+	go sg.run(ctx)
+	return comps, diags, nil
+}
+
+func (s *subgraph) Components() []*controller.ComponentNode {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+	comps := make([]*controller.ComponentNode, 0)
+	comps = append(comps, s.loader.Components()...)
+	for _, x := range s.children {
+		comps = append(comps, x.graph.Components()...)
+	}
+	return comps
+}
+
+// close recursively closes all children
+func (s *subgraph) close() error {
+	var result error
+	for _, x := range s.children {
+		result = multierror.Append(result, x.graph.close())
+	}
+	s.cancel()
+	<-s.exited
+	result = multierror.Append(result, s.sched.Close())
+	return result
+}
+
+func (s *subgraph) run(ctx context.Context) {
+	defer close(s.exited)
+	defer level.Debug(s.log).Log("msg", "subgraph exiting")
+
+	ctx, cancel := context.WithCancel(ctx)
+	s.cancel = cancel
+	defer s.cancel()
+
+	s.loadFinished <- struct{}{}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-s.updateQueue.Chan():
+			// We need to pop _everything_ from the queue and evaluate each of them.
+			// If we only pop a single element, other components may sit waiting for
+			// evaluation forever.
+			for {
+				updated := s.updateQueue.TryDequeue()
+				if updated == nil {
+					break
+				}
+
+				level.Debug(s.log).Log("msg", "handling component with updated state", "node_id", updated.NodeID())
+				s.loader.EvaluateDependencies(nil, updated)
+			}
+
+		case <-s.loadFinished:
+			level.Info(s.log).Log("msg", "scheduling loaded components")
+
+			components := s.loader.Components()
+			runnables := make([]controller.RunnableNode, 0, len(components))
+			for _, uc := range components {
+				runnables = append(runnables, uc)
+			}
+			err := s.sched.Synchronize(runnables)
+			if err != nil {
+				level.Error(s.log).Log("msg", "failed to load components", "err", err)
+			}
+		}
+	}
+}

--- a/pkg/flow/subgraph.go
+++ b/pkg/flow/subgraph.go
@@ -178,7 +178,6 @@ func (s *subgraph) close() error {
 		err := x.graph.close()
 		if err != nil {
 			result = multierror.Append(result, err)
-
 		}
 	}
 	s.cancel()

--- a/pkg/flow/subgraph.go
+++ b/pkg/flow/subgraph.go
@@ -17,8 +17,9 @@ import (
 )
 
 // subgraph represents a namespace in the flow subsystem. The namespace is defined by the calling
-// delegate. In the case of normal operation that is the flow component with a namespace of "".
-// A parent delegate has a unique id that will propagate to child components to create a unique
+// owner. In the case of normal operation that is the flow component with a namespace of "".
+// This is defined as the main module, with `module.*` components loading submodules.
+// A parent owner has a unique id that will propagate to child components to create a unique
 // namespace id that is parent.id + component.id.
 type subgraph struct {
 	mut          sync.Mutex
@@ -86,11 +87,11 @@ func newSubgraph(
 
 // loadInitialSubgraph is a special case used for the main subpgraph, instead of using the delegate we
 // force passing in flow so only it can call this.
-func (s *subgraph) loadInitialSubgraph(flow *Flow, config []byte) ([]component.Component, diag.Diagnostics, error) {
+func (s *subgraph) loadInitialSubgraph(flow *Flow, config []byte, filename string) ([]component.Component, diag.Diagnostics, error) {
 	s.mut.Lock()
 	defer s.mut.Unlock()
 
-	file, err := ReadFile("", config)
+	file, err := ReadFile(filename, config)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/flow/subgraph.md
+++ b/pkg/flow/subgraph.md
@@ -1,0 +1,164 @@
+With the change to modules we need the ability to load subgraphs. In essence every layer of flow becomes a subgraph.
+
+## Concepts
+
+### Subgraph
+
+A subgraph consists of a full running flow system. The primary parts of a subgraph are:
+* Subgraph Owner
+* Subgraph Handler
+* Scheduler
+* Loader
+* Update Queue
+* Child Subgraphs
+
+####  Namespace ID
+
+Namespace ID is the fully qualified ID, including the parent namespace ID and the current ID. For instance if I have
+
+```river
+module.string "mod1" {
+   content = `
+   prometheus.scrape "default" {
+   }
+   `
+}
+
+```
+
+The ID of the inner scrape is `prometheus.scrape.default` but the namespace id is `module.string.mod1.prometheus.scrape.default`. This allows a fully unique name for every component. This impacts several items:
+
+* The data path
+* The metrics component_id
+* The tracing trace_id
+* The UI
+
+When something is needed to be garaunteed to be unique then the namespace ID is the value to use.
+
+### Subgraph Owner
+
+This is the creator of the subgraph. Currently the supported parent delegates are:
+* Flow
+* module.string
+
+Delegate Components own the subgraph lifecycle and can reload, stop and start the subgraph. Along with extracting information about the individual component nodes.
+
+Delegate Component is an interface that exposes the full `ID` and the delimted `IDs`. These are used to build the name space.
+
+### Subgraph Handler
+
+The subgraph handler is an interface supported by the subgraph itself that allows a delegate component to instantiate a new subgraph. Whenever a component is created the current subgraph is passed via `component.options` that allows the delegate to call `LoadSubgraph`, when called this creates a new subgraph, adds that subgraph to the children of the current and then starts the subgraph.
+
+### Scheduler
+
+The scheduler is an existing flow component that handles the update cycle, this is scheduler is responsible for handling the update queue and then calling for a reevaluation of the dependencies. Each component is then ran from the scheduler via the `Synchronize` function.  The `Synchronize` function removes any components no longer needed, and creates any new components.
+
+### Loader
+
+The loader loads a given config parsing the AST and generating the components. The loader is also responsibile for building the dependency graph and applying the changes from an update via `EvaluateDependencies`, which then walks the tree and chaining more updates as needed.
+
+### Update Queue
+
+The update queue is a small object that enqueus and dequeues `OnStateChange` messages. These messages are passed to the loader
+
+### Child Subgraphs
+
+Each time the `LoadSubgraph` is successfully called a new subgraph is created with an entirely new queue, loader, vmscope, and scheduler. The components are loaded with the newly created subgraphas the `DelegateHandler` in this way a chain can be created. If a subgraph is changed or stopped then this triggers a propagation of those actions to all children.
+
+The separated `vm.scope` ensures that local variables stay localized to the namespace they are in.
+
+## Modules
+
+Given the implementation of subgraphs the topic of modules can now be discussed.
+
+Modules are defined as a subgraph loaded from a river configuration. Modules are unable to contain references to singleton components or configuration blocks. Modules instantiate a new subgraph and are marked as the owner of that subgraph. Modules can then control the lifecycle of the subgraph.
+
+Modules communicate to their subgraph and the parent subgraph via `module.export` and `module.argument`.
+
+### module.argument
+
+The `module.argument` allows a value to be passed into a subgraph defined by a module. On loading the subgraph a list of all components is passed to the module that then iterates over the component list finding any arguments. If any are found they are registered and the parent value pushed down via the argument's `Update`. This then updates via `OnStateChange` This means that the only way a `module.argument Update`  can be called is via the parent module. This value then propagates as normal to the subgraph the `module.argument` lives in.
+
+#### module.export
+
+The `module.export` allows a value to be passed from the child subgraph to used in the parent subgraph. When a module loads the subgraph the module receives a list of all the components and iterates through these components. Any that are `module.export` are injected with a callback via `UpdateInform`. When the `Update` is called on `module.export` the export calls `inform` that pushes the value to the parent argument which then calls `OnStateChange`. This then propagates the value in the subgraph of the module.
+
+## Diagrams
+
+### Basic Layout
+
+In this layout creating a simple scraper inside the module `module.string.mod1`, this entire config has two subgraphs. The `root` module created by flow, the ID of this root module is `""` , a blank string. And the `module.string.mod1` subgraph created by `module.string.mod1` whose parent subgraph is `root`. Both this modules have separate loaders, schedulers and queues. This allows them to operate indepedently.
+
+```river
+
+module.string.mod1 {
+	content = `
+	   module.argument "targets" {
+	   }
+	   prometheus.scraper.scrape1 {
+	      targets = module.arguments.targets
+	   } 
+	`
+}
+
+```
+
+```
+┌────────────────────────────────────────────────────────────────────────────┐
+│Flow System                                                                 │
+│   ┌─────────────────────────────────────────────────────────────────────┐  │
+│   │root subgraph            ┌──────────────────┐                        │  │
+│   │- parent `flow`          │children          │                        │  │
+│   │ ┌──────────────────┐    ├──────────────────┴─────────────────────┐  │  │
+│   │ │controller.Queue  │    │module.string.mod1                      │  │  │
+│   │ └──────────────────┘    │- parent `root subgraph`                │  │  │
+│   │ ┌──────────────────┐    │ ┌──────────────────┐                   │  │  │
+│   │ │controller.Loader │    │ │controller.Queue  │                   │  │  │
+│   │ └──────────────────┘    │ └──────────────────┘                   │  │  │
+│   │ ┌──────────────────┐    │ ┌──────────────────┐                   │  │  │
+│   │ │controller.queue  │    │ │controller.Loader │                   │  │  │
+│   │ └──────────────────┘    │ └──────────────────┘                   │  │  │
+│   │ ┌─────────────────────┐ │ ┌──────────────────┐                   │  │  │
+│   │ │Components           │ │ │controller.queue  │                   │  │  │
+│   │ │- module.string.mod1 │ │ └──────────────────┘                   │  │  │
+│   │ │                     │ │ ┌────────────────────────────────┐     │  │  │
+│   │ │                     │ │ │components                      │     │  │  │
+│   │ │                     │ │ │- prometheus.scrape.scrape1     │     │  │  │
+│   │ │                     │ │ │- module.argument.targets       │     │  │  │
+│   │ │                     │ │ │                                │     │  │  │
+│   │ │                     │ │ │                                │     │  │  │
+│   │ │                     │ │ │                                │     │  │  │
+│   │ │                     │ │ │                                │     │  │  │
+│   │ │                     │ │ │                                │     │  │  │
+│   │ │                     │ │ │                                │     │  │  │
+│   │ │                     │ │ │                                │     │  │  │
+│   │ │                     │ │ │                                │     │  │  │
+│   │ │                     │ │ │                                │     │  │  │
+│   │ │                     │ │ │                                │     │  │  │
+│   │ │                     │ │ │                                │     │  │  │
+│   │ │                     │ │ │                                │     │  │  │
+│   │ │                     │ │ │                                │     │  │  │
+│   │ │                     │ │ │                                │     │  │  │
+│   │ │                     │ │ │                                │     │  │  │
+│   │ │                     │ │ │                                │     │  │  │
+│   │ │                     │ │ │                                │     │  │  │
+│   │ │                     │ │ │                                │     │  │  │
+│   │ │                     │ │ │                                │     │  │  │
+│   │ └─────────────────────┘ │ │                                │     │  │  │
+│   │                         │ └────────────────────────────────┘     │  │  │
+│   │                         │                                        │  │  │
+│   │                         │                                        │  │  │
+│   │                         └────────────────────────────────────────┘  │  │
+│   └─────────────────────────────────────────────────────────────────────┘  │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Todo
+
+* Unit Tests
+* Documentation
+* Reload
+* Metrics
+* Closing cleanly
+* Stack limit
+* Disabling singleton components


### PR DESCRIPTION
#### PR Description

This PR inherently makes no user-facing changes until modules are added in the next PR. The primary goal is to add subgraph support, I waffled on naming this submodules but there might be a world where this is used beyond modules. The primary point is to create a parent child tree of subgraphs that are loaded and unloaded on demand.

The general workflow is that when a component is created the SubgraphHandler is passed as an option, the component can use this to create a new subgraph. That component will then become the subgraph owner and a new child subgraph will be created. The subgraph.md file gives a rundown of how it will work with modules.

Most of the flow functionality moved into subgraph, it is possible we could have reused the flow.new and created full flow subsystems but I think its worth having an anchor for the main module (flow.go that spawns the main subgraph) and then child modules (subgraphs). There are likely some functions in the main module (flow.go) we would want to instantiate/control at a root level instead of pivoting in subgraphs.

This also introduces the concept of NamespaceID which is the full unique name, essentially the Parent NamespaceID + ComponentID. I could easily talked into having this just be the parent ID and manually merging the two where needed.

#### Which issue(s) this PR fixes

Fixes #3113

#### Notes to the Reviewer

This is part one of several PRs to introduce.


#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
