### PR TITLE
converter: pretty-print the output

### DIFF
--- a/converter/converter.go
+++ b/converter/converter.go
@@ -3,10 +3,13 @@
 package converter
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/grafana/agent/converter/diag"
 	"github.com/grafana/agent/converter/internal/prometheusconvert"
+	"github.com/grafana/agent/pkg/river/parser"
+	"github.com/grafana/agent/pkg/river/printer"
 )
 
 // Input represents the type of config file being fed into the converter.
@@ -32,10 +35,35 @@ const (
 func Convert(in []byte, kind Input) ([]byte, diag.Diagnostics) {
 	switch kind {
 	case InputPrometheus:
-		return prometheusconvert.Convert(in)
+		return prettyPrint(prometheusconvert.Convert(in))
 	}
 
 	var diags diag.Diagnostics
 	diags.Add(diag.SeverityLevelError, fmt.Sprintf("unrecognized kind %q", kind))
 	return nil, diags
+}
+
+// prettyPrint attempts to pretty print the input slice. If prettyPrint fails,
+// the input slice is returned unmodified.
+func prettyPrint(in []byte, diags diag.Diagnostics) ([]byte, diag.Diagnostics) {
+	// Return early if there was no file.
+	if len(in) == 0 {
+		return in, diags
+	}
+
+	f, err := parser.ParseFile("", in)
+	if err != nil {
+		diags.Add(diag.SeverityLevelWarn, err.Error())
+		return in, diags
+	}
+
+	var buf bytes.Buffer
+	if err := printer.Fprint(&buf, f); err != nil {
+		diags.Add(diag.SeverityLevelWarn, err.Error())
+		return in, diags
+	}
+
+	// Add a trailing newline at the end of the file, which is omitted by Fprint.
+	_, _ = buf.Write([]byte{'\n'})
+	return buf.Bytes(), nil
 }


### PR DESCRIPTION
Normally builder.File already pretty-prints the file, but custom tokens aren't pretty-printed. This makes sure that the resulting file is in the standard format.