### PR TITLE
loki.source.file: fix goroutine leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ Main (unreleased)
   component would cause Grafana Agent Flow's Prometheus metrics endpoint to
   return an error until the process is restarted. (@rfratto)
 
+- Fix issue in `loki.source.file` where updating the component caused
+  goroutines to leak. (@rfratto)
+
 ### Other changes
 
 - Add metrics when clustering mode is enabled. (@rfratto)

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ lint: agentlint
 # more without -race for packages that have known race detection issues.
 test:
 	$(GO_ENV) go test $(GO_FLAGS) -race ./...
-	$(GO_ENV) go test $(GO_FLAGS) ./pkg/integrations/node_exporter ./pkg/logs ./pkg/operator ./pkg/util/k8s ./component/otelcol/processor/tail_sampling
+	$(GO_ENV) go test $(GO_FLAGS) ./pkg/integrations/node_exporter ./pkg/logs ./pkg/operator ./pkg/util/k8s ./component/otelcol/processor/tail_sampling ./component/loki/source/file
 
 test-packages:
 	docker pull $(BUILD_IMAGE)

--- a/component/loki/source/file/file_test.go
+++ b/component/loki/source/file/file_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/loki"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/pkg/flow/componenttest"
 	"github.com/grafana/agent/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -22,35 +23,35 @@ import (
 func Test(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
 
-	// Create opts for component
-	opts := component.Options{
-		Logger:        util.TestFlowLogger(t),
-		Registerer:    prometheus.NewRegistry(),
-		OnStateChange: func(e component.Exports) {},
-		DataPath:      t.TempDir(),
-	}
+	ctx, cancel := context.WithCancel(componenttest.TestContext(t))
+	defer cancel()
 
-	f, err := os.CreateTemp(opts.DataPath, "example")
-	if err != nil {
-		log.Fatal(err)
-	}
+	// Create file to log to.
+	f, err := os.CreateTemp(t.TempDir(), "example")
+	require.NoError(t, err)
 	defer f.Close()
 
-	ch1, ch2 := make(chan loki.Entry), make(chan loki.Entry)
-	args := Arguments{}
-	args.Targets = []discovery.Target{{"__path__": f.Name(), "foo": "bar"}}
-	args.ForwardTo = []loki.LogsReceiver{ch1, ch2}
-
-	c, err := New(opts, args)
+	ctrl, err := componenttest.NewControllerFromID(util.TestLogger(t), "loki.source.file")
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go c.Run(ctx)
-	time.Sleep(100 * time.Millisecond)
+	ch1, ch2 := make(chan loki.Entry), make(chan loki.Entry)
+
+	go func() {
+		err := ctrl.Run(ctx, Arguments{
+			Targets: []discovery.Target{{
+				"__path__": f.Name(),
+				"foo":      "bar",
+			}},
+			ForwardTo: []loki.LogsReceiver{ch1, ch2},
+		})
+		require.NoError(t, err)
+	}()
+
+	ctrl.WaitRunning(time.Minute)
 
 	_, err = f.Write([]byte("writing some text\n"))
 	require.NoError(t, err)
+
 	wantLabelSet := model.LabelSet{
 		"filename": model.LabelValue(f.Name()),
 		"foo":      "bar",
@@ -69,6 +70,44 @@ func Test(t *testing.T) {
 		case <-time.After(5 * time.Second):
 			require.FailNow(t, "failed waiting for log line")
 		}
+	}
+}
+
+// Test that updating the component does not leak goroutines.
+func TestUpdate_NoLeak(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
+
+	ctx, cancel := context.WithCancel(componenttest.TestContext(t))
+	defer cancel()
+
+	// Create file to tail.
+	f, err := os.CreateTemp(t.TempDir(), "example")
+	require.NoError(t, err)
+	defer f.Close()
+
+	ctrl, err := componenttest.NewControllerFromID(util.TestLogger(t), "loki.source.file")
+	require.NoError(t, err)
+
+	args := Arguments{
+		Targets: []discovery.Target{{
+			"__path__": f.Name(),
+			"foo":      "bar",
+		}},
+		ForwardTo: []loki.LogsReceiver{},
+	}
+
+	go func() {
+		err := ctrl.Run(ctx, args)
+		require.NoError(t, err)
+	}()
+
+	ctrl.WaitRunning(time.Minute)
+
+	// Update a bunch of times to ensure that no goroutines get leaked between
+	// updates.
+	for i := 0; i < 10; i++ {
+		err := ctrl.Update(args)
+		require.NoError(t, err)
 	}
 }
 

--- a/component/loki/source/file/file_test.go
+++ b/component/loki/source/file/file_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 package file
 
 import (


### PR DESCRIPTION
Previously, one loki.EntryHandler was created per target, but only the most recent loki.EntryHandler was tracked in memory. This caused all the other loki.EntryHandlers to permanently leak whenever the component was reloaded.

PR #3036 attempted to initially address the leak, but we missed that handlers were being created in a loop in the case of loki.source.file.

Closes #3728.

cc @spartan0x117 I'd like to include this in the v0.33.1 patch release if we could.