### PR TITLE
Make loki.LogsReceiver an interface

### DIFF
--- a/component/common/loki/client/fake/client.go
+++ b/component/common/loki/client/fake/client.go
@@ -11,7 +11,7 @@ import (
 
 // Client is a fake client used for testing.
 type Client struct {
-	entries  loki.LogsReceiver
+	entries  chan loki.Entry
 	received []loki.Entry
 	once     sync.Once
 	mtx      sync.Mutex
@@ -22,7 +22,7 @@ type Client struct {
 func NewClient(stop func()) *Client {
 	c := &Client{
 		OnStop:  stop,
-		entries: make(loki.LogsReceiver),
+		entries: make(chan loki.Entry),
 	}
 	c.wg.Add(1)
 	go func() {
@@ -49,7 +49,7 @@ func (c *Client) Chan() chan<- loki.Entry {
 
 // LogsReceiver returns this client as a LogsReceiver, which is useful in testing.
 func (c *Client) LogsReceiver() loki.LogsReceiver {
-	return c.entries
+	return loki.NewLogsReceiverWithChannel(c.entries)
 }
 
 func (c *Client) Received() []loki.Entry {

--- a/component/loki/echo/echo.go
+++ b/component/loki/echo/echo.go
@@ -53,10 +53,9 @@ type Component struct {
 
 // New creates a new loki.echo component.
 func New(o component.Options, args Arguments) (*Component, error) {
-	ch := make(chan loki.Entry)
 	c := &Component{
 		opts:     o,
-		receiver: ch,
+		receiver: loki.NewLogsReceiver(),
 	}
 
 	// Call to Update() once at the start.
@@ -77,7 +76,7 @@ func (c *Component) Run(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return nil
-		case entry := <-c.receiver:
+		case entry := <-c.receiver.Chan():
 			level.Info(c.opts.Logger).Log("receiver", c.opts.ID, "entry", entry.Line, "labels", entry.Labels.String())
 		}
 	}

--- a/component/loki/source/api/api.go
+++ b/component/loki/source/api/api.go
@@ -90,7 +90,7 @@ func (c *Component) Run(ctx context.Context) (err error) {
 
 			for _, receiver := range receivers {
 				select {
-				case receiver <- entry:
+				case receiver.Chan() <- entry:
 				case <-ctx.Done():
 					return
 				}

--- a/component/loki/source/api/api_test.go
+++ b/component/loki/source/api/api_test.go
@@ -415,7 +415,7 @@ func testArgsWithPorts(httpPort int, grpcPort int) Arguments {
 				ListenPort:    grpcPort,
 			},
 		},
-		ForwardTo: []loki.LogsReceiver{make(chan loki.Entry), make(chan loki.Entry)},
+		ForwardTo: []loki.LogsReceiver{loki.NewLogsReceiver(), loki.NewLogsReceiver()},
 		Labels:    map[string]string{"foo": "bar", "fizz": "buzz"},
 		RelabelRules: relabel.Rules{
 			{

--- a/component/loki/source/aws_firehose/component_test.go
+++ b/component/loki/source/aws_firehose/component_test.go
@@ -64,8 +64,8 @@ func TestComponent(t *testing.T) {
 		OnStateChange: func(e component.Exports) {},
 	}
 
-	ch1, ch2 := make(chan loki.Entry), make(chan loki.Entry)
-	r1, r2 := newReceiver(ch1), newReceiver(ch2)
+	ch1, ch2 := loki.NewLogsReceiver(), loki.NewLogsReceiver()
+	r1, r2 := newReceiver(ch1.Chan()), newReceiver(ch2.Chan())
 
 	// call cancelReceivers to terminate them
 	receiverContext, cancelReceivers := context.WithCancel(context.Background())
@@ -142,8 +142,8 @@ func TestComponent_UpdateWithNewArguments(t *testing.T) {
 		OnStateChange: func(e component.Exports) {},
 	}
 
-	ch1, ch2 := make(chan loki.Entry), make(chan loki.Entry)
-	r1, r2 := newReceiver(ch1), newReceiver(ch2)
+	ch1, ch2 := loki.NewLogsReceiver(), loki.NewLogsReceiver()
+	r1, r2 := newReceiver(ch1.Chan()), newReceiver(ch2.Chan())
 
 	// call cancelReceivers to terminate them
 	receiverContext, cancelReceivers := context.WithCancel(context.Background())

--- a/component/loki/source/gcplog/gcplog_test.go
+++ b/component/loki/source/gcplog/gcplog_test.go
@@ -33,7 +33,7 @@ func TestPush(t *testing.T) {
 		OnStateChange: func(e component.Exports) {},
 	}
 
-	ch1, ch2 := make(chan loki.Entry), make(chan loki.Entry)
+	ch1, ch2 := loki.NewLogsReceiver(), loki.NewLogsReceiver()
 	args := Arguments{}
 
 	port, err := freeport.GetFreePort()
@@ -75,11 +75,11 @@ func TestPush(t *testing.T) {
 
 	for i := 0; i < 2; i++ {
 		select {
-		case logEntry := <-ch1:
+		case logEntry := <-ch1.Chan():
 			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
 			require.Equal(t, wantLogLine, logEntry.Line)
 			require.Equal(t, wantLabelSet, logEntry.Labels)
-		case logEntry := <-ch2:
+		case logEntry := <-ch2.Chan():
 			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
 			require.Equal(t, wantLogLine, logEntry.Line)
 			require.Equal(t, wantLabelSet, logEntry.Labels)

--- a/component/loki/source/gelf/gelf.go
+++ b/component/loki/source/gelf/gelf.go
@@ -55,7 +55,7 @@ func (c *Component) Run(ctx context.Context) error {
 				lokiEntry.Labels["job"] = model.LabelValue(c.o.ID)
 			}
 			for _, r := range c.receivers {
-				r <- lokiEntry
+				r.Chan() <- lokiEntry
 			}
 			c.mut.RUnlock()
 		}

--- a/component/loki/source/gelf/gelf_test.go
+++ b/component/loki/source/gelf/gelf_test.go
@@ -24,7 +24,7 @@ func TestGelf(t *testing.T) {
 	}
 
 	testMsg := `{"version":"1.1","host":"example.org","short_message":"A short message","timestamp":1231231123,"level":5,"_some_extra":"extra"}`
-	ch1 := make(chan loki.Entry)
+	ch1 := loki.NewLogsReceiver()
 
 	udpListenerAddr := getFreeAddr(t)
 	args := Arguments{
@@ -46,7 +46,7 @@ func TestGelf(t *testing.T) {
 	case <-ctx.Done():
 		// If this is called then it failed.
 		require.True(t, false)
-	case e := <-ch1:
+	case e := <-ch1.Chan():
 		require.True(t, strings.Contains(e.Entry.Line, "A short message"))
 		found = true
 	}

--- a/component/loki/source/journal/journal.go
+++ b/component/loki/source/journal/journal.go
@@ -92,7 +92,7 @@ func (c *Component) Run(ctx context.Context) error {
 				Entry:  entry.Entry,
 			}
 			for _, r := range c.receivers {
-				r <- lokiEntry
+				r.Chan() <- lokiEntry
 			}
 			c.mut.RUnlock()
 		}

--- a/component/loki/source/journal/journal_test.go
+++ b/component/loki/source/journal/journal_test.go
@@ -19,7 +19,7 @@ import (
 func TestJournal(t *testing.T) {
 	// Create opts for component
 	tmp := t.TempDir()
-	lr := make(loki.LogsReceiver)
+	lr := loki.NewLogsReceiver()
 	c, err := New(component.Options{
 		ID:         "loki.source.journal.test",
 		Logger:     util.TestFlowLogger(t),
@@ -46,7 +46,7 @@ func TestJournal(t *testing.T) {
 			found = true
 			// Timed out getting message
 			require.True(t, false)
-		case msg := <-lr:
+		case msg := <-lr.Chan():
 			if strings.Contains(msg.Line, ts) {
 				found = true
 				break

--- a/component/loki/source/kafka/kafka.go
+++ b/component/loki/source/kafka/kafka.go
@@ -102,7 +102,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		mut:     sync.RWMutex{},
 		fanout:  args.ForwardTo,
 		target:  nil,
-		handler: make(loki.LogsReceiver),
+		handler: loki.NewLogsReceiver(),
 	}
 
 	// Call to Update() to start readers and set receivers once at the start.
@@ -132,10 +132,10 @@ func (c *Component) Run(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return nil
-		case entry := <-c.handler:
+		case entry := <-c.handler.Chan():
 			c.mut.RLock()
 			for _, receiver := range c.fanout {
-				receiver <- entry
+				receiver.Chan() <- entry
 			}
 			c.mut.RUnlock()
 		}
@@ -157,7 +157,7 @@ func (c *Component) Update(args component.Arguments) error {
 		}
 	}
 
-	entryHandler := loki.NewEntryHandler(c.handler, func() {})
+	entryHandler := loki.NewEntryHandler(c.handler.Chan(), func() {})
 	t, err := kt.NewSyncer(c.opts.Logger, newArgs.Convert(), entryHandler, &kt.KafkaTargetMessageParser{})
 	if err != nil {
 		level.Error(c.opts.Logger).Log("msg", "failed to create kafka client with provided config", "err", err)

--- a/component/loki/source/kubernetes_events/event_controller.go
+++ b/component/loki/source/kubernetes_events/event_controller.go
@@ -66,7 +66,7 @@ func newEventController(task eventControllerTask) *eventController {
 	return &eventController{
 		log:           task.Log,
 		task:          task,
-		handler:       loki.NewEntryHandler(task.Receiver, func() {}),
+		handler:       loki.NewEntryHandler(task.Receiver.Chan(), func() {}),
 		positionsKey:  key,
 		initTimestamp: time.UnixMicro(lastTimestamp),
 	}

--- a/component/loki/source/kubernetes_events/kubernetes_events.go
+++ b/component/loki/source/kubernetes_events/kubernetes_events.go
@@ -116,7 +116,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		log:       o.Logger,
 		opts:      o,
 		positions: positionsFile,
-		handler:   make(loki.LogsReceiver),
+		handler:   loki.NewLogsReceiver(),
 		runner: runner.New(func(t eventControllerTask) runner.Worker {
 			return newEventController(t)
 		}),
@@ -164,13 +164,13 @@ func (c *Component) Run(ctx context.Context) error {
 			select {
 			case <-ctx.Done():
 				return nil
-			case entry := <-c.handler:
+			case entry := <-c.handler.Chan():
 				c.receiversMut.RLock()
 				receivers := c.receivers
 				c.receiversMut.RUnlock()
 
 				for _, receiver := range receivers {
-					receiver <- entry
+					receiver.Chan() <- entry
 				}
 			}
 		}

--- a/component/loki/source/syslog/syslog_test.go
+++ b/component/loki/source/syslog/syslog_test.go
@@ -26,7 +26,7 @@ func Test(t *testing.T) {
 		OnStateChange: func(e component.Exports) {},
 	}
 
-	ch1, ch2 := make(chan loki.Entry), make(chan loki.Entry)
+	ch1, ch2 := loki.NewLogsReceiver(), loki.NewLogsReceiver()
 	args := Arguments{}
 	tcpListenerAddr, udpListenerAddr := getFreeAddr(t), getFreeAddr(t)
 
@@ -63,11 +63,11 @@ func Test(t *testing.T) {
 
 	for i := 0; i < 2; i++ {
 		select {
-		case logEntry := <-ch1:
+		case logEntry := <-ch1.Chan():
 			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
 			require.Equal(t, "An application event log entry...", logEntry.Line)
 			require.Equal(t, wantLabelSet, logEntry.Labels)
-		case logEntry := <-ch2:
+		case logEntry := <-ch2.Chan():
 			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
 			require.Equal(t, "An application event log entry...", logEntry.Line)
 			require.Equal(t, wantLabelSet, logEntry.Labels)
@@ -87,11 +87,11 @@ func Test(t *testing.T) {
 
 	for i := 0; i < 2; i++ {
 		select {
-		case logEntry := <-ch1:
+		case logEntry := <-ch1.Chan():
 			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
 			require.Equal(t, "An application event log entry...", logEntry.Line)
 			require.Equal(t, wantLabelSet, logEntry.Labels)
-		case logEntry := <-ch2:
+		case logEntry := <-ch2.Chan():
 			require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
 			require.Equal(t, "An application event log entry...", logEntry.Line)
 			require.Equal(t, wantLabelSet, logEntry.Labels)
@@ -108,7 +108,7 @@ func TestWithRelabelRules(t *testing.T) {
 		OnStateChange: func(e component.Exports) {},
 	}
 
-	ch1 := make(chan loki.Entry)
+	ch1 := loki.NewLogsReceiver()
 	args := Arguments{}
 	tcpListenerAddr := getFreeAddr(t)
 
@@ -161,7 +161,7 @@ func TestWithRelabelRules(t *testing.T) {
 	}
 
 	select {
-	case logEntry := <-ch1:
+	case logEntry := <-ch1.Chan():
 		require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
 		require.Equal(t, "An application event log entry...", logEntry.Line)
 		require.Equal(t, wantLabelSet, logEntry.Labels)

--- a/component/loki/source/windowsevent/component_test.go
+++ b/component/loki/source/windowsevent/component_test.go
@@ -23,7 +23,7 @@ func TestEventLogger(t *testing.T) {
 	wlog, err := eventlog.Open(loggerName)
 	require.NoError(t, err)
 	dataPath := t.TempDir()
-	rec := make(loki.LogsReceiver)
+	rec := loki.NewLogsReceiver()
 	c, err := New(component.Options{
 		ID:       "loki.source.windowsevent.test",
 		Logger:   util.TestFlowLogger(t),

--- a/component/loki/source/windowsevent/component_windows.go
+++ b/component/loki/source/windowsevent/component_windows.go
@@ -88,7 +88,7 @@ func (c *Component) Run(ctx context.Context) error {
 				Entry:  entry.Entry,
 			}
 			for _, receiver := range c.receivers {
-				receiver <- lokiEntry
+				receiver.Chan() <- lokiEntry
 			}
 			c.mut.RUnlock()
 		}

--- a/component/loki/write/write.go
+++ b/component/loki/write/write.go
@@ -64,7 +64,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 
 	// Create and immediately export the receiver which remains the same for
 	// the component's lifetime.
-	c.receiver = make(loki.LogsReceiver)
+	c.receiver = loki.NewLogsReceiver()
 	o.OnStateChange(Exports{Receiver: c.receiver})
 
 	// Call to Update() to start readers and set receivers once at the start.
@@ -81,7 +81,7 @@ func (c *Component) Run(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return nil
-		case entry := <-c.receiver:
+		case entry := <-c.receiver.Chan():
 			for _, client := range c.clients {
 				if client != nil {
 					select {

--- a/component/loki/write/write_test.go
+++ b/component/loki/write/write_test.go
@@ -100,8 +100,8 @@ func Test(t *testing.T) {
 	}
 
 	exports := tc.Exports().(Exports)
-	exports.Receiver <- logEntry
-	exports.Receiver <- logEntry
+	exports.Receiver.Chan() <- logEntry
+	exports.Receiver.Chan() <- logEntry
 
 	// Wait for our exporter to finish and pass data to our HTTP server.
 	// Make sure the log entries were received correctly.

--- a/component/otelcol/exporter/loki/internal/convert/convert.go
+++ b/component/otelcol/exporter/loki/internal/convert/convert.go
@@ -114,7 +114,7 @@ func (conv *Converter) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 			select {
 			case <-ctx.Done():
 				return nil
-			case receiver <- entry:
+			case receiver.Chan() <- entry:
 				// no-op, send the entry along
 			}
 		}

--- a/component/otelcol/exporter/loki/internal/convert/convert_test.go
+++ b/component/otelcol/exporter/loki/internal/convert/convert_test.go
@@ -456,7 +456,7 @@ func TestConverter(t *testing.T) {
 			require.NoError(t, err)
 
 			l := util.TestLogger(t)
-			ch1, ch2 := make(loki.LogsReceiver), make(loki.LogsReceiver)
+			ch1, ch2 := loki.NewLogsReceiver(), loki.NewLogsReceiver()
 			conv := convert.New(l, prometheus.NewRegistry(), []loki.LogsReceiver{ch1, ch2})
 			go func() {
 				require.NoError(t, conv.ConsumeLogs(context.Background(), payload))
@@ -464,11 +464,11 @@ func TestConverter(t *testing.T) {
 
 			for i := 0; i < 2; i++ {
 				select {
-				case l := <-ch1:
+				case l := <-ch1.Chan():
 					require.Equal(t, tc.expectLine, l.Line)
 					require.Equal(t, tc.expectLabels, l.Labels.String())
 					require.Equal(t, tc.expectTimestamp, l.Timestamp.UTC())
-				case l := <-ch2:
+				case l := <-ch2.Chan():
 					require.Equal(t, tc.expectLine, l.Line)
 					require.Equal(t, tc.expectLabels, l.Labels.String())
 					require.Equal(t, tc.expectTimestamp, l.Timestamp.UTC())

--- a/component/otelcol/receiver/loki/loki.go
+++ b/component/otelcol/receiver/loki/loki.go
@@ -67,7 +67,7 @@ func New(o component.Options, c Arguments) (*Component, error) {
 
 	// Create and immediately export the receiver which remains the same for
 	// the component's lifetime.
-	res.receiver = make(loki.LogsReceiver)
+	res.receiver = loki.NewLogsReceiver()
 	o.OnStateChange(Exports{Receiver: res.receiver})
 
 	if err := res.Update(c); err != nil {
@@ -82,7 +82,7 @@ func (c *Component) Run(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return nil
-		case entry := <-c.receiver:
+		case entry := <-c.receiver.Chan():
 			stanzaEntry := parsePromtailEntry(entry)
 			plogEntry := adapter.Convert(stanzaEntry)
 

--- a/component/otelcol/receiver/loki/loki_test.go
+++ b/component/otelcol/receiver/loki/loki_test.go
@@ -58,7 +58,7 @@ func Test(t *testing.T) {
 				Line:      "It's super effective!",
 			},
 		}
-		exports.Receiver <- entry
+		exports.Receiver.Chan() <- entry
 	}()
 
 	wantAttributes := map[string]interface{}{


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

In order to implement config converter we need to override how a components' export is tokenized. 
* There is an example of [how this is done here](https://github.com/grafana/agent/blob/main/converter/internal/prometheusconvert/remote_write.go#L16) for `prometheus.remote_write` - when we create a block for remote_write, we return an `remotewrite.Exports`.
* That export is then set on river components args that use it and since we override the way its tokenized, we control how it is displayed in the final River configuration that is generated. In the example above, the exported receiver will be displayed as `"prometheus.remote_write.default.receiver"` which is what we want.
* However, the trick to override how an export value is tokenized requires us to [extend the exported type](https://github.com/grafana/agent/blob/main/converter/internal/common/convert_appendable.go#L14), which can only be done when it's an interface.
* `loki.LogsReceiver` is not an interface, so I ran into an issue when trying to implement `promtail` config conversion support. The problem can be[ seen in code in this draft PR](https://github.com/grafana/agent/pull/4160#discussion_r1245394586).

Proposed solution: make `loki.LogsReceiver` an interface.

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
