### PR TITLE
Fix issue where not providing config could result in panic

### DIFF
--- a/component/common/net/server.go
+++ b/component/common/net/server.go
@@ -23,6 +23,7 @@ type TargetServer struct {
 }
 
 // NewTargetServer creates a new TargetServer, applying some defaults to the server configuration.
+// If provided config is nil, a default configuration will be used instead.
 func NewTargetServer(logger log.Logger, metricsNamespace string, reg prometheus.Registerer, config *ServerConfig) (*TargetServer, error) {
 	if !model.IsValidMetricName(model.LabelValue(metricsNamespace)) {
 		return nil, fmt.Errorf("metrics namespace is not prometheus compatiible: %s", metricsNamespace)
@@ -31,6 +32,10 @@ func NewTargetServer(logger log.Logger, metricsNamespace string, reg prometheus.
 	ts := &TargetServer{
 		logger:           logger,
 		metricsNamespace: metricsNamespace,
+	}
+
+	if config == nil {
+		config = &ServerConfig{}
 	}
 
 	// convert from River into the weaveworks config

--- a/component/common/net/server_test.go
+++ b/component/common/net/server_test.go
@@ -3,30 +3,27 @@ package net
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 
-	"github.com/go-kit/log"
 	"github.com/gorilla/mux"
+	"github.com/grafana/agent/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTargetServer(t *testing.T) {
 	// dependencies
-	w := log.NewSyncWriter(os.Stderr)
-	logger := log.NewLogfmtLogger(w)
 	reg := prometheus.NewRegistry()
-
-	ts, err := NewTargetServer(logger, "test_namespace", reg, &ServerConfig{})
+	ts, err := NewTargetServer(util.TestLogger(t), "test_namespace", reg, &ServerConfig{})
 	require.NoError(t, err)
 
-	ts.MountAndRun(func(router *mux.Router) {
+	err = ts.MountAndRun(func(router *mux.Router) {
 		router.Methods("GET").Path("/hello").Handler(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
 	})
+	require.NoError(t, err)
 	defer ts.StopAndShutdown()
 
 	// test mounted endpoint
@@ -42,4 +39,17 @@ func TestTargetServer(t *testing.T) {
 	for _, m := range metrics {
 		require.True(t, strings.HasPrefix(m.GetName(), "test_namespace"))
 	}
+}
+
+func TestTargetServer_NilConfig(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	ts, err := NewTargetServer(util.TestLogger(t), "test_namespace", reg, nil)
+	require.NoError(t, err)
+
+	err = ts.MountAndRun(func(router *mux.Router) {})
+	require.NoError(t, err)
+	defer ts.StopAndShutdown()
+
+	require.Equal(t, "[::]:8080", ts.HTTPListenAddr())
+	require.Equal(t, "[::]:8081", ts.GRPCListenAddr())
 }

--- a/docs/sources/flow/reference/components/loki.source.heroku.md
+++ b/docs/sources/flow/reference/components/loki.source.heroku.md
@@ -51,10 +51,10 @@ before they're forwarded to the list of receivers in `forward_to`.
 
 The following blocks are supported inside the definition of `loki.source.heroku`:
 
-Hierarchy | Name | Description | Required
---------- | ---- | ----------- | --------
-`http`    | [http][]      | Configures the HTTP server that receives requests.              |  | no
-`grpc`    | [grpc][]      | Configures the gRPC server that receives requests.              |  | no
+ Hierarchy | Name     | Description                                        | Required 
+-----------|----------|----------------------------------------------------|----------
+ `http`    | [http][] | Configures the HTTP server that receives requests. | no       
+ `grpc`    | [grpc][] | Configures the gRPC server that receives requests. | no       
 
 [http]: #http
 [grpc]: #grpc


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
When not providing either `http` or `grpc` configuration blocks for `loki.source.(heroku|gcplog)`, the user may get a panic when starting the server.
This PR fixes this by replacing `nil` with default.

#### Which issue(s) this PR fixes
N/A
<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
