### PR TITLE
flow: allow loading a configuration "source" from a folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ Main (unreleased)
 
 - Update OracleDB Exporter dependency to 0.5.0 (@schmikei)
 
+- Allow `grafana-agent run` to accept a path to a directory of `*.river` files.
+  This will load all River files in the directory as a single configuration;
+  component names must be unique across all loaded files. (@rfratto)
+
 ### Bugfixes
 
 - Fix issue where component evaluation time was overridden by a "default

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -184,6 +184,7 @@ func (fr *flowRun) Run(configFile string) error {
 
 	reload := func() (*flow.Source, error) {
 		flowSource, err := loadFlowSource(configFile)
+		instrumentation.InstrumentSHA256(flowSource.SHA256())
 		defer instrumentation.InstrumentLoad(err == nil)
 
 		if err != nil {
@@ -349,9 +350,6 @@ func loadFlowSource(filename string) (*flow.Source, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	instrumentation.InstrumentConfig(bb)
-
 	return flow.ParseSource(filename, bb)
 }
 

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -183,13 +183,13 @@ func (fr *flowRun) Run(configFile string) error {
 	})
 
 	reload := func() error {
-		flowCfg, err := loadFlowFile(configFile)
+		flowSource, err := loadFlowSource(configFile)
 		defer instrumentation.InstrumentLoad(err == nil)
 
 		if err != nil {
 			return fmt.Errorf("reading config file %q: %w", configFile, err)
 		}
-		if err := f.LoadFile(flowCfg, nil); err != nil {
+		if err := f.LoadSource(flowSource, nil); err != nil {
 			return fmt.Errorf("error during the initial gragent load: %w", err)
 		}
 
@@ -346,7 +346,7 @@ func getEnabledComponentsFunc(f *flow.Flow) func() map[string]interface{} {
 	}
 }
 
-func loadFlowFile(filename string) (*flow.File, error) {
+func loadFlowSource(filename string) (*flow.Source, error) {
 	bb, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
@@ -354,7 +354,7 @@ func loadFlowFile(filename string) (*flow.File, error) {
 
 	instrumentation.InstrumentConfig(bb)
 
-	return flow.ReadFile(filename, bb)
+	return flow.ParseSource(filename, bb)
 }
 
 func interruptContext() (context.Context, context.CancelFunc) {

--- a/component/module/file/file.go
+++ b/component/module/file/file.go
@@ -97,7 +97,7 @@ func (c *Component) newManagedLocalComponent(o component.Options) (*file.Compone
 
 		if !c.inUpdate.Load() && c.isCreated.Load() {
 			// Any errors found here are reported via component health
-			_ = c.mod.LoadFlowContent(c.getArgs().Arguments, c.getContent().Value)
+			_ = c.mod.LoadFlowSource(c.getArgs().Arguments, c.getContent().Value)
 		}
 	}
 
@@ -144,7 +144,7 @@ func (c *Component) Update(args component.Arguments) error {
 
 	// Force a content load here and bubble up any error. This will catch problems
 	// on initial load.
-	return c.mod.LoadFlowContent(newArgs.Arguments, c.getContent().Value)
+	return c.mod.LoadFlowSource(newArgs.Arguments, c.getContent().Value)
 }
 
 // Handler implements component.HTTPComponent.

--- a/component/module/git/git.go
+++ b/component/module/git/git.go
@@ -229,7 +229,7 @@ func (c *Component) pollFile(ctx context.Context, args Arguments) error {
 		return err
 	}
 
-	return c.mod.LoadFlowContent(args.Arguments, string(bb))
+	return c.mod.LoadFlowSource(args.Arguments, string(bb))
 }
 
 // CurrentHealth implements component.HealthComponent.

--- a/component/module/module.go
+++ b/component/module/module.go
@@ -59,11 +59,11 @@ func NewModuleComponent(o component.Options) *ModuleComponent {
 	}
 }
 
-// LoadFlowContent loads the flow controller with the current component content. It
-// will set the component health in addition to return the error so that the consumer
-// can rely on either or both.
-func (c *ModuleComponent) LoadFlowContent(args map[string]any, contentValue string) error {
-	f, err := flow.ReadFile(c.opts.ID, []byte(contentValue))
+// LoadFlowSource loads the flow controller with the current component source.
+// It will set the component health in addition to return the error so that the
+// consumer can rely on either or both.
+func (c *ModuleComponent) LoadFlowSource(args map[string]any, contentValue string) error {
+	f, err := flow.ParseSource(c.opts.ID, []byte(contentValue))
 	if err != nil {
 		c.setHealth(component.Health{
 			Health:     component.HealthTypeUnhealthy,
@@ -74,7 +74,7 @@ func (c *ModuleComponent) LoadFlowContent(args map[string]any, contentValue stri
 		return err
 	}
 
-	err = c.ctrl.LoadFile(f, args)
+	err = c.ctrl.LoadSource(f, args)
 	if err != nil {
 		c.setHealth(component.Health{
 			Health:     component.HealthTypeUnhealthy,

--- a/component/module/string/string.go
+++ b/component/module/string/string.go
@@ -64,7 +64,7 @@ func (c *Component) Run(ctx context.Context) error {
 func (c *Component) Update(args component.Arguments) error {
 	newArgs := args.(Arguments)
 
-	return c.mod.LoadFlowContent(newArgs.Arguments, newArgs.Content.Value)
+	return c.mod.LoadFlowSource(newArgs.Arguments, newArgs.Content.Value)
 }
 
 // Handler implements component.HTTPComponent.

--- a/component/module/string/string_test.go
+++ b/component/module/string/string_test.go
@@ -193,9 +193,9 @@ func TestModule(t *testing.T) {
 
 func testFile(t *testing.T, fmtFile string, componentToFind string, searchable []string, expectedErrorContains string) {
 	f := flow.New(testOptions(t))
-	ff, err := flow.ReadFile("test", []byte(fmtFile))
+	source, err := flow.ParseSource("test", []byte(fmtFile))
 	require.NoError(t, err)
-	err = f.LoadFile(ff, nil)
+	err = f.LoadSource(source, nil)
 	if expectedErrorContains == "" {
 		require.NoError(t, err)
 	} else {

--- a/docs/sources/flow/reference/cli/run.md
+++ b/docs/sources/flow/reference/cli/run.md
@@ -10,11 +10,18 @@ interrupt is received.
 
 ## Usage
 
-Usage: `grafana-agent run [FLAG ...] FILE_NAME`
+Usage: `grafana-agent run [FLAG ...] PATH_NAME`
 
-`grafana-agent run` must be provided an argument which points at the River config file
-to use. `grafana-agent run` will immediately exit with an error if the River file
+`grafana-agent run` must be provided an argument which points at the River
+configuration file to use, or a directory containing River configuration files.
+`grafana-agent run` will immediately exit with an error if the River file
 wasn't specified, can't be loaded, or contained errors during the initial load.
+
+If `PATH_NAME` is a directory, all files with a `.river` extension in that
+directory are loaded as a single configuration; component names must be unique
+across all River files in the directory. To allow multiple files that use the
+same component names, use [Modules][] instead. River files in subdirectories
+are ignored.
 
 Grafana Agent Flow will continue to run if subsequent reloads of the config
 file fail, potentially marking components as unhealthy depending on the nature
@@ -40,6 +47,7 @@ The following flags are supported:
 [in-memory HTTP traffic]: {{< relref "../../concepts/component_controller.md#in-memory-traffic" >}}
 [usage reporting]: {{< relref "../../../static/configuration/flags.md#report-information-usage" >}}
 [components]: {{< relref "../../concepts/components.md" >}}
+[Modules]: {{< relref "../../concepts/modules.md" >}}
 
 ## Updating the config file
 

--- a/pkg/config/instrumentation/config_metrics.go
+++ b/pkg/config/instrumentation/config_metrics.go
@@ -52,8 +52,12 @@ func newConfigMetrics() *configMetrics {
 // Create a sha256 hash of the config before expansion and expose it via
 // the agent_config_hash metric.
 func InstrumentConfig(buf []byte) {
+	InstrumentSHA256(sha256.Sum256(buf))
+}
+
+// InstrumentSHA256 stores the provided hash to the agent_config_hash metric.
+func InstrumentSHA256(hash [sha256.Size]byte) {
 	configMetricsInitializer.Do(initializeConfigMetrics)
-	hash := sha256.Sum256(buf)
 	confMetrics.configHash.Reset()
 	confMetrics.configHash.WithLabelValues(fmt.Sprintf("%x", hash)).Set(1)
 }

--- a/pkg/flow/config.go
+++ b/pkg/flow/config.go
@@ -26,13 +26,13 @@ type Argument struct {
 
 // File holds the contents of a parsed Flow file.
 type File struct {
-	Name string    // File name given to ReadFile.
-	Node *ast.File // Raw File node.
+	name string    // File name given to ReadFile.
+	node *ast.File // Raw File node.
 
-	// Components holds the list of raw River AST blocks describing components.
+	// components holds the list of raw River AST blocks describing components.
 	// The Flow controller can interpret them.
-	Components   []*ast.BlockStmt
-	ConfigBlocks []*ast.BlockStmt
+	components   []*ast.BlockStmt
+	configBlocks []*ast.BlockStmt
 }
 
 // ReadFile parses the River file specified by bb into a File. name should be
@@ -89,9 +89,9 @@ func ReadFile(name string, bb []byte) (*File, error) {
 	}
 
 	return &File{
-		Name:         name,
-		Node:         node,
-		Components:   components,
-		ConfigBlocks: configs,
+		name:         name,
+		node:         node,
+		components:   components,
+		configBlocks: configs,
 	}, nil
 }

--- a/pkg/flow/config.go
+++ b/pkg/flow/config.go
@@ -26,9 +26,6 @@ type Argument struct {
 
 // File holds the contents of a parsed Flow file.
 type File struct {
-	name string    // File name given to ReadFile.
-	node *ast.File // Raw File node.
-
 	// components holds the list of raw River AST blocks describing components.
 	// The Flow controller can interpret them.
 	components   []*ast.BlockStmt
@@ -89,8 +86,6 @@ func ReadFile(name string, bb []byte) (*File, error) {
 	}
 
 	return &File{
-		name:         name,
-		node:         node,
 		components:   components,
 		configBlocks: configs,
 	}, nil

--- a/pkg/flow/config_test.go
+++ b/pkg/flow/config_test.go
@@ -1,10 +1,9 @@
-package flow_test
+package flow
 
 import (
 	"strings"
 	"testing"
 
-	"github.com/grafana/agent/pkg/flow"
 	"github.com/grafana/agent/pkg/river/ast"
 	"github.com/stretchr/testify/require"
 
@@ -22,13 +21,13 @@ func TestReadFile(t *testing.T) {
 		}
 	`
 
-	f, err := flow.ReadFile(t.Name(), []byte(content))
+	f, err := ReadFile(t.Name(), []byte(content))
 	require.NoError(t, err)
 	require.NotNil(t, f)
 
-	require.Len(t, f.Components, 2)
-	require.Equal(t, "testcomponents.tick.ticker_a", getBlockID(f.Components[0]))
-	require.Equal(t, "testcomponents.passthrough.static", getBlockID(f.Components[1]))
+	require.Len(t, f.components, 2)
+	require.Equal(t, "testcomponents.tick.ticker_a", getBlockID(f.components[0]))
+	require.Equal(t, "testcomponents.passthrough.static", getBlockID(f.components[1]))
 }
 
 func TestReadFileWithConfigBlock(t *testing.T) {
@@ -42,22 +41,22 @@ func TestReadFileWithConfigBlock(t *testing.T) {
 		}
 	`
 
-	f, err := flow.ReadFile(t.Name(), []byte(content))
+	f, err := ReadFile(t.Name(), []byte(content))
 	require.NoError(t, err)
 	require.NotNil(t, f)
 
-	require.Len(t, f.Components, 1)
-	require.Equal(t, "testcomponents.tick.ticker_a", getBlockID(f.Components[0]))
-	require.Len(t, f.ConfigBlocks, 1)
-	require.Equal(t, "logging", getBlockID(f.ConfigBlocks[0]))
+	require.Len(t, f.components, 1)
+	require.Equal(t, "testcomponents.tick.ticker_a", getBlockID(f.components[0]))
+	require.Len(t, f.configBlocks, 1)
+	require.Equal(t, "logging", getBlockID(f.configBlocks[0]))
 }
 
 func TestReadFile_Defaults(t *testing.T) {
-	f, err := flow.ReadFile(t.Name(), []byte(``))
+	f, err := ReadFile(t.Name(), []byte(``))
 	require.NotNil(t, f)
 	require.NoError(t, err)
 
-	require.Len(t, f.Components, 0)
+	require.Len(t, f.components, 0)
 }
 
 func getBlockID(b *ast.BlockStmt) string {

--- a/pkg/flow/flow.go
+++ b/pkg/flow/flow.go
@@ -1,5 +1,5 @@
 // Package flow implements the Flow component graph system. Flow configuration
-// files are parsed from River, which contain a listing of components to run.
+// sources are parsed from River, which contain a listing of components to run.
 //
 // # Components
 //
@@ -112,7 +112,7 @@ type Options struct {
 	// OnExportsChange is called when the exports of the controller change.
 	// Exports are controlled by "export" configuration blocks. If
 	// OnExportsChange is nil, export configuration blocks are not allowed in the
-	// loaded config file.
+	// loaded config source.
 	OnExportsChange func(exports map[string]any)
 
 	// DialFunc is a function to use for components to properly connect to
@@ -236,20 +236,20 @@ func (c *Flow) Run(ctx context.Context) {
 	}
 }
 
-// LoadFile synchronizes the state of the controller with the current config
-// file. Components in the graph will be marked as unhealthy if there was an
+// LoadSource synchronizes the state of the controller with the current config
+// source. Components in the graph will be marked as unhealthy if there was an
 // error encountered during Load.
 //
 // The controller will only start running components after Load is called once
 // without any configuration errors.
-func (c *Flow) LoadFile(file *File, args map[string]any) error {
+func (c *Flow) LoadSource(source *Source, args map[string]any) error {
 	c.loadMut.Lock()
 	defer c.loadMut.Unlock()
 
-	diags := c.loader.Apply(args, file.components, file.configBlocks)
+	diags := c.loader.Apply(args, source.components, source.configBlocks)
 	if !c.loadedOnce.Load() && diags.HasErrors() {
 		// The first call to Load should not run any components if there were
-		// errors in the configuration file.
+		// errors in the configuration source.
 		return diags
 	}
 	c.loadedOnce.Store(true)

--- a/pkg/flow/flow.go
+++ b/pkg/flow/flow.go
@@ -246,7 +246,7 @@ func (c *Flow) LoadFile(file *File, args map[string]any) error {
 	c.loadMut.Lock()
 	defer c.loadMut.Unlock()
 
-	diags := c.loader.Apply(args, file.Components, file.ConfigBlocks)
+	diags := c.loader.Apply(args, file.components, file.configBlocks)
 	if !c.loadedOnce.Load() && diags.HasErrors() {
 		// The first call to Load should not run any components if there were
 		// errors in the configuration file.

--- a/pkg/flow/flow_test.go
+++ b/pkg/flow/flow_test.go
@@ -35,11 +35,11 @@ func TestController_LoadFile_Evaluation(t *testing.T) {
 	ctrl := New(testOptions(t))
 
 	// Use testFile from graph_builder_test.go.
-	f, err := ReadFile(t.Name(), []byte(testFile))
+	f, err := ParseSource(t.Name(), []byte(testFile))
 	require.NoError(t, err)
 	require.NotNil(t, f)
 
-	err = ctrl.LoadFile(f, nil)
+	err = ctrl.LoadSource(f, nil)
 	require.NoError(t, err)
 	require.Len(t, ctrl.loader.Components(), 4)
 

--- a/pkg/flow/source.go
+++ b/pkg/flow/source.go
@@ -1,6 +1,7 @@
 package flow
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"strings"
 
@@ -12,6 +13,7 @@ import (
 // Source holds the contents of a parsed Flow source.
 type Source struct {
 	sourceMap map[string][]byte
+	hash      [sha256.Size]byte // Hash of all files in sourceMap sorted by name.
 
 	// components holds the list of raw River AST blocks describing components.
 	// The Flow controller can interpret them.
@@ -78,6 +80,7 @@ func ParseSource(name string, bb []byte) (*Source, error) {
 		components:   components,
 		configBlocks: configs,
 		sourceMap:    map[string][]byte{name: bb},
+		hash:         sha256.Sum256(bb),
 	}, nil
 }
 
@@ -88,4 +91,13 @@ func (s *Source) RawConfigs() map[string][]byte {
 		return nil
 	}
 	return s.sourceMap
+}
+
+// SHA256 returns the sha256 checksum of the source. Do not modify the returned
+// byte array.
+func (s *Source) SHA256() [sha256.Size]byte {
+	if s == nil {
+		return [sha256.Size]byte{}
+	}
+	return s.hash
 }

--- a/pkg/flow/source.go
+++ b/pkg/flow/source.go
@@ -9,21 +9,6 @@ import (
 	"github.com/grafana/agent/pkg/river/parser"
 )
 
-// An Argument is an input to a Flow module.
-type Argument struct {
-	// Name of the argument.
-	Name string `river:",label"`
-
-	// Whether the Argument must be provided when evaluating the file.
-	Optional bool `river:"optional,attr,optional"`
-
-	// Description for the Argument.
-	Comment string `river:"comment,attr,optional"`
-
-	// Default value for the argument.
-	Default any `river:"default,attr,optional"`
-}
-
 // Source holds the contents of a parsed Flow source.
 type Source struct {
 	// components holds the list of raw River AST blocks describing components.

--- a/pkg/flow/source.go
+++ b/pkg/flow/source.go
@@ -24,17 +24,17 @@ type Argument struct {
 	Default any `river:"default,attr,optional"`
 }
 
-// File holds the contents of a parsed Flow file.
-type File struct {
+// Source holds the contents of a parsed Flow source.
+type Source struct {
 	// components holds the list of raw River AST blocks describing components.
 	// The Flow controller can interpret them.
 	components   []*ast.BlockStmt
 	configBlocks []*ast.BlockStmt
 }
 
-// ReadFile parses the River file specified by bb into a File. name should be
-// the name of the file used for reporting errors.
-func ReadFile(name string, bb []byte) (*File, error) {
+// ParseSource parses the River contents specified by bb into a Source. name
+// should be the name of the source used for reporting errors.
+func ParseSource(name string, bb []byte) (*Source, error) {
 	node, err := parser.ParseFile(name, bb)
 	if err != nil {
 		return nil, err
@@ -85,7 +85,7 @@ func ReadFile(name string, bb []byte) (*File, error) {
 		}
 	}
 
-	return &File{
+	return &Source{
 		components:   components,
 		configBlocks: configs,
 	}, nil

--- a/pkg/flow/source.go
+++ b/pkg/flow/source.go
@@ -11,6 +11,8 @@ import (
 
 // Source holds the contents of a parsed Flow source.
 type Source struct {
+	sourceMap map[string][]byte
+
 	// components holds the list of raw River AST blocks describing components.
 	// The Flow controller can interpret them.
 	components   []*ast.BlockStmt
@@ -19,6 +21,8 @@ type Source struct {
 
 // ParseSource parses the River contents specified by bb into a Source. name
 // should be the name of the source used for reporting errors.
+//
+// bb must not be modified after passing to ParseSource.
 func ParseSource(name string, bb []byte) (*Source, error) {
 	node, err := parser.ParseFile(name, bb)
 	if err != nil {
@@ -73,5 +77,15 @@ func ParseSource(name string, bb []byte) (*Source, error) {
 	return &Source{
 		components:   components,
 		configBlocks: configs,
+		sourceMap:    map[string][]byte{name: bb},
 	}, nil
+}
+
+// RawConfigs returns the raw source content used to create Source. Do not
+// modify the returned map.
+func (s *Source) RawConfigs() map[string][]byte {
+	if s == nil {
+		return nil
+	}
+	return s.sourceMap
 }

--- a/pkg/flow/source_test.go
+++ b/pkg/flow/source_test.go
@@ -21,7 +21,7 @@ func TestReadFile(t *testing.T) {
 		}
 	`
 
-	f, err := ReadFile(t.Name(), []byte(content))
+	f, err := ParseSource(t.Name(), []byte(content))
 	require.NoError(t, err)
 	require.NotNil(t, f)
 
@@ -41,7 +41,7 @@ func TestReadFileWithConfigBlock(t *testing.T) {
 		}
 	`
 
-	f, err := ReadFile(t.Name(), []byte(content))
+	f, err := ParseSource(t.Name(), []byte(content))
 	require.NoError(t, err)
 	require.NotNil(t, f)
 
@@ -52,7 +52,7 @@ func TestReadFileWithConfigBlock(t *testing.T) {
 }
 
 func TestReadFile_Defaults(t *testing.T) {
-	f, err := ReadFile(t.Name(), []byte(``))
+	f, err := ParseSource(t.Name(), []byte(``))
 	require.NotNil(t, f)
 	require.NoError(t, err)
 


### PR DESCRIPTION
> **NOTE TO REVIEWER**: This PR contains some refactoring; review the PR commit-by-commit to make things easier. 

This PR allows `grafana-agent run` to be given a directory. When given a directory, it will search for all *.river files in that directory (ignoring nested directories) and load them in as a single configuration source. 

This is different from modules; files in the same directory must have unique component names, and can not repeat configuration blocks. 

This allows users to use directories to split up configurations by domain for readability but still share components, similar to Terraform modules or Go packages. 

Module loaders are not modified, and still only support a loading a single configuration source, but could be updated in the future to allow similar behavior, such as pointing module.git at a directory. 