### PR TITLE
Update Redis exporter  to v1.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Main (unreleased)
 
 - Flow: Add retries with backoff logic to Phlare write component. (@cyriltovena)
 
+- Update Redis Exporter Dependency to v1.48.0. (@spartan0x117)
+
 ### Other changes
 
 - Grafana Agent Docker containers and release binaries are now published for

--- a/component/prometheus/exporter/redis/redis.go
+++ b/component/prometheus/exporter/redis/redis.go
@@ -36,6 +36,7 @@ var DefaultConfig = Config{
 	SetClientName:           true,
 	CheckKeyGroupsBatchSize: 10000,
 	MaxDistinctKeyGroups:    100,
+	RedactConfigMetrics:     true,
 }
 
 type Config struct {

--- a/component/prometheus/exporter/redis/redis.go
+++ b/component/prometheus/exporter/redis/redis.go
@@ -60,18 +60,21 @@ type Config struct {
 	CheckStreams            []string          `river:"check_streams,attr,optional"`
 	CheckSingleStreams      []string          `river:"check_single_streams,attr,optional"`
 	CountKeys               []string          `river:"count_keys,attr,optional"`
-	ScriptPath              string            `river:"script_path,attr,optional"`
+	ScriptPaths             []string          `river:"script_paths,attr,optional"`
 	ConnectionTimeout       time.Duration     `river:"connection_timeout,attr,optional"`
 	TLSClientKeyFile        string            `river:"tls_client_key_file,attr,optional"`
 	TLSClientCertFile       string            `river:"tls_client_cert_file,attr,optional"`
 	TLSCaCertFile           string            `river:"tls_ca_cert_file,attr,optional"`
 	SetClientName           bool              `river:"set_client_name,attr,optional"`
 	IsTile38                bool              `river:"is_tile38,attr,optional"`
+	IsCluster               bool              `river:"is_cluster,attr,optional"`
 	ExportClientList        bool              `river:"export_client_list,attr,optional"`
 	ExportClientPort        bool              `river:"export_client_port,attr,optional"`
 	RedisMetricsOnly        bool              `river:"redis_metrics_only,attr,optional"`
 	PingOnConnect           bool              `river:"ping_on_connect,attr,optional"`
 	InclSystemMetrics       bool              `river:"incl_system_metrics,attr,optional"`
+	InclConfigMetrics       bool              `river:"incl_config_metrics,attr,optional"`
+	RedactConfigMetrics     bool              `river:"redact_config_metrics,attr,optional"`
 	SkipTLSVerification     bool              `river:"skip_tls_verification,attr,optional"`
 }
 
@@ -101,18 +104,21 @@ func (c *Config) Convert() *redis_exporter.Config {
 		CheckStreams:            strings.Join(c.CheckStreams, ","),
 		CheckSingleStreams:      strings.Join(c.CheckSingleStreams, ","),
 		CountKeys:               strings.Join(c.CountKeys, ","),
-		ScriptPath:              c.ScriptPath,
+		ScriptPath:              strings.Join(c.ScriptPaths, ","),
 		ConnectionTimeout:       c.ConnectionTimeout,
 		TLSClientKeyFile:        c.TLSClientKeyFile,
 		TLSClientCertFile:       c.TLSClientCertFile,
 		TLSCaCertFile:           c.TLSCaCertFile,
 		SetClientName:           c.SetClientName,
 		IsTile38:                c.IsTile38,
+		IsCluster:               c.IsCluster,
 		ExportClientList:        c.ExportClientList,
 		ExportClientPort:        c.ExportClientPort,
 		RedisMetricsOnly:        c.RedisMetricsOnly,
 		PingOnConnect:           c.PingOnConnect,
 		InclSystemMetrics:       c.InclSystemMetrics,
+		InclConfigMetrics:       c.InclConfigMetrics,
+		RedactConfigMetrics:     c.RedactConfigMetrics,
 		SkipTLSVerification:     c.SkipTLSVerification,
 	}
 }

--- a/docs/sources/configuration/integrations/redis-exporter-config.md
+++ b/docs/sources/configuration/integrations/redis-exporter-config.md
@@ -116,7 +116,7 @@ Full reference of options:
   # Comma separated list of individual keys to export counts for.
   [count_keys: <string>]
 
-  # Path to Lua Redis script for collecting extra metrics.
+  # Comma-separated list of paths to Lua Redis scripts for collecting extra metrics.
   [script_path: <string>]
 
   # Timeout for connection to Redis instance (in Golang duration format).

--- a/docs/sources/configuration/integrations/redis-exporter-config.md
+++ b/docs/sources/configuration/integrations/redis-exporter-config.md
@@ -137,6 +137,9 @@ Full reference of options:
   # Whether to scrape Tile38 specific metrics.
   [is_tile38: <bool>]
 
+  # Whether this is a redis cluster (Enable this if you need to fetch key level data on a Redis Cluster).
+  [is_cluster: <bool> | default = false]
+
   # Whether to scrape Client List specific metrics.
   [export_client_list: <bool>]
 
@@ -152,6 +155,12 @@ Full reference of options:
 
   # Whether to include system metrics like e.g. redis_total_system_memory_bytes.
   [incl_system_metrics: <bool>]
+
+  # Whether to include all redis config settings as metrics.
+  [incl_config_metrics: <bool>]
+
+  # Whether to redact redis config settings that include potentially sensitive information like passwords.
+  [redact_config_metrics: <bool> | default = true]
 
   # Whether to to skip TLS verification.
   [skip_tls_verification: <bool>]

--- a/docs/sources/flow/reference/components/prometheus.exporter.redis.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.redis.md
@@ -48,11 +48,14 @@ Name | Type | Description | Default | Required
 `tls_ca_cert_file`            | `string`       | Name of the CA certificate file (including full path) if the server requires TLS client authentication. | | no
 `set_client_name`             | `bool`         | Whether to set client name to `redis_exporter`. | `true` | no
 `is_tile38`                   | `bool`         | Whether to scrape Tile38-specific metrics. | | no
+`is_cluster`                  | `bool`         | Whether the connection is to a Redis cluster. | | no
 `export_client_list`          | `bool`         | Whether to scrape Client List specific metrics. | | no
 `export_client_port`          | `bool`         | Whether to include the client's port when exporting the client list. | | no
 `redis_metrics_only`          | `bool`         | Whether to just export metrics or to also export go runtime metrics. | | no
 `ping_on_connect`             | `bool`         | Whether to ping the Redis instance after connecting. | | no
 `incl_system_metrics`         | `bool`         | Whether to include system metrics (e.g. `redis_total_system_memory_bytes`). | | no
+`incl_config_metrics`         | `bool`         | Whether to include Redis config values in metrics. | | no
+`redact_config_metrics`       | `bool`         | Whether to redact sensitive elements from Redis config metrics, if `incl_config_metrics` is set. | `true` | no
 `skip_tls_verification`       | `bool`         | Whether to to skip TLS verification. | | no
 
 If `redis_password_file` is defined, it will take precedence over `redis_password`.
@@ -62,6 +65,8 @@ When `check_key_groups` is not set, no key groups are made.
 The `check_key_groups_batch_size` option name reflects key groups for backwards compatibility, but applies to both key and key groups.
 
 Any leftover key groups beyond `max_distinct_key_groups` are aggregated in the 'overflow' bucket.
+
+The `is_cluster` argument should be used when connecting to a Redis cluster and using the `check_keys` and/or `check_single_keys` arguments.
 
 Note that setting `export_client_port` increases the cardinality of all Redis metrics.
 

--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/nerdswords/yet-another-cloudwatch-exporter v0.44.0-alpha
 	github.com/oklog/run v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/oliver006/redis_exporter v1.47.0
+	github.com/oliver006/redis_exporter v1.48.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter v0.63.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.63.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.63.0
@@ -130,7 +130,6 @@ require (
 	github.com/prometheus/prometheus v1.99.0
 	github.com/prometheus/snmp_exporter v0.20.1-0.20220111173215-83399c23888f
 	github.com/prometheus/statsd_exporter v0.22.8
-	github.com/prometheus/tsdb v0.7.1
 	github.com/rancher/k3d/v5 v5.2.2
 	github.com/rfratto/ckit v0.0.0-20220401221852-009169323240
 	github.com/rs/cors v1.8.3
@@ -145,6 +144,7 @@ require (
 	github.com/webdevops/azure-metrics-exporter v0.0.0-20221205214019-9333e682d754
 	github.com/webdevops/go-common v0.0.0-20221205213740-01078f6e07cd
 	github.com/wk8/go-ordered-map v0.2.0
+	github.com/xdg-go/scram v1.1.1
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/collector v0.63.1
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.63.0
@@ -549,7 +549,6 @@ require (
 	github.com/weaveworks/promrus v1.2.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.1 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
-	github.com/xdg-go/scram v1.1.1 // indirect
 	github.com/xdg-go/stringprep v1.0.3 // indirect
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
 	github.com/xdg/stringprep v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/nerdswords/yet-another-cloudwatch-exporter v0.44.0-alpha
 	github.com/oklog/run v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/oliver006/redis_exporter v1.27.1
+	github.com/oliver006/redis_exporter v1.47.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter v0.63.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.63.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.63.0
@@ -455,6 +455,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
+	github.com/mna/redisc v1.3.2 // indirect
 	github.com/moby/sys/mount v0.3.0 // indirect
 	github.com/moby/sys/mountinfo v0.5.0 // indirect
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2440,10 +2440,6 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2/go.mod h1:rSAaSIOAGT9odnlyGlUfAJaoc5w2fSBUmeGDbRWPxyQ=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
-github.com/oliver006/redis_exporter v1.27.1 h1:vYMjrOsZM73Z+KMFeF/9kQ0oDU1QaQhGpsqVxXOHR+c=
-github.com/oliver006/redis_exporter v1.27.1/go.mod h1:XSYKlN8zrq6YLG8FOt0eZfTLRTxArPWc11IgKrnNkk4=
-github.com/oliver006/redis_exporter v1.47.0 h1:zdrknxGCmsxBPmYDVygx5NXGhlhe8gP+PDAfRWzikr4=
-github.com/oliver006/redis_exporter v1.47.0/go.mod h1:O7UOQ4okTayrwJ07AZO6/qz0go+RBRu+Y9EgApY9hj8=
 github.com/oliver006/redis_exporter v1.48.0 h1:mpE6AyD2bG9I1/4hJLQZySanwFA6FyKb7Vwn83aukD8=
 github.com/oliver006/redis_exporter v1.48.0/go.mod h1:O7UOQ4okTayrwJ07AZO6/qz0go+RBRu+Y9EgApY9hj8=
 github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -2768,7 +2764,6 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
-github.com/prometheus/tsdb v0.7.1 h1:YZcsG11NqnK4czYLrWd9mpEuAJIHVQLwdrleYfszMAA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rafaeljusto/redigomock v0.0.0-20190202135759-257e089e14a1/go.mod h1:JaY6n2sDr+z2WTsXkOmNRUfDy6FN0L6Nk7x06ndm4tY=
 github.com/rancher/k3d/v5 v5.2.2 h1:9F+wqmRZz5Gl7o70g0OSPLYVyCOrz/rJPVQhxmaI2Bo=
@@ -2787,8 +2782,6 @@ github.com/rfratto/ckit v0.0.0-20220401221852-009169323240 h1:aWVSpqwdAr+e0IU+zY
 github.com/rfratto/ckit v0.0.0-20220401221852-009169323240/go.mod h1:kr0K+4DiLWPdO8eSEQ9W0XZ6Y/WhVzAHWOZyIG3BTkI=
 github.com/rfratto/go-yaml v0.0.0-20211119180816-77389c3526dc h1:g196Usc63pWDzWallipxVhsEjDdh/+RLc/Oz7q3ihW4=
 github.com/rfratto/go-yaml v0.0.0-20211119180816-77389c3526dc/go.mod h1:rMzeXFmWpS5JnfDANtpzbklRJY4pqZMJNN9/SJHAXPA=
-github.com/rfratto/unsafe-assume-no-moving-gc v0.0.0-20230202205252-987ee08b7700 h1:gXxbdL19p5CZ3MNJk2fa1BGgKujDFPVlFtFwyKOHh0A=
-github.com/rfratto/unsafe-assume-no-moving-gc v0.0.0-20230202205252-987ee08b7700/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
 github.com/rgeyer/github-exporter v0.0.0-20210722215637-d0cec2ee0dc8 h1:wNuNGrFzFmZlhrtz1Q8EiK1Ob6yWli8lX7D2AGmSGzE=
 github.com/rgeyer/github-exporter v0.0.0-20210722215637-d0cec2ee0dc8/go.mod h1:6XoOvFDTfk3aqGaOLHLxoWiZNx4zHobApOhKc3oHF/g=
 github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=

--- a/go.sum
+++ b/go.sum
@@ -2344,6 +2344,8 @@ github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/mna/redisc v1.3.2 h1:sc9C+nj6qmrTFnsXb70xkjAHpXKtjjBuE6v2UcQV0ZE=
+github.com/mna/redisc v1.3.2/go.mod h1:CplIoaSTDi5h9icnj4FLbRgHoNKCHDNJDVRztWDGeSQ=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/sys/mount v0.3.0 h1:bXZYMmq7DBQPwHRxH/MG+u9+XF90ZOwoXpHTOznMGp0=
@@ -2440,6 +2442,10 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/oliver006/redis_exporter v1.27.1 h1:vYMjrOsZM73Z+KMFeF/9kQ0oDU1QaQhGpsqVxXOHR+c=
 github.com/oliver006/redis_exporter v1.27.1/go.mod h1:XSYKlN8zrq6YLG8FOt0eZfTLRTxArPWc11IgKrnNkk4=
+github.com/oliver006/redis_exporter v1.47.0 h1:zdrknxGCmsxBPmYDVygx5NXGhlhe8gP+PDAfRWzikr4=
+github.com/oliver006/redis_exporter v1.47.0/go.mod h1:O7UOQ4okTayrwJ07AZO6/qz0go+RBRu+Y9EgApY9hj8=
+github.com/oliver006/redis_exporter v1.48.0 h1:mpE6AyD2bG9I1/4hJLQZySanwFA6FyKb7Vwn83aukD8=
+github.com/oliver006/redis_exporter v1.48.0/go.mod h1:O7UOQ4okTayrwJ07AZO6/qz0go+RBRu+Y9EgApY9hj8=
 github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/pkg/integrations/redis_exporter/redis_exporter.go
+++ b/pkg/integrations/redis_exporter/redis_exporter.go
@@ -27,6 +27,7 @@ var DefaultConfig = Config{
 	SetClientName:           true,
 	CheckKeyGroupsBatchSize: 10000,
 	MaxDistinctKeyGroups:    100,
+	RedactConfigMetrics:     true,
 }
 
 // Config controls the redis_exporter integration.

--- a/pkg/integrations/redis_exporter/redis_exporter.go
+++ b/pkg/integrations/redis_exporter/redis_exporter.go
@@ -59,11 +59,14 @@ type Config struct {
 	TLSCaCertFile           string             `yaml:"tls_ca_cert_file,omitempty"`
 	SetClientName           bool               `yaml:"set_client_name,omitempty"`
 	IsTile38                bool               `yaml:"is_tile38,omitempty"`
+	IsCluster               bool               `yaml:"is_cluster,omitempty"`
 	ExportClientList        bool               `yaml:"export_client_list,omitempty"`
 	ExportClientPort        bool               `yaml:"export_client_port,omitempty"`
 	RedisMetricsOnly        bool               `yaml:"redis_metrics_only,omitempty"`
 	PingOnConnect           bool               `yaml:"ping_on_connect,omitempty"`
 	InclSystemMetrics       bool               `yaml:"incl_system_metrics,omitempty"`
+	InclConfigMetrics       bool               `yaml:"incl_config_metrics,omitempty"`
+	RedactConfigMetrics     bool               `yaml:"redact_config_metrics,omitempty"`
 	SkipTLSVerification     bool               `yaml:"skip_tls_verification,omitempty"`
 }
 
@@ -84,9 +87,12 @@ func (c Config) GetExporterOptions() re.Options {
 		CheckSingleStreams:    c.CheckSingleStreams,
 		CountKeys:             c.CountKeys,
 		InclSystemMetrics:     c.InclSystemMetrics,
+		InclConfigMetrics:     c.InclConfigMetrics,
+		RedactConfigMetrics:   c.RedactConfigMetrics,
 		SkipTLSVerification:   c.SkipTLSVerification,
 		SetClientName:         c.SetClientName,
 		IsTile38:              c.IsTile38,
+		IsCluster:             c.IsCluster,
 		ExportClientList:      c.ExportClientList,
 		ExportClientsInclPort: c.ExportClientPort,
 		ConnectionTimeouts:    c.ConnectionTimeout,
@@ -135,11 +141,15 @@ func New(log log.Logger, c *Config) (integrations.Integration, error) {
 	}
 
 	if c.ScriptPath != "" {
-		ls, err := os.ReadFile(c.ScriptPath)
-		if err != nil {
-			return nil, fmt.Errorf("Error loading script file %s: %w", c.ScriptPath, err)
+		scripts := map[string][]byte{}
+		for _, path := range strings.Split(c.ScriptPath, ",") {
+			ls, err := os.ReadFile(path)
+			if err != nil {
+				return nil, fmt.Errorf("error loading script file %s: %w", c.ScriptPath, err)
+			}
+			scripts[path] = ls
 		}
-		exporterConfig.LuaScript = ls
+		exporterConfig.LuaScript = scripts
 	}
 
 	//new version of the exporter takes the file paths directly, for hot-reloading support (https://github.com/oliver006/redis_exporter/pull/526)

--- a/pkg/integrations/redis_exporter/redis_exporter_test.go
+++ b/pkg/integrations/redis_exporter/redis_exporter_test.go
@@ -2,6 +2,7 @@ package redis_exporter //nolint:golint
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +18,7 @@ import (
 
 const addr string = "localhost:6379"
 const redisExporterFile string = "./redis_exporter.go"
+const redisPasswordMapFile string = "./testdata/password_map_file.json"
 
 func TestRedisCases(t *testing.T) {
 	tt := []struct {
@@ -57,6 +59,16 @@ func TestRedisCases(t *testing.T) {
 				c := DefaultConfig
 				c.RedisAddr = addr
 				c.ScriptPath = redisExporterFile // file content is irrelevant
+				return c
+			})(),
+		},
+		// Test that multiple lua scripts in a csv doesn't cause errors.
+		{
+			name: "Multiple Lua scripts read OK",
+			cfg: (func() Config {
+				c := DefaultConfig
+				c.RedisAddr = addr
+				c.ScriptPath = fmt.Sprintf("%s,%s", redisExporterFile, redisPasswordMapFile) // file contents are irrelevant
 				return c
 			})(),
 		},
@@ -105,7 +117,7 @@ func TestRedisCases(t *testing.T) {
 			cfg: (func() Config {
 				c := DefaultConfig
 				c.RedisAddr = addr
-				c.RedisPasswordMapFile = "./testdata/password_map_file.json"
+				c.RedisPasswordMapFile = redisPasswordMapFile
 				return c
 			})(),
 		},


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Bumps the redis_exporter dependency to the latest release. This includes a few new options, as well as several bugfixes and metrics additions.

New options:
- `incl_config_metrics`: Adds new gauges for Redis config elements.
- `redact_config_metrics`: Related to `incl_config_metrics`, controls redacting secrets in the Redis config.
- `IsCluster`: Whether the connection is to a cluster, for the purposes of monitoring individual keys with the `check_keys` and `check_single_keys` options.

Updated options:
- `script_path`: For static mode, now supports passing in a comma-separated list of paths to Lua scripts instead of only a single path. For flow mode, this argument has been changed from `string` to `list(string)` and has been renamed to `script_paths`.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #3178 


#### PR Checklist

- [X] CHANGELOG updated
- [X] Documentation added
- [X] Tests updated
