### PR TITLE
misc: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -14,7 +14,7 @@ body:
   - type: textarea
     attributes:
       label: Steps to reproduce
-      descriptions: Please describe steps for us to be able to reproduce the issue.
+      description: Please describe steps for us to be able to reproduce the issue.
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -35,5 +35,5 @@ body:
   - type: textarea
     attributes:
       label: Logs
-      description: Provide logs relevant to the issue.
+      description: Provide logs relevant to the issue. Remove sensitive information before sharing.
       render: text

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,39 @@
+name: Bug report
+description: Create a report to help us improve Grafana Agent.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for opening a bug report for Grafana Agent.
+
+        Please do not use GitHub issues for support questions. If you need help or support, ask a question in [GitHub Discussions](https://github.com/grafana/agent/discussions) or join the `#agent` channel on the [Grafana Slack](https://slack.grafana.com/).
+  - type: textarea
+    attributes:
+      label: What's wrong?
+      description: Provide a brief description of the issue.
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      descriptions: Please describe steps for us to be able to reproduce the issue.
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: System information
+      description: Provide your operating system and architecture.
+      placeholder: e.g. Linux 5.16.15 x86_64
+  - type: input
+    attributes:
+      label: Software version
+      description: Provide the version of the software you are using.
+      placeholder: e.g. Grafana Agent v0.33.0
+  - type: textarea
+    attributes:
+      label: Configuration
+      description: Provide the relevant configuration file here. Remove sensitive information before sharing.
+      render: text
+  - type: textarea
+    attributes:
+      label: Logs
+      description: Provide logs relevant to the issue.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Grafana Agent community support
+    url: https://github.com/grafana/agent/discussions
+    about: If you need help or support, ask questions in Github Discussions.
+  - name: Grafana Agent Slack
+    url: https://slack.grafana.com/
+    about: "Join the #agent slack channel to chat about Grafana Agent in real-time."
+  - name: Grafana Cloud or Grafana Enterprise
+    url: https://grafana.com/profile/org#support
+    about: Open a support ticket for help with Grafana Cloud or Grafana Enterprise.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,21 @@
+name: Feature request
+description: Suggest an idea to be added to Grafana Agent.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for opening a bug report for Grafana Agent.
+
+        Please do not use GitHub issues for support questions. If you need help or support, ask a question in [GitHub Discussions](https://github.com/grafana/agent/discussions) or join the `#agent` channel on the [Grafana Slack](https://slack.grafana.com/).
+  - type: textarea
+    attributes:
+      label: Request
+      description: What feature do you want?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Use case
+      description: Why do you need this feature?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -4,7 +4,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for opening a bug report for Grafana Agent.
+        Thank you for opening a feature request for Grafana Agent.
 
         Please do not use GitHub issues for support questions. If you need help or support, ask a question in [GitHub Discussions](https://github.com/grafana/agent/discussions) or join the `#agent` channel on the [Grafana Slack](https://slack.grafana.com/).
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/proposal.yaml
@@ -1,0 +1,21 @@
+name: Proposal
+description: Propose a way to solve a problem.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for opening a bug report for Grafana Agent.
+
+        Please do not use GitHub issues for support questions. If you need help or support, ask a question in [GitHub Discussions](https://github.com/grafana/agent/discussions) or join the `#agent` channel on the [Grafana Slack](https://slack.grafana.com/).
+  - type: textarea
+    attributes:
+      label: Background
+      description: What is the background for your proposal? Include your use case here.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Proposal
+      description: How do you propose we implement the functionality?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/proposal.yaml
@@ -4,7 +4,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for opening a bug report for Grafana Agent.
+        Thank you for opening a proposal for Grafana Agent.
 
         Please do not use GitHub issues for support questions. If you need help or support, ask a question in [GitHub Discussions](https://github.com/grafana/agent/discussions) or join the `#agent` channel on the [Grafana Slack](https://slack.grafana.com/).
   - type: textarea


### PR DESCRIPTION
Add issue templates for:

* Bug reports, to allow users to report specific problems.
* Feature requests, to allow users to request that new functionality be added.
* Proposals, to allow users to propose a specific implementation for a problem they would like to solve.

Feature requests are just off-the-cuff suggestions, while proposals are expected to go more in depth about the background and the proposed solution(s).