### PR TITLE
docs: fix example for loki.source.journal component

### DIFF
--- a/docs/sources/flow/reference/components/loki.source.journal.md
+++ b/docs/sources/flow/reference/components/loki.source.journal.md
@@ -74,6 +74,8 @@ configuration.
 
 ```river
 loki.relabel "journal" {
+  forward_to = []
+
   rule {
     source_labels = ["__journal__systemd_unit"]
     target_label  = "unit"


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR fixes the incorrect example for loki.source.journal.

Until we decide how to handle relabeling rules for Loki components, the loki.relabel component must still have its `forward_to` argument be set.

#### Which issue(s) this PR fixes
Fixes #3656.

#### Notes to the Reviewer
Nothing to note.

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [X] Documentation added
- [ ] Tests updated (N/A)
