### PR TITLE
Make sure labels are cloned from loki.source.kubernetes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ Main (unreleased)
   was created, and prevented a fresh process from being able to deliver metrics
   at all. (@rfratto)
 
+- Fix an issue where the `loki.source.kubernetes` component could lead to 
+  the Agent crashing due to a race condition. (@tpaschalis)
+
 ### Other changes
 
 - Add metrics when clustering mode is enabled. (@rfratto)

--- a/component/loki/source/kubernetes/kubetail/tailer.go
+++ b/component/loki/source/kubernetes/kubetail/tailer.go
@@ -190,7 +190,7 @@ func (t *tailer) tail(ctx context.Context, handler loki.EntryHandler) error {
 			lastReadTime = entryTimestamp
 
 			entry := loki.Entry{
-				Labels: t.lset,
+				Labels: t.lset.Clone(),
 				Entry: logproto.Entry{
 					Timestamp: entryTimestamp,
 					Line:      entryLine,


### PR DESCRIPTION

#### PR Description
We've gotten some reports of the agent crashing when using loki.source.kubernetes.

Here's a stack trace of this happening:
<details>
```
grafana-agent ts=2023-05-11T15:57:01.398384003Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="starting complete graph evaluation"
grafana-agent ts=2023-05-11T15:57:01.398661803Z level=info msg="now listening for http traffic" addr=0.0.0.0:80
grafana-agent ts=2023-05-11T15:57:01.398753303Z level=info msg="running usage stats reporter"
grafana-agent ts=2023-05-11T15:57:01.398922603Z component=discovery.kubernetes.services level=info msg="Using pod service account via in-cluster config"
grafana-agent ts=2023-05-11T15:57:01.399386203Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=discovery.kubernetes.services duration=676.4µs
grafana-agent ts=2023-05-11T15:57:01.399569803Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=discovery.relabel.ksm duration=161.6µs
grafana-agent ts=2023-05-11T15:57:01.399655103Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=discovery.relabel.agent duration=70.5µs
grafana-agent ts=2023-05-11T15:57:01.399780503Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=discovery.relabel.node_exporter duration=112.2µs
grafana-agent ts=2023-05-11T15:57:01.399868103Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=discovery.relabel.webapp duration=75µs
grafana-agent ts=2023-05-11T15:57:01.399981303Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=discovery.relabel.kubelet duration=100.3µs
grafana-agent ts=2023-05-11T15:57:01.400305203Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=loki.write.grafana_cloud_loki duration=308.5µs
grafana-agent ts=2023-05-11T15:57:01.400607903Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=loki.process.add_cluster_label duration=283.8µs
grafana-agent ts=2023-05-11T15:57:01.400908203Z component=loki.source.kubernetes_events.cluster_events level=info msg="Using pod service account via in-cluster config"
grafana-agent ts=2023-05-11T15:57:01.400926303Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=loki.source.kubernetes_events.cluster_events duration=302.6µs
grafana-agent ts=2023-05-11T15:57:01.404702004Z component=prometheus.remote_write.grafana_cloud_prometheus level=info subcomponent=wal msg="replaying WAL, this may take a while" dir=/tmp/agent/prometheus.remote_write.grafana_cloud_prometheus/wal
grafana-agent ts=2023-05-11T15:57:01.404867404Z component=prometheus.remote_write.grafana_cloud_prometheus level=info subcomponent=wal msg="WAL segment loaded" segment=0 maxSegment=0
grafana-agent ts=2023-05-11T15:57:01.405221004Z component=prometheus.remote_write.grafana_cloud_prometheus subcomponent=rw level=info remote_name=f54ada url=https://prometheus-dev-01-dev-us-central-0.grafana-dev.net/api/prom/push msg="Starting WAL watcher" queue=f54ada
grafana-agent ts=2023-05-11T15:57:01.405237504Z component=prometheus.remote_write.grafana_cloud_prometheus subcomponent=rw level=info remote_name=f54ada url=https://prometheus-dev-01-dev-us-central-0.grafana-dev.net/api/prom/push msg="Starting scraped metadata watcher"
grafana-agent ts=2023-05-11T15:57:01.405249404Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=prometheus.remote_write.grafana_cloud_prometheus duration=4.315401ms
grafana-agent ts=2023-05-11T15:57:01.405316704Z component=prometheus.remote_write.grafana_cloud_prometheus subcomponent=rw level=info remote_name=f54ada url=https://prometheus-dev-01-dev-us-central-0.grafana-dev.net/api/prom/push msg="Replaying WAL" queue=f54ada
grafana-agent ts=2023-05-11T15:57:01.405745104Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=prometheus.relabel.add_cluster_label duration=217.2µs
grafana-agent ts=2023-05-11T15:57:01.415119505Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=prometheus.relabel.ksm duration=9.353401ms
grafana-agent ts=2023-05-11T15:57:01.417155906Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=prometheus.scrape.ksm duration=1.945601ms
grafana-agent ts=2023-05-11T15:57:01.417388306Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=prometheus.scrape.agent duration=131.4µs
grafana-agent ts=2023-05-11T15:57:01.417555706Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=prometheus.scrape.webapp duration=101.5µs
grafana-agent ts=2023-05-11T15:57:01.419084006Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=prometheus.relabel.cadvisor duration=1.4572ms
grafana-agent ts=2023-05-11T15:57:01.419338506Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=prometheus.scrape.cadvisor duration=150.7µs
grafana-agent ts=2023-05-11T15:57:01.420444406Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=prometheus.relabel.kubelet duration=1.0168ms
grafana-agent ts=2023-05-11T15:57:01.420632806Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=prometheus.scrape.kubelet duration=99.9µs
grafana-agent ts=2023-05-11T15:57:01.420806606Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=prometheus.scrape.node_exporter duration=92.3µs
grafana-agent ts=2023-05-11T15:57:01.420938506Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=logging duration=71.5µs
grafana-agent ts=2023-05-11T15:57:01.421290206Z component=discovery.kubernetes.pods level=info msg="Using pod service account via in-cluster config"
grafana-agent ts=2023-05-11T15:57:01.421533506Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=discovery.kubernetes.pods duration=529.4µs
grafana-agent ts=2023-05-11T15:57:01.421685806Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=discovery.relabel.webapp_pod duration=79µs
grafana-agent ts=2023-05-11T15:57:01.422021507Z component=loki.source.kubernetes.pod_logs level=info msg="Using pod service account via in-cluster config"
grafana-agent ts=2023-05-11T15:57:01.422260507Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=loki.source.kubernetes.pod_logs duration=514.501µs
grafana-agent ts=2023-05-11T15:57:01.422375207Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished node evaluation" node_id=tracing duration=41.7µs
grafana-agent ts=2023-05-11T15:57:01.422441807Z level=info trace_id=559f5d0626cd43cb04fc351bc95144b3 msg="finished complete graph evaluation" duration=24.326604ms
grafana-agent ts=2023-05-11T15:57:01.422543407Z level=info msg="scheduling loaded components"
grafana-agent ts=2023-05-11T15:57:01.422718707Z component=loki.source.kubernetes_events.cluster_events level=info msg="watching events for namespace" namespace=
grafana-agent ts=2023-05-11T15:57:01.423437107Z component=prometheus.scrape.cadvisor level=debug msg="passed new targets to scrape manager"
grafana-agent ts=2023-05-11T15:57:01.423612907Z component=prometheus.scrape.kubelet level=debug msg="passed new targets to scrape manager"
grafana-agent ts=2023-05-11T15:57:01.423698207Z component=prometheus.scrape.ksm level=debug msg="passed new targets to scrape manager"
grafana-agent ts=2023-05-11T15:57:01.423735707Z component=prometheus.scrape.node_exporter level=debug msg="passed new targets to scrape manager"
grafana-agent ts=2023-05-11T15:57:01.423840307Z component=prometheus.scrape.agent level=debug msg="passed new targets to scrape manager"
grafana-agent ts=2023-05-11T15:57:01.423850307Z component=prometheus.scrape.webapp level=debug msg="passed new targets to scrape manager"
config-reloader 2023/05/11 15:57:01 Watching directory: "/etc/agent"
grafana-agent ts=2023-05-11T15:57:06.42464914Z level=debug msg="handling component with updated state" node_id=discovery.kubernetes.services
grafana-agent ts=2023-05-11T15:57:06.42472614Z level=info trace_id=1fec6e889fb327d56ee3218439738702 msg="starting partial graph evaluation"
grafana-agent ts=2023-05-11T15:57:06.42539034Z component=prometheus.scrape.kubelet level=debug msg="scrape config was updated"
grafana-agent ts=2023-05-11T15:57:06.42546614Z component=prometheus.scrape.cadvisor level=debug msg="scrape config was updated"
grafana-agent ts=2023-05-11T15:57:06.42560004Z component=prometheus.scrape.ksm level=debug msg="scrape config was updated"
grafana-agent ts=2023-05-11T15:57:06.42568524Z component=prometheus.scrape.kubelet level=debug msg="passed new targets to scrape manager"
grafana-agent ts=2023-05-11T15:57:06.42572864Z component=prometheus.scrape.cadvisor level=debug msg="passed new targets to scrape manager"
grafana-agent ts=2023-05-11T15:57:06.42581054Z component=prometheus.scrape.ksm level=debug msg="passed new targets to scrape manager"
grafana-agent ts=2023-05-11T15:57:06.42627314Z component=prometheus.scrape.agent level=debug msg="scrape config was updated"
grafana-agent ts=2023-05-11T15:57:06.42672574Z component=prometheus.scrape.node_exporter level=debug msg="scrape config was updated"
grafana-agent ts=2023-05-11T15:57:06.42689894Z component=prometheus.scrape.webapp level=debug msg="scrape config was updated"
grafana-agent ts=2023-05-11T15:57:06.42690824Z level=info trace_id=1fec6e889fb327d56ee3218439738702 msg="finished partial graph evaluation" duration=2.2146ms
grafana-agent ts=2023-05-11T15:57:06.42691754Z level=debug msg="handling component with updated state" node_id=discovery.kubernetes.pods
grafana-agent ts=2023-05-11T15:57:06.42693584Z level=info trace_id=17abd4ea6174f4b6e4d437b5217bcfbc msg="starting partial graph evaluation"
grafana-agent ts=2023-05-11T15:57:06.42715534Z component=loki.source.kubernetes.pod_logs level=info msg="Using pod service account via in-cluster config"
grafana-agent ts=2023-05-11T15:57:06.42736554Z level=info trace_id=17abd4ea6174f4b6e4d437b5217bcfbc msg="finished partial graph evaluation" duration=442.6µs
grafana-agent ts=2023-05-11T15:57:06.42737784Z component=loki.source.kubernetes.pod_logs level=info target=default/sample-webapp-7d98bfb95d-dwhg7:sample-webapp msg="tailer running"
grafana-agent ts=2023-05-11T15:57:06.42739574Z component=prometheus.scrape.node_exporter level=debug msg="passed new targets to scrape manager"
grafana-agent ts=2023-05-11T15:57:06.42741144Z component=prometheus.scrape.agent level=debug msg="passed new targets to scrape manager"
grafana-agent ts=2023-05-11T15:57:06.42742134Z component=prometheus.scrape.webapp level=debug msg="passed new targets to scrape manager"
grafana-agent ts=2023-05-11T15:57:06.448771743Z component=loki.source.kubernetes.pod_logs level=info target=default/sample-webapp-7d98bfb95d-dwhg7:sample-webapp msg="opened log stream" starttime=1970-01-01T00:00:00Z
grafana-agent fatal error: concurrent map iteration and map write
grafana-agent 
grafana-agent goroutine 180 [running]:
grafana-agent github.com/grafana/agent/component/loki/write/internal/client.labelsMapToString(0xc00223a330, {0xc001da7be0, 0x1, 0x81?})
grafana-agent     /src/agent/component/loki/write/internal/client/batch.go:78 +0xec
grafana-agent github.com/grafana/agent/component/loki/write/internal/client.(*batch).add(0xc00223aab0, {0xc00223a330, {{0x2a42b584, 0xedbee52f2, 0x0}, {0xc00241b64f, 0x2a}}})
grafana-agent     /src/agent/component/loki/write/internal/client/batch.go:57 +0x9a
grafana-agent github.com/grafana/agent/component/loki/write/internal/client.(*client).run(0xc0011ae400)
grafana-agent     /src/agent/component/loki/write/internal/client/client.go:278 +0x43a
grafana-agent created by github.com/grafana/agent/component/loki/write/internal/client.newClient
grafana-agent     /src/agent/component/loki/write/internal/client/client.go:208 +0x63f
grafana-agent 
grafana-agent goroutine 1 [select]:
grafana-agent github.com/grafana/agent/cmd/internal/flowmode.(*flowRun).Run(0xc0010a27e0, {0x7ffe484077fe, 0x16})
grafana-agent     /src/agent/cmd/internal/flowmode/cmd_run.go:302 +0x1425
grafana-agent github.com/grafana/agent/cmd/internal/flowmode.runCommand.func1(0xc000004900?, {0xc0010bd2c0?, 0x3?, 0x3?})
grafana-agent     /src/agent/cmd/internal/flowmode/cmd_run.go:79 +0x34
grafana-agent github.com/spf13/cobra.(*Command).execute(0xc000004900, {0xc0010bd230, 0x3, 0x3})
grafana-agent     /go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:916 +0x862
grafana-agent github.com/spf13/cobra.(*Command).ExecuteC(0xc000825800)
grafana-agent     /go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x3bd
grafana-agent github.com/spf13/cobra.(*Command).Execute(...)
grafana-agent     /go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
grafana-agent github.com/grafana/agent/cmd/internal/flowmode.Run()
grafana-agent     /src/agent/cmd/internal/flowmode/flowmode.go:31 +0x2af
grafana-agent main.main()
grafana-agent     /src/agent/cmd/grafana-agent/main.go:48 +0x605
grafana-agent 
grafana-agent goroutine 85 [select]:
grafana-agent go.opencensus.io/stats/view.(*worker).start(0xc0000e4e80)
grafana-agent     /go/pkg/mod/go.opencensus.io@v0.24.0/stats/view/worker.go:292 +0xad
grafana-agent created by go.opencensus.io/stats/view.init.0
grafana-agent     /go/pkg/mod/go.opencensus.io@v0.24.0/stats/view/worker.go:34 +0x96
grafana-agent 
grafana-agent goroutine 161 [chan receive]:
grafana-agent github.com/ClickHouse/clickhouse-go.init.0.func1()
grafana-agent     /go/pkg/mod/github.com/!click!house/clickhouse-go@v1.5.4/bootstrap.go:48 +0x2d
grafana-agent created by github.com/ClickHouse/clickhouse-go.init.0
grafana-agent     /go/pkg/mod/github.com/!click!house/clickhouse-go@v1.5.4/bootstrap.go:45 +0x3f
grafana-agent 
grafana-agent goroutine 119 [sleep]:
grafana-agent time.Sleep(0x6fc23ac00)
grafana-agent     /usr/local/go/src/runtime/time.go:195 +0x135
grafana-agent sigs.k8s.io/controller-runtime/pkg/log.init.0.func1()
grafana-agent     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/log/log.go:63 +0x38
grafana-agent created by sigs.k8s.io/controller-runtime/pkg/log.init.0
grafana-agent     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/log/log.go:62 +0x25
grafana-agent 
grafana-agent goroutine 163 [select]:
grafana-agent github.com/grafana/agent/cmd/internal/flowmode.interruptContext.func1()
grafana-agent     /src/agent/cmd/internal/flowmode/cmd_run.go:345 +0xf4
grafana-agent goroutine 205 [chan receive]:
grafana-agent github.com/oklog/run.(*Group).Run(0xc0015b6e80)
grafana-agent     /go/pkg/mod/github.com/oklog/run@v1.1.0/group.go:43 +0x16b
grafana-agent github.com/grafana/agent/component/loki/source/kubernetes_events.(*Component).Run(0xc000da3200, {0x79abb10?, 0xc000127ef0?})
grafana-agent     /src/agent/component/loki/source/kubernetes_events/kubernetes_events.go:186 +0x3d2
grafana-agent github.com/grafana/agent/pkg/flow/internal/controller.(*ComponentNode).Run(0xc000210d80, {0x79abb10, 0xc000127ef0})
grafana-agent     /src/agent/pkg/flow/internal/controller/component.go:344 +0x122
grafana-agent github.com/grafana/agent/pkg/flow/internal/controller.newTask.func1()
grafana-agent     /src/agent/pkg/flow/internal/controller/scheduler.go:140 +0x74
grafana-agent created by github.com/grafana/agent/pkg/flow/internal/controller.newTask
grafana-agent     /src/agent/pkg/flow/internal/controller/scheduler.go:137 +0x150
grafana-agent 
grafana-agent goroutine 206 [chan receive]:
grafana-agent github.com/grafana/agent/component/prometheus/relabel.(*Component).Run(0xc000813680?, {0x79abb10?, 0xc0004ac050?})
grafana-agent     /src/agent/component/prometheus/relabel/relabel.go:163 +0x78
grafana-agent github.com/grafana/agent/pkg/flow/internal/controller.(*ComponentNode).Run(0xc000813680, {0x79abb10, 0xc0004ac050})
grafana-agent     /src/agent/pkg/flow/internal/controller/component.go:344 +0x122
grafana-agent github.com/grafana/agent/pkg/flow/internal/controller.newTask.func1()
grafana-agent     /src/agent/pkg/flow/internal/controller/scheduler.go:140 +0x74
grafana-agent created by github.com/grafana/agent/pkg/flow/internal/controller.newTask
grafana-agent     /src/agent/pkg/flow/internal/controller/scheduler.go:137 +0x150
grafana-agent 
grafana-agent goroutine 207 [chan receive]:
grafana-agent github.com/grafana/agent/component/prometheus/relabel.(*Component).Run(0xc000812b40?, {0x79abb10?, 0xc0004ac0f0?})
grafana-agent     /src/agent/component/prometheus/relabel/relabel.go:163 +0x78
grafana-agent github.com/grafana/agent/pkg/flow/internal/controller.(*ComponentNode).Run(0xc000812b40, {0x79abb10, 0xc0004ac0f0})
grafana-agent     /src/agent/pkg/flow/internal/controller/component.go:344 +0x122
grafana-agent github.com/grafana/agent/pkg/flow/internal/controller.newTask.func1()
grafana-agent     /src/agent/pkg/flow/internal/controller/scheduler.go:140 +0x74
grafana-agent created by github.com/grafana/agent/pkg/flow/internal/controller.newTask
grafana-agent     /src/agent/pkg/flow/internal/controller/scheduler.go:137 +0x150
grafana-agent 
grafana-agent goroutine 208 [select]:
grafana-agent github.com/grafana/agent/component/prometheus/scrape.(*Component).Run(0xc000526480, {0x79abb10, 0xc0004ac4b0})
grafana-agent     /src/agent/component/prometheus/scrape/scrape.go:180 +0x178
grafana-agent github.com/grafana/agent/pkg/flow/internal/controller.(*ComponentNode).Run(0xc000812000, {0x79abb10, 0xc0004ac4b0})
grafana-agent     /src/agent/pkg/flow/internal/controller/component.go:344 +0x122
grafana-agent github.com/grafana/agent/pkg/flow/internal/controller.newTask.func1()
grafana-agent     /src/agent/pkg/flow/internal/controller/scheduler.go:140 +0x74
grafana-agent created by github.com/grafana/agent/pkg/flow/internal/controller.newTask
grafana-agent     /src/agent/pkg/flow/internal/controller/scheduler.go:137 +0x150
grafana-agent 
grafana-agent goroutine 209 [chan receive]:
grafana-agent github.com/grafana/agent/component/discovery/relabel.(*Component).Run(0xc000812fc0?, {0x79abb10?, 0xc0004ac500?})
grafana-agent     /src/agent/component/discovery/relabel/relabel.go:65 +0x2e
grafana-agent github.com/grafana/agent/pkg/flow/internal/controller.(*ComponentNode).Run(0xc000812fc0, {0x79abb10, 0xc0004ac500})
grafana-agent     /src/agent/pkg/flow/internal/controller/component.go:344 +0x122
grafana-agent github.com/grafana/agent/pkg/flow/internal/controller.newTask.func1()
grafana-agent     /src/agent/pkg/flow/internal/controller/scheduler.go:140 +0x74
grafana-agent created by github.com/grafana/agent/pkg/flow/internal/controller.newTask
grafana-agent     /src/agent/pkg/flow/internal/controller/scheduler.go:137 +0x150
grafana-agent 
grafana-agent goroutine 210 [chan receive]:
grafana-agent github.com/grafana/agent/component/discovery/relabel.(*Component).Run(0xc0000f18c0?, {0x79abb10?, 0xc0004ac960?})
grafana-agent     /src/agent/component/discovery/relabel/relabel.go:65 +0x2e
grafana-agent github.com/grafana/agent/pkg/flow/internal/controller.(*ComponentNode).Run(0xc0000f18c0, {0x79abb10, 0xc0004ac960})
grafana-agent     /src/agent/pkg/flow/internal/controller/component.go:344 +0x122
grafana-agent github.com/grafana/agent/pkg/flow/internal/controller.newTask.func1()
grafana-agent     /src/agent/pkg/flow/internal/controller/scheduler.go:140 +0x74
grafana-agent created by github.com/grafana/agent/pkg/flow/internal/controller.newTask
grafana-agent     /src/agent/pkg/flow/internal/controller/scheduler.go:137 +0x150
grafana-agent 
grafana-agent goroutine 211 [chan receive]:
grafana-agent github.com/grafana/agent/component/discovery/relabel.(*Component).Run(0xc0000f1d40?, {0x79abb10?, 0xc0004ac9b0?})
grafana-agent     /src/agent/component/discovery/relabel/relabel.go:65 +0x2e
grafana-agent github.com/grafana/agent/pkg/flow/internal/controller.(*ComponentNode).Run(0xc0000f1d40, {0x79abb10, 0xc0004ac9b0})
grafana-agent     /src/agent/pkg/flow/internal/controller/component.go:344 +0x122
grafana-agent github.com/grafana/agent/pkg/flow/internal/controller.newTask.func1()
grafana-agent     /src/agent/pkg/flow/internal/controller/scheduler.go:140 +0x74
grafana-agent created by github.com/grafana/agent/pkg/flow/internal/controller.newTask
grafana-agent     /src/agent/pkg/flow/internal/controller/scheduler.go:137 +0x150
grafana-agent 
grafana-agent goroutine 129 [select]:
grafana-agent github.com/grafana/agent/component/loki/source/kubernetes_events.(*Component).Run.func3()
grafana-agent     /src/agent/component/loki/source/kubernetes_events/kubernetes_events.go:169 +0xbb
grafana-agent github.com/oklog/run.(*Group).Run.func1({0xc0011c6040?, 0xc0015d40a0?})
grafana-agent     /go/pkg/mod/github.com/oklog/run@v1.1.0/group.go:38 +0x2f
grafana-agent created by github.com/oklog/run.(*Group).Run
grafana-agent     /go/pkg/mod/github.com/oklog/run@v1.1.0/group.go:37 +0x69
grafana-agent 
grafana-agent goroutine 228 [chan receive]:
grafana-agent github.com/grafana/agent/component/loki/source/kubernetes_events.(*eventController).runError(0xc0004a8420, {0x79abb10, 0xc0009e60a0})
grafana-agent     /src/agent/component/loki/source/kubernetes_events/event_controller.go:115 +0x2d8
grafana-agent github.com/grafana/agent/component/loki/source/kubernetes_events.(*eventController).Run(0xc0004a8420, {0x79abb10, 0xc0009e60a0})
grafana-agent     /src/agent/component/loki/source/kubernetes_events/event_controller.go:81 +0x32b
grafana-agent github.com/grafana/agent/pkg/runner.(*Runner[...]).ApplyTasks.func2()
grafana-agent     /src/agent/pkg/runner/runner.go:166 +0x96
grafana-agent created by github.com/grafana/agent/pkg/runner.(*Runner[...]).ApplyTasks
grafana-agent     /src/agent/pkg/runner/runner.go:163 +0x6ea
grafana-agent 
grafana-agent goroutine 232 [select]:
grafana-agent github.com/prometheus/prometheus/scrape.(*Manager).Run(0xc0011116e0, 0xc0011c17a0)
grafana-agent     /go/pkg/mod/github.com/grafana/prometheus@v1.8.2-0.20230328154716-1d0e5416a0de/scrape/manager.go:167 +0xde
grafana-agent github.com/grafana/agent/component/prometheus/scrape.(*Component).Run.func1()
grafana-agent     /src/agent/component/prometheus/scrape/scrape.go:172 +0x3f
grafana-agent created by github.com/grafana/agent/component/prometheus/scrape.(*Component).Run
grafana-agent     /src/agent/component/prometheus/scrape/scrape.go:171 +0x110
grafana-agent 
grafana-agent goroutine 233 [select]:
grafana-agent github.com/prometheus/prometheus/scrape.(*Manager).reloader(0xc0011116e0)
grafana-agent goroutine 261 [select]:
grafana-agent github.com/prometheus/prometheus/scrape.(*Manager).Run(0xc0015c3bc0, 0xc0011c1f80)
grafana-agent     /go/pkg/mod/github.com/grafana/prometheus@v1.8.2-0.20230328154716-1d0e5416a0de/scrape/manager.go:167 +0xde
grafana-agent github.com/grafana/agent/component/prometheus/scrape.(*Component).Run.func1()
grafana-agent     /src/agent/component/prometheus/scrape/scrape.go:172 +0x3f
grafana-agent created by github.com/grafana/agent/component/prometheus/scrape.(*Component).Run
grafana-agent     /src/agent/component/prometheus/scrape/scrape.go:171 +0x110
grafana-agent 
grafana-agent goroutine 262 [select]:
grafana-agent github.com/prometheus/prometheus/scrape.(*Manager).reloader(0xc0015c3bc0)
grafana-agent     /go/pkg/mod/github.com/grafana/prometheus@v1.8.2-0.20230328154716-1d0e5416a0de/scrape/manager.go:193 +0xfc
grafana-agent created by github.com/prometheus/prometheus/scrape.(*Manager).Run
grafana-agent     /go/pkg/mod/github.com/grafana/prometheus@v1.8.2-0.20230328154716-1d0e5416a0de/scrape/manager.go:165 +0x65
grafana-agent 
grafana-agent goroutine 263 [select]:
grafana-agent github.com/prometheus/prometheus/scrape.(*Manager).Run(0xc0015c3f80, 0xc0000ee300)
grafana-agent     /go/pkg/mod/github.com/grafana/prometheus@v1.8.2-0.20230328154716-1d0e5416a0de/scrape/manager.go:167 +0xde
grafana-agent github.com/grafana/agent/component/prometheus/scrape.(*Component).Run.func1()
grafana-agent     /src/agent/component/prometheus/scrape/scrape.go:172 +0x3f
grafana-agent created by github.com/grafana/agent/component/prometheus/scrape.(*Component).Run
grafana-agent     /src/agent/component/prometheus/scrape/scrape.go:171 +0x110
grafana-agent 
grafana-agent goroutine 264 [select]:
grafana-agent github.com/prometheus/prometheus/scrape.(*Manager).reloader(0xc0015c3f80)
grafana-agent     /go/pkg/mod/github.com/grafana/prometheus@v1.8.2-0.20230328154716-1d0e5416a0de/scrape/manager.go:193 +0xfc
grafana-agent created by github.com/prometheus/prometheus/scrape.(*Manager).Run
grafana-agent     /go/pkg/mod/github.com/grafana/prometheus@v1.8.2-0.20230328154716-1d0e5416a0de/scrape/manager.go:165 +0x65
grafana-agent 
grafana-agent goroutine 272 [chan receive]:
grafana-agent k8s.io/client-go/tools/cache.(*processorListener).run.func1()
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/shared_informer.go:906 +0x57
grafana-agent k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:157 +0x3e
grafana-agent k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0010eaf38?, {0x795e3e0, 0xc0011c2f60}, 0x1, 0xc000101d40)
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:158 +0xb6
grafana-agent k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0000ee5a0?, 0x3b9aca00, 0x0, 0xc?, 0x7f46bd187100?)
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:135 +0x89
grafana-agent k8s.io/apimachinery/pkg/util/wait.Until(...)
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:92
grafana-agent k8s.io/client-go/tools/cache.(*processorListener).run(0xc00096d100)
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/shared_informer.go:905 +0x6b
grafana-agent k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:75 +0x5a
grafana-agent created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:73 +0x85
grafana-agent 
grafana-agent goroutine 266 [chan receive]:
grafana-agent k8s.io/client-go/tools/cache.(*sharedProcessor).run(0xc0009e7db0, 0x0?)
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/shared_informer.go:752 +0x58
grafana-agent k8s.io/apimachinery/pkg/util/wait.(*Group).StartWithChannel.func1()
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:58 +0x22
grafana-agent k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:75 +0x5a
grafana-agent created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:73 +0x85
grafana-agent 
grafana-agent goroutine 267 [chan receive]:
grafana-agent k8s.io/client-go/tools/cache.(*controller).Run.func1()
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/controller.go:131 +0x28
grafana-agent created by k8s.io/client-go/tools/cache.(*controller).Run
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/controller.go:130 +0xbe
grafana-agent 
grafana-agent goroutine 268 [select]:
grafana-agent k8s.io/client-go/tools/cache.watchHandler({0x6?, 0x0?, 0xb5a42a0?}, {0x7988380?, 0xc001c2cf00}, {0x7f4694258a80, 0xc000d9c320}, {0x79f0630?, 0x69bc240}, 0x0, ...)
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/reflector.go:493 +0x1b8
grafana-agent k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0xc000d71860, 0xc0011c1d40)
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/reflector.go:329 +0x5ec
grafana-agent k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/reflector.go:223 +0x26
grafana-agent k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc000074230?)
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:157 +0x3e
grafana-agent k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0004a3200?, {0x795e3c0, 0xc000074190}, 0x1, 0xc0011c1d40)
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:158 +0xb6
grafana-agent k8s.io/client-go/tools/cache.(*Reflector).Run(0xc000d71860, 0xc0011c1d40)
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/reflector.go:222 +0x139
grafana-agent k8s.io/apimachinery/pkg/util/wait.(*Group).StartWithChannel.func1()
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:58 +0x22
grafana-agent k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:75 +0x5a
grafana-agent created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:73 +0x85
grafana-agent 
grafana-agent goroutine 296 [select]:
grafana-agent k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch.func1()
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/reflector.go:273 +0x11d
grafana-agent created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/reflector.go:267 +0x21f
grafana-agent 
grafana-agent goroutine 270 [chan receive]:
grafana-agent net/http.(*persistConn).addTLS(0xc0011dd680, {0x79abbb8?, 0xc0011c2e10}, {0xc0011de610, 0x8}, 0xc00096d280)
grafana-agent     /usr/local/go/src/net/http/transport.go:1550 +0x365
grafana-agent net/http.(*Transport).dialConn(0xc0010f8780, {0x79abbb8, 0xc0011c2e10}, {{}, 0x0, {0xc0000ee5a0, 0x5}, {0xc0011de610, 0xc}, 0x0})
grafana-agent     /usr/local/go/src/net/http/transport.go:1624 +0x9e6
grafana-agent net/http.(*Transport).dialConnFor(0xa011de301?, 0xc00035e4d0)
grafana-agent     /usr/local/go/src/net/http/transport.go:1456 +0xb0
grafana-agent created by net/http.(*Transport).queueForDial
grafana-agent     /usr/local/go/src/net/http/transport.go:1425 +0x3ea
grafana-agent 
grafana-agent goroutine 249 [IO wait]:
grafana-agent internal/poll.runtime_pollWait(0x7f4694c98d28, 0x72)
grafana-agent created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:73 +0x85
grafana-agent 
grafana-agent goroutine 254 [select]:
grafana-agent k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch.func1()
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/reflector.go:273 +0x11d
grafana-agent created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/reflector.go:267 +0x21f
grafana-agent 
grafana-agent goroutine 256 [sync.Cond.Wait]:
grafana-agent sync.runtime_notifyListWait(0xc0017d6ac8, 0x0)
grafana-agent     /usr/local/go/src/runtime/sema.go:527 +0x14c
grafana-agent sync.(*Cond).Wait(0xc00116dc20?)
grafana-agent     /usr/local/go/src/sync/cond.go:70 +0x8c
grafana-agent golang.org/x/net/http2.(*pipe).Read(0xc0017d6ab0, {0xc000dfe658, 0x4, 0x4})
grafana-agent     /go/pkg/mod/golang.org/x/net@v0.8.0/http2/pipe.go:76 +0xeb
grafana-agent golang.org/x/net/http2.transportResponseBody.Read({0xc0009d8b9c?}, {0xc000dfe658?, 0xc00116dd18?, 0x410616?})
grafana-agent     /go/pkg/mod/golang.org/x/net@v0.8.0/http2/transport.go:2507 +0x75
grafana-agent io.ReadAtLeast({0x7f46942178c0, 0xc0017d6a80}, {0xc000dfe658, 0x4, 0x4}, 0x4)
grafana-agent     /usr/local/go/src/io/io.go:332 +0x9a
grafana-agent k8s.io/apimachinery/pkg/util/framer.(*lengthDelimitedFrameReader).Read(0xc0005c3950, {0xc001063400, 0x400, 0x400})
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/framer/framer.go:76 +0x88
grafana-agent k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0xc000349270, 0xc000074fa0?, {0x7988128, 0xc00064ecc0})
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/runtime/serializer/streaming/streaming.go:77 +0xa7
grafana-agent k8s.io/client-go/rest/watch.(*Decoder).Decode(0xc00012ccc0)
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/rest/watch/decoder.go:49 +0x4f
grafana-agent k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0xc00064ec80)
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/watch/streamwatcher.go:105 +0xd0
grafana-agent created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/watch/streamwatcher.go:76 +0x130
grafana-agent 
grafana-agent goroutine 396 [chan receive]:
grafana-agent k8s.io/client-go/tools/cache.(*processorListener).run.func1()
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/shared_informer.go:906 +0x57
grafana-agent k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:157 +0x3e
grafana-agent k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc001ab6f38?, {0x795e3e0, 0xc001d04270}, 0x1, 0xc001ad9320)
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:158 +0xb6
grafana-agent k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x0?, 0x3b9aca00, 0x0, 0x0?, 0x0?)
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:135 +0x89
grafana-agent k8s.io/apimachinery/pkg/util/wait.Until(...)
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:92
grafana-agent k8s.io/client-go/tools/cache.(*processorListener).run(0xc000e19600)
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/shared_informer.go:905 +0x6b
grafana-agent k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:75 +0x5a
grafana-agent created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:73 +0x85
grafana-agent 
grafana-agent goroutine 291 [select]:
grafana-agent k8s.io/client-go/tools/cache.(*processorListener).pop(0xc00096d400)
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/shared_informer.go:876 +0x119
grafana-agent k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:75 +0x5a
grafana-agent created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:73 +0x85
grafana-agent 
grafana-agent goroutine 252 [IO wait]:
grafana-agent internal/poll.runtime_pollWait(0x7f4694c98c38, 0x72)
grafana-agent     /usr/local/go/src/runtime/netpoll.go:306 +0x89
grafana-agent internal/poll.(*pollDesc).wait(0xc00096d500?, 0xc0018e2000?, 0x0)
grafana-agent     /usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x32
grafana-agent internal/poll.(*pollDesc).waitRead(...)
grafana-agent     /usr/local/go/src/internal/poll/fd_poll_runtime.go:89
grafana-agent internal/poll.(*FD).Read(0xc00096d500, {0xc0018e2000, 0xa000, 0xa000})
grafana-agent     /usr/local/go/src/internal/poll/fd_unix.go:167 +0x299
grafana-agent net.(*netFD).Read(0xc00096d500, {0xc0018e2000?, 0xc0018ea258?, 0x1372?})
grafana-agent     /usr/local/go/src/net/fd_posix.go:55 +0x29
grafana-agent net.(*conn).Read(0xc0001228e0, {0xc0018e2000?, 0x665178?, 0xc000deb330?})
grafana-agent     /usr/local/go/src/net/net.go:183 +0x45
grafana-agent crypto/tls.(*atLeastReader).Read(0xc002343740, {0xc0018e2000?, 0xc002343740?, 0x0?})
grafana-agent     /usr/local/go/src/crypto/tls/conn.go:788 +0x3d
grafana-agent bytes.(*Buffer).ReadFrom(0xc000deb410, {0x7949b20, 0xc002343740})
grafana-agent     /usr/local/go/src/bytes/buffer.go:202 +0x98
grafana-agent crypto/tls.(*Conn).readFromUntil(0xc000deb180, {0x795ee20?, 0xc0001228e0}, 0x1dad?)
grafana-agent     /usr/local/go/src/crypto/tls/conn.go:810 +0xe5
grafana-agent crypto/tls.(*Conn).readRecordOrCCS(0xc000deb180, 0x0)
grafana-agent     /usr/local/go/src/crypto/tls/conn.go:617 +0x116
grafana-agent crypto/tls.(*Conn).readRecord(...)
grafana-agent     /usr/local/go/src/crypto/tls/conn.go:583
grafana-agent crypto/tls.(*Conn).Read(0xc000deb180, {0xc000b7f000, 0x1000, 0xc0018d8193?})
grafana-agent     /usr/local/go/src/crypto/tls/conn.go:1316 +0x16f
grafana-agent bufio.(*Reader).Read(0xc0008f9260, {0xc0010952a0, 0x9, 0xc001177d38?})
grafana-agent     /usr/local/go/src/bufio/bufio.go:237 +0x1bb
grafana-agent io.ReadAtLeast({0x79481c0, 0xc0008f9260}, {0xc0010952a0, 0x9, 0x9}, 0x9)
grafana-agent     /usr/local/go/src/io/io.go:332 +0x9a
grafana-agent io.ReadFull(...)
grafana-agent     /usr/local/go/src/io/io.go:351
grafana-agent golang.org/x/net/http2.readFrameHeader({0xc0010952a0?, 0x9?, 0xc000000000?}, {0x79481c0?, 0xc0008f9260?})
grafana-agent     /go/pkg/mod/golang.org/x/net@v0.8.0/http2/frame.go:237 +0x6e
grafana-agent golang.org/x/net/http2.(*Framer).ReadFrame(0xc001095260)
grafana-agent     /go/pkg/mod/golang.org/x/net@v0.8.0/http2/frame.go:498 +0x95
grafana-agent golang.org/x/net/http2.(*clientConnReadLoop).run(0xc001177f98)
grafana-agent     /go/pkg/mod/golang.org/x/net@v0.8.0/http2/transport.go:2224 +0x12e
grafana-agent golang.org/x/net/http2.(*ClientConn).readLoop(0xc0017d6780)
grafana-agent     /go/pkg/mod/golang.org/x/net@v0.8.0/http2/transport.go:2119 +0x6f
grafana-agent created by golang.org/x/net/http2.(*Transport).newClientConn
grafana-agent     /go/pkg/mod/golang.org/x/net@v0.8.0/http2/transport.go:817 +0xc1f
grafana-agent 
grafana-agent goroutine 250 [select]:
grafana-agent k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:75 +0x5a
grafana-agent created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:73 +0x85
grafana-agent 
grafana-agent goroutine 300 [chan receive]:
grafana-agent sigs.k8s.io/controller-runtime/pkg/cache/internal.(*specificInformersMap).Start(0x0?, {0x79abb10, 0xc0009e60a0})
grafana-agent     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/cache/internal/informers_map.go:165 +0x3c
grafana-agent created by sigs.k8s.io/controller-runtime/pkg/cache/internal.(*InformersMap).Start
grafana-agent     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/cache/internal/deleg_map.go:69 +0x11b
grafana-agent 
grafana-agent goroutine 303 [sync.Cond.Wait]:
grafana-agent sync.runtime_notifyListWait(0xc001091ba8, 0x1)
grafana-agent     /usr/local/go/src/runtime/sema.go:527 +0x14c
grafana-agent sync.(*Cond).Wait(0xc001c38480?)
grafana-agent     /usr/local/go/src/sync/cond.go:70 +0x8c
grafana-agent k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc001091b80, 0xc001cfc8d0)
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/delta_fifo.go:527 +0x1d6
grafana-agent k8s.io/client-go/tools/cache.(*controller).processLoop(0xc001cb6480)
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/controller.go:184 +0x36
grafana-agent k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:157 +0x3e
grafana-agent k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x10af0a5?, {0x795e3e0, 0xc001cfb890}, 0x1, 0xc0009fd860)
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:158 +0xb6
grafana-agent k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc001cb64e8?, 0x3b9aca00, 0x0, 0x80?, 0x7f4694258a80?)
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:135 +0x89
grafana-agent k8s.io/apimachinery/pkg/util/wait.Until(...)
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:92
grafana-agent k8s.io/client-go/tools/cache.(*controller).Run(0xc001cb6480, 0xc0009fd860)
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/controller.go:155 +0x2c6
grafana-agent k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run(0xc001091ae0, 0x0?)
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/shared_informer.go:461 +0x47d
grafana-agent created by sigs.k8s.io/controller-runtime/pkg/cache/internal.(*specificInformersMap).addInformerToMap
grafana-agent     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/cache/internal/informers_map.go:262 +0x65b
grafana-agent 
grafana-agent goroutine 404 [chan receive]:
grafana-agent k8s.io/client-go/tools/cache.(*controller).Run.func1()
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/controller.go:131 +0x28
grafana-agent created by k8s.io/client-go/tools/cache.(*controller).Run
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/controller.go:130 +0xbe
grafana-agent 
grafana-agent goroutine 393 [select]:
grafana-agent k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch.func1()
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/reflector.go:273 +0x11d
grafana-agent created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/reflector.go:267 +0x21f
grafana-agent 
grafana-agent goroutine 394 [select]:
grafana-agent golang.org/x/net/http2.(*clientStream).writeRequest(0xc001a97800, 0xc001ad3f00)
grafana-agent     /go/pkg/mod/golang.org/x/net@v0.8.0/http2/transport.go:1437 +0xb27
grafana-agent golang.org/x/net/http2.(*clientStream).doRequest(0xa00000001?, 0xc001abdfa0?)
grafana-agent     /go/pkg/mod/golang.org/x/net@v0.8.0/http2/transport.go:1299 +0x1e
grafana-agent created by golang.org/x/net/http2.(*ClientConn).RoundTrip
grafana-agent     /go/pkg/mod/golang.org/x/net@v0.8.0/http2/transport.go:1228 +0x34a
grafana-agent 
grafana-agent goroutine 403 [chan receive]:
grafana-agent k8s.io/client-go/tools/cache.(*sharedProcessor).run(0xc001ca9400, 0xc001abafb0?)
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/shared_informer.go:752 +0x58
grafana-agent k8s.io/apimachinery/pkg/util/wait.(*Group).StartWithChannel.func1()
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:58 +0x22
grafana-agent k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:75 +0x5a
grafana-agent created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/wait/wait.go:73 +0x85
grafana-agent 
grafana-agent goroutine 392 [sync.Cond.Wait]:
grafana-agent sync.runtime_notifyListWait(0xc000dd10c8, 0x1)
grafana-agent     /usr/local/go/src/runtime/sema.go:527 +0x14c
grafana-agent sync.(*Cond).Wait(0xc001aa3d78?)
grafana-agent     /usr/local/go/src/sync/cond.go:70 +0x8c
grafana-agent golang.org/x/net/http2.(*pipe).Read(0xc000dd10b0, {0xc001d8c04c, 0x4, 0x4})
grafana-agent     /go/pkg/mod/golang.org/x/net@v0.8.0/http2/pipe.go:76 +0xeb
grafana-agent golang.org/x/net/http2.transportResponseBody.Read({0x0?}, {0xc001d8c04c?, 0xc001aa3d18?, 0x410616?})
grafana-agent     /go/pkg/mod/golang.org/x/net@v0.8.0/http2/transport.go:2507 +0x75
grafana-agent io.ReadAtLeast({0x7f46942178c0, 0xc000dd1080}, {0xc001d8c04c, 0x4, 0x4}, 0x4)
grafana-agent     /usr/local/go/src/io/io.go:332 +0x9a
grafana-agent k8s.io/apimachinery/pkg/util/framer.(*lengthDelimitedFrameReader).Read(0xc001c36000, {0xc001920500, 0x2000, 0x2500})
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/util/framer/framer.go:76 +0x88
grafana-agent k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0xc001c17a40, 0xc001d86000?, {0x7988128, 0xc001d80440})
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/runtime/serializer/streaming/streaming.go:77 +0xa7
grafana-agent k8s.io/client-go/rest/watch.(*Decoder).Decode(0xc001afffe0)
grafana-agent     /go/pkg/mod/k8s.io/client-go@v0.26.2/rest/watch/decoder.go:49 +0x4f
grafana-agent k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0xc001c2cf00)
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/watch/streamwatcher.go:105 +0xd0
grafana-agent created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher
grafana-agent     /go/pkg/mod/k8s.io/apimachinery@v0.26.2/pkg/watch/streamwatcher.go:76 +0x130
grafana-agent 
grafana-agent goroutine 455 [chan receive]:
grafana-agent github.com/grafana/agent/component/loki/source/kubernetes/kubetail.(*tailer).tail.func1()
grafana-agent     /src/agent/component/loki/source/kubernetes/kubetail/tailer.go:171 +0x3b
grafana-agent created by github.com/grafana/agent/component/loki/source/kubernetes/kubetail.(*tailer).tail
grafana-agent     /src/agent/component/loki/source/kubernetes/kubetail/tailer.go:170 +0x5de
grafana-agent 
grafana-agent goroutine 297 [select]:
grafana-agent golang.org/x/net/http2.(*clientStream).writeRequest(0xc000dd1080, 0xc001bf0000)
grafana-agent     /go/pkg/mod/golang.org/x/net@v0.8.0/http2/transport.go:1437 +0xb27
grafana-agent golang.org/x/net/http2.(*clientStream).doRequest(0x7231434d4147694c?, 0x2f4b564748414c6c?)
grafana-agent     /go/pkg/mod/golang.org/x/net@v0.8.0/http2/transport.go:1299 +0x1e
grafana-agent created by golang.org/x/net/http2.(*ClientConn).RoundTrip
grafana-agent     /go/pkg/mod/golang.org/x/net@v0.8.0/http2/transport.go:1228 +0x34a
Stream closed EOF for default/grafana-agent-5c499dfd78-j824z (grafana-agent)
```
</details>

I _think_ what happens is that when trying to send batches via loki.write, we iterate over the entry's labels in [labelsMapToString](https://github.com/grafana/agent/blob/d355d51bb5756cc6d1f5bd229ea13fc5282fbad8/component/common/loki/client/batch.go#L57). When [sending entries](https://github.com/grafana/agent/blob/d355d51bb5756cc6d1f5bd229ea13fc5282fbad8/component/loki/source/kubernetes/kubetail/tailer.go#L192-L208) through loki.source.kubernetes, we assign the tailer's labels to outgoing entries, but we don't guarantee that the tailer won't go away or change its labels by then.

The proposed fix here is to Clone() the tailer's labels on the outgoing entry to avoid concurrent reads and writes.

#### Which issue(s) this PR fixes
Fixes #3823 

#### Notes to the Reviewer
I want to see if we can add a test for this

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added (N/A)
- [ ] Tests updated
