### PR TITLE
Disable git user warning on build container

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -87,6 +87,13 @@ COPY --from=helm     /usr/bin/helm                   /usr/bin/helm
 COPY --from=golang   /usr/local/go                   /usr/local/go
 COPY --from=golang   /go/bin                         /go/bin
 
+# Git tries to prevent misuse of repositories (CVE-2022-24765), but we don't
+# care about this for build containers, where it's expected that the repository
+# will be accessed by other users (the root user of the build container).
+#
+# Disable that safety check.
+RUN git config --global --add safe.directory \*
+
 # Set CC to viceroycc to ensure that the cross compilers are used for all C
 # compilation.
 ENV CC viceroycc

--- a/build-image/windows/Dockerfile
+++ b/build-image/windows/Dockerfile
@@ -38,3 +38,10 @@ RUN choco install git --version 2.39.0 -y
 # yarn - installs node dependencies
 RUN choco install nodejs.install --version 19.2.0 -y
 RUN choco install yarn --version 1.22.19 -y
+
+# Git tries to prevent misuse of repositories (CVE-2022-24765), but we don't
+# care about this for build containers, where it's expected that the repository
+# will be accessed by other users (the root user of the build container).
+#
+# Disable that safety check.
+RUN git config --global --add safe.directory \*


### PR DESCRIPTION
Disables a warning by git to add /src or /drone/src as a safe directory. This was added as a security measure on systems, but it doesn't make sense in build containers which always use the root user. 
