### PR TITLE
helm: update changelog for 0.18.0 release

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -16,6 +16,13 @@ Unreleased
 
 - Set nodeSelector at podlevel. (@Flasheh)
 
+0.18.0 (2023-07-26)
+-------------------
+
+### Enhancements
+
+- Update Grafana Agent version to v0.35.1. (@ptodev)
+
 0.17.0 (2023-07-19)
 -------------------
 


### PR DESCRIPTION
#4592 didn't update the Helm chart's changelog.