### PR TITLE
operator: conditionally compress config secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Main (unreleased)
 
 - Flow: Add retries with backoff logic to Phlare write component. (@cyriltovena)
 - Operator: Allow setting runtimeClassName on operator-created pods. (@captncraig)
+- Operator: Transparently compress agent configs to stay under size limitations. (@captncraig)
 
 ### Bugfixes
 

--- a/pkg/operator/reconciler_metrics.go
+++ b/pkg/operator/reconciler_metrics.go
@@ -105,7 +105,7 @@ func (r *reconciler) createTelemetryConfigurationSecret(
 				UID:                d.Agent.UID,
 			}},
 		},
-		Data: map[string][]byte{"agent.yml": []byte(rawBytes)},
+		Data: map[string][]byte{"agent.yml": rawBytes},
 	}
 
 	level.Info(l).Log("msg", "reconciling secret", "secret", secret.Name)

--- a/pkg/operator/reconciler_metrics.go
+++ b/pkg/operator/reconciler_metrics.go
@@ -78,7 +78,7 @@ func (r *reconciler) createTelemetryConfigurationSecret(
 		return fmt.Errorf("unable to build config: %w", err)
 	}
 
-	const maxUncompressed = 100 * 1000
+	const maxUncompressed = 100 * 1000 // only compress secrets over 100kB
 	rawBytes := []byte(rawConfig)
 	if len(rawBytes) > maxUncompressed {
 		buf := &bytes.Buffer{}

--- a/pkg/operator/reconciler_metrics.go
+++ b/pkg/operator/reconciler_metrics.go
@@ -1,6 +1,8 @@
 package operator
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
@@ -76,6 +78,20 @@ func (r *reconciler) createTelemetryConfigurationSecret(
 		return fmt.Errorf("unable to build config: %w", err)
 	}
 
+	const maxUncompressed = 100 * 1000
+	rawBytes := []byte(rawConfig)
+	if len(rawBytes) > maxUncompressed {
+		buf := &bytes.Buffer{}
+		w := gzip.NewWriter(buf)
+		if _, err = w.Write(rawBytes); err != nil {
+			return fmt.Errorf("unable to compress config: %w", err)
+		}
+		if err = w.Flush(); err != nil {
+			return fmt.Errorf("flushing gzip writer: %w", err)
+		}
+		rawBytes = buf.Bytes()
+	}
+
 	secret := core_v1.Secret{
 		ObjectMeta: v1.ObjectMeta{
 			Namespace: key.Namespace,
@@ -89,7 +105,7 @@ func (r *reconciler) createTelemetryConfigurationSecret(
 				UID:                d.Agent.UID,
 			}},
 		},
-		Data: map[string][]byte{"agent.yml": []byte(rawConfig)},
+		Data: map[string][]byte{"agent.yml": []byte(rawBytes)},
 	}
 
 	level.Info(l).Log("msg", "reconciling secret", "secret", secret.Name)

--- a/pkg/operator/reconciler_metrics.go
+++ b/pkg/operator/reconciler_metrics.go
@@ -78,7 +78,7 @@ func (r *reconciler) createTelemetryConfigurationSecret(
 		return fmt.Errorf("unable to build config: %w", err)
 	}
 
-	const maxUncompressed = 100 * 1000 // only compress secrets over 100kB
+	const maxUncompressed = 100 * 1024 // only compress secrets over 100kB
 	rawBytes := []byte(rawConfig)
 	if len(rawBytes) > maxUncompressed {
 		buf := &bytes.Buffer{}
@@ -88,6 +88,9 @@ func (r *reconciler) createTelemetryConfigurationSecret(
 		}
 		if err = w.Flush(); err != nil {
 			return fmt.Errorf("flushing gzip writer: %w", err)
+		}
+		if err = w.Close(); err != nil {
+			return fmt.Errorf("closing gzip writer: %w", err)
 		}
 		rawBytes = buf.Bytes()
 	}

--- a/pkg/operator/reconciler_metrics.go
+++ b/pkg/operator/reconciler_metrics.go
@@ -86,9 +86,6 @@ func (r *reconciler) createTelemetryConfigurationSecret(
 		if _, err = w.Write(rawBytes); err != nil {
 			return fmt.Errorf("unable to compress config: %w", err)
 		}
-		if err = w.Flush(); err != nil {
-			return fmt.Errorf("flushing gzip writer: %w", err)
-		}
 		if err = w.Close(); err != nil {
 			return fmt.Errorf("closing gzip writer: %w", err)
 		}


### PR DESCRIPTION
Related to #1649. If you have too many PodMonitors for example, your final agent config can be too big to fit in a secret.

Following comments in https://github.com/prometheus-operator/prometheus-operator/issues/2234, I learned the config reloader container we are already deploying already natively supports gzip compression transparently. So all we need to do to take advantage of that is compress our secret data.

I chose a fairly safe limit at 100kb under which we will not compress, mainly to keep things easier to debug for most installs.

I am currently generating a test install to 100% verify this works.