### PR TITLE
otelcol.exporter.prometheus: Make histogram counts cumulative for Prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ Main (unreleased)
 
 - Fixes several issues with statsd exporter. (@jcreixell, @marctc)
 
+- Fixes a bug in conversion of OpenTelemetry histograms when exported to Prometheus. (@grcevski)
+
 ### Other changes
 
 - Mongodb integration has been disabled for the time being due to licensing issues. (@jcreixell)

--- a/component/otelcol/exporter/prometheus/internal/convert/convert.go
+++ b/component/otelcol/exporter/prometheus/internal/convert/convert.go
@@ -472,7 +472,9 @@ func (conv *Converter) consumeHistogram(app storage.Appender, memResource *memor
 
 		sort.Float64s(bounds)
 
-		// Calculate cumulative count value as Prometheus wants it
+		// Calculate cumulative count values. Prometheus expects cummulative bucket counts for histograms.
+		// This has nothing to do with temporality, it doesn't affect cummulative vs delta histograms, it
+		// simply matches the format of bucket counts expected by Prometheus.
 		var c uint64 = 0
 		for i := 0; i < len(bounds); i++ {
 			bound := bounds[i]

--- a/component/otelcol/exporter/prometheus/internal/convert/convert.go
+++ b/component/otelcol/exporter/prometheus/internal/convert/convert.go
@@ -463,7 +463,7 @@ func (conv *Converter) consumeHistogram(app storage.Appender, memResource *memor
 		// Sort the histogram by bounds ascending
 		bSize := int(math.Min(float64(dp.ExplicitBounds().Len()), float64(dp.BucketCounts().Len())))
 		buckets := make(map[float64]uint64, bSize)
-		bounds := make([]float64, bSize)
+		bounds := make([]float64, 0, bSize)
 		for i := 0; i < dp.ExplicitBounds().Len() && i < dp.BucketCounts().Len(); i++ {
 			bound := dp.ExplicitBounds().At(i)
 			buckets[bound] = dp.BucketCounts().At(i)

--- a/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
+++ b/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
@@ -121,8 +121,41 @@ func TestConverter(t *testing.T) {
 				# TYPE test_metric_seconds histogram
 				test_metric_seconds_bucket{le="0.25"} 0
 				test_metric_seconds_bucket{le="0.5"} 111
-				test_metric_seconds_bucket{le="0.75"} 0
-				test_metric_seconds_bucket{le="1.0"} 222
+				test_metric_seconds_bucket{le="0.75"} 111
+				test_metric_seconds_bucket{le="1.0"} 333
+				test_metric_seconds_bucket{le="+Inf"} 333
+				test_metric_seconds_sum 100.0
+				test_metric_seconds_count 333
+			`,
+		},
+		{
+			name: "Histogram out-of-order bounds",
+			input: `{
+				"resource_metrics": [{
+					"scope_metrics": [{
+						"metrics": [{
+							"name": "test_metric_seconds",
+							"histogram": {
+								"aggregation_temporality": 2,
+								"data_points": [{
+									"start_time_unix_nano": 1000000000,
+									"time_unix_nano": 1000000000,
+									"count": 333,
+									"sum": 100,
+									"bucket_counts": [0, 111, 0, 222],
+									"explicit_bounds": [0.5, 1.0, 0.25, 0.75]
+								}]
+							}
+						}]
+					}]
+				}]
+			}`,
+			expect: `
+				# TYPE test_metric_seconds histogram
+				test_metric_seconds_bucket{le="0.25"} 0
+				test_metric_seconds_bucket{le="0.5"} 0
+				test_metric_seconds_bucket{le="0.75"} 222
+				test_metric_seconds_bucket{le="1.0"} 333
 				test_metric_seconds_bucket{le="+Inf"} 333
 				test_metric_seconds_sum 100.0
 				test_metric_seconds_count 333


### PR DESCRIPTION
#### PR Description

This PR attempts to fix the problem with non-cumulative histograms exported to Prometheus, from the otel metrics collector. The code change follows the approach taken by the opentelemetry-prometheus-exporter as shown here:
https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/prometheusexporter/collector.go#LL224C76-L224C76

Given a number of histogram buckets, we first sort the buckets by the bucket bounds value, then we calculate the cumulative value for each bucket, instead of using the exact bucket count provided by OTel. 

#### Which issue(s) this PR fixes

Fixes #4193

#### Notes to the Reviewer

I'd appreciate any feedback on where to add tests for this issue.

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [x] Tests updated
