### PR TITLE
fix: rpm package should not contain build id links

### DIFF
--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -150,6 +150,7 @@ define generate_fpm =
 		--before-remove packaging/$(1)/control/prerm \
 		--config-files /etc/grafana-agent.yaml \
 		--config-files $(ENVIRONMENT_FILE_$(1)) \
+		$(5) \
 		--package $(4) \
 			dist/grafana-agent-linux-$(3)=/usr/bin/grafana-agent \
 			dist/grafana-agentctl-linux-$(3)=/usr/bin/grafana-agentctl \
@@ -175,7 +176,7 @@ ifeq ($(USE_CONTAINER),1)
 	$(RERUN_IN_CONTAINER)
 else
 	$(call generate_fpm,deb,amd64,amd64,$(PACKAGE_PREFIX).amd64.deb)
-	$(call generate_fpm,rpm,x86_64,amd64,$(PACKAGE_PREFIX).amd64.rpm)
+	$(call generate_fpm,rpm,x86_64,amd64,$(PACKAGE_PREFIX).amd64.rpm,--rpm-rpmbuild-define "_build_id_links none")
 endif
 
 .PHONY: dist-packages-arm64

--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -150,7 +150,7 @@ define generate_fpm =
 		--before-remove packaging/$(1)/control/prerm \
 		--config-files /etc/grafana-agent.yaml \
 		--config-files $(ENVIRONMENT_FILE_$(1)) \
-		$(5) \
+		--rpm-rpmbuild-define "_build_id_links none" \
 		--package $(4) \
 			dist/grafana-agent-linux-$(3)=/usr/bin/grafana-agent \
 			dist/grafana-agentctl-linux-$(3)=/usr/bin/grafana-agentctl \
@@ -176,7 +176,7 @@ ifeq ($(USE_CONTAINER),1)
 	$(RERUN_IN_CONTAINER)
 else
 	$(call generate_fpm,deb,amd64,amd64,$(PACKAGE_PREFIX).amd64.deb)
-	$(call generate_fpm,rpm,x86_64,amd64,$(PACKAGE_PREFIX).amd64.rpm,--rpm-rpmbuild-define "_build_id_links none")
+	$(call generate_fpm,rpm,x86_64,amd64,$(PACKAGE_PREFIX).amd64.rpm)
 endif
 
 .PHONY: dist-packages-arm64


### PR DESCRIPTION
Hello

The rpm package contains some build id link unwanted.

```
curl -sL https://github.com/grafana/agent/releases/download/v0.32.0/grafana-agent-0.32.0-1.amd64.rpm -o dist/grafana-agent-0.32.0-1.amd64.rpm
rpm -qlp dist/grafana-agent-0.32.0-1.amd64.rpm
/etc/grafana-agent.yaml
/etc/sysconfig/grafana-agent
/usr/bin/grafana-agent
/usr/bin/grafana-agentctl
/usr/lib/.build-id
/usr/lib/.build-id/02
/usr/lib/.build-id/02/37ab358b2b1a12883706afb2ca49b156595171
/usr/lib/.build-id/fd
/usr/lib/.build-id/fd/a80dec8593b78ecd34d51fc9601e0fa0d3c581
/usr/lib/systemd/system/grafana-agent.service
```
I suggest to add the fpm command attribute to ignore this with `--rpm-rpmbuild-define "_build_id_links none"`, but I'm clearly not sure about the implementation.

