### PR TITLE
Fix issue with evaluating expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ Main (unreleased)
 
 - Flow: fix issue where Flow would return an error when trying to access a key
   of a map whose value was the zero value (`null`, `0`, `false`, `[]`, `{}`).
-  Whether an error was returned dependend on the internal type of the value.
+  Whether an error was returned depended on the internal type of the value.
   (@rfratto)
 
 - Flow: fix issue where using the `jaeger_remote` sampler for the `tracing`

--- a/pkg/river/parser/parser.go
+++ b/pkg/river/parser/parser.go
@@ -32,6 +32,8 @@ func ParseExpression(expr string) (ast.Expr, error) {
 
 	e := p.ParseExpression()
 
+	// If the current token is not a TERMINATOR then the parsing did not complete
+	// in full and there are still parts of the string left unparsed.
 	p.expect(token.TERMINATOR)
 
 	if len(p.diags) > 0 {

--- a/pkg/river/parser/parser.go
+++ b/pkg/river/parser/parser.go
@@ -32,9 +32,7 @@ func ParseExpression(expr string) (ast.Expr, error) {
 
 	e := p.ParseExpression()
 
-	if p.tok != token.TERMINATOR && p.tok != token.EOF {
-		p.addErrorf("did not parse the expression in full - unexpected token of type %s", p.tok.String())
-	}
+	p.expect(token.TERMINATOR)
 
 	if len(p.diags) > 0 {
 		return nil, p.diags

--- a/pkg/river/parser/parser.go
+++ b/pkg/river/parser/parser.go
@@ -3,6 +3,7 @@ package parser
 
 import (
 	"github.com/grafana/agent/pkg/river/ast"
+	"github.com/grafana/agent/pkg/river/token"
 )
 
 // ParseFile parses an entire River configuration file. The data parameter
@@ -30,6 +31,11 @@ func ParseExpression(expr string) (ast.Expr, error) {
 	p := newParser("", []byte(expr))
 
 	e := p.ParseExpression()
+
+	if p.tok != token.TERMINATOR && p.tok != token.EOF {
+		p.addErrorf("did not parse the expression in full - unexpected token of type %s", p.tok.String())
+	}
+
 	if len(p.diags) > 0 {
 		return nil, p.diags
 	}

--- a/pkg/river/vm/vm_test.go
+++ b/pkg/river/vm/vm_test.go
@@ -36,6 +36,10 @@ func TestVM_Evaluate_Literals(t *testing.T) {
 		"float to float64": {`3.5`, float64(3.5)},
 		"float to string":  {`3.9`, string("3.9")},
 
+		"float with dot to float32": {`.2`, float32(0.2)},
+		"float with dot to float64": {`.5`, float64(0.5)},
+		"float with dot to string":  {`.9`, string("0.9")},
+
 		"string to string":  {`"Hello, world!"`, string("Hello, world!")},
 		"string to int":     {`"12"`, int(12)},
 		"string to float64": {`"12"`, float64(12)},
@@ -214,7 +218,7 @@ func TestVM_Evaluate_AccessExpr(t *testing.T) {
 		require.Equal(t, "", actual)
 	})
 
-	t.Run("Invalid lookup", func(t *testing.T) {
+	t.Run("Invalid lookup 1", func(t *testing.T) {
 		expr, err := parser.ParseExpression(`{ a = 15 }.b`)
 		require.NoError(t, err)
 
@@ -223,6 +227,21 @@ func TestVM_Evaluate_AccessExpr(t *testing.T) {
 		var v interface{}
 		err = eval.Evaluate(nil, &v)
 		require.EqualError(t, err, `1:12: field "b" does not exist`)
+	})
+
+	t.Run("Invalid lookup 2", func(t *testing.T) {
+		_, err := parser.ParseExpression(`{ a = 15 }.7`)
+		require.EqualError(t, err, `1:11: did not parse the expression in full - unexpected token of type FLOAT`)
+	})
+
+	t.Run("Invalid lookup 3", func(t *testing.T) {
+		_, err := parser.ParseExpression(`{ a = { b = 12 }.7 }.a.b`)
+		require.EqualError(t, err, `1:17: missing ',' in field list`)
+	})
+
+	t.Run("Invalid lookup 4", func(t *testing.T) {
+		_, err := parser.ParseExpression(`{ a = { b = 12 } }.a.b.7`)
+		require.EqualError(t, err, `1:23: did not parse the expression in full - unexpected token of type FLOAT`)
 	})
 }
 

--- a/pkg/river/vm/vm_test.go
+++ b/pkg/river/vm/vm_test.go
@@ -231,7 +231,7 @@ func TestVM_Evaluate_AccessExpr(t *testing.T) {
 
 	t.Run("Invalid lookup 2", func(t *testing.T) {
 		_, err := parser.ParseExpression(`{ a = 15 }.7`)
-		require.EqualError(t, err, `1:11: did not parse the expression in full - unexpected token of type FLOAT`)
+		require.EqualError(t, err, `1:11: expected TERMINATOR, got FLOAT`)
 	})
 
 	t.Run("Invalid lookup 3", func(t *testing.T) {
@@ -241,7 +241,7 @@ func TestVM_Evaluate_AccessExpr(t *testing.T) {
 
 	t.Run("Invalid lookup 4", func(t *testing.T) {
 		_, err := parser.ParseExpression(`{ a = { b = 12 } }.a.b.7`)
-		require.EqualError(t, err, `1:23: did not parse the expression in full - unexpected token of type FLOAT`)
+		require.EqualError(t, err, `1:23: expected TERMINATOR, got FLOAT`)
 	})
 }
 


### PR DESCRIPTION
#### PR Description
Fixes the issue mentioned in #3222.  The ParseExpression() function on the main branch does not currently raise an error if trailing parts of the expressions were not evaluated.

#### Which issue(s) this PR fixes
Fixes #3222

#### Notes to the reviewer
Apparently in River it's possible to define a float value without specifying the 0 before the dot. For example, `.8` is equivalent to `0.8`.

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
