### PR TITLE
web/ui: fix issue where nested modules did not properly display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Main (unreleased)
 - Upgrade the embedded windows_exporter to commit 79781c6. (@jkroepke)
 
 - Prometheus exporters in Flow mode now set the `instance` label to a value similar to the one they used to have in Static mode (<hostname> by default, customized by some integrations). (@jcreixell)
- 
+
 - `phlare.scrape` and `phlare.write` have been renamed to `pyroscope.scrape` and `pyroscope.scrape`. (@korniltsev)
 
 ### Features
@@ -104,6 +104,8 @@ Main (unreleased)
 - Fix panic in `prometheus.operator.servicemonitors` from relabel rules without certain defaults. (@captncraig)
 
 - Fix issue in modules export cache throwing uncomparable errors. (@mattdurham)
+
+- Fix issue where the UI could not navigate to components loaded by modules. (@rfratto)
 
 ### Other changes
 

--- a/web/ui/src/features/component/ComponentList.tsx
+++ b/web/ui/src/features/component/ComponentList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { NavLink } from 'react-router-dom';
 
 import { HealthLabel } from '../component/HealthLabel';
@@ -15,8 +14,9 @@ interface ComponentListProps {
 
 const TABLEHEADERS = ['Health', 'ID'];
 
-const ComponentList = ({ components }: ComponentListProps) => {
+const ComponentList = ({ components, parent }: ComponentListProps) => {
   const tableStyles = { width: '130px' };
+  const pathPrefix = parent ? parent + '/' : '';
 
   /**
    * Custom renderer for table data
@@ -29,7 +29,7 @@ const ComponentList = ({ components }: ComponentListProps) => {
         </td>
         <td className={styles.idColumn}>
           <span className={styles.idName}>{id}</span>
-          <NavLink to={'/component/' + id} className={styles.viewButton}>
+          <NavLink to={'/component/' + pathPrefix + id} className={styles.viewButton}>
             View
           </NavLink>
         </td>


### PR DESCRIPTION
grafana/agent#3101 accidentally removed the logic which calculated the proper URL of a component which took parent modules into account.

Fixes #3999.