### PR TITLE
docs: fix macOS log locations for Flow

### DIFF
--- a/docs/sources/flow/install/macos.md
+++ b/docs/sources/flow/install/macos.md
@@ -130,7 +130,7 @@ To expose the UI to other machines, complete the following steps:
 
 ### Viewing Grafana Agent Flow logs
 
-By default, logs are written to `$(brew --prefix)/var/log/grafana-agent.log` and
+By default, logs are written to `$(brew --prefix)/var/log/grafana-agent-flow.log` and
 `$(brew --prefix)/var/log/grafana-agent-flow.err.log`.
 
 If you followed [Configuring the Grafana Agent Flow service](#configuring-the-grafana-agent-flow-service)


### PR DESCRIPTION
Previously, an instance of the grafana/grafana-agent-flow Homebrew formula installed on macOS would generate logs in the same location as the static mode grafana-agent formula.

The documentation here was incorrect, saying that the stderr file would write to a Flow-specific file.

grafana/homebrew-grafana#52 fixes the formula to log files in the proper, Flow-specific, place, and this PR updates the documentation to use the correct file names (assuming grafana/homebrew-grafana#52 is merged).

Related to #3871.