### PR TITLE
Fix the type of Password field in kafka config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ Main (unreleased)
       == null` is true. (@rfratto)
 
 - Added support for python profiling to `pyroscope.ebpf` component. (@korniltsev)
- 
+
 - Windows Flow Installer: Add /CONFIG /DISABLEPROFILING and /DISABLEREPORTING flag (@jkroepke)
 
 - Add queueing logs remote write client for `loki.write` when WAL is enabled. (@thepalbi)
@@ -94,6 +94,8 @@ Main (unreleased)
 
 - Include Faro Measurement `type` field in `faro.receiver` Flow component and legacy `app_agent_receiver` integration. (@rlankfo)
 
+- Mark `password` argument of `loki.source.kafka` as a `secret` rather than a `string`. (@harsiddhdave44)
+
 ### Enhancements
 
 - The `loki.write` WAL now has snappy compression enabled by default. (@thepalbi)
@@ -102,7 +104,7 @@ Main (unreleased)
 
 - Improved performance of `pyroscope.scrape` component when working with a large number of targets. (@cyriltovena)
 
-- Added support for comma-separated list of fields in `source` option and a 
+- Added support for comma-separated list of fields in `source` option and a
   new `separator` option in `drop` stage of `loki.process`. (@thampiotr)
 
 - The `loki.source.docker` component now allows connecting to Docker daemons

--- a/component/loki/source/kafka/kafka.go
+++ b/component/loki/source/kafka/kafka.go
@@ -53,7 +53,7 @@ type KafkaAuthentication struct {
 type KafkaSASLConfig struct {
 	Mechanism   string            `river:"mechanism,attr,optional"`
 	User        string            `river:"user,attr,optional"`
-	Password    string            `river:"password,attr,optional"`
+	Password    flagext.Secret    `river:"password,attr,optional"`
 	UseTLS      bool              `river:"use_tls,attr,optional"`
 	TLSConfig   config.TLSConfig  `river:"tls_config,block,optional"`
 	OAuthConfig OAuthConfigConfig `river:"oauth_config,block,optional"`
@@ -192,13 +192,13 @@ func (args *Arguments) Convert() kt.Config {
 }
 
 func (auth KafkaAuthentication) Convert() kt.Authentication {
-	var secret flagext.Secret
-	if auth.SASLConfig.Password != "" {
-		err := secret.Set(auth.SASLConfig.Password)
-		if err != nil {
-			panic("Unable to set kafka SASLConfig password")
-		}
-	}
+	// var secret flagext.Secret
+	// if auth.SASLConfig.Password.String() != "" {
+	// 	err := secret.Set(auth.SASLConfig.Password)
+	// 	if err != nil {
+	// 		panic("Unable to set kafka SASLConfig password")
+	// 	}
+	// }
 
 	return kt.Authentication{
 		Type:      kt.AuthenticationType(auth.Type),
@@ -206,7 +206,7 @@ func (auth KafkaAuthentication) Convert() kt.Authentication {
 		SASLConfig: kt.SASLConfig{
 			Mechanism: sarama.SASLMechanism(auth.SASLConfig.Mechanism),
 			User:      auth.SASLConfig.User,
-			Password:  secret,
+			Password:  auth.SASLConfig.Password,
 			UseTLS:    auth.SASLConfig.UseTLS,
 			TLSConfig: *auth.SASLConfig.TLSConfig.Convert(),
 			OAuthConfig: kt.OAuthConfig{

--- a/component/loki/source/kafka/kafka.go
+++ b/component/loki/source/kafka/kafka.go
@@ -27,16 +27,6 @@ func init() {
 	})
 }
 
-// Takes in a variable of type `rivertypes.Secret`, converts it to an OptionalSecret in order to extract the string value
-func ConvertSecretToString(secret rivertypes.Secret) (string, error) {
-	var optSecret rivertypes.OptionalSecret
-	err := secret.ConvertInto(&optSecret)
-	if err != nil {
-		return "", err
-	}
-	return optSecret.Value, nil
-}
-
 // Arguments holds values which are used to configure the loki.source.kafka
 // component.
 type Arguments struct {

--- a/component/loki/source/kafka/kafka.go
+++ b/component/loki/source/kafka/kafka.go
@@ -203,14 +203,13 @@ func (args *Arguments) Convert() kt.Config {
 }
 
 func (auth KafkaAuthentication) Convert() kt.Authentication {
-	password, _ := ConvertSecretToString(auth.SASLConfig.Password)
 	return kt.Authentication{
 		Type:      kt.AuthenticationType(auth.Type),
 		TLSConfig: *auth.TLSConfig.Convert(),
 		SASLConfig: kt.SASLConfig{
 			Mechanism: sarama.SASLMechanism(auth.SASLConfig.Mechanism),
 			User:      auth.SASLConfig.User,
-			Password:  flagext.SecretWithValue(password),
+			Password:  flagext.SecretWithValue(string(auth.SASLConfig.Password)),
 			UseTLS:    auth.SASLConfig.UseTLS,
 			TLSConfig: *auth.SASLConfig.TLSConfig.Convert(),
 			OAuthConfig: kt.OAuthConfig{

--- a/component/loki/source/kafka/kafka_test.go
+++ b/component/loki/source/kafka/kafka_test.go
@@ -60,7 +60,10 @@ func TestSASLRiverConfig(t *testing.T) {
 	err := river.Unmarshal([]byte(exampleRiverConfig), &args)
 	require.NoError(t, err)
 
-	require.NotEqual(t, "password", args.Authentication.SASLConfig.Password.String())
+	// Ensures that the rivertype.Secret is working properly and there's no error
+	password, err_ := ConvertSecretToString(args.Authentication.SASLConfig.Password)
+	require.NoError(t, err_)
+	require.Equal(t, "password", password)
 }
 
 func TestSASLOAuthRiverConfig(t *testing.T) {

--- a/component/loki/source/kafka/kafka_test.go
+++ b/component/loki/source/kafka/kafka_test.go
@@ -59,6 +59,8 @@ func TestSASLRiverConfig(t *testing.T) {
 	var args Arguments
 	err := river.Unmarshal([]byte(exampleRiverConfig), &args)
 	require.NoError(t, err)
+
+	require.NotEqual(t, "password", args.Authentication.SASLConfig.Password.String())
 }
 
 func TestSASLOAuthRiverConfig(t *testing.T) {

--- a/component/loki/source/kafka/kafka_test.go
+++ b/component/loki/source/kafka/kafka_test.go
@@ -59,11 +59,6 @@ func TestSASLRiverConfig(t *testing.T) {
 	var args Arguments
 	err := river.Unmarshal([]byte(exampleRiverConfig), &args)
 	require.NoError(t, err)
-
-	// Ensures that the rivertype.Secret is working properly and there's no error
-	password, err_ := ConvertSecretToString(args.Authentication.SASLConfig.Password)
-	require.NoError(t, err_)
-	require.Equal(t, "password", password)
 }
 
 func TestSASLOAuthRiverConfig(t *testing.T) {

--- a/converter/internal/promtailconvert/internal/build/kafka.go
+++ b/converter/internal/promtailconvert/internal/build/kafka.go
@@ -51,7 +51,7 @@ func convertKafkaAuthConfig(kafkaCfg *scrapeconfig.KafkaTargetConfig) kafka.Kafk
 		SASLConfig: kafka.KafkaSASLConfig{
 			Mechanism: string(kafkaCfg.Authentication.SASLConfig.Mechanism),
 			User:      kafkaCfg.Authentication.SASLConfig.User,
-			Password:  kafkaCfg.Authentication.SASLConfig.Password.String(),
+			Password:  rivertypes.Secret(kafkaCfg.Authentication.SASLConfig.Password.String()),
 			UseTLS:    kafkaCfg.Authentication.SASLConfig.UseTLS,
 			TLSConfig: *common.ToTLSConfig(&kafkaCfg.Authentication.SASLConfig.TLSConfig),
 		},

--- a/docs/sources/flow/reference/components/loki.source.kafka.md
+++ b/docs/sources/flow/reference/components/loki.source.kafka.md
@@ -38,17 +38,17 @@ loki.source.kafka "LABEL" {
 
 `loki.source.kafka` supports the following arguments:
 
- Name                     | Type                 | Description                                              | Default               | Required 
+ Name                     | Type                 | Description                                              | Default               | Required
 --------------------------|----------------------|----------------------------------------------------------|-----------------------|----------
- `brokers`                | `list(string)`       | The list of brokers to connect to Kafka.                 |                       | yes      
- `topics`                 | `list(string)`       | The list of Kafka topics to consume.                     |                       | yes      
- `group_id`               | `string`             | The Kafka consumer group id.                             | `"loki.source.kafka"` | no       
- `assignor`               | `string`             | The consumer group rebalancing strategy to use.          | `"range"`             | no       
- `version`                | `string`             | Kafka version to connect to.                             | `"2.2.1"`             | no       
- `use_incoming_timestamp` | `bool`               | Whether or not to use the timestamp received from Kafka. | `false`               | no       
- `labels`                 | `map(string)`        | The labels to associate with each received Kafka event.  | `{}`                  | no       
- `forward_to`             | `list(LogsReceiver)` | List of receivers to send log entries to.                |                       | yes      
- `relabel_rules`          | `RelabelRules`       | Relabeling rules to apply on log entries.                | `{}`                  | no       
+ `brokers`                | `list(string)`       | The list of brokers to connect to Kafka.                 |                       | yes
+ `topics`                 | `list(string)`       | The list of Kafka topics to consume.                     |                       | yes
+ `group_id`               | `string`             | The Kafka consumer group id.                             | `"loki.source.kafka"` | no
+ `assignor`               | `string`             | The consumer group rebalancing strategy to use.          | `"range"`             | no
+ `version`                | `string`             | Kafka version to connect to.                             | `"2.2.1"`             | no
+ `use_incoming_timestamp` | `bool`               | Whether or not to use the timestamp received from Kafka. | `false`               | no
+ `labels`                 | `map(string)`        | The labels to associate with each received Kafka event.  | `{}`                  | no
+ `forward_to`             | `list(LogsReceiver)` | List of receivers to send log entries to.                |                       | yes
+ `relabel_rules`          | `RelabelRules`       | Relabeling rules to apply on log entries.                | `{}`                  | no
 
 `assignor` values can be either `"range"`, `"roundrobin"`, or `"sticky"`.
 
@@ -77,13 +77,13 @@ keep these labels, relabel them using a [loki.relabel][] component and pass its
 
 The following blocks are supported inside the definition of `loki.source.kafka`:
 
- Hierarchy                                   | Name             | Description                                               | Required 
+ Hierarchy                                   | Name             | Description                                               | Required
 ---------------------------------------------|------------------|-----------------------------------------------------------|----------
- authentication                              | [authentication] | Optional authentication configuration with Kafka brokers. | no       
- authentication > tls_config                 | [tls_config]     | Optional authentication configuration with Kafka brokers. | no       
- authentication > sasl_config                | [sasl_config]    | Optional authentication configuration with Kafka brokers. | no       
- authentication > sasl_config > tls_config   | [tls_config]     | Optional authentication configuration with Kafka brokers. | no       
- authentication > sasl_config > oauth_config | [oauth_config]   | Optional authentication configuration with Kafka brokers. | no       
+ authentication                              | [authentication] | Optional authentication configuration with Kafka brokers. | no
+ authentication > tls_config                 | [tls_config]     | Optional authentication configuration with Kafka brokers. | no
+ authentication > sasl_config                | [sasl_config]    | Optional authentication configuration with Kafka brokers. | no
+ authentication > sasl_config > tls_config   | [tls_config]     | Optional authentication configuration with Kafka brokers. | no
+ authentication > sasl_config > oauth_config | [oauth_config]   | Optional authentication configuration with Kafka brokers. | no
 
 [authentication]: #authentication-block
 
@@ -97,9 +97,9 @@ The following blocks are supported inside the definition of `loki.source.kafka`:
 
 The `authentication` block defines the authentication method when communicating with the Kafka event brokers.
 
- Name   | Type     | Description             | Default  | Required 
+ Name   | Type     | Description             | Default  | Required
 --------|----------|-------------------------|----------|----------
- `type` | `string` | Type of authentication. | `"none"` | no       
+ `type` | `string` | Type of authentication. | `"none"` | no
 
 `type` supports the values `"none"`, `"ssl"`, and `"sasl"`. If `"ssl"` is used,
 you must set the `tls_config` block. If `"sasl"` is used, you must set the `sasl_config` block.
@@ -113,21 +113,21 @@ you must set the `tls_config` block. If `"sasl"` is used, you must set the `sasl
 The `sasl_config` block defines the listen address and port where the listener
 expects Kafka messages to be sent to.
 
- Name        | Type                 | Description                                                                   | Default    | Required 
--------------|----------------------|--------------------------------------------------------------------|----------|-----------------------
- `mechanism` | `string`             | Specifies the SASL mechanism the client uses to authenticate with the broker. | `"PLAIN""` | no       
- `user`      | `string`             | The user name to use for SASL authentication.                                 | `""`       | no       
- `password`  | `rivertypes.Secret`  | The password to use for SASL authentication.                                  | `""`       | no       
- `use_tls`   | `bool`               | If true, SASL authentication is executed over TLS.                            | `false`    | no       
+ Name        | Type     | Description                                                                   | Default    | Required
+-------------|----------|--------------------------------------------------------------------|----------|-----------------------
+ `mechanism` | `string` | Specifies the SASL mechanism the client uses to authenticate with the broker. | `"PLAIN""` | no
+ `user`      | `string` | The user name to use for SASL authentication.                                 | `""`       | no
+ `password`  | `secret` | The password to use for SASL authentication.                                  | `""`       | no
+ `use_tls`   | `bool`   | If true, SASL authentication is executed over TLS.                            | `false`    | no
 
 ### oauth_config block
 
 The `oauth_config` is required when the SASL mechanism is set to `OAUTHBEARER`.
 
- Name             | Type           | Description                                                            | Default | Required 
+ Name             | Type           | Description                                                            | Default | Required
 ------------------|----------------|------------------------------------------------------------------------|---------|----------
- `token_provider` | `string`       | The OAuth provider to be used. The only supported provider is `azure`. | `""`    | yes      
- `scopes`         | `list(string)` | The scopes to set in the access token                                  | `[]`    | yes      
+ `token_provider` | `string`       | The OAuth provider to be used. The only supported provider is `azure`. | `""`    | yes
+ `scopes`         | `list(string)` | The scopes to set in the access token                                  | `[]`    | yes
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/loki.source.kafka.md
+++ b/docs/sources/flow/reference/components/loki.source.kafka.md
@@ -113,12 +113,12 @@ you must set the `tls_config` block. If `"sasl"` is used, you must set the `sasl
 The `sasl_config` block defines the listen address and port where the listener
 expects Kafka messages to be sent to.
 
- Name        | Type     | Description                                                                   | Default    | Required 
--------------|----------|-------------------------------------------------------------------------------|------------|----------
- `mechanism` | `string` | Specifies the SASL mechanism the client uses to authenticate with the broker. | `"PLAIN""` | no       
- `user`      | `string` | The user name to use for SASL authentication.                                 | `""`       | no       
- `password`  | `string` | The password to use for SASL authentication.                                  | `""`       | no       
- `use_tls`   | `bool`   | If true, SASL authentication is executed over TLS.                            | `false`    | no       
+ Name        | Type                 | Description                                                                   | Default    | Required 
+-------------|----------------------|--------------------------------------------------------------------|----------|-----------------------
+ `mechanism` | `string`             | Specifies the SASL mechanism the client uses to authenticate with the broker. | `"PLAIN""` | no       
+ `user`      | `string`             | The user name to use for SASL authentication.                                 | `""`       | no       
+ `password`  | `rivertypes.Secret`  | The password to use for SASL authentication.                                  | `""`       | no       
+ `use_tls`   | `bool`               | If true, SASL authentication is executed over TLS.                            | `false`    | no       
 
 ### oauth_config block
 


### PR DESCRIPTION
The `Password` field in `kafka.go` was set to string, which caused it to be exposed. This PR fixes it by changing its type to `flagext.Secret`, which ensures that the value is not exposed directly without explicit calling to its `String()` method

- Fixes #4636

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [x] Tests updated
