### PR TITLE
[release-v0.28] Avoid ambiguous relref lookups by forcing relative resolution

### DIFF
--- a/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
+++ b/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
@@ -40,7 +40,7 @@ Click the nodes to navigate to the associated component page. There, you can vie
 
 ## Scraping component
 
-The [`prometheus.scrape`]({{< relref "prometheus.scrape.md" >}}) component is responsible for scraping the metrics of a particular endpoint and passing them on to another component.
+The [`prometheus.scrape`]({{< relref "../reference/components/prometheus.scrape.md" >}}) component is responsible for scraping the metrics of a particular endpoint and passing them on to another component.
 
 ```river
 // prometheus.scrape is the name of the component and "default" is its label.
@@ -64,7 +64,7 @@ The `forward_to` attribute is an argument that references the [export]({{< relre
 
 ## Remote Write component
 
-The [`prometheus.remote_write`]({{< relref "prometheus.remote_write.md" >}}) component is responsible for writing the metrics to a Prometheus-compatible endpoint (Mimir).
+The [`prometheus.remote_write`]({{< relref "../reference/components/prometheus.remote_write.md" >}}) component is responsible for writing the metrics to a Prometheus-compatible endpoint (Mimir).
 
 ```river
 prometheus.remote_write "prom" {

--- a/docs/sources/flow/tutorials/filtering-metrics.md
+++ b/docs/sources/flow/tutorials/filtering-metrics.md
@@ -7,7 +7,7 @@ weight: 300
 
 # Filtering Prometheus metrics
 
-In this tutorial, you'll add a new component [prometheus.relabel]({{< ref "prometheus.relabel.md" >}}) using [relabel.flow](../assets/flow_configs/relabel.flow) to filter metrics. This tutorial uses the same base as [Collecting Prometheus metrics]({{< relref "./collecting-prometheus-metrics.md">}}).
+In this tutorial, you'll add a new component [prometheus.relabel]({{< ref "../reference/components/prometheus.relabel.md" >}}) using [relabel.flow](../assets/flow_configs/relabel.flow) to filter metrics. This tutorial uses the same base as [Collecting Prometheus metrics]({{< relref "./collecting-prometheus-metrics.md">}}).
 
 ## Prerequisites
 


### PR DESCRIPTION
* Add backport workflow

The workflow automatically backports PRs to branches labeled with `backport <BRANCH>` on closure or labeling of PRs.

Requires GH_BOT_ACCESS_TOKEN to work and in the future this will need to be replaced by a GitHub App based workflow. Timeline TBC.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

* Avoid ambiguous relref lookups by forcing relative resolution

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

---------

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
(cherry picked from commit a0c0072cffce891665737d0e8063ab7880505bed)
