### PR TITLE
Bring back the Flow UI for ARMv6 builds

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -348,8 +348,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agent
+  - GOOS=linux GOARCH=amd64 GOARM= make agent
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -365,8 +364,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agent
+  - GOOS=linux GOARCH=arm64 GOARM= make agent
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -382,7 +380,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="promtail_journal_enabled" make agent
+  - GOOS=linux GOARCH=arm GOARM=6 make agent
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -398,8 +396,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="builtinassets promtail_journal_enabled"
-    make agent
+  - GOOS=linux GOARCH=arm GOARM=7 make agent
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -415,8 +412,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agent
+  - GOOS=linux GOARCH=ppc64le GOARM= make agent
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -432,8 +428,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=s390x GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agent
+  - GOOS=linux GOARCH=s390x GOARM= make agent
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -449,8 +444,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agent
+  - GOOS=darwin GOARCH=amd64 GOARM= make agent
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -466,8 +460,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agent
+  - GOOS=darwin GOARCH=arm64 GOARM= make agent
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -483,8 +476,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agent
+  - GOOS=windows GOARCH=amd64 GOARM= make agent
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -500,8 +492,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agent
+  - GOOS=freebsd GOARCH=amd64 GOARM= make agent
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -517,8 +508,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agentctl
+  - GOOS=linux GOARCH=amd64 GOARM= make agentctl
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -534,8 +524,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agentctl
+  - GOOS=linux GOARCH=arm64 GOARM= make agentctl
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -551,7 +540,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="promtail_journal_enabled" make agentctl
+  - GOOS=linux GOARCH=arm GOARM=6 make agentctl
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -567,8 +556,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="builtinassets promtail_journal_enabled"
-    make agentctl
+  - GOOS=linux GOARCH=arm GOARM=7 make agentctl
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -584,8 +572,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agentctl
+  - GOOS=linux GOARCH=ppc64le GOARM= make agentctl
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -601,8 +588,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=s390x GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agentctl
+  - GOOS=linux GOARCH=s390x GOARM= make agentctl
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -618,8 +604,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agentctl
+  - GOOS=darwin GOARCH=amd64 GOARM= make agentctl
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -635,8 +620,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agentctl
+  - GOOS=darwin GOARCH=arm64 GOARM= make agentctl
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -652,8 +636,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agentctl
+  - GOOS=windows GOARCH=amd64 GOARM= make agentctl
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -669,8 +652,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make agentctl
+  - GOOS=freebsd GOARCH=amd64 GOARM= make agentctl
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -686,8 +668,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make operator
+  - GOOS=linux GOARCH=amd64 GOARM= make operator
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -703,8 +684,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make operator
+  - GOOS=linux GOARCH=arm64 GOARM= make operator
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -720,7 +700,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=6 GO_TAGS="promtail_journal_enabled" make operator
+  - GOOS=linux GOARCH=arm GOARM=6 make operator
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -736,8 +716,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=7 GO_TAGS="builtinassets promtail_journal_enabled"
-    make operator
+  - GOOS=linux GOARCH=arm GOARM=7 make operator
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -753,8 +732,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=ppc64le GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make operator
+  - GOOS=linux GOARCH=ppc64le GOARM= make operator
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -770,8 +748,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=linux GOARCH=s390x GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make operator
+  - GOOS=linux GOARCH=s390x GOARM= make operator
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -787,8 +764,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=darwin GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make operator
+  - GOOS=darwin GOARCH=amd64 GOARM= make operator
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -804,8 +780,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=darwin GOARCH=arm64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make operator
+  - GOOS=darwin GOARCH=arm64 GOARM= make operator
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -821,8 +796,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=windows GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make operator
+  - GOOS=windows GOARCH=amd64 GOARM= make operator
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -838,8 +812,7 @@ platform:
 steps:
 - commands:
   - make generate-ui
-  - GOOS=freebsd GOARCH=amd64 GOARM= GO_TAGS="builtinassets promtail_journal_enabled"
-    make operator
+  - GOOS=freebsd GOARCH=amd64 GOARM= make operator
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -1296,6 +1269,6 @@ kind: secret
 name: gpg_passphrase
 ---
 kind: signature
-hmac: 401f8734ba3079c7128ec0ea5635413a06d57b25ab58b05b70e62b0d63d72cff
+hmac: ea36b39b4cf7c9075321e7d3ca75c02cac36e962bb951ef9fc3022f710ec9933
 
 ...

--- a/.drone/pipelines/crosscompile.jsonnet
+++ b/.drone/pipelines/crosscompile.jsonnet
@@ -5,7 +5,7 @@ local os_arch_tuples = [
   // Linux
   { name: 'Linux amd64', os: 'linux', arch: 'amd64' },
   { name: 'Linux arm64', os: 'linux', arch: 'arm64' },
-  { name: 'Linux armv6', os: 'linux', arch: 'arm', arm: '6', tags: 'promtail_journal_enabled' },
+  { name: 'Linux armv6', os: 'linux', arch: 'arm', arm: '6' },
   { name: 'Linux armv7', os: 'linux', arch: 'arm', arm: '7' },
   { name: 'Linux ppc64le', os: 'linux', arch: 'ppc64le' },
   { name: 'Linux s390x', os: 'linux', arch: 's390x' },
@@ -30,18 +30,12 @@ local targets = [
 std.flatMap(function(target) (
   std.map(function(platform) (
     pipelines.linux('Build %s (%s)' % [target, platform.name]) {
-      local build_tags = (
-        if 'tags' in platform then platform.tags
-        else 'builtinassets promtail_journal_enabled'
-      ),
-
       local env = {
         GOOS: platform.os,
         GOARCH: platform.arch,
         GOARM: if 'arm' in platform then platform.arm else '',
 
         target: target,
-        tags: build_tags,
       },
 
       trigger: {
@@ -52,7 +46,7 @@ std.flatMap(function(target) (
         image: build_image.linux,
         commands: [
           'make generate-ui',
-          'GOOS=%(GOOS)s GOARCH=%(GOARCH)s GOARM=%(GOARM)s GO_TAGS="%(tags)s" make %(target)s' % env,
+          'GOOS=%(GOOS)s GOARCH=%(GOARCH)s GOARM=%(GOARM)s make %(target)s' % env,
         ],
       }],
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Main (unreleased)
 
 - Use Go 1.20.2 for builds. (@rfratto)
 
+- Bring back the Flow UI for 32-bit ARMv6 builds. (@rfratto)
+
 v0.32.1 (2023-03-06)
 --------------------
 

--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -43,11 +43,11 @@ dist/grafana-agent-linux-arm64: GOARCH  := arm64
 dist/grafana-agent-linux-arm64: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/grafana-agent-linux-armv6: GO_TAGS += promtail_journal_enabled
+dist/grafana-agent-linux-armv6: GO_TAGS += builtinassets promtail_journal_enabled
 dist/grafana-agent-linux-armv6: GOOS    := linux
 dist/grafana-agent-linux-armv6: GOARCH  := arm
 dist/grafana-agent-linux-armv6: GOARM   := 6
-dist/grafana-agent-linux-armv6:
+dist/grafana-agent-linux-armv6: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
 dist/grafana-agent-linux-armv7: GO_TAGS += builtinassets promtail_journal_enabled


### PR DESCRIPTION
Now that we're using Go 1.20.2, we can build the UI back.