### PR TITLE
river: retain pointer to capsule when decoding to any

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ Main (unreleased)
   `--server.http.memory-addr` flag to customize which address is used for
   in-memory traffic. (@rfratto)
 
+### Bugfixes
+
+- Fix bug where some capsule values (such as Prometheus receivers) could not
+  properly be used as an argument to a module. (@rfratto)
+
 v0.33.0-rc.2 (2023-04-24)
 -------------------------
 

--- a/pkg/river/internal/value/decode.go
+++ b/pkg/river/internal/value/decode.go
@@ -419,6 +419,14 @@ func (d *decoder) decodeAny(val Value, into reflect.Value) error {
 	case TypeFunction, TypeCapsule:
 		// Functions and capsules must be directly assigned since there's no
 		// "generic" representation for either.
+		//
+		// We retain the pointer if we were given a pointer.
+
+		if val.rv.CanAddr() {
+			into.Set(val.rv.Addr())
+			return nil
+		}
+
 		into.Set(val.rv)
 		return nil
 

--- a/pkg/river/internal/value/decode_test.go
+++ b/pkg/river/internal/value/decode_test.go
@@ -641,3 +641,24 @@ func TestDecode_SquashedSlice_Pointer(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expect, out)
 }
+
+func TestRetainCapsulePointer(t *testing.T) {
+	capsuleVal := &capsule{}
+
+	in := map[string]any{
+		"foo": capsuleVal,
+	}
+
+	var actual map[string]any
+	err := value.Decode(value.Encode(in), &actual)
+	require.NoError(t, err)
+
+	expect := map[string]any{
+		"foo": capsuleVal,
+	}
+	require.Equal(t, expect, actual)
+}
+
+type capsule struct{}
+
+func (*capsule) RiverCapsule() {}


### PR DESCRIPTION
Previously, capsules were always decoded to the `any` type using their fully deferenced values.

Fixes #3565.
