### PR TITLE
Fix README doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ Check out our [documentation][] to see:
 * The list of Grafana Agent Flow [Components][]
 
 [documentation]: https://grafana.com/docs/agent/latest/
-[Installation instructions]: https://grafana.com/docs/agent/latest/set-up/
+[Installation instructions]: https://grafana.com/docs/agent/latest/flow/install/
 [Grafana Agent Flow]: https://grafana.com/docs/agent/latest/flow/
-[Getting started]: https://grafana.com/docs/agent/latest/flow/getting_started/
+[Getting started]: https://grafana.com/docs/agent/latest/flow/getting-started/
 [Components]: https://grafana.com/docs/agent/latest/flow/reference/components/
 
 ## Example


### PR DESCRIPTION
_After_ the v0.33 release is out and the docs revamp gets published as `latest` we should change this link to point to the Flow installation docs instead (as our README basically is all about Flow).