### PR TITLE
Clarify snowflake_config with beta banner

### DIFF
--- a/docs/sources/configuration/integrations/integrations-next/snowflake-config.md
+++ b/docs/sources/configuration/integrations/integrations-next/snowflake-config.md
@@ -4,6 +4,8 @@ title: snowflake_config
 
 # snowflake_config (beta)
 
+>**Note:** This config is associated with the [Integrations revamp experimental feature](_index.md) for multi-instance monitoring using a single agent. A GA snowflake_config for single-instance monitoring can be found [here](../snowflake-config.md).
+
 The `snowflake_configs` block configures the `snowflake` integration,
 which is an embedded version of
 [`snowflake-prometheus-exporter`](https://github.com/grafana/snowflake-prometheus-exporter). This allows the collection of [Snowflake](https://www.snowflake.com/) metrics.


### PR DESCRIPTION

#### PR Description
Adds a banner notifying users that this config is associated with the integrations revamp experimental feature and provides a link to the GA snowflake_config as an alternative option.

#### Which issue(s) this PR fixes
[Issue #717](https://github.com/grafana/cloud-docs/issues/717) in the cloud-docs repo 

#### Notes to the Reviewer
See the issue linked above for additional context 

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
