### PR TITLE
Use missing Secret field in integrations

### DIFF
--- a/pkg/integrations/mssql/sql_exporter.go
+++ b/pkg/integrations/mssql/sql_exporter.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
+	config_util "github.com/prometheus/common/config"
 
 	"github.com/burningalchemist/sql_exporter"
 	"github.com/burningalchemist/sql_exporter/config"
@@ -26,10 +27,10 @@ var DefaultConfig = Config{
 
 // Config is the configuration for the mssql integration
 type Config struct {
-	ConnectionString   string        `yaml:"connection_string,omitempty"`
-	MaxIdleConnections int           `yaml:"max_idle_connections,omitempty"`
-	MaxOpenConnections int           `yaml:"max_open_connections,omitempty"`
-	Timeout            time.Duration `yaml:"timeout,omitempty"`
+	ConnectionString   config_util.Secret `yaml:"connection_string,omitempty"`
+	MaxIdleConnections int                `yaml:"max_idle_connections,omitempty"`
+	MaxOpenConnections int                `yaml:"max_open_connections,omitempty"`
+	Timeout            time.Duration      `yaml:"timeout,omitempty"`
 }
 
 func (c Config) validate() error {
@@ -37,7 +38,7 @@ func (c Config) validate() error {
 		return errors.New("the connection_string parameter is required")
 	}
 
-	url, err := url.Parse(c.ConnectionString)
+	url, err := url.Parse(string(c.ConnectionString))
 	if err != nil {
 		return fmt.Errorf("failed to parse connection_string: %w", err)
 	}
@@ -63,7 +64,7 @@ func (c Config) validate() error {
 
 // Identifier returns a string that identifies the integration.
 func (c *Config) InstanceKey(agentKey string) (string, error) {
-	url, err := url.Parse(c.ConnectionString)
+	url, err := url.Parse(string(c.ConnectionString))
 	if err != nil {
 		return "", fmt.Errorf("failed to parse connection string URL: %w", err)
 	}
@@ -98,7 +99,7 @@ func (c *Config) NewIntegration(l log.Logger) (integrations.Integration, error) 
 	t, err := sql_exporter.NewTarget(
 		"mssqlintegration",
 		"",
-		c.ConnectionString,
+		string(c.ConnectionString),
 		[]*config.CollectorConfig{
 			&collectorConfig,
 		},

--- a/pkg/integrations/oracledb_exporter/oracledb_exporter_test.go
+++ b/pkg/integrations/oracledb_exporter/oracledb_exporter_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	config_util "github.com/prometheus/common/config"
 	go_ora "github.com/sijms/go-ora/v2"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
@@ -51,7 +52,7 @@ func TestConfigValidate(t *testing.T) {
 			name: "go_ora built connection string",
 			getConfig: func() Config {
 				c := DefaultConfig
-				c.ConnectionString = go_ora.BuildUrl("localhost", 1521, "service", "user", "pass", nil)
+				c.ConnectionString = config_util.Secret(go_ora.BuildUrl("localhost", 1521, "service", "user", "pass", nil))
 				return c
 			},
 		},
@@ -59,7 +60,7 @@ func TestConfigValidate(t *testing.T) {
 			name: "no hostname",
 			getConfig: func() Config {
 				c := DefaultConfig
-				c.ConnectionString = go_ora.BuildUrl("", 1521, "service", "user", "pass", nil)
+				c.ConnectionString = config_util.Secret(go_ora.BuildUrl("", 1521, "service", "user", "pass", nil))
 				return c
 			},
 			expectedErr: errNoHostname,
@@ -95,10 +96,10 @@ func TestConfigValidate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := tc.getConfig()
 			if tc.expectedErr == nil {
-				require.NoError(t, validateConnString(cfg.ConnectionString))
+				require.NoError(t, validateConnString(string(cfg.ConnectionString)))
 				return
 			}
-			require.ErrorContains(t, validateConnString(cfg.ConnectionString), tc.expectedErr.Error())
+			require.ErrorContains(t, validateConnString(string(cfg.ConnectionString)), tc.expectedErr.Error())
 		})
 	}
 }

--- a/pkg/integrations/snowflake_exporter/snowflake_exporter.go
+++ b/pkg/integrations/snowflake_exporter/snowflake_exporter.go
@@ -3,7 +3,10 @@ package snowflake_exporter
 import (
 	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/integrations"
+	integrations_v2 "github.com/grafana/agent/pkg/integrations/v2"
+	"github.com/grafana/agent/pkg/integrations/v2/metricsutils"
 	"github.com/grafana/snowflake-prometheus-exporter/collector"
+	config_util "github.com/prometheus/common/config"
 )
 
 // DefaultConfig is the default config for the snowflake integration
@@ -13,18 +16,18 @@ var DefaultConfig = Config{
 
 // Config is the configuration for the snowflake integration
 type Config struct {
-	AccountName string `yaml:"account_name,omitempty"`
-	Username    string `yaml:"username,omitempty"`
-	Password    string `yaml:"password,omitempty"`
-	Role        string `yaml:"role,omitempty"`
-	Warehouse   string `yaml:"warehouse,omitempty"`
+	AccountName string             `yaml:"account_name,omitempty"`
+	Username    string             `yaml:"username,omitempty"`
+	Password    config_util.Secret `yaml:"password,omitempty"`
+	Role        string             `yaml:"role,omitempty"`
+	Warehouse   string             `yaml:"warehouse,omitempty"`
 }
 
 func (c *Config) exporterConfig() *collector.Config {
 	return &collector.Config{
 		AccountName: c.AccountName,
 		Username:    c.Username,
-		Password:    c.Password,
+		Password:    string(c.Password),
 		Role:        c.Role,
 		Warehouse:   c.Warehouse,
 	}
@@ -50,6 +53,7 @@ func (c *Config) Name() string {
 
 func init() {
 	integrations.RegisterIntegration(&Config{})
+	integrations_v2.RegisterLegacy(&Config{}, integrations_v2.TypeMultiplex, metricsutils.NewNamedShim("snowflake"))
 }
 
 // NewIntegration creates a new integration from the config.

--- a/pkg/integrations/snowflake_exporter/snowflake_exporter.go
+++ b/pkg/integrations/snowflake_exporter/snowflake_exporter.go
@@ -3,8 +3,6 @@ package snowflake_exporter
 import (
 	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/integrations"
-	integrations_v2 "github.com/grafana/agent/pkg/integrations/v2"
-	"github.com/grafana/agent/pkg/integrations/v2/metricsutils"
 	"github.com/grafana/snowflake-prometheus-exporter/collector"
 	config_util "github.com/prometheus/common/config"
 )
@@ -53,7 +51,6 @@ func (c *Config) Name() string {
 
 func init() {
 	integrations.RegisterIntegration(&Config{})
-	integrations_v2.RegisterLegacy(&Config{}, integrations_v2.TypeMultiplex, metricsutils.NewNamedShim("snowflake"))
 }
 
 // NewIntegration creates a new integration from the config.


### PR DESCRIPTION
#### PR Description

Some integrations were using plain strings instead of `Secret` type for
secret fields. This PR fixes it.

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
