### PR TITLE
misc: update base image of Docker containers to ubuntu:lunar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,9 @@ Main (unreleased)
   work, leading to better distribution. However, rolling out this change will
   cause some incorrerct or missing assignments until all nodes are updated. (@rfratto)
 
+- Change the Docker base image for Linux containers to `ubuntu:lunar`.
+  (@rfratto)
+
 v0.33.2 (2023-05-11)
 --------------------
 

--- a/cmd/grafana-agent-operator/Dockerfile
+++ b/cmd/grafana-agent-operator/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} \
     make operator
 
-FROM ubuntu:kinetic
+FROM ubuntu:lunar
 
 LABEL org.opencontainers.image.source="https://github.com/grafana/agent"
 

--- a/cmd/grafana-agent/Dockerfile
+++ b/cmd/grafana-agent/Dockerfile
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     GO_TAGS="builtinassets promtail_journal_enabled" \
     make agent
 
-FROM ubuntu:kinetic
+FROM ubuntu:lunar
 
 LABEL org.opencontainers.image.source="https://github.com/grafana/agent"
 

--- a/cmd/grafana-agentctl/Dockerfile
+++ b/cmd/grafana-agentctl/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     RELEASE_BUILD="${RELEASE_BUILD}" VERSION="${VERSION}" \
     make agentctl
 
-FROM ubuntu:kinetic
+FROM ubuntu:lunar
 
 LABEL org.opencontainers.image.source="https://github.com/grafana/agent"
 

--- a/tools/crow/Dockerfile
+++ b/tools/crow/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} \
     make crow
 
-FROM ubuntu:kinetic
+FROM ubuntu:lunar
 
 LABEL org.opencontainers.image.source="https://github.com/grafana/agent"
 

--- a/tools/smoke/Dockerfile
+++ b/tools/smoke/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} \
     make smoke
 
-FROM ubuntu:kinetic
+FROM ubuntu:lunar
 
 LABEL org.opencontainers.image.source="https://github.com/grafana/agent"
 


### PR DESCRIPTION
Updating to ubuntu:lunar includes updating the systemd dependency to 252, which is required to read journald on newer host systems.

Fixes #4004.