### PR TITLE
build: do not produce Windows binaries with netgo build tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Main (unreleased)
 
 - Fix a bug which prevented the `app_agent_receiver` integration from processing traces. (@ptodev)
 
+- Fix issue on Windows where DNS short names were unresolvable. (@rfratto)
+
 v0.35.2 (2023-07-27)
 --------------------
 

--- a/Makefile
+++ b/Makefile
@@ -146,8 +146,8 @@ GO_LDFLAGS   := -X $(VPREFIX).Branch=$(GIT_BRANCH)                        \
                 -X $(VPREFIX).BuildDate=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 DEFAULT_FLAGS    := $(GO_FLAGS)
-DEBUG_GO_FLAGS   := -ldflags "$(GO_LDFLAGS)" -tags "netgo $(GO_TAGS)"
-RELEASE_GO_FLAGS := -ldflags "-s -w $(GO_LDFLAGS)" -tags "netgo $(GO_TAGS)"
+DEBUG_GO_FLAGS   := -ldflags "$(GO_LDFLAGS)" -tags "$(GO_TAGS)"
+RELEASE_GO_FLAGS := -ldflags "-s -w $(GO_LDFLAGS)" -tags "$(GO_TAGS)"
 
 ifeq ($(RELEASE_BUILD),1)
 GO_FLAGS := $(DEFAULT_FLAGS) $(RELEASE_GO_FLAGS)
@@ -254,7 +254,7 @@ endif
 # Targets for building Docker images
 #
 
-DOCKER_FLAGS := --build-arg RELEASE_BUILD=$(RELEASE_BUILD) --build-arg VERSION=$(VERSION) 
+DOCKER_FLAGS := --build-arg RELEASE_BUILD=$(RELEASE_BUILD) --build-arg VERSION=$(VERSION)
 
 ifneq ($(DOCKER_PLATFORM),)
 DOCKER_FLAGS += --platform=$(DOCKER_PLATFORM)

--- a/cmd/grafana-agent-operator/Dockerfile
+++ b/cmd/grafana-agent-operator/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /src/agent
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=${TARGETVARIANT#v} \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=${TARGETVARIANT#v} GO_TAGS=netgo \
     RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} \
     make operator
 

--- a/cmd/grafana-agent/Dockerfile
+++ b/cmd/grafana-agent/Dockerfile
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=${TARGETVARIANT#v} \
     RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} \
-    GO_TAGS="builtinassets promtail_journal_enabled" \
+    GO_TAGS="netgo builtinassets promtail_journal_enabled" \
     GOEXPERIMENT=${GOEXPERIMENT} \
     make agent
 

--- a/cmd/grafana-agentctl/Dockerfile
+++ b/cmd/grafana-agentctl/Dockerfile
@@ -20,7 +20,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     GOOS="$TARGETOS" GOARCH="$TARGETARCH" GOARM="${TARGETVARIANT#v}" \
     RELEASE_BUILD="${RELEASE_BUILD}" VERSION="${VERSION}" \
-    GO_TAGS="promtail_journal_enabled" \
+    GO_TAGS="netgo promtail_journal_enabled" \
     make agentctl
 
 FROM ubuntu:lunar

--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -69,6 +69,9 @@ dist/grafana-agent-darwin-arm64: generate-ui
 
 # NOTE(rfratto): do not use netgo when building Windows binaries, which
 # prevents DNS short names from being resovable. See grafana/agent#4665.
+#
+# TODO(rfratto): add netgo back to Windows builds if a version of Go is
+# released which natively supports resolving DNS short names on Windows.
 dist/grafana-agent-windows-amd64.exe: GO_TAGS += builtinassets
 dist/grafana-agent-windows-amd64.exe: GOOS    := windows
 dist/grafana-agent-windows-amd64.exe: GOARCH  := amd64

--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -31,63 +31,65 @@ dist-agent-binaries: dist/grafana-agent-linux-amd64       \
                      dist/grafana-agent-linux-amd64-boringcrypto  \
                      dist/grafana-agent-linux-arm64-boringcrypto
 
-dist/grafana-agent-linux-amd64: GO_TAGS += builtinassets promtail_journal_enabled
+dist/grafana-agent-linux-amd64: GO_TAGS += netgo builtinassets promtail_journal_enabled
 dist/grafana-agent-linux-amd64: GOOS    := linux
 dist/grafana-agent-linux-amd64: GOARCH  := amd64
 dist/grafana-agent-linux-amd64: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/grafana-agent-linux-arm64: GO_TAGS += builtinassets promtail_journal_enabled
+dist/grafana-agent-linux-arm64: GO_TAGS += netgo builtinassets promtail_journal_enabled
 dist/grafana-agent-linux-arm64: GOOS    := linux
 dist/grafana-agent-linux-arm64: GOARCH  := arm64
 dist/grafana-agent-linux-arm64: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/grafana-agent-linux-ppc64le: GO_TAGS += builtinassets promtail_journal_enabled
+dist/grafana-agent-linux-ppc64le: GO_TAGS += netgo builtinassets promtail_journal_enabled
 dist/grafana-agent-linux-ppc64le: GOOS    := linux
 dist/grafana-agent-linux-ppc64le: GOARCH  := ppc64le
 dist/grafana-agent-linux-ppc64le: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/grafana-agent-linux-s390x: GO_TAGS += builtinassets promtail_journal_enabled
+dist/grafana-agent-linux-s390x: GO_TAGS += netgo builtinassets promtail_journal_enabled
 dist/grafana-agent-linux-s390x: GOOS    := linux
 dist/grafana-agent-linux-s390x: GOARCH  := s390x
 dist/grafana-agent-linux-s390x: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/grafana-agent-darwin-amd64: GO_TAGS += builtinassets
+dist/grafana-agent-darwin-amd64: GO_TAGS += netgo builtinassets
 dist/grafana-agent-darwin-amd64: GOOS    := darwin
 dist/grafana-agent-darwin-amd64: GOARCH  := amd64
 dist/grafana-agent-darwin-amd64: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/grafana-agent-darwin-arm64: GO_TAGS += builtinassets
+dist/grafana-agent-darwin-arm64: GO_TAGS += netgo builtinassets
 dist/grafana-agent-darwin-arm64: GOOS    := darwin
 dist/grafana-agent-darwin-arm64: GOARCH  := arm64
 dist/grafana-agent-darwin-arm64: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
+# NOTE(rfratto): do not use netgo when building Windows binaries, which
+# prevents DNS short names from being resovable. See grafana/agent#4665.
 dist/grafana-agent-windows-amd64.exe: GO_TAGS += builtinassets
 dist/grafana-agent-windows-amd64.exe: GOOS    := windows
 dist/grafana-agent-windows-amd64.exe: GOARCH  := amd64
 dist/grafana-agent-windows-amd64.exe: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/grafana-agent-freebsd-amd64: GO_TAGS += builtinassets
+dist/grafana-agent-freebsd-amd64: GO_TAGS += netgo builtinassets
 dist/grafana-agent-freebsd-amd64: GOOS    := freebsd
 dist/grafana-agent-freebsd-amd64: GOARCH  := amd64
 dist/grafana-agent-freebsd-amd64: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
 
-dist/grafana-agent-linux-amd64-boringcrypto: GO_TAGS      += builtinassets promtail_journal_enabled
+dist/grafana-agent-linux-amd64-boringcrypto: GO_TAGS      += netgo builtinassets promtail_journal_enabled
 dist/grafana-agent-linux-amd64-boringcrypto: GOOS         := linux
 dist/grafana-agent-linux-amd64-boringcrypto: GOARCH       := amd64
 dist/grafana-agent-linux-amd64-boringcrypto: GOEXPERIMENT := boringcrypto
 dist/grafana-agent-linux-amd64-boringcrypto: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent
 
-dist/grafana-agent-linux-arm64-boringcrypto: GO_TAGS      += builtinassets promtail_journal_enabled
+dist/grafana-agent-linux-arm64-boringcrypto: GO_TAGS      += netgo builtinassets promtail_journal_enabled
 dist/grafana-agent-linux-arm64-boringcrypto: GOOS         := linux
 dist/grafana-agent-linux-arm64-boringcrypto: GOARCH       := arm64
 dist/grafana-agent-linux-arm64-boringcrypto: GOEXPERIMENT := boringcrypto
@@ -107,37 +109,39 @@ dist-agentctl-binaries: dist/grafana-agentctl-linux-amd64       \
                         dist/grafana-agentctl-windows-amd64.exe \
                         dist/grafana-agentctl-freebsd-amd64
 
-dist/grafana-agentctl-linux-amd64: GO_TAGS += promtail_journal_enabled
+dist/grafana-agentctl-linux-amd64: GO_TAGS += netgo promtail_journal_enabled
 dist/grafana-agentctl-linux-amd64: GOOS    := linux
 dist/grafana-agentctl-linux-amd64: GOARCH  := amd64
 dist/grafana-agentctl-linux-amd64:
 	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
 
-dist/grafana-agentctl-linux-arm64: GO_TAGS += promtail_journal_enabled
+dist/grafana-agentctl-linux-arm64: GO_TAGS += netgo promtail_journal_enabled
 dist/grafana-agentctl-linux-arm64: GOOS    := linux
 dist/grafana-agentctl-linux-arm64: GOARCH  := arm64
 dist/grafana-agentctl-linux-arm64:
 	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
 
-dist/grafana-agentctl-linux-ppc64le: GO_TAGS += promtail_journal_enabled
+dist/grafana-agentctl-linux-ppc64le: GO_TAGS += netgo promtail_journal_enabled
 dist/grafana-agentctl-linux-ppc64le: GOOS    := linux
 dist/grafana-agentctl-linux-ppc64le: GOARCH  := ppc64le
 dist/grafana-agentctl-linux-ppc64le:
 	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
 
-dist/grafana-agentctl-linux-s390x: GO_TAGS += promtail_journal_enabled
+dist/grafana-agentctl-linux-s390x: GO_TAGS += netgo promtail_journal_enabled
 dist/grafana-agentctl-linux-s390x: GOOS    := linux
 dist/grafana-agentctl-linux-s390x: GOARCH  := s390x
 dist/grafana-agentctl-linux-s390x:
 	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
 
-dist/grafana-agentctl-darwin-amd64: GOOS   := darwin
-dist/grafana-agentctl-darwin-amd64: GOARCH := amd64
+dist/grafana-agentctl-darwin-amd64: GO_TAGS += netgo
+dist/grafana-agentctl-darwin-amd64: GOOS    := darwin
+dist/grafana-agentctl-darwin-amd64: GOARCH  := amd64
 dist/grafana-agentctl-darwin-amd64:
 	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
 
-dist/grafana-agentctl-darwin-arm64: GOOS   := darwin
-dist/grafana-agentctl-darwin-arm64: GOARCH := arm64
+dist/grafana-agentctl-darwin-arm64: GO_TAGS += netgo
+dist/grafana-agentctl-darwin-arm64: GOOS    := darwin
+dist/grafana-agentctl-darwin-arm64: GOARCH  := arm64
 dist/grafana-agentctl-darwin-arm64:
 	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
 
@@ -146,6 +150,7 @@ dist/grafana-agentctl-windows-amd64.exe: GOARCH := amd64
 dist/grafana-agentctl-windows-amd64.exe:
 	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agentctl
 
+dist/grafana-agentctl-freebsd-amd64: GO_TAGS += netgo
 dist/grafana-agentctl-freebsd-amd64: GOOS    := freebsd
 dist/grafana-agentctl-freebsd-amd64: GOARCH  := amd64
 dist/grafana-agentctl-freebsd-amd64:
@@ -167,25 +172,25 @@ dist-agent-flow-binaries: dist.temp/grafana-agent-flow-linux-amd64       \
                           dist.temp/grafana-agent-flow-linux-s390x       \
                           dist.temp/grafana-agent-flow-windows-amd64.exe
 
-dist.temp/grafana-agent-flow-linux-amd64: GO_TAGS += builtinassets promtail_journal_enabled
+dist.temp/grafana-agent-flow-linux-amd64: GO_TAGS += netgo builtinassets promtail_journal_enabled
 dist.temp/grafana-agent-flow-linux-amd64: GOOS    := linux
 dist.temp/grafana-agent-flow-linux-amd64: GOARCH  := amd64
 dist.temp/grafana-agent-flow-linux-amd64: generate-ui
 	$(PACKAGING_VARS) FLOW_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent-flow
 
-dist.temp/grafana-agent-flow-linux-arm64: GO_TAGS += builtinassets promtail_journal_enabled
+dist.temp/grafana-agent-flow-linux-arm64: GO_TAGS += netgo builtinassets promtail_journal_enabled
 dist.temp/grafana-agent-flow-linux-arm64: GOOS    := linux
 dist.temp/grafana-agent-flow-linux-arm64: GOARCH  := arm64
 dist.temp/grafana-agent-flow-linux-arm64: generate-ui
 	$(PACKAGING_VARS) FLOW_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent-flow
 
-dist.temp/grafana-agent-flow-linux-ppc64le: GO_TAGS += builtinassets promtail_journal_enabled
+dist.temp/grafana-agent-flow-linux-ppc64le: GO_TAGS += netgo builtinassets promtail_journal_enabled
 dist.temp/grafana-agent-flow-linux-ppc64le: GOOS    := linux
 dist.temp/grafana-agent-flow-linux-ppc64le: GOARCH  := ppc64le
 dist.temp/grafana-agent-flow-linux-ppc64le: generate-ui
 	$(PACKAGING_VARS) FLOW_BINARY=$@ $(MAKE) -f $(PARENT_MAKEFILE) agent-flow
 
-dist.temp/grafana-agent-flow-linux-s390x: GO_TAGS += builtinassets promtail_journal_enabled
+dist.temp/grafana-agent-flow-linux-s390x: GO_TAGS += netgo builtinassets promtail_journal_enabled
 dist.temp/grafana-agent-flow-linux-s390x: GOOS    := linux
 dist.temp/grafana-agent-flow-linux-s390x: GOARCH  := s390x
 dist.temp/grafana-agent-flow-linux-s390x: generate-ui


### PR DESCRIPTION
Go 1.19 adds Windows support for the native Go network stack, but doesn't include support for resolving DNS short names.

Other projects, including Prometheus, have updated their build process to exclude the netgo build tags when producing Windows binaries to work around this behavior.

Fixes grafana/agent#4665