### PR TITLE
WIP: Add process component to phlare, derived from Loki's

### DIFF
--- a/component/common/phlare/types.go
+++ b/component/common/phlare/types.go
@@ -1,0 +1,138 @@
+package phlare
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/pprof/profile"
+	"github.com/prometheus/common/model"
+)
+
+// finalEntryTimeout is how long NewEntryMutatorHandler will wait before giving
+// up on sending the final profile entry. If this timeout is reached, the final log
+// entry is permanently lost.
+//
+// This timeout can only be reached if the loki.write client is backprofileged due
+// to an outage or erroring (such as limits being hit).
+const finalEntryTimeout = 5 * time.Second
+
+// LogsReceiver is an alias for chan Entry which is used for component
+// communication.
+type ProfilesReceiver chan Entry
+
+// Entry is a profile entry with labels.
+type Entry struct {
+	Labels model.LabelSet
+	profile.Profile
+}
+
+// EntryHandler is something that can "handle" entries via a channel.
+// Stop must be called to gracefully shutdown the EntryHandler
+type EntryHandler interface {
+	Chan() chan<- Entry
+	Stop()
+}
+
+// EntryMiddleware takes an EntryHandler and returns another one that will intercept and forward entries.
+// The newly created EntryHandler should be Stopped independently from the original one.
+type EntryMiddleware interface {
+	Wrap(EntryHandler) EntryHandler
+}
+
+// EntryMiddlewareFunc allows to create EntryMiddleware via a function.
+type EntryMiddlewareFunc func(EntryHandler) EntryHandler
+
+// Wrap uses an EntryMiddlewareFunc to wrap around an EntryHandler and return
+// a new one that applies that func.
+func (e EntryMiddlewareFunc) Wrap(next EntryHandler) EntryHandler {
+	return e(next)
+}
+
+// EntryMutatorFunc is a function that can mutate an entry
+type EntryMutatorFunc func(Entry) Entry
+
+type entryHandler struct {
+	stop    func()
+	entries chan<- Entry
+}
+
+func (e entryHandler) Chan() chan<- Entry {
+	return e.entries
+}
+
+func (e entryHandler) Stop() {
+	e.stop()
+}
+
+// NewEntryHandler creates a new EntryHandler using a input channel and a stop function.
+func NewEntryHandler(entries chan<- Entry, stop func()) EntryHandler {
+	return entryHandler{
+		stop:    stop,
+		entries: entries,
+	}
+}
+
+// NewEntryMutatorHandler creates a EntryHandler that mutates incoming entries from another EntryHandler.
+func NewEntryMutatorHandler(next EntryHandler, f EntryMutatorFunc) EntryHandler {
+	var (
+		ctx, cancel = context.WithCancel(context.Background())
+
+		in       = make(chan Entry)
+		nextChan = next.Chan()
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		defer cancel()
+
+		for e := range in {
+			select {
+			case <-ctx.Done():
+				// This is a hard stop to the reading goroutine. Anything not forwarded
+				// to nextChan at this point will probably be permanently lost, since
+				// the positions file has likely already updated to a byte offset past
+				// the read entry.
+				//
+				// TODO(rfratto): revisit whether this profileic is necessary after we have
+				// a WAL for profiles.
+				return
+			case nextChan <- f(e):
+				// no-op; profile entry has been queued for sending.
+
+			}
+		}
+	}()
+
+	var closeOnce sync.Once
+	return NewEntryHandler(in, func() {
+		closeOnce.Do(func() {
+			close(in)
+
+			select {
+			case <-ctx.Done():
+				// The goroutine above exited on its own so we don't have to wait for
+				// the timeout.
+			case <-time.After(finalEntryTimeout):
+				// We reached the timeout for sending the final entry to nextChan;
+				// request a hard stop from the reading goroutine.
+				cancel()
+			}
+		})
+
+		wg.Wait()
+	})
+}
+
+// AddLabelsMiddleware is an EntryMiddleware that adds some labels.
+func AddLabelsMiddleware(additionalLabels model.LabelSet) EntryMiddleware {
+	return EntryMiddlewareFunc(func(eh EntryHandler) EntryHandler {
+		return NewEntryMutatorHandler(eh, func(e Entry) Entry {
+			e.Labels = additionalLabels.Merge(e.Labels)
+			return e
+		})
+	})
+}

--- a/component/phlare/process/internal/fake/client.go
+++ b/component/phlare/process/internal/fake/client.go
@@ -1,0 +1,73 @@
+package fake
+
+// This code is copied from Promtail. The fake package is used to configure
+// fake client that can be used in testing.
+
+import (
+	"sync"
+
+	"github.com/grafana/agent/component/common/phlare"
+)
+
+// Client is a fake client used for testing.
+type Client struct {
+	entries  phlare.ProfilesReceiver
+	received []phlare.Entry
+	once     sync.Once
+	mtx      sync.Mutex
+	wg       sync.WaitGroup
+	OnStop   func()
+}
+
+func New(stop func()) *Client {
+	c := &Client{
+		OnStop:  stop,
+		entries: make(phlare.ProfilesReceiver),
+	}
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		for e := range c.entries {
+			c.mtx.Lock()
+			c.received = append(c.received, e)
+			c.mtx.Unlock()
+		}
+	}()
+	return c
+}
+
+// Stop implements client.Client
+func (c *Client) Stop() {
+	c.once.Do(func() { close(c.entries) })
+	c.wg.Wait()
+	c.OnStop()
+}
+
+func (c *Client) Chan() chan<- phlare.Entry {
+	return c.entries
+}
+
+func (c *Client) Received() []phlare.Entry {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	cpy := make([]phlare.Entry, len(c.received))
+	copy(cpy, c.received)
+	return cpy
+}
+
+// StopNow implements client.Client
+func (c *Client) StopNow() {
+	c.Stop()
+}
+
+func (c *Client) Name() string {
+	return "fake"
+}
+
+// Clear is used to cleanup the buffered received entries, so the same client can be re-used between
+// test cases.
+func (c *Client) Clear() {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	c.received = []phlare.Entry{}
+}

--- a/component/phlare/process/internal/stages/diff.go
+++ b/component/phlare/process/internal/stages/diff.go
@@ -1,0 +1,211 @@
+package stages
+
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
+import (
+	"github.com/go-kit/log"
+	"github.com/jmespath/go-jmespath"
+)
+
+// DiffConfig represents a JSON Stage configuration
+type DiffConfig struct {
+	// Allow to override settings
+}
+
+// diffStage sets extracted data using JMESPath expressions
+type diffStage struct {
+	cfg         *DiffConfig
+	expressions map[string]*jmespath.JMESPath
+	logger      log.Logger
+}
+
+func validateDiffConfig(*DiffConfig) error {
+	return nil
+}
+
+// newJSONStage creates a new json pipeline stage from a config.
+func newDiffStage(logger log.Logger, cfg DiffConfig) (Stage, error) {
+	return &diffStage{
+		cfg:    &cfg,
+		logger: log.With(logger, "component", "stage", "type", "diff"),
+	}, nil
+}
+
+func (j *diffStage) Run(in chan Entry) chan Entry {
+	out := make(chan Entry)
+
+	go func() {
+		defer close(out)
+		for e := range in {
+			err := j.processEntry(&e)
+			if err != nil {
+				continue
+			}
+			out <- e
+		}
+	}()
+	return out
+}
+
+func (j *diffStage) processEntry(entry *Entry) error {
+	// If a source key is provided, the json stage should process it
+	// from the extracted map, otherwise should fallback to the entry
+	//input := entry
+
+	// TODO: DO THE MAGIC
+
+	return nil
+}
+
+// Name implements Stage
+func (j *diffStage) Name() string {
+	return StageTypeDiff
+}
+
+/*
+
+const (
+	memoryProfileName   = "memory"
+	allocObjectTypeName = "alloc_objects"
+	allocSpaceTypeName  = "alloc_space"
+	blockProfileName    = "block"
+	contentionsTypeName = "contentions"
+	delayTypeName       = "delay"
+)
+
+type samples struct {
+	timeNanos int64
+	samples   []*profile.Sample
+}
+
+// deltaProfiles is a helper to compute delta of profiles.
+type deltaProfiles struct {
+	mtx sync.Mutex
+	// todo cleanup sample profiles that are not used anymore using a cleanup goroutine.
+	highestSamples map[model.Fingerprint]*samples
+}
+
+func newDeltaProfiles() *deltaProfiles {
+	return &deltaProfiles{
+		highestSamples: make(map[model.Fingerprint]*samples),
+	}
+}
+
+func (d *deltaProfiles) computeDelta(ps *profile.Profile, lbs model.LabelSet) *profile.Profile {
+	// there's no delta to compute for those profile.
+	if !isDelta(lbs) {
+		return ps
+	}
+
+	fingerprint := lbs.Fingerprint()
+
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+
+	// we store all series ref so fetching with one work.
+	lastSamples, ok := d.highestSamples[lbs.Fingerprint()]
+	if !ok {
+		// if we don't have the last profile, we can't compute the delta.
+		// so we remove the delta from the list of labels and profiles.
+		d.highestSamples[fingerprint] = &samples{
+			timeNanos: ps.TimeNanos,
+			samples:   copySampleSlice(ps.Sample),
+		}
+
+		return nil
+	}
+
+	// we have the last profile, we can compute the delta.
+	// samples are sorted by stacktrace id.
+	// we need to compute the delta for each stacktrace.
+	if len(lastSamples.samples) == 0 {
+		return ps
+	}
+
+	highestSamples, reset := deltaSamples(lastSamples.samples, ps.Sample)
+	if reset {
+		// if we reset the delta, we can't compute the delta anymore.
+		// so we remove the delta from the list of labels and profiles.
+		d.highestSamples[fingerprint].samples = copySampleSlice(ps.Sample)
+		d.highestSamples[fingerprint].timeNanos = ps.TimeNanos
+		return nil
+	}
+
+	// remove samples that are all zero
+	i := 0
+	for _, x := range ps.Samples {
+		if x.Value != 0 {
+			ps.Samples[i] = x
+			i++
+		}
+	}
+	ps.Samples = copySlice(ps.Samples[:i])
+	samples := d.highestSamples[ps.SeriesFingerprint]
+	samples.samples = highestSamples
+	samples.timeNanos = ps.TimeNanos
+
+	return ps
+}
+
+func copySampleSlice(s []*profile.Sample) []*profile.Sample {
+	if s == nil {
+		return nil
+	}
+	r := make([]*schemav1.Sample, len(s))
+	for i := range s {
+		r[i] = copySample(s[i])
+	}
+	return r
+}
+
+func copySample(s *schemav1.Sample) *schemav1.Sample {
+	if s == nil {
+		return nil
+	}
+	return &schemav1.Sample{
+		StacktraceID: s.StacktraceID,
+		Value:        s.Value,
+	}
+}
+
+func isDelta(lbs model.LabelSet) bool {
+
+	switch lbs.Get(phlaremodel.LabelNameDelta) {
+	case "false":
+		return false
+	case "true":
+		return true
+	}
+	if lbs.Get(model.MetricNameLabel) == memoryProfileName {
+		ty := lbs.Get(phlaremodel.LabelNameType)
+		if ty == allocObjectTypeName || ty == allocSpaceTypeName {
+			return true
+		}
+	}
+	return false
+}
+
+func deltaSamples(highest, new []*profile.Sample) ([]*profile.Sample, bool) {
+	stacktraces := make(map[uint64]*schemav1.Sample)
+	for _, h := range highest {
+		stacktraces[h.StacktraceID] = h
+	}
+	for _, n := range new {
+		if s, ok := stacktraces[n.StacktraceID]; ok {
+			if s.Value <= n.Value {
+				newMax := n.Value
+				n.Value -= s.Value
+				s.Value = newMax
+			} else {
+				// this is a reset, we can't compute the delta anymore.
+				return nil, true
+			}
+			continue
+		}
+		highest = append(highest, copySample(n))
+	}
+	return highest, false
+}
+*/

--- a/component/phlare/process/internal/stages/diff_test.go
+++ b/component/phlare/process/internal/stages/diff_test.go
@@ -1,0 +1,370 @@
+package stages
+
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/agent/pkg/river"
+	"github.com/grafana/agent/pkg/util"
+)
+
+var testJSONRiverSingleStageWithoutSource = `
+stage.json {
+    expressions = {"out" = "message", "app" = "", "nested" = "", duration = "", unknown = "" }
+}
+`
+
+var testJSONRiverMultiStageWithSource = `
+stage.json {
+    expressions = { "extra" = "" }
+}
+
+stage.json {
+    expressions = { "user" = "" }
+	source      = "extra"
+}`
+
+var testJSONLogLine = `
+{
+	"time":"2012-11-01T22:08:41+00:00",
+	"app":"loki",
+	"component": ["parser","type"],
+	"level" : "WARN",
+	"nested" : {"child":"value"},
+    "duration" : 125,
+	"message" : "this is a log line",
+	"extra": "{\"user\":\"marco\"}"
+}
+`
+
+func TestPipeline_JSON(t *testing.T) {
+	t.Parallel()
+	logger := util.TestFlowLogger(t)
+
+	tests := map[string]struct {
+		config          string
+		entry           string
+		expectedExtract map[string]interface{}
+	}{
+		"successfully run a pipeline with 1 json stage without source": {
+			testJSONRiverSingleStageWithoutSource,
+			testJSONLogLine,
+			map[string]interface{}{
+				"out":      "this is a log line",
+				"app":      "loki",
+				"nested":   "{\"child\":\"value\"}",
+				"duration": float64(125),
+				"unknown":  nil,
+			},
+		},
+		"successfully run a pipeline with 2 json stages with source": {
+			testJSONRiverMultiStageWithSource,
+			testJSONLogLine,
+			map[string]interface{}{
+				"extra": "{\"user\":\"marco\"}",
+				"user":  "marco",
+			},
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			pl, err := NewPipeline(logger, loadConfig(testData.config), nil, prometheus.DefaultRegisterer)
+			assert.NoError(t, err, "Expected pipeline creation to not result in error")
+			out := processEntries(pl, newEntry(nil, nil, testData.entry, time.Now()))[0]
+			assert.Equal(t, testData.expectedExtract, out.Extracted)
+		})
+	}
+}
+
+var jsonCfg = `
+  expressions = {
+    key1 = "expression1",
+    key2 = "expression2.expression2",
+  }
+`
+
+// nolint
+func TestRiver(t *testing.T) {
+	t.Parallel()
+
+	// testing that we can use river data into the config structure.
+	var got DiffConfig
+	err := river.Unmarshal([]byte(jsonCfg), &got)
+	assert.NoError(t, err, "error while un-marshalling config: %s", err)
+
+	want := DiffConfig{}
+	assert.True(t, reflect.DeepEqual(got, want), "want: %+v got: %+v", want, got)
+}
+
+func TestDiffConfig_validate(t *testing.T) {
+	t.Parallel()
+
+	//	var emptyString = ""
+	//	var logString = "log"
+
+	tests := map[string]struct {
+		config        *DiffConfig
+		wantExprCount int
+		err           error
+	}{
+		/*
+				"empty config": {
+					nil,
+					0,
+					errors.New(ErrEmptyJSONStageConfig),
+				},
+				"no expressions": {
+					&DiffConfig{},
+					0,
+					errors.New(ErrExpressionsRequired),
+				},
+				"invalid expression": {
+					&DiffConfig{
+						Expressions: map[string]string{
+							"extr1": "3##@$#33",
+						},
+					},
+					0,
+					fmt.Errorf("%s: SyntaxError: Unknown char: '#'", ErrCouldNotCompileJMES),
+				},
+			"empty source": {
+				&DiffConfig{
+					Expressions: map[string]string{
+						"extr1": "expr",
+					},
+					Source: &emptyString,
+				},
+				0,
+				errors.New(ErrEmptyJSONStageSource),
+			},
+			"valid without source": {
+				&DiffConfig{
+					Expressions: map[string]string{
+						"expr1": "expr",
+						"expr2": "",
+						"expr3": "expr1.expr2",
+					},
+				},
+				3,
+				nil,
+			},
+			"valid with source": {
+				&DiffConfig{
+					Expressions: map[string]string{
+						"expr1": "expr",
+						"expr2": "",
+						"expr3": "expr1.expr2",
+					},
+					Source: &logString,
+				},
+				3,
+				nil,
+			},
+		*/
+	}
+	for tName, tt := range tests {
+		tt := tt
+		t.Run(tName, func(t *testing.T) {
+			err := validateDiffConfig(tt.config)
+			if tt.err != nil {
+				assert.NotNil(t, err, "DiffConfig.validate() expected error = %v, but got nil", tt.err)
+			}
+			if err != nil {
+				assert.Equal(t, tt.err.Error(), err.Error(), "DiffConfig.validate() expected error = %v, actual error = %v", tt.err, err)
+			}
+		})
+	}
+}
+
+var logFixture = `
+{
+	"time":"2012-11-01T22:08:41+00:00",
+	"app":"loki",
+	"component": ["parser","type"],
+	"level" : "WARN",
+	"numeric": {
+		"float": 12.34,
+		"integer": 123,
+		"string": "123"
+	},
+	"nested" : {"child":"value"},
+	"message" : "this is a log line",
+	"complex" : {
+		"log" : {"array":[{"test1":"test2"},{"test3":"test4"}],"prop":"value","prop2":"val2"}
+	}
+}
+`
+
+func TestJSONParser_Parse(t *testing.T) {
+	t.Parallel()
+	logger := util.TestFlowLogger(t)
+
+	tests := map[string]struct {
+		config          StageConfig
+		extracted       map[string]interface{}
+		entry           string
+		expectedExtract map[string]interface{}
+	}{
+		/*
+			"successfully decode json on entry": {
+				StageConfig{DiffConfig: &DiffConfig{
+					Expressions: map[string]string{
+						"time":      "",
+						"app":       "",
+						"component": "",
+						"level":     "",
+						"float":     "numeric.float",
+						"integer":   "numeric.integer",
+						"string":    "numeric.string",
+						"nested":    "",
+						"message":   "",
+						"complex":   "complex.log.array[1].test3",
+					},
+				}},
+				map[string]interface{}{},
+				logFixture,
+				map[string]interface{}{
+					"time":      "2012-11-01T22:08:41+00:00",
+					"app":       "loki",
+					"component": "[\"parser\",\"type\"]",
+					"level":     "WARN",
+					"float":     12.34,
+					"integer":   123.0,
+					"string":    "123",
+					"nested":    "{\"child\":\"value\"}",
+					"message":   "this is a log line",
+					"complex":   "test4",
+				},
+			},
+			"successfully decode json on extracted[source]": {
+				StageConfig{DiffConfig: &DiffConfig{
+					Expressions: map[string]string{
+						"time":      "",
+						"app":       "",
+						"component": "",
+						"level":     "",
+						"float":     "numeric.float",
+						"integer":   "numeric.integer",
+						"string":    "numeric.string",
+						"nested":    "",
+						"message":   "",
+						"complex":   "complex.log.array[1].test3",
+					},
+					Source: &logString,
+				}},
+				map[string]interface{}{
+					"log": logFixture,
+				},
+				"{}",
+				map[string]interface{}{
+					"time":      "2012-11-01T22:08:41+00:00",
+					"app":       "loki",
+					"component": "[\"parser\",\"type\"]",
+					"level":     "WARN",
+					"float":     12.34,
+					"integer":   123.0,
+					"string":    "123",
+					"nested":    "{\"child\":\"value\"}",
+					"message":   "this is a log line",
+					"complex":   "test4",
+					"log":       logFixture,
+				},
+			},
+			"missing extracted[source]": {
+				StageConfig{DiffConfig: &DiffConfig{
+					Expressions: map[string]string{
+						"app": "",
+					},
+					Source: &logString,
+				}},
+				map[string]interface{}{},
+				logFixture,
+				map[string]interface{}{},
+			},
+			"invalid json on entry": {
+				StageConfig{DiffConfig: &DiffConfig{
+					Expressions: map[string]string{
+						"expr1": "",
+					},
+				}},
+				map[string]interface{}{},
+				"ts=now log=notjson",
+				map[string]interface{}{},
+			},
+			"invalid json on extracted[source]": {
+				StageConfig{DiffConfig: &DiffConfig{
+					Expressions: map[string]string{
+						"app": "",
+					},
+					Source: &logString,
+				}},
+				map[string]interface{}{
+					"log": "not a json",
+				},
+				logFixture,
+				map[string]interface{}{
+					"log": "not a json",
+				},
+			},
+			"nil source": {
+				StageConfig{DiffConfig: &DiffConfig{
+					Expressions: map[string]string{
+						"app": "",
+					},
+					Source: &logString,
+				}},
+				map[string]interface{}{
+					"log": nil,
+				},
+				logFixture,
+				map[string]interface{}{
+					"log": nil,
+				},
+			},
+		*/
+	}
+	for tName, tt := range tests {
+		tt := tt
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+			p, err := New(logger, nil, tt.config, nil)
+			assert.NoError(t, err, "failed to create json parser: %s", err)
+			out := processEntries(p, newEntry(tt.extracted, nil, tt.entry, time.Now()))[0]
+
+			assert.Equal(t, tt.expectedExtract, out.Extracted)
+		})
+	}
+}
+
+/*
+func TestValidateJSONDrop(t *testing.T) {
+	logger := util.TestFlowLogger(t)
+	labels := map[string]string{"foo": "bar"}
+	matchConfig := &DiffConfig{}
+	s, err := newJSONStage(logger, *matchConfig)
+	assert.NoError(t, err, "withMatcher() error = %v", err)
+	assert.NotNil(t, s, "newJSONStage failed to create the pipeline stage and was nil")
+	out := processEntries(s, newEntry(map[string]interface{}{
+		"test_label": "unimportant value",
+	}, toLabelSet(labels), `{"page": 1, "fruits": ["apple", "peach"]}`, time.Now()))
+	assert.Equal(t, 1, len(out), "stage should have kept one valid json line but got %v", out)
+
+	out = processEntries(s, newEntry(map[string]interface{}{
+		"test_label": "unimportant value",
+	}, toLabelSet(labels), `{"page": 1, fruits": ["apple", "peach"]}`, time.Now()))
+	assert.Equal(t, 0, len(out), "stage should have kept zero valid json line but got %v", out)
+}
+*/

--- a/component/phlare/process/internal/stages/inspector.go
+++ b/component/phlare/process/internal/stages/inspector.go
@@ -1,0 +1,134 @@
+package stages
+
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/google/go-cmp/cmp"
+	"github.com/grafana/agent/component/common/phlare"
+)
+
+type inspector struct {
+	writer    io.Writer
+	formatter *formatter
+}
+
+func newInspector(writer io.Writer, disableFormatting bool) *inspector {
+	f := &formatter{
+		red:    color.New(color.FgRed),
+		yellow: color.New(color.FgYellow),
+		green:  color.New(color.FgGreen),
+		bold:   color.New(color.Bold),
+	}
+
+	if disableFormatting {
+		f.disable()
+	}
+
+	return &inspector{
+		writer:    writer,
+		formatter: f,
+	}
+}
+
+type formatter struct {
+	red    *color.Color
+	yellow *color.Color
+	green  *color.Color
+	bold   *color.Color
+}
+
+func (f *formatter) disable() {
+	f.red.DisableColor()
+	f.yellow.DisableColor()
+	f.green.DisableColor()
+	f.bold.DisableColor()
+}
+
+func (i inspector) inspect(stageName string, before *phlare.Entry, after phlare.Entry) {
+	if before == nil {
+		fmt.Fprintln(i.writer, i.formatter.red.Sprintf("could not copy entry in '%s' stage; inspect aborted", stageName))
+		return
+	}
+
+	r := diffReporter{
+		formatter: i.formatter,
+	}
+
+	cmp.Equal(*before, after, cmp.Reporter(&r))
+
+	diff := r.String()
+	if strings.TrimSpace(diff) == "" {
+		diff = i.formatter.red.Sprintf("none")
+	}
+
+	fmt.Fprintf(i.writer, "[inspect: %s stage]: %s\n", i.formatter.bold.Sprintf("%s", stageName), diff)
+}
+
+// diffReporter is a simple custom reporter that only records differences
+// detected during comparison.
+type diffReporter struct {
+	path cmp.Path
+
+	formatter *formatter
+
+	diffs []string
+}
+
+func (r *diffReporter) PushStep(ps cmp.PathStep) {
+	r.path = append(r.path, ps)
+}
+
+func (r *diffReporter) Report(rs cmp.Result) {
+	if rs.Equal() {
+		return
+	}
+
+	vx, vy := r.path.Last().Values()
+
+	// TODO(dannyk): try using go-cmp to filter this condition out with Equal(), but for now this just makes it work
+	if fmt.Sprintf("%v", vx) == fmt.Sprintf("%v", vy) {
+		return
+	}
+
+	change := vx.IsValid()
+	addition := vy.IsValid()
+	removal := change && !addition
+	mod := addition && change
+
+	var titleColor *color.Color
+	switch {
+	case mod:
+		titleColor = r.formatter.yellow
+	case removal:
+		titleColor = r.formatter.red
+	default:
+		titleColor = r.formatter.green
+	}
+
+	r.diffs = append(r.diffs, titleColor.Sprintf("%#v:", r.path))
+
+	if removal {
+		r.diffs = append(r.diffs, r.formatter.red.Sprintf("\t-: %v", vx))
+	}
+	if mod {
+		r.diffs = append(r.diffs, r.formatter.yellow.Sprintf("\t-: %v", vx))
+	}
+	if addition {
+		r.diffs = append(r.diffs, r.formatter.green.Sprintf("\t+: %v", vy))
+	}
+}
+
+func (r *diffReporter) PopStep() {
+	r.path = r.path[:len(r.path)-1]
+}
+
+func (r *diffReporter) String() string {
+	return fmt.Sprintf("\n%s", strings.Join(r.diffs, "\n"))
+}

--- a/component/phlare/process/internal/stages/pipeline.go
+++ b/component/phlare/process/internal/stages/pipeline.go
@@ -1,0 +1,158 @@
+package stages
+
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/agent/component/common/phlare"
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/time/rate"
+)
+
+type Entry struct {
+	phlare.Entry
+	Extracted map[string]interface{}
+}
+
+// StageConfig defines a single stage in a processing pipeline.
+// We define these as pointers types so we can use reflection to check that
+// exactly one is set.
+type StageConfig struct {
+	DiffConfig *DiffConfig `river:"diff,block,optional"`
+}
+
+var rateLimiter *rate.Limiter
+var rateLimiterDrop bool
+var rateLimiterDropReason = "global_rate_limiter_drop"
+
+// Pipeline pass down a log entry to each stage for mutation and/or label extraction.
+type Pipeline struct {
+	logger    log.Logger
+	stages    []Stage
+	jobName   *string
+	dropCount *prometheus.CounterVec
+}
+
+// NewPipeline creates a new log entry pipeline from a configuration
+func NewPipeline(logger log.Logger, stages []StageConfig, jobName *string, registerer prometheus.Registerer) (*Pipeline, error) {
+	st := []Stage{}
+	for _, stage := range stages {
+		newStage, err := New(logger, jobName, stage, registerer)
+		if err != nil {
+			return nil, fmt.Errorf("invalid stage config %w", err)
+		}
+		st = append(st, newStage)
+	}
+	return &Pipeline{
+		logger:  log.With(logger, "component", "pipeline"),
+		stages:  st,
+		jobName: jobName,
+	}, nil
+}
+
+// RunWith will reads from the input channel entries, mutate them with the process function and returns them via the output channel.
+func RunWith(input chan Entry, process func(e Entry) Entry) chan Entry {
+	out := make(chan Entry)
+	go func() {
+		defer close(out)
+		for e := range input {
+			out <- process(e)
+		}
+	}()
+	return out
+}
+
+// RunWithSkip same as RunWith, except it skip sending it to output channel, if `process` functions returns `skip` true.
+func RunWithSkip(input chan Entry, process func(e Entry) (Entry, bool)) chan Entry {
+	out := make(chan Entry)
+	go func() {
+		defer close(out)
+		for e := range input {
+			ee, skip := process(e)
+			if skip {
+				continue
+			}
+			out <- ee
+		}
+	}()
+
+	return out
+}
+
+// Run implements Stage
+func (p *Pipeline) Run(in chan Entry) chan Entry {
+	in = RunWith(in, func(e Entry) Entry {
+		// Initialize the extracted map with the initial labels (ie. "filename"),
+		// so that stages can operate on initial labels too
+		for labelName, labelValue := range e.Labels {
+			e.Extracted[string(labelName)] = string(labelValue)
+		}
+		return e
+	})
+	// chain all stages together.
+	for _, m := range p.stages {
+		in = m.Run(in)
+	}
+	return in
+}
+
+// Name implements Stage
+func (p *Pipeline) Name() string {
+	return StageTypePipeline
+}
+
+// Wrap implements EntryMiddleware
+func (p *Pipeline) Wrap(next phlare.EntryHandler) phlare.EntryHandler {
+	handlerIn := make(chan phlare.Entry)
+	nextChan := next.Chan()
+	wg, once := sync.WaitGroup{}, sync.Once{}
+	pipelineIn := make(chan Entry)
+	pipelineOut := p.Run(pipelineIn)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for e := range pipelineOut {
+			if rateLimiter != nil {
+				if rateLimiterDrop {
+					if !rateLimiter.Allow() {
+						p.dropCount.WithLabelValues(rateLimiterDropReason).Inc()
+						continue
+					}
+				} else {
+					_ = rateLimiter.Wait(context.Background())
+				}
+			}
+			nextChan <- e.Entry
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		defer close(pipelineIn)
+		for e := range handlerIn {
+			pipelineIn <- Entry{
+				Extracted: map[string]interface{}{},
+				Entry:     e,
+			}
+		}
+	}()
+	return phlare.NewEntryHandler(handlerIn, func() {
+		once.Do(func() { close(handlerIn) })
+		wg.Wait()
+	})
+}
+
+// Size gets the current number of stages in the pipeline
+func (p *Pipeline) Size() int {
+	return len(p.stages)
+}
+
+func SetReadLineRateLimiter(rateVal float64, burstVal int, drop bool) {
+	rateLimiter = rate.NewLimiter(rate.Limit(rateVal), burstVal)
+	rateLimiterDrop = drop
+}

--- a/component/phlare/process/internal/stages/pipeline_test.go
+++ b/component/phlare/process/internal/stages/pipeline_test.go
@@ -1,0 +1,406 @@
+package stages
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/google/pprof/profile"
+	"github.com/grafana/agent/component/common/phlare"
+	"github.com/grafana/agent/component/phlare/process/internal/fake"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
+// Configs defines multiple StageConfigs as consequent blocks.
+type Configs struct {
+	Stages []StageConfig `river:"stage,enum,optional"`
+}
+
+func withInboundEntries(entries ...Entry) chan Entry {
+	in := make(chan Entry, len(entries))
+	defer close(in)
+	for _, e := range entries {
+		in <- e
+	}
+	return in
+}
+
+func processEntries(s Stage, entries ...Entry) []Entry {
+	out := s.Run(withInboundEntries(entries...))
+	var res []Entry
+	for e := range out {
+		res = append(res, e)
+	}
+	return res
+}
+
+func loadConfig(yml string) []StageConfig {
+	var config Configs
+	err := river.Unmarshal([]byte(yml), &config)
+	if err != nil {
+		panic(err)
+	}
+	return config.Stages
+}
+
+func newPipelineFromConfig(logger log.Logger, cfg, name string) (*Pipeline, error) {
+	return NewPipeline(logger, loadConfig(cfg), &name, prometheus.DefaultRegisterer)
+}
+
+// TODO(@tpaschalis) Comment these out until we port over the remaining
+// stages and use these tests to verify their behavior.
+var (
+	ct                = time.Now()
+	rawTestLine       = `{"log":"11.11.11.11 - frank [25/Jan/2000:14:00:01 -0500] \"GET /1986.js HTTP/1.1\" 200 932 \"-\" \"Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6\"","stream":"stderr","time":"2019-04-30T02:12:41.8443515Z"}`
+	processedTestLine = `11.11.11.11 - frank [25/Jan/2000:14:00:01 -0500] "GET /1986.js HTTP/1.1" 200 932 "-" "Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6"`
+)
+
+var testMultiStageRiver = `
+stage.match {
+		selector = "{match=\"true\"}"
+		stage.docker {}
+		stage.regex {
+				expression = "^(?P<ip>\\S+) (?P<identd>\\S+) (?P<user>\\S+) \\[(?P<timestamp>[\\w:/]+\\s[+\\-]\\d{4})\\] \"(?P<action>\\S+)\\s?(?P<path>\\S+)?\\s?(?P<protocol>\\S+)?\" (?P<status>\\d{3}|-) (?P<size>\\d+|-)\\s?\"?(?P<referer>[^\"]*)\"?\\s?\"?(?P<useragent>[^\"]*)?\"?$"
+		}
+		stage.regex {
+				source     = "filename"
+				expression = "(?P<service>[^\\/]+)\\.log"
+		}
+		stage.timestamp {
+				source = "timestamp"
+				format = "02/Jan/2006:15:04:05 -0700"
+		}
+		stage.labels {
+				values = { "action" = "", "service" = "", "status_code" = "status" }
+		}
+}
+stage.match {
+		selector = "{match=\"false\"}"
+		action   = "drop"
+}`
+
+var testLabelsFromJSONRiver = `
+stage.json {
+		expressions = { "app" = "", "message" = "" }
+}
+stage.labels {
+		values = { "app" = "" }
+}
+stage.output {
+		source = "message"
+}`
+
+var logger = log.NewNopLogger()
+
+func TestNewPipeline(t *testing.T) {
+
+	p, err := NewPipeline(logger, loadConfig(testMultiStageRiver), nil, prometheus.DefaultRegisterer)
+	if err != nil {
+		panic(err)
+	}
+	require.Len(t, p.stages, 2)
+}
+
+func TestPipeline_Process(t *testing.T) {
+	t.Parallel()
+
+	est, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatal("could not parse timestamp", err)
+	}
+
+	tests := map[string]struct {
+		config         string
+		entry          string
+		expectedEntry  string
+		t              time.Time
+		expectedT      time.Time
+		initialLabels  model.LabelSet
+		expectedLabels model.LabelSet
+	}{
+		"happy path": {
+			testMultiStageRiver,
+			rawTestLine,
+			processedTestLine,
+			time.Now(),
+			time.Date(2000, 01, 25, 14, 00, 01, 0, est),
+			map[model.LabelName]model.LabelValue{
+				"match": "true",
+			},
+			map[model.LabelName]model.LabelValue{
+				"match":       "true",
+				"stream":      "stderr",
+				"action":      "GET",
+				"status_code": "200",
+			},
+		},
+		"no match": {
+			testMultiStageRiver,
+			rawTestLine,
+			rawTestLine,
+			ct,
+			ct,
+			map[model.LabelName]model.LabelValue{
+				"nomatch": "true",
+			},
+			map[model.LabelName]model.LabelValue{
+				"nomatch": "true",
+			},
+		},
+		"should initialize the extracted map with the initial labels": {
+			testMultiStageRiver,
+			rawTestLine,
+			processedTestLine,
+			time.Now(),
+			time.Date(2000, 01, 25, 14, 00, 01, 0, est),
+			map[model.LabelName]model.LabelValue{
+				"match":    "true",
+				"filename": "/var/log/nginx/frontend.log",
+			},
+			map[model.LabelName]model.LabelValue{
+				"filename":    "/var/log/nginx/frontend.log",
+				"match":       "true",
+				"stream":      "stderr",
+				"service":     "frontend",
+				"action":      "GET",
+				"status_code": "200",
+			},
+		},
+		"should set a label from value extracted from JSON": {
+			testLabelsFromJSONRiver,
+			`{"message":"hello world","app":"api"}`,
+			"hello world",
+			ct,
+			ct,
+			map[model.LabelName]model.LabelValue{},
+			map[model.LabelName]model.LabelValue{
+				"app": "api",
+			},
+		},
+		"should not set a label if the field does not exist in the JSON": {
+			testLabelsFromJSONRiver,
+			`{"message":"hello world"}`,
+			"hello world",
+			ct,
+			ct,
+			map[model.LabelName]model.LabelValue{},
+			map[model.LabelName]model.LabelValue{},
+		},
+		"should not set a label if the value extracted from JSON is null": {
+			testLabelsFromJSONRiver,
+			`{"message":"hello world","app":null}`,
+			"hello world",
+			ct,
+			ct,
+			map[model.LabelName]model.LabelValue{},
+			map[model.LabelName]model.LabelValue{},
+		},
+	}
+
+	for tName, tt := range tests {
+		tt := tt
+
+		t.Run(tName, func(t *testing.T) {
+			var config Configs
+
+			err := river.Unmarshal([]byte(tt.config), &config)
+			require.NoError(t, err)
+
+			p, err := NewPipeline(logger, loadConfig(tt.config), nil, prometheus.DefaultRegisterer)
+			require.NoError(t, err)
+
+			out := processEntries(p, newEntry(nil, tt.initialLabels, tt.entry, tt.t))[0]
+
+			assert.Equal(t, tt.expectedLabels, out.Labels, "did not get expected labels")
+			//assert.Equal(t, tt.expectedEntry, out.Line, "did not receive expected log entry")
+		})
+	}
+}
+
+var (
+	l           = log.NewNopLogger()
+	infoLogger  = level.NewFilter(l, level.AllowInfo())
+	debugLogger = level.NewFilter(l, level.AllowDebug())
+)
+
+func BenchmarkPipeline(b *testing.B) {
+	benchmarks := []struct {
+		name   string
+		stgs   []StageConfig
+		logger log.Logger
+		entry  string
+	}{
+		{
+			"two stage info level",
+			loadConfig(testMultiStageRiver),
+			infoLogger,
+			rawTestLine,
+		},
+		{
+			"two stage debug level",
+			loadConfig(testMultiStageRiver),
+			debugLogger,
+			rawTestLine,
+		},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			pl, err := NewPipeline(bm.logger, bm.stgs, nil, prometheus.DefaultRegisterer)
+			if err != nil {
+				panic(err)
+			}
+			lb := model.LabelSet{}
+			ts := time.Now()
+
+			in := make(chan Entry)
+			out := pl.Run(in)
+			b.ResetTimer()
+
+			go func() {
+				for range out {
+				}
+			}()
+			for i := 0; i < b.N; i++ {
+				in <- newEntry(nil, lb, bm.entry, ts)
+			}
+			close(in)
+		})
+	}
+}
+
+func TestPipeline_Wrap(t *testing.T) {
+	now := time.Now()
+	p, err := NewPipeline(logger, loadConfig(testMultiStageRiver), nil, prometheus.DefaultRegisterer)
+	if err != nil {
+		panic(err)
+	}
+
+	tests := map[string]struct {
+		labels     model.LabelSet
+		shouldSend bool
+	}{
+		"should drop": {
+			map[model.LabelName]model.LabelValue{
+				"stream":      "stderr",
+				"action":      "GET",
+				"status_code": "200",
+				"match":       "false",
+			},
+			false,
+		},
+		"should send": {
+			map[model.LabelName]model.LabelValue{
+				"stream":      "stderr",
+				"action":      "GET",
+				"status_code": "200",
+			},
+			true,
+		},
+	}
+
+	for tName, tt := range tests {
+		tt := tt
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+			c := fake.New(func() {})
+			handler := p.Wrap(c)
+
+			handler.Chan() <- phlare.Entry{
+				Labels: tt.labels,
+				Profile: profile.Profile{
+					TimeNanos: now.UnixNano(),
+				},
+			}
+			handler.Stop()
+			c.Stop()
+			var received bool
+
+			if len(c.Received()) != 0 {
+				received = true
+			}
+
+			assert.Equal(t, tt.shouldSend, received)
+		})
+	}
+}
+
+func Test_PipelineParallel(t *testing.T) {
+	c := fake.New(func() {})
+	cfg := `
+stage.match {
+		selector = "{match=~\".*\"}"
+		stage.multiline {
+				firstline     = "^{"
+				max_wait_time = "3s"
+				max_lines     = 2
+		}
+		stage.json {
+				expressions = { "app" = "", "message" = "" }
+		}
+		stage.labels {
+				values = { "app" = "" }
+		}
+		stage.output {
+				source = "message"
+		}
+}
+stage.match {
+		selector = "{match=~\".*\"}"
+		stage.json {
+				expressions = { "app" = "", "message" = "" }
+		}
+		stage.labels {
+				values = { "app" = "" }
+			}
+		stage.output {
+				source = "message"
+			}
+}
+`
+	p, err := newPipelineFromConfig(logger, cfg, "test")
+	require.NoError(t, err)
+
+	e1 := p.Wrap(c)
+	e2 := phlare.AddLabelsMiddleware(model.LabelSet{"bar": "foo"}).Wrap(e1)
+	entryhandler := phlare.AddLabelsMiddleware(model.LabelSet{"foo": "bar"}).Wrap(e2)
+
+	var wg sync.WaitGroup
+	parallelism := 10
+	wg.Add(parallelism)
+
+	for i := 0; i < parallelism; i++ {
+		go func(i int) {
+			defer wg.Done()
+			entryhandler.Chan() <- phlare.Entry{
+				Labels: make(model.LabelSet),
+				Profile: profile.Profile{
+					TimeNanos: time.Now().UnixNano(),
+				},
+			}
+			entryhandler.Chan() <- phlare.Entry{
+				Labels: make(model.LabelSet),
+				Profile: profile.Profile{
+					TimeNanos: time.Now().UnixNano(),
+				},
+			}
+			t.Log(i)
+		}(i)
+	}
+
+	wg.Wait()
+	entryhandler.Stop()
+	e2.Stop()
+	e1.Stop()
+	c.Stop()
+	t.Log(c.Received())
+}

--- a/component/phlare/process/internal/stages/stage.go
+++ b/component/phlare/process/internal/stages/stage.go
@@ -1,0 +1,65 @@
+package stages
+
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
+import (
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	StageTypeDiff     = "diff"
+	StageTypePipeline = "pipeline"
+)
+
+// Processor takes an existing set of labels, timestamp and log entry and returns either a possibly mutated
+// timestamp and log entry
+type Processor interface {
+	Process(labels model.LabelSet, extracted map[string]interface{}, time *time.Time, entry *string)
+	Name() string
+}
+
+// Stage can receive entries via an inbound channel and forward mutated entries to an outbound channel.
+type Stage interface {
+	Name() string
+	Run(chan Entry) chan Entry
+}
+
+func (entry *Entry) copy() *Entry {
+	out, err := yaml.Marshal(entry)
+	if err != nil {
+		return nil
+	}
+
+	var n *Entry
+	err = yaml.Unmarshal(out, &n)
+	if err != nil {
+		return nil
+	}
+
+	return n
+}
+
+// New creates a new stage for the given type and configuration.
+func New(logger log.Logger, jobName *string, cfg StageConfig, registerer prometheus.Registerer) (Stage, error) {
+	var (
+		s   Stage
+		err error
+	)
+	switch {
+	case cfg.DiffConfig != nil:
+		s, err = newDiffStage(logger, *cfg.DiffConfig)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		panic("unreacheable; should have decoded into one of the StageConfig fields")
+	}
+	return s, nil
+}

--- a/component/phlare/process/internal/stages/util.go
+++ b/component/phlare/process/internal/stages/util.go
@@ -1,0 +1,66 @@
+package stages
+
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
+import (
+	"fmt"
+	"strconv"
+)
+
+var (
+	// Debug is used to wrap debug log statements, the go-kit logger won't let us introspect the current log level
+	// so this global is used for that purpose. This allows us to skip allocations of log messages at the
+	// debug level when debug level logging is not enabled. Log level allocations can become very expensive
+	// as we log numerous log entries per log line at debug level.
+	Debug = false
+
+	// Inspect is used to debug promtail pipelines by showing diffs between pipeline stages
+	Inspect = false
+)
+
+const (
+	ErrTimestampContainsYear = "timestamp '%s' is expected to not contain the year date component"
+)
+
+// getString will convert the input variable to a string if possible
+func getString(unk interface{}) (string, error) {
+	switch i := unk.(type) {
+	case float64:
+		return strconv.FormatFloat(i, 'f', -1, 64), nil
+	case float32:
+		return strconv.FormatFloat(float64(i), 'f', -1, 32), nil
+	case int64:
+		return strconv.FormatInt(i, 10), nil
+	case int32:
+		return strconv.FormatInt(int64(i), 10), nil
+	case int:
+		return strconv.Itoa(i), nil
+	case uint64:
+		return strconv.FormatUint(i, 10), nil
+	case uint32:
+		return strconv.FormatUint(uint64(i), 10), nil
+	case uint:
+		return strconv.FormatUint(uint64(i), 10), nil
+	case string:
+		return unk.(string), nil
+	case bool:
+		if i {
+			return "true", nil
+		}
+		return "false", nil
+	default:
+		return "", fmt.Errorf("Can't convert %v to string", unk)
+	}
+}
+
+func stringsContain(values []string, search string) bool {
+	for _, v := range values {
+		if search == v {
+			return true
+		}
+	}
+
+	return false
+}

--- a/component/phlare/process/internal/stages/util_test.go
+++ b/component/phlare/process/internal/stages/util_test.go
@@ -1,0 +1,95 @@
+package stages
+
+// This package is ported over from grafana/loki/clients/pkg/logentry/stages.
+// We aim to port the stages in steps, to avoid introducing huge amounts of
+// new code without being able to slowly review, examine and test them.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/pprof/profile"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/agent/component/common/phlare"
+)
+
+func newEntry(ex map[string]interface{}, lbs model.LabelSet, line string, ts time.Time) Entry {
+	if ex == nil {
+		ex = map[string]interface{}{}
+	}
+	if lbs == nil {
+		lbs = model.LabelSet{}
+	}
+	return Entry{
+		Extracted: ex,
+		Entry: phlare.Entry{
+			Labels: lbs,
+			Profile: profile.Profile{
+				TimeNanos: ts.UnixNano(),
+			},
+		},
+	}
+}
+
+// nolint
+func mustParseTime(layout, value string) time.Time {
+	t, err := time.Parse(layout, value)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+func toLabelSet(lbs map[string]string) model.LabelSet {
+	res := model.LabelSet{}
+	for k, v := range lbs {
+		res[model.LabelName(k)] = model.LabelValue(v)
+	}
+	return res
+}
+
+func assertLabels(t *testing.T, expect map[string]string, got model.LabelSet) {
+	if len(expect) != len(got) {
+		t.Fatalf("labels are not equal in size want: %s got: %s", expect, got)
+	}
+	for k, v := range expect {
+		gotV, ok := got[model.LabelName(k)]
+		if !ok {
+			t.Fatalf("missing expected label key: %s", k)
+		}
+		assert.Equal(t, model.LabelValue(v), gotV, "mismatch label value")
+	}
+}
+
+// Verify the formatting of float conversion to make sure there are not any trailing zeros,
+// and also make sure unix timestamps are converted properly
+func TestGetString(t *testing.T) {
+	var f64, f64_1 float64
+	var f32 float32
+	f64 = 1
+	f64_1 = 1562723913000
+	f32 = 2.02
+	s64, err := getString(f64)
+	if err != nil {
+		t.Errorf("Failed to get string from float... this shouldn't have happened: %v", err)
+		return
+	}
+	s64_1, err := getString(f64_1)
+	if err != nil {
+		t.Errorf("Failed to get string from float... this shouldn't have happened: %v", err)
+		return
+	}
+	s32, err := getString(f32)
+	if err != nil {
+		t.Errorf("Failed to get string from float... this shouldn't have happened: %v", err)
+		return
+	}
+	assert.Equal(t, "1", s64)
+	assert.Equal(t, "2.02", s32)
+	assert.Equal(t, "1562723913000", s64_1)
+
+	_, err = getString(nil)
+	assert.Error(t, err)
+}

--- a/component/phlare/process/process.go
+++ b/component/phlare/process/process.go
@@ -1,0 +1,174 @@
+package process
+
+import (
+	"context"
+	"reflect"
+	"sync"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/agent/component/phlare"
+	"github.com/grafana/agent/component/phlare/process/internal/stages"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:    "phlare.process",
+		Args:    Arguments{},
+		Exports: Exports{},
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			return New(opts, args.(Arguments))
+		},
+	})
+}
+
+// Arguments holds values which are used to configure the loki.process
+// component.
+type Arguments struct {
+	ForwardTo []phlare.Appendable  `river:"forward_to,attr"`
+	Stages    []stages.StageConfig `river:"stage,enum,optional"`
+}
+
+// Exports exposes the receiver that can be used to send log entries to
+// loki.process.
+type Exports struct {
+	Receiver phlare.Appendable `river:"receiver,attr"`
+}
+
+var (
+	_ component.Component = (*Component)(nil)
+)
+
+// Component implements the loki.process component.
+type Component struct {
+	opts component.Options
+
+	mut          sync.RWMutex
+	receiver     loki.LogsReceiver
+	fanout       []loki.LogsReceiver
+	processIn    chan<- loki.Entry
+	processOut   chan loki.Entry
+	entryHandler loki.EntryHandler
+	stages       []stages.StageConfig
+}
+
+// New creates a new loki.process component.
+func New(o component.Options, args Arguments) (*Component, error) {
+	c := &Component{
+		opts: o,
+	}
+
+	// Create and immediately export the receiver which remains the same for
+	// the component's lifetime.
+	c.receiver = make(loki.LogsReceiver)
+	c.processOut = make(loki.LogsReceiver)
+	o.OnStateChange(Exports{Receiver: c.receiver})
+
+	// Call to Update() to start readers and set receivers once at the start.
+	if err := c.Update(args); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// Run implements component.Component.
+func (c *Component) Run(ctx context.Context) error {
+	defer func() {
+		c.mut.RLock()
+		if c.entryHandler != nil {
+			c.entryHandler.Stop()
+		}
+		close(c.processOut)
+		close(c.processIn)
+		c.mut.RUnlock()
+	}()
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	go c.handleIn(ctx, wg)
+	go c.handleOut(ctx, wg)
+
+	wg.Wait()
+	return nil
+}
+
+// Update implements component.Component.
+func (c *Component) Update(args component.Arguments) error {
+	newArgs := args.(Arguments)
+
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	// We want to create a new pipeline if the config changed or if this is the
+	// first load. This will allow a component with no stages to function
+	// properly.
+	if stagesChanged(c.stages, newArgs.Stages) || c.stages == nil {
+		if c.entryHandler != nil {
+			c.entryHandler.Stop()
+		}
+
+		pipeline, err := stages.NewPipeline(c.opts.Logger, newArgs.Stages, &c.opts.ID, c.opts.Registerer)
+		if err != nil {
+			return err
+		}
+		c.entryHandler = loki.NewEntryHandler(c.processOut, func() {})
+		c.processIn = pipeline.Wrap(c.entryHandler).Chan()
+		c.stages = newArgs.Stages
+	}
+
+	c.fanout = newArgs.ForwardTo
+
+	return nil
+}
+
+func (c *Component) handleIn(ctx context.Context, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case entry := <-c.receiver:
+			c.mut.RLock()
+			select {
+			case <-ctx.Done():
+				return
+			case c.processIn <- entry:
+				// no-op
+			}
+			c.mut.RUnlock()
+		}
+	}
+}
+
+func (c *Component) handleOut(ctx context.Context, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case entry := <-c.processOut:
+			c.mut.RLock()
+			for _, f := range c.fanout {
+				select {
+				case <-ctx.Done():
+					return
+				case f <- entry:
+					// no-op
+				}
+			}
+			c.mut.RUnlock()
+		}
+	}
+}
+
+func stagesChanged(prev, next []stages.StageConfig) bool {
+	if len(prev) != len(next) {
+		return true
+	}
+	for i := range prev {
+		if !reflect.DeepEqual(prev[i], next[i]) {
+			return true
+		}
+	}
+	return false
+}

--- a/component/phlare/process/process_test.go
+++ b/component/phlare/process/process_test.go
@@ -1,0 +1,305 @@
+package process
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/agent/component/phlare/process/internal/stages"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/grafana/agent/pkg/util"
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+func TestJSONLabelsStage(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// The following stages will attempt to parse input lines as JSON.
+	// The first stage _extract_ any fields found with the correct names:
+	// Since 'source' is empty, it implies that we want to parse the log line
+	// itself.
+	//    log    --> output
+	//    stream --> stream
+	//    time   --> timestamp
+	//    extra  --> extra
+	//
+	// The second stage will parse the 'extra' field as JSON, and extract the
+	// 'user' field from the 'extra' field. If the expression value field is
+	// empty, it is inferred we want to use the same name as the key.
+	//    user   --> extra.user
+	//
+	// The third stage will set some labels from the extracted values above.
+	// Again, if the value is empty, it is inferred that we want to use the
+	// populate the label with extracted value of the same name.
+	stg := `stage.json { 
+			    expressions    = {"output" = "log", stream = "stream", timestamp = "time", "extra" = "" }
+				drop_malformed = true
+		    }
+			stage.json {
+			    expressions = { "user" = "" }
+				source      = "extra"
+			}
+			stage.labels {
+			    values = { 
+				  stream = "",
+				  user   = "",
+				  ts     = "timestamp",
+			    }
+			}`
+
+	// Unmarshal the River relabel rules into a custom struct, as we don't have
+	// an easy way to refer to a loki.LogsReceiver value for the forward_to
+	// argument.
+	type cfg struct {
+		Stages []stages.StageConfig `river:"stage,enum"`
+	}
+	var stagesCfg cfg
+	err := river.Unmarshal([]byte(stg), &stagesCfg)
+	require.NoError(t, err)
+
+	ch1, ch2 := make(loki.LogsReceiver), make(loki.LogsReceiver)
+
+	// Create and run the component, so that it can process and forwards logs.
+	opts := component.Options{
+		Logger:        util.TestFlowLogger(t),
+		Registerer:    prometheus.NewRegistry(),
+		OnStateChange: func(e component.Exports) {},
+	}
+	args := Arguments{
+		ForwardTo: []loki.LogsReceiver{ch1, ch2},
+		Stages:    stagesCfg.Stages,
+	}
+
+	c, err := New(opts, args)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+
+	// Send a log entry to the component's receiver.
+	ts := time.Now()
+	logline := `{"log":"log message\n","stream":"stderr","time":"2019-04-30T02:12:41.8443515Z","extra":"{\"user\":\"smith\"}"}`
+	logEntry := loki.Entry{
+		Labels: model.LabelSet{"filename": "/var/log/pods/agent/agent/1.log", "foo": "bar"},
+		Entry: logproto.Entry{
+			Timestamp: ts,
+			Line:      logline,
+		},
+	}
+
+	c.receiver <- logEntry
+
+	wantLabelSet := model.LabelSet{
+		"filename": "/var/log/pods/agent/agent/1.log",
+		"foo":      "bar",
+		"stream":   "stderr",
+		"ts":       "2019-04-30T02:12:41.8443515Z",
+		"user":     "smith",
+	}
+
+	// The log entry should be received in both channels, with the processing
+	// stages correctly applied.
+	for i := 0; i < 2; i++ {
+		select {
+		case logEntry := <-ch1:
+			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
+			require.Equal(t, logline, logEntry.Line)
+			require.Equal(t, wantLabelSet, logEntry.Labels)
+		case logEntry := <-ch2:
+			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
+			require.Equal(t, logline, logEntry.Line)
+			require.Equal(t, wantLabelSet, logEntry.Labels)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "failed waiting for log line")
+		}
+	}
+}
+
+func TestStaticLabelsLabelAllowLabelDrop(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// The following stages manipulate the label set of a log entry.
+	// The first stage will define a static set of labels (foo, bar, baz, qux)
+	// to add to the entry along the `filename` and `dev` labels.
+	// The second stage will drop the foo and bar labels.
+	// The third stage will keep only a subset of the remaining labels.
+	stg := `
+stage.static_labels {
+    values = { "foo" = "fooval", "bar" = "barval", "baz" = "bazval", "qux" = "quxval" }
+}
+stage.label_drop {
+    values = [ "foo", "bar" ]
+}
+stage.label_keep {
+    values = [ "foo", "baz", "filename" ]
+}`
+
+	// Unmarshal the River relabel rules into a custom struct, as we don't have
+	// an easy way to refer to a loki.LogsReceiver value for the forward_to
+	// argument.
+	type cfg struct {
+		Stages []stages.StageConfig `river:"stage,enum"`
+	}
+	var stagesCfg cfg
+	err := river.Unmarshal([]byte(stg), &stagesCfg)
+	require.NoError(t, err)
+
+	ch1, ch2 := make(loki.LogsReceiver), make(loki.LogsReceiver)
+
+	// Create and run the component, so that it can process and forwards logs.
+	opts := component.Options{
+		Logger:        util.TestFlowLogger(t),
+		Registerer:    prometheus.NewRegistry(),
+		OnStateChange: func(e component.Exports) {},
+	}
+	args := Arguments{
+		ForwardTo: []loki.LogsReceiver{ch1, ch2},
+		Stages:    stagesCfg.Stages,
+	}
+
+	c, err := New(opts, args)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+
+	// Send a log entry to the component's receiver.
+	ts := time.Now()
+	logline := `{"log":"log message\n","stream":"stderr","time":"2022-01-09T08:37:45.8233626Z"}`
+	logEntry := loki.Entry{
+		Labels: model.LabelSet{"filename": "/var/log/pods/agent/agent/1.log", "env": "dev"},
+		Entry: logproto.Entry{
+			Timestamp: ts,
+			Line:      logline,
+		},
+	}
+
+	c.receiver <- logEntry
+
+	wantLabelSet := model.LabelSet{
+		"filename": "/var/log/pods/agent/agent/1.log",
+		"baz":      "bazval",
+	}
+
+	// The log entry should be received in both channels, with the processing
+	// stages correctly applied.
+	for i := 0; i < 2; i++ {
+		select {
+		case logEntry := <-ch1:
+			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
+			require.Equal(t, logline, logEntry.Line)
+			require.Equal(t, wantLabelSet, logEntry.Labels)
+		case logEntry := <-ch2:
+			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
+			require.Equal(t, logline, logEntry.Line)
+			require.Equal(t, wantLabelSet, logEntry.Labels)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "failed waiting for log line")
+		}
+	}
+}
+
+func TestRegexTimestampOutput(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// The first stage will attempt to parse the input line using a regular
+	// expression with named capture groups. The three capture groups (time,
+	// stream and content) will be extracted in the shared map of values.
+	// Since 'source' is empty, it implies that we want to parse the log line
+	// itself.
+	//
+	// The second stage will parse the extracted `time` value as Unix epoch
+	// time and set it to the log entry timestamp.
+	//
+	// The third stage will set the `content` value as the message value.
+	//
+	// The fourth and final stage will set the `stream` value as the label.
+	stg := `
+stage.regex {
+		expression = "^(?s)(?P<time>\\S+?) (?P<stream>stdout|stderr) (?P<content>.*)$"
+}
+stage.timestamp {
+		source = "time"
+		format = "RFC3339"
+}
+stage.output {
+		source = "content"
+}
+stage.labels {
+		values = { src = "stream" }
+}`
+
+	// Unmarshal the River relabel rules into a custom struct, as we don't have
+	// an easy way to refer to a loki.LogsReceiver value for the forward_to
+	// argument.
+	type cfg struct {
+		Stages []stages.StageConfig `river:"stage,enum"`
+	}
+	var stagesCfg cfg
+	err := river.Unmarshal([]byte(stg), &stagesCfg)
+	require.NoError(t, err)
+
+	ch1, ch2 := make(loki.LogsReceiver), make(loki.LogsReceiver)
+
+	// Create and run the component, so that it can process and forwards logs.
+	opts := component.Options{
+		Logger:        util.TestFlowLogger(t),
+		Registerer:    prometheus.NewRegistry(),
+		OnStateChange: func(e component.Exports) {},
+	}
+	args := Arguments{
+		ForwardTo: []loki.LogsReceiver{ch1, ch2},
+		Stages:    stagesCfg.Stages,
+	}
+
+	c, err := New(opts, args)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+
+	// Send a log entry to the component's receiver.
+	ts := time.Now()
+	logline := `2022-01-17T08:17:42-07:00 stderr somewhere, somehow, an error occurred`
+	logEntry := loki.Entry{
+		Labels: model.LabelSet{"filename": "/var/log/pods/agent/agent/1.log", "foo": "bar"},
+		Entry: logproto.Entry{
+			Timestamp: ts,
+			Line:      logline,
+		},
+	}
+
+	c.receiver <- logEntry
+
+	wantLabelSet := model.LabelSet{
+		"filename": "/var/log/pods/agent/agent/1.log",
+		"foo":      "bar",
+		"src":      "stderr",
+	}
+	wantTimestamp, err := time.Parse(time.RFC3339, "2022-01-17T08:17:42-07:00")
+	wantLogline := `somewhere, somehow, an error occurred`
+	require.NoError(t, err)
+
+	// The log entry should be received in both channels, with the processing
+	// stages correctly applied.
+	for i := 0; i < 2; i++ {
+		select {
+		case logEntry := <-ch1:
+			require.Equal(t, wantLogline, logEntry.Line)
+			require.Equal(t, wantTimestamp, logEntry.Timestamp)
+			require.Equal(t, wantLabelSet, logEntry.Labels)
+		case logEntry := <-ch2:
+			require.Equal(t, wantLogline, logEntry.Line)
+			require.Equal(t, wantTimestamp, logEntry.Timestamp)
+			require.Equal(t, wantLabelSet, logEntry.Labels)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "failed waiting for log line")
+		}
+	}
+}


### PR DESCRIPTION
This will add a component `phlare.process`, which allows to skip/rewrite/modify profiles after scraping and before sending it of to Phlare API.

The first stage to implement in this PR would be calculate `delta` of a cumulative profile since the last profile received. This is currently done by Pyroscope & Phlare on the server side. 
