### PR TITLE
packaging: fix RPM EnvironmentFile path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ Main (unreleased)
 - Fix an issue where build artifacts for IBM S390x were being built with the
   GOARCH value for the PPC64 instead. (tpaschalis)
 
+- Fix an issue where the Grafana Agent Flow RPM used the wrong path for the
+  environment file, preventing the service from loading. (@rfratto)
+
 ### Other changes
 
 - Add metrics when clustering mode is enabled. (@rfratto)
@@ -110,7 +113,7 @@ v0.33.2 (2023-05-11)
   was created, and prevented a fresh process from being able to deliver metrics
   at all. (@rfratto)
 
-- Fix an issue where the `loki.source.kubernetes` component could lead to 
+- Fix an issue where the `loki.source.kubernetes` component could lead to
   the Agent crashing due to a race condition. (@tpaschalis)
 
 ### Other changes

--- a/packaging/grafana-agent-flow/rpm/grafana-agent-flow.service
+++ b/packaging/grafana-agent-flow/rpm/grafana-agent-flow.service
@@ -8,7 +8,7 @@ After=network-online.target
 Restart=always
 User=grafana-agent-flow
 Environment=HOSTNAME=%H
-EnvironmentFile=/etc/default/grafana-agent-flow
+EnvironmentFile=/etc/sysconfig/grafana-agent-flow
 WorkingDirectory=/var/lib/grafana-agent-flow
 ExecStart=/usr/bin/grafana-agent-flow run $CUSTOM_ARGS --storage.path=/var/lib/grafana-agent-flow $CONFIG_FILE
 ExecReload=/usr/bin/kill -HUP $MAINPID


### PR DESCRIPTION
The EnvironmentFile should be /etc/sysconfig/grafana-agent-flow on RPM systems, but a bad copy caused it to be identical to the DEB EnvironmentFile path.

Closes #3882.
