### PR TITLE
fix #3129 - Support hostPort

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -12,6 +12,7 @@ Unreleased
 
 ### Enhancements
 
+- Add hostPort specification to extraPorts and extraPort documentation. (@pnathan)
 - Selectively template ClusterIP. (@aglees)
 - Add priorityClassName value. (@aglees)
 

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -89,6 +89,21 @@ container. The list of available arguments is documented on [agent run][].
 
 [agent run]: https://grafana.com/docs/agent/latest/flow/reference/cli/run/
 
+
+### agent.extraPorts
+`agent.extraPorts` allows for configuring specific open ports.
+
+The detained specification of ports can be found at the [Kubernetes Pod documents](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#ports).
+
+Port numbers specified must be 0 < x < 65535.
+
+| ChartPort | KubePort | Description |
+|-----------|----------|-------------|
+| targetPort | containerPort | Number of port to expose on the pod's IP address. |
+| hostPort | hostPort | (Optional) Number of port to expose on the host. Daemonsets taking traffic might find this useful. |
+| name | name | If specified, this must be an `IANA_SVC_NAME` and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
+| protocol | protocol | Must be UDP, TCP, or SCTP. Defaults to "TCP". |
+
 ### agent.listenAddr
 
 `agent.listenAddr` allows for restricting which address the agent listens on

--- a/operations/helm/charts/grafana-agent/templates/containers/_agent.yaml
+++ b/operations/helm/charts/grafana-agent/templates/containers/_agent.yaml
@@ -36,6 +36,9 @@
       name: faro
     {{- range $portMap := .Values.agent.extraPorts }}
     - containerPort: {{ $portMap.targetPort }}
+      {{- if $portMap.hostPort }}
+      hostPort: {{ $portMap.hostPort }}
+      {{- end}}
       name: {{ $portMap.name }}
       protocol: {{ coalesce $portMap.protocol "TCP" }}
     {{- end }}


### PR DESCRIPTION
hostPort is useful to set for UDP traffic from on-node tracers in a daemonset deployment.

#### PR Description

Helm Chart: Adds hostPort to the extraPorts fields, along with documentation for same.

#### Which issue(s) this PR fixes

Fixes #3129  

#### Notes to the Reviewer

Tested on a live cluster.  Not confident about running the helm test system in the repo. 

#### PR Checklist

- [X] CHANGELOG updated
- [X] Documentation added
- [ ] Tests updated
