### PR TITLE
prometheus.relabel: allow relabeling of prometheus native histograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Main (unreleased)
 
 - Replace map cache in prometheus.relabel with an LRU cache. (@mattdurham)
 
+- Enable `prometheus.relabel` to work with Prometheus' Native Histograms. (@tpaschalis)
+
 ### Bugfixes
 
 - Add signing region to remote.s3 component for use with custom endpoints so that Authorization Headers work correctly when

--- a/component/prometheus/interceptor.go
+++ b/component/prometheus/interceptor.go
@@ -62,9 +62,9 @@ func WithMetadataHook(f func(ref storage.SeriesRef, l labels.Labels, m metadata.
 	}
 }
 
-// WithAppendHistogram returns an InterceptorOption which hooks into calls to
+// WithHistogramHook returns an InterceptorOption which hooks into calls to
 // AppendHistogram.
-func WithAppendHistogram(f func(ref storage.SeriesRef, l labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram, next storage.Appender) (storage.SeriesRef, error)) InterceptorOption {
+func WithHistogramHook(f func(ref storage.SeriesRef, l labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram, next storage.Appender) (storage.SeriesRef, error)) InterceptorOption {
 	return func(i *Interceptor) {
 		i.onAppendHistogram = f
 	}

--- a/component/prometheus/relabel/relabel.go
+++ b/component/prometheus/relabel/relabel.go
@@ -162,7 +162,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 			}
 			return next.UpdateMetadata(0, newLbl, m)
 		}),
-		prometheus.WithHistogramHook(func(ref storage.SeriesRef, l labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram, next storage.Appender) (storage.SeriesRef, error) {
+		prometheus.WithHistogramHook(func(_ storage.SeriesRef, l labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram, next storage.Appender) (storage.SeriesRef, error) {
 			if c.exited.Load() {
 				return 0, fmt.Errorf("%s has exited", o.ID)
 			}
@@ -171,7 +171,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 			if newLbl.IsEmpty() {
 				return 0, nil
 			}
-			return next.AppendHistogram(ref, newLbl, t, h, fh)
+			return next.AppendHistogram(0, newLbl, t, h, fh)
 		}),
 	)
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR renames the histogram hook to be aligned with the other ones and ties it in to the prometheus.relabel component.

#### Which issue(s) this PR fixes

No issue filed.

#### Notes to the Reviewer

#### PR Checklist

- [X] CHANGELOG updated
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
