### PR TITLE
flow: Add toggle to enable /debug/pprof endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ Main (unreleased)
 - Add `agent_wal_out_of_order_samples_total` metric to track samples received
   out of order. (@rfratto)
 
-- Add CLI flag `--enable-go-profiling` to grafana-agent-flow to conditionally enable `/debug/pprof` endpoints (@jkroepke)
+- Add CLI flag `--server.http.enable-pprof` to grafana-agent-flow to conditionally enable `/debug/pprof` endpoints (@jkroepke)
 
 - Use Go 1.20.4 for builds. (@tpaschalis)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,8 @@ Main (unreleased)
 - Add `agent_wal_out_of_order_samples_total` metric to track samples received
   out of order. (@rfratto)
 
+- Add CLI flag `--enable-go-profiling` to grafana-agent-flow to conditionally enable `/debug/pprof` endpoints (@jkroepke)
+
 - Use Go 1.20.4 for builds. (@tpaschalis)
 
 v0.33.2 (2023-05-11)

--- a/docs/sources/flow/reference/cli/run.md
+++ b/docs/sources/flow/reference/cli/run.md
@@ -27,6 +27,7 @@ running components.
 
 The following flags are supported:
 
+* `--server.http.enable-pprof`: Enable /debug/pprof profiling endpoints. (default `true`)
 * `--server.http.memory-addr`: Address to listen for [in-memory HTTP traffic][] on
   (default `agent.internal:12345`).
 * `--server.http.listen-addr`: Address to listen for HTTP traffic on (default `127.0.0.1:12345`).


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR introduce a CLI flag to conditionally enable the go profiling endpoints. Leaving the default enable to preserve backwards compatibility.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
