### PR TITLE
cluster: transition to StateTerminating before leaving the cluster

### DIFF
--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -168,7 +168,7 @@ func (fr *flowRun) Run(configFile string) error {
 		return fmt.Errorf("building clusterer: %w", err)
 	}
 	defer func() {
-		err := clusterer.Stop()
+		err := clusterer.Stop(ctx)
 		if err != nil {
 			level.Error(l).Log("msg", "failed to terminate clusterer", "err", err)
 		}

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -168,7 +168,7 @@ func (fr *flowRun) Run(configFile string) error {
 		return fmt.Errorf("building clusterer: %w", err)
 	}
 	defer func() {
-		err := clusterer.Stop(ctx)
+		err := clusterer.Stop()
 		if err != nil {
 			level.Error(l).Log("msg", "failed to terminate clusterer", "err", err)
 		}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -231,9 +231,13 @@ func (c *Clusterer) Start(ctx context.Context) error {
 }
 
 // Stop stops the Clusterer.
-func (c *Clusterer) Stop() error {
+func (c *Clusterer) Stop(ctx context.Context) error {
 	switch node := c.Node.(type) {
 	case *GossipNode:
+		err := node.ChangeState(ctx, peer.StateTerminating)
+		if err != nil {
+			level.Error(node.log).Log("msg", "failed to change state to Terminating before shutting down", "err", err)
+		}
 		return node.Stop()
 	}
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -239,6 +239,8 @@ func (c *Clusterer) Stop() error {
 		ctx, ccl := context.WithTimeout(context.Background(), 5*time.Second)
 		defer ccl()
 
+		// TODO(rfratto): should we enter terminating state earlier to allow for
+		// some kind of hand-off between components?
 		err := node.ChangeState(ctx, peer.StateTerminating)
 		if err != nil {
 			level.Error(node.log).Log("msg", "failed to change state to Terminating before shutting down", "err", err)

--- a/pkg/cluster/gossip.go
+++ b/pkg/cluster/gossip.go
@@ -258,8 +258,8 @@ func (n *GossipNode) Start() (err error) {
 // Stop leaves the cluster and terminates n. n cannot be re-used after
 // stopping.
 //
-// It is advisable to ChangeState to StateTerminating and StateGone before
-// stopping so the local node has an opportunity to move work to other nodes.
+// It is advisable to ChangeState to StateTerminating before stopping so the
+// local node has an opportunity to move work to other nodes.
 func (n *GossipNode) Stop() error {
 	return n.innerNode.Stop()
 }


### PR DESCRIPTION
#### PR Description
This PR ensures that cluster nodes shutting down transition to the StateTerminating before leaving the memberlist, so that they're no longer considered owners for write hash operations.


#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer
We introduce a new context here, because when in order to call Stop() on the deferred function, it would mean that the context from `interruptContext` would already be cancelled.

#### PR Checklist

- [ ] CHANGELOG updated (N/A)
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
