### PR TITLE
Sync WAL code with upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,12 +35,14 @@ Main (unreleased)
 - Support `clustering` block in `phlare.scrape` components to distribute
   targets amongst clustered agents. (@rfratto)
 
+- Delete stale series after a single WAL truncate instead of two. (@rfratto)
+
 ### Bugfixes
 
 - Fix issue where component evaluation time was overridden by a "default
   health" message. (@rfratto)
 
-- Fix an issue where defining `logging` or `tracing` blocks inside of a module 
+- Fix an issue where defining `logging` or `tracing` blocks inside of a module
   would generate a panic instead of returning an error. (@erikbaranowski)
 
 - Honor timeout when trying to establish a connection to another agent in Flow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ Main (unreleased)
 
 - Add metrics when clustering mode is enabled. (@rfratto)
 - Document debug metric `loki_process_dropped_lines_by_label_total` in loki.process. (@akselleirv)
+- Add `agent_wal_out_of_order_samples_total` metric to track samples received
+  out of order. (@rfratto)
 
 v0.33.1 (2023-05-01)
 --------------------

--- a/docs/sources/flow/reference/components/prometheus.remote_write.md
+++ b/docs/sources/flow/reference/components/prometheus.remote_write.md
@@ -89,7 +89,7 @@ Name | Type | Description | Default | Required
 
  At most one of the following can be provided:
  - [`bearer_token` argument](#endpoint-block).
- - [`bearer_token_file` argument](#endpoint-block). 
+ - [`bearer_token_file` argument](#endpoint-block).
  - [`basic_auth` block][basic_auth].
  - [`authorization` block][authorization].
  - [`oauth2` block][oauth2].
@@ -228,6 +228,8 @@ information.
   being tracked by the WAL.
 * `agent_wal_storage_deleted_series` (gauge): Current number of series marked
   for deletion from memory.
+* `agent_wal_out_of_order_samples_total` (counter): Total number of out of
+  order samples ingestion failed attempts.
 * `agent_wal_storage_created_series_total` (counter): Total number of created
   series appended to the WAL.
 * `agent_wal_storage_removed_series_total` (counter): Total number of series

--- a/pkg/metrics/wal/series.go
+++ b/pkg/metrics/wal/series.go
@@ -1,5 +1,9 @@
 package wal
 
+// This code is copied from
+// prometheus/prometheus@7c2de14b0bd74303c2ca6f932b71d4585a29ca75, with only
+// minor changes for metric names.
+
 import (
 	"sync"
 

--- a/pkg/metrics/wal/series.go
+++ b/pkg/metrics/wal/series.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 )
 
+// memSeries is a chunkless version of tsdb.memSeries.
 type memSeries struct {
 	sync.Mutex
 
@@ -36,7 +37,7 @@ func (m *memSeries) updateTimestamp(newTs int64) bool {
 // with the label set to avoid re-computing hash throughout the code.
 type seriesHashmap map[uint64][]*memSeries
 
-func (m seriesHashmap) get(hash uint64, lset labels.Labels) *memSeries {
+func (m seriesHashmap) Get(hash uint64, lset labels.Labels) *memSeries {
 	for _, s := range m[hash] {
 		if labels.Equal(s.lset, lset) {
 			return s
@@ -45,18 +46,18 @@ func (m seriesHashmap) get(hash uint64, lset labels.Labels) *memSeries {
 	return nil
 }
 
-func (m seriesHashmap) set(hash uint64, s *memSeries) {
-	l := m[hash]
-	for i, prev := range l {
+func (m seriesHashmap) Set(hash uint64, s *memSeries) {
+	seriesSet := m[hash]
+	for i, prev := range seriesSet {
 		if labels.Equal(prev.lset, s.lset) {
-			l[i] = s
+			seriesSet[i] = s
 			return
 		}
 	}
-	m[hash] = append(l, s)
+	m[hash] = append(seriesSet, s)
 }
 
-func (m seriesHashmap) del(hash uint64, ref chunks.HeadSeriesRef) {
+func (m seriesHashmap) Delete(hash uint64, ref chunks.HeadSeriesRef) {
 	var rem []*memSeries
 	for _, s := range m[hash] {
 		if s.ref != ref {
@@ -143,7 +144,7 @@ func (s *stripeSeries) gc(mint int64) map[chunks.HeadSeriesRef]struct{} {
 
 				deleted[series.ref] = struct{}{}
 				delete(s.series[refLock], series.ref)
-				s.hashes[hashLock].del(hash, series.ref)
+				s.hashes[hashLock].Delete(hash, series.ref)
 
 				// Since the series is gone, we'll also delete
 				// the latest stored exemplar.
@@ -162,21 +163,22 @@ func (s *stripeSeries) gc(mint int64) map[chunks.HeadSeriesRef]struct{} {
 	return deleted
 }
 
-func (s *stripeSeries) getByID(id chunks.HeadSeriesRef) *memSeries {
+func (s *stripeSeries) GetByID(id chunks.HeadSeriesRef) *memSeries {
 	refLock := uint64(id) & uint64(s.size-1)
 	s.locks[refLock].RLock()
 	defer s.locks[refLock].RUnlock()
 	return s.series[refLock][id]
 }
 
-func (s *stripeSeries) getByHash(hash uint64, lset labels.Labels) *memSeries {
+func (s *stripeSeries) GetByHash(hash uint64, lset labels.Labels) *memSeries {
 	hashLock := hash & uint64(s.size-1)
+
 	s.locks[hashLock].RLock()
 	defer s.locks[hashLock].RUnlock()
-	return s.hashes[hashLock].get(hash, lset)
+	return s.hashes[hashLock].Get(hash, lset)
 }
 
-func (s *stripeSeries) set(hash uint64, series *memSeries) {
+func (s *stripeSeries) Set(hash uint64, series *memSeries) {
 	var (
 		hashLock = hash & uint64(s.size-1)
 		refLock  = uint64(series.ref) & uint64(s.size-1)
@@ -192,11 +194,11 @@ func (s *stripeSeries) set(hash uint64, series *memSeries) {
 	s.locks[refLock].Unlock()
 
 	s.locks[hashLock].Lock()
-	s.hashes[hashLock].set(hash, series)
+	s.hashes[hashLock].Set(hash, series)
 	s.locks[hashLock].Unlock()
 }
 
-func (s *stripeSeries) getLatestExemplar(ref chunks.HeadSeriesRef) *exemplar.Exemplar {
+func (s *stripeSeries) GetLatestExemplar(ref chunks.HeadSeriesRef) *exemplar.Exemplar {
 	i := uint64(ref) & uint64(s.size-1)
 
 	s.locks[i].RLock()
@@ -206,7 +208,7 @@ func (s *stripeSeries) getLatestExemplar(ref chunks.HeadSeriesRef) *exemplar.Exe
 	return exemplar
 }
 
-func (s *stripeSeries) setLatestExemplar(ref chunks.HeadSeriesRef, exemplar *exemplar.Exemplar) {
+func (s *stripeSeries) SetLatestExemplar(ref chunks.HeadSeriesRef, exemplar *exemplar.Exemplar) {
 	i := uint64(ref) & uint64(s.size-1)
 
 	// Make sure that's a valid series id and record its latest exemplar

--- a/pkg/metrics/wal/wal.go
+++ b/pkg/metrics/wal/wal.go
@@ -1,5 +1,9 @@
 package wal
 
+// This code is copied from
+// prometheus/prometheus@7c2de14b0bd74303c2ca6f932b71d4585a29ca75, with only
+// minor changes for metric names.
+
 import (
 	"context"
 	"errors"

--- a/pkg/metrics/wal/wal.go
+++ b/pkg/metrics/wal/wal.go
@@ -124,8 +124,8 @@ type Storage struct {
 	appenderPool sync.Pool
 	bufPool      sync.Pool
 
-	ref    *atomic.Uint64
-	series *stripeSeries
+	nextRef *atomic.Uint64
+	series  *stripeSeries
 
 	deletedMtx sync.Mutex
 	deleted    map[chunks.HeadSeriesRef]int // Deleted series, and what WAL segment they must be kept until.
@@ -145,9 +145,9 @@ func NewStorage(logger log.Logger, registerer prometheus.Registerer, path string
 		wal:     w,
 		logger:  logger,
 		deleted: map[chunks.HeadSeriesRef]int{},
-		series:  newStripeSeries(),
+		series:  newStripeSeries(tsdb.DefaultStripeSize),
 		metrics: newStorageMetrics(registerer),
-		ref:     atomic.NewUint64(0),
+		nextRef: atomic.NewUint64(0),
 	}
 
 	storage.bufPool.New = func() interface{} {
@@ -157,10 +157,12 @@ func NewStorage(logger log.Logger, registerer prometheus.Registerer, path string
 
 	storage.appenderPool.New = func() interface{} {
 		return &appender{
-			w:         storage,
-			series:    make([]record.RefSeries, 0, 100),
-			samples:   make([]record.RefSample, 0, 100),
-			exemplars: make([]record.RefExemplar, 0, 10),
+			w:                      storage,
+			pendingSeries:          make([]record.RefSeries, 0, 100),
+			pendingSamples:         make([]record.RefSample, 0, 100),
+			pendingHistograms:      make([]record.RefHistogramSample, 0, 100),
+			pendingFloatHistograms: make([]record.RefFloatHistogramSample, 0, 100),
+			pendingExamplars:       make([]record.RefExemplar, 0, 10),
 		}
 	}
 
@@ -202,6 +204,8 @@ func (w *Storage) replayWAL() error {
 		return fmt.Errorf("find last checkpoint: %w", err)
 	}
 
+	multiRef := map[chunks.HeadSeriesRef]chunks.HeadSeriesRef{}
+
 	if err == nil {
 		sr, err := wlog.NewSegmentsReader(dir)
 		if err != nil {
@@ -215,7 +219,7 @@ func (w *Storage) replayWAL() error {
 
 		// A corrupted checkpoint is a hard error for now and requires user
 		// intervention. There's likely little data that can be recovered anyway.
-		if err := w.loadWAL(wlog.NewReader(sr)); err != nil {
+		if err := w.loadWAL(wlog.NewReader(sr), multiRef); err != nil {
 			return fmt.Errorf("backfill checkpoint: %w", err)
 		}
 		startFrom++
@@ -236,7 +240,7 @@ func (w *Storage) replayWAL() error {
 		}
 
 		sr := wlog.NewSegmentBufReader(s)
-		err = w.loadWAL(wlog.NewReader(sr))
+		err = w.loadWAL(wlog.NewReader(sr), multiRef)
 		if err := sr.Close(); err != nil {
 			level.Warn(w.logger).Log("msg", "error while closing the wal segments reader", "err", err)
 		}
@@ -249,12 +253,11 @@ func (w *Storage) replayWAL() error {
 	return nil
 }
 
-func (w *Storage) loadWAL(r *wlog.Reader) (err error) {
+func (w *Storage) loadWAL(r *wlog.Reader, multiRef map[chunks.HeadSeriesRef]chunks.HeadSeriesRef) (err error) {
 	var (
-		dec record.Decoder
-	)
+		dec     record.Decoder
+		lastRef = chunks.HeadSeriesRef(w.nextRef.Load())
 
-	var (
 		decoded    = make(chan interface{}, 10)
 		errCh      = make(chan error, 1)
 		seriesPool = sync.Pool{
@@ -265,6 +268,16 @@ func (w *Storage) loadWAL(r *wlog.Reader) (err error) {
 		samplesPool = sync.Pool{
 			New: func() interface{} {
 				return []record.RefSample{}
+			},
+		}
+		histogramsPool = sync.Pool{
+			New: func() interface{} {
+				return []record.RefHistogramSample{}
+			},
+		}
+		floatHistogramsPool = sync.Pool{
+			New: func() interface{} {
+				return []record.RefFloatHistogramSample{}
 			},
 		}
 	)
@@ -297,6 +310,30 @@ func (w *Storage) loadWAL(r *wlog.Reader) (err error) {
 					}
 				}
 				decoded <- samples
+			case record.HistogramSamples:
+				histograms := histogramsPool.Get().([]record.RefHistogramSample)[:0]
+				histograms, err = dec.HistogramSamples(rec, histograms)
+				if err != nil {
+					errCh <- &wlog.CorruptionErr{
+						Err:     fmt.Errorf("decode histogram samples: %w", err),
+						Segment: r.Segment(),
+						Offset:  r.Offset(),
+					}
+					return
+				}
+				decoded <- histograms
+			case record.FloatHistogramSamples:
+				floatHistograms := floatHistogramsPool.Get().([]record.RefFloatHistogramSample)[:0]
+				floatHistograms, err = dec.FloatHistogramSamples(rec, floatHistograms)
+				if err != nil {
+					errCh <- &wlog.CorruptionErr{
+						Err:     fmt.Errorf("decode float histogram samples: %w", err),
+						Segment: r.Segment(),
+						Offset:  r.Offset(),
+					}
+					return
+				}
+				decoded <- floatHistograms
 			case record.Tombstones, record.Exemplars:
 				// We don't care about decoding tombstones or exemplars
 				// TODO: If decide to decode exemplars, we should make sure to prepopulate
@@ -313,7 +350,7 @@ func (w *Storage) loadWAL(r *wlog.Reader) (err error) {
 		}
 	}()
 
-	var biggestRef uint64 = w.ref.Load()
+	var nonExistentSeriesRefs atomic.Uint64
 
 	for d := range decoded {
 		switch v := d.(type) {
@@ -326,12 +363,13 @@ func (w *Storage) loadWAL(r *wlog.Reader) (err error) {
 				if w.series.getByID(s.Ref) == nil {
 					series := &memSeries{ref: s.Ref, lset: s.Labels, lastTs: 0}
 					w.series.set(s.Labels.Hash(), series)
+					multiRef[s.Ref] = series.ref
 
 					w.metrics.numActiveSeries.Inc()
 					w.metrics.totalCreatedSeries.Inc()
 
-					if biggestRef <= uint64(s.Ref) {
-						biggestRef = uint64(s.Ref)
+					if s.Ref > lastRef {
+						lastRef = s.Ref
 					}
 				}
 			}
@@ -341,39 +379,72 @@ func (w *Storage) loadWAL(r *wlog.Reader) (err error) {
 		case []record.RefSample:
 			for _, s := range v {
 				// Update the lastTs for the series based
-				series := w.series.getByID(s.Ref)
-				if series == nil {
-					level.Warn(w.logger).Log("msg", "found sample referencing non-existing series, skipping")
+				ref, ok := multiRef[s.Ref]
+				if !ok {
+					nonExistentSeriesRefs.Inc()
 					continue
 				}
 
-				series.Lock()
+				series := w.series.getByID(ref)
 				if s.T > series.lastTs {
 					series.lastTs = s.T
 				}
-				series.Unlock()
 			}
 
 			//nolint:staticcheck
 			samplesPool.Put(v)
+		case []record.RefHistogramSample:
+			for _, entry := range v {
+				// Update the lastTs for the series based
+				ref, ok := multiRef[entry.Ref]
+				if !ok {
+					nonExistentSeriesRefs.Inc()
+					continue
+				}
+				series := w.series.getByID(ref)
+				if entry.T > series.lastTs {
+					series.lastTs = entry.T
+				}
+			}
+
+			//nolint:staticcheck
+			histogramsPool.Put(v)
+		case []record.RefFloatHistogramSample:
+			for _, entry := range v {
+				// Update the lastTs for the series based
+				ref, ok := multiRef[entry.Ref]
+				if !ok {
+					nonExistentSeriesRefs.Inc()
+					continue
+				}
+				series := w.series.getByID(ref)
+				if entry.T > series.lastTs {
+					series.lastTs = entry.T
+				}
+			}
+
+			//nolint:staticcheck
+			floatHistogramsPool.Put(v)
 		default:
 			panic(fmt.Errorf("unexpected decoded type: %T", d))
 		}
 	}
 
-	w.ref.Store(biggestRef)
+	if v := nonExistentSeriesRefs.Load(); v > 0 {
+		level.Warn(w.logger).Log("msg", "found sample referencing non-existing series", "skipped_series", v)
+	}
+
+	w.nextRef.Store(uint64(lastRef))
 
 	select {
 	case err := <-errCh:
 		return err
 	default:
+		if r.Err() != nil {
+			return fmt.Errorf("read records: %w", err)
+		}
+		return nil
 	}
-
-	if r.Err() != nil {
-		return fmt.Errorf("read records: %w", r.Err())
-	}
-
-	return nil
 }
 
 // Directory returns the path where the WAL storage is held.
@@ -437,10 +508,8 @@ func (w *Storage) Truncate(mint int64) error {
 			return true
 		}
 
-		w.deletedMtx.Lock()
-		_, ok := w.deleted[id]
-		w.deletedMtx.Unlock()
-		return ok
+		seg, ok := w.deleted[id]
+		return ok && seg > last
 	}
 	if _, err = wlog.Checkpoint(w.logger, w.wal, first, last, keep, mint); err != nil {
 		return fmt.Errorf("create checkpoint: %w", err)
@@ -454,7 +523,6 @@ func (w *Storage) Truncate(mint int64) error {
 
 	// The checkpoint is written and segments before it is truncated, so we no
 	// longer need to track deleted series that are before it.
-	w.deletedMtx.Lock()
 	for ref, segment := range w.deleted {
 		if segment < first {
 			delete(w.deleted, ref)
@@ -462,7 +530,6 @@ func (w *Storage) Truncate(mint int64) error {
 		}
 	}
 	w.metrics.numDeletedSeries.Set(float64(len(w.deleted)))
-	w.deletedMtx.Unlock()
 
 	if err := wlog.DeleteCheckpoints(w.wal.Dir(), last); err != nil {
 		// Leftover old checkpoints do not cause problems down the line beyond
@@ -482,17 +549,10 @@ func (w *Storage) gc(mint int64) {
 	w.metrics.numActiveSeries.Sub(float64(len(deleted)))
 
 	_, last, _ := wlog.Segments(w.wal.Dir())
-	w.deletedMtx.Lock()
-	defer w.deletedMtx.Unlock()
 
 	// We want to keep series records for any newly deleted series
-	// until we've passed the last recorded segment. The WAL will
-	// still contain samples records with all of the ref IDs until
-	// the segment's samples has been deleted from the checkpoint.
-	//
-	// If the series weren't kept on startup when the WAL was replied,
-	// the samples wouldn't be able to be used since there wouldn't
-	// be any labels for that ref ID.
+	// until we've passed the last recorded segment. This prevents
+	// the WAL having samples for series records that no longer exist.
 	for ref := range deleted {
 		w.deleted[ref] = last
 	}
@@ -577,12 +637,24 @@ func (w *Storage) Close() error {
 }
 
 type appender struct {
-	w               *Storage
-	series          []record.RefSeries
-	samples         []record.RefSample
-	exemplars       []record.RefExemplar
-	histograms      []record.RefHistogramSample
-	floatHistograms []record.RefFloatHistogramSample
+	w                      *Storage
+	pendingSeries          []record.RefSeries
+	pendingSamples         []record.RefSample
+	pendingExamplars       []record.RefExemplar
+	pendingHistograms      []record.RefHistogramSample
+	pendingFloatHistograms []record.RefFloatHistogramSample
+
+	// Pointers to the series referenced by each element of pendingSamples.
+	// Series lock is not held on elements.
+	sampleSeries []*memSeries
+
+	// Pointers to the series referenced by each element of pendingHistograms.
+	// Series lock is not held on elements.
+	histogramSeries []*memSeries
+
+	// Pointers to the series referenced by each element of pendingFloatHistograms.
+	// Series lock is not held on elements.
+	floatHistogramSeries []*memSeries
 }
 
 var _ storage.Appender = (*appender)(nil)
@@ -604,7 +676,7 @@ func (a *appender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v flo
 		var created bool
 		series, created = a.getOrCreate(l)
 		if created {
-			a.series = append(a.series, record.RefSeries{
+			a.pendingSeries = append(a.pendingSeries, record.RefSeries{
 				Ref:    series.ref,
 				Labels: l,
 			})
@@ -617,21 +689,101 @@ func (a *appender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v flo
 	series.Lock()
 	defer series.Unlock()
 
-	// Update last recorded timestamp. Used by Storage.gc to determine if a
-	// series is stale.
-	series.updateTs(t)
+	if t < series.lastTs {
+		return 0, storage.ErrOutOfOrderSample
+	}
 
-	a.samples = append(a.samples, record.RefSample{
+	// NOTE(rfratto): always modify pendingSamples and sampleSeries together.
+	a.pendingSamples = append(a.pendingSamples, record.RefSample{
 		Ref: series.ref,
 		T:   t,
 		V:   v,
 	})
+	a.sampleSeries = append(a.sampleSeries, series)
 
 	a.w.metrics.totalAppendedSamples.Inc()
 	return storage.SeriesRef(series.ref), nil
 }
 
+func (a *appender) getOrCreate(l labels.Labels) (series *memSeries, created bool) {
+	hash := l.Hash()
+
+	series = a.w.series.getByHash(hash, l)
+	if series != nil {
+		return series, false
+	}
+
+	ref := chunks.HeadSeriesRef(a.w.nextRef.Inc())
+	series = &memSeries{ref: ref, lset: l, lastTs: math.MinInt64}
+	a.w.series.set(l.Hash(), series)
+	return series, true
+}
+
+func (a *appender) AppendExemplar(ref storage.SeriesRef, _ labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
+	readRef := chunks.HeadSeriesRef(ref)
+
+	s := a.w.series.getByID(readRef)
+	if s == nil {
+		return 0, fmt.Errorf("unknown series ref when trying to add exemplar: %d", readRef)
+	}
+
+	// Ensure no empty labels have gotten through.
+	e.Labels = e.Labels.WithoutEmpty()
+
+	if lbl, dup := e.Labels.HasDuplicateLabelNames(); dup {
+		return 0, fmt.Errorf("label name %q is not unique: %w", lbl, tsdb.ErrInvalidExemplar)
+	}
+
+	// Exemplar label length does not include chars involved in text rendering such as quotes
+	// equals sign, or commas. See definition of const ExemplarMaxLabelLength.
+	labelSetLen := 0
+	err := e.Labels.Validate(func(l labels.Label) error {
+		labelSetLen += utf8.RuneCountInString(l.Name)
+		labelSetLen += utf8.RuneCountInString(l.Value)
+
+		if labelSetLen > exemplar.ExemplarMaxLabelSetLength {
+			return storage.ErrExemplarLabelLength
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	// Check for duplicate vs last stored exemplar for this series, and discard those.
+	// Otherwise, record the current exemplar as the latest.
+	// Prometheus' TSDB returns 0 when encountering duplicates, so we do the same here.
+	prevExemplar := a.w.series.getLatestExemplar(s.ref)
+	if prevExemplar != nil && prevExemplar.Equals(e) {
+		// Duplicate, don't return an error but don't accept the exemplar.
+		return 0, nil
+	}
+	a.w.series.setLatestExemplar(s.ref, &e)
+
+	a.pendingExamplars = append(a.pendingExamplars, record.RefExemplar{
+		Ref:    readRef,
+		T:      e.Ts,
+		V:      e.Value,
+		Labels: e.Labels,
+	})
+
+	a.w.metrics.totalAppendedExemplars.Inc()
+	return storage.SeriesRef(s.ref), nil
+}
+
 func (a *appender) AppendHistogram(ref storage.SeriesRef, l labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
+	if h != nil {
+		if err := tsdb.ValidateHistogram(h); err != nil {
+			return 0, err
+		}
+	}
+
+	if fh != nil {
+		if err := tsdb.ValidateFloatHistogram(fh); err != nil {
+			return 0, err
+		}
+	}
+
 	series := a.w.series.getByID(chunks.HeadSeriesRef(ref))
 	if series == nil {
 		// Ensure no empty or duplicate labels have gotten through. This mirrors the
@@ -648,7 +800,7 @@ func (a *appender) AppendHistogram(ref storage.SeriesRef, l labels.Labels, t int
 		var created bool
 		series, created = a.getOrCreate(l)
 		if created {
-			a.series = append(a.series, record.RefSeries{
+			a.pendingSeries = append(a.pendingSeries, record.RefSeries{
 				Ref:    series.ref,
 				Labels: l,
 			})
@@ -661,88 +813,33 @@ func (a *appender) AppendHistogram(ref storage.SeriesRef, l labels.Labels, t int
 	series.Lock()
 	defer series.Unlock()
 
-	// Update last recorded timestamp. Used by Storage.gc to determine if a
-	// series is stale.
-	series.updateTs(t)
+	if t < series.lastTs {
+		return 0, storage.ErrOutOfOrderSample
+	}
 
-	if h != nil {
-		a.histograms = append(a.histograms, record.RefHistogramSample{
+	switch {
+	case h != nil:
+		// NOTE(rfratto): always modify pendingHistograms and histogramSeries
+		// together.
+		a.pendingHistograms = append(a.pendingHistograms, record.RefHistogramSample{
 			Ref: series.ref,
 			T:   t,
 			H:   h,
 		})
-	}
-	if fh != nil {
-		a.floatHistograms = append(a.floatHistograms, record.RefFloatHistogramSample{
+		a.histogramSeries = append(a.histogramSeries, series)
+	case fh != nil:
+		// NOTE(rfratto): always modify pendingFloatHistograms and
+		// floatHistogramSeries together.
+		a.pendingFloatHistograms = append(a.pendingFloatHistograms, record.RefFloatHistogramSample{
 			Ref: series.ref,
 			T:   t,
 			FH:  fh,
 		})
+		a.floatHistogramSeries = append(a.floatHistogramSeries, series)
 	}
 
 	a.w.metrics.totalAppendedSamples.Inc()
 	return storage.SeriesRef(series.ref), nil
-}
-
-func (a *appender) getOrCreate(l labels.Labels) (series *memSeries, created bool) {
-	hash := l.Hash()
-
-	series = a.w.series.getByHash(hash, l)
-	if series != nil {
-		return series, false
-	}
-
-	ref := chunks.HeadSeriesRef(a.w.ref.Inc())
-	series = &memSeries{ref: ref, lset: l}
-	a.w.series.set(l.Hash(), series)
-	return series, true
-}
-
-func (a *appender) AppendExemplar(ref storage.SeriesRef, _ labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
-	cref := chunks.HeadSeriesRef(ref)
-	s := a.w.series.getByID(cref)
-	if s == nil {
-		return 0, fmt.Errorf("unknown series ref. when trying to add exemplar: %d", cref)
-	}
-
-	// Ensure no empty labels have gotten through.
-	e.Labels = e.Labels.WithoutEmpty()
-
-	if lbl, dup := e.Labels.HasDuplicateLabelNames(); dup {
-		return 0, fmt.Errorf("label name %q is not unique: %w", lbl, tsdb.ErrInvalidExemplar)
-	}
-
-	// Exemplar label length does not include chars involved in text rendering such as quotes
-	// equals sign, or commas. See definition of const ExemplarMaxLabelLength.
-	labelSetLen := 0
-	for _, l := range e.Labels {
-		labelSetLen += utf8.RuneCountInString(l.Name)
-		labelSetLen += utf8.RuneCountInString(l.Value)
-
-		if labelSetLen > exemplar.ExemplarMaxLabelSetLength {
-			return 0, storage.ErrExemplarLabelLength
-		}
-	}
-
-	// Check for duplicate vs last stored exemplar for this series, and discard those.
-	// Otherwise, record the current exemplar as the latest.
-	// Prometheus returns 0 when encountering duplicates, so we do the same here.
-	prevExemplar := a.w.series.getLatestExemplar(cref)
-	if prevExemplar != nil && prevExemplar.Equals(e) {
-		// Duplicate, don't return an error but don't accept the exemplar.
-		return 0, nil
-	}
-	a.w.series.setLatestExemplar(cref, &e)
-
-	a.exemplars = append(a.exemplars, record.RefExemplar{
-		Ref:    cref,
-		T:      e.Ts,
-		V:      e.Value,
-		Labels: e.Labels,
-	})
-
-	a.w.metrics.totalAppendedExemplars.Inc()
-	return storage.SeriesRef(s.ref), nil
 }
 
 func (a *appender) UpdateMetadata(ref storage.SeriesRef, _ labels.Labels, m metadata.Metadata) (storage.SeriesRef, error) {
@@ -762,67 +859,74 @@ func (a *appender) Commit() error {
 	var encoder record.Encoder
 	buf := a.w.bufPool.Get().([]byte)
 
-	if len(a.series) > 0 {
-		buf = encoder.Series(a.series, buf)
+	if len(a.pendingSeries) > 0 {
+		buf = encoder.Series(a.pendingSeries, buf)
 		if err := a.w.wal.Log(buf); err != nil {
 			return err
 		}
 		buf = buf[:0]
 	}
 
-	if len(a.samples) > 0 {
-		buf = encoder.Samples(a.samples, buf)
+	if len(a.pendingSamples) > 0 {
+		buf = encoder.Samples(a.pendingSamples, buf)
 		if err := a.w.wal.Log(buf); err != nil {
 			return err
 		}
 		buf = buf[:0]
 	}
 
-	if len(a.exemplars) > 0 {
-		buf = encoder.Exemplars(a.exemplars, buf)
+	if len(a.pendingExamplars) > 0 {
+		buf = encoder.Exemplars(a.pendingExamplars, buf)
 		if err := a.w.wal.Log(buf); err != nil {
 			return err
 		}
 		buf = buf[:0]
 	}
 
-	if len(a.histograms) > 0 {
-		buf = encoder.HistogramSamples(a.histograms, buf)
+	if len(a.pendingHistograms) > 0 {
+		buf = encoder.HistogramSamples(a.pendingHistograms, buf)
 		if err := a.w.wal.Log(buf); err != nil {
 			return err
 		}
 		buf = buf[:0]
 	}
 
-	if len(a.floatHistograms) > 0 {
-		buf = encoder.FloatHistogramSamples(a.floatHistograms, buf)
+	if len(a.pendingFloatHistograms) > 0 {
+		buf = encoder.FloatHistogramSamples(a.pendingFloatHistograms, buf)
 		if err := a.w.wal.Log(buf); err != nil {
 			return err
 		}
 		buf = buf[:0]
+	}
+
+	var series *memSeries
+	for i, s := range a.pendingSamples {
+		series = a.sampleSeries[i]
+		series.updateTimestamp(s.T)
+	}
+	for i, s := range a.pendingHistograms {
+		series = a.histogramSeries[i]
+		series.updateTimestamp(s.T)
+	}
+	for i, s := range a.pendingFloatHistograms {
+		series = a.floatHistogramSeries[i]
+		series.updateTimestamp(s.T)
 	}
 
 	//nolint:staticcheck
 	a.w.bufPool.Put(buf)
-
-	for _, sample := range a.samples {
-		series := a.w.series.getByID(sample.Ref)
-		if series != nil {
-			series.Lock()
-			series.pendingCommit = false
-			series.Unlock()
-		}
-	}
-
 	return a.Rollback()
 }
 
 func (a *appender) Rollback() error {
-	a.series = a.series[:0]
-	a.samples = a.samples[:0]
-	a.exemplars = a.exemplars[:0]
-	a.histograms = a.histograms[:0]
-	a.floatHistograms = a.floatHistograms[:0]
+	a.pendingSeries = a.pendingSeries[:0]
+	a.pendingSamples = a.pendingSamples[:0]
+	a.pendingHistograms = a.pendingHistograms[:0]
+	a.pendingFloatHistograms = a.pendingFloatHistograms[:0]
+	a.pendingExamplars = a.pendingExamplars[:0]
+	a.sampleSeries = a.sampleSeries[:0]
+	a.histogramSeries = a.histogramSeries[:0]
+	a.floatHistogramSeries = a.floatHistogramSeries[:0]
 	a.w.appenderPool.Put(a)
 	return nil
 }

--- a/pkg/metrics/wal/wal.go
+++ b/pkg/metrics/wal/wal.go
@@ -134,9 +134,7 @@ type Storage struct {
 
 	nextRef *atomic.Uint64
 	series  *stripeSeries
-
-	deletedMtx sync.Mutex
-	deleted    map[chunks.HeadSeriesRef]int // Deleted series, and what WAL segment they must be kept until.
+	deleted map[chunks.HeadSeriesRef]int // Deleted series, and what WAL segment they must be kept until.
 
 	metrics *storageMetrics
 }

--- a/pkg/metrics/wal/wal_test.go
+++ b/pkg/metrics/wal/wal_test.go
@@ -230,7 +230,7 @@ func TestStorage_ExistingWAL_RefID(t *testing.T) {
 	require.NoError(t, err)
 	defer require.NoError(t, s.Close())
 
-	require.Equal(t, uint64(len(payload)), s.ref.Load(), "cached ref ID should be equal to the number of series written")
+	require.Equal(t, uint64(len(payload)), s.nextRef.Load(), "cached ref ID should be equal to the number of series written")
 }
 
 func TestStorage_Truncate(t *testing.T) {


### PR DESCRIPTION
This commit synchronizes the WAL code with the upstream tsdb/agent code in Prometheus. I synced the code  against the latest main commit at the time of starting the commit; prometheus/prometheus@7c2de14b0bd74303c2ca6f932b71d4585a29ca75.  

For now, I opted to synchronize the code instead of importing upstream literally for two reasons:

1. Importing upstream literally will require more effort and be a breaking change, as the metrics and metric names used by upstream are different than the names we had selected. 
2. For now, we may want to continue to experiment with changes to WAL storage downstream, such as for clustering and cleaning up memory faster. 

This change should have little-to-no noticeable impact on end users, with one exception being that each series should use slightly less memory (2 bytes less, due to removing two bools) and will GC stale series after one truncate rather than two.