### PR TITLE
List backspace escape sequence in the documentation

### DIFF
--- a/docs/sources/flow/config-language/expressions/types_and_values.md
+++ b/docs/sources/flow/config-language/expressions/types_and_values.md
@@ -49,6 +49,7 @@ The supported escape sequences are as follows:
 
 | Sequence | Replacement |
 | -------- | ----------- |
+| `\\` | The `\` character `U+005C` |
 | `\a` | The alert or bell character `U+0007` |
 | `\b` | The backspace character `U+0008` |
 | `\f` | The formfeed character `U+000C` |


### PR DESCRIPTION
The backspace escape sequence has not been listed in the docs even though it has been supported.