### PR TITLE
flow/tracing: fix issue where remote sampler could not be parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ Main (unreleased)
   Whether an error was returned dependend on the internal type of the value.
   (@rfratto)
 
+- Flow: fix issue where using the `jaeger_remote` sampler for the `tracing`
+  block would fail to parse the response from the remote sampler server if it
+  used strings for the strategy type. This caused sampling to fall back
+  to the default rate. (@rfratto)
+
 ### Other changes
 
 - Grafana Agent Docker containers and release binaries are now published for

--- a/pkg/flow/tracing/internal/jaegerremote/sampler_remote.go
+++ b/pkg/flow/tracing/internal/jaegerremote/sampler_remote.go
@@ -18,7 +18,7 @@
 package jaegerremote
 
 import (
-	"encoding/json"
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,6 +27,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/golang/protobuf/jsonpb"
 	jaeger_api_v2 "github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/trace"
@@ -313,7 +314,7 @@ type samplingStrategyParserImpl struct{}
 
 func (p *samplingStrategyParserImpl) Parse(response []byte) (interface{}, error) {
 	strategy := new(jaeger_api_v2.SamplingStrategyResponse)
-	if err := json.Unmarshal(response, strategy); err != nil {
+	if err := jsonpb.Unmarshal(bytes.NewReader(response), strategy); err != nil {
 		return nil, err
 	}
 	return strategy, nil


### PR DESCRIPTION
This fixes an issue where the remote sampler could not be parsed if it used strings for the strategy type instead of numbers. The resolution is to switch to the protobuf JSON encoding, which properly parses this type as a string.

Not being able to parse the remote sampler rules meant that sampling rate fell back to the default (10%).

This change is equivalent to
open-telemetry/opentelemetry-go-contrib#3183. We are still unable to move to the upstream type while
open-telemetry/opentelemetry-go-contrib#2981 remains unresolved.
