### PR TITLE
[release-v0.33] loki.source.heroku: use an unchecked collector for server metrics 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ v0.33.1 (2023-04-28)
 - Fix version information not displaying correctly when passing the `--version`
   flag or in the `agent_build_info` metric. (@rfratto)
 
+- Fix issue in `loki.source.heroku` and `loki.source.gcplog` where updating the
+  component would cause Grafana Agent Flow's Prometheus metrics endpoint to
+  return an error until the process is restarted. (@rfratto)
+
 ### Other changes
 
 - Support Bundles report the status of discovered log targets. (@tpaschalis)

--- a/component/loki/source/heroku/internal/herokutarget/herokutarget.go
+++ b/component/loki/source/heroku/internal/herokutarget/herokutarget.go
@@ -156,11 +156,11 @@ func (h *HerokuTarget) drain(w http.ResponseWriter, r *http.Request) {
 				Line:      message.Message,
 			},
 		}
-		h.metrics.herokuEntries.WithLabelValues().Inc()
+		h.metrics.herokuEntries.Inc()
 	}
 	err := herokuScanner.Err()
 	if err != nil {
-		h.metrics.herokuErrors.WithLabelValues().Inc()
+		h.metrics.herokuErrors.Inc()
 		level.Warn(h.logger).Log("msg", "failed to read incoming heroku request", "err", err.Error())
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/component/loki/source/heroku/internal/herokutarget/metrics.go
+++ b/component/loki/source/heroku/internal/herokutarget/metrics.go
@@ -7,22 +7,22 @@ package herokutarget
 import "github.com/prometheus/client_golang/prometheus"
 
 type Metrics struct {
-	herokuEntries *prometheus.CounterVec
-	herokuErrors  *prometheus.CounterVec
+	herokuEntries prometheus.Counter
+	herokuErrors  prometheus.Counter
 }
 
 func NewMetrics(reg prometheus.Registerer) *Metrics {
 	var m Metrics
 
-	m.herokuEntries = prometheus.NewCounterVec(prometheus.CounterOpts{
+	m.herokuEntries = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "loki_source_heroku_drain_entries_total",
 		Help: "Number of successful entries received by the Heroku target",
-	}, []string{})
+	})
 
-	m.herokuErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+	m.herokuErrors = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "loki_source_heroku_drain_parsing_errors_total",
 		Help: "Number of parsing errors while receiving Heroku messages",
-	}, []string{})
+	})
 
 	reg.MustRegister(m.herokuEntries, m.herokuErrors)
 	return &m

--- a/pkg/util/unchecked_collector.go
+++ b/pkg/util/unchecked_collector.go
@@ -1,0 +1,49 @@
+package util
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// UncheckedCollector is a prometheus.Collector which stores a set of unchecked
+// metrics.
+type UncheckedCollector struct {
+	mut   sync.RWMutex
+	inner prometheus.Collector
+}
+
+var _ prometheus.Collector = (*UncheckedCollector)(nil)
+
+// NewUncheckedCollector creates a new UncheckedCollector. If inner is nil,
+// UncheckedCollector returns no metrics.
+func NewUncheckedCollector(inner prometheus.Collector) *UncheckedCollector {
+	return &UncheckedCollector{inner: inner}
+}
+
+// SetCollector replaces the inner collector.
+func (uc *UncheckedCollector) SetCollector(inner prometheus.Collector) {
+	uc.mut.Lock()
+	defer uc.mut.Unlock()
+
+	uc.inner = inner
+}
+
+// Describe implements [prometheus.Collector], but is a no-op to be considered
+// an "unchecked" collector by Prometheus. See [prometheus.Collector] for more
+// information.
+func (uc *UncheckedCollector) Describe(_ chan<- *prometheus.Desc) {
+	// No-op: do not send any descriptions of metrics to avoid having them be
+	// checked.
+}
+
+// Collector implements [prometheus.Collector]. If the UncheckedCollector has a
+// non-nil inner collector, metrics will be collected from it.
+func (uc *UncheckedCollector) Collect(ch chan<- prometheus.Metric) {
+	uc.mut.RLock()
+	defer uc.mut.RUnlock()
+
+	if uc.inner != nil {
+		uc.inner.Collect(ch)
+	}
+}


### PR DESCRIPTION
(cherry picked from commit 266484c701e123326d508ececf8a9112a3351b6e)
