### PR TITLE
Add redis address to usage docs

### DIFF
--- a/component/prometheus/exporter/redis/redis.go
+++ b/component/prometheus/exporter/redis/redis.go
@@ -45,7 +45,7 @@ type Config struct {
 	//
 	// The exporter binary config differs to this, but these
 	// are the only fields that are relevant to the exporter struct.
-	RedisAddr               string            `river:"redis_addr,attr,optional"`
+	RedisAddr               string            `river:"redis_addr,attr"`
 	RedisUser               string            `river:"redis_user,attr,optional"`
 	RedisPassword           rivertypes.Secret `river:"redis_password,attr,optional"`
 	RedisPasswordFile       string            `river:"redis_password_file,attr,optional"`

--- a/docs/sources/flow/reference/components/prometheus.exporter.redis.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.redis.md
@@ -17,6 +17,7 @@ The `prometheus.exporter.redis` component embeds
 
 ```river
 prometheus.exporter.redis "LABEL" {
+    redis_addr = "REDIS_ADDRESS"
 }
 ```
 


### PR DESCRIPTION
`redis_addr` should be listed in the "usage" section because it is a mandatory attribute.