### PR TITLE
Flow Otelcol: Document default values for gRPC client balancer_name

### DIFF
--- a/component/otelcol/exporter/jaeger/jaeger.go
+++ b/component/otelcol/exporter/jaeger/jaeger.go
@@ -85,6 +85,7 @@ var DefaultGRPCClientArguments = GRPCClientArguments{
 	Headers:         map[string]string{},
 	Compression:     otelcol.CompressionTypeGzip,
 	WriteBufferSize: 512 * 1024,
+	BalancerName:    "pick_first",
 }
 
 // SetToDefault implements river.Defaulter.

--- a/component/otelcol/exporter/loadbalancing/loadbalancing.go
+++ b/component/otelcol/exporter/loadbalancing/loadbalancing.go
@@ -242,6 +242,7 @@ var DefaultGRPCClientArguments = GRPCClientArguments{
 	Headers:         map[string]string{},
 	Compression:     otelcol.CompressionTypeGzip,
 	WriteBufferSize: 512 * 1024,
+	BalancerName:    "pick_first",
 }
 
 // SetToDefault implements river.Defaulter.

--- a/component/otelcol/exporter/loadbalancing/loadbalancing_test.go
+++ b/component/otelcol/exporter/loadbalancing/loadbalancing_test.go
@@ -22,6 +22,7 @@ func TestConfigConversion(t *testing.T) {
 				Compression:     "gzip",
 				WriteBufferSize: 512 * 1024,
 				Headers:         map[string]configopaque.String{},
+				BalancerName:    "pick_first",
 			},
 		},
 	}
@@ -108,6 +109,7 @@ func TestConfigConversion(t *testing.T) {
 							Compression:     "gzip",
 							WriteBufferSize: 512 * 1024,
 							Headers:         map[string]configopaque.String{},
+							BalancerName:    "pick_first",
 						},
 					},
 				},

--- a/component/otelcol/exporter/otlp/otlp.go
+++ b/component/otelcol/exporter/otlp/otlp.go
@@ -85,6 +85,7 @@ var DefaultGRPCClientArguments = GRPCClientArguments{
 	Headers:         map[string]string{},
 	Compression:     otelcol.CompressionTypeGzip,
 	WriteBufferSize: 512 * 1024,
+	BalancerName:    "pick_first",
 }
 
 // SetToDefault implements river.Defaulter.

--- a/component/otelcol/extension/jaeger_remote_sampling/jaeger_remote_sampling.go
+++ b/component/otelcol/extension/jaeger_remote_sampling/jaeger_remote_sampling.go
@@ -56,10 +56,10 @@ type Arguments struct {
 }
 
 type ArgumentsSource struct {
-	Content        string                       `river:"content,attr,optional"`
-	Remote         *otelcol.GRPCClientArguments `river:"remote,block,optional"`
-	File           string                       `river:"file,attr,optional"`
-	ReloadInterval time.Duration                `river:"reload_interval,attr,optional"`
+	Content        string               `river:"content,attr,optional"`
+	Remote         *GRPCClientArguments `river:"remote,block,optional"`
+	File           string               `river:"file,attr,optional"`
+	ReloadInterval time.Duration        `river:"reload_interval,attr,optional"`
 }
 
 var (
@@ -72,7 +72,7 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 		HTTPServerSettings: (*otelcol.HTTPServerArguments)(args.HTTP).Convert(),
 		GRPCServerSettings: (*otelcol.GRPCServerArguments)(args.GRPC).Convert(),
 		Source: jaegerremotesampling.Source{
-			Remote:         args.Source.Remote.Convert(),
+			Remote:         (*otelcol.GRPCClientArguments)(args.Source.Remote).Convert(),
 			File:           args.Source.File,
 			ReloadInterval: args.Source.ReloadInterval,
 			Contents:       args.Source.Content,
@@ -131,4 +131,23 @@ func (args *GRPCServerArguments) SetToDefault() {
 // SetToDefault implements river.Defaulter.
 func (args *HTTPServerArguments) SetToDefault() {
 	*args = DefaultHTTPServerArguments
+}
+
+// GRPCClientArguments is used to configure
+// otelcol.extension.jaeger_remote_sampling with
+// component-specific defaults.
+type GRPCClientArguments otelcol.GRPCClientArguments
+
+// DefaultGRPCClientArguments holds component-specific
+// default settings for GRPCClientArguments.
+var DefaultGRPCClientArguments = GRPCClientArguments{
+	Headers:         map[string]string{},
+	Compression:     otelcol.CompressionTypeGzip,
+	WriteBufferSize: 512 * 1024,
+	BalancerName:    "pick_first",
+}
+
+// SetToDefault implements river.Defaulter.
+func (args *GRPCClientArguments) SetToDefault() {
+	*args = DefaultGRPCClientArguments
 }

--- a/component/otelcol/extension/jaeger_remote_sampling/jaeger_remote_sampling_test.go
+++ b/component/otelcol/extension/jaeger_remote_sampling/jaeger_remote_sampling_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/extension/jaeger_remote_sampling"
 	"github.com/grafana/agent/pkg/flow/componenttest"
 	"github.com/grafana/agent/pkg/river"
@@ -197,6 +198,32 @@ func TestUnmarshalUsesDefaults(t *testing.T) {
 			expected: jaeger_remote_sampling.Arguments{
 				GRPC:   &jaeger_remote_sampling.GRPCServerArguments{Endpoint: "blerg", Transport: "blarg"},
 				Source: jaeger_remote_sampling.ArgumentsSource{File: "remote.json"},
+			},
+		},
+		// tests source grpc defaults
+		{
+			cfg: `
+				grpc {
+					endpoint = "blerg"
+					transport = "blarg"
+				}
+				source {
+					remote {
+						endpoint = "TestRemoteEndpoint"
+					}
+				}
+			`,
+			expected: jaeger_remote_sampling.Arguments{
+				GRPC: &jaeger_remote_sampling.GRPCServerArguments{Endpoint: "blerg", Transport: "blarg"},
+				Source: jaeger_remote_sampling.ArgumentsSource{
+					Remote: &jaeger_remote_sampling.GRPCClientArguments{
+						Endpoint:        "TestRemoteEndpoint",
+						Headers:         map[string]string{},
+						Compression:     otelcol.CompressionTypeGzip,
+						WriteBufferSize: 512 * 1024,
+						BalancerName:    "pick_first",
+					},
+				},
 			},
 		},
 	}

--- a/docs/sources/flow/reference/components/otelcol.exporter.jaeger.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.jaeger.md
@@ -71,14 +71,12 @@ Name | Type | Description | Default | Required
 `write_buffer_size` | `string` | Size of the write buffer the gRPC client to use for writing requests. | `"512KiB"` | no
 `wait_for_ready` | `boolean` | Waits for gRPC connection to be in the `READY` state before sending data. | `false` | no
 `headers` | `map(string)` | Additional headers to send with the request. | `{}` | no
-`balancer_name` | `string` | Which gRPC client-side load balancer to use for requests. | | no
+`balancer_name` | `string` | Which gRPC client-side load balancer to use for requests. | `pick_first` | no
 `auth` | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests. | | no
 
 {{< docs/shared lookup="flow/reference/components/otelcol-compression-field.md" source="agent" >}}
 
-The `balancer_name` argument controls what client-side load balancing mechanism
-to use. See the gRPC documentation on [Load balancing][] for more information.
-When unspecified, `pick_first` is used.
+{{< docs/shared lookup="flow/reference/components/otelcol-grpc-balancer-name.md" source="agent" >}}
 
 An HTTP proxy can be configured through the following environment variables:
 
@@ -100,7 +98,6 @@ that domain and all subdomains. A domain name with a leading "."
 Because `otelcol.exporter.jaeger` uses gRPC, the configured proxy server must be
 able to handle and proxy HTTP/2 traffic.
 
-[Load balancing]: https://github.com/grpc/grpc-go/blob/master/examples/features/load_balancing/README.md#pick_first
 [HTTP CONNECT]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT
 
 ### tls block

--- a/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
@@ -152,14 +152,12 @@ Name | Type | Description | Default | Required
 `write_buffer_size` | `string` | Size of the write buffer the gRPC client to use for writing requests. | `"512KiB"` | no
 `wait_for_ready` | `boolean` | Waits for gRPC connection to be in the `READY` state before sending data. | `false` | no
 `headers` | `map(string)` | Additional headers to send with the request. | `{}` | no
-`balancer_name` | `string` | Which gRPC client-side load balancer to use for requests. | | no
+`balancer_name` | `string` | Which gRPC client-side load balancer to use for requests. | `pick_first` | no
 `auth` | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests. | | no
 
 {{< docs/shared lookup="flow/reference/components/otelcol-compression-field.md" source="agent" >}}
 
-The `balancer_name` argument controls what client-side load balancing mechanism
-to use. See the gRPC documentation on [Load balancing][] for more information.
-When unspecified, `pick_first` is used.
+{{< docs/shared lookup="flow/reference/components/otelcol-grpc-balancer-name.md" source="agent" >}}
 
 You can configure an HTTP proxy with the following environment variables:
 
@@ -181,7 +179,6 @@ that domain and all subdomains. A domain name with a leading "."
 Because `otelcol.exporter.loadbalancing` uses gRPC, the configured proxy server must be
 able to handle and proxy HTTP/2 traffic.
 
-[Load balancing]: https://github.com/grpc/grpc-go/blob/master/examples/features/load_balancing/README.md#pick_first
 [HTTP CONNECT]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT
 
 ### tls block

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
@@ -69,14 +69,12 @@ Name | Type | Description | Default | Required
 `write_buffer_size` | `string` | Size of the write buffer the gRPC client to use for writing requests. | `"512KiB"` | no
 `wait_for_ready` | `boolean` | Waits for gRPC connection to be in the `READY` state before sending data. | `false` | no
 `headers` | `map(string)` | Additional headers to send with the request. | `{}` | no
-`balancer_name` | `string` | Which gRPC client-side load balancer to use for requests. | | no
+`balancer_name` | `string` | Which gRPC client-side load balancer to use for requests. | `pick_first` | no
 `auth` | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests. | | no
 
 {{< docs/shared lookup="flow/reference/components/otelcol-compression-field.md" source="agent" >}}
 
-The `balancer_name` argument controls what client-side load balancing mechanism
-to use. See the gRPC documentation on [Load balancing][] for more information.
-When unspecified, `pick_first` is used.
+{{< docs/shared lookup="flow/reference/components/otelcol-grpc-balancer-name.md" source="agent" >}}
 
 An HTTP proxy can be configured through the following environment variables:
 
@@ -98,7 +96,6 @@ that domain and all subdomains. A domain name with a leading "."
 Because `otelcol.exporter.otlp` uses gRPC, the configured proxy server must be
 able to handle and proxy HTTP/2 traffic.
 
-[Load balancing]: https://github.com/grpc/grpc-go/blob/master/examples/features/load_balancing/README.md#pick_first
 [HTTP CONNECT]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT
 
 ### tls block

--- a/docs/sources/flow/reference/components/otelcol.extension.jaeger_remote_sampling.md
+++ b/docs/sources/flow/reference/components/otelcol.extension.jaeger_remote_sampling.md
@@ -202,14 +202,12 @@ Name | Type | Description | Default | Required
 `write_buffer_size` | `string` | Size of the write buffer the gRPC client to use for writing requests. | `"512KiB"` | no
 `wait_for_ready` | `boolean` | Waits for gRPC connection to be in the `READY` state before sending data. | `false` | no
 `headers` | `map(string)` | Additional headers to send with the request. | `{}` | no
-`balancer_name` | `string` | Which gRPC client-side load balancer to use for requests. | | no
+`balancer_name` | `string` | Which gRPC client-side load balancer to use for requests. | `pick_first` | no
 `auth` | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests. | | no
 
 {{< docs/shared lookup="flow/reference/components/otelcol-compression-field.md" source="agent" >}}
 
-The `balancer_name` argument controls what client-side load balancing mechanism
-to use. See the gRPC documentation on [Load balancing][] for more information.
-When unspecified, `pick_first` is used.
+{{< docs/shared lookup="flow/reference/components/otelcol-grpc-balancer-name.md" source="agent" >}}
 
 An HTTP proxy can be configured through the following environment variables:
 
@@ -231,7 +229,6 @@ that domain and all subdomains. A domain name with a leading "."
 Because `otelcol.extension.jaeger_remote_sampling` uses gRPC, the configured proxy server must be
 able to handle and proxy HTTP/2 traffic.
 
-[Load balancing]: https://github.com/grpc/grpc-go/blob/master/examples/features/load_balancing/README.md#pick_first
 [HTTP CONNECT]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT
 
 ### tls client block

--- a/docs/sources/shared/flow/reference/components/otelcol-grpc-balancer-name.md
+++ b/docs/sources/shared/flow/reference/components/otelcol-grpc-balancer-name.md
@@ -6,10 +6,10 @@ headless: true
 
 The supported values for `balancer_name` are listed in the gRPC documentation on [Load balancing][]:
 * `pick_first`: Tries to connect to the first address, uses it for all RPCs if it connects, 
-  or tries the next address if it fails (and keep doing that until one connection is successful). 
+  or tries the next address if it fails (and keeps doing that until one connection is successful). 
   Because of this, all the RPCs will be sent to the same backend.
 * `round_robin`: Connects to all the addresses it sees, and sends an RPC to each backend one at a time in order. 
-  E.g. the first RPC will be sent to backend-1, the second RPC will be be sent to backend-2, 
-  and the third RPC will be be sent to backend-1 again.
+  For example, the first RPC is sent to backend-1, the second RPC is sent to backend-2, 
+  and the third RPC is sent to backend-1.
 
 [Load balancing]: https://github.com/grpc/grpc-go/blob/master/examples/features/load_balancing/README.md#pick_first

--- a/docs/sources/shared/flow/reference/components/otelcol-grpc-balancer-name.md
+++ b/docs/sources/shared/flow/reference/components/otelcol-grpc-balancer-name.md
@@ -1,0 +1,15 @@
+---
+aliases:
+- /docs/agent/shared/flow/reference/components/otelcol-grpc-balancer-name
+headless: true
+---
+
+The supported values for `balancer_name` are listed in the gRPC documentation on [Load balancing][]:
+* `pick_first`: Tries to connect to the first address, uses it for all RPCs if it connects, 
+  or tries the next address if it fails (and keep doing that until one connection is successful). 
+  Because of this, all the RPCs will be sent to the same backend.
+* `round_robin`: Connects to all the addresses it sees, and sends an RPC to each backend one at a time in order. 
+  E.g. the first RPC will be sent to backend-1, the second RPC will be be sent to backend-2, 
+  and the third RPC will be be sent to backend-1 again.
+
+[Load balancing]: https://github.com/grpc/grpc-go/blob/master/examples/features/load_balancing/README.md#pick_first


### PR DESCRIPTION
`balancer_name` has a default value which is not listed in the tables in our docs.

This was noticed by @mattdurham in [another PR](https://github.com/grafana/agent/pull/4148#discussion_r1237634250).