### PR TITLE
Update otelcol.exporter.otlp.md

### DIFF
--- a/docs/sources/flow/reference/components/otelcol.exporter.jaeger.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.jaeger.md
@@ -5,7 +5,7 @@ title: otelcol.exporter.jaeger
 # otelcol.exporter.jaeger
 
 `otelcol.exporter.jaeger` accepts telemetry data from other `otelcol` components
-and writes them over the network using the Jaeger protocol. 
+and writes them over the network using the Jaeger protocol.
 
 > **NOTE**: `otelcol.exporter.jaeger` is a wrapper over the upstream
 > OpenTelemetry Collector `jaeger` exporter. Bug reports or feature requests will
@@ -42,8 +42,8 @@ Hierarchy | Block | Description | Required
 client | [client][] | Configures the gRPC server to send telemetry data to. | yes
 client > tls | [tls][] | Configures TLS for the gRPC client. | no
 client > keepalive | [keepalive][] | Configures keepalive settings for the gRPC client. | no
-queue | [queue][] | Configures batching of data before sending. | no
-retry | [retry][] | Configures retry mechanism for failed requests. | no
+sending_queue | [sending_queue][] | Configures batching of data before sending. | no
+retry_on_failure | [retry_on_failure][] | Configures retry mechanism for failed requests. | no
 
 The `>` symbol indicates deeper levels of nesting. For example, `client > tls`
 refers to a `tls` block defined inside a `client` block.
@@ -51,8 +51,8 @@ refers to a `tls` block defined inside a `client` block.
 [client]: #client-block
 [tls]: #tls-block
 [keepalive]: #keepalive-block
-[queue]: #queue-block
-[retry]: #retry-block
+[sending_queue]: #sending_queue-block
+[retry_on_failure]: #retry_on_failure-block
 
 ### client block
 
@@ -120,16 +120,16 @@ Name | Type | Description | Default | Required
 `ping_response_timeout` | `duration` | Time to wait before closing inactive connections if the server does not respond to a ping. | | no
 `ping_without_stream` | `boolean` | Send pings even if there is no active stream request. | | no
 
-### queue block
+### sending_queue block
 
-The `queue` block configures an in-memory buffer of batches before data is sent
+The `sending_queue` block configures an in-memory buffer of batches before data is sent
 to the gRPC server.
 
 {{< docs/shared lookup="flow/reference/components/otelcol-queue-block.md" source="agent" >}}
 
-### retry block
+### retry_on_failure block
 
-The `retry` block configures how failed requests to the gRPC server are
+The `retry_on_failure` block configures how failed requests to the gRPC server are
 retried.
 
 {{< docs/shared lookup="flow/reference/components/otelcol-retry-block.md" source="agent" >}}

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
@@ -125,7 +125,7 @@ Name | Type | Description | Default | Required
 `ping_response_timeout` | `duration` | Time to wait before closing inactive connections if the server does not respond to a ping. | | no
 `ping_without_stream` | `boolean` | Send pings even if there is no active stream request. | | no
 
-### queue block
+### sending_queue block
 
 The `sending_queue` block configures an in-memory buffer of batches before data is sent
 to the gRPC server.

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
@@ -127,14 +127,14 @@ Name | Type | Description | Default | Required
 
 ### queue block
 
-The `queue` block configures an in-memory buffer of batches before data is sent
+The `sending_queue` block configures an in-memory buffer of batches before data is sent
 to the gRPC server.
 
 {{< docs/shared lookup="flow/reference/components/otelcol-queue-block.md" source="agent" >}}
 
 ### retry block
 
-The `retry` block configures how failed requests to the gRPC server are
+The `retry_on_failure` block configures how failed requests to the gRPC server are
 retried.
 
 {{< docs/shared lookup="flow/reference/components/otelcol-retry-block.md" source="agent" >}}

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
@@ -132,7 +132,7 @@ to the gRPC server.
 
 {{< docs/shared lookup="flow/reference/components/otelcol-queue-block.md" source="agent" >}}
 
-### retry block
+### retry_on_failure block
 
 The `retry_on_failure` block configures how failed requests to the gRPC server are
 retried.

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
@@ -42,8 +42,8 @@ Hierarchy | Block | Description | Required
 client | [client][] | Configures the gRPC server to send telemetry data to. | yes
 client > tls | [tls][] | Configures TLS for the gRPC client. | no
 client > keepalive | [keepalive][] | Configures keepalive settings for the gRPC client. | no
-queue | [queue][] | Configures batching of data before sending. | no
-retry | [retry][] | Configures retry mechanism for failed requests. | no
+sending_queue | [sending_queue][] | Configures batching of data before sending. | no
+retry_on_failure | [retry_on_failure][] | Configures retry mechanism for failed requests. | no
 
 The `>` symbol indicates deeper levels of nesting. For example, `client > tls`
 refers to a `tls` block defined inside a `client` block.
@@ -51,8 +51,8 @@ refers to a `tls` block defined inside a `client` block.
 [client]: #client-block
 [tls]: #tls-block
 [keepalive]: #keepalive-block
-[queue]: #queue-block
-[retry]: #retry-block
+[sending_queue]: #sending_queue-block
+[retry_on_failure]: #retry_on_failure-block
 
 ### client block
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlphttp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlphttp.md
@@ -47,16 +47,16 @@ Hierarchy | Block | Description | Required
 --------- | ----- | ----------- | --------
 client           | [client][] | Configures the HTTP server to send telemetry data to. | yes
 client > tls     | [tls][] | Configures TLS for the HTTP client. | no
-queue            | [queue][] | Configures batching of data before sending. | no
-retry            | [retry][] | Configures retry mechanism for failed requests. | no
+sending_queue    | [sending_queue][] | Configures batching of data before sending. | no
+retry_on_failure | [retry_on_failure][] | Configures retry mechanism for failed requests. | no
 
 The `>` symbol indicates deeper levels of nesting. For example, `client > tls`
 refers to a `tls` block defined inside a `client` block.
 
 [client]: #client-block
 [tls]: #tls-block
-[queue]: #queue-block
-[retry]: #retry-block
+[sending_queue]: #sending_queue-block
+[retry_on_failure]: #retry_on_failure-block
 
 ### client block
 
@@ -87,16 +87,16 @@ server.
 
 {{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" >}}
 
-### queue block
+### sending_queue block
 
-The `queue` block configures an in-memory buffer of batches before data is sent
+The `sending_queue` block configures an in-memory buffer of batches before data is sent
 to the HTTP server.
 
 {{< docs/shared lookup="flow/reference/components/otelcol-queue-block.md" source="agent" >}}
 
-### retry block
+### retry_on_failure block
 
-The `retry` block configures how failed requests to the HTTP server are
+The `retry_on_failure` block configures how failed requests to the HTTP server are
 retried.
 
 {{< docs/shared lookup="flow/reference/components/otelcol-retry-block.md" source="agent" >}}


### PR DESCRIPTION
Docs don't align with code https://github.com/grafana/agent/blob/7878e6e01c3db150e875861763c095a5707552b1/component/otelcol/exporter/otlp/otlp.go#L33)

Fixes #4186