### PR TITLE
river-jsonnet: change where index gets injected to end

### DIFF
--- a/operations/river-jsonnet/builder.jsonnet
+++ b/operations/river-jsonnet/builder.jsonnet
@@ -7,8 +7,8 @@ local utils = import './internal/utils.jsonnet';
   // block returns the field name that should be used for River blocks.
   block(name, label='', index=0)::
     if label == ''
-    then ('block %d %s' % [index, name])
-    else ('block %d %s %s' % [index, name, label]),
+    then ('block %s %d' % [name, index])
+    else ('block %s %s %d' % [name, label, index]),
 
   // expr returns an object which represents a literal River expression.
   expr(lit):: {

--- a/operations/river-jsonnet/manifest.jsonnet
+++ b/operations/river-jsonnet/manifest.jsonnet
@@ -12,10 +12,15 @@ local parseField(name) = (
     orig: name,
   }
   else if numParts > 1 && numParts <= 4 && parts[0] == 'block' then {
+    // Format is either:
+    //
+    // * block NAME index
+    // * block NAME LABEL index
+
     type: 'block',
-    index: std.parseInt(parts[1]),
-    name: parts[2],
-    label: if numParts == 4 then parts[3] else '',
+    name: parts[1],
+    label: if numParts == 4 then parts[2] else '',
+    index: if numParts == 4 then std.parseInt(parts[3]) else std.parseInt(parts[2]),
     orig: name,
   } else (
     error 'invalid field name %s' % name


### PR DESCRIPTION
Existing usages of river-jsonnet may check for std.startsWith assuming the old internal format. This change makes the prefix of internal format consistent with what it used to be.

A longer-term solution would be to add a utility method to deconstruct these lines rather than relying on an internal representation.
