### PR TITLE
tools: fix cases where s390x artifacts were built using the wrong GOARCH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ Main (unreleased)
 - Fix an issue where not specifying either `http` nor `grpc` blocks could result
   in a panic for `loki.source.heroku` and `loki.source.gcplog` components. (@thampiotr)
 
+- Fix an issue where build artifacts for IBM S390x were being built with the
+  GOARCH value for the PPC64 instead. (tpaschalis)
+
 ### Other changes
 
 - Add metrics when clustering mode is enabled. (@rfratto)

--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -49,7 +49,7 @@ dist/grafana-agent-linux-ppc64le: generate-ui
 
 dist/grafana-agent-linux-s390x: GO_TAGS += builtinassets promtail_journal_enabled
 dist/grafana-agent-linux-s390x: GOOS    := linux
-dist/grafana-agent-linux-s390x: GOARCH  := ppc64le
+dist/grafana-agent-linux-s390x: GOARCH  := s390x
 dist/grafana-agent-linux-s390x: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
@@ -166,7 +166,7 @@ dist.temp/grafana-agent-flow-linux-ppc64le: generate-ui
 
 dist.temp/grafana-agent-flow-linux-s390x: GO_TAGS += builtinassets promtail_journal_enabled
 dist.temp/grafana-agent-flow-linux-s390x: GOOS    := linux
-dist.temp/grafana-agent-flow-linux-s390x: GOARCH  := ppc64le
+dist.temp/grafana-agent-flow-linux-s390x: GOARCH  := s390x
 dist.temp/grafana-agent-flow-linux-s390x: generate-ui
 	$(PACKAGING_VARS) FLOW_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent-flow
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR fixes some occurrences where the s390x artifacts were built using the PowerPC GOARCH value, rendering them unusable.

#### Which issue(s) this PR fixes
Related to #3891

#### Notes to the Reviewer
I'm not sure whether this should be backported to the previous release. I don't think we can rebuild the already-published artifacts, but we can advise people on how to build their own.

WDYT?

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
