### PR TITLE
Export AppAgentReceiverExporter interface

### DIFF
--- a/pkg/integrations/v2/app_agent_receiver/app_agent_receiver.go
+++ b/pkg/integrations/v2/app_agent_receiver/app_agent_receiver.go
@@ -47,7 +47,7 @@ func (c *Config) NewIntegration(l log.Logger, globals integrations.Globals) (int
 
 	receiverMetricsExporter := NewReceiverMetricsExporter(reg)
 
-	var exp = []appAgentReceiverExporter{
+	var exp = []AppAgentReceiverExporter{
 		receiverMetricsExporter,
 	}
 

--- a/pkg/integrations/v2/app_agent_receiver/handler.go
+++ b/pkg/integrations/v2/app_agent_receiver/handler.go
@@ -17,21 +17,21 @@ import (
 
 const apiKeyHeader = "x-api-key"
 
-type appAgentReceiverExporter interface {
+type AppAgentReceiverExporter interface {
 	Name() string
 	Export(ctx context.Context, payload Payload) error
 }
 
 // AppAgentReceiverHandler struct controls the data ingestion http handler of the receiver
 type AppAgentReceiverHandler struct {
-	exporters               []appAgentReceiverExporter
+	exporters               []AppAgentReceiverExporter
 	config                  *Config
 	rateLimiter             *rate.Limiter
 	exporterErrorsCollector *prometheus.CounterVec
 }
 
 // NewAppAgentReceiverHandler creates a new AppReceiver instance based on the given configuration
-func NewAppAgentReceiverHandler(conf *Config, exporters []appAgentReceiverExporter, reg prometheus.Registerer) AppAgentReceiverHandler {
+func NewAppAgentReceiverHandler(conf *Config, exporters []AppAgentReceiverExporter, reg prometheus.Registerer) AppAgentReceiverHandler {
 	var rateLimiter *rate.Limiter
 	if conf.Server.RateLimiting.Enabled {
 		var rps float64
@@ -100,7 +100,7 @@ func (ar *AppAgentReceiverHandler) HTTPHandler(logger log.Logger) http.Handler {
 
 		for _, exporter := range ar.exporters {
 			wg.Add(1)
-			go func(exp appAgentReceiverExporter) {
+			go func(exp AppAgentReceiverExporter) {
 				defer wg.Done()
 				if err := exp.Export(r.Context(), p); err != nil {
 					level.Error(logger).Log("msg", "exporter error", "exporter", exp.Name(), "error", err)

--- a/pkg/integrations/v2/app_agent_receiver/handler_test.go
+++ b/pkg/integrations/v2/app_agent_receiver/handler_test.go
@@ -64,7 +64,7 @@ func TestMultipleExportersAllSucceed(t *testing.T) {
 
 	conf := &Config{}
 
-	fr := NewAppAgentReceiverHandler(conf, []appAgentReceiverExporter{&exporter1, &exporter2}, reg)
+	fr := NewAppAgentReceiverHandler(conf, []AppAgentReceiverExporter{&exporter1, &exporter2}, reg)
 	handler := fr.HTTPHandler(log.NewNopLogger())
 
 	rr := httptest.NewRecorder()
@@ -97,7 +97,7 @@ func TestMultipleExportersOneFails(t *testing.T) {
 
 	conf := &Config{}
 
-	fr := NewAppAgentReceiverHandler(conf, []appAgentReceiverExporter{&exporter1, &exporter2}, reg)
+	fr := NewAppAgentReceiverHandler(conf, []AppAgentReceiverExporter{&exporter1, &exporter2}, reg)
 	handler := fr.HTTPHandler(log.NewNopLogger())
 
 	rr := httptest.NewRecorder()
@@ -139,7 +139,7 @@ func TestMultipleExportersAllFail(t *testing.T) {
 
 	conf := &Config{}
 
-	fr := NewAppAgentReceiverHandler(conf, []appAgentReceiverExporter{&exporter1, &exporter2}, reg)
+	fr := NewAppAgentReceiverHandler(conf, []AppAgentReceiverExporter{&exporter1, &exporter2}, reg)
 	handler := fr.HTTPHandler(log.NewNopLogger())
 
 	rr := httptest.NewRecorder()
@@ -174,7 +174,7 @@ func TestNoContentLengthLimitSet(t *testing.T) {
 
 	req.ContentLength = 89348593894
 
-	fr := NewAppAgentReceiverHandler(conf, []appAgentReceiverExporter{}, reg)
+	fr := NewAppAgentReceiverHandler(conf, []AppAgentReceiverExporter{}, reg)
 	handler := fr.HTTPHandler(nil)
 
 	rr := httptest.NewRecorder()
@@ -195,7 +195,7 @@ func TestLargePayload(t *testing.T) {
 		},
 	}
 
-	fr := NewAppAgentReceiverHandler(conf, []appAgentReceiverExporter{}, reg)
+	fr := NewAppAgentReceiverHandler(conf, []AppAgentReceiverExporter{}, reg)
 	handler := fr.HTTPHandler(nil)
 
 	rr := httptest.NewRecorder()

--- a/pkg/integrations/v2/app_agent_receiver/logs_exporter.go
+++ b/pkg/integrations/v2/app_agent_receiver/logs_exporter.go
@@ -40,7 +40,7 @@ type LogsExporter struct {
 
 // NewLogsExporter creates a new logs exporter with the given
 // configuration
-func NewLogsExporter(logger kitlog.Logger, conf LogsExporterConfig, sourceMapStore SourceMapStore) appAgentReceiverExporter {
+func NewLogsExporter(logger kitlog.Logger, conf LogsExporterConfig, sourceMapStore SourceMapStore) AppAgentReceiverExporter {
 	return &LogsExporter{
 		logger:           logger,
 		getLogsInstance:  conf.GetLogsInstance,
@@ -135,6 +135,6 @@ func (le *LogsExporter) labelSet(kv *KeyVal) prommodel.LabelSet {
 
 // Static typecheck tests
 var (
-	_ appAgentReceiverExporter = (*LogsExporter)(nil)
+	_ AppAgentReceiverExporter = (*LogsExporter)(nil)
 	_ logsInstance             = (*logs.Instance)(nil)
 )

--- a/pkg/integrations/v2/app_agent_receiver/receiver_metrics_exporter.go
+++ b/pkg/integrations/v2/app_agent_receiver/receiver_metrics_exporter.go
@@ -16,7 +16,7 @@ type ReceiverMetricsExporter struct {
 }
 
 // NewReceiverMetricsExporter creates a new ReceiverMetricsExporter
-func NewReceiverMetricsExporter(reg prometheus.Registerer) appAgentReceiverExporter {
+func NewReceiverMetricsExporter(reg prometheus.Registerer) AppAgentReceiverExporter {
 	exp := &ReceiverMetricsExporter{
 		totalLogs: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "app_agent_receiver_logs_total",
@@ -54,3 +54,8 @@ func (re *ReceiverMetricsExporter) Export(ctx context.Context, payload Payload) 
 	re.totalEvents.Add(float64(len(payload.Events)))
 	return nil
 }
+
+// Static typecheck tests
+var (
+	_ AppAgentReceiverExporter = (*ReceiverMetricsExporter)(nil)
+)

--- a/pkg/integrations/v2/app_agent_receiver/traces_exporter.go
+++ b/pkg/integrations/v2/app_agent_receiver/traces_exporter.go
@@ -14,7 +14,7 @@ type TracesExporter struct {
 }
 
 // NewTracesExporter creates a trace exporter for the app agent receiver.
-func NewTracesExporter(getTracesConsumer tracesConsumerGetter) appAgentReceiverExporter {
+func NewTracesExporter(getTracesConsumer tracesConsumerGetter) AppAgentReceiverExporter {
 	return &TracesExporter{getTracesConsumer}
 }
 
@@ -34,3 +34,8 @@ func (te *TracesExporter) Export(ctx context.Context, payload Payload) error {
 	}
 	return consumer.ConsumeTraces(ctx, payload.Traces.Traces)
 }
+
+// Static typecheck tests
+var (
+	_ AppAgentReceiverExporter = (*TracesExporter)(nil)
+)


### PR DESCRIPTION
This will enable external integration of the AppAgent with custom-built exporters

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

While integrating the AppAgent into an existing Go codebase, I was blocked by the fact that the interface used to implement exporters was not exported. I feel like this is a safe change and that potentially breaking change handling is the responsibility of the integrator and not the project.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

N/A

#### Notes to the Reviewer

I was discussing this in [Slack](https://grafana.slack.com/archives/C01050C3D8F/p1690969732012899) and felt like it was an acceptable contribution 😄 
 
#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
