### PR TITLE
prometheus.remote_write: fix issue where unnecessary directory was used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,10 @@ Main (unreleased)
 - Fix issue where scraping native Prometheus histograms would leak memory.
   (@rfratto)
 
-- Fix issue where loki.source.docker component could deadlock. (@tpaschalis)
+- Flow: fix issue where `loki.source.docker` component could deadlock. (@tpaschalis)
+
+- Flow: fix issue where `prometheus.remote_write` created unnecessary extra
+  child directories to store the WAL in. (@rfratto)
 
 ### Other changes
 


### PR DESCRIPTION
prometheus.remote_write was originally creating a folder called `wal/COMPONENT_ID` relative to the data path given to the component.

Because the data path given to the component is already unique, AND because the Prometheus storage code creates a WAL directory, this means that the WAL was being stored at
`DATA_PATH/COMPONENT_ID/wal/COMPONENT_ID/wal`. This issue compounds itself when using modules, as each module adds an additional unnecessary directory to the path.

This commit changes the WAL to be stored at
`DATA_PATH/COMPONENT_ID/wal`.
