### PR TITLE
Cherry-pick "kubetail: add a max lifetime for tailing logs from a container (#3087)" into release v0.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ internal API changes are not present.
 > **NOTE**: As of v0.32.0, builds for 32-bit ARMv6 currently don't support the
 > embedded Flow UI. The Flow UI will return to this target as soon as possible.
 
+v0.32.1 (2023-03-06)
+--------------------
+
+### Bugfixes
+
+- Flow: add a maximum connection lifetime of one hour when tailing logs from
+  `loki.source.kubernetes` and `loki.source.podlogs` to recover from an issue
+  where the Kubernetes API server stops responding with logs without closing
+  the TCP connection. (@rfratto)
+
+- Flow: fix issue in `loki.source.kubernetes` where `__pod__uid__` meta label
+  defaulted incorrectly to the container name, causing tailers to never
+  restart. (@rfratto)
+
 v0.32.0 (2023-02-28)
 --------------------
 

--- a/component/loki/source/kubernetes/kubetail/tailer.go
+++ b/component/loki/source/kubernetes/kubetail/tailer.go
@@ -79,7 +79,11 @@ func newLabelSet(l labels.Labels) model.LabelSet {
 }
 
 var retailBackoff = backoff.Config{
-	MinBackoff: time.Second,
+	// Since our tailers have a maximum lifetime and are expected to regularly
+	// terminate to refresh their connection to the Kubernetes API, the minimum
+	// backoff starts at zero so there's minimum delay between expected
+	// terminations.
+	MinBackoff: 0,
 	MaxBackoff: time.Minute,
 }
 
@@ -120,7 +124,10 @@ func (t *tailer) Run(ctx context.Context) {
 }
 
 func (t *tailer) tail(ctx context.Context, handler loki.EntryHandler) error {
-	ctx, cancel := context.WithCancel(ctx)
+	// Set a maximum lifetime of the tail to ensure that connections are
+	// reestablished. This avoids an issue where the Kubernetes API server stops
+	// responding with new logs while the connection is kept open.
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Hour)
 	defer cancel()
 
 	var (
@@ -155,6 +162,7 @@ func (t *tailer) tail(ctx context.Context, handler loki.EntryHandler) error {
 		SinceTime:  offsetTime,
 		Timestamps: true, // Should be forced to true so we can parse the original timestamp back out.
 	})
+
 	stream, err := req.Stream(ctx)
 	if err != nil {
 		return err
@@ -206,7 +214,7 @@ func (t *tailer) tail(ctx context.Context, handler loki.EntryHandler) error {
 		// until the tailer is shutdown; EOF being returned doesn't necessarily
 		// indicate that the logs are done, and could point to a brief network
 		// outage.
-		if err != nil && errors.Is(err, io.EOF) {
+		if err != nil && (errors.Is(err, io.EOF) || ctx.Err() != nil) {
 			return nil
 		} else if err != nil {
 			return err

--- a/component/loki/source/kubernetes/kubetail/target.go
+++ b/component/loki/source/kubernetes/kubetail/target.go
@@ -208,7 +208,7 @@ func PrepareLabels(lset labels.Labels, defaultJob string) (res labels.Labels, er
 		lb.Set(LabelPodContainerName, podContainerName)
 	}
 	if !lset.Has(LabelPodUID) {
-		lb.Set(LabelPodUID, podContainerName)
+		lb.Set(LabelPodUID, podUID)
 	}
 
 	// Meta labels are deleted after relabelling. Other internal labels propagate


### PR DESCRIPTION
* kubetail: add a max lifetime for tailing logs from a container

This adds a maximum lifetime (1 hour) for each tailing connection to a container. This fixes an issue where the connection between the agent, the Kubernetes API server, and the Kubelet can get disrupted without closing the TCP connection, leading to no logs being read.

* fix misassignment of UID for tailing container

* explain MinBackoff 0

(cherry picked from commit 6788e3f5c4e0ebe3186f003762f891c46221c22e)

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
