### PR TITLE
remote.http: Add OS to user agent

### DIFF
--- a/component/remote/http/http.go
+++ b/component/remote/http/http.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -19,7 +20,7 @@ import (
 	prom_config "github.com/prometheus/common/config"
 )
 
-var userAgent = fmt.Sprintf("GrafanaAgent/%s", build.Version)
+var userAgent = fmt.Sprintf("GrafanaAgent/%s OS/%s", build.Version, runtime.GOOS)
 
 func init() {
 	component.Register(component.Registration{


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR add the OS version of the client to the user agent. Use case: It would like to use remote.http and moulde.string together.

```hcl
remote.http "config" {
  url = "http://localhost:8000/remote/default.river?hostname=" + env("HOSTNAME")
}

module.string "config" {
  content = remote.http.config.content
}
```

With the OS information inside the user agent, I'm to provide different configs for different operating systems.

Example `User-Agent: GrafanaAgent/remote.http-ua-adb58cc-WIP OS/darwin`

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
