### PR TITLE
clusterer: use a 512-token ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ Main (unreleased)
 - Embed Google Fonts on Flow UI (@jkroepke)
 
 - Enable Content-Security-Policies on Flow UI (@jkroepke)
-  
+
 - Update azure-metrics-exporter to v0.0.0-20230502203721-b2bfd97b5313 (@kgeckhart)
 
 - Update azidentity dependency to v1.3.0. (@akselleirv)
@@ -105,6 +105,10 @@ Main (unreleased)
 
 - Integrate the new ExceptionContext which was recently added to the Faro Web-SDK in the
   app_agent_receiver Payload. (@codecapitano)
+
+- Flow clustering: clusters will now use 512 tokens per node for distributing
+  work, leading to better distribution. However, rolling out this change will
+  cause some incorrerct or missing assignments until all nodes are updated. (@rfratto)
 
 v0.33.2 (2023-05-11)
 --------------------

--- a/pkg/cluster/gossip.go
+++ b/pkg/cluster/gossip.go
@@ -28,20 +28,16 @@ var extraDiscoverProviders map[string]discover.Provider
 // the hash ring. All nodes must use the same value, otherwise they will have
 // different views of the ring and assign work differently.
 //
-// Using 256 tokens strikes a good balance between distribution accuracy and
-// memory consumption. A cluster of 1,000 nodes with 256 tokens per node
-// requires 6MB for the hash ring, while 12MB is used for 512 tokens per node.
+// Using 512 tokens strikes a good balance between distribution accuracy and
+// memory consumption. A cluster of 1,000 nodes with 512 tokens per node
+// requires 12MB for the hash ring.
 //
 // Distribution accuracy measures how close a node was to being responsible for
 // exactly 1/N keys during simulation. Simulation tests used a cluster of 10
 // nodes and hashing 100,000 random keys:
 //
-//	256 tokens per node: min 94.0%, median 96.3%, max 115.3%
-//	512 tokens per node: min 96.1%, median 99.9%, max 103.2%
-//
-// While 512 tokens per node is closer to perfect distribution, 256 tokens per
-// node is good enough, optimizing for lower memory usage.
-const tokensPerNode = 256
+//	512 tokens per node: min 96.1%, median 99.9%, max 103.2% (stddev: 197.9 hashes)
+const tokensPerNode = 512
 
 // GossipConfig controls clustering of Agents through gRPC-based gossip.
 // GossipConfig cannot be changed at runtime.


### PR DESCRIPTION
Use a 512-token ring to achieve better distribution. Because a 512-token ring only needs 12MB for 1,000 nodes (compared to 6MB for 1,000 nodes in a 256-token ring), its overhead is marginal enough to be worth it for the improved distribution.

However, this change means that any existing cluster being upgraded to the new version will suffer from incorrect or missing hashing assignments until all nodes are using 512 tokens.

This is the type of change we shouldn't make often; I think it's only feasible now because clustering is still experimental. Future changes would likely need to be opt-in via a flag.
