### PR TITLE
Add a otelcol.auth.oauth2 component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Main (unreleased)
   - `discovery.ec2` service discovery for aws ec2. (@captncraig)
   - `discovery.lightsail` service discovery for aws lightsail. (@captncraig)
   - `prometheus.exporter.mysql` collects metrics from a MySQL database. (@spartan0x117)
-  - `otelcol.auth.oauth2` performs `oauth2` authentication for HTTP and gRPC based 
+  - `otelcol.auth.oauth2` performs OAuth 2.0 authentication for HTTP and gRPC based 
      OpenTelemetry exporters. (@ptodev)
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ Main (unreleased)
   - `discovery.ec2` service discovery for aws ec2. (@captncraig)
   - `discovery.lightsail` service discovery for aws lightsail. (@captncraig)
   - `prometheus.exporter.mysql` collects metrics from a MySQL database. (@spartan0x117)
-
+  - `otelcol.auth.oauth2` performs `oauth2` authentication for HTTP and gRPC based 
+     OpenTelemetry exporters. (@ptodev)
 ### Bugfixes
 
 - Flow: add a maximum connection lifetime of one hour when tailing logs from

--- a/component/all/all.go
+++ b/component/all/all.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/grafana/agent/component/otelcol/auth/basic"              // Import otelcol.auth.basic
 	_ "github.com/grafana/agent/component/otelcol/auth/bearer"             // Import otelcol.auth.bearer
 	_ "github.com/grafana/agent/component/otelcol/auth/headers"            // Import otelcol.auth.headers
+	_ "github.com/grafana/agent/component/otelcol/auth/oauth2"             // Import otelcol.auth.oauth2
 	_ "github.com/grafana/agent/component/otelcol/exporter/jaeger"         // Import otelcol.exporter.jaeger
 	_ "github.com/grafana/agent/component/otelcol/exporter/loki"           // Import otelcol.exporter.loki
 	_ "github.com/grafana/agent/component/otelcol/exporter/otlp"           // Import otelcol.exporter.otlp

--- a/component/otelcol/auth/oauth2/oauth2.go
+++ b/component/otelcol/auth/oauth2/oauth2.go
@@ -1,0 +1,63 @@
+package oauth2
+
+import (
+	"net/url"
+	"time"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otelcol"
+	"github.com/grafana/agent/component/otelcol/auth"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension"
+	otelcomponent "go.opentelemetry.io/collector/component"
+	otelconfig "go.opentelemetry.io/collector/config"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:    "otelcol.auth.oauth2",
+		Args:    Arguments{},
+		Exports: auth.Exports{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			fact := oauth2clientauthextension.NewFactory()
+			return auth.New(opts, fact, args.(Arguments))
+		},
+	})
+}
+
+// Arguments configures the otelcol.auth.oauth2 component.
+type Arguments struct {
+	ClientID       string                     `river:"client_id,attr"`
+	ClientSecret   string                     `river:"client_secret,attr"`
+	TokenURL       string                     `river:"token_url,attr"`
+	EndpointParams url.Values                 `river:"endpoint_params,attr,optional"`
+	Scopes         []string                   `river:"scopes,attr,optional"`
+	TLSSetting     otelcol.TLSClientArguments `river:"tls,block,optional"`
+	Timeout        time.Duration              `river:"timeout,attr,optional"`
+}
+
+var _ auth.Arguments = Arguments{}
+
+// Convert implements auth.Arguments.
+func (args Arguments) Convert() otelconfig.Extension {
+	return &oauth2clientauthextension.Config{
+		ExtensionSettings: otelconfig.NewExtensionSettings(otelconfig.NewComponentID("oauth2")),
+		ClientID:          args.ClientID,
+		ClientSecret:      args.ClientSecret,
+		TokenURL:          args.TokenURL,
+		EndpointParams:    args.EndpointParams,
+		Scopes:            args.Scopes,
+		TLSSetting:        *args.TLSSetting.Convert(),
+		Timeout:           args.Timeout,
+	}
+}
+
+// Extensions implements auth.Arguments.
+func (args Arguments) Extensions() map[otelconfig.ComponentID]otelcomponent.Extension {
+	return nil
+}
+
+// Exporters implements auth.Arguments.
+func (args Arguments) Exporters() map[otelconfig.DataType]map[otelconfig.ComponentID]otelcomponent.Exporter {
+	return nil
+}

--- a/component/otelcol/auth/oauth2/oauth2_test.go
+++ b/component/otelcol/auth/oauth2/oauth2_test.go
@@ -97,6 +97,8 @@ func Test(t *testing.T) {
 				authHeader := r.Header.Get("Authorization")
 				expectedAuthHeader := fmt.Sprintf("%s %s", tt.tokenType, tt.accessToken)
 				assert.Equal(t, expectedAuthHeader, authHeader, "auth header didn't match")
+
+				//TODO: Also write checks for `endpoint_params`` and `scopes``
 			}))
 			defer srv.Close()
 			t.Logf("Created server which will require authentication on address %s", srv.URL)

--- a/component/otelcol/auth/oauth2/oauth2_test.go
+++ b/component/otelcol/auth/oauth2/oauth2_test.go
@@ -18,29 +18,6 @@ import (
 	"gotest.tools/assert"
 )
 
-func TestConfigDefaults(t *testing.T) {
-	cfg := `
-		client_id     = "someclientid"
-		client_secret = "someclientsecret"
-		token_url     = "https://example.com/oauth2/default/v1/token"
-	`
-	var args oauth2.Arguments
-	require.NoError(t, river.Unmarshal([]byte(cfg), &args))
-
-	cfgWithExplicitDefaults := `
-		client_id       = "someclientid"
-		client_secret   = "someclientsecret"
-		token_url       = "https://example.com/oauth2/default/v1/token"
-		endpoint_params = {}
-		scopes          = []
-		timeout         = "0s"
-	`
-	var argsWithExplicitDefaults oauth2.Arguments
-	require.NoError(t, river.Unmarshal([]byte(cfgWithExplicitDefaults), &argsWithExplicitDefaults))
-
-	require.Equal(t, argsWithExplicitDefaults, args)
-}
-
 // Test performs a oauth2 integration test which runs the otelcol.auth.oauth2
 // component and ensures that it can be used for authentication.
 func Test(t *testing.T) {

--- a/component/otelcol/auth/oauth2/oauth2_test.go
+++ b/component/otelcol/auth/oauth2/oauth2_test.go
@@ -1,0 +1,155 @@
+package oauth2_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/component/otelcol/auth"
+	"github.com/grafana/agent/component/otelcol/auth/oauth2"
+	"github.com/grafana/agent/pkg/flow/componenttest"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/grafana/agent/pkg/util"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configauth"
+	"gotest.tools/assert"
+)
+
+func TestConfigDefaults(t *testing.T) {
+	cfg := `
+		client_id     = "someclientid"
+		client_secret = "someclientsecret"
+		token_url     = "https://example.com/oauth2/default/v1/token"
+	`
+	var args oauth2.Arguments
+	require.NoError(t, river.Unmarshal([]byte(cfg), &args))
+
+	cfgWithExplicitDefaults := `
+		client_id       = "someclientid"
+		client_secret   = "someclientsecret"
+		token_url       = "https://example.com/oauth2/default/v1/token"
+		endpoint_params = {}
+		scopes          = []
+		timeout         = "0s"
+	`
+	var argsWithExplicitDefaults oauth2.Arguments
+	require.NoError(t, river.Unmarshal([]byte(cfgWithExplicitDefaults), &argsWithExplicitDefaults))
+
+	require.Equal(t, argsWithExplicitDefaults, args)
+}
+
+// Test performs a oauth2 integration test which runs the otelcol.auth.oauth2
+// component and ensures that it can be used for authentication.
+func Test(t *testing.T) {
+	tests := []struct {
+		testName      string
+		accessToken   string
+		tokenType     string
+		refreshToken  string
+		configBuilder func(string) string
+	}{
+		{
+			"runWithRequiredParams",
+			"TestAccessToken",
+			"TestTokenType",
+			"TestRefreshToken",
+			func(srvProvidingTokensURL string) string {
+				return fmt.Sprintf(`
+					client_id     = "someclientid"
+					client_secret = "someclientsecret"
+					token_url     = "%s/oauth2/default/v1/token"
+				`, srvProvidingTokensURL)
+			},
+		},
+		{
+			"runWithOptionalParams",
+			"TestAccessToken",
+			"TestTokenType",
+			"TestRefreshToken",
+			func(srvProvidingTokensURL string) string {
+				return fmt.Sprintf(`
+					client_id       = "someclientid2"
+					client_secret   = "someclientsecret2"
+					token_url       = "%s/oauth2/default/v1/token"
+					endpoint_params = {"audience" = ["someaudience"]}
+					scopes          = ["api.metrics"]
+					timeout         = "1s"
+					tls {
+						insecure = true
+					}
+				`, srvProvidingTokensURL)
+			},
+		},
+	}
+
+	//TODO: Could we call t.Parallel() here? I am not sure if httptest.NewServer() usage is thread safe.
+	//      For now we do the tests synchronously because there aren't that many of them anyway.
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			// Create an HTTP server which will assert that oauth2 auth has been injected
+			// into the request.
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+
+				authHeader := r.Header.Get("Authorization")
+				expectedAuthHeader := fmt.Sprintf("%s %s", tt.tokenType, tt.accessToken)
+				assert.Equal(t, expectedAuthHeader, authHeader, "auth header didn't match")
+			}))
+			defer srv.Close()
+			t.Logf("Created server which will require authentication on address %s", srv.URL)
+
+			srvProvidingTokens := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(fmt.Sprintf("access_token=%s&token_type=%s&refresh_token=%s", tt.accessToken, tt.tokenType, tt.refreshToken)))
+			}))
+			defer srvProvidingTokens.Close()
+			t.Logf("Created server which will provide authentication tokens on address %s", srvProvidingTokens.URL)
+
+			ctx := componenttest.TestContext(t)
+			ctx, cancel := context.WithTimeout(ctx, time.Minute)
+			defer cancel()
+
+			l := util.TestLogger(t)
+
+			// Create and run our component
+			ctrl, err := componenttest.NewControllerFromID(l, "otelcol.auth.oauth2")
+			require.NoError(t, err)
+
+			cfg := tt.configBuilder(srvProvidingTokens.URL)
+			var args oauth2.Arguments
+			require.NoError(t, river.Unmarshal([]byte(cfg), &args))
+
+			go func() {
+				err := ctrl.Run(ctx, args)
+				require.NoError(t, err)
+			}()
+
+			require.NoError(t, ctrl.WaitRunning(time.Second), "component never started")
+			require.NoError(t, ctrl.WaitExports(time.Second), "component never exported anything")
+
+			// Get the authentication extension from our component and use it to make a
+			// request to our test server.
+			exports := ctrl.Exports().(auth.Exports)
+			require.NotNil(t, exports.Handler.Extension, "handler extension is nil")
+
+			clientAuth, ok := exports.Handler.Extension.(configauth.ClientAuthenticator)
+			require.True(t, ok, "handler does not implement configauth.ClientAuthenticator")
+
+			rt, err := clientAuth.RoundTripper(http.DefaultTransport)
+			require.NoError(t, err)
+			cli := &http.Client{Transport: rt}
+
+			// Wait until the request finishes. We don't assert anything else here; our
+			// HTTP handler won't write the response until it ensures that the oauth2 auth
+			// was found.
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+			require.NoError(t, err)
+			resp, err := cli.Do(req)
+			require.NoError(t, err, "HTTP request failed")
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+	}
+}

--- a/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
@@ -86,7 +86,7 @@ configuration.
 
 ## Example
 
-This example configures [otelcol.exporter.otlp][] to use oauth2 authentication:
+This example configures [otelcol.exporter.otlp][] to use OAuth 2.0 for authentication:
 
 ```river
 otelcol.exporter.otlp "example" {

--- a/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
@@ -9,7 +9,7 @@ components to authenticate requests using oauth2 authentication.
 
 The authorization tokens can be used by HTTP and gRPC based OpenTelemetry exporters. 
 This component can fetch and refresh expired tokens automatically. For further details about 
-OAuth2 Client Credentials flow (2-legged workflow) see [here](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4).
+OAuth 2.0 Client Credentials flow (2-legged workflow) see [here](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4).
 
 > **NOTE**: `otelcol.auth.oauth2` is a wrapper over the upstream OpenTelemetry
 > Collector `oauth2client` extension. Bug reports or feature requests will be

--- a/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
@@ -9,7 +9,7 @@ components to authenticate requests using OAuth 2.0.
 
 The authorization tokens can be used by HTTP and gRPC based OpenTelemetry exporters. 
 This component can fetch and refresh expired tokens automatically. For further details about 
-OAuth 2.0 Client Credentials flow (2-legged workflow) see [here](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4).
+OAuth 2.0 Client Credentials flow (2-legged workflow) see [this document](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4).
 
 > **NOTE**: `otelcol.auth.oauth2` is a wrapper over the upstream OpenTelemetry
 > Collector `oauth2client` extension. Bug reports or feature requests will be
@@ -39,7 +39,7 @@ Name | Type | Description | Default | Required
 `scopes` | `list(string)` | Requested permissions associated for the client. | `[]` | no
 `timeout` | `duration` | The timeout on the client connecting to `token_url`. | `"0s"` | no
 
-`timeout` is used for both initial tokens and refreshing tokens. `"0s"` implies no timeout.
+The `timeout` argument is used both for requesting initial tokens and for refreshing tokens. `"0s"` implies no timeout.
 
 ## Blocks
 
@@ -110,7 +110,7 @@ otelcol.auth.oauth2 "creds" {
     token_url       = "https://example.com/oauth2/default/v1/token"
     endpoint_params = {"audience" = ["someaudience"]}
     scopes          = ["api.metrics"]
-    timeout         = "1s"
+    timeout         = "3600s"
 }
 ```
 

--- a/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
@@ -5,7 +5,7 @@ title: otelcol.auth.oauth2
 # otelcol.auth.oauth2
 
 `otelcol.auth.oauth2` exposes a `handler` that can be used by other `otelcol`
-components to authenticate requests using oauth2 authentication.
+components to authenticate requests using OAuth 2.0.
 
 The authorization tokens can be used by HTTP and gRPC based OpenTelemetry exporters. 
 This component can fetch and refresh expired tokens automatically. For further details about 

--- a/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
@@ -35,7 +35,7 @@ Name | Type | Description | Default | Required
 `client_id` | `string` | The client identifier issued to the client. | | yes
 `client_secret` | `string` | The secret string associated with the client identifier. | | yes
 `token_url` | `string` | The server endpoint URL from which to get tokens. | | yes
-`endpoint_params` | `map([]string)` | Additional parameters that are sent to the token endpoint. | `{}` | no
+`endpoint_params` | `map(list(string))` | Additional parameters that are sent to the token endpoint. | `{}` | no
 `scopes` | `[]string` | Requested permissions associated for the client. | `[]` | no
 `timeout` | `duration` | The timeout on the client connecting to `token_url` for both initial tokens and refreshing tokens. `"0s"` implies no timeout. | `"0s"` | no
 

--- a/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
@@ -37,7 +37,9 @@ Name | Type | Description | Default | Required
 `token_url` | `string` | The server endpoint URL from which to get tokens. | | yes
 `endpoint_params` | `map(list(string))` | Additional parameters that are sent to the token endpoint. | `{}` | no
 `scopes` | `list(string)` | Requested permissions associated for the client. | `[]` | no
-`timeout` | `duration` | The timeout on the client connecting to `token_url` for both initial tokens and refreshing tokens. `"0s"` implies no timeout. | `"0s"` | no
+`timeout` | `duration` | The timeout on the client connecting to `token_url`. | `"0s"` | no
+
+`timeout` is used for both initial tokens and refreshing tokens. `"0s"` implies no timeout.
 
 ## Blocks
 
@@ -55,17 +57,7 @@ tls | [tls][] | TLS settings for the token client. | no
 The `tls` block configures TLS settings used for connecting to the token client. If the `tls` block isn't provided, 
 TLS won't be used for communication.
 
-The following arguments are supported:
-
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`ca_file` | `string` | Path to the CA file. | | no
-`cert_file` | `string` | Path to the TLS certificate. | | no
-`key_file` | `string` | Path to the TLS certificate key. | | no
-`min_version` | `string` | Minimum acceptable TLS version for connections. | `"TLS 1.2"` | no
-`max_version` | `string` | Maximum acceptable TLS version for connections. | `"TLS 1.3"` | no
-`reload_interval` | `duration` | Frequency to reload the certificates. | | no
-`client_ca_file` | `string` | Path to the CA file used to authenticate client certificates. | | no
+{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
@@ -36,7 +36,7 @@ Name | Type | Description | Default | Required
 `client_secret` | `string` | The secret string associated with the client identifier. | | yes
 `token_url` | `string` | The server endpoint URL from which to get tokens. | | yes
 `endpoint_params` | `map(list(string))` | Additional parameters that are sent to the token endpoint. | `{}` | no
-`scopes` | `[]string` | Requested permissions associated for the client. | `[]` | no
+`scopes` | `list(string)` | Requested permissions associated for the client. | `[]` | no
 `timeout` | `duration` | The timeout on the client connecting to `token_url` for both initial tokens and refreshing tokens. `"0s"` implies no timeout. | `"0s"` | no
 
 ## Blocks

--- a/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
@@ -1,0 +1,121 @@
+---
+title: otelcol.auth.oauth2
+---
+
+# otelcol.auth.oauth2
+
+`otelcol.auth.oauth2` exposes a `handler` that can be used by other `otelcol`
+components to authenticate requests using oauth2 authentication.
+
+The authorization tokens can be used by HTTP and gRPC based OpenTelemetry exporters. 
+This component can fetch and refresh expired tokens automatically. For further details about 
+OAuth2 Client Credentials flow (2-legged workflow) see [here](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4).
+
+> **NOTE**: `otelcol.auth.oauth2` is a wrapper over the upstream OpenTelemetry
+> Collector `oauth2client` extension. Bug reports or feature requests will be
+> redirected to the upstream repository, if necessary.
+
+Multiple `otelcol.auth.oauth2` components can be specified by giving them
+different labels.
+
+## Usage
+
+```river
+otelcol.auth.oauth2 "LABEL" {
+    client_id     = "CLIENT_ID"
+    client_secret = "CLIENT_SECRET"
+    token_url     = "TOKEN_URL"
+}
+```
+
+## Arguments
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`client_id` | `string` | The client identifier issued to the client. | | yes
+`client_secret` | `string` | The secret string associated with the client identifier. | | yes
+`token_url` | `string` | The server endpoint URL from which to get tokens. | | yes
+`endpoint_params` | `map([]string)` | Additional parameters that are sent to the token endpoint. | `{}` | no
+`scopes` | `[]string` | Requested permissions associated for the client. | `[]` | no
+`timeout` | `duration` | The timeout on the client connecting to `token_url` for both initial tokens and refreshing tokens. `"0s"` implies no timeout. | `"0s"` | no
+
+## Blocks
+
+The following blocks are supported inside the definition of
+`otelcol.auth.oauth2`:
+
+Hierarchy | Block | Description | Required
+--------- | ----- | ----------- | --------
+tls | [tls][] | TLS settings for the token client. | no
+
+[tls]: #tls-block
+
+### tls block
+
+The `tls` block configures TLS settings used for connecting to the token client. If the `tls` block isn't provided, 
+TLS won't be used for communication.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`ca_file` | `string` | Path to the CA file. | | no
+`cert_file` | `string` | Path to the TLS certificate. | | no
+`key_file` | `string` | Path to the TLS certificate key. | | no
+`min_version` | `string` | Minimum acceptable TLS version for connections. | `"TLS 1.2"` | no
+`max_version` | `string` | Maximum acceptable TLS version for connections. | `"TLS 1.3"` | no
+`reload_interval` | `duration` | Frequency to reload the certificates. | | no
+`client_ca_file` | `string` | Path to the CA file used to authenticate client certificates. | | no
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+Name | Type | Description
+---- | ---- | -----------
+`handler` | `capsule(otelcol.Handler)` | A value that other components can use to authenticate requests.
+
+## Component health
+
+`otelcol.auth.oauth2` is only reported as unhealthy if given an invalid
+configuration.
+
+## Debug information
+
+`otelcol.auth.oauth2` does not expose any component-specific debug information.
+
+## Example
+
+This example configures [otelcol.exporter.otlp][] to use oauth2 authentication:
+
+```river
+otelcol.exporter.otlp "example" {
+  client {
+    endpoint = "my-otlp-grpc-server:4317"
+    auth     = otelcol.auth.oauth2.creds.handler
+  }
+}
+
+otelcol.auth.oauth2 "creds" {
+    client_id     = "someclientid"
+    client_secret = "someclientsecret"
+    token_url     = "https://example.com/oauth2/default/v1/token"
+}
+```
+
+```river
+otelcol.exporter.otlp "example" {
+  client {
+    endpoint = "my-otlp-grpc-server:4317"
+    auth     = otelcol.auth.oauth2.creds.handler
+  }
+}
+
+otelcol.auth.oauth2 "creds" {
+    client_id     = "someclientid"
+    client_secret = "someclientsecret"
+    token_url     = "https://example.com/oauth2/default/v1/token"
+}
+```
+
+[otelcol.exporter.otlp]: {{< relref "./otelcol.exporter.otlp.md" >}}

--- a/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
@@ -103,6 +103,7 @@ otelcol.auth.oauth2 "creds" {
 }
 ```
 
+Here is another example with some optional attributes specified:
 ```river
 otelcol.exporter.otlp "example" {
   client {
@@ -112,9 +113,12 @@ otelcol.exporter.otlp "example" {
 }
 
 otelcol.auth.oauth2 "creds" {
-    client_id     = "someclientid"
-    client_secret = "someclientsecret"
-    token_url     = "https://example.com/oauth2/default/v1/token"
+    client_id       = "someclientid2"
+    client_secret   = "someclientsecret2"
+    token_url       = "https://example.com/oauth2/default/v1/token"
+    endpoint_params = {"audience" = ["someaudience"]}
+    scopes          = ["api.metrics"]
+    timeout         = "1s"
 }
 ```
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.kafka.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.kafka.md
@@ -148,17 +148,7 @@ The `tls` block configures TLS settings used for connecting to the Kafka
 brokers. If the `tls` block isn't provided, TLS won't be used for
 communication.
 
-The following arguments are supported:
-
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`ca_file` | `string` | Path to the CA file. | | no
-`cert_file` | `string` | Path to the TLS certificate. | | no
-`key_file` | `string` | Path to the TLS certificate key. | | no
-`min_version` | `string` | Minimum acceptable TLS version for connections. | `"TLS 1.2"` | no
-`max_version` | `string` | Maximum acceptable TLS version for connections. | `"TLS 1.3"` | no
-`reload_interval` | `duration` | Frequency to reload the certificates. | | no
-`client_ca_file` | `string` | Path to the CA file used to authenticate client certificates. | | no
+{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" >}}
 
 ### kerberos block
 

--- a/docs/sources/shared/flow/reference/components/otelcol-tls-config-block.md
+++ b/docs/sources/shared/flow/reference/components/otelcol-tls-config-block.md
@@ -13,6 +13,7 @@ Name | Type | Description | Default | Required
 `key_file` | `string` | Path to the TLS certificate key. | | no
 `min_version` | `string` | Minimum acceptable TLS version for connections. | `"TLS 1.2"` | no
 `max_version` | `string` | Maximum acceptable TLS version for connections. | `"TLS 1.3"` | no
+`reload_interval` | `duration` | The duration after which the certificate will be reloaded. | `"0s"` | no
 `insecure` | `boolean` | Disables TLS when connecting to the configured server. | | no
 `insecure_skip_verify` | `boolean` | Ignores insecure server TLS certificates. | | no
 `server_name` | `string` | Verifies the hostname of server certificates when set. | | no
@@ -20,3 +21,5 @@ Name | Type | Description | Default | Required
 If the server doesn't support TLS, the tls block must be provided with the
 `insecure` argument set to `true`. To disable `tls` for connections to the
 server, set the `insecure` argument to `true`.
+
+If `reload_interval` is set to `"0s"`, the certificate will never be reloaded.


### PR DESCRIPTION
#### PR Description
Add a `otelcol.auth.oauth2` component which ports over [oauth2client](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/oauth2clientauthextension)

#### Which issue(s) this PR fixes
Fixes #2357

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
