### PR TITLE
Add backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,27 @@
+name: Backport PR Creator
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v3
+        with:
+          repository: "grafana/grafana-github-actions"
+          path: ./actions
+          # Pin the version to before https://github.com/grafana/grafana-github-actions/pull/113 because
+          # to avoid the strict rules for PR labels.
+          ref: d284afd314ca3625c23595e9f62b52d215ead7ce
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run backport
+        uses: ./actions/backport
+        with:
+          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          labelsToAdd: "backport"
+          title: "[{{base}}] {{originalTitle}}"


### PR DESCRIPTION
The workflow automatically backports PRs to branches labeled with `backport <BRANCH>` on closure or labeling of PRs.

Requires GH_BOT_ACCESS_TOKEN to work and in the future this will need to be replaced by a GitHub App based workflow. Timeline TBC.

