### PR TITLE
[Agent Management] Add support for integration snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Main (unreleased)
 
 - Add support for Flow-specific DEB and RPM system packages. This allows users
   to install Grafana Agent Flow alongside Grafana Agent. (@rfratto, @robigan)
+- Agent Management: Add support for integration snippets. (@jcreixell)
 
 ### Enhancements
 

--- a/pkg/config/agentmanagement.go
+++ b/pkg/config/agentmanagement.go
@@ -218,11 +218,6 @@ func loadRemoteConfig(remoteConfigBytes []byte, expandEnvVars bool, fs *flag.Fla
 		return nil, fmt.Errorf("could not build agent config: %w", err)
 	}
 
-	// this is done in order to validate the config semantically
-	if err = applyIntegrationValuesFromFlagset(fs, args, configPath, config); err != nil {
-		instrumentation.InstrumentInvalidRemoteConfig("invalid_integrations_config")
-		return nil, fmt.Errorf("could not load integrations from config: %w", err)
-	}
 	if err = config.Validate(fs); err != nil {
 		instrumentation.InstrumentInvalidRemoteConfig("semantically_invalid_agent_config")
 		return nil, fmt.Errorf("semantically invalid config received from the API: %w", err)

--- a/pkg/config/agentmanagement.go
+++ b/pkg/config/agentmanagement.go
@@ -169,17 +169,17 @@ type AgentManagementConfig struct {
 // getRemoteConfig gets the remote config specified in the initial config, falling back to a local, cached copy
 // of the remote config if the request to the remote fails. If both fail, an empty config and an
 // error will be returned.
-func getRemoteConfig(expandEnvVars bool, configProvider remoteConfigProvider, log *server.Logger, fs *flag.FlagSet, args []string, configPath string) (*Config, error) {
+func getRemoteConfig(expandEnvVars bool, configProvider remoteConfigProvider, log *server.Logger, fs *flag.FlagSet) (*Config, error) {
 	remoteConfigBytes, err := configProvider.FetchRemoteConfig()
 	if err != nil {
 		level.Error(log).Log("msg", "could not fetch from API, falling back to cache", "err", err)
-		return getCachedRemoteConfig(expandEnvVars, configProvider, fs, args, configPath)
+		return getCachedRemoteConfig(expandEnvVars, configProvider, fs)
 	}
 
-	config, err := loadRemoteConfig(remoteConfigBytes, expandEnvVars, fs, args, configPath)
+	config, err := loadRemoteConfig(remoteConfigBytes, expandEnvVars, fs)
 	if err != nil {
 		level.Error(log).Log("msg", "could not load remote config, falling back to cache", "err", err)
-		return getCachedRemoteConfig(expandEnvVars, configProvider, fs, args, configPath)
+		return getCachedRemoteConfig(expandEnvVars, configProvider, fs)
 	}
 
 	level.Info(log).Log("msg", "fetched and loaded remote config from API")
@@ -190,16 +190,16 @@ func getRemoteConfig(expandEnvVars bool, configProvider remoteConfigProvider, lo
 	return config, nil
 }
 
-func getCachedRemoteConfig(expandEnvVars bool, configProvider remoteConfigProvider, fs *flag.FlagSet, args []string, configPath string) (*Config, error) {
+func getCachedRemoteConfig(expandEnvVars bool, configProvider remoteConfigProvider, fs *flag.FlagSet) (*Config, error) {
 	rc, err := configProvider.GetCachedRemoteConfig()
 	if err != nil {
 		return nil, fmt.Errorf("could not load cached config: %w", err)
 	}
-	return loadRemoteConfig(rc, expandEnvVars, fs, args, configPath)
+	return loadRemoteConfig(rc, expandEnvVars, fs)
 }
 
 // loadRemoteConfig parses and validates the remote config, both syntactically and semantically.
-func loadRemoteConfig(remoteConfigBytes []byte, expandEnvVars bool, fs *flag.FlagSet, args []string, configPath string) (*Config, error) {
+func loadRemoteConfig(remoteConfigBytes []byte, expandEnvVars bool, fs *flag.FlagSet) (*Config, error) {
 	expandedRemoteConfigBytes, err := performEnvVarExpansion(remoteConfigBytes, expandEnvVars)
 	if err != nil {
 		instrumentation.InstrumentInvalidRemoteConfig("env_var_expansion")

--- a/pkg/config/agentmanagement_remote_config.go
+++ b/pkg/config/agentmanagement_remote_config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/logs"
 	"github.com/grafana/agent/pkg/metrics/instance"
 	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
@@ -30,6 +31,9 @@ type (
 
 		// LogsScrapeConfigs is a YAML containing list of logs scrape configs.
 		LogsScrapeConfigs []scrapeconfig.Config `yaml:"logs_scrape_configs,omitempty"`
+
+		// IntegrationConfigs is a YAML containing list of integrations.
+		IntegrationConfigs integrations.ManagerConfig `yaml:"integration_configs,omitempty"`
 	}
 )
 
@@ -49,6 +53,12 @@ func (rc *RemoteConfig) BuildAgentConfig() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// For now Agent Management only supports integrations v1
+	if err := c.Integrations.setVersion(integrationsVersion1); err != nil {
+		return nil, err
+	}
+
 	err = appendSnippets(&c, rc.Snippets)
 	if err != nil {
 		return nil, err
@@ -64,6 +74,7 @@ func appendSnippets(c *Config, snippets []Snippet) error {
 		ScrapeConfig: []scrapeconfig.Config{},
 	}
 	logsConfigs.Initialize()
+	integrationConfigs := integrations.DefaultManagerConfig()
 
 	for _, snippet := range snippets {
 		var snippetContent SnippetContent
@@ -73,6 +84,7 @@ func appendSnippets(c *Config, snippets []Snippet) error {
 		}
 		metricsConfigs.ScrapeConfigs = append(metricsConfigs.ScrapeConfigs, snippetContent.MetricsScrapeConfigs...)
 		logsConfigs.ScrapeConfig = append(logsConfigs.ScrapeConfig, snippetContent.LogsScrapeConfigs...)
+		integrationConfigs.Integrations = append(integrationConfigs.Integrations, snippetContent.IntegrationConfigs.Integrations...)
 	}
 	if len(metricsConfigs.ScrapeConfigs) > 0 {
 		c.Metrics.Configs = append(c.Metrics.Configs, metricsConfigs)
@@ -87,5 +99,7 @@ func appendSnippets(c *Config, snippets []Snippet) error {
 		}
 		c.Logs.Configs = append(c.Logs.Configs, &logsConfigs)
 	}
+
+	c.Integrations.configV1.Integrations = append(c.Integrations.configV1.Integrations, integrationConfigs.Integrations...)
 	return nil
 }

--- a/pkg/config/agentmanagement_test.go
+++ b/pkg/config/agentmanagement_test.go
@@ -211,7 +211,7 @@ func TestGetRemoteConfig_UnmarshallableRemoteConfig(t *testing.T) {
 	features.Register(fs, allFeatures)
 	defaultCfg.RegisterFlags(fs)
 
-	cfg, err := getRemoteConfig(true, &testProvider, logger, fs, []string{}, "test")
+	cfg, err := getRemoteConfig(true, &testProvider, logger, fs)
 	assert.NoError(t, err)
 	assert.False(t, testProvider.didCacheRemoteConfig)
 
@@ -237,7 +237,7 @@ func TestGetRemoteConfig_RemoteFetchFails(t *testing.T) {
 	features.Register(fs, allFeatures)
 	defaultCfg.RegisterFlags(fs)
 
-	cfg, err := getRemoteConfig(true, &testProvider, logger, fs, []string{}, "test")
+	cfg, err := getRemoteConfig(true, &testProvider, logger, fs)
 	assert.NoError(t, err)
 	assert.False(t, testProvider.didCacheRemoteConfig)
 
@@ -283,7 +283,7 @@ snippets: []
 	features.Register(fs, allFeatures)
 	defaultCfg.RegisterFlags(fs)
 
-	cfg, err := getRemoteConfig(true, &testProvider, logger, fs, []string{}, "test")
+	cfg, err := getRemoteConfig(true, &testProvider, logger, fs)
 	assert.NoError(t, err)
 	assert.False(t, testProvider.didCacheRemoteConfig)
 
@@ -322,7 +322,7 @@ snippets:
 	features.Register(fs, allFeatures)
 	defaultCfg.RegisterFlags(fs)
 
-	cfg, err := getRemoteConfig(true, &testProvider, logger, fs, []string{}, "test")
+	cfg, err := getRemoteConfig(true, &testProvider, logger, fs)
 	assert.NoError(t, err)
 	assert.False(t, testProvider.didCacheRemoteConfig)
 
@@ -351,7 +351,7 @@ snippets: []
 	features.Register(fs, allFeatures)
 	defaultCfg.RegisterFlags(fs)
 
-	cfg, err := getRemoteConfig(true, &testProvider, logger, fs, []string{}, "test")
+	cfg, err := getRemoteConfig(true, &testProvider, logger, fs)
 	assert.NoError(t, err)
 	assert.True(t, testProvider.didCacheRemoteConfig)
 
@@ -406,7 +406,7 @@ snippets:
 	features.Register(fs, allFeatures)
 	defaultCfg.RegisterFlags(fs)
 
-	cfg, err := getRemoteConfig(true, &testProvider, logger, fs, []string{}, "test")
+	cfg, err := getRemoteConfig(true, &testProvider, logger, fs)
 	assert.NoError(t, err)
 	assert.True(t, testProvider.didCacheRemoteConfig)
 
@@ -466,7 +466,7 @@ snippets:
 	features.Register(fs, allFeatures)
 	defaultCfg.RegisterFlags(fs)
 
-	cfg, err := getRemoteConfig(true, &testProvider, logger, fs, []string{"-config.expand-env"}, "test")
+	cfg, err := getRemoteConfig(true, &testProvider, logger, fs)
 	assert.NoError(t, err)
 	assert.Equal(t, "15s", cfg.Metrics.Configs[0].ScrapeConfigs[0].ScrapeInterval.String())
 	assert.Equal(t, "json", cfg.Server.LogFormat.String())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -258,7 +258,7 @@ func LoadFile(filename string, expandEnvVars bool, c *Config) error {
 //     a) Fetch from remote. If this fails or is invalid:
 //     b) Read the remote config from cache. If this fails, return an error.
 //  4. Merge the initial and remote config into c.
-func loadFromAgentManagementAPI(path string, expandEnvVars bool, c *Config, log *server.Logger, fs *flag.FlagSet, args []string) error {
+func loadFromAgentManagementAPI(path string, expandEnvVars bool, c *Config, log *server.Logger, fs *flag.FlagSet) error {
 	// Load the initial config from disk without instrumenting the config hash
 	buf, err := os.ReadFile(path)
 	if err != nil {
@@ -274,7 +274,7 @@ func loadFromAgentManagementAPI(path string, expandEnvVars bool, c *Config, log 
 	if err != nil {
 		return err
 	}
-	remoteConfig, err := getRemoteConfig(expandEnvVars, configProvider, log, fs, args, path)
+	remoteConfig, err := getRemoteConfig(expandEnvVars, configProvider, log, fs)
 	if err != nil {
 		return err
 	}
@@ -413,7 +413,7 @@ func Load(fs *flag.FlagSet, args []string, log *server.Logger) (*Config, error) 
 				return LoadRemote(path, expandArgs, c)
 			}
 			if features.Enabled(fs, featAgentManagement) {
-				return loadFromAgentManagementAPI(path, expandArgs, c, log, fs, args)
+				return loadFromAgentManagementAPI(path, expandArgs, c, log, fs)
 			}
 			return LoadFile(path, expandArgs, c)
 		case fileTypeDynamic:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,7 +57,7 @@ func DefaultConfig() Config {
 		Server:                &defaultServerCfg,
 		ServerFlags:           server.DefaultFlags,
 		Metrics:               metrics.DefaultConfig,
-		Integrations:          DefaultVersionedIntegrations,
+		Integrations:          DefaultVersionedIntegrations(),
 		DisableSupportBundle:  false,
 		EnableConfigEndpoints: false,
 		EnableUsageReport:     true,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -180,7 +180,7 @@ func TestConfig_Defaults(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, metrics.DefaultConfig, c.Metrics)
-	require.Equal(t, DefaultVersionedIntegrations, c.Integrations)
+	require.Equal(t, DefaultVersionedIntegrations(), c.Integrations)
 }
 
 func TestConfig_TracesLokiValidates(t *testing.T) {

--- a/pkg/config/integrations.go
+++ b/pkg/config/integrations.go
@@ -24,9 +24,12 @@ const (
 )
 
 // DefaultVersionedIntegrations is the default config for integrations.
-var DefaultVersionedIntegrations = VersionedIntegrations{
-	version:  integrationsVersion1,
-	configV1: &v1.DefaultManagerConfig,
+func DefaultVersionedIntegrations() VersionedIntegrations {
+	configV1 := v1.DefaultManagerConfig()
+	return VersionedIntegrations{
+		version:  integrationsVersion1,
+		configV1: &configV1,
+	}
 }
 
 // VersionedIntegrations abstracts the subsystem configs for integrations v1
@@ -95,7 +98,14 @@ func (c *VersionedIntegrations) setVersion(v integrationsVersion) error {
 
 	switch c.version {
 	case integrationsVersion1:
-		cfg := v1.DefaultManagerConfig
+		// Do not overwrite the config if it's already been set. This is relevant for
+		// cases where the config has already been loaded via other means (example: Agent
+		// Management snippets).
+		if c.configV1 != nil {
+			return nil
+		}
+
+		cfg := v1.DefaultManagerConfig()
 		c.configV1 = &cfg
 		return yaml.UnmarshalStrict(c.raw, c.configV1)
 	case integrationsVersion2:

--- a/pkg/config/integrations_test.go
+++ b/pkg/config/integrations_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	_ "github.com/grafana/agent/pkg/integrations/install" // Install integrations for tests
+	"github.com/grafana/agent/pkg/util"
 )
 
 func TestIntegrations_v1(t *testing.T) {
@@ -111,4 +112,22 @@ integrations:
 	})
 	require.NoError(t, err)
 	require.Equal(t, c.Integrations.EnabledIntegrations(), []string{"redis"})
+}
+
+func TestSetVersionDoesNotOverrideExistingV1Integrations(t *testing.T) {
+	cfg := `
+integrations:
+  agent:
+    enabled: true`
+
+	fs := flag.NewFlagSet("test", flag.ExitOnError)
+	c, err := load(fs, []string{"-config.file", "test"}, func(_, _ string, _ bool, c *Config) error {
+		return LoadBytes([]byte(cfg), false, c)
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(c.Integrations.configV1.Integrations))
+
+	c.Integrations.raw = util.RawYAML{}
+	c.Integrations.setVersion(integrationsVersion1)
+	require.Equal(t, 1, len(c.Integrations.configV1.Integrations))
 }

--- a/pkg/integrations/manager.go
+++ b/pkg/integrations/manager.go
@@ -34,14 +34,18 @@ var (
 	}, []string{"integration_name"})
 )
 
-// DefaultManagerConfig holds the default settings for integrations.
-var DefaultManagerConfig = ManagerConfig{
-	ScrapeIntegrations:        true,
-	IntegrationRestartBackoff: 5 * time.Second,
+var CurrentManagerConfig ManagerConfig = DefaultManagerConfig()
 
-	// Deprecated fields which keep their previous defaults:
-	UseHostnameLabel:     true,
-	ReplaceInstanceLabel: true,
+// DefaultManagerConfig holds the default settings for integrations.
+func DefaultManagerConfig() ManagerConfig {
+	return ManagerConfig{
+		ScrapeIntegrations:        true,
+		IntegrationRestartBackoff: 5 * time.Second,
+
+		// Deprecated fields which keep their previous defaults:
+		UseHostnameLabel:     true,
+		ReplaceInstanceLabel: true,
+	}
 }
 
 // ManagerConfig holds the configuration for all integrations.
@@ -94,7 +98,7 @@ func (c ManagerConfig) MarshalYAML() (interface{}, error) {
 
 // UnmarshalYAML implements yaml.Unmarshaler for ManagerConfig.
 func (c *ManagerConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	*c = DefaultManagerConfig
+	*c = DefaultManagerConfig()
 	return UnmarshalYAML(c, unmarshal)
 }
 


### PR DESCRIPTION
#### PR Description

Adds support for integrations in agent management snippets.

#### Notes to the Reviewer

  - Removes global state for integrations configuration (`DefaultManagerConfig` was a global variable that was modified every time an integrations config was unmarshaled; this could lead to all kinds of bugs and unexpected side effects, and becomes particularly relevant for agent management, where configurations are constantly changed and reloaded). The same applies to `DefaultVersionedIntegrations`.
  - Modifies `setVersion` to avoid overriding existing integrations config. This is needed due to the way integrations config is loaded: it is stored as a raw config and only unmarshaled at a later stage once the integrations version from the flagset has been parsed. Integration snippets for agent management are pinned to specific version and need to be processed early as they are extracted from snippets which are not part of the base config.
  - Note: Integrations for agent management are pinned to version 1. This is done for simplicity and to prevent confusion. We will explore the possibility of supporting also v2 integrations in the future if there is a need for it.

#### PR Checklist

- [x] CHANGELOG updated
- [x] Tests updated
