### PR TITLE
Update quick-starts.md

### DIFF
--- a/docs/sources/static/set-up/quick-starts.md
+++ b/docs/sources/static/set-up/quick-starts.md
@@ -21,7 +21,7 @@ The following quick starts help you get up and running with Grafana Agent. Youâ€
 
 ## Grafana Cloud quick starts
 
-- [Grafana Agent for Grafana Cloud](https://grafana.com/docs/grafana-cloud/agent/).
+- [Grafana Agent for Grafana Cloud](https://grafana.com/docs/grafana-cloud/data-configuration/get-started-integration/).
 - [Monitoring a Linux host](https://grafana.com/docs/grafana-cloud/quickstart/agent_linuxnode/) using the Linux Node integration.
 
 - [Grafana Agent Kubernetes quickstarts](https://grafana.com/docs/grafana-cloud/kubernetes/agent-k8s/).


### PR DESCRIPTION
The first Grafana Cloud quick start link for Grafana Agent for Grafana Cloud is broken, 404 page error. I assume the link reference was moved to https://grafana.com/docs/grafana-cloud/data-configuration/get-started-integration/

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
