### PR TITLE
river/vm: support decoding blocks into map[string]T

### DIFF
--- a/pkg/river/river.go
+++ b/pkg/river/river.go
@@ -213,6 +213,11 @@ func (enc *Encoder) EncodeValue(v interface{}) error {
 // Unmarshal uses the inverse of the encoding rules that Marshal uses,
 // allocating maps, slices, and pointers as necessary.
 //
+// To unmarshal a River body into a map[string]T, Unmarshal assigns each
+// attribute to a key in the map, and decodes the attribute's value as the
+// value for the map entry. Only attribute statements are allowed when
+// unmarshaling into a map.
+//
 // To unmarshal a River body into a struct, Unmarshal matches incoming
 // attributes and blocks to the river struct tags specified by v. Incoming
 // attribute and blocks which do not match to a river struct tag cause a

--- a/pkg/river/vm/vm.go
+++ b/pkg/river/vm/vm.go
@@ -103,9 +103,18 @@ func (vm *Evaluator) evaluateBlockOrBody(scope *Scope, assoc map[value.Value]ast
 		rv = rv.Elem()
 	}
 
-	// TODO(rfratto): potentially loosen this restriction and allow decoding into
-	// an interface{} or map[string]interface{}.
-	if rv.Kind() != reflect.Struct {
+	if rv.Kind() == reflect.Interface {
+		var anyMap map[string]interface{}
+		into := reflect.MakeMap(reflect.TypeOf(anyMap))
+		if err := vm.evaluateMap(scope, assoc, node, into); err != nil {
+			return err
+		}
+
+		rv.Set(into)
+		return nil
+	} else if rv.Kind() == reflect.Map {
+		return vm.evaluateMap(scope, assoc, node, rv)
+	} else if rv.Kind() != reflect.Struct {
 		panic(fmt.Sprintf("river/vm: can only evaluate blocks into structs, got %s", rv.Kind()))
 	}
 
@@ -132,6 +141,65 @@ func (vm *Evaluator) evaluateBlockOrBody(scope *Scope, assoc map[value.Value]ast
 		TagInfo: ti,
 	}
 	return sd.Decode(stmts, rv)
+}
+
+// evaluateMap evaluates a block or a body into a map.
+func (vm *Evaluator) evaluateMap(scope *Scope, assoc map[value.Value]ast.Node, node ast.Node, rv reflect.Value) error {
+	var stmts ast.Body
+
+	switch node := node.(type) {
+	case *ast.BlockStmt:
+		if node.Label != "" {
+			return diag.Diagnostic{
+				Severity: diag.SeverityLevelError,
+				StartPos: node.NamePos.Position(),
+				EndPos:   node.LCurlyPos.Position(),
+				Message:  fmt.Sprintf("block %q requires non-empty label", strings.Join(node.Name, ".")),
+			}
+		}
+		stmts = node.Body
+	case ast.Body:
+		stmts = node
+	default:
+		panic(fmt.Sprintf("river/vm: unrecognized node type %T", node))
+	}
+
+	if rv.IsNil() {
+		rv.Set(reflect.MakeMap(rv.Type()))
+	}
+
+	for _, stmt := range stmts {
+		switch stmt := stmt.(type) {
+		case *ast.AttributeStmt:
+			val, err := vm.evaluateExpr(scope, assoc, stmt.Value)
+			if err != nil {
+				// TODO(rfratto): get error as diagnostics.
+				return err
+			}
+
+			target := reflect.New(rv.Type().Elem()).Elem()
+			if err := value.Decode(val, target.Addr().Interface()); err != nil {
+				// TODO(rfratto): get error as diagnostics.
+				return err
+			}
+			rv.SetMapIndex(reflect.ValueOf(stmt.Name.Name), target)
+
+		case *ast.BlockStmt:
+			// TODO(rfratto): potentially relax this restriction where nested blocks
+			// are permitted when decoding to a map.
+			return diag.Diagnostic{
+				Severity: diag.SeverityLevelError,
+				StartPos: ast.StartPos(stmt).Position(),
+				EndPos:   ast.EndPos(stmt).Position(),
+				Message:  "nested blocks not supported here",
+			}
+
+		default:
+			panic(fmt.Sprintf("river/vm: unrecognized node type %T", stmt))
+		}
+	}
+
+	return nil
 }
 
 func (vm *Evaluator) evaluateBlockLabel(node *ast.BlockStmt, tfs []rivertags.Field, rv reflect.Value) error {

--- a/tools/agentlint/internal/rivertags/rivertags.go
+++ b/tools/agentlint/internal/rivertags/rivertags.go
@@ -255,8 +255,8 @@ func lintRiverTag(ty *types.Var, tag string) (diagnostics []string) {
 		}
 
 		innerTy := getInnermostType(ty.Type())
-		if _, ok := innerTy.(*types.Struct); !ok {
-			diagnostics = append(diagnostics, "block fields must be a struct or a slice of structs")
+		if !isStructType(innerTy) && !isStringMap(innerTy) && !isEmptyInterface(innerTy) {
+			diagnostics = append(diagnostics, "block fields must be an interface{}, map[string]T, a struct, or a slice of structs")
 		}
 
 	case "enum", "enum,optional":
@@ -324,4 +324,28 @@ func validateFieldName(name string) (diagnostics []string) {
 	}
 
 	return
+}
+
+func isStructType(ty types.Type) bool {
+	_, ok := ty.(*types.Struct)
+	return ok
+}
+
+func isStringMap(ty types.Type) bool {
+	mapType, ok := ty.(*types.Map)
+	if !ok {
+		return false
+	}
+	if basic, ok := mapType.Key().(*types.Basic); ok {
+		return basic.Kind() == types.String
+	}
+	return false
+}
+
+func isEmptyInterface(ty types.Type) bool {
+	ifaceType, ok := ty.(*types.Interface)
+	if !ok {
+		return false
+	}
+	return ifaceType.Empty()
 }


### PR DESCRIPTION
This allows decoding blocks into maps instead of structs. The map type can be any map[string]T, which is useful of the map values must always be a consistent type. If map values can be anything, use map[string]any for decoding.

Additionally, if decoding into an interface{}, it will default to map[string]any when decoding.

When decoding into a map, nested blocks aren't allowed and will be rejected.

Closes #2903, and unlocks module loader components to accept arguments to propagate to the module as a block rather than an object.

This is not added to the changelog because this is not a user-facing change.