### PR TITLE
flow: Parse default clustering port from --server.http.listen-addr

### DIFF
--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -150,7 +150,7 @@ func (fr *flowRun) Run(configFile string) error {
 	reg := prometheus.DefaultRegisterer
 	reg.MustRegister(newResourcesCollector(l))
 
-	clusterer, err := cluster.New(l, fr.clusterEnabled, fr.clusterAdvAddr, fr.clusterJoinAddr)
+	clusterer, err := cluster.New(l, fr.clusterEnabled, fr.httpListenAddr, fr.clusterAdvAddr, fr.clusterJoinAddr)
 	if err != nil {
 		return fmt.Errorf("building clusterer: %w", err)
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -115,28 +115,25 @@ func getJoinAddr(addrs []string, in string) []string {
 }
 
 // New creates a Clusterer.
-func New(log log.Logger, clusterEnabled bool, addr, joinAddr string) (*Clusterer, error) {
+func New(log log.Logger, clusterEnabled bool, listenAddr, advertiseAddr, joinAddr string) (*Clusterer, error) {
 	// Standalone node.
 	if !clusterEnabled {
-		return &Clusterer{Node: NewLocalNode(addr)}, nil
+		return &Clusterer{Node: NewLocalNode(listenAddr)}, nil
 	}
 
 	gossipConfig := DefaultGossipConfig
 
 	defaultPort := 80
-	if addr != "" {
-		host, portStr, err := net.SplitHostPort(addr)
-		if err != nil {
-			return nil, err
-		}
+	_, portStr, err := net.SplitHostPort(listenAddr)
+	if err == nil { // there was a port
 		defaultPort, err = strconv.Atoi(portStr)
-		if err != nil {
-			return nil, err
-		}
-		gossipConfig.AdvertiseAddr = host
 	}
 
-	err := gossipConfig.ApplyDefaults(defaultPort)
+	if advertiseAddr != "" {
+		gossipConfig.AdvertiseAddr = advertiseAddr
+	}
+
+	err = gossipConfig.ApplyDefaults(defaultPort)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -127,6 +127,9 @@ func New(log log.Logger, clusterEnabled bool, listenAddr, advertiseAddr, joinAdd
 	_, portStr, err := net.SplitHostPort(listenAddr)
 	if err == nil { // there was a port
 		defaultPort, err = strconv.Atoi(portStr)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if advertiseAddr != "" {


### PR DESCRIPTION
#### PR Description
The previous implementation had an oversight where the default port was only set from the `--cluster.advertise-address` flag, _if_ it was provided.

That meant that when using a DNS name as `--cluster.join-addresses`, it was expected that it the other nodes would be reacheable on port 80.

This PR adds a new CLI flag that appends a default port to the advertise and join addresses, if not one is explicitly defined.

Also, as we expect nodes to have their port numbers _mostly_ aligned to prevent networking issues, we continue using the advertise address to set the default port, if it is provided on it.

#### Which issue(s) this PR fixes
No issue filed

#### Notes to the Reviewer
Nothing to note. Tested this using our helm charts, but I should invest in getting some testing in the near future.

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [X] Documentation added
- [ ] Tests updated (N/A)
