### PR TITLE
helm chart: fix CHANGELOG

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -10,17 +10,14 @@ internal API changes are not present.
 Unreleased
 ----------
 
-### Enhancements
-
-- Add hostPort specification to extraPorts and extraPort documentation. (@pnathan)
-- Selectively template ClusterIP. (@aglees)
-- Add priorityClassName value. (@aglees)
-
 0.8.1 (2023-03-06)
 ------------------
 
 ### Enhancements
 
+- Add hostPort specification to extraPorts and extraPort documentation. (@pnathan)
+- Selectively template ClusterIP. (@aglees)
+- Add priorityClassName value. (@aglees)
 - Update Grafana Agent version to v0.32.1. (@erikbaranowski)
 
 0.8.0 (2023-02-28)


### PR DESCRIPTION
0.8.1 released all the pending features. 

It likely should've been 0.9.0 in that case, but since it's already released, we'll leave it as-is.