### PR TITLE
Fix #3999 uncomparable error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,8 @@ Main (unreleased)
 
 - Fix panic in `prometheus.operator.servicemonitors` from relabel rules without certain defaults. (@captncraig)
 
+- Fix issue in modules export cache throwing uncomparable errors. (@mattdurham)
+
 ### Other changes
 
 - Add metrics when clustering mode is enabled. (@rfratto)

--- a/pkg/flow/internal/controller/value_cache.go
+++ b/pkg/flow/internal/controller/value_cache.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"reflect"
 	"sync"
 
 	"github.com/grafana/agent/component"
@@ -86,8 +87,7 @@ func (vc *valueCache) CacheModuleExportValue(name string, value any) {
 	v, found := vc.moduleExports[name]
 	if !found {
 		vc.moduleChangedIndex++
-	}
-	if v != value {
+	} else if reflect.DeepEqual(v, value) {
 		vc.moduleChangedIndex++
 	}
 

--- a/pkg/flow/internal/controller/value_cache_test.go
+++ b/pkg/flow/internal/controller/value_cache_test.go
@@ -105,6 +105,17 @@ func TestExportValueCache(t *testing.T) {
 	require.True(t, vc.ExportChangeIndex() != index)
 }
 
+func TestExportValueCacheUncomparable(t *testing.T) {
+	vc := newValueCache()
+	type test struct {
+		TM map[string]string
+	}
+	// This test for an uncomparable error that is triggered when you do a simple `v == v2` comparison,
+	// instead using deep equals does a smarter approach.
+	vc.CacheModuleExportValue("t2", test{TM: map[string]string{}})
+	vc.CacheModuleExportValue("t2", test{TM: map[string]string{}})
+}
+
 func TestModuleArgumentCache(t *testing.T) {
 	tt := []struct {
 		name     string


### PR DESCRIPTION
#### PR Description

This switches from a straight ` v == value` comparison to `reflect.DeepEquals` that handles slices/maps which are uncomparable.

#### Which issue(s) this PR fixes

Fixes #3999 underlying code issue but not the UI

#### PR Checklist

- [X] CHANGELOG updated
- [ ] Documentation added
- [X] Tests updated
