### PR TITLE
[Agent Management] Add alerts for fallback to empty config

### DIFF
--- a/production/grafana-agent-mixin/alerts.libsonnet
+++ b/production/grafana-agent-mixin/alerts.libsonnet
@@ -377,6 +377,37 @@ local _config = config._config;
               |||,
             },
           },
+          {
+            alert: 'AgentManagementFallbackToEmptyConfig',
+            expr: |||
+              sum(rate(agent_management_config_fallbacks_total{fallback_to="empty_config"}[10m])) by (%(group_by_cluster)s) > 0
+            ||| % _config,
+            'for': '10m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: |||
+                 Instance {{ $labels.instance }} fell back to empty configuration.
+              |||,
+            },
+          },
+          {
+            alert: 'AgentManagementFallbackToEmptyConfig',
+            expr: |||
+              sum(rate(agent_management_config_fallbacks_total{fallback_to="empty_config"}[10m])) by (%(group_by_cluster)s) > 0
+                > 0
+            ||| % _config,
+            'for': '30m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: |||
+                 Instance {{ $labels.instance }} fell back to empty configuration.
+              |||,
+            },
+          },
         ],
       },      
     ],

--- a/production/grafana-agent-mixin/alerts.libsonnet
+++ b/production/grafana-agent-mixin/alerts.libsonnet
@@ -396,7 +396,6 @@ local _config = config._config;
             alert: 'AgentManagementFallbackToEmptyConfig',
             expr: |||
               sum(rate(agent_management_config_fallbacks_total{fallback_to="empty_config"}[10m])) by (%(group_by_cluster)s) > 0
-                > 0
             ||| % _config,
             'for': '30m',
             labels: {


### PR DESCRIPTION
#### PR Description

  - Agent management does a failover to a disk-cached copy of the last valid configuration on failure to fetch a remote config. In certain scenarios, the local copy might not exist (on first run of the agent, or when the local copy has been deleted).
  - When that happens, the agent will fallback to an empty config while trying to reconnect. This needs to be alerted on because during this time, the agent won't do any work, and may indicate issues with the initial configuration.
