### PR TITLE
[release-v0.31] Prefer relative aliases

### DIFF
--- a/docs/sources/README.md
+++ b/docs/sources/README.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/README/
 draft: "True"
 ---
 

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/
 title: Grafana Agent
 weight: 1
 ---

--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/api/
 title: Grafana Agent API
 weight: 400
 ---

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/
 title: Configure Grafana Agent
 weight: 300
 ---

--- a/docs/sources/configuration/create-config-file.md
+++ b/docs/sources/configuration/create-config-file.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/set-up/create-config-file/
+- ../set-up/create-config-file/
 title: Create a config file
 weight: 50
 ---

--- a/docs/sources/configuration/dynamic-config.md
+++ b/docs/sources/configuration/dynamic-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/dynamic-config/
 title: dynamic_config
 weight: 500
 ---

--- a/docs/sources/configuration/flags.md
+++ b/docs/sources/configuration/flags.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/flags/
 title: Command-line flags
 weight: 100
 ---

--- a/docs/sources/configuration/integrations/_index.md
+++ b/docs/sources/configuration/integrations/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/
 title: integrations_config
 weight: 500
 ---

--- a/docs/sources/configuration/integrations/apache-exporter-config.md
+++ b/docs/sources/configuration/integrations/apache-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/apache-exporter-config/
 title: apache_http_config
 ---
 

--- a/docs/sources/configuration/integrations/blackbox-config.md
+++ b/docs/sources/configuration/integrations/blackbox-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/blackbox-config/
 title: blackbox_config
 ---
 

--- a/docs/sources/configuration/integrations/cadvisor-config.md
+++ b/docs/sources/configuration/integrations/cadvisor-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/cadvisor-config/
 title: cadvisor_config
 ---
 

--- a/docs/sources/configuration/integrations/consul-exporter-config.md
+++ b/docs/sources/configuration/integrations/consul-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/consul-exporter-config/
 title: consul_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/dnsmasq-exporter-config.md
+++ b/docs/sources/configuration/integrations/dnsmasq-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/dnsmasq-exporter-config/
 title: dnsmasq_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/elasticsearch-exporter-config.md
+++ b/docs/sources/configuration/integrations/elasticsearch-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/elasticsearch-exporter-config/
 title: elasticsearch_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/github-exporter-config.md
+++ b/docs/sources/configuration/integrations/github-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/github-exporter-config/
 title: github_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/integrations-next/_index.md
+++ b/docs/sources/configuration/integrations/integrations-next/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/integrations-next/
 title: Integrations Revamp
 weight: 100
 ---

--- a/docs/sources/configuration/integrations/integrations-next/app-agent-receiver-config.md
+++ b/docs/sources/configuration/integrations/integrations-next/app-agent-receiver-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/integrations-next/app-agent-receiver-config/
 title: app_agent_config
 ---
 

--- a/docs/sources/configuration/integrations/integrations-next/blackbox-config.md
+++ b/docs/sources/configuration/integrations/integrations-next/blackbox-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/integrations-next/blackbox-config/
 title: blackbox_config
 ---
 

--- a/docs/sources/configuration/integrations/integrations-next/eventhandler-config.md
+++ b/docs/sources/configuration/integrations/integrations-next/eventhandler-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/integrations-next/eventhandler-config/
 title: eventhandler_config
 ---
 

--- a/docs/sources/configuration/integrations/integrations-next/snmp-config.md
+++ b/docs/sources/configuration/integrations/integrations-next/snmp-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/integrations-next/snmp-config/
 title: snmp_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/integrations-next/snowflake-config.md
+++ b/docs/sources/configuration/integrations/integrations-next/snowflake-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/agent/latest/configuration/integrations/integrations-next/snowflake-config/
 title: snowflake_config
 ---
 

--- a/docs/sources/configuration/integrations/integrations-next/vsphere-config.md
+++ b/docs/sources/configuration/integrations/integrations-next/vsphere-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/agent/latest/configuration/integrations/integrations-next/vsphere-config/
 title: vsphere_config
 ---
 

--- a/docs/sources/configuration/integrations/kafka-exporter-config.md
+++ b/docs/sources/configuration/integrations/kafka-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/kafka-exporter-config/
 title: kafka_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/memcached-exporter-config.md
+++ b/docs/sources/configuration/integrations/memcached-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/memcached-exporter-config/
 title: memcached_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/mongodb_exporter-config.md
+++ b/docs/sources/configuration/integrations/mongodb_exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/mongodb_exporter-config/
 title: mongodb_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/mysqld-exporter-config.md
+++ b/docs/sources/configuration/integrations/mysqld-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/mysqld-exporter-config/
 title: mysqld_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/node-exporter-config.md
+++ b/docs/sources/configuration/integrations/node-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/node-exporter-config/
 title: node_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/postgres-exporter-config.md
+++ b/docs/sources/configuration/integrations/postgres-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/postgres-exporter-config/
 title: postgres_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/process-exporter-config.md
+++ b/docs/sources/configuration/integrations/process-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/process-exporter-config/
 title: process_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/redis-exporter-config.md
+++ b/docs/sources/configuration/integrations/redis-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/redis-exporter-config/
 title: redis_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/snmp-config.md
+++ b/docs/sources/configuration/integrations/snmp-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/snmp-config/
 title: snmp_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/snowflake-config.md
+++ b/docs/sources/configuration/integrations/snowflake-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/snowflake-config/
 title: snowflake_config
 ---
 

--- a/docs/sources/configuration/integrations/statsd-exporter-config.md
+++ b/docs/sources/configuration/integrations/statsd-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/statsd-exporter-config/
 title: statsd_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/windows-exporter-config.md
+++ b/docs/sources/configuration/integrations/windows-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/windows-exporter-config/
 title: windows_exporter_config
 ---
 

--- a/docs/sources/configuration/logs-config.md
+++ b/docs/sources/configuration/logs-config.md
@@ -1,7 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/configuration/logs-config/
-- /docs/agent/latest/configuration/loki-config/
+- loki-config/
 title: logs_config
 weight: 300
 ---

--- a/docs/sources/configuration/metrics-config.md
+++ b/docs/sources/configuration/metrics-config.md
@@ -1,7 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/configuration/metrics-config/
-- /docs/agent/latest/configuration/prometheus-config/
+- prometheus-config/
 title: metrics_config
 weight: 200
 ---

--- a/docs/sources/configuration/scraping-service.md
+++ b/docs/sources/configuration/scraping-service.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/scraping-service/
+- ../scraping-service/
 title: Scraping Service Mode
 weight: 600
 ---

--- a/docs/sources/configuration/server-config.md
+++ b/docs/sources/configuration/server-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/server-config/
 title: server_config
 weight: 100
 ---

--- a/docs/sources/configuration/traces-config.md
+++ b/docs/sources/configuration/traces-config.md
@@ -1,7 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/configuration/tempo-config/
-- /docs/agent/latest/configuration/traces-config/
+- tempo-config/
 title: traces_config
 weight: 400
 ---

--- a/docs/sources/cookbook/_index.md
+++ b/docs/sources/cookbook/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/cookbook
 title: Cookbook
 weight: 900
 ---

--- a/docs/sources/cookbook/dynamic-configuration/01_Basics/01_Structure.md
+++ b/docs/sources/cookbook/dynamic-configuration/01_Basics/01_Structure.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/dynamic-configuration/structure
+- ../../../dynamic-configuration/structure/
 title: Structure
 weight: 100
 ---

--- a/docs/sources/cookbook/dynamic-configuration/01_Basics/02_Instances.md
+++ b/docs/sources/cookbook/dynamic-configuration/01_Basics/02_Instances.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/dynamic-configuration/instances
+- ../../../dynamic-configuration/instances/
 title: Instances
 weight: 110
 ---

--- a/docs/sources/cookbook/dynamic-configuration/01_Basics/03_Integrations.md
+++ b/docs/sources/cookbook/dynamic-configuration/01_Basics/03_Integrations.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/dynamic-configuration/integrations
+- ../../../dynamic-configuration/integrations/
 title: Integrations
 weight: 120
 ---

--- a/docs/sources/cookbook/dynamic-configuration/01_Basics/04_Logs_and_Traces.md
+++ b/docs/sources/cookbook/dynamic-configuration/01_Basics/04_Logs_and_Traces.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/dynamic-configuration/logs-traces
+- ../../../dynamic-configuration/logs-traces/
 title: Logs and Traces
 weight: 130
 ---

--- a/docs/sources/cookbook/dynamic-configuration/02_Templates/01_Looping.md
+++ b/docs/sources/cookbook/dynamic-configuration/02_Templates/01_Looping.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/dynamic-configuration/looping
+- ../../../dynamic-configuration/looping/
 title: Looping
 weight: 200
 ---

--- a/docs/sources/cookbook/dynamic-configuration/02_Templates/02_Datasources.md
+++ b/docs/sources/cookbook/dynamic-configuration/02_Templates/02_Datasources.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/dynamic-configuration/datasources
+- ../../../dynamic-configuration/datasources/
 title: Datasources
 weight: 210
 ---

--- a/docs/sources/cookbook/dynamic-configuration/02_Templates/03_Datasource_and_Objects.md
+++ b/docs/sources/cookbook/dynamic-configuration/02_Templates/03_Datasource_and_Objects.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/dynamic-configuration/objects
+- ../../../dynamic-configuration/objects/
 title: Objects
 weight: 220
 ---

--- a/docs/sources/cookbook/dynamic-configuration/03_Advanced_Datasources/01_AWS.md
+++ b/docs/sources/cookbook/dynamic-configuration/03_Advanced_Datasources/01_AWS.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/dynamic-configuration/aws
+- ../../../dynamic-configuration/aws/
 title: Querying AWS
 weight: 300
 ---

--- a/docs/sources/cookbook/dynamic-configuration/_index.md
+++ b/docs/sources/cookbook/dynamic-configuration/_index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/dynamic-configuration
+- ../dynamic-configuration/
 title: Dynamic Configuration
 weight: 100
 ---

--- a/docs/sources/flow/_index.md
+++ b/docs/sources/flow/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/
 title: Grafana Agent Flow
 weight: 900
 ---

--- a/docs/sources/flow/concepts/_index.md
+++ b/docs/sources/flow/concepts/_index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/concepts/
+- ../concepts/
 title: Concepts
 weight: 100
 ---

--- a/docs/sources/flow/concepts/component_controller.md
+++ b/docs/sources/flow/concepts/component_controller.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/concepts/component-controller
+- ../../concepts/component-controller/
 title: Component controller
 weight: 200
 ---

--- a/docs/sources/flow/concepts/components.md
+++ b/docs/sources/flow/concepts/components.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/concepts/components
+- ../../concepts/components/
 title: Components
 weight: 100
 ---

--- a/docs/sources/flow/concepts/configuration_language.md
+++ b/docs/sources/flow/concepts/configuration_language.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/concepts/configuration-language
+- ../../concepts/configuration-language/
 title: Configuration language
 weight: 300
 ---

--- a/docs/sources/flow/config-language/_index.md
+++ b/docs/sources/flow/config-language/_index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/flow/configuration-language
+- configuration-language/
 title: Configuration language
 weight: 400
 ---

--- a/docs/sources/flow/config-language/components.md
+++ b/docs/sources/flow/config-language/components.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/flow/configuration-language/components
+- ../configuration-language/components/
 title: Components
 weight: 300
 ---

--- a/docs/sources/flow/config-language/expressions/_index.md
+++ b/docs/sources/flow/config-language/expressions/_index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/flow/configuration-language/expressions
+- ../configuration-language/expressions/
 title: Expressions
 weight: 400
 ---

--- a/docs/sources/flow/config-language/expressions/function_calls.md
+++ b/docs/sources/flow/config-language/expressions/function_calls.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/flow/configuration-language/expressions/function-calls
+- ../../configuration-language/expressions/function-calls/
 title: Function calls
 weight: 400
 ---

--- a/docs/sources/flow/config-language/expressions/operators.md
+++ b/docs/sources/flow/config-language/expressions/operators.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/flow/configuration-language/expressions/operators
+- ../../configuration-language/expressions/operators/
 title: Operators
 weight: 300
 ---

--- a/docs/sources/flow/config-language/expressions/referencing_exports.md
+++ b/docs/sources/flow/config-language/expressions/referencing_exports.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/flow/configuration-language/expressions/referencing-exports
+- ../../configuration-language/expressions/referencing-exports/
 title: Referencing component exports
 weight: 200
 ---

--- a/docs/sources/flow/config-language/expressions/types_and_values.md
+++ b/docs/sources/flow/config-language/expressions/types_and_values.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/flow/configuration-language/expressions/types-and-values
+- ../../configuration-language/expressions/types-and-values/
 title: Types and values
 weight: 100
 ---

--- a/docs/sources/flow/config-language/files.md
+++ b/docs/sources/flow/config-language/files.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/flow/configuration-language/files
+- ../configuration-language/files/
 title: Files
 weight: 100
 ---

--- a/docs/sources/flow/config-language/syntax.md
+++ b/docs/sources/flow/config-language/syntax.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/flow/configuration-language/syntax
+- ../configuration-language/syntax/
 title: Syntax
 weight: 200
 ---

--- a/docs/sources/flow/getting_started.md
+++ b/docs/sources/flow/getting_started.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/flow/getting-started
+- getting-started/
 title: Getting started
 weight: 200
 ---

--- a/docs/sources/flow/monitoring/_index.md
+++ b/docs/sources/flow/monitoring/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/monitoring
 title: Monitoring Grafana Agent Flow
 weight: 500
 ---

--- a/docs/sources/flow/monitoring/component_metrics.md
+++ b/docs/sources/flow/monitoring/component_metrics.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/flow/monitoring/component-metrics
+- component-metrics/
 title: Component metrics
 weight: 200
 ---

--- a/docs/sources/flow/monitoring/controller_metrics.md
+++ b/docs/sources/flow/monitoring/controller_metrics.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/flow/monitoring/controller-metrics
+- controller-metrics/
 title: Controller metrics
 weight: 100
 ---

--- a/docs/sources/flow/monitoring/debugging.md
+++ b/docs/sources/flow/monitoring/debugging.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/monitoring/debugging
 title: Debugging
 weight: 300
 ---

--- a/docs/sources/flow/reference/_index.md
+++ b/docs/sources/flow/reference/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference
 title: Reference
 weight: 600
 ---

--- a/docs/sources/flow/reference/cli/_index.md
+++ b/docs/sources/flow/reference/cli/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/cli
 title: Command-line interface
 weight: 100
 ---

--- a/docs/sources/flow/reference/cli/fmt.md
+++ b/docs/sources/flow/reference/cli/fmt.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/cli/fmt
 title: agent fmt
 weight: 100
 ---

--- a/docs/sources/flow/reference/cli/run.md
+++ b/docs/sources/flow/reference/cli/run.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/cli/run
 title: grafana-agent run
 weight: 100
 ---

--- a/docs/sources/flow/reference/components/_index.md
+++ b/docs/sources/flow/reference/components/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components
 title: Components
 weight: 300
 ---

--- a/docs/sources/flow/reference/components/discovery.docker.md
+++ b/docs/sources/flow/reference/components/discovery.docker.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/discovery.docker
 title: discovery.docker
 ---
 

--- a/docs/sources/flow/reference/components/discovery.file.md
+++ b/docs/sources/flow/reference/components/discovery.file.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/discovery.file
 title: discovery.file
 ---
 

--- a/docs/sources/flow/reference/components/discovery.kubernetes.md
+++ b/docs/sources/flow/reference/components/discovery.kubernetes.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/discovery.kubernetes
 title: discovery.kubernetes
 ---
 

--- a/docs/sources/flow/reference/components/discovery.relabel.md
+++ b/docs/sources/flow/reference/components/discovery.relabel.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/discovery.relabel
 title: discovery.relabel
 ---
 

--- a/docs/sources/flow/reference/components/local.file.md
+++ b/docs/sources/flow/reference/components/local.file.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/local.file
 title: local.file
 ---
 

--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/loki.process
 title: loki.process
 ---
 

--- a/docs/sources/flow/reference/components/loki.relabel.md
+++ b/docs/sources/flow/reference/components/loki.relabel.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/loki.relabel
 title: loki.relabel
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.cloudflare.md
+++ b/docs/sources/flow/reference/components/loki.source.cloudflare.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/loki.source.cloudflare
 title: loki.source.cloudflare
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.file.md
+++ b/docs/sources/flow/reference/components/loki.source.file.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/loki.source.file
 title: loki.source.file
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.gcplog.md
+++ b/docs/sources/flow/reference/components/loki.source.gcplog.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/loki.source.gcplog
 title: loki.source.gcplog
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.gelf.md
+++ b/docs/sources/flow/reference/components/loki.source.gelf.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/loki.source.gelf
 title: loki.source.gelf
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.heroku.md
+++ b/docs/sources/flow/reference/components/loki.source.heroku.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/loki.source.heroku
 title: loki.source.heroku
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.journal.md
+++ b/docs/sources/flow/reference/components/loki.source.journal.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/loki.source.journal
 title: loki.source.journal
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.kubernetes.md
+++ b/docs/sources/flow/reference/components/loki.source.kubernetes.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/loki.source.kubernetes
 title: loki.source.kubernetes
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.podlogs.md
+++ b/docs/sources/flow/reference/components/loki.source.podlogs.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/loki.source.podlogs
 title: loki.source.podlogs
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.syslog.md
+++ b/docs/sources/flow/reference/components/loki.source.syslog.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/loki.source.syslog
 title: loki.source.syslog
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.windowsevent.md
+++ b/docs/sources/flow/reference/components/loki.source.windowsevent.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/loki.source.windowsevent
 title: loki.source.windowsevent
 ---
 

--- a/docs/sources/flow/reference/components/loki.write.md
+++ b/docs/sources/flow/reference/components/loki.write.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/loki.write
 title: loki.write
 ---
 

--- a/docs/sources/flow/reference/components/mimir.rules.kubernetes.md
+++ b/docs/sources/flow/reference/components/mimir.rules.kubernetes.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/mimir.rules.kubernetes
 title: mimir.rules.kubernetes
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.auth.basic.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.basic.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/otelcol.auth.basic
 title: otelcol.auth.basic
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.auth.bearer.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.bearer.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/otelcol.auth.bearer
 title: otelcol.auth.bearer
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.auth.headers.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.headers.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/otelcol.auth.headers
 title: otelcol.auth.headers
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.jaeger.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.jaeger.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/otelcol.exporter.jaeger
 title: otelcol.exporter.jaeger
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.loki.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.loki.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/otelcol.exporter.loki
 title: otelcol.exporter.loki
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/otelcol.exporter.otlp
 title: otelcol.exporter.otlp
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlphttp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlphttp.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/otelcol.exporter.otlphttp
 title: otelcol.exporter.otlphttp
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/otelcol.exporter.prometheus
 title: otelcol.exporter.prometheus
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.processor.batch.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.batch.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/otelcol.processor.batch
 title: otelcol.processor.batch
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.processor.memory_limiter.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.memory_limiter.md
@@ -6,8 +6,6 @@
 # Ideally, in the future, we can fix the overflow issue with css rather than
 # injecting special characters.
 
-aliases:
-- /docs/agent/latest/flow/reference/components/otelcol.processor.memory_limiter
 title: otelcol.​processor.​memory_limiter
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.jaeger.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.jaeger.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/otelcol.receiver.jaeger
 title: otelcol.receiver.jaeger
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.kafka.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.kafka.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/otelcol.receiver.kafka
 title: otelcol.receiver.kafka
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.loki.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.loki.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/otelcol.receiver.loki
 title: otelcol.receiver.loki
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.opencensus.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.opencensus.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/otelcol.receiver.opencensus
 title: otelcol.receiver.opencensus
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.otlp.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/otelcol.receiver.otlp
 title: otelcol.receiver.otlp
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.prometheus.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.prometheus.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/otelcol.receiver.prometheus
 title: otelcol.receiver.prometheus
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.zipkin.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.zipkin.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/otelcol.receiver.zipkin
 title: otelcol.receiver.zipkin
 ---
 

--- a/docs/sources/flow/reference/components/phlare.scrape.md
+++ b/docs/sources/flow/reference/components/phlare.scrape.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/phlare.scrape
 title: phlare.scrape
 ---
 

--- a/docs/sources/flow/reference/components/phlare.write.md
+++ b/docs/sources/flow/reference/components/phlare.write.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/phlare.write
 title: phlare.write
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.integration.node_exporter.md
+++ b/docs/sources/flow/reference/components/prometheus.integration.node_exporter.md
@@ -6,8 +6,6 @@
 # Ideally, in the future, we can fix the overflow issue with css rather than
 # injecting special characters.
 
-aliases:
-- /docs/agent/latest/flow/reference/components/prometheus.integration.node_exporter
 title: prometheus.​integration.​node_exporter
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.relabel.md
+++ b/docs/sources/flow/reference/components/prometheus.relabel.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/prometheus.relabel
 title: prometheus.relabel
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.remote_write.md
+++ b/docs/sources/flow/reference/components/prometheus.remote_write.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/prometheus.remote_write
 title: prometheus.remote_write
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.scrape.md
+++ b/docs/sources/flow/reference/components/prometheus.scrape.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/prometheus.scrape
 title: prometheus.scrape
 ---
 

--- a/docs/sources/flow/reference/components/remote.http.md
+++ b/docs/sources/flow/reference/components/remote.http.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/remote.http
 title: remote.http
 ---
 

--- a/docs/sources/flow/reference/components/remote.s3.md
+++ b/docs/sources/flow/reference/components/remote.s3.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/components/remote.s3
 title: remote.s3
 ---
 

--- a/docs/sources/flow/reference/config-blocks/_index.md
+++ b/docs/sources/flow/reference/config-blocks/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/config-blocks
 title: Configuration blocks
 weight: 200
 ---

--- a/docs/sources/flow/reference/config-blocks/logging.md
+++ b/docs/sources/flow/reference/config-blocks/logging.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/config-blocks/logging
 title: logging
 weight: 100
 ---

--- a/docs/sources/flow/reference/config-blocks/tracing.md
+++ b/docs/sources/flow/reference/config-blocks/tracing.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/reference/config-blocks/tracing
 title: tracing
 weight: 100
 ---

--- a/docs/sources/flow/reference/stdlib/_index.md
+++ b/docs/sources/flow/reference/stdlib/_index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/flow/reference/standard-library
+- standard-library/
 title: Standard library
 weight: 400
 ---

--- a/docs/sources/flow/reference/stdlib/concat.md
+++ b/docs/sources/flow/reference/stdlib/concat.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/flow/configuration-language/standard-library/concat
+- ../../configuration-language/standard-library/concat/
 title: concat
 ---
 

--- a/docs/sources/flow/reference/stdlib/discovery_target_decode.md
+++ b/docs/sources/flow/reference/stdlib/discovery_target_decode.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/flow/configuration-language/standard-library/discovery_target_decode
+- ../../configuration-language/standard-library/discovery_target_decode/
 title: discovery_target_decode
 ---
 

--- a/docs/sources/flow/reference/stdlib/env.md
+++ b/docs/sources/flow/reference/stdlib/env.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/flow/configuration-language/standard-library/env
+- ../../configuration-language/standard-library/env/
 title: env
 ---
 

--- a/docs/sources/flow/reference/stdlib/json_decode.md
+++ b/docs/sources/flow/reference/stdlib/json_decode.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/flow/configuration-language/standard-library/json_decode
+- ../../configuration-language/standard-library/json_decode/
 title: json_decode
 ---
 

--- a/docs/sources/flow/tutorials/_index.md
+++ b/docs/sources/flow/tutorials/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/agent/latest/flow/tutorials
 title: Tutorials
 weight: 300
 ---

--- a/docs/sources/flow/tutorials/chaining.md
+++ b/docs/sources/flow/tutorials/chaining.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/tutorials/chaining
 title: Chaining Prometheus components
 weight: 400
 ---

--- a/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
+++ b/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/tutorials/collecting-prometheus-metrics
 title: Collecting Prometheus metrics
 weight: 200
 ---

--- a/docs/sources/flow/tutorials/filtering-metrics.md
+++ b/docs/sources/flow/tutorials/filtering-metrics.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/flow/tutorials/filtering-metrics
 title: Filtering Prometheus metrics
 weight: 300
 ---

--- a/docs/sources/operation-guide/_index.md
+++ b/docs/sources/operation-guide/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/operation-guide/
 title: Operation guide
 weight: 700
 ---

--- a/docs/sources/operator/_index.md
+++ b/docs/sources/operator/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/operator/
 title: Grafana Agent Operator
 weight: 500
 ---

--- a/docs/sources/operator/add-custom-scrape-jobs.md
+++ b/docs/sources/operator/add-custom-scrape-jobs.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/operator/add-custom-scrape-jobs/
 title: Add custom scrape jobs
 weight: 400
 ---

--- a/docs/sources/operator/api.md
+++ b/docs/sources/operator/api.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/operator/crd/
+- crd/
 title: Custom Resource Definition Reference
 weight: 500
 ---

--- a/docs/sources/operator/architecture.md
+++ b/docs/sources/operator/architecture.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/operator/architecture/
 title: Agent Operator architecture
 weight: 300
 ---

--- a/docs/sources/operator/deploy-agent-operator-resources.md
+++ b/docs/sources/operator/deploy-agent-operator-resources.md
@@ -1,7 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/operator/deploy-agent-operator-resources/
-- /docs/agent/latest/operator/custom-resource-quickstart/
+- custom-resource-quickstart/
 title: Deploy the Agent Operator resources
 weight: 120
 ---

--- a/docs/sources/operator/getting-started.md
+++ b/docs/sources/operator/getting-started.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/operator/getting-started/
 title: Install Grafana Agent Operator
 weight: 110
 ---

--- a/docs/sources/operator/helm-getting-started.md
+++ b/docs/sources/operator/helm-getting-started.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/operator/helm-getting-started/
 title: Install Grafana Agent Operator with Helm
 weight: 100
 ---

--- a/docs/sources/set-up/_index.md
+++ b/docs/sources/set-up/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/set-up/
 title: Set up Grafana Agent
 weight: 100
 ---

--- a/docs/sources/set-up/install-agent-binary.md
+++ b/docs/sources/set-up/install-agent-binary.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/set-up/install-agent-binary/
 title: Install the Grafana Agent binary
 weight: 140
 ---

--- a/docs/sources/set-up/install-agent-docker.md
+++ b/docs/sources/set-up/install-agent-docker.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/set-up/install-agent-docker/
 title: Run Grafana Agent on Docker
 weight: 110
 ---

--- a/docs/sources/set-up/install-agent-linux.md
+++ b/docs/sources/set-up/install-agent-linux.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/set-up/install-agent-linux/
 title: Install Grafana Agent on Linux
 weight: 115
 ---

--- a/docs/sources/set-up/install-agent-macos.md
+++ b/docs/sources/set-up/install-agent-macos.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/set-up/install-agent-macos/
 title: Install Grafana Agent on macOS
 weight: 130
 ---

--- a/docs/sources/set-up/install-agent-on-windows.md
+++ b/docs/sources/set-up/install-agent-on-windows.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/set-up/install-agent-on-windows/
 title: Install Grafana Agent on Windows
 weight: 120
 ---

--- a/docs/sources/set-up/quick-starts.md
+++ b/docs/sources/set-up/quick-starts.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/set-up/quick-starts/
 title: Grafana Agent quick starts
 weight: 150
 ---

--- a/docs/sources/shared/flow/reference/components/output-block.md
+++ b/docs/sources/shared/flow/reference/components/output-block.md
@@ -1,7 +1,7 @@
 ---
-headless: true
 aliases:
-  - /docs/agent/latest/shared/flow/otelcol/output-block/
+- ../../otelcol/output-block/
+headless: true
 ---
 
 The `output` block configures a set of components to forward resulting

--- a/docs/sources/shared/index.md
+++ b/docs/sources/shared/index.md
@@ -1,6 +1,4 @@
 ---
 headless: true
-aliases:
-  - /docs/agent/latest/shared/
 ---
 

--- a/docs/sources/upgrade-guide/_index.md
+++ b/docs/sources/upgrade-guide/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/upgrade-guide/
 title: Upgrade guide
 weight: 800
 ---


### PR DESCRIPTION
Absolute aliases containing versions can redirect "latest" content to old versions when a page has been removed in newer versions. The redirected pages are indexed by search engines but our robots.txt forbids them crawling the non-latest page.

Relative aliases behave consistently across versions and do not suffer the same problems.

I've checked a bunch of aliases manually by:

1. Running make docs
1. Picking an absolute alias path from a random file
1. Checking that I end up at the page represented by the file containing the alias. For example, to test the relative alias in the file docs/sources/configuration/create-config-file.md:

   ```console 
   $ make docs 
   ``` 
   - Browse to http://localhost:3002/docs/agent/latest/set-up/create-config-file/ 
   - Confirm that I am redirected to http://localhost:3002/docs/agent/latest/configuration/create-config-file/
