### PR TITLE
River: Unmarshal integers from interface{} into int64, uint64 or float64

### DIFF
--- a/pkg/river/internal/value/decode.go
+++ b/pkg/river/internal/value/decode.go
@@ -398,16 +398,16 @@ func tryCapsuleConvert(from Value, into reflect.Value, intoType Type) (ok bool, 
 // decodeAny is invoked by decode when into is an interface{}. We assign the
 // interface{} a known type based on the River value being decoded:
 //
-//			Null values:           nil
-//			Number values:         float64, int64, or uint64 depending on the underlying Go type
-//		                           of the River value. If the underlying type is not a float and the
-//	                               number fits within an "int", then an "int" will be used.
-//			Arrays:                []interface{}
-//			Objects:               map[string]interface{}
-//			Bool:                  bool
-//			String:                string
-//			Function:              Passthrough of the underlying function value
-//			Capsule:               Passthrough of the underlying capsule value
+//	Null values:           nil
+//	Number values:         float64, int64, or uint64 depending on the underlying Go type
+//	                       of the River value. If the underlying type is not a float and the
+//	                       number fits within an "int", then an "int" will be used.
+//	Arrays:                []interface{}
+//	Objects:               map[string]interface{}
+//	Bool:                  bool
+//	String:                string
+//	Function:              Passthrough of the underlying function value
+//	Capsule:               Passthrough of the underlying capsule value
 //
 // In the cases where we do not pass through the underlying value, we create a
 // value of that type, recursively call decode to populate that new value, and

--- a/pkg/river/internal/value/decode.go
+++ b/pkg/river/internal/value/decode.go
@@ -399,9 +399,9 @@ func tryCapsuleConvert(from Value, into reflect.Value, intoType Type) (ok bool, 
 // interface{} a known type based on the River value being decoded:
 //
 //	Null values:           nil
-//	Number values:         float64, int64, or uint64 depending on the underlying Go type
-//	                       of the River value. If the underlying type is not a float and the
-//	                       number fits within an "int", then an "int" will be used.
+//	Number values:         float64, int, int64, or uint64.
+//	                       If the underlying type is a float, always decode to a float64.
+//	                       For non-floats the order of preference is int -> int64 -> uint64.
 //	Arrays:                []interface{}
 //	Objects:               map[string]interface{}
 //	Bool:                  bool
@@ -430,6 +430,9 @@ func (d *decoder) decodeAny(val Value, into reflect.Value) error {
 			uint64Val := val.Uint()
 			if uint64Val <= math.MaxInt {
 				var v int
+				ptr = reflect.ValueOf(&v)
+			} else if uint64Val <= math.MaxInt64 {
+				var v int64
 				ptr = reflect.ValueOf(&v)
 			} else {
 				var v uint64

--- a/pkg/river/internal/value/decode.go
+++ b/pkg/river/internal/value/decode.go
@@ -4,6 +4,7 @@ import (
 	"encoding"
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
 	"time"
 
@@ -397,17 +398,16 @@ func tryCapsuleConvert(from Value, into reflect.Value, intoType Type) (ok bool, 
 // decodeAny is invoked by decode when into is an interface{}. We assign the
 // interface{} a known type based on the River value being decoded:
 //
-//		Null values:           nil
-//		Integer values:        int64, uint64 or float64, in this order of preference;
-//	                           If the number overflows an int64 then we try uint64,
-//	                           and if that also overflows we try a float64.
-//		Floating point values: float64
-//		Arrays:                []interface{}
-//		Objects:               map[string]interface{}
-//		Bool:                  bool
-//		String:                string
-//		Function:              Passthrough of the underlying function value
-//		Capsule:               Passthrough of the underlying capsule value
+//			Null values:           nil
+//			Number values:         float64, int64, or uint64 depending on the underlying Go type
+//		                           of the River value. If the underlying type is not a float and the
+//	                               number fits within an "int", then an "int" will be used.
+//			Arrays:                []interface{}
+//			Objects:               map[string]interface{}
+//			Bool:                  bool
+//			String:                string
+//			Function:              Passthrough of the underlying function value
+//			Capsule:               Passthrough of the underlying capsule value
 //
 // In the cases where we do not pass through the underlying value, we create a
 // value of that type, recursively call decode to populate that new value, and
@@ -427,11 +427,24 @@ func (d *decoder) decodeAny(val Value, into reflect.Value) error {
 			var v float64
 			ptr = reflect.ValueOf(&v)
 		case NumberKindUint:
-			var v uint64
-			ptr = reflect.ValueOf(&v)
+			uint64Val := val.Uint()
+			if uint64Val <= math.MaxInt {
+				var v int
+				ptr = reflect.ValueOf(&v)
+			} else {
+				var v uint64
+				ptr = reflect.ValueOf(&v)
+			}
 		case NumberKindInt:
-			var v int64
-			ptr = reflect.ValueOf(&v)
+			int64Val := val.Int()
+			if math.MinInt <= int64Val && int64Val <= math.MaxInt {
+				var v int
+				ptr = reflect.ValueOf(&v)
+			} else {
+				var v int64
+				ptr = reflect.ValueOf(&v)
+			}
+
 		default:
 			panic("river/value: unreachable")
 		}

--- a/pkg/river/internal/value/decode.go
+++ b/pkg/river/internal/value/decode.go
@@ -398,16 +398,16 @@ func tryCapsuleConvert(from Value, into reflect.Value, intoType Type) (ok bool, 
 // decodeAny is invoked by decode when into is an interface{}. We assign the
 // interface{} a known type based on the River value being decoded:
 //
-//	Null values:           nil
-//	Number values:         float64, int, int64, or uint64.
-//	                       If the underlying type is a float, always decode to a float64.
-//	                       For non-floats the order of preference is int -> int64 -> uint64.
-//	Arrays:                []interface{}
-//	Objects:               map[string]interface{}
-//	Bool:                  bool
-//	String:                string
-//	Function:              Passthrough of the underlying function value
-//	Capsule:               Passthrough of the underlying capsule value
+//	Null values:   nil
+//	Number values: float64, int, int64, or uint64.
+//	               If the underlying type is a float, always decode to a float64.
+//	               For non-floats the order of preference is int -> int64 -> uint64.
+//	Arrays:        []interface{}
+//	Objects:       map[string]interface{}
+//	Bool:          bool
+//	String:        string
+//	Function:      Passthrough of the underlying function value
+//	Capsule:       Passthrough of the underlying capsule value
 //
 // In the cases where we do not pass through the underlying value, we create a
 // value of that type, recursively call decode to populate that new value, and

--- a/pkg/river/internal/value/decode_test.go
+++ b/pkg/river/internal/value/decode_test.go
@@ -664,33 +664,42 @@ func TestDecode_KnownTypes_Any(t *testing.T) {
 		input  any
 		expect any
 	}{
-		// All numbers must decode to float64.
-		{int(15), int64(15)},
-		{int8(15), int64(15)},
-		{int16(15), int64(15)},
-		{int32(15), int64(15)},
-		{int64(15), int64(15)},
-		{uint(15), uint64(15)},
-		{uint8(15), uint64(15)},
-		{uint16(15), uint64(15)},
-		{uint32(15), uint64(15)},
-		{uint64(15), uint64(15)},
+		// expect "int"
+		{int(0), int(0)},
+		{int(-1), int(-1)},
+		{int(15), int(15)},
+		{int8(15), int(15)},
+		{int16(15), int(15)},
+		{int32(15), int(15)},
+		{int64(15), int(15)},
+		{uint(0), int(0)},
+		{uint(15), int(15)},
+		{uint8(15), int(15)},
+		{uint16(15), int(15)},
+		{uint32(15), int(15)},
+		{uint64(15), int(15)},
+		{int64(math.MinInt64), int(math.MinInt64)},
+		{int64(math.MaxInt64), int(math.MaxInt64)},
+		// expect "uint"
+		{uint64(math.MaxInt64 + 1), uint64(math.MaxInt64 + 1)},
 		{uint64(math.MaxUint64), uint64(math.MaxUint64)},
+		// expect "float"
 		{float32(2.5), float64(2.5)},
 		{float64(2.5), float64(2.5)},
 		{float64(math.MinInt64) - 10, float64(math.MinInt64) - 10},
+		{float64(math.MaxInt64) + 10, float64(math.MaxInt64) + 10},
 
 		{bool(true), bool(true)},
 		{string("Hello"), string("Hello")},
 
 		{
 			input:  []int{1, 2, 3},
-			expect: []any{int64(1), int64(2), int64(3)},
+			expect: []any{int(1), int(2), int(3)},
 		},
 
 		{
 			input:  map[string]int{"number": 15},
-			expect: map[string]any{"number": int64(15)},
+			expect: map[string]any{"number": int(15)},
 		},
 		{
 			input: struct {

--- a/pkg/river/internal/value/decode_test.go
+++ b/pkg/river/internal/value/decode_test.go
@@ -665,21 +665,21 @@ func TestDecode_KnownTypes_Any(t *testing.T) {
 		expect any
 	}{
 		// expect "int"
-		{int(0), int(0)},
-		{int(-1), int(-1)},
-		{int(15), int(15)},
-		{int8(15), int(15)},
-		{int16(15), int(15)},
-		{int32(15), int(15)},
-		{int64(15), int(15)},
-		{uint(0), int(0)},
-		{uint(15), int(15)},
-		{uint8(15), int(15)},
-		{uint16(15), int(15)},
-		{uint32(15), int(15)},
-		{uint64(15), int(15)},
-		{int64(math.MinInt64), int(math.MinInt64)},
-		{int64(math.MaxInt64), int(math.MaxInt64)},
+		{int(0), 0},
+		{int(-1), -1},
+		{int(15), 15},
+		{int8(15), 15},
+		{int16(15), 15},
+		{int32(15), 15},
+		{int64(15), 15},
+		{uint(0), 0},
+		{uint(15), 15},
+		{uint8(15), 15},
+		{uint16(15), 15},
+		{uint32(15), 15},
+		{uint64(15), 15},
+		{int64(math.MinInt64), math.MinInt64},
+		{int64(math.MaxInt64), math.MaxInt64},
 		// expect "uint"
 		{uint64(math.MaxInt64 + 1), uint64(math.MaxInt64 + 1)},
 		{uint64(math.MaxUint64), uint64(math.MaxUint64)},
@@ -694,12 +694,12 @@ func TestDecode_KnownTypes_Any(t *testing.T) {
 
 		{
 			input:  []int{1, 2, 3},
-			expect: []any{int(1), int(2), int(3)},
+			expect: []any{1, 2, 3},
 		},
 
 		{
 			input:  map[string]int{"number": 15},
-			expect: map[string]any{"number": int(15)},
+			expect: map[string]any{"number": 15},
 		},
 		{
 			input: struct {

--- a/pkg/river/internal/value/decode_test.go
+++ b/pkg/river/internal/value/decode_test.go
@@ -2,6 +2,7 @@ package value_test
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"testing"
 	"time"
@@ -664,30 +665,32 @@ func TestDecode_KnownTypes_Any(t *testing.T) {
 		expect any
 	}{
 		// All numbers must decode to float64.
-		{int(15), float64(15)},
-		{int8(15), float64(15)},
-		{int16(15), float64(15)},
-		{int32(15), float64(15)},
-		{int64(15), float64(15)},
-		{uint(15), float64(15)},
-		{uint8(15), float64(15)},
-		{uint16(15), float64(15)},
-		{uint32(15), float64(15)},
-		{uint64(15), float64(15)},
+		{int(15), int64(15)},
+		{int8(15), int64(15)},
+		{int16(15), int64(15)},
+		{int32(15), int64(15)},
+		{int64(15), int64(15)},
+		{uint(15), uint64(15)},
+		{uint8(15), uint64(15)},
+		{uint16(15), uint64(15)},
+		{uint32(15), uint64(15)},
+		{uint64(15), uint64(15)},
+		{uint64(math.MaxUint64), uint64(math.MaxUint64)},
 		{float32(2.5), float64(2.5)},
 		{float64(2.5), float64(2.5)},
+		{float64(math.MinInt64) - 10, float64(math.MinInt64) - 10},
 
 		{bool(true), bool(true)},
 		{string("Hello"), string("Hello")},
 
 		{
 			input:  []int{1, 2, 3},
-			expect: []any{float64(1), float64(2), float64(3)},
+			expect: []any{int64(1), int64(2), int64(3)},
 		},
 
 		{
 			input:  map[string]int{"number": 15},
-			expect: map[string]any{"number": float64(15)},
+			expect: map[string]any{"number": int64(15)},
 		},
 		{
 			input: struct {

--- a/pkg/river/internal/value/value_object_test.go
+++ b/pkg/river/internal/value/value_object_test.go
@@ -66,20 +66,20 @@ func TestBlockRepresentation(t *testing.T) {
 			"attr_1": "value_1",
 			"attr_2": "value_2",
 			"unlabeled": object{
-				"a": object{"value": int64(1)},
-				"b": object{"value": int64(2)},
+				"a": object{"value": int(1)},
+				"b": object{"value": int(2)},
 			},
-			"other_unlabeled": object{"value": int64(3)},
+			"other_unlabeled": object{"value": int(3)},
 			"labeled": object{
 				"a": object{
-					"label_a": object{"value": int64(4)},
+					"label_a": object{"value": int(4)},
 				},
 				"b": object{
-					"label_b": object{"value": int64(5)},
+					"label_b": object{"value": int(5)},
 				},
 			},
 			"other_labeled": object{
-				"label_c": object{"value": int64(6)},
+				"label_c": object{"value": int(6)},
 			},
 		}
 
@@ -179,14 +179,14 @@ func TestSliceOfBlocks(t *testing.T) {
 			"attr_1": "value_1",
 			"attr_2": "value_2",
 			"unlabeled": list{
-				object{"value": int64(1)},
-				object{"value": int64(2)},
-				object{"value": int64(3)},
+				object{"value": int(1)},
+				object{"value": int(2)},
+				object{"value": int(3)},
 			},
 			"labeled": object{
-				"label_a": object{"value": int64(4)},
-				"label_b": object{"value": int64(5)},
-				"label_c": object{"value": int64(6)},
+				"label_a": object{"value": int(4)},
+				"label_b": object{"value": int(5)},
+				"label_c": object{"value": int(6)},
 			},
 		}
 

--- a/pkg/river/internal/value/value_object_test.go
+++ b/pkg/river/internal/value/value_object_test.go
@@ -66,20 +66,20 @@ func TestBlockRepresentation(t *testing.T) {
 			"attr_1": "value_1",
 			"attr_2": "value_2",
 			"unlabeled": object{
-				"a": object{"value": int(1)},
-				"b": object{"value": int(2)},
+				"a": object{"value": 1},
+				"b": object{"value": 2},
 			},
-			"other_unlabeled": object{"value": int(3)},
+			"other_unlabeled": object{"value": 3},
 			"labeled": object{
 				"a": object{
-					"label_a": object{"value": int(4)},
+					"label_a": object{"value": 4},
 				},
 				"b": object{
-					"label_b": object{"value": int(5)},
+					"label_b": object{"value": 5},
 				},
 			},
 			"other_labeled": object{
-				"label_c": object{"value": int(6)},
+				"label_c": object{"value": 6},
 			},
 		}
 
@@ -179,14 +179,14 @@ func TestSliceOfBlocks(t *testing.T) {
 			"attr_1": "value_1",
 			"attr_2": "value_2",
 			"unlabeled": list{
-				object{"value": int(1)},
-				object{"value": int(2)},
-				object{"value": int(3)},
+				object{"value": 1},
+				object{"value": 2},
+				object{"value": 3},
 			},
 			"labeled": object{
-				"label_a": object{"value": int(4)},
-				"label_b": object{"value": int(5)},
-				"label_c": object{"value": int(6)},
+				"label_a": object{"value": 4},
+				"label_b": object{"value": 5},
+				"label_c": object{"value": 6},
 			},
 		}
 

--- a/pkg/river/internal/value/value_object_test.go
+++ b/pkg/river/internal/value/value_object_test.go
@@ -66,20 +66,20 @@ func TestBlockRepresentation(t *testing.T) {
 			"attr_1": "value_1",
 			"attr_2": "value_2",
 			"unlabeled": object{
-				"a": object{"value": float64(1)},
-				"b": object{"value": float64(2)},
+				"a": object{"value": int64(1)},
+				"b": object{"value": int64(2)},
 			},
-			"other_unlabeled": object{"value": float64(3)},
+			"other_unlabeled": object{"value": int64(3)},
 			"labeled": object{
 				"a": object{
-					"label_a": object{"value": float64(4)},
+					"label_a": object{"value": int64(4)},
 				},
 				"b": object{
-					"label_b": object{"value": float64(5)},
+					"label_b": object{"value": int64(5)},
 				},
 			},
 			"other_labeled": object{
-				"label_c": object{"value": float64(6)},
+				"label_c": object{"value": int64(6)},
 			},
 		}
 
@@ -179,14 +179,14 @@ func TestSliceOfBlocks(t *testing.T) {
 			"attr_1": "value_1",
 			"attr_2": "value_2",
 			"unlabeled": list{
-				object{"value": float64(1)},
-				object{"value": float64(2)},
-				object{"value": float64(3)},
+				object{"value": int64(1)},
+				object{"value": int64(2)},
+				object{"value": int64(3)},
 			},
 			"labeled": object{
-				"label_a": object{"value": float64(4)},
-				"label_b": object{"value": float64(5)},
-				"label_c": object{"value": float64(6)},
+				"label_a": object{"value": int64(4)},
+				"label_b": object{"value": int64(5)},
+				"label_c": object{"value": int64(6)},
 			},
 		}
 

--- a/pkg/river/river.go
+++ b/pkg/river/river.go
@@ -263,7 +263,10 @@ func Unmarshal(in []byte, v interface{}) error {
 // following:
 //
 //   - bool, for River bools
-//   - float64, for River numbers
+//   - float64, for floating point River numbers
+//     and integers which are too big to fit in either of int/int64/uint64
+//   - int/int64/uint64, in this order of preference, for signed and unsigned
+//     River integer numbers, depending on how big they are
 //   - string, for River strings
 //   - []interface{}, for River arrays
 //   - map[string]interface{}, for River objects

--- a/pkg/river/vm/constant.go
+++ b/pkg/river/vm/constant.go
@@ -18,11 +18,22 @@ func valueFromLiteral(lit string, tok token.Token) (value.Value, error) {
 		return value.Null, nil
 
 	case token.NUMBER:
-		v, err := strconv.ParseInt(lit, 0, 64)
-		if err != nil {
-			return value.Null, err
+		intVal, err1 := strconv.ParseInt(lit, 0, 64)
+		if err1 == nil {
+			return value.Int(intVal), nil
 		}
-		return value.Int(v), nil
+
+		uintVal, err2 := strconv.ParseUint(lit, 0, 64)
+		if err2 == nil {
+			return value.Uint(uintVal), nil
+		}
+
+		floatVal, err3 := strconv.ParseFloat(lit, 64)
+		if err3 == nil {
+			return value.Float(floatVal), nil
+		}
+
+		return value.Null, err3
 
 	case token.FLOAT:
 		v, err := strconv.ParseFloat(lit, 64)

--- a/pkg/river/vm/vm_benchmarks_test.go
+++ b/pkg/river/vm/vm_benchmarks_test.go
@@ -1,6 +1,8 @@
 package vm_test
 
 import (
+	"fmt"
+	"math"
 	"reflect"
 	"testing"
 
@@ -77,6 +79,11 @@ func BenchmarkExprs(b *testing.B) {
 		// Unary
 		{"unary not", `!true`, bool(false)},
 		{"unary neg", `-15`, int(-15)},
+		{"unary float", `-15.0`, float64(-15.0)},
+		{"unary int64", fmt.Sprintf("%v", math.MaxInt64), math.MaxInt64},
+		{"unary uint64", fmt.Sprintf("%v", uint64(math.MaxInt64)+1), uint64(math.MaxInt64) + 1},
+		// math.MaxUint64 + 1 = 18446744073709551616
+		{"unary float64 from overflowing uint", "18446744073709551616", float64(18446744073709551616)},
 	}
 
 	for _, tc := range tt {
@@ -92,7 +99,7 @@ func BenchmarkExprs(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				vPtr := reflect.New(expectType).Interface()
-				_ = eval.Evaluate(scope, vPtr)
+				require.NoError(b, eval.Evaluate(scope, vPtr))
 			}
 		})
 	}

--- a/pkg/river/vm/vm_benchmarks_test.go
+++ b/pkg/river/vm/vm_benchmarks_test.go
@@ -99,7 +99,7 @@ func BenchmarkExprs(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				vPtr := reflect.New(expectType).Interface()
-				require.NoError(b, eval.Evaluate(scope, vPtr))
+				_ = eval.Evaluate(scope, vPtr)
 			}
 		})
 	}

--- a/pkg/river/vm/vm_block_test.go
+++ b/pkg/river/vm/vm_block_test.go
@@ -141,10 +141,10 @@ func TestVM_Block_Attributes(t *testing.T) {
 			val             string
 			expectedValType reflect.Kind
 		}{
-			{testName: "test_int_1", val: "15", expectedValType: reflect.Int64},
-			{testName: "test_int_2", val: "-15", expectedValType: reflect.Int64},
-			{testName: "test_int_3", val: fmt.Sprintf("%v", math.MaxInt64), expectedValType: reflect.Int64},
-			{testName: "test_int_4", val: fmt.Sprintf("%v", math.MinInt64), expectedValType: reflect.Int64},
+			{testName: "test_int_1", val: "15", expectedValType: reflect.Int},
+			{testName: "test_int_2", val: "-15", expectedValType: reflect.Int},
+			{testName: "test_int_3", val: fmt.Sprintf("%v", math.MaxInt64), expectedValType: reflect.Int},
+			{testName: "test_int_4", val: fmt.Sprintf("%v", math.MinInt64), expectedValType: reflect.Int},
 			{testName: "test_uint_1", val: fmt.Sprintf("%v", uint64(math.MaxInt64)+1), expectedValType: reflect.Uint64},
 			{testName: "test_uint_2", val: fmt.Sprintf("%v", uint64(math.MaxUint64)), expectedValType: reflect.Uint64},
 			{testName: "test_float_1", val: fmt.Sprintf("%v9", math.MinInt64), expectedValType: reflect.Float64},
@@ -690,7 +690,7 @@ func TestVM_Block_UnmarshalToMap(t *testing.T) {
 			`,
 			expect: OuterBlock{
 				Settings: map[string]interface{}{
-					"field_a": int64(12345),
+					"field_a": int(12345),
 					"field_b": "helloworld",
 				},
 			},
@@ -759,7 +759,7 @@ func TestVM_Block_UnmarshalToAny(t *testing.T) {
 	require.NoError(t, eval.Evaluate(nil, &actual))
 
 	expect := map[string]interface{}{
-		"field_a": int64(12345),
+		"field_a": int(12345),
 		"field_b": "helloworld",
 	}
 	require.Equal(t, expect, actual.Settings)

--- a/pkg/river/vm/vm_block_test.go
+++ b/pkg/river/vm/vm_block_test.go
@@ -690,7 +690,7 @@ func TestVM_Block_UnmarshalToMap(t *testing.T) {
 			`,
 			expect: OuterBlock{
 				Settings: map[string]interface{}{
-					"field_a": int(12345),
+					"field_a": 12345,
 					"field_b": "helloworld",
 				},
 			},
@@ -759,7 +759,7 @@ func TestVM_Block_UnmarshalToAny(t *testing.T) {
 	require.NoError(t, eval.Evaluate(nil, &actual))
 
 	expect := map[string]interface{}{
-		"field_a": int(12345),
+		"field_a": 12345,
 		"field_b": "helloworld",
 	}
 	require.Equal(t, expect, actual.Settings)

--- a/pkg/river/vm/vm_block_test.go
+++ b/pkg/river/vm/vm_block_test.go
@@ -163,7 +163,6 @@ func TestVM_Block_Attributes(t *testing.T) {
 				err := eval.Evaluate(nil, &actual)
 				require.NoError(t, err)
 				require.Equal(t, tt.expectedValType.String(), reflect.TypeOf(actual.Anything).Kind().String())
-
 			})
 		}
 	})

--- a/pkg/river/vm/vm_stdlib_test.go
+++ b/pkg/river/vm/vm_stdlib_test.go
@@ -21,7 +21,7 @@ func TestVM_Stdlib(t *testing.T) {
 		expect interface{}
 	}{
 		{"env", `env("TEST_VAR")`, string("Hello!")},
-		{"concat", `concat([true, "foo"], [], [false, 1])`, []interface{}{true, "foo", false, float64(1)}},
+		{"concat", `concat([true, "foo"], [], [false, 1])`, []interface{}{true, "foo", false, int64(1)}},
 		{"json_decode object", `json_decode("{\"foo\": \"bar\"}")`, map[string]interface{}{"foo": "bar"}},
 		{"json_decode array", `json_decode("[0, 1, 2]")`, []interface{}{float64(0), float64(1), float64(2)}},
 		{"json_decode nil field", `json_decode("{\"foo\": null}")`, map[string]interface{}{"foo": nil}},

--- a/pkg/river/vm/vm_stdlib_test.go
+++ b/pkg/river/vm/vm_stdlib_test.go
@@ -21,7 +21,7 @@ func TestVM_Stdlib(t *testing.T) {
 		expect interface{}
 	}{
 		{"env", `env("TEST_VAR")`, string("Hello!")},
-		{"concat", `concat([true, "foo"], [], [false, 1])`, []interface{}{true, "foo", false, int64(1)}},
+		{"concat", `concat([true, "foo"], [], [false, 1])`, []interface{}{true, "foo", false, int(1)}},
 		{"json_decode object", `json_decode("{\"foo\": \"bar\"}")`, map[string]interface{}{"foo": "bar"}},
 		{"json_decode array", `json_decode("[0, 1, 2]")`, []interface{}{float64(0), float64(1), float64(2)}},
 		{"json_decode nil field", `json_decode("{\"foo\": null}")`, map[string]interface{}{"foo": nil}},

--- a/pkg/river/vm/vm_stdlib_test.go
+++ b/pkg/river/vm/vm_stdlib_test.go
@@ -21,7 +21,7 @@ func TestVM_Stdlib(t *testing.T) {
 		expect interface{}
 	}{
 		{"env", `env("TEST_VAR")`, string("Hello!")},
-		{"concat", `concat([true, "foo"], [], [false, 1])`, []interface{}{true, "foo", false, int(1)}},
+		{"concat", `concat([true, "foo"], [], [false, 1])`, []interface{}{true, "foo", false, 1}},
 		{"json_decode object", `json_decode("{\"foo\": \"bar\"}")`, map[string]interface{}{"foo": "bar"}},
 		{"json_decode array", `json_decode("[0, 1, 2]")`, []interface{}{float64(0), float64(1), float64(2)}},
 		{"json_decode nil field", `json_decode("{\"foo\": null}")`, map[string]interface{}{"foo": nil}},


### PR DESCRIPTION
#### PR Description

Currently, if River unmarshals a number into an `interface{}` it will always turn it into a float64.  This is similar to json unmarshaling which always unmarshals numbers to floats. 

However, it is a problem in some cases, when we need to be yaml-compatible. For example, in #3822 we have an `interface{}` value in our River struct which could be an int, float or a string. Depending on which type is used, OpenTelemetry will create an attribute (label) in the signal with this same type. Since River always unmarshals numbers into a float when the variable is of type `interface{}`, all Otel attributes of a numerical type will be floats and none will be integers. 

This change makes River more in line with yaml, whose behaviour could be summarised as:

1. Try parsing the string into an integer
2. If that fails, try parsing into an unsigned
3. If that fails, try parsing into a float

[Here](https://github.com/go-yaml/yaml/blob/v2.4.0/resolve.go#L151) is the relevant yaml code. 

In the River code, we only use "64 bit" types for simplicity.

This PR reverts #3630

#### Notes to the reviewer

Do you think I should go through all the components we currently have and identify the ones which use `interface{}`? We may want to list this as a breaking change for these components, since depending on how the users use them there could be user-facing consequences like the ones described with the attributes processor.

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [x] Tests updated
