### PR TITLE
[Agent Management] Move `agent_management.remote_config_cache_location`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Main (unreleased)
 
 - Agent Management: `agent_management.protocol` config field now allows defining "http" and "https" explicitly. Previously, "http" was previously used for both, with the actual protocol used inferred from the api url, which led to confusion. When upgrading, make sure to set to "https" when replacing `api_url` with `host`. (@jcreixell)
 
+- Agent Management: `agent_management.remote_config_cache_location` config field has been replaced by
+`agent_management.remote_configuration.cache_location`. (@jcreixell)
+
 ### Deprecations
 
 - [Dynamic Configuration](https://grafana.com/docs/agent/latest/cookbook/dynamic-configuration/) will be removed in v0.34. Grafana Agent Flow supersedes this functionality. (@mattdurham)

--- a/pkg/config/agentmanagement.go
+++ b/pkg/config/agentmanagement.go
@@ -75,7 +75,7 @@ func initialConfigHashCheck(initialConfig AgentManagementConfig, configCache rem
 // GetCachedRemoteConfig retrieves the cached remote config from the location specified
 // in r.AgentManagement.CacheLocation
 func (r remoteConfigHTTPProvider) GetCachedRemoteConfig() ([]byte, error) {
-	cachePath := filepath.Join(r.InitialConfig.CacheLocation, cacheFilename)
+	cachePath := filepath.Join(r.InitialConfig.RemoteConfiguration.CacheLocation, cacheFilename)
 
 	var configCache remoteConfigCache
 	buf, err := os.ReadFile(cachePath)
@@ -98,7 +98,7 @@ func (r remoteConfigHTTPProvider) GetCachedRemoteConfig() ([]byte, error) {
 // CacheRemoteConfig caches the remote config to the location specified in
 // r.AgentManagement.CacheLocation
 func (r remoteConfigHTTPProvider) CacheRemoteConfig(remoteConfigBytes []byte) error {
-	cachePath := filepath.Join(r.InitialConfig.CacheLocation, cacheFilename)
+	cachePath := filepath.Join(r.InitialConfig.RemoteConfiguration.CacheLocation, cacheFilename)
 	initialConfigHash, err := hashInitialConfig(*r.InitialConfig)
 	if err != nil {
 		return err
@@ -152,8 +152,9 @@ func (r remoteConfigHTTPProvider) FetchRemoteConfig() ([]byte, error) {
 type labelMap map[string]string
 
 type RemoteConfiguration struct {
-	Labels    labelMap `yaml:"labels"`
-	Namespace string   `yaml:"namespace"`
+	Labels        labelMap `yaml:"labels"`
+	Namespace     string   `yaml:"namespace"`
+	CacheLocation string   `yaml:"cache_location"`
 }
 
 type AgentManagementConfig struct {
@@ -162,7 +163,6 @@ type AgentManagementConfig struct {
 	BasicAuth       config.BasicAuth `yaml:"basic_auth"`
 	Protocol        string           `yaml:"protocol"`
 	PollingInterval time.Duration    `yaml:"polling_interval"`
-	CacheLocation   string           `yaml:"remote_config_cache_location"`
 
 	RemoteConfiguration RemoteConfiguration `yaml:"remote_configuration"`
 }
@@ -291,8 +291,8 @@ func (am *AgentManagementConfig) Validate() error {
 		return errors.New("namespace must be specified in 'remote_configuration' block of the config")
 	}
 
-	if am.CacheLocation == "" {
-		return errors.New("path to cache must be specified in 'agent_management.remote_config_cache_location'")
+	if am.RemoteConfiguration.CacheLocation == "" {
+		return errors.New("path to cache must be specified in 'remote_configuration.cache_location'")
 	}
 
 	return nil

--- a/pkg/config/agentmanagement.go
+++ b/pkg/config/agentmanagement.go
@@ -292,7 +292,7 @@ func (am *AgentManagementConfig) Validate() error {
 	}
 
 	if am.RemoteConfiguration.CacheLocation == "" {
-		return errors.New("path to cache must be specified in 'remote_configuration.cache_location'")
+		return errors.New("path to cache must be specified in 'agent_management.remote_configuration.cache_location'")
 	}
 
 	return nil

--- a/pkg/config/agentmanagement_test.go
+++ b/pkg/config/agentmanagement_test.go
@@ -57,10 +57,10 @@ var validAgentManagementConfig = AgentManagementConfig{
 	},
 	Protocol:        "https",
 	PollingInterval: time.Minute,
-	CacheLocation:   "/test/path/",
 	RemoteConfiguration: RemoteConfiguration{
-		Labels:    labelMap{"b": "B", "a": "A"},
-		Namespace: "test_namespace",
+		Labels:        labelMap{"b": "B", "a": "A"},
+		Namespace:     "test_namespace",
+		CacheLocation: "/test/path/",
 	},
 }
 
@@ -77,9 +77,9 @@ func TestValidateInvalidBasicAuth(t *testing.T) {
 		BasicAuth:       config.BasicAuth{},
 		Protocol:        "https",
 		PollingInterval: time.Minute,
-		CacheLocation:   "/test/path/",
 		RemoteConfiguration: RemoteConfiguration{
-			Namespace: "test_namespace",
+			Namespace:     "test_namespace",
+			CacheLocation: "/test/path/",
 		},
 	}
 	assert.Error(t, invalidConfig.Validate())
@@ -116,9 +116,9 @@ basic_auth:
   username: "initial_user"
 protocol: "http"
 polling_interval: "1m"
-remote_config_cache_location: "/etc"
 remote_configuration:
-  namespace: "new_namespace"`
+  namespace: "new_namespace"
+  cache_location:  "/etc"`
 
 	var am AgentManagementConfig
 	yaml.Unmarshal([]byte(cfg), &am)
@@ -180,10 +180,10 @@ func TestNewRemoteConfigProvider_ValidInitialConfig(t *testing.T) {
 		},
 		Protocol:        "https",
 		PollingInterval: time.Minute,
-		CacheLocation:   "/test/path/",
 		RemoteConfiguration: RemoteConfiguration{
-			Labels:    labelMap{"b": "B", "a": "A"},
-			Namespace: "test_namespace",
+			Labels:        labelMap{"b": "B", "a": "A"},
+			Namespace:     "test_namespace",
+			CacheLocation: "/test/path/",
 		},
 	}
 
@@ -204,10 +204,10 @@ func TestNewRemoteConfigProvider_InvalidProtocol(t *testing.T) {
 		},
 		Protocol:        "ws",
 		PollingInterval: time.Minute,
-		CacheLocation:   "/test/path/",
 		RemoteConfiguration: RemoteConfiguration{
-			Labels:    labelMap{"b": "B", "a": "A"},
-			Namespace: "test_namespace",
+			Labels:        labelMap{"b": "B", "a": "A"},
+			Namespace:     "test_namespace",
+			CacheLocation: "/test/path/",
 		},
 	}
 
@@ -228,10 +228,10 @@ func TestNewRemoteConfigHTTPProvider_InvalidInitialConfig(t *testing.T) {
 		},
 		Protocol:        "https",
 		PollingInterval: time.Minute,
-		CacheLocation:   "/test/path/",
 		RemoteConfiguration: RemoteConfiguration{
-			Labels:    labelMap{"b": "B", "a": "A"},
-			Namespace: "test_namespace",
+			Labels:        labelMap{"b": "B", "a": "A"},
+			Namespace:     "test_namespace",
+			CacheLocation: "/test/path/",
 		},
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -473,9 +473,9 @@ agent_management:
     username: "initial_user"
   protocol: "http"
   polling_interval: "1m"
-  remote_config_cache_location: "/etc"
   remote_configuration:
-    namespace: "new_namespace"`
+    namespace: "new_namespace"
+    cache_location: "/etc"`
 
 	remoteCfg := `
 server:
@@ -493,9 +493,9 @@ agent_management:
     username: "new_user"
   protocol: "http"
   polling_interval: "10s"
-  remote_config_cache_location: "/etc"
   remote_configuration:
-    namespace: "new_namespace"`
+    namespace: "new_namespace"
+    cache_location: "/etc"`
 
 	var ic, rc Config
 	err := LoadBytes([]byte(initialCfg), false, &ic)


### PR DESCRIPTION
#### PR Description

  - Moves remote_config_cache_location config field under remote_configuration section.
  - Since we have a remote_config section, all fields specifically related to it should go there.

#### Notes to the Reviewer

  - Although this is a breaking change and last minute before the next rc, I think it is worth doing since we can bundle it together with other breaking changes to the config.

#### PR Checklist

- [x] CHANGELOG updated
- [x] Tests updated
