### PR TITLE
cluster: Fix targets deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ Main (unreleased)
 - Fix an issue where the cluster advertise address was overwriting the join
   addresses. (@laurovenancio)
 
+- Fix targets deduplication when clustering mode is enabled. (@laurovenancio)
+
 ### Other changes
 
 - Add metrics when clustering mode is enabled. (@rfratto)

--- a/component/discovery/discovery.go
+++ b/component/discovery/discovery.go
@@ -3,12 +3,14 @@ package discovery
 import (
 	"context"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/pkg/cluster"
 	"github.com/grafana/ckit/shard"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/labels"
@@ -46,7 +48,7 @@ func (t *DistributedTargets) Get() []Target {
 	// TODO(@tpaschalis): Make sure OpReadWrite is the correct operation;
 	// eg. this determines how clustering behaves when nodes are shutting down.
 	for _, tgt := range t.targets {
-		peers, err := t.node.Lookup(shard.StringKey(tgt.Labels().String()), 1, shard.OpReadWrite)
+		peers, err := t.node.Lookup(shard.StringKey(tgt.NonMetaLabels().String()), 1, shard.OpReadWrite)
 		if err != nil {
 			// This can only fail in case we ask for more owners than the
 			// available peers. This will never happen, but in any case we fall
@@ -66,6 +68,17 @@ func (t Target) Labels() labels.Labels {
 	var lset labels.Labels
 	for k, v := range t {
 		lset = append(lset, labels.Label{Name: k, Value: v})
+	}
+	sort.Sort(lset)
+	return lset
+}
+
+func (t Target) NonMetaLabels() labels.Labels {
+	var lset labels.Labels
+	for k, v := range t {
+		if !strings.HasPrefix(k, model.MetaLabelPrefix) {
+			lset = append(lset, labels.Label{Name: k, Value: v})
+		}
 	}
 	sort.Sort(lset)
 	return lset


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Prometheus deduplicates targets after removing the `__meta_` labels.
If these labels are used to define the targets distribution, targets
that must be deduplicated could end in different nodes, resulting in
duplicated metrics.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [X] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
