### PR TITLE
Spartan0x117/flow exporter module metrics path label fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ Main (unreleased)
 
 - Fix Grafana Agent mixin's "Agent Operational" dashboard expecting pods to always have `grafana-agent-.*` prefix. (@thampiotr)
 
+- Fix the HTTP Path and Data Path from the controller-local ID to the global ID for components loaded from within a module loader. (@spartan0x117)
+
 v0.34.3 (2023-06-27)
 --------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ Main (unreleased)
 
 - Fix Grafana Agent mixin's "Agent Operational" dashboard expecting pods to always have `grafana-agent-.*` prefix. (@thampiotr)
 
-- Fix the HTTP Path and Data Path from the controller-local ID to the global ID for components loaded from within a module loader. (@spartan0x117)
+- Change the HTTP Path and Data Path from the controller-local ID to the global ID for components loaded from within a module loader. (@spartan0x117)
 
 v0.34.3 (2023-06-27)
 --------------------

--- a/pkg/flow/internal/controller/component.go
+++ b/pkg/flow/internal/controller/component.go
@@ -190,10 +190,10 @@ func getManagedOptions(globals ComponentGlobals, cn *ComponentNode) component.Op
 		Tracer:    tracing.WrapTracer(globals.TraceProvider, globalID),
 		Clusterer: globals.Clusterer,
 
-		DataPath:       filepath.Join(globals.DataPath, cn.nodeID),
+		DataPath:       filepath.Join(globals.DataPath, globalID),
 		HTTPListenAddr: globals.HTTPListenAddr,
 		DialFunc:       globals.DialFunc,
-		HTTPPath:       path.Join(prefix, cn.nodeID) + "/",
+		HTTPPath:       path.Join(prefix, globalID) + "/",
 
 		OnStateChange:    cn.setExports,
 		ModuleController: globals.NewModuleController(globalID),


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
I noticed that when defining exporters inside of modules, trying to scrape them resulted in a `404 Not Found` error. After digging a bit, I saw that the exported target's addresses were the same as though the component were not defined inside a module (e.g. `/api/v0/component/prometheus.exporter.redis.example_exporter`) instead of having the module be a part of the path (e.g. `/api/v0/component/module.file.example_module/prometheus.exporter.redis.local_redis`). Debugging a bit further led me to where the value was initially set, and I saw that both `HTTPPath` and `DataPath` were using the controller-local ID rather than the global ID.

I change `DataPath` as well, as I'd assume otherwise two of the same components defined in different modules might conflict where they write to.

Let me know if this is the wrong approach and should be handled a different way :smile: 

#### Notes to the Reviewer

#### PR Checklist

- [X] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
