### PR TITLE
Flow: auto-reload on config file changes

### DIFF
--- a/docs/sources/flow/reference/cli/run.md
+++ b/docs/sources/flow/reference/cli/run.md
@@ -34,6 +34,8 @@ The following flags are supported:
 * `--server.http.ui-path-prefix`: Base path where the UI will be exposed (default `/`).
 * `--storage.path`: Base directory where components can store data (default `data-agent/`).
 * `--disable-reporting`: Disable [usage reporting][] of enabled [components][] to Grafana (default `false`).
+* `--config.auto-reload.poll-interval`: Interval at which to poll the config file for changes when polling is used (default `5s`).
+* `--config.auto-reload`: Automatically reload the config file when it changes on disk (default `true`).
 * `--cluster.enabled`: Start the Agent in clustered mode (default `false`).
 * `--cluster.node-name`: The name to use for this node (defaults to the environment's hostname).
 * `--cluster.join-addresses`: Comma-separated list of addresses to join the cluster at (default `""`).
@@ -47,7 +49,10 @@ The following flags are supported:
 
 ## Updating the config file
 
-The config file can be reloaded from disk by either:
+By default, Grafana Agent Flow will automatically reload the config file when it
+changes on disk. To disable this feature, use the `--config.auto-reload=false` flag.
+
+In addition, the config file can be reloaded from disk by either:
 
 * Sending an HTTP POST request to the `/-/reload` endpoint.
 * Sending a `SIGHUP` signal to the Grafana Agent process.

--- a/pkg/util/filewatch.go
+++ b/pkg/util/filewatch.go
@@ -1,0 +1,77 @@
+package util
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/pkg/flow/logging"
+)
+
+type ReloadFunc func() error
+
+type FileWatcher struct {
+	filePath     string
+	reloadFunc   ReloadFunc
+	pollInterval time.Duration
+}
+
+// NewFileWatcher creates a new file watcher that will call reloadFunc when the file at filePath is modified.
+func NewFileWatcher(filePath string, reloadFunc ReloadFunc, pollInterval time.Duration) *FileWatcher {
+	return &FileWatcher{
+		filePath:     filePath,
+		reloadFunc:   reloadFunc,
+		pollInterval: pollInterval,
+	}
+}
+
+// Watch starts watching the file for changes and calls reloadFunc when the file is modified.
+func (fw *FileWatcher) Watch(l *logging.Logger, ctx context.Context) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		level.Error(l).Log("msg", "failed to create watcher", "err", err)
+		return
+	}
+	defer watcher.Close()
+
+	err = watcher.Add(fw.filePath)
+	if err != nil {
+		level.Error(l).Log("msg", "failed to add file to watcher", "err", err)
+		return
+	}
+
+	ticker := time.NewTicker(fw.pollInterval)
+	defer ticker.Stop()
+
+	var lastModTime time.Time
+	if fileInfo, err := os.Stat(fw.filePath); err == nil {
+		lastModTime = fileInfo.ModTime()
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event := <-watcher.Events:
+			if event.Op&fsnotify.Write == fsnotify.Write {
+				if err := fw.reloadFunc(); err != nil {
+					level.Error(l).Log("msg", "failed to reload", "err", err)
+				}
+			}
+		case err := <-watcher.Errors:
+			level.Error(l).Log("msg", "watcher error", "err", err)
+		case <-ticker.C:
+			if fileInfo, err := os.Stat(fw.filePath); err == nil {
+				modTime := fileInfo.ModTime()
+				if modTime.After(lastModTime) {
+					lastModTime = modTime
+					if err := fw.reloadFunc(); err != nil {
+						level.Error(l).Log("msg", "failed to reload", "err", err)
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
#### PR Description
Adds the feature to automatically reload the config when it changes. This feature is enabled by default, and is controlled with the flag `--config.auto-reload`

#### Which issue(s) this PR fixes
Fixes #2691 

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [ ] Tests updated
