### PR TITLE
operator: add logging if we fail to update a controller

### DIFF
--- a/pkg/operator/clientutil/clientutil.go
+++ b/pkg/operator/clientutil/clientutil.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	apps_v1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
@@ -116,7 +118,7 @@ func CreateOrUpdateEndpoints(ctx context.Context, c client.Client, eps *v1.Endpo
 }
 
 // CreateOrUpdateStatefulSet applies the given StatefulSet against the client.
-func CreateOrUpdateStatefulSet(ctx context.Context, c client.Client, ss *apps_v1.StatefulSet) error {
+func CreateOrUpdateStatefulSet(ctx context.Context, c client.Client, ss *apps_v1.StatefulSet, l log.Logger) error {
 	var exist apps_v1.StatefulSet
 	err := c.Get(ctx, client.ObjectKeyFromObject(ss), &exist)
 	if err != nil && !k8s_errors.IsNotFound(err) {
@@ -136,6 +138,7 @@ func CreateOrUpdateStatefulSet(ctx context.Context, c client.Client, ss *apps_v1
 
 		err := c.Update(ctx, ss)
 		if k8s_errors.IsNotAcceptable(err) || k8s_errors.IsInvalid(err) {
+			level.Error(l).Log("msg", "error updating StatefulSet. Attempting to recreate", "err", err.Error())
 			// Resource version should only be set when updating
 			ss.ResourceVersion = ""
 
@@ -156,7 +159,7 @@ func CreateOrUpdateStatefulSet(ctx context.Context, c client.Client, ss *apps_v1
 }
 
 // CreateOrUpdateDaemonSet applies the given DaemonSet against the client.
-func CreateOrUpdateDaemonSet(ctx context.Context, c client.Client, ss *apps_v1.DaemonSet) error {
+func CreateOrUpdateDaemonSet(ctx context.Context, c client.Client, ss *apps_v1.DaemonSet, l log.Logger) error {
 	var exist apps_v1.DaemonSet
 	err := c.Get(ctx, client.ObjectKeyFromObject(ss), &exist)
 	if err != nil && !k8s_errors.IsNotFound(err) {
@@ -176,6 +179,7 @@ func CreateOrUpdateDaemonSet(ctx context.Context, c client.Client, ss *apps_v1.D
 
 		err := c.Update(ctx, ss)
 		if k8s_errors.IsNotAcceptable(err) || k8s_errors.IsInvalid(err) {
+			level.Error(l).Log("msg", "error updating Daemonset. Attempting to recreate", "err", err.Error())
 			// Resource version should only be set when updating
 			ss.ResourceVersion = ""
 
@@ -196,7 +200,7 @@ func CreateOrUpdateDaemonSet(ctx context.Context, c client.Client, ss *apps_v1.D
 }
 
 // CreateOrUpdateDeployment applies the given DaemonSet against the client.
-func CreateOrUpdateDeployment(ctx context.Context, c client.Client, d *apps_v1.Deployment) error {
+func CreateOrUpdateDeployment(ctx context.Context, c client.Client, d *apps_v1.Deployment, l log.Logger) error {
 	var exist apps_v1.Deployment
 	err := c.Get(ctx, client.ObjectKeyFromObject(d), &exist)
 	if err != nil && !k8s_errors.IsNotFound(err) {
@@ -216,6 +220,7 @@ func CreateOrUpdateDeployment(ctx context.Context, c client.Client, d *apps_v1.D
 
 		err := c.Update(ctx, d)
 		if k8s_errors.IsNotAcceptable(err) || k8s_errors.IsInvalid(err) {
+			level.Error(l).Log("msg", "error updating Deployment. Attempting to recreate", "err", err.Error())
 			// Resource version should only be set when updating
 			d.ResourceVersion = ""
 

--- a/pkg/operator/reconciler_integrations.go
+++ b/pkg/operator/reconciler_integrations.go
@@ -81,7 +81,7 @@ func (r *reconciler) newIntegrationsDeployment(
 	}
 
 	level.Info(l).Log("msg", "reconciling integrations Deployment", "deploy", key)
-	err = clientutil.CreateOrUpdateDeployment(ctx, r.Client, deploy)
+	err = clientutil.CreateOrUpdateDeployment(ctx, r.Client, deploy, l)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile integrations Deployment: %w", err)
 	}
@@ -114,7 +114,7 @@ func (r *reconciler) newIntegrationsDaemonSet(
 	}
 
 	level.Info(l).Log("msg", "reconciling integrations DaemonSet", "ds", key)
-	err = clientutil.CreateOrUpdateDaemonSet(ctx, r.Client, ds)
+	err = clientutil.CreateOrUpdateDaemonSet(ctx, r.Client, ds, l)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile integrations DaemonSet: %w", err)
 	}

--- a/pkg/operator/reconciler_logs.go
+++ b/pkg/operator/reconciler_logs.go
@@ -47,7 +47,7 @@ func (r *reconciler) createLogsDaemonSet(
 	}
 
 	level.Info(l).Log("msg", "reconciling logs daemonset", "ds", key)
-	err = clientutil.CreateOrUpdateDaemonSet(ctx, r.Client, ds)
+	err = clientutil.CreateOrUpdateDaemonSet(ctx, r.Client, ds, l)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile statefulset governing service: %w", err)
 	}

--- a/pkg/operator/reconciler_metrics.go
+++ b/pkg/operator/reconciler_metrics.go
@@ -174,7 +174,7 @@ func (r *reconciler) createMetricsStatefulSets(
 		}
 
 		level.Info(l).Log("msg", "reconciling statefulset", "statefulset", ss.Name)
-		err = clientutil.CreateOrUpdateStatefulSet(ctx, r.Client, ss)
+		err = clientutil.CreateOrUpdateStatefulSet(ctx, r.Client, ss, l)
 		if err != nil {
 			return fmt.Errorf("failed to reconcile statefulset for shard: %w", err)
 		}


### PR DESCRIPTION
There are some cases where kubernetes will not allow you to update a StatefulSet if certain fields have changed. In that case, we will delete and recreate it as a fallback.

This adds a little logging to help diagnose that.