### PR TITLE
misc: favor community.grafana.com over GitHub discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,10 @@
-# NOTE(rfratto): this file *must* have the .yml extension otherwise GitHub doesn't 
+# NOTE(rfratto): this file *must* have the .yml extension otherwise GitHub doesn't
 # recognize it.
 blank_issues_enabled: true
 contact_links:
   - name: Grafana Agent community support
-    url: https://github.com/grafana/agent/discussions
-    about: If you need help or support, ask questions in Github Discussions.
+    url: https://community.grafana.com/c/support/grafana-agent
+    about: If you need help or support, ask questions here.
   - name: Grafana Agent Slack
     url: https://slack.grafana.com/
     about: "Join the #agent slack channel to chat about Grafana Agent in real-time."

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -20,7 +20,7 @@ The Grafana Agent developers and community are expected to follow the values def
 
 ## Projects
 
-Each project must have a [`MAINTAINERS.md`][maintainers] file with at least one maintainer. Where a project has a release process, access and documentation should be such that more than one person can perform a release. Where a project has a release process, access and documentation should be such that more than one person can perform a release. Releases should be announced on the [GitHub Discussions][discussions] page. Any new projects should be first proposed on the [team mailing list][team] following the voting procedures listed below.
+Each project must have a [`MAINTAINERS.md`][maintainers] file with at least one maintainer. Where a project has a release process, access and documentation should be such that more than one person can perform a release. Where a project has a release process, access and documentation should be such that more than one person can perform a release. Releases should be announced on the [Grafana Community][community] page. Any new projects should be first proposed on the [team mailing list][team] following the voting procedures listed below.
 
 ## Decision making
 
@@ -156,4 +156,4 @@ If needed, we reserve the right to publicly announce removal.
 [maintainers]: https://github.com/grafana/agent/blob/main/MAINTAINERS.md
 [rough]: https://tools.ietf.org/html/rfc7282
 [team]: https://groups.google.com/forum/#!forum/grafana-agent-team
-[discussions]: https://github.com/grafana/agent/discussions
+[community]: https://community.grafana.com/c/support/grafana-agent

--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ To engage with the Grafana Agent community:
 * Chat with us on our community Slack channel. To invite yourself to the
   Grafana Slack, visit <https://slack.grafana.com/> and join the `#agent`
   channel.
-* Ask questions on the [Discussions page][].
+* Ask questions on the [Community support page][].
 * [File an issue][] for bugs, issues, and feature suggestions.
 * Attend the monthly [community call][].
 
-[Discussions page]: https://github.com/grafana/agent/discussions
+[Community support page]: https://community.grafana.com/c/support/grafana-agent
 [File an issue]: https://github.com/grafana/agent/issues/new
 [community call]: https://docs.google.com/document/d/1TqaZD1JPfNadZ4V81OCBPCG_TksDYGlNlGdMnTWUSpo
 

--- a/packaging/grafana-agent/windows/install_script.nsis
+++ b/packaging/grafana-agent/windows/install_script.nsis
@@ -5,7 +5,7 @@ Unicode true
 !define APPNAME "Grafana Agent"
 !define DESCRIPTION "The Grafana Agent collects observability data and sends it to a compatible remote write endpoint"
 # These will be displayed by the "Click here for support information" link in "Add/Remove Programs"
-!define HELPURL "https://github.com/grafana/agent/discussions" # "Support Information" link
+!define HELPURL "https://community.grafana.com/c/support/grafana-agent" # "Support Information" link
 !define UPDATEURL "https://github.com/grafana/agent/releases" # "Product Updates" link
 !define ABOUTURL "https://github.com/grafana/agent" # "Publisher" link
 


### PR DESCRIPTION
GitHub discussions were originally used for persistent discussions (non-issue, non-proposals). However, it's been difficult for us as maintainers to keep track of discussions and be notified when someone needs help.

Meanwhile, community.grafana.com has already been hosting questions specific to Grafana Agent that maintainers haven't been watching. This caused a split-brain issue, where there were two forms for long-form questions.

This commit changes the recommendation for long-form questions to be placed at community.grafana.com where maintainers will more actively participate in watching and answering questions.

GitHub discussions will be shut down in favor of community.grafana.com as maintainers were unable to have tooling to monitor and respond to help effectively.