### PR TITLE
Remove oauth2 agent config from example in Operator docs

### DIFF
--- a/docs/sources/operator/deploy-agent-operator-resources.md
+++ b/docs/sources/operator/deploy-agent-operator-resources.md
@@ -19,16 +19,18 @@ Follow the steps in this guide to roll out the Grafana Agent Operator custom res
 The hierarchy of custom resources is as follows:
 
 - `GrafanaAgent`
-    - `MetricsInstance`
-        - `PodMonitor`
-        - `Probe`
-        - `ServiceMonitor`
-    - `LogsInstance`
-        - `PodLogs`
+  - `MetricsInstance`
+    - `PodMonitor`
+    - `Probe`
+    - `ServiceMonitor`
+  - `LogsInstance`
+    - `PodLogs`
 
 To learn more about the custom resources Agent Operator provides and their hierarchy, see [Grafana Agent Operator architecture]({{< relref "./architecture/" >}}).
 
-> **Note:** Agent Operator is currently in beta and its custom resources are subject to change.
+{{% admonition type="note" %}}
+Agent Operator is currently in beta and its custom resources are subject to change.
+{{% /admonition %}}
 
 ## Before you begin
 
@@ -38,7 +40,9 @@ Before you begin, make sure that you have deployed the Grafana Agent Operator CR
 
 In this section, you'll roll out a `GrafanaAgent` resource. See [Grafana Agent Operator architecture]({{< relref "./architecture.md" >}}) for a discussion of the resources in the `GrafanaAgent` resource hierarchy.
 
-> **Note:** Due to the variety of possible deployment architectures, the official Agent Operator Helm chart does not provide built-in templates for the custom resources described in this guide. You must configure and deploy these manually as described in this section. We recommend templating and adding the following manifests to your own in-house Helm charts and GitOps flows.
+{{% admonition type="note" %}}
+Due to the variety of possible deployment architectures, the official Agent Operator Helm chart does not provide built-in templates for the custom resources described in this guide. You must configure and deploy these manually as described in this section. We recommend templating and adding the following manifests to your own in-house Helm charts and GitOps flows.
+{{% /admonition %}}
 
 To deploy the `GrafanaAgent` resource:
 
@@ -371,7 +375,9 @@ To deploy the `LogsInstance` resource into your cluster:
 
 1. Copy the following `PodLogs` manifest to a file, then roll it to your cluster using `kubectl apply -f` followed by the filename. The manifest defines your logging targets. Agent Operator  turns this into Agent configuration for the logs subsystem, and rolls it out to the DaemonSet of logging Agents.
 
-    > **Note**: The following is a minimal working example which you should adapt to your production needs.
+    {{% admonition type="note" %}}
+    The following is a minimal working example which you should adapt to your production needs.
+    {{% /admonition %}}
 
     ```yaml
     apiVersion: monitoring.grafana.com/v1alpha1
@@ -421,5 +427,3 @@ You've now rolled out the following into your cluster:
 You can verify that everything is working correctly by navigating to your Grafana instance and querying your Loki and Prometheus data sources.
 
 > Tip: You can deploy multiple GrafanaAgent resources to isolate allocated resources to the agent pods. By default, the GrafanaAgent resource determines the resources of all deployed agent containers. However, you might want different memory limits for metrics versus logs.
-
-

--- a/docs/sources/operator/deploy-agent-operator-resources.md
+++ b/docs/sources/operator/deploy-agent-operator-resources.md
@@ -182,19 +182,6 @@ To deploy a `MetricsInstance` resource:
             name: primary-credentials-metrics
             key: password
 
-      # As an alternative authentication method, Grafana Agent also supports OAuth2.
-      # - url: your_remote_write_URL
-      #   oauth2:
-      #     clientId:
-      #       secret:
-      #         key: username # Kubernetes Secret Key
-      #         name: primary-credentials-metrics # Kubernetes Secret Name
-      #     clientSecret:
-      #       key: password # Kubernetes Secret Key
-      #       name: primary-credentials-metrics # Kubernetes Secret Name
-      #     tokenUrl: https://auth.example.com/realms/master/protocol/openid-connect/token
-
-
       # Supply an empty namespace selector to look in all namespaces. Remove
       # this to only look in the same namespace as the MetricsInstance CR
       serviceMonitorNamespaceSelector: {}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Oauth2 is mentioned as supported in Operator `remotewrite`. This is incorrect and needs to be removed from the documentation. Oauth2 is supported in static and flow mode `remote_write`, but not in operator.

Reference https://github.com/grafana/agent/pull/2654 that added the information

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
