### PR TITLE
pkg/metrics/wal: always write series records to WAL, even on rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Main (unreleased)
 
 - Fix potential goroutine leak in log file tailing in static mode. (@thampiotr)
 
+- Fix issue where series records would never get written to the WAL if a scrape
+  was rolled back, resulting in "dropped sample for series that was not
+  explicitly dropped via relabelling" log messages. (@rfratto)
+
 ### Other changes
 
 - Compile journald support into builds of `grafana-agentctl` so
@@ -50,7 +54,7 @@ v0.35.1 (2023-07-25)
 ### Bugfixes
 
 - Fix incorrect display of trace IDs in the automatic_logging processor of static mode's traces subsystem.
-  Users of the static mode's service graph processor are also advised to upgrade, 
+  Users of the static mode's service graph processor are also advised to upgrade,
   although the bug should theoretically not affect them. (@ptodev)
 
 v0.35.0 (2023-07-18)


### PR DESCRIPTION
If a new series is introduced in a storage.Appender instance, that series should be written to the WAL once the storage.Appender is closed, even on Rollback.

Previously, new series would only be written to the WAL when calling Commit. However, because the series is stored in memory regardless, subsequent calls to Commit may write samples to the WAL which reference a series ID which that was never written.

Port of prometheus/prometheus#12592