### PR TITLE
ci: repurpose bump-formula-pr action to bump grafana-agent-flow Formula

### DIFF
--- a/.github/workflows/bump-formula-pr.yml
+++ b/.github/workflows/bump-formula-pr.yml
@@ -36,7 +36,7 @@ jobs:
         # Optional, defaults to homebrew/core
         tap: grafana/grafana
         # Formula name, required
-        formula: grafana-agent
+        formula: grafana-agent-flow
         # Optional, will be determined automatically
         tag: ${{github.ref}}
         # Optional, will be determined automatically


### PR DESCRIPTION
The grafana/grafana/grafana-agent Formula was [deprecated][] on 2023-01-08, but the automation to bump it after a Grafana Agent release was left in.

With the introduction of the grafana-agent-flow Formula, we can repurpose the automation to bump that Formula instead.

[deprecated]: https://github.com/grafana/homebrew-grafana/blob/master/grafana-agent.rb