### PR TITLE
docs: add Collect metrics from Kubernetes Pods task

### DIFF
--- a/docs/sources/flow/getting-started/collect-prometheus-metrics.md
+++ b/docs/sources/flow/getting-started/collect-prometheus-metrics.md
@@ -137,7 +137,7 @@ To collect metrics from Kubernetes Pods, complete the following steps:
 2. Discover Kubernetes Pods:
 
     1. Add the following `discovery.kubernetes` component to your configuration
-       file:
+       file to discover every Pod in the cluster across all Namespaces:
 
        ```river
        discovery.kubernetes "DISCOVERY_LABEL" {
@@ -152,7 +152,7 @@ To collect metrics from Kubernetes Pods, complete the following steps:
            `pods`. The label chosen must be unique across all
            `discovery.kubernetes` components in the same configuration file.
 
-    2. To limit the namespaces that Pods are discovered in, add the following
+    2. To limit the Namespaces that Pods are discovered in, add the following
        block inside of the `discovery.kubernetes` component:
 
        ```river
@@ -162,11 +162,11 @@ To collect metrics from Kubernetes Pods, complete the following steps:
        }
        ```
 
-        1. If you do not want to search for Pods in the the namespace Grafana
+        1. If you do not want to search for Pods in the the Namespace Grafana
            Agent is running in, set `own_namespace` to `false`.
 
         2. Replace `NAMESPACE_NAMES` with a comma-delimited list of strings
-           representing namespaces to search. Each string must be wrapped in
+           representing Namespaces to search. Each string must be wrapped in
            double quotes. For example, `"default","kube-system"`.
 
     3. To use a field selector to limit the number of discovered Pods, add the
@@ -232,7 +232,7 @@ To collect metrics from Kubernetes Pods, complete the following steps:
 [Labels and Selectors]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement
 
 The following example demonstrates configuring Grafana Agent to collect metrics
-from running production Kubernetes Pods in the `default` namespace:
+from running production Kubernetes Pods in the `default` Namespace:
 
 ```river
 discovery.kubernetes "pods" {

--- a/docs/sources/flow/getting-started/collect-prometheus-metrics.md
+++ b/docs/sources/flow/getting-started/collect-prometheus-metrics.md
@@ -261,3 +261,7 @@ prometheus.remote_write "default" {
   }
 }
 ```
+
+For more information on configuring Kubernetes service delivery and collecting
+metrics, refer to [discovery.kubernetes][] and [prometheus.scrape][].
+

--- a/docs/sources/flow/getting-started/collect-prometheus-metrics.md
+++ b/docs/sources/flow/getting-started/collect-prometheus-metrics.md
@@ -11,14 +11,17 @@ forward them to any Prometheus-compatible database.
 This topic describes how to:
 
 * Configure metrics delivery
+* Collect metrics from Kubernetes Pods
 
 [Prometheus]: https://prometheus.io
 
 ## Components used in this topic
 
+* [discovery.kubernetes][]
 * [prometheus.remote_write][]
 * [prometheus.scrape][]
 
+[discovery.kubernetes]: {{< relref "../reference/components/discovery.kubernetes.md" >}}
 [prometheus.remote_write]: {{< relref "../reference/components/prometheus.remote_write.md" >}}
 [prometheus.scrape]: {{< relref "../reference/components/prometheus.scrape.md" >}}
 
@@ -117,3 +120,144 @@ prometheus.scrape "example" {
 
 For more information on configuring metrics delivery, refer to
 [prometheus.remote_write][].
+
+## Collect metrics from Kubernetes Pods
+
+Grafana Agent Flow can be configured to collect metrics from Kubernetes Pods
+by:
+
+1. Discovering Kubernetes Pods to collect metrics from
+2. Collecting metrics from those discovered Pods
+
+To collect metrics from Kubernetes Pods, complete the following steps:
+
+1. Follow [Configure metrics delivery](#configure-metrics-delivery) to ensure
+   collected metrics can be written somewhere.
+
+2. Discover Kubernetes Pods:
+
+    1. Add the following `discovery.kubernetes` component to your configuration
+       file:
+
+       ```river
+       discovery.kubernetes "DISCOVERY_LABEL" {
+         role = "pod"
+       }
+       ```
+
+       This will generate one Prometheus target for every exposed port on every
+       discovered Pod.
+
+        1. Replace `DISCOVERY_LABEL` with a label to use for the component, such as
+           `pods`. The label chosen must be unique across all
+           `discovery.kubernetes` components in the same configuration file.
+
+    2. To limit the namespaces that Pods are discovered in, add the following
+       block inside of the `discovery.kubernetes` component:
+
+       ```river
+       namespaces {
+         own_namespace = true
+         names         = [NAMESPACE_NAMES]
+       }
+       ```
+
+        1. If you do not want to search for Pods in the the namespace Grafana
+           Agent is running in, set `own_namespace` to `false`.
+
+        2. Replace `NAMESPACE_NAMES` with a comma-delimited list of strings
+           representing namespaces to search. Each string must be wrapped in
+           double quotes. For example, `"default","kube-system"`.
+
+    3. To use a field selector to limit the number of discovered Pods, add the
+       following block inside of the `discovery.kubernetes` component:
+
+       ```river
+       selectors {
+         role  = "pod"
+         field = "FIELD_SELECTOR"
+       }
+       ```
+
+        1. Replace `FIELD_SELECTOR` with the Kubernetes field selector to use,
+           such as `metadata.name=my-service`. For more information on field
+           selectors, refer to the Kubernetes documentation on [Field
+           Selectors][].
+
+        2. Create additional `selectors` blocks for each field selector you
+           want to apply.
+
+    4. To use a label selector to limit the number of discovered Pods, add the
+       following block inside of the `discovery.kubernetes` component:
+
+       ```river
+       selectors {
+         role  = "pod"
+         label = "LABEL_SELECTOR"
+       }
+       ```
+
+        1. Replace `LABEL_SELECTOR` with the Kubernetes label selector to use,
+           such as `environment in (production, qa)`. For more information on
+           label selectors, refer to the Kubernetes documentation on [Labels
+           and Selectors][].
+
+        2. Create additional `selectors` blocks for each label selector you
+           want to apply.
+
+3. Collect metrics from discovered Pods:
+
+    1. Add the following `prometheus.scrape` component to your configuration
+       file:
+
+       ```river
+       prometheus.scrape "SCRAPE_LABEL" {
+         targets    = discovery.kubernetes.DISCOVERY_LABEL.targets
+         forward_to = [prometheus.remote_write.REMOTE_WRITE_LABEL.receiver]
+       }
+       ```
+
+        1. Replace `SCRAPE_LABEL` with a label to use for the component, such
+           as `pods`. The label chosen must be unique across all
+           `prometeus.scrape` components in the same configuration file.
+
+        2. Replace `DISCOVERY_LABEL` with the label chosen for the
+           `discovery.kubernetes` component in step 2.1.1.
+
+        3. Replace `REMOTE_WRITE_LABEL` with the label chosen for your existing
+           `prometheus.remote_write` component.
+
+
+[Field Selectors]: https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/
+[Labels and Selectors]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement
+
+The following example demonstrates configuring Grafana Agent to collect metrics
+from running production Kubernetes Pods in the `default` namespace:
+
+```river
+discovery.kubernetes "pods" {
+  role = "pod"
+
+  namespaces {
+    own_namespace = false
+
+    names = ["default"]
+  }
+
+  selectors {
+    role  = "pod"
+    label = "environment in (production)"
+  }
+}
+
+prometheus.scrape "pods" {
+  targets    = discovery.kubernetes.pods.targets
+  forward_to = [prometheus.remote_write.default.receiver]
+}
+
+prometheus.remote_write "default" {
+  endpoint {
+    url = "http://localhost:9090/api/prom/push"
+  }
+}
+```


### PR DESCRIPTION
Add a _Collect metrics from Kubernetes Pods_ task to the _Collect Prometheus Metrics_ topic.

This is a follow-up PR on #3332.

Note that I always refer to Pods with capitalization here, since that's how the Kubernetes docs seem to exclusively refer to them.