### PR TITLE
River: add support for string interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Main (unreleased)
 
 - Added coalesce function to river stdlib. (@jkroepke)
 
+- Add support for interpolated strings in River. The string `"1 + 2 is ${1 +
+  2}"` will evaluate to `"1 + 2 is 3"`. (@rfratto)
+
 ### Enhancements
 
 - Support in-memory HTTP traffic for Flow components. `prometheus.exporter`

--- a/docs/sources/flow/config-language/expressions/types_and_values.md
+++ b/docs/sources/flow/config-language/expressions/types_and_values.md
@@ -58,10 +58,41 @@ The supported escape sequences are as follows:
 | `\v` | The vertical tab character `U+000B` |
 | `\'` | The `'` character `U+0027` |
 | `\"` | The `"` character `U+0022`, which prevents terminating the string |
+| `\$` | The `$` character, which escapes [string interpolation][] |
 | `\NNN` | A literal byte (NNN is three octal digits) |
 | `\xNN` | A literal byte (NN is two hexadecimal digits) |
 | `\uNNNN` | A Unicode character from the basic multilingual plane (NNNN is four hexadecimal digits) |
 | `\UNNNNNNNN` | A Unicode character from supplementary planes (NNNNNNNN is eight hexadecimal digits) |
+
+[string interpolation]: #string-interpolation
+
+### String interpolation
+
+Sequences of `${EXPR}` within strings are evaluated as expressions, and their
+results are placed back into the surrounding string.
+
+The string:
+
+```river
+"1 + 2 is: ${1 + 2}"
+```
+
+Evaluates to the following:
+
+```river
+"1 + 2 is: 3"
+```
+
+String interpolation fails if the expression can not be converted into a
+string. String interpolation is compatible with the following types:
+
+* Nulls (`"${null}`)
+* Strings (`"${env("HOME")}`)
+* Numbers (`"${1 + 2}`)
+* Booleans (`${true || false}`)
+
+String interpolation can be escaped by escaping the dollar sign: `"\${EXPR}"`
+will produce the literal string `"${EXPR}"`.
 
 ## Bools
 

--- a/pkg/river/ast/walk.go
+++ b/pkg/river/ast/walk.go
@@ -38,6 +38,12 @@ func Walk(v Visitor, node Node) {
 		Walk(v, n.Ident)
 	case *LiteralExpr:
 		// Nothing to do
+	case *InterpStringExpr:
+		for _, f := range n.Fragments {
+			if f.Expr != nil {
+				Walk(v, f.Expr)
+			}
+		}
 	case *ArrayExpr:
 		for _, e := range n.Elements {
 			Walk(v, e)

--- a/pkg/river/parser/interp_string.go
+++ b/pkg/river/parser/interp_string.go
@@ -1,0 +1,282 @@
+package parser
+
+import (
+	"fmt"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/grafana/agent/pkg/river/scanner"
+	"github.com/grafana/agent/pkg/river/token"
+)
+
+// interpStringScanner is a specialized scanner for interpolated strings. It
+// looks for sequences of "raw" text and sequences of "interpolated
+// expressions."
+//
+// Interpolated expressions start with "${" and end with "}". A "}" inside the
+// interpolated expression is permitted as long as it has a matching "{" to the
+// left of it.
+//
+// interpStringScanner supports the same string escape sequences as normal
+// strings.
+type interpStringScanner struct {
+	file       *token.File
+	input      []byte
+	err        scanner.ErrorHandler // Error reporting (may be nil)
+	baseOffset int
+
+	ch         rune // Current character
+	offset     int  // Byte offset of ch
+	readOffset int  // Byte offset of first character *after* ch
+	numErrors  int  // Number of errors encountered during scanning.
+}
+
+// interpStringToken is a token for interpolated strings.
+type interpStringToken int
+
+const (
+	interpStringTokenIllegal interpStringToken = iota
+	interpStringTokenEOF
+
+	interpStringTokenRaw  // Hello, world!
+	interpStringTokenExpr // ${INTERPOLATED_EXPR}
+)
+
+const (
+	bom = 0xFEFF // byte order mark, permitted as very first character
+	eof = -1     // end of file
+)
+
+// newInterpStringScanner creates a new interpolated string scanner to tokenize
+// the provided input config.
+//
+// input must be a subset of text in file containing an interpolated string.
+// baseOff must be the offset of input within the original source for file.
+// baseOff will be added to all returned position offsets from Scan.
+//
+// Calls to Scan will invoke the error handler eh when a lexical error is found
+// if eh is not nil.
+func newInterpStringScanner(file *token.File, input []byte, eh scanner.ErrorHandler, baseOff int) *interpStringScanner {
+	s := &interpStringScanner{
+		file:       file,
+		input:      input,
+		err:        eh,
+		baseOffset: baseOff,
+	}
+
+	// Preload first character. Note that BOM are not handled since input never
+	// corresponds to a physical file.
+	s.next()
+	return s
+}
+
+// peek gets the next byte after the current character without advancing the
+// scanner. Returns 0 if the scanner is at EOF.
+func (s *interpStringScanner) peek() byte {
+	if s.readOffset < len(s.input) {
+		return s.input[s.readOffset]
+	}
+	return 0
+}
+
+// next advances the scanner and reads the next Unicode character into s.ch.
+// s.ch == eof indicates end of file.
+func (s *interpStringScanner) next() {
+	if s.readOffset >= len(s.input) {
+		s.offset = len(s.input)
+		if s.ch == '\n' {
+			// Make sure we track final newlines at the end of the file
+			s.file.AddLine(s.offset)
+		}
+		s.ch = eof
+		return
+	}
+
+	s.offset = s.readOffset
+	if s.ch == '\n' {
+		s.file.AddLine(s.offset)
+	}
+
+	r, width := rune(s.input[s.readOffset]), 1
+	switch {
+	case r == 0:
+		s.onError(s.offset, "illegal character NUL")
+	case r >= utf8.RuneSelf:
+		r, width = utf8.DecodeRune(s.input[s.readOffset:])
+		if r == utf8.RuneError && width == 1 {
+			s.onError(s.offset, "illegal UTF-8 encoding")
+		} else if r == bom && s.offset > 0 {
+			s.onError(s.offset, "illegal byte order mark")
+		}
+	}
+	s.readOffset += width
+	s.ch = r
+}
+
+func (s *interpStringScanner) onError(offset int, msg string) {
+	if s.err != nil {
+		s.err(s.file.Pos(offset), msg)
+	}
+	s.numErrors++
+}
+
+// Scan scans the next token and return the token's position, the token itself,
+// and the token's literal string. The end of the input is indicated by
+// [interpStringTokenEOF].
+//
+// If the returned token is interpStringTokenRaw, then lit conains the
+// corresponding raw text from the interpolated string.
+//
+// If the returned token is interpStringTokenExpr, then lit contains the
+// interpolated expression, including the surrounding "${" and "}" characters.
+//
+// It is possible for Scan to return multiple interpStringTokenRaw tokens in a
+// row. The caller should combine these tokens as needed.
+func (s *interpStringScanner) Scan() (pos token.Pos, tok interpStringToken, lit string) {
+	// Start of current token.
+	pos = s.file.Pos(s.baseOffset + s.offset)
+
+	switch ch := s.ch; {
+	case ch == eof:
+		tok = interpStringTokenEOF
+		return
+
+	case ch == '$' && s.peek() == '{':
+		s.next() // Consume $.
+		s.next() // Consume {.
+
+		if text, terminated := s.scanExpr(); terminated {
+			tok = interpStringTokenExpr
+			lit = text
+		} else {
+			tok = interpStringTokenRaw
+			lit = text
+		}
+
+	default:
+		tok = interpStringTokenRaw
+		lit = s.scanRaw()
+	}
+
+	return
+}
+
+func (s *interpStringScanner) scanExpr() (fragment string, terminated bool) {
+	// s.offset is first byte after ${; subtract 2 to get the start of $.
+	off := s.offset - 2
+
+	// curlyPairs tracks the number of pairs of {} we expect. We start at 1 to
+	// count the first { from ${. We only stop scanning the expr once we've
+	// consumed the last } from all the expected pairs.
+	curlyPairs := 1
+
+	for {
+		ch := s.ch
+		if ch == eof {
+			break
+		}
+
+		s.next()
+
+		if ch == '{' {
+			curlyPairs++
+		} else if ch == '}' {
+			curlyPairs--
+			if curlyPairs == 0 {
+				terminated = true
+				break
+			}
+		}
+	}
+
+	return string(s.input[off:s.offset]), terminated
+}
+
+func (s *interpStringScanner) scanRaw() string {
+	off := s.offset
+
+	for {
+		ch := s.ch
+		if ch == eof {
+			break
+		}
+
+		if ch == '$' && s.peek() == '{' {
+			break
+		}
+
+		s.next()
+		if ch == '\\' {
+			s.scanEscape()
+		}
+	}
+
+	return string(s.input[off:s.offset])
+}
+
+// scanEscape parses an escape sequence. In case of a syntax error, scanEscape
+// stops at the offending character without consuming it.
+func (s *interpStringScanner) scanEscape() {
+	off := s.offset
+
+	var (
+		n         int
+		base, max uint32
+	)
+
+	switch s.ch {
+	case 'a', 'b', 'f', 'n', 'r', 't', 'v', '\\', '"', '$':
+		s.next()
+		return
+	case '0', '1', '2', '3', '4', '5', '6', '7':
+		n, base, max = 3, 8, 255
+	case 'x':
+		s.next()
+		n, base, max = 2, 16, 255
+	case 'u':
+		s.next()
+		n, base, max = 4, 16, unicode.MaxRune
+	case 'U':
+		s.next()
+		n, base, max = 8, 16, unicode.MaxRune
+	default:
+		msg := "unknown escape sequence"
+		if s.ch == eof {
+			msg = "escape sequence not terminated"
+		}
+		s.onError(off, msg)
+		return
+	}
+
+	var x uint32
+	for n > 0 {
+		d := uint32(digitVal(s.ch))
+		if d >= base {
+			msg := fmt.Sprintf("illegal character %#U in escape sequence", s.ch)
+			if s.ch == eof {
+				msg = "escape sequence not terminated"
+			}
+			s.onError(off, msg)
+			return
+		}
+		x = x*base + d
+		s.next()
+		n--
+	}
+
+	if x > max || x >= 0xD800 && x < 0xE000 {
+		s.onError(off, "escape sequence is invalid Unicode code point")
+	}
+}
+
+func digitVal(ch rune) int {
+	switch {
+	case ch >= '0' && ch <= '9':
+		return int(ch - '0')
+	case lower(ch) >= 'a' && lower(ch) <= 'f':
+		return int(lower(ch) - 'a' + 10)
+	}
+	return 16 // Larger than any legal digit val
+}
+
+func lower(ch rune) rune { return ('a' - 'A') | ch }

--- a/pkg/river/parser/interp_string_test.go
+++ b/pkg/river/parser/interp_string_test.go
@@ -1,0 +1,105 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/grafana/agent/pkg/river/token"
+	"github.com/stretchr/testify/assert"
+)
+
+type result struct {
+	Pos int
+	Tok interpStringToken
+	Lit string
+}
+
+func mergeResults(results []result) []result {
+	var out []result
+
+	for i, result := range results {
+		// Merge results if they're successive sequences of interpStringTokenRaw.
+		if i > 0 && result.Tok == interpStringTokenRaw && out[len(out)-1].Tok == interpStringTokenRaw {
+			out[len(out)-1].Lit += result.Lit
+			continue
+		}
+
+		out = append(out, result)
+	}
+
+	return out
+}
+
+func Test_interpStringScanner(t *testing.T) {
+	tt := []struct {
+		input  string
+		expect []result
+	}{
+		{
+			input:  "",
+			expect: nil,
+		},
+		{
+			input: "hello, world",
+			expect: []result{
+				{0, interpStringTokenRaw, "hello, world"},
+			},
+		},
+		{
+			input: "${1+2}",
+			expect: []result{
+				{0, interpStringTokenExpr, "${1+2}"},
+			},
+		},
+		{
+			// Escaped sequence.
+			input: "\\${1+2}",
+			expect: []result{
+				{0, interpStringTokenRaw, "\\${1+2}"},
+			},
+		},
+		{
+			// Unterminated interpolated expression.
+			input: "Hello, world! ${1+2",
+			expect: []result{
+				{0, interpStringTokenRaw, "Hello, world! ${1+2"},
+			},
+		},
+		{
+			// Multiple pairs of curly braces.
+			input: "${{ a = 5 }}",
+			expect: []result{
+				{0, interpStringTokenExpr, "${{ a = 5 }}"},
+			},
+		},
+		{
+			input: "The Matrix came out in ${1999}.",
+			expect: []result{
+				{0, interpStringTokenRaw, "The Matrix came out in "},
+				{23, interpStringTokenExpr, "${1999}"},
+				{30, interpStringTokenRaw, "."},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		f := token.NewFile(t.Name())
+		s := newInterpStringScanner(f, []byte(tc.input), nil, 0)
+
+		var results []result
+		for {
+			pos, tok, lit := s.Scan()
+			if tok == interpStringTokenEOF {
+				break
+			}
+
+			results = append(results, result{
+				Pos: pos.Offset(),
+				Tok: tok,
+				Lit: lit,
+			})
+		}
+
+		results = mergeResults(results)
+		assert.Equal(t, tc.expect, results, "Unexpected result for scanning %q", tc.input)
+	}
+}

--- a/pkg/river/parser/testdata/valid/expressions.river
+++ b/pkg/river/parser/testdata/valid/expressions.river
@@ -7,6 +7,10 @@ lit_null   = null
 lit_true   = true
 lit_false  = false
 
+// Interpolated strings.
+interp_string        = "1 + 3 is: ${1 + 3}"
+interp_string_escape = "1 + 3 is: \${1 + 3}"
+
 //  Arrays
 array_expr_empty       = []
 array_expr_one_element = [0]

--- a/pkg/river/printer/testdata/interpolated_strings.expect
+++ b/pkg/river/printer/testdata/interpolated_strings.expect
@@ -1,2 +1,6 @@
 interp_string = "Hello, world! 1 + 2 is: ${1 + 2}!"
 escape_string = "Hello, world! 1 + 2 is: \${1  +  2}!"
+
+nested_quotes = "Home \"is\": ${env(\"HOME\")}"
+
+deeply_nested_quotes = "${\"Home is: ${env(\\\"HOME\\\")}\"}"

--- a/pkg/river/printer/testdata/interpolated_strings.expect
+++ b/pkg/river/printer/testdata/interpolated_strings.expect
@@ -1,0 +1,2 @@
+interp_string = "Hello, world! 1 + 2 is: ${1 + 2}!"
+escape_string = "Hello, world! 1 + 2 is: \${1  +  2}!"

--- a/pkg/river/printer/testdata/interpolated_strings.in
+++ b/pkg/river/printer/testdata/interpolated_strings.in
@@ -1,0 +1,2 @@
+interp_string = "Hello, world! 1 + 2 is: ${1  +  2}!"
+escape_string = "Hello, world! 1 + 2 is: \${1  +  2}!"

--- a/pkg/river/printer/testdata/interpolated_strings.in
+++ b/pkg/river/printer/testdata/interpolated_strings.in
@@ -1,2 +1,6 @@
 interp_string = "Hello, world! 1 + 2 is: ${1  +  2}!"
 escape_string = "Hello, world! 1 + 2 is: \${1  +  2}!"
+
+nested_quotes = "Home \"is\": ${env(\"HOME\")}"
+
+deeply_nested_quotes = "${\"Home is: ${env(\\\"HOME\\\")}\"}"

--- a/pkg/river/scanner/scanner.go
+++ b/pkg/river/scanner/scanner.go
@@ -503,7 +503,7 @@ func (s *Scanner) scanEscape() {
 	)
 
 	switch s.ch {
-	case 'a', 'b', 'f', 'n', 'r', 't', 'v', '\\', '"':
+	case 'a', 'b', 'f', 'n', 'r', 't', 'v', '\\', '"', '$':
 		s.next()
 		return
 	case '0', '1', '2', '3', '4', '5', '6', '7':

--- a/pkg/river/scanner/scanner_test.go
+++ b/pkg/river/scanner/scanner_test.go
@@ -41,6 +41,8 @@ var tokens = []tokenExample{
 	{token.FLOAT, "1e-100"},
 	{token.FLOAT, "2.71828e-1000"},
 	{token.STRING, `"Hello, world!"`},
+	{token.STRING, `"The Matrix came out in ${1999}."`},
+	{token.STRING, `"The Matrix came out in \${1999}."`},
 
 	// Operators and delimiters
 	{token.ADD, "+"},

--- a/pkg/river/vm/stringify.go
+++ b/pkg/river/vm/stringify.go
@@ -1,0 +1,44 @@
+package vm
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/grafana/agent/pkg/river/internal/value"
+)
+
+// stringify tries to turn v into a string.
+func stringify(v value.Value) (string, error) {
+	switch ty := v.Type(); ty {
+	case value.TypeNull:
+		return "null", nil
+
+	case value.TypeNumber:
+		switch n := v.Number(); n.Kind() {
+		case value.NumberKindInt:
+			return strconv.FormatInt(n.Int(), 10), nil
+		case value.NumberKindUint:
+			return strconv.FormatUint(n.Uint(), 10), nil
+		case value.NumberKindFloat:
+			return strconv.FormatFloat(n.Float(), 'f', -1, 64), nil
+		default:
+			panic("river/vm: unknown NumberKind value")
+		}
+
+	case value.TypeString:
+		return v.Text(), nil
+
+	case value.TypeBool:
+		if v.Bool() {
+			return "true", nil
+		} else {
+			return "false", nil
+		}
+
+	default:
+		return "", value.Error{
+			Value: v,
+			Inner: fmt.Errorf("value of type %s cannot be converted into string", ty),
+		}
+	}
+}

--- a/pkg/river/vm/vm.go
+++ b/pkg/river/vm/vm.go
@@ -278,6 +278,31 @@ func (vm *Evaluator) evaluateExpr(scope *Scope, assoc map[value.Value]ast.Node, 
 	case *ast.LiteralExpr:
 		return valueFromLiteral(expr.Value, expr.Kind)
 
+	case *ast.InterpStringExpr:
+		var interpolatedString string
+
+		for _, frag := range expr.Fragments {
+			switch {
+			case frag.Raw != nil:
+				interpolatedString += *frag.Raw
+
+			case frag.Expr != nil:
+				val, err := vm.evaluateExpr(scope, assoc, frag.Expr)
+				if err != nil {
+					return value.Null, err
+				}
+
+				text, err := stringify(val)
+				if err != nil {
+					return value.Null, err
+				}
+
+				interpolatedString += text
+			}
+		}
+
+		return value.String(interpolatedString), nil
+
 	case *ast.BinaryExpr:
 		lhs, err := vm.evaluateExpr(scope, assoc, expr.Left)
 		if err != nil {

--- a/pkg/river/vm/vm_test.go
+++ b/pkg/river/vm/vm_test.go
@@ -135,6 +135,12 @@ func TestVM_Evaluate(t *testing.T) {
 		{`!true`, bool(false)},
 		{`!false`, bool(true)},
 		{`-15`, int(-15)},
+
+		// String interpolation of various values.
+		{`"${null}"`, "null"},                     // Null
+		{`"1 + 2: ${1 + 2}"`, string("1 + 2: 3")}, // Number
+		{`"Here's some text: ${\"Hello, world!\"}"`, string("Here's some text: Hello, world!")}, // String
+		{`"false || true is: ${false || true}"`, string("false || true is: true")},              // Bool
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
This PR adds support for string interpolation as specified in grafana/river#15. 

Given the size of the commit, I recommend reviewing it commit-by-commit.

I'm opening this in draft since grafana/river#15 is not formally approved, and it's not clear if we want this functionality.

String interpolation required more code changes than is usually necessary; parsing string interpolation required taking existing strings and parsing them further into fragments; `"1 + 2 is ${1 + 2}"` gets parsed into two fragments: `1 + 2 is ` (including the trailing space) and `${1 + 2}`. 

The pretty-printer formats expressions inside interpolated strings, but leaves the other whitespace in the string alone. 

Evaluation works by building a string from all the fragments. Fragments representing expressions (`${EXPR}`) are evaluated and converted into strings. Conversion into strings are only supported for a few types:

* Nulls
* Strings 
* Numbers 
* Bools 

This means string interpolation fails for any other type, including arrays, objects, capsules, and functions. 

Closes grafana/river#15. 

## Example 

<details>
<summary>Example</summary>

```river 
prometheus.exporter.unix { /* use defaults */ }

prometheus.scrape "default" {
	targets    = prometheus.exporter.unix.targets
	forward_to = [prometheus.remote_write.default.receiver]
}

prometheus.remote_write "default" {
	external_labels = {
		env = "Addr: ${prometheus.exporter.unix.targets[0].__address__}",
	}

	endpoint {
		url = "http://localhost:9009/api/prom/push"
	}
}
```

<img width="1508" alt="image" src="https://user-images.githubusercontent.com/630212/234736917-e1278b76-cc79-4420-90e8-39b0dabfc349.png">


</details>

