### PR TITLE
clustering: add basic UI page for peer info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Main (unreleased)
 
 - Added json_path function to river stdlib. (@jkroepke)
 
+- Flow UI: Add a view for listing the Agent's peers status when clustering is enabled. (@tpaschalis) 
+
 ### Enhancements
 
 - Attributes and blocks set to their default values will no longer be shown in the Flow UI. (@rfratto)

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -262,7 +262,7 @@ func (fr *flowRun) Run(configFile string) error {
 		}).Methods(http.MethodGet, http.MethodPost)
 
 		// Register Routes must be the last
-		fa := api.NewFlowAPI(f)
+		fa := api.NewFlowAPI(f, clusterer.Node)
 		fa.RegisterRoutes(path.Join(fr.uiPrefix, "/api/v0/web"), r)
 
 		// NOTE(rfratto): keep this at the bottom of all other routes, otherwise it

--- a/pkg/flow/module.go
+++ b/pkg/flow/module.go
@@ -130,7 +130,7 @@ func (c *module) Run(ctx context.Context) {
 func (c *module) ComponentHandler() (_ http.Handler) {
 	r := mux.NewRouter()
 
-	fa := api.NewFlowAPI(c.f)
+	fa := api.NewFlowAPI(c.f, c.f.clusterer.Node)
 	fa.RegisterRoutes("/", r)
 
 	r.PathPrefix("/{id}/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/web/api/api.go
+++ b/web/api/api.go
@@ -11,23 +11,26 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/pkg/cluster"
 	"github.com/prometheus/prometheus/util/httputil"
 )
 
 // FlowAPI is a wrapper around the component API.
 type FlowAPI struct {
 	flow component.Provider
+	node cluster.Node
 }
 
 // NewFlowAPI instantiates a new Flow API.
-func NewFlowAPI(flow component.Provider) *FlowAPI {
-	return &FlowAPI{flow: flow}
+func NewFlowAPI(flow component.Provider, node cluster.Node) *FlowAPI {
+	return &FlowAPI{flow: flow, node: node}
 }
 
 // RegisterRoutes registers all the API's routes.
 func (f *FlowAPI) RegisterRoutes(urlPrefix string, r *mux.Router) {
 	r.Handle(path.Join(urlPrefix, "/components"), httputil.CompressionHandler{Handler: f.listComponentsHandler()})
 	r.Handle(path.Join(urlPrefix, "/components/{id}"), httputil.CompressionHandler{Handler: f.getComponentHandler()})
+	r.Handle(path.Join(urlPrefix, "/peers"), httputil.CompressionHandler{Handler: f.getClusteringPeersHandler()})
 }
 
 func (f *FlowAPI) listComponentsHandler() http.HandlerFunc {
@@ -65,6 +68,20 @@ func (f *FlowAPI) getComponentHandler() http.HandlerFunc {
 		}
 
 		bb, err := json.Marshal(component)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write(bb)
+	}
+}
+
+func (f *FlowAPI) getClusteringPeersHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		// TODO(@tpaschalis) Detect if clustering is disabled and propagate to
+		// the Typescript code (eg. via the returned status code?).
+		peers := f.node.Peers()
+		bb, err := json.Marshal(peers)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/web/ui/src/Router.tsx
+++ b/web/ui/src/Router.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 import Navbar from './features/layout/Navbar';
+import PageClusteringPeers from './pages/Clustering';
 import ComponentDetailPage from './pages/ComponentDetailPage';
 import Graph from './pages/Graph';
 import PageComponentList from './pages/PageComponentList';
@@ -19,6 +20,7 @@ const Router = ({ basePath }: Props) => {
           <Route path="/" element={<PageComponentList />} />
           <Route path="/component/*" element={<ComponentDetailPage />} />
           <Route path="/graph" element={<Graph />} />
+          <Route path="/clustering" element={<PageClusteringPeers />} />
         </Routes>
       </main>
     </BrowserRouter>

--- a/web/ui/src/features/clustering/PeerList.module.css
+++ b/web/ui/src/features/clustering/PeerList.module.css
@@ -1,0 +1,35 @@
+.list {
+  border: 1px solid #e4e5e6;
+  border-radius: 3px;
+
+  box-sizing: border-box;
+  color: rgba(36, 41, 46, 0.75);
+}
+
+.list .viewButton {
+  background: none;
+  background-color: rgb(56, 133, 220);
+  color: #ffffff;
+  margin-left: auto;
+
+  border: 1px solid rgb(56, 133, 220);
+  border-radius: 3px;
+
+  text-decoration: none;
+
+  padding: 0px 15px;
+  line-height: 24px;
+  font-size: 0.8em;
+}
+
+.idColumn {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.idName {
+  width: 80%;
+  word-wrap: break-word;
+  display: inline-block;
+}

--- a/web/ui/src/features/clustering/PeerList.tsx
+++ b/web/ui/src/features/clustering/PeerList.tsx
@@ -1,0 +1,45 @@
+import { PeerInfo } from '../clustering/types';
+
+import Table from './Table';
+
+import styles from './PeerList.module.css';
+
+interface PeerListProps {
+  peers: PeerInfo[];
+}
+
+const TABLEHEADERS = ['Node Name', 'Advertised Address', 'Current State', 'Local Node'];
+
+const PeerList = ({ peers }: PeerListProps) => {
+  const tableStyles = { width: '130px' };
+
+  /**
+   * Custom renderer for table data
+   */
+  const renderTableData = () => {
+    return peers.map(({ name, addr, state, isSelf }) => (
+      <tr key={name} style={{ lineHeight: '2.5' }}>
+        <td>
+          <span className={styles.idName}>{name}</span>
+        </td>
+        <td>
+          <span className={styles.idName}>{addr}</span>
+        </td>
+        <td>
+          <span className={styles.idName}>{state}</span>
+        </td>
+        <td>
+          <span> {isSelf ? '✅' : '🚫'}</span>
+        </td>
+      </tr>
+    ));
+  };
+
+  return (
+    <div className={styles.list}>
+      <Table tableHeaders={TABLEHEADERS} renderTableData={renderTableData} style={tableStyles} />
+    </div>
+  );
+};
+
+export default PeerList;

--- a/web/ui/src/features/clustering/Table.module.css
+++ b/web/ui/src/features/clustering/Table.module.css
@@ -1,0 +1,34 @@
+.table {
+  border-collapse: collapse;
+  width: 100%;
+  table-layout: fixed;
+}
+
+.table td,
+.table th {
+  border: none;
+  padding: 0px 8px;
+}
+
+.table tr:nth-child(odd) {
+  background-color: #f4f5f5;
+}
+
+.table tr:nth-child(even) {
+  background-color: white;
+}
+
+.table tr:hover {
+  background-color: #ddd;
+}
+
+.table th {
+  padding: 8px;
+  text-align: left;
+  background-color: #f4f5f5;
+  color: rgba(36, 41, 46, 0.75);
+}
+
+.table td:first-child {
+  width: 40%;
+}

--- a/web/ui/src/features/clustering/Table.module.css
+++ b/web/ui/src/features/clustering/Table.module.css
@@ -1,7 +1,6 @@
 .table {
   border-collapse: collapse;
   width: 100%;
-  table-layout: fixed;
 }
 
 .table td,
@@ -30,5 +29,5 @@
 }
 
 .table td:first-child {
-  width: 40%;
+  width: 25%;
 }

--- a/web/ui/src/features/clustering/Table.tsx
+++ b/web/ui/src/features/clustering/Table.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import styles from './Table.module.css';
+
+interface Props {
+  tableHeaders: string[];
+  style?: React.CSSProperties;
+  renderTableData: () => JSX.Element[];
+}
+
+/**
+ * Simple table component that accept a custom header, and custom render
+ * function for the table data
+ */
+const Table = ({ tableHeaders, style = {}, renderTableData }: Props) => {
+  return (
+    <table className={styles.table}>
+      <colgroup span={1} style={style} />
+      <tbody>
+        <tr>
+          {tableHeaders.map((header) => (
+            <th key={header}>{header}</th>
+          ))}
+        </tr>
+        {renderTableData()}
+      </tbody>
+    </table>
+  );
+};
+
+export default Table;

--- a/web/ui/src/features/clustering/types.ts
+++ b/web/ui/src/features/clustering/types.ts
@@ -1,0 +1,9 @@
+export interface PeerInfo {
+  name: string;
+
+  addr: string;
+
+  state: string;
+
+  isSelf: boolean;
+}

--- a/web/ui/src/features/layout/Navbar.tsx
+++ b/web/ui/src/features/layout/Navbar.tsx
@@ -19,6 +19,11 @@ function Navbar() {
           </NavLink>
         </li>
         <li>
+          <NavLink to="/clustering" className="nav-link">
+            Clustering
+          </NavLink>
+        </li>
+        <li>
           <a href="https://grafana.com/docs/agent/latest">Help</a>
         </li>
       </ul>

--- a/web/ui/src/hooks/peerInfo.tsx
+++ b/web/ui/src/hooks/peerInfo.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+
+import { PeerInfo } from '../features/clustering/types';
+
+/**
+ * usePeerInfo retrieves the list of clustering peers from the API.
+ *
+ * @param fromPeer The peer requesting component info.
+ */
+export const usePeerInfo = (fromPeer?: string): PeerInfo[] => {
+  const [peers, setPeers] = useState<PeerInfo[]>([]);
+
+  useEffect(
+    function () {
+      const worker = async () => {
+        const infoPath = './api/v0/web/peers';
+
+        // Request is relative to the <base> tag inside of <head>.
+        const resp = await fetch(infoPath, {
+          cache: 'no-cache',
+          credentials: 'same-origin',
+        });
+        setPeers(await resp.json());
+      };
+
+      worker().catch(console.error);
+    },
+    [fromPeer]
+  );
+
+  return peers;
+};

--- a/web/ui/src/pages/Clustering.tsx
+++ b/web/ui/src/pages/Clustering.tsx
@@ -1,4 +1,4 @@
-import { faCubes } from '@fortawesome/free-solid-svg-icons';
+import { faNetworkWired } from '@fortawesome/free-solid-svg-icons';
 
 import PeerList from '../features/clustering/PeerList';
 import Page from '../features/layout/Page';
@@ -8,7 +8,7 @@ function PageClusteringPeers() {
   const peers = usePeerInfo();
 
   return (
-    <Page name="Clustering" desc="List of clustering peers." icon={faCubes}>
+    <Page name="Clustering" desc="List of clustering peers" icon={faNetworkWired}>
       <PeerList peers={peers} />
     </Page>
   );

--- a/web/ui/src/pages/Clustering.tsx
+++ b/web/ui/src/pages/Clustering.tsx
@@ -1,0 +1,17 @@
+import { faCubes } from '@fortawesome/free-solid-svg-icons';
+
+import PeerList from '../features/clustering/PeerList';
+import Page from '../features/layout/Page';
+import { usePeerInfo } from '../hooks/peerInfo';
+
+function PageClusteringPeers() {
+  const peers = usePeerInfo();
+
+  return (
+    <Page name="Clustering" desc="List of clustering peers." icon={faCubes}>
+      <PeerList peers={peers} />
+    </Page>
+  );
+}
+
+export default PageClusteringPeers;


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR adds a first version of a Flow UI page that contains information around Agent Clustering.

* It introduces a new /api/v0/web/peers endpoint that is wired to call the Peers() method of the Flow controller's clusterer.
* It copies the Typescript/React `ComponentList` code and adds the hooks and types to populate with the API response
* It adds a new page under /clustering and adds it to the NavBar

![image](https://github.com/grafana/agent/assets/17771679/4117f5cf-4ddd-4635-9d00-64a9c4ee9a10)

One thing that I'd like to do here is to be able to expand the width of the "Node Name" column but so far I've had no luck 🤦 

Another thing that is potentially interesting is to show/hide the page from the NavBar and conditionally render it only when clustering is _enabled_ and we haven't fallen back to the localNode implementation. Do you think it's worth it?

#### Which issue(s) this PR fixes
Fixes #3483 

#### Notes to the Reviewer
* It's my first time ever touching our React-based UI, so please advice about things that could/should be done differently.
* This depends on https://github.com/grafana/ckit/pull/22 to be merged. Alternatively we could introduce a lightweight wrapper around it on our end here.
* Ideally, this table should be sortable/filterable in the future. Similarly, we could explore if we could make our helm chart so that it's easy to navigate from one node's UI to another via the UI.

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
