### PR TITLE
river: retain pointer to capsule when decoding to any (#3620)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
+v0.33.1 (2023-04-28)
+--------------------
+
+### Bugfixes
+
+- Fix bug where some capsule values (such as Prometheus receivers) could not
+  properly be used as an argument to a module. (@rfratto)
 
 v0.33.0 (2023-04-25)
 --------------------

--- a/pkg/river/internal/value/decode.go
+++ b/pkg/river/internal/value/decode.go
@@ -419,6 +419,14 @@ func (d *decoder) decodeAny(val Value, into reflect.Value) error {
 	case TypeFunction, TypeCapsule:
 		// Functions and capsules must be directly assigned since there's no
 		// "generic" representation for either.
+		//
+		// We retain the pointer if we were given a pointer.
+
+		if val.rv.CanAddr() {
+			into.Set(val.rv.Addr())
+			return nil
+		}
+
 		into.Set(val.rv)
 		return nil
 

--- a/pkg/river/internal/value/decode_test.go
+++ b/pkg/river/internal/value/decode_test.go
@@ -641,3 +641,24 @@ func TestDecode_SquashedSlice_Pointer(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expect, out)
 }
+
+func TestRetainCapsulePointer(t *testing.T) {
+	capsuleVal := &capsule{}
+
+	in := map[string]any{
+		"foo": capsuleVal,
+	}
+
+	var actual map[string]any
+	err := value.Decode(value.Encode(in), &actual)
+	require.NoError(t, err)
+
+	expect := map[string]any{
+		"foo": capsuleVal,
+	}
+	require.Equal(t, expect, actual)
+}
+
+type capsule struct{}
+
+func (*capsule) RiverCapsule() {}


### PR DESCRIPTION

(cherry picked from commit 0e7753a92f1b0396320995cc29d7ec409b3244dc)
