### PR TITLE
Fix `common/net` server defaults working incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ Main (unreleased)
 
 ### Bugfixes
 
+- Fix `loki.source.(gcplog|heroku)` `http` and `grpc` blocks were overriding defaults with zero-values
+  on non present fields. (@thepalbi)
+
 - Fix an issue where defining `logging` or `tracing` blocks inside of a module
   would generate a panic instead of returning an error. (@erikbaranowski)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ Main (unreleased)
 ### Bugfixes
 
 - Fix `loki.source.(gcplog|heroku)` `http` and `grpc` blocks were overriding defaults with zero-values
-  on non present fields. (@thepalbi)
+  on non-present fields. (@thepalbi)
 
 - Fix an issue where defining `logging` or `tracing` blocks inside of a module
   would generate a panic instead of returning an error. (@erikbaranowski)

--- a/component/common/net/config.go
+++ b/component/common/net/config.go
@@ -19,6 +19,9 @@ const (
 	Size4MB          = 4 << 20
 )
 
+// Use to populate defaults if some block is not configured
+var defaultServerConfig = DefaultServerConfig()
+
 // ServerConfig is a River configuration that allows one to configure a weaveworks.Server. It
 // exposes a subset of the available configurations.
 type ServerConfig struct {
@@ -81,7 +84,7 @@ func (g *GRPCConfig) Into(c *weaveworks.Config) {
 }
 
 func (c *ServerConfig) UnmarshalRiver(f func(v interface{}) error) error {
-	*c = newDefaults()
+	*c = *DefaultServerConfig()
 	type config ServerConfig
 	if err := f((*config)(c)); err != nil {
 		return err
@@ -95,9 +98,13 @@ func (c *ServerConfig) Convert() weaveworks.Config {
 	cfg := newWeaveworksDefaultConfig()
 	if c.HTTP != nil {
 		c.HTTP.Into(&cfg)
+	} else {
+		defaultServerConfig.HTTP.Into(&cfg)
 	}
 	if c.GRPC != nil {
 		c.GRPC.Into(&cfg)
+	} else {
+		defaultServerConfig.GRPC.Into(&cfg)
 	}
 	cfg.ServerGracefulShutdownTimeout = c.GracefulShutdownTimeout
 	return cfg
@@ -113,10 +120,10 @@ func newWeaveworksDefaultConfig() weaveworks.Config {
 	return c
 }
 
-// newDefaults creates a new ServerConfig with defaults applied. Not that some are inherited from
+// DefaultServerConfig creates a new ServerConfig with defaults applied. Not that some are inherited from
 // weaveworks, but copied in our config model to make the overriding logic simpler.
-func newDefaults() ServerConfig {
-	return ServerConfig{
+func DefaultServerConfig() *ServerConfig {
+	return &ServerConfig{
 		HTTP: &HTTPConfig{
 			ListenAddress:      "",
 			ListenPort:         DefaultHTTPPort,

--- a/component/common/net/config.go
+++ b/component/common/net/config.go
@@ -84,6 +84,8 @@ func (g *GRPCConfig) Into(c *weaveworks.Config) {
 }
 
 func (c *ServerConfig) UnmarshalRiver(f func(v interface{}) error) error {
+	// when unmarshalling, use our defaults to cover cases in which just some of the http/grpc
+	// block attributes are configured
 	*c = *DefaultServerConfig()
 	type config ServerConfig
 	if err := f((*config)(c)); err != nil {
@@ -96,6 +98,8 @@ func (c *ServerConfig) UnmarshalRiver(f func(v interface{}) error) error {
 // Convert converts the River-based ServerConfig into a weaveworks.Config object.
 func (c *ServerConfig) Convert() weaveworks.Config {
 	cfg := newWeaveworksDefaultConfig()
+	// use the configured http/grpc blocks, and if not, use a mixin of our defaults, and
+	// weaveworks's as a fallback
 	if c.HTTP != nil {
 		c.HTTP.Into(&cfg)
 	} else {
@@ -120,8 +124,8 @@ func newWeaveworksDefaultConfig() weaveworks.Config {
 	return c
 }
 
-// DefaultServerConfig creates a new ServerConfig with defaults applied. Not that some are inherited from
-// weaveworks, but copied in our config model to make the overriding logic simpler.
+// DefaultServerConfig creates a new ServerConfig with defaults applied. Note that some are inherited from
+// weaveworks, but copied in our config model to make the mixin logic simpler.
 func DefaultServerConfig() *ServerConfig {
 	return &ServerConfig{
 		HTTP: &HTTPConfig{

--- a/component/common/net/config.go
+++ b/component/common/net/config.go
@@ -15,8 +15,8 @@ const (
 	DefaultGRPCPort = 8081
 
 	// defaults inherited from weaveworks
-	DurationInfinity = time.Duration(math.MaxInt64)
-	Size4MB          = 4 << 20
+	durationInfinity = time.Duration(math.MaxInt64)
+	size4MB          = 4 << 20
 )
 
 // Use to populate defaults if some block is not configured
@@ -136,12 +136,12 @@ func DefaultServerConfig() *ServerConfig {
 			ListenAddress:              "",
 			ListenPort:                 DefaultGRPCPort,
 			ConnLimit:                  0,
-			MaxConnectionAge:           DurationInfinity,
-			MaxConnectionAgeGrace:      DurationInfinity,
-			MaxConnectionIdle:          DurationInfinity,
+			MaxConnectionAge:           durationInfinity,
+			MaxConnectionAgeGrace:      durationInfinity,
+			MaxConnectionIdle:          durationInfinity,
 			ServerMaxConcurrentStreams: 100,
-			ServerMaxSendMsg:           Size4MB,
-			ServerMaxRecvMsg:           Size4MB,
+			ServerMaxSendMsg:           size4MB,
+			ServerMaxRecvMsg:           size4MB,
 		},
 		GracefulShutdownTimeout: 30 * time.Second,
 	}

--- a/component/common/net/config_test.go
+++ b/component/common/net/config_test.go
@@ -10,8 +10,6 @@ import (
 	weaveworks "github.com/weaveworks/common/server"
 )
 
-const size4mb = 4 * 1024 * 1024
-
 func TestConfig(t *testing.T) {
 	type testcase struct {
 		raw         string
@@ -31,8 +29,8 @@ func TestConfig(t *testing.T) {
 				require.False(t, config.RegisterInstrumentation)
 				require.Equal(t, time.Second*30, config.ServerGracefulShutdownTimeout)
 
-				require.Equal(t, size4mb, config.GRPCServerMaxSendMsgSize)
-				require.Equal(t, size4mb, config.GPRCServerMaxRecvMsgSize)
+				require.Equal(t, size4MB, config.GRPCServerMaxSendMsgSize)
+				require.Equal(t, size4MB, config.GPRCServerMaxRecvMsgSize)
 			},
 		},
 		"overriding defaults": {
@@ -79,7 +77,7 @@ func TestConfig(t *testing.T) {
 				require.Equal(t, "0.0.0.0", config.GRPCListenAddress)
 				require.Equal(t, 10, config.GRPCServerMaxSendMsgSize)
 				// this should have the default applied
-				require.Equal(t, size4mb, config.GPRCServerMaxRecvMsgSize)
+				require.Equal(t, size4MB, config.GPRCServerMaxRecvMsgSize)
 
 				require.Equal(t, time.Minute, config.ServerGracefulShutdownTimeout)
 			},
@@ -134,7 +132,7 @@ func TestConfig(t *testing.T) {
 			cfg := ServerConfig{}
 			err := river.Unmarshal([]byte(tc.raw), &cfg)
 			require.Equal(t, tc.errExpected, err != nil)
-			wConfig := cfg.Convert()
+			wConfig := cfg.convert()
 			tc.assert(t, wConfig)
 		})
 	}

--- a/component/common/net/server.go
+++ b/component/common/net/server.go
@@ -35,7 +35,7 @@ func NewTargetServer(logger log.Logger, metricsNamespace string, reg prometheus.
 	}
 
 	if config == nil {
-		config = &ServerConfig{}
+		config = DefaultServerConfig()
 	}
 
 	// convert from River into the weaveworks config

--- a/component/common/net/server.go
+++ b/component/common/net/server.go
@@ -35,11 +35,11 @@ func NewTargetServer(logger log.Logger, metricsNamespace string, reg prometheus.
 	}
 
 	if config == nil {
-		config = DefaultServerConfig()
+		config = defaultServerConfig()
 	}
 
 	// convert from River into the weaveworks config
-	serverCfg := config.Convert()
+	serverCfg := config.convert()
 	// Set the config to the new combined config.
 	// Avoid logging entire received request on failures
 	serverCfg.ExcludeRequestInLog = true

--- a/component/common/net/server_test.go
+++ b/component/common/net/server_test.go
@@ -51,5 +51,5 @@ func TestTargetServer_NilConfig(t *testing.T) {
 	defer ts.StopAndShutdown()
 
 	require.Equal(t, "[::]:8080", ts.HTTPListenAddr())
-	require.Equal(t, "[::]:8081", ts.GRPCListenAddr())
+	// not asserting over grpc port since a random should have been assigned
 }

--- a/component/loki/source/api/api_test.go
+++ b/component/loki/source/api/api_test.go
@@ -169,6 +169,8 @@ func TestLokiSourceAPI_FanOut(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
+	defer comp.(*Component).stop()
+
 	lokiClient := newTestLokiClient(t, args, opts)
 	defer lokiClient.Stop()
 

--- a/docs/sources/shared/flow/reference/components/loki-server-grpc.md
+++ b/docs/sources/shared/flow/reference/components/loki-server-grpc.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /docs/agent/shared/flow/reference/components/loki-server-grpc/
+  - /docs/agent/shared/flow/reference/components/loki-server-grpc/
 headless: true
 ---
 
@@ -9,14 +9,14 @@ The `grpc` block configures the gRPC server.
 The following arguments can be used to configure the `grpc` block. Any omitted
 fields take their default values.
 
- Name                            | Type       | Description                                                                                                          | Default      | Required
+ Name                            | Type       | Description                                                                                                          | Default      | Required 
 ---------------------------------|------------|----------------------------------------------------------------------------------------------------------------------|--------------|----------
- `listen_address`                | `string`   | Network address on which the server will listen for new connections. Defaults to accepting all incoming connections. | `""`         | no
- `listen_port`                   | `int`      | Port number on which the server will listen for new connections.                                                     | `8081`       | no
- `conn_limit`                    | `int`      | Maximum number of simultaneous http connections. Defaults to no limit.                                               | `0`          | no
- `max_connection_age`            | `duration` | The duration for the maximum amount of time a connection may exist before it will be closed.                         | `"infinity"` | no
- `max_connection_age_grace`      | `duration` | An additive period after `max_connection_age` after which the connection will be forcibly closed.                    | `"infinity"` | no
- `max_connection_idle`           | `duration` | The duration after which an idle connection should be closed.                                                        | `"infinity"` | no
- `server_max_recv_msg_size`      | `int`      | Limit on the size of a gRPC message this server can receive (bytes).                                                 | `4MB`        | no
- `server_max_send_msg_size`      | `int`      | Limit on the size of a gRPC message this server can send (bytes).                                                    | `4MB`        | no
- `server_max_concurrent_streams` | `int`      | Limit on the number of concurrent streams for gRPC calls (0 = unlimited).                                            | `100`        | no
+ `listen_address`                | `string`   | Network address on which the server will listen for new connections. Defaults to accepting all incoming connections. | `""`         | no       
+ `listen_port`                   | `int`      | Port number on which the server will listen for new connections. Defaults to a random free port being assigned.      | `0`          | no       
+ `conn_limit`                    | `int`      | Maximum number of simultaneous http connections. Defaults to no limit.                                               | `0`          | no       
+ `max_connection_age`            | `duration` | The duration for the maximum amount of time a connection may exist before it will be closed.                         | `"infinity"` | no       
+ `max_connection_age_grace`      | `duration` | An additive period after `max_connection_age` after which the connection will be forcibly closed.                    | `"infinity"` | no       
+ `max_connection_idle`           | `duration` | The duration after which an idle connection should be closed.                                                        | `"infinity"` | no       
+ `server_max_recv_msg_size`      | `int`      | Limit on the size of a gRPC message this server can receive (bytes).                                                 | `4MB`        | no       
+ `server_max_send_msg_size`      | `int`      | Limit on the size of a gRPC message this server can send (bytes).                                                    | `4MB`        | no       
+ `server_max_concurrent_streams` | `int`      | Limit on the number of concurrent streams for gRPC calls (0 = unlimited).                                            | `100`        | no       

--- a/pkg/traces/traces_test.go
+++ b/pkg/traces/traces_test.go
@@ -78,7 +78,7 @@ configs:
       tls_config:
           insecure_skip_verify: true
   spanmetrics:
-    handler_endpoint: 0.0.0.0:9090
+    handler_endpoint: 0.0.0.0:8888
     const_labels:
       key1: "value1"
       key2: "value2"

--- a/pkg/traces/traces_test.go
+++ b/pkg/traces/traces_test.go
@@ -78,7 +78,7 @@ configs:
       tls_config:
           insecure_skip_verify: true
   spanmetrics:
-    handler_endpoint: 0.0.0.0:8888
+    handler_endpoint: 0.0.0.0:9090
     const_labels:
       key1: "value1"
       key2: "value2"


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR fixes the `common/net` server configuration, which was overriding the defaults inherited from weaveworks. Before, the calls of `http.Into()` or `grpc.Into()` were overriding the defaults that were already present on the weaverworks config object. 

For tackling that, the defaults of the configs we expose were copied over, so that they are used during unmarshalling.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
