### PR TITLE
Update refs to v0.33.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ Main (unreleased)
 
 - Disable node_exporter on Windows systems (@jkroepke)
 
+### Other changes
+
+- Add metrics when clustering mode is enabled. (@rfratto)
+
+v0.33.1 (2023-05-01)
+--------------------
+
 ### Bugfixes
 
 - Fix spelling of the `frequency` argument on the `local.file` component.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,6 @@ v0.33.1 (2023-05-01)
 
 ### Other changes
 
-- Add metrics when clustering mode is enabled. (@rfratto)
-
 - Support Bundles report the status of discovered log targets. (@tpaschalis)
 
 v0.33.0 (2023-04-25)

--- a/docs/sources/flow/upgrade-guide.md
+++ b/docs/sources/flow/upgrade-guide.md
@@ -18,7 +18,7 @@ Grafana Agent Flow.
 > [upgrade-guide-static]: {{< relref "../static/upgrade-guide.md" >}}
 > [upgrade-guide-operator]: {{< relref "../operator/upgrade-guide.md" >}}
 
-## v0.33.0 
+## v0.33.1 
 
 ### Symbolic links in Docker containers removed
 

--- a/docs/sources/operator/deploy-agent-operator-resources.md
+++ b/docs/sources/operator/deploy-agent-operator-resources.md
@@ -53,12 +53,12 @@ To deploy the `GrafanaAgent` resource:
       labels:
         app: grafana-agent
     spec:
-      image: grafana/agent:v0.33.0
+      image: grafana/agent:v0.33.1
       integrations:
         selector:
           matchLabels:
               agent: grafana-agent-integrations
-      image: grafana/agent:v0.33.0
+      image: grafana/agent:v0.33.1
       logLevel: info
       serviceAccountName: grafana-agent
       metrics:

--- a/docs/sources/operator/getting-started.md
+++ b/docs/sources/operator/getting-started.md
@@ -73,7 +73,7 @@ To install Agent Operator:
           serviceAccountName: grafana-agent-operator
           containers:
           - name: operator
-            image: grafana/agent-operator:v0.33.0
+            image: grafana/agent-operator:v0.33.1
             args:
             - --kubelet-service=default/kubelet
     ---

--- a/docs/sources/operator/upgrade-guide.md
+++ b/docs/sources/operator/upgrade-guide.md
@@ -18,7 +18,7 @@ Static mode Kubernetes operator.
 > [upgrade-guide-static]: {{< relref "../static/upgrade-guide.md" >}}
 > [upgrade-guide-flow]: {{< relref "../flow/upgrade-guide.md" >}}
 
-## v0.33.0
+## v0.33.1
 
 ### Symbolic links in Docker containers removed
 

--- a/docs/sources/static/configuration/integrations/node-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/node-exporter-config.md
@@ -28,7 +28,7 @@ docker run \
   -v "/proc:/host/proc:ro,rslave" \
   -v /tmp/agent:/etc/agent \
   -v /path/to/config.yaml:/etc/agent-config/agent.yaml \
-  grafana/agent:v0.33.0 \
+  grafana/agent:v0.33.1 \
   --config.file=/etc/agent-config/agent.yaml
 ```
 
@@ -67,7 +67,7 @@ metadata:
   name: agent
 spec:
   containers:
-  - image: grafana/agent:v0.33.0
+  - image: grafana/agent:v0.33.1
     name: agent
     args:
     - --config.file=/etc/agent-config/agent.yaml

--- a/docs/sources/static/configuration/integrations/process-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/process-exporter-config.md
@@ -20,7 +20,7 @@ docker run \
   -v "/proc:/proc:ro" \
   -v /tmp/agent:/etc/agent \
   -v /path/to/config.yaml:/etc/agent-config/agent.yaml \
-  grafana/agent:v0.33.0 \
+  grafana/agent:v0.33.1 \
   --config.file=/etc/agent-config/agent.yaml
 ```
 
@@ -37,7 +37,7 @@ metadata:
   name: agent
 spec:
   containers:
-  - image: grafana/agent:v0.33.0
+  - image: grafana/agent:v0.33.1
     name: agent
     args:
     - --config.file=/etc/agent-config/agent.yaml

--- a/docs/sources/static/set-up/install-agent-docker.md
+++ b/docs/sources/static/set-up/install-agent-docker.md
@@ -21,7 +21,7 @@ Install Grafana Agent and get it up and running on Docker.
 docker run \
   -v /tmp/agent:/etc/agent/data \
   -v /path/to/config.yaml:/etc/agent/agent.yaml \
-  grafana/agent:v0.33.0
+  grafana/agent:v0.33.1
 ```
 
 2. Replace `/tmp/agent` with the folder you want to store WAL data in.
@@ -40,7 +40,7 @@ container through a bind mount for the flags to work properly.
     docker run ^
       -v c:\grafana-agent-data:c:\etc\grafana-agent\data ^
       -v c:\workspace\config\grafana-agent:c:\etc\grafana-agent ^
-      grafana/agent:v0.33.0-windows
+      grafana/agent:v0.33.1-windows
     ```
 
 2. Replace `c:\grafana-agent-data` with the folder you want to store WAL data in.

--- a/docs/sources/static/upgrade-guide.md
+++ b/docs/sources/static/upgrade-guide.md
@@ -24,7 +24,7 @@ static mode.
 The experimental feature Dynamic Configuration has been removed. The use case of dynamic configuration will be replaced 
 with [Modules](../../concepts/modules/) in Grafana Agent Flow.
 
-## v0.33.0
+## v0.33.1
 
 ### Symbolic links in Docker containers removed
 

--- a/pkg/operator/defaults.go
+++ b/pkg/operator/defaults.go
@@ -2,7 +2,7 @@ package operator
 
 // Supported versions of the Grafana Agent.
 var (
-	DefaultAgentVersion   = "v0.33.0"
+	DefaultAgentVersion   = "v0.33.1"
 	DefaultAgentBaseImage = "grafana/agent"
 	DefaultAgentImage     = DefaultAgentBaseImage + ":" + DefaultAgentVersion
 )

--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -83,7 +83,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.33.0
+        image: grafana/agent:v0.33.1
         imagePullPolicy: IfNotPresent
         name: grafana-agent
         ports:

--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -65,7 +65,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.33.0
+        image: grafana/agent:v0.33.1
         imagePullPolicy: IfNotPresent
         name: grafana-agent-logs
         ports:

--- a/production/kubernetes/agent-traces.yaml
+++ b/production/kubernetes/agent-traces.yaml
@@ -114,7 +114,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.33.0
+        image: grafana/agent:v0.33.1
         imagePullPolicy: IfNotPresent
         name: grafana-agent-traces
         ports:

--- a/production/kubernetes/build/lib/version.libsonnet
+++ b/production/kubernetes/build/lib/version.libsonnet
@@ -1,1 +1,1 @@
-'grafana/agent:v0.33.0'
+'grafana/agent:v0.33.1'

--- a/production/kubernetes/build/templates/operator/main.jsonnet
+++ b/production/kubernetes/build/templates/operator/main.jsonnet
@@ -23,8 +23,8 @@ local ksm = import 'kube-state-metrics/kube-state-metrics.libsonnet';
   local this = self,
 
   _images:: {
-    agent: 'grafana/agent:v0.33.0',
-    agent_operator: 'grafana/agent-operator:v0.33.0',
+    agent: 'grafana/agent:v0.33.1',
+    agent_operator: 'grafana/agent-operator:v0.33.1',
     ksm: 'registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0',
   },
 

--- a/production/kubernetes/install-bare.sh
+++ b/production/kubernetes/install-bare.sh
@@ -25,7 +25,7 @@ check_installed() {
 check_installed curl
 check_installed envsubst
 
-MANIFEST_BRANCH=v0.33.0
+MANIFEST_BRANCH=v0.33.1
 MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent-bare.yaml}
 NAMESPACE=${NAMESPACE:-default}
 

--- a/production/operator/templates/agent-operator.yaml
+++ b/production/operator/templates/agent-operator.yaml
@@ -372,7 +372,7 @@ spec:
       containers:
       - args:
         - --kubelet-service=default/kubelet
-        image: grafana/agent-operator:v0.33.0
+        image: grafana/agent-operator:v0.33.1
         imagePullPolicy: IfNotPresent
         name: grafana-agent-operator
       serviceAccount: grafana-agent-operator
@@ -436,7 +436,7 @@ metadata:
   name: grafana-agent
   namespace: ${NAMESPACE}
 spec:
-  image: grafana/agent:v0.33.0
+  image: grafana/agent:v0.33.1
   integrations:
     selector:
       matchLabels:

--- a/production/tanka/grafana-agent/v1/main.libsonnet
+++ b/production/tanka/grafana-agent/v1/main.libsonnet
@@ -15,8 +15,8 @@ local service = k.core.v1.service;
 (import './lib/traces.libsonnet') +
 {
   _images:: {
-    agent: 'grafana/agent:v0.33.0',
-    agentctl: 'grafana/agentctl:v0.33.0',
+    agent: 'grafana/agent:v0.33.1',
+    agentctl: 'grafana/agentctl:v0.33.1',
   },
 
   // new creates a new DaemonSet deployment of the grafana-agent. By default,

--- a/production/tanka/grafana-agent/v2/internal/base.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/base.libsonnet
@@ -11,8 +11,8 @@ function(name='grafana-agent', namespace='') {
   local this = self,
 
   _images:: {
-    agent: 'grafana/agent:v0.33.0',
-    agentctl: 'grafana/agentctl:v0.33.0',
+    agent: 'grafana/agent:v0.33.1',
+    agentctl: 'grafana/agentctl:v0.33.1',
   },
   _config:: {
     name: name,

--- a/production/tanka/grafana-agent/v2/internal/syncer.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/syncer.libsonnet
@@ -14,7 +14,7 @@ function(
 ) {
   local _config = {
     api: error 'api must be set',
-    image: 'grafana/agentctl:v0.33.0',
+    image: 'grafana/agentctl:v0.33.1',
     schedule: '*/5 * * * *',
     configs: [],
   } + config,


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Updates the CHANGELOG to contain the changes present in `v0.33.1` and bumps all non-helm refs from `v0.33.0` to `v0.33.1`.