### PR TITLE
Remove labelmap from k8s logs relabeling

### DIFF
--- a/production/tanka/grafana-agent-operator/util/k8slogs.libsonnet
+++ b/production/tanka/grafana-agent-operator/util/k8slogs.libsonnet
@@ -7,9 +7,6 @@ local r = pl.spec.relabelings;
         r.withSourceLabels(['__meta_kubernetes_pod_node_name']) +
         r.withTargetLabel('__host__'),
 
-        r.withAction('labelmap') +
-        r.withRegex('__meta_kubernetes_pod_label_(.+)'),
-
         // r.withAction('replace') +
         // r.withReplacement('$1') +
         // r.withSeparator('/') +


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

The use of `labelmap` in the current agent operator configuration (used by the Grafana Cloud Kubernetes Monitoring application) is causing many users to hit the Loki 15-label limit. This PR removes the use of `labelmap` as surplus configuration.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

Part of https://github.com/grafana/grafana-k8s-plugin/issues/452

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
