### PR TITLE
update CODEOWNERS, MAINTAINERS.md

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,40 @@
-/cmd/grafana-agent-operator @captncraig @marctc @jcreixell
-/pkg/integrations/ @rgeyer @gaantunes @captncraig @marctc @jcreixell
-/pkg/operator @captncraig @marctc @jcreixell
-/pkg/traces/ @joe-elliott @mapno
+# The following groups are used to refer to a changing set of users:
+#
+# * @grafana/grafana-agent-core-maintainers: maintainers of type/core issues.
+# * @grafana/grafana-agent-signals-maintainers: maintainers of type/signals issues.
+# * @grafana/grafana-agent-operator-maintainers: maintainers of type/operator issues.
+# * @grafana/grafana-agent-infrastructure-maintainers: maintainers of type/infrastructure issues.
+#
+# Other users may be listed explicitly if maintainership does not fall into one
+# of the above groups.
+
+# The default owners for everything in the repo. Unless a later match takes
+# precedence, these owners are requested for review whenever someone opens a
+# pull request.
+* @grafana/grafana-agent-core-maintainers
+
+# Binaries:
+/cmd/grafana-agent-operator/  @grafana/grafana-agent-operator-maintainers
+
+# Documentation:
+/docs/sources/  @clayton-cornell
+
+# Components:
+/component/discovery/               @grafana/grafana-agent-infrastructure-maintainers
+/component/local/                   @grafana/grafana-agent-infrastructure-maintainers
+/component/loki/                    @grafana/grafana-agent-signals-maintainers
+/component/loki/source/podlogs/     @grafana/grafana-agent-infrastructure-maintainers
+/component/mimir/rules/kubernetes/  @grafana/grafana-agent-infrastructure-maintainers
+/component/otelcol/                 @grafana/grafana-agent-signals-maintainers
+/component/phlare/                  @grafana/grafana-agent-signals-maintainers
+/component/prometheus/              @grafana/grafana-agent-signals-maintainers
+/component/prometheus/exporter/     @grafana/grafana-agent-infrastructure-maintainers
+/component/remote/                  @grafana/grafana-agent-infrastructure-maintainers
+
+# Static mode packages:
+/pkg/integrations/  @grafana/grafana-agent-infrastructure-maintainers
+/pkg/logs/          @grafana/grafana-agent-signals-maintainers
+/pkg/metrics/       @grafana/grafana-agent-signals-maintainers
+/pkg/mimir/client/  @grafana/grafana-agent-infrastructure-maintainers
+/pkg/operator/      @grafana/grafana-agent-operator-maintainers
+/pkg/traces/        @grafana/grafana-agent-signals-maintainers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,19 +1,5 @@
-The following people are the primary maintainers of the project:
+The primary maintainers of the codebase are the list of team members in
+[GOVERNANCE](./GOVERNANCE.md).
 
-* Robert Fratto (<robert.fratto@grafana.com> / @rfratto)
-* Matt Durham (<matt.durham@grafana.com> / @mattdurham)
-* Paschalis Tsilias (<paschalis.tsilias@grafana.com> / @tpaschalis)
-
-Some parts of the codebase have other maintainers:
-
-* `cmd/grafana-agent-operator`: Craig Peterson (<craig.peterson@grafana.com> / @catpncraig), Marc Tudurí (<marc.tuduri@grafana.com> / @marctc), Jorge Creixell (<jorge.creixell@grafana.com> / @jcreixell)
-* `docs/sources`: Eve Meelan (eve.meelan@grafana.com / @Eve832)
-* `pkg/integrations`: Gabriel Antunes (<gabriel.antunes@grafana.com> / @gaantunes), Ryan Geyer (<ryan.geyer@grafana.com> / @rgeyer), Craig Peterson (<craig.peterson@grafana.com> / @catpncraig), Marc Tudurí (<marc.tuduri@grafana.com> / @marctc), Jorge Creixell (<jorge.creixell@grafana.com> / @jcreixell)
-* `pkg/operator`: Craig Peterson (<craig.peterson@grafana.com> / @catpncraig), Marc Tudurí (<marc.tuduri@grafana.com> / @marctc), Jorge Creixell (<jorge.creixell@grafana.com> / @jcreixell)
-* `pkg/traces`: Joe Elliott (<joe.elliott@grafana.com> / @joe-elliott), Mario Rodriguez (<mario.rodriguez@grafana.com>/ @mapno)
-
-For the sake of brevity, not all subtrees are explicitly listed. Due to the
-size of this repository, the natural changes in focus of maintainers over time,
-and nuances of where particular features live, this list will always be
-incomplete and out of date. However the listed maintainer(s) should be able to
-direct a PR/question to the right person.
+Some parts of the codebase have other maintainers based on GitHub groups. Refer
+to [CODEOWNERS](./CODEOWNERS) for which groups own which subtrees.


### PR DESCRIPTION
Update the list of CODEOWNERS to make sure every PR notifies some group of people, even if that group of people should redirect it to others. 

The list of MAINTAINERS.md is then updated to refer back to the GOVERNANCE.md and CODEOWNERS files.