### PR TITLE
Remove symbolic links to old binary names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,11 +56,12 @@ v0.33.0-rc.0 (2023-04-20)
 - Agent Management: `agent_management.remote_config_cache_location` config field has been replaced by
 `agent_management.remote_configuration.cache_location`. (@jcreixell)
 
+- Remove deprecated symbolic links to to `/bin/agent*` in Docker containers,
+  as planned in v0.31. (@tpaschalis)
+
 ### Deprecations
 
 - [Dynamic Configuration](https://grafana.com/docs/agent/latest/cookbook/dynamic-configuration/) will be removed in v0.34. Grafana Agent Flow supersedes this functionality. (@mattdurham)
-- Remove deprecated symbolic links to to `/bin/agent*` in Docker containers,
-  as planned in v0.31. (@tpaschalis)
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ v0.33.0-rc.0 (2023-04-20)
 ### Deprecations
 
 - [Dynamic Configuration](https://grafana.com/docs/agent/latest/cookbook/dynamic-configuration/) will be removed in v0.34. Grafana Agent Flow supersedes this functionality. (@mattdurham)
+- Remove deprecated symbolic links to to `/bin/agent*` in Docker containers,
+  as planned in v0.31. (@tpaschalis)
 
 ### Features
 

--- a/cmd/grafana-agent-operator/Dockerfile
+++ b/cmd/grafana-agent-operator/Dockerfile
@@ -34,5 +34,4 @@ RUN <<EOF
 EOF
 
 COPY --from=build /src/agent/build/grafana-agent-operator /bin/grafana-agent-operator
-RUN ln -sv /bin/grafana-agent-operator /bin/agent-operator
 ENTRYPOINT ["/bin/grafana-agent-operator"]

--- a/cmd/grafana-agent/Dockerfile
+++ b/cmd/grafana-agent/Dockerfile
@@ -43,7 +43,6 @@ EOF
 COPY --from=build /src/agent/build/grafana-agent /bin/grafana-agent
 COPY cmd/grafana-agent/agent-local-config.yaml /etc/agent/agent.yaml
 
-RUN ln -sv /bin/grafana-agent /bin/agent
 
 ENTRYPOINT ["/bin/grafana-agent"]
 CMD ["--config.file=/etc/agent/agent.yaml", "--metrics.wal-directory=/etc/agent/data"]

--- a/cmd/grafana-agentctl/Dockerfile
+++ b/cmd/grafana-agentctl/Dockerfile
@@ -35,5 +35,4 @@ RUN <<EOF
 EOF
 
 COPY --from=build /src/agent/build/grafana-agentctl /bin/grafana-agentctl
-RUN ln -sv /bin/grafana-agentctl /bin/agentctl
-ENTRYPOINT ["/bin/agentctl"]
+ENTRYPOINT ["/bin/grafana-agentctl"]

--- a/docs/sources/flow/upgrade-guide.md
+++ b/docs/sources/flow/upgrade-guide.md
@@ -18,6 +18,12 @@ Grafana Agent Flow.
 > [upgrade-guide-static]: {{< relref "../static/upgrade-guide.md" >}}
 > [upgrade-guide-operator]: {{< relref "../operator/upgrade-guide.md" >}}
 
+## v0.33.0 
+
+We've removed the deprecated symbolic links to `/bin/agent*` in Docker
+containers, as planned in v0.31. In case you're setting a custom entrypoint,
+use the new binaries that are prefixed with `/bin/grafana*`.
+
 ## v0.32.0
 
 ### Breaking change: `http_client_config` Flow blocks merged with parent blocks

--- a/docs/sources/flow/upgrade-guide.md
+++ b/docs/sources/flow/upgrade-guide.md
@@ -20,6 +20,8 @@ Grafana Agent Flow.
 
 ## v0.33.0 
 
+### Symbolic links in Docker containers removed
+
 We've removed the deprecated symbolic links to `/bin/agent*` in Docker
 containers, as planned in v0.31. In case you're setting a custom entrypoint,
 use the new binaries that are prefixed with `/bin/grafana*`.

--- a/docs/sources/operator/upgrade-guide.md
+++ b/docs/sources/operator/upgrade-guide.md
@@ -18,6 +18,14 @@ Static mode Kubernetes operator.
 > [upgrade-guide-static]: {{< relref "../static/upgrade-guide.md" >}}
 > [upgrade-guide-flow]: {{< relref "../flow/upgrade-guide.md" >}}
 
+## v0.33.0
+
+### Symbolic links in Docker containers removed
+
+We've removed the deprecated symbolic links to `/bin/agent*` in Docker
+containers, as planned in v0.31. In case you're setting a custom entrypoint,
+use the new binaries that are prefixed with `/bin/grafana*`.
+
 ## v0.31.0
 
 ### Breaking change: binary names are now prefixed with `grafana-`

--- a/docs/sources/static/upgrade-guide.md
+++ b/docs/sources/static/upgrade-guide.md
@@ -19,7 +19,9 @@ static mode.
 > [upgrade-guide-operator]: {{< relref "../operator/upgrade-guide.md" >}}
 > [upgrade-guide-flow]: {{< relref "../flow/upgrade-guide.md" >}}
 
-## v0.33
+## v0.33.0
+
+### Symbolic links in Docker containers removed
 
 We've removed the deprecated symbolic links to `/bin/agent*` in Docker
 containers, as planned in v0.31. In case you're setting a custom entrypoint,

--- a/docs/sources/static/upgrade-guide.md
+++ b/docs/sources/static/upgrade-guide.md
@@ -21,6 +21,10 @@ static mode.
 
 ## v0.33
 
+We've removed the deprecated symbolic links to `/bin/agent*` in Docker
+containers, as planned in v0.31. In case you're setting a custom entrypoint,
+use the new binaries that are prefixed with `/bin/grafana*`.
+
 ### Deprecation of Dynamic Configuration
 
 [Dynamic Configuration](https://grafana.com/docs/agent/latest/cookbook/dynamic-configuration/) will be removed in v0.34. 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Back in v0.31 when we renamed the binaries to include the `grafana-` prefix, we added symbolic links to the Dockerfiles so that we wouldn't immediately break the workflows of people using a custom entrypoint.

Our [upgrade guide](https://grafana.com/docs/agent/latest/upgrade-guide/#v0310) mentioned removing those in v0.33 which we never did.

#### Which issue(s) this PR fixes
Fixes #2877

#### Notes to the Reviewer
Should this have _another_ changelog entry?

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
