### PR TITLE
feat(configReloader): set securitycontext

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -23,6 +23,8 @@ Unreleased
 
 - Update Grafana Agent version to v0.34.2. (@captncraig)
 
+- Set securityContext for configReloader container. (@yanehi)
+
 ### Other changes
 
 - Make the agent and config-reloader container resources required when using

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -65,6 +65,7 @@ use the older mode (called "static mode"), set the `agent.mode` value to
 | configReloader.image.repository | string | `"jimmidyson/configmap-reload"` | Repository to get config reloader image from. |
 | configReloader.image.tag | string | `"v0.8.0"` | Tag of image to use for config reloading. |
 | configReloader.resources | object | `{"requests":{"cpu":"1m","memory":"5Mi"}}` | Resource requests and limits to apply to the config reloader container. |
+| configReloader.securityContext | object | `{}` | Security context to apply to the Grafana configReloader container. |
 | controller.affinity | object | `{}` | Affinity configuration for pods. |
 | controller.autoscaling.enabled | bool | `false` | Creates a HorizontalPodAutoscaler for controller type deployment. |
 | controller.autoscaling.maxReplicas | int | `5` | The upper limit for the number of replicas to which the autoscaler can scale up. |

--- a/operations/helm/charts/grafana-agent/templates/containers/_watch.yaml
+++ b/operations/helm/charts/grafana-agent/templates/containers/_watch.yaml
@@ -17,5 +17,9 @@
   resources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.configReloader.securityContext }}
+  securityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end -}}

--- a/operations/helm/charts/grafana-agent/values.yaml
+++ b/operations/helm/charts/grafana-agent/values.yaml
@@ -122,6 +122,8 @@ configReloader:
     requests:
       cpu: "1m"
       memory: "5Mi"
+  # -- Security context to apply to the Grafana configReloader container.
+  securityContext: {}
 
 controller:
   # -- Type of controller to use for deploying Grafana Agent in the cluster.


### PR DESCRIPTION
#### PR Description

Users can now set the IDs of the configReloader container in addition to the grafana-agent.

#### Which issue(s) this PR fixes

I would like to run the configReloader container with non-root IDs in my cluster. Unfortunately I currently have no way to set these via the values. With my pullrequest it should be possible to set the IDs for the container optionally.

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added --> Not relevant because it is only a small change?
- [ ] Tests updated --> Not relevant because it is only a small change?
