### PR TITLE
CODEOWNERS: exempt component/all from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,9 +13,10 @@
 # pull request.
 * @grafana/grafana-agent-core-maintainers
 
-# CHANGELOG.md has shared ownership with the respective owners of the specific
-# code for the PR being opened.
+# Some directories have shared ownership with the respective owners of the
+# specific code for the PR being opened, so there's no CODEOWNERS.
 /CHANGELOG.md
+/component/all
 
 # Binaries:
 /cmd/grafana-agent-operator/  @grafana/grafana-agent-operator-maintainers


### PR DESCRIPTION
component/all is a shared directory, so there should be no CODEOWNERS for it.