### PR TITLE
Fixing flaky tests

### DIFF
--- a/component/loki/source/file/file_test.go
+++ b/component/loki/source/file/file_test.go
@@ -2,8 +2,10 @@ package file
 
 import (
 	"context"
+	"errors"
 	"log"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -102,7 +104,6 @@ func TestTwoTargets(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	go c.Run(ctx)
 	time.Sleep(100 * time.Millisecond)
 
@@ -129,4 +130,19 @@ func TestTwoTargets(t *testing.T) {
 	}
 	require.True(t, foundF1)
 	require.True(t, foundF2)
+	cancel()
+	// Verify that positions.yml is written. NOTE: if we didn't wait for it, there would be a race condition between
+	// temporary directory being cleaned up and this file being created.
+	require.Eventually(
+		t,
+		func() bool {
+			if _, err := os.Stat(filepath.Join(opts.DataPath, "positions.yml")); errors.Is(err, os.ErrNotExist) {
+				return false
+			}
+			return true
+		},
+		5*time.Second,
+		10*time.Millisecond,
+		"expected positions.yml file to be written eventually",
+	)
 }

--- a/component/module/file/file.go
+++ b/component/module/file/file.go
@@ -154,10 +154,16 @@ func (c *Component) Handler() http.Handler {
 
 // CurrentHealth implements component.HealthComponent.
 func (c *Component) CurrentHealth() component.Health {
-	return component.LeastHealthy(
+	leastHealthy := component.LeastHealthy(
 		c.managedLocalFile.CurrentHealth(),
 		c.mod.CurrentHealth(),
 	)
+
+	// if both components are healthy - return c.mod's health, so we can have a stable Health.Message.
+	if leastHealthy.Health == component.HealthTypeHealthy {
+		return c.mod.CurrentHealth()
+	}
+	return leastHealthy
 }
 
 // getArgs is a goroutine safe way to get args

--- a/component/module/file/file_test.go
+++ b/component/module/file/file_test.go
@@ -76,24 +76,10 @@ func TestModule(t *testing.T) {
 			)
 
 			require.Equal(t, tc.expectedHealthType, c.CurrentHealth().Health)
-			require.True(
-				t,
-				strings.HasPrefix(c.CurrentHealth().Message, tc.expectedHealthMessagePrefix) ||
-					strings.HasPrefix(c.CurrentHealth().Message, tc.expectedManagedFileHealthMessagePrefix),
-				"expected '%v' to have a prefix of either '%v' or '%v'",
-				c.CurrentHealth().Message,
-				tc.expectedHealthMessagePrefix,
-				tc.expectedHealthMessagePrefix,
-			)
+			requirePrefix(t, c.CurrentHealth().Message, tc.expectedHealthMessagePrefix)
 
 			require.Equal(t, tc.expectedManagedFileHealthType, c.managedLocalFile.CurrentHealth().Health)
-			require.True(
-				t,
-				strings.HasPrefix(c.managedLocalFile.CurrentHealth().Message, tc.expectedManagedFileHealthMessagePrefix),
-				"expected '%v' to have '%v' prefix",
-				c.managedLocalFile.CurrentHealth().Message,
-				tc.expectedManagedFileHealthMessagePrefix,
-			)
+			requirePrefix(t, c.managedLocalFile.CurrentHealth().Message, tc.expectedManagedFileHealthMessagePrefix)
 		})
 	}
 }
@@ -153,4 +139,14 @@ func riverEscape(filePath string) string {
 	}
 
 	return filePath
+}
+
+func requirePrefix(t *testing.T, s string, prefix string) {
+	require.True(
+		t,
+		strings.HasPrefix(s, prefix),
+		"expected '%v' to have '%v' prefix",
+		s,
+		prefix,
+	)
 }

--- a/pkg/util/eventually.go
+++ b/pkg/util/eventually.go
@@ -11,7 +11,7 @@ import (
 var backoffRetry = backoff.Config{
 	MinBackoff: 10 * time.Millisecond,
 	MaxBackoff: 1 * time.Second,
-	MaxRetries: 5,
+	MaxRetries: 10,
 }
 
 // Eventually calls the check function several times until it doesn't report an


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Fixes a few flaky tests:
- `component/loki/source/file/file_test.go` had a race condition on clean up & component creating a file
- `component/module/file/file_test.go` had an issue where health message was not deterministic, leading to test flakiness.
- `Test_serviceManager/can_run_service_binary` fails to dial a local service, potentially not enough time to start up? increased the backoff time.

