### PR TITLE
Add language around where to find default config file locations

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -31,6 +31,8 @@ well-documented.
 The configuration file can be reloaded at runtime using the `/-/reload` API
 endpoint or sending a SIGHUP signal to the process.
 
+For default config file locations, refer to the Install Grafana Agent guides under "Set up Grafana Agent"
+
 ## Variable substitution
 
 You can use environment variables in the configuration file to set values that


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
I was having trouble finding where the default location for the grafana agent config file was located, particularly after installing it via an integration. I eventually found the info I needed in the Install guides, but it took some determination.

I figured that it might make sense to include a reference to it in the first place that I looked (and where Google brought me)

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
