### PR TITLE
loki.source.windowsevents: fix HTTP service dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        platform: [macos-latest]
+        platform: [macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code

--- a/component/loki/source/windowsevent/component_test.go
+++ b/component/loki/source/windowsevent/component_test.go
@@ -25,16 +25,26 @@ func TestEventLogger(t *testing.T) {
 	dataPath := t.TempDir()
 	rec := loki.NewLogsReceiver()
 	c, err := New(component.Options{
-		ID:       "loki.source.windowsevent.test",
-		Logger:   util.TestFlowLogger(t),
+		ID:     "loki.source.windowsevent.test",
+		Logger: util.TestFlowLogger(t),
+		GetServiceData: func(name string) (interface{}, error) {
+			if name == http_service.ServiceName {
+				return http_service.Data{
+					HTTPListenAddr:   "localhost:12345",
+					MemoryListenAddr: "agent.internal:1245",
+					BaseHTTPPath:     "/",
+					DialFunc:         (&net.Dialer{}).DialContext,
+				}, nil
+			}
+
+			return nil, fmt.Errorf("service %q does not exist", name)
+		},
 		DataPath: dataPath,
 		OnStateChange: func(e component.Exports) {
 
 		},
-		Registerer:     prometheus.DefaultRegisterer,
-		Tracer:         nil,
-		HTTPListenAddr: "",
-		HTTPPath:       "",
+		Registerer: prometheus.DefaultRegisterer,
+		Tracer:     nil,
 	}, Arguments{
 		Locale:               0,
 		EventLogName:         "Application",


### PR DESCRIPTION
This PR fixes the dependency of `loki.source.windowsevents` on the HTTP service after #4696 was introduced.

I don't have a Windows machine in hand, so I'm flying in a bit blind; I'm temporarily re-enabling the Windows test runner on Github Actions to verify that it passes.