### PR TITLE
misc: remove CODEOWNERS from CHANGELOG.md

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,6 +13,10 @@
 # pull request.
 * @grafana/grafana-agent-core-maintainers
 
+# CHANGELOG.md has shared ownership with the respective owners of the specific
+# code for the PR being opened.
+/CHANGELOG.md
+
 # Binaries:
 /cmd/grafana-agent-operator/  @grafana/grafana-agent-operator-maintainers
 


### PR DESCRIPTION
Ownership of CHANGELOG.md should be effectively shared; owners of code for which a PR is being opened should be share responsibility for properly modifying the CHANGELOG in that PR.

This avoids an issue where @grafana/grafana-agent-core-maintainers were tagged on any PR that modified the CHANGELOG, even if that PR wasn't relevant to that team.
