### PR TITLE
[Agent Management] Add Label Management

### DIFF
--- a/docs/sources/static/configuration/agent-management.md
+++ b/docs/sources/static/configuration/agent-management.md
@@ -48,6 +48,12 @@ agent_management:
     # Set of self-identifying labels used for snippet selection.
     labels:
       [ <labelname>: <labelvalue> ... ]
+
+    # Whether to use labels from the label management service. If enabled, labels from the API supersede the ones configured in the agent.
+    label_management_enabled: <bool>
+
+    # A unique ID for the agent, which is used to identify the agent in the label management service.
+    agent_id: <string>
 ```
 
 ## API (v2)

--- a/docs/sources/static/configuration/agent-management.md
+++ b/docs/sources/static/configuration/agent-management.md
@@ -50,9 +50,9 @@ agent_management:
       [ <labelname>: <labelvalue> ... ]
 
     # Whether to use labels from the label management service. If enabled, labels from the API supersede the ones configured in the agent.
-    label_management_enabled: <bool>
+    label_management_enabled: <bool> | default = false
 
-    # A unique ID for the agent, which is used to identify the agent in the label management service.
+    # A unique ID for the agent, which is used to identify the agent.
     agent_id: <string>
 ```
 

--- a/pkg/config/agentmanagement.go
+++ b/pkg/config/agentmanagement.go
@@ -156,7 +156,7 @@ func (r remoteConfigHTTPProvider) FetchRemoteConfig() ([]byte, error) {
 	}
 
 	client := &http.Client{
-		Timeout: 5*time.Second,
+		Timeout: 5 * time.Second,
 	}
 	response, err := client.Do(req)
 	if err != nil {

--- a/pkg/config/agentmanagement.go
+++ b/pkg/config/agentmanagement.go
@@ -23,8 +23,12 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const cacheFilename = "remote-config-cache.yaml"
-const apiPath = "/agent-management/api/agent/v2"
+const (
+	cacheFilename                = "remote-config-cache.yaml"
+	apiPath                      = "/agent-management/api/agent/v2"
+	labelManagementEnabledHeader = "X-LabelManagementEnabled"
+	agentIDHeader                = "X-AgentID"
+)
 
 type remoteConfigProvider interface {
 	GetCachedRemoteConfig() ([]byte, error)
@@ -151,8 +155,8 @@ func (r remoteConfigHTTPProvider) FetchRemoteConfig() ([]byte, error) {
 
 	// Set headers for label management, if enabled
 	if r.InitialConfig.RemoteConfiguration.LabelManagementEnabled && r.InitialConfig.RemoteConfiguration.AgentID != "" {
-		req.Header.Add("X-LabelManagementEnabled", "1")
-		req.Header.Add("X-AgentID", r.InitialConfig.RemoteConfiguration.AgentID)
+		req.Header.Add(labelManagementEnabledHeader, "1")
+		req.Header.Add(agentIDHeader, r.InitialConfig.RemoteConfiguration.AgentID)
 	}
 
 	client := &http.Client{

--- a/pkg/config/agentmanagement.go
+++ b/pkg/config/agentmanagement.go
@@ -306,5 +306,9 @@ func (am *AgentManagementConfig) Validate() error {
 		return errors.New("path to cache must be specified in 'agent_management.remote_configuration.cache_location'")
 	}
 
+	if am.RemoteConfiguration.LabelManagementEnabled && am.RemoteConfiguration.AgentID == "" {
+		return errors.New("agent_id must be specified in 'agent_management.remote_configuration' if label_management_enabled is true")
+	}
+
 	return nil
 }

--- a/pkg/config/agentmanagement_test.go
+++ b/pkg/config/agentmanagement_test.go
@@ -518,31 +518,3 @@ func TestGetCachedConfig_RetryAfter(t *testing.T) {
 	// attempt to fetch the remote config
 	assert.Equal(t, 1, testProvider.getCachedConfigCallCount)
 }
-
-func TestCreateHTTPRequest(t *testing.T) {
-	c := validAgentManagementConfig
-	c.BasicAuth.PasswordFile = "./testdata/example_password.txt"
-
-	// First test with no label management enabled
-	req, err := createHTTPRequest(&c)
-	assert.NoError(t, err)
-	assert.Equal(t, "https://localhost:1234/agent-management/api/agent/v2/namespace/test_namespace/remote_config?a=A&b=B", req.URL.String())
-	assert.Equal(t, "GET", req.Method)
-	assert.Equal(t, "", req.Header.Get(agentIDHeader))
-	assert.Equal(t, "", req.Header.Get(labelManagementEnabledHeader))
-
-	// Add label management configurations
-	c.RemoteConfiguration = RemoteConfiguration{
-		AgentID:                "test-agent-id",
-		LabelManagementEnabled: true,
-		Namespace:              "test_namespace",
-		CacheLocation:          "/test/path/",
-	}
-
-	req, err = createHTTPRequest(&c)
-	assert.NoError(t, err)
-	assert.Equal(t, "https://localhost:1234/agent-management/api/agent/v2/namespace/test_namespace/remote_config", req.URL.String())
-	assert.Equal(t, "GET", req.Method)
-	assert.Equal(t, "test-agent-id", req.Header.Get(agentIDHeader))
-	assert.Equal(t, "1", req.Header.Get(labelManagementEnabledHeader))
-}

--- a/pkg/config/agentmanagement_test.go
+++ b/pkg/config/agentmanagement_test.go
@@ -518,3 +518,31 @@ func TestGetCachedConfig_RetryAfter(t *testing.T) {
 	// attempt to fetch the remote config
 	assert.Equal(t, 1, testProvider.getCachedConfigCallCount)
 }
+
+func TestCreateHTTPRequest(t *testing.T) {
+	c := validAgentManagementConfig
+	c.BasicAuth.PasswordFile = "./testdata/example_password.txt"
+
+	// First test with no label management enabled
+	req, err := createHTTPRequest(&c)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://localhost:1234/agent-management/api/agent/v2/namespace/test_namespace/remote_config?a=A&b=B", req.URL.String())
+	assert.Equal(t, "GET", req.Method)
+	assert.Equal(t, "", req.Header.Get(agentIDHeader))
+	assert.Equal(t, "", req.Header.Get(labelManagementEnabledHeader))
+
+	// Add label management configurations
+	c.RemoteConfiguration = RemoteConfiguration{
+		AgentID: 	 "test-agent-id",
+		LabelManagementEnabled: true,
+		Namespace:  "test_namespace",
+		CacheLocation: "/test/path/",
+	}
+
+	req, err = createHTTPRequest(&c)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://localhost:1234/agent-management/api/agent/v2/namespace/test_namespace/remote_config", req.URL.String())
+	assert.Equal(t, "GET", req.Method)
+	assert.Equal(t, "test-agent-id", req.Header.Get(agentIDHeader))
+	assert.Equal(t, "1", req.Header.Get(labelManagementEnabledHeader))
+}

--- a/pkg/config/agentmanagement_test.go
+++ b/pkg/config/agentmanagement_test.go
@@ -109,6 +109,29 @@ func TestMissingCacheLocation(t *testing.T) {
 	assert.Error(t, invalidConfig.Validate())
 }
 
+func TestValidateLabelManagement(t *testing.T) {
+	cfg := &AgentManagementConfig{
+		Enabled: true,
+		Host:    "localhost:1234",
+		BasicAuth: config.BasicAuth{
+			Username:     "test",
+			PasswordFile: "/test/path",
+		},
+		Protocol:        "https",
+		PollingInterval: time.Minute,
+		RemoteConfiguration: RemoteConfiguration{
+			Namespace:              "test_namespace",
+			CacheLocation:          "/test/path/",
+			LabelManagementEnabled: true,
+		},
+	}
+	// This should error as there is no agent_id set
+	assert.Error(t, cfg.Validate())
+
+	cfg.RemoteConfiguration.AgentID = "test_agent_id"
+	assert.NoError(t, cfg.Validate())
+}
+
 func TestSleepTime(t *testing.T) {
 	cfg := `
 api_url: "http://localhost"

--- a/pkg/config/agentmanagement_test.go
+++ b/pkg/config/agentmanagement_test.go
@@ -533,10 +533,10 @@ func TestCreateHTTPRequest(t *testing.T) {
 
 	// Add label management configurations
 	c.RemoteConfiguration = RemoteConfiguration{
-		AgentID: 	 "test-agent-id",
+		AgentID:                "test-agent-id",
 		LabelManagementEnabled: true,
-		Namespace:  "test_namespace",
-		CacheLocation: "/test/path/",
+		Namespace:              "test_namespace",
+		CacheLocation:          "/test/path/",
 	}
 
 	req, err = createHTTPRequest(&c)

--- a/pkg/config/testdata/example_password.txt
+++ b/pkg/config/testdata/example_password.txt
@@ -1,1 +1,0 @@
-example

--- a/pkg/config/testdata/example_password.txt
+++ b/pkg/config/testdata/example_password.txt
@@ -1,0 +1,1 @@
+example


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
In order to add HTTP headers to the request, `FetchRemoteConfig` had to be changed to make raw HTTP requests, rather than using the code in the `remote_config` package. The behavior (in terms of metrics exposed and `Retry-After`) should be the same.

Other than that the primary change is here (and in the `RemoteConfiguration` struct to add the new fields):
```go
// Set headers for label management, if enabled
if r.InitialConfig.RemoteConfiguration.LabelManagementEnabled && r.InitialConfig.RemoteConfiguration.AgentID != "" {
	req.Header.Add("X-LabelManagementEnabled", "1")
	req.Header.Add("X-AgentID", r.InitialConfig.RemoteConfiguration.AgentID)
}
```
which adds the headers necessary for label management when (a) it is enabled in the config and (b) an `agent_id` was set.

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [X] Tests updated
