### PR TITLE
ci: only create Homebrew formula PRs when a release is published

### DIFF
--- a/.github/workflows/bump-formula-pr.yml
+++ b/.github/workflows/bump-formula-pr.yml
@@ -1,17 +1,23 @@
 name: bump-formula-pr
 on:
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-  push:
-    tags:
-      - 'v*'
-      - '!v*-rc*' # Ignore release candidates
+  release:
+    types: [released]
+
 jobs:
   homebrew-core:
     name: homebrew-core
     runs-on: macos-latest
     steps:
+    - name: Get latest release
+      uses: rez0n/actions-github-release@main
+      id: latest_release
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repository: "${{ github.repository }}"
+        type: "stable"
+
     - name: Update Homebrew formula
+      if: 'steps.latest_release.outputs.release_id == github.event.release.id'
       uses: dawidd6/action-homebrew-bump-formula@v3
       with:
         # Required, custom GitHub access token with the 'public_repo' and 'workflow' scopes
@@ -24,11 +30,21 @@ jobs:
         revision: ${{github.sha}}
         # Optional, if don't want to check for already open PRs
         force: false # true
+
   homebrew-grafana:
     name: homebrew-grafana
     runs-on: macos-latest
     steps:
+    - name: Get latest release
+      uses: rez0n/actions-github-release@main
+      id: latest_release
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repository: "${{ github.repository }}"
+        type: "stable"
+
     - name: Update Homebrew formula
+      if: 'steps.latest_release.outputs.release_id == github.event.release.id'
       uses: dawidd6/action-homebrew-bump-formula@v3
       with:
         # Required, custom GitHub access token with the 'public_repo' and 'workflow' scopes


### PR DESCRIPTION
This changes the action which creates a Homebrew formula PR to only run under the following conditions:

* A new release is published on GitHub
* The new release was set to be the latest release

Whether the release was previously a draft does not impact this action.

This was driven by feedback from the Homebrew maintainers, where they won't merge an update to a Homebrew formula unless the release was actually published. If they see the PR before Grafana Agent maintainers publish the release, then it's put in a backlog and merged later than we would normally want. The suggestion was that our automation should only open the PR once the release is actually published.

This was tested in a private repo with the following action:

```yaml
name: New release available

on:
  release:
    types: [released]

jobs:
  on-release:
    runs-on: ubuntu-latest
    steps:
      - name: Get latest release
        uses: rez0n/actions-github-release@main
        id: latest_release
        with:
          token: ${{ secrets.GITHUB_TOKEN }}
          repository: "${{ github.repository }}"
          type: "stable"

      - name: Run if latest release
        if: 'steps.latest_release.outputs.release_id == github.event.release.id'
        run: echo This is the latest release!
```
