### PR TITLE
Fix typo in Flow string escape sequence

### DIFF
--- a/docs/sources/flow/config-language/expressions/types_and_values.md
+++ b/docs/sources/flow/config-language/expressions/types_and_values.md
@@ -41,7 +41,7 @@ quotes `""`:
 "Hello, world!"
 ```
 
-A `\\` in a string starts an escape sequence to represent a special character.
+A `\` in a string starts an escape sequence to represent a special character.
 The supported escape sequences are as follows:
 
 | Sequence | Replacement |


### PR DESCRIPTION
The escape sequence for strings was being incorrectly documented as `\\` instead of `\`.
