### PR TITLE
docs: update prometheus links to point to the latest version

### DIFF
--- a/docs/sources/static/configuration/metrics-config.md
+++ b/docs/sources/static/configuration/metrics-config.md
@@ -259,7 +259,7 @@ remote_write:
   - [<remote_write>]
 ```
 
-> **Note:** For more information on remote_write, refer to the [Prometheus documentation](https://prometheus.io/docs/prometheus/2.42/configuration/configuration/#remote_write)
+> **Note:** For more information on remote_write, refer to the [Prometheus documentation](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write)
 
 ## metrics_instance_config
 
@@ -331,6 +331,6 @@ remote_write:
 > **Note:** More information on the following types can be found on the Prometheus
 > website:
 >
-> * [`relabel_config`](https://prometheus.io/docs/prometheus/2.42/configuration/configuration/#relabel_config)
-> * [`scrape_config`](https://prometheus.io/docs/prometheus/2.42/configuration/configuration/#scrape_config)
-> * [`remote_write`](https://prometheus.io/docs/prometheus/2.42/configuration/configuration/#remote_write)
+> * [`relabel_config`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config)
+> * [`scrape_config`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config)
+> * [`remote_write`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write)


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Similar to #1859 this updates the documentation links as version `2.42` has been removed from the Prometheus website. By changing it to `latest`, it should be available longer at the cost of maybe referencing features which are not yet available in the agent.

#### Notes to the Reviewer

If it makes more sense to pin a specific version, just let me know and I'll figure out which one is currently used 

#### PR Checklist

- [x] ~~CHANGELOG updated~~
- [x] Documentation added
- [x] ~~Tests updated~~
