### PR TITLE
flow: only use component health when component implements component.HealthComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ Main (unreleased)
 
 - Disable node_exporter on Windows systems (@jkroepke)
 
+### Bugfixes
+
+- Fix issue where component evaluation time was overridden by a "default
+  health" message. (@rfratto)
+
 ### Other changes
 
 - Add metrics when clustering mode is enabled. (@rfratto)

--- a/component/component_health.go
+++ b/component/component_health.go
@@ -45,16 +45,6 @@ var (
 	_ encoding.TextUnmarshaler = (*HealthType)(nil)
 )
 
-// Default Health returns a copy of the default health for use when a component
-// does not implement HealthComponent.
-func DefaultHealth() Health {
-	return Health{
-		Health:     HealthTypeHealthy,
-		Message:    "default health",
-		UpdateTime: time.Now(),
-	}
-}
-
 const (
 	// HealthTypeUnknown is the initial health of components, set when they're
 	// first created.

--- a/pkg/flow/internal/controller/component.go
+++ b/pkg/flow/internal/controller/component.go
@@ -445,15 +445,14 @@ func (cn *ComponentNode) CurrentHealth() component.Health {
 	var (
 		runHealth  = cn.runHealth
 		evalHealth = cn.evalHealth
-
-		componentHealth component.Health
 	)
 
 	if hc, ok := cn.managed.(component.HealthComponent); ok {
-		componentHealth = hc.CurrentHealth()
+		componentHealth := hc.CurrentHealth()
+		return component.LeastHealthy(runHealth, evalHealth, componentHealth)
 	}
 
-	return component.LeastHealthy(runHealth, evalHealth, componentHealth)
+	return component.LeastHealthy(runHealth, evalHealth)
 }
 
 // DebugInfo returns debugging information from the managed component (if any).

--- a/pkg/flow/internal/controller/component.go
+++ b/pkg/flow/internal/controller/component.go
@@ -451,8 +451,6 @@ func (cn *ComponentNode) CurrentHealth() component.Health {
 
 	if hc, ok := cn.managed.(component.HealthComponent); ok {
 		componentHealth = hc.CurrentHealth()
-	} else {
-		componentHealth = component.DefaultHealth()
 	}
 
 	return component.LeastHealthy(runHealth, evalHealth, componentHealth)


### PR DESCRIPTION
This commit offers an alternative approach to #3558, where the overall health of a component only considers the component implementation of health if that component implements the component.HealthComponent interface.

It also has the benefit of reducing the overall public API surface. 

This reverts commit b2f8992ce0c8a7e9de53c871e64774c2ae8f8d8e. The previous commit introduced a bug where the "default health" message was always returned for healthy components, overriding the message informing the user when the last time the component evaluated was.