### PR TITLE
docs: fix link to Flow mode in admonition banner

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -14,7 +14,7 @@ Grafana Agent is based around **components**. Components are wired together to
 form programmable observability **pipelines** for telemetry collection,
 processing, and delivery.
 
-> **NOTE**: This page focuses mainly on "[Flow mode][Grafana Agent Flow]," the
+> **NOTE**: This page focuses mainly on "[Flow mode][]," the
 > Terraform-inspired variant of Grafana Agent.
 >
 > For information on other variants of Grafana Agent, refer to [About Grafana
@@ -27,7 +27,7 @@ Grafana Agent can collect, transform, and send data to:
 * The Grafana open source ecosystem ([Loki][], [Grafana][], [Tempo][], [Mimir][], [Phlare][])
 
 [Terraform]: https://terraform.io
-[Grafana Agent in flow mode]: {{< relref "./flow/" >}}
+[Flow mode]: {{< relref "./flow/" >}}
 [About Grafana Agent]: {{< relref "./about.md" >}}
 [Prometheus]: https://prometheus.io
 [OpenTelemetry]: https://opentelemetry.io


### PR DESCRIPTION
The link to Flow mode in the landing page of the docs is currently broken:

![image](https://github.com/grafana/agent/assets/630212/9408b2f0-720a-4e1f-9a6b-ebcb1b5b5259)
