### PR TITLE
helm: add native support for clustering with agent.clustering.enabled value

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -16,7 +16,8 @@ Unreleased
 ### Features
 
 - Add native support for Flow mode clustering with the
-  `agent.clustering.enabled` flag. (@rfratto)
+  `agent.clustering.enabled` flag. Clustering may only be enabled in Flow mode
+  when deploying a StatefulSet. (@rfratto)
 
 ### Enhancements
 

--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -13,6 +13,11 @@ Unreleased
 0.16.0 (2023-06-20)
 -------------------
 
+### Features
+
+- Add native support for Flow mode clustering with the
+  `agent.clustering.enabled` flag. (@rfratto)
+
 ### Enhancements
 
 - Allow requests to be set on the config reloader container. (@tpaschalis)

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -41,6 +41,7 @@ use the older mode (called "static mode"), set the `agent.mode` value to
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| agent.clustering.enabled | bool | `false` | Deploy agents in a cluster to allow for load distribution. Only applies when agent.mode is "flow". |
 | agent.configMap.content | string | `""` | Content to assign to the new ConfigMap.  This is passed into `tpl` allowing for templating from values. |
 | agent.configMap.create | bool | `true` | Create a new ConfigMap for the config file. |
 | agent.configMap.key | string | `nil` | Key in ConfigMap to get config from. |

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -41,7 +41,7 @@ use the older mode (called "static mode"), set the `agent.mode` value to
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| agent.clustering.enabled | bool | `false` | Deploy agents in a cluster to allow for load distribution. Only applies when agent.mode is "flow". |
+| agent.clustering.enabled | bool | `false` | Deploy agents in a cluster to allow for load distribution. Only applies when agent.mode=flow and controller.type=statefulset. |
 | agent.configMap.content | string | `""` | Content to assign to the new ConfigMap.  This is passed into `tpl` allowing for templating from values. |
 | agent.configMap.create | bool | `true` | Create a new ConfigMap for the config file. |
 | agent.configMap.key | string | `nil` | Key in ConfigMap to get config from. |

--- a/operations/helm/charts/grafana-agent/ci/clustering-values.yaml
+++ b/operations/helm/charts/grafana-agent/ci/clustering-values.yaml
@@ -4,5 +4,5 @@ agent:
     enabled: true
 
 controller:
-  type: 'deployment'
+  type: 'statefulset'
   replicas: 3

--- a/operations/helm/charts/grafana-agent/ci/clustering-values.yaml
+++ b/operations/helm/charts/grafana-agent/ci/clustering-values.yaml
@@ -1,0 +1,8 @@
+agent:
+  mode: 'flow'
+  clustering:
+    enabled: true
+
+controller:
+  type: 'deployment'
+  replicas: 3

--- a/operations/helm/charts/grafana-agent/templates/cluster_service.yaml
+++ b/operations/helm/charts/grafana-agent/templates/cluster_service.yaml
@@ -1,0 +1,30 @@
+{{- if and (eq .Values.agent.mode "flow") (.Values.agent.clustering.enabled) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "grafana-agent.fullname" . }}-cluster
+  labels:
+    {{- include "grafana-agent.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: 'None'
+  selector:
+    {{- include "grafana-agent.selectorLabels" . | nindent 4 }}
+  ports:
+    # Do not include the -metrics suffix in the port name, otherwise metrics
+    # can be double-collected with the non-headless Service if it's also
+    # enabled.
+    #
+    # This service should only be used for clustering, and not metric
+    # collection.
+    - name: http
+      port: {{ .Values.agent.listenPort }}
+      targetPort: {{ .Values.agent.listenPort }}
+      protocol: "TCP"
+  {{- range $portMap := .Values.agent.extraPorts }}
+    - name: {{ $portMap.name }}
+      port: {{ $portMap.port }}
+      targetPort: {{ $portMap.targetPort }}
+      protocol: {{ coalesce $portMap.protocol "TCP" }}
+  {{- end }}
+{{- end }}

--- a/operations/helm/charts/grafana-agent/templates/containers/_agent.yaml
+++ b/operations/helm/charts/grafana-agent/templates/containers/_agent.yaml
@@ -11,6 +11,10 @@
     {{- if not .Values.agent.enableReporting }}
     - --disable-reporting
     {{- end}}
+    {{- if .Values.agent.clustering.enabled }}
+    - --cluster.enabled=true
+    - --cluster.join-addresses={{ include "grafana-agent.fullname" . }}-cluster
+    {{- end}}
     {{- end}}
     {{- if eq .Values.agent.mode "static"}}
     - -config.file=/etc/agent/{{ include "grafana-agent.config-map.key" . }}

--- a/operations/helm/charts/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/charts/grafana-agent/templates/controllers/statefulset.yaml
@@ -1,3 +1,7 @@
+{{- if and (.Values.agent.clustering.enabled) (ne .Values.controller.type "statefulset") -}}
+{{ fail "Clustering may only be used with controller.type=statefulset." }}
+{{- end -}}
+
 {{- if eq .Values.controller.type "statefulset" }}
 apiVersion: apps/v1
 kind: StatefulSet

--- a/operations/helm/charts/grafana-agent/values.yaml
+++ b/operations/helm/charts/grafana-agent/values.yaml
@@ -32,7 +32,7 @@ agent:
 
   clustering:
     # -- Deploy agents in a cluster to allow for load distribution. Only
-    # applies when agent.mode is "flow".
+    # applies when agent.mode=flow and controller.type=statefulset.
     enabled: false
 
   # -- Path to where Grafana Agent stores data (for example, the Write-Ahead Log).

--- a/operations/helm/charts/grafana-agent/values.yaml
+++ b/operations/helm/charts/grafana-agent/values.yaml
@@ -30,6 +30,11 @@ agent:
     # -- Key in ConfigMap to get config from.
     key: null
 
+  clustering:
+    # -- Deploy agents in a cluster to allow for load distribution. Only
+    # applies when agent.mode is "flow".
+    enabled: false
+
   # -- Path to where Grafana Agent stores data (for example, the Write-Ahead Log).
   # By default, data is lost between reboots.
   storagePath: /tmp/agent

--- a/operations/helm/tests/clustering/grafana-agent/templates/cluster_service.yaml
+++ b/operations/helm/tests/clustering/grafana-agent/templates/cluster_service.yaml
@@ -1,0 +1,29 @@
+---
+# Source: grafana-agent/templates/cluster_service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-agent-cluster
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  clusterIP: 'None'
+  selector:
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+  ports:
+    # Do not include the -metrics suffix in the port name, otherwise metrics
+    # can be double-collected with the non-headless Service if it's also
+    # enabled.
+    #
+    # This service should only be used for clustering, and not metric
+    # collection.
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: "TCP"

--- a/operations/helm/tests/clustering/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/clustering/grafana-agent/templates/configmap.yaml
@@ -1,0 +1,42 @@
+---
+# Source: grafana-agent/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.river: |-
+    logging {
+    	level  = "info"
+    	format = "logfmt"
+    }
+    
+    discovery.kubernetes "pods" {
+    	role = "pod"
+    }
+    
+    discovery.kubernetes "nodes" {
+    	role = "node"
+    }
+    
+    discovery.kubernetes "services" {
+    	role = "service"
+    }
+    
+    discovery.kubernetes "endpoints" {
+    	role = "endpoints"
+    }
+    
+    discovery.kubernetes "endpointslices" {
+    	role = "endpointslice"
+    }
+    
+    discovery.kubernetes "ingresses" {
+    	role = "ingress"
+    }

--- a/operations/helm/tests/clustering/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/clustering/grafana-agent/templates/controllers/deployment.yaml
@@ -1,0 +1,73 @@
+---
+# Source: grafana-agent/templates/controllers/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 3
+  minReadySeconds: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana-agent
+      app.kubernetes.io/instance: grafana-agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana-agent
+        app.kubernetes.io/instance: grafana-agent
+    spec:
+      serviceAccountName: grafana-agent
+      containers:
+        - name: grafana-agent
+          image: docker.io/grafana/agent:v0.34.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - /etc/agent/config.river
+            - --storage.path=/tmp/agent
+            - --server.http.listen-addr=0.0.0.0:80
+            - --cluster.enabled=true
+            - --cluster.join-addresses=grafana-agent-cluster
+          env:
+            - name: AGENT_MODE
+              value: flow
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - containerPort: 80
+              name: http-metrics
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 80
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+        - name: config-reloader
+          image: docker.io/jimmidyson/configmap-reload:v0.8.0
+          args:
+            - --volume-dir=/etc/agent
+            - --webhook-url=http://localhost:80/-/reload
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+          resources:
+            requests:
+              cpu: 1m
+              memory: 5Mi
+      dnsPolicy: ClusterFirst
+      volumes:
+        - name: config
+          configMap:
+            name: grafana-agent

--- a/operations/helm/tests/clustering/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/clustering/grafana-agent/templates/controllers/statefulset.yaml
@@ -1,7 +1,7 @@
 ---
-# Source: grafana-agent/templates/controllers/deployment.yaml
+# Source: grafana-agent/templates/controllers/statefulset.yaml
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: grafana-agent
   labels:
@@ -13,6 +13,7 @@ metadata:
 spec:
   replicas: 3
   minReadySeconds: 10
+  serviceName: grafana-agent
   selector:
     matchLabels:
       app.kubernetes.io/name: grafana-agent

--- a/operations/helm/tests/clustering/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/clustering/grafana-agent/templates/rbac.yaml
@@ -1,0 +1,101 @@
+---
+# Source: grafana-agent/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  # Rules which allow discovery.kubernetes to function.
+  - apiGroups:
+      - ""
+      - "discovery.k8s.io"
+      - "networking.k8s.io"
+    resources:
+      - endpoints
+      - endpointslices
+      - ingresses
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  # Rules for prometheus.kubernetes.*
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - podmonitors
+      - servicemonitors
+      - probes
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: grafana-agent/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: grafana-agent
+subjects:
+  - kind: ServiceAccount
+    name: grafana-agent
+    namespace: default

--- a/operations/helm/tests/clustering/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/clustering/grafana-agent/templates/service.yaml
@@ -1,0 +1,22 @@
+---
+# Source: grafana-agent/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+  ports:
+    - name: http-metrics
+      port: 80
+      targetPort: 80
+      protocol: "TCP"

--- a/operations/helm/tests/clustering/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/clustering/grafana-agent/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+---
+# Source: grafana-agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
This adds a new value, `agent.clustering.enabled`, to automatically configure clustering with the appropriate service and flags. 

This makes it easier to deploy clustering by having a dedicated service for clustering, compared to the current approach of disabling the existing service, and then switching it to a headless service. 

Because clustering only discovers peers once on startup, and because StatefulSet is the only controller which can roll out one pod at a time, controller.type=statefulset is required to use clustering. A long-term solution would be to periodically rediscover peers, which would allow other controller types to be used correctly. 