### PR TITLE
flow: always log when node evaluation completes

### DIFF
--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -457,6 +457,11 @@ func (l *Loader) EvaluateDependencies(c *ComponentNode) {
 		span.SetAttributes(attribute.String("node_id", n.NodeID()))
 		defer span.End()
 
+		start := time.Now()
+		defer func() {
+			level.Info(logger).Log("msg", "finished node evaluation", "node_id", n.NodeID(), "duration", time.Since(start))
+		}()
+
 		var err error
 
 		switch n := n.(type) {


### PR DESCRIPTION
Previously, a log line when graph node evaluation completes was only generated when a graph node was evaluated as part of a full walk (meaning when the config file was reloaded).

This change ensures that node evaluation always generates a log line, including for partial walks (meaning when a component updates its exports, causing downstream dependencies to reevaluate).