### PR TITLE
web/api: fix Flow UI for components with no arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ Main (unreleased)
   used strings for the strategy type. This caused sampling to fall back
   to the default rate. (@rfratto)
 
+- Flow: fix issue where components with no arguments like `loki.echo` were not
+  viewable in the UI. (@rfratto)
+
 ### Other changes
 
 - Grafana Agent Docker containers and release binaries are now published for

--- a/pkg/river/encoding/encoding.go
+++ b/pkg/river/encoding/encoding.go
@@ -26,6 +26,10 @@ func ConvertRiverBodyToJSON(input interface{}) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if fields == nil {
+		// Make sure that the list of fields is never null.
+		fields = make([]interface{}, 0)
+	}
 	bb, err := json.Marshal(fields)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Components with no arguments returned a `null` for the arguments block, but the UI contract expects that arguments is always an array.

cc @rgeyer 