### PR TITLE
[Flow] Add prometheus.exporter.memcached component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Main (unreleased)
   - `otelcol.auth.sigv4` performs AWS Signature Version 4 (SigV4) authentication 
     for making requests to AWS services via `otelcol` components that support
     authentication extensions. (@ptodev)
+  - `prometheus.exporter.memcached` collects metrics from a Memcached server. (@spartan0x117)
 
 ### Enhancements
 

--- a/component/all/all.go
+++ b/component/all/all.go
@@ -54,6 +54,7 @@ import (
 	_ "github.com/grafana/agent/component/prometheus/exporter/blackbox"             // Import prometheus.exporter.blackbox
 	_ "github.com/grafana/agent/component/prometheus/exporter/consul"               // Import prometheus.exporter.consul
 	_ "github.com/grafana/agent/component/prometheus/exporter/github"               // Import prometheus.exporter.github
+	_ "github.com/grafana/agent/component/prometheus/exporter/memcached"            // Import prometheus.exporter.memcached
 	_ "github.com/grafana/agent/component/prometheus/exporter/mysql"                // Import prometheus.exporter.mysql
 	_ "github.com/grafana/agent/component/prometheus/exporter/postgres"             // Import prometheus.exporter.postgres
 	_ "github.com/grafana/agent/component/prometheus/exporter/process"              // Import prometheus.exporter.process

--- a/component/prometheus/exporter/memcached/memcached.go
+++ b/component/prometheus/exporter/memcached/memcached.go
@@ -31,7 +31,7 @@ var DefaultArguments = Arguments{
 
 // Arguments configures the prometheus.exporter.memcached component.
 type Arguments struct {
-	// Address is the address of the memcached server to connect to.
+	// Address is the address of the memcached server to connect to (host:port).
 	Address string `river:"address,attr,optional"`
 
 	// Timeout is the timeout for the memcached exporter to use when connecting to the

--- a/component/prometheus/exporter/memcached/memcached.go
+++ b/component/prometheus/exporter/memcached/memcached.go
@@ -11,7 +11,7 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "memcached_exporter",
+		Name:    "prometheus.exporter.memcached",
 		Args:    Arguments{},
 		Exports: exporter.Exports{},
 		Build:   exporter.New(createExporter, "memcached"),

--- a/component/prometheus/exporter/memcached/memcached.go
+++ b/component/prometheus/exporter/memcached/memcached.go
@@ -25,7 +25,7 @@ func createExporter(opts component.Options, args component.Arguments) (integrati
 
 // DefaultArguments holds the default arguments for the prometheus.exporter.memcached component.
 var DefaultArguments = Arguments{
-	MemcachedAddress: "localhost:53",
+	MemcachedAddress: "localhost:11211",
 	Timeout:          time.Second,
 }
 

--- a/component/prometheus/exporter/memcached/memcached.go
+++ b/component/prometheus/exporter/memcached/memcached.go
@@ -1,0 +1,55 @@
+package memcached
+
+import (
+	"time"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/pkg/integrations"
+	"github.com/grafana/agent/pkg/integrations/memcached_exporter"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:    "memcached_exporter",
+		Args:    Arguments{},
+		Exports: exporter.Exports{},
+		Build:   exporter.New(createExporter, "memcached"),
+	})
+}
+
+func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, error) {
+	cfg := args.(Arguments)
+	return cfg.Convert().NewIntegration(opts.Logger)
+}
+
+// DefaultArguments holds the default arguments for the prometheus.exporter.memcached component.
+var DefaultArguments = Arguments{
+	MemcachedAddress: "localhost:53",
+	Timeout:          time.Second,
+}
+
+// Arguments configures the prometheus.exporter.memcached component.
+type Arguments struct {
+	// MemcachedAddress is the address of the memcached server to connect to.
+	MemcachedAddress string `river:"memcached_address,attr,optional"`
+
+	// Timeout is the timeout for the memcached exporter to use when connecting to the
+	// memcached server.
+	Timeout time.Duration `river:"timeout,attr,optional"`
+}
+
+// UnmarshalRiver implements River unmarshalling for Arguments.
+func (a *Arguments) UnmarshalRiver(f func(interface{}) error) error {
+	*a = DefaultArguments
+
+	type args Arguments
+	return f((*args)(a))
+}
+
+func (a Arguments) Convert() *memcached_exporter.Config {
+	return &memcached_exporter.Config{
+		MemcachedAddress: a.MemcachedAddress,
+		Timeout:          a.Timeout,
+	}
+}

--- a/component/prometheus/exporter/memcached/memcached.go
+++ b/component/prometheus/exporter/memcached/memcached.go
@@ -25,14 +25,14 @@ func createExporter(opts component.Options, args component.Arguments) (integrati
 
 // DefaultArguments holds the default arguments for the prometheus.exporter.memcached component.
 var DefaultArguments = Arguments{
-	MemcachedAddress: "localhost:11211",
-	Timeout:          time.Second,
+	Address: "localhost:11211",
+	Timeout: time.Second,
 }
 
 // Arguments configures the prometheus.exporter.memcached component.
 type Arguments struct {
-	// MemcachedAddress is the address of the memcached server to connect to.
-	MemcachedAddress string `river:"memcached_address,attr,optional"`
+	// Address is the address of the memcached server to connect to.
+	Address string `river:"address,attr,optional"`
 
 	// Timeout is the timeout for the memcached exporter to use when connecting to the
 	// memcached server.
@@ -49,7 +49,7 @@ func (a *Arguments) UnmarshalRiver(f func(interface{}) error) error {
 
 func (a Arguments) Convert() *memcached_exporter.Config {
 	return &memcached_exporter.Config{
-		MemcachedAddress: a.MemcachedAddress,
+		MemcachedAddress: a.Address,
 		Timeout:          a.Timeout,
 	}
 }

--- a/component/prometheus/exporter/memcached/memcached_test.go
+++ b/component/prometheus/exporter/memcached/memcached_test.go
@@ -33,10 +33,7 @@ func TestRiverUnmarshalDefaults(t *testing.T) {
 	err := river.Unmarshal([]byte(exampleRiverConfig), &args)
 	assert.NoError(t, err)
 
-	expected := Arguments{
-		MemcachedAddress: "localhost:53",
-		Timeout:          time.Second,
-	}
+	expected := DefaultArguments
 
 	assert.Equal(t, expected, args)
 }

--- a/component/prometheus/exporter/memcached/memcached_test.go
+++ b/component/prometheus/exporter/memcached/memcached_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestRiverUnmarshal(t *testing.T) {
 	var exampleRiverConfig = `
-memcached_address = "localhost:99"
+address = "localhost:99"
 timeout = "5s"`
 
 	var args Arguments
@@ -19,8 +19,8 @@ timeout = "5s"`
 	assert.NoError(t, err)
 
 	expected := Arguments{
-		MemcachedAddress: "localhost:99",
-		Timeout:          5 * time.Second,
+		Address: "localhost:99",
+		Timeout: 5 * time.Second,
 	}
 
 	assert.Equal(t, expected, args)
@@ -40,8 +40,8 @@ func TestRiverUnmarshalDefaults(t *testing.T) {
 
 func TestRiverConvert(t *testing.T) {
 	riverArguments := Arguments{
-		MemcachedAddress: "localhost:99",
-		Timeout:          5 * time.Second,
+		Address: "localhost:99",
+		Timeout: 5 * time.Second,
 	}
 
 	expected := &memcached_exporter.Config{

--- a/component/prometheus/exporter/memcached/memcached_test.go
+++ b/component/prometheus/exporter/memcached/memcached_test.go
@@ -1,0 +1,56 @@
+package memcached
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/pkg/integrations/memcached_exporter"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRiverUnmarshal(t *testing.T) {
+	var exampleRiverConfig = `
+memcached_address = "localhost:99"
+timeout = "5s"`
+
+	var args Arguments
+	err := river.Unmarshal([]byte(exampleRiverConfig), &args)
+	assert.NoError(t, err)
+
+	expected := Arguments{
+		MemcachedAddress: "localhost:99",
+		Timeout:          5 * time.Second,
+	}
+
+	assert.Equal(t, expected, args)
+}
+
+func TestRiverUnmarshalDefaults(t *testing.T) {
+	var exampleRiverConfig = ``
+
+	var args Arguments
+	err := river.Unmarshal([]byte(exampleRiverConfig), &args)
+	assert.NoError(t, err)
+
+	expected := Arguments{
+		MemcachedAddress: "localhost:53",
+		Timeout:          time.Second,
+	}
+
+	assert.Equal(t, expected, args)
+}
+
+func TestRiverConvert(t *testing.T) {
+	riverArguments := Arguments{
+		MemcachedAddress: "localhost:99",
+		Timeout:          5 * time.Second,
+	}
+
+	expected := &memcached_exporter.Config{
+		MemcachedAddress: "localhost:99",
+		Timeout:          5 * time.Second,
+	}
+
+	assert.Equal(t, expected, riverArguments.Convert())
+}

--- a/docs/sources/flow/reference/components/prometheus.exporter.memcached.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.memcached.md
@@ -1,0 +1,73 @@
+---
+# NOTE(rfratto): the title below has zero-width spaces injected into it to
+# prevent it from overflowing the sidebar on the rendered site. Be careful when
+# modifying this section to retain the spaces.
+#
+# Ideally, in the future, we can fix the overflow issue with css rather than
+# injecting special characters.
+
+title: prometheus.exporter.memcached
+---
+
+# COMPONENT_NAME
+The `prometheus.exporter.memcached` component embeds
+[memcached_exporter](https://github.com/prometheus/memcached_exporter) for collecting metrics from a memcached server.
+
+## Usage
+```river
+prometheus.exporter.memcached "LABEL" {
+}
+```
+
+## Arguments
+The following arguments are supported:
+
+Name             | Type       | Description                                         | Default               | Required |
+---------------- | ---------- | --------------------------------------------------- | --------------------- | -------- |
+`address`        | `string`   | The memcached server address.                       | `"localhost:11211"`   | no       |
+`timeout`        | `duration` | The timeout for connecting to the memcached server. | `"1s"`                | no       |
+
+## Blocks
+The `prometheus.exporter.memcached` component does not support any blocks, and is configured 
+fully through arguments.
+
+## Exported fields
+The following fields are exported and can be referenced by other components:
+
+Name      | Type                | Description
+--------- | ------------------- | -----------
+`targets` | `list(map(string))` | The targets that can be used to collect `memcached` metrics.
+
+For example, `targets` can either be passed to a `prometheus.relabel`
+component to rewrite the metrics' label set, or to a `prometheus.scrape`
+component that collects the exposed metrics.
+
+## Component health
+`prometheus.exporter.memcached` is only reported as unhealthy if given
+an invalid configuration. In those cases, exported fields retain their last
+healthy values.
+
+## Debug information
+`prometheus.exporter.memcached` does not expose any component-specific
+debug information.
+
+## Debug metrics
+`prometheus.exporter.memcached` does not expose any component-specific
+debug metrics.
+
+## Examples
+This minimal example uses a `prometheus.exporter.memcached` component to collect metrics from a memcached
+server running locally, and scrapes the metrics using a [prometheus.scrape][scrape] component:
+
+```river
+prometheus.exporter.memcached "example" {
+    address = "localhost:13321"
+    timeout = "5s"
+}
+
+prometheus.scrape "example" {
+    targets = [prometheus.exporter.memcached.example.targets]
+}
+```
+
+[scrape]: {{< relref "./prometheus.scrape.md" >}}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Adds a `prometheus.exporter.memcached` component for collecting metrics from a Memcached server.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #2309

#### Notes to the Reviewer
I looked at updating the `memcached_exporter` dependency before making this change, but noted in the  [related issue](https://github.com/grafana/agent/issues/3219#issuecomment-1487683888) that there is a breaking change in `prometheus/procfs` that requires waiting for the next release of and then updating `node_exporter`. Once both of those are done, I will make another PR adding the new `tls` config options to both static and flow modes.

#### PR Checklist

- [X] CHANGELOG updated
- [X] Documentation added
- [X] Tests updated
