### PR TITLE
Improve allocations of the delta profiles appender

### DIFF
--- a/component/pyroscope/scrape/delta_profiles.go
+++ b/component/pyroscope/scrape/delta_profiles.go
@@ -2,7 +2,6 @@ package scrape
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/grafana/agent/component/pyroscope"
 	"github.com/grafana/agent/component/pyroscope/scrape/internal/fastdelta"
+	"github.com/klauspost/compress/gzip"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 )

--- a/component/pyroscope/scrape/delta_profiles.go
+++ b/component/pyroscope/scrape/delta_profiles.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/grafana/agent/component/pyroscope"
 	"github.com/grafana/agent/component/pyroscope/scrape/internal/fastdelta"
@@ -38,12 +40,15 @@ func NewDeltaAppender(appender pyroscope.Appender, labels labels.Labels) pyrosco
 		// for profiles that we don't need to produce delta, just return the appender
 		return appender
 	}
+
+	return newDeltaAppender(appender, types)
+}
+
+func newDeltaAppender(appender pyroscope.Appender, types []fastdelta.ValueType) *deltaAppender {
 	delta := &deltaAppender{
 		appender: appender,
 		delta:    fastdelta.NewDeltaComputer(types...),
-		gzw:      gzip.NewWriter(nil),
 	}
-	delta.reset()
 	return delta
 }
 
@@ -51,17 +56,59 @@ type deltaAppender struct {
 	appender pyroscope.Appender
 	delta    DeltaProfiler
 
-	buf bytes.Buffer
-	gzr gzip.Reader
-	gzw *gzip.Writer
-
 	// true if we have seen at least one sample
 	initialized bool
 }
 
-func (d *deltaAppender) reset() {
-	d.buf.Reset()
-	d.gzw.Reset(&d.buf)
+type gzipBuffer struct {
+	gzr gzip.Reader
+	gzw *gzip.Writer
+
+	out          bytes.Buffer
+	uncompressed bytes.Buffer
+	in           *bytes.Reader
+}
+
+var gzipBufferPool = sync.Pool{
+	New: func() interface{} {
+		return &gzipBuffer{
+			gzw: gzip.NewWriter(nil),
+			in:  bytes.NewReader(nil),
+		}
+	},
+}
+
+func getGzipBuffer() *gzipBuffer {
+	buf := gzipBufferPool.Get().(*gzipBuffer)
+	buf.reset()
+	return buf
+}
+
+func putGzipBuffer(buf *gzipBuffer) {
+	gzipBufferPool.Put(buf)
+}
+
+func (d *gzipBuffer) reset() io.Writer {
+	d.out.Reset()
+	d.gzw.Reset(&d.out)
+	return d.gzw
+}
+
+func (d *gzipBuffer) uncompress(in []byte) ([]byte, error) {
+	if !isGzipData(in) {
+		return in, nil
+	}
+	d.in.Reset(in)
+	if err := d.gzr.Reset(d.in); err != nil {
+		return nil, err
+	}
+	d.uncompressed.Reset()
+	d.uncompressed.Grow(uncompressedSize(in))
+	_, err := d.uncompressed.ReadFrom(&d.gzr)
+	if err != nil {
+		return nil, fmt.Errorf("decompressing profile: %v", err)
+	}
+	return d.uncompressed.Bytes(), nil
 }
 
 func (d *deltaAppender) Append(ctx context.Context, lbs labels.Labels, samples []*pyroscope.RawSample) error {
@@ -89,32 +136,36 @@ func (d *deltaAppender) Append(ctx context.Context, lbs labels.Labels, samples [
 // data is uncompressed if it is gzip compressed.
 // The returned data is always gzip compressed.
 func (d *deltaAppender) computeDelta(data []byte) (b []byte, err error) {
-	if isGzipData(data) {
-		if err := d.gzr.Reset(bytes.NewReader(data)); err != nil {
-			return nil, err
-		}
-		data, err = io.ReadAll(&d.gzr)
-		if err != nil {
-			return nil, fmt.Errorf("decompressing profile: %v", err)
-		}
+	gzipBuf := getGzipBuffer()
+	defer putGzipBuffer(gzipBuf)
+
+	data, err = gzipBuf.uncompress(data)
+	if err != nil {
+		return nil, err
 	}
 
-	d.reset()
-
-	if err = d.delta.Delta(data, d.gzw); err != nil {
+	if err = d.delta.Delta(data, gzipBuf.gzw); err != nil {
 		return nil, fmt.Errorf("computing delta: %v", err)
 	}
-	if err := d.gzw.Close(); err != nil {
+	if err := gzipBuf.gzw.Close(); err != nil {
 		return nil, fmt.Errorf("closing gzip writer: %v", err)
 	}
 	// The returned slice will be retained in case the profile upload fails,
 	// so we need to return a copy of the buffer's bytes to avoid a data
 	// race.
-	b = make([]byte, len(d.buf.Bytes()))
-	copy(b, d.buf.Bytes())
+	b = make([]byte, len(gzipBuf.out.Bytes()))
+	copy(b, gzipBuf.out.Bytes())
 	return b, nil
 }
 
 func isGzipData(data []byte) bool {
 	return bytes.HasPrefix(data, []byte{0x1f, 0x8b})
+}
+
+func uncompressedSize(in []byte) int {
+	last := len(in)
+	if last < 4 {
+		return -1
+	}
+	return int(binary.LittleEndian.Uint32(in[last-4 : last]))
 }

--- a/component/pyroscope/scrape/delta_profiles_test.go
+++ b/component/pyroscope/scrape/delta_profiles_test.go
@@ -2,7 +2,6 @@ package scrape
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"io"
 	"testing"
@@ -11,6 +10,7 @@ import (
 	googlev1 "github.com/grafana/phlare/api/gen/proto/go/google/v1"
 
 	"github.com/grafana/agent/component/pyroscope"
+	"github.com/klauspost/compress/gzip"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"

--- a/component/pyroscope/scrape/internal/fastdelta/fd_test.go
+++ b/component/pyroscope/scrape/internal/fastdelta/fd_test.go
@@ -9,7 +9,6 @@ package fastdelta
 
 import (
 	"bytes"
-	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,6 +24,7 @@ import (
 	"time"
 
 	"github.com/google/pprof/profile"
+	"github.com/klauspost/compress/gzip"
 	"github.com/richardartoul/molecule"
 	"github.com/richardartoul/molecule/src/protowire"
 	"github.com/stretchr/testify/assert"

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/jaegertracing/jaeger v1.41.0
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/json-iterator/go v1.1.12
-	github.com/klauspost/compress v1.16.6
+	github.com/klauspost/compress v1.16.7
 	github.com/lib/pq v1.10.7
 	github.com/mackerelio/go-osstat v0.2.3
 	github.com/miekg/dns v1.1.55

--- a/go.sum
+++ b/go.sum
@@ -2344,6 +2344,8 @@ github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47e
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/compress v1.16.6 h1:91SKEy4K37vkp255cJ8QesJhjyRO0hn9i9G0GoUwLsk=
 github.com/klauspost/compress v1.16.6/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
+github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGCFR9I=
+github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/cpuid v1.2.3/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v1.3.1/go.mod h1:bYW4mA6ZgKPob1/Dlai2LviZJO7KGI3uoWLd42rAQw4=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=


### PR DESCRIPTION
This improves allocations of the delta profiles appender.

Mostly it doesn't use `ioutil.ReadAll` but instead grows and reuses a buffer. I've also moved the buffer to a pool to avoid having those scale with the amount of targets.

Result on a very small profile.

```
❯ benchstat before.txt after.txt
name             old time/op    new time/op    delta
ComputeDelta-16    31.1µs ± 5%    31.1µs ± 3%     ~     (p=0.842 n=9+10)

name             old alloc/op   new alloc/op   delta
ComputeDelta-16      743B ± 0%      169B ± 8%  -77.22%  (p=0.000 n=10+10)

name             old allocs/op  new allocs/op  delta
ComputeDelta-16      3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.000 n=10+10)
```