### PR TITLE
Use a @grafanabot token for managing outdated dependency issues

### DIFF
--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -14,4 +14,4 @@ jobs:
     - name: Invoke action
       uses: rfratto/depcheck@main
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ secrets.MANAGE_ISSUES_GH_TOKEN }}


### PR DESCRIPTION
This avoids an issue where issues created by the default GITHUB_TOKEN were unable to trigger the Workflow to add those issues to the public Grafana Agent project where issues are tracked.

Fixes #3137.
