### PR TITLE
loki.source.file: allow defining the encoding of read files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Main (unreleased)
 - Clustering: Nodes take part in distributing load only after loading their
   component graph. (@tpaschalis)
 
+- Allow `loki.source.file` to define the encoding of files. (@tpaschalis)
+
 - New Grafana Agent Flow components:
 
   - `prometheus.exporter.gcp` - scrape GCP metrics. (@tburgessdev)

--- a/component/loki/source/file/file.go
+++ b/component/loki/source/file/file.go
@@ -35,10 +35,10 @@ const (
 
 // Arguments holds values which are used to configure the loki.source.file
 // component.
-// TODO(@tpaschalis) Allow users to configure the encoding of the tailed files.
 type Arguments struct {
 	Targets   []discovery.Target  `river:"targets,attr"`
 	ForwardTo []loki.LogsReceiver `river:"forward_to,attr"`
+	Encoding  string              `river:"encoding,attr,optional"`
 }
 
 var (
@@ -299,7 +299,7 @@ func (c *Component) startTailing(path string, labels model.LabelSet, handler lok
 			c.posFile,
 			path,
 			labels.String(),
-			"",
+			c.args.Encoding,
 		)
 		if err != nil {
 			level.Error(c.opts.Logger).Log("msg", "failed to start decompressor", "error", err, "filename", path)
@@ -315,7 +315,7 @@ func (c *Component) startTailing(path string, labels model.LabelSet, handler lok
 			c.posFile,
 			path,
 			labels.String(),
-			"",
+			c.args.Encoding,
 		)
 		if err != nil {
 			level.Error(c.opts.Logger).Log("msg", "failed to start tailer", "error", err, "filename", path)

--- a/component/loki/source/file/file_test.go
+++ b/component/loki/source/file/file_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"golang.org/x/text/encoding/unicode"
 )
 
 func Test(t *testing.T) {
@@ -174,6 +175,74 @@ func TestTwoTargets(t *testing.T) {
 	cancel()
 	// Verify that positions.yml is written. NOTE: if we didn't wait for it, there would be a race condition between
 	// temporary directory being cleaned up and this file being created.
+	require.Eventually(
+		t,
+		func() bool {
+			if _, err := os.Stat(filepath.Join(opts.DataPath, "positions.yml")); errors.Is(err, os.ErrNotExist) {
+				return false
+			}
+			return true
+		},
+		5*time.Second,
+		10*time.Millisecond,
+		"expected positions.yml file to be written eventually",
+	)
+}
+
+func TestEncoding(t *testing.T) {
+	// Create opts for component
+	opts := component.Options{
+		Logger:        util.TestFlowLogger(t),
+		Registerer:    prometheus.NewRegistry(),
+		OnStateChange: func(e component.Exports) {},
+		DataPath:      t.TempDir(),
+	}
+
+	// Create a file to write to and set up the component's Arguments.
+	f, err := os.CreateTemp(opts.DataPath, "example")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+
+	ch1 := loki.NewLogsReceiver()
+	args := Arguments{}
+	args.Targets = []discovery.Target{{"__path__": f.Name(), "lbl1": "val1"}}
+	args.Encoding = "UTF-16BE"
+	args.ForwardTo = []loki.LogsReceiver{ch1}
+
+	// Create and run the component.
+	c, err := New(opts, args)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go c.Run(ctx)
+	require.Eventually(t, func() bool { return c.DebugInfo() != nil }, 500*time.Millisecond, 20*time.Millisecond)
+
+	// Write a UTF-16BE encoded byte slice to the file.
+	utf16Encoder := unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM).NewEncoder()
+	utf16Bytes, err := utf16Encoder.Bytes([]byte("hello world!\n"))
+	require.Nil(t, err)
+
+	_, err = f.Write(utf16Bytes)
+	require.Nil(t, err)
+
+	// Make sure the log was received successfully with the correct format.
+	select {
+	case logEntry := <-ch1.Chan():
+		require.WithinDuration(t, time.Now(), logEntry.Timestamp, 1*time.Second)
+		require.Equal(t, "hello world!�", logEntry.Line)
+
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "failed waiting for log line")
+	}
+
+	// Shut down the component
+	cancel()
+
+	// Verify that positions.yml is written. NOTE: if we didn't wait for it,
+	// there would be a race condition between temporary directory being
+	// cleaned up and this file being created.
 	require.Eventually(
 		t,
 		func() bool {

--- a/docs/sources/flow/reference/components/loki.source.file.md
+++ b/docs/sources/flow/reference/components/loki.source.file.md
@@ -29,12 +29,16 @@ log entries to the list of receivers passed in `forward_to`.
 Name         | Type                   | Description          | Default | Required
 ------------ | ---------------------- | -------------------- | ------- | --------
 `targets`    | `list(map(string))`    | List of files to read from. | | yes
-`forward_to` | `list(LogsReceiver)` | List of receivers to send log entries to. | | yes
+`forward_to` | `list(LogsReceiver)`   | List of receivers to send log entries to. | | yes
+`encoding`   | `string`               | The encoding to convert from when reading files. | `""` | no
 
 ## Blocks
 
 The `loki.source.file` component doesn't support any inner blocks and is
 configured fully through arguments.
+
+The `encoding` argument must be a valid [IANA encoding][] name. If not set, it
+defaults to UTF-8. 
 
 ## Exported fields
 
@@ -102,3 +106,5 @@ loki.write "local" {
   }
 }
 ```
+
+[IANA encoding]: https://www.iana.org/assignments/character-sets/character-sets.xhtml


### PR DESCRIPTION
#### PR Description
This PR allows `loki.source.file` to define the encoding of the scraped files as part of the component argument block.

I toyed with the idea of allowing the encoding to be set per-file with a dedicated label (eg. `__filepath_encoding__`) but I'm not sure the added overhead is worth it.

#### Which issue(s) this PR fixes
Fixes #3938 

#### Notes to the Reviewer

If the encoding field is not set in the component's arguments, the test would fail with the following error
```
        	Error Trace:	agent/component/loki/source/file/file_test.go:234
        	Error:      	Not equal:
        	            	expected: "hello world!�"
        	            	actual  : "\x00h\x00e\x00l\x00l\x00o\x00 \x00w\x00o\x00r\x00l\x00d\x00!\x00"
```

#### PR Checklist

- [X] CHANGELOG updated
- [X] Documentation added
- [X] Tests updated
