### PR TITLE
loki.source.file: fix deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Main (unreleased)
     an expression containing a string. (@erikbaranowski, @rfratto)
   - `otelcol.auth.oauth2` performs OAuth 2.0 authentication for HTTP and gRPC
     based OpenTelemetry exporters. (@ptodev)
-  - `otelcol.extension.jaeger_remote_sampling` provides an endpoint from which to 
+  - `otelcol.extension.jaeger_remote_sampling` provides an endpoint from which to
     pull Jaeger remote sampling documents. (@joe-elliott)
   - `prometheus.exporter.blackbox` collects metrics from Blackbox exporter
     (@marctc).
@@ -59,6 +59,10 @@ Main (unreleased)
 
 - Flow: fix issue where components with no arguments like `loki.echo` were not
   viewable in the UI. (@rfratto)
+
+- Flow: fix deadlock in `loki.source.file` where terminating tailers would hang
+  while flushing remaining logs, preventing `loki.source.file` from being able
+  to update. (@rfratto)
 
 ### Other changes
 


### PR DESCRIPTION
`loki.source.file` had a deadlock while updating the component and shutting down old tailers. The terminating tailers try to flush their final log lines, but log lines aren't being processed because the Run goroutine is waiting forever to grab a mutex that the Update goroutine already holds.

This is most visible in environments where the Update goroutine is called frequently, since that's the most likely scenario where tailers will have data to flush.
