### PR TITLE
Fix upgrade guide

### DIFF
--- a/docs/sources/flow/upgrade-guide.md
+++ b/docs/sources/flow/upgrade-guide.md
@@ -19,50 +19,6 @@ Grafana Agent Flow.
 > [upgrade-guide-static]: {{< relref "../static/upgrade-guide.md" >}}
 > [upgrade-guide-operator]: {{< relref "../operator/upgrade-guide.md" >}}
 
-## Main (unreleased)
-
-### Breaking change: The algorithm for the "hash" action of `otelcol.processor.attributes` has changed
-The hash produced when using `action = "hash"` in the `otelcol.processor.attributes` flow component is now using the more secure SHA-256 algorithm.
-The change was made in PR [#22831](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/22831) of opentelemetry-collector-contrib. 
-
-### Breaking change: `otelcol.exporter.loki` now includes instrumentation scope in its output
-
-Additional `instrumentation_scope` information will be added to the OTLP log signal, like this:
-```
-{
-    "body": "Example log",
-    "traceid": "01020304000000000000000000000000",
-    "spanid": "0506070800000000",
-    "severity": "error",
-    "attributes": {
-        "attr1": "1",
-        "attr2": "2"
-    },
-    "resources": {
-        "host.name": "something"
-    },
-    "instrumentation_scope": {
-        "name": "example-logger-name",
-        "version": "v1"
-    }
-}
-```
-
-### Breaking change: `otelcol.extension.jaeger_remote_sampling` removes the `/` HTTP endpoint
-
-The `/` HTTP endpoint was the same as the `/sampling` endpoint. The `/sampling` endpoint is still functional.
-The change was made in PR [#18070](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/18070) of opentelemetry-collector-contrib. 
-
-### Breaking change: The `remote_sampling` block has been removed from `otelcol.receiver.jaeger`
-
-The `remote_sampling` block in `otelcol.receiver.jaeger` has been an undocumented no-op configuration for some time, and has now been removed. 
-Customers are advised to use `otelcol.extension.jaeger_remote_sampling` instead.
-
-### Deprecation: `otelcol.exporter.jaeger` has been deprecated and will be removed in Agent v0.38.0.
-
-This is because Jaeger supports OTLP directly and OpenTelemetry Collector is also removing its 
-[Jaeger receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/jaegerexporter).
-
 ## v0.35
 
 ### Breaking change: `auth` and `version` attributes from `walk_params` block of `prometheus.exporter.snmp` have been removed
@@ -225,6 +181,48 @@ prometehus.scrape "example" {
     forward_to = FORWARD_LIST
 }
 ```
+
+### Breaking change: The algorithm for the "hash" action of `otelcol.processor.attributes` has changed
+The hash produced when using `action = "hash"` in the `otelcol.processor.attributes` flow component is now using the more secure SHA-256 algorithm.
+The change was made in PR [#22831](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/22831) of opentelemetry-collector-contrib. 
+
+### Breaking change: `otelcol.exporter.loki` now includes instrumentation scope in its output
+
+Additional `instrumentation_scope` information will be added to the OTLP log signal, like this:
+```
+{
+    "body": "Example log",
+    "traceid": "01020304000000000000000000000000",
+    "spanid": "0506070800000000",
+    "severity": "error",
+    "attributes": {
+        "attr1": "1",
+        "attr2": "2"
+    },
+    "resources": {
+        "host.name": "something"
+    },
+    "instrumentation_scope": {
+        "name": "example-logger-name",
+        "version": "v1"
+    }
+}
+```
+
+### Breaking change: `otelcol.extension.jaeger_remote_sampling` removes the `/` HTTP endpoint
+
+The `/` HTTP endpoint was the same as the `/sampling` endpoint. The `/sampling` endpoint is still functional.
+The change was made in PR [#18070](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/18070) of opentelemetry-collector-contrib. 
+
+### Breaking change: The `remote_sampling` block has been removed from `otelcol.receiver.jaeger`
+
+The `remote_sampling` block in `otelcol.receiver.jaeger` has been an undocumented no-op configuration for some time, and has now been removed. 
+Customers are advised to use `otelcol.extension.jaeger_remote_sampling` instead.
+
+### Deprecation: `otelcol.exporter.jaeger` has been deprecated and will be removed in Agent v0.38.0.
+
+This is because Jaeger supports OTLP directly and OpenTelemetry Collector is also removing its 
+[Jaeger receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/jaegerexporter).
 
 ## v0.34
 

--- a/docs/sources/static/upgrade-guide.md
+++ b/docs/sources/static/upgrade-guide.md
@@ -20,37 +20,6 @@ static mode.
 > [upgrade-guide-operator]: {{< relref "../operator/upgrade-guide.md" >}}
 > [upgrade-guide-flow]: {{< relref "../flow/upgrade-guide.md" >}}
 
-## Main (unreleased)
-
-### Breaking change: Removed and renamed tracing metrics
-
-In the traces subsystem for Static mode some metrics are removed and others are renamed.
-The reason for the removal is a bug which caused the metrics to be incorrect if more than one instance of a traces configuration is specified.
-
-Removed metrics:
-- "blackbox_exporter_config_last_reload_success_timestamp_seconds" (gauge)
-- "blackbox_exporter_config_last_reload_successful" (gauge)
-- "blackbox_module_unknown_total" (counter)
-- "traces_processor_tail_sampling_count_traces_sampled" (counter)
-- "traces_processor_tail_sampling_new_trace_id_received" (counter)
-- "traces_processor_tail_sampling_sampling_decision_latency" (histogram)
-- "traces_processor_tail_sampling_sampling_decision_timer_latency" (histogram)
-- "traces_processor_tail_sampling_sampling_policy_evaluation_error" (counter)
-- "traces_processor_tail_sampling_sampling_trace_dropped_too_early" (counter)
-- "traces_processor_tail_sampling_sampling_traces_on_memory" (gauge)
-- "traces_receiver_accepted_spans" (counter)
-- "traces_receiver_refused_spans" (counter)
-- "traces_exporter_enqueue_failed_log_records" (counter)
-- "traces_exporter_enqueue_failed_metric_points" (counter)
-- "traces_exporter_enqueue_failed_spans" (counter)
-- "traces_exporter_queue_capacity" (gauge)
-- "traces_exporter_queue_size" (gauge)
-
-Renamed metrics:
-- "traces_receiver_refused_spans" is renamed to "traces_receiver_refused_spans_total"
-- "traces_receiver_accepted_spans" is renamed to "traces_receiver_refused_spans_total"
-- "traces_exporter_sent_metric_points" is renamed to "traces_exporter_sent_metric_points_total"
-
 ## v0.35
 
 ### Breaking change: `auth` and `version` attributes from `walk_params` block of SNMP integration have been removed
@@ -96,6 +65,35 @@ See [Module and Auth Split Migration](https://github.com/prometheus/snmp_exporte
 
 The experimental feature Dynamic Configuration has been removed. The use case of dynamic configuration will be replaced
 with [Modules](../../concepts/modules/) in Grafana Agent Flow.
+
+### Breaking change: Removed and renamed tracing metrics
+
+In the traces subsystem for Static mode some metrics are removed and others are renamed.
+The reason for the removal is a bug which caused the metrics to be incorrect if more than one instance of a traces configuration is specified.
+
+Removed metrics:
+- "blackbox_exporter_config_last_reload_success_timestamp_seconds" (gauge)
+- "blackbox_exporter_config_last_reload_successful" (gauge)
+- "blackbox_module_unknown_total" (counter)
+- "traces_processor_tail_sampling_count_traces_sampled" (counter)
+- "traces_processor_tail_sampling_new_trace_id_received" (counter)
+- "traces_processor_tail_sampling_sampling_decision_latency" (histogram)
+- "traces_processor_tail_sampling_sampling_decision_timer_latency" (histogram)
+- "traces_processor_tail_sampling_sampling_policy_evaluation_error" (counter)
+- "traces_processor_tail_sampling_sampling_trace_dropped_too_early" (counter)
+- "traces_processor_tail_sampling_sampling_traces_on_memory" (gauge)
+- "traces_receiver_accepted_spans" (counter)
+- "traces_receiver_refused_spans" (counter)
+- "traces_exporter_enqueue_failed_log_records" (counter)
+- "traces_exporter_enqueue_failed_metric_points" (counter)
+- "traces_exporter_enqueue_failed_spans" (counter)
+- "traces_exporter_queue_capacity" (gauge)
+- "traces_exporter_queue_size" (gauge)
+
+Renamed metrics:
+- "traces_receiver_refused_spans" is renamed to "traces_receiver_refused_spans_total"
+- "traces_receiver_accepted_spans" is renamed to "traces_receiver_refused_spans_total"
+- "traces_exporter_sent_metric_points" is renamed to "traces_exporter_sent_metric_points_total"
 
 ## v0.33
 


### PR DESCRIPTION
I'd [updated](https://github.com/grafana/agent/pull/4359/files#diff-8f08accdca0d98a1c64aa36075f87267ebe91f6db19ca8074554e58667f73d2f) the upgrade guide with a new "Main (unreleased)" section similar to the one in the changelog, but apparently there was already a 0.35 section underneath which I hadn't noticed. This will PR will add the deprecation information in the right section.