### PR TITLE
Add logging around the /-/reload endpoint

### DIFF
--- a/cmd/grafana-agent/flow_run.go
+++ b/cmd/grafana-agent/flow_run.go
@@ -198,6 +198,9 @@ func (fr *flowRun) Run(configFile string) error {
 		})
 
 		r.HandleFunc("/-/reload", func(w http.ResponseWriter, _ *http.Request) {
+			level.Info(l).Log("msg", "reload requested via /-/reload endpoint")
+			defer level.Info(l).Log("msg", "config reloaded")
+
 			err := reload()
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusBadRequest)


### PR DESCRIPTION
This is a workaround to have some logging around when reloads are requested until a longer-term fix for logging on the HTTP handler is introduced.