### PR TITLE
Add configurable fields loki source cloudflare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ Main (unreleased)
 
 - `loki.write` WAL now exposes a last segment reclaimed metric. (@thepalbi)
 
+- Flow: Users can now define `custom_fields` in `loki.source.cloudflare` (@wildum)
+
 - New Grafana Agent Flow components:
 
   - `prometheus.exporter.gcp` - scrape GCP metrics. (@tburgessdev)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ Main (unreleased)
 
 - `loki.write` WAL now exposes a last segment reclaimed metric. (@thepalbi)
 
-- Flow: Users can now define `custom_fields` in `loki.source.cloudflare` (@wildum)
+- Flow: Users can now define `additional_fields` in `loki.source.cloudflare` (@wildum)
 
 - New Grafana Agent Flow components:
 

--- a/component/loki/source/cloudflare/cloudflare.go
+++ b/component/loki/source/cloudflare/cloudflare.go
@@ -75,38 +75,20 @@ func (c *Arguments) Validate() error {
 	if c.PullRange < 0 {
 		return fmt.Errorf("pull_range must be a positive duration")
 	}
-	fields, err := cft.Fields(cft.FieldsType(c.FieldsType))
+	_, err := cft.Fields(cft.FieldsType(c.FieldsType), c.CustomFields)
 	if err != nil {
 		return fmt.Errorf("invalid fields_type set; the available values are 'default', 'minimal', 'extended', 'custom' and 'all'")
+	}
+
+	if c.FieldsType == "all" && len(c.CustomFields) > 0 {
+		return fmt.Errorf("no need to provide custom fields when fields_type is set to 'all' as it contains already all available fields")
 	}
 
 	if invalidFields := cft.FindInvalidFields(c.CustomFields); len(invalidFields) > 0 {
 		return fmt.Errorf("invalid custom_fields: %v", invalidFields)
 	}
 
-	if commonFields := findCommonElement(fields, c.CustomFields); len(commonFields) > 0 {
-		return fmt.Errorf("duplicated fields; the following fields are already part of %s: %v", c.FieldsType, commonFields)
-	}
-
 	return nil
-}
-
-// Find the common values between two slices
-func findCommonElement(slice1, slice2 []string) []string {
-	elements := make(map[string]bool)
-	var common []string
-
-	for _, element := range slice1 {
-		elements[element] = true
-	}
-
-	for _, element := range slice2 {
-		if elements[element] {
-			common = append(common, element)
-		}
-	}
-
-	return common
 }
 
 // Component implements the loki.source.cloudflare component.

--- a/component/loki/source/cloudflare/cloudflare.go
+++ b/component/loki/source/cloudflare/cloudflare.go
@@ -80,7 +80,7 @@ func (c *Arguments) Validate() error {
 		return fmt.Errorf("invalid fields_type set; the available values are 'default', 'minimal', 'extended', 'custom' and 'all'")
 	}
 
-	if c.FieldsType == "all" && len(c.CustomFields) > 0 {
+	if cft.FieldsType(c.FieldsType) == cft.FieldsTypeAll && len(c.CustomFields) > 0 {
 		return fmt.Errorf("no need to provide custom fields when fields_type is set to 'all' as it contains already all available fields")
 	}
 

--- a/component/loki/source/cloudflare/cloudflare.go
+++ b/component/loki/source/cloudflare/cloudflare.go
@@ -79,11 +79,6 @@ func (c *Arguments) Validate() error {
 	if err != nil {
 		return fmt.Errorf("invalid fields_type set; the available values are 'default', 'minimal', 'extended', 'custom' and 'all'")
 	}
-
-	if invalidFields := cft.FindInvalidFields(c.AdditionalFields); len(invalidFields) > 0 {
-		return fmt.Errorf("invalid additional_fields: %v", invalidFields)
-	}
-
 	return nil
 }
 

--- a/component/loki/source/cloudflare/internal/cloudflaretarget/fields.go
+++ b/component/loki/source/cloudflare/internal/cloudflaretarget/fields.go
@@ -43,8 +43,35 @@ var (
 	allFieldsMap = buildAllFieldsMap(allFields)
 )
 
-// Fields returns the mapping of FieldsType to the set of fields it represents.
-func Fields(t FieldsType) ([]string, error) {
+// Fields returns the concatenation of set of fields represented by the Fieldtype and the give custom fields without duplicates
+func Fields(t FieldsType, customFields []string) ([]string, error) {
+	fieldsSubset, err := getFieldSubset(t)
+	if err != nil {
+		return nil, err
+	}
+	return mergeAndRemoveDuplicatedFields(fieldsSubset, customFields), nil
+}
+
+func mergeAndRemoveDuplicatedFields(fieldsSubset, customFields []string) []string {
+	usedFields := make(map[string]bool)
+	var fields []string
+
+	for _, field := range fieldsSubset {
+		fields = append(fields, field)
+		usedFields[field] = true
+	}
+
+	for _, field := range customFields {
+		if !usedFields[field] {
+			fields = append(fields, field)
+			usedFields[field] = true
+		}
+	}
+	return fields
+}
+
+// getFieldSubset returns the mapping of FieldsType to the set of fields it represents.
+func getFieldSubset(t FieldsType) ([]string, error) {
 	switch t {
 	case FieldsTypeDefault:
 		return defaultFields, nil

--- a/component/loki/source/cloudflare/internal/cloudflaretarget/fields.go
+++ b/component/loki/source/cloudflare/internal/cloudflaretarget/fields.go
@@ -17,6 +17,7 @@ const (
 	FieldsTypeMinimal  FieldsType = "minimal"
 	FieldsTypeExtended FieldsType = "extended"
 	FieldsTypeAll      FieldsType = "all"
+	FieldsTypeCustom   FieldsType = "custom"
 )
 
 var (
@@ -39,6 +40,7 @@ var (
 		"FirewallMatchesActions", "FirewallMatchesRuleIDs", "OriginResponseBytes", "OriginResponseTime", "ClientDeviceType", "WAFFlags", "WAFMatchedVar", "EdgeColoID",
 		"RequestHeaders", "ResponseHeaders",
 	}...)
+	allFieldsMap = buildAllFieldsMap(allFields)
 )
 
 // Fields returns the mapping of FieldsType to the set of fields it represents.
@@ -52,7 +54,28 @@ func Fields(t FieldsType) ([]string, error) {
 		return extendedFields, nil
 	case FieldsTypeAll:
 		return allFields, nil
+	case FieldsTypeCustom:
+		return []string{}, nil
 	default:
 		return nil, fmt.Errorf("unknown fields type: %s", t)
 	}
+}
+
+func buildAllFieldsMap(allFields []string) map[string]bool {
+	fieldsMap := make(map[string]bool)
+	for _, field := range allFields {
+		fieldsMap[field] = true
+	}
+	return fieldsMap
+}
+
+func FindInvalidFields(fields []string) []string {
+	var invalidFields []string
+
+	for _, field := range fields {
+		if !allFieldsMap[field] {
+			invalidFields = append(invalidFields, field)
+		}
+	}
+	return invalidFields
 }

--- a/component/loki/source/cloudflare/internal/cloudflaretarget/fields.go
+++ b/component/loki/source/cloudflare/internal/cloudflaretarget/fields.go
@@ -43,7 +43,7 @@ var (
 	allFieldsMap = buildAllFieldsMap(allFields)
 )
 
-// Fields returns the concatenation of set of fields represented by the Fieldtype and the give custom fields without duplicates
+// Fields returns the concatenation of set of fields represented by the Fieldtype and the give custom fields without duplicates.
 func Fields(t FieldsType, customFields []string) ([]string, error) {
 	fieldsSubset, err := getFieldSubset(t)
 	if err != nil {
@@ -96,6 +96,7 @@ func buildAllFieldsMap(allFields []string) map[string]bool {
 	return fieldsMap
 }
 
+// Returns fields which are not part of the defined allFields list.
 func FindInvalidFields(fields []string) []string {
 	var invalidFields []string
 

--- a/component/loki/source/cloudflare/internal/cloudflaretarget/fields.go
+++ b/component/loki/source/cloudflare/internal/cloudflaretarget/fields.go
@@ -57,7 +57,7 @@ func Fields(t FieldsType, additionalFields []string) ([]string, error) {
 	case FieldsTypeAll:
 		fields = append(allFields, additionalFields...)
 	case FieldsTypeCustom:
-		fields = append(fields, additionalFields)
+		fields = append(fields, additionalFields...)
 	default:
 		return nil, fmt.Errorf("unknown fields type: %s", t)
 	}

--- a/component/loki/source/cloudflare/internal/cloudflaretarget/fields.go
+++ b/component/loki/source/cloudflare/internal/cloudflaretarget/fields.go
@@ -7,7 +7,7 @@ package cloudflaretarget
 import (
 	"fmt"
 
-	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 )
 
 // FieldsType defines the set of fields to fetch alongside logs.
@@ -62,13 +62,7 @@ func Fields(t FieldsType, additionalFields []string) ([]string, error) {
 	default:
 		return nil, fmt.Errorf("unknown fields type: %s", t)
 	}
-	return removeDuplicates(fields), nil
-}
-
-func removeDuplicates(fields []string) []string {
-	m := map[string]struct{}{}
-	for _, field := range fields {
-		m[field] = struct{}{}
-	}
-	return maps.Keys(m)
+	// remove duplicates
+	slices.Sort(fields)
+	return slices.Compact(fields), nil
 }

--- a/component/loki/source/cloudflare/internal/cloudflaretarget/fields.go
+++ b/component/loki/source/cloudflare/internal/cloudflaretarget/fields.go
@@ -57,8 +57,7 @@ func Fields(t FieldsType, additionalFields []string) ([]string, error) {
 	case FieldsTypeAll:
 		fields = append(allFields, additionalFields...)
 	case FieldsTypeCustom:
-		fields = make([]string, len(additionalFields))
-		copy(fields, additionalFields)
+		fields = append(fields, additionalFields)
 	default:
 		return nil, fmt.Errorf("unknown fields type: %s", t)
 	}

--- a/component/loki/source/cloudflare/internal/cloudflaretarget/fields.go
+++ b/component/loki/source/cloudflare/internal/cloudflaretarget/fields.go
@@ -40,7 +40,6 @@ var (
 		"FirewallMatchesActions", "FirewallMatchesRuleIDs", "OriginResponseBytes", "OriginResponseTime", "ClientDeviceType", "WAFFlags", "WAFMatchedVar", "EdgeColoID",
 		"RequestHeaders", "ResponseHeaders",
 	}...)
-	allFieldsSet = buildAllFieldsSet(allFields)
 )
 
 // Fields returns the union of a set of fields represented by the Fieldtype and the given additional fields. The returned slice will contain no duplicates.
@@ -87,24 +86,4 @@ func getFieldSubset(t FieldsType) ([]string, error) {
 	default:
 		return nil, fmt.Errorf("unknown fields type: %s", t)
 	}
-}
-
-func buildAllFieldsSet(allFields []string) map[string]struct{} {
-	fieldsMap := make(map[string]struct{})
-	for _, field := range allFields {
-		fieldsMap[field] = struct{}{}
-	}
-	return fieldsMap
-}
-
-// Returns fields which are not part of the defined allFields list.
-func FindInvalidFields(fields []string) []string {
-	var invalidFields []string
-
-	for _, field := range fields {
-		if _, found := allFieldsSet[field]; !found {
-			invalidFields = append(invalidFields, field)
-		}
-	}
-	return invalidFields
 }

--- a/component/loki/source/cloudflare/internal/cloudflaretarget/fields.go
+++ b/component/loki/source/cloudflare/internal/cloudflaretarget/fields.go
@@ -40,10 +40,10 @@ var (
 		"FirewallMatchesActions", "FirewallMatchesRuleIDs", "OriginResponseBytes", "OriginResponseTime", "ClientDeviceType", "WAFFlags", "WAFMatchedVar", "EdgeColoID",
 		"RequestHeaders", "ResponseHeaders",
 	}...)
-	allFieldsMap = buildAllFieldsSet(allFields)
+	allFieldsSet = buildAllFieldsSet(allFields)
 )
 
-// Fields returns the concatenation of set of fields represented by the Fieldtype and the given custom fields without duplicates.
+// Fields returns the union of a set of fields represented by the Fieldtype and the given additional fields. The returned slice will contain no duplicates.
 func Fields(t FieldsType, additionalFields []string) ([]string, error) {
 	fieldsSubset, err := getFieldSubset(t)
 	if err != nil {
@@ -82,6 +82,7 @@ func getFieldSubset(t FieldsType) ([]string, error) {
 	case FieldsTypeAll:
 		return allFields, nil
 	case FieldsTypeCustom:
+		// Additional fields will be added later.
 		return []string{}, nil
 	default:
 		return nil, fmt.Errorf("unknown fields type: %s", t)
@@ -101,7 +102,7 @@ func FindInvalidFields(fields []string) []string {
 	var invalidFields []string
 
 	for _, field := range fields {
-		if _, found := allFieldsMap[field]; !found {
+		if _, found := allFieldsSet[field]; !found {
 			invalidFields = append(invalidFields, field)
 		}
 	}

--- a/component/loki/source/cloudflare/internal/cloudflaretarget/fields_test.go
+++ b/component/loki/source/cloudflare/internal/cloudflaretarget/fields_test.go
@@ -1,0 +1,56 @@
+package cloudflaretarget
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFields(t *testing.T) {
+	tests := []struct {
+		name         string
+		fieldsType   FieldsType
+		customFields []string
+		expected     []string
+	}{
+		{
+			name:         "Default fields",
+			fieldsType:   FieldsTypeDefault,
+			customFields: []string{},
+			expected:     defaultFields,
+		},
+		{
+			name:         "Custom fields",
+			fieldsType:   FieldsTypeCustom,
+			customFields: []string{"ClientIP", "OriginResponseBytes"},
+			expected:     []string{"ClientIP", "OriginResponseBytes"},
+		},
+		{
+			name:         "Default fields with added custom fields",
+			fieldsType:   FieldsTypeDefault,
+			customFields: []string{"WAFFlags", "WAFMatchedVar"},
+			expected:     append(defaultFields, "WAFFlags", "WAFMatchedVar"),
+		},
+		{
+			name:         "Default fields with duplicated custom fields",
+			fieldsType:   FieldsTypeDefault,
+			customFields: []string{"WAFFlags", "WAFFlags", "ClientIP"},
+			expected:     append(defaultFields, "WAFFlags"), // clientIP is already part of defaultFields
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := Fields(test.fieldsType, test.customFields)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, test.expected, result)
+		})
+	}
+}
+
+func TestFindInvalidFields(t *testing.T) {
+	invalidFields := []string{"InvalidField1", "InvalidField2"}
+
+	result := FindInvalidFields(invalidFields)
+	assert.ElementsMatch(t, invalidFields, result)
+}

--- a/component/loki/source/cloudflare/internal/cloudflaretarget/fields_test.go
+++ b/component/loki/source/cloudflare/internal/cloudflaretarget/fields_test.go
@@ -8,40 +8,40 @@ import (
 
 func TestFields(t *testing.T) {
 	tests := []struct {
-		name         string
-		fieldsType   FieldsType
-		customFields []string
-		expected     []string
+		name             string
+		fieldsType       FieldsType
+		additionalFields []string
+		expected         []string
 	}{
 		{
-			name:         "Default fields",
-			fieldsType:   FieldsTypeDefault,
-			customFields: []string{},
-			expected:     defaultFields,
+			name:             "Default fields",
+			fieldsType:       FieldsTypeDefault,
+			additionalFields: []string{},
+			expected:         defaultFields,
 		},
 		{
-			name:         "Custom fields",
-			fieldsType:   FieldsTypeCustom,
-			customFields: []string{"ClientIP", "OriginResponseBytes"},
-			expected:     []string{"ClientIP", "OriginResponseBytes"},
+			name:             "Custom fields",
+			fieldsType:       FieldsTypeCustom,
+			additionalFields: []string{"ClientIP", "OriginResponseBytes"},
+			expected:         []string{"ClientIP", "OriginResponseBytes"},
 		},
 		{
-			name:         "Default fields with added custom fields",
-			fieldsType:   FieldsTypeDefault,
-			customFields: []string{"WAFFlags", "WAFMatchedVar"},
-			expected:     append(defaultFields, "WAFFlags", "WAFMatchedVar"),
+			name:             "Default fields with added custom fields",
+			fieldsType:       FieldsTypeDefault,
+			additionalFields: []string{"WAFFlags", "WAFMatchedVar"},
+			expected:         append(defaultFields, "WAFFlags", "WAFMatchedVar"),
 		},
 		{
-			name:         "Default fields with duplicated custom fields",
-			fieldsType:   FieldsTypeDefault,
-			customFields: []string{"WAFFlags", "WAFFlags", "ClientIP"},
-			expected:     append(defaultFields, "WAFFlags"), // clientIP is already part of defaultFields
+			name:             "Default fields with duplicated custom fields",
+			fieldsType:       FieldsTypeDefault,
+			additionalFields: []string{"WAFFlags", "WAFFlags", "ClientIP"},
+			expected:         append(defaultFields, "WAFFlags"), // clientIP is already part of defaultFields
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := Fields(test.fieldsType, test.customFields)
+			result, err := Fields(test.fieldsType, test.additionalFields)
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, test.expected, result)
 		})
@@ -49,8 +49,8 @@ func TestFields(t *testing.T) {
 }
 
 func TestFindInvalidFields(t *testing.T) {
-	invalidFields := []string{"InvalidField1", "InvalidField2"}
+	invalidFields := []string{"InvalidField1", "InvalidField2", "ClientIP"}
 
 	result := FindInvalidFields(invalidFields)
-	assert.ElementsMatch(t, invalidFields, result)
+	assert.ElementsMatch(t, []string{"InvalidField1", "InvalidField2"}, result)
 }

--- a/component/loki/source/cloudflare/internal/cloudflaretarget/fields_test.go
+++ b/component/loki/source/cloudflare/internal/cloudflaretarget/fields_test.go
@@ -47,10 +47,3 @@ func TestFields(t *testing.T) {
 		})
 	}
 }
-
-func TestFindInvalidFields(t *testing.T) {
-	invalidFields := []string{"InvalidField1", "InvalidField2", "ClientIP"}
-
-	result := FindInvalidFields(invalidFields)
-	assert.ElementsMatch(t, []string{"InvalidField1", "InvalidField2"}, result)
-}

--- a/component/loki/source/cloudflare/internal/cloudflaretarget/target.go
+++ b/component/loki/source/cloudflare/internal/cloudflaretarget/target.go
@@ -38,12 +38,13 @@ var defaultBackoff = backoff.Config{
 
 // Config defines how to connect to Cloudflare's Logpull API.
 type Config struct {
-	APIToken   string
-	ZoneID     string
-	Labels     model.LabelSet
-	Workers    int
-	PullRange  model.Duration
-	FieldsType string
+	APIToken     string
+	ZoneID       string
+	Labels       model.LabelSet
+	Workers      int
+	PullRange    model.Duration
+	FieldsType   string
+	CustomFields []string
 }
 
 // Target enables pulling HTTP log messages from Cloudflare using the Logpull
@@ -66,10 +67,11 @@ type Target struct {
 
 // NewTarget creates and runs a Cloudflare target.
 func NewTarget(metrics *Metrics, logger log.Logger, handler loki.EntryHandler, position positions.Positions, config *Config) (*Target, error) {
-	fields, err := Fields(FieldsType(config.FieldsType))
+	fieldsSubset, err := Fields(FieldsType(config.FieldsType))
 	if err != nil {
 		return nil, err
 	}
+	fields := append(fieldsSubset, config.CustomFields...)
 	client, err := getClient(config.APIToken, config.ZoneID, fields)
 	if err != nil {
 		return nil, err

--- a/component/loki/source/cloudflare/internal/cloudflaretarget/target.go
+++ b/component/loki/source/cloudflare/internal/cloudflaretarget/target.go
@@ -67,11 +67,10 @@ type Target struct {
 
 // NewTarget creates and runs a Cloudflare target.
 func NewTarget(metrics *Metrics, logger log.Logger, handler loki.EntryHandler, position positions.Positions, config *Config) (*Target, error) {
-	fieldsSubset, err := Fields(FieldsType(config.FieldsType))
+	fields, err := Fields(FieldsType(config.FieldsType), config.CustomFields)
 	if err != nil {
 		return nil, err
 	}
-	fields := append(fieldsSubset, config.CustomFields...)
 	client, err := getClient(config.APIToken, config.ZoneID, fields)
 	if err != nil {
 		return nil, err
@@ -223,7 +222,7 @@ func (t *Target) Ready() bool {
 
 // Details returns debug details about the Cloudflare target.
 func (t *Target) Details() map[string]string {
-	fields, _ := Fields(FieldsType(t.config.FieldsType))
+	fields, _ := Fields(FieldsType(t.config.FieldsType), t.config.CustomFields)
 	var errMsg string
 	if t.err != nil {
 		errMsg = t.err.Error()

--- a/component/loki/source/cloudflare/internal/cloudflaretarget/target.go
+++ b/component/loki/source/cloudflare/internal/cloudflaretarget/target.go
@@ -38,13 +38,13 @@ var defaultBackoff = backoff.Config{
 
 // Config defines how to connect to Cloudflare's Logpull API.
 type Config struct {
-	APIToken     string
-	ZoneID       string
-	Labels       model.LabelSet
-	Workers      int
-	PullRange    model.Duration
-	FieldsType   string
-	CustomFields []string
+	APIToken         string
+	ZoneID           string
+	Labels           model.LabelSet
+	Workers          int
+	PullRange        model.Duration
+	FieldsType       string
+	AdditionalFields []string
 }
 
 // Target enables pulling HTTP log messages from Cloudflare using the Logpull
@@ -67,7 +67,7 @@ type Target struct {
 
 // NewTarget creates and runs a Cloudflare target.
 func NewTarget(metrics *Metrics, logger log.Logger, handler loki.EntryHandler, position positions.Positions, config *Config) (*Target, error) {
-	fields, err := Fields(FieldsType(config.FieldsType), config.CustomFields)
+	fields, err := Fields(FieldsType(config.FieldsType), config.AdditionalFields)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +222,7 @@ func (t *Target) Ready() bool {
 
 // Details returns debug details about the Cloudflare target.
 func (t *Target) Details() map[string]string {
-	fields, _ := Fields(FieldsType(t.config.FieldsType), t.config.CustomFields)
+	fields, _ := Fields(FieldsType(t.config.FieldsType), t.config.AdditionalFields)
 	var errMsg string
 	if t.err != nil {
 		errMsg = t.err.Error()

--- a/docs/sources/flow/reference/components/loki.source.cloudflare.md
+++ b/docs/sources/flow/reference/components/loki.source.cloudflare.md
@@ -39,6 +39,7 @@ Name            | Type                 | Description          | Default | Requir
 `workers`       | `int`                | The number of workers to use for parsing logs.     |  `3` | no
 `pull_range`    | `duration`           | The timeframe to fetch for each pull request.      | `"1m"` | no
 `fields_type`   | `string`             | The set of fields to fetch for log entries.        | `"default"` | no
+`custom_fields` | `list(string)`       | The addionnal list of fields to the one provided by `fields_type`. |  | no
 
 
 By default `loki.source.cloudflare` fetches logs with the `default` set of
@@ -64,6 +65,8 @@ and the fields they include:
 ```
  "BotScore", "BotScoreSrc", "ClientRequestBytes", "ClientSrcPort", "ClientXRequestedWith", "CacheTieredFill", "EdgeResponseCompressionRatio", "EdgeServerIP", "FirewallMatchesSources", "FirewallMatchesActions", "FirewallMatchesRuleIDs", "OriginResponseBytes", "OriginResponseTime", "ClientDeviceType", "WAFFlags", "WAFMatchedVar", "EdgeColoID", "RequestHeaders", "ResponseHeaders"`k
 ```
+
+* `custom` includes only the fields defined in `custom_fields`.
 
 The component saves the last successfully-fetched timestamp in its positions
 file. If a position is found in the file for a given zone ID, the component

--- a/docs/sources/flow/reference/components/loki.source.cloudflare.md
+++ b/docs/sources/flow/reference/components/loki.source.cloudflare.md
@@ -39,7 +39,7 @@ Name            | Type                 | Description          | Default | Requir
 `workers`       | `int`                | The number of workers to use for parsing logs.     |  `3` | no
 `pull_range`    | `duration`           | The timeframe to fetch for each pull request.      | `"1m"` | no
 `fields_type`   | `string`             | The set of fields to fetch for log entries.        | `"default"` | no
-`custom_fields` | `list(string)`       | The addionnal list of fields to the one provided by `fields_type`. |  | no
+`custom_fields` | `list(string)`       | The addional list of fields to supplement those provided via `fields_type`. |  | no
 
 
 By default `loki.source.cloudflare` fetches logs with the `default` set of

--- a/docs/sources/flow/reference/components/loki.source.cloudflare.md
+++ b/docs/sources/flow/reference/components/loki.source.cloudflare.md
@@ -39,12 +39,11 @@ Name            | Type                 | Description          | Default | Requir
 `workers`       | `int`                | The number of workers to use for parsing logs.     |  `3` | no
 `pull_range`    | `duration`           | The timeframe to fetch for each pull request.      | `"1m"` | no
 `fields_type`   | `string`             | The set of fields to fetch for log entries.        | `"default"` | no
-`custom_fields` | `list(string)`       | The addional list of fields to supplement those provided via `fields_type`. |  | no
+`additional_fields` | `list(string)`       | The addional list of fields to supplement those provided via `fields_type`. |  | no
 
 
-By default `loki.source.cloudflare` fetches logs with the `default` set of
-fields. Here are the different sets of `fields_type` available for selection,
-and the fields they include:
+By default `loki.source.cloudflare` fetches logs with the `default` set of fields + the fields passed through `additional_fields`. 
+Here are the different sets of `fields_type` available for selection, and the fields they include:
 
 * `default` includes:
 ```
@@ -66,7 +65,7 @@ and the fields they include:
  "BotScore", "BotScoreSrc", "ClientRequestBytes", "ClientSrcPort", "ClientXRequestedWith", "CacheTieredFill", "EdgeResponseCompressionRatio", "EdgeServerIP", "FirewallMatchesSources", "FirewallMatchesActions", "FirewallMatchesRuleIDs", "OriginResponseBytes", "OriginResponseTime", "ClientDeviceType", "WAFFlags", "WAFMatchedVar", "EdgeColoID", "RequestHeaders", "ResponseHeaders"`k
 ```
 
-* `custom` includes only the fields defined in `custom_fields`.
+* `custom` includes only the fields defined in `additional_fields`.
 
 The component saves the last successfully-fetched timestamp in its positions
 file. If a position is found in the file for a given zone ID, the component

--- a/docs/sources/flow/reference/components/loki.source.cloudflare.md
+++ b/docs/sources/flow/reference/components/loki.source.cloudflare.md
@@ -39,30 +39,34 @@ Name            | Type                 | Description          | Default | Requir
 `workers`       | `int`                | The number of workers to use for parsing logs.     |  `3` | no
 `pull_range`    | `duration`           | The timeframe to fetch for each pull request.      | `"1m"` | no
 `fields_type`   | `string`             | The set of fields to fetch for log entries.        | `"default"` | no
-`additional_fields` | `list(string)`       | The addional list of fields to supplement those provided via `fields_type`. |  | no
+`additional_fields` | `list(string)`   | The additional list of fields to supplement those provided via `fields_type`. |  | no
 
 
-By default `loki.source.cloudflare` fetches logs with the `default` set of fields + the fields passed through `additional_fields`. 
-Here are the different sets of `fields_type` available for selection, and the fields they include:
+By default `loki.source.cloudflare` fetches logs with the `default` set of
+fields. Here are the different sets of `fields_type` available for selection,
+and the fields they include:
 
 * `default` includes:
 ```
 "ClientIP", "ClientRequestHost", "ClientRequestMethod", "ClientRequestURI", "EdgeEndTimestamp", "EdgeResponseBytes", "EdgeRequestHost", "EdgeResponseStatus", "EdgeStartTimestamp", "RayID"
 ```
+plus any extra fields provided via `additional_fields` argument.
 
 * `minimal` includes all `default` fields and adds:
 ```
-"ZoneID", "ClientSSLProtocol", "ClientRequestProtocol", "ClientRequestPath", "ClientRequestUserAgent", "ClientRequestReferer", "EdgeColoCode", "ClientCountry", "CacheCacheStatus", "CacheResponseStatus", "EdgeResponseContentType
+"ZoneID", "ClientSSLProtocol", "ClientRequestProtocol", "ClientRequestPath", "ClientRequestUserAgent", "ClientRequestReferer", "EdgeColoCode", "ClientCountry", "CacheCacheStatus", "CacheResponseStatus", "EdgeResponseContentType"
 ```
+plus any extra fields provided via `additional_fields` argument.
 
 * `extended` includes all `minimal` fields and adds:
 ```
 "ClientSSLCipher", "ClientASN", "ClientIPClass", "CacheResponseBytes", "EdgePathingOp", "EdgePathingSrc", "EdgePathingStatus", "ParentRayID", "WorkerCPUTime", "WorkerStatus", "WorkerSubrequest", "WorkerSubrequestCount", "OriginIP", "OriginResponseStatus", "OriginSSLProtocol", "OriginResponseHTTPExpires", "OriginResponseHTTPLastModified"
 ```
+plus any extra fields provided via `additional_fields` argument.
 
 * `all` includes all `extended` fields and adds:
 ```
- "BotScore", "BotScoreSrc", "ClientRequestBytes", "ClientSrcPort", "ClientXRequestedWith", "CacheTieredFill", "EdgeResponseCompressionRatio", "EdgeServerIP", "FirewallMatchesSources", "FirewallMatchesActions", "FirewallMatchesRuleIDs", "OriginResponseBytes", "OriginResponseTime", "ClientDeviceType", "WAFFlags", "WAFMatchedVar", "EdgeColoID", "RequestHeaders", "ResponseHeaders"`k
+ "BotScore", "BotScoreSrc", "ClientRequestBytes", "ClientSrcPort", "ClientXRequestedWith", "CacheTieredFill", "EdgeResponseCompressionRatio", "EdgeServerIP", "FirewallMatchesSources", "FirewallMatchesActions", "FirewallMatchesRuleIDs", "OriginResponseBytes", "OriginResponseTime", "ClientDeviceType", "WAFFlags", "WAFMatchedVar", "EdgeColoID", "RequestHeaders", "ResponseHeaders"
 ```
 
 * `custom` includes only the fields defined in `additional_fields`.

--- a/docs/sources/flow/reference/components/loki.source.cloudflare.md
+++ b/docs/sources/flow/reference/components/loki.source.cloudflare.md
@@ -68,6 +68,7 @@ plus any extra fields provided via `additional_fields` argument.
 ```
  "BotScore", "BotScoreSrc", "ClientRequestBytes", "ClientSrcPort", "ClientXRequestedWith", "CacheTieredFill", "EdgeResponseCompressionRatio", "EdgeServerIP", "FirewallMatchesSources", "FirewallMatchesActions", "FirewallMatchesRuleIDs", "OriginResponseBytes", "OriginResponseTime", "ClientDeviceType", "WAFFlags", "WAFMatchedVar", "EdgeColoID", "RequestHeaders", "ResponseHeaders"
 ```
+plus any extra fields provided via `additional_fields` argument (this is still relevant in this case if new fields are made available via Cloudflare API but are not yet included in `all`).
 
 * `custom` includes only the fields defined in `additional_fields`.
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Add the property `custom_fields` and the type "custom" to the property `fields_type` to allow the user to define its own field for the loki.source.cloudflare. 
In the case where the `fields_type` is set to "all", then the `custom_fields` is expected to be empty or not set.
In the case where the `fields_type` is set to something else than "all" or "custom", the `custom_fields` will be merged with the one provided by the `fields_type` and the duplicates (if any) will be removed.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #4760 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated