### PR TITLE
clustering: Use only the address on DNS lookups

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -108,7 +108,7 @@ func getJoinAddr(addrs []string, in string) []string {
 	_, srvs, err := net.LookupSRV("", "", in)
 	if err == nil {
 		for _, srv := range srvs {
-			addrs = append(addrs, fmt.Sprintf("%s:%d", srv.Target, srv.Port))
+			addrs = append(addrs, srv.Target)
 		}
 	}
 
@@ -158,6 +158,8 @@ func New(log log.Logger, reg prometheus.Registerer, clusterEnabled bool, listenA
 			},
 		},
 	}
+
+	level.Info(log).Log("msg", "starting a new gossip node", "join-peers", gossipConfig.JoinPeers)
 
 	gossipNode, err := NewGossipNode(log, reg, cli, &gossipConfig)
 	if err != nil {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR makes use of the address only when finding join addresses via a DNS lookup.

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer
I found two clusters with different behavior; in one the lookup returned a port, in the other it didn't and made the cluster unable to bootstrap.

I think this ties better with the recommendation that all nodes use the same port; we should double down on that message instead of allowing wiggle room.

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
