### PR TITLE
flow: Add 'write_to' argument to logging block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ Main (unreleased)
 
 - Update Loki Dependency to k146 which includes configurable file watchers (@mattdurham)
 
+- Flow: Allow the `logging` configuration block to tee the Agent's logs to one
+  or more loki components. (@tpaschalis)
+
 ### Bugfixes
 
 - Flow: fix issue where Flow would return an error when trying to access a key

--- a/docs/sources/flow/reference/config-blocks/logging.md
+++ b/docs/sources/flow/reference/config-blocks/logging.md
@@ -25,6 +25,7 @@ Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `level` | `string` | Level at which log lines should be written | `"info"` | no
 `format` | `string` | Format to use for writing log lines | `"logfmt"` | no
+`write_to` | `list(LogsReceiver)` | List of receivers to send log entries to |  | no
 
 ### Log level
 
@@ -43,6 +44,16 @@ The following strings are recognized as valid log line formats:
 * `"json"`: Write logs as JSON objects.
 
 [logfmt]: https://brandur.org/logfmt
+
+### Log receivers
+
+The `write_to` argument allows the Agent to tee its log entries to one or more
+`loki.*` component log receivers in addition to the default [location][].
+This, for example can be the export of a `loki.write` component to ship log
+entries directly to Loki, or a `loki.relabel` component to add a certain label
+first.
+
+[location]: #log-location
 
 ## Log location
 

--- a/pkg/flow/logging/logging_test.go
+++ b/pkg/flow/logging/logging_test.go
@@ -2,9 +2,12 @@ package logging_test
 
 import (
 	"os"
+	"testing"
 
 	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/component/common/loki"
 	"github.com/grafana/agent/pkg/flow/logging"
+	"github.com/stretchr/testify/require"
 )
 
 func Example() {
@@ -41,4 +44,35 @@ func Example() {
 	// component=outer level=info msg="hello from the outer component!"
 	// component=outer/inner level=info msg="hello from the inner component!"
 	// component=outer/inner level=info msg="hello from the inner controller!"
+}
+
+func TestFanoutWriter(t *testing.T) {
+	var (
+		ch1 = make(loki.LogsReceiver)    // unbuffered/blocked channel
+		ch2 loki.LogsReceiver            // nil
+		ch3 = make(loki.LogsReceiver, 2) // buffered channel
+	)
+	sink, err := logging.WriterSink(os.Stdout, logging.SinkOptions{
+		Level:             logging.LevelDebug,
+		Format:            logging.FormatLogfmt,
+		Fanout:            []loki.LogsReceiver{ch1, ch2, ch3},
+		IncludeTimestamps: false,
+	})
+	require.NoError(t, err)
+
+	controller := logging.New(sink)
+
+	level.Info(controller).Log("msg", "first")
+	level.Info(controller).Log("msg", "second")
+
+	e3 := <-ch3
+	require.Equal(t, e3.Line, "level=info msg=first\n")
+	e3 = <-ch3
+	require.Equal(t, e3.Line, "level=info msg=second\n")
+
+	// Read initial entry from the blocked channel
+	go func() {
+		e1 := <-ch1
+		require.Equal(t, e1.Line, "level=info msg=first\n")
+	}()
 }

--- a/pkg/flow/logging/sink_options.go
+++ b/pkg/flow/logging/sink_options.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/component/common/loki"
 	"github.com/grafana/agent/pkg/river"
 )
 
@@ -14,11 +15,12 @@ type SinkOptions struct {
 	Level  Level  `river:"level,attr,optional"`
 	Format Format `river:"format,attr,optional"`
 
+	// Fanout enables the Sink to forward logs to loki.* components.
+	Fanout []loki.LogsReceiver `river:"write_to,attr,optional"`
+
 	// IncludeTimestamps disables timestamps on log lines. It is not exposed as a
 	// river tag as it is only expected to be used during tests.
 	IncludeTimestamps bool
-
-	// TODO: attributes to forward logs to loki.* components.
 }
 
 // DefaultSinkOptions holds defaults for creating a logging sink.


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR adds a `write_to` argument to the special `logging` configuration block so that it can tee off the Agent's own logs to one or more loki.* components' exported receivers.

#### Which issue(s) this PR fixes
Fixes #2700 

#### Notes to the Reviewer
Do you think there should be more docs/examples?

#### PR Checklist

- [X] CHANGELOG updated
- [X] Documentation added
- [X] Tests updated
