### PR TITLE
supportbundle: add back debug information about logs targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Main (unreleased)
 
 - Add metrics when clustering mode is enabled. (@rfratto)
 
+- Support Bundles report the status of discovered log targets. (@tpaschalis)
+
 v0.33.0-rc.2 (2023-04-24)
 -------------------------
 

--- a/docs/sources/static/api/_index.md
+++ b/docs/sources/static/api/_index.md
@@ -387,8 +387,8 @@ A support bundle contains the following data:
 * `agent-config.yaml` contains the current agent configuration (when the `-config.enable-read-api` flag is passed).
 * `agent-logs.txt` contains the agent logs during the bundle generation.
 * `agent-metadata.yaml` contains the agent's build version, operating system, architecture, uptime, plus a string payload defining which extra agent features have been enabled via command-line flags.
-* `agent-metrics-instances.json` and `agent-metrics-targets.json` contain the active metric subsystem instances, and the discovered scraped targets for each one.
-* `agent-logs-instances.json` contains the active logs subsystem instances.
+* `agent-metrics-instances.json` and `agent-metrics-targets.json` contain the active metric subsystem instances and the discovered scrape targets for each one.
+* `agent-logs-instances.json` and `agent-logs-targets.json` contains the active logs subsystem instances and the discovered scrape targets for each one.
 * `agent-metrics.txt` contains a snapshot of the agent's internal metrics.
 * The `pprof/` directory contains Go runtime profiling data (CPU, heap, goroutine, mutex, block profiles) as exported by the pprof package.
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This fixes a TODO from grafana/agent#2175; this enables the support bundle to emit information about the status of discovered log targets.

#### Which issue(s) this PR fixes
No issue filed

#### Notes to the Reviewer
Nothing to note.

#### PR Checklist

- [X] CHANGELOG updated
- [X] Documentation added
- [ ] Tests updated (N/A)
