### PR TITLE
Ensure DefaultConfig is immutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ Main (unreleased)
 - Flow: fix deadlock in `loki.process` where a component with no stages would
   hang forever on handling logs. (@rfratto)
 
+- Fix issue where a DefaultConfig might be mutated during unmarshaling. (@jcreixell)
+
 ### Other changes
 
 - Grafana Agent Docker containers and release binaries are now published for

--- a/cmd/grafana-agent/main.go
+++ b/cmd/grafana-agent/main.go
@@ -52,7 +52,8 @@ func main() {
 	}
 
 	// Set up logging using default values before loading the config
-	logger := server.NewLogger(&server.DefaultConfig)
+	defaultCfg := server.DefaultConfig()
+	logger := server.NewLogger(&defaultCfg)
 
 	reloader := func(log *server.Logger) (*config.Config, error) {
 		fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)

--- a/cmd/grafana-agent/service_windows.go
+++ b/cmd/grafana-agent/service_windows.go
@@ -30,7 +30,8 @@ func (m *AgentService) Execute(args []string, serviceRequests <-chan svc.ChangeR
 	// oddly enough args is blank
 
 	// Set up logging using default values before loading the config
-	logger := server.NewWindowsEventLogger(&server.DefaultConfig())
+	defaultServerCfg := server.DefaultConfig()
+	logger := server.NewWindowsEventLogger(&defaultServerCfg)
 
 	reloader := func(log *server.Logger) (*config.Config, error) {
 		fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)

--- a/cmd/grafana-agent/service_windows.go
+++ b/cmd/grafana-agent/service_windows.go
@@ -30,7 +30,7 @@ func (m *AgentService) Execute(args []string, serviceRequests <-chan svc.ChangeR
 	// oddly enough args is blank
 
 	// Set up logging using default values before loading the config
-	logger := server.NewWindowsEventLogger(&server.DefaultConfig)
+	logger := server.NewWindowsEventLogger(&server.DefaultConfig())
 
 	reloader := func(log *server.Logger) (*config.Config, error) {
 		fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,15 +50,18 @@ var (
 )
 
 // DefaultConfig holds default settings for all the subsystems.
-var DefaultConfig = Config{
-	// All subsystems with a DefaultConfig should be listed here.
-	Server:                &server.DefaultConfig,
-	ServerFlags:           server.DefaultFlags,
-	Metrics:               metrics.DefaultConfig,
-	Integrations:          DefaultVersionedIntegrations,
-	DisableSupportBundle:  false,
-	EnableConfigEndpoints: false,
-	EnableUsageReport:     true,
+func DefaultConfig() Config {
+	defaultServerCfg := server.DefaultConfig()
+	return Config{
+		// All subsystems with a DefaultConfig should be listed here.
+		Server:                &defaultServerCfg,
+		ServerFlags:           server.DefaultFlags,
+		Metrics:               metrics.DefaultConfig,
+		Integrations:          DefaultVersionedIntegrations,
+		DisableSupportBundle:  false,
+		EnableConfigEndpoints: false,
+		EnableUsageReport:     true,
+	}
 }
 
 // Config contains underlying configurations for the agent
@@ -95,7 +98,7 @@ type Config struct {
 func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// Apply defaults to the config from our struct and any defaults inherited
 	// from flags before unmarshaling.
-	*c = DefaultConfig
+	*c = DefaultConfig()
 	util.DefaultConfigFromFlags(c)
 
 	type baseConfig Config
@@ -447,7 +450,7 @@ func applyIntegrationValuesFromFlagset(fs *flag.FlagSet, args []string, path str
 // doesn't require having a literal file on disk.
 func load(fs *flag.FlagSet, args []string, loader loaderFunc) (*Config, error) {
 	var (
-		cfg = DefaultConfig
+		cfg = DefaultConfig()
 
 		printVersion          bool
 		file                  string

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -522,7 +522,8 @@ agent_management:
 func TestConfig_EmptyServerConfigFails(t *testing.T) {
 	// Since we are testing defaults via config.Load, we need a file instead of a string.
 	// This test file has an empty server stanza, we expect default values out.
-	logger := server.NewLogger(&server.DefaultConfig)
+	defaultServerCfg := server.DefaultConfig()
+	logger := server.NewLogger(&defaultServerCfg)
 	fs := flag.NewFlagSet("", flag.ExitOnError)
 	_, err := Load(fs, []string{"--config.file", "./testdata/server_empty.yml"}, logger)
 	require.Error(t, err)

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -26,7 +26,7 @@ type Config struct {
 
 // UnmarshalYAML unmarshals the server config with defaults applied.
 func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	*c = DefaultConfig
+	*c = DefaultConfig()
 
 	type config Config
 	return unmarshal((*config)(c))
@@ -44,21 +44,6 @@ type GRPCConfig struct {
 
 // Default configuration structs.
 var (
-	DefaultConfig = Config{
-		GRPC:      DefaultGRPCConfig,
-		HTTP:      DefaultHTTPConfig,
-		LogLevel:  DefaultLogLevel,
-		LogFormat: DefaultLogFormat,
-	}
-
-	DefaultHTTPConfig = HTTPConfig{
-		// No non-zero defaults yet
-	}
-
-	DefaultGRPCConfig = GRPCConfig{
-		// No non-zero defaults yet
-	}
-
 	emptyFlagSet    = flag.NewFlagSet("", flag.ExitOnError)
 	DefaultLogLevel = func() LogLevel {
 		var lvl LogLevel
@@ -71,3 +56,20 @@ var (
 		return fmt
 	}()
 )
+
+func DefaultConfig() Config {
+	DefaultHTTPConfig := HTTPConfig{
+		// No non-zero defaults yet
+	}
+
+	DefaultGRPCConfig := GRPCConfig{
+		// No non-zero defaults yet
+	}
+
+	return Config{
+		GRPC:      DefaultGRPCConfig,
+		HTTP:      DefaultHTTPConfig,
+		LogLevel:  DefaultLogLevel,
+		LogFormat: DefaultLogFormat,
+	}
+}

--- a/pkg/server/logger_test.go
+++ b/pkg/server/logger_test.go
@@ -17,7 +17,8 @@ func TestLogger_DefaultParameters(t *testing.T) {
 		require.Equal(t, "logfmt", cfg.LogFormat.String())
 		return l, nil
 	}
-	newLogger(&DefaultConfig, makeLogger).makeLogger(&DefaultConfig)
+	defaultCfg := DefaultConfig()
+	newLogger(&defaultCfg, makeLogger).makeLogger(&defaultCfg)
 }
 
 func TestLogger_ApplyConfig(t *testing.T) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -62,7 +62,7 @@ func TestServer_InMemory(t *testing.T) {
 }
 
 func newTestConfig() Config {
-	cfg := DefaultConfig
+	cfg := DefaultConfig()
 	return cfg
 }
 

--- a/tools/crow/main.go
+++ b/tools/crow/main.go
@@ -28,7 +28,7 @@ func main() {
 	var (
 		fs = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
-		serverCfg   = server.DefaultConfig
+		serverCfg   = server.DefaultConfig()
 		serverFlags = server.DefaultFlags
 
 		crowCfg     = crow.DefaultConfig


### PR DESCRIPTION
#### PR Description

  - A recent [PR](https://github.com/grafana/agent/pull/3030) converted the default server config into a pointer. As a side effect, it also caused the DefaultConfig to be mutated when used for unmarshaling, following a pattern we use consistently across the code base.
  - In order to prevent unwanted side effects (as seen in a different [PR](https://github.com/grafana/agent/pull/2959), where tests affect each other when run sequentially), we now generate a new copy of the DefaultConfig every time via a function call.

#### Notes to the Reviewer

I have tested this in the mentioned broken branch and all tests pass.
I did not add tests since we changed from a variable to a function call returning a struct, which enforces a new copy every time.
I have not fixed this everywhere, follow up PRs my follow top ensure consistency.

#### PR Checklist

- [x] CHANGELOG updated
