### PR TITLE
Part I: converting promtail configs to flow mode

### DIFF
--- a/converter/diag/diagnostics.go
+++ b/converter/diag/diagnostics.go
@@ -28,6 +28,11 @@ func (ds *Diagnostics) AddWithDetail(severity Severity, message string, detail s
 	})
 }
 
+// AddAll adds all given diagnostics to the diagnostics list.
+func (ds *Diagnostics) AddAll(diags Diagnostics) {
+	*ds = append(*ds, diags...)
+}
+
 // Error implements error.
 func (ds Diagnostics) Error() string {
 	var sb strings.Builder

--- a/converter/internal/common/common.go
+++ b/converter/internal/common/common.go
@@ -18,8 +18,14 @@ import (
 // NewBlockWithOverride generates a new [*builder.Block] using a hook to
 // override specific types.
 func NewBlockWithOverride(name []string, label string, args component.Arguments) *builder.Block {
+	return NewBlockWithOverrideFn(name, label, args, getValueOverrideHook())
+}
+
+// NewBlockWithOverrideFn generates a new [*builder.Block] using a hook fn to
+// override specific types.
+func NewBlockWithOverrideFn(name []string, label string, args component.Arguments, fn builder.ValueOverrideHook) *builder.Block {
 	block := builder.NewBlock(name, label)
-	block.Body().SetValueOverrideHook(getValueOverrideHook())
+	block.Body().SetValueOverrideHook(fn)
 	block.Body().AppendFrom(args)
 	return block
 }

--- a/converter/internal/common/convert_appendable.go
+++ b/converter/internal/common/convert_appendable.go
@@ -19,7 +19,7 @@ type ConvertAppendable struct {
 
 var _ storage.Appendable = (*ConvertAppendable)(nil)
 var _ builder.Tokenizer = ConvertAppendable{}
-var _ river.Capsule = ConvertTargets{}
+var _ river.Capsule = ConvertAppendable{}
 
 func (f ConvertAppendable) RiverCapsule() {}
 func (f ConvertAppendable) RiverTokenize() []builder.Token {

--- a/converter/internal/common/convert_logs_receiver.go
+++ b/converter/internal/common/convert_logs_receiver.go
@@ -1,0 +1,28 @@
+package common
+
+import (
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/grafana/agent/pkg/river/token"
+	"github.com/grafana/agent/pkg/river/token/builder"
+)
+
+// ConvertLogsReceiver allows us to override how the loki.LogsReceiver is tokenized.
+// See ConvertAppendable as another example with more details in comments.
+type ConvertLogsReceiver struct {
+	loki.LogsReceiver
+
+	Expr string
+}
+
+var _ loki.LogsReceiver = (*ConvertLogsReceiver)(nil)
+var _ builder.Tokenizer = ConvertLogsReceiver{}
+var _ river.Capsule = ConvertLogsReceiver{}
+
+func (f ConvertLogsReceiver) RiverCapsule() {}
+func (f ConvertLogsReceiver) RiverTokenize() []builder.Token {
+	return []builder.Token{{
+		Tok: token.STRING,
+		Lit: f.Expr,
+	}}
+}

--- a/converter/internal/common/custom_tokenizer.go
+++ b/converter/internal/common/custom_tokenizer.go
@@ -1,0 +1,19 @@
+package common
+
+import (
+	"github.com/grafana/agent/pkg/river/token"
+	"github.com/grafana/agent/pkg/river/token/builder"
+)
+
+type CustomTokenizer struct {
+	Expr string
+}
+
+var _ builder.Tokenizer = CustomTokenizer{}
+
+func (f CustomTokenizer) RiverTokenize() []builder.Token {
+	return []builder.Token{{
+		Tok: token.STRING,
+		Lit: f.Expr,
+	}}
+}

--- a/converter/internal/prometheusconvert/azure.go
+++ b/converter/internal/prometheusconvert/azure.go
@@ -41,7 +41,7 @@ func toDiscoveryAzure(sdConfig *prom_azure.SDConfig) *azure.Arguments {
 }
 
 func validateDiscoveryAzure(sdConfig *prom_azure.SDConfig) diag.Diagnostics {
-	return validateHttpClientConfig(&sdConfig.HTTPClientConfig)
+	return ValidateHttpClientConfig(&sdConfig.HTTPClientConfig)
 }
 
 func toManagedIdentity(sdConfig *prom_azure.SDConfig) *azure.ManagedIdentity {

--- a/converter/internal/prometheusconvert/common.go
+++ b/converter/internal/prometheusconvert/common.go
@@ -8,7 +8,7 @@ import (
 	prom_config "github.com/prometheus/common/config"
 )
 
-func toHttpClientConfig(httpClientConfig *prom_config.HTTPClientConfig) *config.HTTPClientConfig {
+func ToHttpClientConfig(httpClientConfig *prom_config.HTTPClientConfig) *config.HTTPClientConfig {
 	if httpClientConfig == nil {
 		return nil
 	}
@@ -26,9 +26,9 @@ func toHttpClientConfig(httpClientConfig *prom_config.HTTPClientConfig) *config.
 	}
 }
 
-// validateHttpClientConfig returns [diag.Diagnostics] for currently
+// ValidateHttpClientConfig returns [diag.Diagnostics] for currently
 // unsupported Flow features available in Prometheus.
-func validateHttpClientConfig(httpClientConfig *prom_config.HTTPClientConfig) diag.Diagnostics {
+func ValidateHttpClientConfig(httpClientConfig *prom_config.HTTPClientConfig) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	if httpClientConfig.NoProxy != "" {

--- a/converter/internal/prometheusconvert/consul.go
+++ b/converter/internal/prometheusconvert/consul.go
@@ -20,7 +20,7 @@ func appendDiscoveryConsul(pb *prometheusBlocks, label string, sdConfig *prom_co
 }
 
 func validateDiscoveryConsul(sdConfig *prom_consul.SDConfig) diag.Diagnostics {
-	return validateHttpClientConfig(&sdConfig.HTTPClientConfig)
+	return ValidateHttpClientConfig(&sdConfig.HTTPClientConfig)
 }
 
 func toDiscoveryConsul(sdConfig *prom_consul.SDConfig) *consul.Arguments {
@@ -43,6 +43,6 @@ func toDiscoveryConsul(sdConfig *prom_consul.SDConfig) *consul.Arguments {
 		ServiceTags:      sdConfig.ServiceTags,
 		NodeMeta:         sdConfig.NodeMeta,
 		RefreshInterval:  time.Duration(sdConfig.RefreshInterval),
-		HTTPClientConfig: *toHttpClientConfig(&sdConfig.HTTPClientConfig),
+		HTTPClientConfig: *ToHttpClientConfig(&sdConfig.HTTPClientConfig),
 	}
 }

--- a/converter/internal/prometheusconvert/digitalocean.go
+++ b/converter/internal/prometheusconvert/digitalocean.go
@@ -41,7 +41,7 @@ func validateDiscoveryDigitalOcean(sdConfig *prom_digitalocean.SDConfig) diag.Di
 		diags.Add(diag.SeverityLevelError, "unsupported oauth2 for digitalocean_sd_configs")
 	}
 
-	newDiags := validateHttpClientConfig(&sdConfig.HTTPClientConfig)
+	newDiags := ValidateHttpClientConfig(&sdConfig.HTTPClientConfig)
 
 	diags = append(diags, newDiags...)
 	return diags

--- a/converter/internal/prometheusconvert/docker.go
+++ b/converter/internal/prometheusconvert/docker.go
@@ -19,7 +19,7 @@ func appendDiscoveryDocker(pb *prometheusBlocks, label string, sdConfig *prom_do
 }
 
 func validateDiscoveryDocker(sdConfig *prom_docker.DockerSDConfig) diag.Diagnostics {
-	return validateHttpClientConfig(&sdConfig.HTTPClientConfig)
+	return ValidateHttpClientConfig(&sdConfig.HTTPClientConfig)
 }
 
 func toDiscoveryDocker(sdConfig *prom_docker.DockerSDConfig) *docker.Arguments {
@@ -33,7 +33,7 @@ func toDiscoveryDocker(sdConfig *prom_docker.DockerSDConfig) *docker.Arguments {
 		HostNetworkingHost: sdConfig.HostNetworkingHost,
 		RefreshInterval:    time.Duration(sdConfig.RefreshInterval),
 		Filters:            toDockerFilters(sdConfig.Filters),
-		HTTPClientConfig:   *toHttpClientConfig(&sdConfig.HTTPClientConfig),
+		HTTPClientConfig:   *ToHttpClientConfig(&sdConfig.HTTPClientConfig),
 	}
 }
 

--- a/converter/internal/prometheusconvert/kubernetes.go
+++ b/converter/internal/prometheusconvert/kubernetes.go
@@ -10,7 +10,7 @@ import (
 )
 
 func appendDiscoveryKubernetes(pb *prometheusBlocks, label string, sdConfig *prom_kubernetes.SDConfig) discovery.Exports {
-	discoveryKubernetesArgs := toDiscoveryKubernetes(sdConfig)
+	discoveryKubernetesArgs := ToDiscoveryKubernetes(sdConfig)
 	name := []string{"discovery", "kubernetes"}
 	block := common.NewBlockWithOverride(name, label, discoveryKubernetesArgs)
 	pb.discoveryBlocks = append(pb.discoveryBlocks, newPrometheusBlock(block, name, label, "", ""))
@@ -18,10 +18,10 @@ func appendDiscoveryKubernetes(pb *prometheusBlocks, label string, sdConfig *pro
 }
 
 func validateDiscoveryKubernetes(sdConfig *prom_kubernetes.SDConfig) diag.Diagnostics {
-	return validateHttpClientConfig(&sdConfig.HTTPClientConfig)
+	return ValidateHttpClientConfig(&sdConfig.HTTPClientConfig)
 }
 
-func toDiscoveryKubernetes(sdConfig *prom_kubernetes.SDConfig) *kubernetes.Arguments {
+func ToDiscoveryKubernetes(sdConfig *prom_kubernetes.SDConfig) *kubernetes.Arguments {
 	if sdConfig == nil {
 		return nil
 	}
@@ -30,7 +30,7 @@ func toDiscoveryKubernetes(sdConfig *prom_kubernetes.SDConfig) *kubernetes.Argum
 		APIServer:          config.URL(sdConfig.APIServer),
 		Role:               string(sdConfig.Role),
 		KubeConfig:         sdConfig.KubeConfig,
-		HTTPClientConfig:   *toHttpClientConfig(&sdConfig.HTTPClientConfig),
+		HTTPClientConfig:   *ToHttpClientConfig(&sdConfig.HTTPClientConfig),
 		NamespaceDiscovery: toNamespaceDiscovery(&sdConfig.NamespaceDiscovery),
 		Selectors:          toSelectorConfig(sdConfig.Selectors),
 		AttachMetadata:     toAttachMetadata(&sdConfig.AttachMetadata),

--- a/converter/internal/prometheusconvert/relabel.go
+++ b/converter/internal/prometheusconvert/relabel.go
@@ -34,7 +34,7 @@ func toRelabelArguments(relabelConfigs []*prom_relabel.Config, forwardTo []stora
 
 	return &relabel.Arguments{
 		ForwardTo:            forwardTo,
-		MetricRelabelConfigs: toRelabelConfigs(relabelConfigs),
+		MetricRelabelConfigs: ToFlowRelabelConfigs(relabelConfigs),
 	}
 }
 
@@ -56,11 +56,11 @@ func appendDiscoveryRelabel(pb *prometheusBlocks, relabelConfigs []*prom_relabel
 func toDiscoveryRelabelArguments(relabelConfigs []*prom_relabel.Config, targets []discovery.Target) *disc_relabel.Arguments {
 	return &disc_relabel.Arguments{
 		Targets:        targets,
-		RelabelConfigs: toRelabelConfigs(relabelConfigs),
+		RelabelConfigs: ToFlowRelabelConfigs(relabelConfigs),
 	}
 }
 
-func toRelabelConfigs(relabelConfigs []*prom_relabel.Config) []*flow_relabel.Config {
+func ToFlowRelabelConfigs(relabelConfigs []*prom_relabel.Config) []*flow_relabel.Config {
 	if len(relabelConfigs) == 0 {
 		return nil
 	}

--- a/converter/internal/prometheusconvert/remote_write.go
+++ b/converter/internal/prometheusconvert/remote_write.go
@@ -44,7 +44,7 @@ func validateRemoteWriteConfig(remoteWriteConfig *prom_config.RemoteWriteConfig)
 		diags.Add(diag.SeverityLevelError, "unsupported remote_write sigv4 config was provided")
 	}
 
-	newDiags := validateHttpClientConfig(&remoteWriteConfig.HTTPClientConfig)
+	newDiags := ValidateHttpClientConfig(&remoteWriteConfig.HTTPClientConfig)
 	diags = append(diags, newDiags...)
 
 	return diags
@@ -74,10 +74,10 @@ func getEndpointOptions(remoteWriteConfigs []*prom_config.RemoteWriteConfig) []*
 			Headers:              remoteWriteConfig.Headers,
 			SendExemplars:        remoteWriteConfig.SendExemplars,
 			SendNativeHistograms: remoteWriteConfig.SendNativeHistograms,
-			HTTPClientConfig:     toHttpClientConfig(&remoteWriteConfig.HTTPClientConfig),
+			HTTPClientConfig:     ToHttpClientConfig(&remoteWriteConfig.HTTPClientConfig),
 			QueueOptions:         toQueueOptions(&remoteWriteConfig.QueueConfig),
 			MetadataOptions:      toMetadataOptions(&remoteWriteConfig.MetadataConfig),
-			WriteRelabelConfigs:  toRelabelConfigs(remoteWriteConfig.WriteRelabelConfigs),
+			WriteRelabelConfigs:  ToFlowRelabelConfigs(remoteWriteConfig.WriteRelabelConfigs),
 		}
 
 		endpoints = append(endpoints, endpoint)

--- a/converter/internal/prometheusconvert/scrape.go
+++ b/converter/internal/prometheusconvert/scrape.go
@@ -24,7 +24,7 @@ func appendPrometheusScrape(pb *prometheusBlocks, scrapeConfig *prom_config.Scra
 }
 
 func validatePrometheusScrape(scrapeConfig *prom_config.ScrapeConfig) diag.Diagnostics {
-	return validateHttpClientConfig(&scrapeConfig.HTTPClientConfig)
+	return ValidateHttpClientConfig(&scrapeConfig.HTTPClientConfig)
 }
 
 func toScrapeArguments(scrapeConfig *prom_config.ScrapeConfig, forwardTo []storage.Appendable, targets []discovery.Target) *scrape.Arguments {
@@ -49,7 +49,7 @@ func toScrapeArguments(scrapeConfig *prom_config.ScrapeConfig, forwardTo []stora
 		LabelLimit:            scrapeConfig.LabelLimit,
 		LabelNameLengthLimit:  scrapeConfig.LabelNameLengthLimit,
 		LabelValueLengthLimit: scrapeConfig.LabelValueLengthLimit,
-		HTTPClientConfig:      *toHttpClientConfig(&scrapeConfig.HTTPClientConfig),
+		HTTPClientConfig:      *ToHttpClientConfig(&scrapeConfig.HTTPClientConfig),
 		ExtraMetrics:          false,
 		Clustering:            scrape.Clustering{Enabled: false},
 	}

--- a/converter/internal/promtailconvert/internal/build/cloudflare.go
+++ b/converter/internal/promtailconvert/internal/build/cloudflare.go
@@ -1,0 +1,42 @@
+package build
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/agent/component/loki/source/cloudflare"
+	"github.com/grafana/agent/converter/internal/common"
+	"github.com/grafana/agent/pkg/river/rivertypes"
+)
+
+func (s *ScrapeConfigBuilder) AppendCloudFlareConfig() {
+	if s.cfg.CloudflareConfig == nil {
+		return
+	}
+
+	args := cloudflare.Arguments{
+		APIToken:   rivertypes.Secret(s.cfg.CloudflareConfig.APIToken),
+		ZoneID:     s.cfg.CloudflareConfig.ZoneID,
+		Labels:     convertPromLabels(s.cfg.CloudflareConfig.Labels),
+		Workers:    s.cfg.CloudflareConfig.Workers,
+		PullRange:  time.Duration(s.cfg.CloudflareConfig.PullRange),
+		FieldsType: s.cfg.CloudflareConfig.FieldsType,
+	}
+	override := func(val interface{}) interface{} {
+		switch conv := val.(type) {
+		case []loki.LogsReceiver:
+			return common.CustomTokenizer{Expr: fmt.Sprintf("[%s]", s.getOrNewLokiRelabel())}
+		case rivertypes.Secret:
+			return string(conv)
+		default:
+			return val
+		}
+	}
+	s.f.Body().AppendBlock(common.NewBlockWithOverrideFn(
+		[]string{"loki", "source", "cloudfare"},
+		s.cfg.JobName,
+		args,
+		override,
+	))
+}

--- a/converter/internal/promtailconvert/internal/build/global_context.go
+++ b/converter/internal/promtailconvert/internal/build/global_context.go
@@ -1,0 +1,12 @@
+package build
+
+import (
+	"time"
+
+	"github.com/grafana/agent/component/common/loki"
+)
+
+type GlobalContext struct {
+	WriteReceivers   []loki.LogsReceiver
+	TargetSyncPeriod time.Duration
+}

--- a/converter/internal/promtailconvert/internal/build/journal.go
+++ b/converter/internal/promtailconvert/internal/build/journal.go
@@ -1,0 +1,47 @@
+package build
+
+import (
+	"fmt"
+	"time"
+
+	flowrelabel "github.com/grafana/agent/component/common/relabel"
+	"github.com/grafana/agent/component/loki/source/journal"
+	"github.com/grafana/agent/converter/diag"
+	"github.com/grafana/agent/converter/internal/common"
+)
+
+func (s *ScrapeConfigBuilder) AppendJournalConfig() {
+	jc := s.cfg.JournalConfig
+	if jc == nil {
+		return
+	}
+	maxAge, err := time.ParseDuration(jc.MaxAge)
+	if err != nil {
+		s.diags.Add(
+			diag.SeverityLevelError,
+			fmt.Sprintf("failed to parse max_age duration for journal config: %s, will use default", err),
+		)
+		maxAge = time.Hour * 7 // use default value
+	}
+	args := journal.Arguments{
+		FormatAsJson: jc.JSON,
+		MaxAge:       maxAge,
+		Path:         jc.Path,
+		Receivers:    s.getOrNewProcessStageReceivers(),
+		Labels:       convertPromLabels(jc.Labels),
+		RelabelRules: flowrelabel.Rules{},
+	}
+	relabelRulesExpr := s.getOrNewDiscoveryRelabelRules()
+	hook := func(val interface{}) interface{} {
+		if _, ok := val.(flowrelabel.Rules); ok {
+			return common.CustomTokenizer{Expr: relabelRulesExpr}
+		}
+		return val
+	}
+	s.f.Body().AppendBlock(common.NewBlockWithOverrideFn(
+		[]string{"loki", "source", "journal"},
+		s.cfg.JobName,
+		args,
+		hook,
+	))
+}

--- a/converter/internal/promtailconvert/internal/build/kubernetes_sd.go
+++ b/converter/internal/promtailconvert/internal/build/kubernetes_sd.go
@@ -1,0 +1,26 @@
+package build
+
+import (
+	"fmt"
+
+	"github.com/grafana/agent/converter/internal/common"
+	"github.com/grafana/agent/converter/internal/prometheusconvert"
+)
+
+func (s *ScrapeConfigBuilder) AppendKubernetesSDs() {
+	if len(s.cfg.ServiceDiscoveryConfig.KubernetesSDConfigs) == 0 {
+		return
+	}
+
+	for i, sd := range s.cfg.ServiceDiscoveryConfig.KubernetesSDConfigs {
+		s.diags.AddAll(prometheusconvert.ValidateHttpClientConfig(&sd.HTTPClientConfig))
+		args := prometheusconvert.ToDiscoveryKubernetes(sd)
+		compName := fmt.Sprintf("%s_%d", s.cfg.JobName, i)
+		s.f.Body().AppendBlock(common.NewBlockWithOverride(
+			[]string{"discovery", "kubernetes"},
+			compName,
+			args,
+		))
+		s.allTargetsExps = append(s.allTargetsExps, "discovery.kubernetes."+compName+".targets")
+	}
+}

--- a/converter/internal/promtailconvert/internal/build/scrape_builder.go
+++ b/converter/internal/promtailconvert/internal/build/scrape_builder.go
@@ -1,0 +1,219 @@
+package build
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/component/discovery/relabel"
+	filematch "github.com/grafana/agent/component/local/file_match"
+	"github.com/grafana/agent/component/loki/process"
+	"github.com/grafana/agent/component/loki/process/stages"
+	lokirelabel "github.com/grafana/agent/component/loki/relabel"
+	lokisourcefile "github.com/grafana/agent/component/loki/source/file"
+	"github.com/grafana/agent/converter/diag"
+	"github.com/grafana/agent/converter/internal/common"
+	"github.com/grafana/agent/converter/internal/prometheusconvert"
+	"github.com/grafana/agent/pkg/river/token/builder"
+	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
+	"github.com/prometheus/common/model"
+)
+
+type ScrapeConfigBuilder struct {
+	f         *builder.File
+	diags     *diag.Diagnostics
+	cfg       *scrapeconfig.Config
+	globalCtx *GlobalContext
+
+	allTargetsExps             []string
+	processStageReceivers      []loki.LogsReceiver
+	allRelabeledTargetsExpr    string
+	allExpandedFileTargetsExpr string
+	discoveryRelabelRulesExpr  string
+	lokiRelabelReceiverExpr    string
+}
+
+func NewScrapeConfigBuilder(
+	f *builder.File,
+	diags *diag.Diagnostics,
+	cfg *scrapeconfig.Config,
+	globalCtx *GlobalContext,
+
+) *ScrapeConfigBuilder {
+
+	return &ScrapeConfigBuilder{
+		f:         f,
+		diags:     diags,
+		cfg:       cfg,
+		globalCtx: globalCtx,
+	}
+}
+
+func (s *ScrapeConfigBuilder) AppendLokiSourceFile() {
+	// If there were no targets expressions collected, that means
+	// we didn't have any components that produced SD targets, so
+	// we can skip this component.
+	if len(s.allTargetsExps) == 0 {
+		return
+	}
+	targets := s.getExpandedFileTargetsExpr()
+	forwardTo := s.getOrNewProcessStageReceivers()
+
+	args := lokisourcefile.Arguments{
+		ForwardTo: forwardTo,
+	}
+	overrideHook := func(val interface{}) interface{} {
+		if _, ok := val.([]discovery.Target); ok {
+			return common.CustomTokenizer{Expr: targets}
+		}
+		return val
+	}
+
+	s.f.Body().AppendBlock(common.NewBlockWithOverrideFn(
+		[]string{"loki", "source", "file"},
+		s.cfg.JobName,
+		args,
+		overrideHook,
+	))
+}
+
+func (s *ScrapeConfigBuilder) getOrNewLokiRelabel() string {
+	if len(s.cfg.RelabelConfigs) == 0 {
+		// If no relabels - we can send straight to the process stage.
+		return logsReceiversToExpr(s.getOrNewProcessStageReceivers())
+	}
+
+	if s.lokiRelabelReceiverExpr == "" {
+		args := lokirelabel.Arguments{
+			ForwardTo:      s.getOrNewProcessStageReceivers(),
+			RelabelConfigs: prometheusconvert.ToFlowRelabelConfigs(s.cfg.RelabelConfigs),
+		}
+		s.f.Body().AppendBlock(common.NewBlockWithOverride([]string{"loki", "relabel"}, s.cfg.JobName, args))
+		s.lokiRelabelReceiverExpr = "loki.relabel." + s.cfg.JobName + ".receiver"
+	}
+	return s.lokiRelabelReceiverExpr
+}
+
+func (s *ScrapeConfigBuilder) getOrNewProcessStageReceivers() []loki.LogsReceiver {
+	if s.processStageReceivers != nil {
+		return s.processStageReceivers
+	}
+	if len(s.cfg.PipelineStages) == 0 {
+		s.processStageReceivers = s.globalCtx.WriteReceivers
+		return s.processStageReceivers
+	}
+
+	flowStages := make([]stages.StageConfig, len(s.cfg.PipelineStages))
+	for i, ps := range s.cfg.PipelineStages {
+		if fs, ok := convertStage(ps, s.diags); ok {
+			flowStages[i] = fs
+		}
+	}
+	args := process.Arguments{
+		ForwardTo: s.globalCtx.WriteReceivers,
+		Stages:    flowStages,
+	}
+	s.f.Body().AppendBlock(common.NewBlockWithOverride([]string{"loki", "process"}, s.cfg.JobName, args))
+	s.processStageReceivers = []loki.LogsReceiver{common.ConvertLogsReceiver{
+		Expr: fmt.Sprintf("loki.process.%s.receiver", s.cfg.JobName),
+	}}
+	return s.processStageReceivers
+}
+
+func (s *ScrapeConfigBuilder) appendDiscoveryRelabel() {
+	if s.allRelabeledTargetsExpr != "" {
+		return
+	}
+	if len(s.cfg.RelabelConfigs) == 0 {
+		// Skip the discovery.relabel component if there are no relabels needed
+		s.allRelabeledTargetsExpr, s.discoveryRelabelRulesExpr = s.getAllTargetsJoinedExpr(), "null"
+		return
+	}
+
+	relabelConfigs := prometheusconvert.ToFlowRelabelConfigs(s.cfg.RelabelConfigs)
+	args := relabel.Arguments{
+		RelabelConfigs: relabelConfigs,
+	}
+
+	overrideHook := func(val interface{}) interface{} {
+		if _, ok := val.([]discovery.Target); ok {
+			return common.CustomTokenizer{Expr: s.getAllTargetsJoinedExpr()}
+		}
+		return val
+	}
+
+	s.f.Body().AppendBlock(common.NewBlockWithOverrideFn(
+		[]string{"discovery", "relabel"},
+		s.cfg.JobName,
+		args,
+		overrideHook,
+	))
+	compName := fmt.Sprintf("discovery.relabel.%s", s.cfg.JobName)
+	s.allRelabeledTargetsExpr, s.discoveryRelabelRulesExpr = compName+".output", compName+".rules"
+}
+
+func (s *ScrapeConfigBuilder) getAllRelabeledTargetsExpr() string {
+	s.appendDiscoveryRelabel()
+	return s.allRelabeledTargetsExpr
+}
+
+func (s *ScrapeConfigBuilder) getOrNewDiscoveryRelabelRules() string {
+	s.appendDiscoveryRelabel()
+	return s.discoveryRelabelRulesExpr
+}
+
+func (s *ScrapeConfigBuilder) getExpandedFileTargetsExpr() string {
+	if s.allExpandedFileTargetsExpr != "" {
+		return s.allExpandedFileTargetsExpr
+	}
+	args := filematch.Arguments{
+		SyncPeriod: s.globalCtx.TargetSyncPeriod,
+	}
+	overrideHook := func(val interface{}) interface{} {
+		if _, ok := val.([]discovery.Target); ok {
+			return common.CustomTokenizer{Expr: s.getAllRelabeledTargetsExpr()}
+		}
+		return val
+	}
+
+	s.f.Body().AppendBlock(common.NewBlockWithOverrideFn(
+		[]string{"discovery", "file"},
+		s.cfg.JobName,
+		args,
+		overrideHook,
+	))
+	s.allExpandedFileTargetsExpr = "discovery.file." + s.cfg.JobName + ".targets"
+	return s.allExpandedFileTargetsExpr
+}
+
+func (s *ScrapeConfigBuilder) getAllTargetsJoinedExpr() string {
+	targetsExpr := "[]"
+	if len(s.allTargetsExps) == 1 {
+		targetsExpr = s.allTargetsExps[0]
+	} else if len(s.allTargetsExps) > 1 {
+		formatted := make([]string, len(s.allTargetsExps))
+		for i, t := range s.allTargetsExps {
+			formatted[i] = fmt.Sprintf("\t\t%s,", t)
+		}
+		targetsExpr = fmt.Sprintf("concat(\n%s\n\t)", strings.Join(formatted, "\n"))
+	}
+	return targetsExpr
+}
+
+func convertPromLabels(labels model.LabelSet) map[string]string {
+	result := make(map[string]string)
+	for k, v := range labels {
+		result[string(k)] = string(v)
+	}
+	return result
+}
+
+func logsReceiversToExpr(r []loki.LogsReceiver) string {
+	var exprs []string
+	for _, r := range r {
+		clr := r.(*common.ConvertLogsReceiver)
+		exprs = append(exprs, clr.Expr)
+	}
+	return "[" + strings.Join(exprs, ", ") + "]"
+}

--- a/converter/internal/promtailconvert/internal/build/stages.go
+++ b/converter/internal/promtailconvert/internal/build/stages.go
@@ -1,0 +1,61 @@
+package build
+
+import (
+	"fmt"
+
+	"github.com/grafana/agent/component/loki/process/stages"
+	"github.com/grafana/agent/converter/diag"
+	promtailstages "github.com/grafana/loki/clients/pkg/logentry/stages"
+	"github.com/mitchellh/mapstructure"
+)
+
+func convertStage(st interface{}, diags *diag.Diagnostics) (stages.StageConfig, bool) {
+	stage, ok := st.(promtailstages.PipelineStage)
+	if !ok {
+		diags.Add(diag.SeverityLevelCritical, fmt.Sprintf("invalid input YAML config, "+
+			"make sure each stage of your pipeline is a YAML object (must end with a `:`), check stage `- %s`", st))
+		return stages.StageConfig{}, false
+	}
+	if len(stage) != 1 {
+		diags.Add(
+			diag.SeverityLevelCritical,
+			fmt.Sprintf("each pipeline stage must contain exactly one key, got: %v", stage),
+		)
+		return stages.StageConfig{}, false
+	}
+
+	for iName, iCfg := range stage {
+		name, ok := iName.(string)
+		if !ok {
+			addInvalidStageError(diags, iCfg, fmt.Errorf("stage name must be a string, got %T", iName))
+		}
+		//TODO(thampiotr): add support for all the other stages
+		if name == promtailstages.StageTypeJSON {
+			return convertJSONStage(iCfg, diags)
+		}
+	}
+
+	diags.Add(diag.SeverityLevelError, fmt.Sprintf("unsupported pipeline stage: %v", st))
+	return stages.StageConfig{}, false
+}
+
+func convertJSONStage(iCfg interface{}, diags *diag.Diagnostics) (stages.StageConfig, bool) {
+	pCfg := &promtailstages.JSONConfig{}
+	if err := mapstructure.Decode(iCfg, pCfg); err != nil {
+		addInvalidStageError(diags, iCfg, err)
+		return stages.StageConfig{}, false
+	}
+	return stages.StageConfig{
+		JSONConfig: &stages.JSONConfig{
+			Expressions:   pCfg.Expressions,
+			Source:        pCfg.Source,
+			DropMalformed: pCfg.DropMalformed,
+		}}, true
+}
+
+func addInvalidStageError(diags *diag.Diagnostics, iCfg interface{}, err error) {
+	diags.Add(
+		diag.SeverityLevelError,
+		fmt.Sprintf("invalid pipeline stage config: %v - %v", iCfg, err),
+	)
+}

--- a/converter/internal/promtailconvert/promtailconvert.go
+++ b/converter/internal/promtailconvert/promtailconvert.go
@@ -1,0 +1,215 @@
+package promtailconvert
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+
+	"github.com/alecthomas/units"
+	"github.com/grafana/agent/component/common/loki"
+	lokiwrite "github.com/grafana/agent/component/loki/write"
+	"github.com/grafana/agent/converter/diag"
+	"github.com/grafana/agent/converter/internal/common"
+	"github.com/grafana/agent/converter/internal/prometheusconvert"
+	"github.com/grafana/agent/converter/internal/promtailconvert/internal/build"
+	"github.com/grafana/agent/pkg/river/token/builder"
+	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/loki/clients/pkg/promtail/client"
+	promtailcfg "github.com/grafana/loki/clients/pkg/promtail/config"
+	"github.com/grafana/loki/clients/pkg/promtail/limit"
+	"github.com/grafana/loki/clients/pkg/promtail/positions"
+	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
+	lokicfgutil "github.com/grafana/loki/pkg/util/cfg"
+	lokiflag "github.com/grafana/loki/pkg/util/flagext"
+	"gopkg.in/yaml.v2"
+)
+
+type Config struct {
+	promtailcfg.Config `yaml:",inline"`
+}
+
+// Clone takes advantage of pass-by-value semantics to return a distinct *Config.
+// This is primarily used to parse a different flag set without mutating the original *Config.
+func (c *Config) Clone() flagext.Registerer {
+	return func(c Config) *Config {
+		return &c
+	}(*c)
+}
+
+// Convert implements a Promtail config converter.
+func Convert(in []byte) ([]byte, diag.Diagnostics) {
+	var (
+		diags diag.Diagnostics
+		cfg   Config
+	)
+
+	// Set default values first.
+	flagSet := flag.NewFlagSet("", flag.PanicOnError)
+	err := lokicfgutil.Unmarshal(&cfg,
+		lokicfgutil.Defaults(flagSet),
+	)
+	if err != nil {
+		diags.Add(diag.SeverityLevelCritical, fmt.Sprintf("failed to set default Promtail config values: %s", err))
+		return nil, diags
+	}
+
+	// Unmarshall explicitly specified values
+	if err := yaml.UnmarshalStrict(in, &cfg); err != nil {
+		diags.Add(diag.SeverityLevelCritical, fmt.Sprintf("failed to parse Promtail config: %s", err))
+		return nil, diags
+	}
+
+	// Replicate promtails' handling of this deprecated field.
+	if cfg.ClientConfig.URL.URL != nil {
+		// if a single client config is used we add it to the multiple client config for backward compatibility
+		cfg.ClientConfigs = append(cfg.ClientConfigs, cfg.ClientConfig)
+	}
+
+	f := builder.NewFile()
+	diags = AppendAll(f, &cfg.Config, diags)
+
+	var buf bytes.Buffer
+	if _, err := f.WriteTo(&buf); err != nil {
+		diags.Add(diag.SeverityLevelCritical, fmt.Sprintf("failed to render Flow config: %s", err.Error()))
+		return nil, diags
+	}
+
+	if len(buf.Bytes()) == 0 {
+		return nil, diags
+	}
+
+	prettyByte, newDiags := common.PrettyPrint(buf.Bytes())
+	diags = append(diags, newDiags...)
+	return prettyByte, diags
+}
+
+// AppendAll analyzes the entire promtail config in memory and transforms it
+// into Flow components. It then appends each argument to the file builder.
+func AppendAll(f *builder.File, cfg *promtailcfg.Config, diags diag.Diagnostics) diag.Diagnostics {
+	validateTopLevelConfig(cfg, &diags)
+
+	var writeReceivers = make([]loki.LogsReceiver, len(cfg.ClientConfigs))
+	var writeBlocks = make([]*builder.Block, len(cfg.ClientConfigs))
+	// Each client config needs to be a separate remote_write,
+	// because they may have different ExternalLabels fields.
+	for i, cc := range cfg.ClientConfigs {
+		writeBlocks[i], writeReceivers[i] = newLokiWrite(&cc, &diags, i)
+	}
+
+	gc := &build.GlobalContext{
+		WriteReceivers:   writeReceivers,
+		TargetSyncPeriod: cfg.TargetConfig.SyncPeriod,
+	}
+
+	for _, sc := range cfg.ScrapeConfig {
+		appendScrapeConfig(f, &sc, &diags, gc)
+	}
+
+	for _, write := range writeBlocks {
+		f.Body().AppendBlock(write)
+	}
+
+	return diags
+}
+
+func defaultPositionsConfig() positions.Config {
+	// We obtain the default by registering the flags
+	cfg := positions.Config{}
+	cfg.RegisterFlags(flag.NewFlagSet("", flag.PanicOnError))
+	return cfg
+}
+
+func defaultLimitsConfig() limit.Config {
+	cfg := limit.Config{}
+	cfg.RegisterFlagsWithPrefix("", flag.NewFlagSet("", flag.PanicOnError))
+	return cfg
+}
+
+func appendScrapeConfig(
+	f *builder.File,
+	cfg *scrapeconfig.Config,
+	diags *diag.Diagnostics,
+	gctx *build.GlobalContext,
+) {
+
+	b := build.NewScrapeConfigBuilder(f, diags, cfg, gctx)
+
+	// Append all the SD components
+	b.AppendKubernetesSDs()
+	//TODO(thampiotr): add support for other SDs
+
+	// Append loki.source.file to process all SD components' targets.
+	// If any relabelling is required, it will be done via a discovery.relabel component.
+	// The files will be watched and the globs in file paths will be expanded using discovery.file component.
+	// The log entries are sent to loki.process if processing is needed, or directly to loki.write components.
+	b.AppendLokiSourceFile()
+
+	// Append all the components that produce logs directly.
+	// If any relabelling is required, it will be done via a loki.relabel component.
+	// The logs are sent to loki.process if processing is needed, or directly to loki.write components.
+	//TODO(thampiotr): add support for other integrations
+	b.AppendCloudFlareConfig()
+	b.AppendJournalConfig()
+}
+
+func newLokiWrite(client *client.Config, diags *diag.Diagnostics, index int) (*builder.Block, loki.LogsReceiver) {
+	label := fmt.Sprintf("default_%d", index)
+	lokiWriteArgs := toLokiWriteArguments(client, diags)
+	block := common.NewBlockWithOverride([]string{"loki", "write"}, label, lokiWriteArgs)
+	return block, common.ConvertLogsReceiver{
+		Expr: fmt.Sprintf("loki.write.%s.receiver", label),
+	}
+}
+
+func toLokiWriteArguments(config *client.Config, diags *diag.Diagnostics) *lokiwrite.Arguments {
+	batchSize, err := units.ParseBase2Bytes(fmt.Sprintf("%dB", config.BatchSize))
+	if err != nil {
+		diags.Add(
+			diag.SeverityLevelError,
+			fmt.Sprintf("failed to parse BatchSize for client config %s: %s", config.Name, err.Error()),
+		)
+	}
+
+	// This is not supported yet - see https://github.com/grafana/agent/issues/4335.
+	if config.DropRateLimitedBatches {
+		diags.Add(
+			diag.SeverityLevelError,
+			"DropRateLimitedBatches is currently not supported in Grafana Agent Flow.",
+		)
+	}
+
+	// Also deprecated in promtail.
+	if len(config.StreamLagLabels) != 0 {
+		diags.Add(
+			diag.SeverityLevelWarn,
+			"stream_lag_labels is deprecated and the associated metric has been removed",
+		)
+	}
+
+	return &lokiwrite.Arguments{
+		Endpoints: []lokiwrite.EndpointOptions{
+			{
+				Name:              config.Name,
+				URL:               config.URL.String(),
+				BatchWait:         config.BatchWait,
+				BatchSize:         batchSize,
+				HTTPClientConfig:  prometheusconvert.ToHttpClientConfig(&config.Client),
+				Headers:           config.Headers,
+				MinBackoff:        config.BackoffConfig.MinBackoff,
+				MaxBackoff:        config.BackoffConfig.MaxBackoff,
+				MaxBackoffRetries: config.BackoffConfig.MaxRetries,
+				RemoteTimeout:     config.Timeout,
+				TenantID:          config.TenantID,
+			},
+		},
+		ExternalLabels: convertFlagLabels(config.ExternalLabels),
+	}
+}
+
+func convertFlagLabels(labels lokiflag.LabelSet) map[string]string {
+	result := map[string]string{}
+	for k, v := range labels.LabelSet {
+		result[string(k)] = string(v)
+	}
+	return result
+}

--- a/converter/internal/promtailconvert/testdata/bad_config.errors
+++ b/converter/internal/promtailconvert/testdata/bad_config.errors
@@ -1,0 +1,1 @@
+(Critical) failed to parse Promtail config: yaml: unmarshal errors:\n  line 11: field not_a_thing not found in type promtailconvert.Config

--- a/converter/internal/promtailconvert/testdata/bad_config.yaml
+++ b/converter/internal/promtailconvert/testdata/bad_config.yaml
@@ -1,0 +1,15 @@
+clients:
+  - external_labels:
+      cluster: backyard-pine-treehouse-1
+    url: http://localhost/loki/api/v1/push
+scrape_configs:
+  - job_name: kubernetes-pods
+    kubernetes_sd_configs:
+      - role: pod
+    pipeline_stages:
+      - cri: {}
+not_a_thing: true
+server:
+  profiling_enabled: true
+tracing:
+  enabled: false

--- a/converter/internal/promtailconvert/testdata/cloudflare_relabel.river
+++ b/converter/internal/promtailconvert/testdata/cloudflare_relabel.river
@@ -1,0 +1,31 @@
+loki.relabel "fun" {
+	forward_to = [loki.write.default_0.receiver]
+
+	rule {
+		source_labels = ["__trail__"]
+		target_label  = "__path__"
+	}
+	max_cache_size = 0
+}
+
+loki.source.cloudfare "fun" {
+	api_token = "dont_look_at_me_please"
+	zone_id   = "area51"
+	labels    = {
+		identity    = "unidentified",
+		object_type = "flying",
+	}
+	workers     = 42
+	pull_range  = "1h0m0s"
+	fields_type = "all"
+	forward_to  = [loki.relabel.fun.receiver]
+}
+
+loki.write "default_0" {
+	endpoint {
+		url              = "http://localhost/loki/api/v1/push"
+		follow_redirects = false
+		enable_http2     = false
+	}
+	external_labels = {}
+}

--- a/converter/internal/promtailconvert/testdata/cloudflare_relabel.yaml
+++ b/converter/internal/promtailconvert/testdata/cloudflare_relabel.yaml
@@ -1,0 +1,18 @@
+clients:
+  - url: http://localhost/loki/api/v1/push
+scrape_configs:
+  - job_name: fun
+    cloudflare:
+      api_token: dont_look_at_me_please
+      zone_id: area51
+      labels:
+        identity: unidentified
+        object_type: flying
+      workers: 42
+      pull_range: 1h
+      fields_type: all
+    relabel_configs:
+      - source_labels:
+          - __trail__
+        target_label: __path__
+tracing: {enabled: false}

--- a/converter/internal/promtailconvert/testdata/journal.river
+++ b/converter/internal/promtailconvert/testdata/journal.river
@@ -1,0 +1,19 @@
+loki.source.journal "fun" {
+	format_as_json = true
+	max_age        = "20h0m0s"
+	relabel_rules  = null
+	forward_to     = [loki.write.default_0.receiver]
+	labels         = {
+		region  = "chablis",
+		variety = "chardonnay",
+	}
+}
+
+loki.write "default_0" {
+	endpoint {
+		url              = "http://localhost/loki/api/v1/push"
+		follow_redirects = false
+		enable_http2     = false
+	}
+	external_labels = {}
+}

--- a/converter/internal/promtailconvert/testdata/journal.yaml
+++ b/converter/internal/promtailconvert/testdata/journal.yaml
@@ -1,0 +1,11 @@
+clients:
+  - url: http://localhost/loki/api/v1/push
+scrape_configs:
+  - job_name: fun
+    journal:
+      json: true
+      max_age: 20h
+      labels:
+        variety: chardonnay
+        region: chablis
+tracing: {enabled: false}

--- a/converter/internal/promtailconvert/testdata/journal_relabel.river
+++ b/converter/internal/promtailconvert/testdata/journal_relabel.river
@@ -1,0 +1,28 @@
+discovery.relabel "fun" {
+	targets = []
+
+	rule {
+		source_labels = ["__trail__"]
+		target_label  = "__path__"
+	}
+}
+
+loki.source.journal "fun" {
+	format_as_json = true
+	max_age        = "20h0m0s"
+	relabel_rules  = discovery.relabel.fun.rules
+	forward_to     = [loki.write.default_0.receiver]
+	labels         = {
+		region  = "chablis",
+		variety = "chardonnay",
+	}
+}
+
+loki.write "default_0" {
+	endpoint {
+		url              = "http://localhost/loki/api/v1/push"
+		follow_redirects = false
+		enable_http2     = false
+	}
+	external_labels = {}
+}

--- a/converter/internal/promtailconvert/testdata/journal_relabel.yaml
+++ b/converter/internal/promtailconvert/testdata/journal_relabel.yaml
@@ -1,0 +1,15 @@
+clients:
+  - url: http://localhost/loki/api/v1/push
+scrape_configs:
+  - job_name: fun
+    journal:
+      json: true
+      max_age: 20h
+      labels:
+        variety: chardonnay
+        region: chablis
+    relabel_configs:
+      - source_labels:
+          - __trail__
+        target_label: __path__
+tracing: {enabled: false}

--- a/converter/internal/promtailconvert/testdata/kubernetes.errors
+++ b/converter/internal/promtailconvert/testdata/kubernetes.errors
@@ -1,0 +1,1 @@
+(Error) unsupported HTTP Client config proxy_from_environment was provided

--- a/converter/internal/promtailconvert/testdata/kubernetes.river
+++ b/converter/internal/promtailconvert/testdata/kubernetes.river
@@ -1,0 +1,76 @@
+discovery.kubernetes "fun_0" {
+	api_server = "http://toby.pets.com/"
+	role       = "pod"
+
+	basic_auth {
+		username      = "robin"
+		password_file = "/home/robin/.password"
+	}
+	proxy_url = "http://proxy.example.com"
+
+	tls_config {
+		ca_file              = "/home/robin/.ca"
+		cert_file            = "/home/robin/.cert"
+		key_file             = "/home/robin/.key"
+		server_name          = "example.local"
+		insecure_skip_verify = true
+	}
+}
+
+discovery.kubernetes "fun_1" {
+	role            = "pod"
+	kubeconfig_file = "/home/toby/.kube/config"
+}
+
+discovery.kubernetes "fun_2" {
+	api_server = "http://toby.pets.com/"
+	role       = "pod"
+
+	authorization {
+		type             = "Bearer"
+		credentials_file = "/home/robin/.special_token"
+	}
+}
+
+discovery.kubernetes "fun_3" {
+	api_server = "http://toby.pets.com/"
+	role       = "pod"
+
+	authorization {
+		type             = "Bearer"
+		credentials_file = "/home/toby/.token"
+	}
+}
+
+discovery.kubernetes "fun_4" {
+	api_server = "http://toby.pets.com/"
+	role       = "node"
+
+	oauth2 {
+		client_id          = "client_id"
+		client_secret_file = "foo/bar"
+		scopes             = ["scope1", "scope2"]
+		token_url          = "https://example/oauth2/token"
+		endpoint_params    = {
+			host = "example",
+			path = "/oauth2/token",
+		}
+
+		tls_config { }
+	}
+}
+
+discovery.file "fun" {
+	path_targets = concat(
+		discovery.kubernetes.fun_0.targets,
+		discovery.kubernetes.fun_1.targets,
+		discovery.kubernetes.fun_2.targets,
+		discovery.kubernetes.fun_3.targets,
+		discovery.kubernetes.fun_4.targets,
+	)
+}
+
+loki.source.file "fun" {
+	targets    = discovery.file.fun.targets
+	forward_to = []
+}

--- a/converter/internal/promtailconvert/testdata/kubernetes.yaml
+++ b/converter/internal/promtailconvert/testdata/kubernetes.yaml
@@ -1,0 +1,44 @@
+scrape_configs:
+  - job_name: fun
+    kubernetes_sd_configs:
+      - api_server: http://toby.pets.com/
+        role: pod
+        basic_auth:
+          username: robin
+          password_file: /home/robin/.password
+        proxy_url: http://proxy.example.com
+        tls_config:
+          ca_file: /home/robin/.ca
+          cert_file: /home/robin/.cert
+          key_file: /home/robin/.key
+          server_name: example.local
+          insecure_skip_verify: true
+
+      - role: pod
+        kubeconfig_file: /home/toby/.kube/config
+
+      - api_server: http://toby.pets.com/
+        role: pod
+        bearer_token_file: /home/robin/.special_token
+
+      - api_server: http://toby.pets.com/
+        role: pod
+        authorization:
+          type: Bearer
+          credentials_file: /home/toby/.token
+
+      - api_server: http://toby.pets.com/
+        role: node
+        oauth2:
+          client_id: client_id
+          client_secret_file: foo/bar
+          scopes:
+            - scope1
+            - scope2
+          token_url: https://example/oauth2/token
+          endpoint_params:
+            host: example
+            path: /oauth2/token
+        proxy_from_environment: true
+
+tracing: {enabled: false}

--- a/converter/internal/promtailconvert/testdata/remote_write.river
+++ b/converter/internal/promtailconvert/testdata/remote_write.river
@@ -1,0 +1,53 @@
+loki.write "default_0" {
+	endpoint {
+		url            = "http://localhost/loki/api/v1/push"
+		batch_wait     = "10s"
+		batch_size     = "1KiB"
+		remote_timeout = "30s"
+		headers        = {
+			bird = "house",
+			fat  = "ball",
+		}
+		min_backoff_period  = "100ms"
+		max_backoff_period  = "10s"
+		max_backoff_retries = 20
+		tenant_id           = "sparrow"
+
+		basic_auth {
+			username      = "robin"
+			password      = "Worms123"
+			password_file = "/home/robin/.password"
+		}
+
+		oauth2 {
+			client_id          = "client_id"
+			client_secret      = "client_secret"
+			client_secret_file = "foo/bar"
+			scopes             = ["scope1", "scope2"]
+			token_url          = "https://example/oauth2/token"
+			endpoint_params    = {
+				host = "example",
+				path = "/oauth2/token",
+			}
+
+			tls_config { }
+		}
+		bearer_token      = "MySecretsAreSafeHere"
+		bearer_token_file = "/home/robin/.special_token"
+		proxy_url         = "http://proxy.example.com"
+
+		tls_config {
+			ca_file              = "/home/robin/.ca"
+			cert_file            = "/home/robin/.cert"
+			key_file             = "/home/robin/.key"
+			server_name          = "example.local"
+			insecure_skip_verify = true
+		}
+		follow_redirects = false
+		enable_http2     = false
+	}
+	external_labels = {
+		cluster = "backyard-pine-treehouse-1",
+		host    = "strawberry-pi",
+	}
+}

--- a/converter/internal/promtailconvert/testdata/remote_write.yaml
+++ b/converter/internal/promtailconvert/testdata/remote_write.yaml
@@ -1,0 +1,44 @@
+clients:
+  - url: http://localhost/loki/api/v1/push
+    headers:
+      fat: ball
+      bird: house
+    tenant_id: sparrow
+    batchwait: 10s
+    batchsize: 1024
+    basic_auth:
+      username: robin
+      password: Worms123
+      password_file: /home/robin/.password
+    oauth2:
+      client_id: client_id
+      client_secret: client_secret
+      client_secret_file: foo/bar
+      scopes:
+        - scope1
+        - scope2
+      token_url: https://example/oauth2/token
+      endpoint_params:
+        host: example
+        path: /oauth2/token
+    bearer_token: "MySecretsAreSafeHere"
+    bearer_token_file: /home/robin/.special_token
+    proxy_url: http://proxy.example.com
+    tls_config:
+      ca_file: /home/robin/.ca
+      cert_file: /home/robin/.cert
+      key_file: /home/robin/.key
+      server_name: example.local
+      insecure_skip_verify: true
+    backoff_config:
+      min_period: 100ms
+      max_period: 10s
+      max_retries: 20
+    external_labels:
+      cluster: backyard-pine-treehouse-1
+      host: strawberry-pi
+    timeout: 30s
+tracing:
+  enabled: false
+server:
+  disable: true

--- a/converter/internal/promtailconvert/testdata/sd_pipeline_example.river
+++ b/converter/internal/promtailconvert/testdata/sd_pipeline_example.river
@@ -1,0 +1,52 @@
+discovery.kubernetes "fun_0" {
+	role            = "pod"
+	kubeconfig_file = "/home/toby/.kube/config"
+}
+
+discovery.kubernetes "fun_1" {
+	role            = "node"
+	kubeconfig_file = "/home/toby/.kube/config"
+}
+
+discovery.relabel "fun" {
+	targets = concat(
+		discovery.kubernetes.fun_0.targets,
+		discovery.kubernetes.fun_1.targets,
+	)
+
+	rule {
+		source_labels = ["__trail__"]
+		target_label  = "__path__"
+	}
+}
+
+discovery.file "fun" {
+	path_targets = discovery.relabel.fun.output
+}
+
+loki.process "fun" {
+	forward_to = [loki.write.default_0.receiver]
+
+	stage.json {
+		expressions = {
+			face = "smiley",
+			hand = "thumbs-up",
+		}
+		source         = "video"
+		drop_malformed = true
+	}
+}
+
+loki.source.file "fun" {
+	targets    = discovery.file.fun.targets
+	forward_to = [loki.process.fun.receiver]
+}
+
+loki.write "default_0" {
+	endpoint {
+		url              = "http://localhost/loki/api/v1/push"
+		follow_redirects = false
+		enable_http2     = false
+	}
+	external_labels = {}
+}

--- a/converter/internal/promtailconvert/testdata/sd_pipeline_example.yaml
+++ b/converter/internal/promtailconvert/testdata/sd_pipeline_example.yaml
@@ -1,0 +1,22 @@
+clients:
+  - url: http://localhost/loki/api/v1/push
+scrape_configs:
+  - job_name: fun
+    pipeline_stages:
+      - json:
+          expressions:
+            face: smiley
+            hand: thumbs-up
+          source: video
+          drop_malformed: true
+    relabel_configs:
+      - source_labels:
+          - __trail__
+        target_label: __path__
+    kubernetes_sd_configs:
+      - role: pod
+        kubeconfig_file: /home/toby/.kube/config
+      - role: node
+        kubeconfig_file: /home/toby/.kube/config
+
+tracing: {enabled: false}

--- a/converter/internal/promtailconvert/testdata/source_pipeline_example.river
+++ b/converter/internal/promtailconvert/testdata/source_pipeline_example.river
@@ -1,0 +1,41 @@
+loki.process "fun" {
+	forward_to = [loki.write.default_0.receiver]
+
+	stage.json {
+		expressions = {
+			face = "smiley",
+			hand = "thumbs-up",
+		}
+		source         = "video"
+		drop_malformed = true
+	}
+}
+
+discovery.relabel "fun" {
+	targets = []
+
+	rule {
+		source_labels = ["__trail__"]
+		target_label  = "__path__"
+	}
+}
+
+loki.source.journal "fun" {
+	format_as_json = true
+	max_age        = "20h0m0s"
+	relabel_rules  = discovery.relabel.fun.rules
+	forward_to     = [loki.process.fun.receiver]
+	labels         = {
+		region  = "chablis",
+		variety = "chardonnay",
+	}
+}
+
+loki.write "default_0" {
+	endpoint {
+		url              = "http://localhost/loki/api/v1/push"
+		follow_redirects = false
+		enable_http2     = false
+	}
+	external_labels = {}
+}

--- a/converter/internal/promtailconvert/testdata/source_pipeline_example.yaml
+++ b/converter/internal/promtailconvert/testdata/source_pipeline_example.yaml
@@ -1,0 +1,22 @@
+clients:
+  - url: http://localhost/loki/api/v1/push
+scrape_configs:
+  - job_name: fun
+    pipeline_stages:
+      - json:
+          expressions:
+            face: smiley
+            hand: thumbs-up
+          source: video
+          drop_malformed: true
+    relabel_configs:
+      - source_labels:
+          - __trail__
+        target_label: __path__
+    journal:
+      json: true
+      max_age: 20h
+      labels:
+        variety: chardonnay
+        region: chablis
+tracing: {enabled: false}

--- a/converter/internal/promtailconvert/testdata/unsupported.errors
+++ b/converter/internal/promtailconvert/testdata/unsupported.errors
@@ -1,0 +1,9 @@
+(Error) global/file_watch_config is not supported
+(Error) global positions configuration is not supported - each Flow Mode's loki.source.file component has its own positions file in the component's data directory
+(Warning) stream_lag_labels is deprecated and the associated metric has been removed
+(Error) Promtail's WAL is currently not supported in Flow Mode
+(Error) limits_config is not yet supported in Flow Mode
+(Error) tracing configuration cannot be migrated to Flow Mode automatically - please refer to documentation on how to configure tracing in Flow Mode
+(Error) reading targets from stdin is not supported in Flow Mode configuration file
+(Error) DropRateLimitedBatches is currently not supported in Grafana Agent Flow.
+(Warning) stream_lag_labels is deprecated and the associated metric has been removed

--- a/converter/internal/promtailconvert/testdata/unsupported.yaml
+++ b/converter/internal/promtailconvert/testdata/unsupported.yaml
@@ -1,0 +1,22 @@
+global:
+  file_watch_config:
+    min_poll_frequency: 1s
+    max_poll_frequency: 5s
+clients:
+  - url: http://localhost/loki/api/v1/push
+    drop_rate_limited_batches: true
+    stream_lag_labels: hare,tortoise
+positions:
+  filename: /dev/urandom
+options:
+  stream_lag_labels: hare,tortoise
+wal:
+  enabled: true
+limits_config:
+  readline_rate_enabled: true
+target_config:
+  stdin: true
+server:
+  profiling_enabled: true
+  register_instrumentation: true
+  log_level: error

--- a/converter/internal/promtailconvert/validate.go
+++ b/converter/internal/promtailconvert/validate.go
@@ -1,0 +1,71 @@
+package promtailconvert
+
+import (
+	"github.com/grafana/agent/converter/diag"
+	promtailcfg "github.com/grafana/loki/clients/pkg/promtail/config"
+	"github.com/grafana/loki/clients/pkg/promtail/targets/file"
+)
+
+// validateTopLevelConfig validates the top-level config for any unsupported features. There may still be some
+// other unsupported features in scope of each config block, which are raised by their respective conversion code.
+func validateTopLevelConfig(cfg *promtailcfg.Config, diags *diag.Diagnostics) {
+	// We currently do not support the new global file watch config. It's an error, since setting it indicates
+	// some advanced tuning which the user likely needs.
+	if cfg.Global.FileWatch != file.DefaultWatchConig {
+		diags.Add(diag.SeverityLevelError, "global/file_watch_config is not supported")
+	}
+
+	// The positions global config is not supported in Flow Mode.
+	if cfg.PositionsConfig != defaultPositionsConfig() {
+		diags.Add(
+			diag.SeverityLevelError,
+			"global positions configuration is not supported - each Flow Mode's loki.source.file component "+
+				"has its own positions file in the component's data directory",
+		)
+	}
+
+	// The global and per-client stream lag labels is deprecated and has no effect.
+	if len(cfg.Options.StreamLagLabels) > 0 {
+		diags.Add(
+			diag.SeverityLevelWarn,
+			"stream_lag_labels is deprecated and the associated metric has been removed",
+		)
+	}
+
+	// WAL support is still work in progress and not documented. Enabling it won't work, so it's an error.
+	if cfg.WAL.Enabled {
+		diags.Add(
+			diag.SeverityLevelError,
+			"Promtail's WAL is currently not supported in Flow Mode",
+		)
+	}
+
+	// Not yet supported, see https://github.com/grafana/agent/issues/4342. It's an error since we want to
+	// err on the safe side.
+	//TODO(thampiotr): seems like it's possible to support this using loki.process component
+	if cfg.LimitsConfig != defaultLimitsConfig() {
+		diags.Add(
+			diag.SeverityLevelError,
+			"limits_config is not yet supported in Flow Mode",
+		)
+	}
+
+	// We cannot migrate the tracing config to Flow Mode, since in promtail it relies on
+	// environment variables that can be set or not and depending on what is set, different
+	// features of tracing are configured. We'd need to have conditionals in the
+	// flow config to translate this. See https://www.jaegertracing.io/docs/1.16/client-features/
+	if cfg.Tracing.Enabled {
+		diags.Add(
+			diag.SeverityLevelError,
+			"tracing configuration cannot be migrated to Flow Mode automatically - please "+
+				"refer to documentation on how to configure tracing in Flow Mode",
+		)
+	}
+
+	if cfg.TargetConfig.Stdin {
+		diags.Add(
+			diag.SeverityLevelError,
+			"reading targets from stdin is not supported in Flow Mode configuration file",
+		)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -622,6 +622,7 @@ require (
 )
 
 require (
+	github.com/drone/envsubst v1.0.3 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
 	github.com/prometheus-community/prom-label-proxy v0.5.0 // indirect
 	github.com/sony/gobreaker v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1126,6 +1126,8 @@ github.com/docker/libnetwork v0.8.0-dev.2.0.20181012153825-d7b61745d166/go.mod h
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+github.com/drone/envsubst v1.0.3 h1:PCIBwNDYjs50AsLZPYdfhSATKaRg/FJmDc2D6+C2x8g=
+github.com/drone/envsubst v1.0.3/go.mod h1:N2jZmlMufstn1KEqvbHjw40h1KyTmnVzHcSc9bFiJ2g=
 github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46 h1:7QPwrLT79GlD5sizHf27aoY2RTvw62mO6x7mxkScNk0=
 github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46/go.mod h1:esf2rsHFNlZlxsqsZDojNBcnNs5REqIvRrWRHqX0vEU=
 github.com/duosecurity/duo_api_golang v0.0.0-20190308151101-6c680f768e74/go.mod h1:UqXY1lYT/ERa4OEAywUqdok1T4RCRdArkhic1Opuavo=


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This sets up foundations for the promtail configuration conversion to flow mode configuration.

There is some work remaining, but to limit the size of the PR, I am implementing only some features. Specifically, what is remaining is: 
* More SD components
* More log source components
* More pipeline stages support for loki.process

#### Notes to the Reviewer
There are two main kinds of pipelines that this supports:
- Logs source based - see `source_pipeline_example.river` test - for example: `loki.source.journal -> loki.process -> loki.write` with relabel rules directly passed to `loki.source.journal`.
  - Some components will not support taking relabel rules directly, such as `loki.source.cloudflare`, so there is an extra `loki.relabel` added. See `cloudflare_relabel.river` test.
- SD-based - see `sd_pipeline_example.river` test - for example: `discovery.kubernetes -> discovery.relabel -> discovery.file -> loki.source.file -> loki.process -> loki.write`.

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [x] Tests updated
