### PR TITLE
docs: clarify objects, fmt based on feedback in #3304

### DIFF
--- a/docs/sources/flow/config-language/expressions/types_and_values.md
+++ b/docs/sources/flow/config-language/expressions/types_and_values.md
@@ -123,7 +123,7 @@ a string:
 > An _object_ is a value assigned to an [Attribute][Attributes], where
 > commas **must** be provided between key-value pairs on separate lines.
 >
-> A [Block][Blocks] is a structural element composed of multiple attributes,
+> A [Block][Blocks] is a named structural element composed of multiple attributes,
 > where commas **must not** be provided between attributes.
 
 [Attributes]: {{< relref "../syntax.md#Attributes" >}}

--- a/docs/sources/flow/config-language/expressions/types_and_values.md
+++ b/docs/sources/flow/config-language/expressions/types_and_values.md
@@ -118,6 +118,17 @@ a string:
 }
 ```
 
+> **NOTE**: Be careful not to confuse objects with blocks.
+>
+> An _object_ is a value assigned to an [Attribute][Attributes], where
+> commas **must** be provided between key-value pairs on separate lines.
+>
+> A [Block][Blocks] is a structural element composed of multiple attributes,
+> where commas **must not** be provided between attributes.
+
+[Attributes]: {{< relref "../syntax.md#Attributes" >}}
+[Blocks]: {{< relref "../syntax.md#Blocks" >}}
+
 ## Functions
 
 Function values cannot be constructed by users, but can be called from the

--- a/docs/sources/flow/config-language/expressions/types_and_values.md
+++ b/docs/sources/flow/config-language/expressions/types_and_values.md
@@ -24,10 +24,11 @@ River uses the following types for its values:
 * `null`: A type that has no value.
 
 ## Numbers
+
 River handles integers, unsigned integers and floating-point values as a single
 'number' type which simplifies writing and reading River configuration files.
 
-```
+```river
 3    == 3.00     // true
 5.0  == (10 / 2) // true
 1e+2 == 100      // true
@@ -35,9 +36,11 @@ River handles integers, unsigned integers and floating-point values as a single
 ```
 
 ## Strings
+
 Strings are represented by sequences of Unicode characters surrounded by double
 quotes `""`:
-```
+
+```river
 "Hello, world!"
 ```
 
@@ -61,19 +64,23 @@ The supported escape sequences are as follows:
 | `\UNNNNNNNN` | A Unicode character from supplementary planes (NNNNNNNN is eight hexadecimal digits) |
 
 ## Bools
+
 Bools are represented by the symbols `true` and `false`.
 
 ## Arrays
+
 Array values are constructed by a sequence of comma separated values surrounded
 by square brackets `[]`:
-```
+
+```river
 [0, 1, 2, 3]
 ```
 
 Values in array elements may be placed on separate lines for readability. A
 comma after the final value must be present if the closing bracket `]`
 is on a different line as the final value:
-```
+
+```river
 [
   0,
   1,
@@ -82,25 +89,42 @@ is on a different line as the final value:
 ```
 
 ## Objects
+
 Object values are constructed by a sequence of comma separated key-value pairs
 surrounded by curly braces `{}`:
-```
+
+```river
 {
   first_name = "John",
-  last_name = "Doe",
+  last_name  = "Doe",
 }
 ```
+
 A comma after the final key-value pair may be omitted if the closing curly
 brace `}` is on the same line as the final pair:
-```
+
+```river
 { name = "John" }
 ```
 
+If the key is not a valid identifier, it must be wrapped in double quotes like
+a string:
+
+```river
+{
+  "app.kubernetes.io/name"     = "mysql",
+  "app.kubernetes.io/instance" = "mysql-abcxyz",
+  namespace                    = "default",
+}
+```
+
 ## Functions
+
 Function values cannot be constructed by users, but can be called from the
 standard library or when exported by a component.
 
 ## Null
+
 The null value is represented by the symbol `null`.
 
 ## Special Types

--- a/docs/sources/flow/config-language/syntax.md
+++ b/docs/sources/flow/config-language/syntax.md
@@ -6,6 +6,7 @@ weight: 200
 ---
 
 # Syntax
+
 The River syntax is designed to be easy to read and write. Essentially, there
 are just two high-level elements to it: _Attributes_ and _Blocks_.
 
@@ -15,16 +16,20 @@ file is not important; the language will consider all direct and indirect
 dependencies between elements to determine their relationships.
 
 ## Comments
+
 River configuration files support single-line `//` as well as block `/* */`
 comments.
 
 ## Identifiers
+
 River considers an identifier as valid if it consists of one or more UTF-8
-letters, digits or underscores, but doesn't start with a digit.
+letters (A through Z, both upper- and lower-case), digits or underscores, but
+doesn't start with a digit.
 
 ## Attributes and Blocks
 
 ### Attributes
+
 _Attributes_ are used to configure individual settings. They always take the
 form of `ATTRIBUTE_NAME = ATTRIBUTE_VALUE`. They can appear either as
 top-level elements or nested within blocks.
@@ -43,6 +48,7 @@ boolean, number) or an [_expression_]({{< relref "./expressions/_index.md" >}})
 to represent or compute more complex attribute values.
 
 ### Blocks
+
 _Blocks_ are used to configure the Agent behavior as well as Flow components by
 grouping any number of attributes or nested blocks using curly braces.
 Blocks have a _name_, an optional _label_ and a body that contains any number
@@ -97,8 +103,10 @@ local.file "token" {
 ```
 
 ## Terminators
+
 All block and attribute definitions are followed by a newline, which River
 calls a _terminator_, as it terminates the current statement.
+
 A newline is treated as terminator when it follows any expression, `]`,
 `)` or `}`. Other newlines are ignored by River and and a user can enter as many
 newlines as they want.

--- a/docs/sources/flow/reference/cli/fmt.md
+++ b/docs/sources/flow/reference/cli/fmt.md
@@ -19,6 +19,10 @@ The `--write` flag can be specified to replace the contents of the original
 file on disk with the formatted results. `--write` can only be provided when
 `agent fmt` is not reading from standard input.
 
+The command fails if the file being formatted has syntatically incorrect River
+configuration, but does not validate whether Flow components are configured
+properly.
+
 The following flags are supported:
 
 * `--write`, `-w`: Write the formatted file back to disk when not reading from


### PR DESCRIPTION
Clarify documentation around object construction and the `fmt` command based on feedback in provided in #3304. 
