### PR TITLE
river/token/builder: don't always skip zero valued optional fields

### DIFF
--- a/converter/internal/prometheusconvert/testdata/azure.river
+++ b/converter/internal/prometheusconvert/testdata/azure.river
@@ -37,8 +37,9 @@ prometheus.scrape "prometheus2" {
 
 prometheus.remote_write "default" {
 	endpoint {
-		name = "remote1"
-		url  = "http://remote-write-url1"
+		name           = "remote1"
+		url            = "http://remote-write-url1"
+		send_exemplars = false
 
 		queue_config {
 			capacity             = 2500

--- a/converter/internal/prometheusconvert/testdata/consul.river
+++ b/converter/internal/prometheusconvert/testdata/consul.river
@@ -29,8 +29,9 @@ prometheus.scrape "prometheus2" {
 
 prometheus.remote_write "default" {
 	endpoint {
-		name = "remote1"
-		url  = "http://remote-write-url1"
+		name           = "remote1"
+		url            = "http://remote-write-url1"
+		send_exemplars = false
 
 		queue_config {
 			capacity             = 2500

--- a/converter/internal/prometheusconvert/testdata/digitalocean.river
+++ b/converter/internal/prometheusconvert/testdata/digitalocean.river
@@ -27,8 +27,9 @@ prometheus.scrape "prometheus2" {
 
 prometheus.remote_write "default" {
 	endpoint {
-		name = "remote1"
-		url  = "http://remote-write-url1"
+		name           = "remote1"
+		url            = "http://remote-write-url1"
+		send_exemplars = false
 
 		queue_config {
 			capacity             = 2500

--- a/converter/internal/prometheusconvert/testdata/discovery.river
+++ b/converter/internal/prometheusconvert/testdata/discovery.river
@@ -64,8 +64,9 @@ prometheus.relabel "prometheus1" {
 
 prometheus.remote_write "default" {
 	endpoint {
-		name = "remote1"
-		url  = "http://remote-write-url1"
+		name           = "remote1"
+		url            = "http://remote-write-url1"
+		send_exemplars = false
 
 		queue_config {
 			capacity             = 2500

--- a/converter/internal/prometheusconvert/testdata/discovery_relabel.river
+++ b/converter/internal/prometheusconvert/testdata/discovery_relabel.river
@@ -69,8 +69,9 @@ prometheus.scrape "prometheus2" {
 
 prometheus.remote_write "default" {
 	endpoint {
-		name = "remote1"
-		url  = "http://remote-write-url1"
+		name           = "remote1"
+		url            = "http://remote-write-url1"
+		send_exemplars = false
 
 		queue_config {
 			capacity             = 2500

--- a/converter/internal/prometheusconvert/testdata/dns.river
+++ b/converter/internal/prometheusconvert/testdata/dns.river
@@ -28,8 +28,9 @@ prometheus.scrape "prometheus2" {
 
 prometheus.remote_write "default" {
 	endpoint {
-		name = "remote1"
-		url  = "http://remote-write-url1"
+		name           = "remote1"
+		url            = "http://remote-write-url1"
+		send_exemplars = false
 
 		queue_config {
 			capacity             = 2500

--- a/converter/internal/prometheusconvert/testdata/docker.river
+++ b/converter/internal/prometheusconvert/testdata/docker.river
@@ -25,8 +25,9 @@ prometheus.scrape "prometheus2" {
 
 prometheus.remote_write "default" {
 	endpoint {
-		name = "remote1"
-		url  = "http://remote-write-url1"
+		name           = "remote1"
+		url            = "http://remote-write-url1"
+		send_exemplars = false
 
 		queue_config {
 			capacity             = 2500

--- a/converter/internal/prometheusconvert/testdata/ec2.river
+++ b/converter/internal/prometheusconvert/testdata/ec2.river
@@ -31,8 +31,9 @@ prometheus.scrape "prometheus2" {
 
 prometheus.remote_write "default" {
 	endpoint {
-		name = "remote1"
-		url  = "http://remote-write-url1"
+		name           = "remote1"
+		url            = "http://remote-write-url1"
+		send_exemplars = false
 
 		queue_config {
 			capacity             = 2500

--- a/converter/internal/prometheusconvert/testdata/gce.river
+++ b/converter/internal/prometheusconvert/testdata/gce.river
@@ -29,8 +29,9 @@ prometheus.scrape "prometheus2" {
 
 prometheus.remote_write "default" {
 	endpoint {
-		name = "remote1"
-		url  = "http://remote-write-url1"
+		name           = "remote1"
+		url            = "http://remote-write-url1"
+		send_exemplars = false
 
 		queue_config {
 			capacity             = 2500

--- a/converter/internal/prometheusconvert/testdata/kubernetes.river
+++ b/converter/internal/prometheusconvert/testdata/kubernetes.river
@@ -25,8 +25,9 @@ prometheus.scrape "prometheus2" {
 
 prometheus.remote_write "default" {
 	endpoint {
-		name = "remote1"
-		url  = "http://remote-write-url1"
+		name           = "remote1"
+		url            = "http://remote-write-url1"
+		send_exemplars = false
 
 		queue_config {
 			capacity             = 2500

--- a/converter/internal/prometheusconvert/testdata/lightsail.river
+++ b/converter/internal/prometheusconvert/testdata/lightsail.river
@@ -31,8 +31,9 @@ prometheus.scrape "prometheus2" {
 
 prometheus.remote_write "default" {
 	endpoint {
-		name = "remote1"
-		url  = "http://remote-write-url1"
+		name           = "remote1"
+		url            = "http://remote-write-url1"
+		send_exemplars = false
 
 		queue_config {
 			capacity             = 2500

--- a/converter/internal/prometheusconvert/testdata/metric_relabel.river
+++ b/converter/internal/prometheusconvert/testdata/metric_relabel.river
@@ -2,10 +2,11 @@ prometheus.scrape "prometheus1" {
 	targets = [{
 		__address__ = "localhost:9090",
 	}]
-	forward_to      = [prometheus.remote_write.default.receiver]
-	job_name        = "prometheus1"
-	scrape_interval = "10s"
-	scrape_timeout  = "5s"
+	forward_to       = [prometheus.remote_write.default.receiver]
+	job_name         = "prometheus1"
+	honor_timestamps = false
+	scrape_interval  = "10s"
+	scrape_timeout   = "5s"
 
 	basic_auth {
 		username = "user"
@@ -43,8 +44,9 @@ prometheus.remote_write "default" {
 	}
 
 	endpoint {
-		name = "remote1"
-		url  = "http://remote-write-url1"
+		name           = "remote1"
+		url            = "http://remote-write-url1"
+		send_exemplars = false
 
 		queue_config {
 			capacity             = 2500
@@ -58,8 +60,9 @@ prometheus.remote_write "default" {
 	}
 
 	endpoint {
-		name = "remote2"
-		url  = "http://remote-write-url2"
+		name           = "remote2"
+		url            = "http://remote-write-url2"
+		send_exemplars = false
 
 		queue_config {
 			capacity             = 2500

--- a/converter/internal/prometheusconvert/testdata/scrape.river
+++ b/converter/internal/prometheusconvert/testdata/scrape.river
@@ -9,10 +9,11 @@ prometheus.scrape "prometheus1" {
 			app         = "foo",
 		}],
 	)
-	forward_to      = [prometheus.remote_write.default.receiver]
-	job_name        = "prometheus1"
-	scrape_interval = "10s"
-	scrape_timeout  = "5s"
+	forward_to       = [prometheus.remote_write.default.receiver]
+	job_name         = "prometheus1"
+	honor_timestamps = false
+	scrape_interval  = "10s"
+	scrape_timeout   = "5s"
 
 	basic_auth {
 		username = "user"
@@ -42,8 +43,9 @@ prometheus.remote_write "default" {
 	}
 
 	endpoint {
-		name = "remote1"
-		url  = "http://remote-write-url1"
+		name           = "remote1"
+		url            = "http://remote-write-url1"
+		send_exemplars = false
 
 		queue_config {
 			capacity             = 2500
@@ -57,8 +59,9 @@ prometheus.remote_write "default" {
 	}
 
 	endpoint {
-		name = "remote2"
-		url  = "http://remote-write-url2"
+		name           = "remote2"
+		url            = "http://remote-write-url2"
+		send_exemplars = false
 
 		queue_config {
 			capacity             = 2500

--- a/converter/internal/prometheusconvert/testdata/unsupported.river
+++ b/converter/internal/prometheusconvert/testdata/unsupported.river
@@ -2,10 +2,11 @@ prometheus.scrape "prometheus1" {
 	targets = [{
 		__address__ = "localhost:9090",
 	}]
-	forward_to      = [prometheus.remote_write.default.receiver]
-	job_name        = "prometheus1"
-	scrape_interval = "10s"
-	scrape_timeout  = "5s"
+	forward_to       = [prometheus.remote_write.default.receiver]
+	job_name         = "prometheus1"
+	honor_timestamps = false
+	scrape_interval  = "10s"
+	scrape_timeout   = "5s"
 
 	basic_auth {
 		username = "user"
@@ -27,8 +28,9 @@ prometheus.remote_write "default" {
 	}
 
 	endpoint {
-		name = "remote1"
-		url  = "http://remote-write-url1"
+		name           = "remote1"
+		url            = "http://remote-write-url1"
+		send_exemplars = false
 
 		queue_config {
 			capacity             = 2500
@@ -42,8 +44,9 @@ prometheus.remote_write "default" {
 	}
 
 	endpoint {
-		name = "remote2"
-		url  = "http://remote-write-url2"
+		name           = "remote2"
+		url            = "http://remote-write-url2"
+		send_exemplars = false
 
 		queue_config {
 			capacity             = 2500


### PR DESCRIPTION
The logic to check to see if an optional field matches its default takes precedence over the old logic.

This fixes an unreleased issue where converting fields like send_exemplars would never be emitted, because `true` was the default (so it was omitted) and `false` is a zero value (so it was omitted).

The changelog is not updated since this issue is only observable in main.