### PR TITLE
Update prometheus.exporter.unix.md

### DIFF
--- a/docs/sources/flow/reference/components/prometheus.exporter.unix.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.unix.md
@@ -225,7 +225,7 @@ name | type | description | default | required
 ### textfile block
 name | type | description | default | required
 ---- | ---- | ----------- | ------- | --------
-`textfile_directory` | `string` | Directory to read `*.prom` files from for the textfile collector. |  | no
+`directory` | `string` | Directory to read `*.prom` files from for the textfile collector. |  | no
 
 ### vmstat block
 name | type | description | default | required


### PR DESCRIPTION
using textfile_directory throws unrecognized attribute name "textfile_directory" error.

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
