### PR TITLE
Avoid ambiguous relref lookups by forcing relative resolution

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,27 @@
+name: Backport PR Creator
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v3
+        with:
+          repository: "grafana/grafana-github-actions"
+          path: ./actions
+          # Pin the version to before https://github.com/grafana/grafana-github-actions/pull/113 because
+          # to avoid the strict rules for PR labels.
+          ref: d284afd314ca3625c23595e9f62b52d215ead7ce
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run backport
+        uses: ./actions/backport
+        with:
+          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          labelsToAdd: "backport"
+          title: "[{{base}}] {{originalTitle}}"

--- a/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
+++ b/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
@@ -38,7 +38,7 @@ Click the nodes to navigate to the associated component page. There, you can vie
 
 ## Scraping component
 
-The [`prometheus.scrape`]({{< relref "prometheus.scrape.md" >}}) component is responsible for scraping the metrics of a particular endpoint and passing them on to another component.
+The [`prometheus.scrape`]({{< relref "../reference/components/prometheus.scrape.md" >}}) component is responsible for scraping the metrics of a particular endpoint and passing them on to another component.
 
 ```river
 // prometheus.scrape is the name of the component and "default" is its label.
@@ -62,7 +62,7 @@ The `forward_to` attribute is an argument that references the [export]({{< relre
 
 ## Remote Write component
 
-The [`prometheus.remote_write`]({{< relref "prometheus.remote_write.md" >}}) component is responsible for writing the metrics to a Prometheus-compatible endpoint (Mimir).
+The [`prometheus.remote_write`]({{< relref "../reference/components/prometheus.remote_write.md" >}}) component is responsible for writing the metrics to a Prometheus-compatible endpoint (Mimir).
 
 ```river
 prometheus.remote_write "prom" {

--- a/docs/sources/flow/tutorials/filtering-metrics.md
+++ b/docs/sources/flow/tutorials/filtering-metrics.md
@@ -5,7 +5,7 @@ weight: 300
 
 # Filtering Prometheus metrics
 
-In this tutorial, you'll add a new component [prometheus.relabel]({{< ref "prometheus.relabel.md" >}}) using [relabel.river](../assets/flow_configs/relabel.river) to filter metrics. This tutorial uses the same base as [Collecting Prometheus metrics]({{< relref "./collecting-prometheus-metrics.md">}}).
+In this tutorial, you'll add a new component [prometheus.relabel]({{< ref "../reference/components/prometheus.relabel.md" >}}) using [relabel.river](../assets/flow_configs/relabel.river) to filter metrics. This tutorial uses the same base as [Collecting Prometheus metrics]({{< relref "./collecting-prometheus-metrics.md">}}).
 
 ## Prerequisites
 


### PR DESCRIPTION
Follow up from #3233 where I left some behind.

Again needs to be backported all the way back to v0.28 but we can maybe use the workflow in #3262 for that.