### PR TITLE
Remove implementation detail from agent management doc

### DIFF
--- a/docs/sources/static/configuration/agent-management.md
+++ b/docs/sources/static/configuration/agent-management.md
@@ -134,5 +134,3 @@ snippets:
       os: linux
       app: app1
 ```
-
-> **Note:** This example uses YAML. However, both JSON and YAML responses are supported. The choice of serialization format is left to the server-side implementation. Grafana Agent does not send nor reads `Content-Type` or `Accept` headers.


### PR DESCRIPTION
#### PR Description

Iterates on Agent Management documentation.

I think this additional note adds mostly noisy and is not generally relevant to users.