### PR TITLE
Disable blackbox metrics when integration is not enabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -130,7 +130,7 @@ require (
 	github.com/prometheus-operator/prometheus-operator v0.62.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.63.0
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.63.0
-	github.com/prometheus/blackbox_exporter v0.24.0
+	github.com/prometheus/blackbox_exporter v0.24.1-0.20230623125439-bd22efa1c900
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/client_model v0.4.0
 	github.com/prometheus/common v0.44.0

--- a/go.sum
+++ b/go.sum
@@ -2715,8 +2715,8 @@ github.com/prometheus-operator/prometheus-operator/pkg/client v0.63.0/go.mod h1:
 github.com/prometheus/alertmanager v0.23.1-0.20210914172521-e35efbddb66a/go.mod h1:U7pGu+z7A9ZKhK8lq1MvIOp5GdVlZjwOYk+S0h3LSbA=
 github.com/prometheus/alertmanager v0.25.0 h1:vbXKUR6PYRiZPRIKfmXaG+dmCKG52RtPL4Btl8hQGvg=
 github.com/prometheus/alertmanager v0.25.0/go.mod h1:MEZ3rFVHqKZsw7IcNS/m4AWZeXThmJhumpiWR4eHU/w=
-github.com/prometheus/blackbox_exporter v0.24.0 h1:IttStBJcxgyIscyX5INsrIgLOhaADQF346kpf8PnO1g=
-github.com/prometheus/blackbox_exporter v0.24.0/go.mod h1:SfZtJPNWmR8SskeJMmggTpc/mFERPcSAKl7/REjnx/0=
+github.com/prometheus/blackbox_exporter v0.24.1-0.20230623125439-bd22efa1c900 h1:mb3ShwohzXGV4JUW0XlEGPElmCMTQzEaVnWUzuoGMak=
+github.com/prometheus/blackbox_exporter v0.24.1-0.20230623125439-bd22efa1c900/go.mod h1:DA04rk1tezjADhTMhq5fi3yOF1/Z0gY/pczP76BnvwQ=
 github.com/prometheus/client_golang v0.0.0-20180209125602-c332b6f63c06/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.0.0-20180328130430-f504d69affe1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/pkg/integrations/blackbox_exporter/blackbox_exporter.go
+++ b/pkg/integrations/blackbox_exporter/blackbox_exporter.go
@@ -120,7 +120,7 @@ type Integration struct {
 // MetricsHandler implements Integration.
 func (i *Integration) MetricsHandler() (http.Handler, error) {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		prober.Handler(w, r, i.modules, i.log, &prober.ResultHistory{}, i.cfg.ProbeTimeoutOffset, nil)
+		prober.Handler(w, r, i.modules, i.log, &prober.ResultHistory{}, i.cfg.ProbeTimeoutOffset, nil, nil)
 	}), nil
 }
 

--- a/pkg/integrations/v2/blackbox_exporter/blackbox.go
+++ b/pkg/integrations/v2/blackbox_exporter/blackbox.go
@@ -109,7 +109,7 @@ func (bbh *blackboxHandler) createHandler(targets []blackbox_exporter.BlackboxTa
 			params.Set("module", t.Module)
 		}
 
-		prober.Handler(w, r, bbh.modules, bbh.log, &prober.ResultHistory{}, bbh.cfg.ProbeTimeoutOffset, params)
+		prober.Handler(w, r, bbh.modules, bbh.log, &prober.ResultHistory{}, bbh.cfg.ProbeTimeoutOffset, params, nil)
 	}
 }
 


### PR DESCRIPTION
#### PR Description

This PR includes the last changes of blackbox exporter, which has this [PR](https://github.com/prometheus/blackbox_exporter/pull/1060). Those changes are to prevent that some of the metrics of blackbox exporter where automatically added to global metrics registry even if the blackbox integration was not enabled.

#### Which issue(s) this PR fixes

Fixes #2627

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
