### PR TITLE
docs: Add kustomize considerations on flow mode install for kubernetes

### DIFF
--- a/docs/sources/flow/install/kubernetes.md
+++ b/docs/sources/flow/install/kubernetes.md
@@ -82,3 +82,28 @@ perform the following steps:
    2. Replace `VALUES_PATH` with the path to your copy of `values.yaml` to use.
 
 [values.yaml]: https://raw.githubusercontent.com/grafana/agent/main/operations/helm/charts/grafana-agent/values.yaml
+
+### Kustomize considerations
+
+If using [Kustomize][] to inflate and install the [Helm chart][], be careful
+when using a `configMapGenerator` to generate the ConfigMap containing the
+configuration. By default, the generator appends a hash to the name and patches
+the resource mentioning it, triggering a rolling update.
+
+In the case of Grafana Agent Flow, this behavior is undesirable, as the startup
+time can be significant depending on the size of the Write-Ahead Log. Instead,
+the [Helm chart][] provides a sidecar container that will watch the ConfigMap
+and trigger a dynamic reload.
+
+Here is an example snippet of a `kustomization` that disables this behavior:
+
+```yaml
+configMapGenerator:
+  - name: grafana-agent
+    files:
+      - config.river
+    options:
+      disableNameSuffixHash: true
+```
+
+[Kustomize]: https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Following the discussion on slack, the project recommends against using doing new rollouts on config change, which would be the default behavior when using kustomize to generate the ConfigMap if one is not careful.

This PR adds a section to the installation docs mentioning this recommendation, along with a snippet of a kustomization with the appropriate config to disable the behaviour.