### PR TITLE
packaging: fix user used to run grafana-agent-flow service

### DIFF
--- a/packaging/grafana-agent-flow/deb/grafana-agent-flow.service
+++ b/packaging/grafana-agent-flow/deb/grafana-agent-flow.service
@@ -6,7 +6,7 @@ After=network-online.target
 
 [Service]
 Restart=always
-User=grafana-agent
+User=grafana-agent-flow
 Environment=HOSTNAME=%H
 EnvironmentFile=/etc/default/grafana-agent-flow
 WorkingDirectory=/var/lib/grafana-agent-flow

--- a/packaging/grafana-agent-flow/rpm/grafana-agent-flow.service
+++ b/packaging/grafana-agent-flow/rpm/grafana-agent-flow.service
@@ -6,7 +6,7 @@ After=network-online.target
 
 [Service]
 Restart=always
-User=grafana-agent
+User=grafana-agent-flow
 Environment=HOSTNAME=%H
 EnvironmentFile=/etc/default/grafana-agent-flow
 WorkingDirectory=/var/lib/grafana-agent-flow


### PR DESCRIPTION
The user created by the package is `grafana-agent-flow`, not `grafana-agent`.
