### PR TITLE
agent-flow-mixin: change heatmap type from `heatmap-new` to `heatmap`

### DIFF
--- a/operations/agent-flow-mixin/dashboards/utils/panel.jsonnet
+++ b/operations/agent-flow-mixin/dashboards/utils/panel.jsonnet
@@ -30,7 +30,7 @@
     },
   },
 
-  newHeatmap(title=''):: $.new(title, 'heatmap-new') {
+  newHeatmap(title=''):: $.new(title, 'heatmap') {
     maxDataPoints: 30,
     options: {
       calculate: false,


### PR DESCRIPTION
The migration from `heatmap-new` to `heatmap` (in Grafana 10) seems to force the heatmap to calculate the heatmap buckets regardless of the setting of `calculate`. Changing the type to `heatmap` addresses this issue.

Related to #4527, which didn't fully fix the issue when migrating the dashboard to Grafana 10.