### PR TITLE
Test github action for trivy scanning

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -8,6 +8,9 @@ name: build
 on:
   push:
     branches: [ "main", "release-v[0-9].[0-9][0-9]" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,45 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: build
+
+on:
+  push:
+    branches: [ "main", "release-v[0-9].[0-9][0-9]" ]
+
+permissions:
+  contents: read
+  
+jobs:
+  build:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: Build
+    runs-on: "ubuntu-18.04"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Build an image from Dockerfile
+        env:
+          AGENT_IMAGE: 'grafana/agent:${{ github.sha }}'
+        run: |
+          make agent-image
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
+        with:
+          image-ref: 'grafana/agent:${{ github.sha }}'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
This is based off of the github generated action under the security tab for "code scanning".

The idea is that on push to main, it will build the docker image, generate a report, and upload to the security tab. 

Hoping this is a way to centralize the vulnerabilities we know about, and hopefully be a transparent way to communicate status of individual cves.