### PR TITLE
flow: fix typo in local.file argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Main (unreleased)
 
 - Add metrics when clustering mode is enabled. (@rfratto)
 
+- Fix spelling of the `frequency` argument on the `local.file` component.
+  (@tpaschalis)
+
 v0.33.0-rc.2 (2023-04-24)
 -------------------------
 

--- a/component/local/file/detector.go
+++ b/component/local/file/detector.go
@@ -76,10 +76,10 @@ type fsNotify struct {
 }
 
 type fsNotifyOptions struct {
-	Logger       log.Logger
-	Filename     string
-	ReloadFile   func()        // Callback to request file reload.
-	PollFreqency time.Duration // How often to do fallback polling
+	Logger        log.Logger
+	Filename      string
+	ReloadFile    func()        // Callback to request file reload.
+	PollFrequency time.Duration // How often to do fallback polling
 }
 
 // newFSNotify creates a new fsnotify detector which uses filesystem events to
@@ -109,7 +109,7 @@ func newFSNotify(opts fsNotifyOptions) (*fsNotify, error) {
 }
 
 func (fsn *fsNotify) wait(ctx context.Context) {
-	pollTick := time.NewTicker(fsn.opts.PollFreqency)
+	pollTick := time.NewTicker(fsn.opts.PollFrequency)
 	defer pollTick.Stop()
 
 	for {

--- a/component/local/file/file.go
+++ b/component/local/file/file.go
@@ -42,8 +42,8 @@ type Arguments struct {
 	// Type indicates how to detect changes to the file.
 	Type Detector `river:"detector,attr,optional"`
 	// PollFrequency determines the frequency to check for changes when Type is
-	// UpdateTypePoll.
-	PollFrequency time.Duration `river:"poll_freqency,attr,optional"`
+	// Poll.
+	PollFrequency time.Duration `river:"poll_frequency,attr,optional"`
 	// IsSecret marks the file as holding a secret value which should not be
 	// displayed to the user.
 	IsSecret bool `river:"is_secret,attr,optional"`
@@ -195,7 +195,7 @@ func (c *Component) Update(args component.Arguments) error {
 	newArgs := args.(Arguments)
 
 	if newArgs.PollFrequency <= 0 {
-		return fmt.Errorf("poll_freqency must be greater than 0")
+		return fmt.Errorf("poll_frequency must be greater than 0")
 	}
 
 	c.mut.Lock()
@@ -249,10 +249,10 @@ func (c *Component) configureDetector() error {
 		})
 	case DetectorFSNotify:
 		c.detector, err = newFSNotify(fsNotifyOptions{
-			Logger:       c.opts.Logger,
-			Filename:     c.args.Filename,
-			ReloadFile:   reloadFile,
-			PollFreqency: c.args.PollFrequency,
+			Logger:        c.opts.Logger,
+			Filename:      c.args.Filename,
+			ReloadFile:    reloadFile,
+			PollFrequency: c.args.PollFrequency,
 		})
 	}
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Fixes a small typo `s/freqency/frequency` in the local.file component arguments. 

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer
Arguably, this didn't come up as the default `fsnotify` detector is more handy and appears much more _frequently_ in configurations.

I'm not sure whether we should add a CHANGELOG entry or not; it's not a bug in itself so I'm adding it under "other changes" for now.

#### PR Checklist

- [X] CHANGELOG updated
- [X] Documentation added 
- [ ] Tests updated
