### PR TITLE
all: migrate components to use the HTTP service

### DIFF
--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"os/signal"
 	"sync"
@@ -204,19 +203,12 @@ func (fr *flowRun) Run(configFile string) error {
 	})
 
 	f := flow.New(flow.Options{
-		Logger:         l,
-		Tracer:         t,
-		Clusterer:      clusterer,
-		DataPath:       fr.storagePath,
-		Reg:            reg,
-		HTTPPathPrefix: "/api/v0/component/",
-		HTTPListenAddr: fr.inMemoryAddr,
-		Services:       []service.Service{httpService},
-
-		// Send requests to fr.inMemoryAddr directly to our in-memory listener.
-		DialFunc: func(ctx context.Context, network, address string) (net.Conn, error) {
-			return httpService.Data().(httpservice.Data).DialFunc(ctx, network, address)
-		},
+		Logger:    l,
+		Tracer:    t,
+		Clusterer: clusterer,
+		DataPath:  fr.storagePath,
+		Reg:       reg,
+		Services:  []service.Service{httpService},
 	})
 
 	ready = f.Ready

--- a/component/component.go
+++ b/component/component.go
@@ -60,7 +60,6 @@ package component
 
 import (
 	"context"
-	"net/http"
 )
 
 // The Arguments contains the input fields for a specific component, which is
@@ -113,17 +112,6 @@ type DebugComponent interface {
 	//
 	// DebugInfo must be safe for calling concurrently.
 	DebugInfo() interface{}
-}
-
-// HTTPComponent is an extension interface for components which contain their own HTTP handlers.
-type HTTPComponent interface {
-	Component
-
-	// Handler should return a valid HTTP handler for the component.
-	// All requests to the component will have the path trimmed such that the component is at the root.
-	// For example, f a request is made to `/component/{id}/metrics`, the component
-	// will receive a request to just `/metrics`.
-	Handler() http.Handler
 }
 
 // ClusteredComponent is an extension interface for components which implement

--- a/component/local/file_match/file_test.go
+++ b/component/local/file_match/file_test.go
@@ -228,10 +228,8 @@ func createComponentWithLabels(t *testing.T, dir string, paths []string, exclude
 		OnStateChange: func(e component.Exports) {
 
 		},
-		Registerer:     prometheus.DefaultRegisterer,
-		Tracer:         nil,
-		HTTPListenAddr: "",
-		HTTPPath:       "",
+		Registerer: prometheus.DefaultRegisterer,
+		Tracer:     nil,
 	}, Arguments{
 		PathTargets: tPaths,
 		SyncPeriod:  1 * time.Second,

--- a/component/module/file/file.go
+++ b/component/module/file/file.go
@@ -10,13 +10,15 @@ import (
 	"github.com/grafana/agent/component/local/file"
 	"github.com/grafana/agent/component/module"
 	"github.com/grafana/agent/pkg/river/rivertypes"
+	"github.com/grafana/agent/service/http"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "module.file",
-		Args:    Arguments{},
-		Exports: module.Exports{},
+		Name:          "module.file",
+		Args:          Arguments{},
+		Exports:       module.Exports{},
+		NeedsServices: []string{http.ServiceName},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/module/git/git.go
+++ b/component/module/git/git.go
@@ -13,13 +13,15 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/module"
 	"github.com/grafana/agent/component/module/git/internal/vcs"
+	"github.com/grafana/agent/service/http"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "module.git",
-		Args:    Arguments{},
-		Exports: module.Exports{},
+		Name:          "module.git",
+		Args:          Arguments{},
+		Exports:       module.Exports{},
+		NeedsServices: []string{http.ServiceName},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/module/http/http.go
+++ b/component/module/http/http.go
@@ -10,13 +10,15 @@ import (
 	"github.com/grafana/agent/component/module"
 	remote_http "github.com/grafana/agent/component/remote/http"
 	"github.com/grafana/agent/pkg/river/rivertypes"
+	http_service "github.com/grafana/agent/service/http"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "module.http",
-		Args:    Arguments{},
-		Exports: module.Exports{},
+		Name:          "module.http",
+		Args:          Arguments{},
+		Exports:       module.Exports{},
+		NeedsServices: []string{http_service.ServiceName},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/module/string/string.go
+++ b/component/module/string/string.go
@@ -6,13 +6,15 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/module"
 	"github.com/grafana/agent/pkg/river/rivertypes"
+	"github.com/grafana/agent/service/http"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "module.string",
-		Args:    Arguments{},
-		Exports: module.Exports{},
+		Name:          "module.string",
+		Args:          Arguments{},
+		Exports:       module.Exports{},
+		NeedsServices: []string{http.ServiceName},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/prometheus/exporter/apache/apache.go
+++ b/component/prometheus/exporter/apache/apache.go
@@ -8,14 +8,16 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/apache_http"
+	"github.com/grafana/agent/service/http"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.apache",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
-		Build:   exporter.NewWithTargetBuilder(createExporter, "apache", customizeTarget),
+		Name:          "prometheus.exporter.apache",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.NewWithTargetBuilder(createExporter, "apache", customizeTarget),
 	})
 }
 

--- a/component/prometheus/exporter/apache/apache.go
+++ b/component/prometheus/exporter/apache/apache.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/apache_http"
-	"github.com/grafana/agent/service/http"
 )
 
 func init() {
@@ -16,7 +15,7 @@ func init() {
 		Name:          "prometheus.exporter.apache",
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.NewWithTargetBuilder(createExporter, "apache", customizeTarget),
 	})
 }

--- a/component/prometheus/exporter/blackbox/blackbox.go
+++ b/component/prometheus/exporter/blackbox/blackbox.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/blackbox_exporter"
 	"github.com/grafana/agent/pkg/river/rivertypes"
-	"github.com/grafana/agent/service/http"
 )
 
 func init() {
@@ -22,7 +21,7 @@ func init() {
 		Name:          "prometheus.exporter.blackbox",
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.NewWithTargetBuilder(createExporter, "blackbox", buildBlackboxTargets),
 	})
 }

--- a/component/prometheus/exporter/blackbox/blackbox.go
+++ b/component/prometheus/exporter/blackbox/blackbox.go
@@ -14,14 +14,16 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/blackbox_exporter"
 	"github.com/grafana/agent/pkg/river/rivertypes"
+	"github.com/grafana/agent/service/http"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.blackbox",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
-		Build:   exporter.NewWithTargetBuilder(createExporter, "blackbox", buildBlackboxTargets),
+		Name:          "prometheus.exporter.blackbox",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.NewWithTargetBuilder(createExporter, "blackbox", buildBlackboxTargets),
 	})
 }
 

--- a/component/prometheus/exporter/cloudwatch/cloudwatch.go
+++ b/component/prometheus/exporter/cloudwatch/cloudwatch.go
@@ -7,14 +7,16 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/cloudwatch_exporter"
+	"github.com/grafana/agent/service/http"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.cloudwatch",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
-		Build:   exporter.New(createExporter, "cloudwatch"),
+		Name:          "prometheus.exporter.cloudwatch",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.New(createExporter, "cloudwatch"),
 	})
 }
 

--- a/component/prometheus/exporter/cloudwatch/cloudwatch.go
+++ b/component/prometheus/exporter/cloudwatch/cloudwatch.go
@@ -7,7 +7,6 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/cloudwatch_exporter"
-	"github.com/grafana/agent/service/http"
 )
 
 func init() {
@@ -15,7 +14,7 @@ func init() {
 		Name:          "prometheus.exporter.cloudwatch",
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.New(createExporter, "cloudwatch"),
 	})
 }

--- a/component/prometheus/exporter/consul/consul.go
+++ b/component/prometheus/exporter/consul/consul.go
@@ -9,14 +9,16 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/consul_exporter"
+	"github.com/grafana/agent/service/http"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.consul",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
-		Build:   exporter.NewWithTargetBuilder(createExporter, "consul", customizeTarget),
+		Name:          "prometheus.exporter.consul",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.NewWithTargetBuilder(createExporter, "consul", customizeTarget),
 	})
 }
 

--- a/component/prometheus/exporter/consul/consul.go
+++ b/component/prometheus/exporter/consul/consul.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/consul_exporter"
-	"github.com/grafana/agent/service/http"
 )
 
 func init() {
@@ -17,7 +16,7 @@ func init() {
 		Name:          "prometheus.exporter.consul",
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.NewWithTargetBuilder(createExporter, "consul", customizeTarget),
 	})
 }

--- a/component/prometheus/exporter/dnsmasq/dnsmasq.go
+++ b/component/prometheus/exporter/dnsmasq/dnsmasq.go
@@ -6,7 +6,6 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/dnsmasq_exporter"
-	"github.com/grafana/agent/service/http"
 )
 
 func init() {
@@ -14,7 +13,7 @@ func init() {
 		Name:          "prometheus.exporter.dnsmasq",
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.NewWithTargetBuilder(createExporter, "dnsmasq", customizeTarget),
 	})
 }

--- a/component/prometheus/exporter/dnsmasq/dnsmasq.go
+++ b/component/prometheus/exporter/dnsmasq/dnsmasq.go
@@ -6,14 +6,16 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/dnsmasq_exporter"
+	"github.com/grafana/agent/service/http"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.dnsmasq",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
-		Build:   exporter.NewWithTargetBuilder(createExporter, "dnsmasq", customizeTarget),
+		Name:          "prometheus.exporter.dnsmasq",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.NewWithTargetBuilder(createExporter, "dnsmasq", customizeTarget),
 	})
 }
 

--- a/component/prometheus/exporter/elasticsearch/elasticsearch.go
+++ b/component/prometheus/exporter/elasticsearch/elasticsearch.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/elasticsearch_exporter"
-	"github.com/grafana/agent/service/http"
 )
 
 func init() {
@@ -16,7 +15,7 @@ func init() {
 		Name:          "prometheus.exporter.elasticsearch",
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.NewWithTargetBuilder(createExporter, "elasticsearch", customizeTarget),
 	})
 }

--- a/component/prometheus/exporter/elasticsearch/elasticsearch.go
+++ b/component/prometheus/exporter/elasticsearch/elasticsearch.go
@@ -8,14 +8,16 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/elasticsearch_exporter"
+	"github.com/grafana/agent/service/http"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.elasticsearch",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
-		Build:   exporter.NewWithTargetBuilder(createExporter, "elasticsearch", customizeTarget),
+		Name:          "prometheus.exporter.elasticsearch",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.NewWithTargetBuilder(createExporter, "elasticsearch", customizeTarget),
 	})
 }
 

--- a/component/prometheus/exporter/exporter.go
+++ b/component/prometheus/exporter/exporter.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/discovery"
 	"github.com/grafana/agent/pkg/integrations"
+	http_service "github.com/grafana/agent/service/http"
 	"github.com/prometheus/common/model"
 )
 
@@ -126,10 +127,16 @@ func newExporter(creator Creator, name string, targetBuilderFunc func(discovery.
 		jobName := fmt.Sprintf("integrations/%s", name)
 		instance := defaultInstance()
 
+		data, err := opts.GetServiceData(http_service.ServiceName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get HTTP information: %w", err)
+		}
+		httpData := data.(http_service.Data)
+
 		c.baseTarget = discovery.Target{
-			model.AddressLabel:                  opts.HTTPListenAddr,
+			model.AddressLabel:                  httpData.MemoryListenAddr,
 			model.SchemeLabel:                   "http",
-			model.MetricsPathLabel:              path.Join(opts.HTTPPath, "metrics"),
+			model.MetricsPathLabel:              path.Join(httpData.HTTPPathForComponent(opts.ID), "metrics"),
 			"instance":                          instance,
 			"job":                               jobName,
 			"__meta_agent_integration_name":     jobName,

--- a/component/prometheus/exporter/gcp/gcp.go
+++ b/component/prometheus/exporter/gcp/gcp.go
@@ -7,14 +7,16 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/gcp_exporter"
+	"github.com/grafana/agent/service/http"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.gcp",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
-		Build:   exporter.New(createExporter, "gcp"),
+		Name:          "prometheus.exporter.gcp",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.New(createExporter, "gcp"),
 	})
 }
 

--- a/component/prometheus/exporter/gcp/gcp.go
+++ b/component/prometheus/exporter/gcp/gcp.go
@@ -7,7 +7,6 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/gcp_exporter"
-	"github.com/grafana/agent/service/http"
 )
 
 func init() {
@@ -15,7 +14,7 @@ func init() {
 		Name:          "prometheus.exporter.gcp",
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.New(createExporter, "gcp"),
 	})
 }

--- a/component/prometheus/exporter/github/github.go
+++ b/component/prometheus/exporter/github/github.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/github_exporter"
 	"github.com/grafana/agent/pkg/river/rivertypes"
-	"github.com/grafana/agent/service/http"
 	config_util "github.com/prometheus/common/config"
 )
 
@@ -18,7 +17,7 @@ func init() {
 		Name:          "prometheus.exporter.github",
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.NewWithTargetBuilder(createExporter, "github", customizeTarget),
 	})
 }

--- a/component/prometheus/exporter/github/github.go
+++ b/component/prometheus/exporter/github/github.go
@@ -9,15 +9,17 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/github_exporter"
 	"github.com/grafana/agent/pkg/river/rivertypes"
+	"github.com/grafana/agent/service/http"
 	config_util "github.com/prometheus/common/config"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.github",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
-		Build:   exporter.NewWithTargetBuilder(createExporter, "github", customizeTarget),
+		Name:          "prometheus.exporter.github",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.NewWithTargetBuilder(createExporter, "github", customizeTarget),
 	})
 }
 

--- a/component/prometheus/exporter/kafka/kafka.go
+++ b/component/prometheus/exporter/kafka/kafka.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/kafka_exporter"
+	"github.com/grafana/agent/service/http"
 	config_util "github.com/prometheus/common/config"
 )
 
@@ -50,10 +51,11 @@ type Arguments struct {
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.kafka",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
-		Build:   exporter.NewWithTargetBuilder(createIntegration, "kafka", customizeTarget),
+		Name:          "prometheus.exporter.kafka",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.NewWithTargetBuilder(createIntegration, "kafka", customizeTarget),
 	})
 }
 

--- a/component/prometheus/exporter/kafka/kafka.go
+++ b/component/prometheus/exporter/kafka/kafka.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/kafka_exporter"
-	"github.com/grafana/agent/service/http"
 	config_util "github.com/prometheus/common/config"
 )
 
@@ -54,7 +53,7 @@ func init() {
 		Name:          "prometheus.exporter.kafka",
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.NewWithTargetBuilder(createIntegration, "kafka", customizeTarget),
 	})
 }

--- a/component/prometheus/exporter/memcached/memcached.go
+++ b/component/prometheus/exporter/memcached/memcached.go
@@ -8,14 +8,16 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/memcached_exporter"
+	"github.com/grafana/agent/service/http"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.memcached",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
-		Build:   exporter.NewWithTargetBuilder(createExporter, "memcached", customizeTarget),
+		Name:          "prometheus.exporter.memcached",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.NewWithTargetBuilder(createExporter, "memcached", customizeTarget),
 	})
 }
 

--- a/component/prometheus/exporter/memcached/memcached.go
+++ b/component/prometheus/exporter/memcached/memcached.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/memcached_exporter"
-	"github.com/grafana/agent/service/http"
 )
 
 func init() {
@@ -16,7 +15,7 @@ func init() {
 		Name:          "prometheus.exporter.memcached",
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.NewWithTargetBuilder(createExporter, "memcached", customizeTarget),
 	})
 }

--- a/component/prometheus/exporter/mongodb/mongodb.go
+++ b/component/prometheus/exporter/mongodb/mongodb.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/mongodb_exporter"
 	"github.com/grafana/agent/pkg/river/rivertypes"
-	"github.com/grafana/agent/service/http"
 	config_util "github.com/prometheus/common/config"
 )
 
@@ -18,7 +17,7 @@ func init() {
 		Name:          "prometheus.exporter.mongodb",
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.NewWithTargetBuilder(createExporter, "mongodb", customizeTarget),
 	})
 }

--- a/component/prometheus/exporter/mongodb/mongodb.go
+++ b/component/prometheus/exporter/mongodb/mongodb.go
@@ -9,15 +9,17 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/mongodb_exporter"
 	"github.com/grafana/agent/pkg/river/rivertypes"
+	"github.com/grafana/agent/service/http"
 	config_util "github.com/prometheus/common/config"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.mongodb",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
-		Build:   exporter.NewWithTargetBuilder(createExporter, "mongodb", customizeTarget),
+		Name:          "prometheus.exporter.mongodb",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.NewWithTargetBuilder(createExporter, "mongodb", customizeTarget),
 	})
 }
 

--- a/component/prometheus/exporter/mssql/mssql.go
+++ b/component/prometheus/exporter/mssql/mssql.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/mssql"
 	"github.com/grafana/agent/pkg/river/rivertypes"
-	"github.com/grafana/agent/service/http"
 	config_util "github.com/prometheus/common/config"
 )
 
@@ -20,7 +19,7 @@ func init() {
 		Name:          "prometheus.exporter.mssql",
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.NewWithTargetBuilder(createExporter, "mssql", customizeTarget),
 	})
 }

--- a/component/prometheus/exporter/mssql/mssql.go
+++ b/component/prometheus/exporter/mssql/mssql.go
@@ -11,15 +11,17 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/mssql"
 	"github.com/grafana/agent/pkg/river/rivertypes"
+	"github.com/grafana/agent/service/http"
 	config_util "github.com/prometheus/common/config"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.mssql",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
-		Build:   exporter.NewWithTargetBuilder(createExporter, "mssql", customizeTarget),
+		Name:          "prometheus.exporter.mssql",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.NewWithTargetBuilder(createExporter, "mssql", customizeTarget),
 	})
 }
 

--- a/component/prometheus/exporter/mysql/mysql.go
+++ b/component/prometheus/exporter/mysql/mysql.go
@@ -10,15 +10,17 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/mysqld_exporter"
 	"github.com/grafana/agent/pkg/river/rivertypes"
+	"github.com/grafana/agent/service/http"
 	config_util "github.com/prometheus/common/config"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.mysql",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
-		Build:   exporter.NewWithTargetBuilder(createExporter, "mysql", customizeTarget),
+		Name:          "prometheus.exporter.mysql",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.NewWithTargetBuilder(createExporter, "mysql", customizeTarget),
 	})
 }
 

--- a/component/prometheus/exporter/mysql/mysql.go
+++ b/component/prometheus/exporter/mysql/mysql.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/mysqld_exporter"
 	"github.com/grafana/agent/pkg/river/rivertypes"
-	"github.com/grafana/agent/service/http"
 	config_util "github.com/prometheus/common/config"
 )
 
@@ -19,7 +18,7 @@ func init() {
 		Name:          "prometheus.exporter.mysql",
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.NewWithTargetBuilder(createExporter, "mysql", customizeTarget),
 	})
 }

--- a/component/prometheus/exporter/oracledb/oracledb.go
+++ b/component/prometheus/exporter/oracledb/oracledb.go
@@ -11,15 +11,17 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/oracledb_exporter"
 	"github.com/grafana/agent/pkg/river/rivertypes"
+	"github.com/grafana/agent/service/http"
 	config_util "github.com/prometheus/common/config"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.oracledb",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
-		Build:   exporter.NewWithTargetBuilder(createExporter, "oracledb", customizeTarget),
+		Name:          "prometheus.exporter.oracledb",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.NewWithTargetBuilder(createExporter, "oracledb", customizeTarget),
 	})
 }
 

--- a/component/prometheus/exporter/oracledb/oracledb.go
+++ b/component/prometheus/exporter/oracledb/oracledb.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/oracledb_exporter"
 	"github.com/grafana/agent/pkg/river/rivertypes"
-	"github.com/grafana/agent/service/http"
 	config_util "github.com/prometheus/common/config"
 )
 
@@ -20,7 +19,7 @@ func init() {
 		Name:          "prometheus.exporter.oracledb",
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.NewWithTargetBuilder(createExporter, "oracledb", customizeTarget),
 	})
 }

--- a/component/prometheus/exporter/postgres/postgres.go
+++ b/component/prometheus/exporter/postgres/postgres.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/postgres_exporter"
 	"github.com/grafana/agent/pkg/river/rivertypes"
-	"github.com/grafana/agent/service/http"
 	"github.com/lib/pq"
 	config_util "github.com/prometheus/common/config"
 )
@@ -20,7 +19,7 @@ func init() {
 		Name:          "prometheus.exporter.postgres",
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.NewWithTargetBuilder(createExporter, "postgres", customizeTarget),
 	})
 }

--- a/component/prometheus/exporter/postgres/postgres.go
+++ b/component/prometheus/exporter/postgres/postgres.go
@@ -10,16 +10,18 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/postgres_exporter"
 	"github.com/grafana/agent/pkg/river/rivertypes"
+	"github.com/grafana/agent/service/http"
 	"github.com/lib/pq"
 	config_util "github.com/prometheus/common/config"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.postgres",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
-		Build:   exporter.NewWithTargetBuilder(createExporter, "postgres", customizeTarget),
+		Name:          "prometheus.exporter.postgres",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.NewWithTargetBuilder(createExporter, "postgres", customizeTarget),
 	})
 }
 

--- a/component/prometheus/exporter/process/process.go
+++ b/component/prometheus/exporter/process/process.go
@@ -5,15 +5,17 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/process_exporter"
+	"github.com/grafana/agent/service/http"
 	exporter_config "github.com/ncabatoff/process-exporter/config"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.process",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
-		Build:   exporter.New(createIntegration, "process"),
+		Name:          "prometheus.exporter.process",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.New(createIntegration, "process"),
 	})
 }
 

--- a/component/prometheus/exporter/process/process.go
+++ b/component/prometheus/exporter/process/process.go
@@ -5,7 +5,6 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/process_exporter"
-	"github.com/grafana/agent/service/http"
 	exporter_config "github.com/ncabatoff/process-exporter/config"
 )
 
@@ -14,7 +13,7 @@ func init() {
 		Name:          "prometheus.exporter.process",
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.New(createIntegration, "process"),
 	})
 }

--- a/component/prometheus/exporter/redis/redis.go
+++ b/component/prometheus/exporter/redis/redis.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/redis_exporter"
 	"github.com/grafana/agent/pkg/river/rivertypes"
-	"github.com/grafana/agent/service/http"
 	config_util "github.com/prometheus/common/config"
 )
 
@@ -20,7 +19,7 @@ func init() {
 		Name:          "prometheus.exporter.redis",
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.NewWithTargetBuilder(createExporter, "redis", customizeTarget),
 	})
 }

--- a/component/prometheus/exporter/redis/redis.go
+++ b/component/prometheus/exporter/redis/redis.go
@@ -11,15 +11,17 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/redis_exporter"
 	"github.com/grafana/agent/pkg/river/rivertypes"
+	"github.com/grafana/agent/service/http"
 	config_util "github.com/prometheus/common/config"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.redis",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
-		Build:   exporter.NewWithTargetBuilder(createExporter, "redis", customizeTarget),
+		Name:          "prometheus.exporter.redis",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.NewWithTargetBuilder(createExporter, "redis", customizeTarget),
 	})
 }
 

--- a/component/prometheus/exporter/services.go
+++ b/component/prometheus/exporter/services.go
@@ -1,0 +1,20 @@
+package exporter
+
+import (
+	"github.com/grafana/agent/service/http"
+	"golang.org/x/exp/maps"
+)
+
+// RequiredServices returns the set of services needed by all
+// prometheus.exporter components. Callers may optionally pass in additional
+// services to add to the returned list.
+func RequiredServices(additionalServices ...string) []string {
+	services := map[string]struct{}{
+		http.ServiceName: {},
+	}
+	for _, svc := range additionalServices {
+		services[svc] = struct{}{}
+	}
+
+	return maps.Keys(services)
+}

--- a/component/prometheus/exporter/snmp/snmp.go
+++ b/component/prometheus/exporter/snmp/snmp.go
@@ -11,16 +11,18 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/snmp_exporter"
 	"github.com/grafana/agent/pkg/river/rivertypes"
+	"github.com/grafana/agent/service/http"
 	snmp_config "github.com/prometheus/snmp_exporter/config"
 	"gopkg.in/yaml.v2"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.snmp",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
-		Build:   exporter.NewWithTargetBuilder(createExporter, "snmp", buildSNMPTargets),
+		Name:          "prometheus.exporter.snmp",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.NewWithTargetBuilder(createExporter, "snmp", buildSNMPTargets),
 	})
 }
 

--- a/component/prometheus/exporter/snmp/snmp.go
+++ b/component/prometheus/exporter/snmp/snmp.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/snmp_exporter"
 	"github.com/grafana/agent/pkg/river/rivertypes"
-	"github.com/grafana/agent/service/http"
 	snmp_config "github.com/prometheus/snmp_exporter/config"
 	"gopkg.in/yaml.v2"
 )
@@ -21,7 +20,7 @@ func init() {
 		Name:          "prometheus.exporter.snmp",
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.NewWithTargetBuilder(createExporter, "snmp", buildSNMPTargets),
 	})
 }

--- a/component/prometheus/exporter/snowflake/snowflake.go
+++ b/component/prometheus/exporter/snowflake/snowflake.go
@@ -7,7 +7,6 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/snowflake_exporter"
 	"github.com/grafana/agent/pkg/river/rivertypes"
-	"github.com/grafana/agent/service/http"
 	config_util "github.com/prometheus/common/config"
 )
 
@@ -16,7 +15,7 @@ func init() {
 		Name:          "prometheus.exporter.snowflake",
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.NewWithTargetBuilder(createExporter, "snowflake", customizeTarget),
 	})
 }

--- a/component/prometheus/exporter/snowflake/snowflake.go
+++ b/component/prometheus/exporter/snowflake/snowflake.go
@@ -7,15 +7,17 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/snowflake_exporter"
 	"github.com/grafana/agent/pkg/river/rivertypes"
+	"github.com/grafana/agent/service/http"
 	config_util "github.com/prometheus/common/config"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.snowflake",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
-		Build:   exporter.NewWithTargetBuilder(createExporter, "snowflake", customizeTarget),
+		Name:          "prometheus.exporter.snowflake",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.NewWithTargetBuilder(createExporter, "snowflake", customizeTarget),
 	})
 }
 

--- a/component/prometheus/exporter/squid/squid.go
+++ b/component/prometheus/exporter/squid/squid.go
@@ -9,15 +9,17 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/squid_exporter"
 	"github.com/grafana/agent/pkg/river/rivertypes"
+	"github.com/grafana/agent/service/http"
 	"github.com/prometheus/common/config"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.squid",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
-		Build:   exporter.NewWithTargetBuilder(createExporter, "squid", customizeTarget),
+		Name:          "prometheus.exporter.squid",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.NewWithTargetBuilder(createExporter, "squid", customizeTarget),
 	})
 }
 

--- a/component/prometheus/exporter/squid/squid.go
+++ b/component/prometheus/exporter/squid/squid.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/squid_exporter"
 	"github.com/grafana/agent/pkg/river/rivertypes"
-	"github.com/grafana/agent/service/http"
 	"github.com/prometheus/common/config"
 )
 
@@ -18,7 +17,7 @@ func init() {
 		Name:          "prometheus.exporter.squid",
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.NewWithTargetBuilder(createExporter, "squid", customizeTarget),
 	})
 }

--- a/component/prometheus/exporter/statsd/statsd.go
+++ b/component/prometheus/exporter/statsd/statsd.go
@@ -6,14 +6,16 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
+	"github.com/grafana/agent/service/http"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.statsd",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
-		Build:   exporter.New(createExporter, "statsd"),
+		Name:          "prometheus.exporter.statsd",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.New(createExporter, "statsd"),
 	})
 }
 

--- a/component/prometheus/exporter/statsd/statsd.go
+++ b/component/prometheus/exporter/statsd/statsd.go
@@ -6,7 +6,6 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
-	"github.com/grafana/agent/service/http"
 )
 
 func init() {
@@ -14,7 +13,7 @@ func init() {
 		Name:          "prometheus.exporter.statsd",
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.New(createExporter, "statsd"),
 	})
 }

--- a/component/prometheus/exporter/unix/unix.go
+++ b/component/prometheus/exporter/unix/unix.go
@@ -5,7 +5,6 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	node_integration "github.com/grafana/agent/pkg/integrations/node_exporter"
-	"github.com/grafana/agent/service/http"
 )
 
 func init() {
@@ -14,7 +13,7 @@ func init() {
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
 		Singleton:     true,
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.New(createExporter, "unix"),
 	})
 }

--- a/component/prometheus/exporter/unix/unix.go
+++ b/component/prometheus/exporter/unix/unix.go
@@ -5,15 +5,17 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	node_integration "github.com/grafana/agent/pkg/integrations/node_exporter"
+	"github.com/grafana/agent/service/http"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:      "prometheus.exporter.unix",
-		Args:      Arguments{},
-		Exports:   exporter.Exports{},
-		Singleton: true,
-		Build:     exporter.New(createExporter, "unix"),
+		Name:          "prometheus.exporter.unix",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		Singleton:     true,
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.New(createExporter, "unix"),
 	})
 }
 

--- a/component/prometheus/exporter/windows/windows.go
+++ b/component/prometheus/exporter/windows/windows.go
@@ -5,15 +5,17 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/windows_exporter"
+	"github.com/grafana/agent/service/http"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:      "prometheus.exporter.windows",
-		Args:      Arguments{},
-		Exports:   exporter.Exports{},
-		Singleton: false,
-		Build:     exporter.New(createExporter, "windows"),
+		Name:          "prometheus.exporter.windows",
+		Args:          Arguments{},
+		Exports:       exporter.Exports{},
+		Singleton:     false,
+		NeedsServices: []string{http.ServiceName},
+		Build:         exporter.New(createExporter, "windows"),
 	})
 }
 

--- a/component/prometheus/exporter/windows/windows.go
+++ b/component/prometheus/exporter/windows/windows.go
@@ -5,7 +5,6 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/windows_exporter"
-	"github.com/grafana/agent/service/http"
 )
 
 func init() {
@@ -14,7 +13,7 @@ func init() {
 		Args:          Arguments{},
 		Exports:       exporter.Exports{},
 		Singleton:     false,
-		NeedsServices: []string{http.ServiceName},
+		NeedsServices: exporter.RequiredServices(),
 		Build:         exporter.New(createExporter, "windows"),
 	})
 }

--- a/component/prometheus/scrape/scrape.go
+++ b/component/prometheus/scrape/scrape.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/agent/component/discovery"
 	"github.com/grafana/agent/component/prometheus"
 	"github.com/grafana/agent/pkg/build"
+	"github.com/grafana/agent/service/http"
 	client_prometheus "github.com/prometheus/client_golang/prometheus"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -27,8 +28,9 @@ func init() {
 	scrape.UserAgent = fmt.Sprintf("GrafanaAgent/%s", build.Version)
 
 	component.Register(component.Registration{
-		Name: "prometheus.scrape",
-		Args: Arguments{},
+		Name:          "prometheus.scrape",
+		Args:          Arguments{},
+		NeedsServices: []string{http.ServiceName},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/prometheus/scrape/scrape_test.go
+++ b/component/prometheus/scrape/scrape_test.go
@@ -173,9 +173,6 @@ func TestCustomDialer(t *testing.T) {
 			Node: cluster.NewLocalNode("inmemory:80"),
 		},
 		Registerer: prometheus_client.NewRegistry(),
-		DialFunc: func(ctx context.Context, network, address string) (net.Conn, error) {
-			return memLis.DialContext(ctx)
-		},
 		GetServiceData: func(name string) (interface{}, error) {
 			if name == http_service.ServiceName {
 				return http_service.Data{

--- a/component/prometheus/scrape/scrape_test.go
+++ b/component/prometheus/scrape/scrape_test.go
@@ -2,6 +2,7 @@ package scrape
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/grafana/agent/pkg/cluster"
 	"github.com/grafana/agent/pkg/river"
 	"github.com/grafana/agent/pkg/util"
+	http_service "github.com/grafana/agent/service/http"
 	"github.com/grafana/ckit/memconn"
 	prometheus_client "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -71,6 +73,18 @@ func TestForwardingToAppendable(t *testing.T) {
 	opts := component.Options{
 		Logger:     util.TestFlowLogger(t),
 		Registerer: prometheus_client.NewRegistry(),
+		GetServiceData: func(name string) (interface{}, error) {
+			if name == http_service.ServiceName {
+				return http_service.Data{
+					HTTPListenAddr:   "localhost:12345",
+					MemoryListenAddr: "agent.internal:1245",
+					BaseHTTPPath:     "/",
+					DialFunc:         (&net.Dialer{}).DialContext,
+				}, nil
+			}
+
+			return nil, fmt.Errorf("service %q does not exist", name)
+		},
 	}
 
 	nilReceivers := []storage.Appendable{nil, nil}
@@ -161,6 +175,20 @@ func TestCustomDialer(t *testing.T) {
 		Registerer: prometheus_client.NewRegistry(),
 		DialFunc: func(ctx context.Context, network, address string) (net.Conn, error) {
 			return memLis.DialContext(ctx)
+		},
+		GetServiceData: func(name string) (interface{}, error) {
+			if name == http_service.ServiceName {
+				return http_service.Data{
+					HTTPListenAddr:   "inmemory:80",
+					MemoryListenAddr: "inmemory:80",
+					BaseHTTPPath:     "/",
+					DialFunc: func(ctx context.Context, network, address string) (net.Conn, error) {
+						return memLis.DialContext(ctx)
+					},
+				}, nil
+			}
+
+			return nil, fmt.Errorf("service %q does not exist", name)
 		},
 	}
 

--- a/component/registry.go
+++ b/component/registry.go
@@ -3,7 +3,6 @@ package component
 import (
 	"context"
 	"fmt"
-	"net"
 	"reflect"
 	"strings"
 
@@ -100,19 +99,6 @@ type Options struct {
 	// clusterer is shared between all components initialized by a Flow
 	// controller.
 	Clusterer *cluster.Clusterer
-
-	// HTTPListenAddr is the address the server is configured to listen on.
-	HTTPListenAddr string
-
-	// DialFunc is a function for components to use to properly communicate to
-	// HTTPListenAddr. If set, components which send HTTP requests to
-	// HTTPListenAddr must use this function to establish connections.
-	DialFunc func(ctx context.Context, network, address string) (net.Conn, error)
-
-	// HTTPPath is the base path that requests need in order to route to this
-	// component. Requests received by a component handler will have this already
-	// trimmed off.
-	HTTPPath string
 
 	// GetServiceData retrieves data for a service by calling
 	// [service.Service.Data] for the specified service.

--- a/converter/internal/test_common/testing.go
+++ b/converter/internal/test_common/testing.go
@@ -15,6 +15,8 @@ import (
 	"github.com/grafana/agent/pkg/cluster"
 	"github.com/grafana/agent/pkg/flow"
 	"github.com/grafana/agent/pkg/flow/logging"
+	"github.com/grafana/agent/service"
+	http_service "github.com/grafana/agent/service/http"
 	"github.com/stretchr/testify/require"
 )
 
@@ -182,6 +184,12 @@ func attemptLoadingFlowConfig(t *testing.T, river []byte) {
 		Clusterer:      &cluster.Clusterer{Node: cluster.NewLocalNode("")},
 		DataPath:       t.TempDir(),
 		HTTPListenAddr: ":0",
+		Services: []service.Service{
+			// The HTTP service isn't used, but we still need to provide an
+			// implementation of one so that components which rely on the HTTP
+			// service load properly.
+			http_service.New(http_service.Options{}),
+		},
 	})
 	err = f.LoadFile(cfg, nil)
 

--- a/converter/internal/test_common/testing.go
+++ b/converter/internal/test_common/testing.go
@@ -180,10 +180,9 @@ func attemptLoadingFlowConfig(t *testing.T, river []byte) {
 	logger, err := logging.New(os.Stderr, logging.DefaultOptions)
 	require.NoError(t, err)
 	f := flow.New(flow.Options{
-		Logger:         logger,
-		Clusterer:      &cluster.Clusterer{Node: cluster.NewLocalNode("")},
-		DataPath:       t.TempDir(),
-		HTTPListenAddr: ":0",
+		Logger:    logger,
+		Clusterer: &cluster.Clusterer{Node: cluster.NewLocalNode("")},
+		DataPath:  t.TempDir(),
 		Services: []service.Service{
 			// The HTTP service isn't used, but we still need to provide an
 			// implementation of one so that components which rely on the HTTP

--- a/pkg/flow/internal/controller/node_component.go
+++ b/pkg/flow/internal/controller/node_component.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"net/http"
 	"path"
 	"path/filepath"
 	"reflect"
@@ -500,16 +499,6 @@ func (cn *ComponentNode) setRunHealth(t component.HealthType, msg string) {
 		Message:    msg,
 		UpdateTime: time.Now(),
 	}
-}
-
-// HTTPHandler returns an http handler for a component IF it implements HTTPComponent.
-// otherwise it will return nil.
-func (cn *ComponentNode) HTTPHandler() http.Handler {
-	handler, ok := cn.managed.(component.HTTPComponent)
-	if !ok {
-		return nil
-	}
-	return handler.Handler()
 }
 
 // ModuleIDs returns the current list of modules that this component is

--- a/pkg/flow/internal/controller/node_component_test.go
+++ b/pkg/flow/internal/controller/node_component_test.go
@@ -9,9 +9,8 @@ import (
 
 func TestGlobalID(t *testing.T) {
 	mo := getManagedOptions(ComponentGlobals{
-		DataPath:       "/data/",
-		HTTPPathPrefix: "/http/",
-		ControllerID:   "module.file",
+		DataPath:     "/data/",
+		ControllerID: "module.file",
 		NewModuleController: func(id string, availableServices []string) ModuleController {
 			return nil
 		},
@@ -19,15 +18,13 @@ func TestGlobalID(t *testing.T) {
 		nodeID:   "local.id",
 		globalID: "module.file/local.id",
 	})
-	require.Equal(t, "/http/module.file/local.id/", filepath.ToSlash(mo.HTTPPath))
 	require.Equal(t, "/data/module.file/local.id", filepath.ToSlash(mo.DataPath))
 }
 
 func TestLocalID(t *testing.T) {
 	mo := getManagedOptions(ComponentGlobals{
-		DataPath:       "/data/",
-		HTTPPathPrefix: "/http/",
-		ControllerID:   "",
+		DataPath:     "/data/",
+		ControllerID: "",
 		NewModuleController: func(id string, availableServices []string) ModuleController {
 			return nil
 		},
@@ -35,6 +32,5 @@ func TestLocalID(t *testing.T) {
 		nodeID:   "local.id",
 		globalID: "local.id",
 	})
-	require.Equal(t, "/http/local.id/", filepath.ToSlash(mo.HTTPPath))
 	require.Equal(t, "/data/local.id", filepath.ToSlash(mo.DataPath))
 }

--- a/pkg/flow/module.go
+++ b/pkg/flow/module.go
@@ -112,20 +112,17 @@ func newModule(o *moduleOptions) *module {
 			ModuleRegistry:    o.ModuleRegistry,
 			ComponentRegistry: o.ComponentRegistry,
 			Options: Options{
-				ControllerID:   o.ID,
-				Tracer:         o.Tracer,
-				Clusterer:      o.Clusterer,
-				Reg:            o.Reg,
-				Logger:         o.Logger,
-				DataPath:       o.DataPath,
-				HTTPPathPrefix: o.HTTPPath,
-				HTTPListenAddr: o.HTTPListenAddr,
+				ControllerID: o.ID,
+				Tracer:       o.Tracer,
+				Clusterer:    o.Clusterer,
+				Reg:          o.Reg,
+				Logger:       o.Logger,
+				DataPath:     o.DataPath,
 				OnExportsChange: func(exports map[string]any) {
 					if o.export != nil {
 						o.export(exports)
 					}
 				},
-				DialFunc: o.DialFunc,
 				Services: o.ServiceMap.List(),
 			},
 		}),
@@ -173,19 +170,6 @@ type moduleControllerOptions struct {
 	// The directory may not exist when the component is created; components
 	// should create the directory if needed.
 	DataPath string
-
-	// HTTPListenAddr is the address the server is configured to listen on.
-	HTTPListenAddr string
-
-	// HTTPPath is the base path that requests need in order to route to this
-	// component. Requests received by a component handler will have this already
-	// trimmed off.
-	HTTPPath string
-
-	// DialFunc is a function for components to use to properly communicate to
-	// HTTPListenAddr. If set, components which send HTTP requests to
-	// HTTPListenAddr must use this function to establish connections.
-	controller.DialFunc
 
 	// ID is the attached components full ID.
 	ID string

--- a/service/http/http.go
+++ b/service/http/http.go
@@ -27,6 +27,9 @@ import (
 	"golang.org/x/net/http2/h2c"
 )
 
+// ServiceName defines the name used for the HTTP service.
+const ServiceName = "http"
+
 // Options are used to configure the HTTP service. Options are constant for the
 // lifetime of the HTTP service.
 type Options struct {
@@ -98,7 +101,7 @@ func New(opts Options) *Service {
 // Definition returns the definition of the HTTP service.
 func (s *Service) Definition() service.Definition {
 	return service.Definition{
-		Name:       "http",
+		Name:       ServiceName,
 		ConfigType: nil, // http does not accept configuration
 		DependsOn:  nil, // http has no dependencies.
 	}

--- a/service/http/http.go
+++ b/service/http/http.go
@@ -248,6 +248,7 @@ func (s *Service) Data() any {
 	return Data{
 		HTTPListenAddr:   s.opts.HTTPListenAddr,
 		MemoryListenAddr: s.opts.MemoryListenAddr,
+		BaseHTTPPath:     s.componentHttpPathPrefix,
 
 		DialFunc: func(ctx context.Context, network, address string) (net.Conn, error) {
 			switch address {
@@ -269,8 +270,21 @@ type Data struct {
 	// traffic when [DialFunc] is used to establish a connection.
 	MemoryListenAddr string
 
+	// BaseHTTPPath is the base path where component HTTP routes are exposed.
+	BaseHTTPPath string
+
 	// DialFunc is a function which establishes in-memory network connection when
 	// address is MemoryListenAddr. If address is not MemoryListenAddr, DialFunc
 	// establishes an outbound network connection.
 	DialFunc func(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+// HTTPPathForComponent returns the full HTTP path for a given global component
+// ID.
+func (d Data) HTTPPathForComponent(componentID string) string {
+	merged := path.Join(d.BaseHTTPPath, componentID)
+	if !strings.HasSuffix(merged, "/") {
+		return merged + "/"
+	}
+	return merged
 }

--- a/service/http/http.go
+++ b/service/http/http.go
@@ -216,7 +216,7 @@ func (s *Service) componentHandler(host service.Host) http.HandlerFunc {
 			return
 		}
 
-		component, ok := info.Component.(component.HTTPComponent)
+		component, ok := info.Component.(Component)
 		if !ok {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -287,4 +287,15 @@ func (d Data) HTTPPathForComponent(componentID string) string {
 		return merged + "/"
 	}
 	return merged
+}
+
+// Component is a Flow component which also contains a custom HTTP handler.
+type Component interface {
+	component.Component
+
+	// Handler should return a valid HTTP handler for the component.
+	// All requests to the component will have the path trimmed such that the component is at the root.
+	// For example, f a request is made to `/component/{id}/metrics`, the component
+	// will receive a request to just `/metrics`.
+	Handler() http.Handler
 }


### PR DESCRIPTION
> **NOTE**: Like all the other PRs for services, I recommended reviewing this commit-by-commit.

This change migrates all components to use the new HTTP service, and removes the old built-in HTTP service fields. 

With this change, all HTTP code has been successfully decoupled from the Flow controller.

Related to #4253.