### PR TITLE
river/encoding/riverjson: ensure required fields are always marshaled

### DIFF
--- a/pkg/river/encoding/riverjson/riverjson_test.go
+++ b/pkg/river/encoding/riverjson/riverjson_test.go
@@ -18,7 +18,7 @@ func TestValues(t *testing.T) {
 		{
 			name:       "null",
 			input:      nil,
-			expectJSON: `{ "type": "null" }`,
+			expectJSON: `{ "type": "null", "value": null }`,
 		},
 		{
 			name:       "number",

--- a/pkg/river/encoding/riverjson/types.go
+++ b/pkg/river/encoding/riverjson/types.go
@@ -10,30 +10,30 @@ type (
 
 	// jsonBlock represents a River block as JSON. jsonBlock is a jsonStatement.
 	jsonBlock struct {
-		Name  string          `json:"name,omitempty"`
-		Type  string          `json:"type,omitempty"` // Always "block"
+		Name  string          `json:"name"`
+		Type  string          `json:"type"` // Always "block"
 		Label string          `json:"label,omitempty"`
-		Body  []jsonStatement `json:"body,omitempty"`
+		Body  []jsonStatement `json:"body"`
 	}
 
 	// jsonAttr represents a River attribute as JSON. jsonAttr is a
 	// jsonStatement.
 	jsonAttr struct {
-		Name  string    `json:"name,omitempty"`
-		Type  string    `json:"type,omitempty"` // Always "attr"
-		Value jsonValue `json:"value,omitempty"`
+		Name  string    `json:"name"`
+		Type  string    `json:"type"` // Always "attr"
+		Value jsonValue `json:"value"`
 	}
 
 	// jsonValue represents a single River value as JSON.
 	jsonValue struct {
-		Type  string      `json:"type,omitempty"`
-		Value interface{} `json:"value,omitempty"`
+		Type  string      `json:"type"`
+		Value interface{} `json:"value"`
 	}
 
 	// jsonObjectField represents a field within a River object.
 	jsonObjectField struct {
-		Key   string      `json:"key,omitempty"`
-		Value interface{} `json:"value,omitempty"`
+		Key   string      `json:"key"`
+		Value interface{} `json:"value"`
 	}
 )
 


### PR DESCRIPTION
This change ensures that required fields in the API are always returned; the only truly optional field is the label on blocks.

This resolves an issue from #4069 where a module with no exports omitted the `body` field, crashing the UI.

This was tested with the following module:

```txtar 
-- root.river --

prometheus.remote_write "default" { }

module.file "a" {
	filename = "child_a.river"
}

-- child_a.river -- 

prometheus.remote_write "default_a" { }

module.file "b" {
	filename = "child_b.river"
}

-- child_b.river --

prometheus.remote_write "default_b" { }
```

No CHANGELOG entry was added because this issue is only present in main and hasn't been released yet.