### PR TITLE
remote.http: set health after poll on Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Main (unreleased)
 
 - Add support for converting Prometheus `file_sd_config` to `discovery.file`. (@erikbaranowski)
 
+### Bugfixes
+
+- Fix issue where `remote.http` incorrectly had a status of "Unknown" until the
+  period specified by the polling frquency elapsed. (@rfratto)
+
 v0.35.0-rc.0 (2023-07-13)
 -------------------------
 

--- a/component/module/http/http.go
+++ b/component/module/http/http.go
@@ -139,8 +139,6 @@ func (c *Component) Update(args component.Arguments) error {
 
 // CurrentHealth implements component.HealthComponent.
 func (c *Component) CurrentHealth() component.Health {
-	// Note that it takes until the first successful poll for c.managedRemoteHTTP to
-	// become healthy.
 	leastHealthy := component.LeastHealthy(
 		c.managedRemoteHTTP.CurrentHealth(),
 		c.mod.CurrentHealth(),


### PR DESCRIPTION
Previously, the health of the component was only set on background polls, which caused the health of the component to be listed as "Unknown" until a background poll occured.

In cases where the polling interval is extremely infrequent, the component appeared to be permanently in state "Unknown."

Closes #4451.