### PR TITLE
Do not fail on startup when a module loader receives invalid config

### DIFF
--- a/component/module/file/file.go
+++ b/component/module/file/file.go
@@ -6,6 +6,7 @@ import (
 
 	"go.uber.org/atomic"
 
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/local/file"
 	"github.com/grafana/agent/component/module"
@@ -75,7 +76,8 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		return nil, err
 	}
 	if err := c.Update(args); err != nil {
-		return nil, err
+		level.Error(o.Logger).Log("msg", "loading of component failed", "err", err)
+		return c, nil
 	}
 	return c, nil
 }

--- a/component/module/git/git.go
+++ b/component/module/git/git.go
@@ -87,7 +87,8 @@ func New(o component.Options, args Arguments) (*Component, error) {
 	}
 
 	if err := c.Update(args); err != nil {
-		return nil, err
+		level.Error(o.Logger).Log("msg", "loading of component failed", "err", err)
+		return c, nil
 	}
 	return c, nil
 }

--- a/component/module/http/http.go
+++ b/component/module/http/http.go
@@ -6,6 +6,7 @@ import (
 
 	"go.uber.org/atomic"
 
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/module"
 	remote_http "github.com/grafana/agent/component/remote/http"
@@ -51,8 +52,8 @@ type Component struct {
 }
 
 var (
-	_ component.Component       = (*Component)(nil)
-	_ component.HealthComponent = (*Component)(nil)
+	_ component.Component = (*Component)(nil)
+	//_ component.HealthComponent = (*Component)(nil)
 )
 
 // New creates a new module.http component.
@@ -74,7 +75,8 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		return nil, err
 	}
 	if err := c.Update(args); err != nil {
-		return nil, err
+		level.Error(o.Logger).Log("msg", "loading of component failed", "err", err)
+		return c, nil
 	}
 	return c, nil
 }
@@ -138,19 +140,19 @@ func (c *Component) Update(args component.Arguments) error {
 }
 
 // CurrentHealth implements component.HealthComponent.
-func (c *Component) CurrentHealth() component.Health {
-	// Note that it takes until the first successful poll for c.managedRemoteHTTP to
-	// become healthy.
-	leastHealthy := component.LeastHealthy(
-		c.managedRemoteHTTP.CurrentHealth(),
-		c.mod.CurrentHealth(),
-	)
+// func (c *Component) CurrentHealth() component.Health {
+// 	// Note that it takes until the first successful poll for c.managedRemoteHTTP to
+// 	// become healthy.
+// 	leastHealthy := component.LeastHealthy(
+// 		c.managedRemoteHTTP.CurrentHealth(),
+// 		c.mod.CurrentHealth(),
+// 	)
 
-	if leastHealthy.Health == component.HealthTypeHealthy {
-		return c.mod.CurrentHealth()
-	}
-	return leastHealthy
-}
+// 	if leastHealthy.Health == component.HealthTypeHealthy {
+// 		return c.mod.CurrentHealth()
+// 	}
+// 	return leastHealthy
+// }
 
 // getArgs is a goroutine safe way to get args
 func (c *Component) getArgs() Arguments {

--- a/component/module/http/http.go
+++ b/component/module/http/http.go
@@ -52,8 +52,8 @@ type Component struct {
 }
 
 var (
-	_ component.Component = (*Component)(nil)
-	//_ component.HealthComponent = (*Component)(nil)
+	_ component.Component       = (*Component)(nil)
+	_ component.HealthComponent = (*Component)(nil)
 )
 
 // New creates a new module.http component.
@@ -140,19 +140,19 @@ func (c *Component) Update(args component.Arguments) error {
 }
 
 // CurrentHealth implements component.HealthComponent.
-// func (c *Component) CurrentHealth() component.Health {
-// 	// Note that it takes until the first successful poll for c.managedRemoteHTTP to
-// 	// become healthy.
-// 	leastHealthy := component.LeastHealthy(
-// 		c.managedRemoteHTTP.CurrentHealth(),
-// 		c.mod.CurrentHealth(),
-// 	)
+func (c *Component) CurrentHealth() component.Health {
+	// Note that it takes until the first successful poll for c.managedRemoteHTTP to
+	// become healthy.
+	leastHealthy := component.LeastHealthy(
+		c.managedRemoteHTTP.CurrentHealth(),
+		c.mod.CurrentHealth(),
+	)
 
-// 	if leastHealthy.Health == component.HealthTypeHealthy {
-// 		return c.mod.CurrentHealth()
-// 	}
-// 	return leastHealthy
-// }
+	if leastHealthy.Health == component.HealthTypeHealthy {
+		return c.mod.CurrentHealth()
+	}
+	return leastHealthy
+}
 
 // getArgs is a goroutine safe way to get args
 func (c *Component) getArgs() Arguments {

--- a/component/module/string/string.go
+++ b/component/module/string/string.go
@@ -3,6 +3,7 @@ package string
 import (
 	"context"
 
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/module"
 	"github.com/grafana/agent/pkg/river/rivertypes"
@@ -51,7 +52,8 @@ func New(o component.Options, args Arguments) (*Component, error) {
 	}
 
 	if err := c.Update(args); err != nil {
-		return nil, err
+		level.Error(o.Logger).Log("msg", "loading of component failed", "err", err)
+		return c, nil
 	}
 	return c, nil
 }

--- a/component/remote/http/http.go
+++ b/component/remote/http/http.go
@@ -156,7 +156,7 @@ func (c *Component) nextPoll() time.Duration {
 	return nextPoll.Sub(now)
 }
 
-// poll performs a HTTP GET for the component's configured URL. c.mut must
+// poll performs a HTTP request for the component's configured URL. c.mut must
 // not be held when calling. After polling, the component's health is updated
 // with the success or failure status.
 func (c *Component) poll() {


### PR DESCRIPTION
#### PR Description

This PR changes the behavior of module loaders which currently make the Agent panic on startup if the module loaders
loads a Flow config with errors. In cases like `module.http` (specially using it combined with agent-management) it's important to keep the agents running regardless of the loaded configuration.

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
