### PR TITLE
docs: fix page title for cli/fmt.md

### DIFF
--- a/docs/sources/flow/reference/cli/fmt.md
+++ b/docs/sources/flow/reference/cli/fmt.md
@@ -1,5 +1,5 @@
 ---
-title: agent fmt
+title: grafana-agent fmt
 weight: 100
 ---
 


### PR DESCRIPTION
The title page was not consistent with the `run` command.

![Screenshot 2023-04-20 at 12 36 23](https://user-images.githubusercontent.com/17771679/233326104-f39446ed-92f5-431a-9200-9b2cfe8848f1.png)
