### PR TITLE
Make RPM file digests use FIPS-compliant sha256 instead of MD5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Main (unreleased)
 
 - Fix potential goroutine leak in log file tailing in static mode. (@thampiotr)
 
+- Fix RPM file digests so that installation on FIPS-enabled systems succeeds. (@andrewimeson)
+
 ### Other changes
 
 - Compile journald support into builds of `grafana-agentctl` so

--- a/packaging/grafana-agent-flow/rpm/gpg-sign.sh
+++ b/packaging/grafana-agent-flow/rpm/gpg-sign.sh
@@ -18,6 +18,7 @@ echo "%_gpg_name Grafana Labs <engineering@grafana.com>
 %_gpg_path /root/.gnupg
 %_gpgbin /usr/bin/gpg
 %_gpg_digest_algo sha256
+%_binary_filedigest_algorithm 8
 %__gpg /usr/bin/gpg
 %__gpg_sign_cmd     %{__gpg} \
          gpg --no-tty --batch --yes --no-verbose --no-armor \

--- a/packaging/grafana-agent/rpm/gpg-sign.sh
+++ b/packaging/grafana-agent/rpm/gpg-sign.sh
@@ -18,6 +18,7 @@ echo "%_gpg_name Grafana Labs <engineering@grafana.com>
 %_gpg_path /root/.gnupg
 %_gpgbin /usr/bin/gpg
 %_gpg_digest_algo sha256
+%_binary_filedigest_algorithm 8
 %__gpg /usr/bin/gpg
 %__gpg_sign_cmd     %{__gpg} \
          gpg --no-tty --batch --yes --no-verbose --no-armor \


### PR DESCRIPTION
#### PR Description

Make RPM file digests use FIPS-compliant sha256 instead of MD5

#### Which issue(s) this PR fixes

Closes #4419, relates to #4267

#### Notes to the Reviewer

#### PR Checklist

- [X] CHANGELOG updated
- [X] Documentation added
- [X] Tests updated
