### PR TITLE
[Agent Management] Replace `api_url` with `host`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,11 @@ Main (unreleased)
 
 - Support for 32-bit ARM builds is temporarily removed. We are aiming to bring
   back support for these builds prior to publishing v0.33.0. (@rfratto)
-- Agent Management: Agent now makes use of the v2 agent API. The config field
-  `api_url` in the `agent_management` block should be updated accordingly. (@jcreixell)
+
+- Agent Management: `agent_management.api_url` config field has been replaced by
+`agent_management.host`. The API path and version is now defined by the Agent. (@jcreixell)
+
+- Agent Management: `agent_management.protocol` config field now allows defining "http" and "https" explicitly. Previously, "http" was previously used for both, with the actual protocol used inferred from the api url, which led to confusion. When upgrading, make sure to set to "https" when replacing `api_url` with `host`. (@jcreixell)
 
 ### Features
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -468,7 +468,7 @@ server:
 logs:
   positions_directory: /tmp
 agent_management:
-  api_url: "http://localhost"
+  host: "localhost"
   basic_auth:
     username: "initial_user"
   protocol: "http"
@@ -488,7 +488,7 @@ integrations:
   scrape_integrations: true
 
 agent_management:
-  api_url: "http://localhost:80"
+  host: "localhost:80"
   basic_auth:
     username: "new_user"
   protocol: "http"


### PR DESCRIPTION

#### PR Description

  - Replaces the `agent_management.api_url` config field with `agent_management.host`. This allows
    pinning the agent to a specific API version without the need for
    configuration changes, which removes the need for maintaining
    multiple protocol versions in newer versions of the Agent.
  - In addition, it now supports both `http` and `https` protocols
    explicitly via `agent_management.protocol`. Previously, `http` was
    used for both, with the final protocol used being inferred from the url.
    This led to confusion on which protocol was actually being used.

#### PR Checklist

- [x] CHANGELOG updated
- [x] Tests updated
