### PR TITLE
Use `rivertypes.OptionalSecret` for SNMP and Blackbox components inline config

### DIFF
--- a/component/prometheus/exporter/blackbox/blackbox.go
+++ b/component/prometheus/exporter/blackbox/blackbox.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/blackbox_exporter"
+	"github.com/grafana/agent/pkg/river/rivertypes"
 )
 
 func init() {
@@ -81,10 +82,10 @@ func (t TargetBlock) Convert() []blackbox_exporter.BlackboxTarget {
 }
 
 type Arguments struct {
-	ConfigFile         string        `river:"config_file,attr,optional"`
-	Config             string        `river:"config,attr,optional"`
-	Targets            TargetBlock   `river:"target,block"`
-	ProbeTimeoutOffset time.Duration `river:"probe_timeout_offset,attr,optional"`
+	ConfigFile         string            `river:"config_file,attr,optional"`
+	Config             rivertypes.Secret `river:"config,attr,optional"`
+	Targets            TargetBlock       `river:"target,block"`
+	ProbeTimeoutOffset time.Duration     `river:"probe_timeout_offset,attr,optional"`
 	ConfigStruct       blackbox_config.Config
 }
 

--- a/component/prometheus/exporter/blackbox/blackbox.go
+++ b/component/prometheus/exporter/blackbox/blackbox.go
@@ -82,10 +82,10 @@ func (t TargetBlock) Convert() []blackbox_exporter.BlackboxTarget {
 }
 
 type Arguments struct {
-	ConfigFile         string            `river:"config_file,attr,optional"`
-	Config             rivertypes.Secret `river:"config,attr,optional"`
-	Targets            TargetBlock       `river:"target,block"`
-	ProbeTimeoutOffset time.Duration     `river:"probe_timeout_offset,attr,optional"`
+	ConfigFile         string                    `river:"config_file,attr,optional"`
+	Config             rivertypes.OptionalSecret `river:"config,attr,optional"`
+	Targets            TargetBlock               `river:"target,block"`
+	ProbeTimeoutOffset time.Duration             `river:"probe_timeout_offset,attr,optional"`
 	ConfigStruct       blackbox_config.Config
 }
 
@@ -96,11 +96,11 @@ func (a *Arguments) SetToDefault() {
 
 // Validate implements river.Validator.
 func (a *Arguments) Validate() error {
-	if a.ConfigFile != "" && a.Config != "" {
+	if a.ConfigFile != "" && a.Config.Value != "" {
 		return errors.New("config and config_file are mutually exclusive")
 	}
 
-	err := yaml.UnmarshalStrict([]byte(a.Config), &a.ConfigStruct)
+	err := yaml.UnmarshalStrict([]byte(a.Config.Value), &a.ConfigStruct)
 	if err != nil {
 		return fmt.Errorf("invalid backbox_exporter config: %s", err)
 	}

--- a/component/prometheus/exporter/snmp/snmp.go
+++ b/component/prometheus/exporter/snmp/snmp.go
@@ -109,10 +109,10 @@ func (w WalkParams) Convert() map[string]snmp_config.WalkParams {
 }
 
 type Arguments struct {
-	ConfigFile   string            `river:"config_file,attr,optional"`
-	Config       rivertypes.Secret `river:"config,attr,optional"`
-	Targets      TargetBlock       `river:"target,block"`
-	WalkParams   WalkParams        `river:"walk_param,block,optional"`
+	ConfigFile   string                    `river:"config_file,attr,optional"`
+	Config       rivertypes.OptionalSecret `river:"config,attr,optional"`
+	Targets      TargetBlock               `river:"target,block"`
+	WalkParams   WalkParams                `river:"walk_param,block,optional"`
 	ConfigStruct snmp_config.Config
 }
 
@@ -123,11 +123,11 @@ func (a *Arguments) UnmarshalRiver(f func(interface{}) error) error {
 		return err
 	}
 
-	if a.ConfigFile != "" && a.Config != "" {
+	if a.ConfigFile != "" && a.Config.Value != "" {
 		return errors.New("config and config_file are mutually exclusive")
 	}
 
-	err := yaml.UnmarshalStrict([]byte(a.Config), &a.ConfigStruct)
+	err := yaml.UnmarshalStrict([]byte(a.Config.Value), &a.ConfigStruct)
 	if err != nil {
 		return fmt.Errorf("invalid snmp_exporter config: %s", err)
 	}

--- a/component/prometheus/exporter/snmp/snmp.go
+++ b/component/prometheus/exporter/snmp/snmp.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/snmp_exporter"
+	"github.com/grafana/agent/pkg/river/rivertypes"
 	snmp_config "github.com/prometheus/snmp_exporter/config"
 	"gopkg.in/yaml.v2"
 )
@@ -108,10 +109,10 @@ func (w WalkParams) Convert() map[string]snmp_config.WalkParams {
 }
 
 type Arguments struct {
-	ConfigFile   string      `river:"config_file,attr,optional"`
-	Config       string      `river:"config,attr,optional"`
-	Targets      TargetBlock `river:"target,block"`
-	WalkParams   WalkParams  `river:"walk_param,block,optional"`
+	ConfigFile   string            `river:"config_file,attr,optional"`
+	Config       rivertypes.Secret `river:"config,attr,optional"`
+	Targets      TargetBlock       `river:"target,block"`
+	WalkParams   WalkParams        `river:"walk_param,block,optional"`
 	ConfigStruct snmp_config.Config
 }
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
@@ -34,7 +34,7 @@ Omitted fields take their default values.
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `config_file`                 | `string`       | blackbox_exporter configuration file path. | | no
-`config`                      | `secret`       | blackbox_exporter configuration as inline string.  | |no
+`config`                      | `string` or `secret`       | blackbox_exporter configuration as inline string.  | |no
 `probe_timeout_offset`        | `duration`     | Offset in seconds to subtract from timeout when probing targets.  | `"0.5s"` | no
 
 The `config_file` argument points to a YAML file defining which blackbox_exporter modules to use.

--- a/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
@@ -34,7 +34,7 @@ Omitted fields take their default values.
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `config_file`                 | `string`       | blackbox_exporter configuration file path. | | no
-`config`                      | `string`       | blackbox_exporter configuration as inline string.  | |no
+`config`                      | `secret`       | blackbox_exporter configuration as inline string.  | |no
 `probe_timeout_offset`        | `duration`     | Offset in seconds to subtract from timeout when probing targets.  | `"0.5s"` | no
 
 The `config_file` argument points to a YAML file defining which blackbox_exporter modules to use.

--- a/docs/sources/flow/reference/components/prometheus.exporter.snmp.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.snmp.md
@@ -37,7 +37,7 @@ Omitted fields take their default values.
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `config_file` | `string`       | SNMP configuration file defining custom modules. | | no
-`config` | `secret`       | SNMP configuration as inline string.  | |no
+`config` | `string` or `secret`       | SNMP configuration as inline string.  | |no
 
 The `config_file` argument points to a YAML file defining which snmp_exporter modules to use. See [snmp_exporter](https://github.com/prometheus/snmp_exporter#generating-configuration) for details on how to generate a config file.
 
@@ -155,12 +155,13 @@ prometheus.scrape "demo" {
 }
 ```
 
-This example is the same above with using an embedded configuration:
+This example is the same above with using an embedded configuration (with secrets):
 
 
 ```river
 local.file "snmp_config" {
-    path = "snmp_modules.yml"
+    path      = "snmp_modules.yml"
+    is_secret = true
 }
 
 prometheus.exporter.snmp "example" {

--- a/docs/sources/flow/reference/components/prometheus.exporter.snmp.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.snmp.md
@@ -37,7 +37,7 @@ Omitted fields take their default values.
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `config_file` | `string`       | SNMP configuration file defining custom modules. | | no
-`config` | `string`       | SNMP configuration as inline string.  | |no
+`config` | `secret`       | SNMP configuration as inline string.  | |no
 
 The `config_file` argument points to a YAML file defining which snmp_exporter modules to use. See [snmp_exporter](https://github.com/prometheus/snmp_exporter#generating-configuration) for details on how to generate a config file.
 


### PR DESCRIPTION
#### PR Description

This PR changes inline `config` fields of blackbox and snmp exporter to be type `Secret`.

#### Which issue(s) this PR fixes

Fixes #4302

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
