### PR TITLE
river: match documentation when decoding numbers into any

### DIFF
--- a/pkg/river/internal/value/decode.go
+++ b/pkg/river/internal/value/decode.go
@@ -386,19 +386,8 @@ func (d *decoder) decodeAny(val Value, into reflect.Value) error {
 		return nil
 
 	case TypeNumber:
-		switch val.Number().Kind() {
-		case NumberKindFloat:
-			var v float64
-			ptr = reflect.ValueOf(&v)
-		case NumberKindInt:
-			var v int
-			ptr = reflect.ValueOf(&v)
-		case NumberKindUint:
-			var v uint
-			ptr = reflect.ValueOf(&v)
-		default:
-			panic("river/value: unreachable")
-		}
+		var v = val.Number().Float()
+		ptr = reflect.ValueOf(&v)
 
 	case TypeArray:
 		var v []interface{}

--- a/pkg/river/internal/value/decode_test.go
+++ b/pkg/river/internal/value/decode_test.go
@@ -661,6 +661,8 @@ func TestDecode_KnownTypes_Any(t *testing.T) {
 		{uint16(15), float64(15)},
 		{uint32(15), float64(15)},
 		{uint64(15), float64(15)},
+		{float32(2.5), float64(2.5)},
+		{float64(2.5), float64(2.5)},
 
 		{bool(true), bool(true)},
 		{string("Hello"), string("Hello")},

--- a/pkg/river/internal/value/decode_test.go
+++ b/pkg/river/internal/value/decode_test.go
@@ -8,6 +8,7 @@ import (
 	"unsafe"
 
 	"github.com/grafana/agent/pkg/river/internal/value"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -640,4 +641,73 @@ func TestDecode_SquashedSlice_Pointer(t *testing.T) {
 	err := value.Decode(value.Encode(in), &out)
 	require.NoError(t, err)
 	require.Equal(t, expect, out)
+}
+
+// TestDecode_KnownTypes_Any asserts that decoding River values into an
+// any/interface{} results in known types.
+func TestDecode_KnownTypes_Any(t *testing.T) {
+	tt := []struct {
+		input  any
+		expect any
+	}{
+		// All numbers must decode to float64.
+		{int(15), float64(15)},
+		{int8(15), float64(15)},
+		{int16(15), float64(15)},
+		{int32(15), float64(15)},
+		{int64(15), float64(15)},
+		{uint(15), float64(15)},
+		{uint8(15), float64(15)},
+		{uint16(15), float64(15)},
+		{uint32(15), float64(15)},
+		{uint64(15), float64(15)},
+
+		{bool(true), bool(true)},
+		{string("Hello"), string("Hello")},
+
+		{
+			input:  []int{1, 2, 3},
+			expect: []any{float64(1), float64(2), float64(3)},
+		},
+
+		{
+			input:  map[string]int{"number": 15},
+			expect: map[string]any{"number": float64(15)},
+		},
+		{
+			input: struct {
+				Name string `river:"name,attr"`
+			}{Name: "John"},
+
+			expect: map[string]any{"name": "John"},
+		},
+	}
+
+	t.Run("basic types", func(t *testing.T) {
+		for _, tc := range tt {
+			var actual any
+			err := value.Decode(value.Encode(tc.input), &actual)
+
+			if assert.NoError(t, err) {
+				assert.Equal(t, tc.expect, actual,
+					"Expected %[1]v (%[1]T) to transcode to %[2]v (%[2]T)", tc.input, tc.expect)
+			}
+		}
+	})
+
+	t.Run("inside maps", func(t *testing.T) {
+		for _, tc := range tt {
+			input := map[string]any{
+				"key": tc.input,
+			}
+
+			var actual map[string]any
+			err := value.Decode(value.Encode(input), &actual)
+
+			if assert.NoError(t, err) {
+				assert.Equal(t, tc.expect, actual["key"],
+					"Expected %[1]v (%[1]T) to transcode to %[2]v (%[2]T) inside a map", tc.input, tc.expect)
+			}
+		}
+	})
 }

--- a/pkg/river/internal/value/value_object_test.go
+++ b/pkg/river/internal/value/value_object_test.go
@@ -66,20 +66,20 @@ func TestBlockRepresentation(t *testing.T) {
 			"attr_1": "value_1",
 			"attr_2": "value_2",
 			"unlabeled": object{
-				"a": object{"value": 1},
-				"b": object{"value": 2},
+				"a": object{"value": float64(1)},
+				"b": object{"value": float64(2)},
 			},
-			"other_unlabeled": object{"value": 3},
+			"other_unlabeled": object{"value": float64(3)},
 			"labeled": object{
 				"a": object{
-					"label_a": object{"value": 4},
+					"label_a": object{"value": float64(4)},
 				},
 				"b": object{
-					"label_b": object{"value": 5},
+					"label_b": object{"value": float64(5)},
 				},
 			},
 			"other_labeled": object{
-				"label_c": object{"value": 6},
+				"label_c": object{"value": float64(6)},
 			},
 		}
 
@@ -179,14 +179,14 @@ func TestSliceOfBlocks(t *testing.T) {
 			"attr_1": "value_1",
 			"attr_2": "value_2",
 			"unlabeled": list{
-				object{"value": 1},
-				object{"value": 2},
-				object{"value": 3},
+				object{"value": float64(1)},
+				object{"value": float64(2)},
+				object{"value": float64(3)},
 			},
 			"labeled": object{
-				"label_a": object{"value": 4},
-				"label_b": object{"value": 5},
-				"label_c": object{"value": 6},
+				"label_a": object{"value": float64(4)},
+				"label_b": object{"value": float64(5)},
+				"label_c": object{"value": float64(6)},
 			},
 		}
 

--- a/pkg/river/vm/vm_block_test.go
+++ b/pkg/river/vm/vm_block_test.go
@@ -648,7 +648,7 @@ func TestVM_Block_UnmarshalToMap(t *testing.T) {
 			`,
 			expect: OuterBlock{
 				Settings: map[string]interface{}{
-					"field_a": 12345,
+					"field_a": float64(12345),
 					"field_b": "helloworld",
 				},
 			},
@@ -717,7 +717,7 @@ func TestVM_Block_UnmarshalToAny(t *testing.T) {
 	require.NoError(t, eval.Evaluate(nil, &actual))
 
 	expect := map[string]interface{}{
-		"field_a": 12345,
+		"field_a": float64(12345),
 		"field_b": "helloworld",
 	}
 	require.Equal(t, expect, actual.Settings)

--- a/pkg/river/vm/vm_stdlib_test.go
+++ b/pkg/river/vm/vm_stdlib_test.go
@@ -20,7 +20,7 @@ func TestVM_Stdlib(t *testing.T) {
 		expect interface{}
 	}{
 		{"env", `env("TEST_VAR")`, string("Hello!")},
-		{"concat", `concat([true, "foo"], [], [false, 1])`, []interface{}{true, "foo", false, 1}},
+		{"concat", `concat([true, "foo"], [], [false, 1])`, []interface{}{true, "foo", false, float64(1)}},
 		{"json_decode object", `json_decode("{\"foo\": \"bar\"}")`, map[string]interface{}{"foo": "bar"}},
 		{"json_decode array", `json_decode("[0, 1, 2]")`, []interface{}{float64(0), float64(1), float64(2)}},
 		{"json_decode nil field", `json_decode("{\"foo\": null}")`, map[string]interface{}{"foo": nil}},


### PR DESCRIPTION
Previously, all non-floating point numbers decoded into an int, and all floating-point numbers decoded into a float64. This did not match the documentation, which stated that all River numbers should decode into a float64.

No changelog entry is added because this is only a developer-facing change.

Closes #3629.