### PR TITLE
agent-flow-mixin: fix display of heatmaps

### DIFF
--- a/operations/agent-flow-mixin/dashboards/utils/panel.jsonnet
+++ b/operations/agent-flow-mixin/dashboards/utils/panel.jsonnet
@@ -33,6 +33,7 @@
   newHeatmap(title=''):: $.new(title, 'heatmap-new') {
     maxDataPoints: 30,
     options: {
+      calculate: false,
       color: {
         exponent: 0.5,
         fill: 'dark-orange',


### PR DESCRIPTION
In newer versions of Grafana, heatmap panels default to calculating the buckets based on the query. However, the heatmaps we're using in the dashboard have precalculated buckets.

This adds a `calculate: false` option so that the heatmaps display as expected.

Before:

<img width="505" alt="image" src="https://github.com/grafana/agent/assets/630212/ad6b01bc-434b-425b-aad5-74424bd4afe8">

After:

<img width="500" alt="image" src="https://github.com/grafana/agent/assets/630212/e478fe9b-b6a2-4ad0-9b52-49c28c868fd5">
