### PR TITLE
flow: fix bug where GetServiceConsumers didn't search through loaded modules

### DIFF
--- a/pkg/flow/flow_services.go
+++ b/pkg/flow/flow_services.go
@@ -1,13 +1,28 @@
 package flow
 
-import "github.com/grafana/agent/pkg/flow/internal/controller"
+import (
+	"github.com/grafana/agent/pkg/flow/internal/controller"
+	"github.com/grafana/agent/pkg/flow/internal/dag"
+)
 
 // GetServiceConsumers implements [service.Host]. It returns a slice of
 // [component.Component] and [service.Service]s which declared a dependency on
 // the named service.
 func (f *Flow) GetServiceConsumers(serviceName string) []any {
-	graph := f.loader.OriginalGraph()
+	consumers := serviceConsumersForGraph(f.loader.OriginalGraph(), serviceName, true)
 
+	// Iterate through all modules to find other components that depend on the
+	// service. Peer services aren't checked here, since the services are always
+	// a subset of the services from the root controller.
+	for _, mod := range f.modules.List() {
+		moduleGraph := mod.f.loader.OriginalGraph()
+		consumers = append(consumers, serviceConsumersForGraph(moduleGraph, serviceName, false)...)
+	}
+
+	return consumers
+}
+
+func serviceConsumersForGraph(graph *dag.Graph, serviceName string, includePeerServices bool) []any {
 	serviceNode, _ := graph.GetByID(serviceName).(*controller.ServiceNode)
 	if serviceNode == nil {
 		return nil
@@ -25,6 +40,10 @@ func (f *Flow) GetServiceConsumers(serviceName string) []any {
 			}
 
 		case *controller.ServiceNode:
+			if !includePeerServices {
+				continue
+			}
+
 			if svc := consumer.Service(); svc != nil {
 				consumers = append(consumers, svc)
 			}

--- a/pkg/flow/flow_services_test.go
+++ b/pkg/flow/flow_services_test.go
@@ -166,8 +166,12 @@ func TestFlow_GetServiceConsumers(t *testing.T) {
 	ctrl := New(opts)
 	require.NoError(t, ctrl.LoadFile(makeEmptyFile(t), nil))
 
-	consumers := ctrl.GetServiceConsumers("svc_a")
-	require.Equal(t, []any{svcB}, consumers)
+	expectConsumers := []service.Consumer{{
+		Type:  service.ConsumerTypeService,
+		ID:    "svc_b",
+		Value: svcB,
+	}}
+	require.Equal(t, expectConsumers, ctrl.GetServiceConsumers("svc_a"))
 }
 
 func TestFlow_GetServiceConsumers_Modules(t *testing.T) {

--- a/pkg/flow/module_registry.go
+++ b/pkg/flow/module_registry.go
@@ -25,6 +25,18 @@ func (reg *moduleRegistry) Get(id string) (*module, bool) {
 	return mod, ok
 }
 
+// List returns the set of all modules. The return order is not guaranteed.
+func (reg *moduleRegistry) List() []*module {
+	reg.mut.RLock()
+	defer reg.mut.RUnlock()
+
+	list := make([]*module, 0, len(reg.modules))
+	for _, mod := range reg.modules {
+		list = append(list, mod)
+	}
+	return list
+}
+
 // Register registers a module by ID. It returns an error if that module is
 // already registered.
 func (reg *moduleRegistry) Register(id string, mod *module) error {

--- a/service/service.go
+++ b/service/service.go
@@ -8,6 +8,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/grafana/agent/component"
 )
@@ -50,11 +51,44 @@ type Host interface {
 	// exist.
 	ListComponents(moduleID string, opts component.InfoOptions) ([]*component.Info, error)
 
-	// GetServiceConsumers gets the list of components and
-	// services which depend on a service by name. The returned
-	// values will be an instance of [component.Component] or
-	// [Service].
-	GetServiceConsumers(serviceName string) []any
+	// GetServiceConsumers gets the list of components and services which depend
+	// on a service by name.
+	GetServiceConsumers(serviceName string) []Consumer
+}
+
+type Consumer struct {
+	Type ConsumerType // Type of consumer.
+	ID   string       // Unique identifier for the consumer.
+
+	// Value of the consumer. When Type is ConsumerTypeComponent, this is an
+	// instance of [component.Component]. When Type is ConsumerTypeServcice, this
+	// is an instance of [Service].
+	Value any
+}
+
+// ConsumerType represents the type of consumer who is consuming a service.
+type ConsumerType int
+
+const (
+	// ConsumerTypeInvalid is the default value for ConsumerType.
+	ConsumerTypeInvalid ConsumerType = iota
+
+	ConsumerTypeComponent // ConsumerTypeComponent represents a component which uses a service.
+	ConsumerTypeService   // ConsumerTypeService represents a serviec which uses another service.
+)
+
+// String returns a string representation of the ConsumerType.
+func (ct ConsumerType) String() string {
+	switch ct {
+	case ConsumerTypeInvalid:
+		return "invalid"
+	case ConsumerTypeComponent:
+		return "component"
+	case ConsumerTypeService:
+		return "service"
+	}
+
+	return fmt.Sprintf("ConsumerType(%d)", ct)
 }
 
 // Service is an individual service to run.


### PR DESCRIPTION
GetServiceConsumers will be used by services to quickly retrieve a list of components and services which depend on a service for service-related operations.

For example, the clustering service will use GetServiceConsumers to know which components to notify of a cluster update.

GetServiceConsumers needs to return dependant components throughout all modules, otherwise the clustering service will be unable to notify all appropriate components when the clustering state changes.
