### PR TITLE
[Docs] Replace 'agent fmt' with 'grafana-agent fmt'

### DIFF
--- a/docs/sources/flow/reference/cli/fmt.md
+++ b/docs/sources/flow/reference/cli/fmt.md
@@ -3,21 +3,21 @@ title: grafana-agent fmt
 weight: 100
 ---
 
-# `agent fmt` command
+# `grafana-agent fmt` command
 
-The `agent fmt` command formats a given Grafana Agent Flow configuration file.
+The `grafana-agent fmt` command formats a given Grafana Agent Flow configuration file.
 
 ## Usage
 
-Usage: `agent fmt [FLAG ...] FILE_NAME`
+Usage: `grafana-agent fmt [FLAG ...] FILE_NAME`
 
 If the `FILE_NAME` argument is not provided or if the `FILE_NAME` argument is
-equal to `-`, `agent fmt` formats the contents of standard input. Otherwise,
-`agent fmt` reads and formats the file from disk specified by the argument.
+equal to `-`, `grafana-agent fmt` formats the contents of standard input. Otherwise,
+`grafana-agent fmt` reads and formats the file from disk specified by the argument.
 
 The `--write` flag can be specified to replace the contents of the original
 file on disk with the formatted results. `--write` can only be provided when
-`agent fmt` is not reading from standard input.
+`grafana-agent fmt` is not reading from standard input.
 
 The command fails if the file being formatted has syntactically incorrect River
 configuration, but does not validate whether Flow components are configured


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Fixes the binary name for the command to format river files.

#### PR Checklist

- [ ] CHANGELOG updated
- [X] Documentation added
- [ ] Tests updated
