### PR TITLE
docs: document how to expose the UI to other machines on the network

### DIFF
--- a/docs/sources/flow/install/docker.md
+++ b/docs/sources/flow/install/docker.md
@@ -52,6 +52,11 @@ The last line may be modified to change the arguments passed to the Grafana
 Agent Flow binary. To see the set of options available to the `run` command,
 refer to the documentation for [run][].
 
+> **NOTE**: Make sure to pass `--server.http.listen-addr=0.0.0.0:12345` as an
+> argument like in the example above, otherwise the [debugging UI][] won't be
+> available outside of the Docker container.
+
+[debugging UI]: {{< relref "../monitoring/debugging.md#grafana-agent-flow-ui" >}}
 [run]: {{< relref "../reference/cli/run.md" >}}
 
 ## Run a Windows Docker container
@@ -77,6 +82,11 @@ The last line may be modified to change the arguments passed to the Grafana
 Agent Flow binary. To see the set of options available to the `run` command,
 refer to the documentation for [run][].
 
+> **NOTE**: Make sure to pass `--server.http.listen-addr=0.0.0.0:12345` as an
+> argument like in the example above, otherwise the [debugging UI][] won't be
+> available outside of the Docker container.
+
+[debugging UI]: {{< relref "../monitoring/debugging.md#grafana-agent-flow-ui" >}}
 [run]: {{< relref "../reference/cli/run.md" >}}
 
 ## Result
@@ -89,4 +99,3 @@ To validate that Grafana Agent Flow is running successfully, navigate to
 without error.
 
 [UI]: {{< relref "../monitoring/debugging.md#grafana-agent-flow-ui" >}}
-

--- a/docs/sources/flow/install/linux.md
+++ b/docs/sources/flow/install/linux.md
@@ -169,7 +169,7 @@ To expose the UI to other machines, complete the following steps:
    to edit command line flags passed to Grafana Agent Flow, including the
    following customizations:
 
-    1. Add the following command line arugment to `CUSTOM_ARGS`:
+    1. Add the following command line argument to `CUSTOM_ARGS`:
 
        ```
        --server.http.listen-addr=LISTEN_ADDR:12345

--- a/docs/sources/flow/install/linux.md
+++ b/docs/sources/flow/install/linux.md
@@ -157,6 +157,32 @@ refer to the documentation for the [run][] command.
 
 [run]: {{< relref "../reference/cli/run.md" >}}
 
+### Exposing the UI to other machines
+
+By default, Grafana Agent Flow listens on the local network for its HTTP
+server. This prevents other machines on the network from being able to access
+the [UI for debugging][UI].
+
+To expose the UI to other machines, complete the following steps:
+
+1. Follow [Passing additional command-line flags](#passing-additional-command-line-flags)
+   to edit command line flags passed to Grafana Agent Flow, including the
+   following customizations:
+
+    1. Add the following command line arugment to `CUSTOM_ARGS`:
+
+       ```
+       --server.http.listen-addr=LISTEN_ADDR:12345
+       ```
+
+       Replace `LISTEN_ADDR` with an address which other machines on the
+       network have access to, like the network IP address of the machine
+       Grafana Agent Flow is running on.
+
+       To listen on all interfaces, replace `LISTEN_ADDR` with `0.0.0.0`.
+
+[UI]: {{< relref "../monitoring/debugging.md#grafana-agent-flow-ui" >}}
+
 ### Viewing Grafana Agent Flow logs
 
 Logs of Grafana Agent Flow can be found by running the following command in a

--- a/docs/sources/flow/install/macos.md
+++ b/docs/sources/flow/install/macos.md
@@ -107,6 +107,27 @@ steps:
    brew services restart grafana-agent-flow
    ```
 
+### Exposing the UI to other machines
+
+By default, Grafana Agent Flow listens on the local network for its HTTP
+server. This prevents other machines on the network from being able to access
+the [UI for debugging][UI].
+
+To expose the UI to other machines, complete the following steps:
+
+1. Follow [Configuring the Grafana Agent Flow service](#configuring-the-grafana-agent-flow-service)
+   to edit command line flags passed to Grafana Agent Flow, including the
+   following customizations:
+
+    1. Modify the line inside the `service` block containing
+       `--server.http.listen-addr=127.0.0.1:12345`, replacing `127.0.0.1` with
+       the address which other machines on the network have access to, like the
+       network IP address of the machine Grafana Agent Flow is running on.
+
+       To listen on all interfaces, replace `127.0.0.1` with `0.0.0.0`.
+
+[UI]: {{< relref "../monitoring/debugging.md#grafana-agent-flow-ui" >}}
+
 ### Viewing Grafana Agent Flow logs
 
 By default, logs are written to `$(brew --prefix)/var/log/grafana-agent.log` and

--- a/docs/sources/flow/install/windows.md
+++ b/docs/sources/flow/install/windows.md
@@ -114,6 +114,32 @@ binary, perform the following steps:
 
    3. In the resulting dialog menu, click on All Tasks > Restart.
 
+### Exposing the UI to other machines
+
+By default, Grafana Agent Flow listens on the local network for its HTTP
+server. This prevents other machines on the network from being able to access
+the [UI for debugging][UI].
+
+To expose the UI to other machines, complete the following steps:
+
+1. Follow [Change command-line arguments](#change-command-line-arguments)
+   to edit command line flags passed to Grafana Agent Flow, including the
+   following customizations:
+
+    1. Add the following command line argument:
+
+       ```
+       --server.http.listen-addr=LISTEN_ADDR:12345
+       ```
+
+       Replace `LISTEN_ADDR` with an address which other machines on the
+       network have access to, like the network IP address of the machine
+       Grafana Agent Flow is running on.
+
+       To listen on all interfaces, replace `LISTEN_ADDR` with `0.0.0.0`.
+
+[UI]: {{< relref "../monitoring/debugging.md#grafana-agent-flow-ui" >}}
+
 ### Viewing Grafana Agent Flow logs
 
 When running on Windows, Grafana Agent Flow writes its logs to Windows Event

--- a/docs/sources/flow/monitoring/debugging.md
+++ b/docs/sources/flow/monitoring/debugging.md
@@ -16,8 +16,18 @@ Follow these steps to debug issues with Grafana Agent Flow:
 Grafana Agent Flow includes an embedded UI viewable from Grafana Agent's HTTP
 server, which defaults to listening at `http://localhost:12345`.
 
-> The documentation for the [`grafana-agent run`][grafana-agent run] command describes how to
-> modify the address Grafana Agent listens on for HTTP traffic.
+> **NOTE**: For security reasons, installations of Grafana Agent Flow on
+> non-containerized platforms default to listening on `localhost`. default
+> prevents other machines on the network from being able to view the UI.
+>
+> To expose the UI to other machines on the network on non-containerized
+> platforms, refer to the documentation for how you [installed][install]
+> Grafana Agent Flow.
+>
+> If you are running a custom installation of Grafana Agent Flow, refer to the
+> documentation for [`grafana-agent run`][grafana-agent run] to learn how to
+> change the HTTP listen address, and pass the appropriate flag when running
+> Grafana Agent Flow.
 
 ### Home page
 

--- a/docs/sources/flow/monitoring/debugging.md
+++ b/docs/sources/flow/monitoring/debugging.md
@@ -28,6 +28,8 @@ server, which defaults to listening at `http://localhost:12345`.
 > documentation for [`grafana-agent run`][grafana-agent run] to learn how to
 > change the HTTP listen address, and pass the appropriate flag when running
 > Grafana Agent Flow.
+>
+> [install]: {{< relref "../install/" >}}
 
 ### Home page
 

--- a/docs/sources/flow/monitoring/debugging.md
+++ b/docs/sources/flow/monitoring/debugging.md
@@ -25,11 +25,13 @@ server, which defaults to listening at `http://localhost:12345`.
 > Grafana Agent Flow.
 >
 > If you are running a custom installation of Grafana Agent Flow, refer to the
-> documentation for [`grafana-agent run`][grafana-agent run] to learn how to
-> change the HTTP listen address, and pass the appropriate flag when running
-> Grafana Agent Flow.
+> documentation for [the `grafana-agent run` command][grafana-agent run] to
+> learn how to change the HTTP listen address, and pass the appropriate flag
+> when running Grafana Agent Flow.
 >
 > [install]: {{< relref "../install/" >}}
+
+[grafana-agent run]: {{< relref "../reference/cli/run.md" >}}
 
 ### Home page
 
@@ -65,6 +67,8 @@ The component detail page shows the following information for each component:
 > Values marked as a [secret][] are obfuscated and will display as the text
 > `(secret)`.
 
+[secret]: {{< relref "../config-language/expressions/types_and_values.md#secrets" >}}
+
 ## Debugging using the UI
 
 To debug using the UI:
@@ -73,19 +77,16 @@ To debug using the UI:
 * Ensure that the arguments and exports for misbehaving components appear
   correct.
 
-[grafana-agent run]: {{< relref "../reference/cli/run.md" >}}
-[secret]: {{< relref "../config-language/expressions/types_and_values.md#secrets" >}}
-
 ## Examining logs
 
 Logs may also help debug issues with Grafana Agent Flow.
 
 To reduce logging noise, many components hide debugging info behind debug-level
-log lines. It is recommended that you configure the [`logging block`][logging]
+log lines. It is recommended that you configure the [`logging` block][logging]
 to show debug-level log lines when debugging issues with Grafana Agent Flow.
 
 The location of Grafana Agent's logs is different based on how it is deployed.
-Refer to the [`logging block`][logging] page to see how to find logs for your
+Refer to the [`logging` block][logging] page to see how to find logs for your
 system.
 
 [logging]: {{< relref "../reference/config-blocks/logging.md" >}}


### PR DESCRIPTION
The default listen address for non-containerized installations is `localhost`, which prevents other machines on the network from being able to see the UI.

This default behavior may not be obvious to people, so this commit documents that behavior more clearly and instructs people on how to change the listen address.
