### PR TITLE
allow passing in labels from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ Main (unreleased)
 
 - Update azidentity dependency to v1.3.0. (@akselleirv)
 
+- Add custom labels to journal entries in `loki.source.journal` (@sbhrule15)
+
 ### Bugfixes
 
 - Fix `loki.source.(gcplog|heroku)` `http` and `grpc` blocks were overriding defaults with zero-values

--- a/component/loki/source/journal/journal.go
+++ b/component/loki/source/journal/journal.go
@@ -120,10 +120,18 @@ func (c *Component) Update(args component.Arguments) error {
 }
 
 func convertArgs(job string, a Arguments) *scrapeconfig.JournalTargetConfig {
+	labels := model.LabelSet{
+		model.LabelName("job"): model.LabelValue(job),
+	}
+
+	for k, v := range a.Labels {
+		labels[model.LabelName(k)] = model.LabelValue(v)
+	}
+
 	return &scrapeconfig.JournalTargetConfig{
 		MaxAge:  a.MaxAge.String(),
 		JSON:    a.FormatAsJson,
-		Labels:  model.LabelSet{"job": model.LabelValue(job)},
+		Labels:  labels,
 		Path:    a.Path,
 		Matches: a.Matches,
 	}

--- a/component/loki/source/journal/types.go
+++ b/component/loki/source/journal/types.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/grafana/agent/component/common/loki"
 	flow_relabel "github.com/grafana/agent/component/common/relabel"
-	"github.com/prometheus/common/model"
 )
 
 // Arguments are the arguments for the component.
@@ -16,7 +15,7 @@ type Arguments struct {
 	RelabelRules flow_relabel.Rules  `river:"relabel_rules,attr,optional"`
 	Matches      string              `river:"matches,attr,optional"`
 	Receivers    []loki.LogsReceiver `river:"forward_to,attr"`
-	Labels       model.LabelSet      `river:"labels,attr,optional"`
+	Labels       map[string]string   `river:"labels,attr,optional"`
 }
 
 func defaultArgs() Arguments {

--- a/component/loki/source/journal/types.go
+++ b/component/loki/source/journal/types.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/agent/component/common/loki"
 	flow_relabel "github.com/grafana/agent/component/common/relabel"
+	"github.com/prometheus/common/model"
 )
 
 // Arguments are the arguments for the component.
@@ -15,6 +16,7 @@ type Arguments struct {
 	RelabelRules flow_relabel.Rules  `river:"relabel_rules,attr,optional"`
 	Matches      string              `river:"matches,attr,optional"`
 	Receivers    []loki.LogsReceiver `river:"forward_to,attr"`
+	Labels       model.LabelSet      `river:"labels,attr,optional"`
 }
 
 func defaultArgs() Arguments {

--- a/docs/sources/flow/reference/components/loki.source.journal.md
+++ b/docs/sources/flow/reference/components/loki.source.journal.md
@@ -32,6 +32,7 @@ Name | Type | Description | Default | Required
 `matches` | `string` | Journal matches to filter. The `+` character is not supported, only logical AND matches will be added. | `""` | no
 `forward_to` | `list(LogsReceiver)` | List of receivers to send log entries to. | | yes
 `relabel_rules` | `RelabelRules` | Relabeling rules to apply on log entries. | `{}` | no
+`labels` | `map(string)` | The labels to apply to every log coming out of the journal. | `{}` | no
 
 > **NOTE**:  A `job` label is added with the full name of the component `loki.source.journal.LABEL`.
 
@@ -82,6 +83,7 @@ loki.relabel "journal" {
 loki.source.journal "read"  {
   forward_to    = [loki.write.endpoint.receiver]
   relabel_rules = loki.relabel.journal.rules
+  labels        = {component = "loki.source.journal"}
 }
 
 loki.write "endpoint" {


### PR DESCRIPTION
#### PR Description

Allow adding custom labels to journal scrapers. Keeps the default behaviors of defaulting to adding a `job: <name>` label, but can be overridden if `job` label passed in explicitly. 

#### Which issue this PR fixes
https://github.com/grafana/agent/issues/3182#event-9273947588
Fixes #3182 

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #3182 -->

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [ ] Tests updated
