### PR TITLE
grafana-agent-flow: ensure time/tzdata is imported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ Main (unreleased)
 
 - Support `clustering` block in `prometheus.operator.servicemonitors` and `prometheus.operator.podmonitors` components to distribute
   targets amongst clustered agents. (@captncraig)
-  
+
 - Update `redis_exporter` dependency to v1.51.0. (@jcreixell)
 
 - The Grafana Agent mixin now includes a dashboard for the logs pipeline. (@thampiotr)
@@ -87,7 +87,6 @@ Main (unreleased)
 - Allow setting the node name for clustering with a command-line flag. (@tpaschalis)
 
 - Allow `prometheus.exporter.snmp` and SNMP integration to be configured passing a YAML block. (@marctc)
-
 
 ### Bugfixes
 
@@ -110,6 +109,10 @@ Main (unreleased)
 - Fix Grafana Agent mixin's "Agent Operational" dashboard expecting pods to always have `grafana-agent-.*` prefix. (@thampiotr)
 
 - Change the HTTP Path and Data Path from the controller-local ID to the global ID for components loaded from within a module loader. (@spartan0x117)
+
+- Fix bug where `stage.timestamp` in `loki.process` wasn't able to correctly
+  parse timezones. This issue only impacts the dedicated `grafana-agent-flow`
+  binary. (@rfratto)
 
 v0.34.3 (2023-06-27)
 --------------------

--- a/component/loki/process/internal/stages/timestamp.go
+++ b/component/loki/process/internal/stages/timestamp.go
@@ -14,6 +14,8 @@ import (
 	"github.com/go-kit/log/level"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/prometheus/common/model"
+
+	_ "time/tzdata" // embed timezone data
 )
 
 // Config errors.


### PR DESCRIPTION
time/tzdata needs to be imported to ensure all timezones are embedded into the binary. pkg/logs already imported this for the grafana-agent binary, but the grafana-agent-flow binary did not have it in its import path.

Related to #4337.
