### PR TITLE
module.string: new component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Main (unreleased)
 
   - `discovery.ec2` service discovery for aws ec2. (@captncraig)
   - `discovery.lightsail` service discovery for aws lightsail. (@captncraig)
+  - `module.string` runs a Grafana Agent Flow module passed to the component by
+    an expression containing a string. (@erikbaranowski, @rfratto)
   - `otelcol.auth.oauth2` performs OAuth 2.0 authentication for HTTP and gRPC
     based OpenTelemetry exporters. (@ptodev)
   - `prometheus.exporter.blackbox` collects metrics from Blackbox exporter

--- a/cmd/grafana-agent/flow_run.go
+++ b/cmd/grafana-agent/flow_run.go
@@ -145,6 +145,7 @@ func (fr *flowRun) Run(configFile string) error {
 		HTTPPathPrefix: "/api/v0/component/",
 		HTTPListenAddr: fr.httpListenAddr,
 	})
+	f.Run()
 
 	reload := func() error {
 		flowCfg, err := loadFlowFile(configFile)

--- a/component/all/all.go
+++ b/component/all/all.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/grafana/agent/component/loki/source/windowsevent"        // Import loki.source.windowsevent
 	_ "github.com/grafana/agent/component/loki/write"                      // Import loki.write
 	_ "github.com/grafana/agent/component/mimir/rules/kubernetes"          // Import mimir.rules.kubernetes
+	_ "github.com/grafana/agent/component/module/string"                   // Import module.string
 	_ "github.com/grafana/agent/component/otelcol/auth/basic"              // Import otelcol.auth.basic
 	_ "github.com/grafana/agent/component/otelcol/auth/bearer"             // Import otelcol.auth.bearer
 	_ "github.com/grafana/agent/component/otelcol/auth/headers"            // Import otelcol.auth.headers

--- a/component/module/string/string.go
+++ b/component/module/string/string.go
@@ -43,8 +43,8 @@ type Arguments struct {
 
 // Exports holds values which are exported from the run module.
 type Exports struct {
-	// Values exported from the running module.
-	Values map[string]any `river:"values,attr"`
+	// Exports exported from the running module.
+	Exports map[string]any `river:"exports,attr"`
 }
 
 // Component implements the module.string component.
@@ -89,10 +89,11 @@ func New(o component.Options, args Arguments) (*Component, error) {
 			HTTPListenAddr: o.HTTPListenAddr,
 
 			OnExportsChange: func(exports map[string]any) {
-				o.OnStateChange(Exports{Values: exports})
+				o.OnStateChange(Exports{Exports: exports})
 			},
 		}),
 	}
+
 	if err := c.Update(args); err != nil {
 		return nil, err
 	}
@@ -128,7 +129,6 @@ func (c *Component) updateHealth(err error) {
 
 // Update implements component.Component.
 func (c *Component) Update(args component.Arguments) error {
-	// TODO: Figure out a way for sibling components to have access to exports
 	newArgs := args.(Arguments)
 
 	f, err := flow.ReadFile(c.opts.ID, []byte(newArgs.Content))

--- a/component/module/string/string.go
+++ b/component/module/string/string.go
@@ -36,8 +36,8 @@ func init() {
 // Arguments holds values which are used to configure the module.string
 // component.
 type Arguments struct {
-	// Source code to load for the module.
-	Source rivertypes.Secret `river:"source,attr"`
+	// Content to load for the module.
+	Content rivertypes.Secret `river:"content,attr"`
 
 	// Arguments to pass into the module.
 	Arguments map[string]any `river:"arguments,attr,optional"`
@@ -146,7 +146,7 @@ func (c *Component) updateHealth(err error) {
 func (c *Component) Update(args component.Arguments) error {
 	newArgs := args.(Arguments)
 
-	f, err := flow.ReadFile(c.opts.ID, []byte(newArgs.Source))
+	f, err := flow.ReadFile(c.opts.ID, []byte(newArgs.Content))
 	if err != nil {
 		return err
 	}

--- a/component/module/string/string.go
+++ b/component/module/string/string.go
@@ -35,7 +35,7 @@ func init() {
 // component.
 type Arguments struct {
 	// Content to load for the module.
-	Content rivertypes.Secret `river:"content,attr"`
+	Content rivertypes.OptionalSecret `river:"content,attr"`
 
 	// Arguments to pass into the module.
 	Arguments map[string]any `river:"arguments,attr,optional"`
@@ -129,7 +129,7 @@ func (c *Component) updateHealth(err error) {
 func (c *Component) Update(args component.Arguments) error {
 	newArgs := args.(Arguments)
 
-	f, err := flow.ReadFile(c.opts.ID, []byte(newArgs.Content))
+	f, err := flow.ReadFile(c.opts.ID, []byte(newArgs.Content.Value))
 	if err != nil {
 		return err
 	}

--- a/component/module/string/string.go
+++ b/component/module/string/string.go
@@ -1,0 +1,205 @@
+// Package string defines the module.string component.
+package string
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"go.uber.org/atomic"
+
+	"github.com/go-kit/log"
+	"github.com/gorilla/mux"
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/pkg/flow"
+	"github.com/grafana/agent/pkg/flow/logging"
+	"github.com/grafana/agent/pkg/flow/rivertypes"
+	"github.com/grafana/agent/pkg/flow/tracing"
+	"github.com/grafana/agent/web/api"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:    "module.string",
+		Args:    Arguments{},
+		Exports: Exports{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			return New(opts, args.(Arguments))
+		},
+	})
+}
+
+// Arguments holds values which are used to configure the module.string
+// component.
+type Arguments struct {
+	// Source code to load for the module.
+	Source rivertypes.Secret `river:"source,attr"`
+
+	// Arguments to pass into the module.
+	Arguments map[string]any `river:"arguments,attr,optional"`
+}
+
+// Exports holds values which are exported from the run module.
+type Exports struct {
+	// Values exported from the running module.
+	Values map[string]any `river:"values,attr"`
+}
+
+// Component implements the module.string component.
+type Component struct {
+	opts component.Options
+	log  log.Logger
+	ctrl *flow.Flow
+
+	moduleArgs        atomic.Pointer[map[string]any]
+	file              atomic.Pointer[flow.File]
+	updateContollerCh chan struct{}
+
+	healthMut sync.RWMutex
+	health    component.Health
+}
+
+var (
+	_ component.Component       = (*Component)(nil)
+	_ component.HealthComponent = (*Component)(nil)
+	_ component.HTTPComponent   = (*Component)(nil)
+)
+
+// New creates a new module.string component.
+func New(o component.Options, args Arguments) (*Component, error) {
+	// TODO(rfratto): replace these with a logger/tracer/registry which properly
+	// propagates data back to the parent.
+	flowLogger, _ := logging.New(os.Stderr, logging.Options{
+		Level:  logging.LevelDebug,
+		Format: logging.FormatLogfmt,
+	})
+	flowTracer, _ := tracing.New(tracing.DefaultOptions)
+	flowRegistry := prometheus.NewRegistry()
+
+	c := &Component{
+		opts: o,
+		log:  o.Logger,
+
+		ctrl: flow.New(flow.Options{
+			ControllerID: o.ID,
+			Logger:       flowLogger,
+			Tracer:       flowTracer,
+			Reg:          flowRegistry,
+
+			DataPath:       o.DataPath,
+			HTTPPathPrefix: o.HTTPPath,
+			HTTPListenAddr: o.HTTPListenAddr,
+
+			OnExportsChange: func(exports map[string]any) {
+				o.OnStateChange(Exports{Values: exports})
+			},
+		}),
+
+		updateContollerCh: make(chan struct{}, 1),
+	}
+	if err := c.Update(args); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// Run implements component.Component.
+func (c *Component) Run(ctx context.Context) error {
+Loop:
+	for {
+		select {
+		case <-ctx.Done():
+			break Loop
+		case <-c.updateContollerCh:
+			err := c.ctrl.LoadFile(c.file.Load(), *c.moduleArgs.Load())
+			c.updateHealth(err)
+		}
+	}
+
+	return c.ctrl.Close()
+}
+
+func (c *Component) updateHealth(err error) {
+	c.healthMut.Lock()
+	defer c.healthMut.Unlock()
+
+	if err == nil {
+		c.health = component.Health{
+			Health:     component.HealthTypeHealthy,
+			Message:    "module updated",
+			UpdateTime: time.Now(),
+		}
+	} else {
+		c.health = component.Health{
+			Health:     component.HealthTypeUnhealthy,
+			Message:    err.Error(),
+			UpdateTime: time.Now(),
+		}
+	}
+}
+
+// Update implements component.Component.
+func (c *Component) Update(args component.Arguments) error {
+	newArgs := args.(Arguments)
+
+	f, err := flow.ReadFile(c.opts.ID, []byte(newArgs.Source))
+	if err != nil {
+		return err
+	}
+
+	// TODO(rfratto): sync exports with current set rather than updating it in
+	// full every time.
+	var emptyExports = map[string]any{}
+
+	for _, b := range f.ConfigBlocks {
+		if b.Name[0] == "export" {
+			emptyExports[b.Label] = nil
+		}
+	}
+
+	// Create an initial exported value which contains all the keys that
+	// correspond with the exports from our module so that sibling components can
+	// properly reference them by name, albeit with the zero value.
+	//
+	// Currently, this runs every time Update is called, so there will always be
+	// two calls to OnStateChange happening every time: once which sets everything
+	// to the zero value, and once where the evaluated concrete values are
+	// exposed (in the callback to OnExportsChange).
+	//
+	// TODO(rfratto): find a way to not override the last evaluated value with
+	// null.
+	c.opts.OnStateChange(Exports{Values: emptyExports})
+
+	c.file.Store(f)
+	c.moduleArgs.Store(&newArgs.Arguments)
+
+	select {
+	case c.updateContollerCh <- struct{}{}:
+	default: // no-op
+	}
+
+	return nil
+}
+
+// CurrentHealth implements component.HealthComponent.
+func (c *Component) CurrentHealth() component.Health {
+	c.healthMut.RLock()
+	defer c.healthMut.RUnlock()
+
+	return c.health
+}
+
+// Handler implements component.HTTPComponent.
+func (c *Component) Handler() http.Handler {
+	r := mux.NewRouter()
+
+	fa := api.NewFlowAPI(c.ctrl, r)
+	fa.RegisterRoutes("/", r)
+
+	r.PathPrefix("/{id}/").Handler(c.ctrl.ComponentHandler())
+	return r
+}

--- a/docs/sources/flow/reference/components/module.string.md
+++ b/docs/sources/flow/reference/components/module.string.md
@@ -127,9 +127,3 @@ prometheus.remote_write "grafana_cloud" {
 	}
 }
 ```
-
-> **NOTE**: For the purpose of the above example we have exported the entire
-> `prometheus.remote_write.grafana_cloud` component. Alternatively, the module above
-> could have exported `prometheus.remote_write.grafana_cloud.receiver` instead of
-> the entire component since that is the only part of the component we need in the
-> parent river config.

--- a/docs/sources/flow/reference/components/module.string.md
+++ b/docs/sources/flow/reference/components/module.string.md
@@ -4,7 +4,7 @@ title: module.string
 
 # module.string
 
-`module.string` is a *Module loader* component. A *Module loader* is a Grafana Agent Flow 
+`module.string` is a *module loader* component. A module loader is a Grafana Agent Flow 
 component which retreives a module and runs the components defined inside of it.
 
 *TODO: Add link to module concept page above once merged*
@@ -28,15 +28,15 @@ The following arguments are supported:
 
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`content`   | `secret`    | The contents of the module to load as a secret string. | | yes
+`content`   | `secret` or `string` | The contents of the module to load as a secret string. | | yes
 `arguments` | `map(any)`  | The values for the supported arguments in the module contents. | | no
 
 `content` is a string that contains all the arguments, exports and components for the module. 
 `content` is typically loaded via the exports of another component. For example,
 
-- local.file.[label].content
-- remote.http.[label].content
-- remote.s3.[label].content
+- local.file.LABEL.content
+- remote.http.LABEL.content
+- remote.s3.LABEL.content
 
 `arguments` can contain, but are not limited to strings, components and component exports.
 
@@ -52,11 +52,11 @@ Name | Type | Description
 
 ## Component health
 
-`module.string` will be reported as healthy whenever all of its components have
-been loaded successfully.
+`module.string` is reported as healthy if the most recent load of the module was 
+successful. 
 
-If a component is not loaded successfully, the current health will show as
-unhealthy and the health will include the error from the component.
+If the module is not loaded successfully, the current health displays as
+unhealthy and the health includes the error from loading the module.
 
 ## Debug information
 

--- a/docs/sources/flow/reference/components/module.string.md
+++ b/docs/sources/flow/reference/components/module.string.md
@@ -1,0 +1,136 @@
+---
+title: module.string
+---
+
+# module.string
+
+`module.string` is a *Module loader* component. A *Module loader* is a Grafana Agent Flow 
+component which retreives a module and runs the components defined inside of it.
+
+*TODO: Add link to module concept page above once merged*
+
+## Usage
+
+```river
+module.string "LABEL" {
+	content   = CONTENT
+	arguments = {
+		argument1 = ARGUMENT1,
+		argument2 = ARGUMENT2,
+		...
+	}
+}
+```
+
+## Arguments
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`content`   | `secret`    | The contents of the module to load as a secret string. | | yes
+`arguments` | `map(any)`  | The values for the supported arguments in the module contents. | | no
+
+`content` is a string that contains all the arguments, exports and components for the module. 
+`content` is typically loaded via the exports of another component. For example,
+
+- local.file.[label].content
+- remote.http.[label].content
+- remote.s3.[label].content
+
+`arguments` can contain, but are not limited to strings, components and component exports.
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+Name | Type | Description
+---- | ---- | -----------
+`exports` | `map(any)` | The exports of the Module loader.
+
+`exports` can contain, but is not limited to strings, components and component exports.
+
+## Component health
+
+`module.string` will be reported as healthy whenever all of its components have
+been loaded successfully.
+
+If a component is not loaded successfully, the current health will show as
+unhealthy and the health will include the error from the component.
+
+## Debug information
+
+`module.string` does not expose any component-specific debug information.
+
+### Debug metrics
+
+`module.string` does not expose any component-specific debug metrics.
+
+## Example
+
+This example demonstrates the 3 parts (arguments, exports and components) of
+a Module loader for `module.string`. In this example, we pass credentials from a
+parent river config to a module for a `prometheus.remote_write` flow component.
+We then export that component for use in the parent river config. The export can 
+then be used by `prometheus.scrape.forward_to` to send metrics to the cloud.
+
+Here's an example of the module `contents`. This module accepts arguments for `username` and
+`password` then exports `prometheus_remote_write`. `prometheus_remote_write` is an export
+of another flow component which can later be accessed by the parent river config.
+
+```river
+argument "username" { }
+
+argument "password" { }
+
+export "prometheus_remote_write" {
+	value = prometheus.remote_write.grafana_cloud
+}
+
+prometheus.remote_write "grafana_cloud" {
+	endpoint {
+		url = "https://prometheus-us-central1.grafana.net/api/prom/push"
+
+		basic_auth {
+			username = argument.username.value
+			password = argument.password.value
+		}
+	}
+}
+```
+
+Here's an example of the parent river config leveraging a `local.file` component
+to specify the location of the contents for `module.string`. We also access the
+exported component from the module.
+
+The `username` and `password` are set via environment variables before being passed
+to the module. The `prometheus_remote_write` export from the module is accessed via
+`module.string.metrics.exports.prometheus_remote_write` and then we access the
+`prometheus.remote_write` export `receiver` that `prometheus.scrape` is expecting.
+
+For the purpose of this example we have exported the entire `prometheus.remote_write.grafana_cloud`
+component. Alternatively, the module above could have exported 
+`prometheus.remote_write.grafana_cloud.receiver` instead of the entire component
+since that is all we really need in the parent river config.
+
+```river
+local.file "metrics" {
+	filename = "/path/to/prometheus_remote_write_module.river"
+}
+
+module.string "metrics" {
+	content   = local.file.metrics.content
+	arguments = {
+		username = env("PROMETHEUS_USERNAME"),
+		password = env("PROMETHEUS_PASSWORD"),
+	}
+}
+
+prometheus.exporter.unix { }
+
+prometheus.scrape "local_agent" {
+	targets         = prometheus.exporter.unix.targets
+	forward_to      = [module.string.metrics.exports.prometheus_remote_write.receiver]
+	scrape_interval = "10s"
+}
+```

--- a/pkg/flow/flow.go
+++ b/pkg/flow/flow.go
@@ -124,7 +124,6 @@ type Flow struct {
 	sched       *controller.Scheduler
 	loader      *controller.Loader
 
-	cancel       context.CancelFunc
 	loadFinished chan struct{}
 
 	loadMut    sync.RWMutex

--- a/pkg/flow/flow_test.go
+++ b/pkg/flow/flow_test.go
@@ -31,7 +31,7 @@ var testFile = `
 `
 
 func TestController_LoadFile_Evaluation(t *testing.T) {
-	ctrl, _ := newFlow(testOptions(t))
+	ctrl := New(testOptions(t))
 
 	// Use testFile from graph_builder_test.go.
 	f, err := ReadFile(t.Name(), []byte(testFile))


### PR DESCRIPTION
This commit adds a `module.string` component, which loads a flow module from a string and runs it in a nested controller.

The `module.string` component accept arguments to pass to the controller, and exposes the controller's exports back out to peer components.

TODO:

- [x] Resolve any TODOs in the code 
- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated(?) 

Closes #3114