### PR TITLE
helm: rename pod template's serviceAccount to serviceAccountName

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -16,8 +16,8 @@ Unreleased
 
 - Make the Faro port optional. (@tpaschalis)
 
-- Rename the deprecated `serviceAccount` alias to to `serviceAccountName` in
-  pod template. This is a no-op for existing deployments. (@tpaschalis)
+- Rename the deprecated `serviceAccount` alias to `serviceAccountName` in
+  pod template. This is a no-op change. (@tpaschalis)
 
 0.14.0 (2023-05-11)
 -------------------

--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -16,6 +16,9 @@ Unreleased
 
 - Make the Faro port optional. (@tpaschalis)
 
+- Rename the deprecated `serviceAccount` alias to to `serviceAccountName` in
+  pod template. This is a no-op for existing deployments. (@tpaschalis)
+
 0.14.0 (2023-05-11)
 -------------------
 

--- a/operations/helm/charts/grafana-agent/templates/controllers/_pod.yaml
+++ b/operations/helm/charts/grafana-agent/templates/controllers/_pod.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  serviceAccount: {{ include "grafana-agent.serviceAccountName" . }}
+  serviceAccountName: {{ include "grafana-agent.serviceAccountName" . }}
   {{- with .Values.image.pullSecrets }}
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}

--- a/operations/helm/tests/controller-volumes-extra/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/controller-volumes-extra/grafana-agent/templates/controllers/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent
     spec:
-      serviceAccount: grafana-agent
+      serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
           image: grafana/agent:v0.33.2

--- a/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/controllers/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent
     spec:
-      serviceAccount: grafana-agent
+      serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
           image: grafana/agent:v0.33.2

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent
     spec:
-      serviceAccount: grafana-agent
+      serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
           image: grafana/agent:v0.33.2

--- a/operations/helm/tests/create-deployment-autoscaling/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment-autoscaling/grafana-agent/templates/controllers/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent
     spec:
-      serviceAccount: grafana-agent
+      serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
           image: grafana/agent:v0.33.2

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent
     spec:
-      serviceAccount: grafana-agent
+      serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
           image: grafana/agent:v0.33.2

--- a/operations/helm/tests/create-statefulset-autoscaling/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset-autoscaling/grafana-agent/templates/controllers/statefulset.yaml
@@ -24,7 +24,7 @@ spec:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent
     spec:
-      serviceAccount: grafana-agent
+      serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
           image: grafana/agent:v0.33.2

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
@@ -24,7 +24,7 @@ spec:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent
     spec:
-      serviceAccount: grafana-agent
+      serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
           image: grafana/agent:v0.33.2

--- a/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent
     spec:
-      serviceAccount: grafana-agent
+      serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
           image: grafana/agent:v0.33.2

--- a/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent
     spec:
-      serviceAccount: grafana-agent
+      serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
           image: grafana/agent:v0.33.2

--- a/operations/helm/tests/envFrom/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/envFrom/grafana-agent/templates/controllers/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent
     spec:
-      serviceAccount: grafana-agent
+      serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
           image: grafana/agent:v0.33.2

--- a/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent
     spec:
-      serviceAccount: grafana-agent
+      serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
           image: grafana/agent:v0.33.2

--- a/operations/helm/tests/extra-env/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-env/grafana-agent/templates/controllers/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent
     spec:
-      serviceAccount: grafana-agent
+      serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
           image: grafana/agent:v0.33.2

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent
     spec:
-      serviceAccount: grafana-agent
+      serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
           image: grafana/agent:v0.33.2

--- a/operations/helm/tests/faro-ingress/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/faro-ingress/grafana-agent/templates/controllers/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent
     spec:
-      serviceAccount: grafana-agent
+      serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
           image: grafana/agent:v0.33.2

--- a/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent
     spec:
-      serviceAccount: grafana-agent
+      serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
           image: grafana/agent:v0.33.2

--- a/operations/helm/tests/tolerations/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/tolerations/grafana-agent/templates/controllers/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent
     spec:
-      serviceAccount: grafana-agent
+      serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
           image: grafana/agent:v0.33.2


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
As per the [Kubernetes docs](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podspec-v1-core), in PodSpec the `serviceAccount` field is a deprecated alias for `serviceAccountName`, which should be used in its place.

This change should be a no-op to people using the Helm chart.

```
serviceAccount (string) | Deprecated - ServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.
```

#### Which issue(s) this PR fixes
No issue filed

#### Notes to the Reviewer
Do we want to notify users that this is a no-op change so that they're not worried if they see a diff in their rendered manifests?

#### PR Checklist

- [X] CHANGELOG updated
- [ ] Documentation added (N/A)
- [X] Tests updated
