### PR TITLE
Update and rename config.yaml to config.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,5 @@
+# NOTE(rfratto): this file *must* have the .yml extension otherwise GitHub doesn't 
+# recognize it.
 blank_issues_enabled: true
 contact_links:
   - name: Grafana Agent community support


### PR DESCRIPTION
GitHub requires the config file for issue templates to be called `config.yml` and _not_ `config.yaml`.