### PR TITLE
all: make component builders return the concrete structs

### DIFF
--- a/component/discovery/azure/azure.go
+++ b/component/discovery/azure/azure.go
@@ -107,7 +107,8 @@ func (a *Arguments) Convert() *prom_discovery.SDConfig {
 	}
 }
 
-func New(opts component.Options, args Arguments) (component.Component, error) {
+// New returns a new instance of a discovery.azure component.
+func New(opts component.Options, args Arguments) (*discovery.Component, error) {
 	return discovery.New(opts, args, func(args component.Arguments) (discovery.Discoverer, error) {
 		newArgs := args.(Arguments)
 		return prom_discovery.NewDiscovery(newArgs.Convert(), opts.Logger), nil

--- a/component/discovery/consul/consul.go
+++ b/component/discovery/consul/consul.go
@@ -88,7 +88,8 @@ func (args *Arguments) Convert() *prom_discovery.SDConfig {
 	}
 }
 
-func New(opts component.Options, args Arguments) (component.Component, error) {
+// New returns a new instance of a discovery.consul component.
+func New(opts component.Options, args Arguments) (*discovery.Component, error) {
 	return discovery.New(opts, args, func(args component.Arguments) (discovery.Discoverer, error) {
 		newArgs := args.(Arguments)
 		return prom_discovery.NewDiscovery(newArgs.Convert(), opts.Logger)

--- a/component/discovery/digitalocean/digitalocean.go
+++ b/component/discovery/digitalocean/digitalocean.go
@@ -76,7 +76,8 @@ func (a *Arguments) Convert() *prom_discovery.SDConfig {
 	}
 }
 
-func New(opts component.Options, args Arguments) (component.Component, error) {
+// New returns a new instance of a discovery.digitalocean component.
+func New(opts component.Options, args Arguments) (*discovery.Component, error) {
 	return discovery.New(opts, args, func(args component.Arguments) (discovery.Discoverer, error) {
 		newArgs := args.(Arguments)
 		return prom_discovery.NewDiscovery(newArgs.Convert(), opts.Logger)

--- a/component/discovery/dns/dns.go
+++ b/component/discovery/dns/dns.go
@@ -67,7 +67,7 @@ func (args Arguments) Convert() dns.SDConfig {
 }
 
 // New returns a new instance of a discovery.dns component.
-func New(opts component.Options, args Arguments) (component.Component, error) {
+func New(opts component.Options, args Arguments) (*discovery.Component, error) {
 	return discovery.New(opts, args, func(args component.Arguments) (discovery.Discoverer, error) {
 		conf := args.(Arguments).Convert()
 		return dns.NewDiscovery(conf, opts.Logger), nil

--- a/component/discovery/docker/docker.go
+++ b/component/discovery/docker/docker.go
@@ -98,7 +98,7 @@ func (args Arguments) Convert() moby.DockerSDConfig {
 }
 
 // New returns a new instance of a discovery.docker component.
-func New(opts component.Options, args Arguments) (component.Component, error) {
+func New(opts component.Options, args Arguments) (*discovery.Component, error) {
 	return discovery.New(opts, args, func(args component.Arguments) (discovery.Discoverer, error) {
 		conf := args.(Arguments).Convert()
 		return moby.NewDockerDiscovery(&conf, opts.Logger)

--- a/component/discovery/gce/gce.go
+++ b/component/discovery/gce/gce.go
@@ -57,7 +57,7 @@ func (args Arguments) Convert() gce.SDConfig {
 }
 
 // New returns a new instance of a discovery.gce component.
-func New(opts component.Options, args Arguments) (component.Component, error) {
+func New(opts component.Options, args Arguments) (*discovery.Component, error) {
 	return discovery.New(opts, args, func(args component.Arguments) (discovery.Discoverer, error) {
 		conf := args.(Arguments).Convert()
 		return gce.NewDiscovery(conf, opts.Logger)

--- a/component/discovery/kubernetes/kubernetes.go
+++ b/component/discovery/kubernetes/kubernetes.go
@@ -103,7 +103,7 @@ func (am *AttachMetadataConfig) convert() *promk8s.AttachMetadataConfig {
 }
 
 // New returns a new instance of a discovery.kubernetes component.
-func New(opts component.Options, args Arguments) (component.Component, error) {
+func New(opts component.Options, args Arguments) (*discovery.Component, error) {
 	return discovery.New(opts, args, func(args component.Arguments) (discovery.Discoverer, error) {
 		newArgs := args.(Arguments)
 		return promk8s.New(opts.Logger, newArgs.Convert())

--- a/component/loki/source/api/api.go
+++ b/component/loki/source/api/api.go
@@ -63,7 +63,7 @@ type Component struct {
 	receivers    []loki.LogsReceiver
 }
 
-func New(opts component.Options, args Arguments) (component.Component, error) {
+func New(opts component.Options, args Arguments) (*Component, error) {
 	c := &Component{
 		opts:               opts,
 		entriesChan:        make(chan loki.Entry),

--- a/component/loki/source/api/api_test.go
+++ b/component/loki/source/api/api_test.go
@@ -169,7 +169,7 @@ func TestLokiSourceAPI_FanOut(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	defer comp.(*Component).stop()
+	defer comp.stop()
 
 	lokiClient := newTestLokiClient(t, args, opts)
 	defer lokiClient.Stop()
@@ -283,22 +283,19 @@ func TestComponent_detectsWhenUpdateRequiresARestart(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			c, ok := comp.(*Component)
-			require.True(t, ok)
-
 			// in order to cleanly update, we want to make sure the server is running first.
-			waitForServerToBeReady(t, c)
+			waitForServerToBeReady(t, comp)
 
-			serverBefore := c.server
-			err = c.Update(tc.newArgs)
+			serverBefore := comp.server
+			err = comp.Update(tc.newArgs)
 			require.NoError(t, err)
 
-			restarted := serverBefore != c.server
+			restarted := serverBefore != comp.server
 			assert.Equal(t, restarted, tc.restartRequired)
 
 			// in order to cleanly shutdown, we want to make sure the server is running first.
-			waitForServerToBeReady(t, c)
-			c.stop()
+			waitForServerToBeReady(t, comp)
+			comp.stop()
 		})
 	}
 }
@@ -313,9 +310,6 @@ func TestDefaultServerConfig(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	c, ok := comp.(*Component)
-	require.True(t, ok)
-
 	require.Eventuallyf(t, func() bool {
 		resp, err := http.Get(fmt.Sprintf(
 			"http://%v:%d/wrong/url",
@@ -325,7 +319,7 @@ func TestDefaultServerConfig(t *testing.T) {
 		return err == nil && resp.StatusCode == 404
 	}, 5*time.Second, 20*time.Millisecond, "server failed to start before timeout")
 
-	c.stop()
+	comp.stop()
 }
 
 func startTestComponent(
@@ -342,13 +336,10 @@ func startTestComponent(
 		require.NoError(t, err)
 	}()
 
-	c, ok := comp.(*Component)
-	require.True(t, ok)
-
 	return comp, func() {
 		// in order to cleanly shutdown, we want to make sure the server is running first.
-		waitForServerToBeReady(t, c)
-		c.stop()
+		waitForServerToBeReady(t, comp)
+		comp.stop()
 	}
 }
 

--- a/component/loki/source/gelf/gelf.go
+++ b/component/loki/source/gelf/gelf.go
@@ -117,7 +117,7 @@ func convertConfig(a Arguments) *scrapeconfig.GelfTargetConfig {
 }
 
 // New creates a new gelf component.
-func New(o component.Options, args Arguments) (component.Component, error) {
+func New(o component.Options, args Arguments) (*Component, error) {
 	metrics := target.NewMetrics(o.Registerer)
 	c := &Component{
 		o:       o,

--- a/component/loki/source/journal/journal.go
+++ b/component/loki/source/journal/journal.go
@@ -44,7 +44,7 @@ type Component struct {
 }
 
 // New creates a new  component.
-func New(o component.Options, args Arguments) (component.Component, error) {
+func New(o component.Options, args Arguments) (*Component, error) {
 	err := os.MkdirAll(o.DataPath, 0750)
 	if err != nil {
 		return nil, err

--- a/component/loki/source/journal/journal_stub.go
+++ b/component/loki/source/journal/journal_stub.go
@@ -27,7 +27,7 @@ type Component struct {
 }
 
 // New creates a new  component.
-func New(o component.Options, args Arguments) (component.Component, error) {
+func New(o component.Options, args Arguments) (*Component, error) {
 	level.Info(o.Logger).Log("msg", "loki.source.journal is not enabled, and must be ran on linux with journal support")
 	c := &Component{}
 	return c, nil

--- a/component/mimir/rules/kubernetes/rules.go
+++ b/component/mimir/rules/kubernetes/rules.go
@@ -33,7 +33,7 @@ func init() {
 		Args:    Arguments{},
 		Exports: nil,
 		Build: func(o component.Options, c component.Arguments) (component.Component, error) {
-			return NewComponent(o, c.(Arguments))
+			return New(o, c.(Arguments))
 		},
 	})
 }
@@ -128,7 +128,7 @@ var _ component.Component = (*Component)(nil)
 var _ component.DebugComponent = (*Component)(nil)
 var _ component.HealthComponent = (*Component)(nil)
 
-func NewComponent(o component.Options, args Arguments) (*Component, error) {
+func New(o component.Options, args Arguments) (*Component, error) {
 	metrics := newMetrics()
 	err := metrics.Register(o.Registerer)
 	if err != nil {

--- a/component/otelcol/receiver/loki/loki.go
+++ b/component/otelcol/receiver/loki/loki.go
@@ -25,7 +25,7 @@ func init() {
 		Exports: Exports{},
 
 		Build: func(o component.Options, a component.Arguments) (component.Component, error) {
-			return NewComponent(o, a.(Arguments))
+			return New(o, a.(Arguments))
 		},
 	})
 }
@@ -56,8 +56,8 @@ type Component struct {
 
 var _ component.Component = (*Component)(nil)
 
-// NewComponent creates a new otelcol.receiver.loki component.
-func NewComponent(o component.Options, c Arguments) (*Component, error) {
+// New creates a new otelcol.receiver.loki component.
+func New(o component.Options, c Arguments) (*Component, error) {
 	// TODO(@tpaschalis) Create a metrics struct to count
 	// total/successful/errored log entries?
 	res := &Component{

--- a/component/otelcol/receiver/prometheus/prometheus.go
+++ b/component/otelcol/receiver/prometheus/prometheus.go
@@ -30,7 +30,7 @@ func init() {
 		Exports: Exports{},
 
 		Build: func(o component.Options, a component.Arguments) (component.Component, error) {
-			return NewComponent(o, a.(Arguments))
+			return New(o, a.(Arguments))
 		},
 	})
 }
@@ -59,8 +59,8 @@ type Component struct {
 
 var _ component.Component = (*Component)(nil)
 
-// NewComponent creates a new otelcol.receiver.prometheus component.
-func NewComponent(o component.Options, c Arguments) (*Component, error) {
+// New creates a new otelcol.receiver.prometheus component.
+func New(o component.Options, c Arguments) (*Component, error) {
 	res := &Component{
 		log:  o.Logger,
 		opts: o,

--- a/component/prometheus/receive_http/receive_http.go
+++ b/component/prometheus/receive_http/receive_http.go
@@ -51,7 +51,7 @@ type Component struct {
 	server    *fnet.TargetServer
 }
 
-func New(opts component.Options, args Arguments) (component.Component, error) {
+func New(opts component.Options, args Arguments) (*Component, error) {
 	fanout := agentprom.NewFanout(args.ForwardTo, opts.ID, opts.Registerer)
 
 	uncheckedCollector := util.NewUncheckedCollector(nil)

--- a/component/prometheus/receive_http/receive_http_test.go
+++ b/component/prometheus/receive_http/receive_http_test.go
@@ -244,21 +244,20 @@ func TestServerRestarts(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			c, err := New(testOptions(t), tc.initialArgs)
+			comp, err := New(testOptions(t), tc.initialArgs)
 			require.NoError(t, err)
 
 			serverExit := make(chan error)
 			go func() {
-				serverExit <- c.Run(ctx)
+				serverExit <- comp.Run(ctx)
 			}()
 
-			comp := c.(*Component)
 			waitForServerToBeReady(t, comp.args)
 
 			initialServer := comp.server
 			require.NotNil(t, initialServer)
 
-			err = c.Update(tc.newArgs)
+			err = comp.Update(tc.newArgs)
 			require.NoError(t, err)
 
 			waitForServerToBeReady(t, comp.args)

--- a/component/prometheus/remotewrite/remote_write.go
+++ b/component/prometheus/remotewrite/remote_write.go
@@ -40,7 +40,7 @@ func init() {
 		Args:    Arguments{},
 		Exports: Exports{},
 		Build: func(o component.Options, c component.Arguments) (component.Component, error) {
-			return NewComponent(o, c.(Arguments))
+			return New(o, c.(Arguments))
 		},
 	})
 }
@@ -61,8 +61,8 @@ type Component struct {
 	receiver *prometheus.Interceptor
 }
 
-// NewComponent creates a new prometheus.remote_write component.
-func NewComponent(o component.Options, c Arguments) (*Component, error) {
+// New creates a new prometheus.remote_write component.
+func New(o component.Options, c Arguments) (*Component, error) {
 	// Older versions of prometheus.remote_write used the subpath below, which
 	// added in too many extra unnecessary directories (since o.DataPath is
 	// already unique).

--- a/component/pyroscope/write/write.go
+++ b/component/pyroscope/write/write.go
@@ -39,7 +39,7 @@ func init() {
 		Args:    Arguments{},
 		Exports: Exports{},
 		Build: func(o component.Options, c component.Arguments) (component.Component, error) {
-			return NewComponent(o, c.(Arguments))
+			return New(o, c.(Arguments))
 		},
 	})
 }
@@ -108,8 +108,8 @@ type Exports struct {
 	Receiver pyroscope.Appendable `river:"receiver,attr"`
 }
 
-// NewComponent creates a new pyroscope.write component.
-func NewComponent(o component.Options, c Arguments) (*Component, error) {
+// New creates a new pyroscope.write component.
+func New(o component.Options, c Arguments) (*Component, error) {
 	metrics := newMetrics(o.Registerer)
 	receiver, err := NewFanOut(o, c, metrics)
 	if err != nil {

--- a/component/pyroscope/write/write_test.go
+++ b/component/pyroscope/write/write_test.go
@@ -83,7 +83,7 @@ func Test_Write_FanOut(t *testing.T) {
 		t.Helper()
 		var wg sync.WaitGroup
 		wg.Add(1)
-		c, err := NewComponent(component.Options{
+		c, err := New(component.Options{
 			ID:         "1",
 			Logger:     util.TestFlowLogger(t),
 			Registerer: prometheus.NewRegistry(),
@@ -159,7 +159,7 @@ func Test_Write_Update(t *testing.T) {
 	)
 	var wg sync.WaitGroup
 	wg.Add(1)
-	c, err := NewComponent(component.Options{
+	c, err := New(component.Options{
 		ID:         "1",
 		Logger:     util.TestFlowLogger(t),
 		Registerer: prometheus.NewRegistry(),

--- a/component/remote/s3/s3.go
+++ b/component/remote/s3/s3.go
@@ -29,8 +29,8 @@ func init() {
 	})
 }
 
-// S3 handles reading content from a file located in an S3-compatible system.
-type S3 struct {
+// Component handles reading content from a file located in an Component-compatible system.
+type Component struct {
 	mut     sync.Mutex
 	opts    component.Options
 	args    Arguments
@@ -44,12 +44,12 @@ type S3 struct {
 }
 
 var (
-	_ component.Component       = (*S3)(nil)
-	_ component.HealthComponent = (*S3)(nil)
+	_ component.Component       = (*Component)(nil)
+	_ component.HealthComponent = (*Component)(nil)
 )
 
 // New initializes the S3 component.
-func New(o component.Options, args Arguments) (*S3, error) {
+func New(o component.Options, args Arguments) (*Component, error) {
 	s3cfg, err := generateS3Config(args)
 	if err != nil {
 		return nil, err
@@ -60,7 +60,7 @@ func New(o component.Options, args Arguments) (*S3, error) {
 	})
 
 	bucket, file := getPathBucketAndFile(args.Path)
-	s := &S3{
+	s := &Component{
 		opts:       o,
 		args:       args,
 		health:     component.Health{},
@@ -93,7 +93,7 @@ func New(o component.Options, args Arguments) (*S3, error) {
 }
 
 // Run activates the content handler and watcher.
-func (s *S3) Run(ctx context.Context) error {
+func (s *Component) Run(ctx context.Context) error {
 	go s.handleContentUpdate(ctx)
 	go s.watcher.run(ctx)
 	<-ctx.Done()
@@ -102,7 +102,7 @@ func (s *S3) Run(ctx context.Context) error {
 }
 
 // Update is called whenever the arguments have changed.
-func (s *S3) Update(args component.Arguments) error {
+func (s *Component) Update(args component.Arguments) error {
 	newArgs := args.(Arguments)
 
 	s3cfg, err := generateS3Config(newArgs)
@@ -124,7 +124,7 @@ func (s *S3) Update(args component.Arguments) error {
 }
 
 // CurrentHealth returns the health of the component.
-func (s *S3) CurrentHealth() component.Health {
+func (s *Component) CurrentHealth() component.Health {
 	s.mut.Lock()
 	defer s.mut.Unlock()
 	return s.health
@@ -186,7 +186,7 @@ func generateS3Config(args Arguments) (*aws.Config, error) {
 }
 
 // handleContentUpdate reads from the update and error channels setting as appropriate
-func (s *S3) handleContentUpdate(ctx context.Context) {
+func (s *Component) handleContentUpdate(ctx context.Context) {
 	for {
 		select {
 		case r := <-s.updateChan:
@@ -198,7 +198,7 @@ func (s *S3) handleContentUpdate(ctx context.Context) {
 	}
 }
 
-func (s *S3) handleContentPolling(newContent string, err error) {
+func (s *Component) handleContentPolling(newContent string, err error) {
 	s.mut.Lock()
 	defer s.mut.Unlock()
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR shouldn't have any user-facing changes. It goes through the code for various components and a) standardizes the struct and builder names, b) makes sure the components builders return a struct as per Go's "Accept interfaces, return structs" idiom.

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
