### PR TITLE
dnsmasq - Add customizeTarget which matches InstanceKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ v0.34.0-rc.1 (2023-06-02)
 
 - Fix issue where updating some modules' config (e.g. `loki.process`) could lead to a panic. (@thampiotr)
 
+- Fix missing `instance` key for `prometheus.exporter.dnsmasq` component. (@spartan0x117)
+
 v0.34.0-rc.0 (2023-06-01)
 --------------------
 

--- a/component/prometheus/exporter/dnsmasq/dnsmasq.go
+++ b/component/prometheus/exporter/dnsmasq/dnsmasq.go
@@ -2,6 +2,7 @@ package dnsmasq
 
 import (
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/discovery"
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/dnsmasq_exporter"
@@ -12,13 +13,21 @@ func init() {
 		Name:    "prometheus.exporter.dnsmasq",
 		Args:    Arguments{},
 		Exports: exporter.Exports{},
-		Build:   exporter.New(createExporter, "dnsmasq"),
+		Build:   exporter.NewWithTargetBuilder(createExporter, "dnsmasq", customizeTarget),
 	})
 }
 
 func createExporter(opts component.Options, args component.Arguments) (integrations.Integration, error) {
 	a := args.(Arguments)
 	return a.Convert().NewIntegration(opts.Logger)
+}
+
+func customizeTarget(baseTarget discovery.Target, args component.Arguments) []discovery.Target {
+	a := args.(Arguments)
+	target := baseTarget
+
+	target["instance"] = a.Address
+	return []discovery.Target{target}
 }
 
 // DefaultArguments holds the default arguments for the prometheus.exporter.dnsmasq component.

--- a/component/prometheus/exporter/dnsmasq/dnsmasq_test.go
+++ b/component/prometheus/exporter/dnsmasq/dnsmasq_test.go
@@ -3,6 +3,7 @@ package dnsmasq
 import (
 	"testing"
 
+	"github.com/grafana/agent/component/discovery"
 	"github.com/grafana/agent/pkg/integrations/dnsmasq_exporter"
 	"github.com/grafana/agent/pkg/river"
 	"github.com/stretchr/testify/assert"
@@ -46,4 +47,15 @@ func TestConvert(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, riverArguments.Convert())
+}
+
+func TestCustomizeTarget(t *testing.T) {
+	args := Arguments{
+		Address: "localhost:53",
+	}
+
+	baseTarget := discovery.Target{}
+	newTargets := customizeTarget(baseTarget, args)
+	assert.Equal(t, 1, len(newTargets))
+	assert.Equal(t, "localhost:53", newTargets[0]["instance"])
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Changes to use `NewWithTargetBuilder` to set the `"instance"` key for metrics, matching what is currently set in https://github.com/grafana/agent/blob/main/pkg/integrations/dnsmasq_exporter/dnsmasq_exporter.go#L35.

#### PR Checklist

- [X] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
