### PR TITLE
Update Grafana Agent to use v1 CronJob API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Main (unreleased)
 ### Enhancements
 
 - Add [godeltaprof](https://github.com/grafana/godeltaprof) profiling types (`godeltaprof_memory`, `godeltaprof_mutex`, `godeltaprof_block`) to `pyroscope.scrape` component
-- Update jsonnet libraries to use the `v1` CronJob API instead of the `v1beta1` that is removed from Kubernetes 1.25. The `v1` CronJob has been around since Kubernetes 1.21, making it a safe change breakage-wise.
+
 
 v0.35.0-rc.1 (2023-07-17)
 -------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Main (unreleased)
 ### Enhancements
 
 - Add [godeltaprof](https://github.com/grafana/godeltaprof) profiling types (`godeltaprof_memory`, `godeltaprof_mutex`, `godeltaprof_block`) to `pyroscope.scrape` component
-
+- Update jsonnet libraries to use the `v1` CronJob API instead of the `v1beta1` that is removed from Kubernetes 1.25. The `v1` CronJob has been around since Kubernetes 1.21, making it a safe change breakage-wise.
 
 v0.35.0-rc.1 (2023-07-17)
 -------------------------

--- a/production/tanka/grafana-agent/scraping-svc/syncer.libsonnet
+++ b/production/tanka/grafana-agent/scraping-svc/syncer.libsonnet
@@ -1,6 +1,6 @@
 local k = import 'ksonnet-util/kausal.libsonnet';
 
-local cronJob = k.batch.v1beta1.cronJob;
+local cronJob = k.batch.v1.cronJob;
 local configMap = k.core.v1.configMap;
 local container = k.core.v1.container;
 local deployment = k.apps.v1.deployment;

--- a/production/tanka/grafana-agent/v2/internal/syncer.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/syncer.libsonnet
@@ -1,6 +1,6 @@
 local k = import 'ksonnet-util/kausal.libsonnet';
 
-local cronJob = k.batch.v1beta1.cronJob;
+local cronJob = k.batch.v1.cronJob;
 local configMap = k.core.v1.configMap;
 local container = k.core.v1.container;
 local deployment = k.apps.v1.deployment;


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

The `v1beta1` CronJob API has been removed in Kubernetes 1.25 and its
stable replacement in `v1` exists since Kubernetes 1.21, which is not
supported for a fairly long time anymore.

Signed-off-by: Milan Plzik <milan.plzik@grafana.com>

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
