### PR TITLE
Convert() method for otel auth extensions to return an error

### DIFF
--- a/component/otelcol/auth/auth.go
+++ b/component/otelcol/auth/auth.go
@@ -31,7 +31,7 @@ type Arguments interface {
 
 	// Convert converts the Arguments into an OpenTelemetry Collector
 	// authentication extension configuration.
-	Convert() otelconfig.Extension
+	Convert() (otelconfig.Extension, error)
 
 	// Extensions returns the set of extensions that the configured component is
 	// allowed to use.
@@ -150,7 +150,10 @@ func (a *Auth) Update(args component.Arguments) error {
 		},
 	}
 
-	extensionConfig := rargs.Convert()
+	extensionConfig, err := rargs.Convert()
+	if err != nil {
+		return err
+	}
 
 	// Create instances of the extension from our factory.
 	var components []otelcomponent.Component

--- a/component/otelcol/auth/auth_test.go
+++ b/component/otelcol/auth/auth_test.go
@@ -82,9 +82,9 @@ type fakeAuthArgs struct {
 
 var _ auth.Arguments = fakeAuthArgs{}
 
-func (fa fakeAuthArgs) Convert() otelconfig.Extension {
+func (fa fakeAuthArgs) Convert() (otelconfig.Extension, error) {
 	settings := otelconfig.NewExtensionSettings(otelconfig.NewComponentID("testcomponent"))
-	return &settings
+	return &settings, nil
 }
 
 func (fa fakeAuthArgs) Extensions() map[otelconfig.ComponentID]otelcomponent.Extension {

--- a/component/otelcol/auth/basic/basic.go
+++ b/component/otelcol/auth/basic/basic.go
@@ -34,14 +34,14 @@ type Arguments struct {
 var _ auth.Arguments = Arguments{}
 
 // Convert implements auth.Arguments.
-func (args Arguments) Convert() otelconfig.Extension {
+func (args Arguments) Convert() (otelconfig.Extension, error) {
 	return &basicauthextension.Config{
 		ExtensionSettings: otelconfig.NewExtensionSettings(otelconfig.NewComponentID("basic")),
 		ClientAuth: &basicauthextension.ClientAuthSettings{
 			Username: args.Username,
 			Password: string(args.Password),
 		},
-	}
+	}, nil
 }
 
 // Extensions implements auth.Arguments.

--- a/component/otelcol/auth/bearer/bearer.go
+++ b/component/otelcol/auth/bearer/bearer.go
@@ -31,11 +31,11 @@ type Arguments struct {
 var _ auth.Arguments = Arguments{}
 
 // Convert implements auth.Arguments.
-func (args Arguments) Convert() otelconfig.Extension {
+func (args Arguments) Convert() (otelconfig.Extension, error) {
 	return &bearertokenauthextension.Config{
 		ExtensionSettings: otelconfig.NewExtensionSettings(otelconfig.NewComponentID("bearer")),
 		BearerToken:       string(args.Token),
-	}
+	}, nil
 }
 
 // Extensions implements auth.Arguments.

--- a/component/otelcol/auth/headers/headers.go
+++ b/component/otelcol/auth/headers/headers.go
@@ -34,7 +34,7 @@ type Arguments struct {
 var _ auth.Arguments = Arguments{}
 
 // Convert implements auth.Arguments.
-func (args Arguments) Convert() otelconfig.Extension {
+func (args Arguments) Convert() (otelconfig.Extension, error) {
 	var upstreamHeaders []headerssetterextension.HeaderConfig
 	for _, h := range args.Headers {
 		upstreamHeader := headerssetterextension.HeaderConfig{
@@ -54,7 +54,7 @@ func (args Arguments) Convert() otelconfig.Extension {
 	return &headerssetterextension.Config{
 		ExtensionSettings: otelconfig.NewExtensionSettings(otelconfig.NewComponentID("headers")),
 		HeadersConfig:     upstreamHeaders,
-	}
+	}, nil
 }
 
 // Extensions implements auth.Arguments.

--- a/component/otelcol/auth/oauth2/oauth2.go
+++ b/component/otelcol/auth/oauth2/oauth2.go
@@ -39,7 +39,7 @@ type Arguments struct {
 var _ auth.Arguments = Arguments{}
 
 // Convert implements auth.Arguments.
-func (args Arguments) Convert() otelconfig.Extension {
+func (args Arguments) Convert() (otelconfig.Extension, error) {
 	return &oauth2clientauthextension.Config{
 		ExtensionSettings: otelconfig.NewExtensionSettings(otelconfig.NewComponentID("oauth2")),
 		ClientID:          args.ClientID,
@@ -49,7 +49,7 @@ func (args Arguments) Convert() otelconfig.Extension {
 		Scopes:            args.Scopes,
 		TLSSetting:        *args.TLSSetting.Convert(),
 		Timeout:           args.Timeout,
-	}
+	}, nil
 }
 
 // Extensions implements auth.Arguments.

--- a/component/otelcol/auth/sigv4/sigv4.go
+++ b/component/otelcol/auth/sigv4/sigv4.go
@@ -35,7 +35,7 @@ var (
 )
 
 // Convert implements auth.Arguments.
-func (args Arguments) Convert() otelconfig.Extension {
+func (args Arguments) Convert() (otelconfig.Extension, error) {
 	res := sigv4authextension.Config{
 		ExtensionSettings: otelconfig.NewExtensionSettings(otelconfig.NewComponentID("sigv4")),
 		Region:            args.Region,
@@ -44,8 +44,10 @@ func (args Arguments) Convert() otelconfig.Extension {
 	}
 	// sigv4authextension.Config has a private member called "credsProvider" which gets initialized when we call Validate().
 	// If we don't call validate, the unit tests for this component will fail.
-	_ = res.Validate()
-	return &res
+	if err := res.Validate(); err != nil {
+		return nil, err
+	}
+	return &res, nil
 }
 
 func (args *Arguments) UnmarshalRiver(f func(interface{}) error) error {
@@ -54,7 +56,8 @@ func (args *Arguments) UnmarshalRiver(f func(interface{}) error) error {
 		return err
 	}
 
-	return args.Convert().(*sigv4authextension.Config).Validate()
+	_, err := args.Convert()
+	return err
 }
 
 // Extensions implements auth.Arguments.

--- a/component/otelcol/exporter/exporter.go
+++ b/component/otelcol/exporter/exporter.go
@@ -30,7 +30,7 @@ type Arguments interface {
 
 	// Convert converts the Arguments into an OpenTelemetry Collector exporter
 	// configuration.
-	Convert() otelconfig.Exporter
+	Convert() (otelconfig.Exporter, error)
 
 	// Extensions returns the set of extensions that the configured component is
 	// allowed to use.
@@ -141,7 +141,10 @@ func (e *Exporter) Update(args component.Arguments) error {
 		},
 	}
 
-	exporterConfig := eargs.Convert()
+	exporterConfig, err := eargs.Convert()
+	if err != nil {
+		return err
+	}
 
 	// Create instances of the exporter from our factory for each of our
 	// supported telemetry signals.

--- a/component/otelcol/exporter/exporter_test.go
+++ b/component/otelcol/exporter/exporter_test.go
@@ -93,7 +93,9 @@ func newTestEnvironment(t *testing.T, fe *fakeExporter) *testEnvironment {
 			factory := otelcomponent.NewExporterFactory(
 				"testcomponent",
 				func() otelconfig.Exporter {
-					return fakeExporterArgs{}.Convert()
+					res, err := fakeExporterArgs{}.Convert()
+					require.NoError(t, err)
+					return res
 				},
 				otelcomponent.WithTracesExporter(func(ctx context.Context, ecs otelcomponent.ExporterCreateSettings, e otelconfig.Exporter) (otelcomponent.TracesExporter, error) {
 					return fe, nil
@@ -123,9 +125,9 @@ type fakeExporterArgs struct {
 
 var _ exporter.Arguments = fakeExporterArgs{}
 
-func (fa fakeExporterArgs) Convert() otelconfig.Exporter {
+func (fa fakeExporterArgs) Convert() (otelconfig.Exporter, error) {
 	settings := otelconfig.NewExporterSettings(otelconfig.NewComponentID("testcomponent"))
-	return &settings
+	return &settings, nil
 }
 
 func (fa fakeExporterArgs) Extensions() map[otelconfig.ComponentID]otelcomponent.Extension {

--- a/component/otelcol/exporter/jaeger/jaeger.go
+++ b/component/otelcol/exporter/jaeger/jaeger.go
@@ -58,7 +58,7 @@ func (args *Arguments) UnmarshalRiver(f func(interface{}) error) error {
 }
 
 // Convert implements exporter.Arguments.
-func (args Arguments) Convert() otelconfig.Exporter {
+func (args Arguments) Convert() (otelconfig.Exporter, error) {
 	return &jaegerexporter.Config{
 		ExporterSettings: otelconfig.NewExporterSettings(otelconfig.NewComponentID("jaeger")),
 		TimeoutSettings: otelpexporterhelper.TimeoutSettings{
@@ -67,7 +67,7 @@ func (args Arguments) Convert() otelconfig.Exporter {
 		QueueSettings:      *args.Queue.Convert(),
 		RetrySettings:      *args.Retry.Convert(),
 		GRPCClientSettings: *(*otelcol.GRPCClientArguments)(&args.Client).Convert(),
-	}
+	}, nil
 }
 
 // Extensions implements exporter.Arguments.

--- a/component/otelcol/exporter/otlp/otlp.go
+++ b/component/otelcol/exporter/otlp/otlp.go
@@ -58,7 +58,7 @@ func (args *Arguments) UnmarshalRiver(f func(interface{}) error) error {
 }
 
 // Convert implements exporter.Arguments.
-func (args Arguments) Convert() otelconfig.Exporter {
+func (args Arguments) Convert() (otelconfig.Exporter, error) {
 	return &otlpexporter.Config{
 		ExporterSettings: otelconfig.NewExporterSettings(otelconfig.NewComponentID("otlp")),
 		TimeoutSettings: otelpexporterhelper.TimeoutSettings{
@@ -67,7 +67,7 @@ func (args Arguments) Convert() otelconfig.Exporter {
 		QueueSettings:      *args.Queue.Convert(),
 		RetrySettings:      *args.Retry.Convert(),
 		GRPCClientSettings: *(*otelcol.GRPCClientArguments)(&args.Client).Convert(),
-	}
+	}, nil
 }
 
 // Extensions implements exporter.Arguments.

--- a/component/otelcol/exporter/otlphttp/otlphttp.go
+++ b/component/otelcol/exporter/otlphttp/otlphttp.go
@@ -67,13 +67,13 @@ func (args *Arguments) UnmarshalRiver(f func(interface{}) error) error {
 }
 
 // Convert implements exporter.Arguments.
-func (args Arguments) Convert() otelconfig.Exporter {
+func (args Arguments) Convert() (otelconfig.Exporter, error) {
 	return &otlphttpexporter.Config{
 		ExporterSettings:   otelconfig.NewExporterSettings(otelconfig.NewComponentID("otlp")),
 		HTTPClientSettings: *(*otelcol.HTTPClientArguments)(&args.Client).Convert(),
 		QueueSettings:      *args.Queue.Convert(),
 		RetrySettings:      *args.Retry.Convert(),
-	}
+	}, nil
 }
 
 // Extensions implements exporter.Arguments.

--- a/component/otelcol/extension/extension.go
+++ b/component/otelcol/extension/extension.go
@@ -30,7 +30,7 @@ type Arguments interface {
 
 	// Convert converts the Arguments into an OpenTelemetry Collector
 	// extension configuration.
-	Convert() otelconfig.Extension
+	Convert() (otelconfig.Extension, error)
 
 	// Extensions returns the set of extensions that the configured component is
 	// allowed to use.
@@ -127,7 +127,10 @@ func (e *Extension) Update(args component.Arguments) error {
 		},
 	}
 
-	extensionConfig := rargs.Convert()
+	extensionConfig, err := rargs.Convert()
+	if err != nil {
+		return err
+	}
 
 	// Create instances of the extension from our factory.
 	var components []otelcomponent.Component

--- a/component/otelcol/extension/extension_test.go
+++ b/component/otelcol/extension/extension_test.go
@@ -82,9 +82,9 @@ type fakeExtensionArgs struct {
 
 var _ extension.Arguments = fakeExtensionArgs{}
 
-func (fa fakeExtensionArgs) Convert() otelconfig.Extension {
+func (fa fakeExtensionArgs) Convert() (otelconfig.Extension, error) {
 	settings := otelconfig.NewExtensionSettings(otelconfig.NewComponentID("testcomponent"))
-	return &settings
+	return &settings, nil
 }
 
 func (fa fakeExtensionArgs) Extensions() map[otelconfig.ComponentID]otelcomponent.Extension {

--- a/component/otelcol/extension/jaeger_remote_sampling/jaeger_remote_sampling.go
+++ b/component/otelcol/extension/jaeger_remote_sampling/jaeger_remote_sampling.go
@@ -74,7 +74,7 @@ var (
 )
 
 // Convert implements extension.Arguments.
-func (args Arguments) Convert() otelconfig.Extension {
+func (args Arguments) Convert() (otelconfig.Extension, error) {
 	return &jaegerremotesampling.Config{
 		HTTPServerSettings: (*otelcol.HTTPServerArguments)(args.HTTP).Convert(),
 		GRPCServerSettings: (*otelcol.GRPCServerArguments)(args.GRPC).Convert(),
@@ -84,7 +84,7 @@ func (args Arguments) Convert() otelconfig.Extension {
 			ReloadInterval: args.Source.ReloadInterval,
 			Contents:       args.Source.Content,
 		},
-	}
+	}, nil
 }
 
 // Extensions implements extension.Arguments.

--- a/component/otelcol/processor/batch/batch.go
+++ b/component/otelcol/processor/batch/batch.go
@@ -65,13 +65,13 @@ func (args *Arguments) UnmarshalRiver(f func(interface{}) error) error {
 }
 
 // Convert implements processor.Arguments.
-func (args Arguments) Convert() otelconfig.Processor {
+func (args Arguments) Convert() (otelconfig.Processor, error) {
 	return &batchprocessor.Config{
 		ProcessorSettings: otelconfig.NewProcessorSettings(otelconfig.NewComponentID("batch")),
 		Timeout:           args.Timeout,
 		SendBatchSize:     args.SendBatchSize,
 		SendBatchMaxSize:  args.SendBatchMaxSize,
-	}
+	}, nil
 }
 
 // Extensions implements processor.Arguments.

--- a/component/otelcol/processor/memorylimiter/memorylimiter.go
+++ b/component/otelcol/processor/memorylimiter/memorylimiter.go
@@ -96,7 +96,7 @@ func (args *Arguments) UnmarshalRiver(f func(interface{}) error) error {
 }
 
 // Convert implements processor.Arguments.
-func (args Arguments) Convert() otelconfig.Processor {
+func (args Arguments) Convert() (otelconfig.Processor, error) {
 	return &memorylimiterprocessor.Config{
 		ProcessorSettings: otelconfig.NewProcessorSettings(otelconfig.NewComponentID("memory_limiter")),
 
@@ -105,7 +105,7 @@ func (args Arguments) Convert() otelconfig.Processor {
 		MemorySpikeLimitMiB:   uint32(args.MemorySpikeLimit / units.Mebibyte),
 		MemoryLimitPercentage: args.MemoryLimitPercentage,
 		MemorySpikePercentage: args.MemorySpikePercentage,
-	}
+	}, nil
 }
 
 // Extensions implements processor.Arguments.

--- a/component/otelcol/processor/processor.go
+++ b/component/otelcol/processor/processor.go
@@ -31,7 +31,7 @@ type Arguments interface {
 
 	// Convert converts the Arguments into an OpenTelemetry Collector processor
 	// configuration.
-	Convert() otelconfig.Processor
+	Convert() (otelconfig.Processor, error)
 
 	// Extensions returns the set of extensions that the configured component is
 	// allowed to use.
@@ -145,7 +145,10 @@ func (p *Processor) Update(args component.Arguments) error {
 		},
 	}
 
-	processorConfig := pargs.Convert()
+	processorConfig, err := pargs.Convert()
+	if err != nil {
+		return err
+	}
 
 	var (
 		next        = pargs.NextConsumers()

--- a/component/otelcol/processor/processor_test.go
+++ b/component/otelcol/processor/processor_test.go
@@ -114,7 +114,9 @@ func newTestEnvironment(
 			factory := otelcomponent.NewProcessorFactory(
 				"testcomponent",
 				func() otelconfig.Processor {
-					return fakeProcessorArgs{}.Convert()
+					res, err := fakeProcessorArgs{}.Convert()
+					require.NoError(t, err)
+					return res
 				},
 				otelcomponent.WithTracesProcessor(func(
 					_ context.Context,
@@ -152,9 +154,9 @@ type fakeProcessorArgs struct {
 
 var _ processor.Arguments = fakeProcessorArgs{}
 
-func (fa fakeProcessorArgs) Convert() otelconfig.Processor {
+func (fa fakeProcessorArgs) Convert() (otelconfig.Processor, error) {
 	settings := otelconfig.NewProcessorSettings(otelconfig.NewComponentID("testcomponent"))
-	return &settings
+	return &settings, nil
 }
 
 func (fa fakeProcessorArgs) Extensions() map[otelconfig.ComponentID]otelcomponent.Extension {

--- a/component/otelcol/processor/tail_sampling/tail_sampling.go
+++ b/component/otelcol/processor/tail_sampling/tail_sampling.go
@@ -71,7 +71,7 @@ func (args *Arguments) UnmarshalRiver(f func(interface{}) error) error {
 }
 
 // Convert implements processor.Arguments.
-func (args Arguments) Convert() otelconfig.Processor {
+func (args Arguments) Convert() (otelconfig.Processor, error) {
 	// TODO: Get rid of mapstructure once tailsamplingprocessor.Config has all public types
 	var otelConfig tsp.Config
 
@@ -89,7 +89,7 @@ func (args Arguments) Convert() otelconfig.Processor {
 
 	otelConfig.ProcessorSettings = otelconfig.NewProcessorSettings(otelconfig.NewComponentID("tail_sampling"))
 
-	return &otelConfig
+	return &otelConfig, nil
 }
 
 // Extensions implements processor.Arguments.

--- a/component/otelcol/receiver/jaeger/jaeger.go
+++ b/component/otelcol/receiver/jaeger/jaeger.go
@@ -116,7 +116,7 @@ func (args *Arguments) Validate() error {
 }
 
 // Convert implements receiver.Arguments.
-func (args Arguments) Convert() otelconfig.Receiver {
+func (args Arguments) Convert() (otelconfig.Receiver, error) {
 	return &jaegerreceiver.Config{
 		ReceiverSettings: otelconfig.NewReceiverSettings(otelconfig.NewComponentID("jaeger")),
 		Protocols: jaegerreceiver.Protocols{
@@ -126,7 +126,7 @@ func (args Arguments) Convert() otelconfig.Receiver {
 			ThriftCompact: args.Protocols.ThriftCompact.Convert(),
 		},
 		RemoteSampling: args.RemoteSampling.Convert(),
-	}
+	}, nil
 }
 
 // Extensions implements receiver.Arguments.

--- a/component/otelcol/receiver/kafka/kafka.go
+++ b/component/otelcol/receiver/kafka/kafka.go
@@ -87,7 +87,7 @@ func (args *Arguments) UnmarshalRiver(f func(interface{}) error) error {
 }
 
 // Convert implements receiver.Arguments.
-func (args Arguments) Convert() otelconfig.Receiver {
+func (args Arguments) Convert() (otelconfig.Receiver, error) {
 	return &kafkareceiver.Config{
 		ReceiverSettings: otelconfig.NewReceiverSettings(otelconfig.NewComponentID("kafka")),
 
@@ -102,7 +102,7 @@ func (args Arguments) Convert() otelconfig.Receiver {
 		Metadata:       args.Metadata.Convert(),
 		AutoCommit:     args.AutoCommit.Convert(),
 		MessageMarking: args.MessageMarking.Convert(),
-	}
+	}, nil
 }
 
 // Extensions implements receiver.Arguments.

--- a/component/otelcol/receiver/opencensus/opencensus.go
+++ b/component/otelcol/receiver/opencensus/opencensus.go
@@ -59,13 +59,13 @@ func (args *Arguments) UnmarshalRiver(f func(interface{}) error) error {
 }
 
 // Convert implements receiver.Arguments.
-func (args Arguments) Convert() otelconfig.Receiver {
+func (args Arguments) Convert() (otelconfig.Receiver, error) {
 	return &opencensusreceiver.Config{
 		ReceiverSettings: otelconfig.NewReceiverSettings(otelconfig.NewComponentID("opencensus")),
 
 		CorsOrigins:        args.CorsAllowedOrigins,
 		GRPCServerSettings: *args.GRPC.Convert(),
-	}
+	}, nil
 }
 
 // Extensions implements receiver.Arguments.

--- a/component/otelcol/receiver/opencensus/opencensus_test.go
+++ b/component/otelcol/receiver/opencensus/opencensus_test.go
@@ -47,10 +47,11 @@ func TestDefaultArguments_UnmarshalRiver(t *testing.T) {
 
 	var args opencensus.Arguments
 	require.NoError(t, river.Unmarshal([]byte(in), &args))
-	args.Convert()
-	otelArgs, err := (args.Convert()).(*opencensusreceiver.Config)
+	ext, err := args.Convert()
+	require.NoError(t, err)
+	otelArgs, ok := (ext).(*opencensusreceiver.Config)
 
-	require.True(t, err)
+	require.True(t, ok)
 
 	// Check the gRPC arguments
 	require.Equal(t, opencensus.DefaultArguments.GRPC.Endpoint, otelArgs.NetAddr.Endpoint)
@@ -72,9 +73,11 @@ func TestArguments_UnmarshalRiver(t *testing.T) {
 	var args opencensus.Arguments
 	require.NoError(t, river.Unmarshal([]byte(in), &args))
 	args.Convert()
-	otelArgs, err := (args.Convert()).(*opencensusreceiver.Config)
+	ext, err := args.Convert()
+	require.NoError(t, err)
+	otelArgs, ok := (ext).(*opencensusreceiver.Config)
 
-	require.True(t, err)
+	require.True(t, ok)
 
 	// Check the gRPC arguments
 	require.Equal(t, otelArgs.NetAddr.Endpoint, httpAddr)

--- a/component/otelcol/receiver/otlp/otlp.go
+++ b/component/otelcol/receiver/otlp/otlp.go
@@ -36,14 +36,14 @@ type Arguments struct {
 var _ receiver.Arguments = Arguments{}
 
 // Convert implements receiver.Arguments.
-func (args Arguments) Convert() otelconfig.Receiver {
+func (args Arguments) Convert() (otelconfig.Receiver, error) {
 	return &otlpreceiver.Config{
 		ReceiverSettings: otelconfig.NewReceiverSettings(otelconfig.NewComponentID("otlp")),
 		Protocols: otlpreceiver.Protocols{
 			GRPC: (*otelcol.GRPCServerArguments)(args.GRPC).Convert(),
 			HTTP: (*otelcol.HTTPServerArguments)(args.HTTP).Convert(),
 		},
-	}
+	}, nil
 }
 
 // Extensions implements receiver.Arguments.

--- a/component/otelcol/receiver/receiver.go
+++ b/component/otelcol/receiver/receiver.go
@@ -30,7 +30,7 @@ type Arguments interface {
 
 	// Convert converts the Arguments into an OpenTelemetry Collector receiver
 	// configuration.
-	Convert() otelconfig.Receiver
+	Convert() (otelconfig.Receiver, error)
 
 	// Extensions returns the set of extensions that the configured component is
 	// allowed to use.
@@ -134,7 +134,10 @@ func (r *Receiver) Update(args component.Arguments) error {
 		},
 	}
 
-	receiverConfig := rargs.Convert()
+	receiverConfig, err := rargs.Convert()
+	if err != nil {
+		return err
+	}
 
 	var (
 		next        = rargs.NextConsumers()

--- a/component/otelcol/receiver/receiver_test.go
+++ b/component/otelcol/receiver/receiver_test.go
@@ -111,9 +111,9 @@ type fakeReceiverArgs struct {
 
 var _ receiver.Arguments = fakeReceiverArgs{}
 
-func (fa fakeReceiverArgs) Convert() otelconfig.Receiver {
+func (fa fakeReceiverArgs) Convert() (otelconfig.Receiver, error) {
 	settings := otelconfig.NewReceiverSettings(otelconfig.NewComponentID("testcomponent"))
-	return &settings
+	return &settings, nil
 }
 
 func (fa fakeReceiverArgs) Extensions() map[otelconfig.ComponentID]otelcomponent.Extension {

--- a/component/otelcol/receiver/zipkin/zipkin.go
+++ b/component/otelcol/receiver/zipkin/zipkin.go
@@ -54,13 +54,13 @@ func (args *Arguments) UnmarshalRiver(f func(interface{}) error) error {
 }
 
 // Convert implements receiver.Arguments.
-func (args Arguments) Convert() otelconfig.Receiver {
+func (args Arguments) Convert() (otelconfig.Receiver, error) {
 	return &zipkinreceiver.Config{
 		ReceiverSettings: otelconfig.NewReceiverSettings(otelconfig.NewComponentID("zipkin")),
 
 		ParseStringTags:    args.ParseStringTags,
 		HTTPServerSettings: *args.HTTPServer.Convert(),
-	}
+	}, nil
 }
 
 // Extensions implements receiver.Arguments.

--- a/component/otelcol/receiver/zipkin/zipkin_test.go
+++ b/component/otelcol/receiver/zipkin/zipkin_test.go
@@ -56,10 +56,11 @@ func TestArguments_UnmarshalRiver(t *testing.T) {
 
 		var args zipkin.Arguments
 		require.NoError(t, river.Unmarshal([]byte(in), &args))
-		args.Convert()
-		otelArgs, err := (args.Convert()).(*zipkinreceiver.Config)
+		ext, err := args.Convert()
+		require.NoError(t, err)
+		otelArgs, ok := (ext).(*zipkinreceiver.Config)
 
-		require.True(t, err)
+		require.True(t, ok)
 
 		// Check the arguments
 		require.Equal(t, otelArgs.HTTPServerSettings.Endpoint, httpAddr)


### PR DESCRIPTION
#### PR Description
If the Convert() method returns an error, this allows us to handle errors in UnmarshalRiver without doing a type assertion. It also makes sense to return an error if a conversion could not be done. This change was discussed in a [comment](https://github.com/grafana/agent/pull/3200#discussion_r1143298235) in a prior PR.

#### Notes to the reviewer

It is such a minor change, that I think there is no need for a changelog entry?

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
