### PR TITLE
agent-flow-mixin: change filename to be compatible with ConfigMaps

### DIFF
--- a/operations/agent-flow-mixin/dashboards/prometheus.remote_write.libsonnet
+++ b/operations/agent-flow-mixin/dashboards/prometheus.remote_write.libsonnet
@@ -1,6 +1,6 @@
 local dashboard = import './utils/dashboard.jsonnet';
 local panel = import './utils/panel.jsonnet';
-local filename = 'agent-flow-prometheus.remote_write.json';
+local filename = 'agent-flow-prometheus-remote-write.json';
 
 local stackedPanelMixin = {
   fieldConfig+: {


### PR DESCRIPTION
To be compatible with kube-prometheus, filenames must be valid for ConfigMaps, containing only alphanumerics, hyphens (`-`), and periods (`.`).

This means that the underscore character used by the component name is not valid for the filename.

Fixes #4633.