### PR TITLE
Support in-memory HTTP connections for scraping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Main (unreleased)
   components will now export a target containing an internal HTTP address.
   `prometheus.scrape`, when given that internal HTTP address, will connect to
   the server in-memory, bypassing the network stack. Use the new
-  `--server.http.memory-address` flag to customize which address is used for
+  `--server.http.memory-addr` flag to customize which address is used for
   in-memory traffic. (@rfratto)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,24 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Enhancements
+
+- Support in-memory HTTP traffic for Flow components. `prometheus.exporter`
+  components will now export a target containing an internal HTTP address.
+  `prometheus.scrape`, when given that internal HTTP address, will connect to
+  the server in-memory, bypassing the network stack. Use the new
+  `--server.http.memory-address` flag to customize which address is used for
+  in-memory traffic. (@rfratto)
+
+
 v0.33.0-rc.1 (2023-04-21)
 -------------------------
+
 ### Bugfixes
+
 - Fix bug introduced to operator when FilterRunning not specified in PodMonitors. (@captncraig)
 
 - Remove `otelcol.processor.attributes`. (@ptodev)
-
 
 v0.33.0-rc.0 (2023-04-20)
 -------------------------
@@ -112,7 +123,7 @@ v0.33.0-rc.0 (2023-04-20)
 
 - Agent Management: Introduces backpressure mechanism for remote config fetching (obeys 429 request
   `Retry-After` header). (@spartan0x117)
-  
+
 - Flow: support client TLS settings (CA, client certificate, client key) being
   provided from other components for the following components:
 

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -269,7 +269,7 @@ func (fr *flowRun) Run(configFile string) error {
 				defer cancel()
 
 				if err := srv.Serve(lis); err != nil {
-					level.Info(l).Log("msg", "http server closed", "err", err)
+					level.Info(l).Log("msg", "http server closed", "addr", lis.Addr(), "err", err)
 				}
 			}(lis)
 		}

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/grafana/agent/web/api"
 	"github.com/grafana/agent/web/ui"
+	"github.com/rfratto/ckit/memconn"
 	"go.opentelemetry.io/otel"
 	"golang.org/x/exp/maps"
 	"golang.org/x/net/http2"
@@ -40,6 +41,7 @@ import (
 
 func runCommand() *cobra.Command {
 	r := &flowRun{
+		inMemoryAddr:     "agent.internal:12345",
 		httpListenAddr:   "127.0.0.1:12345",
 		storagePath:      "data-agent/",
 		uiPrefix:         "/",
@@ -82,6 +84,7 @@ depending on the nature of the reload error.
 
 	cmd.Flags().
 		StringVar(&r.httpListenAddr, "server.http.listen-addr", r.httpListenAddr, "Address to listen for HTTP traffic on")
+	cmd.Flags().StringVar(&r.inMemoryAddr, "server.http.memory-addr", r.inMemoryAddr, "Address to listen for in-memory HTTP traffic on. Change if it collides with a real address")
 	cmd.Flags().StringVar(&r.storagePath, "storage.path", r.storagePath, "Base directory where components can store data")
 	cmd.Flags().StringVar(&r.uiPrefix, "server.http.ui-path-prefix", r.uiPrefix, "Prefix to serve the HTTP UI at")
 	cmd.Flags().
@@ -96,6 +99,7 @@ depending on the nature of the reload error.
 }
 
 type flowRun struct {
+	inMemoryAddr     string
 	httpListenAddr   string
 	storagePath      string
 	uiPrefix         string
@@ -155,6 +159,9 @@ func (fr *flowRun) Run(configFile string) error {
 		return fmt.Errorf("building clusterer: %w", err)
 	}
 
+	// In-memory listener, used for inner HTTP traffic without the network.
+	memLis := memconn.NewListener(nil)
+
 	f := flow.New(flow.Options{
 		LogSink:        logSink,
 		Tracer:         t,
@@ -162,7 +169,17 @@ func (fr *flowRun) Run(configFile string) error {
 		DataPath:       fr.storagePath,
 		Reg:            reg,
 		HTTPPathPrefix: "/api/v0/component/",
-		HTTPListenAddr: fr.httpListenAddr,
+		HTTPListenAddr: fr.inMemoryAddr,
+
+		// Send requests to fr.inMemoryAddr directly to our in-memory listener.
+		DialFunc: func(ctx context.Context, network, address string) (net.Conn, error) {
+			switch address {
+			case fr.inMemoryAddr:
+				return memLis.DialContext(ctx)
+			default:
+				return (&net.Dialer{}).DialContext(ctx, network, address)
+			}
+		},
 	})
 
 	reload := func() error {
@@ -190,7 +207,8 @@ func (fr *flowRun) Run(configFile string) error {
 
 	// HTTP server
 	{
-		lis, err := net.Listen("tcp", fr.httpListenAddr)
+		// Network listener.
+		netLis, err := net.Listen("tcp", fr.httpListenAddr)
 		if err != nil {
 			return fmt.Errorf("failed to listen on %s: %w", fr.httpListenAddr, err)
 		}
@@ -241,16 +259,20 @@ func (fr *flowRun) Run(configFile string) error {
 
 		srv := &http.Server{Handler: h2c.NewHandler(r, &http2.Server{})}
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			defer cancel()
+		level.Info(l).Log("msg", "now listening for http traffic", "addr", fr.httpListenAddr)
 
-			level.Info(l).Log("msg", "now listening for http traffic", "addr", fr.httpListenAddr)
-			if err := srv.Serve(lis); err != nil {
-				level.Info(l).Log("msg", "http server closed", "err", err)
-			}
-		}()
+		listeners := []net.Listener{netLis, memLis}
+		for _, lis := range listeners {
+			wg.Add(1)
+			go func(lis net.Listener) {
+				defer wg.Done()
+				defer cancel()
+
+				if err := srv.Serve(lis); err != nil {
+					level.Info(l).Log("msg", "http server closed", "err", err)
+				}
+			}(lis)
+		}
 
 		defer func() { _ = srv.Shutdown(ctx) }()
 	}

--- a/component/prometheus/scrape/scrape.go
+++ b/component/prometheus/scrape/scrape.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/agent/component/prometheus"
 	"github.com/grafana/agent/pkg/build"
 	client_prometheus "github.com/prometheus/client_golang/prometheus"
+	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -135,7 +136,12 @@ var (
 // New creates a new prometheus.scrape component.
 func New(o component.Options, args Arguments) (*Component, error) {
 	flowAppendable := prometheus.NewFanout(args.ForwardTo, o.ID, o.Registerer)
-	scrapeOptions := &scrape.Options{ExtraMetrics: args.ExtraMetrics}
+	scrapeOptions := &scrape.Options{
+		ExtraMetrics: args.ExtraMetrics,
+		HTTPClientOptions: []config_util.HTTPClientOption{
+			config_util.WithDialContextFunc(o.DialFunc),
+		},
+	}
 	scraper := scrape.NewManager(scrapeOptions, o.Logger, flowAppendable)
 
 	targetsGauge := client_prometheus.NewGauge(client_prometheus.GaugeOpts{

--- a/component/prometheus/scrape/scrape_test.go
+++ b/component/prometheus/scrape/scrape_test.go
@@ -2,16 +2,21 @@ package scrape
 
 import (
 	"context"
+	"net"
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus"
+	"github.com/grafana/agent/pkg/cluster"
 	"github.com/grafana/agent/pkg/river"
 	"github.com/grafana/agent/pkg/util"
 	prometheus_client "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/rfratto/ckit/memconn"
 	"github.com/stretchr/testify/require"
 )
 
@@ -110,4 +115,59 @@ func TestForwardingToAppendable(t *testing.T) {
 	require.Equal(t, receivedTs, timestamp)
 	require.Len(t, receivedSamples, 1)
 	require.Equal(t, receivedSamples, sample)
+}
+
+// TestCustomDialer ensures that prometheus.scrape respects the custom dialer
+// given to it.
+func TestCustomDialer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var (
+		reg        = prometheus_client.NewRegistry()
+		regHandler = promhttp.HandlerFor(reg, promhttp.HandlerOpts{})
+
+		scrapeTrigger = util.NewWaitTrigger()
+
+		srv = &http.Server{
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				scrapeTrigger.Trigger()
+				regHandler.ServeHTTP(w, r)
+			}),
+		}
+
+		memLis = memconn.NewListener(util.TestLogger(t))
+	)
+
+	go srv.Serve(memLis)
+	defer srv.Shutdown(ctx)
+
+	var config = `
+	targets         = [{ __address__ = "inmemory:80" }]
+	forward_to      = []
+	scrape_interval = "100ms"
+	scrape_timeout  = "85ms"
+	`
+	var args Arguments
+	err := river.Unmarshal([]byte(config), &args)
+	require.NoError(t, err)
+
+	opts := component.Options{
+		Logger: util.TestFlowLogger(t),
+		Clusterer: &cluster.Clusterer{
+			Node: cluster.NewLocalNode("inmemory:80"),
+		},
+		Registerer: prometheus_client.NewRegistry(),
+		DialFunc: func(ctx context.Context, network, address string) (net.Conn, error) {
+			return memLis.DialContext(ctx)
+		},
+	}
+
+	s, err := New(opts, args)
+	require.NoError(t, err)
+	go s.Run(ctx)
+
+	// Wait for our scrape to be invoked.
+	err = scrapeTrigger.Wait(1 * time.Minute)
+	require.NoError(t, err, "custom dialer was not used")
 }

--- a/component/registry.go
+++ b/component/registry.go
@@ -1,7 +1,9 @@
 package component
 
 import (
+	"context"
 	"fmt"
+	"net"
 	"reflect"
 	"strings"
 
@@ -70,8 +72,14 @@ type Options struct {
 	// HTTPListenAddr is the address the server is configured to listen on.
 	HTTPListenAddr string
 
-	// HTTPPath is the base path that requests need in order to route to this component.
-	// Requests received by a component handler will have this already trimmed off.
+	// DialFunc is a function for components to use to properly communicate to
+	// HTTPListenAddr. If set, components which send HTTP requests to
+	// HTTPListenAddr must use this function to establish connections.
+	DialFunc func(ctx context.Context, network, address string) (net.Conn, error)
+
+	// HTTPPath is the base path that requests need in order to route to this
+	// component. Requests received by a component handler will have this already
+	// trimmed off.
 	HTTPPath string
 }
 

--- a/docs/sources/flow/concepts/component_controller.md
+++ b/docs/sources/flow/concepts/component_controller.md
@@ -106,6 +106,24 @@ This prevents failure propagation: if your `local.file` component which watches
 API keys suddenly stops working, other components continues using the last
 valid API key until the component returns to a healthy state.
 
+## In-memory traffic
+
+Components which expose HTTP endpoints, such as [prometheus.exporter.unix][],
+can expose an internal address which will completely bypass the network and
+communicate in-memory. This allows components within the same process to
+communicate with one another without needing to be aware of any network-level
+protections such as authentication or mutual TLS.
+
+The internal address defaults to `agent.internal:12345`. If this address
+collides with a real target on your network, change it to something unique
+using the `--server.http.memory-addr` flag in the [run][] command.
+
+Components must opt-in to using in-memory traffic; see the individual
+documentation for components to learn if in-memory traffic is supported.
+
+[prometheus.exporter.unix]: {{< relref "../reference/components/prometheus.exporter.unix.md" >}}
+[run]: {{< relref "../reference/cli/run.md" >}}
+
 ## Updating the config file
 
 Both the `/-/reload` HTTP endpoint and the `SIGHUP` signal can be used to

--- a/docs/sources/flow/reference/cli/run.md
+++ b/docs/sources/flow/reference/cli/run.md
@@ -27,6 +27,8 @@ running components.
 
 The following flags are supported:
 
+* `--server.http.memory-addr`: Address to listen for [in-memory HTTP traffic][] on
+  (default `agent.internal:12345`).
 * `--server.http.listen-addr`: Address to listen for HTTP traffic on (default `127.0.0.1:12345`).
 * `--server.http.ui-path-prefix`: Base path where the UI will be exposed (default `/`).
 * `--storage.path`: Base directory where components can store data (default `data-agent/`).
@@ -35,6 +37,7 @@ The following flags are supported:
 * `--cluster.join-addresses`: Comma-separated list of addresses to join the cluster at (default `""`).
 * `--cluster.advertise-address`: Address to advertise to other cluster nodes (default `""`).
 
+[in-memory HTTP traffic]: {{< relref "../../concepts/component_controller.md#in-memory-traffic" >}}
 [usage reporting]: {{< relref "../../../static/configuration/flags.md#report-information-usage" >}}
 [components]: {{< relref "../../concepts/components.md" >}}
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.apache.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.apache.md
@@ -41,6 +41,12 @@ For example, the `targets` can either be passed to a `prometheus.relabel`
 component to rewrite the metric's label set, or to a `prometheus.scrape`
 component that collects the exposed metrics.
 
+The exported targets will use the configured [in-memory traffic][] address
+specified by the [run command][].
+
+[in-memory traffic]: {{< relref "../../concepts/component_controller.md#in-memory-traffic" >}}
+[run command]: {{< relref "../cli/run.md" >}}
+
 ## Component health
 
 `prometheus.exporter.apache` is only reported as unhealthy if given

--- a/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
@@ -18,11 +18,11 @@ The `prometheus.exporter.blackbox` component embeds
 ```river
 prometheus.exporter.blackbox "LABEL" {
   config_file = "PATH_BLACKBOX_CONFIG_FILE"
-  
+
   target "TARGET_NAME" {
-    address = "TARGET_ADDRESS" 
+    address = "TARGET_ADDRESS"
   }
-  
+
   ...
 }
 ```
@@ -37,7 +37,7 @@ Name | Type | Description | Default | Required
 `config`                      | `string`       | blackbox_exporter configuration as inline string.  | |no
 `probe_timeout_offset`        | `duration`     | Offset in seconds to subtract from timeout when probing targets.  | `"0.5s"` | no
 
-The `config_file` argument points to a YAML file defining which blackbox_exporter modules to use. 
+The `config_file` argument points to a YAML file defining which blackbox_exporter modules to use.
 The `config` argument must be a YAML document as string defining which blackbox_exporter modules to use.
 `config` is typically loaded by using the exports of another component. For example,
 
@@ -81,6 +81,12 @@ For example, `targets` can either be passed to a `prometheus.relabel`
 component to rewrite the metrics' label set, or to a `prometheus.scrape`
 component that collects the exposed metrics.
 
+The exported targets will use the configured [in-memory traffic][] address
+specified by the [run command][].
+
+[in-memory traffic]: {{< relref "../../concepts/component_controller.md#in-memory-traffic" >}}
+[run command]: {{< relref "../cli/run.md" >}}
+
 ## Component health
 
 `prometheus.exporter.blackbox` is only reported as unhealthy if given
@@ -103,18 +109,18 @@ This example uses a [`prometheus.scrape` component][scrape] to collect metrics
 from `prometheus.exporter.blackbox`:
 
 ```river
-prometheus.exporter.blackbox "example" { 
-	config_file = "blackbox_modules.yml"
-	
-	target "example" {
-		address = "http://example.com"
-		module  = "http_2xx"
-	}
-	
-	target "grafana" {
-		address = "http://grafana.com"
-		module  = "http_2xx"
-	}	
+prometheus.exporter.blackbox "example" {
+    config_file = "blackbox_modules.yml"
+
+    target "example" {
+        address = "http://example.com"
+        module  = "http_2xx"
+    }
+
+    target "grafana" {
+        address = "http://grafana.com"
+        module  = "http_2xx"
+    }
 }
 
 // Configure a prometheus.scrape component to collect Blackbox metrics.
@@ -127,18 +133,18 @@ prometheus.scrape "demo" {
 This example is the same above with using an embedded configuration:
 
 ```river
-prometheus.exporter.blackbox "example" { 
-	config = "{ modules: { http_2xx: { prober: http, timeout: 5s } } }"
-	
-	target "example" {
-		address = "http://example.com"
-		module  = "http_2xx"
-	}
-	
-	target "grafana" {
-		address = "http://grafana.com"
-		module  = "http_2xx"
-	}	
+prometheus.exporter.blackbox "example" {
+    config = "{ modules: { http_2xx: { prober: http, timeout: 5s } } }"
+
+    target "example" {
+        address = "http://example.com"
+        module  = "http_2xx"
+    }
+
+    target "grafana" {
+        address = "http://grafana.com"
+        module  = "http_2xx"
+    }
 }
 
 // Configure a prometheus.scrape component to collect Blackbox metrics.

--- a/docs/sources/flow/reference/components/prometheus.exporter.consul.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.consul.md
@@ -51,6 +51,12 @@ For example, the `targets` could either be passed to a `prometheus.relabel`
 component to rewrite the metrics' label set, or to a `prometheus.scrape`
 component that collects the exposed metrics.
 
+The exported targets will use the configured [in-memory traffic][] address
+specified by the [run command][].
+
+[in-memory traffic]: {{< relref "../../concepts/component_controller.md#in-memory-traffic" >}}
+[run command]: {{< relref "../cli/run.md" >}}
+
 ## Component health
 
 `prometheus.exporter.consul` is only reported as unhealthy if given

--- a/docs/sources/flow/reference/components/prometheus.exporter.github.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.github.md
@@ -48,6 +48,12 @@ For example, the `targets` can either be passed to a `prometheus.relabel`
 component to rewrite the metric's label set, or to a `prometheus.scrape`
 component that collects the exposed metrics.
 
+The exported targets will use the configured [in-memory traffic][] address
+specified by the [run command][].
+
+[in-memory traffic]: {{< relref "../../concepts/component_controller.md#in-memory-traffic" >}}
+[run command]: {{< relref "../cli/run.md" >}}
+
 ## Component health
 
 `prometheus.exporter.github` is only reported as unhealthy if given

--- a/docs/sources/flow/reference/components/prometheus.exporter.memcached.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.memcached.md
@@ -28,7 +28,7 @@ Name             | Type       | Description                                     
 `timeout`        | `duration` | The timeout for connecting to the Memcached server. | `"1s"`                | no       |
 
 ## Blocks
-The `prometheus.exporter.memcached` component does not support any blocks, and is configured 
+The `prometheus.exporter.memcached` component does not support any blocks, and is configured
 fully through arguments.
 
 ## Exported fields
@@ -41,6 +41,12 @@ Name      | Type                | Description
 For example, `targets` can either be passed to a `prometheus.relabel`
 component to rewrite the metrics' label set, or to a `prometheus.scrape`
 component that collects the exposed metrics.
+
+The exported targets will use the configured [in-memory traffic][] address
+specified by the [run command][].
+
+[in-memory traffic]: {{< relref "../../concepts/component_controller.md#in-memory-traffic" >}}
+[run command]: {{< relref "../cli/run.md" >}}
 
 ## Component health
 `prometheus.exporter.memcached` is only reported as unhealthy if given

--- a/docs/sources/flow/reference/components/prometheus.exporter.mysql.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mysql.md
@@ -154,6 +154,12 @@ For example, the `targets` can either be passed to a `prometheus.relabel`
 component to rewrite the metric's label set, or to a `prometheus.scrape`
 component that collects the exposed metrics.
 
+The exported targets will use the configured [in-memory traffic][] address
+specified by the [run command][].
+
+[in-memory traffic]: {{< relref "../../concepts/component_controller.md#in-memory-traffic" >}}
+[run command]: {{< relref "../cli/run.md" >}}
+
 ## Component health
 
 `prometheus.exporter.mysql` is only reported as unhealthy if given

--- a/docs/sources/flow/reference/components/prometheus.exporter.postgres.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.postgres.md
@@ -15,7 +15,7 @@ labels:
 The `prometheus.exporter.postgres` component embeds
 [postgres_exporter](https://github.com/prometheus-community/postgres_exporter) for collecting metrics from a postgres database.
 
-Multiple `prometheus.exporter.postgres` components can be specified by giving them different 
+Multiple `prometheus.exporter.postgres` components can be specified by giving them different
 labels.
 
 ## Usage
@@ -77,6 +77,12 @@ For example, `targets` can either be passed to a `prometheus.relabel`
 component to rewrite the metrics' label set, or to a `prometheus.scrape`
 component that collects the exposed metrics.
 
+The exported targets will use the configured [in-memory traffic][] address
+specified by the [run command][].
+
+[in-memory traffic]: {{< relref "../../concepts/component_controller.md#in-memory-traffic" >}}
+[run command]: {{< relref "../cli/run.md" >}}
+
 ## Component health
 
 `prometheus.exporter.postgres` is only reported as unhealthy if given
@@ -130,7 +136,7 @@ prometheus.exporter.postgres "example" {
     enabled = true
     database_allowlist = ["frontend_app", "backend_app"]
   }
-  
+
   disable_default_metrics = true
   custom_queries_path     = "/etc/agent/custom-postgres-metrics.yaml"
 }
@@ -153,7 +159,7 @@ for the `secrets` database.
 prometheus.exporter.postgres "example" {
   data_source_names       = ["postgresql://username:password@localhost:5432/database_name?sslmode=disable"]
 
-  // The database_denylist field will filter out those databases from the list of databases to scrape, 
+  // The database_denylist field will filter out those databases from the list of databases to scrape,
   // meaning that all databases *except* these will be scraped.
   //
   // In this example it will scrape all databases except for the one named 'secrets'.

--- a/docs/sources/flow/reference/components/prometheus.exporter.process.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.process.md
@@ -51,7 +51,7 @@ Name | Type | Description | Default | Required
 `exe`        | `list(string)`  | A list of strings that match `argv[0]` for a process. | | no
 `cmdline`    | `list(string)`  | A list of regular expressions applied to the `argv` of the process. | | no
 
-The `name` argument can use the following template variables. By default it uses the base path of the executable: 
+The `name` argument can use the following template variables. By default it uses the base path of the executable:
 - `{{.Comm}}`:      Basename of the original executable from /proc/\<pid\>/stat.
 - `{{.ExeBase}}`:   Basename of the executable from argv[0].
 - `{{.ExeFull}}`:   Fully qualified path of the executable.
@@ -79,6 +79,12 @@ Name      | Type                | Description
 For example, the `targets` can either be passed to a `prometheus.relabel`
 component to rewrite the metric's label set, or to a `prometheus.scrape`
 component that collects the exposed metrics.
+
+The exported targets will use the configured [in-memory traffic][] address
+specified by the [run command][].
+
+[in-memory traffic]: {{< relref "../../concepts/component_controller.md#in-memory-traffic" >}}
+[run command]: {{< relref "../cli/run.md" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.redis.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.redis.md
@@ -84,6 +84,12 @@ For example, `targets` can either be passed to a `prometheus.relabel`
 component to rewrite the metrics' label set, or to a `prometheus.scrape`
 component that collects the exposed metrics.
 
+The exported targets will use the configured [in-memory traffic][] address
+specified by the [run command][].
+
+[in-memory traffic]: {{< relref "../../concepts/component_controller.md#in-memory-traffic" >}}
+[run command]: {{< relref "../cli/run.md" >}}
+
 ## Component health
 
 `prometheus.exporter.redis` is only reported as unhealthy if given

--- a/docs/sources/flow/reference/components/prometheus.exporter.snmp.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.snmp.md
@@ -18,14 +18,14 @@ The `prometheus.exporter.snmp` component embeds
 ```river
 prometheus.exporter.snmp "LABEL" {
   config_file = "PATH_SNMP_CONFIG_FILE"
-  
+
   target "TARGET_NAME" {
-    address = "TARGET_ADDRESS" 
+    address = "TARGET_ADDRESS"
   }
 
   walk_param "PARAM_NAME" {
   }
-  
+
   ...
 }
 ```
@@ -117,6 +117,12 @@ For example, `targets` can either be passed to a `prometheus.relabel`
 component to rewrite the metrics' label set, or to a `prometheus.scrape`
 component that collects the exposed metrics.
 
+The exported targets will use the configured [in-memory traffic][] address
+specified by the [run command][].
+
+[in-memory traffic]: {{< relref "../../concepts/component_controller.md#in-memory-traffic" >}}
+[run command]: {{< relref "../cli/run.md" >}}
+
 ## Component health
 
 `prometheus.exporter.snmp` is only reported as unhealthy if given
@@ -140,40 +146,40 @@ from `prometheus.exporter.snmp`:
 
 ```river
 prometheus.exporter.snmp "example" {
-	config_file = "snmp_modules.yml"
+    config_file = "snmp_modules.yml"
 
-	target "network_switch_1" {
-		address     = "192.168.1.2"
-		module      = "if_mib"
-		walk_params = "public"
-	}
+    target "network_switch_1" {
+        address     = "192.168.1.2"
+        module      = "if_mib"
+        walk_params = "public"
+    }
 
-	target "network_router_2" {
-		address     = "192.168.1.3"
-		module      = "mikrotik"
-		walk_params = "private"
-	}
+    target "network_router_2" {
+        address     = "192.168.1.3"
+        module      = "mikrotik"
+        walk_params = "private"
+    }
 
-	walk_param "private" {
-		version = "2"
+    walk_param "private" {
+        version = "2"
 
-		auth {
-			community = "secret"
-		}
-	}
+        auth {
+            community = "secret"
+        }
+    }
 
-	walk_param "public" {
-		version = "2"
+    walk_param "public" {
+        version = "2"
 
-		auth {
-			community = "public"
-		}
-	}
+        auth {
+            community = "public"
+        }
+    }
 }
 // Configure a prometheus.scrape component to collect SNMP metrics.
 prometheus.scrape "demo" {
-	targets    = prometheus.exporter.snmp.example.targets
-	forward_to = [ /* ... */ ]
+    targets    = prometheus.exporter.snmp.example.targets
+    forward_to = [ /* ... */ ]
 }
 ```
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.statsd.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.statsd.md
@@ -17,7 +17,7 @@ The `prometheus.exporter.statsd` component embeds
 
 ```river
 prometheus.exporter.statsd "LABEL" {
-    
+
 }
 ```
 
@@ -44,14 +44,14 @@ Name | Type | Description | Default | Required
 `parse_signalfx_tags`                             | `string`       | Parse SignalFX style tags. | `true`| no
 
 At least one of `listen_udp`, `listen_tcp`, or `listen_unixgram` should be enabled.
-For details on how to use the mapping config file, please check the official 
+For details on how to use the mapping config file, please check the official
 [statsd_exporter docs](https://github.com/prometheus/statsd_exporter#metric-mapping-and-configuration).
-Please make sure the kernel parameter `net.core.rmem_max` is set to a value greater 
+Please make sure the kernel parameter `net.core.rmem_max` is set to a value greater
 than the value specified in `read_buffer`.
 
 ### Blocks
 
-The `prometheus.exporter.statsd` component does not support any blocks, and is configured 
+The `prometheus.exporter.statsd` component does not support any blocks, and is configured
 fully through arguments.
 
 ## Exported fields
@@ -64,6 +64,12 @@ Name      | Type                | Description
 For example, the `targets` could either be passed to a `prometheus.relabel`
 component to rewrite the metrics' label set, or to a `prometheus.scrape`
 component that collects the exposed metrics.
+
+The exported targets will use the configured [in-memory traffic][] address
+specified by the [run command][].
+
+[in-memory traffic]: {{< relref "../../concepts/component_controller.md#in-memory-traffic" >}}
+[run command]: {{< relref "../cli/run.md" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.unix.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.unix.md
@@ -243,6 +243,12 @@ For example, the `targets` could either be passed to a `prometheus.relabel`
 component to rewrite the metrics' label set, or to a `prometheus.scrape`
 component that collects the exposed metrics.
 
+The exported targets will use the configured [in-memory traffic][] address
+specified by the [run command][].
+
+[in-memory traffic]: {{< relref "../../concepts/component_controller.md#in-memory-traffic" >}}
+[run command]: {{< relref "../cli/run.md" >}}
+
 ## Component health
 
 `prometheus.exporter.unix` is only reported as unhealthy if given

--- a/docs/sources/flow/reference/components/prometheus.exporter.windows.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.windows.md
@@ -21,7 +21,7 @@ enabled and disabled at will. For more information on collectors, refer to the
 ## Usage
 
 ```river
-prometheus.exporter.windows "LABEL" { 
+prometheus.exporter.windows "LABEL" {
 }
 ```
 
@@ -42,18 +42,18 @@ default. See the [Collectors list](#collectors-list) for the default set.
 The following blocks are supported inside the definition of
 `prometheus.exporter.windows` to configure collector-specific options:
 
-Hierarchy    | Name             | Description                            | Required 
+Hierarchy    | Name             | Description                            | Required
 -------------|------------------|----------------------------------------|----------
-exchange     | [exchange][]     | Configures the exchange collector.     | no       
-iis          | [iis][]          | Configures the iis collector.          | no       
-text_file    | [text_file][]    | Configures the text_file collector.    | no       
-smtp         | [smtp][]         | Configures the smtp collector.         | no       
-service      | [service][]      | Configures the service collector.      | no       
-process      | [process][]      | Configures the process collector.      | no       
-network      | [network][]      | Configures the network collector.      | no       
-mssql        | [mssql][]        | Configures the mssql collector.        | no       
-msmq         | [msmq][]         | Configures the msmq collector.         | no       
-logical_disk | [logical_disk][] | Configures the logical_disk collector. | no       
+exchange     | [exchange][]     | Configures the exchange collector.     | no
+iis          | [iis][]          | Configures the iis collector.          | no
+text_file    | [text_file][]    | Configures the text_file collector.    | no
+smtp         | [smtp][]         | Configures the smtp collector.         | no
+service      | [service][]      | Configures the service collector.      | no
+process      | [process][]      | Configures the process collector.      | no
+network      | [network][]      | Configures the network collector.      | no
+mssql        | [mssql][]        | Configures the mssql collector.        | no
+msmq         | [msmq][]         | Configures the msmq collector.         | no
+logical_disk | [logical_disk][] | Configures the logical_disk collector. | no
 
 [exchange]: #exchange-block
 [iis]: #iis-block
@@ -81,9 +81,9 @@ The collectors specified by `enabled_list` can include the following:
 - `OutlookWebAccess`
 - `Autodiscover`
 - `WorkloadManagement`
-- `RpcClientAccess` 
+- `RpcClientAccess`
 
-For example, `enabled_list` may be set to `"AvailabilityService,OutlookWebAccess"`. 
+For example, `enabled_list` may be set to `"AvailabilityService,OutlookWebAccess"`.
 
 
 ### iis block
@@ -99,7 +99,7 @@ Name | Type     | Description | Default | Required
 ---- |----------| ----------- | ------- | --------
 `text_file_directory` | `string` | The directory containing the files to be ingested. | `C:\Program Files\windows_exporter\textfile_inputs` | no
 
-When `text_file_directory` is set, only files with the extension `.prom` inside the specified directory are read. Each `.prom` file found must end with an empty line feed to work properly.  
+When `text_file_directory` is set, only files with the extension `.prom` inside the specified directory are read. Each `.prom` file found must end with an empty line feed to work properly.
 
 
 ### smtp block
@@ -108,7 +108,7 @@ Name | Type     | Description | Default | Required
 `blacklist` | `string` | Regexp of virtual servers to ignore. |  | no
 `whitelist` | `string` | Regexp of virtual servers to include. | `".+"` | no
 
-For a server name to be included, it must match the regular expression specified by `whitelist` and must _not_ match the regular expression specified by `blacklist`. 
+For a server name to be included, it must match the regular expression specified by `whitelist` and must _not_ match the regular expression specified by `blacklist`.
 
 ### service block
 Name | Type     | Description | Default | Required
@@ -144,7 +144,7 @@ Name | Type     | Description | Default | Required
 ---- |----------| ----------- | ------- | --------
 `where_clause` | `string` | WQL 'where' clause to use in WMI metrics query. |  | no
 
-Specifying `enabled_classes` is useful to limit the response to the MSMQs you specify, reducing the size of the response. 
+Specifying `enabled_classes` is useful to limit the response to the MSMQs you specify, reducing the size of the response.
 
 
 ### logical_disk block
@@ -165,6 +165,12 @@ Name      | Type                | Description
 For example, the `targets` could either be passed to a `prometheus.relabel`
 component to rewrite the metrics' label set, or to a `prometheus.scrape`
 component that collects the exposed metrics.
+
+The exported targets will use the configured [in-memory traffic][] address
+specified by the [run command][].
+
+[in-memory traffic]: {{< relref "../../concepts/component_controller.md#in-memory-traffic" >}}
+[run command]: {{< relref "../cli/run.md" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.scrape.md
+++ b/docs/sources/flow/reference/components/prometheus.scrape.md
@@ -62,7 +62,7 @@ Name | Type | Description | Default | Required
 
  At most one of the following can be provided:
  - [`bearer_token` argument](#arguments).
- - [`bearer_token_file` argument](#arguments). 
+ - [`bearer_token_file` argument](#arguments).
  - [`basic_auth` block][basic_auth].
  - [`authorization` block][authorization].
  - [`oauth2` block][oauth2].
@@ -126,7 +126,7 @@ upstream components in their `targets` argument.
 All `prometheus.scrape` components instances opting in to clustering use target
 labels and a consistent hashing algorithm to determine ownership for each of
 the targets between the cluster peers. Then, each peer only scrapes the subset
-of targets that it is responsible for, so that the scrape load is distributed. 
+of targets that it is responsible for, so that the scrape load is distributed.
 When a node joins or leaves the cluster, every peer recalculates ownership and
 continues scraping with the new target set. This performs better than hashmod
 sharding where _all_ nodes have to be re-distributed, as only 1/N of the
@@ -176,6 +176,10 @@ endpoints using HTTP, with a scrape interval of 1 minute and scrape timeout of
 query parameters, as well as any other settings can be configured using the
 component's arguments.
 
+If a target is hosted at the [in-memory traffic][] address specified by the
+[run command][], `prometheus.scrape` will scrape the metrics in-memory,
+bypassing the network.
+
 The scrape job expects the metrics exposed by the endpoint to follow the
 [OpenMetrics](https://openmetrics.io/) format. All metrics are then propagated
 to each receiver listed in the component's `forward_to` argument.
@@ -219,6 +223,9 @@ scrape target, either because it is not reachable, because the connection
 times out while scraping, or because the samples from the target could not be
 processed. When the target is behaving normally, the `up` metric is set to
 `1`.
+
+[in-memory traffic]: {{< relref "../../concepts/component_controller.md#in-memory-traffic" >}}
+[run command]: {{< relref "../cli/run.md" >}}
 
 ## Example
 

--- a/pkg/flow/internal/controller/component.go
+++ b/pkg/flow/internal/controller/component.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"path"
 	"path/filepath"
@@ -56,6 +57,9 @@ func (id ComponentID) Equals(other ComponentID) bool {
 	return true
 }
 
+// DialFunc is a function to establish a network connection.
+type DialFunc func(ctx context.Context, network, address string) (net.Conn, error)
+
 // ComponentGlobals are used by ComponentNodes to build managed components. All
 // ComponentNodes should use the same ComponentGlobals.
 type ComponentGlobals struct {
@@ -69,6 +73,7 @@ type ComponentGlobals struct {
 	Registerer        prometheus.Registerer        // Registerer for serving agent and component metrics
 	HTTPPathPrefix    string                       // HTTP prefix for components.
 	HTTPListenAddr    string                       // Base address for server
+	DialFunc          DialFunc                     // Function to connect to HTTPListenAddr.
 	ControllerID      string                       // ID of controller.
 }
 
@@ -186,6 +191,7 @@ func getManagedOptions(globals ComponentGlobals, cn *ComponentNode) component.Op
 
 		DataPath:       filepath.Join(globals.DataPath, cn.nodeID),
 		HTTPListenAddr: globals.HTTPListenAddr,
+		DialFunc:       globals.DialFunc,
 		HTTPPath:       path.Join(prefix, cn.nodeID) + "/",
 
 		OnStateChange: cn.setExports,


### PR DESCRIPTION
This PR integrates github.com/rfratto/ckit/memconn into Flow, which was already in use in the integrations-next subsystem in static mode. 

memconn allows establishing fully in-memory HTTP connections to avoid the network stack. This is primarily useful in the presence of mTLS, where otherwise Flow would need to know how to connect to itself as a client with the proper TLS certificates.  

As of this PR, in-memory HTTP connections are only used for prometheus.exporter.* components and prometheus.scrape, where prometheus.exporter.* components export an in-memory address, and prometheus.scrape can use a custom dialer to connect to that address. 

I am not really happy with the API as-is, but @mattdurham is actively working on refactoring the controller/module API which would be able to implement this logic in a cleaner way; so for now I think the slightly ugly API is acceptable. 

Closes #2984. 

Related to #2715, #3601.