### PR TITLE
fix: Add deployment replicas if autoscaling is disabled

### DIFF
--- a/operations/helm/charts/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/charts/grafana-agent/templates/controllers/deployment.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "grafana-agent.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.controller.autoscaling.enabled }}
   replicas: {{ .Values.controller.replicas }}
+  {{- end }}
   minReadySeconds: 10
   selector:
     matchLabels:


### PR DESCRIPTION
If autoscaling is enabled and replicas is set then it will end up creating and killing pods endlessly when agent is deployed with ArgoCD.
