### PR TITLE
flow: fix typo in local.file argument (#3626)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
+v0.33.1 (2023-04-28)
+--------------------
+
+### Bugfixes
+
+- Fix spelling of the `frequency` argument on the `local.file` component.
+  (@tpaschalis)
 
 v0.33.0 (2023-04-25)
 --------------------

--- a/component/local/file/detector.go
+++ b/component/local/file/detector.go
@@ -76,10 +76,10 @@ type fsNotify struct {
 }
 
 type fsNotifyOptions struct {
-	Logger       log.Logger
-	Filename     string
-	ReloadFile   func()        // Callback to request file reload.
-	PollFreqency time.Duration // How often to do fallback polling
+	Logger        log.Logger
+	Filename      string
+	ReloadFile    func()        // Callback to request file reload.
+	PollFrequency time.Duration // How often to do fallback polling
 }
 
 // newFSNotify creates a new fsnotify detector which uses filesystem events to
@@ -109,7 +109,7 @@ func newFSNotify(opts fsNotifyOptions) (*fsNotify, error) {
 }
 
 func (fsn *fsNotify) wait(ctx context.Context) {
-	pollTick := time.NewTicker(fsn.opts.PollFreqency)
+	pollTick := time.NewTicker(fsn.opts.PollFrequency)
 	defer pollTick.Stop()
 
 	for {

--- a/component/local/file/file.go
+++ b/component/local/file/file.go
@@ -42,8 +42,8 @@ type Arguments struct {
 	// Type indicates how to detect changes to the file.
 	Type Detector `river:"detector,attr,optional"`
 	// PollFrequency determines the frequency to check for changes when Type is
-	// UpdateTypePoll.
-	PollFrequency time.Duration `river:"poll_freqency,attr,optional"`
+	// Poll.
+	PollFrequency time.Duration `river:"poll_frequency,attr,optional"`
 	// IsSecret marks the file as holding a secret value which should not be
 	// displayed to the user.
 	IsSecret bool `river:"is_secret,attr,optional"`
@@ -195,7 +195,7 @@ func (c *Component) Update(args component.Arguments) error {
 	newArgs := args.(Arguments)
 
 	if newArgs.PollFrequency <= 0 {
-		return fmt.Errorf("poll_freqency must be greater than 0")
+		return fmt.Errorf("poll_frequency must be greater than 0")
 	}
 
 	c.mut.Lock()
@@ -249,10 +249,10 @@ func (c *Component) configureDetector() error {
 		})
 	case DetectorFSNotify:
 		c.detector, err = newFSNotify(fsNotifyOptions{
-			Logger:       c.opts.Logger,
-			Filename:     c.args.Filename,
-			ReloadFile:   reloadFile,
-			PollFreqency: c.args.PollFrequency,
+			Logger:        c.opts.Logger,
+			Filename:      c.args.Filename,
+			ReloadFile:    reloadFile,
+			PollFrequency: c.args.PollFrequency,
 		})
 	}
 


### PR DESCRIPTION
(cherry picked from commit 79b21ffecba9a1949b79150f99845c9db83fb62d)
