### PR TITLE
Extend statsd integration to configure relay endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Main (unreleased)
 
 - Attributes and blocks set to their default values will no longer be shown in the Flow UI. (@rfratto)
 
+- Integrations: Extend `statsd` integration to configure relay endpoint. (@arminaaki)
 ### Bugfixes
 
 - Add signing region to remote.s3 component for use with custom endpoints so that Authorization Headers work correctly when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Main (unreleased)
 - Attributes and blocks set to their default values will no longer be shown in the Flow UI. (@rfratto)
 
 - Integrations: Extend `statsd` integration to configure relay endpoint. (@arminaaki)
+
 ### Bugfixes
 
 - Add signing region to remote.s3 component for use with custom endpoints so that Authorization Headers work correctly when

--- a/component/prometheus/exporter/statsd/config.go
+++ b/component/prometheus/exporter/statsd/config.go
@@ -27,6 +27,9 @@ type Arguments struct {
 	ParseInfluxDB  bool `river:"parse_influxdb_tags,attr,optional"`
 	ParseLibrato   bool `river:"parse_librato_tags,attr,optional"`
 	ParseSignalFX  bool `river:"parse_signalfx_tags,attr,optional"`
+
+	RelayAddr         string `river:"relay_addr,attr,optional"`
+	RelayPacketLength int    `river:"relay_packet_length,attr,optional"`
 }
 
 // DefaultConfig holds non-zero default options for the Config when it is
@@ -49,6 +52,8 @@ var DefaultConfig = Arguments{
 	ParseInfluxDB:  statsd_exporter.DefaultConfig.ParseInfluxDB,
 	ParseLibrato:   statsd_exporter.DefaultConfig.ParseLibrato,
 	ParseSignalFX:  statsd_exporter.DefaultConfig.ParseSignalFX,
+
+	RelayPacketLength: statsd_exporter.DefaultConfig.RelayPacketLength,
 }
 
 // Convert gives a config suitable for use with github.com/grafana/agent/pkg/integrations/statsd_exporter.
@@ -73,6 +78,8 @@ func (c *Arguments) Convert() (*statsd_exporter.Config, error) {
 		ParseInfluxDB:       c.ParseInfluxDB,
 		ParseLibrato:        c.ParseLibrato,
 		ParseSignalFX:       c.ParseSignalFX,
+		RelayAddr:           c.RelayAddr,
+		RelayPacketLength:   c.RelayPacketLength,
 		MappingConfig:       mappingConfig,
 	}, nil
 }

--- a/component/prometheus/exporter/statsd/statsd_test.go
+++ b/component/prometheus/exporter/statsd/statsd_test.go
@@ -24,6 +24,8 @@ var (
 		parse_influxdb_tags = false
 		parse_librato_tags = false
 		parse_signalfx_tags = false
+		relay_addr = "localhost:7125"
+		relay_packet_length = 2000
 		`
 	duration1m, _ = time.ParseDuration("1m")
 )
@@ -47,6 +49,8 @@ func TestRiverUnmarshal(t *testing.T) {
 	require.Equal(t, false, args.ParseLibrato)
 	require.Equal(t, false, args.ParseSignalFX)
 	require.Equal(t, `./testdata/mapTest.yaml`, args.MappingConfig)
+	require.Equal(t, "localhost:7125", args.RelayAddr)
+	require.Equal(t, 2000, args.RelayPacketLength)
 }
 
 func TestConvert(t *testing.T) {
@@ -70,4 +74,6 @@ func TestConvert(t *testing.T) {
 	require.Equal(t, false, configStatsd.ParseInfluxDB)
 	require.Equal(t, false, configStatsd.ParseLibrato)
 	require.Equal(t, false, configStatsd.ParseSignalFX)
+	require.Equal(t, "localhost:7125", configStatsd.RelayAddr)
+	require.Equal(t, 2000, configStatsd.RelayPacketLength)
 }

--- a/docs/sources/flow/reference/components/prometheus.exporter.statsd.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.statsd.md
@@ -42,6 +42,8 @@ Name | Type | Description | Default | Required
 `parse_influxdb_tags`                             | `string`       | Parse InfluxDB style tags. | `true`| no
 `parse_librato_tags`                              | `string`       | Parse Librato style tags. | `true`| no
 `parse_signalfx_tags`                             | `string`       | Parse SignalFX style tags. | `true`| no
+`relay_addr`                                      | `string`       | Relay address configuration(UDP endpoint in the format 'host:port'). | | no
+`relay_packet_length`                             | `int`          | Maximum relay output packet length to avoid fragmentation. | `1400` | no
 
 At least one of `listen_udp`, `listen_tcp`, or `listen_unixgram` should be enabled.
 For details on how to use the mapping config file, please check the official

--- a/docs/sources/flow/reference/components/prometheus.exporter.statsd.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.statsd.md
@@ -42,7 +42,7 @@ Name | Type | Description | Default | Required
 `parse_influxdb_tags`                             | `string`       | Parse InfluxDB style tags. | `true`| no
 `parse_librato_tags`                              | `string`       | Parse Librato style tags. | `true`| no
 `parse_signalfx_tags`                             | `string`       | Parse SignalFX style tags. | `true`| no
-`relay_addr`                                      | `string`       | Relay address configuration(UDP endpoint in the format 'host:port'). | | no
+`relay_addr`                                      | `string`       | Relay address configuration (UDP endpoint in the format 'host:port'). | | no
 `relay_packet_length`                             | `int`          | Maximum relay output packet length to avoid fragmentation. | `1400` | no
 
 At least one of `listen_udp`, `listen_tcp`, or `listen_unixgram` should be enabled.

--- a/docs/sources/static/configuration/integrations/statsd-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/statsd-exporter-config.md
@@ -112,4 +112,13 @@ Full reference of options:
 
   # Parse SignalFX style tags.
   [parse_signalfx_tags: <bool> | default = true]
+
+  # Optional: Relay address configuration. This setting, if provided,
+  # specifies the destination to forward your metrics.
+
+  # Note that it must be a UDP endpoint in the format 'host:port'.
+  [relay_address: <string>]
+
+  # Maximum relay output packet length to avoid fragmentation.
+  [relay_packet_length: <int> | default = 1400]
 ```

--- a/pkg/integrations/statsd_exporter/statsd_exporter.go
+++ b/pkg/integrations/statsd_exporter/statsd_exporter.go
@@ -27,6 +27,7 @@ import (
 	"github.com/prometheus/statsd_exporter/pkg/mapper"
 	"github.com/prometheus/statsd_exporter/pkg/mappercache/lru"
 	"github.com/prometheus/statsd_exporter/pkg/mappercache/randomreplacement"
+	"github.com/prometheus/statsd_exporter/pkg/relay"
 	"gopkg.in/yaml.v2"
 )
 
@@ -46,6 +47,8 @@ var DefaultConfig = Config{
 	ParseInfluxDB:  true,
 	ParseLibrato:   true,
 	ParseSignalFX:  true,
+
+	RelayPacketLength: 1400,
 }
 
 // Config controls the statsd_exporter integration.
@@ -67,6 +70,9 @@ type Config struct {
 	ParseInfluxDB  bool `yaml:"parse_influxdb_tags,omitempty"`
 	ParseLibrato   bool `yaml:"parse_librato_tags,omitempty"`
 	ParseSignalFX  bool `yaml:"parse_signalfx_tags,omitempty"`
+
+	RelayAddr         string `yaml:"relay_addr,omitempty"`
+	RelayPacketLength int    `yaml:"relay_packet_length,omitempty"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler for Config.
@@ -202,6 +208,15 @@ func (e *Exporter) Run(ctx context.Context) error {
 	defer close(events)
 	eventQueue := event.NewEventQueue(events, e.cfg.EventFlushThreshold, e.cfg.EventFlushInterval, e.metrics.EventsFlushed)
 
+	var relayTarget *relay.Relay
+	if e.cfg.RelayAddr != "" {
+		var err error
+		relayTarget, err = relay.NewRelay(e.log, e.cfg.RelayAddr, uint(e.cfg.RelayPacketLength))
+		if err != nil {
+			return fmt.Errorf("failed to create relay: %w", err)
+		}
+	}
+
 	if e.cfg.ListenUDP != "" {
 		addr, err := address.UDPAddrFromString(e.cfg.ListenUDP)
 		if err != nil {
@@ -228,6 +243,7 @@ func (e *Exporter) Run(ctx context.Context) error {
 		ul := &listener.StatsDUDPListener{
 			Conn:            uconn,
 			EventHandler:    eventQueue,
+			Relay:           relayTarget,
 			Logger:          e.log,
 			LineParser:      parser,
 			UDPPackets:      e.metrics.UDPPackets,
@@ -261,6 +277,7 @@ func (e *Exporter) Run(ctx context.Context) error {
 		tl := &listener.StatsDTCPListener{
 			Conn:            tconn,
 			EventHandler:    eventQueue,
+			Relay:           relayTarget,
 			Logger:          e.log,
 			LineParser:      parser,
 			LinesReceived:   e.metrics.LinesReceived,
@@ -307,6 +324,7 @@ func (e *Exporter) Run(ctx context.Context) error {
 			Conn:            uxgconn,
 			EventHandler:    eventQueue,
 			Logger:          e.log,
+			Relay:           relayTarget,
 			LineParser:      parser,
 			UnixgramPackets: e.metrics.UnixgramPackets,
 			LinesReceived:   e.metrics.LinesReceived,


### PR DESCRIPTION
#### PR Description

`statsd_exporter` natively supports setting the relay endpoint. However, the current implementation of statsd integration doesn't allow configuring the endpoint.

The proposed PR extends statsd integration to configure relay endpoint.

#### Notes to the Reviewer

The default value for `RelayPacketLength` was taken from the original implementation. Please refer to the code reference [here](https://github.com/prometheus/statsd_exporter/blob/c3752cf30f14d53838a3104c1fd1b20f3cc354eb/main.go#L262).

#### PR Checklist

- [x] CHANGELOG updated
- [X] Documentation added
- [X] Tests updated
