### PR TITLE
Temporarily remove 32-bit ARM builds

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -373,38 +373,6 @@ trigger:
 type: docker
 ---
 kind: pipeline
-name: Build agent (Linux armv6)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=6 make agent
-  image: grafana/agent-build-image:0.23.0
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
-name: Build agent (Linux armv7)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=7 make agent
-  image: grafana/agent-build-image:0.23.0
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
 name: Build agent (Linux ppc64le)
 platform:
   arch: amd64
@@ -533,38 +501,6 @@ trigger:
 type: docker
 ---
 kind: pipeline
-name: Build agentctl (Linux armv6)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=6 make agentctl
-  image: grafana/agent-build-image:0.23.0
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
-name: Build agentctl (Linux armv7)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=7 make agentctl
-  image: grafana/agent-build-image:0.23.0
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
 name: Build agentctl (Linux ppc64le)
 platform:
   arch: amd64
@@ -685,38 +621,6 @@ steps:
 - commands:
   - make generate-ui
   - GOOS=linux GOARCH=arm64 GOARM= make operator
-  image: grafana/agent-build-image:0.23.0
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
-name: Build operator (Linux armv6)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=6 make operator
-  image: grafana/agent-build-image:0.23.0
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
-name: Build operator (Linux armv7)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - make generate-ui
-  - GOOS=linux GOARCH=arm GOARM=7 make operator
   image: grafana/agent-build-image:0.23.0
   name: Build
 trigger:
@@ -1269,6 +1173,6 @@ kind: secret
 name: gpg_passphrase
 ---
 kind: signature
-hmac: ea36b39b4cf7c9075321e7d3ca75c02cac36e962bb951ef9fc3022f710ec9933
+hmac: 5c37f51ea9c0d52177fc2427da1ac150c16833fed7b835160c3cc0c207d73dfa
 
 ...

--- a/.drone/pipelines/crosscompile.jsonnet
+++ b/.drone/pipelines/crosscompile.jsonnet
@@ -5,8 +5,6 @@ local os_arch_tuples = [
   // Linux
   { name: 'Linux amd64', os: 'linux', arch: 'amd64' },
   { name: 'Linux arm64', os: 'linux', arch: 'arm64' },
-  { name: 'Linux armv6', os: 'linux', arch: 'arm', arm: '6' },
-  { name: 'Linux armv7', os: 'linux', arch: 'arm', arm: '7' },
   { name: 'Linux ppc64le', os: 'linux', arch: 'ppc64le' },
   { name: 'Linux s390x', os: 'linux', arch: 's390x' },
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,18 @@ internal API changes are not present.
 
 > **NOTE**: As of v0.32.0, builds for 32-bit ARMv6 currently don't support the
 > embedded Flow UI. The Flow UI will return to this target as soon as possible.
+>
+> **NOTE**: The main branch currently doesn't support any 32-bit ARM builds.
+> Support for these builds will return as soon as possible, ideally before
+> v0.33 is released.
 
 Main (unreleased)
 -----------------
+
+### Breaking changes
+
+- Support for 32-bit ARM builds is temporarily removed. We are aiming to bring
+  back support for these builds prior to publishing v0.33.0. (@rfratto)
 
 ### Features
 

--- a/Makefile
+++ b/Makefile
@@ -122,15 +122,6 @@ PROPAGATE_VARS := \
 
 GO_ENV := GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOARM) CGO_ENABLED=$(CGO_ENABLED)
 
-# Selectively pass -mlong-calls when building for 32-bit ARM targets (armv6,
-# armv7). This works around an issue where the text segment has gotten big
-# enough (>32MB) that "relocation truncated to fit" errors occur.
-ifeq ($(GOARCH),arm)
-ifeq ($(GOOS),linux)
-GO_ENV += CGO_CFLAGS="$(CGO_CFLAGS) -mlong-calls"
-endif
-endif
-
 VERSION      ?= $(shell ./tools/image-tag)
 GIT_REVISION := $(shell git rev-parse --short HEAD)
 GIT_BRANCH   := $(shell git rev-parse --abbrev-ref HEAD)

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -107,7 +107,7 @@ The Grafana Agent is also capable of exporting to any OpenTelemetry GRPC compati
 
 * Linux
   * Minimum version: kernel 2.6.32 or later
-  * Architectures: AMD64, ARM64, ARMv6, ARMv7
+  * Architectures: AMD64, ARM64
 * Windows
   * Minimum version: Windows Server 2012 or later, or Windows 10 or later.
   * Architectures: AMD64

--- a/docs/sources/set-up/_index.md
+++ b/docs/sources/set-up/_index.md
@@ -16,14 +16,14 @@ To get started with Grafana Agent Operator, refer to the Operator-specific
 
 ## Installation options
 
-Grafana Agent is currently distributed in plain binary form, Docker container images, a Windows installer, a Homebrew package, and a Kubernetes install script. 
+Grafana Agent is currently distributed in plain binary form, Docker container images, a Windows installer, a Homebrew package, and a Kubernetes install script.
 
 The following architectures receive active support.
 
- - macOS: Intel Mac or Apple Silicon 
- - Windows: A x64 machine 
- - Linux: AMD64, ARM64, ARMv6, or ARMv7 machines
- - FreeBSD: A AMD64 machine 
+ - macOS: Intel Mac or Apple Silicon
+ - Windows: A x64 machine
+ - Linux: AMD64 or ARM64 machines
+ - FreeBSD: A AMD64 machine
 
 In addition, best-effort support is provided for Linux: ppc64le.
 
@@ -32,7 +32,7 @@ Choose from the following platforms and installation options according to which 
 ### Kubernetes
 
 Deploy Kubernetes manifests from the [`kubernetes` directory](https://github.com/grafana/agent/tree/main/production/kubernetes).
-You can manually modify the Kubernetes manifests by downloading them. These manifests do not include Grafana Agent configuration files. 
+You can manually modify the Kubernetes manifests by downloading them. These manifests do not include Grafana Agent configuration files.
 
 For sample configuration files, refer to the Grafana Cloud Kubernetes quick start guide: https://grafana.com/docs/grafana-cloud/kubernetes/agent-k8s/.
 

--- a/tools/ci/docker-containers
+++ b/tools/ci/docker-containers
@@ -53,7 +53,7 @@ fi
 
 # Build all of our images.
 
-export BUILD_PLATFORMS=linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x
+export BUILD_PLATFORMS=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
 
 
 case "$TARGET_CONTAINER" in

--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -22,8 +22,6 @@ PACKAGING_VARS = RELEASE_BUILD=1 GO_TAGS="$(GO_TAGS)" GOOS=$(GOOS) GOARCH=$(GOAR
 
 dist-agent-binaries: dist/grafana-agent-linux-amd64       \
                      dist/grafana-agent-linux-arm64       \
-                     dist/grafana-agent-linux-armv6       \
-                     dist/grafana-agent-linux-armv7       \
                      dist/grafana-agent-linux-ppc64le     \
                      dist/grafana-agent-linux-s390x       \
                      dist/grafana-agent-darwin-amd64      \
@@ -41,20 +39,6 @@ dist/grafana-agent-linux-arm64: GO_TAGS += builtinassets promtail_journal_enable
 dist/grafana-agent-linux-arm64: GOOS    := linux
 dist/grafana-agent-linux-arm64: GOARCH  := arm64
 dist/grafana-agent-linux-arm64: generate-ui
-	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
-
-dist/grafana-agent-linux-armv6: GO_TAGS += builtinassets promtail_journal_enabled
-dist/grafana-agent-linux-armv6: GOOS    := linux
-dist/grafana-agent-linux-armv6: GOARCH  := arm
-dist/grafana-agent-linux-armv6: GOARM   := 6
-dist/grafana-agent-linux-armv6: generate-ui
-	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
-
-dist/grafana-agent-linux-armv7: GO_TAGS += builtinassets promtail_journal_enabled
-dist/grafana-agent-linux-armv7: GOOS    := linux
-dist/grafana-agent-linux-armv7: GOARCH  := arm
-dist/grafana-agent-linux-armv7: GOARM   := 7
-dist/grafana-agent-linux-armv7: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
 dist/grafana-agent-linux-ppc64le: GO_TAGS += builtinassets promtail_journal_enabled
@@ -99,8 +83,6 @@ dist/grafana-agent-freebsd-amd64: generate-ui
 
 dist-agentctl-binaries: dist/grafana-agentctl-linux-amd64       \
                         dist/grafana-agentctl-linux-arm64       \
-                        dist/grafana-agentctl-linux-armv6       \
-                        dist/grafana-agentctl-linux-armv7       \
                         dist/grafana-agentctl-linux-ppc64le     \
                         dist/grafana-agentctl-linux-s390x       \
                         dist/grafana-agentctl-darwin-amd64      \
@@ -116,18 +98,6 @@ dist/grafana-agentctl-linux-amd64:
 dist/grafana-agentctl-linux-arm64: GOOS   := linux
 dist/grafana-agentctl-linux-arm64: GOARCH := arm64
 dist/grafana-agentctl-linux-arm64:
-	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
-
-dist/grafana-agentctl-linux-armv6: GOOS   := linux
-dist/grafana-agentctl-linux-armv6: GOARCH := arm
-dist/grafana-agentctl-linux-armv6: GOARM  := 6
-dist/grafana-agentctl-linux-armv6:
-	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
-
-dist/grafana-agentctl-linux-armv7: GOOS   := linux
-dist/grafana-agentctl-linux-armv7: GOARCH := arm
-dist/grafana-agentctl-linux-armv7: GOARM  := 7
-dist/grafana-agentctl-linux-armv7:
 	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
 
 dist/grafana-agentctl-linux-ppc64le: GOOS   := linux
@@ -195,8 +165,6 @@ PACKAGE_PREFIX  := dist/grafana-agent-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE)
 .PHONY: dist-packages
 dist-packages: dist-packages-amd64   \
                dist-packages-arm64   \
-               dist-packages-armv6   \
-               dist-packages-armv7   \
                dist-packages-arm64   \
                dist-packages-ppc64le \
                dist-packages-s390x
@@ -217,24 +185,6 @@ ifeq ($(USE_CONTAINER),1)
 else
 	$(call generate_fpm,deb,arm64,arm64,$(PACKAGE_PREFIX).arm64.deb)
 	$(call generate_fpm,rpm,aarch64,arm64,$(PACKAGE_PREFIX).arm64.rpm)
-endif
-
-# There's no RPM for armv6 so only debs are produced.
-.PHONY: dist-packages-armv6
-dist-packages-armv6: dist/grafana-agent-linux-armv6 dist/grafana-agentctl-linux-armv6
-ifeq ($(USE_CONTAINER),1)
-	$(RERUN_IN_CONTAINER)
-else
-	$(call generate_fpm,deb,armhf,armv6,$(PACKAGE_PREFIX).armv6.deb)
-endif
-
-.PHONY: dist-packages-armv7
-dist-packages-armv7: dist/grafana-agent-linux-armv7 dist/grafana-agentctl-linux-armv7
-ifeq ($(USE_CONTAINER),1)
-	$(RERUN_IN_CONTAINER)
-else
-	$(call generate_fpm,deb,armhf,armv7,$(PACKAGE_PREFIX).armv7.deb)
-	$(call generate_fpm,rpm,armhfp,armv7,$(PACKAGE_PREFIX).armv7.rpm)
 endif
 
 .PHONY: dist-packages-ppc64le


### PR DESCRIPTION
32-bit ARM builds are broken again (see CI for #3259). This commit temporarily removes support for 32-bit ARM builds so we can keep iterating while we wait for a new Go patch (golang/go#58425) and bring them back.

Ideally 32-bit ARM builds are restored prior to releasing v0.33.0.
