### PR TITLE
Introduce documentation to explain modules

### DIFF
--- a/docs/sources/flow/concepts/configuration_language.md
+++ b/docs/sources/flow/concepts/configuration_language.md
@@ -2,7 +2,7 @@
 aliases:
 - ../../concepts/configuration-language/
 title: Configuration language
-weight: 300
+weight: 400
 ---
 
 # Configuration language

--- a/docs/sources/flow/concepts/modules.md
+++ b/docs/sources/flow/concepts/modules.md
@@ -47,7 +47,7 @@ refer to the documentation for the module loader you are using for more
 information.
 
 [Component controller]: {{< relref "./component_controller.md" >}}
-[Component]: {{< relref "../reference/components/" >}}
+[Components]: {{< relref "../reference/components/" >}}
 
 ## Module sources
 
@@ -84,7 +84,7 @@ This example module manages a pipeline which filters out debug- and info-level
 log lines which are given to it:
 
 ```river
-// argument.write_to is an optional argument which specifies where filtered
+// argument.write_to is a required argument which specifies where filtered
 // log lines should be sent.
 //
 // The value of the argument can be retrieved in this file with

--- a/docs/sources/flow/concepts/modules.md
+++ b/docs/sources/flow/concepts/modules.md
@@ -1,0 +1,145 @@
+---
+aliases:
+- ../../concepts/modules/
+title: Modules
+weight: 300
+---
+
+# Modules
+
+_Modules_ are a way to create Grafana Agent Flow configuration files which can
+laoded as a component. Modules are a great way to parameterize configuration
+files to create reusable pipelines.
+
+Modules are Grafana Agent Flow configuration files which have:
+
+* Arguments: settings which configure a module.
+* Exports: named values which a module exposes to the consumer of the module.
+* Components: Grafana Agent Flow Components to run when the module is running.
+
+Modules are loaded into Grafana Agent Flow by using a [Module
+loader](#module-loaders).
+
+Refer to the documentation for the [argument block][] and [export block][] to
+learn how to define arguments and exports for a module.
+
+[argument block]: {{< relref "../reference/config-blocks/argument.md" >}}
+[export block]: {{< relref "../reference/config-blocks/export.md" >}}
+
+## Module loaders
+
+A _Module loader_ is a Grafana Agent Flow component which retreives a module
+and runs the components defined inside of it.
+
+Module loader components are responsible for:
+
+* Retreiving the module source to run.
+* Creating a [Component controller][] for the module to run in.
+* Passing arguments to the loaded module.
+* Exposing exports from the loaded module.
+
+Module loaders typically are called `module.LOADER_NAME`. The list of module
+loader components can be found in the list of Grafana Agent Flow
+[Components][].
+
+Some module loaders may not support running modules with arguments or exports;
+refer to the documentation for the module loader you are using for more
+information.
+
+[Component controller]: {{< relref "./component_controller.md" >}}
+[Component]: {{< relref "../reference/components/" >}}
+
+## Module sources
+
+Modules are designed to be flexible, and can have their configuration retrieved
+from anywhere, such as:
+
+* The local filesystem
+* An S3 bucket
+* An HTTP endpoint
+
+Each module loader component will support different ways of retrieving module
+sources. The most generic module loader component, `module.string`, can load
+modules from the export of another Flow component:
+
+```river
+local.file "my_module" {
+  filename = "PATH_TO_MODULE"
+}
+
+module.string "my_module" {
+  source = local.file.my_module.content
+
+  arguments = {
+    MODULE_ARGUMENT_NAME_1 = MODULE_ARGUMENT_VALUE_1,
+    MODULE_ARGUMENT_NAME_2 = MODULE_ARGUMENT_VALUE_2,
+    // ...
+  }
+}
+```
+
+## Example module
+
+This example module manages a pipeline which filters out debug- and info-level
+log lines which are given to it:
+
+```river
+// argument.write_to is an optional argument which specifies where filtered
+// log lines should be sent.
+//
+// The value of the argument can be retrieved in this file with
+// argument.write_to.value.
+argument "write_to" {
+  optional = false
+}
+
+// loki.process.filter is our component which executes the filtering, passing
+// filtered logs to argument.write_to.value.
+loki.process "filter" {
+  // Drop all debug- and info-level logs.
+  stage.match {
+    selector = "{job!=\"\"} |~ \"level=(debug|info)\""
+    action   = "drop"
+  }
+
+  // Send processed logs to our argument.
+  forward_to = argument.write_to.value
+}
+
+// export.filter_input exports a value to the consumer of the module.
+export "filter_input" {
+  // Expose the receiver of loki.process so the module consumer can send
+  // logs to our loki.process component.
+  value = loki.process.filter.receiver
+}
+```
+
+It can then be used as a processing step before writing logs to Loki:
+
+```river
+loki.source.file "self" {
+  targets = LOG_TARGETS
+
+  // Forward collected logs to the input of our filter.
+  forward_to = [module.string.filter.values.logs_input]
+}
+
+local.file "log_filter" {
+  filename = "/path/to/modules/log_filter.river"
+}
+
+module.string "log_filter" {
+  source = local.file.log_filter.content
+
+  arguments = {
+    // Configure the filter to forward filtered logs to loki.echo below.
+    logs_output = [loki.write.default.receiver],
+  }
+}
+
+loki.write "default" {
+  endpoint {
+    url = "LOKI_URL"
+  }
+}
+```

--- a/docs/sources/flow/concepts/modules.md
+++ b/docs/sources/flow/concepts/modules.md
@@ -7,11 +7,11 @@ weight: 300
 
 # Modules
 
-_Modules_ are a way to create Grafana Agent Flow configuration files which can
-laoded as a component. Modules are a great way to parameterize configuration
-files to create reusable pipelines.
+_Modules_ are a way to create Grafana Agent Flow configurations which can be
+loaded as a component. Modules are a great way to parameterize a configuration
+to create reusable pipelines.
 
-Modules are Grafana Agent Flow configuration files which have:
+Modules are Grafana Agent Flow configurations which have:
 
 * Arguments: settings which configure a module.
 * Exports: named values which a module exposes to the consumer of the module.
@@ -28,12 +28,12 @@ learn how to define arguments and exports for a module.
 
 ## Module loaders
 
-A _Module loader_ is a Grafana Agent Flow component which retreives a module
+A _Module loader_ is a Grafana Agent Flow component which retrieves a module
 and runs the components defined inside of it.
 
 Module loader components are responsible for:
 
-* Retreiving the module source to run.
+* Retrieving the module source to run.
 * Creating a [Component controller][] for the module to run in.
 * Passing arguments to the loaded module.
 * Exposing exports from the loaded module.
@@ -68,7 +68,7 @@ local.file "my_module" {
 }
 
 module.string "my_module" {
-  source = local.file.my_module.content
+  content = local.file.my_module.content
 
   arguments = {
     MODULE_ARGUMENT_NAME_1 = MODULE_ARGUMENT_VALUE_1,
@@ -121,7 +121,7 @@ loki.source.file "self" {
   targets = LOG_TARGETS
 
   // Forward collected logs to the input of our filter.
-  forward_to = [module.string.filter.values.logs_input]
+  forward_to = [module.string.filter.exports.logs_input]
 }
 
 local.file "log_filter" {
@@ -129,7 +129,7 @@ local.file "log_filter" {
 }
 
 module.string "log_filter" {
-  source = local.file.log_filter.content
+  content = local.file.log_filter.content
 
   arguments = {
     // Configure the filter to forward filtered logs to loki.echo below.

--- a/docs/sources/flow/reference/components/module.string.md
+++ b/docs/sources/flow/reference/components/module.string.md
@@ -4,21 +4,21 @@ title: module.string
 
 # module.string
 
-`module.string` is a *module loader* component. A module loader is a Grafana Agent Flow 
-component which retreives a module and runs the components defined inside of it.
+`module.string` is a *module loader* component. A module loader is a Grafana Agent Flow
+component which retreives a [module][] and runs the components defined inside of it.
 
-*TODO: Add link to modules concept page once merged*
+[module]: {{< relref "../../concepts/modules.md" >}}
 
 ## Usage
 
 ```river
 module.string "LABEL" {
-	content   = CONTENT
-	arguments = {
-		argument1 = ARGUMENT1,
-		argument2 = ARGUMENT2,
-		...
-	}
+  content   = CONTENT
+  arguments = {
+    argument1 = ARGUMENT1,
+    argument2 = ARGUMENT2,
+    ...
+  }
 }
 ```
 
@@ -38,12 +38,15 @@ Name | Type | Description | Default | Required
 - `remote.http.LABEL.content`
 - `remote.s3.LABEL.content`
 
-`arguments` allows us to pass parameterized input into a module.
+`arguments` allows us to pass parameterized input into a module. The values
+passed in `arguments` correspond to [argument blocks][] defined in the module
+source.
+
 An `argument` marked non-optional in the module being loaded is required in the
 `arguments`. It is also not valid to provide an `argument` not defined in the
 module being loaded.
 
-*TODO: Add link to argument config-blocks page once merged*
+[argument blocks]: {{< relref "../config-blocks/argument.md" >}}
 
 ## Exported fields
 
@@ -53,15 +56,18 @@ Name | Type | Description
 ---- | ---- | -----------
 `exports` | `map(any)` | The exports of the Module loader.
 
-`exports` exposes the `export` config block inside a module. It can be accessed from
-the parent config via `module.string.LABEL.exports.EXPORT_LABEL
+`exports` exposes the `export` config block inside a module. It can be accessed
+from the parent config via `module.string.LABEL.exports.EXPORT_LABEL`.
 
-*TODO: Add link to export config-blocks page once merged*
+Values in `exports` correspond to [export blocks][] defined in the module
+source.
+
+[export blocks]: {{< relref "../config-blocks/export.md" >}}
 
 ## Component health
 
-`module.string` is reported as healthy if the most recent load of the module was 
-successful. 
+`module.string` is reported as healthy if the most recent load of the module was
+successful.
 
 If the module is not loaded successfully, the current health displays as
 unhealthy and the health includes the error from loading the module.
@@ -77,31 +83,31 @@ unhealthy and the health includes the error from loading the module.
 ## Example
 
 In this example, we pass credentials from a parent config to a module which loads
-a `prometheus.remote_write` component. The exports of the 
-`prometheus.remote_write` component are exposed to parent config, allowing 
+a `prometheus.remote_write` component. The exports of the
+`prometheus.remote_write` component are exposed to parent config, allowing
 the parent config to pass metrics to it.
 
 Parent:
 
 ```river
 local.file "metrics" {
-	filename = "/path/to/prometheus_remote_write_module.river"
+  filename = "/path/to/prometheus_remote_write_module.river"
 }
 
 module.string "metrics" {
-	content   = local.file.metrics.content
-	arguments = {
-		username = env("PROMETHEUS_USERNAME"),
-		password = env("PROMETHEUS_PASSWORD"),
-	}
+  content   = local.file.metrics.content
+  arguments = {
+    username = env("PROMETHEUS_USERNAME"),
+    password = env("PROMETHEUS_PASSWORD"),
+  }
 }
 
 prometheus.exporter.unix { }
 
 prometheus.scrape "local_agent" {
-	targets         = prometheus.exporter.unix.targets
-	forward_to      = [module.string.metrics.exports.prometheus_remote_write.receiver]
-	scrape_interval = "10s"
+  targets         = prometheus.exporter.unix.targets
+  forward_to      = [module.string.metrics.exports.prometheus_remote_write.receiver]
+  scrape_interval = "10s"
 }
 ```
 
@@ -113,17 +119,17 @@ argument "username" { }
 argument "password" { }
 
 export "prometheus_remote_write" {
-	value = prometheus.remote_write.grafana_cloud
+  value = prometheus.remote_write.grafana_cloud
 }
 
 prometheus.remote_write "grafana_cloud" {
-	endpoint {
-		url = "https://prometheus-us-central1.grafana.net/api/prom/push"
+  endpoint {
+    url = "https://prometheus-us-central1.grafana.net/api/prom/push"
 
-		basic_auth {
-			username = argument.username.value
-			password = argument.password.value
-		}
-	}
+    basic_auth {
+      username = argument.username.value
+      password = argument.password.value
+    }
+  }
 }
 ```

--- a/docs/sources/flow/reference/config-blocks/argument.md
+++ b/docs/sources/flow/reference/config-blocks/argument.md
@@ -1,0 +1,70 @@
+---
+title: argument
+---
+
+# argument block
+
+`argument` is an optional configuration block used to specify parameterized
+input to a [Module][Modules]. `argument` blocks must be given a label which
+determine the name of the argument.
+
+The `argument` block may not be specified in the main configuration file given
+to Grafana Agent Flow.
+
+[Modules]: {{< relref "../../concepts/modules.md" >}}
+
+## Example
+
+```river
+argument "ARGUMENT_NAME" {}
+```
+
+## Arguments
+
+> **NOTE**: For clarity, "argument" in this section refers to arguments which
+> can be given to the argument block. "Module argument" refers to the argument
+> being defined for a module, determined by the label of the argument block.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`optional` | `bool` | Whether the argument may be omitted. | `false` | no
+`comment` | `string` | Description for the argument. | `false` | no
+`default` | `any` | Default value for the argument. | `null` | no
+
+By default, all module arguments are required. The `optional` argument can be
+used to mark the module argument as optional. When `optional` is false, the
+initial value for the module argument is specified by `default`.
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+Name | Type | Description
+---- | ---- | -----------
+`value` | `any` | The current value of the argument.
+
+The module loader is responsible for determining the values for arguments.
+Components in a module may use `argument.ARGUMENT_NAME.value` to retrieve the
+value provided by the module loader.
+
+## Example
+
+This example creates a module where agent metrics are collected. Collected
+metrics are then forwarded to the argument specified by the loader:
+
+```river
+argument "metrics_output" {
+  optional = false
+  comment  = "Where to send collected metrics."
+}
+
+prometheus.scrape "selfmonitor" {
+  targets = [{
+    __address__ = "127.0.0.1:12345",
+  }]
+
+  forward_to = [argument.metrics_output.value]
+}
+```

--- a/docs/sources/flow/reference/config-blocks/argument.md
+++ b/docs/sources/flow/reference/config-blocks/argument.md
@@ -6,7 +6,7 @@ title: argument
 
 `argument` is an optional configuration block used to specify parameterized
 input to a [Module][Modules]. `argument` blocks must be given a label which
-determine the name of the argument.
+determines the name of the argument.
 
 The `argument` block may not be specified in the main configuration file given
 to Grafana Agent Flow.

--- a/docs/sources/flow/reference/config-blocks/export.md
+++ b/docs/sources/flow/reference/config-blocks/export.md
@@ -1,0 +1,60 @@
+---
+title: export
+---
+
+# export block
+
+`export` is an optional configuration block used to specify an emitted value of
+a [Module][Modules]. `export` blocks must be given a label which determine the
+name of the export.
+
+The `export` block may not be specified in the main configuration file given
+to Grafana Agent Flow.
+
+[Modules]: {{< relref "../../concepts/modules.md" >}}
+
+## Example
+
+```river
+export "ARGUMENT_NAME" {
+  value = ARGUMENT_VALUE
+}
+```
+
+## Arguments
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`value` | `any` | Value to export. | yes
+
+The `value` argument determines what the value of the export will be. To expose
+an exported field of another component to the module loader, set `value` to an
+expression which references that exported value.
+
+## Exported fields
+
+The `export` block does not export any fields.
+
+## Example
+
+This example creates a module where the output of discovering Kubernetes pods
+and nodes are exposed to the module loader:
+
+```river
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+
+discovery.kubernetes "nodes" {
+  role = "nodes"
+}
+
+export "kubernetes_resources" {
+  value = concat(
+    discovery.kubernetes.pods.targets,
+    discovery.kubernetes.nodes.targets,
+  )
+}
+```

--- a/docs/sources/flow/reference/config-blocks/logging.md
+++ b/docs/sources/flow/reference/config-blocks/logging.md
@@ -1,6 +1,5 @@
 ---
 title: logging
-weight: 100
 ---
 
 # logging block

--- a/docs/sources/flow/reference/config-blocks/tracing.md
+++ b/docs/sources/flow/reference/config-blocks/tracing.md
@@ -1,6 +1,5 @@
 ---
 title: tracing
-weight: 100
 ---
 
 # tracing block


### PR DESCRIPTION
This PR adds concept-level documentation for Flow modules, and configuration block reference pages for `argument` and `export`.

I'm a little worried that this isn't being explained very well; let me know if there's anything I can do here to help make things clearer.

Closes #3105.