### PR TITLE
[integrations] Add udev data path arg to node_exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Main (unreleased)
 ### Enhancements
 
 - Add [godeltaprof](https://github.com/grafana/godeltaprof) profiling types (`godeltaprof_memory`, `godeltaprof_mutex`, `godeltaprof_block`) to `pyroscope.scrape` component
-
+- Integrations: make `udev` data path configurable in the `node_exporter` integration. (@sduranc)
 
 ### Bugfixes
 

--- a/component/prometheus/exporter/unix/config.go
+++ b/component/prometheus/exporter/unix/config.go
@@ -12,9 +12,10 @@ import (
 //
 // Some defaults are populated from init functions in the github.com/grafana/agent/pkg/integrations/node_exporter package.
 var DefaultArguments = Arguments{
-	ProcFSPath: node_integration.DefaultConfig.ProcFSPath,
-	RootFSPath: node_integration.DefaultConfig.RootFSPath,
-	SysFSPath:  node_integration.DefaultConfig.SysFSPath,
+	ProcFSPath:   node_integration.DefaultConfig.ProcFSPath,
+	RootFSPath:   node_integration.DefaultConfig.RootFSPath,
+	SysFSPath:    node_integration.DefaultConfig.SysFSPath,
+	UdevDataPath: node_integration.DefaultConfig.UdevDataPath,
 	Disk: DiskStatsConfig{
 		DeviceExclude: node_integration.DefaultConfig.DiskStatsDeviceExclude,
 	},

--- a/component/prometheus/exporter/unix/config.go
+++ b/component/prometheus/exporter/unix/config.go
@@ -66,6 +66,7 @@ type Arguments struct {
 	ProcFSPath             string `river:"procfs_path,attr,optional"`
 	SysFSPath              string `river:"sysfs_path,attr,optional"`
 	RootFSPath             string `river:"rootfs_path,attr,optional"`
+	UdevDataPath           string `river:"udev_data_path,attr,optional"`
 
 	// Collectors to mark as enabled
 	EnableCollectors flagext.StringSlice `river:"enable_collectors,attr,optional"`
@@ -106,6 +107,7 @@ func (a *Arguments) Convert() *node_integration.Config {
 		ProcFSPath:                       a.ProcFSPath,
 		SysFSPath:                        a.SysFSPath,
 		RootFSPath:                       a.RootFSPath,
+		UdevDataPath:                     a.UdevDataPath,
 		EnableCollectors:                 a.EnableCollectors,
 		DisableCollectors:                a.DisableCollectors,
 		SetCollectors:                    a.SetCollectors,

--- a/docs/sources/flow/reference/components/prometheus.exporter.unix.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.unix.md
@@ -35,6 +35,7 @@ Name | Type | Description | Default | Required
 `procfs_path`              | `string`       | The procfs mountpoint. | `/proc` | no
 `sysfs_path`               | `string`       | The sysfs mountpoint.  | `/sys`   | no
 `rootfs_path`              | `string`       | Specify a prefix for accessing the host filesystem. | `/` | no
+`udev_data_path`           | `string`       | The udev data path.  | `/run/udev/data` | no
 
 `set_collectors` defines a hand-picked list of enabled-by-default
 collectors. If set, anything not provided in that list is disabled by

--- a/docs/sources/static/configuration/integrations/node-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/node-exporter-config.md
@@ -56,6 +56,7 @@ integrations:
     rootfs_path: /host/root
     sysfs_path: /host/sys
     procfs_path: /host/proc
+    udev_data_path: /host/root/run/udev/data
 ```
 
 For running on Kubernetes, ensure to set the equivalent mounts and capabilities
@@ -265,6 +266,10 @@ the Agent is running on is a no-op.
   # machine should be mounted and this value should be changed to the mount
   # directory.
   [rootfs_path: <string> | default = "/"]
+
+  # udev data path needed for diskstats from Node exporter. When running
+  # in Kubernetes it should be set to /host/root/run/udev/data.
+  [udev_data_path: <string> | default = "/run/udev/data"]
 
   # Expose expensive bcache priority stats.
   [enable_bcache_priority_stats: <boolean>]

--- a/pkg/integrations/node_exporter/config.go
+++ b/pkg/integrations/node_exporter/config.go
@@ -82,9 +82,10 @@ func init() {
 type Config struct {
 	IncludeExporterMetrics bool `yaml:"include_exporter_metrics,omitempty"`
 
-	ProcFSPath string `yaml:"procfs_path,omitempty"`
-	SysFSPath  string `yaml:"sysfs_path,omitempty"`
-	RootFSPath string `yaml:"rootfs_path,omitempty"`
+	ProcFSPath   string `yaml:"procfs_path,omitempty"`
+	SysFSPath    string `yaml:"sysfs_path,omitempty"`
+	RootFSPath   string `yaml:"rootfs_path,omitempty"`
+	UdevDataPath string `yaml:"udev_data_path,omitempty"`
 
 	// Collectors to mark as enabled
 	EnableCollectors flagext.StringSlice `yaml:"enable_collectors,omitempty"`
@@ -307,6 +308,7 @@ func MapConfigToNodeExporterFlags(c *Config) (accepted []string, ignored []strin
 		"--path.procfs", c.ProcFSPath,
 		"--path.sysfs", c.SysFSPath,
 		"--path.rootfs", c.RootFSPath,
+		"--path.udev.data", c.UdevDataPath,
 	)
 
 	if collectors[CollectorBCache] {

--- a/pkg/integrations/node_exporter/config.go
+++ b/pkg/integrations/node_exporter/config.go
@@ -23,8 +23,9 @@ var (
 	// DefaultConfig's defaults are populated from init functions in this package.
 	// See the init function here and in node_exporter_linux.go.
 	DefaultConfig = Config{
-		ProcFSPath: procfs.DefaultMountPoint,
-		RootFSPath: "/",
+		ProcFSPath:   procfs.DefaultMountPoint,
+		RootFSPath:   "/",
+		UdevDataPath: "/run/udev/data",
 
 		DiskStatsDeviceExclude: "^(ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\\d+n\\d+p)\\d+$",
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Node exporter has added udev data to it's diskstats collector. It's possible to set up this path in node_exporter but right now we can't do the same in the grafana agent, so this PR just makes that available. Also, it appears that when node_exporter can't access the path it fails to create disk metrics. This has already been fixed in [prometheus operator](https://github.com/prometheus-operator/kube-prometheus/pull/1913) and in the [helm chart](https://github.com/prometheus-community/helm-charts/pull/2941).

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

It seems like it fixes https://github.com/grafana/agent/issues/4207
Fixes  #4517 

#### Notes to the Reviewer
As far as I understand, no tests need to updated for this change. Please correct me if I'm wong.

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [ ] Tests updated
