### PR TITLE
[Flow] Fix attribute docs for the Prometheus Windows Exporter

### DIFF
--- a/docs/sources/flow/reference/components/prometheus.exporter.windows.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.windows.md
@@ -83,7 +83,7 @@ Name | Type     | Description | Default | Required
 ### exchange block
 Name | Type     | Description | Default | Required
 ---- |----------| ----------- | ------- | --------
-`enabled_list` | `string` | Comma-separated list of collectors to use. | `[]` | no
+`enabled_list` | `string` | Comma-separated list of collectors to use. | `""` | no
 
 The collectors specified by `enabled_list` can include the following:
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.windows.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.windows.md
@@ -32,10 +32,10 @@ prometheus.exporter.windows "LABEL" {
 The following arguments can be used to configure the exporter's behavior.
 All arguments are optional. Omitted fields take their default values.
 
-| Name                 | Type       | Description                               | Default | Required |
-|----------------------|------------|-------------------------------------------|---------|----------|
-| `enabled_collectors` | `string`   | List of collectors to enable.             |         | no       |
-| `timeout`            | `duration` | Configure timeout for collecting metrics. | `4m`    | no       |
+| Name                 | Type             | Description                               | Default | Required |
+|----------------------|------------------|-------------------------------------------|---------|----------|
+| `enabled_collectors` | `list(string)`   | List of collectors to enable.             | `["cpu","cs","logical_disk","net","os","service","system"]` | no       |
+| `timeout`            | `duration`       | Configure timeout for collecting metrics. | `4m`    | no       |
 
 `enabled_collectors` defines a hand-picked list of enabled-by-default
 collectors. If set, anything not provided in that list is disabled by
@@ -49,7 +49,7 @@ The following blocks are supported inside the definition of
 Hierarchy      | Name               | Description                              | Required
 ---------------|--------------------|------------------------------------------|----------
 dfsr           | [dfsr][]           | Configures the iis collector.            | no       
-exchange       | [exchange][]       | Configures the exchange collector.        | no
+exchange       | [exchange][]       | Configures the exchange collector.       | no
 iis            | [iis][]            | Configures the iis collector.            | no
 logical_disk   | [logical_disk][]   | Configures the logical_disk collector.   | no       
 msmq           | [msmq][]           | Configures the msmq collector.           | no
@@ -83,7 +83,7 @@ Name | Type     | Description | Default | Required
 ### exchange block
 Name | Type     | Description | Default | Required
 ---- |----------| ----------- | ------- | --------
-`enabled_list` | `list(string)` | Comma-separated list of collectors to use. | `["cpu", "cs", "logical_disk", "net", "os", "service", "system"]` | no
+`enabled_list` | `string` | Comma-separated list of collectors to use. | `[]` | no
 
 The collectors specified by `enabled_list` can include the following:
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.windows.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.windows.md
@@ -77,7 +77,7 @@ text_file      | [text_file][]      | Configures the text_file collector.      |
 ### dfsr block
 Name | Type     | Description | Default | Required
 ---- |----------| ----------- | ------- | --------
-`source_enabled` | `list(string)` | Comma-seperated list of DFSR Perflib sources to use. | `["connection","folder","volume"]` | no
+`source_enabled` | `list(string)` | Comma-separated list of DFSR Perflib sources to use. | `["connection","folder","volume"]` | no
 
 
 ### exchange block


### PR DESCRIPTION
I think there was a mixup in the documentation for the windows exporter. `enabled_list` was documented in the way that `enabled_collectors` should have been documented, and vice versa. 

### Note to reviewers

I raised this PR just to fix the docs, but I think we should make another PR to also convert the `enabled_list` to a `list(string)`