### PR TITLE
Fix issue where the in-memory dialer was not being passed to modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Bugs
+
+- Fix issue where using exporters in modules failed due to not passing the in-memory address dialer. (@mattdurham)
+
 v0.34.0-rc.0 (2023-06-01)
 --------------------
 
@@ -113,8 +117,6 @@ v0.34.0-rc.0 (2023-06-01)
 - Fix issue where the UI could not navigate to components loaded by modules. (@rfratto)
 
 - Fix issue where updating some modules' config (e.g. `loki.process`) could lead to a panic. (@thampiotr) 
-
-- Fix issue where using exporters in modules failed due to not passing the in-memory address dialer. (@mattdurham) 
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,8 @@ v0.34.0-rc.0 (2023-06-01)
 
 - Fix issue where updating some modules' config (e.g. `loki.process`) could lead to a panic. (@thampiotr) 
 
+- Fix issue where using exports in modules failed due to not passing the in-memory address dialer. (@mattdurham) 
+
 ### Other changes
 
 - Add metrics when clustering mode is enabled. (@rfratto)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,7 @@ v0.34.0-rc.0 (2023-06-01)
 
 - Fix issue where updating some modules' config (e.g. `loki.process`) could lead to a panic. (@thampiotr) 
 
-- Fix issue where using exports in modules failed due to not passing the in-memory address dialer. (@mattdurham) 
+- Fix issue where using exporters in modules failed due to not passing the in-memory address dialer. (@mattdurham) 
 
 ### Other changes
 

--- a/component/module/module.go
+++ b/component/module/module.go
@@ -55,6 +55,7 @@ func NewModuleComponent(o component.Options) *ModuleComponent {
 			OnExportsChange: func(exports map[string]any) {
 				o.OnStateChange(Exports{Exports: exports})
 			},
+			DialFunc: o.DialFunc,
 		}),
 	}
 }


### PR DESCRIPTION
#### PR Description

The dialerfunc is not being passed to the child modules, this caused exporters to fail since they were exporting agent.internal but serving on normal http.

#### PR Checklist

- [X ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
