### PR TITLE
Remove stale comment

### DIFF
--- a/cmd/grafana-agent-flow/main.go
+++ b/cmd/grafana-agent-flow/main.go
@@ -24,6 +24,5 @@ func init() {
 }
 
 func main() {
-	// TODO: Allow Flow to run as a Windows service.
 	flowmode.Run()
 }


### PR DESCRIPTION
Remove stale TODO comment about supporting Flow to run as a system service, which was implemented in #3429, which allows a dedicated program to manage Flow as a Windows service. See #3243 for context.

cc @jkroepke 