### PR TITLE
clustering: wire in go-discover for discovering peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Main (unreleased)
 
 - Add [godeltaprof](https://github.com/grafana/godeltaprof) profiling types (`godeltaprof_memory`, `godeltaprof_mutex`, `godeltaprof_block`) to `pyroscope.scrape` component
 - Integrations: make `udev` data path configurable in the `node_exporter` integration. (@sduranc)
+- Clustering: Enable peer discovery with the go-discover package. (@tpaschalis)
 
 - New Grafana Agent Flow components:
 

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -96,6 +96,8 @@ depending on the nature of the reload error.
 	cmd.Flags().
 		StringVar(&r.clusterJoinAddr, "cluster.join-addresses", r.clusterJoinAddr, "Comma-separated list of addresses to join the cluster at")
 	cmd.Flags().
+		StringVar(&r.clusterDiscoverPeers, "cluster.discover-peers", r.clusterDiscoverPeers, "List of key-value tuples for discovering peers")
+	cmd.Flags().
 		BoolVar(&r.disableReporting, "disable-reporting", r.disableReporting, "Disable reporting of enabled components to Grafana.")
 	cmd.Flags().StringVar(&r.configFormat, "config.format", r.configFormat, "The format of the source file. Supported formats: 'flow', 'prometheus'.")
 	cmd.Flags().BoolVar(&r.configBypassConversionErrors, "config.bypass-conversion-errors", r.configBypassConversionErrors, "Enable bypassing errors when converting")
@@ -113,6 +115,7 @@ type flowRun struct {
 	clusterNodeName              string
 	clusterAdvAddr               string
 	clusterJoinAddr              string
+	clusterDiscoverPeers         string
 	configFormat                 string
 	configBypassConversionErrors bool
 }
@@ -163,7 +166,7 @@ func (fr *flowRun) Run(configFile string) error {
 	reg := prometheus.DefaultRegisterer
 	reg.MustRegister(newResourcesCollector(l))
 
-	clusterer, err := cluster.New(l, reg, fr.clusterEnabled, fr.clusterNodeName, fr.httpListenAddr, fr.clusterAdvAddr, fr.clusterJoinAddr)
+	clusterer, err := cluster.New(l, reg, fr.clusterEnabled, fr.clusterNodeName, fr.httpListenAddr, fr.clusterAdvAddr, fr.clusterJoinAddr, fr.clusterDiscoverPeers)
 	if err != nil {
 		return fmt.Errorf("building clusterer: %w", err)
 	}

--- a/docs/sources/flow/reference/cli/run.md
+++ b/docs/sources/flow/reference/cli/run.md
@@ -37,7 +37,8 @@ The following flags are supported:
 * `--disable-reporting`: Disable [usage reporting][] of enabled [components][] to Grafana (default `false`).
 * `--cluster.enabled`: Start the Agent in clustered mode (default `false`).
 * `--cluster.node-name`: The name to use for this node (defaults to the environment's hostname).
-* `--cluster.join-addresses`: Comma-separated list of addresses to join the cluster at (default `""`).
+* `--cluster.join-addresses`: Comma-separated list of addresses to join the cluster at (default `""`). Mutually exclusive with `--cluster.discover-peers`.
+* `--cluster.discover-peers`: List of key-value tuples for discovering peers (default `""`). Mutually exclusive with `--cluster.join-addresses`.
 * `--cluster.advertise-address`: Address to advertise to other cluster nodes (default `""`).
 * `--config.format`: The format of the source file. Supported formats: 'flow', 'prometheus' (default `"flow"`).
 * `--config.bypass-conversion-errors`: Enable bypassing errors when converting (default `false`).
@@ -92,9 +93,22 @@ listener if not explicitly provided. We recommend that you
 align the port numbers on as many nodes as possible to simplify the deployment
 process.
 
-Discovering peers using the `--cluster.join-addresses` flag only happens on
-startup; after that, cluster nodes depend on gossiping messages with each other
-to converge on the cluster's state.
+The `--cluster.discover-peers` command-line flag expects a list of tuples in
+the form of `provider=XXX key=val key=val ...`. Clustering makes use of the
+[go-discover] package to discover peers and fetch their IP addresses, based
+on the chosen provider and the filtering key-values it supports. Clustering
+supports the default set of providers available in go-discover and registers
+the `k8s` provider on top.
+
+If either the key or the value in a pair contains a space, a backslash or
+double quotes, then it must be quoted with double quotes. Within this quoted
+string, the backslash can be used to escape double quotes or the backslash
+itself.
+
+Discovering peers using the `--cluster.join-addresses` and
+`--cluster.discover-peers` flags only happens on startup; after that, cluster
+nodes depend on gossiping messages with each other to converge on the cluster's
+state.
 
 The first node that is used to bootstrap a new cluster (also known as
 the "seed node") can either omit the flag that specifies peers to join or can
@@ -137,3 +151,4 @@ original configuration.
 
 [grafana-agent convert]: {{< relref "./convert.md" >}}
 [clustering]:  {{< relref "../../concepts/clustering.md" >}}
+[go-discover]: https://github.com/hashicorp/go-discover

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -117,7 +117,7 @@ func getJoinAddr(addrs []string, in string) []string {
 }
 
 // New creates a Clusterer.
-func New(log log.Logger, reg prometheus.Registerer, clusterEnabled bool, name, listenAddr, advertiseAddr, joinAddr string) (*Clusterer, error) {
+func New(log log.Logger, reg prometheus.Registerer, clusterEnabled bool, name, listenAddr, advertiseAddr, joinAddr, discoverPeers string) (*Clusterer, error) {
 	// Standalone node.
 	if !clusterEnabled {
 		return &Clusterer{Node: NewLocalNode(listenAddr)}, nil
@@ -149,6 +149,7 @@ func New(log log.Logger, reg prometheus.Registerer, clusterEnabled bool, name, l
 			gossipConfig.JoinPeers = getJoinAddr(gossipConfig.JoinPeers, jaddr)
 		}
 	}
+	gossipConfig.DiscoverPeers = discoverPeers
 
 	err = gossipConfig.ApplyDefaults(defaultPort)
 	if err != nil {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -175,7 +175,7 @@ func New(log log.Logger, reg prometheus.Registerer, clusterEnabled bool, name, l
 		},
 	}
 
-	level.Info(log).Log("msg", "starting a new gossip node", "join-peers", gossipConfig.JoinPeers)
+	level.Info(log).Log("msg", "starting a new gossip node", "join-peers", gossipConfig.JoinPeers, "discover-peers", gossipConfig.DiscoverPeers)
 
 	gossipNode, err := NewGossipNode(log, reg, cli, &gossipConfig)
 	if err != nil {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR adds a new `cluster.discover-peers` command-line flag, to enable discovering clustering peers using the [go-discover](https://github.com/hashicorp/go-discover) library based on a list of key-value tuples, depending on the used "provider" and the settings it allows for.

We support all the default providers, plus the extra `k8s` provider.

#### Which issue(s) this PR fixes
Fixes #3484

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG updated
- [x] Documentation added
- [ ] Tests updated
