### PR TITLE
river/vm: unwrap nonsesitive OptionalSecret before performing binary ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Main (unreleased)
 
 - Added json_path function to river stdlib. (@jkroepke)
 
-- Flow UI: Add a view for listing the Agent's peers status when clustering is enabled. (@tpaschalis) 
+- Flow UI: Add a view for listing the Agent's peers status when clustering is enabled. (@tpaschalis)
 
 ### Enhancements
 
@@ -73,6 +73,9 @@ Main (unreleased)
   config file. (@rfratto)
 
 - Fix issue where published RPMs were not signed. (@rfratto)
+
+- Fix issue where flow mode exports labeled as "string or secret" could not be
+  used in a binary operation. (@rfratto)
 
 ### Other changes
 

--- a/pkg/river/vm/op_binary_test.go
+++ b/pkg/river/vm/op_binary_test.go
@@ -46,6 +46,21 @@ func TestVM_OptionalSecret_Conversion(t *testing.T) {
 			expect: bool(true),
 		},
 		{
+			name:   "capsule (secret) == capsule (secret)",
+			input:  `secret_val == secret_val`,
+			expect: bool(true),
+		},
+		{
+			name:   "capsule (non secret) == capsule (non secret)",
+			input:  `non_secret_val == non_secret_val`,
+			expect: bool(true),
+		},
+		{
+			name:   "capsule (non secret) == capsule (secret)",
+			input:  `non_secret_val == secret_val`,
+			expect: bool(false),
+		},
+		{
 			name:        "secret + string",
 			input:       `secret_val + string_val`,
 			expectError: "secret_val should be one of [number string] for binop +",

--- a/pkg/river/vm/op_binary_test.go
+++ b/pkg/river/vm/op_binary_test.go
@@ -1,0 +1,79 @@
+package vm_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/grafana/agent/pkg/river/parser"
+	"github.com/grafana/agent/pkg/river/rivertypes"
+	"github.com/grafana/agent/pkg/river/vm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVM_OptionalSecret_Conversion(t *testing.T) {
+	scope := &vm.Scope{
+		Variables: map[string]any{
+			"string_val":     "hello",
+			"non_secret_val": rivertypes.OptionalSecret{IsSecret: false, Value: "world"},
+			"secret_val":     rivertypes.OptionalSecret{IsSecret: true, Value: "secret"},
+		},
+	}
+
+	tt := []struct {
+		name        string
+		input       string
+		expect      interface{}
+		expectError string
+	}{
+		{
+			name:   "string + capsule",
+			input:  `string_val + non_secret_val`,
+			expect: string("helloworld"),
+		},
+		{
+			name:   "capsule + string",
+			input:  `non_secret_val + string_val`,
+			expect: string("worldhello"),
+		},
+		{
+			name:   "string == capsule",
+			input:  `"world" == non_secret_val`,
+			expect: bool(true),
+		},
+		{
+			name:   "capsule == string",
+			input:  `non_secret_val == "world"`,
+			expect: bool(true),
+		},
+		{
+			name:        "secret + string",
+			input:       `secret_val + string_val`,
+			expectError: "secret_val should be one of [number string] for binop +",
+		},
+		{
+			name:        "string + secret",
+			input:       `string_val + secret_val`,
+			expectError: "secret_val should be one of [number string] for binop +",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := parser.ParseExpression(tc.input)
+			require.NoError(t, err)
+
+			expectTy := reflect.TypeOf(tc.expect)
+			if expectTy == nil {
+				expectTy = reflect.TypeOf((*any)(nil)).Elem()
+			}
+			rv := reflect.New(expectTy)
+
+			if err := vm.New(expr).Evaluate(scope, rv.Interface()); tc.expectError == "" {
+				require.NoError(t, err)
+				require.Equal(t, tc.expect, rv.Elem().Interface())
+			} else {
+				require.ErrorContains(t, err, tc.expectError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change unwraps an OptionalSecret (when IsSecret is false) to a string for the purposes of binary operations. This allows OptionalSecret to be compared to strings and concatenated with strings, including with other OptionalSecret values.

This is a hack to fix the observable behavior, but the nature of the fix means that other issues may still occur in the future if there are ever more capsule types which support conversion to a non-capsule type. A longer-term fix is needed once we identify what type of conversions binary operations should do.

Fixes #4036.