### PR TITLE
Fix deadlock in loki.source.docker with a separate mutex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ Main (unreleased)
 - Fix issue where scraping native Prometheus histograms would leak memory.
   (@rfratto)
 
+- Fix issue where loki.source.docker component could deadlock. (@tpaschalis)
+
 ### Other changes
 
 - Grafana Agent Docker containers and release binaries are now published for

--- a/component/loki/source/docker/docker.go
+++ b/component/loki/source/docker/docker.go
@@ -64,10 +64,12 @@ type Component struct {
 	manager       *manager
 	lastOptions   *options
 	handler       loki.LogsReceiver
-	receivers     []loki.LogsReceiver
 	posFile       positions.Positions
 	rcs           []*relabel.Config
 	defaultLabels model.LabelSet
+
+	receiversMut sync.RWMutex
+	receivers    []loki.LogsReceiver
 }
 
 // New creates a new loki.source.file component.
@@ -124,9 +126,9 @@ func (c *Component) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			return nil
 		case entry := <-c.handler:
-			c.mut.RLock()
+			c.receiversMut.RLock()
 			receivers := c.receivers
-			c.mut.RUnlock()
+			c.receiversMut.RUnlock()
 			for _, receiver := range receivers {
 				receiver <- entry
 			}
@@ -138,10 +140,13 @@ func (c *Component) Run(ctx context.Context) error {
 func (c *Component) Update(args component.Arguments) error {
 	newArgs := args.(Arguments)
 
+	// Update the receivers before anything else, just in case something fails.
+	c.receiversMut.Lock()
+	c.receivers = newArgs.ForwardTo
+	c.receiversMut.Unlock()
+
 	c.mut.Lock()
 	defer c.mut.Unlock()
-	c.args = newArgs
-	c.receivers = newArgs.ForwardTo
 
 	managerOpts, err := c.getManagerOptions(newArgs)
 	if err != nil {
@@ -200,6 +205,8 @@ func (c *Component) Update(args component.Arguments) error {
 		// This will never fail because it only fails if the context gets canceled.
 		_ = c.manager.syncTargets(context.Background(), targets)
 	}
+
+	c.args = newArgs
 	return nil
 }
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR fixes the loki.source.docker deadlock by adding a separate mutex for updating the LogsReceiver fanout and allowing containers to flush their log lines before being shut down.

#### Which issue(s) this PR fixes

Fixes #3391

#### Notes to the Reviewer

#### PR Checklist

- [X] CHANGELOG updated
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A? will look if there's a way of emulating docker containers and makes sense)
