### PR TITLE
[helm] Allow configuring dnsPolicy

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -15,6 +15,7 @@ Unreleased
 - Add support for adding Annotations to Service (@ofirshtrull)
 - Add `agent.envFrom` value. (@carlosjgp)
 - Add `controller.hostNetwork` value. (@carlosjgp)
+- Add `controller.dnsPolicy` value. (@carlosjgp)
 
 ### Bugfixes
 

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -70,6 +70,7 @@ use the older mode (called "static mode"), set the `agent.mode` value to
 | controller.autoscaling.minReplicas | int | `1` | The lower limit for the number of replicas to which the autoscaler can scale down. |
 | controller.autoscaling.targetCPUUtilizationPercentage | int | `0` | Average CPU utilization across all relevant pods, a percentage of the requested value of the resource for the pods. Setting `targetCPUUtilizationPercentage` to 0 will disable CPU scaling. |
 | controller.autoscaling.targetMemoryUtilizationPercentage | int | `80` | Average Memory utilization across all relevant pods, a percentage of the requested value of the resource for the pods. Setting `targetMemoryUtilizationPercentage` to 0 will disable Memory scaling. |
+| controller.dnsPolicy | string | `"ClusterFirst"` | Configures the DNS policy for the pod. https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
 | controller.hostNetwork | bool | `false` | Configures Pods to use the host network. When set to true, the ports that will be used must be specified. |
 | controller.podAnnotations | object | `{}` | Extra pod annotations to add. |
 | controller.podLabels | object | `{}` | Extra pod labels to add. |

--- a/operations/helm/charts/grafana-agent/ci/create-daemonset-hostnetwork-values.yaml
+++ b/operations/helm/charts/grafana-agent/ci/create-daemonset-hostnetwork-values.yaml
@@ -1,0 +1,5 @@
+# Test rendering of the chart with the controller explicitly set to DaemonSet.
+controller:
+  type: daemonset
+  hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet

--- a/operations/helm/charts/grafana-agent/templates/controllers/_pod.yaml
+++ b/operations/helm/charts/grafana-agent/templates/controllers/_pod.yaml
@@ -22,7 +22,7 @@ spec:
   priorityClassName: {{ .Values.controller.priorityClassName }}
   {{- end }}
   {{- if .Values.controller.hostNetwork }}
-  hostNetwork:  {{ .Values.controller.hostNetwork }}
+  hostNetwork: {{ .Values.controller.hostNetwork }}
   {{- end }}
   dnsPolicy: {{ .Values.controller.dnsPolicy }}
   {{- with .Values.controller.affinity }}

--- a/operations/helm/charts/grafana-agent/templates/controllers/_pod.yaml
+++ b/operations/helm/charts/grafana-agent/templates/controllers/_pod.yaml
@@ -24,6 +24,7 @@ spec:
   {{- if .Values.controller.hostNetwork }}
   hostNetwork:  {{ .Values.controller.hostNetwork }}
   {{- end }}
+  dnsPolicy: {{ .Values.controller.dnsPolicy }}
   {{- with .Values.controller.affinity }}
   affinity:
     {{- toYaml . | nindent 4 }}

--- a/operations/helm/charts/grafana-agent/values.yaml
+++ b/operations/helm/charts/grafana-agent/values.yaml
@@ -113,6 +113,9 @@ controller:
   # -- Configures Pods to use the host network. When set to true, the ports that will be used must be specified.
   hostNetwork: false
 
+  # -- Configures the DNS policy for the pod. https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+  dnsPolicy: ClusterFirst
+
   # -- Update strategy for updating deployed Pods.
   updateStrategy: {}
 

--- a/operations/helm/tests/controller-volumes-extra/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/controller-volumes-extra/grafana-agent/templates/controllers/daemonset.yaml
@@ -64,6 +64,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/agent
+      dnsPolicy: ClusterFirst
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/configmap.yaml
@@ -1,0 +1,42 @@
+---
+# Source: grafana-agent/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.river: |-
+    logging {
+    	level  = "info"
+    	format = "logfmt"
+    }
+    
+    discovery.kubernetes "pods" {
+    	role = "pod"
+    }
+    
+    discovery.kubernetes "nodes" {
+    	role = "node"
+    }
+    
+    discovery.kubernetes "services" {
+    	role = "service"
+    }
+    
+    discovery.kubernetes "endpoints" {
+    	role = "endpoints"
+    }
+    
+    discovery.kubernetes "endpointslices" {
+    	role = "endpointslice"
+    }
+    
+    discovery.kubernetes "ingresses" {
+    	role = "ingress"
+    }

--- a/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/controllers/daemonset.yaml
@@ -28,11 +28,13 @@ spec:
           image: grafana/agent:v0.32.1
           imagePullPolicy: IfNotPresent
           args:
-            - -config.file=/etc/agent/config.yaml
-            - -server.http.address=0.0.0.0:80
+            - run
+            - /etc/agent/config.river
+            - --storage.path=/tmp/agent
+            - --server.http.listen-addr=0.0.0.0:80
           env:
             - name: AGENT_MODE
-              value: static
+              value: flow
             - name: HOSTNAME
               valueFrom:
                 fieldRef:
@@ -59,7 +61,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/agent
-      dnsPolicy: ClusterFirst
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/rbac.yaml
@@ -1,0 +1,100 @@
+---
+# Source: grafana-agent/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  # Rules which allow discovery.kubernetes to function.
+  - apiGroups:
+      - ""
+      - "discovery.k8s.io"
+      - "networking.k8s.io"
+    resources:
+      - endpoints
+      - endpointslices
+      - ingresses
+      - nodes
+      - nodes/proxy
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  # Rules for prometheus.kubernetes.*
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - podmonitors
+      - servicemonitors
+      - probes
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: grafana-agent/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: grafana-agent
+subjects:
+  - kind: ServiceAccount
+    name: grafana-agent
+    namespace: default

--- a/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: grafana-agent/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+  ports:
+    - name: http-metrics
+      port: 80
+      targetPort: 80
+      protocol: "TCP"
+    - name: faro
+      port: 12347
+      targetPort: 12347
+      protocol: "TCP"

--- a/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+---
+# Source: grafana-agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
@@ -61,6 +61,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/agent
+      dnsPolicy: ClusterFirst
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/create-deployment-autoscaling/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment-autoscaling/grafana-agent/templates/controllers/deployment.yaml
@@ -62,6 +62,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/agent
+      dnsPolicy: ClusterFirst
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
@@ -62,6 +62,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/agent
+      dnsPolicy: ClusterFirst
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
@@ -63,6 +63,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/agent
+      dnsPolicy: ClusterFirst
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -61,6 +61,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/agent
+      dnsPolicy: ClusterFirst
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
@@ -61,6 +61,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/agent
+      dnsPolicy: ClusterFirst
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/envFrom/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/envFrom/grafana-agent/templates/controllers/daemonset.yaml
@@ -64,6 +64,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/agent
+      dnsPolicy: ClusterFirst
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -61,6 +61,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/agent
+      dnsPolicy: ClusterFirst
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/extra-env/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-env/grafana-agent/templates/controllers/daemonset.yaml
@@ -70,6 +70,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/agent
+      dnsPolicy: ClusterFirst
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
@@ -64,6 +64,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/agent
+      dnsPolicy: ClusterFirst
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/faro-ingress/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/faro-ingress/grafana-agent/templates/controllers/daemonset.yaml
@@ -61,6 +61,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/agent
+      dnsPolicy: ClusterFirst
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/tolerations/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/tolerations/grafana-agent/templates/controllers/daemonset.yaml
@@ -61,6 +61,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/agent
+      dnsPolicy: ClusterFirst
       tolerations:
         - effect: NoSchedule
           key: key1


### PR DESCRIPTION
#### PR Description

Allows configuring `dnsPolicy` especially important when enabling `hostNetwork: true` although not strictly necessary unless you have to resolve a DNS in the same cluster we are running the grafana agent pod

Related to this PR #728

#### Which issue(s) this PR fixes

N/A

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
