### PR TITLE
loki.source.docker: fix issue where building a client always fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Main (unreleased)
 
 ### Bugfixes
 
-- Fix bug where `loki.source.docker` never started. (@rfratto)
+- Fix bug where `loki.source.docker` always failed to start. (@rfratto)
 
 v0.33.0-rc.1 (2023-04-21)
 -------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Bugfixes
+
+- Fix bug where `loki.source.docker` never started. (@rfratto)
+
 v0.33.0-rc.1 (2023-04-21)
 -------------------------
 ### Bugfixes
@@ -112,7 +116,7 @@ v0.33.0-rc.0 (2023-04-20)
 
 - Agent Management: Introduces backpressure mechanism for remote config fetching (obeys 429 request
   `Retry-After` header). (@spartan0x117)
-  
+
 - Flow: support client TLS settings (CA, client certificate, client key) being
   provided from other components for the following components:
 

--- a/component/loki/source/docker/docker.go
+++ b/component/loki/source/docker/docker.go
@@ -221,7 +221,7 @@ func (c *Component) getManagerOptions(args Arguments) (*options, error) {
 	}
 
 	opts := []client.Opt{
-		client.WithHost(c.args.Host),
+		client.WithHost(args.Host),
 		client.WithAPIVersionNegotiation(),
 	}
 	client, err := client.NewClientWithOpts(opts...)

--- a/component/loki/source/docker/docker_test.go
+++ b/component/loki/source/docker/docker_test.go
@@ -1,0 +1,34 @@
+package docker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/pkg/flow/componenttest"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/grafana/agent/pkg/util"
+	"github.com/stretchr/testify/require"
+)
+
+func Test(t *testing.T) {
+	var cfg = `
+		host       = "unix:///var/run/docker.sock"
+		targets    = []
+		forward_to = []
+	`
+
+	var args Arguments
+	err := river.Unmarshal([]byte(cfg), &args)
+	require.NoError(t, err)
+
+	ctrl, err := componenttest.NewControllerFromID(util.TestLogger(t), "loki.source.docker")
+	require.NoError(t, err)
+
+	go func() {
+		err := ctrl.Run(context.Background(), args)
+		require.NoError(t, err)
+	}()
+
+	require.NoError(t, ctrl.WaitRunning(time.Minute))
+}

--- a/component/loki/source/docker/docker_test.go
+++ b/component/loki/source/docker/docker_test.go
@@ -12,8 +12,9 @@ import (
 )
 
 func Test(t *testing.T) {
+	// Use host that works on all platforms (including Windows).
 	var cfg = `
-		host       = "unix:///var/run/docker.sock"
+		host       = "tcp://127.0.0.1:9375"
 		targets    = []
 		forward_to = []
 	`


### PR DESCRIPTION
Building a client relied on the zero value of previous options, which would always result in an error.

Closes #3609.