### PR TITLE
cmd/operator: Fix bug where StatefulSets get fully recreated on version upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ Main (unreleased)
 
 - Fix targets deduplication when clustering mode is enabled. (@laurovenancio)
 
+- Fix issue in operator where any version update will restart all agent pods simultaneously. (@captncraig)
+
 ### Other changes
 
 - Add metrics when clustering mode is enabled. (@rfratto)

--- a/pkg/operator/resources_metrics.go
+++ b/pkg/operator/resources_metrics.go
@@ -213,10 +213,18 @@ func metricsPodTemplateOptions(name string, d gragent.Deployment, shard int32) p
 }
 
 func metadataFromPodTemplate(name string, d gragent.Deployment, tmpl core_v1.PodTemplateSpec) meta_v1.ObjectMeta {
+	labels := make(map[string]string, len(tmpl.Labels))
+	for k, v := range tmpl.Labels {
+		// do not put version label on the statefulset, as that will prevent us from updating it
+		// in the future. Statefulset labels are immutable.
+		if k != "app.kubernetes.io/version" {
+			labels[k] = v
+		}
+	}
 	return meta_v1.ObjectMeta{
 		Name:        name,
 		Namespace:   d.Agent.Namespace,
-		Labels:      tmpl.Labels,
+		Labels:      labels,
 		Annotations: prepareAnnotations(d.Agent.Annotations),
 		OwnerReferences: []meta_v1.OwnerReference{{
 			APIVersion:         d.Agent.APIVersion,

--- a/pkg/operator/resources_metrics.go
+++ b/pkg/operator/resources_metrics.go
@@ -25,6 +25,7 @@ var (
 	minReplicas                 int32 = 1
 	managedByOperatorLabel            = "app.kubernetes.io/managed-by"
 	managedByOperatorLabelValue       = "grafana-agent-operator"
+	versionLabelName                  = "app.kubernetes.io/version"
 	managedByOperatorLabels           = map[string]string{
 		managedByOperatorLabel: managedByOperatorLabelValue,
 	}
@@ -217,7 +218,7 @@ func metadataFromPodTemplate(name string, d gragent.Deployment, tmpl core_v1.Pod
 	for k, v := range tmpl.Labels {
 		// do not put version label on the statefulset, as that will prevent us from updating it
 		// in the future. Statefulset labels are immutable.
-		if k != "app.kubernetes.io/version" {
+		if k != versionLabelName {
 			labels[k] = v
 		}
 	}

--- a/pkg/operator/resources_metrics_test.go
+++ b/pkg/operator/resources_metrics_test.go
@@ -1,0 +1,25 @@
+package operator
+
+import (
+	"testing"
+
+	gragent "github.com/grafana/agent/pkg/operator/apis/monitoring/v1alpha1"
+	"github.com/stretchr/testify/require"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMetadataFromPodTemplate(t *testing.T) {
+	t.Run("Should not include version label in statefulset metadata", func(t *testing.T) {
+		meta := metadataFromPodTemplate("foo",
+			gragent.Deployment{
+				Agent: &gragent.GrafanaAgent{},
+			},
+			core_v1.PodTemplateSpec{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{versionLabelName: "v1.2.3"},
+				},
+			})
+		require.NotContains(t, meta.Labels, versionLabelName)
+	})
+}

--- a/pkg/operator/resources_pod_template.go
+++ b/pkg/operator/resources_pod_template.go
@@ -154,11 +154,13 @@ func generatePodTemplate(
 	}
 
 	var (
-		podAnnotations    = map[string]string{}
-		podLabels         = map[string]string{}
+		podAnnotations = map[string]string{}
+		podLabels      = map[string]string{
+			// version can be a pod label, but should not go in selectors
+			versionLabelName: clientutil.SanitizeVolumeName(build.Version) + "aaa",
+		}
 		podSelectorLabels = map[string]string{
 			"app.kubernetes.io/name":     "grafana-agent",
-			"app.kubernetes.io/version":  clientutil.SanitizeVolumeName(build.Version),
 			"app.kubernetes.io/instance": d.Agent.Name,
 			"grafana-agent":              d.Agent.Name,
 			managedByOperatorLabel:       managedByOperatorLabelValue,

--- a/pkg/operator/resources_pod_template.go
+++ b/pkg/operator/resources_pod_template.go
@@ -157,7 +157,7 @@ func generatePodTemplate(
 		podAnnotations = map[string]string{}
 		podLabels      = map[string]string{
 			// version can be a pod label, but should not go in selectors
-			versionLabelName: clientutil.SanitizeVolumeName(build.Version) + "aaa",
+			versionLabelName: clientutil.SanitizeVolumeName(build.Version),
 		}
 		podSelectorLabels = map[string]string{
 			"app.kubernetes.io/name":     "grafana-agent",

--- a/pkg/operator/resources_pod_template_test.go
+++ b/pkg/operator/resources_pod_template_test.go
@@ -37,9 +37,11 @@ func Test_generatePodTemplate(t *testing.T) {
 			},
 		}
 
-		tmpl, _, err := generatePodTemplate(cfg, "agent", deploy, podTemplateOptions{})
+		tmpl, selectors, err := generatePodTemplate(cfg, "agent", deploy, podTemplateOptions{})
 		require.NoError(t, err)
 		require.Equal(t, DefaultAgentBaseImage+":vX.Y.Z", tmpl.Spec.Containers[1].Image)
+		// version label should not be set in selectors, since that is immutable
+		require.NotContains(t, selectors, versionLabelName)
 	})
 
 	t.Run("security ctx does not contain privileged", func(t *testing.T) {

--- a/pkg/operator/resources_pod_template_test.go
+++ b/pkg/operator/resources_pod_template_test.go
@@ -40,8 +40,21 @@ func Test_generatePodTemplate(t *testing.T) {
 		tmpl, selectors, err := generatePodTemplate(cfg, "agent", deploy, podTemplateOptions{})
 		require.NoError(t, err)
 		require.Equal(t, DefaultAgentBaseImage+":vX.Y.Z", tmpl.Spec.Containers[1].Image)
+	})
+	
+	t.Run("does not set version label in spec selector", func(t *testing.T) {
+		deploy := gragent.Deployment{
+			Agent: &gragent.GrafanaAgent{
+				ObjectMeta: v1.ObjectMeta{Name: name, Namespace: name},
+			},
+		}
+
+		tmpl, selectors, err := generatePodTemplate(cfg, "agent", deploy, podTemplateOptions{})
+		require.NoError(t, err)
+
 		// version label should not be set in selectors, since that is immutable
 		require.NotContains(t, selectors.MatchLabels, versionLabelName)
+		require.Contains(t, tmpl.ObjectMeta.Labels, versionLabelName)
 	})
 
 	t.Run("security ctx does not contain privileged", func(t *testing.T) {

--- a/pkg/operator/resources_pod_template_test.go
+++ b/pkg/operator/resources_pod_template_test.go
@@ -41,7 +41,7 @@ func Test_generatePodTemplate(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, DefaultAgentBaseImage+":vX.Y.Z", tmpl.Spec.Containers[1].Image)
 		// version label should not be set in selectors, since that is immutable
-		require.NotContains(t, selectors, versionLabelName)
+		require.NotContains(t, selectors.MatchLabels, versionLabelName)
 	})
 
 	t.Run("security ctx does not contain privileged", func(t *testing.T) {

--- a/pkg/operator/resources_pod_template_test.go
+++ b/pkg/operator/resources_pod_template_test.go
@@ -37,11 +37,11 @@ func Test_generatePodTemplate(t *testing.T) {
 			},
 		}
 
-		tmpl, selectors, err := generatePodTemplate(cfg, "agent", deploy, podTemplateOptions{})
+		tmpl, _, err := generatePodTemplate(cfg, "agent", deploy, podTemplateOptions{})
 		require.NoError(t, err)
 		require.Equal(t, DefaultAgentBaseImage+":vX.Y.Z", tmpl.Spec.Containers[1].Image)
 	})
-	
+
 	t.Run("does not set version label in spec selector", func(t *testing.T) {
 		deploy := gragent.Deployment{
 			Agent: &gragent.GrafanaAgent{


### PR DESCRIPTION
StatefulSet labels cannot be changed after creation (depending on your kubernetes version).

We were putting the agent version in as a label on agent pods, AND on the StatefulSets themselves. That meant that anytime a version upgrade happens, the statefulset needed to be dropped and recreated, causing all pods to restart at once.

This change removes the version label from the stateful set. This means all pods will restart after this upgrade one last time, but future upgrades should be smoother.

I also decreased the termination grace period on the recreate code path, so that the pods shut down faster, and hopefully downtime will be less when this happens.