### PR TITLE
agent-flow-mixin: fix alerts format

### DIFF
--- a/operations/agent-flow-mixin/alerts.libsonnet
+++ b/operations/agent-flow-mixin/alerts.libsonnet
@@ -1,4 +1,7 @@
 {
-  prometheusAlerts+:
-    (import './alerts/clustering.libsonnet'),
+  prometheusAlerts+: {
+    groups: [
+      (import './alerts/clustering.libsonnet'),
+    ],
+  },
 }

--- a/operations/agent-flow-mixin/alerts/clustering.libsonnet
+++ b/operations/agent-flow-mixin/alerts/clustering.libsonnet
@@ -1,30 +1,29 @@
 local alert = import './utils/alert.jsonnet';
-local filename = 'clustering.json';
 
-{
-  [filename]:
-    alert.newGroup([
-      // Cluster not converging.
-      alert.newRule(
-        'ClusterNotConverged',
-        'stddev by (cluster, namespace) ((sum without (state) (cluster_node_peers))) != 0',
-        'Cluster is not converging.',
-        '5m',
-      ),
+alert.newGroup(
+  'clustering',
+  [
+    // Cluster not converging.
+    alert.newRule(
+      'ClusterNotConverged',
+      'stddev by (cluster, namespace) ((sum without (state) (cluster_node_peers))) != 0',
+      'Cluster is not converging.',
+      '5m',
+    ),
 
-      // Clustering has entered a split brain state
-      alert.newRule(
-        'ClusterSplitBrain',
-        // Assert that the set of known peers (regardless of state) for an
-        // agent matches the same number of running agents in the same cluster
-        // and namespace.
-        |||
-          sum without (state) (cluster_node_peers) !=
-          on (cluster, namespace) group_left
-          count by (cluster, namespace) (cluster_node_info)
-        |||,
-        'Cluster nodes have entered a split brain state.',
-        '5m',
-      ),
-    ]),
-}
+    // Clustering has entered a split brain state
+    alert.newRule(
+      'ClusterSplitBrain',
+      // Assert that the set of known peers (regardless of state) for an
+      // agent matches the same number of running agents in the same cluster
+      // and namespace.
+      |||
+        sum without (state) (cluster_node_peers) !=
+        on (cluster, namespace) group_left
+        count by (cluster, namespace) (cluster_node_info)
+      |||,
+      'Cluster nodes have entered a split brain state.',
+      '5m',
+    ),
+  ]
+)

--- a/operations/agent-flow-mixin/alerts/utils/alert.jsonnet
+++ b/operations/agent-flow-mixin/alerts/utils/alert.jsonnet
@@ -1,7 +1,8 @@
 // alert.jsonnet defines utilities to create alerts.
 
 {
-  newGroup(rules):: {
+  newGroup(name, rules):: {
+    name: name,
     rules: rules,
   },
 

--- a/operations/agent-flow-mixin/dashboards/utils/panel.jsonnet
+++ b/operations/agent-flow-mixin/dashboards/utils/panel.jsonnet
@@ -87,13 +87,13 @@
   },
 
   withCenteredAxis():: {
-    fieldConfig +: {
-      defaults +: {
-        custom +: {
+    fieldConfig+: {
+      defaults+: {
+        custom+: {
           axisCenteredZero: true,
-        }
-      }
-    }
+        },
+      },
+    },
   },
 
   withPosition(pos):: { gridPos: pos },

--- a/operations/agent-flow-mixin/grizzly/alerts.jsonnet
+++ b/operations/agent-flow-mixin/grizzly/alerts.jsonnet
@@ -1,17 +1,17 @@
 local mixin = import '../mixin.libsonnet';
 
 {
-  prometheus_rules: {
-    [file]: {
-      apiVersion: 'grizzly.grafana.com/v1alpha1',
-      kind: 'PrometheusRuleGroup',
-      metadata: {
-        folder: $.folder.metadata.name,
-        namespace: 'agent-flow',
-        name: std.split(file, '.')[0],
+  prometheus_rules: std.map(
+    function(group)
+      {
+        apiVersion: 'grizzly.grafana.com/v1alpha1',
+        kind: 'PrometheusRuleGroup',
+        metadata: {
+          namespace: 'agent-flow',
+          name: group.name,
+        },
+        spec: group,
       },
-      spec: mixin.prometheusAlerts[file],
-    }
-    for file in std.objectFields(mixin.prometheusAlerts)
-  },
+    mixin.prometheusAlerts.groups
+  ),
 }


### PR DESCRIPTION
#### PR Description
When using `mixtool` to render alerting rules, I noticed that it required a different approach than dashboards; instead of being rendered in a different file each, they all get listed under a groups key. Meanwhile grizzly still requires them to be present as a separate item each.

This change allows alerts to be usable _both_ when using grizzly and in the context of a rendered mixin.

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer
The alerts can now be applied via grizzly _and_ work when rendering the mixin using `mixtool generate alerts`.

```
grr apply grizzly.jsonnet --log-level=debug
INFO[0000] Applying 7 resources
DEBU[0000] Getting the remote value for `DashboardFolder.grafana-agent-flow`
DEBU[0000] `DashboardFolder.grafana-agent-flow` was found, updating it...
DashboardFolder.grafana-agent-flow updated
DEBU[0000] Getting the remote value for `Dashboard.d47aae5c53be5550f8e3bc8a904ba61a`
DEBU[0000] `Dashboard.d47aae5c53be5550f8e3bc8a904ba61a` was found, updating it...
Dashboard.d47aae5c53be5550f8e3bc8a904ba61a no differences
DEBU[0000] Getting the remote value for `Dashboard.dd370cd333b2d9258435fb1b5a20a89b`
DEBU[0000] `Dashboard.dd370cd333b2d9258435fb1b5a20a89b` was found, updating it...
Dashboard.dd370cd333b2d9258435fb1b5a20a89b no differences
DEBU[0000] Getting the remote value for `Dashboard.7e07f9c975fcfc2a6e120a95f579f843`
DEBU[0000] `Dashboard.7e07f9c975fcfc2a6e120a95f579f843` was found, updating it...
Dashboard.7e07f9c975fcfc2a6e120a95f579f843 no differences
DEBU[0000] Getting the remote value for `Dashboard.f861e5fef2e795edd5c4c73bee1ba769`
DEBU[0000] `Dashboard.f861e5fef2e795edd5c4c73bee1ba769` was found, updating it...
Dashboard.f861e5fef2e795edd5c4c73bee1ba769 no differences
DEBU[0000] Getting the remote value for `Dashboard.513c25187e0289ec960f252466d5190d`
DEBU[0000] `Dashboard.513c25187e0289ec960f252466d5190d` was found, updating it...
Dashboard.513c25187e0289ec960f252466d5190d no differences
DEBU[0000] Getting the remote value for `PrometheusRuleGroup.agent-flow.clustering`
DEBU[0000] `PrometheusRuleGroup.agent-flow.clustering` was found, updating it...
PrometheusRuleGroup.agent-flow.clustering updated
```

<img width="351" alt="image" src="https://user-images.githubusercontent.com/17771679/236573692-70159cdf-1d8a-4fd1-85a1-566abe25b433.png">


#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
