### PR TITLE
add ability to specify fips mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,15 @@ else
 	$(GO_ENV) go build $(GO_FLAGS) -o $(AGENT_BINARY) ./cmd/grafana-agent
 endif
 
+# Run with GO_TAGS=fips make agent-fips
+agent-fips:
+ifeq ($(USE_CONTAINER),1)
+	$(RERUN_IN_CONTAINER)
+else 
+	$(GO_ENV) GOEXPERIMENT=boringcrypto go build $(GO_FLAGS) -o $(AGENT_BINARY) ./cmd/grafana-agent
+endif
+
+
 agentctl:
 ifeq ($(USE_CONTAINER),1)
 	$(RERUN_IN_CONTAINER)

--- a/cmd/grafana-agent/fips.go
+++ b/cmd/grafana-agent/fips.go
@@ -1,0 +1,5 @@
+//go:build fips
+
+package main
+
+import _ "crypto/tls/fipsonly"


### PR DESCRIPTION
#### PR Description

Adds the ability to build in FIPS mode with `GO_TAGS=fips make agent-fips` command.

#### Notes to the Reviewer

Verified fips was active via [this](https://developers.redhat.com/articles/2022/05/31/your-go-application-fips-compliant) 

With fips active
![Screenshot from 2023-03-27 09-23-52](https://user-images.githubusercontent.com/3036838/227950320-25306082-eea4-406d-9ebc-8aac13ef43db.png)

Without

![Screenshot from 2023-03-27 09-24-03](https://user-images.githubusercontent.com/3036838/227950435-ef802011-84a4-4016-bc04-2ddde5aa5afb.png)

Note AWS has some funcs named with fips that are in both.



- [NA] CHANGELOG updated
- [NA] Documentation added
- [NA] Tests updated
