### PR TITLE
feat(pyroscope.scrape): add godeltaprof profiling types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Main (unreleased)
 
 ### Enhancements
 
-- Add [godeltaprof](https://github.com/grafana/godeltaprof) profiling types (`delta_memory`, `delta_mutex`, `delta_block`) to `pyroscope.scrape` component
+- Add [godeltaprof](https://github.com/grafana/godeltaprof) profiling types (`godeltaprof_memory`, `godeltaprof_mutex`, `godeltaprof_block`) to `pyroscope.scrape` component
 
 v0.35.0-rc.0 (2023-07-13)
 -------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Main (unreleased)
 - Fix issue where `remote.http` incorrectly had a status of "Unknown" until the
   period specified by the polling frquency elapsed. (@rfratto)
 
+### Enhancements
+
+- Add [godeltaprof](https://github.com/grafana/godeltaprof) profiling types (`delta_memory`, `delta_mutex`, `delta_block`) to `pyroscope.scrape` component
+
 v0.35.0-rc.0 (2023-07-13)
 -------------------------
 

--- a/component/pyroscope/scrape/scrape.go
+++ b/component/pyroscope/scrape/scrape.go
@@ -19,12 +19,15 @@ import (
 )
 
 const (
-	pprofMemory     string = "memory"
-	pprofBlock      string = "block"
-	pprofGoroutine  string = "goroutine"
-	pprofMutex      string = "mutex"
-	pprofProcessCPU string = "process_cpu"
-	pprofFgprof     string = "fgprof"
+	pprofMemory      string = "memory"
+	pprofBlock       string = "block"
+	pprofGoroutine   string = "goroutine"
+	pprofMutex       string = "mutex"
+	pprofProcessCPU  string = "process_cpu"
+	pprofFgprof      string = "fgprof"
+	pprofDeltaMemory string = "delta_memory"
+	pprofDeltaBlock  string = "delta_block"
+	pprofDeltaMutex  string = "delta_mutex"
 )
 
 func init() {
@@ -80,13 +83,16 @@ type Arguments struct {
 }
 
 type ProfilingConfig struct {
-	Memory     ProfilingTarget         `river:"profile.memory,block,optional"`
-	Block      ProfilingTarget         `river:"profile.block,block,optional"`
-	Goroutine  ProfilingTarget         `river:"profile.goroutine,block,optional"`
-	Mutex      ProfilingTarget         `river:"profile.mutex,block,optional"`
-	ProcessCPU ProfilingTarget         `river:"profile.process_cpu,block,optional"`
-	FGProf     ProfilingTarget         `river:"profile.fgprof,block,optional"`
-	Custom     []CustomProfilingTarget `river:"profile.custom,block,optional"`
+	Memory      ProfilingTarget         `river:"profile.memory,block,optional"`
+	Block       ProfilingTarget         `river:"profile.block,block,optional"`
+	Goroutine   ProfilingTarget         `river:"profile.goroutine,block,optional"`
+	Mutex       ProfilingTarget         `river:"profile.mutex,block,optional"`
+	ProcessCPU  ProfilingTarget         `river:"profile.process_cpu,block,optional"`
+	FGProf      ProfilingTarget         `river:"profile.fgprof,block,optional"`
+	DeltaMemory ProfilingTarget         `river:"profile.delta_memory,block,optional"`
+	DeltaMutex  ProfilingTarget         `river:"profile.delta_mutex,block,optional"`
+	DeltaBlock  ProfilingTarget         `river:"profile.delta_block,block,optional"`
+	Custom      []CustomProfilingTarget `river:"profile.custom,block,optional"`
 
 	PprofPrefix string `river:"path_prefix,attr,optional"`
 }
@@ -96,12 +102,15 @@ type ProfilingConfig struct {
 // of the target.
 func (cfg ProfilingConfig) AllTargets() map[string]ProfilingTarget {
 	targets := map[string]ProfilingTarget{
-		pprofMemory:     cfg.Memory,
-		pprofBlock:      cfg.Block,
-		pprofGoroutine:  cfg.Goroutine,
-		pprofMutex:      cfg.Mutex,
-		pprofProcessCPU: cfg.ProcessCPU,
-		pprofFgprof:     cfg.FGProf,
+		pprofMemory:      cfg.Memory,
+		pprofBlock:       cfg.Block,
+		pprofGoroutine:   cfg.Goroutine,
+		pprofMutex:       cfg.Mutex,
+		pprofProcessCPU:  cfg.ProcessCPU,
+		pprofFgprof:      cfg.FGProf,
+		pprofDeltaMemory: cfg.DeltaMemory,
+		pprofDeltaMutex:  cfg.DeltaMutex,
+		pprofDeltaBlock:  cfg.DeltaBlock,
 	}
 
 	for _, custom := range cfg.Custom {
@@ -141,6 +150,19 @@ var DefaultProfilingConfig = ProfilingConfig{
 		Enabled: false,
 		Path:    "/debug/fgprof",
 		Delta:   true,
+	},
+	// https://github.com/grafana/godeltaprof/blob/main/http/pprof/pprof.go#L21
+	DeltaMemory: ProfilingTarget{
+		Enabled: false,
+		Path:    "/debug/pprof/delta_heap",
+	},
+	DeltaMutex: ProfilingTarget{
+		Enabled: false,
+		Path:    "/debug/pprof/delta_mutex",
+	},
+	DeltaBlock: ProfilingTarget{
+		Enabled: false,
+		Path:    "/debug/pprof/delta_block",
 	},
 }
 

--- a/component/pyroscope/scrape/scrape.go
+++ b/component/pyroscope/scrape/scrape.go
@@ -19,15 +19,15 @@ import (
 )
 
 const (
-	pprofMemory      string = "memory"
-	pprofBlock       string = "block"
-	pprofGoroutine   string = "goroutine"
-	pprofMutex       string = "mutex"
-	pprofProcessCPU  string = "process_cpu"
-	pprofFgprof      string = "fgprof"
-	pprofDeltaMemory string = "delta_memory"
-	pprofDeltaBlock  string = "delta_block"
-	pprofDeltaMutex  string = "delta_mutex"
+	pprofMemory            string = "memory"
+	pprofBlock             string = "block"
+	pprofGoroutine         string = "goroutine"
+	pprofMutex             string = "mutex"
+	pprofProcessCPU        string = "process_cpu"
+	pprofFgprof            string = "fgprof"
+	pprofGoDeltaProfMemory string = "godeltaprof_memory"
+	pprofGoDeltaProfBlock  string = "godeltaprof_block"
+	pprofGoDeltaProfMutex  string = "godeltaprof_mutex"
 )
 
 func init() {
@@ -83,16 +83,16 @@ type Arguments struct {
 }
 
 type ProfilingConfig struct {
-	Memory      ProfilingTarget         `river:"profile.memory,block,optional"`
-	Block       ProfilingTarget         `river:"profile.block,block,optional"`
-	Goroutine   ProfilingTarget         `river:"profile.goroutine,block,optional"`
-	Mutex       ProfilingTarget         `river:"profile.mutex,block,optional"`
-	ProcessCPU  ProfilingTarget         `river:"profile.process_cpu,block,optional"`
-	FGProf      ProfilingTarget         `river:"profile.fgprof,block,optional"`
-	DeltaMemory ProfilingTarget         `river:"profile.delta_memory,block,optional"`
-	DeltaMutex  ProfilingTarget         `river:"profile.delta_mutex,block,optional"`
-	DeltaBlock  ProfilingTarget         `river:"profile.delta_block,block,optional"`
-	Custom      []CustomProfilingTarget `river:"profile.custom,block,optional"`
+	Memory            ProfilingTarget         `river:"profile.memory,block,optional"`
+	Block             ProfilingTarget         `river:"profile.block,block,optional"`
+	Goroutine         ProfilingTarget         `river:"profile.goroutine,block,optional"`
+	Mutex             ProfilingTarget         `river:"profile.mutex,block,optional"`
+	ProcessCPU        ProfilingTarget         `river:"profile.process_cpu,block,optional"`
+	FGProf            ProfilingTarget         `river:"profile.fgprof,block,optional"`
+	GoDeltaProfMemory ProfilingTarget         `river:"profile.godeltaprof_memory,block,optional"`
+	GoDeltaProfMutex  ProfilingTarget         `river:"profile.godeltaprof_mutex,block,optional"`
+	GoDeltaProfBlock  ProfilingTarget         `river:"profile.godeltaprof_block,block,optional"`
+	Custom            []CustomProfilingTarget `river:"profile.custom,block,optional"`
 
 	PprofPrefix string `river:"path_prefix,attr,optional"`
 }
@@ -102,15 +102,15 @@ type ProfilingConfig struct {
 // of the target.
 func (cfg ProfilingConfig) AllTargets() map[string]ProfilingTarget {
 	targets := map[string]ProfilingTarget{
-		pprofMemory:      cfg.Memory,
-		pprofBlock:       cfg.Block,
-		pprofGoroutine:   cfg.Goroutine,
-		pprofMutex:       cfg.Mutex,
-		pprofProcessCPU:  cfg.ProcessCPU,
-		pprofFgprof:      cfg.FGProf,
-		pprofDeltaMemory: cfg.DeltaMemory,
-		pprofDeltaMutex:  cfg.DeltaMutex,
-		pprofDeltaBlock:  cfg.DeltaBlock,
+		pprofMemory:            cfg.Memory,
+		pprofBlock:             cfg.Block,
+		pprofGoroutine:         cfg.Goroutine,
+		pprofMutex:             cfg.Mutex,
+		pprofProcessCPU:        cfg.ProcessCPU,
+		pprofFgprof:            cfg.FGProf,
+		pprofGoDeltaProfMemory: cfg.GoDeltaProfMemory,
+		pprofGoDeltaProfMutex:  cfg.GoDeltaProfMutex,
+		pprofGoDeltaProfBlock:  cfg.GoDeltaProfBlock,
 	}
 
 	for _, custom := range cfg.Custom {
@@ -152,15 +152,15 @@ var DefaultProfilingConfig = ProfilingConfig{
 		Delta:   true,
 	},
 	// https://github.com/grafana/godeltaprof/blob/main/http/pprof/pprof.go#L21
-	DeltaMemory: ProfilingTarget{
+	GoDeltaProfMemory: ProfilingTarget{
 		Enabled: false,
 		Path:    "/debug/pprof/delta_heap",
 	},
-	DeltaMutex: ProfilingTarget{
+	GoDeltaProfMutex: ProfilingTarget{
 		Enabled: false,
 		Path:    "/debug/pprof/delta_mutex",
 	},
-	DeltaBlock: ProfilingTarget{
+	GoDeltaProfBlock: ProfilingTarget{
 		Enabled: false,
 		Path:    "/debug/pprof/delta_block",
 	},

--- a/docs/sources/flow/reference/components/pyroscope.scrape.md
+++ b/docs/sources/flow/reference/components/pyroscope.scrape.md
@@ -85,7 +85,7 @@ The following blocks are supported inside the definition of `pyroscope.scrape`:
 | profiling_config > profile.fgprof             | [profile.fgprof][]             | Collect [fgprof][] profiles.                                             | no       |
 | profiling_config > profile.godeltaprof_memory | [profile.godeltaprof_memory][] | Collect [godeltaprof][] memory profiles.                                 | no       |
 | profiling_config > profile.godeltaprof_mutex  | [profile.godeltaprof_mutex][]  | Collect [godeltaprof][] mutex profiles.                                  | no       |
-| profiling_config > profile.godeltaprof_block  | [profile.delta_block][]        | Collect [godeltaprof][] block profiles.                                  | no       |
+| profiling_config > profile.godeltaprof_block  | [profile.godeltaprof_block][]        | Collect [godeltaprof][] block profiles.                                  | no       |
 | profiling_config > profile.custom             | [profile.custom][]             | Collect custom profiles.                                                 | no       |
 | clustering                                    | [clustering][]                 | Configure the component for when the Agent is running in clustered mode. | no       |
 

--- a/docs/sources/flow/reference/components/pyroscope.scrape.md
+++ b/docs/sources/flow/reference/components/pyroscope.scrape.md
@@ -69,25 +69,25 @@ Name | Type | Description | Default | Required
 
 The following blocks are supported inside the definition of `pyroscope.scrape`:
 
-| Hierarchy                               | Block                    | Description                                                              | Required |
-|-----------------------------------------|--------------------------|--------------------------------------------------------------------------|----------|
-| basic_auth                              | [basic_auth][]           | Configure basic_auth for authenticating to targets.                      | no       |
-| authorization                           | [authorization][]        | Configure generic authorization to targets.                              | no       |
-| oauth2                                  | [oauth2][]               | Configure OAuth2 for authenticating to targets.                          | no       |
-| oauth2 > tls_config                     | [tls_config][]           | Configure TLS settings for connecting to targets via OAuth2.             | no       |
-| tls_config                              | [tls_config][]           | Configure TLS settings for connecting to targets.                        | no       |
-| profiling_config                        | [profiling_config][]     | Configure profiling settings for the scrape job.                         | no       |
-| profiling_config > profile.memory       | [profile.memory][]       | Collect memory profiles.                                                 | no       |
-| profiling_config > profile.block        | [profile.block][]        | Collect profiles on blocks.                                              | no       |
-| profiling_config > profile.goroutine    | [profile.goroutine][]    | Collect goroutine profiles.                                              | no       |
-| profiling_config > profile.mutex        | [profile.mutex][]        | Collect mutex profiles.                                                  | no       |
-| profiling_config > profile.process_cpu  | [profile.process_cpu][]  | Collect CPU profiles.                                                    | no       |
-| profiling_config > profile.fgprof       | [profile.fgprof][]       | Collect [fgprof][] profiles.                                             | no       |
-| profiling_config > profile.delta_memory | [profile.delta_memory][] | Collect [godeltaprof][] memory profiles.                                 | no       |
-| profiling_config > profile.delta_mutex  | [profile.delta_mutex][]  | Collect [godeltaprof][] mutex profiles.                                  | no       |
-| profiling_config > profile.delta_block  | [profile.delta_block][]  | Collect [godeltaprof][] block profiles.                                  | no       |
-| profiling_config > profile.custom       | [profile.custom][]       | Collect custom profiles.                                                 | no       |
-| clustering                              | [clustering][]           | Configure the component for when the Agent is running in clustered mode. | no       |
+| Hierarchy                                     | Block                          | Description                                                              | Required |
+|-----------------------------------------------|--------------------------------|--------------------------------------------------------------------------|----------|
+| basic_auth                                    | [basic_auth][]                 | Configure basic_auth for authenticating to targets.                      | no       |
+| authorization                                 | [authorization][]              | Configure generic authorization to targets.                              | no       |
+| oauth2                                        | [oauth2][]                     | Configure OAuth2 for authenticating to targets.                          | no       |
+| oauth2 > tls_config                           | [tls_config][]                 | Configure TLS settings for connecting to targets via OAuth2.             | no       |
+| tls_config                                    | [tls_config][]                 | Configure TLS settings for connecting to targets.                        | no       |
+| profiling_config                              | [profiling_config][]           | Configure profiling settings for the scrape job.                         | no       |
+| profiling_config > profile.memory             | [profile.memory][]             | Collect memory profiles.                                                 | no       |
+| profiling_config > profile.block              | [profile.block][]              | Collect profiles on blocks.                                              | no       |
+| profiling_config > profile.goroutine          | [profile.goroutine][]          | Collect goroutine profiles.                                              | no       |
+| profiling_config > profile.mutex              | [profile.mutex][]              | Collect mutex profiles.                                                  | no       |
+| profiling_config > profile.process_cpu        | [profile.process_cpu][]        | Collect CPU profiles.                                                    | no       |
+| profiling_config > profile.fgprof             | [profile.fgprof][]             | Collect [fgprof][] profiles.                                             | no       |
+| profiling_config > profile.godeltaprof_memory | [profile.godeltaprof_memory][] | Collect [godeltaprof][] memory profiles.                                 | no       |
+| profiling_config > profile.godeltaprof_mutex  | [profile.godeltaprof_mutex][]  | Collect [godeltaprof][] mutex profiles.                                  | no       |
+| profiling_config > profile.godeltaprof_block  | [profile.delta_block][]        | Collect [godeltaprof][] block profiles.                                  | no       |
+| profiling_config > profile.custom             | [profile.custom][]             | Collect custom profiles.                                                 | no       |
+| clustering                                    | [clustering][]                 | Configure the component for when the Agent is running in clustered mode. | no       |
 
 The `>` symbol indicates deeper levels of nesting. For example,
 `oauth2 > tls_config` refers to a `tls_config` block defined inside
@@ -104,9 +104,9 @@ an `oauth2` block.
 [profile.mutex]: #profile.mutex-block
 [profile.process_cpu]: #profile.process_cpu-block
 [profile.fgprof]: #profile.fgprof-block
-[profile.delta_memory]: #profile.delta_memory-block
-[profile.delta_mutex]: #profile.delta_mutex-block
-[profile.delta_block]: #profile.delta_block-block
+[profile.godeltaprof_memory]: #profile.godeltaprof_memory-block
+[profile.godeltaprof_mutex]: #profile.godeltaprof_mutex-block
+[profile.godeltaprof_block]: #profile.godeltaprof_block-block
 [profile.custom]: #profile.custom-block
 [pprof]: https://github.com/google/pprof/blob/main/doc/README.md
 [clustering]: #clustering-beta
@@ -243,9 +243,9 @@ It accepts the following arguments:
 | `enabled` | `boolean` | Enable this profile type to be scraped.     | `false`                     | no       |
 | `path`    | `string`  | The path to the profile type on the target. | `"/debug/pprof/delta_heap"` | no       |
 
-### profile.delta_mutex block
+### profile.godeltaprof_mutex block
 
-The `profile.delta_mutex` block collects profiles from [godeltaprof][] mutex endpoint.
+The `profile.godeltaprof_mutex` block collects profiles from [godeltaprof][] mutex endpoint.
 
 It accepts the following arguments:
 
@@ -254,9 +254,9 @@ It accepts the following arguments:
 | `enabled` | `boolean` | Enable this profile type to be scraped.     | `false`                      | no       |
 | `path`    | `string`  | The path to the profile type on the target. | `"/debug/pprof/delta_mutex"` | no       |
 
-### profile.delta_block block
+### profile.godeltaprof_block block
 
-The `profile.delta_block` block collects profiles from [godeltaprof][] block endpoint.
+The `profile.godeltaprof_block` block collects profiles from [godeltaprof][] block endpoint.
 
 It accepts the following arguments:
 

--- a/docs/sources/flow/reference/components/pyroscope.scrape.md
+++ b/docs/sources/flow/reference/components/pyroscope.scrape.md
@@ -232,9 +232,9 @@ Name | Type | Description | Default | Required
 When the `delta` argument is `true`, a `seconds` query parameter is
 automatically added to requests.
 
-### profile.delta_memory block
+### profile.godeltaprof_memory block
 
-The `profile.delta_memory` block collects profiles from [godeltaprof][] memory endpoint.
+The `profile.godeltaprof_memory` block collects profiles from [godeltaprof][] memory endpoint. The delta is computed on the target.
 
 It accepts the following arguments:
 
@@ -245,7 +245,7 @@ It accepts the following arguments:
 
 ### profile.godeltaprof_mutex block
 
-The `profile.godeltaprof_mutex` block collects profiles from [godeltaprof][] mutex endpoint.
+The `profile.godeltaprof_mutex` block collects profiles from [godeltaprof][] mutex endpoint. The delta is computed on the target.
 
 It accepts the following arguments:
 
@@ -256,7 +256,7 @@ It accepts the following arguments:
 
 ### profile.godeltaprof_block block
 
-The `profile.godeltaprof_block` block collects profiles from [godeltaprof][] block endpoint.
+The `profile.godeltaprof_block` block collects profiles from [godeltaprof][] block endpoint. The delta is computed on the target.
 
 It accepts the following arguments:
 

--- a/docs/sources/flow/reference/components/pyroscope.scrape.md
+++ b/docs/sources/flow/reference/components/pyroscope.scrape.md
@@ -69,22 +69,25 @@ Name | Type | Description | Default | Required
 
 The following blocks are supported inside the definition of `pyroscope.scrape`:
 
-Hierarchy | Block | Description | Required
---------- | ----- | ----------- | --------
-basic_auth | [basic_auth][] | Configure basic_auth for authenticating to targets. | no
-authorization | [authorization][] | Configure generic authorization to targets. | no
-oauth2 | [oauth2][] | Configure OAuth2 for authenticating to targets. | no
-oauth2 > tls_config | [tls_config][] | Configure TLS settings for connecting to targets via OAuth2. | no
-tls_config | [tls_config][] | Configure TLS settings for connecting to targets. | no
-profiling_config | [profiling_config][] | Configure profiling settings for the scrape job. | no
-profiling_config > profile.memory | [profile.memory][] | Collect memory profiles. | no
-profiling_config > profile.block | [profile.block][] | Collect profiles on blocks. | no
-profiling_config > profile.goroutine | [profile.goroutine][] | Collect goroutine profiles. | no
-profiling_config > profile.mutex | [profile.mutex][] | Collect mutex profiles. | no
-profiling_config > profile.process_cpu | [profile.process_cpu][] | Collect CPU profiles. | no
-profiling_config > profile.fgprof | [profile.fgprof][] | Collect [fgprof][] profiles. | no
-profiling_config > profile.custom | [profile.custom][] | Collect custom profiles. | no
-clustering | [clustering][] | Configure the component for when the Agent is running in clustered mode. | no
+| Hierarchy                               | Block                    | Description                                                              | Required |
+|-----------------------------------------|--------------------------|--------------------------------------------------------------------------|----------|
+| basic_auth                              | [basic_auth][]           | Configure basic_auth for authenticating to targets.                      | no       |
+| authorization                           | [authorization][]        | Configure generic authorization to targets.                              | no       |
+| oauth2                                  | [oauth2][]               | Configure OAuth2 for authenticating to targets.                          | no       |
+| oauth2 > tls_config                     | [tls_config][]           | Configure TLS settings for connecting to targets via OAuth2.             | no       |
+| tls_config                              | [tls_config][]           | Configure TLS settings for connecting to targets.                        | no       |
+| profiling_config                        | [profiling_config][]     | Configure profiling settings for the scrape job.                         | no       |
+| profiling_config > profile.memory       | [profile.memory][]       | Collect memory profiles.                                                 | no       |
+| profiling_config > profile.block        | [profile.block][]        | Collect profiles on blocks.                                              | no       |
+| profiling_config > profile.goroutine    | [profile.goroutine][]    | Collect goroutine profiles.                                              | no       |
+| profiling_config > profile.mutex        | [profile.mutex][]        | Collect mutex profiles.                                                  | no       |
+| profiling_config > profile.process_cpu  | [profile.process_cpu][]  | Collect CPU profiles.                                                    | no       |
+| profiling_config > profile.fgprof       | [profile.fgprof][]       | Collect [fgprof][] profiles.                                             | no       |
+| profiling_config > profile.delta_memory | [profile.delta_memory][] | Collect [godeltaprof][] memory profiles.                                 | no       |
+| profiling_config > profile.delta_mutex  | [profile.delta_mutex][]  | Collect [godeltaprof][] mutex profiles.                                  | no       |
+| profiling_config > profile.delta_block  | [profile.delta_block][]  | Collect [godeltaprof][] block profiles.                                  | no       |
+| profiling_config > profile.custom       | [profile.custom][]       | Collect custom profiles.                                                 | no       |
+| clustering                              | [clustering][]           | Configure the component for when the Agent is running in clustered mode. | no       |
 
 The `>` symbol indicates deeper levels of nesting. For example,
 `oauth2 > tls_config` refers to a `tls_config` block defined inside
@@ -101,11 +104,15 @@ an `oauth2` block.
 [profile.mutex]: #profile.mutex-block
 [profile.process_cpu]: #profile.process_cpu-block
 [profile.fgprof]: #profile.fgprof-block
+[profile.delta_memory]: #profile.delta_memory-block
+[profile.delta_mutex]: #profile.delta_mutex-block
+[profile.delta_block]: #profile.delta_block-block
 [profile.custom]: #profile.custom-block
 [pprof]: https://github.com/google/pprof/blob/main/doc/README.md
 [clustering]: #clustering-beta
 
 [fgprof]: https://github.com/felixge/fgprof
+[godeltaprof]: https://github.com/grafana/godeltaprof
 
 ### basic_auth block
 
@@ -224,6 +231,40 @@ Name | Type | Description | Default | Required
 
 When the `delta` argument is `true`, a `seconds` query parameter is
 automatically added to requests.
+
+### profile.delta_memory block
+
+The `profile.delta_memory` block collects profiles from [godeltaprof][] memory endpoint.
+
+It accepts the following arguments:
+
+| Name      | Type      | Description                                 | Default                     | Required |
+|-----------|-----------|---------------------------------------------|-----------------------------|----------|
+| `enabled` | `boolean` | Enable this profile type to be scraped.     | `false`                     | no       |
+| `path`    | `string`  | The path to the profile type on the target. | `"/debug/pprof/delta_heap"` | no       |
+
+### profile.delta_mutex block
+
+The `profile.delta_mutex` block collects profiles from [godeltaprof][] mutex endpoint.
+
+It accepts the following arguments:
+
+| Name      | Type      | Description                                 | Default                      | Required |
+|-----------|-----------|---------------------------------------------|------------------------------|----------|
+| `enabled` | `boolean` | Enable this profile type to be scraped.     | `false`                      | no       |
+| `path`    | `string`  | The path to the profile type on the target. | `"/debug/pprof/delta_mutex"` | no       |
+
+### profile.delta_block block
+
+The `profile.delta_block` block collects profiles from [godeltaprof][] block endpoint.
+
+It accepts the following arguments:
+
+| Name      | Type      | Description                                 | Default                      | Required |
+|-----------|-----------|---------------------------------------------|------------------------------|----------|
+| `enabled` | `boolean` | Enable this profile type to be scraped.     | `false`                      | no       |
+| `path`    | `string`  | The path to the profile type on the target. | `"/debug/pprof/delta_block"` | no       |
+
 
 ### profile.custom block
 

--- a/go.mod
+++ b/go.mod
@@ -505,7 +505,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.80.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.80.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.80.0 // indirect
@@ -620,6 +620,8 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
+
+require github.com/pyroscope-io/godeltaprof v0.1.1
 
 require (
 	github.com/drone/envsubst v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -855,8 +855,6 @@ github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.7.0/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
-github.com/cilium/ebpf v0.10.0 h1:nk5HPMeoBXtOzbkZBWym+ZWq1GIiHUsBFXxwewXAHLQ=
-github.com/cilium/ebpf v0.10.0/go.mod h1:DPiVdY/kT534dgc9ERmvP8mWA+9gvwgKfRvk4nNWnoE=
 github.com/cilium/ebpf v0.11.0 h1:V8gS/bTCCjX9uUnkUFUpPsksM8n1lXBAvHcpiFk1X2Y=
 github.com/cilium/ebpf v0.11.0/go.mod h1:WE7CZAnqOL2RouJ4f1uyNhqr2P4CCvXFIqdRDUgWsVs=
 github.com/circonus-labs/circonus-gometrics v0.0.0-20161109192337-d17a8420c36e/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
@@ -1240,7 +1238,7 @@ github.com/frankban/quicktest v1.10.2/go.mod h1:K+q6oSqb0W0Ininfk863uOk1lMy69l/P
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/frankban/quicktest v1.13.0/go.mod h1:qLE0fzW0VuyUAJgPU19zByoIr0HtCHN/r/VLSOOIySU=
 github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
-github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
+github.com/frankban/quicktest v1.14.5 h1:dfYrrRyLtiqT9GyKXgdh+k4inNeTvmGbuSgZ3lx3GhA=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
@@ -1754,8 +1752,6 @@ github.com/grafana/perflib_exporter v0.1.1-0.20230511173423-6166026bd090 h1:Ko80
 github.com/grafana/perflib_exporter v0.1.1-0.20230511173423-6166026bd090/go.mod h1:MinSWm88jguXFFrGsP56PtleUb4Qtm4tNRH/wXNXRTI=
 github.com/grafana/phlare/api v0.1.2 h1:1jrwd3KnsXMzj/tJih9likx5EvbY3pbvLbDqAAYem30=
 github.com/grafana/phlare/api v0.1.2/go.mod h1:29vcLwFDmZBDce2jwFIMtzvof7fzPadT8VMKw9ks7FU=
-github.com/grafana/phlare/ebpf v0.1.0 h1:u4E9BpXoqjvw1WCyM0TeZHbHWochwwJ/rPFzot/QZmU=
-github.com/grafana/phlare/ebpf v0.1.0/go.mod h1:5RGW1YCur7bhRlhATPc25drRYbzpekhh+f2HCmmfE3g=
 github.com/grafana/phlare/ebpf v0.1.1 h1:BnT06KcNDNr46yz2BY3YiaC7ECIU2qUwvi2sbsi8E3A=
 github.com/grafana/phlare/ebpf v0.1.1/go.mod h1:rh3+TSpue02kR7DW26O1qnlCLoVbiS0leHia1y/0QFM=
 github.com/grafana/postgres_exporter v0.8.1-0.20210722175051-db35d7c2f520 h1:HnFWqxhoSF3WC7sKAdMZ+SRXvHLVZlZ3sbQjuUlTqkw=
@@ -2844,6 +2840,8 @@ github.com/prometheus/statsd_exporter v0.22.7/go.mod h1:N/TevpjkIh9ccs6nuzY3jQn9
 github.com/prometheus/statsd_exporter v0.22.8 h1:Qo2D9ZzaQG+id9i5NYNGmbf1aa/KxKbB9aKfMS+Yib0=
 github.com/prometheus/statsd_exporter v0.22.8/go.mod h1:/DzwbTEaFTE0Ojz5PqcSk6+PFHOPWGxdXVr6yC8eFOM=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/pyroscope-io/godeltaprof v0.1.1 h1:+Mmi+b9gR3s/qufuQSxOBjyXZR1fmvS/C12Q73PIPvw=
+github.com/pyroscope-io/godeltaprof v0.1.1/go.mod h1:psMITXp90+8pFenXkKIpNhrfmI9saQnPbba27VIaiQE=
 github.com/rafaeljusto/redigomock v0.0.0-20190202135759-257e089e14a1/go.mod h1:JaY6n2sDr+z2WTsXkOmNRUfDy6FN0L6Nk7x06ndm4tY=
 github.com/rcrowley/go-metrics v0.0.0-20160613154715-cfa5a85e9f0a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	_ "github.com/pyroscope-io/godeltaprof/http/pprof" // anonymous import to get the godeltaprof handler registered
 	"github.com/weaveworks/common/logging"
 	"github.com/weaveworks/common/middleware"
 	"golang.org/x/net/netutil"


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR introduces `godeltaprof_memory`, `godeltaprof_mutex`, `godeltaprof_block` from [godeltaprof](https://github.com/grafana/godeltaprof)  package.

Currently we have two options to compute delta profiles: in pyroscope server, and in agent before sending to the pyroscope server. 

This PR adds another option to compute the delta on the scraped service itself.
Usually it  consumes less cpu and produce smaller profile size.
In og pyroscope it was named `delta_heap`,  `delta_block`, `delta_mutex`, here I named it `godeltaprof_{...}` to be not confused with `delta` parameter of other profiling types. Maybe we could come up with a better name before we merge it.
  
#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer
Unfortunately
#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [ ] Tests updated
