### PR TITLE
remote.http: fail early and add logs for failed requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ Main (unreleased)
 - Add signing region to remote.s3 component for use with custom endpoints so that Authorization Headers work correctly when
   proxying requests. (@mattdurham)
 
+- Fix issue where `remote.http` did not fail early if the initial rquest
+  failed. This caused failed requests to initially export empty values, which
+  could lead to propagating issues downstream to other components which expect
+  the export to be non-empty. (@rfratto)
+
+### Other changes
+
+- Add logging to failed requests in `remote.http`. (@rfratto)
+
 v0.34.0 (2023-06-08)
 --------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Main (unreleased)
 - Add signing region to remote.s3 component for use with custom endpoints so that Authorization Headers work correctly when
   proxying requests. (@mattdurham)
 
-- Fix issue where `remote.http` did not fail early if the initial rquest
+- Fix issue where `remote.http` did not fail early if the initial request
   failed. This caused failed requests to initially export empty values, which
   could lead to propagating issues downstream to other components which expect
   the export to be non-empty. (@rfratto)

--- a/component/remote/http/http.go
+++ b/component/remote/http/http.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/component"
 	common_config "github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/pkg/build"
@@ -194,6 +195,7 @@ func (c *Component) pollError() error {
 
 	req, err := http.NewRequest(c.args.Method, c.args.URL, nil)
 	if err != nil {
+		level.Error(c.log).Log("msg", "failed to build request", "err", err)
 		return fmt.Errorf("building request: %w", err)
 	}
 	for name, value := range c.args.Headers {
@@ -203,15 +205,18 @@ func (c *Component) pollError() error {
 
 	resp, err := c.cli.Do(req)
 	if err != nil {
+		level.Error(c.log).Log("msg", "failed to perform request", "err", err)
 		return fmt.Errorf("performing request: %w", err)
 	}
 
 	bb, err := io.ReadAll(resp.Body)
 	if err != nil {
+		level.Error(c.log).Log("msg", "failed to read response", "err", err)
 		return fmt.Errorf("reading response: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		level.Error(c.log).Log("msg", "unexpected status code from response", "status", resp.Status)
 		return fmt.Errorf("unexpected status code %s", resp.Status)
 	}
 
@@ -236,13 +241,17 @@ func (c *Component) pollError() error {
 // Update updates the remote.http component. After the update completes, a
 // poll is forced.
 func (c *Component) Update(args component.Arguments) (err error) {
-	// poll after updating. If an error occurred during Update, we don't bother
-	// to do anything.
+	// Poll after updating and propagate the error if the poll fails. If an error
+	// occurred during Update, we don't bother to do anything.
+	//
+	// It's important to propagate the error in update so the initial state of
+	// the component is calculated correctly, otherwise the exports will be empty
+	// and may cause unexpected errors in downstream components.
 	defer func() {
 		if err != nil {
 			return
 		}
-		c.poll()
+		err = c.pollError()
 	}()
 
 	c.mut.Lock()


### PR DESCRIPTION
This updates `remote.http` to return an error if polling after Update fails. Returning an error following Update is important to make sure that background failures don't cause issues to propagate across components:

If a component expects remote.http to have a non-empty body, remote.http should be unhealthy on first evaluation to prevent downstream components from evaluating.

In addition to failing early, failed requests are now logged to assist with user debugging.

Fixes #4084.