### PR TITLE
Correct file name in the Agent standalone install and macOS install

### DIFF
--- a/docs/sources/flow/setup/install/binary.md
+++ b/docs/sources/flow/setup/install/binary.md
@@ -25,7 +25,7 @@ To download the Grafana Agent as a standalone binary, perform the following step
 
 1. Scroll down to the **Assets** section.
 
-1. Download the `grafana-agent-flow` zip file that matches your operating system and machine's architecture.
+1. Download the `grafana-agent` zip file that matches your operating system and machine's architecture.
 
 1. Extract the package contents into a directory.
 

--- a/docs/sources/flow/setup/install/macos.md
+++ b/docs/sources/flow/setup/install/macos.md
@@ -45,7 +45,7 @@ To upgrade Grafana Agent on macOS, run the following commands in a terminal wind
 1. Upgrade Grafana Agent:
 
    ```shell
-   brew upgrade grafana-agent
+   brew upgrade grafana-agent-flow
    ```
 
 1. Restart Grafana Agent:


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR corrects the filename in the Agent standalone binary install topic.

* Change `grafana-agent-flow` to `grafana-agent` in step 3 of the download procedure.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
