### PR TITLE
[release-v0.27] Prefer relative aliases

### DIFF
--- a/docs/sources/README.md
+++ b/docs/sources/README.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/README/
 draft: "True"
 ---
 

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/
 title: Grafana Agent
 weight: 1
 ---

--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/api/
 title: Grafana Agent API
 weight: 400
 ---

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/
 title: Configure Grafana Agent
 weight: 300
 ---

--- a/docs/sources/configuration/create-config-file.md
+++ b/docs/sources/configuration/create-config-file.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/set-up/create-config-file/
+- ../set-up/create-config-file/
 title: Create a config file
 weight: 50
 ---

--- a/docs/sources/configuration/dynamic-config.md
+++ b/docs/sources/configuration/dynamic-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/dynamic-config/
 title: dynamic_config
 weight: 500
 ---

--- a/docs/sources/configuration/flags.md
+++ b/docs/sources/configuration/flags.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/flags/
 title: Command-line flags
 weight: 100
 ---

--- a/docs/sources/configuration/integrations/_index.md
+++ b/docs/sources/configuration/integrations/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/
 title: integrations_config
 weight: 500
 ---

--- a/docs/sources/configuration/integrations/apache-exporter-config.md
+++ b/docs/sources/configuration/integrations/apache-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/apache-exporter-config/
 title: apache_http_config
 ---
 

--- a/docs/sources/configuration/integrations/cadvisor-config.md
+++ b/docs/sources/configuration/integrations/cadvisor-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/cadvisor-config/
 title: cadvisor_config
 ---
 

--- a/docs/sources/configuration/integrations/consul-exporter-config.md
+++ b/docs/sources/configuration/integrations/consul-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/consul-exporter-config/
 title: consul_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/dnsmasq-exporter-config.md
+++ b/docs/sources/configuration/integrations/dnsmasq-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/dnsmasq-exporter-config/
 title: dnsmasq_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/ebpf-config.md
+++ b/docs/sources/configuration/integrations/ebpf-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/ebpf-config/
 title: ebpf_config
 ---
 

--- a/docs/sources/configuration/integrations/elasticsearch-exporter-config.md
+++ b/docs/sources/configuration/integrations/elasticsearch-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/elasticsearch-exporter-config/
 title: elasticsearch_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/github-exporter-config.md
+++ b/docs/sources/configuration/integrations/github-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/github-exporter-config/
 title: github_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/integrations-next/_index.md
+++ b/docs/sources/configuration/integrations/integrations-next/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/integrations-next/
 title: Integrations Revamp
 weight: 100
 ---

--- a/docs/sources/configuration/integrations/integrations-next/app-agent-receiver-config.md
+++ b/docs/sources/configuration/integrations/integrations-next/app-agent-receiver-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/integrations-next/app-agent-receiver-config/
 title: app_agent_config
 ---
 

--- a/docs/sources/configuration/integrations/integrations-next/eventhandler-config.md
+++ b/docs/sources/configuration/integrations/integrations-next/eventhandler-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/integrations-next/eventhandler-config/
 title: eventhandler_config
 ---
 

--- a/docs/sources/configuration/integrations/integrations-next/snmp-config.md
+++ b/docs/sources/configuration/integrations/integrations-next/snmp-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/integrations-next/snmp-config/
 title: snmp_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/integrations-next/vsphere-config.md
+++ b/docs/sources/configuration/integrations/integrations-next/vsphere-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/agent/latest/configuration/integrations/integrations-next/vsphere-config/
 title: vsphere_config
 ---
 

--- a/docs/sources/configuration/integrations/kafka-exporter-config.md
+++ b/docs/sources/configuration/integrations/kafka-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/kafka-exporter-config/
 title: kafka_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/memcached-exporter-config.md
+++ b/docs/sources/configuration/integrations/memcached-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/memcached-exporter-config/
 title: memcached_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/mongodb_exporter-config.md
+++ b/docs/sources/configuration/integrations/mongodb_exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/mongodb_exporter-config/
 title: mongodb_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/mysqld-exporter-config.md
+++ b/docs/sources/configuration/integrations/mysqld-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/mysqld-exporter-config/
 title: mysqld_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/node-exporter-config.md
+++ b/docs/sources/configuration/integrations/node-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/node-exporter-config/
 title: node_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/postgres-exporter-config.md
+++ b/docs/sources/configuration/integrations/postgres-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/postgres-exporter-config/
 title: postgres_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/process-exporter-config.md
+++ b/docs/sources/configuration/integrations/process-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/process-exporter-config/
 title: process_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/redis-exporter-config.md
+++ b/docs/sources/configuration/integrations/redis-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/redis-exporter-config/
 title: redis_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/snmp-config.md
+++ b/docs/sources/configuration/integrations/snmp-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/snmp-config/
 title: snmp_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/statsd-exporter-config.md
+++ b/docs/sources/configuration/integrations/statsd-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/statsd-exporter-config/
 title: statsd_exporter_config
 ---
 

--- a/docs/sources/configuration/integrations/windows-exporter-config.md
+++ b/docs/sources/configuration/integrations/windows-exporter-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/integrations/windows-exporter-config/
 title: windows_exporter_config
 ---
 

--- a/docs/sources/configuration/logs-config.md
+++ b/docs/sources/configuration/logs-config.md
@@ -1,7 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/configuration/logs-config/
-- /docs/agent/latest/configuration/loki-config/
+- loki-config/
 title: logs_config
 weight: 300
 ---

--- a/docs/sources/configuration/metrics-config.md
+++ b/docs/sources/configuration/metrics-config.md
@@ -1,7 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/configuration/metrics-config/
-- /docs/agent/latest/configuration/prometheus-config/
+- prometheus-config/
 title: metrics_config
 weight: 200
 ---

--- a/docs/sources/configuration/scraping-service.md
+++ b/docs/sources/configuration/scraping-service.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/scraping-service/
+- ../scraping-service/
 title: Scraping Service Mode
 weight: 600
 ---

--- a/docs/sources/configuration/server-config.md
+++ b/docs/sources/configuration/server-config.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/configuration/server-config/
 title: server_config
 weight: 100
 ---

--- a/docs/sources/configuration/traces-config.md
+++ b/docs/sources/configuration/traces-config.md
@@ -1,7 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/configuration/tempo-config/
-- /docs/agent/latest/configuration/traces-config/
+- tempo-config/
 title: traces_config
 weight: 400
 ---

--- a/docs/sources/cookbook/_index.md
+++ b/docs/sources/cookbook/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/cookbook
 title: Cookbook
 weight: 900
 ---

--- a/docs/sources/cookbook/dynamic-configuration/01_Basics/01_Structure.md
+++ b/docs/sources/cookbook/dynamic-configuration/01_Basics/01_Structure.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/dynamic-configuration/structure
+- ../../../dynamic-configuration/structure/
 title: Structure
 weight: 100
 ---

--- a/docs/sources/cookbook/dynamic-configuration/01_Basics/02_Instances.md
+++ b/docs/sources/cookbook/dynamic-configuration/01_Basics/02_Instances.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/dynamic-configuration/instances
+- ../../../dynamic-configuration/instances/
 title: Instances
 weight: 110
 ---

--- a/docs/sources/cookbook/dynamic-configuration/01_Basics/03_Integrations.md
+++ b/docs/sources/cookbook/dynamic-configuration/01_Basics/03_Integrations.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/dynamic-configuration/integrations
+- ../../../dynamic-configuration/integrations/
 title: Integrations
 weight: 120
 ---

--- a/docs/sources/cookbook/dynamic-configuration/01_Basics/04_Logs_and_Traces.md
+++ b/docs/sources/cookbook/dynamic-configuration/01_Basics/04_Logs_and_Traces.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/dynamic-configuration/logs-traces
+- ../../../dynamic-configuration/logs-traces/
 title: Logs and Traces
 weight: 130
 ---

--- a/docs/sources/cookbook/dynamic-configuration/02_Templates/01_Looping.md
+++ b/docs/sources/cookbook/dynamic-configuration/02_Templates/01_Looping.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/dynamic-configuration/looping
+- ../../../dynamic-configuration/looping/
 title: Looping
 weight: 200
 ---

--- a/docs/sources/cookbook/dynamic-configuration/02_Templates/02_Datasources.md
+++ b/docs/sources/cookbook/dynamic-configuration/02_Templates/02_Datasources.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/dynamic-configuration/datasources
+- ../../../dynamic-configuration/datasources/
 title: Datasources
 weight: 210
 ---

--- a/docs/sources/cookbook/dynamic-configuration/02_Templates/03_Datasource_and_Objects.md
+++ b/docs/sources/cookbook/dynamic-configuration/02_Templates/03_Datasource_and_Objects.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/dynamic-configuration/objects
+- ../../../dynamic-configuration/objects/
 title: Objects
 weight: 220
 ---

--- a/docs/sources/cookbook/dynamic-configuration/03_Advanced_Datasources/01_AWS.md
+++ b/docs/sources/cookbook/dynamic-configuration/03_Advanced_Datasources/01_AWS.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/dynamic-configuration/aws
+- ../../../dynamic-configuration/aws/
 title: Querying AWS
 weight: 300
 ---

--- a/docs/sources/cookbook/dynamic-configuration/_index.md
+++ b/docs/sources/cookbook/dynamic-configuration/_index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/latest/dynamic-configuration
+- ../dynamic-configuration/
 title: Dynamic Configuration
 weight: 100
 ---

--- a/docs/sources/operation-guide/_index.md
+++ b/docs/sources/operation-guide/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/operation-guide/
 title: Operation guide
 weight: 700
 ---

--- a/docs/sources/operator/_index.md
+++ b/docs/sources/operator/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/operator/
 title: Grafana Agent Operator
 weight: 500
 ---

--- a/docs/sources/operator/add-custom-scrape-jobs.md
+++ b/docs/sources/operator/add-custom-scrape-jobs.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/operator/add-custom-scrape-jobs/
 title: Add custom scrape jobs
 weight: 400
 ---

--- a/docs/sources/operator/architecture.md
+++ b/docs/sources/operator/architecture.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/operator/architecture/
 title: Operator architecture
 weight: 300
 ---

--- a/docs/sources/operator/custom-resource-quickstart.md
+++ b/docs/sources/operator/custom-resource-quickstart.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/operator/custom-resource-quickstart/
 title: Custom Resource Quickstart
 weight: 120
 ---

--- a/docs/sources/operator/getting-started.md
+++ b/docs/sources/operator/getting-started.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/operator/getting-started/
 title: Installing Grafana Agent Operator
 weight: 100
 ---

--- a/docs/sources/operator/helm-getting-started.md
+++ b/docs/sources/operator/helm-getting-started.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/operator/helm-getting-started/
 title: Installing Grafana Agent Operator with Helm
 weight: 110
 ---

--- a/docs/sources/set-up/_index.md
+++ b/docs/sources/set-up/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/set-up/
 title: Set up Grafana Agent
 weight: 100
 ---

--- a/docs/sources/set-up/install-agent-binary.md
+++ b/docs/sources/set-up/install-agent-binary.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/set-up/install-agent-binary/
 title: Install the Grafana Agent binary
 weight: 140
 ---

--- a/docs/sources/set-up/install-agent-docker.md
+++ b/docs/sources/set-up/install-agent-docker.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/set-up/install-agent-docker/
 title: Run Grafana Agent on Docker
 weight: 110
 ---

--- a/docs/sources/set-up/install-agent-macos.md
+++ b/docs/sources/set-up/install-agent-macos.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/set-up/install-agent-macos/
 title: Install Grafana Agent on macOS
 weight: 130
 ---

--- a/docs/sources/set-up/install-agent-on-windows.md
+++ b/docs/sources/set-up/install-agent-on-windows.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/set-up/install-agent-on-windows/
 title: Install Grafana Agent on Windows
 weight: 120
 ---

--- a/docs/sources/set-up/quick-starts.md
+++ b/docs/sources/set-up/quick-starts.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/set-up/quick-starts/
 title: Grafana Agent quick starts
 weight: 150
 ---

--- a/docs/sources/upgrade-guide/_index.md
+++ b/docs/sources/upgrade-guide/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-- /docs/agent/latest/upgrade-guide/
 title: Upgrade guide
 weight: 800
 ---


### PR DESCRIPTION
Absolute aliases containing versions can redirect "latest" content to old versions when a page has been removed in newer versions. The redirected pages are indexed by search engines but our robots.txt forbids them crawling the non-latest page.

Relative aliases behave consistently across versions and do not suffer the same problems.

I've checked a bunch of aliases manually by:

1. Running make docs
1. Picking an absolute alias path from a random file
1. Checking that I end up at the page represented by the file containing the alias. For example, to test the relative alias in the file docs/sources/configuration/create-config-file.md:

   ```console 
   $ make docs 
   ``` 
   - Browse to http://localhost:3002/docs/agent/latest/set-up/create-config-file/ 
   - Confirm that I am redirected to http://localhost:3002/docs/agent/latest/configuration/create-config-file/
