### PR TITLE
agentlint: alert when a Flow component uses the wrong field tag

### DIFF
--- a/component/discovery/aws/ec2.go
+++ b/component/discovery/aws/ec2.go
@@ -28,7 +28,7 @@ func init() {
 // EC2Filter is the configuration for filtering EC2 instances.
 type EC2Filter struct {
 	Name   string   `river:"name,attr"`
-	Values []string `yaml:"values,attr"`
+	Values []string `river:"values,attr"`
 }
 
 // EC2Arguments is the configuration for EC2 based service discovery.

--- a/tools/agentlint/internal/rivertags/rivertags.go
+++ b/tools/agentlint/internal/rivertags/rivertags.go
@@ -18,7 +18,12 @@ var Analyzer = &analysis.Analyzer{
 }
 
 var noLintRegex = regexp.MustCompile(`//\s*nolint:(\S+)`)
-var riverTagRegex = regexp.MustCompile(`river:"([^"]*)"`)
+
+var (
+	riverTagRegex = regexp.MustCompile(`river:"([^"]*)"`)
+	jsonTagRegex  = regexp.MustCompile(`json:"([^"]*)"`)
+	yamlTagRegex  = regexp.MustCompile(`yaml:"([^"]*)"`)
+)
 
 // Rules for river tag linting:
 //
@@ -48,6 +53,16 @@ func run(p *analysis.Pass) (interface{}, error) {
 		sNode := sInfo.Node
 		s := sInfo.Type
 
+		var hasRiverTags bool
+
+		for i := 0; i < s.NumFields(); i++ {
+			matches := riverTagRegex.FindAllStringSubmatch(s.Tag(i), -1)
+			if len(matches) > 0 {
+				hasRiverTags = true
+				break
+			}
+		}
+
 	NextField:
 		for i := 0; i < s.NumFields(); i++ {
 			field := s.Field(i)
@@ -63,7 +78,22 @@ func run(p *analysis.Pass) (interface{}, error) {
 			}
 
 			matches := riverTagRegex.FindAllStringSubmatch(s.Tag(i), -1)
-			if len(matches) == 0 {
+			if len(matches) == 0 && hasRiverTags {
+				// If this struct has River tags, but this field only has json/yaml
+				// tags, emit an error.
+				jsonMatches := jsonTagRegex.FindAllStringSubmatch(s.Tag(i), -1)
+				yamlMatches := yamlTagRegex.FindAllStringSubmatch(s.Tag(i), -1)
+
+				if len(jsonMatches) != 0 || len(yamlMatches) != 0 {
+					p.Report(analysis.Diagnostic{
+						Pos:      field.Pos(),
+						Category: "rivertags",
+						Message:  "field has yaml or json tags, but no river tags",
+					})
+				}
+
+				continue
+			} else if len(matches) == 0 {
 				continue
 			} else if len(matches) > 1 {
 				p.Report(analysis.Diagnostic{

--- a/tools/agentlint/internal/rivertags/rivertags.go
+++ b/tools/agentlint/internal/rivertags/rivertags.go
@@ -84,7 +84,7 @@ func run(p *analysis.Pass) (interface{}, error) {
 				jsonMatches := jsonTagRegex.FindAllStringSubmatch(s.Tag(i), -1)
 				yamlMatches := yamlTagRegex.FindAllStringSubmatch(s.Tag(i), -1)
 
-				if len(jsonMatches) != 0 || len(yamlMatches) != 0 {
+				if len(jsonMatches) > 0 || len(yamlMatches) > 0 {
 					p.Report(analysis.Diagnostic{
 						Pos:      field.Pos(),
 						Category: "rivertags",


### PR DESCRIPTION
This adds a linting rule where if a struct has at least one field with a `river` tag, an error is emitted if there is a field with `json`/`yaml` tags but no `river` tags. 

I fixed the one instance which fails this check.