### PR TITLE
Update to go 1.20.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,7 @@ Main (unreleased)
 ### Other changes
 
 - Mongodb integration has been re-enabled. (@jcreixell, @marctc)
-- Build with go 1.20.5 (@captncraig)
+- Build with go 1.20.6 (@captncraig)
 
 v0.34.3 (2023-06-27)
 --------------------

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -23,7 +23,7 @@ FROM alpine:3.17 as helm
 RUN apk add --no-cache helm
 
 # Dependency: Go and Go dependencies
-FROM golang:1.20.5-bullseye as golang
+FROM golang:1.20.6-bullseye as golang
 
 # Keep in sync with cmd/grafana-agent-operator/DEVELOPERS.md
 ENV CONTROLLER_GEN_VERSION v0.9.2

--- a/build-image/windows/Dockerfile
+++ b/build-image/windows/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/golang:1.20.5-windowsservercore-1809
+FROM library/golang:1.20.6-windowsservercore-1809
 
 SHELL ["powershell", "-command"]
 


### PR DESCRIPTION
1.20.6 is a security release.

After this, will update build-image immediately.