### PR TITLE
flow: fix graceful termination on kubernetes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Main (unreleased)
 
 - Allow `loki.source.file` to define the encoding of files. (@tpaschalis)
 
+- Enable graceful termination when receiving SIGTERM/CTRL_SHUTDOWN_EVENT
+  signals. (@tpaschalis)
+
 - New Grafana Agent Flow components:
 
   - `prometheus.exporter.gcp` - scrape GCP metrics. (@tburgessdev)

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -360,7 +360,7 @@ func interruptContext() (context.Context, context.CancelFunc) {
 	go func() {
 		defer cancel()
 		sig := make(chan os.Signal, 1)
-		signal.Notify(sig, os.Interrupt)
+		signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 		select {
 		case <-sig:
 		case <-ctx.Done():


### PR DESCRIPTION
#### PR Description
The signal is natively implemented in Linux and macOS.

On Windows, _CTRL_SHUTDOWN_EVENT which is used on Windows Kubernetes to signal graceful termination is [mapped](https://github.com/golang/go/blob/5f2e24efb3c7e021308d15a26d93e5a7aa3c05f0/src/runtime/os_windows.go#L1105-L1112) to SIGTERM internally so it should work in the same way.

#### Which issue(s) this PR fixes
Fixes #4684

#### Notes to the Reviewer
The SIGKILL signal is used as a backup when the graceful termination period is over. Do we think we should have some extra handling around this?

Also, I find it weird this hasn't caused any other problems recently. Is it possible I'm missing any context or that this was done on purpose?

#### PR Checklist

- [X] CHANGELOG updated
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)