### PR TITLE
Move misplaced release note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ Main (unreleased)
 v0.34.0-rc.1 (2023-06-02)
 --------------------
 
-### Bugs
+### Bugfixes
 
 - Fix issue where using exporters in modules failed due to not passing the in-memory address dialer. (@mattdurham)
+
+- Fix issue where updating some modules' config (e.g. `loki.process`) could lead to a panic. (@thampiotr)
 
 v0.34.0-rc.0 (2023-06-01)
 --------------------
@@ -118,8 +120,6 @@ v0.34.0-rc.0 (2023-06-01)
 - Fix issue in modules export cache throwing uncomparable errors. (@mattdurham)
 
 - Fix issue where the UI could not navigate to components loaded by modules. (@rfratto)
-
-- Fix issue where updating some modules' config (e.g. `loki.process`) could lead to a panic. (@thampiotr) 
 
 ### Other changes
 


### PR DESCRIPTION
My PR https://github.com/grafana/agent/pull/3995 was in-flight when we cut the release and the release note landed in a wrong place. 