### PR TITLE
Fix broken test on Windows

### DIFF
--- a/component/loki/source/windowsevent/component_test.go
+++ b/component/loki/source/windowsevent/component_test.go
@@ -58,7 +58,7 @@ func TestEventLogger(t *testing.T) {
 	case <-ctx.Done():
 		// Fail!
 		require.True(t, false)
-	case e := <-rec:
+	case e := <-rec.Chan():
 		if strings.Contains(e.Line, tm) {
 			found = true
 			break


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

My previous PR https://github.com/grafana/agent/pull/4303 caused one windows test to fail to build, but we don't run windows tests as a merge gate, so I missed this.

This should fix the compilation error.
