### PR TITLE
Updates redis_exporter to v1.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ Main (unreleased)
 
 - Operator: Transparently compress agent configs to stay under size limitations. (@captncraig)
 
-- Update Redis Exporter Dependency to v1.48.0. (@spartan0x117)
+- Update Redis Exporter Dependency to v1.49.0. (@spartan0x117)
 
 - Update Loki dependency to the k142 branch. (@rfratto)
 

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/nerdswords/yet-another-cloudwatch-exporter v0.44.0-alpha
 	github.com/oklog/run v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/oliver006/redis_exporter v1.48.0
+	github.com/oliver006/redis_exporter v1.49.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter v0.63.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.63.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.63.0
@@ -612,7 +612,6 @@ require github.com/efficientgo/tools/core v0.0.0-20220817170617-6c25e3b627dd // 
 // If upstream is unresponsive, you should consider making a hard fork
 // (i.e., creating a new Go module with the same source) or picking a different
 // dependency.
-
 
 // Replace directives from Prometheus
 replace (

--- a/go.sum
+++ b/go.sum
@@ -1863,10 +1863,10 @@ github.com/grafana/snmp_exporter v0.20.1-0.20220405135227-49087c510bb1 h1:NrBQ7O
 github.com/grafana/snmp_exporter v0.20.1-0.20220405135227-49087c510bb1/go.mod h1:tN0QNzW5uuq81pX41VmfWI+/lfeEuYYaQ6y4kCNPhPA=
 github.com/grafana/snowflake-prometheus-exporter v0.0.0-20221213150626-862cad8e9538 h1:tkT0yha3JzB5S5VNjfY4lT0cJAe20pU8XGt3Nuq73rM=
 github.com/grafana/snowflake-prometheus-exporter v0.0.0-20221213150626-862cad8e9538/go.mod h1:VxVydRyq8f6w1qmX/5MSYIdSbgujre8rdFRLgU6u/RI=
-github.com/grafana/tail v0.0.0-20220426200921-98e8eb28ea4c h1:qIsCzNln5YzuXfXbJgXhpfM+4gY7qi3mED3eYQS4Fls=
-github.com/grafana/tail v0.0.0-20220426200921-98e8eb28ea4c/go.mod h1:GIMXMPB/lRAllP5rVDvcGif87ryO2hgD7tCtHMdHrho=
 github.com/grafana/statsd_exporter v0.18.1-0.20211118164740-8e806158da0b h1:eFIcZ12/3lY1Ot3PJswIhfKTOQTAZzYA1eN+XR8Ijho=
 github.com/grafana/statsd_exporter v0.18.1-0.20211118164740-8e806158da0b/go.mod h1:N4Z1+iSqc9rnxlT1N8Qn3l65Vzb5t4Uq0jpg8nxyhio=
+github.com/grafana/tail v0.0.0-20220426200921-98e8eb28ea4c h1:qIsCzNln5YzuXfXbJgXhpfM+4gY7qi3mED3eYQS4Fls=
+github.com/grafana/tail v0.0.0-20220426200921-98e8eb28ea4c/go.mod h1:GIMXMPB/lRAllP5rVDvcGif87ryO2hgD7tCtHMdHrho=
 github.com/grafana/tail v0.0.0-20230328181249-aa6682d7843a h1:ypBalFlWhbqP+60je3ZRse1I0iRB2fwkvGsZW7j8i7M=
 github.com/grafana/tail v0.0.0-20230328181249-aa6682d7843a/go.mod h1:7t5XR+2IA8P2qggOAHTj/GCZfoLBle3OvNSYh1VkRBU=
 github.com/grafana/vmware_exporter v0.0.4-beta h1:Tb8Edm/wDYh0Lvhm38HLNTlkflUrlPGB+jD+/hW4xHI=
@@ -2587,6 +2587,8 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/oliver006/redis_exporter v1.48.0 h1:mpE6AyD2bG9I1/4hJLQZySanwFA6FyKb7Vwn83aukD8=
 github.com/oliver006/redis_exporter v1.48.0/go.mod h1:O7UOQ4okTayrwJ07AZO6/qz0go+RBRu+Y9EgApY9hj8=
+github.com/oliver006/redis_exporter v1.49.0 h1:ks5t4rYvauBqJpxzPhbDwzOIlUSmYznCEaU2191x3TE=
+github.com/oliver006/redis_exporter v1.49.0/go.mod h1:O7UOQ4okTayrwJ07AZO6/qz0go+RBRu+Y9EgApY9hj8=
 github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #3400 

#### Notes to the Reviewer
There were no config updates. This just contains a bugfix for connecting to a TLS-enabled Redis Cluster.

#### PR Checklist

- [X] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
