### PR TITLE
Decouple the API used by the UI

### DIFF
--- a/component/component_provider.go
+++ b/component/component_provider.go
@@ -86,9 +86,10 @@ func (info *Info) MarshalJSON() ([]byte, error) {
 		}
 
 		componentDetailJSON struct {
-			Name         string               `json:"name,omitempty"`
+			Name         string               `json:"name"`
 			Type         string               `json:"type,omitempty"`
-			ID           string               `json:"id,omitempty"`
+			ID           string               `json:"id"`
+			ModuleID     string               `json:"moduleID"`
 			Label        string               `json:"label,omitempty"`
 			References   []string             `json:"referencesTo"`
 			ReferencedBy []string             `json:"referencedBy"`
@@ -97,6 +98,7 @@ func (info *Info) MarshalJSON() ([]byte, error) {
 			Arguments    json.RawMessage      `json:"arguments,omitempty"`
 			Exports      json.RawMessage      `json:"exports,omitempty"`
 			DebugInfo    json.RawMessage      `json:"debugInfo,omitempty"`
+			ModuleIDs    []string             `json:"moduleIDs,omitempty"`
 		}
 	)
 
@@ -131,7 +133,8 @@ func (info *Info) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&componentDetailJSON{
 		Name:         info.Registration.Name,
 		Type:         "block",
-		ID:           info.ID.LocalID, // TODO(rfratto): support getting component from module.
+		ModuleID:     info.ID.ModuleID,
+		ID:           info.ID.LocalID,
 		Label:        info.Label,
 		References:   references,
 		ReferencedBy: referencedBy,
@@ -143,6 +146,7 @@ func (info *Info) MarshalJSON() ([]byte, error) {
 		Arguments: arguments,
 		Exports:   exports,
 		DebugInfo: debugInfo,
+		ModuleIDs: info.ModuleIDs,
 	})
 }
 

--- a/pkg/flow/module.go
+++ b/pkg/flow/module.go
@@ -15,7 +15,6 @@ import (
 	"github.com/grafana/agent/pkg/flow/tracing"
 	"github.com/grafana/agent/pkg/river/scanner"
 	"github.com/grafana/agent/pkg/river/token"
-	"github.com/grafana/agent/web/api"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/exp/maps"
 )
@@ -149,9 +148,6 @@ func (c *module) Run(ctx context.Context) {
 // components managed by the underlying flow system.
 func (c *module) ComponentHandler() (_ http.Handler) {
 	r := mux.NewRouter()
-
-	fa := api.NewFlowAPI(c.f, c.f.clusterer.Node)
-	fa.RegisterRoutes("/", r)
 
 	r.PathPrefix("/{id}/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Re-add the full path to ensure that nested controllers propagate

--- a/web/api/api.go
+++ b/web/api/api.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"path"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/grafana/agent/component"
@@ -28,14 +29,26 @@ func NewFlowAPI(flow component.Provider, node cluster.Node) *FlowAPI {
 
 // RegisterRoutes registers all the API's routes.
 func (f *FlowAPI) RegisterRoutes(urlPrefix string, r *mux.Router) {
+	// NOTE(rfratto): {id:.+} is used in routes below to allow the
+	// id to contain / characters, which is used by nested module IDs and
+	// component IDs.
+
+	r.Handle(path.Join(urlPrefix, "/modules/{moduleID:.+}/components"), httputil.CompressionHandler{Handler: f.listComponentsHandler()})
 	r.Handle(path.Join(urlPrefix, "/components"), httputil.CompressionHandler{Handler: f.listComponentsHandler()})
-	r.Handle(path.Join(urlPrefix, "/components/{id}"), httputil.CompressionHandler{Handler: f.getComponentHandler()})
+	r.Handle(path.Join(urlPrefix, "/components/{id:.+}"), httputil.CompressionHandler{Handler: f.getComponentHandler()})
 	r.Handle(path.Join(urlPrefix, "/peers"), httputil.CompressionHandler{Handler: f.getClusteringPeersHandler()})
 }
 
 func (f *FlowAPI) listComponentsHandler() http.HandlerFunc {
-	return func(w http.ResponseWriter, _ *http.Request) {
-		components, err := f.flow.ListComponents("", component.InfoOptions{
+	return func(w http.ResponseWriter, r *http.Request) {
+		// moduleID is set from the /modules/{moduleID:.+}/components route above
+		// but not from the /compoents route.
+		var moduleID string
+		if vars := mux.Vars(r); vars != nil {
+			moduleID = vars["moduleID"]
+		}
+
+		components, err := f.flow.ListComponents(moduleID, component.InfoOptions{
 			GetHealth: true,
 		})
 		if err != nil {
@@ -55,12 +68,9 @@ func (f *FlowAPI) listComponentsHandler() http.HandlerFunc {
 func (f *FlowAPI) getComponentHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
-		requestedComponent := vars["id"]
+		requestedComponent := parseID(vars["id"])
 
-		component, err := f.flow.GetComponent(component.ID{
-			ModuleID: "", // TODO(rfratto): support getting component from module.
-			LocalID:  requestedComponent,
-		}, component.InfoOptions{
+		component, err := f.flow.GetComponent(requestedComponent, component.InfoOptions{
 			GetHealth:    true,
 			GetArguments: true,
 			GetExports:   true,
@@ -77,6 +87,17 @@ func (f *FlowAPI) getComponentHandler() http.HandlerFunc {
 			return
 		}
 		_, _ = w.Write(bb)
+	}
+}
+
+func parseID(input string) component.ID {
+	slashIndex := strings.LastIndexByte(input, '/')
+	if slashIndex == -1 {
+		return component.ID{LocalID: input}
+	}
+	return component.ID{
+		ModuleID: input[:slashIndex],
+		LocalID:  input[slashIndex+1:],
 	}
 }
 

--- a/web/ui/src/features/component/ComponentList.tsx
+++ b/web/ui/src/features/component/ComponentList.tsx
@@ -9,14 +9,14 @@ import styles from './ComponentList.module.css';
 
 interface ComponentListProps {
   components: ComponentInfo[];
-  parent?: string;
+  moduleID?: string;
 }
 
 const TABLEHEADERS = ['Health', 'ID'];
 
-const ComponentList = ({ components, parent }: ComponentListProps) => {
+const ComponentList = ({ components, moduleID }: ComponentListProps) => {
   const tableStyles = { width: '130px' };
-  const pathPrefix = parent ? parent + '/' : '';
+  const pathPrefix = moduleID ? moduleID + '/' : '';
 
   /**
    * Custom renderer for table data

--- a/web/ui/src/features/component/ComponentView.tsx
+++ b/web/ui/src/features/component/ComponentView.tsx
@@ -120,7 +120,7 @@ export const ComponentView: FC<ComponentViewProps> = (props) => {
           <section id="dependencies">
             <h2>Dependencies</h2>
             <div className={styles.sectionContent}>
-              <ComponentList components={referencesTo} parent={props.component.parent} />
+              <ComponentList components={referencesTo} moduleID={props.component.moduleID} />
             </div>
           </section>
         )}
@@ -129,7 +129,7 @@ export const ComponentView: FC<ComponentViewProps> = (props) => {
           <section id="dependants">
             <h2>Dependants</h2>
             <div className={styles.sectionContent}>
-              <ComponentList components={referencedBy} parent={props.component.parent} />
+              <ComponentList components={referencedBy} moduleID={props.component.moduleID} />
             </div>
           </section>
         )}
@@ -140,7 +140,7 @@ export const ComponentView: FC<ComponentViewProps> = (props) => {
             <div className={styles.sectionContent}>
               <ComponentList
                 components={props.component.moduleInfo}
-                parent={pathJoin([props.component.parent, props.component.id])}
+                moduleID={pathJoin([props.component.moduleID, props.component.id])}
               />
             </div>
           </section>

--- a/web/ui/src/features/component/types.ts
+++ b/web/ui/src/features/component/types.ts
@@ -4,6 +4,9 @@ import { AttrStmt, Body as RiverBody } from '../river-js/types';
  * ComponentInfo is high-level information for a component.
  */
 export interface ComponentInfo {
+  /** The moduleID that the component is defined in. moduleID may be the empty string. */
+  moduleID: string;
+
   /** The id of the component uniquely identifies the component. */
   id: string;
 
@@ -99,9 +102,9 @@ export interface ComponentDetail extends ComponentInfo {
   debugInfo?: RiverBody;
 
   /**
-   * If a component is loaded from a module, this is the parent ID.
+   * If a component is a module loader, the IDs of modules it loaded are included here.
    */
-  parent?: string;
+  moduleIDs?: string[];
 
   /**
    * If a component is a module loader, the loaded components from the module are included here.

--- a/web/ui/src/hooks/componentInfo.tsx
+++ b/web/ui/src/hooks/componentInfo.tsx
@@ -8,18 +8,13 @@ import { ComponentInfo } from '../features/component/types';
  * @param fromComponent The component requesting component info. Required for
  * determining the proper list of components from the context of a module.
  */
-export const useComponentInfo = (fromComponent?: string): ComponentInfo[] => {
+export const useComponentInfo = (moduleID: string): ComponentInfo[] => {
   const [components, setComponents] = useState<ComponentInfo[]>([]);
 
   useEffect(
     function () {
       const worker = async () => {
-        const fragments = (fromComponent || '').split('/');
-
-        const infoPath =
-          fragments.length === 1
-            ? './api/v0/web/components'
-            : `./api/v0/component/${fragments.slice(0, fragments.length - 1).join('/')}/components`;
+        const infoPath = moduleID === '' ? './api/v0/web/components' : `./api/v0/web/modules/${moduleID}/components`;
 
         // Request is relative to the <base> tag inside of <head>.
         const resp = await fetch(infoPath, {
@@ -31,7 +26,7 @@ export const useComponentInfo = (fromComponent?: string): ComponentInfo[] => {
 
       worker().catch(console.error);
     },
-    [fromComponent]
+    [moduleID]
   );
 
   return components;

--- a/web/ui/src/pages/ComponentDetailPage.tsx
+++ b/web/ui/src/pages/ComponentDetailPage.tsx
@@ -2,13 +2,15 @@ import { FC, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { ComponentView } from '../features/component/ComponentView';
-import { ComponentDetail, componentInfoByID } from '../features/component/types';
+import { ComponentDetail, ComponentInfo, componentInfoByID } from '../features/component/types';
 import { useComponentInfo } from '../hooks/componentInfo';
+import { parseID } from '../utils/id';
 
 const ComponentDetailPage: FC = () => {
   const { '*': id } = useParams();
 
-  const components = useComponentInfo(id);
+  const { moduleID } = parseID(id || '');
+  const components = useComponentInfo(moduleID);
   const infoByID = componentInfoByID(components);
 
   const [component, setComponent] = useState<ComponentDetail | undefined>(undefined);
@@ -19,30 +21,22 @@ const ComponentDetailPage: FC = () => {
         return;
       }
 
-      const fragments = id.split('/');
-
-      const infoRoot =
-        fragments.length === 1
-          ? './api/v0/web/components/'
-          : `./api/v0/component/${fragments.slice(0, fragments.length - 1).join('/')}/components/`;
-
       const worker = async () => {
         // Request is relative to the <base> tag inside of <head>.
-        const resp = await fetch(infoRoot + fragments[fragments.length - 1], {
+        const resp = await fetch(`./api/v0/web/components/${id}`, {
           cache: 'no-cache',
           credentials: 'same-origin',
         });
         const data: ComponentDetail = await resp.json();
 
-        // Set parent.
-        if (fragments.length > 1) {
-          data.parent = fragments.slice(0, fragments.length - 1).join('/');
-        }
+        for (const moduleID of data.moduleIDs || []) {
+          const moduleComponentsResp = await fetch(`./api/v0/web/modules/${moduleID}/components`, {
+            cache: 'no-cache',
+            credentials: 'same-origin',
+          });
+          const moduleCompoents = (await moduleComponentsResp.json()) as ComponentInfo[];
 
-        // Get data from the component module API.
-        if (data.id.startsWith('module.')) {
-          const resp = await fetch(`./api/v0/component/${id}/components`);
-          data.moduleInfo = await resp.json();
+          data.moduleInfo = (data.moduleInfo || []).concat(moduleCompoents);
         }
 
         setComponent(data);

--- a/web/ui/src/pages/Graph.tsx
+++ b/web/ui/src/pages/Graph.tsx
@@ -5,7 +5,7 @@ import Page from '../features/layout/Page';
 import { useComponentInfo } from '../hooks/componentInfo';
 
 function Graph() {
-  const components = useComponentInfo();
+  const components = useComponentInfo('');
 
   return (
     <Page name="Graph" desc="Relationships between defined components" icon={faDiagramProject}>

--- a/web/ui/src/pages/PageComponentList.tsx
+++ b/web/ui/src/pages/PageComponentList.tsx
@@ -5,7 +5,7 @@ import Page from '../features/layout/Page';
 import { useComponentInfo } from '../hooks/componentInfo';
 
 function PageComponentList() {
-  const components = useComponentInfo();
+  const components = useComponentInfo('');
 
   return (
     <Page name="Components" desc="List of defined components" icon={faCubes}>

--- a/web/ui/src/utils/id.ts
+++ b/web/ui/src/utils/id.ts
@@ -1,0 +1,19 @@
+type ID = {
+  moduleID: string;
+  localID: string;
+};
+
+/**
+ * parseID parses a full component ID into its moduleID and localID halves.
+ */
+export function parseID(id: string): ID {
+  const lastSlashIndex = id.lastIndexOf('/');
+  if (lastSlashIndex === -1) {
+    return { moduleID: '', localID: id };
+  }
+
+  return {
+    moduleID: id.slice(0, lastSlashIndex),
+    localID: id.slice(lastSlashIndex + 1),
+  };
+}


### PR DESCRIPTION
This PR decouples the UI's API into a single consumer (service/http). The API now serves requests for all components across all modules rather than requiring each module loader to expose the API as part of its HTTP handlers. 

See individual commit messages for more details. 

I have successfully tested these changes by rebuilding the UI and using a multi-module config, with module nesting and components within modules which have references to other components in the same module. 