### PR TITLE
river-jsonnet: support block indexes

### DIFF
--- a/operations/river-jsonnet/README.md
+++ b/operations/river-jsonnet/README.md
@@ -15,7 +15,10 @@ Instead of following these naming conventions, helper functions are provided to
 make it easier:
 
 * `river.attr(name)` returns a field name that can be used as an attribute.
-* `river.block(name, label="")` returns a field name that represents a block.
+* `river.block(name, label="", index=0)` returns a field name that represents a block.
+  * The `index` parameter can be provided to make sure blocks get marshaled in
+    a specific order. If two blocks have the same index, they will be ordered
+    lexicographically by name and label.
 
 In addition to the helper functions, `river.expr(literal)` is used to inject a
 literal River expression, so that `river.expr('env("HOME")')` is manifested as

--- a/operations/river-jsonnet/builder.jsonnet
+++ b/operations/river-jsonnet/builder.jsonnet
@@ -5,10 +5,10 @@ local utils = import './internal/utils.jsonnet';
   attr(name):: name,
 
   // block returns the field name that should be used for River blocks.
-  block(name, label='')::
+  block(name, label='', index=0)::
     if label == ''
-    then ('block %s' % name)
-    else ('block %s %s' % [name, label]),
+    then ('block %d %s' % [index, name])
+    else ('block %d %s %s' % [index, name, label]),
 
   // expr returns an object which represents a literal River expression.
   expr(lit):: {

--- a/operations/river-jsonnet/main_test.jsonnet
+++ b/operations/river-jsonnet/main_test.jsonnet
@@ -57,6 +57,29 @@ local tests = [
     |||,
   },
   {
+    name: 'Ordered blocks',
+    input: {
+      [river.block('labeled_block', 'foobar', index=1)]: {
+        attr_1: 15,
+        attr_2: 30,
+      },
+      [river.block('unlabeled_block', index=0)]: {
+        attr_1: 15,
+        attr_2: 30,
+      },
+    },
+    expect: |||
+      unlabeled_block {
+        attr_1 = 15
+        attr_2 = 30
+      }
+      labeled_block "foobar" {
+        attr_1 = 15
+        attr_2 = 30
+      }
+    |||,
+  },
+  {
     name: 'Nested blocks',
     input: {
       [river.block('outer.block')]: {

--- a/operations/river-jsonnet/manifest.jsonnet
+++ b/operations/river-jsonnet/manifest.jsonnet
@@ -8,12 +8,14 @@ local parseField(name) = (
   if numParts == 1 then {
     type: 'attr',
     name: parts[0],
+    index: 0,
     orig: name,
   }
-  else if numParts > 1 && numParts <= 3 && parts[0] == 'block' then {
+  else if numParts > 1 && numParts <= 4 && parts[0] == 'block' then {
     type: 'block',
-    name: parts[1],
-    label: if numParts == 3 then parts[2] else '',
+    index: std.parseInt(parts[1]),
+    name: parts[2],
+    label: if numParts == 4 then parts[3] else '',
     orig: name,
   } else (
     error 'invalid field name %s' % name
@@ -36,7 +38,10 @@ local manifester(indent=0) = {
   body(value): (
     // First we need to look at each public field of the value and parse it as
     // an attribute or block.
-    local parsedFields = std.map(function(field) parseField(field), std.objectFields(value));
+    local parsedFields = std.sort(
+      std.map(function(field) parseField(field), std.objectFields(value)),
+      function(field) field.index,
+    );
 
     // Now we can accumulate all of the fields into a single string. Each field
     // will be separated by exactly one newline.


### PR DESCRIPTION
Support adding an index argument to river.block to ensure that blocks get marshaled in a specific order.
