### PR TITLE
prometheus.relabel: do a more resilient empty label check

### DIFF
--- a/component/prometheus/relabel/relabel.go
+++ b/component/prometheus/relabel/relabel.go
@@ -119,7 +119,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 			}
 
 			newLbl := c.relabel(v, l)
-			if newLbl == nil {
+			if newLbl.IsEmpty() {
 				return 0, nil
 			}
 			c.metricsOutgoing.Inc()
@@ -131,7 +131,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 			}
 
 			newLbl := c.relabel(0, l)
-			if newLbl == nil {
+			if newLbl.IsEmpty() {
 				return 0, nil
 			}
 			return next.AppendExemplar(0, newLbl, e)
@@ -142,7 +142,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 			}
 
 			newLbl := c.relabel(0, l)
-			if newLbl == nil {
+			if newLbl.IsEmpty() {
 				return 0, nil
 			}
 			return next.UpdateMetadata(0, newLbl, m)


### PR DESCRIPTION
Checking for a labelset to be nil is not always correct; an dropped metric from relabel will return a non-nil, but still empty labelset.
