### PR TITLE
[release-v0.31] docs: fix existing references to old binary names #3317

### DIFF
--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -35,7 +35,7 @@ compiling and testing your changes do:
 ```bash
 # For building:
 go build ./cmd/grafana-agent/
-./agent -config.file=<config-file>
+./grafana-agent -config.file=<config-file>
 
 # For testing:
 make lint test # Make sure all the tests pass before you commit and push :)
@@ -63,7 +63,7 @@ To build Grafana Agent from source code, please install the following tools:
 You can directly use the go tool to download and install the agent binary into your GOPATH:
 
     $ GO111MODULE=on go install github.com/grafana/agent/cmd/grafana-agent
-    $ agent -config.file=your_config.yml
+    $ grafana-agent -config.file=your_config.yml
 
 An example of the above configuration file can be found [here][example-config].
 
@@ -74,7 +74,7 @@ You can also clone the repository yourself and build using `make agent`:
     $ git clone https://github.com/grafana/agent.git
     $ cd agent
     $ make agent
-    $ ./agent -config.file=your_config.yml
+    $ ./build/grafana-agent -config.file=your_config.yml
 
 The Makefile provides several targets:
 

--- a/docs/sources/flow/monitoring/component_metrics.md
+++ b/docs/sources/flow/monitoring/component_metrics.md
@@ -20,7 +20,7 @@ Component-specific metrics are exposed at the `/metrics` HTTP endpoint of the
 Grafana Agent HTTP server, which defaults to listening on
 `http://localhost:12345`.
 
-> The documentation for the [`agent run`][agent run] command describes how to
+> The documentation for the [`grafana-agent run`][grafana-agent run] command describes how to
 > modify the address Grafana Agent listens on for HTTP traffic.
 
 Component-specific metrics will have a `component_id` label matching the
@@ -33,5 +33,5 @@ component-specific metrics that component exposes. Not all components will
 expose metrics.
 
 [components]: {{< relref "../concepts/components.md" >}}
-[agent run]: {{< relref "../reference/cli/run.md" >}}
+[grafana-agent run]: {{< relref "../reference/cli/run.md" >}}
 [reference documentation]: {{< relref "../reference/components/_index.md" >}}

--- a/docs/sources/flow/monitoring/controller_metrics.md
+++ b/docs/sources/flow/monitoring/controller_metrics.md
@@ -14,8 +14,9 @@ Metrics for the controller are exposed at the `/metrics` HTTP endpoint of the
 Grafana Agent HTTP server, which defaults to listening on
 `http://localhost:12345`.
 
-> The documentation for the [`agent run`][agent run] command describes how to
-> modify the address Grafana Agent listens on for HTTP traffic.
+> The documentation for the [`grafana-agent run`][grafana-agent run] command
+> describes how to modify the address Grafana Agent listens on for HTTP
+> traffic.
 
 The controller exposes the following metrics:
 
@@ -31,4 +32,4 @@ The controller exposes the following metrics:
   took.
 
 [component controller]: {{< relref "../concepts/component_controller.md" >}}
-[agent run]: {{< relref "../reference/cli/run.md" >}}
+[grafana-agent run]: {{< relref "../reference/cli/run.md" >}}

--- a/docs/sources/flow/monitoring/debugging.md
+++ b/docs/sources/flow/monitoring/debugging.md
@@ -18,7 +18,7 @@ Follow these steps to debug issues with Grafana Agent Flow:
 Grafana Agent Flow includes an embedded UI viewable from Grafana Agent's HTTP
 server, which defaults to listening at `http://localhost:12345`.
 
-> The documentation for the [`agent run`][agent run] command describes how to
+> The documentation for the [`grafana-agent run`][grafana-agent run] command describes how to
 > modify the address Grafana Agent listens on for HTTP traffic.
 
 ### Home page
@@ -63,7 +63,7 @@ To debug using the UI:
 * Ensure that the arguments and exports for misbehaving components appear
   correct.
 
-[agent run]: {{< relref "../reference/cli/run.md" >}}
+[grafana-agent run]: {{< relref "../reference/cli/run.md" >}}
 [secret]: {{< relref "../config-language/expressions/types_and_values.md#secrets" >}}
 
 ## Examining logs

--- a/docs/sources/flow/reference/cli/_index.md
+++ b/docs/sources/flow/reference/cli/_index.md
@@ -7,7 +7,7 @@ weight: 100
 
 # Command-line interface
 
-When in Flow mode, the `agent` binary exposes a command-line interface with
+When in Flow mode, the `grafana-agent` binary exposes a command-line interface with
 subcommands to perform various operations.
 
 The most common subcommand is [`run`][run] which accepts a config file and
@@ -15,10 +15,10 @@ starts Grafana Agent Flow.
 
 Available commands:
 
-* [`agent run`][run]: Start Grafana Agent Flow, given a config file.
-* [`agent fmt`][fmt]: Format a Grafana Agent Flow config file.
-* `agent completion`: Generate shell completion for the `agent` CLI.
-* `agent help`: Print help for supported commands.
+* [`grafana-agent run`][run]: Start Grafana Agent Flow, given a config file.
+* [`grafana-agent fmt`][fmt]: Format a Grafana Agent Flow config file.
+* `grafana-agent completion`: Generate shell completion for the `grafana-agent` CLI.
+* `grafana-agent help`: Print help for supported commands.
 
 [run]: {{< relref "./run.md" >}}
 [fmt]: {{< relref "./fmt.md" >}}

--- a/docs/sources/flow/reference/cli/run.md
+++ b/docs/sources/flow/reference/cli/run.md
@@ -1,21 +1,21 @@
 ---
 aliases:
 - /docs/agent/latest/flow/reference/cli/run
-title: agent run
+title: grafana-agent run
 weight: 100
 ---
 
-# `agent run` command
+# `grafana-agent run` command
 
-The `agent run` command runs Grafana Agent Flow in the foreground until an
+The `grafana-agent run` command runs Grafana Agent Flow in the foreground until an
 interrupt is received.
 
 ## Usage
 
-Usage: `agent run [FLAG ...] FILE_NAME`
+Usage: `grafana-agent run [FLAG ...] FILE_NAME`
 
-`agent run` must be provided an argument which points at the River config file
-to use. `agent run` will immediately exit with an error if the River file
+`grafana-agent run` must be provided an argument which points at the River config file
+to use. `grafana-agent run` will immediately exit with an error if the River file
 wasn't specified, can't be loaded, or contained errors during the initial load.
 
 Grafana Agent Flow will continue to run if subsequent reloads of the config
@@ -23,7 +23,7 @@ file fail, potentially marking components as unhealthy depending on the nature
 of the failure. When this happens, Grafana Agent Flow will continue functioning
 in the last valid state.
 
-`agent run` launches an HTTP server for expose metrics about itself and
+`grafana-agent run` launches an HTTP server for expose metrics about itself and
 components. The HTTP server is also used for exposing a UI at `/` for debugging
 running components.
 

--- a/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
+++ b/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
@@ -79,4 +79,4 @@ prometheus.remote_write "prom" {
 To try out the Grafana Agent without using Docker:
 1. Download the Grafana Agent.
 1. Set the environment variable `AGENT_MODE=flow`.
-1. Run the agent with `agent run <path_to_flow_config>`.
+1. Run the agent with `grafana-agent run <path_to_flow_config>`.


### PR DESCRIPTION
Backport 9ed71e2e80aef883d3ece778bc4411f8c86f29d6 from #3315