### PR TITLE
agentctl: add journald support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ Main (unreleased)
   `prometheus.operator` component which discovered no custom resources.
   (@rfratto)
 
+### Other changes
+
+- Compile journald support into builds of `grafana-agentctl` so
+  `grafana-agentctl test-logs` functions as expected when testing tailing the
+  systemd journal. (@rfratto)
+
 v0.35.0 (2023-07-18)
 --------------------
 

--- a/cmd/grafana-agentctl/Dockerfile
+++ b/cmd/grafana-agentctl/Dockerfile
@@ -20,6 +20,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     GOOS="$TARGETOS" GOARCH="$TARGETARCH" GOARM="${TARGETVARIANT#v}" \
     RELEASE_BUILD="${RELEASE_BUILD}" VERSION="${VERSION}" \
+    GO_TAGS="promtail_journal_enabled" \
     make agentctl
 
 FROM ubuntu:lunar

--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -107,23 +107,27 @@ dist-agentctl-binaries: dist/grafana-agentctl-linux-amd64       \
                         dist/grafana-agentctl-windows-amd64.exe \
                         dist/grafana-agentctl-freebsd-amd64
 
+dist/grafana-agentctl-linux-amd64: GO_TAGS += promtail_journal_enabled
 dist/grafana-agentctl-linux-amd64: GOOS    := linux
 dist/grafana-agentctl-linux-amd64: GOARCH  := amd64
 dist/grafana-agentctl-linux-amd64:
 	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
 
-dist/grafana-agentctl-linux-arm64: GOOS   := linux
-dist/grafana-agentctl-linux-arm64: GOARCH := arm64
+dist/grafana-agentctl-linux-arm64: GO_TAGS += promtail_journal_enabled
+dist/grafana-agentctl-linux-arm64: GOOS    := linux
+dist/grafana-agentctl-linux-arm64: GOARCH  := arm64
 dist/grafana-agentctl-linux-arm64:
 	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
 
-dist/grafana-agentctl-linux-ppc64le: GOOS   := linux
-dist/grafana-agentctl-linux-ppc64le: GOARCH := ppc64le
+dist/grafana-agentctl-linux-ppc64le: GO_TAGS += promtail_journal_enabled
+dist/grafana-agentctl-linux-ppc64le: GOOS    := linux
+dist/grafana-agentctl-linux-ppc64le: GOARCH  := ppc64le
 dist/grafana-agentctl-linux-ppc64le:
 	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
 
-dist/grafana-agentctl-linux-s390x: GOOS   := linux
-dist/grafana-agentctl-linux-s390x: GOARCH := s390x
+dist/grafana-agentctl-linux-s390x: GO_TAGS += promtail_journal_enabled
+dist/grafana-agentctl-linux-s390x: GOOS    := linux
+dist/grafana-agentctl-linux-s390x: GOARCH  := s390x
 dist/grafana-agentctl-linux-s390x:
 	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
 


### PR DESCRIPTION
Add journald support into agentctl so `grafana-agentctl test-logs` functions properly when using a config which reads log entries from the systemd journal.

Fixes #4520.