### PR TITLE
Switch to upstream windows_exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ Main (unreleased)
 
 - The experimental dynamic configuration feature has been removed in favor of Flow mode. (@mattdurham)
 - The `oracledb` integration configuration has removed a redundant field `metrics_scrape_interval`. Use the `scrape_interval` parameter of the integration if a custom scrape interval is required. (@schmikei)
+- Upgrade the embedded windows_exporter to the last version. The windows_exporter contains some breaking changes.
+  - `iss.app_blacklist` is now `iss.app_exclude`
+  - `iss.app_whitelist` is now `iss.app_include`
+  - `iss.site_blacklist` is now `iss.site_exclude`
+  - `iss.site_whitelist` is now `iss.site_include`
+  - `logical_disk.blacklist` is now `logical_disk.exclude`
+  - `logical_disk.whitelist` is now `logical_disk.include`
+  - `network.blacklist` is now `network.exclude`
+  - `network.whitelist` is now `network.include`
+  - `process.blacklist` is now `process.exclude`
+  - `process.whitelist` is now `process.include`
+  - `smtp.blacklist` is now `smtp.exclude`
+  - `smtp.whitelist` is now `smtp.include`
 
 ### Features
 - New Grafana Agent Flow components:

--- a/component/prometheus/exporter/windows/config.go
+++ b/component/prometheus/exporter/windows/config.go
@@ -9,16 +9,67 @@ import (
 // DefaultArguments holds non-zero default options for Arguments when it is
 // unmarshaled from YAML.
 //
-// Some defaults are populated from init functions in the github.com/grafana/agent/pkg/integrations/node_exporter package.
+// Some defaults are populated from init functions in the github.com/grafana/agent/pkg/integrations/windows_exporter package.
+
 var DefaultArguments = Arguments{
-	EnabledCollectors: []string{"cpu", "cs", "logical_disk", "net", "os", "service", "system"},
-	IIS:               IISConfig{AppWhiteList: ".+", SiteWhiteList: ".+"},
-	TextFile:          TextFileConfig{TextFileDirectory: "C:\\Program Files\\windows_exporter\\textfile_inputs"},
-	SMTP:              SMTPConfig{WhiteList: ".+"},
-	Process:           ProcessConfig{WhiteList: ".*"},
-	Network:           NetworkConfig{WhiteList: ".*"},
-	MSSQL:             MSSQLConfig{EnabledClasses: []string{"accessmethods", "availreplica", "bufman", "databases", "dbreplica", "genstats", "locks", "memmgr", "sqlstats", "sqlerrorstransactions"}},
-	LogicalDisk:       LogicalDiskConfig{WhiteList: ".+"},
+	EnabledCollectors: strings.Split(windows_integration.DefaultConfig.EnabledCollectors, ","),
+	Dfsr: DfsrConfig{
+		SourcesEnabled: strings.Split(windows_integration.DefaultConfig.Dfsr.SourcesEnabled, ","),
+	},
+	Exchange: ExchangeConfig{
+		EnabledList: strings.Split(windows_integration.DefaultConfig.Exchange.EnabledList, ","),
+	},
+	IIS: IISConfig{
+		AppBlackList:  windows_integration.DefaultConfig.IIS.AppBlackList,
+		AppWhiteList:  windows_integration.DefaultConfig.IIS.AppWhiteList,
+		SiteBlackList: windows_integration.DefaultConfig.IIS.SiteBlackList,
+		SiteWhiteList: windows_integration.DefaultConfig.IIS.SiteWhiteList,
+		AppInclude:    windows_integration.DefaultConfig.IIS.AppInclude,
+		AppExclude:    windows_integration.DefaultConfig.IIS.AppExclude,
+		SiteInclude:   windows_integration.DefaultConfig.IIS.SiteInclude,
+		SiteExclude:   windows_integration.DefaultConfig.IIS.SiteExclude,
+	},
+	LogicalDisk: LogicalDiskConfig{
+		BlackList: windows_integration.DefaultConfig.LogicalDisk.BlackList,
+		WhiteList: windows_integration.DefaultConfig.LogicalDisk.WhiteList,
+		Include:   windows_integration.DefaultConfig.LogicalDisk.Include,
+		Exclude:   windows_integration.DefaultConfig.LogicalDisk.Exclude,
+	},
+	MSMQ: MSMQConfig{
+		Where: windows_integration.DefaultConfig.MSMQ.Where,
+	},
+	MSSQL: MSSQLConfig{
+		EnabledClasses: strings.Split(windows_integration.DefaultConfig.MSSQL.EnabledClasses, ","),
+	},
+	Network: NetworkConfig{
+		BlackList: windows_integration.DefaultConfig.Network.BlackList,
+		WhiteList: windows_integration.DefaultConfig.Network.WhiteList,
+		Include:   windows_integration.DefaultConfig.Network.Include,
+		Exclude:   windows_integration.DefaultConfig.Network.Exclude,
+	},
+	Process: ProcessConfig{
+		BlackList: windows_integration.DefaultConfig.Process.BlackList,
+		WhiteList: windows_integration.DefaultConfig.Process.WhiteList,
+		Include:   windows_integration.DefaultConfig.Process.Include,
+		Exclude:   windows_integration.DefaultConfig.Process.Exclude,
+	},
+	ScheduledTask: ScheduledTaskConfig{
+		Include: windows_integration.DefaultConfig.ScheduledTask.Include,
+		Exclude: windows_integration.DefaultConfig.ScheduledTask.Exclude,
+	},
+	Service: ServiceConfig{
+		UseApi: windows_integration.DefaultConfig.Service.UseApi,
+		Where:  windows_integration.DefaultConfig.Service.Where,
+	},
+	SMTP: SMTPConfig{
+		BlackList: windows_integration.DefaultConfig.SMTP.BlackList,
+		WhiteList: windows_integration.DefaultConfig.SMTP.WhiteList,
+		Include:   windows_integration.DefaultConfig.SMTP.Include,
+		Exclude:   windows_integration.DefaultConfig.SMTP.Exclude,
+	},
+	TextFile: TextFileConfig{
+		TextFileDirectory: windows_integration.DefaultConfig.TextFile.TextFileDirectory,
+	},
 }
 
 // Arguments is used for controlling for this exporter.
@@ -27,16 +78,18 @@ type Arguments struct {
 	EnabledCollectors []string `river:"enabled_collectors,attr,optional"`
 
 	// Collector-specific config options
-	Exchange    ExchangeConfig    `river:"exchange,block,optional"`
-	IIS         IISConfig         `river:"iis,block,optional"`
-	TextFile    TextFileConfig    `river:"text_file,block,optional"`
-	SMTP        SMTPConfig        `river:"smtp,block,optional"`
-	Service     ServiceConfig     `river:"service,block,optional"`
-	Process     ProcessConfig     `river:"process,block,optional"`
-	Network     NetworkConfig     `river:"network,block,optional"`
-	MSSQL       MSSQLConfig       `river:"mssql,block,optional"`
-	MSMQ        MSMQConfig        `river:"msmq,block,optional"`
-	LogicalDisk LogicalDiskConfig `river:"logical_disk,block,optional"`
+	Dfsr          DfsrConfig          `river:"dfsr,block,optional"`
+	Exchange      ExchangeConfig      `river:"exchange,block,optional"`
+	IIS           IISConfig           `river:"iis,block,optional"`
+	LogicalDisk   LogicalDiskConfig   `river:"logical_disk,block,optional"`
+	MSMQ          MSMQConfig          `river:"msmq,block,optional"`
+	MSSQL         MSSQLConfig         `river:"mssql,block,optional"`
+	Network       NetworkConfig       `river:"network,block,optional"`
+	Process       ProcessConfig       `river:"process,block,optional"`
+	ScheduledTask ScheduledTaskConfig `river:"scheduled_task,block,optional"`
+	Service       ServiceConfig       `river:"service,block,optional"`
+	SMTP          SMTPConfig          `river:"smtp,block,optional"`
+	TextFile      TextFileConfig      `river:"text_file,block,optional"`
 }
 
 // UnmarshalRiver implements River unmarshalling for Config.
@@ -51,16 +104,30 @@ func (a *Arguments) UnmarshalRiver(f func(interface{}) error) error {
 func (a *Arguments) Convert() *windows_integration.Config {
 	return &windows_integration.Config{
 		EnabledCollectors: strings.Join(a.EnabledCollectors, ","),
+		Dfsr:              a.Dfsr.Convert(),
 		Exchange:          a.Exchange.Convert(),
 		IIS:               a.IIS.Convert(),
-		TextFile:          a.TextFile.Convert(),
-		SMTP:              a.SMTP.Convert(),
-		Service:           a.Service.Convert(),
-		Process:           a.Process.Convert(),
-		Network:           a.Network.Convert(),
-		MSSQL:             a.MSSQL.Convert(),
-		MSMQ:              a.MSMQ.Convert(),
 		LogicalDisk:       a.LogicalDisk.Convert(),
+		MSMQ:              a.MSMQ.Convert(),
+		MSSQL:             a.MSSQL.Convert(),
+		Network:           a.Network.Convert(),
+		Process:           a.Process.Convert(),
+		ScheduledTask:     a.ScheduledTask.Convert(),
+		Service:           a.Service.Convert(),
+		SMTP:              a.SMTP.Convert(),
+		TextFile:          a.TextFile.Convert(),
+	}
+}
+
+// DfsrConfig handles settings for the windows_exporter Exchange collector
+type DfsrConfig struct {
+	SourcesEnabled []string `river:"sources_enabled,attr,optional"`
+}
+
+// Convert converts the component's DfsrConfig to the integration's ExchangeConfig.
+func (t DfsrConfig) Convert() windows_integration.DfsrConfig {
+	return windows_integration.DfsrConfig{
+		SourcesEnabled: strings.Join(t.SourcesEnabled, ","),
 	}
 }
 
@@ -82,6 +149,10 @@ type IISConfig struct {
 	AppWhiteList  string `river:"app_whitelist,attr,optional"`
 	SiteBlackList string `river:"site_blacklist,attr,optional"`
 	SiteWhiteList string `river:"site_whitelist,attr,optional"`
+	AppExclude    string `river:"app_exclude,attr,optional"`
+	AppInclude    string `river:"app_include,attr,optional"`
+	SiteExclude   string `river:"site_exclude,attr,optional"`
+	SiteInclude   string `river:"site_include,attr,optional"`
 }
 
 // Convert converts the component's IISConfig to the integration's IISConfig.
@@ -91,6 +162,10 @@ func (t IISConfig) Convert() windows_integration.IISConfig {
 		AppWhiteList:  t.AppWhiteList,
 		SiteBlackList: t.SiteBlackList,
 		SiteWhiteList: t.SiteWhiteList,
+		AppExclude:    t.AppExclude,
+		AppInclude:    t.AppInclude,
+		SiteExclude:   t.SiteExclude,
+		SiteInclude:   t.SiteInclude,
 	}
 }
 
@@ -110,25 +185,31 @@ func (t TextFileConfig) Convert() windows_integration.TextFileConfig {
 type SMTPConfig struct {
 	BlackList string `river:"blacklist,attr,optional"`
 	WhiteList string `river:"whitelist,attr,optional"`
+	Exclude   string `river:"exclude,attr,optional"`
+	Include   string `river:"include,attr,optional"`
 }
 
 // Convert converts the component's SMTPConfig to the integration's SMTPConfig.
 func (t SMTPConfig) Convert() windows_integration.SMTPConfig {
 	return windows_integration.SMTPConfig{
-		BlackList: t.BlackList,
 		WhiteList: t.WhiteList,
+		BlackList: t.BlackList,
+		Exclude:   t.Exclude,
+		Include:   t.Include,
 	}
 }
 
 // ServiceConfig handles settings for the windows_exporter service collector
 type ServiceConfig struct {
-	Where string `river:"where_clause,attr,optional"`
+	UseApi string `river:"use_api,attr,optional"`
+	Where  string `river:"where_clause,attr,optional"`
 }
 
 // Convert converts the component's ServiceConfig to the integration's ServiceConfig.
 func (t ServiceConfig) Convert() windows_integration.ServiceConfig {
 	return windows_integration.ServiceConfig{
-		Where: t.Where,
+		UseApi: t.UseApi,
+		Where:  t.Where,
 	}
 }
 
@@ -136,13 +217,31 @@ func (t ServiceConfig) Convert() windows_integration.ServiceConfig {
 type ProcessConfig struct {
 	BlackList string `river:"blacklist,attr,optional"`
 	WhiteList string `river:"whitelist,attr,optional"`
+	Exclude   string `river:"exclude,attr,optional"`
+	Include   string `river:"include,attr,optional"`
 }
 
 // Convert converts the component's ProcessConfig to the integration's ProcessConfig.
 func (t ProcessConfig) Convert() windows_integration.ProcessConfig {
 	return windows_integration.ProcessConfig{
-		BlackList: t.BlackList,
 		WhiteList: t.WhiteList,
+		BlackList: t.BlackList,
+		Exclude:   t.Exclude,
+		Include:   t.Include,
+	}
+}
+
+// ScheduledTaskConfig handles settings for the windows_exporter process collector
+type ScheduledTaskConfig struct {
+	Exclude string `river:"exclude,attr,optional"`
+	Include string `river:"include,attr,optional"`
+}
+
+// Convert converts the component's ScheduledTaskConfig to the integration's ScheduledTaskConfig.
+func (t ScheduledTaskConfig) Convert() windows_integration.ScheduledTaskConfig {
+	return windows_integration.ScheduledTaskConfig{
+		Exclude: t.Exclude,
+		Include: t.Include,
 	}
 }
 
@@ -150,13 +249,17 @@ func (t ProcessConfig) Convert() windows_integration.ProcessConfig {
 type NetworkConfig struct {
 	BlackList string `river:"blacklist,attr,optional"`
 	WhiteList string `river:"whitelist,attr,optional"`
+	Exclude   string `river:"exclude,attr,optional"`
+	Include   string `river:"include,attr,optional"`
 }
 
 // Convert converts the component's NetworkConfig to the integration's NetworkConfig.
 func (t NetworkConfig) Convert() windows_integration.NetworkConfig {
 	return windows_integration.NetworkConfig{
-		BlackList: t.BlackList,
 		WhiteList: t.WhiteList,
+		BlackList: t.BlackList,
+		Exclude:   t.Exclude,
+		Include:   t.Include,
 	}
 }
 
@@ -186,8 +289,10 @@ func (t MSMQConfig) Convert() windows_integration.MSMQConfig {
 
 // LogicalDiskConfig handles settings for the windows_exporter logical disk collector
 type LogicalDiskConfig struct {
-	WhiteList string `river:"whitelist,attr,optional"`
 	BlackList string `river:"blacklist,attr,optional"`
+	WhiteList string `river:"whitelist,attr,optional"`
+	Include   string `river:"include,attr,optional"`
+	Exclude   string `river:"exclude,attr,optional"`
 }
 
 // Convert converts the component's LogicalDiskConfig to the integration's LogicalDiskConfig.
@@ -195,5 +300,7 @@ func (t LogicalDiskConfig) Convert() windows_integration.LogicalDiskConfig {
 	return windows_integration.LogicalDiskConfig{
 		WhiteList: t.WhiteList,
 		BlackList: t.BlackList,
+		Include:   t.Include,
+		Exclude:   t.Exclude,
 	}
 }

--- a/component/prometheus/exporter/windows/config.go
+++ b/component/prometheus/exporter/windows/config.go
@@ -192,8 +192,8 @@ type SMTPConfig struct {
 // Convert converts the component's SMTPConfig to the integration's SMTPConfig.
 func (t SMTPConfig) Convert() windows_integration.SMTPConfig {
 	return windows_integration.SMTPConfig{
-		WhiteList: t.WhiteList,
 		BlackList: t.BlackList,
+		WhiteList: t.WhiteList,
 		Exclude:   t.Exclude,
 		Include:   t.Include,
 	}
@@ -224,8 +224,8 @@ type ProcessConfig struct {
 // Convert converts the component's ProcessConfig to the integration's ProcessConfig.
 func (t ProcessConfig) Convert() windows_integration.ProcessConfig {
 	return windows_integration.ProcessConfig{
-		WhiteList: t.WhiteList,
 		BlackList: t.BlackList,
+		WhiteList: t.WhiteList,
 		Exclude:   t.Exclude,
 		Include:   t.Include,
 	}
@@ -256,8 +256,8 @@ type NetworkConfig struct {
 // Convert converts the component's NetworkConfig to the integration's NetworkConfig.
 func (t NetworkConfig) Convert() windows_integration.NetworkConfig {
 	return windows_integration.NetworkConfig{
-		WhiteList: t.WhiteList,
 		BlackList: t.BlackList,
+		WhiteList: t.WhiteList,
 		Exclude:   t.Exclude,
 		Include:   t.Include,
 	}
@@ -298,8 +298,8 @@ type LogicalDiskConfig struct {
 // Convert converts the component's LogicalDiskConfig to the integration's LogicalDiskConfig.
 func (t LogicalDiskConfig) Convert() windows_integration.LogicalDiskConfig {
 	return windows_integration.LogicalDiskConfig{
-		WhiteList: t.WhiteList,
 		BlackList: t.BlackList,
+		WhiteList: t.WhiteList,
 		Include:   t.Include,
 		Exclude:   t.Exclude,
 	}

--- a/component/prometheus/exporter/windows/config_default_windows_test.go
+++ b/component/prometheus/exporter/windows/config_default_windows_test.go
@@ -1,0 +1,39 @@
+package windows
+
+import (
+	"strings"
+	"testing"
+
+	windows_integration "github.com/grafana/agent/pkg/integrations/windows_exporter"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRiverUnmarshalWithDefaultConfig(t *testing.T) {
+	var args Arguments
+	err := river.Unmarshal([]byte(""), &args)
+	require.NoError(t, err)
+
+	require.Equal(t, strings.Split(windows_integration.DefaultConfig.EnabledCollectors, ","), args.EnabledCollectors)
+	require.Equal(t, strings.Split(windows_integration.DefaultConfig.Dfsr.SourcesEnabled, ","), args.Dfsr.SourcesEnabled)
+	require.Equal(t, strings.Split(windows_integration.DefaultConfig.Exchange.EnabledList, ","), args.Exchange.EnabledList)
+	require.Equal(t, windows_integration.DefaultConfig.IIS.AppExclude, args.IIS.AppExclude)
+	require.Equal(t, windows_integration.DefaultConfig.IIS.AppInclude, args.IIS.AppInclude)
+	require.Equal(t, windows_integration.DefaultConfig.IIS.SiteExclude, args.IIS.SiteExclude)
+	require.Equal(t, windows_integration.DefaultConfig.IIS.SiteInclude, args.IIS.SiteInclude)
+	require.Equal(t, windows_integration.DefaultConfig.LogicalDisk.Exclude, args.LogicalDisk.Exclude)
+	require.Equal(t, windows_integration.DefaultConfig.LogicalDisk.Include, args.LogicalDisk.Include)
+	require.Equal(t, windows_integration.DefaultConfig.MSMQ.Where, args.MSMQ.Where)
+	require.Equal(t, strings.Split(windows_integration.DefaultConfig.MSSQL.EnabledClasses, ","), args.MSSQL.EnabledClasses)
+	require.Equal(t, windows_integration.DefaultConfig.Network.Exclude, args.Network.Exclude)
+	require.Equal(t, windows_integration.DefaultConfig.Network.Include, args.Network.Include)
+	require.Equal(t, windows_integration.DefaultConfig.Process.Exclude, args.Process.Exclude)
+	require.Equal(t, windows_integration.DefaultConfig.Process.Include, args.Process.Include)
+	require.Equal(t, windows_integration.DefaultConfig.ScheduledTask.Exclude, args.ScheduledTask.Exclude)
+	require.Equal(t, windows_integration.DefaultConfig.ScheduledTask.Include, args.ScheduledTask.Include)
+	require.Equal(t, windows_integration.DefaultConfig.Service.UseApi, args.Service.UseApi)
+	require.Equal(t, windows_integration.DefaultConfig.Service.Where, args.Service.Where)
+	require.Equal(t, windows_integration.DefaultConfig.SMTP.Exclude, args.SMTP.Exclude)
+	require.Equal(t, windows_integration.DefaultConfig.SMTP.Include, args.SMTP.Include)
+	require.Equal(t, windows_integration.DefaultConfig.TextFile.TextFileDirectory, args.TextFile.TextFileDirectory)
+}

--- a/component/prometheus/exporter/windows/windows_test.go
+++ b/component/prometheus/exporter/windows/windows_test.go
@@ -16,10 +16,10 @@ var (
 		}
 		
 		iis {
-			site_whitelist = ".+"
-			site_blacklist = ""
-			app_whitelist = ".+"
-			app_blacklist = ""
+			site_include = ".+"
+			site_exclude = ""
+			app_include = ".+"
+			app_exclude = ""
 		}
 		
 		text_file {
@@ -27,8 +27,8 @@ var (
 		}
 		
 		smtp {
-			whitelist = ".+"
-			blacklist = ""
+			include = ".+"
+			exclude = ""
 		}
 
         service {
@@ -36,13 +36,13 @@ var (
         }
 		
 		process {
-			whitelist = ".+"
-			blacklist = ""
+			include = ".+"
+			exclude = ""
 		}
 		
 		network {
-			whitelist = ".+"
-			blacklist = ""
+			include = ".+"
+			exclude = ""
 		}
 		
 		mssql {
@@ -54,7 +54,8 @@ var (
 		}
 		
 		logical_disk {
-			blacklist = ""
+			include = ".+"
+			exclude = ""
 		}
 		`
 )
@@ -66,22 +67,22 @@ func TestRiverUnmarshal(t *testing.T) {
 
 	require.Equal(t, []string{"textfile", "cpu"}, args.EnabledCollectors)
 	require.Equal(t, []string{"example"}, args.Exchange.EnabledList)
-	require.Equal(t, "", args.IIS.SiteBlackList)
-	require.Equal(t, ".+", args.IIS.SiteWhiteList)
-	require.Equal(t, "", args.IIS.AppBlackList)
-	require.Equal(t, ".+", args.IIS.AppWhiteList)
+	require.Equal(t, "", args.IIS.SiteExclude)
+	require.Equal(t, ".+", args.IIS.SiteInclude)
+	require.Equal(t, "", args.IIS.AppExclude)
+	require.Equal(t, ".+", args.IIS.AppInclude)
 	require.Equal(t, "C:", args.TextFile.TextFileDirectory)
-	require.Equal(t, "", args.SMTP.BlackList)
-	require.Equal(t, ".+", args.SMTP.WhiteList)
+	require.Equal(t, "", args.SMTP.Exclude)
+	require.Equal(t, ".+", args.SMTP.Include)
 	require.Equal(t, "where", args.Service.Where)
-	require.Equal(t, "", args.Process.BlackList)
-	require.Equal(t, ".+", args.Process.WhiteList)
-	require.Equal(t, "", args.Network.BlackList)
-	require.Equal(t, ".+", args.Network.WhiteList)
+	require.Equal(t, "", args.Process.Exclude)
+	require.Equal(t, ".+", args.Process.Include)
+	require.Equal(t, "", args.Network.Exclude)
+	require.Equal(t, ".+", args.Network.Include)
 	require.Equal(t, []string{"accessmethods"}, args.MSSQL.EnabledClasses)
 	require.Equal(t, "where", args.MSMQ.Where)
-	require.Equal(t, "", args.LogicalDisk.BlackList)
-	require.Equal(t, ".+", args.LogicalDisk.WhiteList)
+	require.Equal(t, "", args.LogicalDisk.Exclude)
+	require.Equal(t, ".+", args.LogicalDisk.Include)
 }
 
 func TestConvert(t *testing.T) {
@@ -93,20 +94,20 @@ func TestConvert(t *testing.T) {
 
 	require.Equal(t, "textfile,cpu", conf.EnabledCollectors)
 	require.Equal(t, "example", conf.Exchange.EnabledList)
-	require.Equal(t, "", conf.IIS.SiteBlackList)
-	require.Equal(t, ".+", conf.IIS.SiteWhiteList)
-	require.Equal(t, "", conf.IIS.AppBlackList)
-	require.Equal(t, ".+", conf.IIS.AppWhiteList)
+	require.Equal(t, "", conf.IIS.SiteExclude)
+	require.Equal(t, ".+", conf.IIS.SiteInclude)
+	require.Equal(t, "", conf.IIS.AppExclude)
+	require.Equal(t, ".+", conf.IIS.AppInclude)
 	require.Equal(t, "C:", conf.TextFile.TextFileDirectory)
-	require.Equal(t, "", conf.SMTP.BlackList)
-	require.Equal(t, ".+", conf.SMTP.WhiteList)
+	require.Equal(t, "", conf.SMTP.Exclude)
+	require.Equal(t, ".+", conf.SMTP.Include)
 	require.Equal(t, "where", conf.Service.Where)
-	require.Equal(t, "", conf.Process.BlackList)
-	require.Equal(t, ".+", conf.Process.WhiteList)
-	require.Equal(t, "", conf.Network.BlackList)
-	require.Equal(t, ".+", conf.Network.WhiteList)
+	require.Equal(t, "", conf.Process.Exclude)
+	require.Equal(t, ".+", conf.Process.Include)
+	require.Equal(t, "", conf.Network.Exclude)
+	require.Equal(t, ".+", conf.Network.Include)
 	require.Equal(t, "accessmethods", conf.MSSQL.EnabledClasses)
 	require.Equal(t, "where", conf.MSMQ.Where)
-	require.Equal(t, "", conf.LogicalDisk.BlackList)
-	require.Equal(t, ".+", conf.LogicalDisk.WhiteList)
+	require.Equal(t, "", conf.LogicalDisk.Exclude)
+	require.Equal(t, ".+", conf.LogicalDisk.Include)
 }

--- a/docs/sources/flow/reference/components/prometheus.exporter.windows.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.windows.md
@@ -29,9 +29,10 @@ prometheus.exporter.windows "LABEL" {
 The following arguments can be used to configure the exporter's behavior.
 All arguments are optional. Omitted fields take their default values.
 
-| Name                       | Type           | Description                                                   | Default | Required |
-|----------------------------|----------------|---------------------------------------------------------------|---------|----------|
-| `enabled_collectors`       | string`        | List of collectors to enable.                                |         | no       |
+| Name                 | Type       | Description                               | Default | Required |
+|----------------------|------------|-------------------------------------------|---------|----------|
+| `enabled_collectors` | `string`   | List of collectors to enable.             |         | no       |
+| `timeout`            | `duration` | Configure timeout for collecting metrics. | `4m`    | no       |
 
 `enabled_collectors` defines a hand-picked list of enabled-by-default
 collectors. If set, anything not provided in that list is disabled by
@@ -42,29 +43,39 @@ default. See the [Collectors list](#collectors-list) for the default set.
 The following blocks are supported inside the definition of
 `prometheus.exporter.windows` to configure collector-specific options:
 
-Hierarchy    | Name             | Description                            | Required
--------------|------------------|----------------------------------------|----------
-exchange     | [exchange][]     | Configures the exchange collector.     | no
-iis          | [iis][]          | Configures the iis collector.          | no
-text_file    | [text_file][]    | Configures the text_file collector.    | no
-smtp         | [smtp][]         | Configures the smtp collector.         | no
-service      | [service][]      | Configures the service collector.      | no
-process      | [process][]      | Configures the process collector.      | no
-network      | [network][]      | Configures the network collector.      | no
-mssql        | [mssql][]        | Configures the mssql collector.        | no
-msmq         | [msmq][]         | Configures the msmq collector.         | no
-logical_disk | [logical_disk][] | Configures the logical_disk collector. | no
+Hierarchy      | Name               | Description                              | Required
+---------------|--------------------|------------------------------------------|----------
+dfsr           | [dfsr][]           | Configures the iis collector.            | no       
+exchange       | [exchange][]       | Configures the exchange collector.        | no
+iis            | [iis][]            | Configures the iis collector.            | no
+logical_disk   | [logical_disk][]   | Configures the logical_disk collector.   | no       
+msmq           | [msmq][]           | Configures the msmq collector.           | no
+mssql          | [mssql][]          | Configures the mssql collector.          | no
+network        | [network][]        | Configures the network collector.        | no
+process        | [process][]        | Configures the process collector.        | no
+scheduled_task | [scheduled_task][] | Configures the scheduled_task collector. | no
+service        | [service][]        | Configures the service collector.        | no
+smtp           | [smtp][]           | Configures the smtp collector.           | no
+text_file      | [text_file][]      | Configures the text_file collector.      | no
 
+[dfsr]: #dfsr-block
 [exchange]: #exchange-block
 [iis]: #iis-block
-[text_file]: #textfile-block
-[smtp]: #smtp-block
-[service]: #service-block
-[process]: #process-block
-[network]: #network-block
-[mssql]: #mssql-block
-[msmq]: #msmq-block
 [logical_disk]: #logicaldisk-block
+[msmq]: #msmq-block
+[mssql]: #mssql-block
+[network]: #network-block
+[process]: #process-block
+[scheduled_task]: #scheduledtask-block
+[service]: #service-block
+[smtp]: #smtp-block
+[text_file]: #textfile-block
+
+### dfsr block
+Name | Type     | Description | Default | Required
+---- |----------| ----------- | ------- | --------
+`source_enabled` | `list(string)` | Comma-seperated list of DFSR Perflib sources to use. | `["connection","folder","volume"]` | no
+
 
 ### exchange block
 Name | Type     | Description | Default | Required
@@ -89,10 +100,80 @@ For example, `enabled_list` may be set to `"AvailabilityService,OutlookWebAccess
 ### iis block
 Name | Type     | Description | Default | Required
 ---- |----------| ----------- | ------- | --------
-`app_blacklist` | `string` | Regular expression of applications to ignore. |  | no
-`app_whitelist` | `string` | Regular expression of applications to report on. |  | no
-`site_blacklist` | `string` | Regular expression of sites to ignore. |  | no
-`site_whitelist` | `string` | Regular expression of sites to report on. |  | no
+`app_exclude` | `string` | Regular expression of applications to ignore. | `""` | no
+`app_include` | `string` | Regular expression of applications to report on. | `".*"` | no
+`site_exclude` | `string` | Regular expression of sites to ignore. | `""` | no
+`site_include` | `string` | Regular expression of sites to report on. | `".*"` | no
+
+
+### logical_disk block
+Name | Type     | Description | Default | Required
+---- |----------| ----------- | ------- | --------
+`exclude` | `string` | Regular expression of volumes to exclude. | `""` | no
+`include` | `string` | Regular expression of volumes to include. | `".+"` | no
+
+Volume names must match the regular expression specified by `include` and must _not_ match the regular expression specified by `exclude` to be included.
+
+
+### msmq block
+Name | Type     | Description | Default | Required
+---- |----------| ----------- | ------- | --------
+`where_clause` | `string` | WQL 'where' clause to use in WMI metrics query. | `""` | no
+
+Specifying `enabled_classes` is useful to limit the response to the MSMQs you specify, reducing the size of the response.
+
+
+### mssql block
+Name | Type     | Description | Default | Required
+---- |----------| ----------- | ------- | --------
+`enabled_classes` | `list(string)` | Comma-separated list of MSSQL WMI classes to use. | `["accessmethods", "availreplica", "bufman", "databases", "dbreplica", "genstats", "locks", "memmgr", "sqlstats", "sqlerrorstransactions"]` | no
+
+
+### network block
+Name | Type     | Description | Default | Required
+---- |----------| ----------- | ------- | --------
+`exclude` | `string` | Regular expression of NIC:s to exclude. | `""` | no
+`include` | `string` | Regular expression of NIC:s to include. | `".*"` | no
+
+NIC names must match the regular expression specified by `include` and must _not_ match the regular expression specified by `exclude` to be included.
+
+
+### process block
+Name | Type     | Description | Default | Required
+---- |----------| ----------- | ------- | --------
+`exclude` | `string` | Regular expression of processes to exclude. | `""` | no
+`include` | `string` | Regular expression of processes to include. | `".*"` | no
+
+Processes must match the regular expression specified by `include` and must _not_ match the regular expression specified by `exclude` to be included.
+
+
+### scheduled_task block
+Name | Type     | Description | Default | Required
+---- |----------| ----------- | ------- | --------
+`exclude` | `string` | Regexp of tasks to exclude. | `""` | no
+`include` | `string` | Regexp of tasks to include. | `".+"` | no
+
+For a server name to be included, it must match the regular expression specified by `include` and must _not_ match the regular expression specified by `exclude`.
+
+
+### service block
+Name | Type     | Description | Default | Required
+---- |----------| ----------- | ------- | --------
+`use_api` | `string` | Use API calls to collect service data instead of WMI. | `false` | no
+`where_clause` | `string` | WQL 'where' clause to use in WMI metrics query. | `""` | no
+
+The `where_clause` argument can be used to limit the response to the services you specify, reducing the size of the response.
+If `use_api` is enabled, 'where_clause' won't be effective.
+
+
+### smtp block
+Name | Type     | Description | Default | Required
+---- |----------| ----------- | ------- | --------
+`exclude` | `string` | Regexp of virtual servers to ignore. |  | no
+`include` | `string` | Regexp of virtual servers to include. | `".+"` | no
+
+For a server name to be included, it must match the regular expression specified by `include` and must _not_ match the regular expression specified by `exclude`.
+
 
 ### text_file block
 Name | Type     | Description | Default | Required
@@ -101,59 +182,6 @@ Name | Type     | Description | Default | Required
 
 When `text_file_directory` is set, only files with the extension `.prom` inside the specified directory are read. Each `.prom` file found must end with an empty line feed to work properly.
 
-
-### smtp block
-Name | Type     | Description | Default | Required
----- |----------| ----------- | ------- | --------
-`blacklist` | `string` | Regexp of virtual servers to ignore. |  | no
-`whitelist` | `string` | Regexp of virtual servers to include. | `".+"` | no
-
-For a server name to be included, it must match the regular expression specified by `whitelist` and must _not_ match the regular expression specified by `blacklist`.
-
-### service block
-Name | Type     | Description | Default | Required
----- |----------| ----------- | ------- | --------
-`where_clause` | `string` | WQL 'where' clause to use in WMI metrics query. |  | no
-
-The `where_clause` argument can be used to limit the response to the services you specify, reducing the size of the response.
-
-
-### process block
-Name | Type     | Description | Default | Required
----- |----------| ----------- | ------- | --------
-`blacklist` | `string` | Regular expression of processes to exclude. |  | no
-`whitelist` | `string` | Regular expression of processes to include. | `".*"` | no
-
-Processes must match the regular expression specified by `whitelist` and must _not_ match the regular expression specified by `blacklist` to be included.
-
-### network block
-Name | Type     | Description | Default | Required
----- |----------| ----------- | ------- | --------
-`blacklist` | `string` | Regular expression of NIC:s to exclude. |  | no
-`whitelist` | `string` | Regular expression of NIC:s to include. | `".*"` | no
-
-NIC names must match the regular expression specified by `whitelist` and must _not_ match the regular expression specified by `blacklist` to be included.
-
-### mssql block
-Name | Type     | Description | Default | Required
----- |----------| ----------- | ------- | --------
-`enabled_classes` | `list(string)` | Comma-separated list of MSSQL WMI classes to use. | `["accessmethods", "availreplica", "bufman", "databases", "dbreplica", "genstats", "locks", "memmgr", "sqlstats", "sqlerrorstransactions"]` | no
-
-### msmq block
-Name | Type     | Description | Default | Required
----- |----------| ----------- | ------- | --------
-`where_clause` | `string` | WQL 'where' clause to use in WMI metrics query. |  | no
-
-Specifying `enabled_classes` is useful to limit the response to the MSMQs you specify, reducing the size of the response.
-
-
-### logical_disk block
-Name | Type     | Description | Default | Required
----- |----------| ----------- | ------- | --------
-`blacklist` | `string` | Regular expression of volumes to exclude. |  | no
-`whitelist` | `string` | Regular expression of volumes to include. | `".+"` | no
-
-Volume names must match the regular expression specified by `whitelist` and must _not_ match the regular expression specified by `blacklist` to be included.
 
 ## Exported fields
 The following fields are exported and can be referenced by other components:
@@ -201,46 +229,55 @@ or disable collectors that are expensive to run.
 
 Name     | Description | Enabled by default
 ---------|-------------|--------------------
-[ad](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.ad.md) | Active Directory Domain Services |
-[adfs](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.adfs.md) | Active Directory Federation Services |
-[cache](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.cache.md) | Cache metrics |
-[cpu](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.cpu.md) | CPU usage | &#10003;
-[cpu_info](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.cpu_info.md) | CPU Information |
-[cs](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.cs.md) | "Computer System" metrics (system properties, num cpus/total memory) | &#10003;
-[container](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.container.md) | Container metrics |
-[dfsr](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.dfsr.md) | DFSR metrics |
-[dhcp](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.dhcp.md) | DHCP Server |
-[dns](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.dns.md) | DNS Server |
-[exchange](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.exchange.md) | Exchange metrics |
-[fsrmquota](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.fsrmquota.md) | Microsoft File Server Resource Manager (FSRM) Quotas collector |
-[hyperv](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.hyperv.md) | Hyper-V hosts |
-[iis](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.iis.md) | IIS sites and applications |
-[logical_disk](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.logical_disk.md) | Logical disks, disk I/O | &#10003;
-[logon](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.logon.md) | User logon sessions |
-[memory](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.memory.md) | Memory usage metrics |
-[msmq](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.msmq.md) | MSMQ queues |
-[mssql](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.mssql.md) | [SQL Server Performance Objects](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/use-sql-server-objects#SQLServerPOs) metrics  |
-[netframework_clrexceptions](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.netframework_clrexceptions.md) | .NET Framework CLR Exceptions |
-[netframework_clrinterop](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.netframework_clrinterop.md) | .NET Framework Interop Metrics |
-[netframework_clrjit](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.netframework_clrjit.md) | .NET Framework JIT metrics |
-[netframework_clrloading](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.netframework_clrloading.md) | .NET Framework CLR Loading metrics |
-[netframework_clrlocksandthreads](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.netframework_clrlocksandthreads.md) | .NET Framework locks and metrics threads |
-[netframework_clrmemory](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.netframework_clrmemory.md) |  .NET Framework Memory metrics |
-[netframework_clrremoting](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.netframework_clrremoting.md) | .NET Framework Remoting metrics |
-[netframework_clrsecurity](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.netframework_clrsecurity.md) | .NET Framework Security Check metrics |
-[net](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.net.md) | Network interface I/O | &#10003;
-[os](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.os.md) | OS metrics (memory, processes, users) | &#10003;
-[process](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.process.md) | Per-process metrics |
-[remote_fx](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.remote_fx.md) | RemoteFX protocol (RDP) metrics |
-[service](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.service.md) | Service state metrics | &#10003;
-[smtp](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.smtp.md) | IIS SMTP Server |
-[system](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.system.md) | System calls | &#10003;
-[tcp](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.tcp.md) | TCP connections |
-[time](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.time.md) | Windows Time Service |
-[thermalzone](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.thermalzone.md) | Thermal information
-[terminal_services](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.terminal_services.md) | Terminal services (RDS)
-[textfile](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.textfile.md) | Read prometheus metrics from a text file |
-[vmware](https://github.com/grafana/windows_exporter/blob/871715ba0b43c640257fb5ff6491b7420f23dcdd/docs/collector.vmware.md) | Performance counters installed by the Vmware Guest agent |
+[ad](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.ad.md) | Active Directory Domain Services |
+[adcs](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.adcs.md) | Active Directory Certificate Services |
+[adfs](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.adfs.md) | Active Directory Federation Services |
+[cache](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.cache.md) | Cache metrics |
+[cpu](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.cpu.md) | CPU usage | &#10003;
+[cpu_info](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.cpu_info.md) | CPU Information |
+[cs](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.cs.md) | "Computer System" metrics (system properties, num cpus/total memory) | &#10003;
+[container](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.container.md) | Container metrics |
+[dfsr](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.dfsr.md) | DFSR metrics |
+[dhcp](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.dhcp.md) | DHCP Server |
+[dns](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.dns.md) | DNS Server |
+[exchange](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.exchange.md) | Exchange metrics |
+[fsrmquota](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.fsrmquota.md) | Microsoft File Server Resource Manager (FSRM) Quotas collector |
+[hyperv](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.hyperv.md) | Hyper-V hosts |
+[iis](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.iis.md) | IIS sites and applications |
+[logical_disk](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.logical_disk.md) | Logical disks, disk I/O | &#10003;
+[logon](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.logon.md) | User logon sessions |
+[memory](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.memory.md) | Memory usage metrics |
+[mscluster_cluster](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.mscluster_cluster.md) | MSCluster cluster metrics |
+[mscluster_network](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.mscluster_network.md) | MSCluster network metrics |
+[mscluster_node](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.mscluster_node.md) | MSCluster Node metrics |
+[mscluster_resource](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.mscluster_resource.md) | MSCluster Resource metrics |
+[mscluster_resourcegroup](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.mscluster_resourcegroup.md) | MSCluster ResourceGroup metrics |
+[msmq](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.msmq.md) | MSMQ queues |
+[mssql](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.mssql.md) | [SQL Server Performance Objects](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/use-sql-server-objects#SQLServerPOs) metrics  |
+[netframework_clrexceptions](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework_clrexceptions.md) | .NET Framework CLR Exceptions |
+[netframework_clrinterop](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework_clrinterop.md) | .NET Framework Interop Metrics |
+[netframework_clrjit](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework_clrjit.md) | .NET Framework JIT metrics |
+[netframework_clrloading](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework_clrloading.md) | .NET Framework CLR Loading metrics |
+[netframework_clrlocksandthreads](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework_clrlocksandthreads.md) | .NET Framework locks and metrics threads |
+[netframework_clrmemory](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework_clrmemory.md) |  .NET Framework Memory metrics |
+[netframework_clrremoting](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework_clrremoting.md) | .NET Framework Remoting metrics |
+[netframework_clrsecurity](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework_clrsecurity.md) | .NET Framework Security Check metrics |
+[net](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.net.md) | Network interface I/O | &#10003;
+[os](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.os.md) | OS metrics (memory, processes, users) | &#10003;
+[process](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.process.md) | Per-process metrics |
+[remote_fx](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.remote_fx.md) | RemoteFX protocol (RDP) metrics |
+[scheduled_task](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.scheduled_task.md) | Scheduled Tasks metrics |
+[service](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.service.md) | Service state metrics | &#10003;
+[smtp](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.smtp.md) | IIS SMTP Server |
+[system](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.system.md) | System calls | &#10003;
+[tcp](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.tcp.md) | TCP connections |
+[teradici_pcoip](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.teradici_pcoip.md) | [Teradici PCoIP](https://www.teradici.com/web-help/pcoip_wmi_specs/) session metrics |
+[time](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.time.md) | Windows Time Service |
+[thermalzone](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.thermalzone.md) | Thermal information
+[terminal_services](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.terminal_services.md) | Terminal services (RDS)
+[textfile](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.textfile.md) | Read prometheus metrics from a text file |
+[vmware_blast](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.vmware_blast.md) | VMware Blast session metrics |
+[vmware](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.vmware.md) | Performance counters installed by the Vmware Guest agent |
 
 See the linked documentation on each collector for more information on reported metrics, configuration settings and usage examples.
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.windows.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.windows.md
@@ -292,7 +292,7 @@ prometheus.exporter.windows "default" {
 
 // Configure a prometheus.scrape component to collect windows metrics.
 prometheus.scrape "example" {
-  targets    = prometheus.exporter.windows.this.targets
+  targets    = prometheus.exporter.windows.default.targets
   forward_to = [ /* ... */ ]
 }
 ```

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/PuerkitoBio/rehttp v1.1.0
 	github.com/Shopify/sarama v1.38.1
+	github.com/alecthomas/kingpin/v2 v2.3.2
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
 	github.com/aws/aws-sdk-go v1.44.187
 	github.com/aws/aws-sdk-go-v2 v1.17.2
@@ -120,7 +121,7 @@ require (
 	github.com/prometheus-community/elasticsearch_exporter v1.5.0
 	github.com/prometheus-community/postgres_exporter v0.11.1
 	github.com/prometheus-community/stackdriver_exporter v0.13.0
-	github.com/prometheus-community/windows_exporter v0.0.0-00010101000000-000000000000
+	github.com/prometheus-community/windows_exporter v0.0.0-20230507104622-79781c6d75fc
 	github.com/prometheus-operator/prometheus-operator v0.62.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.63.0
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.63.0
@@ -423,7 +424,7 @@ require (
 	github.com/krallistic/kazoo-go v0.0.0-20170526135507-a15279744f4e // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165 // indirect
-	github.com/leoluk/perflib_exporter v0.1.0 // indirect
+	github.com/leoluk/perflib_exporter v0.2.0 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/linode/linodego v1.12.0 // indirect
 	github.com/lufia/iostat v1.2.1 // indirect
@@ -601,6 +602,7 @@ require (
 	github.com/willf/bitset v1.1.11 // indirect
 	github.com/willf/bloom v2.0.3+incompatible // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
+	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 )
 
 // NOTE: replace directives below must always be *temporary*.
@@ -655,7 +657,6 @@ replace (
 	// Upstream seems to be inactive, see https://github.com/grafana/agent/issues/1845
 	github.com/infinityworks/github-exporter => github.com/grafana/github-exporter v0.0.0-20230418063919-fa34e926116a
 	github.com/prometheus-community/postgres_exporter => github.com/grafana/postgres_exporter v0.8.1-0.20210722175051-db35d7c2f520
-	github.com/prometheus-community/windows_exporter => github.com/grafana/windows_exporter v0.15.1-0.20220202211901-871715ba0b43
 	github.com/prometheus/mysqld_exporter => github.com/grafana/mysqld_exporter v0.12.2-0.20201015182516-5ac885b2d38a
 	github.com/prometheus/snmp_exporter => github.com/grafana/snmp_exporter v0.20.1-0.20220405135227-49087c510bb1
 
@@ -677,9 +678,6 @@ replace (
 	go.opentelemetry.io/collector/exporter/otlphttpexporter => github.com/grafana/opentelemetry-collector/exporter/otlphttpexporter v0.0.0-20230412190723-62ec42799a7d
 	go.opentelemetry.io/collector/pdata => github.com/grafana/opentelemetry-collector/pdata v0.0.0-20230412190723-62ec42799a7d
 )
-
-// Replacement necessary for windows_exporter so that we can use gokit logging and not the old prometheus logging
-replace github.com/leoluk/perflib_exporter v0.1.0 => github.com/grafana/perflib_exporter v0.1.1-0.20211013152516-e37e14fb8b0a
 
 // Required until https://github.com/weaveworks/common/pull/240 is merged
 replace google.golang.org/grpc => google.golang.org/grpc v1.45.0

--- a/go.mod
+++ b/go.mod
@@ -232,7 +232,7 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/Microsoft/go-winio v0.6.0 // indirect
-	github.com/Microsoft/hcsshim v0.9.7 // indirect
+	github.com/Microsoft/hcsshim v0.9.8 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20210920160938-87db9fbc61c7 // indirect
 	github.com/StackExchange/wmi v1.2.1 // indirect
@@ -601,8 +601,8 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/willf/bitset v1.1.11 // indirect
 	github.com/willf/bloom v2.0.3+incompatible // indirect
-	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
+	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 )
 
 // NOTE: replace directives below must always be *temporary*.

--- a/go.sum
+++ b/go.sum
@@ -564,8 +564,8 @@ github.com/Microsoft/hcsshim v0.8.14/go.mod h1:NtVKoYxQuTLx6gEq0L96c9Ju4JbRJ4nY2
 github.com/Microsoft/hcsshim v0.8.15/go.mod h1:x38A4YbHbdxJtc0sF6oIz+RG0npwSCAvn69iY6URG00=
 github.com/Microsoft/hcsshim v0.8.16/go.mod h1:o5/SZqmR7x9JNKsW3pu+nqHm0MF8vbA+VxGOoXdC600=
 github.com/Microsoft/hcsshim v0.8.21/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
-github.com/Microsoft/hcsshim v0.9.7 h1:mKNHW/Xvv1aFH87Jb6ERDzXTJTLPlmzfZ28VBFD/bfg=
-github.com/Microsoft/hcsshim v0.9.7/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
+github.com/Microsoft/hcsshim v0.9.8 h1:lf7xxK2+Ikbj9sVf2QZsouGjRjEp2STj1yDHgoVtU5k=
+github.com/Microsoft/hcsshim v0.9.8/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
 github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5hlzMzRKMLyo42nCZ9oml8AdTlq/0cvIaBv6tK1RehU=
 github.com/Microsoft/hcsshim/test v0.0.0-20210227013316-43a75bb4edd3/go.mod h1:mw7qgWloBUl75W/gVH3cQszUg1+gUITj7D6NY7ywVnY=
 github.com/Mottl/ctimefmt v0.0.0-20190803144728-fd2ac23a585a/go.mod h1:eyj2WSIdoPMPs2eNTLpSmM6Nzqo4V80/d6jHpnJ1SAI=
@@ -601,7 +601,6 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWso
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/Shopify/toxiproxy/v2 v2.5.0 h1:i4LPT+qrSlKNtQf5QliVjdP08GyAH8+BUIc9gT0eahc=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
@@ -615,9 +614,9 @@ github.com/aerospike/aerospike-client-go v1.27.0/go.mod h1:zj8LBEnWBDOVEIJt8LvaR
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
-github.com/alecthomas/kingpin v2.2.6+incompatible h1:5svnBTFgJjZvGKyYBtMB0+m5wvrbUHiqye8wRJMlnYI=
 github.com/alecthomas/kingpin/v2 v2.3.1/go.mod h1:oYL5vtsvEHZGHxU7DMp32Dvx+qL+ptGn6lWaot2vCNE=
 github.com/alecthomas/kingpin/v2 v2.3.2 h1:H0aULhgmSzN8xQ3nX1uxtdlTHYoPLu5AhHxWrKI6ocU=
+github.com/alecthomas/kingpin/v2 v2.3.2/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -1788,8 +1787,6 @@ github.com/grafana/opentelemetry-collector/exporter/otlphttpexporter v0.0.0-2023
 github.com/grafana/opentelemetry-collector/exporter/otlphttpexporter v0.0.0-20230412190723-62ec42799a7d/go.mod h1:GbE0IhSPvKRe3868XUG7sYdyvqAgfj6ESKFz9kaAnrM=
 github.com/grafana/opentelemetry-collector/pdata v0.0.0-20230412190723-62ec42799a7d h1:Fbxo2JIdS4qSWWkypyiMHRdX0oEykyyEC/5Va1Sjq5A=
 github.com/grafana/opentelemetry-collector/pdata v0.0.0-20230412190723-62ec42799a7d/go.mod h1:IzvXUGQml2mrnvdb8zIlEW3qQs9oFLdD2hLwJdZ+pek=
-github.com/grafana/perflib_exporter v0.1.1-0.20211013152516-e37e14fb8b0a h1:H+syQKTZuBnoVp9qOuHoktNeuCDrgySAbMT9jyTp564=
-github.com/grafana/perflib_exporter v0.1.1-0.20211013152516-e37e14fb8b0a/go.mod h1:MinSWm88jguXFFrGsP56PtleUb4Qtm4tNRH/wXNXRTI=
 github.com/grafana/phlare/api v0.1.2 h1:1jrwd3KnsXMzj/tJih9likx5EvbY3pbvLbDqAAYem30=
 github.com/grafana/phlare/api v0.1.2/go.mod h1:29vcLwFDmZBDce2jwFIMtzvof7fzPadT8VMKw9ks7FU=
 github.com/grafana/postgres_exporter v0.8.1-0.20210722175051-db35d7c2f520 h1:HnFWqxhoSF3WC7sKAdMZ+SRXvHLVZlZ3sbQjuUlTqkw=
@@ -1808,8 +1805,6 @@ github.com/grafana/tail v0.0.0-20230328181249-aa6682d7843a h1:ypBalFlWhbqP+60je3
 github.com/grafana/tail v0.0.0-20230328181249-aa6682d7843a/go.mod h1:7t5XR+2IA8P2qggOAHTj/GCZfoLBle3OvNSYh1VkRBU=
 github.com/grafana/vmware_exporter v0.0.4-beta h1:Tb8Edm/wDYh0Lvhm38HLNTlkflUrlPGB+jD+/hW4xHI=
 github.com/grafana/vmware_exporter v0.0.4-beta/go.mod h1:+SsUoWeCJ3nDm1gkw8xqBp4NNSUIrGVoEbnwJeeoIVU=
-github.com/grafana/windows_exporter v0.15.1-0.20220202211901-871715ba0b43 h1:gb+wDKb+9r4n3QbMzfudcHDtE9lI+kKjx+98bYphqK4=
-github.com/grafana/windows_exporter v0.15.1-0.20220202211901-871715ba0b43/go.mod h1:zWjLDqyEy3ZEy1LNlR6iUJJgYCoUDJTyUbrjeLUp3ZE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grobie/gomemcache v0.0.0-20201204163352-08d7c80fcac6 h1:vqwzYov9hrRoGAmy61um8mVteOCD0bEbKgXr1mmkTlI=
 github.com/grobie/gomemcache v0.0.0-20201204163352-08d7c80fcac6/go.mod h1:L69/dBlPQlWkcnU76WgcppK5e4rrxzQdi6LhLnK/ytA=
@@ -2259,6 +2254,8 @@ github.com/leodido/go-urn v1.1.0/go.mod h1:+cyI34gQWZcE1eQU7NVgKkkzdXDQHr1dBMtdA
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165 h1:bCiVCRCs1Heq84lurVinUPy19keqGEe4jh5vtK37jcg=
 github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165/go.mod h1:WZxr2/6a/Ar9bMDc2rN/LJrE/hF6bXE4LPyDSIxwAfg=
+github.com/leoluk/perflib_exporter v0.2.0 h1:WJU7N3AIHxfc3CjoEJcBgG3i2ltF5Yz1ADVY9T6f1BY=
+github.com/leoluk/perflib_exporter v0.2.0/go.mod h1:MinSWm88jguXFFrGsP56PtleUb4Qtm4tNRH/wXNXRTI=
 github.com/lib/pq v0.0.0-20150723085316-0dad96c0b94f/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v0.0.0-20180327071824-d34b9ff171c2/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v0.0.0-20180523175426-90697d60dd84/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -2772,6 +2769,8 @@ github.com/prometheus-community/prom-label-proxy v0.5.0 h1:f9RqZ+xwznh/7XbTEr0LD
 github.com/prometheus-community/prom-label-proxy v0.5.0/go.mod h1:qiIPYa/ju9u4wq3LjvL3ofzd3jcyW0Rt5jkZ6QgF4nc=
 github.com/prometheus-community/stackdriver_exporter v0.13.0 h1:4h7v28foRJ4/RuchNZCYsoDp+CkF4Mp9nebtPzgil3g=
 github.com/prometheus-community/stackdriver_exporter v0.13.0/go.mod h1:ZFO015Mexz1xNHSvFjZFiIspYx6qhDg9Kre4LPUjO9s=
+github.com/prometheus-community/windows_exporter v0.0.0-20230507104622-79781c6d75fc h1:5HoXejMR9fh1Sh46I/pe/Y3M1vJpm5UvCSqWdBmUZHs=
+github.com/prometheus-community/windows_exporter v0.0.0-20230507104622-79781c6d75fc/go.mod h1:O3yNykuN8H0YOdVc4NEzs12Ugp4x2MgNhZvXHPkf7j8=
 github.com/prometheus-operator/prometheus-operator v0.62.0 h1:9pjQm5NgZrhJgLIapWxKJXeZ0hasBZ/ekWcyHnsldk0=
 github.com/prometheus-operator/prometheus-operator v0.62.0/go.mod h1:fyio1iC7r5NSFw/AQaNH8E+7N7embyY2W1ozINQRShw=
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.63.0 h1:efsW3CfymG5bZUpeIsYfdihB33YItCn7uHBOEbnHQG8=
@@ -2799,7 +2798,6 @@ github.com/prometheus/client_golang v1.5.1/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3O
 github.com/prometheus/client_golang v1.6.0/go.mod h1:ZLOG9ck3JLRdB5MgO8f+lLTe83AXG6ro35rLTxvnIl4=
 github.com/prometheus/client_golang v1.6.1-0.20200604110148-03575cad4e55/go.mod h1:25h+Uz1WvXDBZYwqGX8PAb71RBkcjxEVV/R5wGnsq4I=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
-github.com/prometheus/client_golang v1.8.0/go.mod h1:O9VU6huf47PktckDQfMTX0Y8tY0/7TSWwj+ITvv0TnM=
 github.com/prometheus/client_golang v1.9.0/go.mod h1:FqZLKOZnGdFAhOK4nqGHa7D66IdsO+O441Eve7ptJDU=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
@@ -2824,7 +2822,6 @@ github.com/prometheus/common/sigv4 v0.1.0 h1:qoVebwtwwEhS85Czm2dSROY5fTo2PAPEVdD
 github.com/prometheus/common/sigv4 v0.1.0/go.mod h1:2Jkxxk9yYvCkE5G1sQT7GuEXm57JrvHu9k5YwTjsNtI=
 github.com/prometheus/consul_exporter v0.8.0 h1:2z3drFic65WFoHaJRKkmnJRRlBLmmxVqT8L9LO2yxAo=
 github.com/prometheus/consul_exporter v0.8.0/go.mod h1:KHTgkT1/oLpXKC4+mKZV63hZSMHuKskUnHoenEave4Y=
-github.com/prometheus/exporter-toolkit v0.5.1/go.mod h1:OCkM4805mmisBhLmVFw858QYi3v0wKdY6/UxrT0pZVg=
 github.com/prometheus/exporter-toolkit v0.6.0/go.mod h1:ZUBIj498ePooX9t/2xtDjeQYwvRpiPP2lh5u4iblj2g=
 github.com/prometheus/exporter-toolkit v0.6.1/go.mod h1:ZUBIj498ePooX9t/2xtDjeQYwvRpiPP2lh5u4iblj2g=
 github.com/prometheus/exporter-toolkit v0.7.0/go.mod h1:ZUBIj498ePooX9t/2xtDjeQYwvRpiPP2lh5u4iblj2g=
@@ -3188,9 +3185,9 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:
 github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
-github.com/xhit/go-str2duration v1.2.0 h1:BcV5u025cITWxEQKGWr1URRzrcXtu7uk8+luz3Yuhwc=
 github.com/xhit/go-str2duration v1.2.0/go.mod h1:3cPSlfZlUHVlneIVfePFWcJZsuwf+P1v2SRTV4cUmp4=
 github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
+github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v1.1.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/xo/dburl v0.13.0 h1:kq+oD1j/m8DnJ/p6G/LQXRosVchs8q5/AszEUKkvYfo=
@@ -3415,7 +3412,6 @@ golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
-golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
@@ -3751,7 +3747,6 @@ golang.org/x/sys v0.0.0-20200916030750-2334cc1a136f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200922070232-aee5d888a860/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201117170446-d9b008d0a637/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/integrations/windows_exporter/config.go
+++ b/pkg/integrations/windows_exporter/config.go
@@ -20,14 +20,20 @@ var DefaultConfig = Config{
 		EnabledList: "",
 	},
 	IIS: IISConfig{
-		AppInclude:  "",
-		AppExclude:  "",
-		SiteInclude: "",
-		SiteExclude: "",
+		AppBlackList:  "",
+		AppWhiteList:  "",
+		SiteBlackList: "",
+		SiteWhiteList: "",
+		AppInclude:    "",
+		AppExclude:    "",
+		SiteInclude:   "",
+		SiteExclude:   "",
 	},
 	LogicalDisk: LogicalDiskConfig{
-		Include: "",
-		Exclude: "",
+		BlackList: "",
+		WhiteList: "",
+		Include:   "",
+		Exclude:   "",
 	},
 	MSMQ: MSMQConfig{
 		Where: "",
@@ -36,12 +42,16 @@ var DefaultConfig = Config{
 		EnabledClasses: "",
 	},
 	Network: NetworkConfig{
-		Include: "",
-		Exclude: "",
+		BlackList: "",
+		WhiteList: "",
+		Include:   "",
+		Exclude:   "",
 	},
 	Process: ProcessConfig{
-		Include: "",
-		Exclude: "",
+		BlackList: "",
+		WhiteList: "",
+		Include:   "",
+		Exclude:   "",
 	},
 	ScheduledTask: ScheduledTaskConfig{
 		Include: "",
@@ -52,8 +62,10 @@ var DefaultConfig = Config{
 		Where:  "",
 	},
 	SMTP: SMTPConfig{
-		Include: "",
-		Exclude: "",
+		BlackList: "",
+		WhiteList: "",
+		Include:   "",
+		Exclude:   "",
 	},
 	TextFile: TextFileConfig{
 		TextFileDirectory: "",
@@ -184,8 +196,6 @@ type LogicalDiskConfig struct {
 
 // ScheduledTaskConfig handles settings for the windows_exporter scheduled_task collector
 type ScheduledTaskConfig struct {
-	BlackList string `yaml:"blacklist,omitempty"`
-	WhiteList string `yaml:"whitelist,omitempty"`
-	Include   string `yaml:"include,omitempty"`
-	Exclude   string `yaml:"exclude,omitempty"`
+	Include string `yaml:"include,omitempty"`
+	Exclude string `yaml:"exclude,omitempty"`
 }

--- a/pkg/integrations/windows_exporter/config.go
+++ b/pkg/integrations/windows_exporter/config.go
@@ -9,10 +9,55 @@ import (
 
 // DefaultConfig holds the default settings for the windows_exporter integration.
 var DefaultConfig = Config{
-	EnabledCollectors: "cpu,cs,logical_disk,net,os,service,system",
-
 	// NOTE(rfratto): there is an init function in config_windows.go that
 	// populates defaults for collectors based on the exporter defaults.
+	EnabledCollectors: "cpu,cs,logical_disk,net,os,service,system",
+
+	Dfsr: DfsrConfig{
+		SourcesEnabled: "",
+	},
+	Exchange: ExchangeConfig{
+		EnabledList: "",
+	},
+	IIS: IISConfig{
+		AppInclude:  "",
+		AppExclude:  "",
+		SiteInclude: "",
+		SiteExclude: "",
+	},
+	LogicalDisk: LogicalDiskConfig{
+		Include: "",
+		Exclude: "",
+	},
+	MSMQ: MSMQConfig{
+		Where: "",
+	},
+	MSSQL: MSSQLConfig{
+		EnabledClasses: "",
+	},
+	Network: NetworkConfig{
+		Include: "",
+		Exclude: "",
+	},
+	Process: ProcessConfig{
+		Include: "",
+		Exclude: "",
+	},
+	ScheduledTask: ScheduledTaskConfig{
+		Include: "",
+		Exclude: "",
+	},
+	Service: ServiceConfig{
+		UseApi: "",
+		Where:  "",
+	},
+	SMTP: SMTPConfig{
+		Include: "",
+		Exclude: "",
+	},
+	TextFile: TextFileConfig{
+		TextFileDirectory: "",
+	},
 }
 
 func init() {
@@ -21,20 +66,22 @@ func init() {
 }
 
 // Config controls the windows_exporter integration.
-// All of these and their child fields are pointers so we can determine if the value was set or not.
+// All of these and their child fields are pointers, so we can determine if the value was set or not.
 type Config struct {
 	EnabledCollectors string `yaml:"enabled_collectors"`
 
-	Exchange    ExchangeConfig    `yaml:"exchange,omitempty"`
-	IIS         IISConfig         `yaml:"iis,omitempty"`
-	TextFile    TextFileConfig    `yaml:"text_file,omitempty"`
-	SMTP        SMTPConfig        `yaml:"smtp,omitempty"`
-	Service     ServiceConfig     `yaml:"service,omitempty"`
-	Process     ProcessConfig     `yaml:"process,omitempty"`
-	Network     NetworkConfig     `yaml:"network,omitempty"`
-	MSSQL       MSSQLConfig       `yaml:"mssql,omitempty"`
-	MSMQ        MSMQConfig        `yaml:"msmq,omitempty"`
-	LogicalDisk LogicalDiskConfig `yaml:"logical_disk,omitempty"`
+	Dfsr          DfsrConfig          `yaml:"dfsr,omitempty"`
+	Exchange      ExchangeConfig      `yaml:"exchange,omitempty"`
+	IIS           IISConfig           `yaml:"iis,omitempty"`
+	TextFile      TextFileConfig      `yaml:"text_file,omitempty"`
+	SMTP          SMTPConfig          `yaml:"smtp,omitempty"`
+	Service       ServiceConfig       `yaml:"service,omitempty"`
+	Process       ProcessConfig       `yaml:"process,omitempty"`
+	Network       NetworkConfig       `yaml:"network,omitempty"`
+	MSSQL         MSSQLConfig         `yaml:"mssql,omitempty"`
+	MSMQ          MSMQConfig          `yaml:"msmq,omitempty"`
+	LogicalDisk   LogicalDiskConfig   `yaml:"logical_disk,omitempty"`
+	ScheduledTask ScheduledTaskConfig `yaml:"scheduled_task,omitempty"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler for Config.
@@ -60,6 +107,11 @@ func (c *Config) NewIntegration(l log.Logger) (integrations.Integration, error) 
 	return New(l, c)
 }
 
+// DfsrConfig handles settings for the windows_exporter dfsr collector
+type DfsrConfig struct {
+	SourcesEnabled string `yaml:"sources_enabled,omitempty"`
+}
+
 // ExchangeConfig handles settings for the windows_exporter Exchange collector
 type ExchangeConfig struct {
 	EnabledList string `yaml:"enabled_list,omitempty"`
@@ -71,6 +123,10 @@ type IISConfig struct {
 	SiteBlackList string `yaml:"site_blacklist,omitempty"`
 	AppWhiteList  string `yaml:"app_whitelist,omitempty"`
 	AppBlackList  string `yaml:"app_blacklist,omitempty"`
+	SiteInclude   string `yaml:"site_include,omitempty"`
+	SiteExclude   string `yaml:"site_exclude,omitempty"`
+	AppInclude    string `yaml:"app_include,omitempty"`
+	AppExclude    string `yaml:"app_exclude,omitempty"`
 }
 
 // TextFileConfig handles settings for the windows_exporter Text File collector
@@ -82,23 +138,30 @@ type TextFileConfig struct {
 type SMTPConfig struct {
 	BlackList string `yaml:"blacklist,omitempty"`
 	WhiteList string `yaml:"whitelist,omitempty"`
+	Include   string `yaml:"include,omitempty"`
+	Exclude   string `yaml:"exclude,omitempty"`
 }
 
 // ServiceConfig handles settings for the windows_exporter service collector
 type ServiceConfig struct {
-	Where string `yaml:"where_clause,omitempty"`
+	UseApi string `yaml:"use_api,omitempty"`
+	Where  string `yaml:"where_clause,omitempty"`
 }
 
 // ProcessConfig handles settings for the windows_exporter process collector
 type ProcessConfig struct {
 	BlackList string `yaml:"blacklist,omitempty"`
 	WhiteList string `yaml:"whitelist,omitempty"`
+	Include   string `yaml:"include,omitempty"`
+	Exclude   string `yaml:"exclude,omitempty"`
 }
 
 // NetworkConfig handles settings for the windows_exporter network collector
 type NetworkConfig struct {
 	BlackList string `yaml:"blacklist,omitempty"`
 	WhiteList string `yaml:"whitelist,omitempty"`
+	Include   string `yaml:"include,omitempty"`
+	Exclude   string `yaml:"exclude,omitempty"`
 }
 
 // MSSQLConfig handles settings for the windows_exporter SQL server collector
@@ -115,4 +178,14 @@ type MSMQConfig struct {
 type LogicalDiskConfig struct {
 	BlackList string `yaml:"blacklist,omitempty"`
 	WhiteList string `yaml:"whitelist,omitempty"`
+	Include   string `yaml:"include,omitempty"`
+	Exclude   string `yaml:"exclude,omitempty"`
+}
+
+// ScheduledTaskConfig handles settings for the windows_exporter scheduled_task collector
+type ScheduledTaskConfig struct {
+	BlackList string `yaml:"blacklist,omitempty"`
+	WhiteList string `yaml:"whitelist,omitempty"`
+	Include   string `yaml:"include,omitempty"`
+	Exclude   string `yaml:"exclude,omitempty"`
 }

--- a/pkg/integrations/windows_exporter/config_windows.go
+++ b/pkg/integrations/windows_exporter/config_windows.go
@@ -1,113 +1,96 @@
 package windows_exporter //nolint:golint
 
 import (
+	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/collector"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 // Populate defaults for all collector configs.
 func init() {
 	// Register flags from all collector configs to a fake integration and then
 	// parse an empty command line to force defaults to be populated.
-	ka := kingpin.New("init", "")
+	app := kingpin.New("", "")
 
-	configs := collector.AllConfigs()
-	for _, cfg := range configs {
-		cfg.RegisterFlags(ka)
-	}
-	_, err := ka.Parse(nil)
+	// Register all flags from collector
+	collector.RegisterCollectorsFlags(app)
+
+	_, err := app.Parse([]string{})
 	if err != nil {
 		panic(err)
 	}
 
 	// Map the configs with defaults applied to our default config.
-	DefaultConfig.fromExporterConfig(configs)
+	DefaultConfig.fromExporterConfig(app)
 }
 
 // fromExporterConfig converts windows_exporter configs into the integration Config.
-func (c *Config) fromExporterConfig(configs []collector.Config) {
-	for _, ec := range configs {
-		switch other := ec.(type) {
-		case *collector.ExchangeConfig:
-			c.Exchange.EnabledList = other.Enabled
-
-		case *collector.IISConfig:
-			c.IIS.SiteWhiteList = other.SiteWhitelist
-			c.IIS.SiteBlackList = other.SiteBlacklist
-			c.IIS.AppWhiteList = other.AppWhitelist
-			c.IIS.AppBlackList = other.AppBlacklist
-
-		case *collector.TextFileConfig:
-			c.TextFile.TextFileDirectory = other.Directory
-
-		case *collector.SMTPConfig:
-			c.SMTP.WhiteList = other.ServerWhitelist
-			c.SMTP.BlackList = other.ServerBlacklist
-
-		case *collector.ServiceConfig:
-			c.Service.Where = other.WhereClause
-
-		case *collector.ProcessConfig:
-			c.Process.WhiteList = other.ProcessWhitelist
-			c.Process.BlackList = other.ProcessBlacklist
-
-		case *collector.NetworkConfig:
-			c.Network.WhiteList = other.NICWhitelist
-			c.Network.BlackList = other.NICBlacklist
-
-		case *collector.MSSQLConfig:
-			c.MSSQL.EnabledClasses = other.EnabledCollectors
-
-		case *collector.MSMQConfig:
-			c.MSMQ.Where = other.WhereClause
-
-		case *collector.LogicalDiskConfig:
-			c.LogicalDisk.WhiteList = other.VolumeWhitelist
-			c.LogicalDisk.BlackList = other.VolumeBlacklist
-		}
-	}
+func (c *Config) fromExporterConfig(app *kingpin.Application) {
+	c.Dfsr.SourcesEnabled = *app.GetFlag(collector.FlagDfsrEnabledCollectors).String()
+	c.Exchange.EnabledList = *app.GetFlag(collector.FlagExchangeCollectorsEnabled).String()
+	c.IIS.SiteBlackList = *app.GetFlag(collector.FlagIISSiteOldExclude).String()
+	c.IIS.SiteWhiteList = *app.GetFlag(collector.FlagIISSiteOldInclude).String()
+	c.IIS.AppBlackList = *app.GetFlag(collector.FlagIISAppOldExclude).String()
+	c.IIS.AppWhiteList = *app.GetFlag(collector.FlagIISAppOldInclude).String()
+	c.IIS.SiteExclude = *app.GetFlag(collector.FlagIISSiteExclude).String()
+	c.IIS.SiteInclude = *app.GetFlag(collector.FlagIISSiteInclude).String()
+	c.IIS.AppExclude = *app.GetFlag(collector.FlagIISAppExclude).String()
+	c.IIS.AppInclude = *app.GetFlag(collector.FlagIISAppInclude).String()
+	c.LogicalDisk.BlackList = *app.GetFlag(collector.FlagLogicalDiskVolumeOldExclude).String()
+	c.LogicalDisk.WhiteList = *app.GetFlag(collector.FlagLogicalDiskVolumeOldInclude).String()
+	c.LogicalDisk.Exclude = *app.GetFlag(collector.FlagLogicalDiskVolumeExclude).String()
+	c.LogicalDisk.Include = *app.GetFlag(collector.FlagLogicalDiskVolumeInclude).String()
+	c.MSMQ.Where = *app.GetFlag(collector.FlagMsmqWhereClause).String()
+	c.MSSQL.EnabledClasses = *app.GetFlag(collector.FlagMssqlEnabledCollectors).String()
+	c.Network.BlackList = *app.GetFlag(collector.FlagNicOldExclude).String()
+	c.Network.WhiteList = *app.GetFlag(collector.FlagNicOldInclude).String()
+	c.Network.Exclude = *app.GetFlag(collector.FlagNicExclude).String()
+	c.Network.Include = *app.GetFlag(collector.FlagNicInclude).String()
+	c.Process.BlackList = *app.GetFlag(collector.FlagProcessOldExclude).String()
+	c.Process.WhiteList = *app.GetFlag(collector.FlagProcessOldInclude).String()
+	c.Process.Exclude = *app.GetFlag(collector.FlagProcessExclude).String()
+	c.Process.Include = *app.GetFlag(collector.FlagProcessInclude).String()
+	c.ScheduledTask.Exclude = *app.GetFlag(collector.FlagScheduledTaskExclude).String()
+	c.ScheduledTask.Include = *app.GetFlag(collector.FlagScheduledTaskInclude).String()
+	c.Service.Where = *app.GetFlag(collector.FlagServiceWhereClause).String()
+	c.Service.UseApi = *app.GetFlag(collector.FlagServiceUseAPI).String()
+	c.SMTP.BlackList = *app.GetFlag(collector.FlagSmtpServerOldExclude).String()
+	c.SMTP.WhiteList = *app.GetFlag(collector.FlagSmtpServerOldInclude).String()
+	c.SMTP.Exclude = *app.GetFlag(collector.FlagSmtpServerExclude).String()
+	c.SMTP.Include = *app.GetFlag(collector.FlagSmtpServerInclude).String()
+	c.TextFile.TextFileDirectory = *app.GetFlag(collector.FlagTextFileDirectory).String()
 }
 
 // toExporterConfig converts integration Configs into windows_exporter configs.
-func (c *Config) toExporterConfig(configs []collector.Config) {
-	for _, ec := range configs {
-		switch other := ec.(type) {
-		case *collector.ExchangeConfig:
-			other.Enabled = c.Exchange.EnabledList
-
-		case *collector.IISConfig:
-			other.SiteWhitelist = c.IIS.SiteWhiteList
-			other.SiteBlacklist = c.IIS.SiteBlackList
-			other.AppWhitelist = c.IIS.AppWhiteList
-			other.AppBlacklist = c.IIS.AppBlackList
-
-		case *collector.TextFileConfig:
-			other.Directory = c.TextFile.TextFileDirectory
-
-		case *collector.SMTPConfig:
-			other.ServerWhitelist = c.SMTP.WhiteList
-			other.ServerBlacklist = c.SMTP.BlackList
-
-		case *collector.ServiceConfig:
-			other.WhereClause = c.Service.Where
-
-		case *collector.ProcessConfig:
-			other.ProcessWhitelist = c.Process.WhiteList
-			other.ProcessBlacklist = c.Process.BlackList
-
-		case *collector.NetworkConfig:
-			other.NICWhitelist = c.Network.WhiteList
-			other.NICBlacklist = c.Network.BlackList
-
-		case *collector.MSSQLConfig:
-			other.EnabledCollectors = c.MSSQL.EnabledClasses
-
-		case *collector.MSMQConfig:
-			other.WhereClause = c.MSMQ.Where
-
-		case *collector.LogicalDiskConfig:
-			other.VolumeWhitelist = c.LogicalDisk.WhiteList
-			other.VolumeBlacklist = c.LogicalDisk.BlackList
-		}
-	}
+func (c *Config) toExporterConfig(app *kingpin.Application) {
+	app.GetFlag(collector.FlagDfsrEnabledCollectors).StringVar(&c.Dfsr.SourcesEnabled)
+	app.GetFlag(collector.FlagExchangeCollectorsEnabled).StringVar(&c.Exchange.EnabledList)
+	app.GetFlag(collector.FlagIISSiteOldExclude).StringVar(&c.IIS.SiteBlackList)
+	app.GetFlag(collector.FlagIISSiteOldInclude).StringVar(&c.IIS.SiteWhiteList)
+	app.GetFlag(collector.FlagIISAppOldExclude).StringVar(&c.IIS.AppBlackList)
+	app.GetFlag(collector.FlagIISAppOldInclude).StringVar(&c.IIS.AppWhiteList)
+	app.GetFlag(collector.FlagIISSiteExclude).StringVar(&c.IIS.SiteExclude)
+	app.GetFlag(collector.FlagIISSiteInclude).StringVar(&c.IIS.SiteInclude)
+	app.GetFlag(collector.FlagIISAppExclude).StringVar(&c.IIS.AppExclude)
+	app.GetFlag(collector.FlagIISAppInclude).StringVar(&c.IIS.AppInclude)
+	app.GetFlag(collector.FlagLogicalDiskVolumeOldExclude).StringVar(&c.LogicalDisk.BlackList)
+	app.GetFlag(collector.FlagLogicalDiskVolumeOldInclude).StringVar(&c.LogicalDisk.WhiteList)
+	app.GetFlag(collector.FlagLogicalDiskVolumeExclude).StringVar(&c.LogicalDisk.Exclude)
+	app.GetFlag(collector.FlagLogicalDiskVolumeInclude).StringVar(&c.LogicalDisk.Include)
+	app.GetFlag(collector.FlagMsmqWhereClause).StringVar(&c.MSMQ.Where)
+	app.GetFlag(collector.FlagMssqlEnabledCollectors).StringVar(&c.MSSQL.EnabledClasses)
+	app.GetFlag(collector.FlagNicOldExclude).StringVar(&c.Network.BlackList)
+	app.GetFlag(collector.FlagNicOldInclude).StringVar(&c.Network.WhiteList)
+	app.GetFlag(collector.FlagNicExclude).StringVar(&c.Network.Exclude)
+	app.GetFlag(collector.FlagNicInclude).StringVar(&c.Network.Include)
+	app.GetFlag(collector.FlagProcessOldExclude).StringVar(&c.Process.BlackList)
+	app.GetFlag(collector.FlagProcessOldInclude).StringVar(&c.Process.WhiteList)
+	app.GetFlag(collector.FlagProcessExclude).StringVar(&c.Process.Exclude)
+	app.GetFlag(collector.FlagProcessInclude).StringVar(&c.Process.Include)
+	app.GetFlag(collector.FlagScheduledTaskExclude).StringVar(&c.Process.Exclude)
+	app.GetFlag(collector.FlagScheduledTaskInclude).StringVar(&c.Process.Include)
+	app.GetFlag(collector.FlagServiceWhereClause).StringVar(&c.Service.Where)
+	app.GetFlag(collector.FlagServiceUseAPI).StringVar(&c.Service.UseApi)
+	app.GetFlag(collector.FlagSmtpServerExclude).StringVar(&c.SMTP.Exclude)
+	app.GetFlag(collector.FlagNicInclude).StringVar(&c.SMTP.Include)
+	app.GetFlag(collector.FlagTextFileDirectory).StringVar(&c.TextFile.TextFileDirectory)
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR removes the outdated internal grafana/windows_exporter fork.

This PR is still in draft, since various upstream PR needs to be solved first. This PR based on personal forks of windows_exporter which are planned to be merged upstreamed. After that, the PR is ready to review.

I'm creating the PR right now to indicate that some is working on the windows_exporter.

It introduce a breaking change from https://github.com/prometheus-community/windows_exporter/pull/1170 (not sure how to handle this). If Grafana Agent follows SemVer, the breaking change is fine.

Test on a windows 10 system with following config:

```
prometheus.exporter.windows "exporter1" {
  // Subset of overall collectors  
  enabled_collectors = "cpu,cs,logical_disk"
}

prometheus.exporter.windows "exporter2" {
  // Different subset of overall collectors  
  enabled_collectors = "net,os,service,system"
}

prometheus.scrape "example" {
  targets = concat(
    prometheus.exporter.windows.exporter1.targets,
    prometheus.exporter.windows.exporter2.targets,
  )

  forward_to = [...]
}
```

Prometheus UI:

<img width="1249" alt="image" src="https://user-images.githubusercontent.com/1560587/236693483-303540d9-7ee8-49fc-9920-a62b114088f2.png">

#### Which issue(s) this PR fixes

* Fixes #1631 
* Fixes #3364 
* Fixes #3420 
* Relates #3122 (not sure, if the issues exists upstreams)

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
