### PR TITLE
The commit the exporter to was originally pinned to doesnt work 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -689,7 +689,7 @@ replace (
 	github.com/prometheus-community/postgres_exporter => github.com/grafana/postgres_exporter v0.8.1-0.20210722175051-db35d7c2f520
 
 	// TODO(mattdurham): this is to allow defaults to propogate properly.
-	github.com/prometheus-community/windows_exporter => github.com/grafana/windows_exporter v0.15.1-0.20230609142740-b47fa97c3c47
+	github.com/prometheus-community/windows_exporter => github.com/grafana/windows_exporter v0.15.1-0.20230612134738-fdb3ba7accd8
 	github.com/prometheus/mysqld_exporter => github.com/grafana/mysqld_exporter v0.12.2-0.20201015182516-5ac885b2d38a
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1940,8 +1940,8 @@ github.com/grafana/tail v0.0.0-20230328181249-aa6682d7843a h1:ypBalFlWhbqP+60je3
 github.com/grafana/tail v0.0.0-20230328181249-aa6682d7843a/go.mod h1:7t5XR+2IA8P2qggOAHTj/GCZfoLBle3OvNSYh1VkRBU=
 github.com/grafana/vmware_exporter v0.0.4-beta h1:Tb8Edm/wDYh0Lvhm38HLNTlkflUrlPGB+jD+/hW4xHI=
 github.com/grafana/vmware_exporter v0.0.4-beta/go.mod h1:+SsUoWeCJ3nDm1gkw8xqBp4NNSUIrGVoEbnwJeeoIVU=
-github.com/grafana/windows_exporter v0.15.1-0.20230609142740-b47fa97c3c47 h1:0B4dYFrny1h51kdddXbvg6yHn8LAEfoYuxeQceV6uXw=
-github.com/grafana/windows_exporter v0.15.1-0.20230609142740-b47fa97c3c47/go.mod h1:VP/c/Xo6p/PRlSN5s7M2SGscCxLGFRHydjmk0WqxaHU=
+github.com/grafana/windows_exporter v0.15.1-0.20230612134738-fdb3ba7accd8 h1:xa9iGJ1pl7nzrmMxkVxgkOrXoIwozCe5RH5sYjGk8QM=
+github.com/grafana/windows_exporter v0.15.1-0.20230612134738-fdb3ba7accd8/go.mod h1:Fxr4FlDGM8TLI58WNi9Zu1Kd4Jg2x61Zv+DZdKI75DM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grobie/gomemcache v0.0.0-20201204163352-08d7c80fcac6 h1:vqwzYov9hrRoGAmy61um8mVteOCD0bEbKgXr1mmkTlI=
 github.com/grobie/gomemcache v0.0.0-20201204163352-08d7c80fcac6/go.mod h1:L69/dBlPQlWkcnU76WgcppK5e4rrxzQdi6LhLnK/ytA=


### PR DESCRIPTION
Due to me amending the PR the commit hash is different and likely only working due to go proxy caching the commit. Switching to using the most recent commit in the multi collector. The date is slightly newer since I included a change that better allows debugging and some minor cleanup.