### PR TITLE
Improve Phlare target reloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,11 @@ Main (unreleased)
 
 ### Enhancements
 
-- Flow: Add retries with backoff logic to Phlare write component. (@ctovena)
+- Flow: Add retries with backoff logic to Phlare write component. (@cyriltovena)
 
 ### Bugfixes
+
+- Flow: Fixes slow reloading of targets in `phlare.scrape` component. (@cyriltovena)
 
 - Flow: add a maximum connection lifetime of one hour when tailing logs from
   `loki.source.kubernetes` and `loki.source.podlogs` to recover from an issue
@@ -113,7 +115,7 @@ v0.32.0 (2023-02-28)
 
 ### Enhancements
 
-- Flow: Support `keepequal` and `dropequal` actions for relabeling. (@ctovena)
+- Flow: Support `keepequal` and `dropequal` actions for relabeling. (@cyriltovena)
 
 - Update Prometheus Node Exporter integration to v1.5.0. (@Thor77)
 

--- a/component/phlare/scrape/manager.go
+++ b/component/phlare/scrape/manager.go
@@ -83,11 +83,6 @@ func (m *Manager) reloader() {
 }
 
 func (m *Manager) reload() {
-	now := time.Now()
-	level.Warn(m.logger).Log("msg", "phlare reloading scrape manager")
-	defer func() {
-		level.Warn(m.logger).Log("msg", "phlare reloaded scrape manager", "duration", time.Since(now))
-	}()
 	m.mtxScrape.Lock()
 	defer m.mtxScrape.Unlock()
 

--- a/component/phlare/scrape/manager.go
+++ b/component/phlare/scrape/manager.go
@@ -84,6 +84,8 @@ func (m *Manager) reloader() {
 
 func (m *Manager) reload() {
 	m.mtxScrape.Lock()
+	defer m.mtxScrape.Unlock()
+
 	var wg sync.WaitGroup
 	for setName, groups := range m.targetSets {
 		if _, ok := m.targetsGroups[setName]; !ok {
@@ -102,7 +104,6 @@ func (m *Manager) reload() {
 			wg.Done()
 		}(m.targetsGroups[setName], groups)
 	}
-	m.mtxScrape.Unlock()
 	wg.Wait()
 }
 

--- a/component/phlare/scrape/manager.go
+++ b/component/phlare/scrape/manager.go
@@ -83,6 +83,11 @@ func (m *Manager) reloader() {
 }
 
 func (m *Manager) reload() {
+	now := time.Now()
+	level.Warn(m.logger).Log("msg", "phlare reloading scrape manager")
+	defer func() {
+		level.Warn(m.logger).Log("msg", "phlare reloaded scrape manager", "duration", time.Since(now))
+	}()
 	m.mtxScrape.Lock()
 	defer m.mtxScrape.Unlock()
 

--- a/component/phlare/scrape/scrape_loop_test.go
+++ b/component/phlare/scrape/scrape_loop_test.go
@@ -185,7 +185,7 @@ func TestScrapeLoop(t *testing.T) {
 			return nil
 		}),
 		200*time.Millisecond, 30*time.Second, util.TestLogger(t))
-	defer loop.stop()
+	defer loop.stop(true)
 
 	require.Equal(t, HealthUnknown, loop.Health())
 	loop.start()

--- a/component/phlare/scrape/scrape_test.go
+++ b/component/phlare/scrape/scrape_test.go
@@ -3,6 +3,9 @@ package scrape
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,6 +18,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 	"go.uber.org/goleak"
 )
 
@@ -97,7 +101,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				profile.custom "something" {
 					enabled = true
 					path    = "/debug/fgprof"
-					delta   = true 
+					delta   = true
 				}
 		   }
 		   `,
@@ -167,5 +171,82 @@ func TestUnmarshalConfig(t *testing.T) {
 			require.NoError(t, river.Unmarshal([]byte(tt.in), &arg))
 			require.Equal(t, tt.expected(), arg)
 		})
+	}
+}
+
+func TestUpdateWhileScraping(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	args := NewDefaultArguments()
+	// speed up reload interval for this tests
+	old := reloadInterval
+	reloadInterval = 1 * time.Microsecond
+	defer func() {
+		reloadInterval = old
+	}()
+	args.ScrapeInterval = 1 * time.Second
+
+	c, err := New(component.Options{
+		Logger:        util.TestLogger(t),
+		Registerer:    prometheus.NewRegistry(),
+		OnStateChange: func(e component.Exports) {},
+	}, args)
+	require.NoError(t, err)
+	scraping := atomic.NewBool(false)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		scraping.Store(true)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(15 * time.Second):
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	address := strings.TrimPrefix(server.URL, "http://")
+
+	defer cancel()
+
+	go c.Run(ctx)
+
+	args.Targets = []discovery.Target{
+		{
+			model.AddressLabel: address,
+			"foo":              "bar",
+		},
+		{
+			model.AddressLabel: address,
+			"foo":              "buz",
+		},
+	}
+
+	c.Update(args)
+	c.scraper.reload()
+	// Wait for the targets to be scraping.
+	require.Eventually(t, func() bool {
+		return scraping.Load()
+	}, 10*time.Second, 1*time.Second)
+
+	// Send updates to the targets.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 100; i++ {
+			args.Targets = []discovery.Target{
+				{
+					model.AddressLabel: address,
+					"foo":              fmt.Sprintf("%d", i),
+				},
+			}
+			require.NoError(t, c.Update(args))
+			c.scraper.reload()
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for updates to finish")
 	}
 }

--- a/component/phlare/scrape/scrape_test.go
+++ b/component/phlare/scrape/scrape_test.go
@@ -175,7 +175,6 @@ func TestUnmarshalConfig(t *testing.T) {
 }
 
 func TestUpdateWhileScraping(t *testing.T) {
-	defer goleak.VerifyNone(t)
 	args := NewDefaultArguments()
 	// speed up reload interval for this tests
 	old := reloadInterval

--- a/component/phlare/scrape/target.go
+++ b/component/phlare/scrape/target.go
@@ -118,8 +118,8 @@ func (t *Target) Labels() labels.Labels {
 
 // DiscoveredLabels returns a copy of the target's labels before any processing.
 func (t *Target) DiscoveredLabels() labels.Labels {
-	t.mtx.Lock()
-	defer t.mtx.Unlock()
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
 	lset := make(labels.Labels, len(t.discoveredLabels))
 	copy(lset, t.discoveredLabels)
 	return lset

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -131,6 +131,11 @@ func (l *Loader) Apply(parentScope *vm.Scope, blocks []*ast.BlockStmt, configBlo
 		span.SetAttributes(attribute.String("node_id", n.NodeID()))
 		defer span.End()
 
+		start := time.Now()
+		defer func() {
+			level.Info(logger).Log("msg", "finished node evaluation", "node_id", n.NodeID(), "duration", time.Since(start))
+		}()
+
 		var err error
 
 		switch c := n.(type) {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PRs improves the target reloading in `phlare.scrape` component.

We basically only wait for the scraping loop to end when shutting down the component, but not anymore when reloading targets.

This means the target will gracefully finish and terminate asynchronously.

Finally @rfratto help me figure a second bug that was caused by a lock taken while retrying push to the backend but it was required only to update the status.



#### Which issue(s) this PR fixes

Fixes #2871 

#### Notes to the Reviewer

Going to test this in dev.

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
