### PR TITLE
helm: make faro port optional

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -14,6 +14,8 @@ Unreleased
 
 - Add HPA support for Deployments and StatefulSets. (@tpaschalis)
 
+- Make the Faro port optional. (@tpaschalis)
+
 0.14.0 (2023-05-11)
 -------------------
 

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -50,7 +50,6 @@ use the older mode (called "static mode"), set the `agent.mode` value to
 | agent.extraArgs | list | `[]` | Extra args to pass to `agent run`: https://grafana.com/docs/agent/latest/flow/reference/cli/run/ |
 | agent.extraEnv | list | `[]` | Extra environment variables to pass to the agent container. |
 | agent.extraPorts | list | `[]` | Extra ports to expose on the Agent |
-| agent.faroPort | int | `12347` | Port to listen for faro traffic on. |
 | agent.listenAddr | string | `"0.0.0.0"` | Address to listen for traffic on. 0.0.0.0 exposes the UI to other containers. |
 | agent.listenPort | int | `80` | Port to listen for traffic on. |
 | agent.mode | string | `"flow"` | Mode to run Grafana Agent in. Can be "flow" or "static". |
@@ -90,6 +89,7 @@ use the older mode (called "static mode"), set the `agent.mode` value to
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` | Enables ingress for the agent (faro port) |
 | ingress.extraPaths | list | `[]` |  |
+| ingress.faroPort | int | `12347` |  |
 | ingress.hosts[0] | string | `"chart-example.local"` |  |
 | ingress.labels | object | `{}` |  |
 | ingress.path | string | `"/"` |  |

--- a/operations/helm/charts/grafana-agent/ci/faro-ingress-values.yaml
+++ b/operations/helm/charts/grafana-agent/ci/faro-ingress-values.yaml
@@ -1,2 +1,9 @@
+agent:
+  extraPorts:
+    - name: "faro"
+      port: 12347
+      targetPort: 12347
+      protocol: "TCP"
+
 ingress:
   enabled: true

--- a/operations/helm/charts/grafana-agent/templates/containers/_agent.yaml
+++ b/operations/helm/charts/grafana-agent/templates/containers/_agent.yaml
@@ -36,8 +36,6 @@
   ports:
     - containerPort: {{ .Values.agent.listenPort }}
       name: http-metrics
-    - containerPort: {{ .Values.agent.faroPort }}
-      name: faro
     {{- range $portMap := .Values.agent.extraPorts }}
     - containerPort: {{ $portMap.targetPort }}
       {{- if $portMap.hostPort }}

--- a/operations/helm/charts/grafana-agent/templates/ingress.yaml
+++ b/operations/helm/charts/grafana-agent/templates/ingress.yaml
@@ -3,7 +3,7 @@
 {{- $ingressSupportsIngressClassName := eq (include "grafana-agent.ingress.supportsIngressClassName" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "grafana-agent.ingress.supportsPathType" .) "true" -}}
 {{- $fullName := include "grafana-agent.fullname" . -}}
-{{- $servicePort := .Values.agent.faroPort -}}
+{{- $servicePort := .Values.ingress.faroPort -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $ingressPathType := .Values.ingress.pathType -}}
 {{- $extraPaths := .Values.ingress.extraPaths -}}

--- a/operations/helm/charts/grafana-agent/templates/service.yaml
+++ b/operations/helm/charts/grafana-agent/templates/service.yaml
@@ -21,10 +21,6 @@ spec:
       port: {{ .Values.agent.listenPort }}
       targetPort: {{ .Values.agent.listenPort }}
       protocol: "TCP"
-    - name: faro
-      port: {{ .Values.agent.faroPort }}
-      targetPort: {{ .Values.agent.faroPort }}
-      protocol: "TCP"
 {{- range $portMap := .Values.agent.extraPorts }}
     - name: {{ $portMap.name }}
       port: {{ $portMap.port }}

--- a/operations/helm/charts/grafana-agent/values.yaml
+++ b/operations/helm/charts/grafana-agent/values.yaml
@@ -27,11 +27,9 @@ agent:
   # -- Address to listen for traffic on. 0.0.0.0 exposes the UI to other
   # containers.
   listenAddr: 0.0.0.0
+
   # -- Port to listen for traffic on.
   listenPort: 80
-
-  # -- Port to listen for faro traffic on.
-  faroPort: 12347
 
   # -- Enables sending Grafana Labs anonymous usage stats to help improve Grafana
   # Agent.
@@ -48,6 +46,10 @@ agent:
 
   # -- Extra ports to expose on the Agent
   extraPorts: []
+  # - name: "faro"
+  #   port: 12347
+  #   targetPort: 12347
+  #   protocol: "TCP"
 
   mounts:
     # -- Mount /var/log from the host into the container for log collection.
@@ -179,6 +181,7 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   labels: {}
   path: /
+  faroPort: 12347
 
   # pathType is only for k8s >= 1.1=
   pathType: Prefix

--- a/operations/helm/tests/controller-volumes-extra/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/controller-volumes-extra/grafana-agent/templates/controllers/daemonset.yaml
@@ -42,8 +42,6 @@ spec:
           ports:
             - containerPort: 80
               name: http-metrics
-            - containerPort: 12347
-              name: faro
           readinessProbe:
             httpGet:
               path: /-/ready

--- a/operations/helm/tests/controller-volumes-extra/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/controller-volumes-extra/grafana-agent/templates/service.yaml
@@ -20,7 +20,3 @@ spec:
       port: 80
       targetPort: 80
       protocol: "TCP"
-    - name: faro
-      port: 12347
-      targetPort: 12347
-      protocol: "TCP"

--- a/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/controllers/daemonset.yaml
@@ -42,8 +42,6 @@ spec:
           ports:
             - containerPort: 80
               name: http-metrics
-            - containerPort: 12347
-              name: faro
           readinessProbe:
             httpGet:
               path: /-/ready

--- a/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/service.yaml
@@ -20,7 +20,3 @@ spec:
       port: 80
       targetPort: 80
       protocol: "TCP"
-    - name: faro
-      port: 12347
-      targetPort: 12347
-      protocol: "TCP"

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
@@ -42,8 +42,6 @@ spec:
           ports:
             - containerPort: 80
               name: http-metrics
-            - containerPort: 12347
-              name: faro
           readinessProbe:
             httpGet:
               path: /-/ready

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/service.yaml
@@ -20,7 +20,3 @@ spec:
       port: 80
       targetPort: 80
       protocol: "TCP"
-    - name: faro
-      port: 12347
-      targetPort: 12347
-      protocol: "TCP"

--- a/operations/helm/tests/create-deployment-autoscaling/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment-autoscaling/grafana-agent/templates/controllers/deployment.yaml
@@ -43,8 +43,6 @@ spec:
           ports:
             - containerPort: 80
               name: http-metrics
-            - containerPort: 12347
-              name: faro
           readinessProbe:
             httpGet:
               path: /-/ready

--- a/operations/helm/tests/create-deployment-autoscaling/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-deployment-autoscaling/grafana-agent/templates/service.yaml
@@ -20,7 +20,3 @@ spec:
       port: 80
       targetPort: 80
       protocol: "TCP"
-    - name: faro
-      port: 12347
-      targetPort: 12347
-      protocol: "TCP"

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
@@ -43,8 +43,6 @@ spec:
           ports:
             - containerPort: 80
               name: http-metrics
-            - containerPort: 12347
-              name: faro
           readinessProbe:
             httpGet:
               path: /-/ready

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/service.yaml
@@ -20,7 +20,3 @@ spec:
       port: 80
       targetPort: 80
       protocol: "TCP"
-    - name: faro
-      port: 12347
-      targetPort: 12347
-      protocol: "TCP"

--- a/operations/helm/tests/create-statefulset-autoscaling/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset-autoscaling/grafana-agent/templates/controllers/statefulset.yaml
@@ -44,8 +44,6 @@ spec:
           ports:
             - containerPort: 80
               name: http-metrics
-            - containerPort: 12347
-              name: faro
           readinessProbe:
             httpGet:
               path: /-/ready

--- a/operations/helm/tests/create-statefulset-autoscaling/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-statefulset-autoscaling/grafana-agent/templates/service.yaml
@@ -20,7 +20,3 @@ spec:
       port: 80
       targetPort: 80
       protocol: "TCP"
-    - name: faro
-      port: 12347
-      targetPort: 12347
-      protocol: "TCP"

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
@@ -44,8 +44,6 @@ spec:
           ports:
             - containerPort: 80
               name: http-metrics
-            - containerPort: 12347
-              name: faro
           readinessProbe:
             httpGet:
               path: /-/ready

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/service.yaml
@@ -20,7 +20,3 @@ spec:
       port: 80
       targetPort: 80
       protocol: "TCP"
-    - name: faro
-      port: 12347
-      targetPort: 12347
-      protocol: "TCP"

--- a/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -42,8 +42,6 @@ spec:
           ports:
             - containerPort: 80
               name: http-metrics
-            - containerPort: 12347
-              name: faro
           readinessProbe:
             httpGet:
               path: /-/ready

--- a/operations/helm/tests/custom-config/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/service.yaml
@@ -20,7 +20,3 @@ spec:
       port: 80
       targetPort: 80
       protocol: "TCP"
-    - name: faro
-      port: 12347
-      targetPort: 12347
-      protocol: "TCP"

--- a/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
@@ -42,8 +42,6 @@ spec:
           ports:
             - containerPort: 80
               name: http-metrics
-            - containerPort: 12347
-              name: faro
           readinessProbe:
             httpGet:
               path: /-/ready

--- a/operations/helm/tests/default-values/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/service.yaml
@@ -20,7 +20,3 @@ spec:
       port: 80
       targetPort: 80
       protocol: "TCP"
-    - name: faro
-      port: 12347
-      targetPort: 12347
-      protocol: "TCP"

--- a/operations/helm/tests/envFrom/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/envFrom/grafana-agent/templates/controllers/daemonset.yaml
@@ -45,8 +45,6 @@ spec:
           ports:
             - containerPort: 80
               name: http-metrics
-            - containerPort: 12347
-              name: faro
           readinessProbe:
             httpGet:
               path: /-/ready

--- a/operations/helm/tests/envFrom/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/envFrom/grafana-agent/templates/service.yaml
@@ -20,7 +20,3 @@ spec:
       port: 80
       targetPort: 80
       protocol: "TCP"
-    - name: faro
-      port: 12347
-      targetPort: 12347
-      protocol: "TCP"

--- a/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -42,8 +42,6 @@ spec:
           ports:
             - containerPort: 80
               name: http-metrics
-            - containerPort: 12347
-              name: faro
           readinessProbe:
             httpGet:
               path: /-/ready

--- a/operations/helm/tests/existing-config/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/service.yaml
@@ -20,7 +20,3 @@ spec:
       port: 80
       targetPort: 80
       protocol: "TCP"
-    - name: faro
-      port: 12347
-      targetPort: 12347
-      protocol: "TCP"

--- a/operations/helm/tests/extra-env/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-env/grafana-agent/templates/controllers/daemonset.yaml
@@ -51,8 +51,6 @@ spec:
           ports:
             - containerPort: 80
               name: http-metrics
-            - containerPort: 12347
-              name: faro
           readinessProbe:
             httpGet:
               path: /-/ready

--- a/operations/helm/tests/extra-env/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/extra-env/grafana-agent/templates/service.yaml
@@ -20,7 +20,3 @@ spec:
       port: 80
       targetPort: 80
       protocol: "TCP"
-    - name: faro
-      port: 12347
-      targetPort: 12347
-      protocol: "TCP"

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
@@ -42,8 +42,6 @@ spec:
           ports:
             - containerPort: 80
               name: http-metrics
-            - containerPort: 12347
-              name: faro
             - containerPort: 14268
               name: jaeger-thrift
               protocol: TCP

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/service.yaml
@@ -20,10 +20,6 @@ spec:
       port: 80
       targetPort: 80
       protocol: "TCP"
-    - name: faro
-      port: 12347
-      targetPort: 12347
-      protocol: "TCP"
     - name: jaeger-thrift
       port: 14268
       targetPort: 14268

--- a/operations/helm/tests/faro-ingress/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/faro-ingress/grafana-agent/templates/controllers/daemonset.yaml
@@ -44,6 +44,7 @@ spec:
               name: http-metrics
             - containerPort: 12347
               name: faro
+              protocol: TCP
           readinessProbe:
             httpGet:
               path: /-/ready

--- a/operations/helm/tests/faro-ingress/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/faro-ingress/grafana-agent/templates/service.yaml
@@ -23,4 +23,4 @@ spec:
     - name: faro
       port: 12347
       targetPort: 12347
-      protocol: "TCP"
+      protocol: TCP

--- a/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
@@ -40,8 +40,6 @@ spec:
           ports:
             - containerPort: 80
               name: http-metrics
-            - containerPort: 12347
-              name: faro
           readinessProbe:
             httpGet:
               path: /-/ready

--- a/operations/helm/tests/static-mode/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/service.yaml
@@ -20,7 +20,3 @@ spec:
       port: 80
       targetPort: 80
       protocol: "TCP"
-    - name: faro
-      port: 12347
-      targetPort: 12347
-      protocol: "TCP"

--- a/operations/helm/tests/tolerations/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/tolerations/grafana-agent/templates/controllers/daemonset.yaml
@@ -42,8 +42,6 @@ spec:
           ports:
             - containerPort: 80
               name: http-metrics
-            - containerPort: 12347
-              name: faro
           readinessProbe:
             httpGet:
               path: /-/ready

--- a/operations/helm/tests/tolerations/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/tolerations/grafana-agent/templates/service.yaml
@@ -20,7 +20,3 @@ spec:
       port: 80
       targetPort: 80
       protocol: "TCP"
-    - name: faro
-      port: 12347
-      targetPort: 12347
-      protocol: "TCP"


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR makes the faro port on the Agent pods optional; people who still wish to use `:12347` for Faro can opt-in to it by defining it on `extraPorts`, like in the provided example.

Notice that the `faro-ingress` test is virtually the same.

#### Which issue(s) this PR fixes
Fixes #2957

#### Notes to the Reviewer

I just saw the pre-existing issue #2957 which outlines some possible solutions. For now, I've moved `faroPort` inside of the ingress which sounds like it's custom-made for it.

Would we prefer to allow a list of ports that we loop over to create a `rule` for each on the same ingress so we don't have to explicitly refer to Faro (and leave it as an example so people can enable it with ease)? This is not an ideal long-term solution but at least a step towards it.

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [x] Tests updated
