### PR TITLE
Update macOS steps to fix Homebrew information and correct syntax

### DIFF
--- a/docs/sources/static/set-up/install-agent-macos.md
+++ b/docs/sources/static/set-up/install-agent-macos.md
@@ -21,7 +21,7 @@ The default prefix for Homebrew on Intel is `/usr/local`. The default prefix for
 
 ## Installing Grafana Agent with Homebrew
 
-1. Open a terminal and run the following commands:
+Open a terminal and run the following commands:
 
    ```shell
    brew update
@@ -46,7 +46,7 @@ To send your data to Grafana Cloud, set up Grafana Agent using the Grafana Cloud
 
 ## Starting Grafana Agent
 
-1. Open a terminal and run the following command to start Grafana Agent:
+Open a terminal and run the following command to start Grafana Agent:
 
     ```shell
     brew services start grafana-agent
@@ -58,7 +58,7 @@ By default, logs are written to `$(brew --prefix)/var/log/grafana-agent.log` and
 
 ## Upgrading Grafana Agent
 
-1. Open a terminal and run the following command to upgrade Grafana Agent:
+Open a terminal and run the following command to upgrade Grafana Agent:
 
     ```shell
     brew upgrade grafana-agent

--- a/docs/sources/static/set-up/install-agent-macos.md
+++ b/docs/sources/static/set-up/install-agent-macos.md
@@ -23,10 +23,10 @@ The default prefix for Homebrew on Intel is `/usr/local`. The default prefix for
 
 Open a terminal and run the following commands:
 
-   ```shell
-   brew update
-   brew install grafana-agent
-   ```
+```shell
+brew update
+brew install grafana-agent
+```
 
    Grafana Agent is installed by default at `$(brew --prefix)/Cellar/grafana-agent/VERSION`.
 
@@ -48,18 +48,21 @@ To send your data to Grafana Cloud, set up Grafana Agent using the Grafana Cloud
 
 Open a terminal and run the following command to start Grafana Agent:
 
-    ```shell
-    brew services start grafana-agent
-    ```
+```shell
+brew services start grafana-agent
+```
 
 ## Viewing Grafana Agent Logs
 
-By default, logs are written to `$(brew --prefix)/var/log/grafana-agent.log` and `$(brew --prefix)/var/log/grafana-agent.err.log`.
+By default, logs are written to the following locations:
+
+* `$(brew --prefix)/var/log/grafana-agent.log`
+* `$(brew --prefix)/var/log/grafana-agent.err.log`
 
 ## Upgrading Grafana Agent
 
 Open a terminal and run the following command to upgrade Grafana Agent:
 
-    ```shell
-    brew upgrade grafana-agent
-    ```
+```shell
+brew upgrade grafana-agent
+ ```

--- a/docs/sources/static/set-up/install-agent-macos.md
+++ b/docs/sources/static/set-up/install-agent-macos.md
@@ -14,7 +14,7 @@ You can install Grafana Agent in static mode on macOS.
 Ensure that [Homebrew][] is installed on your machine.
 
 {{% admonition type="note" %}}
-The default prefix for Homebrew on Intel is `/usr/local`. The default prefix for Homebrew on Apple Silicon is `/opt/Homebrew`. You can verify this by opening a terminal and typing `brew --prefix`.
+The default prefix for Homebrew on Intel is `/usr/local`. The default prefix for Homebrew on Apple Silicon is `/opt/Homebrew`. You can verify the default prefix by opening a terminal and typing `brew --prefix`.
 {{% /admonition %}}
 
 [Homebrew]: https://brew.sh
@@ -54,7 +54,7 @@ To send your data to Grafana Cloud, set up Grafana Agent using the Grafana Cloud
 
 ## Viewing Grafana Agent Logs
 
-By defualt, logs are written to `$(brew --prefix)/var/log/grafana-agent.log` and `$(brew --prefix)/var/log/grafana-agent.err.log`.
+By default, logs are written to `$(brew --prefix)/var/log/grafana-agent.log` and `$(brew --prefix)/var/log/grafana-agent.err.log`.
 
 ## Upgrading Grafana Agent
 

--- a/docs/sources/static/set-up/install-agent-macos.md
+++ b/docs/sources/static/set-up/install-agent-macos.md
@@ -40,6 +40,10 @@ The default prefix for Homebrew on Intel is `/usr/local`. The default prefix for
 
 1. Edit `$(brew --prefix)/etc/grafana-agent/config.yml` and add the configuration blocks for your specific telemetry needs. Refer to [Configure Grafana Agent]({{< relref "../configuration/" >}}) for more information.
 
+{{% admonition type="note" %}}
+To send your data to Grafana Cloud, set up Grafana Agent using the Grafana Cloud integration. Refer to [how to install an integration](/docs/grafana-cloud/data-configuration/integrations/install-and-manage-integrations/) and [macOS integration](/docs/grafana-cloud/data-configuration/integrations/integration-reference/integration-macos-node/).
+{{%/admonition %}}
+
 ## Starting Grafana Agent
 
 1. Open a terminal and run the following command to start Grafana Agent:
@@ -50,7 +54,7 @@ The default prefix for Homebrew on Intel is `/usr/local`. The default prefix for
 
 ## Viewing Grafana Agent Logs
 
-By default, logs are written to `$(brew --prefix)/var/log/grafana-agent.log` and `$(brew --prefix)/var/log/grafana-agent.err.log`.
+By defualt, logs are written to `$(brew --prefix)/var/log/grafana-agent.log` and `$(brew --prefix)/var/log/grafana-agent.err.log`.
 
 ## Upgrading Grafana Agent
 

--- a/docs/sources/static/set-up/install-agent-macos.md
+++ b/docs/sources/static/set-up/install-agent-macos.md
@@ -13,44 +13,49 @@ You can install Grafana Agent in static mode on macOS.
 
 Ensure that [Homebrew][] is installed on your machine.
 
+{{% admonition type="note" %}}
+The default prefix for Homebrew on Intel is `/usr/local`. The default prefix for Homebrew on Apple Silicon is `/opt/Homebrew`. You can verify this by opening a terminal and typing `brew --prefix`.
+{{% /admonition %}}
+
 [Homebrew]: https://brew.sh
 
-## Install Grafana Agent with Homebrew
+## Installing Grafana Agent with Homebrew
 
 1. Open a terminal and run the following commands:
 
-   ```
+   ```shell
    brew update
    brew install grafana-agent
    ```
 
-    The brew install command downloads Grafana Agent and installs it at `/opt/homebrew/Cellar/grafana-agent/VERSION`.
-    
-    Grafana Agent logs are in `/opt/homebrew/var/log/` by default.
+   Grafana Agent is installed by default at `$(brew --prefix)/Cellar/grafana-agent/VERSION`.
 
-1. Open a terminal and run the following commands:
+## Configuring Grafana Agent
 
-    ```
-    mkdir -p $(brew --prefix)/etc/grafana-agent/
+1. To create the Agent `config.yml` file, open a terminal and run the following command:
+
+    ```shell
     touch $(brew --prefix)/etc/grafana-agent/config.yml
     ```
 
-1. Modify `config.yml` with your configuration requirements.
+1. Edit `$(brew --prefix)/etc/grafana-agent/config.yml` and add the configuration blocks for your specific telemetry needs. Refer to [Configure Grafana Agent]({{< relref "../configuration/" >}}) for more information.
 
-    Refer to [Configure Grafana Agent]({{< relref "../configuration/" >}}) for information about the Agent configuration .
+## Starting Grafana Agent
 
 1. Open a terminal and run the following command to start Grafana Agent:
 
-    ` brew services start grafana-agent`
+    ```shell
+    brew services start grafana-agent
+    ```
 
-    For logs, see:
-    - stdout: `$(brew --prefix)/var/log/grafana-agent.log`
-    - stderr: `$(brew --prefix)/var/log/grafana-agent.err.log`
+## Viewing Grafana Agent Logs
+
+By default, logs are written to `$(brew --prefix)/var/log/grafana-agent.log` and `$(brew --prefix)/var/log/grafana-agent.err.log`.
+
+## Upgrading Grafana Agent
 
 1. Open a terminal and run the following command to upgrade Grafana Agent:
 
-    `brew upgrade grafana-agent`.
-
-{{% admonition type="note" %}}
-To send your data to Grafana Cloud, set up Grafana Agent using the Grafana Cloud integration. Refer to [how to install an integration](/docs/grafana-cloud/data-configuration/integrations/install-and-manage-integrations/) and [macOS integration](/docs/grafana-cloud/data-configuration/integrations/integration-reference/integration-macos-node/).
-{{%/admonition %}}
+    ```shell
+    brew upgrade grafana-agent
+    ```

--- a/docs/sources/static/set-up/install-agent-macos.md
+++ b/docs/sources/static/set-up/install-agent-macos.md
@@ -61,8 +61,9 @@ By default, logs are written to the following locations:
 
 ## Upgrading Grafana Agent
 
-Open a terminal and run the following command to upgrade Grafana Agent:
+Open a terminal and run the following commands to upgrade and restart Grafana Agent:
 
 ```shell
 brew upgrade grafana-agent
+brew services restart grafana-agent
  ```

--- a/docs/sources/static/set-up/install-agent-macos.md
+++ b/docs/sources/static/set-up/install-agent-macos.md
@@ -11,10 +11,10 @@ You can install Grafana Agent in static mode on macOS.
 
 ## Before you begin
 
-Ensure that [Homebrew][] is installed on your machine.
+Ensure that [Homebrew][] is installed.
 
 {{% admonition type="note" %}}
-The default prefix for Homebrew on Intel is `/usr/local`. The default prefix for Homebrew on Apple Silicon is `/opt/Homebrew`. You can verify the default prefix by opening a terminal and typing `brew --prefix`.
+The default prefix for Homebrew on Intel is `/usr/local`. The default prefix for Homebrew on Apple Silicon is `/opt/Homebrew`. You can verify the default prefix for Homebrew on your computer by opening a terminal and typing `brew --prefix`.
 {{% /admonition %}}
 
 [Homebrew]: https://brew.sh


### PR DESCRIPTION
#### PR Description

A review of macOS installation steps showed that the install information for Agent static install was incorrect in some areas and other important information was completely missing.

1. The default prefix for Homebrew is based on CPU type (Intel vs Apple Silicon). Added a note about this.
2. The information about where grafana-agent is installed by default is now based on the CPU type.
3. Removed `mkdir $(brew --prefix)/etc/grafana-agent/` because this directory is created by the installer.
4. The sections are now split by task with new headings for each task.
5. Clarified the information around where the `config.yml` file is located - this was confusing people.
6. The log information is updated to match the Flow style.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
