### PR TITLE
Clarify otelcol.exporter.jaeger deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ Main (unreleased)
 
 - The `remote_sampling` block has been removed from `otelcol.receiver.jaeger`. (@ptodev)
 
+### Deprecations
+
+- `otelcol.exporter.jaeger` has been deprecated and will be removed in Agent v0.38.0. (@ptodev)
+
 ### Features
 
 - The Pyroscope scrape component computes and sends delta profiles automatically when required to reduce bandwidth usage. (@cyriltovena)
@@ -192,8 +196,6 @@ Main (unreleased)
 
 - Mongodb integration has been re-enabled. (@jcreixell, @marctc)
 - Build with go 1.20.6 (@captncraig)
-
-- `otelcol.exporter.jaeger` has been deprecated and will be removed soon. (@ptodev)
 
 v0.34.3 (2023-06-27)
 --------------------

--- a/docs/sources/flow/upgrade-guide.md
+++ b/docs/sources/flow/upgrade-guide.md
@@ -52,10 +52,15 @@ Additional `instrumentation_scope` information will be added to the OTLP log sig
 The `/` HTTP endpoint was the same as the `/sampling` endpoint. The `/sampling` endpoint is still functional.
 The change was made in PR [#18070](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/18070) of opentelemetry-collector-contrib. 
 
-### The `remote_sampling` block has been removed from `otelcol.receiver.jaeger`
+### Breaking change: The `remote_sampling` block has been removed from `otelcol.receiver.jaeger`
 
 The `remote_sampling` block in `otelcol.receiver.jaeger` has been an undocumented no-op configuration for some time, and has now been removed. 
 Customers are advised to use `otelcol.extension.jaeger_remote_sampling` instead.
+
+### Deprecation: `otelcol.exporter.jaeger` has been deprecated and will be removed in Agent v0.38.0.
+
+This is because Jaeger supports OTLP directly and OpenTelemetry Collector is also removing its 
+[Jaeger receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/jaegerexporter).
 
 ## v0.35
 


### PR DESCRIPTION
I added this deprecation recently, but didn't know it needs to be under a "deprecation" section and listed in the upgrade guide.

The exporter is due to be deleted from the Collector in July 2023, so I think v0.38.0 is ok as a target version for removal.