### PR TITLE
Update Loki dependency to the k144 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ Main (unreleased)
 
 - Update Redis Exporter Dependency to v1.49.0. (@spartan0x117)
 
-- Update Loki dependency to the k142 branch. (@rfratto)
+- Update Loki dependency to the k144 branch. (@andriikushch)
 
 - Flow: Add OAUTHBEARER mechanism to `loki.source.kafka` using Azure as provider. (@akselleirv)
 

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2
 	github.com/grafana/dskit v0.0.0-20230201083518-528d8a7d52f2
 	github.com/grafana/go-gelf/v2 v2.0.1
-	github.com/grafana/loki v1.6.2-0.20230323092517-38203f870999 // k142 branch
+	github.com/grafana/loki v1.6.2-0.20230331204151-e2c4454a2d7d // k144 branch
 	github.com/grafana/phlare/api v0.1.2
 	github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd
 	github.com/grafana/snowflake-prometheus-exporter v0.0.0-20221213150626-862cad8e9538
@@ -567,7 +567,7 @@ require (
 	go.etcd.io/etcd/api/v3 v3.5.5 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.5 // indirect
 	go.etcd.io/etcd/client/v3 v3.5.5 // indirect
-	go.mongodb.org/mongo-driver v1.11.0 // indirect
+	go.mongodb.org/mongo-driver v1.11.2 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.36.4 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.37.0 // indirect
 	go4.org/intern v0.0.0-20211027215823-ae77deb06f29 // indirect
@@ -600,6 +600,9 @@ require (
 require (
 	github.com/efficientgo/tools/core v0.0.0-20220817170617-6c25e3b627dd // indirect
 	github.com/gomodule/redigo v1.8.9 // indirect
+	github.com/spaolacci/murmur3 v1.1.0 // indirect
+	github.com/willf/bitset v1.1.11 // indirect
+	github.com/willf/bloom v2.0.3+incompatible // indirect
 )
 
 // NOTE: replace directives below must always be *temporary*.

--- a/go.sum
+++ b/go.sum
@@ -1833,8 +1833,8 @@ github.com/grafana/go-gelf/v2 v2.0.1/go.mod h1:lexHie0xzYGwCgiRGcvZ723bSNyNI8ZRD
 github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85/go.mod h1:crI9WX6p0IhrqB+DqIUHulRW853PaNFf7o4UprV//3I=
 github.com/grafana/gomemcache v0.0.0-20230105173749-11f792309e1f h1:ANwIMe7kOiMNTK88tusoNDb840pWVskI4rCrdoMv5i0=
 github.com/grafana/gomemcache v0.0.0-20230105173749-11f792309e1f/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
-github.com/grafana/loki v1.6.2-0.20230323092517-38203f870999 h1:GimbYpCz7k8Y+FxGVoP2jR8lREjmFHMNaJtj3T1qzo4=
-github.com/grafana/loki v1.6.2-0.20230323092517-38203f870999/go.mod h1:kxNnWCr4EMobhndjy7a2Qpm7jkLPnJW2ariYvY77hLE=
+github.com/grafana/loki v1.6.2-0.20230331204151-e2c4454a2d7d h1:ziUJPxwypE8MeLaFhRafWs08/Q9j1UKFdGMHFN57vmA=
+github.com/grafana/loki v1.6.2-0.20230331204151-e2c4454a2d7d/go.mod h1:uFmggx1VSDTqr50ZlOetE/GSzlqi4TcDY5r7zgdVE6Y=
 github.com/grafana/loki/pkg/push v0.0.0-20230127102416-571f88bc5765 h1:VXitROTlmZtLzvokNe8ZbUKpmwldM4Hy1zdNRO32jKU=
 github.com/grafana/loki/pkg/push v0.0.0-20230127102416-571f88bc5765/go.mod h1:DhJMrd2QInI/1CNtTN43BZuTmkccdizW1jZ+F6aHkhY=
 github.com/grafana/mysqld_exporter v0.12.2-0.20201015182516-5ac885b2d38a h1:D5NSR64/6xMXnSFD9y1m1DPYIcBcHvtfeuI9/M/0qtI=
@@ -3055,6 +3055,7 @@ github.com/soundcloud/go-runit v0.0.0-20150630195641-06ad41a06c4a/go.mod h1:LeFC
 github.com/soveran/redisurl v0.0.0-20180322091936-eb325bc7a4b8/go.mod h1:FVJ8jbHu7QrNFs3bZEsv/L5JjearIAY9N0oXh2wk+6Y=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
+github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.0/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/afero v1.2.1/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
@@ -3230,6 +3231,7 @@ github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT
 github.com/willf/bitset v1.1.11 h1:N7Z7E9UvjW+sGsEl7k/SJrvY2reP1A07MrGuCjIOjRE=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/willf/bloom v2.0.3+incompatible h1:QDacWdqcAUI1MPOwIQZRy9kOR7yxfyEmxX8Wdm2/JPA=
+github.com/willf/bloom v2.0.3+incompatible/go.mod h1:MmAltL9pDMNTrvUkxdg0k0q5I0suxmuwp3KbyrZLOZ8=
 github.com/wk8/go-ordered-map v0.2.0 h1:KlvGyHstD1kkGZkPtHCyCfRYS0cz84uk6rrW/Dnhdtk=
 github.com/wk8/go-ordered-map v0.2.0/go.mod h1:9ZIbRunKbuvfPKyBP1SIKLcXNlv74YCOZ3t3VTS6gRk=
 github.com/wvanbergen/kafka v0.0.0-20171203153745-e2edea948ddf/go.mod h1:nxx7XRXbR9ykhnC8lXqQyJS0rfvJGxKyKw/sT1YOttg=
@@ -3330,8 +3332,9 @@ go.mongodb.org/mongo-driver v1.7.3/go.mod h1:NqaYOwnXWr5Pm7AOpO5QFxKJ503nbMse/R7
 go.mongodb.org/mongo-driver v1.7.5/go.mod h1:VXEWRZ6URJIkUq2SCAyapmhH0ZLRBP+FT4xhp5Zvxng=
 go.mongodb.org/mongo-driver v1.8.3/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
 go.mongodb.org/mongo-driver v1.10.0/go.mod h1:wsihk0Kdgv8Kqu1Anit4sfK+22vSFbUrAVEYRhCXrA8=
-go.mongodb.org/mongo-driver v1.11.0 h1:FZKhBSTydeuffHj9CBjXlR8vQLee1cQyTWYPA6/tqiE=
 go.mongodb.org/mongo-driver v1.11.0/go.mod h1:s7p5vEtfbeR1gYi6pnj3c3/urpbLv2T5Sfd6Rp2HBB8=
+go.mongodb.org/mongo-driver v1.11.2 h1:+1v2rDQUWNcGW7/7E0Jvdz51V38XXxJfhzbV17aNHCw=
+go.mongodb.org/mongo-driver v1.11.2/go.mod h1:s7p5vEtfbeR1gYi6pnj3c3/urpbLv2T5Sfd6Rp2HBB8=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
 go.opencensus.io v0.15.0/go.mod h1:UffZAU+4sDEINUGP/B7UfBBkq4fqLu9zXAX7ke6CHW0=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=


### PR DESCRIPTION
#### PR Description

This PR updates `github.com/grafana/loki` dependency. 

The reason why we want to add it is to include this change:

`17e05d28e4bf4f3a3c382180e4ba0fdb141af26f Promtail: Add a new target for the Azure Event Hub (#8787)`

It allows us to add support for Azure Event Hub in the future, which will be implemented in a separate PR.


#### Which issue(s) this PR fixes
Not available

#### Notes to the Reviewer
Output for diff between loki branches`git log --pretty=oneline origin/k142..origin/k144`:

```
e2c4454a2d7deeec9996eb4c8a6303e44f4a996f Fix dns-port in network-policy (#8733)
9f41182da2f69fe7164a6e93915e34cd4162f54b Fix the link in the Azure Event Hubs doc (#8904)
c4d016fd53de7c4af0a4a6d60d191859d244417d Add projected volume type to psp (#8747)
1fcefe8efaccc4175506d2a64f7d4dbe55a5e608 index-gateway: fix failure in initializing index gateway when boltdb-shipper is not being used (#8755)
0f98b45d8dd16ada81ba39c30f27357ddb811c18 Loki: Add UsageStatsURL to usagestats Config (#8779)
82a1f23ac93aa8f2e3f67c91078cce71a6cda5d5 Bump helm/chart-testing-action from 2.3.1 to 2.4.0 (#8907)
a4aeb0e651fe999273f9cbc08b892b935490f884 Update rbac.authorization.k8s.io/v1beta1 to rbac.authorization.k8s.io/v1 (#8270)
2cccc1bc6893c0b129bf2c81dbcd449ff837a53d Docs: Fix typos and grammar (#8966)
09f23ecd03fa5ddf9304fd42b89405fc9b77999b Docs: Improve time range documentation (#8847)
b88aa08d899da68dfb7970ea4673034cec085a05 Loki Canary: Enable insecure-skip-verify for all requests (#8869)
8233a1560a55e1102c78beab60b6cb394f46f11c Adding release cadence docs (#8893)
7264e0ef530ed56fc8dfd0926c95100e135b3228 Loki: Remove global singleton of the tsdb.Store and keep it scoped to the storage.Store (#8928)
f3a49f4734659a8dfb7630783ba580cf37ae7ca1 Update contains and hasPrefix/hasSuffix with the correct examples (#8929)
9efbd5ca455e9af57d486f448e79dd71495d25b7 typo and phrasing (#8942)
f9c90a0e43242dc8bf3863325edcf2def6ca2369 Diff configs script (#8944)
75ec3f33864ce98df1b89b0973cc67479d7486bc Redefine 1x.extra-small to have 0 requirements. (#8977)
73f9ece8679e85a6d09ad367838b3f7d820af84f [doc] client : ilogtail loki integration (#8970)
b892cade6a87931de96c7dcc03233cb73fa81abb Loki: Fixes incorrect query result when querying with start time == end time (#8979)
edc6b0bff76714ff584c20d7ff0235461a4f4a88 Loki: Add a limit for the [range] value on range queries (#8343)
69d6ee293ee0b8c9de85847a3b0394149615d7f0 tsdb: use unique uploader name while building tsdb index filename, same as boltdb-shipper (#8975)
9159c1dac3ad1e80b9ebf0fe256dbe6dc0b8e903 Loki: Improve spans usage (#8927)
de84737368914fa240108c0a3ef843eb5b5e4d3b Fix fetched chunk from store size in metric (#8971)
e7b0d4d26e4af0968c9d15e6d3e7758fc4c38f27 feat(cos): Support authentication with trusted profiles (#8939)
6bb8a071caf508f2f76b440d84f6eb0c7aea5227 Querier: block query by hash (#8953)
0030cafb167fd70375399599acd8568c9290746e Remove dedupe cache from operations documentation. (#8957)
1bcf683513b5e11fb1dcc5625761b9760cfbd958 Expose optional label matcher for label values handler (#8824)
b97525a448bc6068bb902a475d34a46d9cc6182d [CI/CD] Update yaml file `./production/helm/loki/values.yaml` (+1 other) (#8955)
28a7733edeb6eddff99952b98fcba2121f78ed37 Rename config for enforcing a minimum number of label matchers (#8940)
abc0fd26d2255d670b21d18e305b2d0b69d54af5 Enforce per tenant queue size (#8947)
0adedfa689d73289ec1c8277065253677f892bc3 Revert high cardinality metric in scheduler (#8946)
89996c9714a049877607805d6e53ac6e435c3de6 Promtail WAL support: Implement reader side (#8302)
b76be36e0c69c6c0a76725806986e5f73cebd350 operator: Fix makefile target operatorhub (#8930)
43ae1db14c4f8bc5aeccb8a2db7887189f97f111 Give examples for all cache configurations. (#8832)
d421feafe6c9a480dcfe844adaf6fd6f2a4df8bf Log when returning query-time limit (#8938)
038a7722d6aba68640e662bb946476233ef809e4 Ask users to add node types to the sizing tool. (#8834)
ee045312a9cb5078c4c5663d0ffdf730cc6c1525 Automatically Reorder Pipeline Filters (#8914)
782ffca40931e564d8355bf986c9a236aadfb241 operator: Add missing replaces directives for release v0.2.0 (#8912)
45775c82f79eb52acad7dcb0bc5aa269d6bf4ec5 Implement `RequiredNumberLabels` query limit (#8918)
c81975bd9c1407459267a2c0882fcce809aee3bd operator: Fix calculator dockerfile (#8931)
34486d4ba24a473668e98b4f79bb64272a0905d9 Change mention of 2.7.3 to 2.7.5 in Nomad (#8934)
ee69f2bd37b79230f316bebaccc9d5b6bc7446ad Split index request in 24h intervals (#8909)
f6a3300f872f8dfdebc131c73b43bbd8d49d0f03 [CI/CD] Update yaml file `./production/helm/loki/Chart.yaml` (+1 other) (#8923)
e7e752378f0c5f8abe5767be7574d3c6a9fb7f2d Add release notes for v2.7.5 release (#8924)
035f673e24f58d279857dbcfa051887bd3c4560c Update Loki version to latest (#8926)
6f2aa5fb68a756681caa647a900731abfb8a6082 operator: Update LokiStack annotation on RulerConfig delete (#8911)
ce14592686482a6b757309cf3920c598ab6bbc80 Update version used in production scripts (#8925)
163fd9d8afe862a201fb4e3b3408ee7564b49f1d Short circuit parsing when label matchers are present (#8890)
b3cce9e84b46ec93a1fa36ec7651dc94e965eb2f Update changelog for 2.7.5 release (#8919)
ffb961c439b086136db84b6296d35e376749b09f feat(storage): add support for IBM cloud object storage as storage client (#8826)
336e08fc4b6280f82b9f38bb15ff679819cc4b70 Salvacorts/max querier size messaging (#8916)
44f1d8d7f6b1fb9b7fac32e913bd6517d15bad3f azure: respect retry config before cancelling the context (#8732)
46b7c2cfb6d178dd0a79f093c00efc2f5c0b9490 operator: Prepare community release v0.2.0 (#8651)
c9d5a91206d1b9400cb1972943ec45e6f06dcb23 Ruler: Implement consistent rule evaluation jitter (#8896)
d38d481f355cacc0c68719dda3fb30cbbd94c0e6 Distributor: add detail to stream rates failure (#8900)
4c4c7e3010fae0ae51c9931fd9bd493b06576bd2 Promtail: Fix examples how to build it (#8898)
cba31024d4d0cc5c45612dd051c032f248817729 Extend scheduler queue metrics with enqueue/dequeue counters (#8891)
3344d59fb5256907429a89f4f9f77613767c2353 Extract scheduler queue metrics into separate field
99acb9b34553bbbaaab00b9a7a21126ece53380f operator: Provide community bundle for openshift community hub (#8881)
1c012d6a26c9ebcc8986f16311149e5be921829e Bump actions/setup-go from 3 to 4 (#8837)
17e05d28e4bf4f3a3c382180e4ba0fdb141af26f Promtail: Add a new target for the Azure Event Hub (#8787)
793a689d1ffd78333fe651d81addfaa180ae8886 Iterators: re-implement mergeEntryIterator using loser.Tree for performance (#8637)
3b57ad2a5432f2d13a97b009762e91e8eadd0d2c WAL: remove ePool that is unused (#8669)
3ed9f0c9ef42eb7632bb45e40eeb6f9e0da66129 Canary: support filtering / parsing logs with LogQL (#8871)
4f94b89fdb8b7220a3de77965551b359263ecd36 Loki: Add more spans to write path (#8888)
d24fe3e68be4be16b3654e6aedafaa71ac9d307c Max bytes read limit (#8670)
94725e79084aff513b39d9aa42fafa45d6dfe706 Define `RequiredLabels` query limit. (#8851)
4e893a0a88b2c8c3ea9d1d8b1037f54d8fb7f1af tsdb: sample chunk info from tsdb index to limit the amount of chunkrefs we read from index (#8742)
1549fec2fa050326104731f81d4e930bc6ffb6eb mixins: Normalize headless service name for query-frontend/scheduler (#8880)
93a1c21da5c9d768dc685210bf5e7adff282fe1c operator: Break the API types out into their own module (#8863)
a2370e3af3260e3705061092c0c5e8314d2669ee operator: Refactor all type validations into own package (#8878)
c6c07a827665a735de2d78b1eb2f143f2587ca42 Document how to install Loki and Promtail using APT/DNF. (#8841)
9844fad8b4110a1a706b114335402228599c81d9 Rename LeafQueue to TreeQueue (#8856)
4721d7efd308e7d85fe03464041179bb1414fe8c operator: Remove mutations to non-updatable statefulset fields (#8875)
b8221dc68fb9b4a6a4f8689dedb8ed4e76a5d10d Correcting typos merged in #8870. (#8873)
9d20bed26a3ba40fedef07c48c25debea7fa267c Short circuit parsers (#8724)
01936330f41ef454676d021d6733836bd4f2d88f update on Running Promtail on AWS EC2 tutorial (#8870)
f3309add87df3c1f76a9943b19b973a7781496df operator: Pin go version used in netlify env (#8861)
183fe85f1cc27ad59e8c092f50b3fc531b97271f Loki: Add route_randomly to Redis options (#8852)
528ed22dc2dd4f4e54f0a8cb5ca6fea7b9ff0962 Ruler: remote rule evaluation hardening (#8785)
2d93952929471eb5e6434ebfb719ee89cbc701dd (chore): remove incorrect cache config preample (#8859)
ee371a867df379d36e06e98c0639c899ee719b9d operator: Add support for rules configmap sharding (#7451)
dca859afafc2fea3de8e0b68ac2725a4fe7c19ac operator: Update Dockerfile to go1.20 images (#8857)
5a08a6bcb9ecc816328cb7859bbdcc7cf9d004c5 Label selector optimizations (#8763)
cb8a7440d4539a23ab5137758190f729656a8829 ksonnet/loki: Add gRPC port to compactor mixin (#8855)
b502ee23adb74b31d5467f46289c6cd0c834836c Remove ./tools/fetch-tags invocation from Makefile (#8854)
7d2eeddfb8a6d99a124b57b109df3abb82a761c2 LogQL: Fix panic when using `unpack` with empty line (#8853)
5c3d204ebf5d37b511a79a73505045aab2526557 Ruler: rule evaluation jitter (#8848)
f5f17538517ce1b8e93eab6cc06cd6d8171857a3 Print duration in error messages with more readable. (#8816)
be8b4eece30df592bd8843d3f0f271a8387a4695 Scheduler: Add query fairness control across multiple actors within a tenant (#8752)
3bed7eef55dddfca49251c85844afa286d7fd3ea chore: Fix typo in "tcp" (#8842)
```


#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
