### PR TITLE
drone: only run Windows tests on merge

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -218,8 +218,8 @@ steps:
   image: grafana/agent-build-image:0.26.0-windows
   name: Run Go tests
 trigger:
-  event:
-  - pull_request
+  ref:
+  - refs/heads/main
 type: docker
 ---
 kind: pipeline
@@ -1330,6 +1330,6 @@ kind: secret
 name: gpg_public_key
 ---
 kind: signature
-hmac: 11a9c3f165ebc6d5296a2c48c079bf463b635a28d281916b0ceb47cc46ebe272
+hmac: 5b3ff58a3b1e14b0c099dc76ecf2f5535232faef6faf160c86007f9b2391332f
 
 ...

--- a/.drone/pipelines/test.jsonnet
+++ b/.drone/pipelines/test.jsonnet
@@ -93,7 +93,7 @@ local pipelines = import '../util/pipelines.jsonnet';
 
   pipelines.windows('Test (Windows)') {
     trigger: {
-      event: ['pull_request'],
+      ref: ['refs/heads/main'],
     },
     steps: [{
       name: 'Run Go tests',


### PR DESCRIPTION
The Windows tests historically have bad performance, causing the turnaround time for a PR to be anywhere up to 10-15 minutes, even though all other jobs finish in 3 minutes or less.

This commit takes Windows tests out of the PR testing path to reduce total turnaround time for a PR.

Windows tests will now be run on main commits, and maintainers will need to be on the lookout for test failures so they can follow up if a bad PR gets merged that breaks Windows.