### PR TITLE
cmd/grafana-agent-flow: add agentctl tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ Main (unreleased)
 
 - Support custom fields in MMDB file for `stage.geoip`. (@akselleirv)
 
+- Added json_path function to river stdlib. (@jkroepke)
+
+- Flow UI: Add a view for listing the Agent's peers status when clustering is enabled. (@tpaschalis)
+
+- Add a new CLI command `grafana-agent convert` for converting a river file from supported formats to river. (@erikbaranowski)
+
+- Add support to the `grafana-agent run` CLI for converting a river file from supported formats to river. (@erikbaranowski)
+
+- Add boringcrypto builds and docker images for Linux arm64 and x64. (@mattdurham)
+
 - New Grafana Agent Flow components:
 
   - `discovery.kubelet` collect scrape targets from the Kubelet API. (@gcampbell12)
@@ -50,15 +60,10 @@ Main (unreleased)
   - `prometheus.exporter.mongodb` collects metrics from MongoDB. (@marctc)
   - `module.http` runs a Grafana Agent Flow module loaded from a remote HTTP endpoint. (@spartan0x117)
 
-- Added json_path function to river stdlib. (@jkroepke)
+- New Grafana Agent Flow command line utilities:
 
-- Flow UI: Add a view for listing the Agent's peers status when clustering is enabled. (@tpaschalis)
-
-- Add a new CLI command `grafana-agent convert` for converting a river file from supported formats to river. (@erikbaranowski)
-
-- Add support to the `grafana-agent run` CLI for converting a river file from supported formats to river. (@erikbaranowski)
-
-- Add boringcrypto builds and docker images for Linux arm64 and x64. (@mattdurham)
+  - `grafana-agent tools prometheus.remote_write` holds a collection of remote
+    write-specific tools. These have been ported over from the `agentctl` command. (@rfratto)
 
 ### Enhancements
 
@@ -122,8 +127,8 @@ Main (unreleased)
 - Fix bug where `stage.timestamp` in `loki.process` wasn't able to correctly
   parse timezones. This issue only impacts the dedicated `grafana-agent-flow`
   binary. (@rfratto)
-  
-- Fix bug where JSON requests to `loki.source.api` would not be handled correctly. This adds `/loki/api/v1/raw` and `/loki/api/v1/push` endpoints to `loki.source.api` and maps the `/api/v1/push` and `/api/v1/raw` to 
+
+- Fix bug where JSON requests to `loki.source.api` would not be handled correctly. This adds `/loki/api/v1/raw` and `/loki/api/v1/push` endpoints to `loki.source.api` and maps the `/api/v1/push` and `/api/v1/raw` to
   the `/loki` prefixed endpoints. (@mattdurham)
 
 ### Other changes

--- a/cmd/grafana-agentctl/main.go
+++ b/cmd/grafana-agentctl/main.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/grafana/agent/pkg/agentctl/waltools"
 	"github.com/grafana/agent/pkg/build"
 	"github.com/grafana/agent/pkg/config"
 	"github.com/grafana/agent/pkg/logs"
@@ -182,7 +183,7 @@ $ agentctl sample-stats -s '{job="a"}' /tmp/wal
 				directory = filepath.Join(directory, "wal")
 			}
 
-			stats, err := agentctl.FindSamples(directory, selector)
+			stats, err := waltools.FindSamples(directory, selector)
 			if err != nil {
 				fmt.Printf("failed to get sample stats: %v\n", err)
 				os.Exit(1)
@@ -235,7 +236,7 @@ high-cardinality series that you do not want to send.`,
 				directory = filepath.Join(directory, "wal")
 			}
 
-			cardinality, err := agentctl.FindCardinality(directory, jobLabel, instanceLabel)
+			cardinality, err := waltools.FindCardinality(directory, jobLabel, instanceLabel)
 			if err != nil {
 				fmt.Printf("failed to get cardinality: %v\n", err)
 				os.Exit(1)
@@ -289,7 +290,7 @@ deletion but then comes back at some point).`,
 				directory = filepath.Join(directory, "wal")
 			}
 
-			stats, err := agentctl.CalculateStats(directory)
+			stats, err := waltools.CalculateStats(directory)
 			if err != nil {
 				fmt.Printf("failed to get WAL stats: %v\n", err)
 				os.Exit(1)
@@ -312,7 +313,7 @@ deletion but then comes back at some point).`,
 
 			table.SetHeader([]string{"Job", "Instance", "Series", "Samples"})
 
-			sort.Sort(agentctl.BySeriesCount(stats.Targets))
+			sort.Sort(waltools.BySeriesCount(stats.Targets))
 
 			for _, t := range stats.Targets {
 				seriesStr := fmt.Sprintf("%d", t.Series)

--- a/cmd/internal/flowmode/cmd_tools.go
+++ b/cmd/internal/flowmode/cmd_tools.go
@@ -1,0 +1,31 @@
+package flowmode
+
+import (
+	"fmt"
+
+	"github.com/grafana/agent/component/prometheus/remotewrite"
+	"github.com/spf13/cobra"
+)
+
+func toolsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tools",
+		Short: "Utilties for various Flow components",
+		Long:  `The tools command contains a collection of utilities for Grafana Agent Flow components.`,
+	}
+
+	cmd.AddCommand(
+		getTools("prometheus.remote_write", remotewrite.InstallTools),
+	)
+
+	return cmd
+}
+
+func getTools(name string, installFunc func(*cobra.Command)) *cobra.Command {
+	groupCommand := &cobra.Command{
+		Use:   name,
+		Short: fmt.Sprintf("Tools for the %s component", name),
+	}
+	installFunc(groupCommand)
+	return groupCommand
+}

--- a/cmd/internal/flowmode/flowmode.go
+++ b/cmd/internal/flowmode/flowmode.go
@@ -27,6 +27,7 @@ func Run() {
 		convertCommand(),
 		fmtCommand(),
 		runCommand(),
+		toolsCommand(),
 	)
 
 	if err := cmd.Execute(); err != nil {

--- a/component/prometheus/remotewrite/cli.go
+++ b/component/prometheus/remotewrite/cli.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/grafana/agent/pkg/agentctl"
+	"github.com/grafana/agent/pkg/agentctl/waltools"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
@@ -62,7 +62,7 @@ sample-stats -s '{job="a"}' /tmp/wal
 				directory = filepath.Join(directory, "wal")
 			}
 
-			stats, err := agentctl.FindSamples(directory, selector)
+			stats, err := waltools.FindSamples(directory, selector)
 			if err != nil {
 				fmt.Printf("failed to get sample stats: %v\n", err)
 				os.Exit(1)
@@ -115,7 +115,7 @@ high-cardinality series that you do not want to send.`,
 				directory = filepath.Join(directory, "wal")
 			}
 
-			cardinality, err := agentctl.FindCardinality(directory, jobLabel, instanceLabel)
+			cardinality, err := waltools.FindCardinality(directory, jobLabel, instanceLabel)
 			if err != nil {
 				fmt.Printf("failed to get cardinality: %v\n", err)
 				os.Exit(1)
@@ -169,7 +169,7 @@ deletion but then comes back at some point).`,
 				directory = filepath.Join(directory, "wal")
 			}
 
-			stats, err := agentctl.CalculateStats(directory)
+			stats, err := waltools.CalculateStats(directory)
 			if err != nil {
 				fmt.Printf("failed to get WAL stats: %v\n", err)
 				os.Exit(1)
@@ -192,7 +192,7 @@ deletion but then comes back at some point).`,
 
 			table.SetHeader([]string{"Job", "Instance", "Series", "Samples"})
 
-			sort.Sort(agentctl.BySeriesCount(stats.Targets))
+			sort.Sort(waltools.BySeriesCount(stats.Targets))
 
 			for _, t := range stats.Targets {
 				seriesStr := fmt.Sprintf("%d", t.Series)

--- a/component/prometheus/remotewrite/cli.go
+++ b/component/prometheus/remotewrite/cli.go
@@ -1,0 +1,210 @@
+package remotewrite
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/grafana/agent/pkg/agentctl"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+// InstallTools installs command line utilities as subcommands of the provided
+// cmd.
+func InstallTools(cmd *cobra.Command) {
+	cmd.AddCommand(
+		samplesCmd(),
+		targetStatsCmd(),
+		walStatsCmd(),
+	)
+}
+
+func samplesCmd() *cobra.Command {
+	var selector string
+
+	cmd := &cobra.Command{
+		Use:   "sample-stats [WAL directory]",
+		Short: "Discover sample statistics for series matching a label selector",
+		Long: `sample-stats reads a WAL directory and collects information on the series and
+samples within it. A label selector can be used to filter the series that should be targeted.
+
+Examples:
+
+Show sample stats for all series in the WAL:
+
+sample-stats /tmp/wal
+
+
+Show sample stats for the 'up' series:
+
+sample-stats -s up /tmp/wal
+
+
+Show sample stats for all series within 'job=a':
+
+sample-stats -s '{job="a"}' /tmp/wal
+`,
+		Args: cobra.ExactArgs(1),
+		Run: func(_ *cobra.Command, args []string) {
+			directory := args[0]
+			if _, err := os.Stat(directory); os.IsNotExist(err) {
+				fmt.Printf("%s does not exist\n", directory)
+				os.Exit(1)
+			} else if err != nil {
+				fmt.Printf("error getting wal: %v\n", err)
+				os.Exit(1)
+			}
+
+			// Check if ./wal is a subdirectory, use that instead.
+			if _, err := os.Stat(filepath.Join(directory, "wal")); err == nil {
+				directory = filepath.Join(directory, "wal")
+			}
+
+			stats, err := agentctl.FindSamples(directory, selector)
+			if err != nil {
+				fmt.Printf("failed to get sample stats: %v\n", err)
+				os.Exit(1)
+			}
+
+			for _, series := range stats {
+				fmt.Print(series.Labels.String(), "\n")
+				fmt.Printf("  Oldest Sample:      %s\n", series.From)
+				fmt.Printf("  Newest Sample:      %s\n", series.To)
+				fmt.Printf("  Total Samples:      %d\n", series.Samples)
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&selector, "selector", "s", "{}", "label selector to search for")
+	return cmd
+}
+
+func targetStatsCmd() *cobra.Command {
+	var (
+		jobLabel      string
+		instanceLabel string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "target-stats [WAL directory]",
+		Short: "Discover statistics on a specific target",
+		Long: `target-stats computes statistics on a specific target within the WAL at
+greater detail than the general wal-stats. The statistics computed is the
+cardinality of all series within that target.
+
+The cardinality for a series is defined as the total number of unique
+combinations of label names and values that a given metric has. The result of
+this operation can be used to define metric_relabel_rules and drop
+high-cardinality series that you do not want to send.`,
+		Args: cobra.ExactArgs(1),
+
+		Run: func(_ *cobra.Command, args []string) {
+			directory := args[0]
+			if _, err := os.Stat(directory); os.IsNotExist(err) {
+				fmt.Printf("%s does not exist\n", directory)
+				os.Exit(1)
+			} else if err != nil {
+				fmt.Printf("error getting wal: %v\n", err)
+				os.Exit(1)
+			}
+
+			// Check if ./wal is a subdirectory, use that instead.
+			if _, err := os.Stat(filepath.Join(directory, "wal")); err == nil {
+				directory = filepath.Join(directory, "wal")
+			}
+
+			cardinality, err := agentctl.FindCardinality(directory, jobLabel, instanceLabel)
+			if err != nil {
+				fmt.Printf("failed to get cardinality: %v\n", err)
+				os.Exit(1)
+			}
+
+			sort.Slice(cardinality, func(i, j int) bool {
+				return cardinality[i].Instances > cardinality[j].Instances
+			})
+
+			fmt.Printf("Metric cardinality:\n\n")
+
+			for _, metric := range cardinality {
+				fmt.Printf("%s: %d\n", metric.Metric, metric.Instances)
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&jobLabel, "job", "j", "", "job label to search for")
+	cmd.Flags().StringVarP(&instanceLabel, "instance", "i", "", "instance label to search for")
+	must(cmd.MarkFlagRequired("job"))
+	must(cmd.MarkFlagRequired("instance"))
+	return cmd
+}
+
+func walStatsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "wal-stats [WAL directory]",
+		Short: "Collect stats on the WAL",
+		Long: `wal-stats reads a WAL directory and collects information on the series and
+samples within it.
+
+The "Hash Collisions" value refers to the number of ref IDs a label's hash was
+assigned to. A non-zero amount of collisions has no negative effect on the data
+sent to the Remote Write endpoint, but may have an impact on memory usage. Labels
+may collide with multiple ref IDs normally if a series flaps (i.e., gets marked for
+deletion but then comes back at some point).`,
+		Args: cobra.ExactArgs(1),
+
+		Run: func(_ *cobra.Command, args []string) {
+			directory := args[0]
+			if _, err := os.Stat(directory); os.IsNotExist(err) {
+				fmt.Printf("%s does not exist\n", directory)
+				os.Exit(1)
+			} else if err != nil {
+				fmt.Printf("error getting wal: %v\n", err)
+				os.Exit(1)
+			}
+
+			// Check if ./wal is a subdirectory, use that instead.
+			if _, err := os.Stat(filepath.Join(directory, "wal")); err == nil {
+				directory = filepath.Join(directory, "wal")
+			}
+
+			stats, err := agentctl.CalculateStats(directory)
+			if err != nil {
+				fmt.Printf("failed to get WAL stats: %v\n", err)
+				os.Exit(1)
+			}
+
+			fmt.Printf("Oldest Sample:      %s\n", stats.From)
+			fmt.Printf("Newest Sample:      %s\n", stats.To)
+			fmt.Printf("Total Series:       %d\n", stats.Series())
+			fmt.Printf("Total Samples:      %d\n", stats.Samples())
+			fmt.Printf("Hash Collisions:    %d\n", stats.HashCollisions)
+			fmt.Printf("Invalid Refs:       %d\n", stats.InvalidRefs)
+			fmt.Printf("Checkpoint Segment: %d\n", stats.CheckpointNumber)
+			fmt.Printf("First Segment:      %d\n", stats.FirstSegment)
+			fmt.Printf("Latest Segment:     %d\n", stats.LastSegment)
+
+			fmt.Printf("\nPer-target stats:\n")
+
+			table := tablewriter.NewWriter(os.Stdout)
+			defer table.Render()
+
+			table.SetHeader([]string{"Job", "Instance", "Series", "Samples"})
+
+			sort.Sort(agentctl.BySeriesCount(stats.Targets))
+
+			for _, t := range stats.Targets {
+				seriesStr := fmt.Sprintf("%d", t.Series)
+				samplesStr := fmt.Sprintf("%d", t.Samples)
+				table.Append([]string{t.Job, t.Instance, seriesStr, samplesStr})
+			}
+		},
+	}
+}
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/docs/sources/flow/reference/cli/tools.md
+++ b/docs/sources/flow/reference/cli/tools.md
@@ -1,0 +1,81 @@
+---
+title: grafana-agent tools
+weight: 100
+---
+
+# `grafana-agent tools` command
+
+The `grafana-agent tools` command contains command line tooling grouped by Flow
+component.
+
+{{% admonition type="note" %}}
+Utilities in this command have no backward compatibility
+guarantees and may change or be removed between releases.
+{{% /admonition %}}
+
+## Subcommands
+
+### prometheus.remote_write sample-stats
+
+Usage: `grafana-agent tools prometheus.remote_write sample-stats [FLAG ...] WAL_DIRECTORY`
+
+The `sample-stats` command reads the Write-Ahead Log (WAL) specified by
+`WAL_DIRECTORY` and collects information on metric samples within it.
+
+For each metric discovered, `sample-stats` emits:
+
+* The timestamp of the oldest sample received for that metric.
+* The timestamp of the newest sample received for that metric.
+* The total number of samples discovered for that metric.
+
+By default, `sample-stats` will return information for every metric in the WAL.
+You can pass the `--selector` flag to filter the reported metrics to a smaller set.
+
+The following flag is supported:
+
+* `--selector`: A PromQL label selector to filter data by. (default `{}`)
+
+### prometheus.remote_write target-stats
+
+Usage: `grafana-agent tools prometheus.remote_write target-stats --job JOB --instance INSTANCE WAL_DIRECTORY`
+
+The `target-stats` command reads the Write-Ahead Log (WAL) specified by
+`WAL_DIRECTORY` and collects metric cardinality information for a specific
+target.
+
+For the target specified by the `--job` and `--instance` flags, unique metric
+names for that target are printed along with the number of series with that
+metric name.
+
+The following flags are supported:
+
+* `--job`: The `job` label of the target.
+* `--instance`: The `instance` label of the target.
+
+The `--job` and `--instance` labels are required.
+
+### prometheus.remote_write wal-stats
+
+Usage: `grafana-agent tools prometheus.remote_write wal-stats WAL_DIRECTORY`
+
+The `wal-stats` command reads the Write-Ahead Log (WAL) specified by
+`WAL_DIRECTORY` and collects general information about it.
+
+The following information is reported:
+
+* The timestamp of the oldest sample in the WAL.
+* The timestamp of the newest sample in the WAL.
+* The total number of unique series defined in the WAL.
+* The total number of samples in the WAL.
+* The number of hash collisions detected, if any.
+* The total number of invalid records in the WAL, if any.
+* The most recent WAL checkpoint segment number.
+* The oldest segment number in the WAL.
+* The newest segment number in the WAL.
+
+Additionally, `wal-stats` reports per-target information, where a target is
+defined as a unique combination of the `job` and `instance` label values. For
+each target, `wal-stats` reports the number of series and the number of
+metric samples associated with that target.
+
+The `wal-stats` command does not support any flags.

--- a/pkg/agentctl/waltools/cardinality.go
+++ b/pkg/agentctl/waltools/cardinality.go
@@ -1,4 +1,4 @@
-package agentctl
+package waltools
 
 import (
 	"github.com/prometheus/prometheus/tsdb/record"

--- a/pkg/agentctl/waltools/cardinality_test.go
+++ b/pkg/agentctl/waltools/cardinality_test.go
@@ -1,4 +1,4 @@
-package agentctl
+package waltools
 
 import (
 	"sort"

--- a/pkg/agentctl/waltools/samples.go
+++ b/pkg/agentctl/waltools/samples.go
@@ -1,4 +1,4 @@
-package agentctl
+package waltools
 
 import (
 	"fmt"

--- a/pkg/agentctl/waltools/wal_iterator.go
+++ b/pkg/agentctl/waltools/wal_iterator.go
@@ -1,4 +1,4 @@
-package agentctl
+package waltools
 
 import (
 	"github.com/prometheus/prometheus/tsdb/record"

--- a/pkg/agentctl/waltools/walstats.go
+++ b/pkg/agentctl/waltools/walstats.go
@@ -1,4 +1,4 @@
-package agentctl
+package waltools
 
 import (
 	"math"

--- a/pkg/agentctl/waltools/walstats_test.go
+++ b/pkg/agentctl/waltools/walstats_test.go
@@ -1,4 +1,4 @@
-package agentctl
+package waltools
 
 import (
 	"fmt"


### PR DESCRIPTION
This commit adds a new subcommand to Flow, `tools`, which contains a bunch of per-component command line utilities. Each component has its own subcommand within `tools`.

The first of these commands is for prometheus.remote_write, where the old tooling from agentctl has been ported as:

* `grafana-agent tools prometheus.remote_write sample-stats`
* `grafana-agent tools prometheus.remote_write target-stats`
* `grafana-agent tools prometheus.remote_write wal-stats`

The command names are quite long, but I appreciate how they're namespaced per-component to avoid long-term confusion as we gradually add more of these. 

Closes grafana/agent#2708.