### PR TITLE
Add last reclaimed segment metric to logs WAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Main (unreleased)
 
 - Flow: Add a new stage `non_indexed_labels` to attach non-indexed labels from extracted data to log line entry. (@vlad-diachenko)
 
+- `loki.write` WAL now exposes a last segment reclaimed metric. (@thepalbi)
+
 - New Grafana Agent Flow components:
 
   - `prometheus.exporter.gcp` - scrape GCP metrics. (@tburgessdev)
@@ -45,7 +47,6 @@ Main (unreleased)
   - `discovery.openstack` - service discovery for OpenStack. (@marctc)
   - `discovery.hetzner` - service discovery for Hetzner Cloud. (@marctc)
   - `loki.write` now exposes basic WAL support. (@thepalbi)
-  - `loki.write` WAL now exposes a last segment reclaimed metric. (@thepalbi)
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Main (unreleased)
   - `discovery.openstack` - service discovery for OpenStack. (@marctc)
   - `discovery.hetzner` - service discovery for Hetzner Cloud. (@marctc)
   - `loki.write` now exposes basic WAL support. (@thepalbi)
+  - `loki.write` WAL now exposes a last segment reclaimed metric. (@thepalbi)
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Main (unreleased)
 
 - Flow: Add a new stage `non_indexed_labels` to attach non-indexed labels from extracted data to log line entry. (@vlad-diachenko)
 
+- `loki.write` now exposes basic WAL support. (@thepalbi)
+
 - `loki.write` WAL now exposes a last segment reclaimed metric. (@thepalbi)
 
 - New Grafana Agent Flow components:
@@ -46,7 +48,6 @@ Main (unreleased)
   - `discovery.eureka` discovers targets from a Eureka Service Registry. (@spartan0x117)
   - `discovery.openstack` - service discovery for OpenStack. (@marctc)
   - `discovery.hetzner` - service discovery for Hetzner Cloud. (@marctc)
-  - `loki.write` now exposes basic WAL support. (@thepalbi)
 
 ### Bugfixes
 

--- a/component/common/loki/wal/writer.go
+++ b/component/common/loki/wal/writer.go
@@ -58,6 +58,7 @@ type Writer struct {
 	writeSubscribers     []WriteEventSubscriber
 
 	reclaimedOldSegmentsSpaceCounter *prometheus.CounterVec
+	lastReclaimedSegment             *prometheus.GaugeVec
 
 	closeCleaner chan struct{}
 }
@@ -89,8 +90,16 @@ func NewWriter(walCfg Config, logger log.Logger, reg prometheus.Registerer) (*Wr
 		Help:      "Number of bytes reclaimed from storage.",
 	}, []string{})
 
+	wrt.lastReclaimedSegment = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "loki_write",
+		Subsystem: "wal_writer",
+		Name:      "last_reclaimed_segment",
+		Help:      "Last reclaimed segment number",
+	}, []string{})
+
 	if reg != nil {
 		_ = reg.Register(wrt.reclaimedOldSegmentsSpaceCounter)
+		_ = reg.Register(wrt.lastReclaimedSegment)
 	}
 
 	wrt.start(walCfg.MaxSegmentAge)
@@ -202,6 +211,7 @@ func (wrt *Writer) cleanSegments(maxAge time.Duration) error {
 		for _, subscriber := range wrt.cleanupSubscribers {
 			subscriber.SeriesReset(maxReclaimed)
 		}
+		wrt.lastReclaimedSegment.WithLabelValues().Set(float64(maxReclaimed))
 	}
 	return nil
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Small PR that adds a new metric that tacks the last reclaimed segment on the logs WAL.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
