### PR TITLE
Apply all config defaults in a centralized place

### DIFF
--- a/pkg/config/agentmanagement_remote_config.go
+++ b/pkg/config/agentmanagement_remote_config.go
@@ -68,9 +68,9 @@ func (rc *RemoteConfig) BuildAgentConfig() (*Config, error) {
 
 func appendSnippets(c *Config, snippets []Snippet) error {
 	metricsConfigs := instance.DefaultConfig
-	metricsConfigs.Name = "Metrics Snippets"
+	metricsConfigs.Name = "snippets"
 	logsConfigs := logs.InstanceConfig{
-		Name:         "Logs Snippets",
+		Name:         "snippets",
 		ScrapeConfig: []scrapeconfig.Config{},
 	}
 	logsConfigs.Initialize()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -186,6 +186,12 @@ func (c *Config) Validate(fs *flag.FlagSet) error {
 		return err
 	}
 
+	if c.Logs != nil {
+		if err := c.Logs.ApplyDefaults(); err != nil {
+			return err
+		}
+	}
+
 	// Need to propagate the listen address to the host and grpcPort
 	_, grpcPort, err := c.ServerFlags.GRPC.ListenHostPort()
 	if err != nil {

--- a/pkg/logs/config.go
+++ b/pkg/logs/config.go
@@ -27,7 +27,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	return c.ApplyDefaults()
+	return nil
 }
 
 // ApplyDefaults applies defaults to the Config and ensures that it is valid.

--- a/pkg/logs/config_test.go
+++ b/pkg/logs/config_test.go
@@ -96,6 +96,8 @@ func TestConfig_ApplyDefaults_Validations(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var cfg Config
 			err := yaml.UnmarshalStrict([]byte(tc.cfg), &cfg)
+			require.NoError(t, err)
+			err = cfg.ApplyDefaults()
 			if tc.err == nil {
 				require.NoError(t, err)
 			} else {
@@ -128,6 +130,8 @@ func TestConfig_ApplyDefaults_Defaults(t *testing.T) {
   `)
 	var cfg Config
 	err := yaml.UnmarshalStrict([]byte(cfgText), &cfg)
+	require.NoError(t, err)
+	err = cfg.ApplyDefaults()
 	require.NoError(t, err)
 
 	var (

--- a/pkg/logs/logs_test.go
+++ b/pkg/logs/logs_test.go
@@ -87,7 +87,7 @@ configs:
 	dec := yaml.NewDecoder(strings.NewReader(cfgText))
 	dec.SetStrict(true)
 	require.NoError(t, dec.Decode(&cfg))
-
+	require.NoError(t, cfg.ApplyDefaults())
 	logger := log.NewSyncLogger(log.NewNopLogger())
 	l, err := New(prometheus.NewRegistry(), &cfg, logger, false)
 	require.NoError(t, err)
@@ -128,7 +128,7 @@ configs:
 	dec = yaml.NewDecoder(strings.NewReader(cfgText))
 	dec.SetStrict(true)
 	require.NoError(t, dec.Decode(&newCfg))
-
+	require.NoError(t, newCfg.ApplyDefaults())
 	require.NoError(t, l.ApplyConfig(&newCfg, false))
 
 	fmt.Fprintf(tmpFile, "Hello again!\n")
@@ -155,7 +155,7 @@ configs:
 		dec = yaml.NewDecoder(strings.NewReader(cfgText))
 		dec.SetStrict(true)
 		require.NoError(t, dec.Decode(&newCfg))
-
+		require.NoError(t, newCfg.ApplyDefaults())
 		require.NoError(t, l.ApplyConfig(&newCfg, false))
 
 		fmt.Fprintf(tmpFile, "Hello again!\n")
@@ -194,7 +194,7 @@ configs:
 	dec := yaml.NewDecoder(strings.NewReader(cfgText))
 	dec.SetStrict(true)
 	require.NoError(t, dec.Decode(&cfg))
-
+	require.NoError(t, cfg.ApplyDefaults())
 	logger := util.TestLogger(t)
 	l, err := New(prometheus.NewRegistry(), &cfg, logger, false)
 	require.NoError(t, err)


### PR DESCRIPTION
#### PR Description

  - This change fixes a bug with agent management where log defaults would not be applied, resulting in missing validations and failure to initialize the positions file for log snippets.

#### Notes to the Reviewer

  - In order to avoid calling `ApplyDefaults` in multiple places, it has been moved to the `Validate` function, where defaults for metrics and integrations are also applied.
  - Additionally, the name of snippet metrics and logs instance configs has been changed to just "snippets". This is done to prevent filenames (i.e. positions) with spaces and for consistency.
  - Note: Logs config might be nil if no log configs have been defined, hence the extra check.

#### PR Checklist

- [x] Tests updated
