### PR TITLE
agent-flow: fix S3 object fetch when path has parent directories

### DIFF
--- a/component/remote/s3/s3.go
+++ b/component/remote/s3/s3.go
@@ -222,8 +222,8 @@ func (s *S3) handleContentPolling(newContent string, err error) {
 // getPathBucketAndFile takes the path and splits it into a bucket and file.
 func getPathBucketAndFile(path string) (bucket, file string) {
 	parts := strings.Split(path, "/")
-	file = parts[len(parts)-1]
-	bucket = strings.Join(parts[:len(parts)-1], "/")
+	file = strings.Join(parts[3:], "/")
+	bucket = strings.Join(parts[:3], "/")
 	bucket = strings.ReplaceAll(bucket, "s3://", "")
 	return
 }


### PR DESCRIPTION
## Agent Flow S3 object fetch fix

This PR fix S3 object fetch when path contains one or more parent directories before the filename. 

Fixes #3784