### PR TITLE
prometheus.operator.*: fix UI issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,17 @@ Main (unreleased)
 
 - Rename `GrafanaAgentManagement` mixin rules to `GrafanaAgentConfig` and update individual alerts to be more accurate. (@spartan0x117)
 
+- Fix issue where the flow mode UI would show an empty page when navigating to
+  an unhealthy `prometheus.operator` component or a healthy
+  `prometheus.operator` component which discovered no custom resources.
+  (@rfratto)
+
 v0.35.0 (2023-07-18)
 --------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
- 
+
 ### Breaking changes
 
 - The algorithm for the "hash" action of `otelcol.processor.attributes` has changed.

--- a/component/prometheus/operator/common/crdmanager.go
+++ b/component/prometheus/operator/common/crdmanager.go
@@ -205,7 +205,11 @@ func (c *crdManager) DebugInfo() interface{} {
 	for _, pm := range c.debugInfo {
 		info.DiscoveredCRDs = append(info.DiscoveredCRDs, pm)
 	}
-	info.Targets = compscrape.BuildTargetStatuses(c.scrapeManager.TargetsActive())
+
+	// c.scrapeManager can be nil if the client failed to build.
+	if c.scrapeManager != nil {
+		info.Targets = compscrape.BuildTargetStatuses(c.scrapeManager.TargetsActive())
+	}
 	return info
 }
 

--- a/pkg/river/encoding/riverjson/riverjson.go
+++ b/pkg/river/encoding/riverjson/riverjson.go
@@ -87,15 +87,6 @@ func encodeFieldAsStatements(prefix []string, field rivertags.Field, fieldValue 
 		fullName := mergeStringSlice(prefix, field.Name)
 
 		switch {
-		case fieldValue.IsZero():
-			// It shouldn't be possible to have a required block which is unset, but
-			// we'll encode something anyway.
-			return []jsonStatement{jsonBlock{
-				Name: strings.Join(fullName, "."),
-				Type: "block",
-				Body: nil,
-			}}
-
 		case fieldValue.Kind() == reflect.Map:
 			// Iterate over the map and add each element as an attribute into it.
 
@@ -137,6 +128,19 @@ func encodeFieldAsStatements(prefix []string, field rivertags.Field, fieldValue 
 			return statements
 
 		case fieldValue.Kind() == reflect.Struct:
+			if fieldValue.IsZero() {
+				// It shouldn't be possible to have a required block which is unset, but
+				// we'll encode something anyway.
+				return []jsonStatement{jsonBlock{
+					Name: strings.Join(fullName, "."),
+					Type: "block",
+
+					// Never set this to nil, since the API contract always expects blocks
+					// to have an array value for the body.
+					Body: []jsonStatement{},
+				}}
+			}
+
 			return []jsonStatement{jsonBlock{
 				Name:  strings.Join(fullName, "."),
 				Type:  "block",

--- a/pkg/river/encoding/riverjson/riverjson_test.go
+++ b/pkg/river/encoding/riverjson/riverjson_test.go
@@ -199,6 +199,30 @@ func TestBlock(t *testing.T) {
 	require.JSONEq(t, expect, string(actual))
 }
 
+func TestBlock_Empty_Required_Block_Slice(t *testing.T) {
+	type wrapper struct {
+		Blocks []testBlock `river:"some_block,block"`
+	}
+
+	tt := []struct {
+		name string
+		val  any
+	}{
+		{"nil block slice", wrapper{Blocks: nil}},
+		{"empty block slice", wrapper{Blocks: []testBlock{}}},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			expect := `[]`
+
+			actual, err := riverjson.MarshalBody(tc.val)
+			require.NoError(t, err)
+			require.JSONEq(t, expect, string(actual))
+		})
+	}
+}
+
 type testBlock struct {
 	Number  int            `river:"number,attr,optional"`
 	String  string         `river:"string,attr,optional"`


### PR DESCRIPTION
This commit fixes two issues:

* If the component failed to build and was unhealthy, a nil pointer panic would be generated when requesting debug info.
* An empty slice of discovered CRDs failed to be encoded as JSON in a way expected by the UI.

Fixes #4512.