### PR TITLE
Change config file name to be consistent with Helm Chart to config.ya…

### DIFF
--- a/docs/sources/set-up/install-agent-macos.md
+++ b/docs/sources/set-up/install-agent-macos.md
@@ -29,10 +29,10 @@ Use Homebrew to install the most recent released version of Grafana using the Ho
 
     ```
     mkdir -p $(brew --prefix)/etc/grafana-agent/
-    touch $(brew --prefix)/etc/grafana-agent/config.yml
+    touch $(brew --prefix)/etc/grafana-agent/config.yaml
     ```
 
-1. Modify `config.yml` with your configuration requirements. 
+1. Modify `config.yaml` with your configuration requirements. 
 
     See [Configure Grafana Agent for details]({{< relref "../configuration/" >}}). 
   


### PR DESCRIPTION
…ml (#3507)

Currently the Grafana Agent config files is given many names in the documentation. This is a change to keep the name consistent with the Helm Chart. More detail in this issue: #3496

Co-authored-by: Clayton Cornell <clayton.cornell@grafana.com>
(cherry picked from commit b1356db3014c06601f359fae06c1d1ea52cff23f)

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
