### PR TITLE
Add default logging and tracing nodes back into the dag when not provided in the river config

### DIFF
--- a/pkg/flow/internal/controller/component_references.go
+++ b/pkg/flow/internal/controller/component_references.go
@@ -35,7 +35,9 @@ func ComponentReferences(parent *vm.Scope, cn dag.Node, g *dag.Graph) ([]Referen
 
 	switch cn := cn.(type) {
 	case BlockNode:
-		traversals = expressionsFromBody(cn.Block().Body)
+		if cn.Block() != nil {
+			traversals = expressionsFromBody(cn.Block().Body)
+		}
 	}
 
 	refs := make([]Reference, 0, len(traversals))

--- a/pkg/flow/internal/controller/config_tracing.go
+++ b/pkg/flow/internal/controller/config_tracing.go
@@ -12,7 +12,6 @@ import (
 )
 
 type TracingConfigNode struct {
-	label         string
 	nodeID        string
 	componentName string
 	traceProvider trace.TracerProvider // Tracer shared between all managed components.
@@ -39,7 +38,6 @@ func NewTracingConfigNode(block *ast.BlockStmt, globals ComponentGlobals, isInMo
 	}
 
 	return &TracingConfigNode{
-		label:         block.Label,
 		nodeID:        BlockComponentID(block).String(),
 		componentName: block.GetBlockName(),
 		traceProvider: globals.TraceProvider,
@@ -47,6 +45,19 @@ func NewTracingConfigNode(block *ast.BlockStmt, globals ComponentGlobals, isInMo
 		block: block,
 		eval:  vm.New(block.Body),
 	}, diags
+}
+
+// NewDefaulTracingConfigNode creates a new TracingConfigNode with nil block and eval.
+// This will force evaluate to use the default tracing options for this node.
+func NewDefaulTracingConfigNode(globals ComponentGlobals) *TracingConfigNode {
+	return &TracingConfigNode{
+		nodeID:        tracingBlockID,
+		componentName: tracingBlockID,
+		traceProvider: globals.TraceProvider,
+
+		block: nil,
+		eval:  nil,
+	}
 }
 
 // Evaluate implements BlockNode and updates the arguments for the managed config block
@@ -59,8 +70,10 @@ func (cn *TracingConfigNode) Evaluate(scope *vm.Scope) error {
 	cn.mut.RLock()
 	defer cn.mut.RUnlock()
 	args := tracing.DefaultOptions
-	if err := cn.eval.Evaluate(scope, &args); err != nil {
-		return fmt.Errorf("decoding River: %w", err)
+	if cn.eval != nil {
+		if err := cn.eval.Evaluate(scope, &args); err != nil {
+			return fmt.Errorf("decoding River: %w", err)
+		}
 	}
 
 	t, ok := cn.traceProvider.(*tracing.Tracer)
@@ -70,6 +83,7 @@ func (cn *TracingConfigNode) Evaluate(scope *vm.Scope) error {
 			return fmt.Errorf("could not update tracer: %v", err)
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -219,7 +219,13 @@ func (l *Loader) populateConfigBlockNodes(g *dag.Graph, configBlocks []*ast.Bloc
 
 	// If a logging config block is not provided, use the defaults.
 	if _, ok := blockMap[loggingBlockID]; !ok && !l.isModule() {
-		l.globals.LogSink.Update(logging.DefaultSinkOptions)
+		err := l.globals.LogSink.Update(logging.DefaultSinkOptions)
+		if err != nil {
+			diags.Add(diag.Diagnostic{
+				Severity: diag.SeverityLevelError,
+				Message:  err.Error(),
+			})
+		}
 	}
 
 	return diags

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -217,6 +217,11 @@ func (l *Loader) populateConfigBlockNodes(g *dag.Graph, configBlocks []*ast.Bloc
 		g.Add(c)
 	}
 
+	// If a logging config block is not provided, use the defaults.
+	if _, ok := blockMap[loggingBlockID]; !ok && !l.isModule() {
+		l.globals.LogSink.Update(logging.DefaultSinkOptions)
+	}
+
 	return diags
 }
 

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -225,15 +225,16 @@ func (l *Loader) populateConfigBlockNodes(g *dag.Graph, configBlocks []*ast.Bloc
 		g.Add(c)
 	}
 
-	// If a logging config block is not provided, use the defaults.
+	// If a logging config block is not provided, we create an empty node which uses defaults.
 	if _, ok := blockMap[loggingBlockID]; !ok && !l.isModule() {
-		err := l.globals.LogSink.Update(logging.DefaultSinkOptions)
-		if err != nil {
-			diags.Add(diag.Diagnostic{
-				Severity: diag.SeverityLevelError,
-				Message:  err.Error(),
-			})
-		}
+		c := NewDefaultLoggingConfigNode(l.globals)
+		g.Add(c)
+	}
+
+	// If a tracing config block is not provided, we create an empty node which uses defaults.
+	if _, ok := blockMap[tracingBlockID]; !ok && !l.isModule() {
+		c := NewDefaulTracingConfigNode(l.globals)
+		g.Add(c)
 	}
 
 	return diags

--- a/pkg/flow/internal/controller/loader_test.go
+++ b/pkg/flow/internal/controller/loader_test.go
@@ -41,7 +41,7 @@ func TestLoader(t *testing.T) {
 			level = "debug"
 			format = "logfmt"
 		}
-		
+
 		tracing {
 			sampling_fraction = 1
 		}
@@ -77,6 +77,13 @@ func TestLoader(t *testing.T) {
 	t.Run("New Graph", func(t *testing.T) {
 		l := controller.NewLoader(newGlobals())
 		diags := applyFromContent(t, l, []byte(testFile), []byte(testConfig))
+		require.NoError(t, diags.ErrorOrNil())
+		requireGraph(t, l.Graph(), testGraphDefinition)
+	})
+
+	t.Run("New Graph No Config", func(t *testing.T) {
+		l := controller.NewLoader(newGlobals())
+		diags := applyFromContent(t, l, []byte(testFile), nil)
 		require.NoError(t, diags.ErrorOrNil())
 		requireGraph(t, l.Graph(), testGraphDefinition)
 	})

--- a/pkg/river/ast/ast.go
+++ b/pkg/river/ast/ast.go
@@ -6,6 +6,7 @@ package ast
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/grafana/agent/pkg/river/token"
@@ -221,7 +222,7 @@ func (n *ParenExpr) astExpr()      {}
 
 // StartPos returns the position of the first character belonging to a Node.
 func StartPos(n Node) token.Pos {
-	if n == nil {
+	if n == nil || reflect.ValueOf(n).IsZero() {
 		return token.NoPos
 	}
 	switch n := n.(type) {
@@ -272,7 +273,7 @@ func StartPos(n Node) token.Pos {
 
 // EndPos returns the position of the final character in a Node.
 func EndPos(n Node) token.Pos {
-	if n == nil {
+	if n == nil || reflect.ValueOf(n).IsZero() {
 		return token.NoPos
 	}
 	switch n := n.(type) {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

Fixes #3334

#### Notes to the Reviewer

This can be done without the opts caching that was added to sink.go but it seems nicer to not mess with the logger if nothing changed. I also considered if this should be done here or have the caller to Update track the state but I think this is much simpler and improves all consumers of the sink functionality.

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
