### PR TITLE
Porting decompression support from promtail to loki.source.file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+> **BREAKING CHANGES**: This release has breaking changes. Please read entries
+> carefully and consult the [upgrade guide][] for specific instructions.
+
+### Breaking changes
+
+- `loki.source.file` component will no longer automatically detect and
+  decompress logs from compressed files. A new configuration block is available
+  to enable decompression explicitly. See the [upgrade guide][] for migration
+  instructions. (@thampiotr)
+
 ### Enhancements
 
 - Better validation of config file with `grafana-agentctl config-check` cmd (@fgouteroux)

--- a/component/loki/source/file/compression_format.go
+++ b/component/loki/source/file/compression_format.go
@@ -1,0 +1,40 @@
+package file
+
+import (
+	"encoding"
+	"fmt"
+	"strings"
+
+	"golang.org/x/exp/maps"
+)
+
+type CompressionFormat string
+
+var (
+	_ encoding.TextMarshaler   = CompressionFormat("")
+	_ encoding.TextUnmarshaler = (*CompressionFormat)(nil)
+)
+
+func (ut CompressionFormat) String() string {
+	return string(ut)
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (ut CompressionFormat) MarshalText() (text []byte, err error) {
+	return []byte(ut.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (ut *CompressionFormat) UnmarshalText(text []byte) error {
+	s := string(text)
+	_, ok := supportedCompressedFormats()[s]
+	if !ok {
+		return fmt.Errorf(
+			"unsupported compression format: %q - please use one of %q",
+			s,
+			strings.Join(maps.Keys(supportedCompressedFormats()), ", "),
+		)
+	}
+	*ut = CompressionFormat(s)
+	return nil
+}

--- a/component/loki/source/file/decompresser.go
+++ b/component/loki/source/file/decompresser.go
@@ -117,10 +117,10 @@ func newDecompressor(
 //
 // The selected reader implementation is based on the extension of the given file name.
 // It'll error if the extension isn't supported.
-func mountReader(f *os.File, logger log.Logger, format string) (reader io.Reader, err error) {
+func mountReader(f *os.File, logger log.Logger, format CompressionFormat) (reader io.Reader, err error) {
 	var decompressLib string
 
-	switch format {
+	switch format.String() {
 	case "gz":
 		decompressLib = "compress/gzip"
 		reader, err = gzip.NewReader(f)

--- a/component/loki/source/file/decompresser.go
+++ b/component/loki/source/file/decompresser.go
@@ -115,8 +115,10 @@ func newDecompressor(
 
 // mountReader instantiate a reader ready to be used by the decompressor.
 //
-// The selected reader implementation is based on the extension of the given file name.
-// It'll error if the extension isn't supported.
+// The reader implementation is selected based on the given CompressionFormat.
+// If the actual file format is incorrect, the reading of the header may fail and return an error - depending on the
+// implementation of the underlying compression library. In any case, when a file is corrupted, the subsequent reading
+// of lines will fail.
 func mountReader(f *os.File, logger log.Logger, format CompressionFormat) (reader io.Reader, err error) {
 	var decompressLib string
 

--- a/component/loki/source/file/decompresser.go
+++ b/component/loki/source/file/decompresser.go
@@ -32,11 +32,10 @@ import (
 
 func supportedCompressedFormats() map[string]struct{} {
 	return map[string]struct{}{
-		".gz":     {},
-		".tar.gz": {},
-		".z":      {},
-		".bz2":    {},
-		// TODO: add support for .zip extension.
+		"gz":  {},
+		"z":   {},
+		"bz2": {},
+		// TODO: add support for zip.
 	}
 }
 
@@ -61,9 +60,20 @@ type decompressor struct {
 
 	position int64
 	size     int64
+	cfg      DecompressionConfig
 }
 
-func newDecompressor(metrics *metrics, logger log.Logger, handler loki.EntryHandler, positions positions.Positions, path string, labels string, encodingFormat string) (*decompressor, error) {
+func newDecompressor(
+	metrics *metrics,
+	logger log.Logger,
+	handler loki.EntryHandler,
+	positions positions.Positions,
+	path string,
+	labels string,
+	encodingFormat string,
+	cfg DecompressionConfig,
+) (*decompressor, error) {
+
 	logger = log.With(logger, "component", "decompressor")
 
 	pos, err := positions.Get(path, labels)
@@ -94,6 +104,7 @@ func newDecompressor(metrics *metrics, logger log.Logger, handler loki.EntryHand
 		done:      make(chan struct{}),
 		position:  pos,
 		decoder:   decoder,
+		cfg:       cfg,
 	}
 
 	go decompressor.readLines()
@@ -106,37 +117,35 @@ func newDecompressor(metrics *metrics, logger log.Logger, handler loki.EntryHand
 //
 // The selected reader implementation is based on the extension of the given file name.
 // It'll error if the extension isn't supported.
-func mountReader(f *os.File, logger log.Logger) (reader io.Reader, err error) {
-	ext := filepath.Ext(f.Name())
+func mountReader(f *os.File, logger log.Logger, format string) (reader io.Reader, err error) {
 	var decompressLib string
 
-	if strings.Contains(ext, "gz") { // .gz, .tar.gz
+	switch format {
+	case "gz":
 		decompressLib = "compress/gzip"
 		reader, err = gzip.NewReader(f)
-	} else if ext == ".z" {
+	case "z":
 		decompressLib = "compress/zlib"
 		reader, err = zlib.NewReader(f)
-	} else if ext == ".bz2" {
+	case "bz2":
 		decompressLib = "bzip2"
 		reader = bzip2.NewReader(f)
-	}
-	// TODO: add support for .zip extension.
-
-	level.Debug(logger).Log("msg", fmt.Sprintf("using %q to decompress file %q", decompressLib, f.Name()))
-
-	if reader != nil {
-		return reader, nil
 	}
 
 	if err != nil && err != io.EOF {
 		return nil, err
 	}
 
-	supportedExtsList := strings.Builder{}
-	for ext := range supportedCompressedFormats() {
-		supportedExtsList.WriteString(ext)
+	if reader == nil {
+		supportedFormatsList := strings.Builder{}
+		for format := range supportedCompressedFormats() {
+			supportedFormatsList.WriteString(format)
+		}
+		return nil, fmt.Errorf("file %q has unsupported format, it has to be one of %q", f.Name(), supportedFormatsList.String())
 	}
-	return nil, fmt.Errorf("file %q has unsupported extension, it has to be one of %q", f.Name(), supportedExtsList.String())
+
+	level.Debug(logger).Log("msg", fmt.Sprintf("using %q to decompress file %q", decompressLib, f.Name()))
+	return reader, nil
 }
 
 func (d *decompressor) updatePosition() {
@@ -170,6 +179,11 @@ func (d *decompressor) readLines() {
 	level.Info(d.logger).Log("msg", "read lines routine: started", "path", d.path)
 	d.running.Store(true)
 
+	if d.cfg.InitialDelay > 0 {
+		level.Info(d.logger).Log("msg", "sleeping before starting decompression", "path", d.path, "duration", d.cfg.InitialDelay.String())
+		time.Sleep(d.cfg.InitialDelay)
+	}
+
 	defer func() {
 		d.cleanupMetrics()
 		level.Info(d.logger).Log("msg", "read lines routine finished", "path", d.path)
@@ -184,7 +198,7 @@ func (d *decompressor) readLines() {
 	}
 	defer f.Close()
 
-	r, err := mountReader(f, d.logger)
+	r, err := mountReader(f, d.logger, d.cfg.Format)
 	if err != nil {
 		level.Error(d.logger).Log("msg", "error mounting new reader", "err", err)
 		return
@@ -300,16 +314,4 @@ func (d *decompressor) cleanupMetrics() {
 
 func (d *decompressor) Path() string {
 	return d.path
-}
-
-func isCompressed(p string) bool {
-	ext := filepath.Ext(p)
-
-	for format := range supportedCompressedFormats() {
-		if ext == format {
-			return true
-		}
-	}
-
-	return false
 }

--- a/component/loki/source/file/decompresser_test.go
+++ b/component/loki/source/file/decompresser_test.go
@@ -93,6 +93,7 @@ func TestGigantiqueGunzipFile(t *testing.T) {
 		path:    file,
 		done:    make(chan struct{}),
 		metrics: newMetrics(prometheus.NewRegistry()),
+		cfg:     DecompressionConfig{Format: "gz"},
 	}
 
 	d.readLines()
@@ -122,6 +123,7 @@ func TestOnelineFiles(t *testing.T) {
 			path:    file,
 			done:    make(chan struct{}),
 			metrics: newMetrics(prometheus.NewRegistry()),
+			cfg:     DecompressionConfig{Format: "gz"},
 		}
 
 		d.readLines()
@@ -146,6 +148,7 @@ func TestOnelineFiles(t *testing.T) {
 			path:    file,
 			done:    make(chan struct{}),
 			metrics: newMetrics(prometheus.NewRegistry()),
+			cfg:     DecompressionConfig{Format: "bz2"},
 		}
 
 		d.readLines()
@@ -170,6 +173,7 @@ func TestOnelineFiles(t *testing.T) {
 			path:    file,
 			done:    make(chan struct{}),
 			metrics: newMetrics(prometheus.NewRegistry()),
+			cfg:     DecompressionConfig{Format: "gz"},
 		}
 
 		d.readLines()

--- a/component/loki/source/file/file.go
+++ b/component/loki/source/file/file.go
@@ -15,7 +15,6 @@ import (
 	"github.com/grafana/agent/component/common/loki/positions"
 	"github.com/grafana/agent/component/discovery"
 	"github.com/prometheus/common/model"
-	"golang.org/x/exp/maps"
 )
 
 func init() {
@@ -44,25 +43,9 @@ type Arguments struct {
 }
 
 type DecompressionConfig struct {
-	Enabled      bool          `river:"enabled,attr"`
-	InitialDelay time.Duration `river:"initial_delay,attr,optional"`
-	Format       string        `river:"format,attr"`
-}
-
-func (d DecompressionConfig) Validate() error {
-	if d.Format == "" {
-		return nil
-	}
-	for sf := range supportedCompressedFormats() {
-		if d.Format == sf {
-			return nil
-		}
-	}
-	return fmt.Errorf(
-		"unsupported compression format: %q - please use one of %q",
-		d.Format,
-		strings.Join(maps.Keys(supportedCompressedFormats()), ", "),
-	)
+	Enabled      bool              `river:"enabled,attr"`
+	InitialDelay time.Duration     `river:"initial_delay,attr,optional"`
+	Format       CompressionFormat `river:"format,attr"`
 }
 
 var (

--- a/component/loki/source/file/file.go
+++ b/component/loki/source/file/file.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/agent/component/common/loki/positions"
 	"github.com/grafana/agent/component/discovery"
 	"github.com/prometheus/common/model"
+	"golang.org/x/exp/maps"
 )
 
 func init() {
@@ -46,6 +47,22 @@ type DecompressionConfig struct {
 	Enabled      bool          `river:"enabled,attr"`
 	InitialDelay time.Duration `river:"initial_delay,attr,optional"`
 	Format       string        `river:"format,attr"`
+}
+
+func (d DecompressionConfig) Validate() error {
+	if d.Format == "" {
+		return nil
+	}
+	for sf := range supportedCompressedFormats() {
+		if d.Format == sf {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"unsupported compression format: %q - please use one of %q",
+		d.Format,
+		strings.Join(maps.Keys(supportedCompressedFormats()), ", "),
+	)
 }
 
 var (

--- a/component/loki/source/file/file.go
+++ b/component/loki/source/file/file.go
@@ -36,9 +36,16 @@ const (
 // Arguments holds values which are used to configure the loki.source.file
 // component.
 type Arguments struct {
-	Targets   []discovery.Target  `river:"targets,attr"`
-	ForwardTo []loki.LogsReceiver `river:"forward_to,attr"`
-	Encoding  string              `river:"encoding,attr,optional"`
+	Targets             []discovery.Target  `river:"targets,attr"`
+	ForwardTo           []loki.LogsReceiver `river:"forward_to,attr"`
+	Encoding            string              `river:"encoding,attr,optional"`
+	DecompressionConfig DecompressionConfig `river:"decompression,block,optional"`
+}
+
+type DecompressionConfig struct {
+	Enabled      bool          `river:"enabled,attr"`
+	InitialDelay time.Duration `river:"initial_delay,attr,optional"`
+	Format       string        `river:"format,attr"`
 }
 
 var (
@@ -290,7 +297,7 @@ func (c *Component) startTailing(path string, labels model.LabelSet, handler lok
 	}
 
 	var reader reader
-	if isCompressed(path) {
+	if c.args.DecompressionConfig.Enabled {
 		level.Debug(c.opts.Logger).Log("msg", "reading from compressed file", "filename", path)
 		decompressor, err := newDecompressor(
 			c.metrics,
@@ -300,6 +307,7 @@ func (c *Component) startTailing(path string, labels model.LabelSet, handler lok
 			path,
 			labels.String(),
 			c.args.Encoding,
+			c.args.DecompressionConfig,
 		)
 		if err != nil {
 			level.Error(c.opts.Logger).Log("msg", "failed to start decompressor", "error", err, "filename", path)

--- a/converter/internal/promtailconvert/internal/build/scrape_builder.go
+++ b/converter/internal/promtailconvert/internal/build/scrape_builder.go
@@ -249,7 +249,7 @@ func convertDecompressionConfig(cfg *scrapeconfig.DecompressionConfig) lokisourc
 	return lokisourcefile.DecompressionConfig{
 		Enabled:      cfg.Enabled,
 		InitialDelay: cfg.InitialDelay,
-		Format:       cfg.Format,
+		Format:       lokisourcefile.CompressionFormat(cfg.Format),
 	}
 }
 

--- a/converter/internal/promtailconvert/testdata/static_pipeline_example.river
+++ b/converter/internal/promtailconvert/testdata/static_pipeline_example.river
@@ -67,6 +67,12 @@ loki.source.file "example" {
 	targets    = local.file_match.example.targets
 	forward_to = [loki.process.example.receiver]
 	encoding   = "UTF-16"
+
+	decompression {
+		enabled       = true
+		initial_delay = "30s"
+		format        = "z"
+	}
 }
 
 loki.write "default" {

--- a/converter/internal/promtailconvert/testdata/static_pipeline_example.yaml
+++ b/converter/internal/promtailconvert/testdata/static_pipeline_example.yaml
@@ -3,6 +3,10 @@ clients:
 scrape_configs:
   - job_name: example
     encoding: UTF-16
+    decompression:
+      enabled: true
+      format: z
+      initial_delay: 30s
     pipeline_stages:
       - json:
           expressions:

--- a/converter/internal/promtailconvert/testdata/unsupported.diags
+++ b/converter/internal/promtailconvert/testdata/unsupported.diags
@@ -18,4 +18,3 @@
 (Error) marathon_sd_configs is not supported
 (Error) openstack_sd_configs is not supported
 (Error) triton_sd_configs is not supported
-(Error) decompression is currently not supported

--- a/converter/internal/promtailconvert/testdata/unsupported.yaml
+++ b/converter/internal/promtailconvert/testdata/unsupported.yaml
@@ -51,7 +51,3 @@ scrape_configs:
         dns_suffix: .example.com
         endpoint: triton.example.com
     encoding: utf-16
-    decompression:
-      enabled: true
-      format: z
-      initial_delay: 30s

--- a/docs/sources/flow/reference/components/loki.source.file.md
+++ b/docs/sources/flow/reference/components/loki.source.file.md
@@ -26,19 +26,44 @@ log entries to the list of receivers passed in `forward_to`.
 
 `loki.source.file` supports the following arguments:
 
-Name         | Type                   | Description          | Default | Required
------------- | ---------------------- | -------------------- | ------- | --------
-`targets`    | `list(map(string))`    | List of files to read from. | | yes
-`forward_to` | `list(LogsReceiver)`   | List of receivers to send log entries to. | | yes
-`encoding`   | `string`               | The encoding to convert from when reading files. | `""` | no
+ Name         | Type                 | Description                                      | Default | Required 
+--------------|----------------------|--------------------------------------------------|---------|----------
+ `targets`    | `list(map(string))`  | List of files to read from.                      |         | yes      
+ `forward_to` | `list(LogsReceiver)` | List of receivers to send log entries to.        |         | yes      
+ `encoding`   | `string`             | The encoding to convert from when reading files. | `""`    | no       
+
+The `encoding` argument must be a valid [IANA encoding][] name. If not set, it
+defaults to UTF-8.
 
 ## Blocks
 
-The `loki.source.file` component doesn't support any inner blocks and is
-configured fully through arguments.
+The following blocks are supported inside the definition of `loki.source.file`:
 
-The `encoding` argument must be a valid [IANA encoding][] name. If not set, it
-defaults to UTF-8. 
+ Hierarchy      | Name               | Description                                   | Required 
+----------------|--------------------|-----------------------------------------------|----------
+ decompresssion | [decompresssion][] | Configure reading logs from compressed files. | no       
+
+[decompresssion]: #decompresssion-block
+
+### decompresssion block
+
+The `decompression` block contains configuration for reading logs from 
+compressed files. The following arguments are supported:
+
+ Name            | Type       | Description                                                     | Default | Required 
+-----------------|------------|-----------------------------------------------------------------|---------|----------
+ `enabled`       | `bool`     | Whether decompression is enabled.                               |         | yes      
+ `initial_delay` | `duration` | Time to wait before starting to read from new compressed files. | 0       | no       
+ `format`        | `string`   | Compression format.                                             |         | yes      
+
+If you compress a file under a folder being scraped, `loki.source.file` might
+try to ingest your file before you finish compressing it. To avoid it, pick
+an `initial_delay` that is enough to avoid it.
+
+Currently supported compression formats are:
+* `gz` - for gzip
+* `z` - for zlib
+* `bz2` - for bzip2
 
 ## Exported fields
 
@@ -85,8 +110,9 @@ If a file is removed from the `targets` list, its positions file entry is also
 removed. When it's added back on, `loki.source.file` starts reading it from the
 beginning.
 
-## Example
+## Examples
 
+### Static targets
 This example collects log entries from the files specified in the targets
 argument and forwards them to a `loki.write` component to be written to Loki.
 
@@ -98,6 +124,61 @@ loki.source.file "tmpfiles" {
     {__path__ = "/tmp/baz.txt", "color" = "grey"},
   ]
   forward_to = [loki.write.local.receiver]
+}
+
+loki.write "local" {
+  endpoint {
+    url = "loki:3100/api/v1/push"
+  }
+}
+```
+
+### File globbing
+This example collects log entries from the files matching `*.log` pattern
+using `local.file_match` component. When files appear or disappear, the list of
+targets will be updated accordingly.
+
+```river
+
+local.file_match "logs" {
+  path_targets = [
+    {__path__ = "/tmp/*.log"},
+  ]
+}
+
+loki.source.file "tmpfiles" {
+  targets    = local.file_match.logs.targets
+  forward_to = [loki.write.local.receiver]
+}
+
+loki.write "local" {
+  endpoint {
+    url = "loki:3100/api/v1/push"
+  }
+}
+```
+
+### Decompression
+This example collects log entries from the compressed files matching `*.gz`
+pattern using `local.file_match` component and the decompression configuration
+on the `loki.source.file` component.
+
+```river
+
+local.file_match "logs" {
+  path_targets = [
+    {__path__ = "/tmp/*.gz"},
+  ]
+}
+
+loki.source.file "tmpfiles" {
+  targets    = local.file_match.logs.targets
+  forward_to = [loki.write.local.receiver]
+  decompression {
+    enabled       = true
+    initial_delay = "10s"
+    format        = "gz"
+  }
 }
 
 loki.write "local" {

--- a/docs/sources/flow/reference/components/loki.source.file.md
+++ b/docs/sources/flow/reference/components/loki.source.file.md
@@ -65,6 +65,9 @@ Currently supported compression formats are:
 * `z` - for zlib
 * `bz2` - for bzip2
 
+The component can only support one compression format at a time, in order to
+handle multiple formats, you will need to create multiple components.
+
 ## Exported fields
 
 `loki.source.file` does not export any fields.

--- a/docs/sources/flow/upgrade-guide.md
+++ b/docs/sources/flow/upgrade-guide.md
@@ -19,6 +19,42 @@ Grafana Agent Flow.
 > [upgrade-guide-static]: {{< relref "../static/upgrade-guide.md" >}}
 > [upgrade-guide-operator]: {{< relref "../operator/upgrade-guide.md" >}}
 
+## v0.36
+
+## Breaking change: `loki.source.file` no longer automatically extracts logs from compressed files
+
+`loki.source.file` component will no longer automatically detect and decompress
+logs from compressed files (this was an undocumented behaviour).
+
+This file-extension-based detection of compressed files has been replaced by a
+new configuration block that explicitly enables and specifies the compression
+format. By default, the decompression of files is entirely disabled.
+
+How to migrate:
+
+* If your agent never reads logs from files with
+  extensions `.gz`, `.tar.gz`, `.z` or `.bz2` then no action is required.
+  > You can check what are the file extensions your agent reads from by looking
+  at the `path` label on `loki_source_file_file_bytes_total` metric.
+
+* If your agent extracts data from compressed files, please add the following
+  configuration block to your `loki.source.file` component:
+
+    ```river
+    loki.source.file "example" {
+      ...
+      decompression {
+        enabled       = true
+        format        = "<compression format>"
+      }
+    }
+    ``` 
+
+    where the `<compression format>` is the appropriate compression format -
+    see [`loki.source.file` documentation][loki-source-file-docs] for details.
+    
+    [loki-source-file-docs]: {{< relref "./reference/components/loki.source.file.md" >}}
+
 ## v0.35
 
 ### Breaking change: `auth` and `version` attributes from `walk_params` block of `prometheus.exporter.snmp` have been removed


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This adds a decompression support in `loki.source.file` that matches the current behaviour of `promtail`.
It is a breaking change, since it was also a breaking change in `promtail`.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

Fixes #4669 

#### Notes to the Reviewer

The PR that made equivalent change in promtail is this: https://github.com/grafana/loki/pull/8994

Tested this locally using `gzip`:
```
➜  /tmp echo hello_zip > foo.txt
➜  /tmp gzip foo.txt
```

Used the following River config
```
local.file_match "logs" {
  path_targets = [
    {__path__ = "/tmp/*.gz"},
  ]
}

loki.source.file "tmpfiles" {
  targets    = local.file_match.logs.targets
  forward_to = [loki.echo.print.receiver]
  decompression {
    enabled       = true
    initial_delay = "10s"
    format        = "gz"
  }
}

loki.echo "print" {}
```

Observed these logs:
```
ts=2023-08-03T12:40:36.611169Z level=info controller_id= trace_id=ffae15ec97959d9fb70063116e1fe9aa msg="finished partial graph evaluation" duration=1.850875ms
ts=2023-08-03T12:40:36.611344Z level=info component=loki.source.file.tmpfiles component=decompressor msg="read lines routine: started" path=/tmp/foo.txt.gz
ts=2023-08-03T12:40:36.611353Z level=info component=loki.source.file.tmpfiles component=decompressor msg="sleeping before starting decompression" path=/tmp/foo.txt.gz duration=10s
ts=2023-08-03T12:40:46.613484Z level=info component=loki.source.file.tmpfiles component=decompressor msg="successfully mounted reader" path=/tmp/foo.txt.gz ext=.gz
ts=2023-08-03T12:40:46.613576Z level=info component=loki.source.file.tmpfiles component=decompressor msg="read lines routine finished" path=/tmp/foo.txt.gz
ts=2023-08-03T12:40:46.613633Z level=info component=loki.echo.print receiver=loki.echo.print entry=hello_zip labels="{filename=\"/tmp/foo.txt.gz\"}"
```

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated