### PR TITLE
[Helm] Update Agent version to v0.33.1

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -14,6 +14,14 @@ Unreleased
 
 - Update RBAC rules to permit `node/metrics`. (@yurii-kryvosheia)
 
+0.13.0 (2023-05-01)
+-------------------
+
+### Enhancements
+
+- Update Grafana Agent version to v0.33.1. (@spartan0x117)
+
+
 0.12.0 (2023-04-25)
 -------------------
 

--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -10,9 +10,6 @@ internal API changes are not present.
 Unreleased
 ----------
 
-### Enhancements
-
-- Update RBAC rules to permit `node/metrics`. (@yurii-kryvosheia)
 
 0.13.0 (2023-05-01)
 -------------------
@@ -21,6 +18,7 @@ Unreleased
 
 - Update Grafana Agent version to v0.33.1. (@spartan0x117)
 
+- Update RBAC rules to permit `node/metrics`. (@yurii-kryvosheia)
 
 0.12.0 (2023-04-25)
 -------------------

--- a/operations/helm/charts/grafana-agent/Chart.yaml
+++ b/operations/helm/charts/grafana-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: grafana-agent
 description: 'Grafana Agent'
 type: application
-version: 0.12.0
-appVersion: 'v0.33.0'
+version: 0.13.0
+appVersion: 'v0.33.1'

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -1,6 +1,6 @@
 # Grafana Agent Helm chart
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![AppVersion: v0.33.0](https://img.shields.io/badge/AppVersion-v0.33.0-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![AppVersion: v0.33.1](https://img.shields.io/badge/AppVersion-v0.33.1-informational?style=flat-square)
 
 Helm chart for deploying [Grafana Agent][] to Kubernetes.
 

--- a/operations/helm/tests/controller-volumes-extra/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/controller-volumes-extra/grafana-agent/templates/controllers/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
         - name: grafana-agent
-          image: grafana/agent:v0.33.0
+          image: grafana/agent:v0.33.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/controllers/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
         - name: grafana-agent
-          image: grafana/agent:v0.33.0
+          image: grafana/agent:v0.33.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
         - name: grafana-agent
-          image: grafana/agent:v0.33.0
+          image: grafana/agent:v0.33.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-deployment-autoscaling/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment-autoscaling/grafana-agent/templates/controllers/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
         - name: grafana-agent
-          image: grafana/agent:v0.33.0
+          image: grafana/agent:v0.33.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
         - name: grafana-agent
-          image: grafana/agent:v0.33.0
+          image: grafana/agent:v0.33.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
         - name: grafana-agent
-          image: grafana/agent:v0.33.0
+          image: grafana/agent:v0.33.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
         - name: grafana-agent
-          image: grafana/agent:v0.33.0
+          image: grafana/agent:v0.33.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
         - name: grafana-agent
-          image: grafana/agent:v0.33.0
+          image: grafana/agent:v0.33.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/envFrom/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/envFrom/grafana-agent/templates/controllers/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
         - name: grafana-agent
-          image: grafana/agent:v0.33.0
+          image: grafana/agent:v0.33.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
         - name: grafana-agent
-          image: grafana/agent:v0.33.0
+          image: grafana/agent:v0.33.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/extra-env/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-env/grafana-agent/templates/controllers/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
         - name: grafana-agent
-          image: grafana/agent:v0.33.0
+          image: grafana/agent:v0.33.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
         - name: grafana-agent
-          image: grafana/agent:v0.33.0
+          image: grafana/agent:v0.33.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/faro-ingress/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/faro-ingress/grafana-agent/templates/controllers/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
         - name: grafana-agent
-          image: grafana/agent:v0.33.0
+          image: grafana/agent:v0.33.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
         - name: grafana-agent
-          image: grafana/agent:v0.33.0
+          image: grafana/agent:v0.33.1
           imagePullPolicy: IfNotPresent
           args:
             - -config.file=/etc/agent/config.yaml

--- a/operations/helm/tests/tolerations/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/tolerations/grafana-agent/templates/controllers/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccount: grafana-agent
       containers:
         - name: grafana-agent
-          image: grafana/agent:v0.33.0
+          image: grafana/agent:v0.33.1
           imagePullPolicy: IfNotPresent
           args:
             - run


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Bumps helm chart version to `0.13.0` and updates the agent version to `v0.33.1`.
