### PR TITLE
Fix canonical URLs that were added with incorrect path prefix

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/
+canonical: https://grafana.com/docs/agent/latest/
 title: Grafana Agent
 weight: 550
 ---

--- a/docs/sources/about.md
+++ b/docs/sources/about.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ./about-agent/
-canonical: https://grafana.com/docs/grafana/agent/latest/about/
+canonical: https://grafana.com/docs/agent/latest/about/
 title: About Grafana Agent
 weight: 100
 ---

--- a/docs/sources/flow/_index.md
+++ b/docs/sources/flow/_index.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/
+canonical: https://grafana.com/docs/agent/latest/flow/
 title: Flow mode
 weight: 400
 ---

--- a/docs/sources/flow/concepts/_index.md
+++ b/docs/sources/flow/concepts/_index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../concepts/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/concepts/
+canonical: https://grafana.com/docs/agent/latest/flow/concepts/
 title: Concepts
 weight: 100
 ---

--- a/docs/sources/flow/concepts/clustering.md
+++ b/docs/sources/flow/concepts/clustering.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/concepts/clustering/
+canonical: https://grafana.com/docs/agent/latest/flow/concepts/clustering/
 labels:
   stage: beta
 menuTitle: Clustering

--- a/docs/sources/flow/concepts/component_controller.md
+++ b/docs/sources/flow/concepts/component_controller.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../concepts/component-controller/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/concepts/component_controller/
+canonical: https://grafana.com/docs/agent/latest/flow/concepts/component_controller/
 title: Component controller
 weight: 200
 ---

--- a/docs/sources/flow/concepts/components.md
+++ b/docs/sources/flow/concepts/components.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../concepts/components/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/concepts/components/
+canonical: https://grafana.com/docs/agent/latest/flow/concepts/components/
 title: Components
 weight: 100
 ---

--- a/docs/sources/flow/concepts/configuration_language.md
+++ b/docs/sources/flow/concepts/configuration_language.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../concepts/configuration-language/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/concepts/configuration_language/
+canonical: https://grafana.com/docs/agent/latest/flow/concepts/configuration_language/
 title: Configuration language
 weight: 400
 ---

--- a/docs/sources/flow/concepts/modules.md
+++ b/docs/sources/flow/concepts/modules.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../concepts/modules/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/concepts/modules/
+canonical: https://grafana.com/docs/agent/latest/flow/concepts/modules/
 title: Modules
 weight: 300
 ---

--- a/docs/sources/flow/config-language/_index.md
+++ b/docs/sources/flow/config-language/_index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - configuration-language/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/config-language/
+canonical: https://grafana.com/docs/agent/latest/flow/config-language/
 title: Configuration language
 weight: 400
 ---

--- a/docs/sources/flow/config-language/components.md
+++ b/docs/sources/flow/config-language/components.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../configuration-language/components/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/config-language/components/
+canonical: https://grafana.com/docs/agent/latest/flow/config-language/components/
 title: Components
 weight: 300
 ---

--- a/docs/sources/flow/config-language/expressions/_index.md
+++ b/docs/sources/flow/config-language/expressions/_index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../configuration-language/expressions/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/config-language/expressions/
+canonical: https://grafana.com/docs/agent/latest/flow/config-language/expressions/
 title: Expressions
 weight: 400
 ---

--- a/docs/sources/flow/config-language/expressions/function_calls.md
+++ b/docs/sources/flow/config-language/expressions/function_calls.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration-language/expressions/function-calls/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/config-language/expressions/function_calls/
+canonical: https://grafana.com/docs/agent/latest/flow/config-language/expressions/function_calls/
 title: Function calls
 weight: 400
 ---

--- a/docs/sources/flow/config-language/expressions/operators.md
+++ b/docs/sources/flow/config-language/expressions/operators.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration-language/expressions/operators/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/config-language/expressions/operators/
+canonical: https://grafana.com/docs/agent/latest/flow/config-language/expressions/operators/
 title: Operators
 weight: 300
 ---

--- a/docs/sources/flow/config-language/expressions/referencing_exports.md
+++ b/docs/sources/flow/config-language/expressions/referencing_exports.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration-language/expressions/referencing-exports/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/config-language/expressions/referencing_exports/
+canonical: https://grafana.com/docs/agent/latest/flow/config-language/expressions/referencing_exports/
 title: Referencing component exports
 weight: 200
 ---

--- a/docs/sources/flow/config-language/expressions/types_and_values.md
+++ b/docs/sources/flow/config-language/expressions/types_and_values.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration-language/expressions/types-and-values/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/config-language/expressions/types_and_values/
+canonical: https://grafana.com/docs/agent/latest/flow/config-language/expressions/types_and_values/
 title: Types and values
 weight: 100
 ---

--- a/docs/sources/flow/config-language/files.md
+++ b/docs/sources/flow/config-language/files.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../configuration-language/files/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/config-language/files/
+canonical: https://grafana.com/docs/agent/latest/flow/config-language/files/
 title: Files
 weight: 100
 ---

--- a/docs/sources/flow/config-language/syntax.md
+++ b/docs/sources/flow/config-language/syntax.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../configuration-language/syntax/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/config-language/syntax/
+canonical: https://grafana.com/docs/agent/latest/flow/config-language/syntax/
 title: Syntax
 weight: 200
 ---

--- a/docs/sources/flow/getting-started/_index.md
+++ b/docs/sources/flow/getting-started/_index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - getting_started/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/getting-started/
+canonical: https://grafana.com/docs/agent/latest/flow/getting-started/
 menuTitle: Get started
 title: Get started with Grafana Agent in flow mode
 weight: 200

--- a/docs/sources/flow/getting-started/collect-opentelemetry-data.md
+++ b/docs/sources/flow/getting-started/collect-opentelemetry-data.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/getting-started/collect-opentelemetry-data/
+canonical: https://grafana.com/docs/agent/latest/flow/getting-started/collect-opentelemetry-data/
 title: Collect OpenTelemetry data
 weight: 300
 ---

--- a/docs/sources/flow/getting-started/collect-prometheus-metrics.md
+++ b/docs/sources/flow/getting-started/collect-prometheus-metrics.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/getting-started/collect-prometheus-metrics/
+canonical: https://grafana.com/docs/agent/latest/flow/getting-started/collect-prometheus-metrics/
 title: Collect Prometheus metrics
 weight: 200
 ---

--- a/docs/sources/flow/getting-started/configure-agent-clustering.md
+++ b/docs/sources/flow/getting-started/configure-agent-clustering.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/getting-started/configure-agent-clustering/
+canonical: https://grafana.com/docs/agent/latest/flow/getting-started/configure-agent-clustering/
 menuTitle: Configure Grafana Agent clustering
 title: Configure Grafana Agent clustering in an existing installation
 weight: 400

--- a/docs/sources/flow/getting-started/distribute-prometheus-scrape-load.md
+++ b/docs/sources/flow/getting-started/distribute-prometheus-scrape-load.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/getting-started/distribute-prometheus-scrape-load/
+canonical: https://grafana.com/docs/agent/latest/flow/getting-started/distribute-prometheus-scrape-load/
 menuTitle: Distribute Prometheus metrics scrape load
 title: Distribute your Prometheus metrics scrape load
 weight: 500

--- a/docs/sources/flow/getting-started/migrating-from-prometheus.md
+++ b/docs/sources/flow/getting-started/migrating-from-prometheus.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/getting-started/migrating-from-prometheus/
+canonical: https://grafana.com/docs/agent/latest/flow/getting-started/migrating-from-prometheus/
 description: Learn how to migrate your configuration from Prometheus to Grafana Agent
   flow mode
 menuTitle: Migrate from Prometheus

--- a/docs/sources/flow/getting-started/opentelemetry-to-lgtm-stack.md
+++ b/docs/sources/flow/getting-started/opentelemetry-to-lgtm-stack.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/getting-started/opentelemetry-to-lgtm-stack/
+canonical: https://grafana.com/docs/agent/latest/flow/getting-started/opentelemetry-to-lgtm-stack/
 title: OpenTelemetry to Grafana stack
 weight: 350
 ---

--- a/docs/sources/flow/monitoring/_index.md
+++ b/docs/sources/flow/monitoring/_index.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/monitoring/
+canonical: https://grafana.com/docs/agent/latest/flow/monitoring/
 title: Monitoring Grafana Agent Flow
 weight: 500
 ---

--- a/docs/sources/flow/monitoring/component_metrics.md
+++ b/docs/sources/flow/monitoring/component_metrics.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - component-metrics/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/monitoring/component_metrics/
+canonical: https://grafana.com/docs/agent/latest/flow/monitoring/component_metrics/
 title: Component metrics
 weight: 200
 ---

--- a/docs/sources/flow/monitoring/controller_metrics.md
+++ b/docs/sources/flow/monitoring/controller_metrics.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - controller-metrics/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/monitoring/controller_metrics/
+canonical: https://grafana.com/docs/agent/latest/flow/monitoring/controller_metrics/
 title: Controller metrics
 weight: 100
 ---

--- a/docs/sources/flow/monitoring/debugging.md
+++ b/docs/sources/flow/monitoring/debugging.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/monitoring/debugging/
+canonical: https://grafana.com/docs/agent/latest/flow/monitoring/debugging/
 title: Debugging
 weight: 300
 ---

--- a/docs/sources/flow/reference/_index.md
+++ b/docs/sources/flow/reference/_index.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/
 title: Reference
 weight: 600
 ---

--- a/docs/sources/flow/reference/cli/_index.md
+++ b/docs/sources/flow/reference/cli/_index.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/cli/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/cli/
 title: Command-line interface
 weight: 100
 ---

--- a/docs/sources/flow/reference/cli/convert.md
+++ b/docs/sources/flow/reference/cli/convert.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/cli/convert/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/cli/convert/
 labels:
   stage: beta
 title: grafana-agent convert

--- a/docs/sources/flow/reference/cli/fmt.md
+++ b/docs/sources/flow/reference/cli/fmt.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/cli/fmt/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/cli/fmt/
 title: grafana-agent fmt
 weight: 100
 ---

--- a/docs/sources/flow/reference/cli/run.md
+++ b/docs/sources/flow/reference/cli/run.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/cli/run/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/cli/run/
 title: grafana-agent run
 weight: 100
 ---

--- a/docs/sources/flow/reference/cli/tools.md
+++ b/docs/sources/flow/reference/cli/tools.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/cli/tools/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/cli/tools/
 title: grafana-agent tools
 weight: 100
 ---

--- a/docs/sources/flow/reference/components/_index.md
+++ b/docs/sources/flow/reference/components/_index.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/
 title: Components
 weight: 300
 ---

--- a/docs/sources/flow/reference/components/discovery.azure.md
+++ b/docs/sources/flow/reference/components/discovery.azure.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/discovery.azure/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/discovery.azure/
 title: discovery.azure
 ---
 

--- a/docs/sources/flow/reference/components/discovery.consul.md
+++ b/docs/sources/flow/reference/components/discovery.consul.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/discovery.consul/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/discovery.consul/
 title: discovery.consul
 ---
 

--- a/docs/sources/flow/reference/components/discovery.digitalocean.md
+++ b/docs/sources/flow/reference/components/discovery.digitalocean.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/discovery.digitalocean/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/discovery.digitalocean/
 title: discovery.digitalocean
 ---
 

--- a/docs/sources/flow/reference/components/discovery.dns.md
+++ b/docs/sources/flow/reference/components/discovery.dns.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/latest/flow/reference/components/discovery.dns
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/discovery.dns/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/discovery.dns/
 title: discovery.dns
 ---
 

--- a/docs/sources/flow/reference/components/discovery.docker.md
+++ b/docs/sources/flow/reference/components/discovery.docker.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/discovery.docker/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/discovery.docker/
 title: discovery.docker
 ---
 

--- a/docs/sources/flow/reference/components/discovery.ec2.md
+++ b/docs/sources/flow/reference/components/discovery.ec2.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/discovery.ec2/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/discovery.ec2/
 title: discovery.ec2
 ---
 

--- a/docs/sources/flow/reference/components/discovery.file.md
+++ b/docs/sources/flow/reference/components/discovery.file.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/discovery.file/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/discovery.file/
 title: discovery.file
 ---
 

--- a/docs/sources/flow/reference/components/discovery.gce.md
+++ b/docs/sources/flow/reference/components/discovery.gce.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/discovery.gce/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/discovery.gce/
 title: discovery.gce
 ---
 

--- a/docs/sources/flow/reference/components/discovery.http.md
+++ b/docs/sources/flow/reference/components/discovery.http.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/discovery.http/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/discovery.http/
 title: discovery.http
 ---
 

--- a/docs/sources/flow/reference/components/discovery.kubelet.md
+++ b/docs/sources/flow/reference/components/discovery.kubelet.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/discovery.kubelet/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/discovery.kubelet/
 labels:
   stage: beta
 title: discovery.kubelet

--- a/docs/sources/flow/reference/components/discovery.kubernetes.md
+++ b/docs/sources/flow/reference/components/discovery.kubernetes.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/discovery.kubernetes/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/discovery.kubernetes/
 title: discovery.kubernetes
 ---
 

--- a/docs/sources/flow/reference/components/discovery.lightsail.md
+++ b/docs/sources/flow/reference/components/discovery.lightsail.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/discovery.lightsail/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/discovery.lightsail/
 title: discovery.lightsail
 ---
 

--- a/docs/sources/flow/reference/components/discovery.relabel.md
+++ b/docs/sources/flow/reference/components/discovery.relabel.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/discovery.relabel/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/discovery.relabel/
 title: discovery.relabel
 ---
 

--- a/docs/sources/flow/reference/components/local.file.md
+++ b/docs/sources/flow/reference/components/local.file.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/local.file/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/local.file/
 title: local.file
 ---
 

--- a/docs/sources/flow/reference/components/local.file_match.md
+++ b/docs/sources/flow/reference/components/local.file_match.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/local.file_match/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/local.file_match/
 title: local.file_match
 ---
 

--- a/docs/sources/flow/reference/components/loki.echo.md
+++ b/docs/sources/flow/reference/components/loki.echo.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/loki.echo/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/loki.echo/
 labels:
   stage: beta
 title: loki.echo

--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/loki.process/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/loki.process/
 title: loki.process
 ---
 

--- a/docs/sources/flow/reference/components/loki.relabel.md
+++ b/docs/sources/flow/reference/components/loki.relabel.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/loki.relabel/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/loki.relabel/
 title: loki.relabel
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.api.md
+++ b/docs/sources/flow/reference/components/loki.source.api.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/loki.source.api/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/loki.source.api/
 title: loki.source.api
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.awsfirehose.md
+++ b/docs/sources/flow/reference/components/loki.source.awsfirehose.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/loki.source.awsfirehose/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/loki.source.awsfirehose/
 title: loki.source.awsfirehose
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.azure_event_hubs.md
+++ b/docs/sources/flow/reference/components/loki.source.azure_event_hubs.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/loki.source.azure_event_hubs/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/loki.source.azure_event_hubs/
 title: loki.source.azure_event_hubs
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.cloudflare.md
+++ b/docs/sources/flow/reference/components/loki.source.cloudflare.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/loki.source.cloudflare/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/loki.source.cloudflare/
 title: loki.source.cloudflare
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.docker.md
+++ b/docs/sources/flow/reference/components/loki.source.docker.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/latest/flow/reference/components/loki.source.docker
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/loki.source.docker/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/loki.source.docker/
 title: loki.source.docker
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.file.md
+++ b/docs/sources/flow/reference/components/loki.source.file.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/loki.source.file/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/loki.source.file/
 title: loki.source.file
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.gcplog.md
+++ b/docs/sources/flow/reference/components/loki.source.gcplog.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/loki.source.gcplog/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/loki.source.gcplog/
 title: loki.source.gcplog
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.gelf.md
+++ b/docs/sources/flow/reference/components/loki.source.gelf.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/loki.source.gelf/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/loki.source.gelf/
 title: loki.source.gelf
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.heroku.md
+++ b/docs/sources/flow/reference/components/loki.source.heroku.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/loki.source.heroku/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/loki.source.heroku/
 title: loki.source.heroku
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.journal.md
+++ b/docs/sources/flow/reference/components/loki.source.journal.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/loki.source.journal/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/loki.source.journal/
 title: loki.source.journal
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.kafka.md
+++ b/docs/sources/flow/reference/components/loki.source.kafka.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/loki.source.kafka/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/loki.source.kafka/
 title: loki.source.kafka
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.kubernetes.md
+++ b/docs/sources/flow/reference/components/loki.source.kubernetes.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/loki.source.kubernetes/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/loki.source.kubernetes/
 labels:
   stage: experimental
 title: loki.source.kubernetes

--- a/docs/sources/flow/reference/components/loki.source.kubernetes_events.md
+++ b/docs/sources/flow/reference/components/loki.source.kubernetes_events.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/loki.source.kubernetes_events/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/loki.source.kubernetes_events/
 title: loki.source.kubernetes_events
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.podlogs.md
+++ b/docs/sources/flow/reference/components/loki.source.podlogs.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/loki.source.podlogs/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/loki.source.podlogs/
 labels:
   stage: experimental
 title: loki.source.podlogs

--- a/docs/sources/flow/reference/components/loki.source.syslog.md
+++ b/docs/sources/flow/reference/components/loki.source.syslog.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/loki.source.syslog/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/loki.source.syslog/
 title: loki.source.syslog
 ---
 

--- a/docs/sources/flow/reference/components/loki.source.windowsevent.md
+++ b/docs/sources/flow/reference/components/loki.source.windowsevent.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/loki.source.windowsevent/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/loki.source.windowsevent/
 title: loki.source.windowsevent
 ---
 

--- a/docs/sources/flow/reference/components/loki.write.md
+++ b/docs/sources/flow/reference/components/loki.write.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/loki.write/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/loki.write/
 title: loki.write
 ---
 

--- a/docs/sources/flow/reference/components/mimir.rules.kubernetes.md
+++ b/docs/sources/flow/reference/components/mimir.rules.kubernetes.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/mimir.rules.kubernetes/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/mimir.rules.kubernetes/
 labels:
   stage: beta
 title: mimir.rules.kubernetes

--- a/docs/sources/flow/reference/components/module.file.md
+++ b/docs/sources/flow/reference/components/module.file.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/module.file/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/module.file/
 labels:
   stage: beta
 title: module.file

--- a/docs/sources/flow/reference/components/module.git.md
+++ b/docs/sources/flow/reference/components/module.git.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/module.git/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/module.git/
 labels:
   stage: beta
 title: module.git

--- a/docs/sources/flow/reference/components/module.http.md
+++ b/docs/sources/flow/reference/components/module.http.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/module.http/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/module.http/
 labels:
   stage: beta
 title: module.http

--- a/docs/sources/flow/reference/components/module.string.md
+++ b/docs/sources/flow/reference/components/module.string.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/module.string/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/module.string/
 labels:
   stage: beta
 title: module.string

--- a/docs/sources/flow/reference/components/otelcol.auth.basic.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.basic.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.auth.basic/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.auth.basic/
 title: otelcol.auth.basic
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.auth.bearer.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.bearer.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.auth.bearer/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.auth.bearer/
 title: otelcol.auth.bearer
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.auth.headers.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.headers.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.auth.headers/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.auth.headers/
 title: otelcol.auth.headers
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.auth.oauth2/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.auth.oauth2/
 title: otelcol.auth.oauth2
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.auth.sigv4.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.sigv4.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.auth.sigv4/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.auth.sigv4/
 title: otelcol.auth.sigv4
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.jaeger.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.jaeger.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.exporter.jaeger/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.jaeger/
 title: otelcol.exporter.jaeger
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.exporter.loadbalancing/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.loadbalancing/
 labels:
   stage: beta
 title: otelcol.exporter.loadbalancing

--- a/docs/sources/flow/reference/components/otelcol.exporter.logging.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.logging.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.exporter.logging/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.logging/
 title: otelcol.exporter.logging
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.loki.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.loki.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.exporter.loki/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.loki/
 title: otelcol.exporter.loki
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.exporter.otlp/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.otlp/
 title: otelcol.exporter.otlp
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlphttp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlphttp.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.exporter.otlphttp/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.otlphttp/
 title: otelcol.exporter.otlphttp
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.exporter.prometheus/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.prometheus/
 title: otelcol.exporter.prometheus
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.extension.jaeger_remote_sampling.md
+++ b/docs/sources/flow/reference/components/otelcol.extension.jaeger_remote_sampling.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.extension.jaeger_remote_sampling/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.extension.jaeger_remote_sampling/
 label:
   stage: experimental
 title: otelcol.extension.jaeger_remote_sampling

--- a/docs/sources/flow/reference/components/otelcol.processor.attributes.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.attributes.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.processor.attributes/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.attributes/
 title: otelcol.processor.attributes
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.processor.batch.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.batch.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.processor.batch/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.batch/
 title: otelcol.processor.batch
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.processor.memory_limiter.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.memory_limiter.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.processor.memory_limiter/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.memory_limiter/
 title: otelcol.​processor.​memory_limiter
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.processor.tail_sampling.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.tail_sampling.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.processor.tail_sampling/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.tail_sampling/
 labels:
   stage: beta
 title: otelcol.​processor.tail_sampling

--- a/docs/sources/flow/reference/components/otelcol.receiver.jaeger.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.jaeger.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.receiver.jaeger/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.receiver.jaeger/
 title: otelcol.receiver.jaeger
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.kafka.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.kafka.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.receiver.kafka/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.receiver.kafka/
 title: otelcol.receiver.kafka
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.loki.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.loki.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.receiver.loki/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.receiver.loki/
 labels:
   stage: beta
 title: otelcol.receiver.loki

--- a/docs/sources/flow/reference/components/otelcol.receiver.opencensus.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.opencensus.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.receiver.opencensus/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.receiver.opencensus/
 title: otelcol.receiver.opencensus
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.otlp.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.receiver.otlp/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.receiver.otlp/
 title: otelcol.receiver.otlp
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.prometheus.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.prometheus.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.receiver.prometheus/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.receiver.prometheus/
 labels:
   stage: beta
 title: otelcol.receiver.prometheus

--- a/docs/sources/flow/reference/components/otelcol.receiver.zipkin.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.zipkin.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/otelcol.receiver.zipkin/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.receiver.zipkin/
 title: otelcol.receiver.zipkin
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.apache.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.apache.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.apache/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.apache/
 title: prometheus.exporter.​apache
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.blackbox/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.blackbox/
 title: prometheus.exporter.blackbox
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.cloudwatch.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.cloudwatch.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.cloudwatch/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.cloudwatch/
 title: prometheus.exporter.cloudwatch
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.consul.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.consul.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.consul/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.consul/
 title: prometheus.exporter.​consul
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.dnsmasq.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.dnsmasq.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.dnsmasq/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.dnsmasq/
 title: prometheus.exporter.dnsmasq
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.elasticsearch.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.elasticsearch.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.elasticsearch/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.elasticsearch/
 title: prometheus.exporter.elasticsearch
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.github.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.github.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.github/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.github/
 title: prometheus.exporter.github
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.kafka.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.kafka.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.kafka/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.kafka/
 title: prometheus.exporter.kafka
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.memcached.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.memcached.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.memcached/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.memcached/
 title: prometheus.exporter.memcached
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.mongodb.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mongodb.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.mongodb/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.mongodb/
 title: prometheus.exporter.mongodb
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.mssql.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mssql.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.mssql/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.mssql/
 title: prometheus.exporter.mssql
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.mysql.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mysql.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.mysql/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.mysql/
 title: prometheus.exporter.​mysql
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.oracledb.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.oracledb.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.oracledb/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.oracledb/
 title: prometheus.exporter.oracledb
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.postgres.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.postgres.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.postgres/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.postgres/
 labels:
   stage: beta
 title: prometheus.exporter.postgres

--- a/docs/sources/flow/reference/components/prometheus.exporter.process.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.process.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.process/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.process/
 title: prometheus.exporter.​process
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.redis.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.redis.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.redis/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.redis/
 title: prometheus.exporter.redis
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.snmp.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.snmp.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.snmp/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.snmp/
 title: prometheus.exporter.snmp
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.snowflake.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.snowflake.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.snowflake/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.snowflake/
 title: prometheus.exporter.snowflake
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.squid.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.squid.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.squid/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.squid/
 title: prometheus.exporter.squid
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.statsd.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.statsd.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.statsd/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.statsd/
 title: prometheus.exporter.statsd
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.unix.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.unix.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.unix/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.unix/
 title: prometheus.exporter.unix
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.windows.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.windows.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.exporter.windows/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.windows/
 title: prometheus.exporter.windows
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.operator.podmonitors.md
+++ b/docs/sources/flow/reference/components/prometheus.operator.podmonitors.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.operator.podmonitors/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.operator.podmonitors/
 labels:
   stage: beta
 title: prometheus.operator.podmonitors

--- a/docs/sources/flow/reference/components/prometheus.operator.probes.md
+++ b/docs/sources/flow/reference/components/prometheus.operator.probes.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.operator.probes/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.operator.probes/
 labels:
   stage: beta
 title: prometheus.operator.probes

--- a/docs/sources/flow/reference/components/prometheus.operator.servicemonitors.md
+++ b/docs/sources/flow/reference/components/prometheus.operator.servicemonitors.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.operator.servicemonitors/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.operator.servicemonitors/
 labels:
   stage: beta
 title: prometheus.operator.servicemonitors

--- a/docs/sources/flow/reference/components/prometheus.receive_http.md
+++ b/docs/sources/flow/reference/components/prometheus.receive_http.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.receive_http/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.receive_http/
 title: prometheus.receive_http
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.relabel.md
+++ b/docs/sources/flow/reference/components/prometheus.relabel.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.relabel/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.relabel/
 title: prometheus.relabel
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.remote_write.md
+++ b/docs/sources/flow/reference/components/prometheus.remote_write.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.remote_write/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.remote_write/
 title: prometheus.remote_write
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.scrape.md
+++ b/docs/sources/flow/reference/components/prometheus.scrape.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/prometheus.scrape/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.scrape/
 title: prometheus.scrape
 ---
 

--- a/docs/sources/flow/reference/components/pyroscope.ebpf.md
+++ b/docs/sources/flow/reference/components/pyroscope.ebpf.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/pyroscope.ebpf/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/pyroscope.ebpf/
 labels:
   stage: beta
 title: pyroscope.ebpf

--- a/docs/sources/flow/reference/components/pyroscope.scrape.md
+++ b/docs/sources/flow/reference/components/pyroscope.scrape.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/pyroscope.scrape/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/pyroscope.scrape/
 labels:
   stage: beta
 title: pyroscope.scrape

--- a/docs/sources/flow/reference/components/pyroscope.write.md
+++ b/docs/sources/flow/reference/components/pyroscope.write.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/pyroscope.write/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/pyroscope.write/
 labels:
   stage: beta
 title: pyroscope.write

--- a/docs/sources/flow/reference/components/remote.http.md
+++ b/docs/sources/flow/reference/components/remote.http.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/remote.http/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/remote.http/
 title: remote.http
 ---
 

--- a/docs/sources/flow/reference/components/remote.s3.md
+++ b/docs/sources/flow/reference/components/remote.s3.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/remote.s3/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/remote.s3/
 title: remote.s3
 ---
 

--- a/docs/sources/flow/reference/components/remote.vault.md
+++ b/docs/sources/flow/reference/components/remote.vault.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/latest/flow/reference/components/remote.vault
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/components/remote.vault/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/remote.vault/
 title: remote.vault
 ---
 

--- a/docs/sources/flow/reference/config-blocks/_index.md
+++ b/docs/sources/flow/reference/config-blocks/_index.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/config-blocks/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/config-blocks/
 title: Configuration blocks
 weight: 200
 ---

--- a/docs/sources/flow/reference/config-blocks/argument.md
+++ b/docs/sources/flow/reference/config-blocks/argument.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/config-blocks/argument/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/config-blocks/argument/
 title: argument
 ---
 

--- a/docs/sources/flow/reference/config-blocks/export.md
+++ b/docs/sources/flow/reference/config-blocks/export.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/config-blocks/export/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/config-blocks/export/
 title: export
 ---
 

--- a/docs/sources/flow/reference/config-blocks/logging.md
+++ b/docs/sources/flow/reference/config-blocks/logging.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/config-blocks/logging/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/config-blocks/logging/
 title: logging
 ---
 

--- a/docs/sources/flow/reference/config-blocks/tracing.md
+++ b/docs/sources/flow/reference/config-blocks/tracing.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/config-blocks/tracing/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/config-blocks/tracing/
 title: tracing
 ---
 

--- a/docs/sources/flow/reference/stdlib/_index.md
+++ b/docs/sources/flow/reference/stdlib/_index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - standard-library/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/stdlib/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/stdlib/
 title: Standard library
 weight: 400
 ---

--- a/docs/sources/flow/reference/stdlib/coalesce.md
+++ b/docs/sources/flow/reference/stdlib/coalesce.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration-language/standard-library/coalesce/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/stdlib/coalesce/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/stdlib/coalesce/
 title: coalesce
 ---
 

--- a/docs/sources/flow/reference/stdlib/concat.md
+++ b/docs/sources/flow/reference/stdlib/concat.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration-language/standard-library/concat/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/stdlib/concat/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/stdlib/concat/
 title: concat
 ---
 

--- a/docs/sources/flow/reference/stdlib/constants.md
+++ b/docs/sources/flow/reference/stdlib/constants.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration-language/standard-library/constants/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/stdlib/constants/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/stdlib/constants/
 title: constants
 ---
 

--- a/docs/sources/flow/reference/stdlib/env.md
+++ b/docs/sources/flow/reference/stdlib/env.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration-language/standard-library/env/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/stdlib/env/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/stdlib/env/
 title: env
 ---
 

--- a/docs/sources/flow/reference/stdlib/format.md
+++ b/docs/sources/flow/reference/stdlib/format.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration-language/standard-library/format/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/stdlib/format/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/stdlib/format/
 title: format
 ---
 

--- a/docs/sources/flow/reference/stdlib/join.md
+++ b/docs/sources/flow/reference/stdlib/join.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration-language/standard-library/join/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/stdlib/join/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/stdlib/join/
 title: join
 ---
 

--- a/docs/sources/flow/reference/stdlib/json_decode.md
+++ b/docs/sources/flow/reference/stdlib/json_decode.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration-language/standard-library/json_decode/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/stdlib/json_decode/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/stdlib/json_decode/
 title: json_decode
 ---
 

--- a/docs/sources/flow/reference/stdlib/json_path.md
+++ b/docs/sources/flow/reference/stdlib/json_path.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration-language/standard-library/json_path/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/stdlib/json_path/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/stdlib/json_path/
 title: json_path
 ---
 

--- a/docs/sources/flow/reference/stdlib/nonsensitive.md
+++ b/docs/sources/flow/reference/stdlib/nonsensitive.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration-language/standard-library/nonsensitive/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/stdlib/nonsensitive/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/stdlib/nonsensitive/
 title: nonsensitive
 ---
 

--- a/docs/sources/flow/reference/stdlib/replace.md
+++ b/docs/sources/flow/reference/stdlib/replace.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration-language/standard-library/replace/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/stdlib/replace/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/stdlib/replace/
 title: replace
 ---
 

--- a/docs/sources/flow/reference/stdlib/split.md
+++ b/docs/sources/flow/reference/stdlib/split.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration-language/standard-library/split/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/stdlib/split/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/stdlib/split/
 title: split
 ---
 

--- a/docs/sources/flow/reference/stdlib/to_lower.md
+++ b/docs/sources/flow/reference/stdlib/to_lower.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration-language/standard-library/to_lower/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/stdlib/to_lower/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/stdlib/to_lower/
 title: to_lower
 ---
 

--- a/docs/sources/flow/reference/stdlib/to_upper.md
+++ b/docs/sources/flow/reference/stdlib/to_upper.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration-language/standard-library/to_upper/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/stdlib/to_upper/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/stdlib/to_upper/
 title: to_upper
 ---
 

--- a/docs/sources/flow/reference/stdlib/trim.md
+++ b/docs/sources/flow/reference/stdlib/trim.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration-language/standard-library/trim/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/stdlib/trim/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/stdlib/trim/
 title: trim
 ---
 

--- a/docs/sources/flow/reference/stdlib/trim_prefix.md
+++ b/docs/sources/flow/reference/stdlib/trim_prefix.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration-language/standard-library/trim_prefix/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/stdlib/trim_prefix/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/stdlib/trim_prefix/
 title: trim_prefix
 ---
 

--- a/docs/sources/flow/reference/stdlib/trim_space.md
+++ b/docs/sources/flow/reference/stdlib/trim_space.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration-language/standard-library/trim_space/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/stdlib/trim_space/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/stdlib/trim_space/
 title: trim_space
 ---
 

--- a/docs/sources/flow/reference/stdlib/trim_suffix.md
+++ b/docs/sources/flow/reference/stdlib/trim_suffix.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration-language/standard-library/trim_suffix/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/reference/stdlib/trim_suffix/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/stdlib/trim_suffix/
 title: trim_suffix
 ---
 

--- a/docs/sources/flow/setup/_index.md
+++ b/docs/sources/flow/setup/_index.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/setup/
+canonical: https://grafana.com/docs/agent/latest/flow/setup/
 description: Install and configure Grafana Agent in flow mode
 menuTitle: Set up flow mode
 title: Set up Grafana Agent in flow mode

--- a/docs/sources/flow/setup/configure/_index.md
+++ b/docs/sources/flow/setup/configure/_index.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/setup/configure/
+canonical: https://grafana.com/docs/agent/latest/flow/setup/configure/
 description: Configure Grafana Agent in flow mode after it is installed
 menuTitle: Configure flow mode
 title: Configure Grafana Agent in flow mode

--- a/docs/sources/flow/setup/configure/configure-kubernetes.md
+++ b/docs/sources/flow/setup/configure/configure-kubernetes.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/setup/configure/configure-kubernetes/
+canonical: https://grafana.com/docs/agent/latest/flow/setup/configure/configure-kubernetes/
 description: Learn how to configure Grafana Agent in flow mode on Kubernetes
 menuTitle: Kubernetes
 title: Configure Grafana Agent in flow mode on Kubernetes

--- a/docs/sources/flow/setup/configure/configure-linux.md
+++ b/docs/sources/flow/setup/configure/configure-linux.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/setup/configure/configure-linux/
+canonical: https://grafana.com/docs/agent/latest/flow/setup/configure/configure-linux/
 description: Learn how to configure Grafana Agent in flow mode on Linux
 menuTitle: Linux
 title: Configure Grafana Agent in flow mode on Linux

--- a/docs/sources/flow/setup/configure/configure-macos.md
+++ b/docs/sources/flow/setup/configure/configure-macos.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/setup/configure/configure-macos/
+canonical: https://grafana.com/docs/agent/latest/flow/setup/configure/configure-macos/
 description: Learn how to configure Grafana Agent in flow mode on macOS
 menuTitle: macOS
 title: Configure Grafana Agent in flow mode on macOS

--- a/docs/sources/flow/setup/configure/configure-windows.md
+++ b/docs/sources/flow/setup/configure/configure-windows.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/setup/configure/configure-windows/
+canonical: https://grafana.com/docs/agent/latest/flow/setup/configure/configure-windows/
 description: Learn how to configure Grafana Agent in flow mode on Windows
 menuTitle: Windows
 title: Configure Grafana Agent in flow mode on Windows

--- a/docs/sources/flow/setup/install/_index.md
+++ b/docs/sources/flow/setup/install/_index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/sources/flow/install/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/setup/install/
+canonical: https://grafana.com/docs/agent/latest/flow/setup/install/
 menuTitle: Install flow mode
 title: Install Grafana Agent in flow mode
 weight: 50

--- a/docs/sources/flow/setup/install/binary.md
+++ b/docs/sources/flow/setup/install/binary.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../install/binary/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/setup/install/binary/
+canonical: https://grafana.com/docs/agent/latest/flow/setup/install/binary/
 description: Learn how to install Grafana Agent in flow mode as a standalone binary
 menuTitle: Standalone
 title: Install Grafana Agent in flow mode as a standalone binary

--- a/docs/sources/flow/setup/install/docker.md
+++ b/docs/sources/flow/setup/install/docker.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../install/docker/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/setup/install/docker/
+canonical: https://grafana.com/docs/agent/latest/flow/setup/install/docker/
 description: Learn how to install Grafana Agent in flow mode on Docker
 menuTitle: Docker
 title: Run Grafana Agent in flow mode in a Docker container

--- a/docs/sources/flow/setup/install/kubernetes.md
+++ b/docs/sources/flow/setup/install/kubernetes.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../install/kubernetes/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/setup/install/kubernetes/
+canonical: https://grafana.com/docs/agent/latest/flow/setup/install/kubernetes/
 description: Learn how to deploy Grafana Agent in flow mode on Kubernetes
 menuTitle: Kubernetes
 title: Deploy Grafana Agent in flow mode on Kubernetes

--- a/docs/sources/flow/setup/install/linux.md
+++ b/docs/sources/flow/setup/install/linux.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../install/linux/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/setup/install/linux/
+canonical: https://grafana.com/docs/agent/latest/flow/setup/install/linux/
 description: Learn how to install Grafana Agent in flow mode on Linux
 menuTitle: Linux
 title: Install Grafana Agent in flow mode on Linux

--- a/docs/sources/flow/setup/install/macos.md
+++ b/docs/sources/flow/setup/install/macos.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../install/macos/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/setup/install/macos/
+canonical: https://grafana.com/docs/agent/latest/flow/setup/install/macos/
 description: Learn how to install Grafana Agent in flow mode on macOS
 menuTitle: macOS
 title: Install Grafana Agent in flow mode on macOS

--- a/docs/sources/flow/setup/install/windows.md
+++ b/docs/sources/flow/setup/install/windows.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../install/windows/
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/setup/install/windows/
+canonical: https://grafana.com/docs/agent/latest/flow/setup/install/windows/
 description: Learn how to install Grafana Agent in flow mode on Windows
 menuTitle: Windows
 title: Install Grafana Agent in flow mode on Windows

--- a/docs/sources/flow/setup/start-agent.md
+++ b/docs/sources/flow/setup/start-agent.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/setup/start-agent/
+canonical: https://grafana.com/docs/agent/latest/flow/setup/start-agent/
 description: Learn how to start, restart, and stop Grafana Agent after it is installed
 menuTitle: Start flow mode
 title: Start, restart, and stop Grafana Agent in flow mode

--- a/docs/sources/flow/tutorials/_index.md
+++ b/docs/sources/flow/tutorials/_index.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/tutorials/
+canonical: https://grafana.com/docs/agent/latest/flow/tutorials/
 title: Tutorials
 weight: 300
 ---

--- a/docs/sources/flow/tutorials/chaining.md
+++ b/docs/sources/flow/tutorials/chaining.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/tutorials/chaining/
+canonical: https://grafana.com/docs/agent/latest/flow/tutorials/chaining/
 title: Chaining Prometheus components
 weight: 400
 ---

--- a/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
+++ b/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/tutorials/collecting-prometheus-metrics/
+canonical: https://grafana.com/docs/agent/latest/flow/tutorials/collecting-prometheus-metrics/
 title: Collecting Prometheus metrics
 weight: 200
 ---

--- a/docs/sources/flow/tutorials/filtering-metrics.md
+++ b/docs/sources/flow/tutorials/filtering-metrics.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/tutorials/filtering-metrics/
+canonical: https://grafana.com/docs/agent/latest/flow/tutorials/filtering-metrics/
 title: Filtering Prometheus metrics
 weight: 300
 ---

--- a/docs/sources/flow/upgrade-guide.md
+++ b/docs/sources/flow/upgrade-guide.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/flow/upgrade-guide/
+canonical: https://grafana.com/docs/agent/latest/flow/upgrade-guide/
 title: Upgrade guide
 weight: 999
 ---

--- a/docs/sources/operator/_index.md
+++ b/docs/sources/operator/_index.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/operator/
+canonical: https://grafana.com/docs/agent/latest/operator/
 title: Static mode Kubernetes operator
 weight: 300
 ---

--- a/docs/sources/operator/add-custom-scrape-jobs.md
+++ b/docs/sources/operator/add-custom-scrape-jobs.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/operator/add-custom-scrape-jobs/
+canonical: https://grafana.com/docs/agent/latest/operator/add-custom-scrape-jobs/
 title: Add custom scrape jobs
 weight: 400
 ---

--- a/docs/sources/operator/api.md
+++ b/docs/sources/operator/api.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/latest/operator/crd/
-canonical: https://grafana.com/docs/grafana/agent/latest/operator/api/
+canonical: https://grafana.com/docs/agent/latest/operator/api/
 title: Custom Resource Definition Reference
 weight: 500
 ---

--- a/docs/sources/operator/architecture.md
+++ b/docs/sources/operator/architecture.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/operator/architecture/
+canonical: https://grafana.com/docs/agent/latest/operator/architecture/
 title: Architecture
 weight: 300
 ---

--- a/docs/sources/operator/deploy-agent-operator-resources.md
+++ b/docs/sources/operator/deploy-agent-operator-resources.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - custom-resource-quickstart/
-canonical: https://grafana.com/docs/grafana/agent/latest/operator/deploy-agent-operator-resources/
+canonical: https://grafana.com/docs/agent/latest/operator/deploy-agent-operator-resources/
 title: Deploy Operator resources
 weight: 120
 ---

--- a/docs/sources/operator/getting-started.md
+++ b/docs/sources/operator/getting-started.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/operator/getting-started/
+canonical: https://grafana.com/docs/agent/latest/operator/getting-started/
 title: Install the Operator
 weight: 110
 ---

--- a/docs/sources/operator/helm-getting-started.md
+++ b/docs/sources/operator/helm-getting-started.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/operator/helm-getting-started/
+canonical: https://grafana.com/docs/agent/latest/operator/helm-getting-started/
 title: Install the Operator with Helm
 weight: 100
 ---

--- a/docs/sources/operator/operator-integrations.md
+++ b/docs/sources/operator/operator-integrations.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/operator/operator-integrations/
+canonical: https://grafana.com/docs/agent/latest/operator/operator-integrations/
 title: Set up integrations
 weight: 350
 ---

--- a/docs/sources/operator/upgrade-guide.md
+++ b/docs/sources/operator/upgrade-guide.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/operator/upgrade-guide/
+canonical: https://grafana.com/docs/agent/latest/operator/upgrade-guide/
 title: Upgrade guide
 weight: 999
 ---

--- a/docs/sources/shared/flow/reference/components/authorization-block.md
+++ b/docs/sources/shared/flow/reference/components/authorization-block.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/shared/flow/reference/components/authorization-block/
-canonical: https://grafana.com/docs/grafana/agent/latest/shared/flow/reference/components/authorization-block/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/reference/components/authorization-block/
 headless: true
 ---
 

--- a/docs/sources/shared/flow/reference/components/basic-auth-block.md
+++ b/docs/sources/shared/flow/reference/components/basic-auth-block.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/shared/flow/reference/components/basic-auth-block/
-canonical: https://grafana.com/docs/grafana/agent/latest/shared/flow/reference/components/basic-auth-block/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/reference/components/basic-auth-block/
 headless: true
 ---
 

--- a/docs/sources/shared/flow/reference/components/http-client-config-block.md
+++ b/docs/sources/shared/flow/reference/components/http-client-config-block.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/shared/flow/reference/components/http-client-config-block/
-canonical: https://grafana.com/docs/grafana/agent/latest/shared/flow/reference/components/http-client-config-block/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/reference/components/http-client-config-block/
 headless: true
 ---
 

--- a/docs/sources/shared/flow/reference/components/local-file-arguments-text.md
+++ b/docs/sources/shared/flow/reference/components/local-file-arguments-text.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/shared/flow/reference/components/local-file-arguments-text/
-canonical: https://grafana.com/docs/grafana/agent/latest/shared/flow/reference/components/local-file-arguments-text/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/reference/components/local-file-arguments-text/
 headless: true
 ---
 

--- a/docs/sources/shared/flow/reference/components/loki-server-grpc.md
+++ b/docs/sources/shared/flow/reference/components/loki-server-grpc.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/shared/flow/reference/components/loki-server-grpc/
-canonical: https://grafana.com/docs/grafana/agent/latest/shared/flow/reference/components/loki-server-grpc/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/reference/components/loki-server-grpc/
 headless: true
 ---
 

--- a/docs/sources/shared/flow/reference/components/loki-server-http.md
+++ b/docs/sources/shared/flow/reference/components/loki-server-http.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/shared/flow/reference/components/loki-server-http/
-canonical: https://grafana.com/docs/grafana/agent/latest/shared/flow/reference/components/loki-server-http/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/reference/components/loki-server-http/
 headless: true
 ---
 

--- a/docs/sources/shared/flow/reference/components/match-properties-block.md
+++ b/docs/sources/shared/flow/reference/components/match-properties-block.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/shared/flow/reference/components/match-properties-block/
-canonical: https://grafana.com/docs/grafana/agent/latest/shared/flow/reference/components/match-properties-block/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/reference/components/match-properties-block/
 headless: true
 ---
 

--- a/docs/sources/shared/flow/reference/components/oauth2-block.md
+++ b/docs/sources/shared/flow/reference/components/oauth2-block.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/shared/flow/reference/components/oauth2-block/
-canonical: https://grafana.com/docs/grafana/agent/latest/shared/flow/reference/components/oauth2-block/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/reference/components/oauth2-block/
 headless: true
 ---
 

--- a/docs/sources/shared/flow/reference/components/otelcol-compression-field.md
+++ b/docs/sources/shared/flow/reference/components/otelcol-compression-field.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/shared/flow/reference/components/otelcol-compression-field
-canonical: https://grafana.com/docs/grafana/agent/latest/shared/flow/reference/components/otelcol-compression-field/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/reference/components/otelcol-compression-field/
 headless: true
 ---
 

--- a/docs/sources/shared/flow/reference/components/otelcol-queue-block.md
+++ b/docs/sources/shared/flow/reference/components/otelcol-queue-block.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/shared/flow/reference/components/otelcol-queue-block/
-canonical: https://grafana.com/docs/grafana/agent/latest/shared/flow/reference/components/otelcol-queue-block/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/reference/components/otelcol-queue-block/
 headless: true
 ---
 

--- a/docs/sources/shared/flow/reference/components/otelcol-retry-block.md
+++ b/docs/sources/shared/flow/reference/components/otelcol-retry-block.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/shared/flow/reference/components/otelcol-retry-block/
-canonical: https://grafana.com/docs/grafana/agent/latest/shared/flow/reference/components/otelcol-retry-block/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/reference/components/otelcol-retry-block/
 headless: true
 ---
 

--- a/docs/sources/shared/flow/reference/components/otelcol-tls-config-block.md
+++ b/docs/sources/shared/flow/reference/components/otelcol-tls-config-block.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/shared/flow/reference/components/otelcol-tls-config-block/
-canonical: https://grafana.com/docs/grafana/agent/latest/shared/flow/reference/components/otelcol-tls-config-block/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/reference/components/otelcol-tls-config-block/
 headless: true
 ---
 

--- a/docs/sources/shared/flow/reference/components/output-block.md
+++ b/docs/sources/shared/flow/reference/components/output-block.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../otelcol/output-block/
-canonical: https://grafana.com/docs/grafana/agent/latest/shared/flow/reference/components/output-block/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/reference/components/output-block/
 headless: true
 ---
 

--- a/docs/sources/shared/flow/reference/components/rule-block-logs.md
+++ b/docs/sources/shared/flow/reference/components/rule-block-logs.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/shared/flow/reference/components/rule-block/
-canonical: https://grafana.com/docs/grafana/agent/latest/shared/flow/reference/components/rule-block-logs/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/reference/components/rule-block-logs/
 headless: true
 ---
 

--- a/docs/sources/shared/flow/reference/components/rule-block.md
+++ b/docs/sources/shared/flow/reference/components/rule-block.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/shared/flow/reference/components/rule-block/
-canonical: https://grafana.com/docs/grafana/agent/latest/shared/flow/reference/components/rule-block/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/reference/components/rule-block/
 headless: true
 ---
 

--- a/docs/sources/shared/flow/reference/components/tls-config-block.md
+++ b/docs/sources/shared/flow/reference/components/tls-config-block.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/shared/flow/reference/components/tls-config-block/
-canonical: https://grafana.com/docs/grafana/agent/latest/shared/flow/reference/components/tls-config-block/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/reference/components/tls-config-block/
 headless: true
 ---
 

--- a/docs/sources/shared/flow/stability/beta.md
+++ b/docs/sources/shared/flow/stability/beta.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/shared/flow/stability/beta/
-canonical: https://grafana.com/docs/grafana/agent/latest/shared/flow/stability/beta/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/stability/beta/
 headless: true
 ---
 

--- a/docs/sources/shared/flow/stability/experimental.md
+++ b/docs/sources/shared/flow/stability/experimental.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /docs/agent/shared/flow/stability/experimental/
-canonical: https://grafana.com/docs/grafana/agent/latest/shared/flow/stability/experimental/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/stability/experimental/
 headless: true
 ---
 

--- a/docs/sources/shared/index.md
+++ b/docs/sources/shared/index.md
@@ -1,6 +1,6 @@
 ---
 aliases: null
-canonical: https://grafana.com/docs/grafana/agent/latest/shared/
+canonical: https://grafana.com/docs/agent/latest/shared/
 headless: true
 ---
 

--- a/docs/sources/stability.md
+++ b/docs/sources/stability.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/stability/
+canonical: https://grafana.com/docs/agent/latest/stability/
 title: Stability
 weight: 600
 ---

--- a/docs/sources/static/_index.md
+++ b/docs/sources/static/_index.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/static/
+canonical: https://grafana.com/docs/agent/latest/static/
 title: Static mode
 weight: 200
 ---

--- a/docs/sources/static/api/_index.md
+++ b/docs/sources/static/api/_index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../api/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/api/
+canonical: https://grafana.com/docs/agent/latest/static/api/
 title: Static mode API
 weight: 400
 ---

--- a/docs/sources/static/configuration/_index.md
+++ b/docs/sources/static/configuration/_index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../configuration/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/
 title: Configure static mode
 weight: 300
 ---

--- a/docs/sources/static/configuration/agent-management.md
+++ b/docs/sources/static/configuration/agent-management.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/agent-management/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/agent-management/
 title: Agent Management
 weight: 700
 ---

--- a/docs/sources/static/configuration/create-config-file.md
+++ b/docs/sources/static/configuration/create-config-file.md
@@ -2,7 +2,7 @@
 aliases:
 - ../../set-up/create-config-file/
 - ../../configuration/create-config-file/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/create-config-file/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/create-config-file/
 title: Create a config file
 weight: 50
 ---

--- a/docs/sources/static/configuration/flags.md
+++ b/docs/sources/static/configuration/flags.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration/flags/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/flags/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/flags/
 title: Command-line flags
 weight: 100
 ---

--- a/docs/sources/static/configuration/integrations/_index.md
+++ b/docs/sources/static/configuration/integrations/_index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration/integrations/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/
 title: integrations_config
 weight: 500
 ---

--- a/docs/sources/static/configuration/integrations/apache-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/apache-exporter-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/apache-exporter-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/apache-exporter-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/apache-exporter-config/
 title: apache_http_config
 ---
 

--- a/docs/sources/static/configuration/integrations/azure-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/azure-exporter-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/azure-exporter-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/azure-exporter-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/azure-exporter-config/
 title: azure_exporter_config
 ---
 

--- a/docs/sources/static/configuration/integrations/blackbox-config.md
+++ b/docs/sources/static/configuration/integrations/blackbox-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/blackbox-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/blackbox-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/blackbox-config/
 title: blackbox_config
 ---
 

--- a/docs/sources/static/configuration/integrations/cadvisor-config.md
+++ b/docs/sources/static/configuration/integrations/cadvisor-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/cadvisor-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/cadvisor-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/cadvisor-config/
 title: cadvisor_config
 ---
 

--- a/docs/sources/static/configuration/integrations/cloudwatch-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/cloudwatch-exporter-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/cloudwatch-exporter-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/cloudwatch-exporter-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/cloudwatch-exporter-config/
 title: cloudwatch_exporter_config
 ---
 

--- a/docs/sources/static/configuration/integrations/consul-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/consul-exporter-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/consul-exporter-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/consul-exporter-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/consul-exporter-config/
 title: consul_exporter_config
 ---
 

--- a/docs/sources/static/configuration/integrations/dnsmasq-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/dnsmasq-exporter-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/dnsmasq-exporter-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/dnsmasq-exporter-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/dnsmasq-exporter-config/
 title: dnsmasq_exporter_config
 ---
 

--- a/docs/sources/static/configuration/integrations/elasticsearch-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/elasticsearch-exporter-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/elasticsearch-exporter-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/elasticsearch-exporter-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/elasticsearch-exporter-config/
 title: elasticsearch_exporter_config
 ---
 

--- a/docs/sources/static/configuration/integrations/gcp-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/gcp-exporter-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/gcp-exporter-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/gcp-exporter-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/gcp-exporter-config/
 title: gcp_exporter_config
 ---
 

--- a/docs/sources/static/configuration/integrations/github-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/github-exporter-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/github-exporter-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/github-exporter-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/github-exporter-config/
 title: github_exporter_config
 ---
 

--- a/docs/sources/static/configuration/integrations/integrations-next/_index.md
+++ b/docs/sources/static/configuration/integrations/integrations-next/_index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/integrations-next/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/integrations-next/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/integrations-next/
 title: Integrations Revamp
 weight: 100
 ---

--- a/docs/sources/static/configuration/integrations/integrations-next/app-agent-receiver-config.md
+++ b/docs/sources/static/configuration/integrations/integrations-next/app-agent-receiver-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../../configuration/integrations/integrations-next/app-agent-receiver-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/integrations-next/app-agent-receiver-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/integrations-next/app-agent-receiver-config/
 title: app_agent_receiver_config
 ---
 

--- a/docs/sources/static/configuration/integrations/integrations-next/blackbox-config.md
+++ b/docs/sources/static/configuration/integrations/integrations-next/blackbox-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../../configuration/integrations/integrations-next/blackbox-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/integrations-next/blackbox-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/integrations-next/blackbox-config/
 title: blackbox_config
 ---
 

--- a/docs/sources/static/configuration/integrations/integrations-next/eventhandler-config.md
+++ b/docs/sources/static/configuration/integrations/integrations-next/eventhandler-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../../configuration/integrations/integrations-next/eventhandler-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/integrations-next/eventhandler-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/integrations-next/eventhandler-config/
 title: eventhandler_config
 ---
 

--- a/docs/sources/static/configuration/integrations/integrations-next/snmp-config.md
+++ b/docs/sources/static/configuration/integrations/integrations-next/snmp-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../../configuration/integrations/integrations-next/snmp-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/integrations-next/snmp-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/integrations-next/snmp-config/
 title: snmp_exporter_config
 ---
 

--- a/docs/sources/static/configuration/integrations/integrations-next/vsphere-config.md
+++ b/docs/sources/static/configuration/integrations/integrations-next/vsphere-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../../configuration/integrations/integrations-next/vsphere-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/integrations-next/vsphere-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/integrations-next/vsphere-config/
 title: vsphere_config
 ---
 

--- a/docs/sources/static/configuration/integrations/kafka-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/kafka-exporter-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/kafka-exporter-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/kafka-exporter-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/kafka-exporter-config/
 title: kafka_exporter_config
 ---
 

--- a/docs/sources/static/configuration/integrations/memcached-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/memcached-exporter-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/memcached-exporter-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/memcached-exporter-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/memcached-exporter-config/
 title: memcached_exporter_config
 ---
 

--- a/docs/sources/static/configuration/integrations/mongodb_exporter-config.md
+++ b/docs/sources/static/configuration/integrations/mongodb_exporter-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/mongodb_exporter-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/mongodb_exporter-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/mongodb_exporter-config/
 title: mongodb_exporter_config
 ---
 

--- a/docs/sources/static/configuration/integrations/mssql-config.md
+++ b/docs/sources/static/configuration/integrations/mssql-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/mssql-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/mssql-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/mssql-config/
 title: mssql_config
 ---
 

--- a/docs/sources/static/configuration/integrations/mysqld-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/mysqld-exporter-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/mysqld-exporter-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/mysqld-exporter-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/mysqld-exporter-config/
 title: mysqld_exporter_config
 ---
 

--- a/docs/sources/static/configuration/integrations/node-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/node-exporter-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/node-exporter-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/node-exporter-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/node-exporter-config/
 title: node_exporter_config
 ---
 

--- a/docs/sources/static/configuration/integrations/oracledb-config.md
+++ b/docs/sources/static/configuration/integrations/oracledb-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/oracledb-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/oracledb-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/oracledb-config/
 title: oracledb_config
 ---
 

--- a/docs/sources/static/configuration/integrations/postgres-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/postgres-exporter-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/postgres-exporter-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/postgres-exporter-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/postgres-exporter-config/
 title: postgres_exporter_config
 ---
 

--- a/docs/sources/static/configuration/integrations/process-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/process-exporter-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/process-exporter-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/process-exporter-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/process-exporter-config/
 title: process_exporter_config
 ---
 

--- a/docs/sources/static/configuration/integrations/redis-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/redis-exporter-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/redis-exporter-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/redis-exporter-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/redis-exporter-config/
 title: redis_exporter_config
 ---
 

--- a/docs/sources/static/configuration/integrations/snmp-config.md
+++ b/docs/sources/static/configuration/integrations/snmp-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/snmp-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/snmp-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/snmp-config/
 title: snmp_exporter_config
 ---
 

--- a/docs/sources/static/configuration/integrations/snowflake-config.md
+++ b/docs/sources/static/configuration/integrations/snowflake-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/snowflake-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/snowflake-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/snowflake-config/
 title: snowflake_config
 ---
 

--- a/docs/sources/static/configuration/integrations/squid-config.md
+++ b/docs/sources/static/configuration/integrations/squid-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/squid-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/squid-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/squid-config/
 title: squid_config
 ---
 

--- a/docs/sources/static/configuration/integrations/statsd-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/statsd-exporter-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/statsd-exporter-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/statsd-exporter-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/statsd-exporter-config/
 title: statsd_exporter_config
 ---
 

--- a/docs/sources/static/configuration/integrations/windows-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/windows-exporter-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../../configuration/integrations/windows-exporter-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/integrations/windows-exporter-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/windows-exporter-config/
 title: windows_exporter_config
 ---
 

--- a/docs/sources/static/configuration/logs-config.md
+++ b/docs/sources/static/configuration/logs-config.md
@@ -2,7 +2,7 @@
 aliases:
 - ../../configuration/loki-config/
 - ../../configuration/logs-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/logs-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/logs-config/
 title: logs_config
 weight: 300
 ---

--- a/docs/sources/static/configuration/metrics-config.md
+++ b/docs/sources/static/configuration/metrics-config.md
@@ -2,7 +2,7 @@
 aliases:
 - ../../configuration/prometheus-config/
 - ../../configuration/metrics-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/metrics-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/metrics-config/
 title: metrics_config
 weight: 200
 ---

--- a/docs/sources/static/configuration/scraping-service.md
+++ b/docs/sources/static/configuration/scraping-service.md
@@ -2,7 +2,7 @@
 aliases:
 - ../../scraping-service/
 - ../../configuration/scraping-service/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/scraping-service/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/scraping-service/
 title: Scraping Service Mode
 weight: 600
 ---

--- a/docs/sources/static/configuration/server-config.md
+++ b/docs/sources/static/configuration/server-config.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../configuration/server-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/server-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/server-config/
 title: server_config
 weight: 100
 ---

--- a/docs/sources/static/configuration/traces-config.md
+++ b/docs/sources/static/configuration/traces-config.md
@@ -2,7 +2,7 @@
 aliases:
 - ../../configuration/tempo-config/
 - ../../configuration/traces-config/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/configuration/traces-config/
+canonical: https://grafana.com/docs/agent/latest/static/configuration/traces-config/
 title: traces_config
 weight: 400
 ---

--- a/docs/sources/static/operation-guide/_index.md
+++ b/docs/sources/static/operation-guide/_index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../operation-guide/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/operation-guide/
+canonical: https://grafana.com/docs/agent/latest/static/operation-guide/
 title: Operation guide
 weight: 700
 ---

--- a/docs/sources/static/set-up/_index.md
+++ b/docs/sources/static/set-up/_index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../set-up
-canonical: https://grafana.com/docs/grafana/agent/latest/static/set-up/
+canonical: https://grafana.com/docs/agent/latest/static/set-up/
 description: Install and configure Grafana Agent in static mode
 menuTitle: Set up static mode
 title: Set up Grafana Agent in static mode

--- a/docs/sources/static/set-up/install/_index.md
+++ b/docs/sources/static/set-up/install/_index.md
@@ -2,7 +2,7 @@
 aliases:
 - ../set-up/
 - ../
-canonical: https://grafana.com/docs/grafana/agent/latest/static/set-up/install/
+canonical: https://grafana.com/docs/agent/latest/static/set-up/install/
 menuTitle: Install static mode
 title: Install Grafana Agent in static mode
 weight: 100

--- a/docs/sources/static/set-up/install/install-agent-binary.md
+++ b/docs/sources/static/set-up/install/install-agent-binary.md
@@ -2,7 +2,7 @@
 aliases:
 - ../../set-up/install-agent-binary/
 - ../set-up/install-agent-binary/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/set-up/install/install-agent-binary/
+canonical: https://grafana.com/docs/agent/latest/static/set-up/install/install-agent-binary/
 menuTitle: Standalone
 title: Install Grafana Agent in static mode as a standalone binary
 weight: 700

--- a/docs/sources/static/set-up/install/install-agent-docker.md
+++ b/docs/sources/static/set-up/install/install-agent-docker.md
@@ -2,7 +2,7 @@
 aliases:
 - ../../set-up/install-agent-docker/
 - ../set-up/install-agent-docker/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/set-up/install/install-agent-docker/
+canonical: https://grafana.com/docs/agent/latest/static/set-up/install/install-agent-docker/
 menuTitle: Docker
 title: Run Grafana Agent in static mode in a Docker container
 weight: 200

--- a/docs/sources/static/set-up/install/install-agent-kubernetes.md
+++ b/docs/sources/static/set-up/install/install-agent-kubernetes.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/static/set-up/install/install-agent-kubernetes/
+canonical: https://grafana.com/docs/agent/latest/static/set-up/install/install-agent-kubernetes/
 menuTitle: Kubernetes
 title: Deploy Grafana Agent in static mode on Kubernetes
 weight: 300

--- a/docs/sources/static/set-up/install/install-agent-linux.md
+++ b/docs/sources/static/set-up/install/install-agent-linux.md
@@ -2,7 +2,7 @@
 aliases:
 - ../../set-up/install-agent-linux/
 - ../set-up/install-agent-linux/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/set-up/install/install-agent-linux/
+canonical: https://grafana.com/docs/agent/latest/static/set-up/install/install-agent-linux/
 menuTitle: Linux
 title: Install Grafana Agent in static mode on Linux
 weight: 400

--- a/docs/sources/static/set-up/install/install-agent-macos.md
+++ b/docs/sources/static/set-up/install/install-agent-macos.md
@@ -2,7 +2,7 @@
 aliases:
 - ../../set-up/install-agent-macos/
 - ../set-up/install-agent-macos/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/set-up/install/install-agent-macos/
+canonical: https://grafana.com/docs/agent/latest/static/set-up/install/install-agent-macos/
 menuTitle: macOS
 title: Install Grafana Agent in static mode on macOS
 weight: 500

--- a/docs/sources/static/set-up/install/install-agent-on-windows.md
+++ b/docs/sources/static/set-up/install/install-agent-on-windows.md
@@ -2,7 +2,7 @@
 aliases:
 - ../../set-up/install-agent-on-windows/
 - ../set-up/install-agent-on-windows/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/set-up/install/install-agent-on-windows/
+canonical: https://grafana.com/docs/agent/latest/static/set-up/install/install-agent-on-windows/
 menuTitle: Windows
 title: Install Grafana Agent in static mode on Windows
 weight: 600

--- a/docs/sources/static/set-up/quick-starts.md
+++ b/docs/sources/static/set-up/quick-starts.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../../set-up/quick-starts/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/set-up/quick-starts/
+canonical: https://grafana.com/docs/agent/latest/static/set-up/quick-starts/
 menuTitle: Get started
 title: Get started with Grafana Agent in static mode
 weight: 300

--- a/docs/sources/static/set-up/start-agent.md
+++ b/docs/sources/static/set-up/start-agent.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/grafana/agent/latest/static/set-up/start-agent/
+canonical: https://grafana.com/docs/agent/latest/static/set-up/start-agent/
 description: Learn how to start, restart, and stop Grafana Agent after it is installed
 menuTitle: Start static mode
 title: Start, restart, and stop Grafana Agent in static mode

--- a/docs/sources/static/upgrade-guide.md
+++ b/docs/sources/static/upgrade-guide.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ../upgrade-guide/
-canonical: https://grafana.com/docs/grafana/agent/latest/static/upgrade-guide/
+canonical: https://grafana.com/docs/agent/latest/static/upgrade-guide/
 title: Upgrade guide
 weight: 999
 ---


### PR DESCRIPTION
I set the path prefix to /`docs/grafana/agent/latest/` and not `/docs/agent/latest/`