### PR TITLE
fix script zip expand issues

### DIFF
--- a/production/grafanacloud-install.ps1
+++ b/production/grafanacloud-install.ps1
@@ -35,9 +35,10 @@ Install-Module PowerShell-yaml
 Write-Host "Downloading Grafana agent Windows Installer"
 $DOWLOAD_URL = "https://github.com/grafana/agent/releases/latest/download/grafana-agent-installer.exe.zip"
 $OUTPUT_ZIP_FILE = ".\grafana-agent-installer.exe.zip"
-$OUTPUT_FILE = ".\grafana-agent-installer.exe"
+# $OUTPUT_FILE = "grafana-agent-installer.exe"
+$WORKING_DIR = Get-Location
 Invoke-WebRequest -Uri $DOWLOAD_URL -OutFile $OUTPUT_ZIP_FILE
-Expand-Archive -LiteralPath $OUTPUT_ZIP_FILE -DestinationPath $OUTPUT_FILE
+Expand-Archive -LiteralPath $OUTPUT_ZIP_FILE -DestinationPath $WORKING_DIR.path
 
 # Install Grafana agent in silent mode
 Write-Host "Installing Grafana agent for Windows"


### PR DESCRIPTION
Prior to changes here, the Expand-Archive command was extracting the agent installer into a path with the same name and then not executing it from the path in the subsequent command, causing the script to fail.  These changes get the current path and use that in the -DestinationPath parameter, effectively extracting the ZIP into the same directory the ps1 script runs in which is also where the zip is downloaded to. This fixes the installation failing.

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
