### PR TITLE
supportbundle: add debug information about log targets (#3625)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
+v0.33.1 (2023-04-28)
+--------------------
+
+### Other changes
+
+- Support Bundles report the status of discovered log targets. (@tpaschalis)
+
 
 v0.33.0 (2023-04-25)
 --------------------

--- a/docs/sources/static/api/_index.md
+++ b/docs/sources/static/api/_index.md
@@ -387,8 +387,8 @@ A support bundle contains the following data:
 * `agent-config.yaml` contains the current agent configuration (when the `-config.enable-read-api` flag is passed).
 * `agent-logs.txt` contains the agent logs during the bundle generation.
 * `agent-metadata.yaml` contains the agent's build version, operating system, architecture, uptime, plus a string payload defining which extra agent features have been enabled via command-line flags.
-* `agent-metrics-instances.json` and `agent-metrics-targets.json` contain the active metric subsystem instances, and the discovered scraped targets for each one.
-* `agent-logs-instances.json` contains the active logs subsystem instances.
+* `agent-metrics-instances.json` and `agent-metrics-targets.json` contain the active metric subsystem instances and the discovered scrape targets for each one.
+* `agent-logs-instances.json` and `agent-logs-targets.json` contains the active logs subsystem instances and the discovered log targets for each one.
 * `agent-metrics.txt` contains a snapshot of the agent's internal metrics.
 * The `pprof/` directory contains Go runtime profiling data (CPU, heap, goroutine, mutex, block profiles) as exported by the pprof package.
 

--- a/docs/sources/static/configuration/flags.md
+++ b/docs/sources/static/configuration/flags.md
@@ -71,7 +71,7 @@ Support bundles contain the following data:
 * `agent-logs.txt` contains the agent logs during the bundle generation.
 * `agent-metadata.yaml` contains the agent's build version, operating system, architecture, uptime, plus a string payload defining which extra agent features have been enabled via command-line flags.
 * `agent-metrics-instances.json` and `agent-metrics-targets.json` contain the active metric subsystem instances, and the discovered scraped targets for each one.
-* `agent-logs-instances.json` contains the active logs subsystem instances.
+* `agent-logs-instances.json` and `agent-logs-targets.json` contains the active logs subsystem instances and the discovered log targets for each one.
 * `agent-metrics.txt` contains a snapshot of the agent's internal metrics.
 * The `pprof/` directory contains Go runtime profiling data (CPU, heap, goroutine, mutex, block profiles) as exported by the pprof package.
 


### PR DESCRIPTION
(cherry picked from commit 689587f700e8b6101ee8ca9691f2fc6797970d12)
