### PR TITLE
Fix argument name in `module.http` example

### DIFF
--- a/docs/sources/flow/reference/components/module.http.md
+++ b/docs/sources/flow/reference/components/module.http.md
@@ -121,7 +121,7 @@ Parent:
 ```river
 module.http "remote_module" {
   url              = "http://localhost:8080/redis_module.yaml"
-  polling_interval = "1m"
+  poll_frequency   = "1m"
 }
 
 prometheus.exporter.unix { }


### PR DESCRIPTION
#### PR Description

The example of usage of `module.http` refers wrongly to `polling_interval`.
Changing to `poll_frequency`.

#### PR Checklist

- [ ] CHANGELOG updated
- [x] Documentation added
- [ ] Tests updated
