### PR TITLE
loki.process: fix deadlock on components with no stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ Main (unreleased)
   while flushing remaining logs, preventing `loki.source.file` from being able
   to update. (@rfratto)
 
+- Flow: fix deadlock in `loki.process` where a component with no stages would
+  hang forever on handling logs. (@rfratto)
+
 ### Other changes
 
 - Grafana Agent Docker containers and release binaries are now published for

--- a/component/loki/process/process.go
+++ b/component/loki/process/process.go
@@ -98,7 +98,10 @@ func (c *Component) Update(args component.Arguments) error {
 	c.mut.Lock()
 	defer c.mut.Unlock()
 
-	if stagesChanged(c.stages, newArgs.Stages) {
+	// We want to create a new pipeline if the config changed or if this is the
+	// first load. This will allow a component with no stages to function
+	// properly.
+	if stagesChanged(c.stages, newArgs.Stages) || c.stages == nil {
 		if c.entryHandler != nil {
 			c.entryHandler.Stop()
 		}


### PR DESCRIPTION
This fixes a deadlock when loki.process has no stages defined, since previously it needed at least one stage to create the input pipelines.
