### PR TITLE
fix(azure_event_hubs): default scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Main (unreleased)
   could lead to propagating issues downstream to other components which expect
   the export to be non-empty. (@rfratto)
 
+- Fix oauth default scope in `loki.source.azure_event_hubs`. (@akselleirv)
+
 ### Other changes
 
 - Add logging to failed requests in `remote.http`. (@rfratto)

--- a/component/loki/source/azure_event_hubs/azure_event_hubs.go
+++ b/component/loki/source/azure_event_hubs/azure_event_hubs.go
@@ -192,7 +192,7 @@ func (a *Arguments) Convert() (kt.Config, error) {
 			if err != nil {
 				return kt.Config{}, fmt.Errorf("unable to extract host from fully qualified namespace: %w", err)
 			}
-			a.Authentication.Scopes = []string{fmt.Sprintf("https://%s", host)}
+			a.Authentication.Scopes = []string{fmt.Sprintf("https://%s/.default", host)}
 		}
 
 		cfg.KafkaConfig.Authentication = kt.Authentication{


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Fixed an issue I had when using workload identity in AKS to authenticate to Azure Event Hubs. It was fixed by adding the path `/.default` to the scope. 

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
