### PR TITLE
node_exporter: fix usage of diskstat flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Main (unreleased)
 - Fix issue where component evaluation time was overridden by a "default
   health" message. (@rfratto)
 
+- Fix issue where the the `node_exporter` integration and
+  `prometheus.exporter.unix` `diskstat_device_include` component could not set
+  the allowlist field for the diskstat collector. (@tpaschalis)
+
 ### Other changes
 
 - Add metrics when clustering mode is enabled. (@rfratto)

--- a/docs/sources/flow/reference/components/prometheus.exporter.unix.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.unix.md
@@ -116,8 +116,8 @@ Name | Type | Description | Default | Required
 ### disk block
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`device_exclude` | `string` | Regexp of devices to exclude for diskstats (mutually exclusive with `device_include`). | `"^(ram\|loop\|fd\|(h\|s\|v\|xv)d[a-z]\|nvme\\d+n\\d+p)\\d+$"` | no
-`device_include` | `string` | Regexp of devices to include for diskstats (mutually exclusive with `device_exclude`). | | no
+`device_exclude` | `string` | Regexp of devices to exclude for diskstats. | `"^(ram\|loop\|fd\|(h\|s\|v\|xv)d[a-z]\|nvme\\d+n\\d+p)\\d+$"` | no
+`device_include` | `string` | Regexp of devices to include for diskstats. If set, `device_exclude` is ignored.  | | no
 
 ### ethtool block
 Name | Type | Description | Default | Required

--- a/docs/sources/static/configuration/integrations/node-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/node-exporter-config.md
@@ -278,10 +278,10 @@ the Agent is running on is a no-op.
   # Regexp of `flags` field in cpu info to filter.
   [cpu_flags_include: <string>]
 
-  # Regexp of devices to ignore for diskstats (mutually exclusive with diskstats_device_include).
+  # Regexp of devices to ignore for diskstats.
   [diskstats_device_exclude: <string> | default = "^(ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\\d+n\\d+p)\\d+$"]
 
-  # Regexp of devices to include for diskstats (mutually exclusive with diskstats_device_exclude).
+  # Regexp of devices to include for diskstats. If set, the diskstat_device_exclude field is ignored.
   [diskstats_device_include: <string>]
 
   # Regexp of ethtool devices to exclude (mutually exclusive with ethtool_device_include)

--- a/pkg/integrations/node_exporter/config.go
+++ b/pkg/integrations/node_exporter/config.go
@@ -319,8 +319,11 @@ func MapConfigToNodeExporterFlags(c *Config) (accepted []string, ignored []strin
 	}
 
 	if collectors[CollectorDiskstats] {
-		flags.add("--collector.diskstats.device-include", c.DiskStatsDeviceInclude)
-		flags.add("--collector.diskstats.device-exclude", c.DiskStatsDeviceExclude)
+		if c.DiskStatsDeviceInclude != "" {
+			flags.add("--collector.diskstats.device-include", c.DiskStatsDeviceInclude)
+		} else {
+			flags.add("--collector.diskstats.device-exclude", c.DiskStatsDeviceExclude)
+		}
 	}
 
 	if collectors[CollectorEthtool] {


### PR DESCRIPTION
#### PR Description
The current logic in the node_exporter integration, that was also inherited by the prometheus.exporter.unix component was that a) the `device_exclude` field had a default value and b) the `device_exclude` and `device_include` fields were mutually exclusive.

This meant that the first field was always being set implicitly, and if the second was defined then node_exporter could not start.

That means that the following two config files failed to start the Agent and there was no way to make use of `device_include`.

```yaml
integrations:
  node_exporter:
    enabled: true
    scrape_integration: true
    set_collectors:
      - "diskstats"
    diskstats_device_include: "/dev/vd.*"
```

```river
prometheus.exporter.unix {
	disk {
		device_include = "foo"
	}
}
```

This PR changes the logic of the two fields to allow the default value being set by having the include field _take precedence_, and making it so that when it is set, the exclude field be ignored.

#### Which issue(s) this PR fixes
Fixes #3759

#### Notes to the Reviewer
Do you think this is a bug that warrants a patch release? I'd lean towards no, but let me know if you think otherwise.

#### PR Checklist

- [X] CHANGELOG updated
- [X] Documentation added
- [ ] Tests updated
