### PR TITLE
Fix CHANGELOG Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Main (unreleased)
   `--server.http.memory-addr` flag to customize which address is used for
   in-memory traffic. (@rfratto)
 
+v0.33.0-rc.2 (2023-04-24)
+-------------------------
+
 ### Bugfixes
 
 - Fix bug where `loki.source.docker` always failed to start. (@rfratto)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
-v0.33.0-rc.2 (2023-04-24)
--------------------------
+Main (unreleased)
+-----------------
 
 ### Enhancements
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Adds back the `Main (unreleased)` header that was mistakenly removed.
