### PR TITLE
Reverting config yml filename

### DIFF
--- a/docs/sources/static/set-up/install-agent-macos.md
+++ b/docs/sources/static/set-up/install-agent-macos.md
@@ -32,10 +32,10 @@ Use Homebrew to install the most recent released version of Grafana using the Ho
 
     ```
     mkdir -p $(brew --prefix)/etc/grafana-agent/
-    touch $(brew --prefix)/etc/grafana-agent/config.yaml
+    touch $(brew --prefix)/etc/grafana-agent/config.yml
     ```
 
-1. Modify `config.yaml` with your configuration requirements.
+1. Modify `config.yml` with your configuration requirements.
 
     See [Configure Grafana Agent for details]({{< relref "../configuration/" >}}).
 


### PR DESCRIPTION
#### PR Description

Setting config yaml filename back to `config.yml`. It was noted in usability testing that the default config filename for OSX uses `.yml` for the file extension. This change is a quick fix to change the documented filename back to match the install.

Original change was in https://github.com/grafana/agent/pull/3507

Future editing/changes will look at using placeholder naming instead of explicit filenames.

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
