### PR TITLE
Fix release signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ Main (unreleased)
   `metadata_config` blocks used incorrect defaults when not specified in the
   config file. (@rfratto)
 
+- Fix issue where published RPMs were not signed. (@rfratto)
+
 v0.34.2 (2023-06-20)
 --------------------
 

--- a/tools/release
+++ b/tools/release
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This script should be run from the root of the repository.
-set -x
+set -ex
 
 # Zip up all the agent binaries to reduce the download size. DEBs and RPMs
 # aren't included to be easier to work with.

--- a/tools/release
+++ b/tools/release
@@ -10,7 +10,8 @@ find dist/ -type f \
   -exec zip -j -m "{}.zip" "{}" \;
 
 # Sign the RPM packages. DEB packages aren't signed.
-./packaging/rpm/gpg-sign.sh
+./packaging/grafana-agent/rpm/gpg-sign.sh
+./packaging/grafana-agent-flow/rpm/gpg-sign.sh
 
 # Get the SHA256SUMS before continuing.
 pushd dist && sha256sum -- * > SHA256SUMS && popd || exit


### PR DESCRIPTION
@julienduchesne found that the `tools/release` script wasn't updated to call the new gpg-sign.sh paths after the Grafana Agent Flow package was introduced.

Related to #4268. 