### PR TITLE
Fix relabel bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Main (unreleased)
 
 - Fix a bug where `prometheus.relabel` would not relabel correctly when there is a cache miss. (@thampiotr)
 
-- Fix a bug where `prometheus.relabel` would not relabel correctly the exemplars or metadata. (@tpaschalis)
+- Fix a bug where `prometheus.relabel` would not correctly relabel exemplars or metadata. (@tpaschalis)
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,9 @@ Main (unreleased)
 
 - Fix oauth default scope in `loki.source.azure_event_hubs`. (@akselleirv)
 
-- Fix a bug where `prometheus.relabel` would not relabel correctly when there is a cache miss. (@thampiotr) 
+- Fix a bug where `prometheus.relabel` would not relabel correctly when there is a cache miss. (@thampiotr)
+
+- Fix a bug where `prometheus.relabel` would not relabel correctly the exemplars or metadata. (@tpaschalis)
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Main (unreleased)
 
 - Fix oauth default scope in `loki.source.azure_event_hubs`. (@akselleirv)
 
+- Fix a bug where `prometheus.relabel` would not relabel correctly when there is a cache miss. (@thampiotr) 
+
 ### Other changes
 
 - Mongodb integration has been disabled for the time being due to licensing issues. (@jcreixell)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Main (unreleased)
 
 - Fix oauth default scope in `loki.source.azure_event_hubs`. (@akselleirv)
 
-- Fix a bug where `prometheus.relabel` would not relabel correctly when there is a cache miss. (@thampiotr)
+- Fix a bug where `prometheus.relabel` would not correctly relabel when there is a cache miss. (@thampiotr)
 
 - Fix a bug where `prometheus.relabel` would not correctly relabel exemplars or metadata. (@tpaschalis)
 

--- a/component/prometheus/relabel/relabel.go
+++ b/component/prometheus/relabel/relabel.go
@@ -59,6 +59,7 @@ type Component struct {
 	cacheHits        prometheus_client.Counter
 	cacheMisses      prometheus_client.Counter
 	cacheSize        prometheus_client.Gauge
+	cacheDeletes     prometheus_client.Counter
 	fanout           *prometheus.Fanout
 	exited           atomic.Bool
 
@@ -95,6 +96,10 @@ func New(o component.Options, args Arguments) (*Component, error) {
 	c.cacheSize = prometheus_client.NewGauge(prometheus_client.GaugeOpts{
 		Name: "agent_prometheus_relabel_cache_size",
 		Help: "Total size of relabel cache",
+	})
+	c.cacheDeletes = prometheus_client.NewCounter(prometheus_client.CounterOpts{
+		Name: "agent_prometheus_relabel_cache_deletes",
+		Help: "Total number of cache deletes",
 	})
 
 	var err error
@@ -225,7 +230,7 @@ func (c *Component) getFromCache(id uint64) (*labelAndID, bool) {
 func (c *Component) deleteFromCache(id uint64) {
 	c.cacheMut.Lock()
 	defer c.cacheMut.Unlock()
-
+	c.cacheDeletes.Inc()
 	delete(c.cache, id)
 }
 

--- a/component/prometheus/relabel/relabel.go
+++ b/component/prometheus/relabel/relabel.go
@@ -129,7 +129,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 			if newLbl == nil {
 				return 0, nil
 			}
-			return next.AppendExemplar(0, l, e)
+			return next.AppendExemplar(0, newLbl, e)
 		}),
 		prometheus.WithMetadataHook(func(_ storage.SeriesRef, l labels.Labels, m metadata.Metadata, next storage.Appender) (storage.SeriesRef, error) {
 			if c.exited.Load() {
@@ -140,7 +140,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 			if newLbl == nil {
 				return 0, nil
 			}
-			return next.UpdateMetadata(0, l, m)
+			return next.UpdateMetadata(0, newLbl, m)
 		}),
 	)
 

--- a/component/prometheus/relabel/relabel.go
+++ b/component/prometheus/relabel/relabel.go
@@ -103,7 +103,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 	})
 
 	var err error
-	for _, metric := range []prometheus_client.Collector{c.metricsProcessed, c.metricsOutgoing, c.cacheMisses, c.cacheHits, c.cacheSize} {
+	for _, metric := range []prometheus_client.Collector{c.metricsProcessed, c.metricsOutgoing, c.cacheMisses, c.cacheHits, c.cacheSize, c.cacheDeletes} {
 		err = o.Registerer.Register(metric)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

In [this change](https://github.com/grafana/agent/commit/edcc83858ad92f3b96c44fa77142db352dd431de#diff-5f10a07e4c853517c2aad2506e6686e92430e34aaa059f7338c7fcd89df2e0bfL198), the use of `:=` creates a new `relabelled` variable in scope only of the `else` block. This means that even though we call `addToCache`, we will return `nil` from `relabel` method.

It likely means that relabel is not done correctly when we have a first cache miss.

It's not clear if this can lead to issues with caching yet (e.g. memory leak), further testing is required.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
