### PR TITLE
flow: experiment with explicit component telemetry types

### DIFF
--- a/pkg/flow/logger/component.go
+++ b/pkg/flow/logger/component.go
@@ -9,6 +9,8 @@ import (
 // Component is a logger passed to Grafana Agent Flow components. It implements
 // the [log.Logger] interface.
 type Component struct {
+	componentID string
+
 	orig log.Logger // Original logger before the component name was added.
 	log  log.Logger // Logger with component name injected.
 }
@@ -21,8 +23,10 @@ func NewComponentLogger(sink *Sink, componentID string) *Component {
 	}
 
 	return &Component{
+		componentID: fullID(sink.parentComponentID, componentID),
+
 		orig: sink.l,
-		log:  log.With(sink.l, "component", componentID),
+		log:  wrapWithComponentID(sink.l, sink.parentComponentID, componentID),
 	}
 }
 

--- a/pkg/flow/logger/component.go
+++ b/pkg/flow/logger/component.go
@@ -1,0 +1,32 @@
+package logger
+
+import (
+	"io"
+
+	"github.com/go-kit/log"
+)
+
+// Component is a logger passed to Grafana Agent Flow components. It implements
+// the [log.Logger] interface.
+type Component struct {
+	orig log.Logger // Original logger before the component name was added.
+	log  log.Logger // Logger with component name injected.
+}
+
+// NewComponentLogger creates a component logger from the provided logging
+// sink.
+func NewComponentLogger(sink *Sink, componentID string) *Component {
+	if sink == nil {
+		sink, _ = WriterSink(io.Discard, DefaultSinkOptions)
+	}
+
+	return &Component{
+		orig: sink.l,
+		log:  log.With(sink.l, "component", componentID),
+	}
+}
+
+// Log implements log.Logger.
+func (c *Component) Log(kvps ...interface{}) error {
+	return c.log.Log(kvps...)
+}

--- a/pkg/flow/logger/controller.go
+++ b/pkg/flow/logger/controller.go
@@ -1,0 +1,57 @@
+package logger
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/go-kit/log"
+)
+
+// Controller is a logger for Grafana Agent Flow controllers. It implements the
+// [log.Logger] interface.
+type Controller struct {
+	sink *Sink
+
+	mut sync.RWMutex
+	l   log.Logger
+}
+
+// NewControllerLogger creates a controller logger from the provided logging
+// sink. If [WriterSink] is used, the resulting Controller may be updated by
+// invoking [Controller.Update].
+func NewControllerLogger(sink *Sink) *Controller {
+	if sink == nil {
+		sink, _ = WriterSink(io.Discard, DefaultSinkOptions)
+	}
+
+	return &Controller{
+		sink: sink,
+		l:    sink.l,
+	}
+}
+
+// Log implements log.Logger.
+func (c *Controller) Log(kvps ...interface{}) error {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+	return c.l.Log(kvps...)
+}
+
+// Update reconfigures the options used for the Logger. Update may only be
+// called when a WriterSink was used to construct the Controller.
+func (c *Controller) Update(o SinkOptions) error {
+	if !c.sink.updatable {
+		return fmt.Errorf("updating logging settings is not supported in this context")
+	}
+
+	newLogger, err := writerSinkLogger(c.sink.w, o)
+	if err != nil {
+		return err
+	}
+
+	c.mut.Lock()
+	defer c.mut.Unlock()
+	c.l = newLogger
+	return nil
+}

--- a/pkg/flow/logger/logger_test.go
+++ b/pkg/flow/logger/logger_test.go
@@ -1,0 +1,39 @@
+package logger_test
+
+import (
+	"os"
+
+	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/pkg/flow/logger"
+)
+
+func Example() {
+	// Create a sink to send logs to. WriterSink supports options to customize
+	// the logs sent to the sink.
+	sink, err := logger.WriterSink(os.Stdout, logger.SinkOptions{
+		Level:             logger.LevelDebug,
+		Format:            logger.FormatLogfmt,
+		IncludeTimestamps: false,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Create a controller logger.
+	controller := logger.NewControllerLogger(sink)
+
+	// Create two component loggers. The first component sends logs to the
+	// controller, and the other sends logs to the first component.
+	component1 := logger.NewComponentLogger(logger.ControllerSink(controller), "my-component-1")
+	component2 := logger.NewComponentLogger(logger.ComponentSink(component1), "my-component-2")
+
+	// Log some log lines.
+	level.Info(controller).Log("msg", "hello from controller!")
+	level.Info(component1).Log("msg", "hello from component 1!")
+	level.Info(component2).Log("msg", "hello from component 2!")
+
+	// Output:
+	// level=info msg="hello from controller!"
+	// component=my-component-1 level=info msg="hello from component 1!"
+	// component=my-component-2 level=info msg="hello from component 2!"
+}

--- a/pkg/flow/logger/logger_test.go
+++ b/pkg/flow/logger/logger_test.go
@@ -24,16 +24,20 @@ func Example() {
 
 	// Create two component loggers. The first component sends logs to the
 	// controller, and the other sends logs to the first component.
-	component1 := logger.NewComponentLogger(logger.ControllerSink(controller), "my-component-1")
-	component2 := logger.NewComponentLogger(logger.ComponentSink(component1), "my-component-2")
+	component1 := logger.NewComponentLogger(logger.ControllerSink(controller), "outer")
+	component2 := logger.NewComponentLogger(logger.ComponentSink(component1), "inner")
+
+	innerController := logger.NewControllerLogger(logger.ComponentSink(component2))
 
 	// Log some log lines.
-	level.Info(controller).Log("msg", "hello from controller!")
-	level.Info(component1).Log("msg", "hello from component 1!")
-	level.Info(component2).Log("msg", "hello from component 2!")
+	level.Info(controller).Log("msg", "hello from the controller!")
+	level.Info(component1).Log("msg", "hello from the outer component!")
+	level.Info(component2).Log("msg", "hello from the inner component!")
+	level.Info(innerController).Log("msg", "hello from the inner controller!")
 
 	// Output:
-	// level=info msg="hello from controller!"
-	// component=my-component-1 level=info msg="hello from component 1!"
-	// component=my-component-2 level=info msg="hello from component 2!"
+	// level=info msg="hello from the controller!"
+	// component=outer level=info msg="hello from the outer component!"
+	// component=outer/inner level=info msg="hello from the inner component!"
+	// component=outer/inner level=info msg="hello from the inner controller!"
 }

--- a/pkg/flow/logger/sink.go
+++ b/pkg/flow/logger/sink.go
@@ -1,0 +1,76 @@
+package logger
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+// Sink is where a Controller logger will send log lines to.
+type Sink struct {
+	w         io.Writer // Raw writer to use
+	updatable bool      // Whether the sink supports being updated.
+
+	l log.Logger // Constructed logger to use.
+}
+
+// WriterSink forwards logs to the provided [io.Writer].
+func WriterSink(w io.Writer, o SinkOptions) (*Sink, error) {
+	if w == nil {
+		w = io.Discard
+	}
+
+	l, err := writerSinkLogger(w, o)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Sink{
+		w:         w,
+		updatable: true,
+
+		l: l,
+	}, nil
+}
+
+// ControllerSink forwards logs to the provided Controller logger.
+func ControllerSink(c *Controller) *Sink {
+	return &Sink{
+		w: io.Discard,
+		l: c,
+	}
+}
+
+// ComponentSink forwards logs to the provided Component logger. The component
+// label from c is dropped.
+func ComponentSink(c *Component) *Sink {
+	return &Sink{
+		w: io.Discard,
+
+		// Send logs to the original logger the Component uses so the component ID
+		// gets dropped.
+		l: c.orig,
+	}
+}
+
+func writerSinkLogger(w io.Writer, o SinkOptions) (log.Logger, error) {
+	var l log.Logger
+
+	switch o.Format {
+	case FormatLogfmt:
+		l = log.NewLogfmtLogger(log.NewSyncWriter(w))
+	case FormatJSON:
+		l = log.NewJSONLogger(log.NewSyncWriter(w))
+	default:
+		return nil, fmt.Errorf("unrecognized log format %q", o.Format)
+	}
+
+	l = level.NewFilter(l, o.Level.Filter())
+
+	if o.IncludeTimestamps {
+		l = log.With(l, "ts", log.DefaultTimestampUTC)
+	}
+	return l, nil
+}

--- a/pkg/flow/logger/sink.go
+++ b/pkg/flow/logger/sink.go
@@ -13,6 +13,8 @@ type Sink struct {
 	w         io.Writer // Raw writer to use
 	updatable bool      // Whether the sink supports being updated.
 
+	parentComponentID string // Whether the sink has a parent component ID associated with it.
+
 	l log.Logger // Constructed logger to use.
 }
 
@@ -38,15 +40,18 @@ func WriterSink(w io.Writer, o SinkOptions) (*Sink, error) {
 // ControllerSink forwards logs to the provided Controller logger.
 func ControllerSink(c *Controller) *Sink {
 	return &Sink{
+		parentComponentID: c.parentComponentID,
+
 		w: io.Discard,
 		l: c,
 	}
 }
 
-// ComponentSink forwards logs to the provided Component logger. The component
-// label from c is dropped.
+// ComponentSink forwards logs to the provided Component logger.
 func ComponentSink(c *Component) *Sink {
 	return &Sink{
+		parentComponentID: c.componentID,
+
 		w: io.Discard,
 
 		// Send logs to the original logger the Component uses so the component ID

--- a/pkg/flow/logger/sink_options.go
+++ b/pkg/flow/logger/sink_options.go
@@ -1,0 +1,126 @@
+package logger
+
+import (
+	"encoding"
+	"fmt"
+
+	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/pkg/river"
+)
+
+// SinkOptions is a set of options used to construct and configure a logging
+// sink.
+type SinkOptions struct {
+	Level  Level  `river:"level,attr,optional"`
+	Format Format `river:"format,attr,optional"`
+
+	// IncludeTimestamps disables timestamps on log lines. It is not exposed as a
+	// river tag as it is only expected to be used during tests.
+	IncludeTimestamps bool
+
+	// TODO: log sink parameter (e.g., to use the Windows Event logger)
+}
+
+// DefaultSinkOptions holds defaults for creating a logging sink.
+var DefaultSinkOptions = SinkOptions{
+	Level:  LevelDefault,
+	Format: FormatDefault,
+
+	IncludeTimestamps: true,
+}
+
+var _ river.Unmarshaler = (*SinkOptions)(nil)
+
+// UnmarshalRiver implements river.Unmarshaler.
+func (o *SinkOptions) UnmarshalRiver(f func(interface{}) error) error {
+	*o = DefaultSinkOptions
+
+	type options SinkOptions
+	return f((*options)(o))
+}
+
+// Level represents how verbose logging should be.
+type Level string
+
+// Supported log levels
+const (
+	LevelDebug Level = "debug"
+	LevelInfo  Level = "info"
+	LevelWarn  Level = "warn"
+	LevelError Level = "error"
+
+	LevelDefault = LevelInfo
+)
+
+var (
+	_ encoding.TextMarshaler   = LevelDefault
+	_ encoding.TextUnmarshaler = (*Level)(nil)
+)
+
+// MarshalText implements encoding.TextMarshaler.
+func (ll Level) MarshalText() (text []byte, err error) {
+	return []byte(ll), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (ll *Level) UnmarshalText(text []byte) error {
+	switch Level(text) {
+	case "":
+		*ll = LevelDefault
+	case LevelDebug, LevelInfo, LevelWarn, LevelError:
+		*ll = Level(text)
+	default:
+		return fmt.Errorf("unrecognized log level %q", string(text))
+	}
+	return nil
+}
+
+// Filter returns a go-kit logging filter from the level.
+func (ll Level) Filter() level.Option {
+	switch ll {
+	case LevelDebug:
+		return level.AllowDebug()
+	case LevelInfo:
+		return level.AllowInfo()
+	case LevelWarn:
+		return level.AllowWarn()
+	case LevelError:
+		return level.AllowError()
+	default:
+		return level.AllowAll()
+	}
+}
+
+// Format represents a text format to use when writing logs.
+type Format string
+
+// Supported log formats.
+const (
+	FormatLogfmt Format = "logfmt"
+	FormatJSON   Format = "json"
+
+	FormatDefault = FormatLogfmt
+)
+
+var (
+	_ encoding.TextMarshaler   = FormatDefault
+	_ encoding.TextUnmarshaler = (*Format)(nil)
+)
+
+// MarshalText implements encoding.TextMarshaler.
+func (ll Format) MarshalText() (text []byte, err error) {
+	return []byte(ll), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (ll *Format) UnmarshalText(text []byte) error {
+	switch Format(text) {
+	case "":
+		*ll = FormatDefault
+	case FormatLogfmt, FormatJSON:
+		*ll = Format(text)
+	default:
+		return fmt.Errorf("unrecognized log format %q", string(text))
+	}
+	return nil
+}


### PR DESCRIPTION
> **NOTE TO REVIEWER**: this PR is easier to follow if reviewed commit-by-commit instead of looking at the entire diff. 

This PR prototypes a solution for #3107 by creating a logging type, `github.com/grafana/agent/pkg/flow/logger`, with two main loggers:

* `logger.Controller` 
* `logger.Component` 

Each of these is created from a Sink, which can be one of: 

* An io.Writer 
* A Controller logger 
* A Component logger 

Sinks propagate the component ID correctly, allowing Controller loggers to be created from Component loggers without losing the ID of the component which created the controller. 

An alternative approach could be to give generic telemetry types to components, with no automatic label injection of the component ID. This would make it much easier to create controllers, but would also make it much easier for components to do the wrong thing and trample over metrics generated by another component, causing scrapes to fail. 

This approach is a more complicated API, but I appreciate how it makes it hard to do the wrong thing when creating controllers. 