### PR TITLE
Fix bug where otelcol.exporter.otlphttp ignores configuration for TracesEndpoint/ MetricsEndpoint/ LogsEndpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,7 @@ Main (unreleased)
 
 - Fixes several issues with statsd exporter. (@jcreixell, @marctc)
 
-- Fix bug where `otelcol.exporter.otlphttp` ignores configuration for TracesEndpoint/ MetricsEndpoint/ LogsEndpoint
-
+- Fix bug where `otelcol.exporter.otlphttp` ignores configuration for TracesEndpoint, MetricsEndpoint, and LogsEndpoint. (@SimoneFalzone)
 ### Other changes
 
 - Mongodb integration has been disabled for the time being due to licensing issues. (@jcreixell)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ Main (unreleased)
 
 - Fixes a bug in conversion of OpenTelemetry histograms when exported to Prometheus. (@grcevski)
 
-- Fix bug where `otelcol.exporter.otlphttp` ignores configuration for TracesEndpoint, MetricsEndpoint, and LogsEndpoint. (@SimoneFalzone)
+- Fix bug where `otelcol.exporter.otlphttp` ignores configuration for `traces_endpoint`, `metrics_endpoint`, and `logs_endpoint` attributes. (@SimoneFalzone)
 ### Other changes
 
 - Mongodb integration has been disabled for the time being due to licensing issues. (@jcreixell)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ Main (unreleased)
 
 - Fixes several issues with statsd exporter. (@jcreixell, @marctc)
 
+- Fix bug where `otelcol.exporter.otlphttp` ignores configuration for TracesEndpoint/ MetricsEndpoint/ LogsEndpoint
+
 ### Other changes
 
 - Mongodb integration has been disabled for the time being due to licensing issues. (@jcreixell)

--- a/component/otelcol/exporter/otlphttp/otlphttp.go
+++ b/component/otelcol/exporter/otlphttp/otlphttp.go
@@ -64,6 +64,9 @@ func (args Arguments) Convert() (otelconfig.Exporter, error) {
 		HTTPClientSettings: *(*otelcol.HTTPClientArguments)(&args.Client).Convert(),
 		QueueSettings:      *args.Queue.Convert(),
 		RetrySettings:      *args.Retry.Convert(),
+		TracesEndpoint:     args.TracesEndpoint,
+		MetricsEndpoint:    args.MetricsEndpoint,
+		LogsEndpoint:       args.MetricsEndpoint,
 	}, nil
 }
 

--- a/component/otelcol/exporter/otlphttp/otlphttp.go
+++ b/component/otelcol/exporter/otlphttp/otlphttp.go
@@ -66,7 +66,7 @@ func (args Arguments) Convert() (otelconfig.Exporter, error) {
 		RetrySettings:      *args.Retry.Convert(),
 		TracesEndpoint:     args.TracesEndpoint,
 		MetricsEndpoint:    args.MetricsEndpoint,
-		LogsEndpoint:       args.MetricsEndpoint,
+		LogsEndpoint:       args.LogsEndpoint,
 	}, nil
 }
 


### PR DESCRIPTION
#### PR Description
Fix bug where `otelcol.exporter.otlphttp` ignores configuration for TracesEndpoint/ MetricsEndpoint/ LogsEndpoint

#### Which issue(s) this PR fixes

Fixes [#4206](https://github.com/grafana/agent/issues/4210)

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
