### PR TITLE
component: allow components to consume data for services 

### DIFF
--- a/component/registry.go
+++ b/component/registry.go
@@ -160,6 +160,12 @@ type Registration struct {
 	// A component which does not expose exports must leave this set to nil.
 	Exports Exports
 
+	// NeedsServices holds the set of service names which this component depends
+	// on to run. If NeedsServices includes an invalid service name (either
+	// because of a cyclic dependency or the named service doesn't exist),
+	// components will fail to evaluate.
+	NeedsServices []string
+
 	// Build should construct a new component from an initial Arguments and set
 	// of options.
 	Build func(opts Options, args Arguments) (Component, error)

--- a/component/registry.go
+++ b/component/registry.go
@@ -113,6 +113,16 @@ type Options struct {
 	// component. Requests received by a component handler will have this already
 	// trimmed off.
 	HTTPPath string
+
+	// GetServiceData retrieves data for a service by calling
+	// [service.Service.Data] for the specified service.
+	//
+	// GetServiceData will return an error if the service does not exist or was
+	// not listed as a dependency with the registration of the component.
+	//
+	// The result of GetServiceData may be cached as the value will not change at
+	// runtime.
+	GetServiceData func(name string) (interface{}, error)
 }
 
 // Registration describes a single component.

--- a/pkg/flow/internal/controller/node_component.go
+++ b/pkg/flow/internal/controller/node_component.go
@@ -65,18 +65,19 @@ type DialFunc func(ctx context.Context, network, address string) (net.Conn, erro
 // ComponentGlobals are used by ComponentNodes to build managed components. All
 // ComponentNodes should use the same ComponentGlobals.
 type ComponentGlobals struct {
-	Logger              *logging.Logger                  // Logger shared between all managed components.
-	TraceProvider       trace.TracerProvider             // Tracer shared between all managed components.
-	Clusterer           *cluster.Clusterer               // Clusterer shared between all managed components.
-	DataPath            string                           // Shared directory where component data may be stored
-	OnComponentUpdate   func(cn *ComponentNode)          // Informs controller that we need to reevaluate
-	OnExportsChange     func(exports map[string]any)     // Invoked when the managed component updated its exports
-	Registerer          prometheus.Registerer            // Registerer for serving agent and component metrics
-	HTTPPathPrefix      string                           // HTTP prefix for components.
-	HTTPListenAddr      string                           // Base address for server
-	DialFunc            DialFunc                         // Function to connect to HTTPListenAddr.
-	ControllerID        string                           // ID of controller.
-	NewModuleController func(id string) ModuleController // Func to generate a module controller.
+	Logger              *logging.Logger                        // Logger shared between all managed components.
+	TraceProvider       trace.TracerProvider                   // Tracer shared between all managed components.
+	Clusterer           *cluster.Clusterer                     // Clusterer shared between all managed components.
+	DataPath            string                                 // Shared directory where component data may be stored
+	OnComponentUpdate   func(cn *ComponentNode)                // Informs controller that we need to reevaluate
+	OnExportsChange     func(exports map[string]any)           // Invoked when the managed component updated its exports
+	Registerer          prometheus.Registerer                  // Registerer for serving agent and component metrics
+	HTTPPathPrefix      string                                 // HTTP prefix for components.
+	HTTPListenAddr      string                                 // Base address for server
+	DialFunc            DialFunc                               // Function to connect to HTTPListenAddr.
+	ControllerID        string                                 // ID of controller.
+	NewModuleController func(id string) ModuleController       // Func to generate a module controller.
+	GetServiceData      func(name string) (interface{}, error) // Get data for a service.
 }
 
 // ComponentNode is a controller node which manages a user-defined component.
@@ -184,6 +185,11 @@ func getManagedOptions(globals ComponentGlobals, cn *ComponentNode) component.Op
 		prefix = "/" + prefix
 	}
 
+	allowedServices := make(map[string]struct{}, len(cn.Registration().NeedsServices))
+	for _, svc := range cn.Registration().NeedsServices {
+		allowedServices[svc] = struct{}{}
+	}
+
 	cn.registry = prometheus.NewRegistry()
 	return component.Options{
 		ID:     cn.globalID,
@@ -201,6 +207,13 @@ func getManagedOptions(globals ComponentGlobals, cn *ComponentNode) component.Op
 
 		OnStateChange:    cn.setExports,
 		ModuleController: cn.moduleController,
+
+		GetServiceData: func(name string) (interface{}, error) {
+			if _, allowed := allowedServices[name]; !allowed {
+				return nil, fmt.Errorf("cannot access service data for service %q because it was not listed as a dependency", name)
+			}
+			return globals.GetServiceData(name)
+		},
 	}
 }
 

--- a/pkg/flow/internal/testcomponents/service_consumer.go
+++ b/pkg/flow/internal/testcomponents/service_consumer.go
@@ -52,8 +52,7 @@ func NewServiceConsumer(o component.Options, args ServiceConsumerArguments) (*Se
 }
 
 var (
-	_ component.Component      = (*Passthrough)(nil)
-	_ component.DebugComponent = (*Passthrough)(nil)
+	_ component.Component      = (*ServiceConsumer)(nil)
 )
 
 // Run implements Component.

--- a/pkg/flow/internal/testcomponents/service_consumer.go
+++ b/pkg/flow/internal/testcomponents/service_consumer.go
@@ -1,0 +1,69 @@
+package testcomponents
+
+import (
+	"context"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/pkg/flow/internal/testservices"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name: "testcomponents.service_consumer",
+		Args: ServiceConsumerArguments{},
+		NeedsServices: []string{
+			"hook", // From testservices.Hook
+		},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			return NewServiceConsumer(opts, args.(ServiceConsumerArguments))
+		},
+	})
+}
+
+// ServiceConsumerArguments describes how to configure the
+// testcomponents.service_consumer component.
+type ServiceConsumerArguments struct{}
+
+// ServiceConsumer implements the testcomponents.service_consumer component.
+type ServiceConsumer struct {
+	opts component.Options
+	log  log.Logger
+}
+
+// NewServiceConsumer creates a new service consumer component.
+func NewServiceConsumer(o component.Options, args ServiceConsumerArguments) (*ServiceConsumer, error) {
+	hookData, err := o.GetServiceData("hook")
+	if err != nil {
+		return nil, err
+	}
+	hooks := hookData.(testservices.Hooks)
+	hooks.OnComponentCreate(o, args)
+
+	sc := &ServiceConsumer{
+		opts: o,
+		log:  o.Logger,
+	}
+	if err := sc.Update(args); err != nil {
+		return nil, err
+	}
+	return sc, nil
+}
+
+var (
+	_ component.Component      = (*Passthrough)(nil)
+	_ component.DebugComponent = (*Passthrough)(nil)
+)
+
+// Run implements Component.
+func (sc *ServiceConsumer) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+// Update implements Component.
+func (sc *ServiceConsumer) Update(args component.Arguments) error {
+	// no-op
+	return nil
+}

--- a/pkg/flow/internal/testcomponents/service_consumer.go
+++ b/pkg/flow/internal/testcomponents/service_consumer.go
@@ -52,7 +52,7 @@ func NewServiceConsumer(o component.Options, args ServiceConsumerArguments) (*Se
 }
 
 var (
-	_ component.Component      = (*ServiceConsumer)(nil)
+	_ component.Component = (*ServiceConsumer)(nil)
 )
 
 // Run implements Component.

--- a/pkg/flow/internal/testservices/hook.go
+++ b/pkg/flow/internal/testservices/hook.go
@@ -1,0 +1,51 @@
+package testservices
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/service"
+)
+
+// The Hook service allows components to invoke hooks used for testing.
+type Hook struct {
+	hooks Hooks
+}
+
+// NewHook creates a new Hook service.
+func NewHook(hooks Hooks) *Hook {
+	return &Hook{hooks: hooks}
+}
+
+// Hooks is a set of hooks that are exposed to a component using the hook
+// service.
+type Hooks struct {
+	OnComponentCreate func(o component.Options, args component.Arguments)
+}
+
+var _ service.Service = (*Hook)(nil)
+
+// Definition implements [service.Serivce]. The name of the returned service is
+// "test".
+func (h *Hook) Definition() service.Definition {
+	return service.Definition{
+		Name:       "hook",
+		ConfigType: nil,
+		DependsOn:  nil,
+	}
+}
+
+// Run implements [service.Service].
+func (h *Hook) Run(ctx context.Context, host service.Host) error {
+	<-ctx.Done()
+	return nil
+}
+
+// Update implements [service.Service].
+func (h *Hook) Update(newConfig any) error {
+	return fmt.Errorf("Update should not have been called")
+}
+
+// Data implements [service.Service]. It returns a *testing.T.
+func (h *Hook) Data() any { return h.hooks }


### PR DESCRIPTION
> **NOTE**: I recommend reviewing this PR commit-by-commit.

This change allows components to declare a dependency on a service and access data for services for which a dependency has been declared. This follows up on #4664, which initially introduced the concept of services into the Flow controller.

Related to #4253.

A follow up PR will be opened to complete the services implementation: allow components in modules to have access to services. 