### PR TITLE
Fix ambiguous link

### DIFF
--- a/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
+++ b/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
@@ -56,7 +56,7 @@ prometheus.scrape "default" {
 
 The `prometheus.scrape "default"` annotation indicates the name of the component, `prometheus.scrape`, and its label, `default`. All components must have a unique combination of name and if applicable label.
 
-The `targets` [attribute]({{< relref "configuration_language.md#Attributes" >}}) is an [argument]({{< relref "../concepts/components.md">}}). `targets` is a list of labels that specify the target via the special key `__address__`. The scraper is targeting the Agent's `/metrics` endpoint. Both `http` and `/metrics` are implied but can be overridden.
+The `targets` [attribute]({{< relref "../concepts/configuration_language/#attributes" >}}) is an [argument]({{< relref "../concepts/components.md">}}). `targets` is a list of labels that specify the target via the special key `__address__`. The scraper is targeting the Agent's `/metrics` endpoint. Both `http` and `/metrics` are implied but can be overridden.
 
 The `forward_to` attribute is an argument that references the [export]({{< relref "../concepts/components.md">}}) of the `prometheus.remote_write.prom` component. This is where the scraper will send the metrics for further processing.
 


### PR DESCRIPTION
When a relref target is not explicitly set as relative to the current page with a preceding `./` or `../`, Hugo attempts to resolve the relref target by seeing if it could refer any page in the site.

For local builds, this relref results in the relative permalink /docs/agent/latest/flow/concepts/configuration_language/#Attributes because of the docs/sources/flow/concepts/configuration_language.md file. This works locally because there is only one file with this name. However, in the website, multiple files have this name because of the multiple published versions of Agent documentation. When the resolution is ambiguous, Hugo prefers to avoid linking to any of the pages and instead makes the permalink point to the current page.

This should be backported to all the way back to `v0.28` to fix seven useless links in the website and the associated build errors.

I can open the backport PRs once this is approved.
