### PR TITLE
helm: use consistent versioning when rendering chart tests

### DIFF
--- a/operations/helm/charts/grafana-agent/templates/_helpers.tpl
+++ b/operations/helm/charts/grafana-agent/templates/_helpers.tpl
@@ -27,7 +27,11 @@ If release name contains chart name it will be used as a full name.
 Create chart name and version as used by the chart label.
 */}}
 {{- define "grafana-agent.chart" -}}
+{{- if index .Values "$chart_tests" }}
+{{- printf "%s" .Chart.Name | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- else }}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -47,10 +51,15 @@ Common labels
 {{- define "grafana-agent.labels" -}}
 helm.sh/chart: {{ include "grafana-agent.chart" . }}
 {{ include "grafana-agent.selectorLabels" . }}
+{{- if index .Values "$chart_tests" }}
+app.kubernetes.io/version: "vX.Y.Z"
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- else }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/operations/helm/scripts/rebuild-tests.sh
+++ b/operations/helm/scripts/rebuild-tests.sh
@@ -12,5 +12,5 @@ for FILEPATH in $TESTS; do
   FILENAME=$(basename $FILEPATH)
   TESTNAME=${FILENAME%.values.yaml}
 
-  helm template --namespace default --debug ${CHART_NAME} ${CHART_PATH} -f ${FILEPATH} --output-dir ${OUTPUT_PATH}/${TESTNAME}
+  helm template --namespace default --debug ${CHART_NAME} ${CHART_PATH} -f ${FILEPATH} --output-dir ${OUTPUT_PATH}/${TESTNAME} --set '$chart_tests=true'
 done

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 data:
   config.river: |- 

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/rbac.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Rules which allow discovery.kubernetes to function.
@@ -85,10 +85,10 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 data:
   config.river: |- 

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/rbac.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Rules which allow discovery.kubernetes to function.
@@ -85,10 +85,10 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 data:
   config.river: |- 

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
@@ -5,10 +5,10 @@ kind: StatefulSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/rbac.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Rules which allow discovery.kubernetes to function.
@@ -85,10 +85,10 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/custom-config/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 data:
   config.river:   |-

--- a/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10

--- a/operations/helm/tests/custom-config/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/rbac.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Rules which allow discovery.kubernetes to function.
@@ -85,10 +85,10 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/custom-config/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/custom-config/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/default-values/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 data:
   config.river: |- 

--- a/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10

--- a/operations/helm/tests/default-values/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/rbac.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Rules which allow discovery.kubernetes to function.
@@ -85,10 +85,10 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/default-values/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/default-values/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10

--- a/operations/helm/tests/existing-config/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/rbac.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Rules which allow discovery.kubernetes to function.
@@ -85,10 +85,10 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/existing-config/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/existing-config/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 data:
   config.river: |- 

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/rbac.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Rules which allow discovery.kubernetes to function.
@@ -85,10 +85,10 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/faro-ingress/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/faro-ingress/grafana-agent/templates/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 data:
   config.river: |- 

--- a/operations/helm/tests/faro-ingress/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/faro-ingress/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10

--- a/operations/helm/tests/faro-ingress/grafana-agent/templates/ingress.yaml
+++ b/operations/helm/tests/faro-ingress/grafana-agent/templates/ingress.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana-agent
   namespace: default
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 spec:
   rules:

--- a/operations/helm/tests/faro-ingress/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/faro-ingress/grafana-agent/templates/rbac.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Rules which allow discovery.kubernetes to function.
@@ -85,10 +85,10 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/faro-ingress/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/faro-ingress/grafana-agent/templates/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/faro-ingress/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/faro-ingress/grafana-agent/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/static-mode/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |- 

--- a/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10

--- a/operations/helm/tests/static-mode/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/rbac.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Rules which allow discovery.kubernetes to function.
@@ -85,10 +85,10 @@ kind: ClusterRoleBinding
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/static-mode/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/static-mode/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: grafana-agent
   labels:
-    helm.sh/chart: grafana-agent-0.9.0
+    helm.sh/chart: grafana-agent
     app.kubernetes.io/name: grafana-agent
     app.kubernetes.io/instance: grafana-agent
-    app.kubernetes.io/version: "v0.32.1"
+    app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
This adds an undocumented value, `$chart_tests`, which changes how the charts get rendered when creating the manifests. When `$chart_tests` is true, the chart identifier has its version removed and the app.kubernetes.io/version label is forced to vX.Y.Z.

This will be useful for reducing the size of PRs which update the Helm chart to focus on only the important changes.
