### PR TITLE
clustering: allow setting the node's name with a CLI flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ Main (unreleased)
 
 - Update OpenTelemetry Collector dependencies from v0.63.0 to v0.80.0. (@ptodev)
 
+- Allow setting the node name for clusterng with a command-line flag. (@tpaschalis)
+
 ### Bugfixes
 
 - Add signing region to remote.s3 component for use with custom endpoints so that Authorization Headers work correctly when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ Main (unreleased)
 
 - Update OpenTelemetry Collector dependencies from v0.63.0 to v0.80.0. (@ptodev)
 
-- Allow setting the node name for clusterng with a command-line flag. (@tpaschalis)
+- Allow setting the node name for clustering with a command-line flag. (@tpaschalis)
 
 ### Bugfixes
 

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -97,7 +97,7 @@ depending on the nature of the reload error.
 	cmd.Flags().
 		BoolVar(&r.clusterEnabled, "cluster.enabled", r.clusterEnabled, "Start in clustered mode")
 	cmd.Flags().
-		StringVar(&r.clusterAdvAddr, "cluster.node-name", r.clusterNodeName, "The name to use for this node")
+		StringVar(&r.clusterNodeName, "cluster.node-name", r.clusterNodeName, "The name to use for this node")
 	cmd.Flags().
 		StringVar(&r.clusterAdvAddr, "cluster.advertise-address", r.clusterAdvAddr, "Address to advertise to the cluster")
 	cmd.Flags().

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -97,6 +97,8 @@ depending on the nature of the reload error.
 	cmd.Flags().
 		BoolVar(&r.clusterEnabled, "cluster.enabled", r.clusterEnabled, "Start in clustered mode")
 	cmd.Flags().
+		StringVar(&r.clusterAdvAddr, "cluster.node-name", r.clusterNodeName, "The name to use for this node")
+	cmd.Flags().
 		StringVar(&r.clusterAdvAddr, "cluster.advertise-address", r.clusterAdvAddr, "Address to advertise to the cluster")
 	cmd.Flags().
 		StringVar(&r.clusterJoinAddr, "cluster.join-addresses", r.clusterJoinAddr, "Comma-separated list of addresses to join the cluster at")
@@ -115,6 +117,7 @@ type flowRun struct {
 	enablePprof                    bool
 	disableReporting               bool
 	clusterEnabled                 bool
+	clusterNodeName                string
 	clusterAdvAddr                 string
 	clusterJoinAddr                string
 	configFormat                   string
@@ -165,7 +168,7 @@ func (fr *flowRun) Run(configFile string) error {
 	reg := prometheus.DefaultRegisterer
 	reg.MustRegister(newResourcesCollector(l))
 
-	clusterer, err := cluster.New(l, reg, fr.clusterEnabled, fr.httpListenAddr, fr.clusterAdvAddr, fr.clusterJoinAddr)
+	clusterer, err := cluster.New(l, reg, fr.clusterEnabled, fr.clusterNodeName, fr.httpListenAddr, fr.clusterAdvAddr, fr.clusterJoinAddr)
 	if err != nil {
 		return fmt.Errorf("building clusterer: %w", err)
 	}

--- a/docs/sources/flow/reference/cli/run.md
+++ b/docs/sources/flow/reference/cli/run.md
@@ -35,7 +35,7 @@ The following flags are supported:
 * `--storage.path`: Base directory where components can store data (default `data-agent/`).
 * `--disable-reporting`: Disable [usage reporting][] of enabled [components][] to Grafana (default `false`).
 * `--cluster.enabled`: Start the Agent in clustered mode (default `false`).
-* `--cluster.node-name`: The name to use for this node (defaults to the environment's HOSTNAME).
+* `--cluster.node-name`: The name to use for this node (defaults to the environment's hostname).
 * `--cluster.join-addresses`: Comma-separated list of addresses to join the cluster at (default `""`).
 * `--cluster.advertise-address`: Address to advertise to other cluster nodes (default `""`).
 * `--config.format`: The format of the source file. Supported formats: 'flow', 'prometheus' (default `"flow"`).
@@ -75,7 +75,8 @@ bootstrapping a new cluster of its own.
 
 Each node's name must be unique within the cluster. The node name defaults to
 the machine's hostname but can be set to a different value by using the
-`--cluster.node-name` flag.
+`--cluster.node-name` flag. Mainly useful for running clustered agents on the
+same machine.
 
 The agent will advertise its own address as `--cluster.advertise-address` to
 other agent nodes; if this is empty it will attempt to find a suitable address

--- a/docs/sources/flow/reference/cli/run.md
+++ b/docs/sources/flow/reference/cli/run.md
@@ -35,6 +35,7 @@ The following flags are supported:
 * `--storage.path`: Base directory where components can store data (default `data-agent/`).
 * `--disable-reporting`: Disable [usage reporting][] of enabled [components][] to Grafana (default `false`).
 * `--cluster.enabled`: Start the Agent in clustered mode (default `false`).
+* `--cluster.node-name`: The name to use for this node (defaults to the environment's HOSTNAME).
 * `--cluster.join-addresses`: Comma-separated list of addresses to join the cluster at (default `""`).
 * `--cluster.advertise-address`: Address to advertise to other cluster nodes (default `""`).
 * `--config.format`: The format of the source file. Supported formats: 'flow', 'prometheus' (default `"flow"`).
@@ -71,6 +72,10 @@ The agent tries to connect over HTTP/2 to one or more peers provided in the
 comma-separated `--cluster.join-addresses` list to join an existing cluster.
 If no connection can be made or the argument is empty, the agent falls back to
 bootstrapping a new cluster of its own.
+
+Each node's name must be unique within the cluster. The node name defaults to
+the machine's hostname but can be set to a different value by using the
+`--cluster.node-name` flag.
 
 The agent will advertise its own address as `--cluster.advertise-address` to
 other agent nodes; if this is empty it will attempt to find a suitable address

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -117,7 +117,7 @@ func getJoinAddr(addrs []string, in string) []string {
 }
 
 // New creates a Clusterer.
-func New(log log.Logger, reg prometheus.Registerer, clusterEnabled bool, listenAddr, advertiseAddr, joinAddr string) (*Clusterer, error) {
+func New(log log.Logger, reg prometheus.Registerer, clusterEnabled bool, name, listenAddr, advertiseAddr, joinAddr string) (*Clusterer, error) {
 	// Standalone node.
 	if !clusterEnabled {
 		return &Clusterer{Node: NewLocalNode(listenAddr)}, nil
@@ -132,6 +132,10 @@ func New(log log.Logger, reg prometheus.Registerer, clusterEnabled bool, listenA
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if name != "" {
+		gossipConfig.NodeName = name
 	}
 
 	if advertiseAddr != "" {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR allows users to configure the node name used for clustering with a command line flag. Since the empty node name defaults to the node's HOSTNAME, it made it difficult to test clustering on a single machine.

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer
The list of clustering-based options has continued growing. This is the last new option I'm adding without some kind of structure to it. Once/if https://github.com/grafana/agent/issues/4253 is up, then we'll probably need to refactor the way we configure clustering either way.

#### PR Checklist

- [X] CHANGELOG updated
- [X] Documentation added
- [ ] Tests updated
