### PR TITLE
agent-flow-mixin: add template variables to queries; relax NodeConflict alert

### DIFF
--- a/operations/agent-flow-mixin/alerts/clustering.libsonnet
+++ b/operations/agent-flow-mixin/alerts/clustering.libsonnet
@@ -30,7 +30,7 @@ alert.newGroup(
     alert.newRule(
       'ClusterLamportClockDrift',
       'stddev by (cluster, namespace) (cluster_node_lamport_time) > 4',
-      'Cluster nodes\' lamport clocks are not converging.',
+      "Cluster nodes' lamport clocks are not converging.",
       '5m'
     ),
 
@@ -48,7 +48,7 @@ alert.newGroup(
     alert.newRule(
       'ClusterLamportClockStuck',
       'sum by (cluster, namespace, instance) (rate(cluster_node_lamport_time[2m])) == 0',
-      'Cluster nodes\'s lamport clocks is not progressing.',
+      "Cluster nodes's lamport clocks is not progressing.",
       '5m',
     ),
 
@@ -57,7 +57,7 @@ alert.newGroup(
       'ClusterNodeNameConflict',
       'sum by (cluster, namespace) (rate(cluster_node_gossip_received_events_total{event="node_conflict"}[2m])) > 0',
       'A node tried to join the cluster with a name conflicting with an existing peer.',
-      '5m',
+      '10m',
     ),
 
     // Node stuck in Terminating state.

--- a/operations/agent-flow-mixin/dashboards/cluster-node.libsonnet
+++ b/operations/agent-flow-mixin/dashboards/cluster-node.libsonnet
@@ -49,22 +49,22 @@ local filename = 'agent-cluster-node.json';
         panel.withPosition({ x: 0, y: 1, w: 12, h: 8 }) +
         panel.withQueries([
           panel.newNamedInstantQuery(
-            expr='sum(cluster_node_lamport_time{instance="$instance"})',
+            expr='sum(cluster_node_lamport_time{instance="$instance", cluster="$cluster", namespace="$namespace"})',
             refId='Lamport clock time',
             format='table',
           ),
           panel.newNamedInstantQuery(
-            expr='sum(cluster_node_update_observers{instance="$instance"})',
+            expr='sum(cluster_node_update_observers{instance="$instance", cluster="$cluster", namespace="$namespace"})',
             refId='Internal cluster state observers',
             format='table',
           ),
           panel.newNamedInstantQuery(
-            expr='sum(cluster_node_gossip_health_score{instance="$instance"})',
+            expr='sum(cluster_node_gossip_health_score{instance="$instance", cluster="$cluster", namespace="$namespace"})',
             refId='Gossip health score',
             format='table',
           ),
           panel.newNamedInstantQuery(
-            expr='sum(cluster_node_gossip_proto_version{instance="$instance"})',
+            expr='sum(cluster_node_gossip_proto_version{instance="$instance", cluster="$cluster", namespace="$namespace"})',
             refId='Gossip protocol version',
             format='table',
           ),
@@ -100,7 +100,7 @@ local filename = 'agent-cluster-node.json';
         panel.withPosition({ x: 12, y: 1, w: 12, h: 8 }) +
         panel.withQueries([
           panel.newQuery(
-            expr='rate(cluster_node_gossip_received_events_total{instance="$instance"}[$__rate_interval])',
+            expr='rate(cluster_node_gossip_received_events_total{instance="$instance", cluster="$cluster", namespace="$namespace"}[$__rate_interval])',
             legendFormat='{{event}}'
           ),
         ])
@@ -114,7 +114,7 @@ local filename = 'agent-cluster-node.json';
         panel.withPosition({ x: 0, y: 9, w: 12, h: 8 }) +
         panel.withQueries([
           panel.newQuery(
-            expr='sum(cluster_node_peers{instance="$instance"})',
+            expr='sum(cluster_node_peers{instance="$instance", cluster="$cluster", namespace="$namespace"})',
           ),
         ]) +
         panel.withUnit('suffix:peers')
@@ -128,7 +128,7 @@ local filename = 'agent-cluster-node.json';
         panel.withPosition({ x: 12, y: 9, w: 12, h: 8 }) +
         panel.withQueries([
           panel.newQuery(
-            expr='cluster_node_peers{instance="$instance"}',
+            expr='cluster_node_peers{instance="$instance", cluster="$cluster", namespace="$namespace"}',
             legendFormat='{{state}}',
           ),
         ]) +
@@ -150,11 +150,11 @@ local filename = 'agent-cluster-node.json';
         }) +
         panel.withQueries([
           panel.newQuery(
-            expr='rate(cluster_transport_rx_bytes_total{instance="$instance"}[$__rate_interval])',
+            expr='rate(cluster_transport_rx_bytes_total{instance="$instance", cluster="$cluster", namespace="$namespace"}[$__rate_interval])',
             legendFormat='rx',
           ),
           panel.newQuery(
-            expr='-1 * rate(cluster_transport_tx_bytes_total{instance="$instance"}[$__rate_interval])',
+            expr='-1 * rate(cluster_transport_tx_bytes_total{instance="$instance", cluster="$cluster", namespace="$namespace"}[$__rate_interval])',
             legendFormat='tx',
           ),
         ]) +
@@ -174,8 +174,8 @@ local filename = 'agent-cluster-node.json';
           panel.newQuery(
             expr=|||
               1 - (
-              rate(cluster_transport_tx_packets_failed_total{instance="$instance"}[$__rate_interval]) /
-              rate(cluster_transport_tx_packets_total{instance="$instance"}[$__rate_interval])
+              rate(cluster_transport_tx_packets_failed_total{instance="$instance", cluster="$cluster", namespace="$namespace"}[$__rate_interval]) /
+              rate(cluster_transport_tx_packets_total{instance="$instance", cluster="$cluster", namespace="$namespace"}[$__rate_interval])
               )
             |||,
             legendFormat='Tx success %',
@@ -183,8 +183,8 @@ local filename = 'agent-cluster-node.json';
           panel.newQuery(
             expr=|||
               1 - (
-                rate(cluster_transport_rx_packets_failed_total{instance="$instance"}[$__rate_interval]) /
-                rate(cluster_transport_rx_packets_total{instance="$instance"}[$__rate_interval])
+                rate(cluster_transport_rx_packets_failed_total{instance="$instance", cluster="$cluster", namespace="$namespace"}[$__rate_interval]) /
+                rate(cluster_transport_rx_packets_total{instance="$instance", cluster="$cluster", namespace="$namespace"}[$__rate_interval])
                 )
             |||,
             legendFormat='Rx success %',
@@ -208,11 +208,11 @@ local filename = 'agent-cluster-node.json';
         }) +
         panel.withQueries([
           panel.newQuery(
-            expr='cluster_transport_tx_packet_queue_length{instance="$instance"}',
+            expr='cluster_transport_tx_packet_queue_length{instance="$instance", cluster="$cluster", namespace="$namespace"}',
             legendFormat='tx queue',
           ),
           panel.newQuery(
-            expr='cluster_transport_rx_packet_queue_length{instance="$instance"}',
+            expr='cluster_transport_rx_packet_queue_length{instance="$instance", cluster="$cluster", namespace="$namespace"}',
             legendFormat='rx queue',
           ),
         ]) +
@@ -229,11 +229,11 @@ local filename = 'agent-cluster-node.json';
         }) +
         panel.withQueries([
           panel.newQuery(
-            expr='rate(cluster_transport_stream_rx_bytes_total{instance="$instance"}[$__rate_interval])',
+            expr='rate(cluster_transport_stream_rx_bytes_total{instance="$instance", cluster="$cluster", namespace="$namespace"}[$__rate_interval])',
             legendFormat='rx',
           ),
           panel.newQuery(
-            expr='-1 * rate(cluster_transport_stream_tx_bytes_total{instance="$instance"}[$__rate_interval])',
+            expr='-1 * rate(cluster_transport_stream_tx_bytes_total{instance="$instance", cluster="$cluster", namespace="$namespace"}[$__rate_interval])',
             legendFormat='tx',
           ),
         ]) +
@@ -253,8 +253,8 @@ local filename = 'agent-cluster-node.json';
           panel.newQuery(
             expr=|||
               1 - (
-                rate(cluster_transport_stream_tx_packets_failed_total{instance="$instance"}[$__rate_interval]) /
-                rate(cluster_transport_stream_tx_packets_total{instance="$instance"}[$__rate_interval])
+                rate(cluster_transport_stream_tx_packets_failed_total{instance="$instance", cluster="$cluster", namespace="$namespace"}[$__rate_interval]) /
+                rate(cluster_transport_stream_tx_packets_total{instance="$instance", cluster="$cluster", namespace="$namespace"}[$__rate_interval])
                 )
             |||,
             legendFormat='Tx success %'
@@ -262,8 +262,8 @@ local filename = 'agent-cluster-node.json';
           panel.newQuery(
             expr=|||
               1 - (
-                rate(cluster_transport_stream_rx_packets_failed_total{instance="$instance"}[$__rate_interval]) /
-                rate(cluster_transport_stream_rx_packets_total{instance="$instance"}[$__rate_interval])
+                rate(cluster_transport_stream_rx_packets_failed_total{instance="$instance", cluster="$cluster", namespace="$namespace"}[$__rate_interval]) /
+                rate(cluster_transport_stream_rx_packets_total{instance="$instance", cluster="$cluster", namespace="$namespace"}[$__rate_interval])
                 )
             |||,
             legendFormat='Rx success %'
@@ -287,7 +287,7 @@ local filename = 'agent-cluster-node.json';
         }) +
         panel.withQueries([
           panel.newQuery(
-            expr='cluster_transport_streams{instance="$instance"}',
+            expr='cluster_transport_streams{instance="$instance", cluster="$cluster", namespace="$namespace"}',
             legendFormat='Open streams'
           ),
         ])

--- a/operations/agent-flow-mixin/dashboards/cluster-overview.libsonnet
+++ b/operations/agent-flow-mixin/dashboards/cluster-overview.libsonnet
@@ -31,7 +31,7 @@ local cluster_node_filename = 'agent-cluster-node.json';
         panel.withPosition({ h: 9, w: 8, x: 0, y: 0 }) +
         panel.withQueries([
           panel.newInstantQuery(
-            expr='count(cluster_node_info)'
+            expr='count(cluster_node_info{cluster="$cluster", namespace="$namespace"})'
           ),
         ])
       ),
@@ -44,7 +44,7 @@ local cluster_node_filename = 'agent-cluster-node.json';
         panel.withPosition({ h: 9, w: 16, x: 8, y: 0 }) +
         panel.withQueries([
           panel.newInstantQuery(
-            expr='cluster_node_info',
+            expr='cluster_node_info{cluster="$cluster", namespace="$namespace"}',
             format='table',
           ),
         ]) +
@@ -124,8 +124,8 @@ local cluster_node_filename = 'agent-cluster-node.json';
           panel.newInstantQuery(
             expr=|||
               clamp((
-                sum(stddev by (state) (cluster_node_peers) != 0) or
-                (sum(abs(sum without (state) (cluster_node_peers)) - scalar(count(cluster_node_info)) != 0))
+                sum(stddev by (state) (cluster_node_peers{cluster="$cluster", namespace="$namespace"}) != 0) or
+                (sum(abs(sum without (state) (cluster_node_peers{cluster="$cluster", namespace="$namespace"})) - scalar(count(cluster_node_info{cluster="$cluster", namespace="$namespace"})) != 0))
                 ),
                 1, 1
               )
@@ -193,8 +193,8 @@ local cluster_node_filename = 'agent-cluster-node.json';
           panel.newQuery(
             expr=|||
               ceil(clamp((
-                sum(stddev by (state) (cluster_node_peers)) or
-                (sum(abs(sum without (state) (cluster_node_peers)) - scalar(count(cluster_node_info))))
+                sum(stddev by (state) (cluster_node_peers{cluster="$cluster", namespace="$namespace"})) or
+                (sum(abs(sum without (state) (cluster_node_peers{cluster="$cluster", namespace="$namespace"})) - scalar(count(cluster_node_info{cluster="$cluster", namespace="$namespace"}))))
                 ),
                 0, 1
               ))


### PR DESCRIPTION
#### PR Description
This PR adds the proper template variables on the queries for the Cluster Overview and Cluster Node dashboards. It also relaxes the alert for NodeConflict time to fire from 5 to 10 minutes.

#### Which issue(s) this PR fixes
Fixes #3940

#### Notes to the Reviewer
Nothing to add :)

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
