### PR TITLE
Added coalesce function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Features
+
+- Added coalesce function to river stdlib. (@jkroepke)
+
 ### Enhancements
 
 - Support in-memory HTTP traffic for Flow components. `prometheus.exporter`

--- a/docs/sources/flow/reference/stdlib/coalesce.md
+++ b/docs/sources/flow/reference/stdlib/coalesce.md
@@ -6,8 +6,7 @@ title: coalesce
 
 # coalesce
 
-`coalesce` takes any number of arguments and returns the first one that isn't null, an empty string, empty list or empty object. It can
-be combined with other functions to provide a default.
+`coalesce` takes any number of arguments and returns the first one that isn't null, an empty string, empty list, or an empty object. It is useful for obtaining a default value, such as if an environment variable isn't defined.
 
 ## Examples
 

--- a/docs/sources/flow/reference/stdlib/coalesce.md
+++ b/docs/sources/flow/reference/stdlib/coalesce.md
@@ -1,0 +1,21 @@
+---
+aliases:
+- ../../configuration-language/standard-library/coalesce/
+title: coalesce
+---
+
+# coalesce
+
+`coalesce` takes any number of arguments and returns the first one that isn't null, an empty string, empty list or empty object. It can
+be combined with other functions to provide a default.
+
+## Examples
+
+```
+> coalesce("a", "b")
+a
+> coalesce("", "b")
+b
+> coalesce(env("DOES_NOT_EXIST"), "c")
+c
+```

--- a/docs/sources/flow/reference/stdlib/coalesce.md
+++ b/docs/sources/flow/reference/stdlib/coalesce.md
@@ -6,7 +6,9 @@ title: coalesce
 
 # coalesce
 
-`coalesce` takes any number of arguments and returns the first one that isn't null, an empty string, empty list, or an empty object. It is useful for obtaining a default value, such as if an environment variable isn't defined.
+`coalesce` takes any number of arguments and returns the first one that isn't null, an empty string, empty list, or an empty object.
+It is useful for obtaining a default value, such as if an environment variable isn't defined.
+The last argument is always returned, if there is no other non-empty or non-zero argument.
 
 ## Examples
 

--- a/docs/sources/flow/reference/stdlib/coalesce.md
+++ b/docs/sources/flow/reference/stdlib/coalesce.md
@@ -8,7 +8,7 @@ title: coalesce
 
 `coalesce` takes any number of arguments and returns the first one that isn't null, an empty string, empty list, or an empty object.
 It is useful for obtaining a default value, such as if an environment variable isn't defined.
-The last argument is always returned, if there is no other non-empty or non-zero argument.
+If no argument is non-empty or non-zero, the last argument is returned. 
 
 ## Examples
 

--- a/pkg/river/internal/stdlib/stdlib.go
+++ b/pkg/river/internal/stdlib/stdlib.go
@@ -73,4 +73,18 @@ var Identifiers = map[string]interface{}{
 		}
 		return res, nil
 	},
+
+	"coalesce": value.RawFunction(func(funcValue value.Value, args ...value.Value) (value.Value, error) {
+		for _, arg := range args {
+			if !arg.Reflect().IsZero() {
+				if argType := value.RiverType(arg.Reflect().Type()); (argType == value.TypeArray || argType == value.TypeObject) && arg.Len() == 0 {
+					continue
+				}
+
+				return arg, nil
+			}
+		}
+
+		return value.Null, nil
+	}),
 }

--- a/pkg/river/internal/stdlib/stdlib.go
+++ b/pkg/river/internal/stdlib/stdlib.go
@@ -75,7 +75,15 @@ var Identifiers = map[string]interface{}{
 	},
 
 	"coalesce": value.RawFunction(func(funcValue value.Value, args ...value.Value) (value.Value, error) {
+		if len(args) == 0 {
+			return value.Null, nil
+		}
+
 		for _, arg := range args {
+			if arg.Type() == value.TypeNull {
+				continue
+			}
+
 			if !arg.Reflect().IsZero() {
 				if argType := value.RiverType(arg.Reflect().Type()); (argType == value.TypeArray || argType == value.TypeObject) && arg.Len() == 0 {
 					continue
@@ -85,6 +93,6 @@ var Identifiers = map[string]interface{}{
 			}
 		}
 
-		return value.Null, nil
+		return args[len(args)-1], nil
 	}),
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Adding an coalesce function as described in https://github.com/grafana/agent/pull/3540#issuecomment-1511352098

#### Which issue(s) this PR fixes

Fixes #3389
Replaces #3540 

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

I currently, it's not tested, if updates from components like `local.file` or `remote.http` are passed. 

For example 

```
local.file "blackbox_exporter_config" {
  filename  = "/etc/grafana-agent/blackbox_exporter.yaml"
}

prometheus.exporter.blackbox "this" {
  config = coalesce(local.file.blackbox_exporter_config.content, "{ modules: { http_2xx: { prober: http, timeout: 5s } } }")
  
  target "TARGET_NAME" {
    address = "TARGET_ADDRESS" 
  }
}

```

If `local.file.blackbox_exporter_config.content` switches from empty string to content, the `coalesce` function needs to aware of this. Not sure, if river functions supporting this.


#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
