### PR TITLE
Switch to using capped LRU cache instead of raw map.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Main (unreleased)
 
 - Update `node_exporter` dependency to v1.6.0. (@spartan0x117)
 
+- Replace map cache in prometheus.relabel with an LRU cache. (@mattdurham)
+
 ### Bugfixes
 
 - Add signing region to remote.s3 component for use with custom endpoints so that Authorization Headers work correctly when

--- a/component/prometheus/relabel/relabel_test.go
+++ b/component/prometheus/relabel/relabel_test.go
@@ -2,6 +2,7 @@ package relabel
 
 import (
 	"math"
+	"strconv"
 	"testing"
 	"time"
 
@@ -25,7 +26,7 @@ func TestCache(t *testing.T) {
 	relabeller := generateRelabel(t)
 	lbls := labels.FromStrings("__address__", "localhost")
 	relabeller.relabel(0, lbls)
-	require.Len(t, relabeller.cache, 1)
+	require.True(t, relabeller.cache.Len() == 1)
 	entry, found := relabeller.getFromCache(prometheus.GlobalRefMapping.GetOrAddGlobalRefID(lbls))
 	require.True(t, found)
 	require.NotNil(t, entry)
@@ -35,24 +36,15 @@ func TestCache(t *testing.T) {
 	)
 }
 
-func TestEviction(t *testing.T) {
-	relabeller := generateRelabel(t)
-	lbls := labels.FromStrings("__address__", "localhost")
-	relabeller.relabel(0, lbls)
-	require.Len(t, relabeller.cache, 1)
-	relabeller.relabel(math.Float64frombits(value.StaleNaN), lbls)
-	require.Len(t, relabeller.cache, 0)
-}
-
 func TestUpdateReset(t *testing.T) {
 	relabeller := generateRelabel(t)
 	lbls := labels.FromStrings("__address__", "localhost")
 	relabeller.relabel(0, lbls)
-	require.Len(t, relabeller.cache, 1)
+	require.True(t, relabeller.cache.Len() == 1)
 	_ = relabeller.Update(Arguments{
 		MetricRelabelConfigs: []*flow_relabel.Config{},
 	})
-	require.Len(t, relabeller.cache, 0)
+	require.True(t, relabeller.cache.Len() == 0)
 }
 
 func TestNil(t *testing.T) {
@@ -80,6 +72,25 @@ func TestNil(t *testing.T) {
 
 	lbls := labels.FromStrings("__address__", "localhost")
 	relabeller.relabel(0, lbls)
+}
+
+func TestLRU(t *testing.T) {
+	relabeller := generateRelabel(t)
+
+	for i := 0; i < 600_000; i++ {
+		lbls := labels.FromStrings("__address__", "localhost", "inc", strconv.Itoa(i))
+		relabeller.relabel(0, lbls)
+	}
+	require.True(t, relabeller.cache.Len() == 100_000)
+}
+
+func TestLRUNaN(t *testing.T) {
+	relabeller := generateRelabel(t)
+	lbls := labels.FromStrings("__address__", "localhost")
+	relabeller.relabel(0, lbls)
+	require.True(t, relabeller.cache.Len() == 1)
+	relabeller.relabel(math.Float64frombits(value.StaleNaN), lbls)
+	require.True(t, relabeller.cache.Len() == 0)
 }
 
 func BenchmarkCache(b *testing.B) {

--- a/go.mod
+++ b/go.mod
@@ -582,6 +582,7 @@ require (
 	github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c // indirect
 	github.com/apache/arrow/go/v12 v12.0.1 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.3 // indirect
 	github.com/klauspost/asmfmt v1.3.2 // indirect
 	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 // indirect
 	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1898,6 +1898,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.6.0 h1:uL2shRDx7RTrOrTCUZEGP/wJUFiUI8QT6E7z5o8jga4=
 github.com/hashicorp/golang-lru v0.6.0/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.3 h1:kmRrRLlInXvng0SmLxmQpQkpbYAvcXm7NPDrgxJa9mE=
+github.com/hashicorp/golang-lru/v2 v2.0.3/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v0.0.0-20180906183839-65a6292f0157/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=


### PR DESCRIPTION
#### PR Description

Instead of using an unbounded `map` for relabel caches instead use an LRU of 100_000 items. Currently its not configurable but likely to become so once we sort out good defaults and performance.

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

- [X] CHANGELOG updated
- [ ] Documentation added
- [X] Tests updated
