### PR TITLE
helm: allow custom resources for config reloader container

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -10,6 +10,10 @@ internal API changes are not present.
 Unreleased
 ----------
 
+### Enhancements
+
+- Allow requests to be set on the config reloader container. (@tpaschalis)
+
 0.15.0 (2023-06-08)
 -------------------
 

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -63,6 +63,7 @@ use the older mode (called "static mode"), set the `agent.mode` value to
 | configReloader.enabled | bool | `true` | Enables automatically reloading when the agent config changes. |
 | configReloader.image.repository | string | `"jimmidyson/configmap-reload"` | Repository to get config reloader image from. |
 | configReloader.image.tag | string | `"v0.8.0"` | Tag of image to use for config reloading. |
+| configReloader.resources | object | `{}` | Resource requests and limits to apply to the config reloader container. |
 | controller.affinity | object | `{}` | Affinity configuration for pods. |
 | controller.autoscaling.enabled | bool | `false` | Creates a HorizontalPodAutoscaler for controller type deployment. |
 | controller.autoscaling.maxReplicas | int | `5` | The upper limit for the number of replicas to which the autoscaler can scale up. |

--- a/operations/helm/charts/grafana-agent/templates/containers/_watch.yaml
+++ b/operations/helm/charts/grafana-agent/templates/containers/_watch.yaml
@@ -13,5 +13,9 @@
   volumeMounts:
     - name: config
       mountPath: /etc/agent
+  {{- with .Values.configReloader.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end -}}

--- a/operations/helm/charts/grafana-agent/values.yaml
+++ b/operations/helm/charts/grafana-agent/values.yaml
@@ -103,6 +103,8 @@ configReloader:
     tag: v0.8.0
   # -- Override the args passed to the container.
   customArgs: []
+  # -- Resource requests and limits to apply to the config reloader container.
+  resources: {}
 
 controller:
   # -- Type of controller to use for deploying Grafana Agent in the cluster.


### PR DESCRIPTION
#### PR Description
Making use of the HPA requires both containers to have resource requests set up to calculate a replica count from memory resource utilization.

This PR allows setting the config reloader 

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer

#### PR Checklist

- [X] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
