### PR TITLE
Remove zero width spaces from reference titles

### DIFF
--- a/docs/sources/flow/reference/components/otelcol.processor.memory_limiter.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.memory_limiter.md
@@ -1,6 +1,6 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.memory_limiter/
-title: otelcol.​processor.​memory_limiter
+title: otelcol.processor.memory_limiter
 ---
 
 # otelcol.processor.memory_limiter

--- a/docs/sources/flow/reference/components/otelcol.processor.tail_sampling.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.tail_sampling.md
@@ -2,7 +2,7 @@
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.tail_sampling/
 labels:
   stage: beta
-title: otelcol.​processor.tail_sampling
+title: otelcol.processor.tail_sampling
 ---
 
 # otelcol.processor.tail_sampling

--- a/docs/sources/flow/reference/components/prometheus.exporter.apache.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.apache.md
@@ -1,6 +1,6 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.apache/
-title: prometheus.exporter.​apache
+title: prometheus.exporter.apache
 ---
 
 # prometheus.exporter.apache

--- a/docs/sources/flow/reference/components/prometheus.exporter.consul.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.consul.md
@@ -1,6 +1,6 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.consul/
-title: prometheus.exporter.​consul
+title: prometheus.exporter.consul
 ---
 
 # prometheus.exporter.consul

--- a/docs/sources/flow/reference/components/prometheus.exporter.mysql.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mysql.md
@@ -1,6 +1,6 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.mysql/
-title: prometheus.exporter.​mysql
+title: prometheus.exporter.mysql
 ---
 
 # prometheus.exporter.mysql

--- a/docs/sources/flow/reference/components/prometheus.exporter.process.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.process.md
@@ -1,6 +1,6 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.process/
-title: prometheus.exporter.​process
+title: prometheus.exporter.process
 ---
 
 # prometheus.exporter.process


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Zero width spaces in titles is a legacy workaround that's no longer needed. There are still a few titles in the Agent ref docs that contain zero width spaces. This PR removes them 

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
