### PR TITLE
Remove 32-bit ARM support (revert #3476)

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -371,40 +371,6 @@ trigger:
 type: docker
 ---
 kind: pipeline
-name: Build agent (Linux armv6)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - make generate-ui
-  - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm GOARM=6
-    make agent
-  image: grafana/agent-build-image:0.24.0
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
-name: Build agent (Linux armv7)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - make generate-ui
-  - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm GOARM=7
-    make agent
-  image: grafana/agent-build-image:0.24.0
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
 name: Build agent (Linux ppc64le)
 platform:
   arch: amd64
@@ -528,40 +494,6 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm64 GOARM=
-    make agent-flow
-  image: grafana/agent-build-image:0.24.0
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
-name: Build agent-flow (Linux armv6)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - make generate-ui
-  - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm GOARM=6
-    make agent-flow
-  image: grafana/agent-build-image:0.24.0
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
-name: Build agent-flow (Linux armv7)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - make generate-ui
-  - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm GOARM=7
     make agent-flow
   image: grafana/agent-build-image:0.24.0
   name: Build
@@ -703,40 +635,6 @@ trigger:
 type: docker
 ---
 kind: pipeline
-name: Build agentctl (Linux armv6)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - make generate-ui
-  - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm GOARM=6
-    make agentctl
-  image: grafana/agent-build-image:0.24.0
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
-name: Build agentctl (Linux armv7)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - make generate-ui
-  - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm GOARM=7
-    make agentctl
-  image: grafana/agent-build-image:0.24.0
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
 name: Build agentctl (Linux ppc64le)
 platform:
   arch: amd64
@@ -860,40 +758,6 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm64 GOARM=
-    make operator
-  image: grafana/agent-build-image:0.24.0
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
-name: Build operator (Linux armv6)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - make generate-ui
-  - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm GOARM=6
-    make operator
-  image: grafana/agent-build-image:0.24.0
-  name: Build
-trigger:
-  event:
-  - pull_request
-type: docker
----
-kind: pipeline
-name: Build operator (Linux armv7)
-platform:
-  arch: amd64
-  os: linux
-steps:
-- commands:
-  - make generate-ui
-  - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm GOARM=7
     make operator
   image: grafana/agent-build-image:0.24.0
   name: Build
@@ -1448,6 +1312,6 @@ kind: secret
 name: gpg_passphrase
 ---
 kind: signature
-hmac: 2d20585a6504daf96ca62e5b719192332893313f37c78919a716d6fd9792642d
+hmac: 87903c0d6a95eeeceadf071d21a18984c8daf1b02f39feaf1fe51ca5aba1349b
 
 ...

--- a/.drone/pipelines/crosscompile.jsonnet
+++ b/.drone/pipelines/crosscompile.jsonnet
@@ -12,8 +12,6 @@ local os_arch_tuples = [
   // Linux
   { name: 'Linux amd64', os: 'linux', arch: 'amd64' },
   { name: 'Linux arm64', os: 'linux', arch: 'arm64' },
-  { name: 'Linux armv6', os: 'linux', arch: 'arm', arm: '6' },
-  { name: 'Linux armv7', os: 'linux', arch: 'arm', arm: '7' },
   { name: 'Linux ppc64le', os: 'linux', arch: 'ppc64le' },
   { name: 'Linux s390x', os: 'linux', arch: 's390x' },
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,20 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
+> **NOTE**: As of v0.32.0, builds for 32-bit ARMv6 currently don't support the
+> embedded Flow UI. The Flow UI will return to this target as soon as possible.
+>
+> **NOTE**: The main branch currently doesn't support any 32-bit ARM builds.
+> Support for these builds will return as soon as possible, ideally before
+> v0.33 is released.
+
 Main (unreleased)
 -----------------
 
 ### Breaking changes
+
+- Support for 32-bit ARM builds is temporarily removed. We are aiming to bring
+  back support for these builds prior to publishing v0.33.0. (@rfratto)
 
 - Agent Management: `agent_management.api_url` config field has been replaced by
 `agent_management.host`. The API path and version is now defined by the Agent. (@jcreixell)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ Main (unreleased)
 
 ### Breaking changes
 
-- Support for 32-bit ARM builds is temporarily removed. We are aiming to bring
-  back support for these builds prior to publishing v0.33.0. (@rfratto)
+- Support for 32-bit ARM builds is removed for the foreseeable future due to Go
+  compiler issues. We will consider bringing back 32-bit ARM support once our Go
+  compiler issues are resolved and 32-bit ARM builds are stable. (@rfratto)
 
 - Agent Management: `agent_management.api_url` config field has been replaced by
 `agent_management.host`. The API path and version is now defined by the Agent. (@jcreixell)
@@ -55,7 +56,7 @@ Main (unreleased)
   - `loki.source.azure_event_hubs` reads messages from Azure Event Hub using Kafka and forwards them to other `loki`
     components. (@akselleirv)
   - `discovery.gce` discovers resources on Google Compute Engine (GCE). (@marctc)
-  
+
 
 - Add support for Flow-specific system packages:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,6 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
-> **NOTE**: As of v0.32.0, builds for 32-bit ARMv6 currently don't support the
-> embedded Flow UI. The Flow UI will return to this target as soon as possible.
->
-> **NOTE**: The main branch currently doesn't support any 32-bit ARM builds.
-> Support for these builds will return as soon as possible, ideally before
-> v0.33 is released.
-
 Main (unreleased)
 -----------------
 
@@ -124,8 +117,6 @@ Main (unreleased)
   s390x. (@rfratto)
 
 - Use Go 1.20.3 for builds. (@rfratto)
-
-- Bring back the Flow UI for 32-bit ARMv6 builds. (@rfratto)
 
 - Change the Docker base image for Linux containers to `ubuntu:kinetic`.
   (@rfratto)

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -107,7 +107,7 @@ The Grafana Agent is also capable of exporting to any OpenTelemetry GRPC compati
 
 * Linux
   * Minimum version: kernel 2.6.32 or later
-  * Architectures: AMD64, ARM64, ARMv6, ARMv7
+  * Architectures: AMD64, ARM64
 * Windows
   * Minimum version: Windows Server 2012 or later, or Windows 10 or later.
   * Architectures: AMD64

--- a/docs/sources/set-up/_index.md
+++ b/docs/sources/set-up/_index.md
@@ -22,7 +22,7 @@ The following architectures receive active support.
 
  - macOS: Intel Mac or Apple Silicon
  - Windows: A x64 machine
- - Linux: AMD64, ARM64, ARMv6, or ARMv7 machines
+ - Linux: AMD64 or ARM64 machines
  - FreeBSD: A AMD64 machine
 
 In addition, best-effort support is provided for Linux: ppc64le.

--- a/tools/ci/docker-containers
+++ b/tools/ci/docker-containers
@@ -53,7 +53,7 @@ fi
 
 # Build all of our images.
 
-export BUILD_PLATFORMS=linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x
+export BUILD_PLATFORMS=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
 
 
 case "$TARGET_CONTAINER" in

--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -22,8 +22,6 @@ PACKAGING_VARS = RELEASE_BUILD=1 GO_TAGS="$(GO_TAGS)" GOOS=$(GOOS) GOARCH=$(GOAR
 
 dist-agent-binaries: dist/grafana-agent-linux-amd64       \
                      dist/grafana-agent-linux-arm64       \
-                     dist/grafana-agent-linux-armv6       \
-                     dist/grafana-agent-linux-armv7       \
                      dist/grafana-agent-linux-ppc64le     \
                      dist/grafana-agent-linux-s390x       \
                      dist/grafana-agent-darwin-amd64      \
@@ -67,20 +65,6 @@ dist/grafana-agent-darwin-arm64: GOARCH  := arm64
 dist/grafana-agent-darwin-arm64: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/grafana-agent-linux-armv6: GO_TAGS += builtinassets promtail_journal_enabled
-dist/grafana-agent-linux-armv6: GOOS    := linux
-dist/grafana-agent-linux-armv6: GOARCH  := arm
-dist/grafana-agent-linux-armv6: GOARM   := 6
-dist/grafana-agent-linux-armv6: generate-ui
-	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
-
-dist/grafana-agent-linux-armv7: GO_TAGS += builtinassets promtail_journal_enabled
-dist/grafana-agent-linux-armv7: GOOS    := linux
-dist/grafana-agent-linux-armv7: GOARCH  := arm
-dist/grafana-agent-linux-armv7: GOARM   := 7
-dist/grafana-agent-linux-armv7: generate-ui
-	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
-
 dist/grafana-agent-windows-amd64.exe: GO_TAGS += builtinassets
 dist/grafana-agent-windows-amd64.exe: GOOS    := windows
 dist/grafana-agent-windows-amd64.exe: GOARCH  := amd64
@@ -99,8 +83,6 @@ dist/grafana-agent-freebsd-amd64: generate-ui
 
 dist-agentctl-binaries: dist/grafana-agentctl-linux-amd64       \
                         dist/grafana-agentctl-linux-arm64       \
-                        dist/grafana-agentctl-linux-armv6       \
-                        dist/grafana-agentctl-linux-armv7       \
                         dist/grafana-agentctl-linux-ppc64le     \
                         dist/grafana-agentctl-linux-s390x       \
                         dist/grafana-agentctl-darwin-amd64      \
@@ -116,18 +98,6 @@ dist/grafana-agentctl-linux-amd64:
 dist/grafana-agentctl-linux-arm64: GOOS   := linux
 dist/grafana-agentctl-linux-arm64: GOARCH := arm64
 dist/grafana-agentctl-linux-arm64:
-	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
-
-dist/grafana-agentctl-linux-armv6: GOOS   := linux
-dist/grafana-agentctl-linux-armv6: GOARCH := arm
-dist/grafana-agentctl-linux-armv6: GOARM  := 6
-dist/grafana-agentctl-linux-armv6:
-	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
-
-dist/grafana-agentctl-linux-armv7: GOOS   := linux
-dist/grafana-agentctl-linux-armv7: GOARCH := arm
-dist/grafana-agentctl-linux-armv7: GOARM  := 7
-dist/grafana-agentctl-linux-armv7:
 	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
 
 dist/grafana-agentctl-linux-ppc64le: GOOS   := linux
@@ -261,8 +231,6 @@ AGENT_PACKAGE_PREFIX  := dist/grafana-agent-$(AGENT_PACKAGE_VERSION)-$(AGENT_PAC
 .PHONY: dist-agent-packages
 dist-agent-packages: dist-agent-packages-amd64   \
                      dist-agent-packages-arm64   \
-                     dist-agent-packages-armv6   \
-                     dist-agent-packages-armv7   \
                      dist-agent-packages-ppc64le \
                      dist-agent-packages-s390x
 
@@ -282,24 +250,6 @@ ifeq ($(USE_CONTAINER),1)
 else
 	$(call generate_agent_fpm,deb,arm64,arm64,$(AGENT_PACKAGE_PREFIX).arm64.deb)
 	$(call generate_agent_fpm,rpm,aarch64,arm64,$(AGENT_PACKAGE_PREFIX).arm64.rpm)
-endif
-
-# There's no RPM support for armv6 so only DEBs are produced.
-.PHONY: dist-agent-packages-armv6
-dist-agent-packages-armv6: dist/grafana-agent-linux-armv6 dist/grafana-agentctl-linux-armv6
-ifeq ($(USE_CONTAINER),1)
-	$(RERUN_IN_CONTAINER)
-else
-	$(call generate_agent_fpm,deb,armhf,armv6,$(AGENT_PACKAGE_PREFIX).armv6.deb)
-endif
-
-PHONY: dist-agent-packages-armv7
-dist-agent-packages-armv7: dist/grafana-agent-linux-armv7 dist/grafana-agentctl-linux-armv7
-ifeq ($(USE_CONTAINER),1)
-	$(RERUN_IN_CONTAINER)
-else
-	$(call generate_agent_fpm,deb,armhf,armv7,$(PACKAGE_PREFIX).armv7.deb)
-	$(call generate_agent_fpm,rpm,armhfp,armv7,$(PACKAGE_PREFIX).armv7.rpm)
 endif
 
 .PHONY: dist-agent-packages-ppc64le
@@ -355,8 +305,6 @@ FLOW_PACKAGE_PREFIX  := dist/grafana-agent-flow-$(AGENT_PACKAGE_VERSION)-$(AGENT
 .PHONY: dist-agent-flow-packages
 dist-agent-flow-packages: dist-agent-flow-packages-amd64   \
                           dist-agent-flow-packages-arm64   \
-                          dist-agent-flow-packages-armv6   \
-                          dist-agent-flow-packages-armv7   \
                           dist-agent-flow-packages-ppc64le \
                           dist-agent-flow-packages-s390x
 
@@ -376,24 +324,6 @@ ifeq ($(USE_CONTAINER),1)
 else
 	$(call generate_flow_fpm,deb,arm64,arm64,$(FLOW_PACKAGE_PREFIX).arm64.deb)
 	$(call generate_flow_fpm,rpm,aarch64,arm64,$(FLOW_PACKAGE_PREFIX).arm64.rpm)
-endif
-
-# There's no RPM support for armv6 so only DEBs are produced.
-.PHONY: dist-agent-flow-packages-armv6
-dist-agent-flow-packages-armv6: dist.temp/grafana-agent-flow-linux-armv6
-ifeq ($(USE_CONTAINER),1)
-	$(RERUN_IN_CONTAINER)
-else
-	$(call generate_flow_fpm,deb,armhf,armv6,$(AGENT_PACKAGE_PREFIX).armv6.deb)
-endif
-
-PHONY: dist-agent-packages-armv7
-dist-agent-packages-armv7: dist.temp/grafana-agent-flow-linux-armv7
-ifeq ($(USE_CONTAINER),1)
-	$(RERUN_IN_CONTAINER)
-else
-	$(call generate_flow_fpm,deb,armhf,armv7,$(PACKAGE_PREFIX).armv7.deb)
-	$(call generate_flow_fpm,rpm,armhfp,armv7,$(PACKAGE_PREFIX).armv7.rpm)
 endif
 
 .PHONY: dist-agent-flow-packages-ppc64le


### PR DESCRIPTION
This PR reverts #3476, as we're once again running into compiler issues with 32-bit ARM builds. If a compiler patch is released where 32-bit ARM builds become stable again, we will consider bringing back support, but for now, we need to remove support so we can continue iterating. 