### PR TITLE
helm: make resources required for autoscaling

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -18,6 +18,11 @@ Unreleased
 
 - Don't specify replica count for StatefulSets when autoscaling is enabled (@captncraig)
 
+### Other changes
+
+- Make the agent and config-reloader container resources required when using
+  autoscaling. (@tpaschalis)
+
 0.15.0 (2023-06-08)
 -------------------
 

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -191,6 +191,11 @@ Kubernetes version `>=1.23-0` and your cluster has the
 `StatefulSetAutoDeletePVC` feature gate enabled, you can set
 `enableStatefulSetAutoDeletePVC` to true to automatically delete stale PVCs.
 
+Using `controller.autoscaling` requires the target metric (cpu/memory) to have
+its resource requests set up for both the agent and config-reloader containers
+so that the HPA can use them to calculate the replica count from the actual
+resource utilization.
+
 ## Collecting logs from other containers
 
 There are two ways to collect logs from other containers within the cluster

--- a/operations/helm/charts/grafana-agent/README.md.gotmpl
+++ b/operations/helm/charts/grafana-agent/README.md.gotmpl
@@ -120,6 +120,11 @@ Kubernetes version `>=1.23-0` and your cluster has the
 `StatefulSetAutoDeletePVC` feature gate enabled, you can set
 `enableStatefulSetAutoDeletePVC` to true to automatically delete stale PVCs.
 
+Using `controller.autoscaling` requires the target metric (cpu/memory) to have
+its resource requests set up for both the agent and config-reloader containers
+so that the HPA can use them to calculate the replica count from the actual
+resource utilization.
+
 ## Collecting logs from other containers
 
 There are two ways to collect logs from other containers within the cluster

--- a/operations/helm/charts/grafana-agent/ci/create-deployment-autoscaling-values.yaml
+++ b/operations/helm/charts/grafana-agent/ci/create-deployment-autoscaling-values.yaml
@@ -5,5 +5,5 @@ controller:
     enabled: true
 agent:
   resources:
-    requests: 
+    requests:
       memory: 100Mi

--- a/operations/helm/charts/grafana-agent/ci/create-deployment-autoscaling-values.yaml
+++ b/operations/helm/charts/grafana-agent/ci/create-deployment-autoscaling-values.yaml
@@ -3,3 +3,7 @@ controller:
   type: deployment
   autoscaling:
     enabled: true
+agent:
+  resources:
+    requests: 
+      memory: 100Mi

--- a/operations/helm/charts/grafana-agent/ci/create-statefulset-autoscaling-values.yaml
+++ b/operations/helm/charts/grafana-agent/ci/create-statefulset-autoscaling-values.yaml
@@ -3,3 +3,7 @@ controller:
   type: statefulset
   autoscaling:
     enabled: true
+agent:
+  resources:
+    requests:
+      memory: 100Mi

--- a/operations/helm/charts/grafana-agent/templates/hpa.yaml
+++ b/operations/helm/charts/grafana-agent/templates/hpa.yaml
@@ -1,4 +1,6 @@
 {{- if and (or (eq .Values.controller.type "deployment") (eq .Values.controller.type "statefulset" ))  .Values.controller.autoscaling.enabled }}
+{{- $name := .Values.agent.resources.requests | required ".Values.agent.resources.requests is required when using autoscaling." -}}
+{{- $name := .Values.configReloader.resources.requests | required ".Values.configReloader.resources.requests is required when using autoscaling." -}}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/operations/helm/charts/grafana-agent/templates/hpa.yaml
+++ b/operations/helm/charts/grafana-agent/templates/hpa.yaml
@@ -1,6 +1,16 @@
 {{- if and (or (eq .Values.controller.type "deployment") (eq .Values.controller.type "statefulset" ))  .Values.controller.autoscaling.enabled }}
-{{- $name := .Values.agent.resources.requests | required ".Values.agent.resources.requests is required when using autoscaling." -}}
-{{- $name := .Values.configReloader.resources.requests | required ".Values.configReloader.resources.requests is required when using autoscaling." -}}
+{{- if not (eq .targetMemoryUtilizationPercentage "0") }} 
+  {{- $name := .Values.agent.resources.requests | required ".Values.agent.resources.requests is required when using autoscaling." -}}
+  {{- $name := .Values.agent.resources.requests.memory | required ".Values.agent.resources.requests.memory is required when using autoscaling based on memory utilization." -}}
+  {{- $name := .Values.configReloader.resources.requests  | required ".Values.configReloader.resources.requests is required when using autoscaling." -}}
+  {{- $name := .Values.configReloader.resources.requests.memory  | required ".Values.configReloader.resources.requests.memory is required when using autoscaling based on memory utilization." -}}
+{{- end}}
+{{- if not (eq .targetCPUUtilizationPercentage "0") }} 
+  {{- $name := .Values.agent.resources.requests | required ".Values.agent.resources.requests is required when using autoscaling." -}}
+  {{- $name := .Values.agent.resources.requests.cpu | required ".Values.agent.resources.requests.cpu is required when using autoscaling based on cpu utilization." -}}
+  {{- $name := .Values.configReloader.resources.requests  | required ".Values.configReloader.resources.requests is required when using autoscaling." -}}
+  {{- $name := .Values.configReloader.resources.requests.cpu  | required ".Values.configReloader.resources.requests.cpu is required when using autoscaling based on cpu utilization." -}}
+{{- end}}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/operations/helm/charts/grafana-agent/templates/hpa.yaml
+++ b/operations/helm/charts/grafana-agent/templates/hpa.yaml
@@ -1,11 +1,11 @@
 {{- if and (or (eq .Values.controller.type "deployment") (eq .Values.controller.type "statefulset" ))  .Values.controller.autoscaling.enabled }}
-{{- if not (eq .targetMemoryUtilizationPercentage "0") }} 
+{{- if not (empty .targetMemoryUtilizationPercentage) }} 
   {{- $name := .Values.agent.resources.requests | required ".Values.agent.resources.requests is required when using autoscaling." -}}
   {{- $name := .Values.agent.resources.requests.memory | required ".Values.agent.resources.requests.memory is required when using autoscaling based on memory utilization." -}}
   {{- $name := .Values.configReloader.resources.requests  | required ".Values.configReloader.resources.requests is required when using autoscaling." -}}
   {{- $name := .Values.configReloader.resources.requests.memory  | required ".Values.configReloader.resources.requests.memory is required when using autoscaling based on memory utilization." -}}
 {{- end}}
-{{- if not (eq .targetCPUUtilizationPercentage "0") }} 
+{{- if not (empty .targetCPUUtilizationPercentage)}} 
   {{- $name := .Values.agent.resources.requests | required ".Values.agent.resources.requests is required when using autoscaling." -}}
   {{- $name := .Values.agent.resources.requests.cpu | required ".Values.agent.resources.requests.cpu is required when using autoscaling based on cpu utilization." -}}
   {{- $name := .Values.configReloader.resources.requests  | required ".Values.configReloader.resources.requests is required when using autoscaling." -}}

--- a/operations/helm/charts/grafana-agent/templates/hpa.yaml
+++ b/operations/helm/charts/grafana-agent/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and (or (eq .Values.controller.type "deployment") (eq .Values.controller.type "statefulset" ))  .Values.controller.autoscaling.enabled }}
-{{- if not (empty .targetMemoryUtilizationPercentage) }} 
+{{- if not (empty .targetMemoryUtilizationPercentage)}} 
   {{- $name := .Values.agent.resources.requests | required ".Values.agent.resources.requests is required when using autoscaling." -}}
   {{- $name := .Values.agent.resources.requests.memory | required ".Values.agent.resources.requests.memory is required when using autoscaling based on memory utilization." -}}
   {{- $name := .Values.configReloader.resources.requests  | required ".Values.configReloader.resources.requests is required when using autoscaling." -}}

--- a/operations/helm/charts/grafana-agent/templates/hpa.yaml
+++ b/operations/helm/charts/grafana-agent/templates/hpa.yaml
@@ -1,15 +1,15 @@
 {{- if and (or (eq .Values.controller.type "deployment") (eq .Values.controller.type "statefulset" ))  .Values.controller.autoscaling.enabled }}
-{{- if not (empty .targetMemoryUtilizationPercentage)}} 
-  {{- $name := .Values.agent.resources.requests | required ".Values.agent.resources.requests is required when using autoscaling." -}}
-  {{- $name := .Values.agent.resources.requests.memory | required ".Values.agent.resources.requests.memory is required when using autoscaling based on memory utilization." -}}
-  {{- $name := .Values.configReloader.resources.requests  | required ".Values.configReloader.resources.requests is required when using autoscaling." -}}
-  {{- $name := .Values.configReloader.resources.requests.memory  | required ".Values.configReloader.resources.requests.memory is required when using autoscaling based on memory utilization." -}}
+{{- if not (empty .Values.controller.autoscaling.targetMemoryUtilizationPercentage)}} 
+  {{- $_ := .Values.agent.resources.requests | required ".Values.agent.resources.requests is required when using autoscaling." -}}
+  {{- $_ := .Values.agent.resources.requests.memory | required ".Values.agent.resources.requests.memory is required when using autoscaling based on memory utilization." -}}
+  {{- $_ := .Values.configReloader.resources.requests  | required ".Values.configReloader.resources.requests is required when using autoscaling." -}}
+  {{- $_ := .Values.configReloader.resources.requests.memory  | required ".Values.configReloader.resources.requests.memory is required when using autoscaling based on memory utilization." -}}
 {{- end}}
-{{- if not (empty .targetCPUUtilizationPercentage)}} 
-  {{- $name := .Values.agent.resources.requests | required ".Values.agent.resources.requests is required when using autoscaling." -}}
-  {{- $name := .Values.agent.resources.requests.cpu | required ".Values.agent.resources.requests.cpu is required when using autoscaling based on cpu utilization." -}}
-  {{- $name := .Values.configReloader.resources.requests  | required ".Values.configReloader.resources.requests is required when using autoscaling." -}}
-  {{- $name := .Values.configReloader.resources.requests.cpu  | required ".Values.configReloader.resources.requests.cpu is required when using autoscaling based on cpu utilization." -}}
+{{- if not (empty .Values.controller.autoscaling.targetCPUUtilizationPercentage)}} 
+  {{- $_ := .Values.agent.resources.requests | required ".Values.agent.resources.requests is required when using autoscaling." -}}
+  {{- $_ := .Values.agent.resources.requests.cpu | required ".Values.agent.resources.requests.cpu is required when using autoscaling based on cpu utilization." -}}
+  {{- $_ := .Values.configReloader.resources.requests  | required ".Values.configReloader.resources.requests is required when using autoscaling." -}}
+  {{- $_ := .Values.configReloader.resources.requests.cpu  | required ".Values.configReloader.resources.requests.cpu is required when using autoscaling based on cpu utilization." -}}
 {{- end}}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/operations/helm/tests/create-deployment-autoscaling/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment-autoscaling/grafana-agent/templates/controllers/deployment.yaml
@@ -48,6 +48,9 @@ spec:
               port: 80
             initialDelaySeconds: 10
             timeoutSeconds: 1
+          resources:
+            requests:
+              memory: 100Mi
           volumeMounts:
             - name: config
               mountPath: /etc/agent

--- a/operations/helm/tests/create-statefulset-autoscaling/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset-autoscaling/grafana-agent/templates/controllers/statefulset.yaml
@@ -49,6 +49,9 @@ spec:
               port: 80
             initialDelaySeconds: 10
             timeoutSeconds: 1
+          resources:
+            requests:
+              memory: 100Mi
           volumeMounts:
             - name: config
               mountPath: /etc/agent


### PR DESCRIPTION
#### PR Description
This PR amends the Helm chart to fail when trying to use autoscaling without having the resources key set for both the agent and configReloader containers.

I'm on the fence whether the added complexity is worth it from a Helm-conventions perspective, let me know what you think. If these were not set, the HPA would be created, but will have no effect.

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer
* This will require amending if/when we allow the HPA to act on custom metrics instead of CPU/Memory utilization
* This started out with the generic verification that the `resources.request` field just exists; the last commit adds specific validations for when the user has chosen cpu/memory-utilization based autoscaling. Let me know if you think it's too much and I can revert back to the previous solution. 
* We have to check for both the resources and resources.X field, otherwise we're getting errors like `<.Values.agent.resources.requests.memory>: nil pointer evaluating interface {}.memory`
 
#### PR Checklist

- [X] CHANGELOG updated
- [X] Documentation added
- [X] Tests updated
