### PR TITLE
Add a otelcol.exporter.loadbalancing component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ Main (unreleased)
     cluster and scrape the targets they reference. (@captncraig)
   - `pyroscope.ebpf` collects system-wide performance profiles from the current
     host (@korniltsev)
+  - `otelcol.exporter.loadbalancing` - export traces and logs to multiple OTLP gRPC 
+    endpoints in a load-balanced way. (@ptodev)
 
 - New Grafana Agent Flow command line utilities:
 

--- a/component/all/all.go
+++ b/component/all/all.go
@@ -45,6 +45,7 @@ import (
 	_ "github.com/grafana/agent/component/otelcol/auth/oauth2"                      // Import otelcol.auth.oauth2
 	_ "github.com/grafana/agent/component/otelcol/auth/sigv4"                       // Import otelcol.auth.sigv4
 	_ "github.com/grafana/agent/component/otelcol/exporter/jaeger"                  // Import otelcol.exporter.jaeger
+	_ "github.com/grafana/agent/component/otelcol/exporter/loadbalancing"           // Import otelcol.exporter.loadbalancing
 	_ "github.com/grafana/agent/component/otelcol/exporter/logging"                 // Import otelcol.exporter.logging
 	_ "github.com/grafana/agent/component/otelcol/exporter/loki"                    // Import otelcol.exporter.loki
 	_ "github.com/grafana/agent/component/otelcol/exporter/otlp"                    // Import otelcol.exporter.otlp

--- a/component/otelcol/config_grpc.go
+++ b/component/otelcol/config_grpc.go
@@ -129,6 +129,8 @@ func (args *KeepaliveEnforcementPolicy) Convert() *otelconfiggrpc.KeepaliveEnfor
 
 // GRPCClientArguments holds shared gRPC settings for components which launch
 // gRPC clients.
+// NOTE: When changing this structure, note that similar structures such as
+// loadbalancing.GRPCClientArguments may also need to be changed.
 type GRPCClientArguments struct {
 	Endpoint string `river:"endpoint,attr"`
 

--- a/component/otelcol/config_tls.go
+++ b/component/otelcol/config_tls.go
@@ -70,31 +70,17 @@ func (args *TLSSetting) Convert() *otelconfigtls.TLSSetting {
 		return nil
 	}
 
-	res := &otelconfigtls.TLSSetting{
+	return &otelconfigtls.TLSSetting{
+		CAPem:          configopaque.String(args.CA),
 		CAFile:         args.CAFile,
+		CertPem:        configopaque.String(args.Cert),
 		CertFile:       args.CertFile,
+		KeyPem:         configopaque.String(string(args.Key)),
 		KeyFile:        args.KeyFile,
 		MinVersion:     args.MinVersion,
 		MaxVersion:     args.MaxVersion,
 		ReloadInterval: args.ReloadInterval,
 	}
-
-	// Collector sets the pem attributes to nil by default,
-	// so let's match this.
-
-	if args.CA != "" {
-		res.CAPem = configopaque.String(args.CA)
-	}
-
-	if args.Cert != "" {
-		res.CertPem = configopaque.String(args.Cert)
-	}
-
-	if args.Key != "" {
-		res.KeyPem = configopaque.String(args.Key)
-	}
-
-	return res
 }
 
 // Validate implements river.Validator.

--- a/component/otelcol/config_tls.go
+++ b/component/otelcol/config_tls.go
@@ -70,17 +70,31 @@ func (args *TLSSetting) Convert() *otelconfigtls.TLSSetting {
 		return nil
 	}
 
-	return &otelconfigtls.TLSSetting{
-		CAPem:          configopaque.String(args.CA),
+	res := &otelconfigtls.TLSSetting{
 		CAFile:         args.CAFile,
-		CertPem:        configopaque.String(args.Cert),
 		CertFile:       args.CertFile,
-		KeyPem:         configopaque.String(string(args.Key)),
 		KeyFile:        args.KeyFile,
 		MinVersion:     args.MinVersion,
 		MaxVersion:     args.MaxVersion,
 		ReloadInterval: args.ReloadInterval,
 	}
+
+	// Collector sets the pem attributes to nil by default,
+	// so let's match this.
+
+	if args.CA != "" {
+		res.CAPem = configopaque.String(args.CA)
+	}
+
+	if args.Cert != "" {
+		res.CertPem = configopaque.String(args.Cert)
+	}
+
+	if args.Key != "" {
+		res.KeyPem = configopaque.String(args.Key)
+	}
+
+	return res
 }
 
 // Validate implements river.Validator.

--- a/component/otelcol/exporter/loadbalancing/loadbalancing.go
+++ b/component/otelcol/exporter/loadbalancing/loadbalancing.go
@@ -1,0 +1,250 @@
+// Package loadbalancing provides an otelcol.exporter.loadbalancing component.
+package loadbalancing
+
+import (
+	"time"
+
+	"github.com/alecthomas/units"
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otelcol"
+	"github.com/grafana/agent/component/otelcol/auth"
+	"github.com/grafana/agent/component/otelcol/exporter"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
+	otelcomponent "go.opentelemetry.io/collector/component"
+	otelconfigauth "go.opentelemetry.io/collector/config/configauth"
+	otelconfiggrpc "go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/exporter/otlpexporter"
+	otelextension "go.opentelemetry.io/collector/extension"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:    "otelcol.exporter.loadbalancing",
+		Args:    Arguments{},
+		Exports: otelcol.ConsumerExports{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			fact := loadbalancingexporter.NewFactory()
+			return exporter.New(opts, fact, args.(Arguments))
+		},
+	})
+}
+
+// Arguments configures the otelcol.exporter.loadbalancing component.
+type Arguments struct {
+	Protocol   Protocol         `river:"protocol,block"`
+	Resolver   ResolverSettings `river:"resolver,block"`
+	RoutingKey string           `river:"routing_key,attr,optional"`
+}
+
+var (
+	_ exporter.Arguments = Arguments{}
+	_ river.Defaulter    = &Arguments{}
+)
+
+// DefaultArguments holds default values for Arguments.
+var DefaultArguments = Arguments{
+	RoutingKey: "traceID",
+}
+
+// SetToDefault implements river.Defaulter.
+func (args *Arguments) SetToDefault() {
+	*args = DefaultArguments
+}
+
+// Convert implements exporter.Arguments.
+func (args Arguments) Convert() (otelcomponent.Config, error) {
+	return &loadbalancingexporter.Config{
+		Protocol:   args.Protocol.Convert(),
+		Resolver:   args.Resolver.Convert(),
+		RoutingKey: args.RoutingKey,
+	}, nil
+}
+
+// Protocol holds the individual protocol-specific settings. Only OTLP is supported at the moment.
+type Protocol struct {
+	OTLP OtlpConfig `river:"otlp,block"`
+}
+
+func (protocol Protocol) Convert() loadbalancingexporter.Protocol {
+	return loadbalancingexporter.Protocol{
+		OTLP: protocol.OTLP.Convert(),
+	}
+}
+
+// OtlpConfig defines the config for an OTLP exporter
+type OtlpConfig struct {
+	Timeout time.Duration          `river:"timeout,attr,optional"`
+	Queue   otelcol.QueueArguments `river:"queue,block,optional"`
+	Retry   otelcol.RetryArguments `river:"retry,block,optional"`
+	// Most of the time, the user will not have to set anything in the client block.
+	// However, the block should not be "optional" so that the defaults are populated.
+	Client GRPCClientArguments `river:"client,block"`
+}
+
+func (otlpConfig OtlpConfig) Convert() otlpexporter.Config {
+	return otlpexporter.Config{
+		TimeoutSettings: exporterhelper.TimeoutSettings{
+			Timeout: otlpConfig.Timeout,
+		},
+		QueueSettings:      *otlpConfig.Queue.Convert(),
+		RetrySettings:      *otlpConfig.Retry.Convert(),
+		GRPCClientSettings: *otlpConfig.Client.Convert(),
+	}
+}
+
+// ResolverSettings defines the configurations for the backend resolver
+type ResolverSettings struct {
+	Static *StaticResolver `river:"static,block,optional"`
+	DNS    *DNSResolver    `river:"dns,block,optional"`
+}
+
+func (resolverSettings ResolverSettings) Convert() loadbalancingexporter.ResolverSettings {
+	res := loadbalancingexporter.ResolverSettings{}
+
+	if resolverSettings.Static != nil {
+		staticResolver := resolverSettings.Static.Convert()
+		res.Static = &staticResolver
+	}
+
+	if resolverSettings.DNS != nil {
+		dnsResolver := resolverSettings.DNS.Convert()
+		res.DNS = &dnsResolver
+	}
+
+	return res
+}
+
+// StaticResolver defines the configuration for the resolver providing a fixed list of backends
+type StaticResolver struct {
+	Hostnames []string `river:"hostnames,attr"`
+}
+
+func (staticResolver StaticResolver) Convert() loadbalancingexporter.StaticResolver {
+	return loadbalancingexporter.StaticResolver{
+		Hostnames: staticResolver.Hostnames,
+	}
+}
+
+// DNSResolver defines the configuration for the DNS resolver
+type DNSResolver struct {
+	Hostname string        `river:"hostname,attr"`
+	Port     string        `river:"port,attr,optional"`
+	Interval time.Duration `river:"interval,attr,optional"`
+	Timeout  time.Duration `river:"timeout,attr,optional"`
+}
+
+var (
+	_ river.Defaulter = &DNSResolver{}
+)
+
+// DefaultDNSResolver holds default values for DNSResolver.
+var DefaultDNSResolver = DNSResolver{
+	Port:     "4317",
+	Interval: 5 * time.Second,
+	Timeout:  1 * time.Second,
+}
+
+// SetToDefault implements river.Defaulter.
+func (args *DNSResolver) SetToDefault() {
+	*args = DefaultDNSResolver
+}
+
+func (dnsResolver *DNSResolver) Convert() loadbalancingexporter.DNSResolver {
+	return loadbalancingexporter.DNSResolver{
+		Hostname: dnsResolver.Hostname,
+		Port:     dnsResolver.Port,
+		Interval: dnsResolver.Interval,
+		Timeout:  dnsResolver.Timeout,
+	}
+}
+
+// Extensions implements exporter.Arguments.
+func (args Arguments) Extensions() map[otelcomponent.ID]otelextension.Extension {
+	return args.Protocol.OTLP.Client.Extensions()
+}
+
+// Exporters implements exporter.Arguments.
+func (args Arguments) Exporters() map[otelcomponent.DataType]map[otelcomponent.ID]otelcomponent.Component {
+	return nil
+}
+
+// GRPCClientArguments is the same as otelcol.GRPCClientArguments, but without an "endpoint" attribute
+type GRPCClientArguments struct {
+	Compression otelcol.CompressionType `river:"compression,attr,optional"`
+
+	TLS       otelcol.TLSClientArguments        `river:"tls,block,optional"`
+	Keepalive *otelcol.KeepaliveClientArguments `river:"keepalive,block,optional"`
+
+	ReadBufferSize  units.Base2Bytes  `river:"read_buffer_size,attr,optional"`
+	WriteBufferSize units.Base2Bytes  `river:"write_buffer_size,attr,optional"`
+	WaitForReady    bool              `river:"wait_for_ready,attr,optional"`
+	Headers         map[string]string `river:"headers,attr,optional"`
+	BalancerName    string            `river:"balancer_name,attr,optional"`
+
+	// Auth is a binding to an otelcol.auth.* component extension which handles
+	// authentication.
+	Auth *auth.Handler `river:"auth,attr,optional"`
+}
+
+var (
+	_ river.Defaulter = &GRPCClientArguments{}
+)
+
+// Convert converts args into the upstream type.
+func (args *GRPCClientArguments) Convert() *otelconfiggrpc.GRPCClientSettings {
+	if args == nil {
+		return nil
+	}
+
+	opaqueHeaders := make(map[string]configopaque.String)
+	for headerName, headerVal := range args.Headers {
+		opaqueHeaders[headerName] = configopaque.String(headerVal)
+	}
+
+	// Configure the authentication if args.Auth is set.
+	var auth *otelconfigauth.Authentication
+	if args.Auth != nil {
+		auth = &otelconfigauth.Authentication{AuthenticatorID: args.Auth.ID}
+	}
+
+	return &otelconfiggrpc.GRPCClientSettings{
+		Compression: args.Compression.Convert(),
+
+		TLSSetting: *args.TLS.Convert(),
+		Keepalive:  args.Keepalive.Convert(),
+
+		ReadBufferSize:  int(args.ReadBufferSize),
+		WriteBufferSize: int(args.WriteBufferSize),
+		WaitForReady:    args.WaitForReady,
+		Headers:         opaqueHeaders,
+		BalancerName:    args.BalancerName,
+
+		Auth: auth,
+	}
+}
+
+// Extensions exposes extensions used by args.
+func (args *GRPCClientArguments) Extensions() map[otelcomponent.ID]otelextension.Extension {
+	m := make(map[otelcomponent.ID]otelextension.Extension)
+	if args.Auth != nil {
+		m[args.Auth.ID] = args.Auth.Extension
+	}
+	return m
+}
+
+// DefaultGRPCClientArguments holds component-specific default settings for
+// GRPCClientArguments.
+var DefaultGRPCClientArguments = GRPCClientArguments{
+	Headers:         map[string]string{},
+	Compression:     otelcol.CompressionTypeGzip,
+	WriteBufferSize: 512 * 1024,
+}
+
+// SetToDefault implements river.Defaulter.
+func (args *GRPCClientArguments) SetToDefault() {
+	*args = DefaultGRPCClientArguments
+}

--- a/component/otelcol/exporter/loadbalancing/loadbalancing_test.go
+++ b/component/otelcol/exporter/loadbalancing/loadbalancing_test.go
@@ -1,0 +1,193 @@
+package loadbalancing_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/component/otelcol/exporter/loadbalancing"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/exporter/otlpexporter"
+)
+
+func TestConfigConversion(t *testing.T) {
+	defaultProtocol := loadbalancingexporter.Protocol{
+		OTLP: otlpexporter.Config{
+			GRPCClientSettings: configgrpc.GRPCClientSettings{
+				Endpoint:        "",
+				Compression:     "gzip",
+				WriteBufferSize: 512 * 1024,
+				Headers:         map[string]configopaque.String{},
+			},
+		},
+	}
+
+	tests := []struct {
+		testName string
+		agentCfg string
+		expected loadbalancingexporter.Config
+	}{
+		{
+			testName: "static",
+			agentCfg: `
+			resolver {
+				static {
+					hostnames = ["endpoint-1"]
+				}
+			}
+			protocol {
+				otlp {
+					client {}
+				}
+			}
+			`,
+			expected: loadbalancingexporter.Config{
+				Resolver: loadbalancingexporter.ResolverSettings{
+					Static: &loadbalancingexporter.StaticResolver{
+						Hostnames: []string{"endpoint-1"},
+					},
+					DNS: nil,
+				},
+				RoutingKey: "traceID",
+				Protocol:   defaultProtocol,
+			},
+		},
+		{
+			testName: "static with service routing",
+			agentCfg: `
+			routing_key = "service"
+			resolver {
+				static {
+					hostnames = ["endpoint-1"]
+				}
+			}
+			protocol {
+				otlp {
+					client {}
+				}
+			}
+			`,
+			expected: loadbalancingexporter.Config{
+				Resolver: loadbalancingexporter.ResolverSettings{
+					Static: &loadbalancingexporter.StaticResolver{
+						Hostnames: []string{"endpoint-1"},
+					},
+					DNS: nil,
+				},
+				RoutingKey: "service",
+				Protocol:   defaultProtocol,
+			},
+		},
+		{
+			testName: "static with timeout",
+			agentCfg: `
+			protocol {
+				otlp {
+					timeout = "1s"
+					client {}
+				}
+			}
+			resolver {
+				static {
+					hostnames = ["endpoint-1", "endpoint-2:55678"]
+				}
+			}
+			`,
+			expected: loadbalancingexporter.Config{
+				Protocol: loadbalancingexporter.Protocol{
+					OTLP: otlpexporter.Config{
+						TimeoutSettings: exporterhelper.TimeoutSettings{
+							Timeout: 1 * time.Second,
+						},
+						GRPCClientSettings: configgrpc.GRPCClientSettings{
+							Endpoint:        "",
+							Compression:     "gzip",
+							WriteBufferSize: 512 * 1024,
+							Headers:         map[string]configopaque.String{},
+						},
+					},
+				},
+				Resolver: loadbalancingexporter.ResolverSettings{
+					Static: &loadbalancingexporter.StaticResolver{
+						Hostnames: []string{"endpoint-1", "endpoint-2:55678"},
+					},
+					DNS: nil,
+				},
+				RoutingKey: "traceID",
+			},
+		},
+		{
+			testName: "dns with defaults",
+			agentCfg: `
+			resolver {
+				dns {
+					hostname = "service-1"
+				}
+			}
+			protocol {
+				otlp {
+					client {}
+				}
+			}
+			`,
+			expected: loadbalancingexporter.Config{
+				Resolver: loadbalancingexporter.ResolverSettings{
+					Static: nil,
+					DNS: &loadbalancingexporter.DNSResolver{
+						Hostname: "service-1",
+						Port:     "4317",
+						Interval: 5 * time.Second,
+						Timeout:  1 * time.Second,
+					},
+				},
+				RoutingKey: "traceID",
+				Protocol:   defaultProtocol,
+			},
+		},
+		{
+			testName: "dns with non-defaults",
+			agentCfg: `
+			resolver {
+				dns {
+					hostname = "service-1"
+					port = "55690"
+					interval = "123s"
+					timeout = "321s"
+				}
+			}
+			protocol {
+				otlp {
+					client {}
+				}
+			}
+			`,
+			expected: loadbalancingexporter.Config{
+				Resolver: loadbalancingexporter.ResolverSettings{
+					Static: nil,
+					DNS: &loadbalancingexporter.DNSResolver{
+						Hostname: "service-1",
+						Port:     "55690",
+						Interval: 123 * time.Second,
+						Timeout:  321 * time.Second,
+					},
+				},
+				RoutingKey: "traceID",
+				Protocol:   defaultProtocol,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			var args loadbalancing.Arguments
+			require.NoError(t, river.Unmarshal([]byte(tc.agentCfg), &args))
+			actual, err := args.Convert()
+			require.NoError(t, err)
+			require.Equal(t, &tc.expected, actual.(*loadbalancingexporter.Config))
+		})
+	}
+}

--- a/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
@@ -1,0 +1,268 @@
+---
+title: otelcol.exporter.loadbalancing
+labels:
+  stage: beta
+---
+
+# otelcol.exporter.loadbalancing
+
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+
+`otelcol.exporter.loadbalancing` accepts logs and traces from other `otelcol` components
+and writes them over the network using the OpenTelemetry Protocol (OTLP) protocol. 
+
+> **NOTE**: `otelcol.exporter.loadbalancing` is a wrapper over the upstream
+> OpenTelemetry Collector `loadbalancing` exporter. Bug reports or feature requests will
+> be redirected to the upstream repository, if necessary.
+
+Multiple `otelcol.exporter.loadbalancing` components can be specified by giving them
+different labels.
+
+The decision which backend to use depends on the trace ID or the service name. 
+The backend load doesn't influence the choice. Even though this load-balancer won't do 
+round-robin balancing of the batches, the load distribution should be very similar among backends, 
+with a standard deviation under 5% at the current configuration.
+
+`otelcol.exporter.loadbalancing` is especially useful for backends configured with tail-based samplers
+which choose a backend based on the view of the full trace.
+
+When a list of backends is updated, some of the signals will be rerouted to different backends. 
+Around R/N of the "routes" will be rerouted differently, where:
+
+* A "route" is either a trace ID or a service name mapped to a certain backend.
+* "R" is the total number of routes.
+* "N" is the total number of backends.
+
+This should be stable enough for most cases, and the larger the number of backends, the less disruption it should cause.
+
+## Usage
+
+```river
+otelcol.exporter.loadbalancing "LABEL" {
+  resolver {
+    ...
+  }
+  protocol {
+    otlp {
+      client {}
+    }
+  }
+}
+```
+
+## Arguments
+
+`otelcol.exporter.loadbalancing` supports the following arguments:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`routing_key` | `string` | Routing strategy for load balancing. | `"traceID"` | no
+
+The `routing_key` attribute determines how to route signals across endpoints. Its value could be one of the following:
+* `"service"`: spans with the same `service.name` will be exported to the same backend.
+This is useful when using processors like the span metrics, so all spans for each service are sent to consistent Agent instances 
+for metric collection. Otherwise, metrics for the same services would be sent to different Agents, making aggregations inaccurate.
+* `"traceID"`: spans belonging to the same traceID will be exported to the same backend.
+
+## Blocks
+
+The following blocks are supported inside the definition of
+`otelcol.exporter.loadbalancing`:
+
+Hierarchy | Block | Description | Required
+--------- | ----- | ----------- | --------
+resolver | [resolver][] | Configures discovering the endpoints to export to. | yes
+resolver > static | [static][] | Static list of endpoints to export to. | no
+resolver > dns | [dns][] | DNS-sourced list of endpoints to export to. | no
+protocol | [protocol][] | Protocol settings. Only OTLP is supported at the moment. | no
+protocol > otlp | [otlp][] | Configures an OTLP exporter. | no
+protocol > otlp > client | [client][] | Configures the exporter gRPC client. | no
+protocol > otlp > client > tls | [tls][] | Configures TLS for the gRPC client. | no
+protocol > otlp > client > keepalive | [keepalive][] | Configures keepalive settings for the gRPC client. | no
+protocol > otlp > queue | [queue][] | Configures batching of data before sending. | no
+protocol > otlp > retry | [retry][] | Configures retry mechanism for failed requests. | no
+
+The `>` symbol indicates deeper levels of nesting. For example, `resolver > static`
+refers to a `static` block defined inside a `resolver` block.
+
+[resolver]: #resolver-block
+[static]: #static-block
+[dns]: #dns-block
+[protocol]: #protocol-block
+[otlp]: #otlp-block
+[client]: #client-block
+[tls]: #tls-block
+[keepalive]: #keepalive-block
+[queue]: #queue-block
+[retry]: #retry-block
+
+### resolver block
+
+The `resolver` block configures how to retrieve the endpoint to which this exporter will send data.
+
+Inside the `resolver` block, either the [dns][] block or the [static][] block 
+should be specified. If both `dns` and `static` are specified, `dns` takes precedence.
+
+### static block
+
+The `static` block configures a list of endpoints which this exporter will send data to.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`hostnames` | `list(string)` | List of endpoints to export to. |  | yes
+
+### dns block
+
+The `dns` block periodically resolves an IP address via the DNS `hostname` attribute. This IP address 
+and the port specified via the `port` attribute will then be used by the gRPC exporter 
+as the endpoint to which to export data to.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`hostname` | `string`   | DNS hostname to resolve. |  | yes
+`interval` | `duration` | Resolver interval. | `"5s"` | no
+`timeout`  | `duration` | Resolver timeout. | `"1s"`  | no
+`port`     | `string`   | Port to be used with the IP addresses resolved from the DNS hostname. | `"4317"` | no
+
+### protocol block
+
+The `protocol` block configures protocol-related settings for exporting.
+At the moment only the OTLP protocol is supported.
+
+### otlp block
+
+The `otlp` block configures OTLP-related settings for exporting.
+
+### client block
+
+The `client` block configures the gRPC client used by the component. 
+The endpoints used by the client block are the ones from the `resolver` block
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`compression` | `string` | Compression mechanism to use for requests. | `"gzip"` | no
+`read_buffer_size` | `string` | Size of the read buffer the gRPC client to use for reading server responses. | | no
+`write_buffer_size` | `string` | Size of the write buffer the gRPC client to use for writing requests. | `"512KiB"` | no
+`wait_for_ready` | `boolean` | Waits for gRPC connection to be in the `READY` state before sending data. | `false` | no
+`headers` | `map(string)` | Additional headers to send with the request. | `{}` | no
+`balancer_name` | `string` | Which gRPC client-side load balancer to use for requests. | | no
+`auth` | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests. | | no
+
+{{< docs/shared lookup="flow/reference/components/otelcol-compression-field.md" source="agent" >}}
+
+The `balancer_name` argument controls what client-side load balancing mechanism
+to use. See the gRPC documentation on [Load balancing][] for more information.
+When unspecified, `pick_first` is used.
+
+You can configure an HTTP proxy with the following environment variables:
+
+* `HTTPS_PROXY`
+* `NO_PROXY`
+
+The `HTTPS_PROXY` environment variable specifies a URL to use for proxying
+requests. Connections to the proxy are established via [the `HTTP CONNECT`
+method][HTTP CONNECT].
+
+The `NO_PROXY` environment variable is an optional list of comma-separated
+hostnames for which the HTTPS proxy should _not_ be used. Each hostname can be
+provided as an IP address (`1.2.3.4`), an IP address in CIDR notation
+(`1.2.3.4/8`), a domain name (`example.com`), or `*`. A domain name matches
+that domain and all subdomains. A domain name with a leading "."
+(`.example.com`) matches subdomains only. `NO_PROXY` is only read when
+`HTTPS_PROXY` is set.
+
+Because `otelcol.exporter.loadbalancing` uses gRPC, the configured proxy server must be
+able to handle and proxy HTTP/2 traffic.
+
+[Load balancing]: https://github.com/grpc/grpc-go/blob/master/examples/features/load_balancing/README.md#pick_first
+[HTTP CONNECT]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT
+
+### tls block
+
+The `tls` block configures TLS settings used for the connection to the gRPC
+server.
+
+{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" >}}
+
+### keepalive block
+
+The `keepalive` block configures keepalive settings for gRPC client
+connections.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`ping_wait` | `duration` | How often to ping the server after no activity. | | no
+`ping_response_timeout` | `duration` | Time to wait before closing inactive connections if the server does not respond to a ping. | | no
+`ping_without_stream` | `boolean` | Send pings even if there is no active stream request. | | no
+
+### queue block
+
+The `queue` block configures an in-memory buffer of batches before data is sent
+to the gRPC server.
+
+{{< docs/shared lookup="flow/reference/components/otelcol-queue-block.md" source="agent" >}}
+
+### retry block
+
+The `retry` block configures how failed requests to the gRPC server are
+retried.
+
+{{< docs/shared lookup="flow/reference/components/otelcol-retry-block.md" source="agent" >}}
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+Name | Type | Description
+---- | ---- | -----------
+`input` | `otelcol.Consumer` | A value that other components can use to send telemetry data to.
+
+`input` accepts `otelcol.Consumer` OTLP-formatted data for telemetry signals of these types:
+* logs
+* traces
+
+## Component health
+
+`otelcol.exporter.loadbalancing` is only reported as unhealthy if given an invalid
+configuration.
+
+## Debug information
+
+`otelcol.exporter.loadbalancing` does not expose any component-specific debug
+information.
+
+## Example
+
+This example accepts OTLP logs and traces over gRPC. It then sends them in a load-balanced 
+way to "localhost:55690" or "localhost:55700".
+
+```river
+otelcol.receiver.otlp "default" {
+    grpc {}
+    output {
+        traces  = [otelcol.exporter.loadbalancing.default.input]
+        logs    = [otelcol.exporter.loadbalancing.default.input]
+    }
+}
+
+otelcol.exporter.loadbalancing "default" {
+    resolver {
+        static {
+            hostnames = ["localhost:55690", "localhost:55700"]
+        }
+    }
+    protocol {
+        otlp {
+            client {}
+        }
+    }
+}
+```

--- a/go.sum
+++ b/go.sum
@@ -1756,8 +1756,6 @@ github.com/grafana/phlare/api v0.1.2 h1:1jrwd3KnsXMzj/tJih9likx5EvbY3pbvLbDqAAYe
 github.com/grafana/phlare/api v0.1.2/go.mod h1:29vcLwFDmZBDce2jwFIMtzvof7fzPadT8VMKw9ks7FU=
 github.com/grafana/phlare/ebpf v0.1.0 h1:u4E9BpXoqjvw1WCyM0TeZHbHWochwwJ/rPFzot/QZmU=
 github.com/grafana/phlare/ebpf v0.1.0/go.mod h1:5RGW1YCur7bhRlhATPc25drRYbzpekhh+f2HCmmfE3g=
-github.com/grafana/phlare/ebpf v0.1.1-0.20230706055724-a2b0f4125a12 h1:q9/IDyFx2aPJL3yZDkwe41+Got9YykwclhE/tID6bGI=
-github.com/grafana/phlare/ebpf v0.1.1-0.20230706055724-a2b0f4125a12/go.mod h1:5RGW1YCur7bhRlhATPc25drRYbzpekhh+f2HCmmfE3g=
 github.com/grafana/postgres_exporter v0.8.1-0.20210722175051-db35d7c2f520 h1:HnFWqxhoSF3WC7sKAdMZ+SRXvHLVZlZ3sbQjuUlTqkw=
 github.com/grafana/postgres_exporter v0.8.1-0.20210722175051-db35d7c2f520/go.mod h1:+HPXgiOV0InDHcZ2jNijL1SOKvo0eEPege5fQA0+ICI=
 github.com/grafana/prometheus v1.8.2-0.20230511165250-22c61d1811b2 h1:1h8KeWFbA2ytUcHok2SIUi+hQubaUEwq2yS2GEh5V6I=


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR is mostly done, with the exception of the items listed in the "notes to the Reviewer" section. 

For now the main thing I'd appreciate feedback on is the `endpoint` attribute in the client block. Could we make it mandatory for all components except this, without copying the whole struct? And would you prefer copying the struct to making it an optional argument, as is done in this PR?

Having it as an optional argument is more in line with the Collector, but I fear that it goes too much agains the Agent way of doing things. It's a "three steps back and one step forward" type situation :)

#### Which issue(s) this PR fixes

#4068

#### Notes to the Reviewer

There are a few controversial things that I'm not sure about:

* The `endpoint` attribute in the gRPC client block used to be mandatory and I changed it to optional. I couldn't think of a clean way to have it be optional just for that component. If you can think of one, please let me know because it'd make more sense to have a mandatory `endpoint` for the other components.
* According to the official Collector [docs](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/loadbalancingexporter), this exporter also works for logs? See the table at the top of the Collector's docs. I didn't mention this in our docs. I'll double check if this is the case.
* This component also uses [metrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/loadbalancingexporter#metrics). However, I didn't list them in the Agent docs because I'm not sure if they work. I'll try running the collector locally to make sure we can see them.

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
