### PR TITLE
Fix incorrect display of trace IDs in the automatic_logging processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Main (unreleased)
 
 - Fix potential goroutine leak in log file tailing in static mode. (@thampiotr)
 
+- Fix incorrect display of trace IDs in the automatic_logging processor of static mode's traces subsystem. (@ptodev)
+
 ### Other changes
 
 - Compile journald support into builds of `grafana-agentctl` so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@ Main (unreleased)
 
 - Fix potential goroutine leak in log file tailing in static mode. (@thampiotr)
 
-- Fix incorrect display of trace IDs in the automatic_logging processor of static mode's traces subsystem. (@ptodev)
+- Fix incorrect display of trace IDs in the automatic_logging processor of static mode's traces subsystem.
+  Users of the static mode's service graph processor are also advised to upgrade, 
+  although the bug should theoretically not affect them. (@ptodev)
 
 ### Other changes
 

--- a/pkg/integrations/v2/app_agent_receiver/payload.go
+++ b/pkg/integrations/v2/app_agent_receiver/payload.go
@@ -1,7 +1,6 @@
 package app_agent_receiver
 
 import (
-	"encoding/hex"
 	"fmt"
 	"sort"
 	"strconv"
@@ -154,11 +153,11 @@ func SpanToKeyVal(s ptrace.Span) *KeyVal {
 		KeyValAdd(kv, "end_timestamp", s.StartTimestamp().AsTime().String())
 	}
 	KeyValAdd(kv, "kind", "span")
-	KeyValAdd(kv, "traceID", hex.EncodeToString([]byte(s.TraceID().String())))
-	KeyValAdd(kv, "spanID", hex.EncodeToString([]byte(s.SpanID().String())))
+	KeyValAdd(kv, "traceID", s.TraceID().String())
+	KeyValAdd(kv, "spanID", s.SpanID().String())
 	KeyValAdd(kv, "span_kind", s.Kind().String())
 	KeyValAdd(kv, "name", s.Name())
-	KeyValAdd(kv, "parent_spanID", hex.EncodeToString([]byte(s.ParentSpanID().String())))
+	KeyValAdd(kv, "parent_spanID", s.ParentSpanID().String())
 	s.Attributes().Range(func(k string, v pcommon.Value) bool {
 		KeyValAdd(kv, "attr_"+k, fmt.Sprintf("%v", v))
 		return true

--- a/pkg/traces/automaticloggingprocessor/automaticloggingprocessor.go
+++ b/pkg/traces/automaticloggingprocessor/automaticloggingprocessor.go
@@ -2,7 +2,6 @@ package automaticloggingprocessor
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"strconv"
@@ -124,7 +123,7 @@ func (p *automaticLoggingProcessor) ConsumeTraces(ctx context.Context, td ptrace
 			lastTraceID := ""
 			for k := 0; k < spanLen; k++ {
 				span := ss.Spans().At(k)
-				traceID := hex.EncodeToString([]byte(span.TraceID().String()))
+				traceID := span.TraceID().String()
 
 				if p.cfg.Spans {
 					keyValues := append(p.spanKeyVals(span), p.processKeyVals(rs.Resource(), svc)...)

--- a/pkg/traces/servicegraphprocessor/processor.go
+++ b/pkg/traces/servicegraphprocessor/processor.go
@@ -2,7 +2,6 @@ package servicegraphprocessor
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"time"
@@ -316,7 +315,7 @@ func (p *processor) consume(trace ptrace.Traces) error {
 
 				switch span.Kind() {
 				case ptrace.SpanKindClient:
-					k := key(hex.EncodeToString([]byte(span.TraceID().String())), hex.EncodeToString([]byte(span.SpanID().String())))
+					k := key(span.TraceID().String(), span.SpanID().String())
 
 					edge, err := p.store.upsertEdge(k, func(e *edge) {
 						e.clientService = svc.Str()
@@ -339,7 +338,7 @@ func (p *processor) consume(trace ptrace.Traces) error {
 					}
 
 				case ptrace.SpanKindServer:
-					k := key(hex.EncodeToString([]byte(span.TraceID().String())), hex.EncodeToString([]byte(span.ParentSpanID().String())))
+					k := key(span.TraceID().String(), span.ParentSpanID().String())
 
 					edge, err := p.store.upsertEdge(k, func(e *edge) {
 						e.serverService = svc.Str()


### PR DESCRIPTION
#### PR Description

This is a bug which was introduced in the Otel upgrade in #3858. I must have gotten confused about the [deprecation](https://github.com/open-telemetry/opentelemetry-collector/pull/6530) of the HexString function. Apologies for this - the bug could have been easily prevented if I'd taken more care reading the functions and the deprecation PR.

#### Which issue(s) this PR fixes

Fixes #4552

#### Notes to the Reviewer

There are two other places which use such code, but I think they are not impacted from an external user point of view:
* The `SpanToKeyVal` function in `pkg/integrations/v2/app_agent_receiver/payload.go` appears to be unused.
* In the service graph processor as long as a unique ID is generated (which I think is the case), then the code should work, even if the ID is not the same hex ID.

I will mention the service graph in the changelog anyway so that users are advised to upgrade.

I tested this locally for the automatic_logging processor only.

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
