### PR TITLE
CODEOWNERS: add /component/prometheus/operator/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,6 +34,7 @@
 /component/phlare/                  @grafana/grafana-agent-signals-maintainers
 /component/prometheus/              @grafana/grafana-agent-signals-maintainers
 /component/prometheus/exporter/     @grafana/grafana-agent-infrastructure-maintainers
+/component/prometheus/operator/     @grafana/grafana-agent-operator-maintainers
 /component/remote/                  @grafana/grafana-agent-infrastructure-maintainers
 
 # Static mode packages:


### PR DESCRIPTION
`prometheus.operator.*` components were missing from CODEOWNERS.