### PR TITLE
Use sha256 for rpm signing to allow installation on fips-enabed systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ Main (unreleased)
 
 - Update `redis_exporter` dependency to v1.51.0. (@jcreixell)
 
+- Enforce sha256 digest signing for rpms enabling installation on FIPS-enabled OSes. (@kfriedrich123)
+
 ### Bugfixes
 
 - Add signing region to remote.s3 component for use with custom endpoints so that Authorization Headers work correctly when

--- a/packaging/grafana-agent-flow/rpm/gpg-sign.sh
+++ b/packaging/grafana-agent-flow/rpm/gpg-sign.sh
@@ -17,6 +17,7 @@ echo "%_gpg_name Grafana <info@grafana.com>
 %_signature gpg
 %_gpg_path /root/.gnupg
 %_gpgbin /usr/bin/gpg
+%_gpg_digest_algo sha256
 %__gpg /usr/bin/gpg
 %__gpg_sign_cmd     %{__gpg} \
          gpg --no-tty --batch --yes --no-verbose --no-armor \

--- a/packaging/grafana-agent/rpm/gpg-sign.sh
+++ b/packaging/grafana-agent/rpm/gpg-sign.sh
@@ -17,6 +17,7 @@ echo "%_gpg_name Grafana <info@grafana.com>
 %_signature gpg
 %_gpg_path /root/.gnupg
 %_gpgbin /usr/bin/gpg
+%_gpg_digest_algo sha256
 %__gpg /usr/bin/gpg
 %__gpg_sign_cmd     %{__gpg} \
          gpg --no-tty --batch --yes --no-verbose --no-armor \


### PR DESCRIPTION
#### PR Description

Sets gpg digest signing algo to sha256 to allow rpm installation on FIPS enabled OS'es

#### Which issue(s) this PR fixes

Fixes #4267 

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
