### PR TITLE
clustering: delay startup until after the HTTP server is up

### DIFF
--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -298,7 +298,7 @@ func (fr *flowRun) Run(configFile string) error {
 	}
 
 	// Start the Clusterer's Node implementation.
-	err = clusterer.Start()
+	err = clusterer.Start(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to start the clusterer: %w", err)
 	}

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -297,6 +297,12 @@ func (fr *flowRun) Run(configFile string) error {
 		}()
 	}
 
+	// Start the Clusterer's Node implementation.
+	err = clusterer.Start()
+	if err != nil {
+		return fmt.Errorf("failed to start the clusterer: %w", err)
+	}
+
 	// Perform the initial reload. This is done after starting the HTTP server so
 	// that /metric and pprof endpoints are available while the Flow controller
 	// is loading.

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -190,7 +190,7 @@ func (c *Clusterer) Start() error {
 	case *localNode:
 		return nil // no-op, always ready
 	case *GossipNode:
-		err := node.Start()
+		err := node.Start() // TODO(@tpaschalis) Should we backoff and retry before moving on to the fallback here?
 		if err != nil {
 			level.Debug(node.log).Log("msg", "failed to connect to peers; bootstrapping a new cluster")
 			node.cfg.JoinPeers = nil
@@ -219,7 +219,8 @@ func (c *Clusterer) Start() error {
 		}))
 		return nil
 	default:
-		panic("cluster: unreachable")
+		msg := fmt.Sprintf("node type: %T", c.Node)
+		panic("cluster: unreachable:" + msg)
 	}
 }
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
We would like to delay the clusterer implementation's startup (which includes connecting to the configured list of peers) until after the Flow HTTP server is up.

In that case, when Start() is experiencing delays, or it deadlocks, we will still be able to grab pprof profiles to figure out what's wrong. This can also allow the clusterer implementation to _always_ have at least one valid peer to connect to; itself.

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer
Nothing in particular.

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
