### PR TITLE
flow: Add docs around clustering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ Main (unreleased)
 
 - Agent Management: Add support for integration snippets. (@jcreixell)
 
+- Flow: Introduce a gossip-over-HTTP/2 _clustered mode_. `prometheus.scrape`
+  component instances can opt-in to distributing scrape load between cluster
+  peers. (@tpaschalis)
+
 ### Enhancements
 
 - Flow: Add retries with backoff logic to Phlare write component. (@cyriltovena)

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -89,7 +89,7 @@ depending on the nature of the reload error.
 	cmd.Flags().
 		StringVar(&r.clusterJoinAddr, "cluster.advertise-address", r.clusterAdvAddr, "Address to advertise to the cluster")
 	cmd.Flags().
-		StringVar(&r.clusterJoinAddr, "cluster.join-address", r.clusterJoinAddr, "Address to join the cluster at")
+		StringVar(&r.clusterJoinAddr, "cluster.join-addresses", r.clusterJoinAddr, "Comma-separated list of addresses to join the cluster at")
 	cmd.Flags().
 		BoolVar(&r.disableReporting, "disable-reporting", r.disableReporting, "Disable reporting of enabled components to Grafana.")
 	return cmd

--- a/docs/sources/flow/reference/cli/run.md
+++ b/docs/sources/flow/reference/cli/run.md
@@ -31,6 +31,9 @@ The following flags are supported:
 * `--server.http.ui-path-prefix`: Base path where the UI will be exposed (default `/`).
 * `--storage.path`: Base directory where components can store data (default `data-agent/`).
 * `--disable-reporting`: Disable [usage reporting][] of enabled [components][] to Grafana (default `false`).
+* `--cluster.enabled`: Start the Agent in clustered mode (default `false`).
+* `--cluster.join-address string`: Address to join the cluster at (default `""`).
+* `--cluster.advertise-address`: Address to advertise to other cluster nodes (default `""`).
 
 [usage reporting]: {{< relref "../../../static/configuration/flags.md#report-information-usage" >}}
 [components]: {{< relref "../../concepts/components.md" >}}
@@ -52,3 +55,17 @@ All components managed by the component controller are reevaluated after
 reloading.
 
 [component controller]: {{< relref "../../concepts/component_controller.md" >}}
+
+## Clustered mode
+
+When the `--cluster.enabled` command-line argument is provided, Grafana Agent will
+start in _clustered mode_.
+
+The agent tries to connect over HTTP/2 to one or more peers provided in the
+comma-separated `--cluster.join-address` list to join an existing cluster,
+otherwise it falls back to bootstrapping a new cluster on its own.
+
+The agent will advertise its address as `--cluster.advertise-address` to other
+nodes; if this is empty it will attempt to find a suitable address to advertise
+from a list of default network interface. Communication happens over the
+agent's HTTP server that is configured via `--server.http.listen-addr`.

--- a/docs/sources/flow/reference/cli/run.md
+++ b/docs/sources/flow/reference/cli/run.md
@@ -56,7 +56,7 @@ reloading.
 
 [component controller]: {{< relref "../../concepts/component_controller.md" >}}
 
-## Clustered mode
+## Clustered mode (experimental)
 
 When the `--cluster.enabled` command-line argument is provided, Grafana Agent will
 start in _clustered mode_.

--- a/docs/sources/flow/reference/cli/run.md
+++ b/docs/sources/flow/reference/cli/run.md
@@ -32,7 +32,7 @@ The following flags are supported:
 * `--storage.path`: Base directory where components can store data (default `data-agent/`).
 * `--disable-reporting`: Disable [usage reporting][] of enabled [components][] to Grafana (default `false`).
 * `--cluster.enabled`: Start the Agent in clustered mode (default `false`).
-* `--cluster.join-address string`: Address to join the cluster at (default `""`).
+* `--cluster.join-address`: Address to join the cluster at (default `""`).
 * `--cluster.advertise-address`: Address to advertise to other cluster nodes (default `""`).
 
 [usage reporting]: {{< relref "../../../static/configuration/flags.md#report-information-usage" >}}
@@ -62,10 +62,12 @@ When the `--cluster.enabled` command-line argument is provided, Grafana Agent wi
 start in _clustered mode_.
 
 The agent tries to connect over HTTP/2 to one or more peers provided in the
-comma-separated `--cluster.join-address` list to join an existing cluster,
-otherwise it falls back to bootstrapping a new cluster on its own.
+comma-separated `--cluster.join-address` list to join an existing cluster.
+If no connection can be made or the argument is empty, the agent falls back to
+bootstrapping a new cluster of its own.
 
-The agent will advertise its address as `--cluster.advertise-address` to other
-nodes; if this is empty it will attempt to find a suitable address to advertise
-from a list of default network interface. Communication happens over the
-agent's HTTP server that is configured via `--server.http.listen-addr`.
+The agent will advertise its own address as `--cluster.advertise-address` to
+other agent nodes; if this is empty it will attempt to find a suitable address
+to advertise from a list of default network interface. The agent must be
+reachable over HTTP on this address as communication happens over the agent's
+HTTP server.

--- a/docs/sources/flow/reference/cli/run.md
+++ b/docs/sources/flow/reference/cli/run.md
@@ -32,7 +32,7 @@ The following flags are supported:
 * `--storage.path`: Base directory where components can store data (default `data-agent/`).
 * `--disable-reporting`: Disable [usage reporting][] of enabled [components][] to Grafana (default `false`).
 * `--cluster.enabled`: Start the Agent in clustered mode (default `false`).
-* `--cluster.join-address`: Address to join the cluster at (default `""`).
+* `--cluster.join-addresses`: Comma-separated list of addresses to join the cluster at (default `""`).
 * `--cluster.advertise-address`: Address to advertise to other cluster nodes (default `""`).
 
 [usage reporting]: {{< relref "../../../static/configuration/flags.md#report-information-usage" >}}
@@ -62,7 +62,7 @@ When the `--cluster.enabled` command-line argument is provided, Grafana Agent wi
 start in _clustered mode_.
 
 The agent tries to connect over HTTP/2 to one or more peers provided in the
-comma-separated `--cluster.join-address` list to join an existing cluster.
+comma-separated `--cluster.join-addresses` list to join an existing cluster.
 If no connection can be made or the argument is empty, the agent falls back to
 bootstrapping a new cluster of its own.
 

--- a/docs/sources/flow/reference/cli/run.md
+++ b/docs/sources/flow/reference/cli/run.md
@@ -68,6 +68,6 @@ bootstrapping a new cluster of its own.
 
 The agent will advertise its own address as `--cluster.advertise-address` to
 other agent nodes; if this is empty it will attempt to find a suitable address
-to advertise from a list of default network interface. The agent must be
+to advertise from a list of default network interfaces. The agent must be
 reachable over HTTP on this address as communication happens over the agent's
 HTTP server.

--- a/docs/sources/flow/reference/components/prometheus.scrape.md
+++ b/docs/sources/flow/reference/components/prometheus.scrape.md
@@ -89,7 +89,7 @@ an `oauth2` block.
 [authorization]: #authorization-block
 [oauth2]: #oauth2-block
 [tls_config]: #tls_config-block
-[clustering]: #clustering
+[clustering]: #clustering-experimental
 
 ### basic_auth block
 
@@ -107,7 +107,7 @@ an `oauth2` block.
 
 {{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
 
-### clustering
+### clustering (experimental)
 
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
@@ -135,7 +135,7 @@ re-distributed, as only 1/N of the targets ownership is transferred.
 If the agent is _not_ running in clustered mode, then the block is a no-op and
 `prometheus.scrape` scrapes every target it receives in its arguments.
 
-[clustered mode]: {{< relref "../cli/run.md#clustered-mode" >}}
+[clustered mode]: {{< relref "../cli/run.md#clustered-mode-experimental" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/prometheus.scrape.md
+++ b/docs/sources/flow/reference/components/prometheus.scrape.md
@@ -78,6 +78,7 @@ authorization | [authorization][] | Configure generic authorization to targets. 
 oauth2 | [oauth2][] | Configure OAuth2 for authenticating to targets. | no
 oauth2 > tls_config | [tls_config][] | Configure TLS settings for connecting to targets via OAuth2. | no
 tls_config | [tls_config][] | Configure TLS settings for connecting to targets. | no
+clustering | [clustering][] | Configure the component for when the Agent is running in clustered mode | no
 
 The `>` symbol indicates deeper levels of nesting. For example,
 `oauth2 > tls_config` refers to a `tls_config` block defined inside
@@ -88,6 +89,7 @@ an `oauth2` block.
 [authorization]: #authorization-block
 [oauth2]: #oauth2-block
 [tls_config]: #tls_config-block
+[clustering]: #clustering
 
 ### basic_auth block
 
@@ -104,6 +106,36 @@ an `oauth2` block.
 ### tls_config block
 
 {{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+
+### clustering
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`enabled` | `bool` | Enables sharing targets with other cluster nodes.| `false` | yes
+
+When the agent is running in [clustered mode][], and `enabled` is set to true,
+then this `prometheus.scrape` component instance opts-in to participating in
+the cluster to distribute scrape load between all cluster nodes.
+
+Clustering assumes that all cluster nodes are running with the same
+configuration file, have access to the same service discovery APIs and that all
+`prometheus.scrape` components that have opted-in to using clustering are
+receiving the _exact same_ target set from upstream components in their
+`targets` argument.
+
+What happens is that all participating `prometheus.scrape` components use
+target labels and a consistent hashing algorithm to determine ownership for
+each of the targets between the cluster peers. Then, each peer only scrapes the
+subset of targets that it is responsible for, so that the scrape load is
+(nearly) evenly split. When a node joins or leaves the cluster, every peer
+re-calculates ownership and continues scraping with the new target set. This
+performs better than hashmod sharding where _all_ nodes have to be
+re-distributed, as only 1/N of the targets ownership is transferred.
+
+If the agent is _not_ running in clustered mode, then the block is a no-op and
+`prometheus.scrape` scrapes every target it receives in its arguments
+
+[clustered mode]: {{< relref "../cli/run.md#clustered-mode" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/prometheus.scrape.md
+++ b/docs/sources/flow/reference/components/prometheus.scrape.md
@@ -123,14 +123,15 @@ configuration file, have access to the same service discovery APIs and that all
 receiving the _exact same_ target set from upstream components in their
 `targets` argument.
 
-What happens is that all participating `prometheus.scrape` components use
-target labels and a consistent hashing algorithm to determine ownership for
-each of the targets between the cluster peers. Then, each peer only scrapes the
-subset of targets that it is responsible for, so that the scrape load is
-(nearly) evenly split. When a node joins or leaves the cluster, every peer
-re-calculates ownership and continues scraping with the new target set. This
-performs better than hashmod sharding where _all_ nodes have to be
-re-distributed, as only 1/N of the targets ownership is transferred.
+All `prometheus.scrape` components instances opting in to clustering use target
+labels and a consistent hashing algorithm to determine ownership for each of
+the targets between the cluster peers. Then, each peer only scrapes the subset
+of targets that it is responsible for, so that the scrape load is distributed. 
+When a node joins or leaves the cluster, every peer re-calculates ownership and
+continues scraping with the new target set. This performs better than hashmod
+sharding where _all_ nodes have to be re-distributed, as only 1/N of the
+targets ownership is transferred, but is eventually consistent (rather than
+fully consistent like hashmod sharding is).
 
 If the agent is _not_ running in clustered mode, then the block is a no-op and
 `prometheus.scrape` scrapes every target it receives in its arguments.

--- a/docs/sources/flow/reference/components/prometheus.scrape.md
+++ b/docs/sources/flow/reference/components/prometheus.scrape.md
@@ -119,15 +119,15 @@ the cluster to distribute scrape load between all cluster nodes.
 
 Clustering assumes that all cluster nodes are running with the same
 configuration file, have access to the same service discovery APIs and that all
-`prometheus.scrape` components that have opted-in to using clustering are
-receiving the _exact same_ target set from upstream components in their
-`targets` argument.
+`prometheus.scrape` components that have opted-in to using clustering, over
+the course of a scrape interval, are converging on the same target set from
+upstream components in their `targets` argument.
 
 All `prometheus.scrape` components instances opting in to clustering use target
 labels and a consistent hashing algorithm to determine ownership for each of
 the targets between the cluster peers. Then, each peer only scrapes the subset
 of targets that it is responsible for, so that the scrape load is distributed. 
-When a node joins or leaves the cluster, every peer re-calculates ownership and
+When a node joins or leaves the cluster, every peer recalculates ownership and
 continues scraping with the new target set. This performs better than hashmod
 sharding where _all_ nodes have to be re-distributed, as only 1/N of the
 targets ownership is transferred, but is eventually consistent (rather than

--- a/docs/sources/flow/reference/components/prometheus.scrape.md
+++ b/docs/sources/flow/reference/components/prometheus.scrape.md
@@ -78,7 +78,7 @@ authorization | [authorization][] | Configure generic authorization to targets. 
 oauth2 | [oauth2][] | Configure OAuth2 for authenticating to targets. | no
 oauth2 > tls_config | [tls_config][] | Configure TLS settings for connecting to targets via OAuth2. | no
 tls_config | [tls_config][] | Configure TLS settings for connecting to targets. | no
-clustering | [clustering][] | Configure the component for when the Agent is running in clustered mode | no
+clustering | [clustering][] | Configure the component for when the Agent is running in clustered mode. | no
 
 The `>` symbol indicates deeper levels of nesting. For example,
 `oauth2 > tls_config` refers to a `tls_config` block defined inside
@@ -111,7 +111,7 @@ an `oauth2` block.
 
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`enabled` | `bool` | Enables sharing targets with other cluster nodes.| `false` | yes
+`enabled` | `bool` | Enables sharing targets with other cluster nodes. | `false` | yes
 
 When the agent is running in [clustered mode][], and `enabled` is set to true,
 then this `prometheus.scrape` component instance opts-in to participating in
@@ -133,7 +133,7 @@ performs better than hashmod sharding where _all_ nodes have to be
 re-distributed, as only 1/N of the targets ownership is transferred.
 
 If the agent is _not_ running in clustered mode, then the block is a no-op and
-`prometheus.scrape` scrapes every target it receives in its arguments
+`prometheus.scrape` scrapes every target it receives in its arguments.
 
 [clustered mode]: {{< relref "../cli/run.md#clustered-mode" >}}
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR adds some documentation around clustering, the new cli args that can enable it as well as the single component that can opt-in to using it (prometheus.scrape).

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer
Nothing in particular.

#### PR Checklist

- [x] CHANGELOG updated
- [X] Documentation added
- [ ] Tests updated (N/A)
