### PR TITLE
Do not use hard-coded `kill` command path

### DIFF
--- a/packaging/grafana-agent-flow/deb/grafana-agent-flow.service
+++ b/packaging/grafana-agent-flow/deb/grafana-agent-flow.service
@@ -11,7 +11,7 @@ Environment=HOSTNAME=%H
 EnvironmentFile=/etc/default/grafana-agent-flow
 WorkingDirectory=/var/lib/grafana-agent-flow
 ExecStart=/usr/bin/grafana-agent-flow run $CUSTOM_ARGS --storage.path=/var/lib/grafana-agent-flow $CONFIG_FILE
-ExecReload=/usr/bin/kill -HUP $MAINPID
+ExecReload=/usr/bin/env kill -HUP $MAINPID
 TimeoutStopSec=20s
 SendSIGKILL=no
 

--- a/packaging/grafana-agent-flow/rpm/grafana-agent-flow.service
+++ b/packaging/grafana-agent-flow/rpm/grafana-agent-flow.service
@@ -11,7 +11,7 @@ Environment=HOSTNAME=%H
 EnvironmentFile=/etc/default/grafana-agent-flow
 WorkingDirectory=/var/lib/grafana-agent-flow
 ExecStart=/usr/bin/grafana-agent-flow run $CUSTOM_ARGS --storage.path=/var/lib/grafana-agent-flow $CONFIG_FILE
-ExecReload=/usr/bin/kill -HUP $MAINPID
+ExecReload=/usr/bin/env kill -HUP $MAINPID
 TimeoutStopSec=20s
 SendSIGKILL=no
 

--- a/packaging/grafana-agent/deb/grafana-agent.service
+++ b/packaging/grafana-agent/deb/grafana-agent.service
@@ -11,7 +11,7 @@ Environment=HOSTNAME=%H
 EnvironmentFile=/etc/default/grafana-agent
 WorkingDirectory=/var/lib/grafana-agent
 ExecStart=/usr/bin/grafana-agent --config.file $CONFIG_FILE $CUSTOM_ARGS
-ExecReload=/usr/bin/kill -HUP $MAINPID
+ExecReload=/usr/bin/env kill -HUP $MAINPID
 # If running the Agent in scraping service mode, you will want to override this value with
 # something larger to allow the Agent to gracefully leave the cluster. 4800s is recommend.
 TimeoutStopSec=20s

--- a/packaging/grafana-agent/rpm/grafana-agent.service
+++ b/packaging/grafana-agent/rpm/grafana-agent.service
@@ -11,7 +11,7 @@ Environment=HOSTNAME=%H
 EnvironmentFile=/etc/sysconfig/grafana-agent
 WorkingDirectory=/var/lib/grafana-agent
 ExecStart=/usr/bin/grafana-agent --config.file $CONFIG_FILE $CUSTOM_ARGS
-ExecReload=/usr/bin/kill -HUP $MAINPID
+ExecReload=/usr/bin/env kill -HUP $MAINPID
 # If running the Agent in scraping service mode, you will want to override this value with
 # something larger to allow the Agent to gracefully leave the cluster. 4800s is recommend.
 TimeoutStopSec=20s


### PR DESCRIPTION
#### PR Description

The current systemd unit file specifies `/usr/bin/kill` for the `kill` command. The command isn't always placed in that location. It's best to call the command using `/usr/bin/env kill` to always receive the path to the actual location of the command.

#### Which issue(s) this PR fixes
N/A

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
