### PR TITLE
Fix static mode operational dash for agent-logs namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ Main (unreleased)
 - Fix issue where flow mode exports labeled as "string or secret" could not be
   used in a binary operation. (@rfratto)
 
+- Fix Grafana Agent mixin's "Agent Operational" dashboard expecting pods to always have `grafana-agent-.*` prefix. (@thampiotr)
+
 ### Other changes
 
 - Build with go version 1.20.5 (@captncraig)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ Main (unreleased)
 
 - Enforce sha256 digest signing for rpms enabling installation on FIPS-enabled OSes. (@kfriedrich123)
 
-- The Grafana Agent mixin now includes a dashboard for the logs pipeline. (@thampiotr)
+- The Grafana Agent mixin now includes a dashboard for the logs pipeline and some panel titles have more descriptive names. (@thampiotr)
 
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,10 @@ Main (unreleased)
 
 - Enforce sha256 digest signing for rpms enabling installation on FIPS-enabled OSes. (@kfriedrich123)
 
-- The Grafana Agent mixin now includes a dashboard for the logs pipeline and some panel titles have more descriptive names. (@thampiotr)
+- The Grafana Agent mixin now includes a dashboard for the logs pipeline. (@thampiotr)
+
+- The Agent Operational dashboard of Grafana Agent mixin now has more descriptive panel titles, Y-axis units
+  and templates that narrow down the list of available values based on previous selection. (@thampiotr) 
 
 
 ### Bugfixes

--- a/example/docker-compose/grafana/dashboards/agent-operational.json
+++ b/example/docker-compose/grafana/dashboards/agent-operational.json
@@ -1093,7 +1093,7 @@
             "multi": true,
             "name": "namespace",
             "options": [ ],
-            "query": "label_values(agent_build_info, namespace)",
+            "query": "label_values(agent_build_info{cluster=~\"$cluster\"}, namespace)",
             "refresh": 1,
             "regex": "",
             "sort": 2,
@@ -1117,7 +1117,7 @@
             "multi": true,
             "name": "container",
             "options": [ ],
-            "query": "label_values(agent_build_info, container)",
+            "query": "label_values(agent_build_info{cluster=~\"$cluster\", namespace=\"$namespace\"}, container)",
             "refresh": 1,
             "regex": "",
             "sort": 2,
@@ -1128,7 +1128,7 @@
             "useTags": false
          },
          {
-            "allValue": ".*agent.*",
+            "allValue": ".+",
             "current": {
                "selected": true,
                "text": "All",
@@ -1141,7 +1141,7 @@
             "multi": true,
             "name": "pod",
             "options": [ ],
-            "query": "label_values(agent_build_info{container=~\"$container\", namespace=\"$namespace\"}, pod)",
+            "query": "label_values(agent_build_info{cluster=~\"$cluster\", namespace=\"$namespace\", container=\"$container\"}, pod)",
             "refresh": 1,
             "regex": "",
             "sort": 2,

--- a/example/docker-compose/grafana/dashboards/agent-operational.json
+++ b/example/docker-compose/grafana/dashboards/agent-operational.json
@@ -56,7 +56,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "GCs",
+               "title": "GCs [count/s]",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -132,7 +132,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Go Heap",
+               "title": "Go Heap In Use",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -284,7 +284,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "CPU",
+               "title": "CPU Usage [time/s]",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -360,7 +360,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "WSS",
+               "title": "Working Set Size",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -376,7 +376,7 @@
                },
                "yaxes": [
                   {
-                     "format": "short",
+                     "format": "decbytes",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -436,7 +436,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Bad Words",
+               "title": "Promtail Bad Words",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -524,7 +524,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "RX by Pod",
+               "title": "Received Bytes [B/s]",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -540,7 +540,7 @@
                },
                "yaxes": [
                   {
-                     "format": "short",
+                     "format": "Bps",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -600,7 +600,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "TX by Pod",
+               "title": "Transmitted Bytes [B/s]",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -616,7 +616,7 @@
                },
                "yaxes": [
                   {
-                     "format": "short",
+                     "format": "Bps",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -688,7 +688,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Bytes/Series/Pod",
+               "title": "Heap Used per Series per Pod",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -764,7 +764,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Bytes/Series",
+               "title": "Avg Heap Used per Series",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -840,7 +840,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Series/Pod",
+               "title": "Series Count per Pod",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -916,7 +916,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Series/Config",
+               "title": "Series per Config",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -992,7 +992,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Series",
+               "title": "Total Series",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -1128,7 +1128,7 @@
             "useTags": false
          },
          {
-            "allValue": "grafana-agent-.*",
+            "allValue": ".*agent.*",
             "current": {
                "selected": true,
                "text": "All",

--- a/production/grafana-agent-mixin/debugging.libsonnet
+++ b/production/grafana-agent-mixin/debugging.libsonnet
@@ -6,9 +6,9 @@ local g = import 'grafana-builder/grafana.libsonnet';
     'agent-operational.json':
       utils.injectUtils(g.dashboard('Agent Operational'))
       .addMultiTemplate('cluster', 'agent_build_info', 'cluster')
-      .addMultiTemplate('namespace', 'agent_build_info', 'namespace')
-      .addMultiTemplate('container', 'agent_build_info', 'container')
-      .addMultiTemplateWithAll('pod', 'agent_build_info{container=~"$container", namespace="$namespace"}', 'pod', all='.*agent.*')
+      .addMultiTemplate('namespace', 'agent_build_info{cluster=~"$cluster"}', 'namespace')
+      .addMultiTemplate('container', 'agent_build_info{cluster=~"$cluster", namespace="$namespace"}', 'container')
+      .addMultiTemplate('pod', 'agent_build_info{cluster=~"$cluster", namespace="$namespace", container="$container"}', 'pod')
       .addRow(
         g.row('General')
         .addPanel(


### PR DESCRIPTION
#### PR Description

When using dashboard mixin, on the "Agent Operational" dashboard, the `all` option for `pod` template expects that pods have `grafana-agent-.*` prefix. This is not always the case for every user. At the same time filtering pods in some way is useful, so this PR changes the regex to `.*agent.*`. 

Also gave some panels more descriptive names as I found some of them quite cryptic.

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
