### PR TITLE
Use latest version of Prometheus in URLs to Prometheus docs

### DIFF
--- a/docs/sources/flow/reference/components/prometheus.receive_http.md
+++ b/docs/sources/flow/reference/components/prometheus.receive_http.md
@@ -9,7 +9,7 @@ title: prometheus.receive_http
 The HTTP API exposed is compatible with [Prometheus `remote_write` API][prometheus-remote-write-docs]. This means that other [`prometheus.remote_write`][prometheus.remote_write] components can be used as a client and send requests to `prometheus.receive_http` which enables using the Agent as a proxy for prometheus metrics.
 
 [prometheus.remote_write]: {{< relref "./prometheus.remote_write.md" >}}
-[prometheus-remote-write-docs]: https://prometheus.io/docs/prometheus/latest/querying/api/#remote-write-receiver
+[prometheus-remote-write-docs]: https://prometheus.io/docs/prometheus/2.42/querying/api/#remote-write-receiver
 
 ## Usage
 

--- a/docs/sources/static/api/_index.md
+++ b/docs/sources/static/api/_index.md
@@ -407,7 +407,7 @@ GET /agent/api/v1/metrics/integrations/sd
 
 This endpoint returns all running metrics-based integrations. It conforms to
 the Prometheus [http_sd_config
-API](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_sd_config).
+API](https://prometheus.io/docs/prometheus/2.42/configuration/configuration/#http_sd_config).
 Targets include integrations regardless of autoscrape being enabled; this
 allows for manually configuring scrape jobs to collect metrics from an
 integration running on an external agent.

--- a/docs/sources/static/configuration/flags.md
+++ b/docs/sources/static/configuration/flags.md
@@ -31,7 +31,7 @@ Valid feature names are:
 
 * `remote-configs`: Enable [retrieving]({{< relref "./_index.md#remote-configuration-experimental" >}}) config files over HTTP/HTTPS
 * `integrations-next`: Enable [revamp]({{< relref "./integrations/integrations-next/" >}}) of the integrations subsystem
-* `extra-scrape-metrics`: When enabled, additional time series  are exposed for each metrics instance scrape. See [Extra scrape metrics](https://prometheus.io/docs/prometheus/latest/feature_flags/#extra-scrape-metrics).
+* `extra-scrape-metrics`: When enabled, additional time series  are exposed for each metrics instance scrape. See [Extra scrape metrics](https://prometheus.io/docs/prometheus/2.42/feature_flags/#extra-scrape-metrics).
 * `agent-management`: Enable support for [agent management]({{< relref "./agent-management" >}}).
 
 ## Report information usage

--- a/docs/sources/static/configuration/integrations/integrations-next/_index.md
+++ b/docs/sources/static/configuration/integrations/integrations-next/_index.md
@@ -42,7 +42,7 @@ original subsystem:
 * Autoscrape, when enabled, now works completely in-memory without using the
   network.
 
-[http_sd_config]: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_sd_config
+[http_sd_config]: https://prometheus.io/docs/prometheus/2.42/configuration/configuration/#http_sd_config
 
 ## Config changes
 

--- a/docs/sources/static/configuration/integrations/integrations-next/snmp-config.md
+++ b/docs/sources/static/configuration/integrations/integrations-next/snmp-config.md
@@ -42,7 +42,7 @@ integrations:
 
 ## Prometheus service discovery use case
 
-If you need to scrape SNMP devices in more dynamic environment, and cannot define devices in `snmp_targets` because targets would change over time, you can use service discovery approach. For instance, with [DNS discovery](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#dns_sd_config):
+If you need to scrape SNMP devices in more dynamic environment, and cannot define devices in `snmp_targets` because targets would change over time, you can use service discovery approach. For instance, with [DNS discovery](https://prometheus.io/docs/prometheus/2.42/configuration/configuration/#dns_sd_config):
 
 ```yaml
 

--- a/docs/sources/static/configuration/integrations/snmp-config.md
+++ b/docs/sources/static/configuration/integrations/snmp-config.md
@@ -43,7 +43,7 @@ integrations:
 
 ## Prometheus service discovery use case
 
-If you need to scrape SNMP devices in more dynamic environment, and cannot define devices in `snmp_targets` because targets would change over time, you can use service discovery approach. For instance, with [DNS discovery](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#dns_sd_config):
+If you need to scrape SNMP devices in more dynamic environment, and cannot define devices in `snmp_targets` because targets would change over time, you can use service discovery approach. For instance, with [DNS discovery](https://prometheus.io/docs/prometheus/2.42/configuration/configuration/#dns_sd_config):
 
 ```yaml
 

--- a/docs/sources/static/configuration/traces-config.md
+++ b/docs/sources/static/configuration/traces-config.md
@@ -388,7 +388,7 @@ service_graphs:
   * [`otlpreceiver`: OpenTelemetry-Collector](https://github.com/open-telemetry/opentelemetry-collector/tree/1f5dd9f9a566a937ec15093ca3bc377fba86f5f9/receiver/otlpreceiver)
   * [`opencensusreceiver`: OpenTelemetry-Collector-Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/b2327211df976e0a57ef0425493448988772a16b/receiver/opencensusreceiver)
   * [`zipkinreceiver`: OpenTelemetry-Collector-Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/b2327211df976e0a57ef0425493448988772a16b/receiver/zipkinreceiver)
-* [`scrape_config`: Prometheus](https://prometheus.io/docs/prometheus/2.34/configuration/configuration/#scrape_config)
+* [`scrape_config`: Prometheus](https://prometheus.io/docs/prometheus/2.42/configuration/configuration/#scrape_config)
 * [`spanmetricsprocessor.latency_histogram_buckets`: OpenTelemetry-Collector-Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/b2327211df976e0a57ef0425493448988772a16b/processor/spanmetricsprocessor/config.go#L38-L47)
 * [`spanmetricsprocessor.dimensions`: OpenTelemetry-Collector-Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/b2327211df976e0a57ef0425493448988772a16b/processor/spanmetricsprocessor/config.go#L38-L47)
 * [`tailsamplingprocessor.policies`: OpenTelemetry-Collector-Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/b2327211df976e0a57ef0425493448988772a16b/processor/tailsamplingprocessor)


### PR DESCRIPTION
Some of the links in the documentation have been broken. This change will point those links to the latest version of Prometheus.

There's only one minor issue with this change - ideally we should point to the version of Prometheus which the Agent is using. However, I suppose Prometheus is relatively stable and this is not a big concern.

Closes #4051.