### PR TITLE
docs: changes to loki.source.journal

### DIFF
--- a/docs/sources/flow/reference/components/loki.source.gelf.md
+++ b/docs/sources/flow/reference/components/loki.source.gelf.md
@@ -5,7 +5,7 @@ title: loki.source.gelf
 # loki.source.gelf
 
 `loki.source.gelf` reads [Graylog Extended Long Format (GELF) logs](https://github.com/Graylog2/graylog2-server) from a UDP listener and forwards them to other
-`loki.*` components. 
+`loki.*` components.
 
 Multiple `loki.source.gelf` components can be specified by giving them
 different labels and ports.
@@ -31,27 +31,25 @@ Name         | Type                 | Description                               
 `relabel_rules` | `RelabelRules`         | Relabeling rules to apply on log entries. | "{}" | no
 
 
-> **NOTE**: GELF logs can be sent uncompressed or compressed with GZIP or ZLIB. 
-> A `job` label is added with the full name of the component `loki.source.gelf.LABEL`. 
+> **NOTE**: GELF logs can be sent uncompressed or compressed with GZIP or ZLIB.
+> A `job` label is added with the full name of the component `loki.source.gelf.LABEL`.
 
-Incoming messages have the following labels available:
+The `relabel_rules` argument can make use of the `rules` export from a
+[loki.relabel][] component to apply one or more relabling rules to log entries
+before they're forward to the list of receivers specified in `forward_to`.
+
+Incoming messages have the following internal labels available:
+
 * `__gelf_message_level`: The GELF level as a string.
 * `__gelf_message_host`: The host sending the GELF message.
 * `__gelf_message_host`: The GELF level message version sent by the client.
 * `__gelf_message_facility`: The GELF facility.
 
-These labels are stripped unless relabeling is used to retain the labels with a
-`loki.relabel` component and its Rules export as the `relabel_rules` argument.
-An example rule is presented below.
+All labels starting with `__` are removed prior to forwarding log entries. To
+keep these labels, relabel them using a [loki.relabel][] component and pass its
+`rules` export to the `relabel_rules` argument.
 
-```river
-rule {
-		action      = "labelmap"
-		regex       = "__gelf_(.*)"
-		replacement = "gelf_${1}"
-	}
-```
-
+[loki.relabel]: {{< relref "./loki.relabel.md" >}}
 
 ## Component health
 
@@ -66,13 +64,21 @@ configuration.
 ## Example
 
 ```river
+loki.relabel "gelf" {
+  rule {
+    source_labels = ["__gelf_message_host"]
+    target_label  = "host"
+  }
+}
+
 loki.source.gelf "listen"  {
-    forward_to = [loki.write.endpoint.receiver]
+  forward_to    = [loki.write.endpoint.receiver]
+  relabel_rules = loki.relabel.gelf.rules
 }
 
 loki.write "endpoint" {
-    endpoint {
-        url ="loki:3100/api/v1/push"
-    }  
+  endpoint {
+    url ="loki:3100/api/v1/push"
+  }
 }
 ```

--- a/docs/sources/flow/reference/components/loki.source.journal.md
+++ b/docs/sources/flow/reference/components/loki.source.journal.md
@@ -5,7 +5,7 @@ title: loki.source.journal
 # loki.source.journal
 
 `loki.source.journal` reads from the systemd journal and forwards them to other
-`loki.*` components. 
+`loki.*` components.
 
 Multiple `loki.source.journal` components can be specified by giving them
 different labels.
@@ -24,43 +24,38 @@ log entries to the list of receivers passed in `forward_to`.
 
 `loki.source.journal` supports the following arguments:
 
-Name         | Type   | Description                                                                                                                                                                                                                                | Default | Required
------------- |--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------| --------
-`format_as_json`    | `bool` | When true, log messages from the journal are passed through the pipeline as a JSON message with all of the journal entries' original  fields. When false, the log message is the text content of the MESSAGE field from the journal entry. | `false` | no
-`max_age`    | `duration` | The oldest relative time from process start that will be read                                                                                                                                                                              | `"7h"` | no
-`path` | `string` | Path to a directory to read entries from. Defaults to system paths (/var/log/journal and /run/log/journal) when empty.                                                                                                                     | `""` | no
-`matches` | `string` | Journal matches to filter. Character (+) is not supported, only logical AND matches will be added. | `""` | no
-`forward_to` | `list(LogsReceiver)` | List of receivers to send log entries to.                                                                                                                                                                                                  | | yes
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`format_as_json` | `bool` | Whether to forward the original journal entry as JSON. | `false` | no
+`max_age` | `duration` | The oldest relative time from process start that will be read. | `"7h"` | no
+`path` | `string` | Path to a directory to read entries from. | `""` | no
+`matches` | `string` | Journal matches to filter. The `+` character is not supported, only logical AND matches will be added. | `""` | no
+`forward_to` | `list(LogsReceiver)` | List of receivers to send log entries to. | | yes
+`relabel_rules` | `RelabelRules` | Relabeling rules to apply on log entries. | `{}` | no
 
-> **NOTE**:  A `job` label is added with the full name of the component `loki.source.journal.LABEL`. 
+> **NOTE**:  A `job` label is added with the full name of the component `loki.source.journal.LABEL`.
 
-## Blocks
+When the `format_as_json` argument is true, log messages are passed through as
+JSON with all of the original fields from the journal entry. Otherwise, the log
+message is taken from the content of the `MESSAGE` field from the journal
+entry.
 
-The following blocks are supported inside the definition of `loki.source.journal`:
+When the `path` argument is empty, `/var/log/journal` and `/run/log/journal`
+will be used for discovering journal entries.
 
-Hierarchy | Name | Description | Required
---------- | ---- | ----------- | --------
-relabel_rules | [relabel_rules][] | Relabeling rules to apply to received log entries. | no
+The `relabel_rules` field can make use of the `rules` export value from a
+`loki.relabel` component to apply one or more relabeling rules to log entries
+before they're forwarded to the list of receivers in `forward_to`.
 
-[relabel_rules]: #relabel_rules
+All messages read from the journal include internal labels following the
+pattern of `__journal_FIELDNAME` and will be dropped before sending to the list
+of receivers specified in `forward_to`. To keep these labels, use the
+`relabel_rules` argument and relabel them to not be prefixed with `__`.
 
-### relabel_rules block
-
-{{< docs/shared lookup="flow/reference/components/rule-block.md" source="agent" >}}
-
-Incoming messages have labels from the journal following the patten `__journal_FIELDNAME`
-
-These labels are stripped unless a rule is created to retain the labels. An example rule is 
-below.
-
-```river
-rule {
-		action      = "labelmap"
-		regex       = "__journal_(.*)"
-		replacement = "journal_${1}"
-	}
-```
-
+> **NOTE**: many field names from journald start with an `_`, such as
+> `_systemd_unit`. The final internal label name would be
+> `__journal__systemd_unit`, with _two_ underscores between `__journal` and
+> `systemd_unit`.
 
 ## Component health
 
@@ -75,13 +70,21 @@ configuration.
 ## Example
 
 ```river
+loki.relabel "journal" {
+  rule {
+    source_labels = ["__journal__systemd_unit"]
+    target_label  = "unit"
+  }
+}
+
 loki.source.journal "read"  {
-    forward_to = [loki.write.endpoint.receiver]
+  forward_to    = [loki.write.endpoint.receiver]
+  relabel_rules = loki.relabel.journal.rules
 }
 
 loki.write "endpoint" {
-    endpoint {
-        url ="loki:3100/api/v1/push"
-    }  
+  endpoint {
+    url ="loki:3100/api/v1/push"
+  }
 }
 ```

--- a/docs/sources/flow/reference/components/loki.source.journal.md
+++ b/docs/sources/flow/reference/components/loki.source.journal.md
@@ -43,8 +43,8 @@ entry.
 When the `path` argument is empty, `/var/log/journal` and `/run/log/journal`
 will be used for discovering journal entries.
 
-The `relabel_rules` field can make use of the `rules` export value from a
-`loki.relabel` component to apply one or more relabeling rules to log entries
+The `relabel_rules` argument can make use of the `rules` export value from a
+[loki.relabel][] component to apply one or more relabeling rules to log entries
 before they're forwarded to the list of receivers in `forward_to`.
 
 All messages read from the journal include internal labels following the
@@ -56,6 +56,8 @@ of receivers specified in `forward_to`. To keep these labels, use the
 > `_systemd_unit`. The final internal label name would be
 > `__journal__systemd_unit`, with _two_ underscores between `__journal` and
 > `systemd_unit`.
+
+[loki.relabel]: {{< relref "./loki.relabel.md" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/loki.source.kafka.md
+++ b/docs/sources/flow/reference/components/loki.source.kafka.md
@@ -139,7 +139,7 @@ loki.source.kafka "local" {
   brokers                = ["localhost:9092"]
   topics                 = ["quickstart-events"]
   labels                 = {component = "loki.source.kafka"}
-  forward_to             = [loki.write.loki.receiver]
+  forward_to             = [loki.write.local.receiver]
   use_incoming_timestamp = true
   relabel_rules          = loki.relabel.kafka.rules
 }

--- a/docs/sources/flow/reference/components/loki.source.syslog.md
+++ b/docs/sources/flow/reference/components/loki.source.syslog.md
@@ -37,8 +37,10 @@ Name            | Type                   | Description          | Default | Requ
 `relabel_rules` | `RelabelRules`         | Relabeling rules to apply on log entries. | "{}" | no
 
 The `relabel_rules` field can make use of the `rules` export value from a
-`loki.relabel` component to apply one or more relabeling rules to log entries
+[loki.relabel][] component to apply one or more relabeling rules to log entries
 before they're forwarded to the list of receivers in `forward_to`.
+
+[loki.relabel]: {{< relref "./loki.relabel.md" >}}
 
 ## Blocks
 
@@ -50,7 +52,7 @@ Hierarchy | Name | Description | Required
 listener | [listener][] | Configures a listener for IETF Syslog (RFC5424) messages. | no
 listener > tls_config | [tls_config][] | Configures TLS settings for connecting to the endpoint for TCP connections. | no
 
-The `>` symbol indicates deeper levels of nesting. For example, `config > tls_config` 
+The `>` symbol indicates deeper levels of nesting. For example, `config > tls_config`
 refers to a `tls_config` block defined inside a `config` block.
 
 [listener]: #listener-block
@@ -88,7 +90,7 @@ internal labels, prefixed with `__syslog_`.
 If `label_structured_data` is set, structured data in the syslog header is also
 translated to internal labels in the form of
 `__syslog_message_sd_<ID>_<KEY>`. For example, a  structured data entry of
-`[example@99999 test="yes"]` becomes the label 
+`[example@99999 test="yes"]` becomes the label
 `__syslog_message_sd_example_99999_test` with the value `"yes"`.
 
 ### tls_config block
@@ -125,13 +127,13 @@ UDP in the specified ports and forwards them to a `loki.write` component.
 loki.source.syslog "local" {
   listener {
     address  = "127.0.0.1:51893"
-    labels   = { component = "loki.source.syslog", protocol = "tcp" } 
+    labels   = { component = "loki.source.syslog", protocol = "tcp" }
   }
 
   listener {
     address  = "127.0.0.1:51898"
     protocol = "udp"
-    labels   = { component = "loki.source.syslog", protocol = "udp"} 
+    labels   = { component = "loki.source.syslog", protocol = "udp"}
   }
 
   forward_to = [loki.write.local.receiver]


### PR DESCRIPTION
1. Removes the incorrect `relabel_rules` block section, as `relabel_rules` is a capsule and not a block.

2. Shortens the arguments table length and moves descriptions to outside of the table, following the recent recommendations for writing component docs.

3. Adds using relabeling to the example.

I've mirrored some of these changes to other `loki.source.` components which also seemed unclear.  

Closes #3460
