### PR TITLE
Update v0.33 stable release refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,24 +37,8 @@ Main (unreleased)
 
 - Support Bundles report the status of discovered log targets. (@tpaschalis)
 
-v0.33.0-rc.2 (2023-04-24)
--------------------------
-
-### Bugfixes
-
-- Fix bug where `loki.source.docker` always failed to start. (@rfratto)
-
-v0.33.0-rc.1 (2023-04-21)
--------------------------
-
-### Bugfixes
-
-- Fix bug introduced to operator when FilterRunning not specified in PodMonitors. (@captncraig)
-
-- Remove `otelcol.processor.attributes`. (@ptodev)
-
-v0.33.0-rc.0 (2023-04-20)
--------------------------
+v0.33.0 (2023-04-25)
+--------------------
 
 ### Breaking changes
 
@@ -102,8 +86,6 @@ v0.33.0-rc.0 (2023-04-20)
   - `otelcol.auth.sigv4` performs AWS Signature Version 4 (SigV4) authentication
     for making requests to AWS services via `otelcol` components that support
     authentication extensions. (@ptodev)
-  - `otelcol.processor.attributes` accepts telemetry data from other `otelcol`
-    components and modifies attributes of a span, log, or metric. (@ptodev)
   - `prometheus.exporter.blackbox` collects metrics from Blackbox exporter. (@marctc)
   - `prometheus.exporter.mysql` collects metrics from a MySQL database. (@spartan0x117)
   - `prometheus.exporter.postgres` collects metrics from a PostgreSQL database. (@spartan0x117)
@@ -234,6 +216,7 @@ v0.33.0-rc.0 (2023-04-20)
 
 - Fixes a bug where the github exporter would get stuck in an infinite loop under certain conditions. (@jcreixell)
 
+- Fix bug where `loki.source.docker` always failed to start. (@rfratto)
 
 ### Other changes
 

--- a/docs/sources/operator/deploy-agent-operator-resources.md
+++ b/docs/sources/operator/deploy-agent-operator-resources.md
@@ -53,12 +53,12 @@ To deploy the `GrafanaAgent` resource:
       labels:
         app: grafana-agent
     spec:
-      image: grafana/agent:v0.33.0-rc.2
+      image: grafana/agent:v0.33.0
       integrations:
         selector:
           matchLabels:
               agent: grafana-agent-integrations
-      image: grafana/agent:v0.33.0-rc.2
+      image: grafana/agent:v0.33.0
       logLevel: info
       serviceAccountName: grafana-agent
       metrics:

--- a/docs/sources/operator/getting-started.md
+++ b/docs/sources/operator/getting-started.md
@@ -73,7 +73,7 @@ To install Agent Operator:
           serviceAccountName: grafana-agent-operator
           containers:
           - name: operator
-            image: grafana/agent-operator:v0.33.0-rc.2
+            image: grafana/agent-operator:v0.33.0
             args:
             - --kubelet-service=default/kubelet
     ---

--- a/docs/sources/static/configuration/integrations/node-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/node-exporter-config.md
@@ -28,7 +28,7 @@ docker run \
   -v "/proc:/host/proc:ro,rslave" \
   -v /tmp/agent:/etc/agent \
   -v /path/to/config.yaml:/etc/agent-config/agent.yaml \
-  grafana/agent:v0.33.0-rc.2 \
+  grafana/agent:v0.33.0 \
   --config.file=/etc/agent-config/agent.yaml
 ```
 
@@ -67,7 +67,7 @@ metadata:
   name: agent
 spec:
   containers:
-  - image: grafana/agent:v0.33.0-rc.2
+  - image: grafana/agent:v0.33.0
     name: agent
     args:
     - --config.file=/etc/agent-config/agent.yaml

--- a/docs/sources/static/configuration/integrations/process-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/process-exporter-config.md
@@ -20,7 +20,7 @@ docker run \
   -v "/proc:/proc:ro" \
   -v /tmp/agent:/etc/agent \
   -v /path/to/config.yaml:/etc/agent-config/agent.yaml \
-  grafana/agent:v0.33.0-rc.2 \
+  grafana/agent:v0.33.0 \
   --config.file=/etc/agent-config/agent.yaml
 ```
 
@@ -37,7 +37,7 @@ metadata:
   name: agent
 spec:
   containers:
-  - image: grafana/agent:v0.33.0-rc.2
+  - image: grafana/agent:v0.33.0
     name: agent
     args:
     - --config.file=/etc/agent-config/agent.yaml

--- a/docs/sources/static/set-up/install-agent-docker.md
+++ b/docs/sources/static/set-up/install-agent-docker.md
@@ -21,7 +21,7 @@ Install Grafana Agent and get it up and running on Docker.
 docker run \
   -v /tmp/agent:/etc/agent/data \
   -v /path/to/config.yaml:/etc/agent/agent.yaml \
-  grafana/agent:v0.33.0-rc.2
+  grafana/agent:v0.33.0
 ```
 
 2. Replace `/tmp/agent` with the folder you want to store WAL data in.
@@ -40,7 +40,7 @@ container through a bind mount for the flags to work properly.
     docker run ^
       -v c:\grafana-agent-data:c:\etc\grafana-agent\data ^
       -v c:\workspace\config\grafana-agent:c:\etc\grafana-agent ^
-      grafana/agent:v0.33.0-rc.2-windows
+      grafana/agent:v0.33.0-windows
     ```
 
 2. Replace `c:\grafana-agent-data` with the folder you want to store WAL data in.

--- a/pkg/operator/defaults.go
+++ b/pkg/operator/defaults.go
@@ -2,7 +2,7 @@ package operator
 
 // Supported versions of the Grafana Agent.
 var (
-	DefaultAgentVersion   = "v0.33.0-rc.2"
+	DefaultAgentVersion   = "v0.33.0"
 	DefaultAgentBaseImage = "grafana/agent"
 	DefaultAgentImage     = DefaultAgentBaseImage + ":" + DefaultAgentVersion
 )

--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -83,7 +83,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.33.0-rc.2
+        image: grafana/agent:v0.33.0
         imagePullPolicy: IfNotPresent
         name: grafana-agent
         ports:

--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -65,7 +65,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.33.0-rc.2
+        image: grafana/agent:v0.33.0
         imagePullPolicy: IfNotPresent
         name: grafana-agent-logs
         ports:

--- a/production/kubernetes/agent-traces.yaml
+++ b/production/kubernetes/agent-traces.yaml
@@ -114,7 +114,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.33.0-rc.2
+        image: grafana/agent:v0.33.0
         imagePullPolicy: IfNotPresent
         name: grafana-agent-traces
         ports:

--- a/production/kubernetes/build/lib/version.libsonnet
+++ b/production/kubernetes/build/lib/version.libsonnet
@@ -1,1 +1,1 @@
-'grafana/agent:v0.33.0-rc.2'
+'grafana/agent:v0.33.0'

--- a/production/kubernetes/build/templates/operator/main.jsonnet
+++ b/production/kubernetes/build/templates/operator/main.jsonnet
@@ -23,8 +23,8 @@ local ksm = import 'kube-state-metrics/kube-state-metrics.libsonnet';
   local this = self,
 
   _images:: {
-    agent: 'grafana/agent:v0.33.0-rc.2',
-    agent_operator: 'grafana/agent-operator:v0.33.0-rc.2',
+    agent: 'grafana/agent:v0.33.0',
+    agent_operator: 'grafana/agent-operator:v0.33.0',
     ksm: 'registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0',
   },
 

--- a/production/kubernetes/install-bare.sh
+++ b/production/kubernetes/install-bare.sh
@@ -25,7 +25,7 @@ check_installed() {
 check_installed curl
 check_installed envsubst
 
-MANIFEST_BRANCH=v0.33.0-rc.2
+MANIFEST_BRANCH=v0.33.0
 MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent-bare.yaml}
 NAMESPACE=${NAMESPACE:-default}
 

--- a/production/operator/templates/agent-operator.yaml
+++ b/production/operator/templates/agent-operator.yaml
@@ -372,7 +372,7 @@ spec:
       containers:
       - args:
         - --kubelet-service=default/kubelet
-        image: grafana/agent-operator:v0.33.0-rc.2
+        image: grafana/agent-operator:v0.33.0
         imagePullPolicy: IfNotPresent
         name: grafana-agent-operator
       serviceAccount: grafana-agent-operator
@@ -436,7 +436,7 @@ metadata:
   name: grafana-agent
   namespace: ${NAMESPACE}
 spec:
-  image: grafana/agent:v0.33.0-rc.2
+  image: grafana/agent:v0.33.0
   integrations:
     selector:
       matchLabels:

--- a/production/tanka/grafana-agent/v1/main.libsonnet
+++ b/production/tanka/grafana-agent/v1/main.libsonnet
@@ -15,8 +15,8 @@ local service = k.core.v1.service;
 (import './lib/traces.libsonnet') +
 {
   _images:: {
-    agent: 'grafana/agent:v0.33.0-rc.2',
-    agentctl: 'grafana/agentctl:v0.33.0-rc.2',
+    agent: 'grafana/agent:v0.33.0',
+    agentctl: 'grafana/agentctl:v0.33.0',
   },
 
   // new creates a new DaemonSet deployment of the grafana-agent. By default,

--- a/production/tanka/grafana-agent/v2/internal/base.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/base.libsonnet
@@ -11,8 +11,8 @@ function(name='grafana-agent', namespace='') {
   local this = self,
 
   _images:: {
-    agent: 'grafana/agent:v0.33.0-rc.2',
-    agentctl: 'grafana/agentctl:v0.33.0-rc.2',
+    agent: 'grafana/agent:v0.33.0',
+    agentctl: 'grafana/agentctl:v0.33.0',
   },
   _config:: {
     name: name,

--- a/production/tanka/grafana-agent/v2/internal/syncer.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/syncer.libsonnet
@@ -14,7 +14,7 @@ function(
 ) {
   local _config = {
     api: error 'api must be set',
-    image: 'grafana/agentctl:v0.33.0-rc.2',
+    image: 'grafana/agentctl:v0.33.0',
     schedule: '*/5 * * * *',
     configs: [],
   } + config,


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Removes `v0.33.0-rc.*` entries from the `CHANGELOG` and places changes under `v0.33.0` header. Also removes any entries from the `v0.33.0` section that were removed in one of the RCs or was a fix for an issue introduced in the `v0.33` cycle.

Updates all references to `v0.33.0-rc.2` -> `v0.33.0`.

