### PR TITLE
agent-flow-mixin: amended descriptions and fixes around clustering dashboards

### DIFF
--- a/operations/agent-flow-mixin/dashboards/cluster-node.libsonnet
+++ b/operations/agent-flow-mixin/dashboards/cluster-node.libsonnet
@@ -150,12 +150,15 @@ local filename = 'agent-cluster-node.json';
         }) +
         panel.withQueries([
           panel.newQuery(
-            expr='rate(cluster_transport_rx_bytes_total{instance="$instance"}[$__rate_interval])'
+            expr='rate(cluster_transport_rx_bytes_total{instance="$instance"}[$__rate_interval])',
+            legendFormat='rx',
           ),
           panel.newQuery(
-            expr='-1 * rate(cluster_transport_tx_bytes_total{instance="$instance"}[$__rate_interval])'
+            expr='-1 * rate(cluster_transport_tx_bytes_total{instance="$instance"}[$__rate_interval])',
+            legendFormat='tx',
           ),
         ]) +
+        panel.withCenteredAxis() +
         panel.withUnit('Bps')
       ),
       // Packet write success rate
@@ -234,6 +237,7 @@ local filename = 'agent-cluster-node.json';
             legendFormat='tx',
           ),
         ]) +
+        panel.withCenteredAxis() +
         panel.withUnit('Bps')
       ),
       // Stream write success rate

--- a/operations/agent-flow-mixin/dashboards/cluster-node.libsonnet
+++ b/operations/agent-flow-mixin/dashboards/cluster-node.libsonnet
@@ -172,21 +172,21 @@ local filename = 'agent-cluster-node.json';
         }) +
         panel.withQueries([
           panel.newQuery(
-            expr = ||| 
-              1 - ( 
-                rate(cluster_transport_tx_packets_failed_total{instance="$instance"}[$__rate_interval]) / 
-                rate(cluster_transport_tx_packets_total{instance="$instance"}[$__rate_interval])
-                )
-|||,
+            expr=|||
+              1 - (
+              rate(cluster_transport_tx_packets_failed_total{instance="$instance"}[$__rate_interval]) /
+              rate(cluster_transport_tx_packets_total{instance="$instance"}[$__rate_interval])
+              )
+            |||,
             legendFormat='Tx success %',
           ),
           panel.newQuery(
-            expr = |||
+            expr=|||
               1 - (
-                rate(cluster_transport_rx_packets_failed_total{instance="$instance"}[$__rate_interval]) / 
+                rate(cluster_transport_rx_packets_failed_total{instance="$instance"}[$__rate_interval]) /
                 rate(cluster_transport_rx_packets_total{instance="$instance"}[$__rate_interval])
                 )
-|||,
+            |||,
             legendFormat='Rx success %',
           ),
         ]) +
@@ -251,21 +251,21 @@ local filename = 'agent-cluster-node.json';
         }) +
         panel.withQueries([
           panel.newQuery(
-            expr = |||
-              1 - ( 
-                rate(cluster_transport_stream_tx_packets_failed_total{instance="$instance"}[$__rate_interval]) / 
+            expr=|||
+              1 - (
+                rate(cluster_transport_stream_tx_packets_failed_total{instance="$instance"}[$__rate_interval]) /
                 rate(cluster_transport_stream_tx_packets_total{instance="$instance"}[$__rate_interval])
                 )
-|||,
+            |||,
             legendFormat='Tx success %'
           ),
           panel.newQuery(
-            expr = |||
-              1 - ( 
-                rate(cluster_transport_stream_rx_packets_failed_total{instance="$instance"}[$__rate_interval]) / 
+            expr=|||
+              1 - (
+                rate(cluster_transport_stream_rx_packets_failed_total{instance="$instance"}[$__rate_interval]) /
                 rate(cluster_transport_stream_rx_packets_total{instance="$instance"}[$__rate_interval])
                 )
-|||,
+            |||,
             legendFormat='Rx success %'
           ),
         ]) +

--- a/operations/agent-flow-mixin/dashboards/cluster-node.libsonnet
+++ b/operations/agent-flow-mixin/dashboards/cluster-node.libsonnet
@@ -38,13 +38,13 @@ local filename = 'agent-cluster-node.json';
         panel.withDescription(|||
           Information about a specific cluster node.
 
-          Lamport clock time: The observed Lamport time on the specific node's clock used to provide partial ordering around gossip messages. Nodes should ideally be observing roughly the same time, meaning they are up-to-date on the cluster state. If a node is falling behind, it means that it has not recently processed the same number of messages and may have an outdated view of its peers.
+          * Lamport clock time: The observed Lamport time on the specific node's clock used to provide partial ordering around gossip messages. Nodes should ideally be observing roughly the same time, meaning they are up-to-date on the cluster state. If a node is falling behind, it means that it has not recently processed the same number of messages and may have an outdated view of its peers.
 
-          Internal cluster state observers: The number of Observer functions that are registered to run whenever the node detects a cluster change.
+          * Internal cluster state observers: The number of Observer functions that are registered to run whenever the node detects a cluster change.
 
-          Gossip health score: A health score assigned to this node by the memberlist implementation. The lower, the better.
+          * Gossip health score: A health score assigned to this node by the memberlist implementation. The lower, the better.
 
-          Gossip protocol version: The protocol version used by nodes to communicate with one another. It should match across all nodes.
+          * Gossip protocol version: The protocol version used by nodes to communicate with one another. It should match across all nodes.
         |||) +
         panel.withPosition({ x: 0, y: 1, w: 12, h: 8 }) +
         panel.withQueries([
@@ -273,7 +273,7 @@ local filename = 'agent-cluster-node.json';
         panel.withDescription(|||
           The number of open connections from this node to its peers.
 
-          Each node picks up a subset of its peers to continuously gossip messages around cluster status using streaming HTTP/2 connections. In case there are networking errors, 
+          Each node picks up a subset of its peers to continuously gossip messages around cluster status using streaming HTTP/2 connections. This panel can be used to detect networking failures that result in cluster communication being disrupted and convergence taking longer than expected or outright failing.
         |||) +
         panel.withPosition({
           h: 8,

--- a/operations/agent-flow-mixin/dashboards/cluster-node.libsonnet
+++ b/operations/agent-flow-mixin/dashboards/cluster-node.libsonnet
@@ -37,6 +37,14 @@ local filename = 'agent-cluster-node.json';
         panel.new('Node Info', 'table') +
         panel.withDescription(|||
           Information about a specific cluster node.
+
+          Lamport clock time: The observed Lamport time on the specific node's clock used to provide partial ordering around gossip messages. Nodes should ideally be observing roughly the same time, meaning they are up-to-date on the cluster state. If a node is falling behind, it means that it has not recently processed the same number of messages and may have an outdated view of its peers.
+
+          Internal cluster state observers: The number of Observer functions that are registered to run whenever the node detects a cluster change.
+
+          Gossip health score: A health score assigned to this node by the memberlist implementation. The lower, the better.
+
+          Gossip protocol version: The protocol version used by nodes to communicate with one another. It should match across all nodes.
         |||) +
         panel.withPosition({ x: 0, y: 1, w: 12, h: 8 }) +
         panel.withQueries([
@@ -89,9 +97,6 @@ local filename = 'agent-cluster-node.json';
       // Gossip ops/sec
       (
         panel.new('Gossip ops/s', 'timeseries') +
-        panel.withDescription(|||
-          Gossip ops/sec for this node.
-        |||) +
         panel.withPosition({ x: 12, y: 1, w: 12, h: 8 }) +
         panel.withQueries([
           panel.newQuery(
@@ -118,7 +123,7 @@ local filename = 'agent-cluster-node.json';
       (
         panel.new('Peers by state', 'timeseries') +
         panel.withDescription(|||
-          Known peers to the node by state.
+          Known peers to the node by state (including the local node).
         |||) +
         panel.withPosition({ x: 12, y: 9, w: 12, h: 8 }) +
         panel.withQueries([
@@ -164,11 +169,21 @@ local filename = 'agent-cluster-node.json';
         }) +
         panel.withQueries([
           panel.newQuery(
-            expr='1 - ( \r\n    rate(cluster_transport_tx_packets_failed_total{instance="$instance"}[$__rate_interval]) / \r\n    rate(cluster_transport_tx_packets_total{instance="$instance"}[$__rate_interval])\r\n)',
+            expr = ||| 
+              1 - ( 
+                rate(cluster_transport_tx_packets_failed_total{instance="$instance"}[$__rate_interval]) / 
+                rate(cluster_transport_tx_packets_total{instance="$instance"}[$__rate_interval])
+                )
+|||,
             legendFormat='Tx success %',
           ),
           panel.newQuery(
-            expr='1 - ( \r\n    rate(cluster_transport_rx_packets_failed_total{instance="$instance"}[$__rate_interval]) / \r\n    rate(cluster_transport_rx_packets_total{instance="$instance"}[$__rate_interval])\r\n)',
+            expr = |||
+              1 - (
+                rate(cluster_transport_rx_packets_failed_total{instance="$instance"}[$__rate_interval]) / 
+                rate(cluster_transport_rx_packets_total{instance="$instance"}[$__rate_interval])
+                )
+|||,
             legendFormat='Rx success %',
           ),
         ]) +
@@ -177,6 +192,11 @@ local filename = 'agent-cluster-node.json';
       // Pending packet queue
       (
         panel.new('Pending packet queue', 'timeseries') +
+        panel.withDescription(|||
+          The number of packets enqueued currently to be decoded or encoded and sent during communication with other nodes.
+
+          The incoming and outgoing packet queue should be as empty as possible; a growing queue means that the Agent cannot keep up with the number of messages required to have all nodes informed of cluster changes, and the nodes may not converge in a timely fashion.
+        |||) +
         panel.withPosition({
           h: 8,
           w: 8,
@@ -227,11 +247,21 @@ local filename = 'agent-cluster-node.json';
         }) +
         panel.withQueries([
           panel.newQuery(
-            expr='1 - ( \r\n    rate(cluster_transport_stream_tx_packets_failed_total{instance="$instance"}[$__rate_interval]) / \r\n    rate(cluster_transport_stream_tx_packets_total{instance="$instance"}[$__rate_interval])\r\n)',
+            expr = |||
+              1 - ( 
+                rate(cluster_transport_stream_tx_packets_failed_total{instance="$instance"}[$__rate_interval]) / 
+                rate(cluster_transport_stream_tx_packets_total{instance="$instance"}[$__rate_interval])
+                )
+|||,
             legendFormat='Tx success %'
           ),
           panel.newQuery(
-            expr='1 - ( \r\n    rate(cluster_transport_stream_rx_packets_failed_total{instance="$instance"}[$__rate_interval]) / \r\n    rate(cluster_transport_stream_rx_packets_total{instance="$instance"}[$__rate_interval])\r\n)',
+            expr = |||
+              1 - ( 
+                rate(cluster_transport_stream_rx_packets_failed_total{instance="$instance"}[$__rate_interval]) / 
+                rate(cluster_transport_stream_rx_packets_total{instance="$instance"}[$__rate_interval])
+                )
+|||,
             legendFormat='Rx success %'
           ),
         ]) +
@@ -240,6 +270,11 @@ local filename = 'agent-cluster-node.json';
       // Open transport streams
       (
         panel.new('Open transport streams', 'timeseries') +
+        panel.withDescription(|||
+          The number of open connections from this node to its peers.
+
+          Each node picks up a subset of its peers to continuously gossip messages around cluster status using streaming HTTP/2 connections. In case there are networking errors, 
+        |||) +
         panel.withPosition({
           h: 8,
           w: 8,

--- a/operations/agent-flow-mixin/dashboards/cluster-overview.libsonnet
+++ b/operations/agent-flow-mixin/dashboards/cluster-overview.libsonnet
@@ -97,11 +97,7 @@ local cluster_node_filename = 'agent-cluster-node.json';
                     {
                       targetBlank: false,
                       title: 'Detail dashboard for node',
-                      // Use this URL for development with Grizzly where links are not replaced with a UID.
-                      // url: '/d/agent-cluster-node/grafana-agent-flow-cluster-node?var-instance=${__data.fields.instance}&var-datasource=${datasource}&var-loki_datasource=${loki_datasource}&var-cluster=${cluster}&var-namespace=${namespace}',
-
-                      // Use this URL to render and deploy the mixin.
-                      url: '/d/%(uid)s/grafana-agent-flow-cluster-node?var-instance=${__data.fields.instance}&var-datasource=${datasource}&var-loki_datasource=${loki_datasource}&var-cluster=${cluster}&var-namespace=${namespace}' % { uid: std.md5(cluster_node_filename) },
+                      url: '/d/%(uid)s/grafana-agent-flow-cluster-node?var-instance=${__data.fields.instance}&var-datasource=${datasource}&var-loki_datasource=${loki_datasource}&var-cluster=${cluster}&var-namespace=${namespace}' % {uid: std.md5(cluster_node_filename)},
                     },
                   ],
                 },

--- a/operations/agent-flow-mixin/dashboards/cluster-overview.libsonnet
+++ b/operations/agent-flow-mixin/dashboards/cluster-overview.libsonnet
@@ -98,10 +98,10 @@ local cluster_node_filename = 'agent-cluster-node.json';
                       targetBlank: false,
                       title: 'Detail dashboard for node',
                       // Use this URL for development with Grizzly where links are not replaced with a UID.
-                      // url: '/d/agent-cluster-node/grafana-agent-flow-cluster-node?var-instance=${__data.fields.instance}&var-datasource=${datasource}&var-loki_datasource=${loki_datasource}&var-cluster=${cluster}&var-namespace=${namespace}',                      
-                      
+                      // url: '/d/agent-cluster-node/grafana-agent-flow-cluster-node?var-instance=${__data.fields.instance}&var-datasource=${datasource}&var-loki_datasource=${loki_datasource}&var-cluster=${cluster}&var-namespace=${namespace}',
+
                       // Use this URL to render and deploy the mixin.
-                      url: '/d/%(uid)s/grafana-agent-flow-cluster-node?var-instance=${__data.fields.instance}&var-datasource=${datasource}&var-loki_datasource=${loki_datasource}&var-cluster=${cluster}&var-namespace=${namespace}' % {uid: std.md5(cluster_node_filename)},
+                      url: '/d/%(uid)s/grafana-agent-flow-cluster-node?var-instance=${__data.fields.instance}&var-datasource=${datasource}&var-loki_datasource=${loki_datasource}&var-cluster=${cluster}&var-namespace=${namespace}' % { uid: std.md5(cluster_node_filename) },
                     },
                   ],
                 },
@@ -126,14 +126,14 @@ local cluster_node_filename = 'agent-cluster-node.json';
         panel.withPosition({ h: 9, w: 8, x: 0, y: 9 }) +
         panel.withQueries([
           panel.newInstantQuery(
-            expr = ||| 
+            expr=|||
               clamp((
-                sum(stddev by (state) (cluster_node_peers) != 0) or 
+                sum(stddev by (state) (cluster_node_peers) != 0) or
                 (sum(abs(sum without (state) (cluster_node_peers)) - scalar(count(cluster_node_info)) != 0))
-                ), 
+                ),
                 1, 1
               )
-|||,
+            |||,
             format='time_series'
           ),
         ]) +

--- a/operations/agent-flow-mixin/dashboards/cluster-overview.libsonnet
+++ b/operations/agent-flow-mixin/dashboards/cluster-overview.libsonnet
@@ -1,6 +1,7 @@
 local dashboard = import './utils/dashboard.jsonnet';
 local panel = import './utils/panel.jsonnet';
 local filename = 'agent-cluster-overview.json';
+local cluster_node_filename = 'agent-cluster-node.json';
 
 {
   [filename]:
@@ -96,7 +97,11 @@ local filename = 'agent-cluster-overview.json';
                     {
                       targetBlank: false,
                       title: 'Detail dashboard for node',
-                      url: '/d/agent-cluster-node/grafana-agent-flow-cluster-node?var-instance=${__data.fields.instance}&var-datasource=${datasource}&var-loki_datasource=${loki_datasource}&var-cluster=${cluster}&var-namespace=${namespace}',
+                      // Use this URL for development with Grizzly where links are not replaced with a UID.
+                      // url: '/d/agent-cluster-node/grafana-agent-flow-cluster-node?var-instance=${__data.fields.instance}&var-datasource=${datasource}&var-loki_datasource=${loki_datasource}&var-cluster=${cluster}&var-namespace=${namespace}',                      
+                      
+                      // Use this URL to render and deploy the mixin.
+                      url: '/d/%(uid)s/grafana-agent-flow-cluster-node?var-instance=${__data.fields.instance}&var-datasource=${datasource}&var-loki_datasource=${loki_datasource}&var-cluster=${cluster}&var-namespace=${namespace}' % {uid: std.md5(cluster_node_filename)},
                     },
                   ],
                 },

--- a/operations/agent-flow-mixin/dashboards/cluster-overview.libsonnet
+++ b/operations/agent-flow-mixin/dashboards/cluster-overview.libsonnet
@@ -27,9 +27,6 @@ local filename = 'agent-cluster-overview.json';
       // Nodes
       (
         panel.new('Nodes', 'stat') +
-        panel.withDescription(|||
-          Node count.
-        |||) +
         panel.withPosition({ h: 9, w: 8, x: 0, y: 0 }) +
         panel.withQueries([
           panel.newInstantQuery(
@@ -124,7 +121,14 @@ local filename = 'agent-cluster-overview.json';
         panel.withPosition({ h: 9, w: 8, x: 0, y: 9 }) +
         panel.withQueries([
           panel.newInstantQuery(
-            expr='clamp((\r\n  sum(stddev by (state) (cluster_node_peers) != 0) or \r\n  (sum(abs(sum without (state) (cluster_node_peers)) - scalar(count(cluster_node_info)) != 0))\r\n), 1, 1)',
+            expr = ||| 
+              clamp((
+                sum(stddev by (state) (cluster_node_peers) != 0) or 
+                (sum(abs(sum without (state) (cluster_node_peers)) - scalar(count(cluster_node_info)) != 0))
+                ), 
+                1, 1
+              )
+|||,
             format='time_series'
           ),
         ]) +

--- a/operations/agent-flow-mixin/dashboards/utils/panel.jsonnet
+++ b/operations/agent-flow-mixin/dashboards/utils/panel.jsonnet
@@ -86,6 +86,16 @@
     },
   },
 
+  withCenteredAxis():: {
+    fieldConfig +: {
+      defaults +: {
+        custom +: {
+          axisCenteredZero: true,
+        }
+      }
+    }
+  },
+
   withPosition(pos):: { gridPos: pos },
   withDescription(desc):: { description: desc },
   withOptions(options):: { options: options },

--- a/operations/agent-flow-mixin/grizzly.jsonnet
+++ b/operations/agent-flow-mixin/grizzly.jsonnet
@@ -28,7 +28,7 @@ local mixin = import './mixin.libsonnet';
       kind: 'Dashboard',
       metadata: {
         folder: $.folder.metadata.name,
-        name: std.split(file, '.')[0],
+        name: std.md5(file),
       },
       spec: mixin.grafanaDashboards[file],
     }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

There was some feedback that _I thought_ I'd incorporated into #3744, but I'd committed them to the wrong branch, so apologies for missing them the first time out.

In this PR we've
a) Added actually helpful descriptions for panels that need one, and removed descriptions for self-explanatory panels
b) Made long queries into multi-line strings for better readability
c) Made the axis centered and fixed the legend for the Stream Bandwidth and Transport Bandwidth channels
d) Added a dirty hack so that relative dashboard links still work whenever Grafana splices part of the URL with the dashboards UID.

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer
Here's how the two affected panels look with their axis centered and their legend fixed. The difference between rx/tx is now more pronounced.

![image](https://user-images.githubusercontent.com/17771679/236202838-5c0b077d-5159-4951-90fc-3bdc75b63fc9.png)

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
