### PR TITLE
Revert "build: build with stringlabels to reduce memory footprint of metrics (#4641)" 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,6 @@ Main (unreleased)
   - `discovery.eureka` discovers targets from a Eureka Service Registry. (@spartan0x117)
   - `discovery.openstack` - service discovery for OpenStack. (@marctc)
 
-- Reduce memory footprint of metrics. (@bboreham)
-
 ### Bugfixes
 
 - Rename `GrafanaAgentManagement` mixin rules to `GrafanaAgentConfig` and update individual alerts to be more accurate. (@spartan0x117)

--- a/cmd/grafana-agent/Dockerfile
+++ b/cmd/grafana-agent/Dockerfile
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=${TARGETVARIANT#v} \
     RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} \
-    GO_TAGS="stringlabels builtinassets promtail_journal_enabled" \
+    GO_TAGS="builtinassets promtail_journal_enabled" \
     GOEXPERIMENT=${GOEXPERIMENT} \
     make agent
 

--- a/cmd/grafana-agent/Dockerfile.windows
+++ b/cmd/grafana-agent/Dockerfile.windows
@@ -10,7 +10,7 @@ SHELL ["cmd", "/S", "/C"]
 # Creating new layers can be really slow on Windows so we clean up any caches
 # we can before moving on to the next step.
 RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} make generate-ui && rm -rf web/ui/node_modules && yarn cache clean --all""
-RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} GO_TAGS="stringlabels builtinassets" make agent && go clean -cache -modcache""
+RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} make agent && go clean -cache -modcache""
 
 # Use the smallest container possible for the final image
 FROM mcr.microsoft.com/windows/nanoserver:1809

--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -31,63 +31,63 @@ dist-agent-binaries: dist/grafana-agent-linux-amd64       \
                      dist/grafana-agent-linux-amd64-boringcrypto  \
                      dist/grafana-agent-linux-arm64-boringcrypto
 
-dist/grafana-agent-linux-amd64: GO_TAGS += stringlabels builtinassets promtail_journal_enabled
+dist/grafana-agent-linux-amd64: GO_TAGS += builtinassets promtail_journal_enabled
 dist/grafana-agent-linux-amd64: GOOS    := linux
 dist/grafana-agent-linux-amd64: GOARCH  := amd64
 dist/grafana-agent-linux-amd64: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/grafana-agent-linux-arm64: GO_TAGS += stringlabels builtinassets promtail_journal_enabled
+dist/grafana-agent-linux-arm64: GO_TAGS += builtinassets promtail_journal_enabled
 dist/grafana-agent-linux-arm64: GOOS    := linux
 dist/grafana-agent-linux-arm64: GOARCH  := arm64
 dist/grafana-agent-linux-arm64: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/grafana-agent-linux-ppc64le: GO_TAGS += stringlabels builtinassets promtail_journal_enabled
+dist/grafana-agent-linux-ppc64le: GO_TAGS += builtinassets promtail_journal_enabled
 dist/grafana-agent-linux-ppc64le: GOOS    := linux
 dist/grafana-agent-linux-ppc64le: GOARCH  := ppc64le
 dist/grafana-agent-linux-ppc64le: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/grafana-agent-linux-s390x: GO_TAGS += stringlabels builtinassets promtail_journal_enabled
+dist/grafana-agent-linux-s390x: GO_TAGS += builtinassets promtail_journal_enabled
 dist/grafana-agent-linux-s390x: GOOS    := linux
 dist/grafana-agent-linux-s390x: GOARCH  := s390x
 dist/grafana-agent-linux-s390x: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/grafana-agent-darwin-amd64: GO_TAGS += stringlabels builtinassets
+dist/grafana-agent-darwin-amd64: GO_TAGS += builtinassets
 dist/grafana-agent-darwin-amd64: GOOS    := darwin
 dist/grafana-agent-darwin-amd64: GOARCH  := amd64
 dist/grafana-agent-darwin-amd64: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/grafana-agent-darwin-arm64: GO_TAGS += stringlabels builtinassets
+dist/grafana-agent-darwin-arm64: GO_TAGS += builtinassets
 dist/grafana-agent-darwin-arm64: GOOS    := darwin
 dist/grafana-agent-darwin-arm64: GOARCH  := arm64
 dist/grafana-agent-darwin-arm64: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/grafana-agent-windows-amd64.exe: GO_TAGS += stringlabels builtinassets
+dist/grafana-agent-windows-amd64.exe: GO_TAGS += builtinassets
 dist/grafana-agent-windows-amd64.exe: GOOS    := windows
 dist/grafana-agent-windows-amd64.exe: GOARCH  := amd64
 dist/grafana-agent-windows-amd64.exe: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/grafana-agent-freebsd-amd64: GO_TAGS += stringlabels builtinassets
+dist/grafana-agent-freebsd-amd64: GO_TAGS += builtinassets
 dist/grafana-agent-freebsd-amd64: GOOS    := freebsd
 dist/grafana-agent-freebsd-amd64: GOARCH  := amd64
 dist/grafana-agent-freebsd-amd64: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
 
-dist/grafana-agent-linux-amd64-boringcrypto: GO_TAGS      += stringlabels builtinassets promtail_journal_enabled
+dist/grafana-agent-linux-amd64-boringcrypto: GO_TAGS      += builtinassets promtail_journal_enabled
 dist/grafana-agent-linux-amd64-boringcrypto: GOOS         := linux
 dist/grafana-agent-linux-amd64-boringcrypto: GOARCH       := amd64
 dist/grafana-agent-linux-amd64-boringcrypto: GOEXPERIMENT := boringcrypto
 dist/grafana-agent-linux-amd64-boringcrypto: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/grafana-agent-linux-arm64-boringcrypto: GO_TAGS      += stringlabels builtinassets promtail_journal_enabled
+dist/grafana-agent-linux-arm64-boringcrypto: GO_TAGS      += builtinassets promtail_journal_enabled
 dist/grafana-agent-linux-arm64-boringcrypto: GOOS         := linux
 dist/grafana-agent-linux-arm64-boringcrypto: GOARCH       := arm64
 dist/grafana-agent-linux-arm64-boringcrypto: GOEXPERIMENT := boringcrypto
@@ -167,31 +167,31 @@ dist-agent-flow-binaries: dist.temp/grafana-agent-flow-linux-amd64       \
                           dist.temp/grafana-agent-flow-linux-s390x       \
                           dist.temp/grafana-agent-flow-windows-amd64.exe
 
-dist.temp/grafana-agent-flow-linux-amd64: GO_TAGS += stringlabels builtinassets promtail_journal_enabled
+dist.temp/grafana-agent-flow-linux-amd64: GO_TAGS += builtinassets promtail_journal_enabled
 dist.temp/grafana-agent-flow-linux-amd64: GOOS    := linux
 dist.temp/grafana-agent-flow-linux-amd64: GOARCH  := amd64
 dist.temp/grafana-agent-flow-linux-amd64: generate-ui
 	$(PACKAGING_VARS) FLOW_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent-flow
 
-dist.temp/grafana-agent-flow-linux-arm64: GO_TAGS += stringlabels builtinassets promtail_journal_enabled
+dist.temp/grafana-agent-flow-linux-arm64: GO_TAGS += builtinassets promtail_journal_enabled
 dist.temp/grafana-agent-flow-linux-arm64: GOOS    := linux
 dist.temp/grafana-agent-flow-linux-arm64: GOARCH  := arm64
 dist.temp/grafana-agent-flow-linux-arm64: generate-ui
 	$(PACKAGING_VARS) FLOW_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent-flow
 
-dist.temp/grafana-agent-flow-linux-ppc64le: GO_TAGS += stringlabels builtinassets promtail_journal_enabled
+dist.temp/grafana-agent-flow-linux-ppc64le: GO_TAGS += builtinassets promtail_journal_enabled
 dist.temp/grafana-agent-flow-linux-ppc64le: GOOS    := linux
 dist.temp/grafana-agent-flow-linux-ppc64le: GOARCH  := ppc64le
 dist.temp/grafana-agent-flow-linux-ppc64le: generate-ui
 	$(PACKAGING_VARS) FLOW_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent-flow
 
-dist.temp/grafana-agent-flow-linux-s390x: GO_TAGS += stringlabels builtinassets promtail_journal_enabled
+dist.temp/grafana-agent-flow-linux-s390x: GO_TAGS += builtinassets promtail_journal_enabled
 dist.temp/grafana-agent-flow-linux-s390x: GOOS    := linux
 dist.temp/grafana-agent-flow-linux-s390x: GOARCH  := s390x
 dist.temp/grafana-agent-flow-linux-s390x: generate-ui
 	$(PACKAGING_VARS) FLOW_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent-flow
 
-dist.temp/grafana-agent-flow-windows-amd64.exe: GO_TAGS += stringlabels builtinassets
+dist.temp/grafana-agent-flow-windows-amd64.exe: GO_TAGS += builtinassets
 dist.temp/grafana-agent-flow-windows-amd64.exe: GOOS    := windows
 dist.temp/grafana-agent-flow-windows-amd64.exe: GOARCH  := amd64
 dist.temp/grafana-agent-flow-windows-amd64.exe: generate-ui
@@ -209,7 +209,7 @@ dist.temp/grafana-agent-flow-windows-amd64.exe: generate-ui
 
 dist-agent-service-binaries: dist.temp/grafana-agent-service-windows-amd64.exe
 
-dist.temp/grafana-agent-service-windows-amd64.exe: GO_TAGS += stringlabels builtinassets
+dist.temp/grafana-agent-service-windows-amd64.exe: GO_TAGS += builtinassets
 dist.temp/grafana-agent-service-windows-amd64.exe: GOOS    := windows
 dist.temp/grafana-agent-service-windows-amd64.exe: GOARCH  := amd64
 dist.temp/grafana-agent-service-windows-amd64.exe: generate-ui


### PR DESCRIPTION
Unfortunately, my local test was wrong and misled me to think we were ready for stringlabels (I tested with `GO_TAGS=stringlabels go test ./...` instead of `GOFLAGS="-tags stringlabels" go test ./...`. 

We can't use stringlabels right now because we have dependencies (mainly grafana/loki) which need to be updated to use the strings API and not depend on the implementation of labels.

This reverts commit 60f3432973c094bb73969b95da06e0c764a57604.