### PR TITLE
CODEOWNERS: change codeownership of component/pyroscope

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,13 +21,13 @@
 # Binaries:
 /cmd/grafana-agent-operator/  @grafana/grafana-agent-operator-maintainers
 
-# `make docs` procedure and related workflows are owned @grafana/docs-tooling. Slack #docs.
-/.github/workflows/publish-technical-documentation-next.yml    @grafana/docs-tooling
-/.github/workflows/publish-technical-documentation-release.yml @grafana/docs-tooling
-/.github/workflows/update-make-docs.yml                        @grafana/docs-tooling
-/docs/docs.mk                                                  @grafana/docs-tooling
-/docs/make-docs                                                @grafana/docs-tooling
-/docs/variables.mk                                             @grafana/docs-tooling
+# `make docs` procedure and related workflows are owned by @jdbaldry.
+/.github/workflows/publish-technical-documentation-next.yml    @jdbaldry
+/.github/workflows/publish-technical-documentation-release.yml @jdbaldry
+/.github/workflows/update-make-docs.yml                        @jdbaldry
+/docs/docs.mk                                                  @jdbaldry
+/docs/make-docs                                                @jdbaldry
+/docs/variables.mk                                             @jdbaldry
 
 # Documentation:
 /docs/sources/  @clayton-cornell

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -39,10 +39,10 @@
 /component/loki/source/podlogs/     @grafana/grafana-agent-infrastructure-maintainers
 /component/mimir/rules/kubernetes/  @grafana/grafana-agent-infrastructure-maintainers
 /component/otelcol/                 @grafana/grafana-agent-signals-maintainers
-/component/phlare/                  @grafana/grafana-agent-signals-maintainers
 /component/prometheus/              @grafana/grafana-agent-signals-maintainers
 /component/prometheus/exporter/     @grafana/grafana-agent-infrastructure-maintainers
 /component/prometheus/operator/     @grafana/grafana-agent-operator-maintainers
+/component/pyroscope/               @grafana/grafana-agent-profiling-maintainers
 /component/remote/                  @grafana/grafana-agent-infrastructure-maintainers
 
 # Static mode packages:


### PR DESCRIPTION
Have @grafana/grafana-agent-profiling-maintainers be the maintainers of component/pyroscope.