### PR TITLE
agent-flow-mixin: Add convergence state timeline

### DIFF
--- a/operations/agent-flow-mixin/grizzly.jsonnet
+++ b/operations/agent-flow-mixin/grizzly.jsonnet
@@ -10,45 +10,5 @@
 // To deploy alerts and recording rules, set up the environment variables used
 // by cortextool to authenticate with a Prometheus or Alertmanager intance.
 
-local mixin = import './mixin.libsonnet';
-
-{
-  folder: {
-    apiVersion: 'grizzly.grafana.com/v1alpha1',
-    kind: 'DashboardFolder',
-    metadata: {
-      name: 'grafana-agent-flow',
-    },
-    spec: {
-      title: mixin.grafanaDashboardFolder,
-    },
-  },
-
-  dashboards: {
-    [file]: {
-      apiVersion: 'grizzly.grafana.com/v1alpha1',
-      kind: 'Dashboard',
-      metadata: {
-        folder: $.folder.metadata.name,
-        name: std.md5(file),
-      },
-      spec: mixin.grafanaDashboards[file],
-    }
-    for file in std.objectFields(mixin.grafanaDashboards)
-  },
-
-
-  prometheus_rules: {
-    [file]: {
-      apiVersion: 'grizzly.grafana.com/v1alpha1',
-      kind: 'PrometheusRuleGroup',
-      metadata: {
-        folder: $.folder.metadata.name,
-        namespace: 'agent-flow',
-        name: std.split(file, '.')[0],
-      },
-      spec: mixin.prometheusAlerts[file],
-    }
-    for file in std.objectFields(mixin.prometheusAlerts)
-  },
-}
+(import './grizzly/dashboards.jsonnet') +
+(import './grizzly/alerts.jsonnet')

--- a/operations/agent-flow-mixin/grizzly/alerts.jsonnet
+++ b/operations/agent-flow-mixin/grizzly/alerts.jsonnet
@@ -1,0 +1,17 @@
+local mixin = import '../mixin.libsonnet';
+
+{
+  prometheus_rules: {
+    [file]: {
+      apiVersion: 'grizzly.grafana.com/v1alpha1',
+      kind: 'PrometheusRuleGroup',
+      metadata: {
+        folder: $.folder.metadata.name,
+        namespace: 'agent-flow',
+        name: std.split(file, '.')[0],
+      },
+      spec: mixin.prometheusAlerts[file],
+    }
+    for file in std.objectFields(mixin.prometheusAlerts)
+  },
+}

--- a/operations/agent-flow-mixin/grizzly/dashboards.jsonnet
+++ b/operations/agent-flow-mixin/grizzly/dashboards.jsonnet
@@ -1,0 +1,27 @@
+local mixin = import '../mixin.libsonnet';
+
+{
+  folder: {
+    apiVersion: 'grizzly.grafana.com/v1alpha1',
+    kind: 'DashboardFolder',
+    metadata: {
+      name: 'grafana-agent-flow',
+    },
+    spec: {
+      title: mixin.grafanaDashboardFolder,
+    },
+  },
+
+  dashboards: {
+    [file]: {
+      apiVersion: 'grizzly.grafana.com/v1alpha1',
+      kind: 'Dashboard',
+      metadata: {
+        folder: $.folder.metadata.name,
+        name: std.md5(file),
+      },
+      spec: mixin.grafanaDashboards[file],
+    }
+    for file in std.objectFields(mixin.grafanaDashboards)
+  },
+}


### PR DESCRIPTION
This adds a convergence state timeline to the overview dashboard, allowing users to see a history of when the cluster was converged or not converged, along with the time it took to transition between the states.

<img width="1444" alt="image" src="https://user-images.githubusercontent.com/630212/236488548-78cdd099-a909-4c4d-a89f-9677b70a346b.png">

Additionally, Grizzly functionality has been split into multiple files in a folder. This allows the primary grizzly.jsonnet entry file to be used for syncing everything, while allowing developers to opt in to only developing a specific set of resources (like dashboards but not alerts).