### PR TITLE
drone: remove usage of Docker from test path

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -915,7 +915,6 @@ trigger:
   ref:
   - refs/heads/main
   - refs/tags/v*
-  - refs/heads/dev.*
 type: docker
 volumes:
 - host:
@@ -960,7 +959,6 @@ trigger:
   ref:
   - refs/heads/main
   - refs/tags/v*
-  - refs/heads/dev.*
 type: docker
 volumes:
 - host:
@@ -1005,7 +1003,6 @@ trigger:
   ref:
   - refs/heads/main
   - refs/tags/v*
-  - refs/heads/dev.*
 type: docker
 volumes:
 - host:
@@ -1050,7 +1047,6 @@ trigger:
   ref:
   - refs/heads/main
   - refs/tags/v*
-  - refs/heads/dev.*
 type: docker
 volumes:
 - host:
@@ -1095,7 +1091,6 @@ trigger:
   ref:
   - refs/heads/main
   - refs/tags/v*
-  - refs/heads/dev.*
 type: docker
 volumes:
 - host:
@@ -1125,7 +1120,6 @@ trigger:
   ref:
   - refs/heads/main
   - refs/tags/v*
-  - refs/heads/dev.*
 type: docker
 volumes:
 - host:
@@ -1155,7 +1149,6 @@ trigger:
   ref:
   - refs/heads/main
   - refs/tags/v*
-  - refs/heads/dev.*
 type: docker
 volumes:
 - host:
@@ -1325,6 +1318,6 @@ kind: secret
 name: gpg_passphrase
 ---
 kind: signature
-hmac: b6dde7c72a550d8fea1778471ffd8c8cfeb255124427a2f5e8d0bca691590805
+hmac: fcb2db578d46920304124037a3ffb63024492007b274d134e3ab9810e5bb9499
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -13,12 +13,11 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 trigger:
-  event:
-    include:
-    - pull_request
   paths:
     include:
     - build-image/**
+  ref:
+  - refs/heads/main
 type: docker
 volumes:
 - host:
@@ -74,12 +73,11 @@ steps:
   - name: docker
     path: //./pipe/docker_engine/
 trigger:
-  event:
-    include:
-    - pull_request
   paths:
     include:
     - build-image/**
+  ref:
+  - refs/heads/main
 type: docker
 volumes:
 - host:
@@ -178,6 +176,21 @@ platform:
   os: linux
 steps:
 - commands:
+  - make GO_TAGS="nodocker" test
+  image: grafana/agent-build-image:0.24.0
+  name: Run Go tests
+trigger:
+  event:
+  - pull_request
+type: docker
+---
+kind: pipeline
+name: Test (Full)
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
   - K8S_USE_DOCKER_NETWORK=1 make test
   image: grafana/agent-build-image:0.24.0
   name: Run Go tests
@@ -185,8 +198,8 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 trigger:
-  event:
-  - pull_request
+  ref:
+  - refs/heads/main
 type: docker
 volumes:
 - host:
@@ -223,11 +236,11 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 trigger:
-  event:
-  - pull_request
   paths:
   - cmd/grafana-agent/Dockerfile
   - tools/ci/docker-containers
+  ref:
+  - refs/heads/main
 type: docker
 volumes:
 - host:
@@ -248,11 +261,11 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 trigger:
-  event:
-  - pull_request
   paths:
   - cmd/grafana-agentctl/Dockerfile
   - tools/ci/docker-containers
+  ref:
+  - refs/heads/main
 type: docker
 volumes:
 - host:
@@ -273,11 +286,11 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 trigger:
-  event:
-  - pull_request
   paths:
   - cmd/grafana-agent-operator/Dockerfile
   - tools/ci/docker-containers
+  ref:
+  - refs/heads/main
 type: docker
 volumes:
 - host:
@@ -299,11 +312,11 @@ steps:
   - name: docker
     path: //./pipe/docker_engine/
 trigger:
-  event:
-  - pull_request
   paths:
   - cmd/grafana-agent/Dockerfile.windows
   - tools/ci/docker-containers-windows
+  ref:
+  - refs/heads/main
 type: docker
 volumes:
 - host:
@@ -325,11 +338,11 @@ steps:
   - name: docker
     path: //./pipe/docker_engine/
 trigger:
-  event:
-  - pull_request
   paths:
   - cmd/grafana-agentctl/Dockerfile.windows
   - tools/ci/docker-containers-windows
+  ref:
+  - refs/heads/main
 type: docker
 volumes:
 - host:
@@ -1264,11 +1277,11 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 trigger:
-  event:
-  - pull_request
   paths:
   - packaging/**
   - Makefile
+  ref:
+  - refs/heads/main
 type: docker
 volumes:
 - host:
@@ -1312,6 +1325,6 @@ kind: secret
 name: gpg_passphrase
 ---
 kind: signature
-hmac: 87903c0d6a95eeeceadf071d21a18984c8daf1b02f39feaf1fe51ca5aba1349b
+hmac: b6dde7c72a550d8fea1778471ffd8c8cfeb255124427a2f5e8d0bca691590805
 
 ...

--- a/.drone/pipelines/build_images.jsonnet
+++ b/.drone/pipelines/build_images.jsonnet
@@ -1,8 +1,8 @@
 local pipelines = import '../util/pipelines.jsonnet';
 
 local locals = {
-  on_pr: {
-    event: { include: ['pull_request'] },
+  on_merge: {
+    ref: ['refs/heads/main'],
     paths: { include: ['build-image/**'] },
   },
   on_build_image_tag: {
@@ -17,7 +17,7 @@ local locals = {
 
 [
   pipelines.linux('Check Linux build image') {
-    trigger: locals.on_pr,
+    trigger: locals.on_merge,
     steps: [{
       name: 'Build',
       image: 'docker',
@@ -60,7 +60,7 @@ local locals = {
   },
 
   pipelines.windows('Check Windows build image') {
-    trigger: locals.on_pr,
+    trigger: locals.on_merge,
     steps: [{
       name: 'Build',
       image: 'docker:windowsservercore-1809',

--- a/.drone/pipelines/check_containers.jsonnet
+++ b/.drone/pipelines/check_containers.jsonnet
@@ -15,7 +15,7 @@ local windows_containers = [
 (
   std.map(function(container) pipelines.linux('Check Linux container (%s)' % container.name) {
     trigger: {
-      event: ['pull_request'],
+      ref: ['refs/heads/main'],
       paths: [container.path, 'tools/ci/docker-containers'],
     },
     steps: [{
@@ -37,7 +37,7 @@ local windows_containers = [
 ) + (
   std.map(function(container) pipelines.windows('Check Windows container (%s)' % container.name) {
     trigger: {
-      event: ['pull_request'],
+      ref: ['refs/heads/main'],
       paths: [container.path, 'tools/ci/docker-containers-windows'],
     },
     steps: [{

--- a/.drone/pipelines/publish.jsonnet
+++ b/.drone/pipelines/publish.jsonnet
@@ -11,7 +11,6 @@ local linux_containers_jobs = std.map(function(container) (
       ref: [
         'refs/heads/main',
         'refs/tags/v*',
-        'refs/heads/dev.*',
       ],
     },
     steps: [{
@@ -66,7 +65,6 @@ local windows_containers_jobs = std.map(function(container) (
       ref: [
         'refs/heads/main',
         'refs/tags/v*',
-        'refs/heads/dev.*',
       ],
     },
     steps: [{

--- a/.drone/pipelines/test.jsonnet
+++ b/.drone/pipelines/test.jsonnet
@@ -57,6 +57,20 @@ local pipelines = import '../util/pipelines.jsonnet';
     steps: [{
       name: 'Run Go tests',
       image: build_image.linux,
+
+      commands: [
+        'make GO_TAGS="nodocker" test',
+      ],
+    }],
+  },
+
+  pipelines.linux('Test (Full)') {
+    trigger: {
+      ref: ['refs/heads/main'],
+    },
+    steps: [{
+      name: 'Run Go tests',
+      image: build_image.linux,
       volumes: [{
         name: 'docker',
         path: '/var/run/docker.sock',

--- a/.drone/pipelines/test_packages.jsonnet
+++ b/.drone/pipelines/test_packages.jsonnet
@@ -4,7 +4,7 @@ local pipelines = import '../util/pipelines.jsonnet';
 [
   pipelines.linux('Test Linux system packages') {
     trigger: {
-      event: ['pull_request'],
+      ref: ['refs/heads/main'],
       paths: [
         'packaging/**',
         'Makefile',


### PR DESCRIPTION
Remove the usage of Docker from the test path so CI tests run faster.
