### PR TITLE
Make the Flow controller cluster-aware and use it to distribute targets between prometheus.scrape components

### DIFF
--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -87,6 +87,8 @@ depending on the nature of the reload error.
 	cmd.Flags().
 		BoolVar(&r.clusterEnabled, "cluster.enabled", r.clusterEnabled, "Start in clustered mode")
 	cmd.Flags().
+		StringVar(&r.clusterJoinAddr, "cluster.advertise-address", r.clusterAdvAddr, "Address to advertise to the cluster")
+	cmd.Flags().
 		StringVar(&r.clusterJoinAddr, "cluster.join-address", r.clusterJoinAddr, "Address to join the cluster at")
 	cmd.Flags().
 		BoolVar(&r.disableReporting, "disable-reporting", r.disableReporting, "Disable reporting of enabled components to Grafana.")
@@ -99,6 +101,7 @@ type flowRun struct {
 	uiPrefix         string
 	disableReporting bool
 	clusterEnabled   bool
+	clusterAdvAddr   string
 	clusterJoinAddr  string
 }
 
@@ -147,7 +150,7 @@ func (fr *flowRun) Run(configFile string) error {
 	reg := prometheus.DefaultRegisterer
 	reg.MustRegister(newResourcesCollector(l))
 
-	clusterer, err := cluster.New(l, fr.clusterEnabled, fr.httpListenAddr, fr.clusterJoinAddr)
+	clusterer, err := cluster.New(l, fr.clusterEnabled, fr.clusterAdvAddr, fr.clusterJoinAddr)
 	if err != nil {
 		return fmt.Errorf("building clusterer: %w", err)
 	}

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -201,7 +201,10 @@ func (fr *flowRun) Run(configFile string) error {
 		r.Handle("/metrics", promhttp.Handler())
 		r.PathPrefix("/debug/pprof").Handler(http.DefaultServeMux)
 		r.PathPrefix("/api/v0/component/{id}/").Handler(f.ComponentHandler())
-		r.PathPrefix("/api/v1/ckit/transport").Handler(clusterer.Mux)
+
+		// Register routes for the clusterer.
+		cr, ch := clusterer.Node.Handler()
+		r.PathPrefix(cr).Handler(ch)
 
 		r.HandleFunc("/-/ready", func(w http.ResponseWriter, _ *http.Request) {
 			if f.Ready() {

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/grafana/agent/web/api"
 	"github.com/grafana/agent/web/ui"
-	"github.com/rfratto/ckit/peer"
 	"go.opentelemetry.io/otel"
 	"golang.org/x/exp/maps"
 	"golang.org/x/net/http2"
@@ -251,21 +250,6 @@ func (fr *flowRun) Run(configFile string) error {
 		}()
 
 		defer func() { _ = srv.Shutdown(ctx) }()
-	}
-
-	// Start the clusterer after having started the HTTP server.
-	err = clusterer.Node.Start()
-	if err != nil {
-		level.Error(l).Log("msg", "failed to connect to any peers; including ourselves to bootstrap a new cluster", "err", err)
-		return err
-	}
-
-	// Nodes initially join the cluster in the Viewer state. We can move to the
-	// Participant state to signal that we wish to participate in reading or
-	// writing data.
-	err = clusterer.Node.ChangeState(context.Background(), peer.StateParticipant)
-	if err != nil {
-		return err
 	}
 
 	// Report usage of enabled components

--- a/component/component.go
+++ b/component/component.go
@@ -126,7 +126,7 @@ type HTTPComponent interface {
 	Handler() http.Handler
 }
 
-// ClusteredComponent is an extension interface for componens which implement
+// ClusteredComponent is an extension interface for components which implement
 // clustering-specific behavior.
 type ClusteredComponent interface {
 	Component

--- a/component/component.go
+++ b/component/component.go
@@ -125,3 +125,11 @@ type HTTPComponent interface {
 	// will receive a request to just `/metrics`.
 	Handler() http.Handler
 }
+
+// ClusteredComponent is an extension interface for componens which implement
+// clustering-specific behavior.
+type ClusteredComponent interface {
+	Component
+
+	ClusterUpdatesRegistration() bool
+}

--- a/component/discovery/discovery.go
+++ b/component/discovery/discovery.go
@@ -36,6 +36,7 @@ func NewDistributedTargets(e bool, n cluster.Node, t []Target) DistributedTarget
 //
 // If a cluster size is 1, then all targets will be returned.
 func (t *DistributedTargets) Get() []Target {
+	// TODO(@tpaschalis): Make this into a single code-path to simplify logic.
 	if !t.useClustering || t.node == nil {
 		return t.targets
 	}

--- a/component/discovery/discovery.go
+++ b/component/discovery/discovery.go
@@ -43,6 +43,8 @@ func (t *DistributedTargets) Get() []Target {
 
 	res := make([]Target, 0, (len(t.targets)+1)/len(t.node.Peers()))
 
+	// TODO(@tpaschalis): Make sure OpReadWrite is the correct operation;
+	// eg. this determines how clustering behaves when nodes are shutting down.
 	for _, tgt := range t.targets {
 		peers, err := t.node.Lookup(shard.StringKey(tgt.Labels().String()), 1, shard.OpReadWrite)
 		if err != nil {

--- a/component/discovery/discovery.go
+++ b/component/discovery/discovery.go
@@ -21,20 +21,25 @@ type Target map[string]string
 // DistributedTargets uses the node's Lookup method to distribute discovery
 // targets when a Flow component runs in a cluster.
 type DistributedTargets struct {
-	node    cluster.Node
-	targets []Target
+	useClustering bool
+	node          cluster.Node
+	targets       []Target
 }
 
 // NewDistributedTargets creates the abstraction that allows components to
 // dynamically shard targets between components.
-func NewDistributedTargets(s cluster.Node, t []Target) DistributedTargets {
-	return DistributedTargets{s, t}
+func NewDistributedTargets(e bool, n cluster.Node, t []Target) DistributedTargets {
+	return DistributedTargets{e, n, t}
 }
 
 // Get distributes discovery targets a clustered environment.
 //
 // If a cluster size is 1, then all targets will be returned.
 func (t *DistributedTargets) Get() []Target {
+	if !t.useClustering || t.node == nil {
+		return t.targets
+	}
+
 	res := make([]Target, 0, (len(t.targets)+1)/len(t.node.Peers()))
 
 	for _, tgt := range t.targets {

--- a/component/loki/process/process_test.go
+++ b/component/loki/process/process_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestJSONLabelsStage(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
 
 	// The following stages will attempt to parse input lines as JSON.
 	// The first stage _extract_ any fields found with the correct names:
@@ -122,7 +122,7 @@ func TestJSONLabelsStage(t *testing.T) {
 }
 
 func TestStaticLabelsLabelAllowLabelDrop(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
 
 	// The following stages manipulate the label set of a log entry.
 	// The first stage will define a static set of labels (foo, bar, baz, qux)
@@ -206,7 +206,7 @@ stage.label_keep {
 }
 
 func TestRegexTimestampOutput(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
 
 	// The first stage will attempt to parse the input line using a regular
 	// expression with named capture groups. The three capture groups (time,

--- a/component/loki/source/file/file_test.go
+++ b/component/loki/source/file/file_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func Test(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
 
 	// Create opts for component
 	opts := component.Options{

--- a/component/module/file/file_test.go
+++ b/component/module/file/file_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/pkg/cluster"
 	"github.com/grafana/agent/pkg/river"
 	"github.com/grafana/agent/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
@@ -51,6 +52,7 @@ func TestModule(t *testing.T) {
 			opts := component.Options{
 				ID:            "module.file.test",
 				Logger:        util.TestFlowLogger(t),
+				Clusterer:     noOpClusterer(),
 				Registerer:    prometheus.NewRegistry(),
 				OnStateChange: func(e component.Exports) {},
 				DataPath:      t.TempDir(),
@@ -122,6 +124,7 @@ func TestBadFile(t *testing.T) {
 			opts := component.Options{
 				ID:            "module.file.test",
 				Logger:        util.TestFlowLogger(t),
+				Clusterer:     noOpClusterer(),
 				Registerer:    prometheus.NewRegistry(),
 				OnStateChange: func(e component.Exports) {},
 				DataPath:      t.TempDir(),
@@ -149,4 +152,8 @@ func requirePrefix(t *testing.T, s string, prefix string) {
 		s,
 		prefix,
 	)
+}
+
+func noOpClusterer() *cluster.Clusterer {
+	return &cluster.Clusterer{Node: cluster.NewLocalNode("")}
 }

--- a/component/module/module.go
+++ b/component/module/module.go
@@ -46,6 +46,7 @@ func NewModuleComponent(o component.Options) *ModuleComponent {
 			LogSink:      logging.LoggerSink(o.Logger),
 			Tracer:       flowTracer,
 			Reg:          flowRegistry,
+			Clusterer:    o.Clusterer,
 
 			DataPath:       o.DataPath,
 			HTTPPathPrefix: o.HTTPPath,

--- a/component/module/string/string_test.go
+++ b/component/module/string/string_test.go
@@ -137,9 +137,12 @@ func testOptions(t *testing.T) flow.Options {
 	s, err := logging.WriterSink(os.Stderr, logging.DefaultSinkOptions)
 	require.NoError(t, err)
 
+	c := &clusterer.Clusterer{Node: clusterer.NewLocalNode("")}
+
 	return flow.Options{
-		LogSink:  s,
-		DataPath: t.TempDir(),
-		Reg:      nil,
+		LogSink:   s,
+		DataPath:  t.TempDir(),
+		Reg:       nil,
+		Clusterer: c,
 	}
 }

--- a/component/module/string/string_test.go
+++ b/component/module/string/string_test.go
@@ -138,7 +138,7 @@ func testOptions(t *testing.T) flow.Options {
 	s, err := logging.WriterSink(os.Stderr, logging.DefaultSinkOptions)
 	require.NoError(t, err)
 
-	c := &clusterer.Clusterer{Node: clusterer.NewLocalNode("")}
+	c := &cluster.Clusterer{Node: cluster.NewLocalNode("")}
 
 	return flow.Options{
 		LogSink:   s,

--- a/component/module/string/string_test.go
+++ b/component/module/string/string_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	_ "github.com/grafana/agent/component/local/file"
+	"github.com/grafana/agent/pkg/cluster"
 	"github.com/grafana/agent/pkg/flow"
 	"github.com/grafana/agent/pkg/flow/logging"
 	"github.com/stretchr/testify/require"

--- a/component/phlare/scrape/scrape_loop_test.go
+++ b/component/phlare/scrape/scrape_loop_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestScrapePool(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
 
 	args := NewDefaultArguments()
 	args.Targets = []discovery.Target{
@@ -152,7 +152,8 @@ func TestScrapePool(t *testing.T) {
 }
 
 func TestScrapeLoop(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
+
 	down := atomic.NewBool(false)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// The test was failing on Windows, as the scrape loop was too fast for

--- a/component/phlare/scrape/scrape_test.go
+++ b/component/phlare/scrape/scrape_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestComponent(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
 	reloadInterval = 100 * time.Millisecond
 	arg := NewDefaultArguments()
 	arg.JobName = "test"

--- a/component/phlare/scrape/scrape_test.go
+++ b/component/phlare/scrape/scrape_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/agent/component/discovery"
 	"github.com/grafana/agent/component/phlare"
 	"github.com/grafana/agent/component/prometheus/scrape"
+	"github.com/grafana/agent/pkg/cluster"
 	"github.com/grafana/agent/pkg/river"
 	"github.com/grafana/agent/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
@@ -31,6 +32,7 @@ func TestComponent(t *testing.T) {
 		Logger:        util.TestFlowLogger(t),
 		Registerer:    prometheus.NewRegistry(),
 		OnStateChange: func(e component.Exports) {},
+		Clusterer:     &cluster.Clusterer{Node: cluster.NewLocalNode("")},
 	}, arg)
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/component/prometheus/scrape/scrape.go
+++ b/component/prometheus/scrape/scrape.go
@@ -81,7 +81,13 @@ type Arguments struct {
 	// Scrape Options
 	ExtraMetrics bool `river:"extra_metrics,attr,optional"`
 
-	ClusteringEnabled bool `river:"clustering_enabled,attr,optional"`
+	Clustering Clustering `river:"clustering,block,optional"`
+}
+
+// Clustering holds values that configure clustering-specific behavior.
+type Clustering struct {
+	// TODO(@tpaschalis) Move this block to a shared place for all components using clustering.
+	Enabled bool `river:"enabled,attr"`
 }
 
 // DefaultArguments defines the default settings for a scrape job.
@@ -179,7 +185,7 @@ func (c *Component) Run(ctx context.Context) error {
 			var (
 				tgs     = c.args.Targets
 				jobName = c.opts.ID
-				cl      = c.args.ClusteringEnabled
+				cl      = c.args.Clustering.Enabled
 			)
 			if c.args.JobName != "" {
 				jobName = c.args.JobName
@@ -314,7 +320,7 @@ func (c *Component) DebugInfo() interface{} {
 func (c *Component) ClusterUpdatesRegistration() bool {
 	c.mut.RLock()
 	defer c.mut.RUnlock()
-	return c.args.ClusteringEnabled
+	return c.args.Clustering.Enabled
 }
 
 func (c *Component) componentTargetsToProm(jobName string, tgs []discovery.Target) map[string][]*targetgroup.Group {

--- a/component/registry.go
+++ b/component/registry.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/grafana/agent/pkg/cluster"
 	"github.com/grafana/agent/pkg/flow/logging"
 	"github.com/grafana/regexp"
 	"github.com/prometheus/client_golang/prometheus"
@@ -60,6 +61,11 @@ type Options struct {
 	// Tracer allows components to record spans. The tracer will include an
 	// attribute denoting the component ID.
 	Tracer trace.TracerProvider
+
+	// Clusterer allows components to work in a clustered fashion. The
+	// clusterer is shared between all components initialized by a Flow
+	// controller.
+	Clusterer *cluster.Clusterer
 
 	// HTTPListenAddr is the address the server is configured to listen on.
 	HTTPListenAddr string

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 	github.com/prometheus/snmp_exporter v0.20.1-0.20220111173215-83399c23888f
 	github.com/prometheus/statsd_exporter v0.22.8
 	github.com/rancher/k3d/v5 v5.2.2
-	github.com/rfratto/ckit v0.0.0-20220401221852-009169323240
+	github.com/rfratto/ckit v0.0.0-20230407094334-439cbde2a5cf
 	github.com/rs/cors v1.8.3
 	github.com/shirou/gopsutil/v3 v3.22.9
 	github.com/sijms/go-ora/v2 v2.5.24

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 	github.com/prometheus/snmp_exporter v0.20.1-0.20220111173215-83399c23888f
 	github.com/prometheus/statsd_exporter v0.22.8
 	github.com/rancher/k3d/v5 v5.2.2
-	github.com/rfratto/ckit v0.0.0-20230407094334-439cbde2a5cf
+	github.com/rfratto/ckit v0.0.0-20230410121755-15c17e2c0d9b
 	github.com/rs/cors v1.8.3
 	github.com/shirou/gopsutil/v3 v3.22.9
 	github.com/sijms/go-ora/v2 v2.5.24

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 	github.com/prometheus/snmp_exporter v0.20.1-0.20220111173215-83399c23888f
 	github.com/prometheus/statsd_exporter v0.22.8
 	github.com/rancher/k3d/v5 v5.2.2
-	github.com/rfratto/ckit v0.0.0-20230410121755-15c17e2c0d9b
+	github.com/rfratto/ckit v0.0.0-20230413073832-e0725e49faea
 	github.com/rs/cors v1.8.3
 	github.com/shirou/gopsutil/v3 v3.22.9
 	github.com/sijms/go-ora/v2 v2.5.24

--- a/go.sum
+++ b/go.sum
@@ -2906,6 +2906,10 @@ github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 h1:Wdi9nwnhFNAlseAOe
 github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03/go.mod h1:gRAiPF5C5Nd0eyyRdqIu9qTiFSoZzpTq727b5B8fkkU=
 github.com/rfratto/ckit v0.0.0-20220401221852-009169323240 h1:aWVSpqwdAr+e0IU+zYibVjAiD2QdrY3eylfTRNThNzQ=
 github.com/rfratto/ckit v0.0.0-20220401221852-009169323240/go.mod h1:kr0K+4DiLWPdO8eSEQ9W0XZ6Y/WhVzAHWOZyIG3BTkI=
+github.com/rfratto/ckit v0.0.0-20230405165508-a26788592e26 h1:EOKiSyWo8oWV8D3PZZrUAzbMWXZgdtbQYCHMkWbo6Jg=
+github.com/rfratto/ckit v0.0.0-20230405165508-a26788592e26/go.mod h1:759U3a/8xE3OO/uSYy72K/XKH3wnDnGU5KSUS7g0Jx0=
+github.com/rfratto/ckit v0.0.0-20230407094334-439cbde2a5cf h1:4PAWxvscTHPV32xkcPti+baSxyMoxwcY9XVUOeLMHcQ=
+github.com/rfratto/ckit v0.0.0-20230407094334-439cbde2a5cf/go.mod h1:759U3a/8xE3OO/uSYy72K/XKH3wnDnGU5KSUS7g0Jx0=
 github.com/rfratto/go-yaml v0.0.0-20211119180816-77389c3526dc h1:g196Usc63pWDzWallipxVhsEjDdh/+RLc/Oz7q3ihW4=
 github.com/rfratto/go-yaml v0.0.0-20211119180816-77389c3526dc/go.mod h1:rMzeXFmWpS5JnfDANtpzbklRJY4pqZMJNN9/SJHAXPA=
 github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=

--- a/go.sum
+++ b/go.sum
@@ -2905,6 +2905,8 @@ github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 h1:Wdi9nwnhFNAlseAOe
 github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03/go.mod h1:gRAiPF5C5Nd0eyyRdqIu9qTiFSoZzpTq727b5B8fkkU=
 github.com/rfratto/ckit v0.0.0-20230410121755-15c17e2c0d9b h1:/xBe/W3pG3t9A0qtS1+OTsZheTgQMmPWNNifY8PRFac=
 github.com/rfratto/ckit v0.0.0-20230410121755-15c17e2c0d9b/go.mod h1:759U3a/8xE3OO/uSYy72K/XKH3wnDnGU5KSUS7g0Jx0=
+github.com/rfratto/ckit v0.0.0-20230413073832-e0725e49faea h1:nYh9V3NKy2rOsIZl7jEWxKJPNvFveGhIK8wbgJ3ZJgc=
+github.com/rfratto/ckit v0.0.0-20230413073832-e0725e49faea/go.mod h1:9DKdYk48N1SdIXVsk/MStJHv3Xm0M2Tcvgbp+UCnreY=
 github.com/rfratto/go-yaml v0.0.0-20211119180816-77389c3526dc h1:g196Usc63pWDzWallipxVhsEjDdh/+RLc/Oz7q3ihW4=
 github.com/rfratto/go-yaml v0.0.0-20211119180816-77389c3526dc/go.mod h1:rMzeXFmWpS5JnfDANtpzbklRJY4pqZMJNN9/SJHAXPA=
 github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=

--- a/go.sum
+++ b/go.sum
@@ -2031,7 +2031,6 @@ github.com/hashicorp/memberlist v0.2.2/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOn
 github.com/hashicorp/memberlist v0.2.3/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/memberlist v0.2.4/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/memberlist v0.3.0/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/hashicorp/memberlist v0.3.1/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/memberlist v0.5.0 h1:EtYPN8DpAURiapus508I4n9CzHs2W+8NZGbmmR/prTM=
 github.com/hashicorp/memberlist v0.5.0/go.mod h1:yvyXLpo0QaGE59Y7hDTsTzDD25JYBZ4mHgHUZ8lrOI0=
 github.com/hashicorp/net-rpc-msgpackrpc v0.0.0-20151116020338-a14192a58a69/go.mod h1:/z+jUGRBlwVpUZfjute9jWaF6/HuhjuFQuL1YXzVD1Q=
@@ -2904,12 +2903,8 @@ github.com/remeh/sizedwaitgroup v1.0.0/go.mod h1:3j2R4OIe/SeS6YDhICBy22RWjJC5eNC
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 h1:Wdi9nwnhFNAlseAOekn6B5G/+GMtks9UKbvRU/CMM/o=
 github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03/go.mod h1:gRAiPF5C5Nd0eyyRdqIu9qTiFSoZzpTq727b5B8fkkU=
-github.com/rfratto/ckit v0.0.0-20220401221852-009169323240 h1:aWVSpqwdAr+e0IU+zYibVjAiD2QdrY3eylfTRNThNzQ=
-github.com/rfratto/ckit v0.0.0-20220401221852-009169323240/go.mod h1:kr0K+4DiLWPdO8eSEQ9W0XZ6Y/WhVzAHWOZyIG3BTkI=
-github.com/rfratto/ckit v0.0.0-20230405165508-a26788592e26 h1:EOKiSyWo8oWV8D3PZZrUAzbMWXZgdtbQYCHMkWbo6Jg=
-github.com/rfratto/ckit v0.0.0-20230405165508-a26788592e26/go.mod h1:759U3a/8xE3OO/uSYy72K/XKH3wnDnGU5KSUS7g0Jx0=
-github.com/rfratto/ckit v0.0.0-20230407094334-439cbde2a5cf h1:4PAWxvscTHPV32xkcPti+baSxyMoxwcY9XVUOeLMHcQ=
-github.com/rfratto/ckit v0.0.0-20230407094334-439cbde2a5cf/go.mod h1:759U3a/8xE3OO/uSYy72K/XKH3wnDnGU5KSUS7g0Jx0=
+github.com/rfratto/ckit v0.0.0-20230410121755-15c17e2c0d9b h1:/xBe/W3pG3t9A0qtS1+OTsZheTgQMmPWNNifY8PRFac=
+github.com/rfratto/ckit v0.0.0-20230410121755-15c17e2c0d9b/go.mod h1:759U3a/8xE3OO/uSYy72K/XKH3wnDnGU5KSUS7g0Jx0=
 github.com/rfratto/go-yaml v0.0.0-20211119180816-77389c3526dc h1:g196Usc63pWDzWallipxVhsEjDdh/+RLc/Oz7q3ihW4=
 github.com/rfratto/go-yaml v0.0.0-20211119180816-77389c3526dc/go.mod h1:rMzeXFmWpS5JnfDANtpzbklRJY4pqZMJNN9/SJHAXPA=
 github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -83,8 +83,14 @@ type Clusterer struct {
 func New(log log.Logger, clusterEnabled bool, addr, joinAddr string) (*Clusterer, error) {
 	// Standalone node.
 	if !clusterEnabled {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("clustering is disabled"))
+			w.WriteHeader(http.StatusBadRequest)
+		}))
 		return &Clusterer{
 			Node: NewLocalNode(addr),
+			Mux:  mux,
 		}, nil
 	}
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -119,18 +119,22 @@ func New(log log.Logger, clusterEnabled bool, addr, joinAddr string) (*Clusterer
 		return &Clusterer{Node: NewLocalNode(addr)}, nil
 	}
 
-	host, portStr, err := net.SplitHostPort(addr)
-	if err != nil {
-		return nil, err
-	}
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		return nil, err
+	gossipConfig := DefaultGossipConfig
+
+	defaultPort := 80
+	if addr != "" {
+		host, portStr, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+		defaultPort, err = strconv.Atoi(portStr)
+		if err != nil {
+			return nil, err
+		}
+		gossipConfig.AdvertiseAddr = host
 	}
 
-	gossipConfig := DefaultGossipConfig
-	gossipConfig.AdvertiseAddr = host
-	err = gossipConfig.ApplyDefaults(port)
+	err := gossipConfig.ApplyDefaults(defaultPort)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -157,7 +157,6 @@ func New(log log.Logger, clusterEnabled bool, addr, joinAddr string) (*Clusterer
 
 	res := &Clusterer{Node: gossipNode}
 
-	fmt.Println("Observer A called")
 	gossipNode.Observe(ckit.FuncObserver(func(peers []peer.Peer) (reregister bool) {
 		names := make([]string, len(peers))
 		for i, p := range peers {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -21,10 +21,6 @@ import (
 
 // Node is a read-only view of a cluster node.
 type Node interface {
-	// Start runs the Node with the configures list of peers.
-	// Start may not be called after the Node has been stopped.
-	Start() error
-
 	// Lookup determines the set of replicationFactor owners for a given key.
 	// peer.Peer.Self can be used to determine if the local node is the owner,
 	// allowing for short-circuiting logic to connect directly to the local node
@@ -41,23 +37,13 @@ type Node interface {
 	// Peers returns the current set of peers for a Node.
 	Peers() []peer.Peer
 
-	// ChangeState changes the state of the node. ChangeState will block until
-	// the state change has been received by another node; cancel the context
-	// to stop waiting. ChangeState will fail if the current state cannot move
-	// to the target state.
-	//
-	// Nodes must be a StateParticipant to receive writes.
-	ChangeState(ctx context.Context, to peer.State) error
-
-	// Handler returns the base route where the node's HTTP/2 handler should
-	// be registered on, as well as the handler itself.
 	Handler() (string, http.Handler)
 }
 
 // NewLocalNode returns a Node which forms a single-node cluster and never
 // connects to other nodes.
 //
-// selfAddr is the address for a Node to use to connect to itself over HTTP/2.
+// selfAddr is the address for a Node to use to connect to itself over gRPC.
 func NewLocalNode(selfAddr string) Node {
 	p := peer.Peer{
 		Name:  "local",
@@ -70,10 +56,6 @@ func NewLocalNode(selfAddr string) Node {
 }
 
 type localNode struct{ self peer.Peer }
-
-func (ln *localNode) Start() error {
-	return nil
-}
 
 func (ln *localNode) Lookup(key shard.Key, replicationFactor int, op shard.Op) ([]peer.Peer, error) {
 	if replicationFactor == 0 {
@@ -91,10 +73,6 @@ func (ln *localNode) Observe(ckit.Observer) {
 
 func (ln *localNode) Peers() []peer.Peer {
 	return []peer.Peer{ln.self}
-}
-
-func (ln *localNode) ChangeState(ctx context.Context, to peer.State) error {
-	return nil
 }
 
 func (ln *localNode) Handler() (string, http.Handler) {
@@ -153,6 +131,27 @@ func New(log log.Logger, clusterEnabled bool, addr, joinAddr string) (*Clusterer
 	}
 
 	gossipNode, err := NewGossipNode(log, cli, &gossipConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// Attempt to start the Node by connecting to the peers in gossipConfig.
+	// If we cannot connect to any peers, fall back to bootstrapping a new
+	// cluster by ourselves.
+	err = gossipNode.Start()
+	if err != nil {
+		level.Debug(log).Log("msg", "failed to connect to peers; bootstrapping a new cluster")
+		gossipConfig.JoinPeers = nil
+		err = gossipNode.Start()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Nodes initially join the cluster in the Viewer state. We can move to the
+	// Participant state to signal that we wish to participate in reading or
+	// writing data.
+	err = gossipNode.ChangeState(context.Background(), peer.StateParticipant)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/google/uuid"
 	"github.com/rfratto/ckit"
 	"github.com/rfratto/ckit/peer"
 	"github.com/rfratto/ckit/shard"
@@ -109,7 +108,6 @@ func New(log log.Logger, clusterEnabled bool, addr, joinAddr string) (*Clusterer
 	}
 
 	gossipConfig := DefaultGossipConfig
-	gossipConfig.NodeName = uuid.NewString()
 	gossipConfig.AdvertiseAddr = host
 	err = gossipConfig.ApplyDefaults(port)
 	if err != nil {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -79,7 +79,7 @@ func (ln *localNode) Peers() []peer.Peer {
 func (ln *localNode) Handler() (string, http.Handler) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("clustering is disabled"))
+		_, _ = w.Write([]byte("clustering is disabled"))
 		w.WriteHeader(http.StatusBadRequest)
 	}))
 
@@ -111,7 +111,10 @@ func New(log log.Logger, clusterEnabled bool, addr, joinAddr string) (*Clusterer
 	gossipConfig := DefaultGossipConfig
 	gossipConfig.NodeName = uuid.NewString()
 	gossipConfig.AdvertiseAddr = host
-	gossipConfig.ApplyDefaults(port)
+	err = gossipConfig.ApplyDefaults(port)
+	if err != nil {
+		return nil, err
+	}
 
 	if joinAddr != "" {
 		gossipConfig.JoinPeers = strings.Split(joinAddr, ",")

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -95,11 +95,13 @@ func getJoinAddr(addrs []string, in string) []string {
 	_, _, err := net.SplitHostPort(in)
 	if err == nil {
 		addrs = append(addrs, in)
+		return addrs
 	}
 
 	ip := net.ParseIP(in)
 	if ip != nil {
 		addrs = append(addrs, ip.String())
+		return addrs
 	}
 
 	_, srvs, err := net.LookupSRV("", "", in)
@@ -152,9 +154,6 @@ func New(log log.Logger, clusterEnabled bool, addr, joinAddr string) (*Clusterer
 			AllowHTTP: true,
 			DialTLS: func(network, addr string, _ *tls.Config) (net.Conn, error) {
 				return net.Dial(network, addr)
-			},
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
 			},
 		},
 	}

--- a/pkg/cluster/gossip.go
+++ b/pkg/cluster/gossip.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	stdlog "log"
 	"net"
+	"net/http"
 	"os"
 
 	"github.com/go-kit/log"
@@ -18,7 +19,6 @@ import (
 	"github.com/rfratto/ckit/peer"
 	"github.com/rfratto/ckit/shard"
 	"go.uber.org/atomic"
-	"google.golang.org/grpc"
 )
 
 // extraDiscoverProviders used in tests.
@@ -167,11 +167,11 @@ type GossipNode struct {
 }
 
 // NewGossipNode creates an unstarted GossipNode. The GossipNode will register
-// itself as a gRPC service to srv. GossipConfig is expected to be valid and
-// have already had ApplyDefaults called on it.
+// HTTP endpoints to communicate with other nodes over HTTP/2. GossipConfig is
+// expected to be valid and have already had ApplyDefaults called on it.
 //
 // GossipNode operations are unavailable until the node is started.
-func NewGossipNode(l log.Logger, srv *grpc.Server, c *GossipConfig) (*GossipNode, error) {
+func NewGossipNode(l log.Logger, mux *http.ServeMux, c *GossipConfig) (*GossipNode, error) {
 	if l == nil {
 		l = log.NewNopLogger()
 	}
@@ -186,7 +186,7 @@ func NewGossipNode(l log.Logger, srv *grpc.Server, c *GossipConfig) (*GossipNode
 		Pool:          c.Pool,
 	}
 
-	inner, err := ckit.NewNode(srv, ckitConfig)
+	inner, err := ckit.NewHTTPNode(mux, ckitConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cluster/gossip.go
+++ b/pkg/cluster/gossip.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/go-discover/provider/k8s"
 	"github.com/rfratto/ckit"
 	"github.com/rfratto/ckit/advertise"
-	"github.com/rfratto/ckit/clientpool"
 	"github.com/rfratto/ckit/peer"
 	"github.com/rfratto/ckit/shard"
 	"go.uber.org/atomic"
@@ -67,9 +66,6 @@ type GossipConfig struct {
 	// Discover peers to connect to using go-discover. Mutually exclusive with
 	// JoinPeers.
 	DiscoverPeers string
-
-	// Client pool to use for connecting to peers.
-	Pool *clientpool.Pool
 }
 
 // DefaultGossipConfig holds default GossipConfig options.
@@ -184,10 +180,9 @@ func NewGossipNode(l log.Logger, cli *http.Client, c *GossipConfig) (*GossipNode
 		AdvertiseAddr: c.AdvertiseAddr,
 		Sharder:       sharder,
 		Log:           l,
-		Pool:          c.Pool,
 	}
 
-	inner, err := ckit.NewHTTPNode(cli, ckitConfig)
+	inner, err := ckit.NewNode(cli, ckitConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/flow/flow_test.go
+++ b/pkg/flow/flow_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/pkg/cluster"
 	"github.com/grafana/agent/pkg/flow/internal/controller"
 	"github.com/grafana/agent/pkg/flow/internal/dag"
 	"github.com/grafana/agent/pkg/flow/internal/testcomponents"
@@ -65,9 +66,12 @@ func testOptions(t *testing.T) Options {
 	s, err := logging.WriterSink(os.Stderr, logging.DefaultSinkOptions)
 	require.NoError(t, err)
 
+	c := &cluster.Clusterer{Node: cluster.NewLocalNode("")}
+
 	return Options{
-		LogSink:  s,
-		DataPath: t.TempDir(),
-		Reg:      nil,
+		LogSink:   s,
+		DataPath:  t.TempDir(),
+		Reg:       nil,
+		Clusterer: c,
 	}
 }

--- a/pkg/flow/internal/controller/component.go
+++ b/pkg/flow/internal/controller/component.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/pkg/cluster"
 	"github.com/grafana/agent/pkg/flow/logging"
 	"github.com/grafana/agent/pkg/river/ast"
 	"github.com/grafana/agent/pkg/river/vm"
@@ -61,6 +62,7 @@ type ComponentGlobals struct {
 	LogSink           *logging.Sink                // Sink used for Logging.
 	Logger            *logging.Logger              // Logger shared between all managed components.
 	TraceProvider     trace.TracerProvider         // Tracer shared between all managed components.
+	Clusterer         *cluster.Clusterer           // Clusterer shared between all managed components.
 	DataPath          string                       // Shared directory where component data may be stored
 	OnComponentUpdate func(cn *ComponentNode)      // Informs controller that we need to reevaluate
 	OnExportsChange   func(exports map[string]any) // Invoked when the managed component updated its exports
@@ -179,7 +181,8 @@ func getManagedOptions(globals ComponentGlobals, cn *ComponentNode) component.Op
 		Registerer: prometheus.WrapRegistererWith(prometheus.Labels{
 			"component_id": globalID,
 		}, wrapped),
-		Tracer: wrapTracer(globals.TraceProvider, globalID),
+		Tracer:    wrapTracer(globals.TraceProvider, globalID),
+		Clusterer: globals.Clusterer,
 
 		DataPath:       filepath.Join(globals.DataPath, cn.nodeID),
 		HTTPListenAddr: globals.HTTPListenAddr,

--- a/pkg/flow/internal/controller/component.go
+++ b/pkg/flow/internal/controller/component.go
@@ -250,6 +250,37 @@ func (cn *ComponentNode) Evaluate(scope *vm.Scope) error {
 	return err
 }
 
+// Revisit calls Update on the managed component with its last used arguments.
+// Revisit does not build the component if it is not already built and does not
+// re-evaluate the River block.
+// Its only use case is for components opting-in to clustering where calling
+// Update with the same Arguments may result in different functionality.
+func (cn *ComponentNode) Revisit() error {
+	cn.mut.Lock()
+	defer cn.mut.Unlock()
+
+	cn.doingEval.Store(true)
+	defer cn.doingEval.Store(false)
+
+	if cn.managed == nil {
+		// We haven't built the managed component successfully yet.
+		return nil
+	}
+
+	// Update the existing managed component with the same arguments.
+	err := cn.managed.Update(cn.args)
+
+	switch err {
+	case nil:
+		cn.setEvalHealth(component.HealthTypeHealthy, "component evaluated")
+		return nil
+	default:
+		msg := fmt.Sprintf("component evaluation failed: %s", err)
+		cn.setEvalHealth(component.HealthTypeUnhealthy, msg)
+		return err
+	}
+}
+
 func (cn *ComponentNode) evaluate(scope *vm.Scope) error {
 	cn.mut.Lock()
 	defer cn.mut.Unlock()

--- a/pkg/flow/internal/controller/component.go
+++ b/pkg/flow/internal/controller/component.go
@@ -250,12 +250,12 @@ func (cn *ComponentNode) Evaluate(scope *vm.Scope) error {
 	return err
 }
 
-// Revisit calls Update on the managed component with its last used arguments.
-// Revisit does not build the component if it is not already built and does not
-// re-evaluate the River block.
+// Reevaluate calls Update on the managed component with its last used
+// arguments.Reevaluate does not build the component if it is not already built
+// and does not re-evaluate the River block itself.
 // Its only use case is for components opting-in to clustering where calling
 // Update with the same Arguments may result in different functionality.
-func (cn *ComponentNode) Revisit() error {
+func (cn *ComponentNode) Reevaluate() error {
 	cn.mut.Lock()
 	defer cn.mut.Unlock()
 

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -65,7 +65,7 @@ func NewLoader(globals ComponentGlobals) *Loader {
 				if cc.ClusterUpdatesRegistration() {
 					err := cmp.Reevaluate()
 					if err != nil {
-						level.Error(globals.Logger).Log("msg", "failed to revisit component", "componentID", cmp.NodeID(), "err", err)
+						level.Error(globals.Logger).Log("msg", "failed to reevaluate component", "componentID", cmp.NodeID(), "err", err)
 					}
 				}
 			}

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -61,10 +61,12 @@ func NewLoader(globals ComponentGlobals) *Loader {
 
 	globals.Clusterer.Node.Observe(ckit.FuncObserver(func(peers []peer.Peer) (reregister bool) {
 		for _, cmp := range l.Components() {
-			if globals.Clusterer.IsRegistered(cmp.ID().String()) {
-				err := cmp.Revisit()
-				if err != nil {
-					level.Error(globals.Logger).Log("msg", "failed to revisit component", "componentID", cmp.NodeID(), "err", err)
+			if cc, ok := cmp.managed.(component.ClusteredComponent); ok {
+				if cc.ClusterUpdatesRegistration() {
+					err := cmp.Reevaluate()
+					if err != nil {
+						level.Error(globals.Logger).Log("msg", "failed to revisit component", "componentID", cmp.NodeID(), "err", err)
+					}
 				}
 			}
 		}

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -60,6 +60,8 @@ func NewLoader(globals ComponentGlobals) *Loader {
 	}
 
 	globals.Clusterer.Node.Observe(ckit.FuncObserver(func(peers []peer.Peer) (reregister bool) {
+		_, span := l.tracer.Tracer("").Start(context.Background(), "ClusterStateChange", trace.WithSpanKind(trace.SpanKindInternal))
+		defer span.End()
 		for _, cmp := range l.Components() {
 			if cc, ok := cmp.managed.(component.ClusteredComponent); ok {
 				if cc.ClusterUpdatesRegistration() {

--- a/pkg/flow/internal/controller/loader_test.go
+++ b/pkg/flow/internal/controller/loader_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/grafana/agent/pkg/cluster"
 	"github.com/grafana/agent/pkg/flow/internal/controller"
 	"github.com/grafana/agent/pkg/flow/internal/dag"
 	"github.com/grafana/agent/pkg/flow/logging"
@@ -68,6 +69,7 @@ func TestLoader(t *testing.T) {
 			LogSink:           noOpSink(),
 			Logger:            logging.New(nil),
 			TraceProvider:     trace.NewNoopTracerProvider(),
+			Clusterer:         noOpClusterer(),
 			DataPath:          t.TempDir(),
 			OnComponentUpdate: func(cn *controller.ComponentNode) { /* no-op */ },
 			Registerer:        prometheus.NewRegistry(),
@@ -213,6 +215,7 @@ func TestScopeWithFailingComponent(t *testing.T) {
 			DataPath:          t.TempDir(),
 			OnComponentUpdate: func(cn *controller.ComponentNode) { /* no-op */ },
 			Registerer:        prometheus.NewRegistry(),
+			Clusterer:         noOpClusterer(),
 		}
 	}
 
@@ -226,6 +229,10 @@ func TestScopeWithFailingComponent(t *testing.T) {
 func noOpSink() *logging.Sink {
 	s, _ := logging.WriterSink(io.Discard, logging.DefaultSinkOptions)
 	return s
+}
+
+func noOpClusterer() *cluster.Clusterer {
+	return &cluster.Clusterer{Node: cluster.NewLocalNode("")}
 }
 
 func applyFromContent(t *testing.T, l *controller.Loader, componentBytes []byte, configBytes []byte) diag.Diagnostics {


### PR DESCRIPTION
This is a PR to showcase a first use of clustering in the Agent.

For easier review, I suggest going commit-by-commit.

I'd like to throw out the idea that we may even split this up into multiple PRs if we at least agree in the way that we make the controller cluster-aware if we don't agree on the way we implement component behavior.

More specifically, this PR:

* Introduces a couple of new command-line arguments that enable clustered mode and specifying which peers to connect to.
* Introduces a `Clusterer` struct which is a thin layer over rfratto/ckit
* Propagates the Clusterer to be used by components through their Arguments
* Allows components to register and unregister themselves to have their Update method called 
* Uses the above to have the `prometheus.scrape` component wrap its input targets in a new struct and distribute between multiple components.

To test this, one can work with a config like the following
```river
prometheus.scrape "default" {
	clustering {
                enabled = true
        }

	targets = [
		{"__address__" = "http://demo.robustperception.io:9090/metrics", "color" = "pink"},
		{"__address__" = "http://demo.robustperception.io:9090/metrics", "color" = "yellow"},
		{"__address__" = "http://demo.robustperception.io:9090/metrics", "color" = "red"},
		{"__address__" = "http://demo.robustperception.io:9090/metrics", "color" = "blue"},
		{"__address__" = "http://demo.robustperception.io:9090/metrics", "color" = "white"},
	]
	forward_to = []
}
```

Then, start a bootstrap node on port 12345
```
$ AGENT_MODE=flow ./build/grafana-agent run ~/clustering_targets.river --server.http.listen-addr 127.0.0.1:12345 --cluster.enabled --cluster.join-address 127.0.0.1
```

and as many additional nodes as you'd like
```
$ AGENT_MODE=flow ./build/grafana-agent run ~/clustering_targets.river --server.http.listen-addr 127.0.0.1:12346 --cluster.enabled --cluster.join-address 127.0.0.1:12345
$ AGENT_MODE=flow ./build/grafana-agent run ~/clustering_targets.river --server.http.listen-addr 127.0.0.1:12347 --cluster.enabled --cluster.join-address 127.0.0.1:12345
$ AGENT_MODE=flow ./build/grafana-agent run ~/clustering_targets.river --server.http.listen-addr 127.0.0.1:12348 --cluster.enabled --cluster.join-address 127.0.0.1:12345
```

When you navigate to the UI of each of your nodes, you'll see the DebugInfo only listing the targets the Agent is responsible for.
```
http://localhost:12345/component/prometheus.scrape.default#Debug%20info-target_3
http://localhost:12346/component/prometheus.scrape.default#Debug%20info-target_3
```