### PR TITLE
river: allow referencing zero values in Go maps

### DIFF
--- a/pkg/river/encoding/map.go
+++ b/pkg/river/encoding/map.go
@@ -1,7 +1,6 @@
 package encoding
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/grafana/agent/pkg/river/internal/value"
@@ -42,8 +41,6 @@ func (mf *mapField) convertMap(val value.Value) error {
 
 		kf.Key = key
 		mapVal, found := val.Key(key)
-		// The above val.Key(key) will return false if the value is nil or zero. This is an issue that will be evaluated
-		// later.
 		if !found {
 			continue
 		}
@@ -54,7 +51,7 @@ func (mf *mapField) convertMap(val value.Value) error {
 		if rv.hasValue() {
 			kf.Value = rv
 		} else {
-			return fmt.Errorf("unable to find value for %T in map", val.Interface())
+			kf.Value = &valueField{Type: "null"}
 		}
 		fields = append(fields, kf)
 	}

--- a/pkg/river/encoding/map_test.go
+++ b/pkg/river/encoding/map_test.go
@@ -8,20 +8,30 @@ import (
 )
 
 func TestMap(t *testing.T) {
-	testMap := make(map[string]string)
-	testMap["testBlank"] = ""
-	testMap["testValue"] = "value"
-	mf, err := newRiverMap(value.Encode(testMap))
-	require.NoError(t, err)
-	require.True(t, mf.hasValue())
-}
 
-func TestMapNullValue(t *testing.T) {
-	testMap := make(map[string]any)
-	testMap["testBlank"] = ""
-	testMap["testValue"] = "value"
-	testMap["testNull"] = value.Null
-	mf, err := newRiverMap(value.Encode(testMap))
-	require.NoError(t, err)
-	require.True(t, mf.hasValue())
+	tt := []struct {
+		name    string
+		testMap map[string]interface{}
+	}{
+		{
+			name:    "Test Map Value",
+			testMap: map[string]any{"testValue": "value"},
+		},
+		{
+			name:    "Test Map Blank",
+			testMap: map[string]any{"testBlank": ""},
+		},
+		{
+			name:    "Test Map Null",
+			testMap: map[string]any{"testNull": value.Null},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			mf, err := newRiverMap(value.Encode(tc.testMap))
+			require.NoError(t, err)
+			require.True(t, mf.hasValue())
+		})
+	}
 }

--- a/pkg/river/encoding/map_test.go
+++ b/pkg/river/encoding/map_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestMap(t *testing.T) {
-
 	tt := []struct {
 		name    string
 		testMap map[string]interface{}

--- a/pkg/river/encoding/map_test.go
+++ b/pkg/river/encoding/map_test.go
@@ -15,3 +15,13 @@ func TestMap(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, mf.hasValue())
 }
+
+func TestMapNullValue(t *testing.T) {
+	testMap := make(map[string]any)
+	testMap["testBlank"] = ""
+	testMap["testValue"] = "value"
+	testMap["testNull"] = value.Null
+	mf, err := newRiverMap(value.Encode(testMap))
+	require.NoError(t, err)
+	require.True(t, mf.hasValue())
+}

--- a/pkg/river/internal/value/value.go
+++ b/pkg/river/internal/value/value.go
@@ -362,12 +362,9 @@ func (v Value) Key(key string) (index Value, ok bool) {
 		// We return the struct with the label intact.
 		return wrapStruct(v.rv, true).Key(key)
 	case v.rv.Kind() == reflect.Map:
-		// TODO There is a known issue where value.Keys returns an array of keys
-		// but MapIndex does not find the key just returned because it is a nil/zero value.
-		// This is a bug and will be evaluated later when the ramifications are better known.
 		val := v.rv.MapIndex(reflect.ValueOf(key))
-		if !val.IsValid() || val.IsZero() {
-			return
+		if !val.IsValid() {
+			return Null, false
 		}
 		return makeValue(val), true
 

--- a/pkg/river/internal/value/value_test.go
+++ b/pkg/river/internal/value/value_test.go
@@ -62,6 +62,15 @@ func TestEncodeKeyLookup(t *testing.T) {
 			expectKeyValue:  value.Null,
 			expectKeyType:   value.TypeNull,
 		},
+		{
+			name:            "Map Encode empty value Key",
+			encodeTarget:    map[string]string{"data": ""},
+			key:             "data",
+			expectBodyType:  value.TypeObject,
+			expectKeyExists: true,
+			expectKeyValue:  value.String(""),
+			expectKeyType:   value.TypeString,
+		},
 	}
 
 	for _, tc := range tt {

--- a/pkg/river/internal/value/value_test.go
+++ b/pkg/river/internal/value/value_test.go
@@ -21,7 +21,7 @@ func TestInterfacePointerReceiver(t *testing.T) {
 		require.Equal(t, "Hello, world!", val.Text())
 	})
 
-	t.Run("From field", func(t *testing.T) {
+	t.Run("Struct Encode Key", func(t *testing.T) {
 		type Body struct {
 			Data pointerMarshaler `river:"data,attr"`
 		}
@@ -35,6 +35,26 @@ func TestInterfacePointerReceiver(t *testing.T) {
 		require.True(t, ok, "data key did not exist")
 		require.Equal(t, value.TypeString, val.Type())
 		require.Equal(t, "Hello, world!", val.Text())
+
+		val, ok = bodyVal.Key("missing")
+		require.False(t, ok, "missing key should not exist")
+		require.Equal(t, value.Null, val)
+	})
+
+	t.Run("Map Encode Key", func(t *testing.T) {
+		mapVar := map[string]string{"data": "Data"}
+
+		bodyVal := value.Encode(mapVar)
+		require.Equal(t, value.TypeObject, bodyVal.Type())
+
+		val, ok := bodyVal.Key("data")
+		require.True(t, ok, "data key did not exist")
+		require.Equal(t, value.TypeString, val.Type())
+		require.Equal(t, "Data", val.Text())
+
+		val, ok = bodyVal.Key("missing")
+		require.False(t, ok, "missing key should not exist")
+		require.Equal(t, value.Null, val)
 	})
 }
 


### PR DESCRIPTION
This fixes an issue where any reference to a zero value in a Go map would be treated as if the key didn't exist. This was due to a misunderstanding of the Go documentation that said "the zero Value" will be returned if the key does not exist in the map. This documentation referred to an invalid `reflect.Value` instead of the zero value of the map's value type.

This allows to simplify the logic when performing a map lookup to determine if the key was found or not, and permits expressions which reference a map key set to the zero value of the value type.

Opening in draft because it still needs some unit tests.