### PR TITLE
Fix ServerConfig defaults due to block squashing

### DIFF
--- a/component/common/net/config.go
+++ b/component/common/net/config.go
@@ -82,18 +82,6 @@ func (g *GRPCConfig) Into(c *weaveworks.Config) {
 	c.GPRCServerMaxConcurrentStreams = g.ServerMaxConcurrentStreams
 }
 
-func (c *ServerConfig) UnmarshalRiver(f func(v interface{}) error) error {
-	// when unmarshalling, use our defaults to cover cases in which just some of the http/grpc
-	// block attributes are configured
-	*c = *defaultServerConfig()
-	type config ServerConfig
-	if err := f((*config)(c)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // Convert converts the River-based ServerConfig into a weaveworks.Config object.
 func (c *ServerConfig) convert() weaveworks.Config {
 	cfg := newWeaveworksDefaultConfig()
@@ -102,12 +90,12 @@ func (c *ServerConfig) convert() weaveworks.Config {
 	if c.HTTP != nil {
 		c.HTTP.Into(&cfg)
 	} else {
-		defaultServerConfig().HTTP.Into(&cfg)
+		DefaultServerConfig().HTTP.Into(&cfg)
 	}
 	if c.GRPC != nil {
 		c.GRPC.Into(&cfg)
 	} else {
-		defaultServerConfig().GRPC.Into(&cfg)
+		DefaultServerConfig().GRPC.Into(&cfg)
 	}
 	cfg.ServerGracefulShutdownTimeout = c.GracefulShutdownTimeout
 	return cfg
@@ -123,9 +111,9 @@ func newWeaveworksDefaultConfig() weaveworks.Config {
 	return c
 }
 
-// defaultServerConfig creates a new ServerConfig with defaults applied. Note that some are inherited from
+// DefaultServerConfig creates a new ServerConfig with defaults applied. Note that some are inherited from
 // weaveworks, but copied in our config model to make the mixin logic simpler.
-func defaultServerConfig() *ServerConfig {
+func DefaultServerConfig() *ServerConfig {
 	return &ServerConfig{
 		HTTP: &HTTPConfig{
 			ListenAddress:      "",

--- a/component/common/net/server.go
+++ b/component/common/net/server.go
@@ -35,7 +35,7 @@ func NewTargetServer(logger log.Logger, metricsNamespace string, reg prometheus.
 	}
 
 	if config == nil {
-		config = defaultServerConfig()
+		config = DefaultServerConfig()
 	}
 
 	// convert from River into the weaveworks config

--- a/component/loki/source/api/api.go
+++ b/component/loki/source/api/api.go
@@ -34,6 +34,19 @@ type Arguments struct {
 	UseIncomingTimestamp bool                `river:"use_incoming_timestamp,attr,optional"`
 }
 
+func (a *Arguments) UnmarshalRiver(f func(v interface{}) error) error {
+	*a = Arguments{
+		Server: fnet.DefaultServerConfig(),
+	}
+
+	type args Arguments
+	err := f((*args)(a))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (a *Arguments) labelSet() model.LabelSet {
 	labelSet := make(model.LabelSet, len(a.Labels))
 	for k, v := range a.Labels {

--- a/component/loki/source/gcplog/internal/gcplogtarget/types.go
+++ b/component/loki/source/gcplog/internal/gcplogtarget/types.go
@@ -33,6 +33,11 @@ type PushConfig struct {
 
 // UnmarshalRiver implements the unmarshaller
 func (p *PushConfig) UnmarshalRiver(f func(v interface{}) error) error {
+	// apply server defaults from here since the fields are squashed
+	*p = PushConfig{
+		Server: fnet.DefaultServerConfig(),
+	}
+
 	type pushCfg PushConfig
 	err := f((*pushCfg)(p))
 	if err != nil {

--- a/component/loki/source/heroku/heroku.go
+++ b/component/loki/source/heroku/heroku.go
@@ -38,6 +38,21 @@ type Arguments struct {
 	RelabelRules         flow_relabel.Rules  `river:"relabel_rules,attr,optional"`
 }
 
+// UnmarshalRiver implements the unmarshaller
+func (a *Arguments) UnmarshalRiver(f func(v interface{}) error) error {
+	// apply server defaults from here since the fields are squashed
+	*a = Arguments{
+		Server: fnet.DefaultServerConfig(),
+	}
+
+	type args Arguments
+	err := f((*args)(a))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // Component implements the loki.source.heroku component.
 type Component struct {
 	opts          component.Options

--- a/component/prometheus/receive_http/receive_http.go
+++ b/component/prometheus/receive_http/receive_http.go
@@ -33,6 +33,19 @@ type Arguments struct {
 	ForwardTo []storage.Appendable `river:"forward_to,attr"`
 }
 
+func (a *Arguments) UnmarshalRiver(f func(v interface{}) error) error {
+	*a = Arguments{
+		Server: fnet.DefaultServerConfig(),
+	}
+
+	type args Arguments
+	err := f((*args)(a))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 type Component struct {
 	opts               component.Options
 	handler            http.Handler


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Most flow components that use `fnet.TargetServer` expose the `fnet.ServerConfig` squashed in their river config. The unmarshalling of `ServerConfig` was applying defaults by implementing `UnmsarshalRiver`. Since the block is squashed, this doesn't work as expected.

This PR applies the same pattern as https://github.com/grafana/agent/blob/f5ed4ce08fff02fd030d7a0d35663d19888eaef4/component/prometheus/scrape/scrape.go#L100 which is, when a block is squashed, to apply the defaults from the unsmarshall river in the outermost struct.

Also, this PR adapts the `ServerConfig` testing suite to test the unmarshalling with the block being squashed.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
