### PR TITLE
enhancement(agentctl): better validation of config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Main (unreleased)
 
 ### Enhancements
 
+- Better validation of config file with `grafana-agentctl config-check` cmd (@fgouteroux)
 - Add [godeltaprof](https://github.com/grafana/godeltaprof) profiling types (`godeltaprof_memory`, `godeltaprof_mutex`, `godeltaprof_block`) to `pyroscope.scrape` component
 
 - Integrations: make `udev` data path configurable in the `node_exporter` integration. (@sduranc)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Main (unreleased)
 ### Enhancements
 
 - Better validation of config file with `grafana-agentctl config-check` cmd (@fgouteroux)
+
 - Add [godeltaprof](https://github.com/grafana/godeltaprof) profiling types (`godeltaprof_memory`, `godeltaprof_mutex`, `godeltaprof_block`) to `pyroscope.scrape` component
 
 - Integrations: make `udev` data path configurable in the `node_exporter` integration. (@sduranc)

--- a/cmd/grafana-agentctl/main.go
+++ b/cmd/grafana-agentctl/main.go
@@ -130,32 +130,13 @@ the exit code will be 1.`,
 			cfg := config.Config{}
 			err := config.LoadFile(file, expandEnv, &cfg)
 			if err != nil {
+				fmt.Fprintf(os.Stderr, "failed to load config: %s\n", err)
+				os.Exit(1)
+			}
+
+			if err := cfg.Validate(nil); err != nil {
 				fmt.Fprintf(os.Stderr, "failed to validate config: %s\n", err)
 				os.Exit(1)
-			}
-
-			if err := cfg.Metrics.ApplyDefaults(); err != nil {
-				fmt.Fprintf(os.Stderr, "invalid metrics config: %s\n", err)
-				os.Exit(1)
-			}
-
-			if cfg.Logs != nil {
-				if err := cfg.Logs.ApplyDefaults(); err != nil {
-					fmt.Fprintf(os.Stderr, "invalid logs config: %s\n", err)
-					os.Exit(1)
-				}
-			}
-
-			if err := cfg.Traces.Validate(cfg.Logs); err != nil {
-				fmt.Fprintf(os.Stderr, "invalid trace config: %s\n", err)
-				os.Exit(1)
-			}
-
-			if cfg.AgentManagement.Enabled {
-				if err := cfg.AgentManagement.Validate(); err != nil {
-					fmt.Fprintf(os.Stderr, "invalid agent management config: %s\n", err)
-					os.Exit(1)
-				}
 			}
 
 			fmt.Fprintln(os.Stdout, "config valid")

--- a/cmd/grafana-agentctl/main.go
+++ b/cmd/grafana-agentctl/main.go
@@ -132,9 +132,33 @@ the exit code will be 1.`,
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "failed to validate config: %s\n", err)
 				os.Exit(1)
-			} else {
-				fmt.Fprintln(os.Stdout, "config valid")
 			}
+
+			if err := cfg.Metrics.ApplyDefaults(); err != nil {
+				fmt.Fprintf(os.Stderr, "invalid metrics config: %s\n", err)
+				os.Exit(1)
+			}
+
+			if cfg.Logs != nil {
+				if err := cfg.Logs.ApplyDefaults(); err != nil {
+					fmt.Fprintf(os.Stderr, "invalid logs config: %s\n", err)
+					os.Exit(1)
+				}
+			}
+
+			if err := cfg.Traces.Validate(cfg.Logs); err != nil {
+				fmt.Fprintf(os.Stderr, "invalid trace config: %s\n", err)
+				os.Exit(1)
+			}
+
+			if cfg.AgentManagement.Enabled {
+				if err := cfg.AgentManagement.Validate(); err != nil {
+					fmt.Fprintf(os.Stderr, "invalid agent management config: %s\n", err)
+					os.Exit(1)
+				}
+			}
+
+			fmt.Fprintln(os.Stdout, "config valid")
 		},
 	}
 


### PR DESCRIPTION
#### PR Description

Hello, I would like to add some validation steps in `grafana-agentctl config-check` cmd, like this:
```
$ grafana-agentctl config-check bad-config-values.yaml 
invalid metrics config: error validating instance test: scrape interval greater than wal_truncate_frequency for scrape config with job name "agent-3"
```
I'm using the `grafana-agentctl` cmd to check the config file validity before applying changes and restart the agent, so I would expect it fail at this step.

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added
- [ ] Tests updated
