### PR TITLE
loki.source.journald: sync positions directory permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,9 @@ Main (unreleased)
 
 - Fix issue in operator where any version update will restart all agent pods simultaneously. (@captncraig)
 
+- Fix an issue where `loki.source.journald` did not create the positions
+  directory with the appropriate permissions. (@tpaschalis)
+
 ### Other changes
 
 - Add metrics when clustering mode is enabled. (@rfratto)

--- a/component/loki/source/journal/journal.go
+++ b/component/loki/source/journal/journal.go
@@ -45,6 +45,11 @@ type Component struct {
 
 // New creates a new  component.
 func New(o component.Options, args Arguments) (component.Component, error) {
+	err := os.MkdirAll(o.DataPath, 0750)
+	if err != nil {
+		return nil, err
+	}
+
 	positionsFile, err := positions.New(o.Logger, positions.Config{
 		SyncPeriod:        10 * time.Second,
 		PositionsFile:     filepath.Join(o.DataPath, "positions.yml"),
@@ -54,10 +59,7 @@ func New(o component.Options, args Arguments) (component.Component, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = os.MkdirAll(o.DataPath, 0644)
-	if err != nil {
-		return nil, err
-	}
+
 	c := &Component{
 		metrics:   target.NewMetrics(o.Registerer),
 		o:         o,


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR fixes the permissions which are used to create the positions directory for loki.source.journal to match all the other `loki.source.*` components. It also moves the directory creation to before the definition of the file.

Eg. here's how it works for loki.source.docker

https://github.com/grafana/agent/blob/4b8807a517071556c7fd520d7ddd792fbcd311f7/component/loki/source/docker/docker.go#L77-L85

#### Which issue(s) this PR fixes
Fixes #3972

#### Notes to the Reviewer
Nothing in particular. Maybe this should also be part of the shared abstraction for logging components.

#### PR Checklist

- [X] CHANGELOG updated
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
