### PR TITLE
Update URL for static mode Kubernetes operator

### DIFF
--- a/docs/sources/static/set-up/_index.md
+++ b/docs/sources/static/set-up/_index.md
@@ -14,7 +14,7 @@ If this is your first time using Grafana Agent, use one of the installation opti
 If you have already installed Grafana Agent on your machine, you can jump to the [Configure Grafana Agent]({{< relref "../configuration/_index.md" >}}) section.
 
 To get started with Grafana Agent Operator, refer to the Operator-specific
-[documentation](../operator/).
+[documentation](../../operator/_index.md).
 
 ## Installation options
 


### PR DESCRIPTION
Adjusted URL from https://grafana.com/docs/agent/latest/static/operator/ to https://grafana.com/docs/agent/latest/operator/

Current URL is resulting in a 404 page

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
