### PR TITLE
clustering: wait for graph evaluation before changing to Participant state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Main (unreleased)
 - Flow: Allow the `logging` configuration block to tee the Agent's logs to one
   or more loki.* components. (@tpaschalis)
 
+- Clustering: Nodes take part in distributing load only after loading their
+  component graph. (@tpaschalis)
+
 - New Grafana Agent Flow components:
 
   - `prometheus.exporter.gcp` - scrape GCP metrics. (@tburgessdev)

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -264,7 +264,7 @@ func (fr *flowRun) Run(configFile string) error {
 	}
 
 	// Start the Clusterer's Node implementation.
-	err = clusterer.Start(ctx)
+	err = clusterer.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start the clusterer: %w", err)
 	}

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -10,15 +10,12 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/grafana/agent/component"
-	"github.com/grafana/agent/converter"
-	convert_diag "github.com/grafana/agent/converter/diag"
-	"go.opentelemetry.io/otel"
-	"golang.org/x/exp/maps"
-
 	"github.com/fatih/color"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/converter"
+	convert_diag "github.com/grafana/agent/converter/diag"
 	"github.com/grafana/agent/pkg/boringcrypto"
 	"github.com/grafana/agent/pkg/cluster"
 	"github.com/grafana/agent/pkg/config/instrumentation"
@@ -28,8 +25,11 @@ import (
 	"github.com/grafana/agent/pkg/river/diag"
 	"github.com/grafana/agent/pkg/usagestats"
 	httpservice "github.com/grafana/agent/service/http"
+	"github.com/grafana/ckit/peer"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel"
+	"golang.org/x/exp/maps"
 
 	// Install Components
 	_ "github.com/grafana/agent/component/all"
@@ -292,6 +292,15 @@ func (fr *flowRun) Run(configFile string) error {
 
 		// Exit if the initial load files
 		return err
+	}
+
+	// By now, have either joined or started a new cluster.
+	// Nodes initially join in the Viewer state. After the graph has been
+	// loaded successfully, we can move to the Participant state to signal that
+	// we wish to participate in reading or writing data.
+	err = clusterer.ChangeState(peer.StateParticipant)
+	if err != nil {
+		return fmt.Errorf("failed to set clusterer state to Participant after initial load")
 	}
 
 	reloadSignal := make(chan os.Signal, 1)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -192,7 +192,7 @@ func New(log log.Logger, reg prometheus.Registerer, clusterEnabled bool, name, l
 // new cluster of its own.
 // The gossipNode will start out as a Viewer; to participate in clustering,
 // the node needs to transition to the Participant state using ChangeState.
-func (c *Clusterer) Start(ctx context.Context) error {
+func (c *Clusterer) Start() error {
 	switch node := c.Node.(type) {
 	case *localNode:
 		return nil // no-op, always ready

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -190,6 +190,8 @@ func New(log log.Logger, reg prometheus.Registerer, clusterEnabled bool, name, l
 // For the gossipNode implementation, Start will attempt to connect to the
 // configured list of peers; if this fails it will fall back to bootstrapping a
 // new cluster of its own.
+// The gossipNode will start out as a Viewer; to participate in clustering,
+// the node needs to transition to the Participant state using ChangeState.
 func (c *Clusterer) Start(ctx context.Context) error {
 	switch node := c.Node.(type) {
 	case *localNode:

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -205,17 +205,6 @@ func (c *Clusterer) Start(ctx context.Context) error {
 			}
 		}
 
-		// We now have either joined or started a new cluster.
-		// Nodes initially join in the Viewer state. We can move to the
-		// Participant state to signal that we wish to participate in reading
-		// or writing data.
-		ctx, ccl := context.WithTimeout(ctx, 5*time.Second)
-		defer ccl()
-		err = node.ChangeState(ctx, peer.StateParticipant)
-		if err != nil {
-			return err
-		}
-
 		node.Observe(ckit.FuncObserver(func(peers []peer.Peer) (reregister bool) {
 			names := make([]string, len(peers))
 			for i, p := range peers {
@@ -237,16 +226,27 @@ func (c *Clusterer) Stop() error {
 	case *GossipNode:
 		// The node is going away. We move to the Terminating state to signal
 		// that we should not be owners for write hashing operations anymore.
-		ctx, ccl := context.WithTimeout(context.Background(), 5*time.Second)
-		defer ccl()
-
 		// TODO(rfratto): should we enter terminating state earlier to allow for
 		// some kind of hand-off between components?
-		err := node.ChangeState(ctx, peer.StateTerminating)
+		err := c.ChangeState(peer.StateTerminating)
 		if err != nil {
 			level.Error(node.log).Log("msg", "failed to change state to Terminating before shutting down", "err", err)
 		}
 		return node.Stop()
+	}
+
+	// Nothing to do for unrecognized types.
+	return nil
+}
+
+// ChangeState transitions the Clusterer's node toState.
+func (c *Clusterer) ChangeState(toState peer.State) error {
+	switch node := c.Node.(type) {
+	case *GossipNode:
+		ctx, ccl := context.WithTimeout(context.Background(), 5*time.Second)
+		defer ccl()
+
+		return node.ChangeState(ctx, toState)
 	}
 
 	// Nothing to do for unrecognized types.


### PR DESCRIPTION
#### PR Description
This commit enables delaying the transition of the GossipNode to Participant state to after the graph has been completely evaluated at least once. This guards against missing scrapes when other peers think we're ready to participate to distributing load, but we're still loading all our components.

#### Which issue(s) this PR fixes
Fixes #4639.

#### Notes to the Reviewer
A more straighforward solution would be to move the [Start call](https://github.com/grafana/agent/pull/4647/files#diff-a5071380b513bfb7750c3b1d67b1f7b9e34fcd4e86d24c0ac19df8b9dddc6900R267) in  `cmd/internal/flowmode/cmd_run.go` to after the block performing the initial reload. 

On one hand, this would be simpler/synchronous but on the other hand would add another unnecessary waiting time to bootstrap a new cluster, especially if it's a large one. Since we don't have #4464 in place yet, this can be expensive; this solution makes sure that the cluster bootstrapping and the graph evaluation can happen in parallel.

#### PR Checklist

- [x] CHANGELOG updated
- [ ] Documentation added (N/A)
- [X] Tests updated
