### PR TITLE
feat(loki): add custom headers to loki.remote_write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Main (unreleased)
 
 ### Enhancements
 
+- Support ability to add optional custom headers to `loki.write` endpoint block (@aos)
+
 - Support in-memory HTTP traffic for Flow components. `prometheus.exporter`
   components will now export a target containing an internal HTTP address.
   `prometheus.scrape`, when given that internal HTTP address, will connect to

--- a/component/common/loki/client/client.go
+++ b/component/common/loki/client/client.go
@@ -404,6 +404,17 @@ func (c *client) send(ctx context.Context, tenantID string, buf []byte) (int, er
 		req.Header.Set("X-Scope-OrgID", tenantID)
 	}
 
+	// Add custom headers on request
+	if len(c.cfg.Headers) > 0 {
+		for k, v := range c.cfg.Headers {
+			if req.Header.Get(k) == "" {
+				req.Header.Add(k, v)
+			} else {
+				level.Warn(c.logger).Log("msg", "custom header key already exists, skipping", "key", k)
+			}
+		}
+	}
+
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return -1, err

--- a/component/common/loki/client/config.go
+++ b/component/common/loki/client/config.go
@@ -28,6 +28,7 @@ const (
 type Config struct {
 	Name      string `yaml:"name,omitempty"`
 	URL       flagext.URLValue
+	Headers   map[string]string `yaml:"headers,omitempty"`
 	BatchWait time.Duration
 	BatchSize int
 

--- a/component/common/loki/client/config_test.go
+++ b/component/common/loki/client/config_test.go
@@ -31,6 +31,8 @@ backoff_config:
 batchwait: 5s
 batchsize: 204800
 timeout: 5s
+headers:
+  name: value
 `
 
 func Test_Config(t *testing.T) {
@@ -61,6 +63,9 @@ func Test_Config(t *testing.T) {
 			Config{
 				URL: flagext.URLValue{
 					URL: u,
+				},
+				Headers: map[string]string{
+					"name": "value",
 				},
 				BackoffConfig: backoff.Config{
 					MaxBackoff: 1 * time.Minute,

--- a/component/loki/write/types.go
+++ b/component/loki/write/types.go
@@ -22,6 +22,7 @@ type EndpointOptions struct {
 	BatchWait         time.Duration           `river:"batch_wait,attr,optional"`
 	BatchSize         units.Base2Bytes        `river:"batch_size,attr,optional"`
 	RemoteTimeout     time.Duration           `river:"remote_timeout,attr,optional"`
+	Headers           map[string]string       `river:"headers,attr,optional"`
 	MinBackoff        time.Duration           `river:"min_backoff_period,attr,optional"`  // start backoff at this level
 	MaxBackoff        time.Duration           `river:"max_backoff_period,attr,optional"`  // increase exponentially to this level
 	MaxBackoffRetries int                     `river:"max_backoff_retries,attr,optional"` // give up after this many; zero means infinite retries
@@ -76,6 +77,7 @@ func (args Arguments) convertClientConfigs() []client.Config {
 		cc := client.Config{
 			Name:      cfg.Name,
 			URL:       flagext.URLValue{URL: url},
+			Headers:   cfg.Headers,
 			BatchWait: cfg.BatchWait,
 			BatchSize: int(cfg.BatchSize),
 			Client:    *cfg.HTTPClientConfig.Convert(),

--- a/docs/sources/flow/reference/components/loki.write.md
+++ b/docs/sources/flow/reference/components/loki.write.md
@@ -60,22 +60,23 @@ The `endpoint` block describes a single location to send logs to. Multiple
 
 The following arguments are supported:
 
-Name                  | Type       | Description                           | Default        | Required
---------------------- | -----------| ------------------------------------- | -------------- | --------
-`url`                 | `string`   | Full URL to send logs to. | | yes
-`name`                | `string`   | Optional name to identify this endpoint with. | | no
-`batch_wait`          | `duration` | Maximum amount of time to wait before sending a batch. | `"1s"` | no
-`batch_size`          | `string`   | Maximum batch size of logs to accumulate before sending. | `"1MiB"` | no
-`remote_timeout`      | `duration` | Timeout for requests made to the URL. | `"10s"` | no
-`tenant_id`           | `string`   | The tenant ID used by default to push logs. | | no
-`min_backoff_period`  | `duration` | Initial backoff time between retries. | `"500ms"` | no
-`max_backoff_period`  | `duration` | Maximum backoff time between retries. | `"5m"` | no
-`max_backoff_retries` | `int`      | Maximum number of retries. | 10 | no
-`bearer_token`        | `secret`   | Bearer token to authenticate with. | | no
-`bearer_token_file`   | `string`   | File containing a bearer token to authenticate with. | | no
-`proxy_url`           | `string`   | HTTP proxy to proxy requests through. | | no
-`follow_redirects`    | `bool`     | Whether redirects returned by the server should be followed. | `true` | no
-`enable_http2`        | `bool`     | Whether HTTP2 is supported for requests. | `true` | no
+Name                  | Type          | Description                           | Default        | Required
+--------------------- | ------------- | ------------------------------------- | -------------- | --------
+`url`                 | `string`      | Full URL to send logs to. | | yes
+`name`                | `string`      | Optional name to identify this endpoint with. | | no
+`headers`             | `map(string)` | Extra headers to deliver with the request. | | no
+`batch_wait`          | `duration`    | Maximum amount of time to wait before sending a batch. | `"1s"` | no
+`batch_size`          | `string`      | Maximum batch size of logs to accumulate before sending. | `"1MiB"` | no
+`remote_timeout`      | `duration`    | Timeout for requests made to the URL. | `"10s"` | no
+`tenant_id`           | `string`      | The tenant ID used by default to push logs. | | no
+`min_backoff_period`  | `duration`    | Initial backoff time between retries. | `"500ms"` | no
+`max_backoff_period`  | `duration`    | Maximum backoff time between retries. | `"5m"` | no
+`max_backoff_retries` | `int`         | Maximum number of retries. | 10 | no
+`bearer_token`        | `secret`      | Bearer token to authenticate with. | | no
+`bearer_token_file`   | `string`      | File containing a bearer token to authenticate with. | | no
+`proxy_url`           | `string`      | HTTP proxy to proxy requests through. | | no
+`follow_redirects`    | `bool`        | Whether redirects returned by the server should be followed. | `true` | no
+`enable_http2`        | `bool`        | Whether HTTP2 is supported for requests. | `true` | no
 
  At most one of the following can be provided:
  - [`bearer_token` argument](#endpoint-block).


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR adds configuration to support custom headers for the `loki.write` endpoint block. This is needed in certain situations such as sending to Loki sitting behind Cloudflare Access network.

This PR is essentially a copy of: https://github.com/grafana/loki/pull/7472 retrofit to work with Agent.

#### Which issue(s) this PR fixes

Fixes #3879 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
