### PR TITLE
binary renamed from agent to grafana-agent

### DIFF
--- a/example/docker-compose/docker-compose.yaml
+++ b/example/docker-compose/docker-compose.yaml
@@ -85,7 +85,7 @@ services:
     volumes:
       - ./agent/config:/etc/agent-config
     entrypoint:
-      - /bin/agent
+      - /bin/grafana-agent
       - -server.http.address=0.0.0.0:12345
       - -config.file=/etc/agent-config/agent.yaml
       - -metrics.wal-directory=/tmp/agent/wal


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
As a newcomer to the grafana-agent project, I tried using the example docker compose files and then realized that the binary was renamed from agent to grafana-agent.

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->
