### PR TITLE
helm: add missing CHANGELOG entry

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -26,6 +26,8 @@ Unreleased
 
 - Set securityContext at podlevel. (@yanehi)
 
+- Update Grafana Agent version to v0.35.0. (@mattdurham)
+
 0.16.0 (2023-06-20)
 -------------------
 


### PR DESCRIPTION
The CHANGELOG for the Helm chart was missing an entry saying that the Grafana Agent version has been updated.

cc @mattdurham

