### PR TITLE
remote.http: Add fail_on_error property

### DIFF
--- a/docs/sources/flow/reference/components/remote.http.md
+++ b/docs/sources/flow/reference/components/remote.http.md
@@ -31,6 +31,7 @@ Name | Type | Description | Default | Required
 `poll_frequency` | `duration` | Frequency to poll the URL. | `"1m"` | no
 `poll_timeout` | `duration` | Timeout when polling the URL. | `"10s"` | no
 `is_secret` | `bool` | Whether the response body should be treated as a secret. | false | no
+`fail_on_error` | `bool` | Throw an error, if http connection is not successful | false | no
 
 When `remote.http` performs a poll operation, an HTTP `GET` request is made
 against the URL specified by the `url` argument. A poll is triggered by the


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Currently, `http.remote` always fails silently without any error on log. The error is maybe available on the UI.

In my use-case, if  `http.remote` fails, that should be result into a critical and visible error. If `remote.http` is used together with `module.string`, it could really hard to debug, what the error is.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
