### PR TITLE
Introduce `component.LeastHealthy` utility function and fix bug in module.file

### DIFF
--- a/component/component_health.go
+++ b/component/component_health.go
@@ -101,7 +101,7 @@ func (ht *HealthType) UnmarshalText(text []byte) error {
 // considered to be the least healthy.
 //
 // Health types are first prioritized by [HealthTypeExited], followed by
-// [HealthTypeUnhealthy], [HealthTypeHealthy], and [HealthTypeUnknown].
+// [HealthTypeUnhealthy], [HealthTypeUnknown], and [HealthTypeHealthy].
 //
 // If multiple arguments have the same Health type, the Health with the most
 // recent timestamp is returned.
@@ -117,7 +117,7 @@ func LeastHealthy(h Health, hh ...Health) Health {
 
 	for _, compareHealth := range hh {
 		switch {
-		case compareHealth.Health > leastHealthy.Health:
+		case healthPriority[compareHealth.Health] > healthPriority[leastHealthy.Health]:
 			// Higher health precedence.
 			leastHealthy = compareHealth
 		case compareHealth.Health == leastHealthy.Health:
@@ -129,4 +129,13 @@ func LeastHealthy(h Health, hh ...Health) Health {
 	}
 
 	return leastHealthy
+}
+
+// healthPriority maps a HealthType to its priority; higher numbers means "less
+// healthy."
+var healthPriority = [...]int{
+	HealthTypeHealthy:   0,
+	HealthTypeUnknown:   1,
+	HealthTypeUnhealthy: 2,
+	HealthTypeExited:    3,
 }

--- a/component/component_health.go
+++ b/component/component_health.go
@@ -96,3 +96,37 @@ func (ht *HealthType) UnmarshalText(text []byte) error {
 	}
 	return nil
 }
+
+// LeastHealthy returns the Health from the provided arguments which is
+// considered to be the least healthy.
+//
+// Health types are first prioritized by [HealthTypeExited], followed by
+// [HealthTypeUnhealthy], [HealthTypeHealthy], and [HealthTypeUnknown].
+//
+// If multiple arguments have the same Health type, the Health with the most
+// recent timestamp is returned.
+//
+// Finally, if multiple arguments have the same Health type and the same
+// timestamp, the earlier argument is chosen.
+func LeastHealthy(h Health, hh ...Health) Health {
+	if len(hh) == 0 {
+		return h
+	}
+
+	leastHealthy := h
+
+	for _, compareHealth := range hh {
+		switch {
+		case compareHealth.Health > leastHealthy.Health:
+			// Higher health precedence.
+			leastHealthy = compareHealth
+		case compareHealth.Health == leastHealthy.Health:
+			// Same health precedence; check timestamp.
+			if compareHealth.UpdateTime.After(leastHealthy.UpdateTime) {
+				leastHealthy = compareHealth
+			}
+		}
+	}
+
+	return leastHealthy
+}

--- a/component/component_health_test.go
+++ b/component/component_health_test.go
@@ -52,12 +52,12 @@ func TestMergeHealth(t *testing.T) {
 			expectIndex: 1,
 		},
 		{
-			name: "healthy > unknown",
+			name: "unknown > healthy",
 			healths: []component.Health{{
-				Health:     component.HealthTypeUnknown,
+				Health:     component.HealthTypeHealthy,
 				UpdateTime: jan1,
 			}, {
-				Health:     component.HealthTypeHealthy,
+				Health:     component.HealthTypeUnknown,
 				UpdateTime: jan1,
 			}},
 			expectIndex: 1,
@@ -101,5 +101,4 @@ func TestMergeHealth(t *testing.T) {
 			require.Equal(t, expect, actual)
 		})
 	}
-
 }

--- a/component/component_health_test.go
+++ b/component/component_health_test.go
@@ -1,0 +1,105 @@
+package component_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/component"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeHealth(t *testing.T) {
+	var (
+		jan1 = time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC)
+		jan2 = time.Date(2023, time.January, 2, 0, 0, 0, 0, time.UTC)
+	)
+
+	_ = jan2
+
+	tt := []struct {
+		name        string
+		healths     []component.Health
+		expectIndex int
+	}{
+		{
+			name: "returns first health",
+			healths: []component.Health{{
+				Health:     component.HealthTypeHealthy,
+				UpdateTime: jan1,
+			}},
+			expectIndex: 0,
+		},
+		{
+			name: "exited > unhealthy",
+			healths: []component.Health{{
+				Health:     component.HealthTypeUnhealthy,
+				UpdateTime: jan1,
+			}, {
+				Health:     component.HealthTypeExited,
+				UpdateTime: jan1,
+			}},
+			expectIndex: 1,
+		},
+		{
+			name: "unhealthy > healthy",
+			healths: []component.Health{{
+				Health:     component.HealthTypeHealthy,
+				UpdateTime: jan1,
+			}, {
+				Health:     component.HealthTypeUnhealthy,
+				UpdateTime: jan1,
+			}},
+			expectIndex: 1,
+		},
+		{
+			name: "healthy > unknown",
+			healths: []component.Health{{
+				Health:     component.HealthTypeUnknown,
+				UpdateTime: jan1,
+			}, {
+				Health:     component.HealthTypeHealthy,
+				UpdateTime: jan1,
+			}},
+			expectIndex: 1,
+		},
+		{
+			name: "newer timestamp",
+			healths: []component.Health{{
+				Health:     component.HealthTypeUnhealthy,
+				UpdateTime: jan1,
+			}, {
+				Health:     component.HealthTypeUnhealthy,
+				UpdateTime: jan2,
+			}},
+			expectIndex: 1,
+		},
+		{
+			name: "use first found of matching health type and time",
+			healths: []component.Health{{
+				Health:     component.HealthTypeHealthy,
+				UpdateTime: jan2,
+			}, {
+				Health:     component.HealthTypeUnhealthy,
+				UpdateTime: jan2,
+			}, {
+				Health:     component.HealthTypeUnhealthy,
+				UpdateTime: jan2,
+			}},
+			expectIndex: 1,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			if len(tc.healths) == 0 {
+				panic("Must have at least one health in test case")
+			}
+
+			expect := tc.healths[tc.expectIndex]
+			actual := component.LeastHealthy(tc.healths[0], tc.healths[1:]...)
+
+			require.Equal(t, expect, actual)
+		})
+	}
+
+}

--- a/component/module/file/file.go
+++ b/component/module/file/file.go
@@ -154,7 +154,10 @@ func (c *Component) Handler() http.Handler {
 
 // CurrentHealth implements component.HealthComponent.
 func (c *Component) CurrentHealth() component.Health {
-	return c.mod.CurrentHealth()
+	return component.LeastHealthy(
+		c.managedLocalFile.CurrentHealth(),
+		c.mod.CurrentHealth(),
+	)
 }
 
 // getArgs is a goroutine safe way to get args


### PR DESCRIPTION
This introduces a new function called `component.LeastHealth` which returns the least healthy Health from a list. 

This is useful when there are multiple Health values for a given component, such as with `module.file` containing the health of the managed `local.file` component and its module controller. 

Using this function in `module.file` fixes an issue where the health of `local.file` was never reported, which can be observed by using `module.file` and deleting the file on disk after the agent first loads successfully. 