### PR TITLE
flow/operator: Move label matching into service discovery configs

### DIFF
--- a/component/prometheus/operator/common/crdmanager.go
+++ b/component/prometheus/operator/common/crdmanager.go
@@ -109,13 +109,8 @@ func (c *crdManager) Run(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return nil
-		case pools := <-c.discoveryManager.SyncCh():
-			for pName, groups := range pools {
-				for _, group := range groups {
-					fmt.Println(pName, group.Source, len(group.Targets), "!!!!!")
-				}
-			}
-			targetSetsChan <- pools
+		case m := <-c.discoveryManager.SyncCh():
+			targetSetsChan <- m
 		}
 	}
 }

--- a/component/prometheus/operator/common/crdmanager.go
+++ b/component/prometheus/operator/common/crdmanager.go
@@ -109,8 +109,13 @@ func (c *crdManager) Run(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return nil
-		case m := <-c.discoveryManager.SyncCh():
-			targetSetsChan <- m
+		case pools := <-c.discoveryManager.SyncCh():
+			for pName, groups := range pools {
+				for _, group := range groups {
+					fmt.Println(pName, group.Source, len(group.Targets), "!!!!!")
+				}
+			}
+			targetSetsChan <- pools
 		}
 	}
 }

--- a/component/prometheus/operator/configgen/config_gen.go
+++ b/component/prometheus/operator/configgen/config_gen.go
@@ -32,6 +32,7 @@ func (cg *ConfigGenerator) generateK8SSDConfig(
 	attachMetadata *promopv1.AttachMetadata,
 	matchLabels map[string]string,
 ) *promk8s.SDConfig {
+
 	cfg := &promk8s.SDConfig{
 		Role: role,
 	}

--- a/component/prometheus/operator/configgen/config_gen.go
+++ b/component/prometheus/operator/configgen/config_gen.go
@@ -25,13 +25,23 @@ var (
 // generateK8SSDConfig generates a kubernetes service discovery config based on the given namespace selector.
 // The k8s sd config is mostly dependent on our local config for accessing the kubernetes cluster.
 // If undefined it will default to an in-cluster config
-func (cg *ConfigGenerator) generateK8SSDConfig(namespaceSelector promopv1.NamespaceSelector, namespace string, role promk8s.Role, attachMetadata *promopv1.AttachMetadata) *promk8s.SDConfig {
+func (cg *ConfigGenerator) generateK8SSDConfig(
+	namespaceSelector promopv1.NamespaceSelector,
+	namespace string,
+	role promk8s.Role,
+	attachMetadata *promopv1.AttachMetadata,
+	matchLabels map[string]string,
+) *promk8s.SDConfig {
 	cfg := &promk8s.SDConfig{
 		Role: role,
 	}
 	namespaces := cg.getNamespacesFromNamespaceSelector(namespaceSelector, namespace)
 	if len(namespaces) != 0 {
 		cfg.NamespaceDiscovery.Names = namespaces
+	}
+	for k, v := range matchLabels {
+		sel := promk8s.SelectorConfig{Role: role, Label: fmt.Sprintf("%s=%s", k, v)}
+		cfg.Selectors = append(cfg.Selectors, sel)
 	}
 	client := cg.Client
 	if client.KubeConfig != "" {

--- a/component/prometheus/operator/configgen/config_gen_podmonitor_test.go
+++ b/component/prometheus/operator/configgen/config_gen_podmonitor_test.go
@@ -152,9 +152,6 @@ func TestGeneratePodMonitorConfig(t *testing.T) {
 			expectedRelabels: util.Untab(`
 				- source_labels: [job]
 				  target_label: __tmp_prometheus_job_name
-				- action: keep
-				  regex: (bar);true
-				  source_labels: [__meta_kubernetes_pod_label_foo,__meta_kubernetes_pod_labelpresent_foo]
 				- source_labels: [__meta_kubernetes_pod_label_key,__meta_kubernetes_pod_labelpresent_key]
 				  regex: "(val0|val1);true"
 				  action: keep
@@ -231,6 +228,12 @@ func TestGeneratePodMonitorConfig(t *testing.T) {
 						NamespaceDiscovery: promk8s.NamespaceDiscovery{
 							IncludeOwnNamespace: false,
 							Names:               []string{"ns_a", "ns_b"},
+						},
+						Selectors: []promk8s.SelectorConfig{
+							{
+								Role:  promk8s.RolePod,
+								Label: "foo=bar",
+							},
 						},
 					},
 				},

--- a/component/prometheus/operator/configgen/config_gen_servicemonitor_test.go
+++ b/component/prometheus/operator/configgen/config_gen_servicemonitor_test.go
@@ -166,9 +166,6 @@ func TestGenerateServiceMonitorConfig(t *testing.T) {
 			expectedRelabels: util.Untab(`
 				- source_labels: [job]
 				  target_label: __tmp_prometheus_job_name
-				- source_labels: [__meta_kubernetes_service_label_foo, __meta_kubernetes_service_labelpresent_foo]
-				  action: keep
-				  regex: (bar);true
 				- source_labels: [__meta_kubernetes_service_label_key, __meta_kubernetes_service_labelpresent_key]
 				  action: keep
 				  regex: (val0|val1);true
@@ -257,6 +254,12 @@ func TestGenerateServiceMonitorConfig(t *testing.T) {
 						NamespaceDiscovery: promk8s.NamespaceDiscovery{
 							IncludeOwnNamespace: false,
 							Names:               []string{"ns_a", "ns_b"},
+						},
+						Selectors: []promk8s.SelectorConfig{
+							{
+								Role:  promk8s.RoleEndpoint,
+								Label: "foo=bar",
+							},
 						},
 					},
 				},

--- a/component/prometheus/operator/configgen/config_gen_test.go
+++ b/component/prometheus/operator/configgen/config_gen_test.go
@@ -127,7 +127,7 @@ func TestGenerateK8SSDConfig(t *testing.T) {
 			cg := &ConfigGenerator{
 				Client: tt.client,
 			}
-			got := cg.generateK8SSDConfig(promopv1.NamespaceSelector{}, "", promk8s.RoleEndpoint, tt.attachMetadata)
+			got := cg.generateK8SSDConfig(promopv1.NamespaceSelector{}, "", promk8s.RoleEndpoint, tt.attachMetadata, nil)
 			assert.Equal(t, tt.expected, got)
 		})
 	}


### PR DESCRIPTION
This is a significant change from how the current operator generates scrape configs, but I think a useful one.

Currently, for each PodMonitor, we generate a kubernetesSD entry that catches ALL pods in the cluster. We also add relabel rules for each specified label match the PodMonitor specifies. This means we will repeatedly be fetching huge lists of pods, and passing them from the discoveryManager to the scrapeManager, only for the scrapeManager to immediately discard almost all of them in the relabeling phase.

This changes a little bit of that. Any labels specified in a Monitor's `Spec.Selector.MatchLabels` will be converted to a selector on the service discovery config. There may be tradeoffs here, but I think we still come out ahead:

### Pros:
- Fewer targets returned by discovery means we use less memory and cpu to relabel and discard uneeded targets.
- We will consume less bandwidth to the k8s api server as less data is transfered.

### Cons:
- We may be shifting the load of filtering into the k8s api server. This change should not add or remove connection (pooling and sharing discoveries across all monitors would be a much larger optimization, but also much more difficult). My gut says the api server should deal with this just fine, but it is the main thing we'd need to watch out for.

There is a note in the prometheus config docs that may be relevant:

> Note: When making decision about using field/label selector make sure that this
 is the best approach - it will prevent Prometheus from reusing single list/watch
 for all scrape configs. This might result in a bigger load on the Kubernetes API,
 because per each selector combination there will be additional LIST/WATCH. On the other hand,
 if you just want to monitor small subset of pods in large cluster it's recommended to use selectors.
 Decision, if selectors should be used or not depends on the particular situation.

I am not sure this is relevant to this situation though, because each SD is running independently. UNLESS there is code deep in the bowels that is combining these queries, I do not think we are saving on list/watch requests.
