### PR TITLE
otel/prometheus_exporter: disable otel_scope_info by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Main (unreleased)
   to enable decompression explicitly. See the [upgrade guide][] for migration
   instructions. (@thampiotr)
 
+- `otelcol.exporter.prometheus`: Set `include_scope_info` to `false` by default. You can set 
+  it to `true` to preserve previous behavior. (@gouthamve)
+
 ### Enhancements
 
 - Integrations: include `direct_connect`, `discovering_mode` and `tls_basic_auth_config_path` fields for MongoDB configuration. (@gaantunes)

--- a/component/otelcol/exporter/prometheus/prometheus.go
+++ b/component/otelcol/exporter/prometheus/prometheus.go
@@ -39,7 +39,7 @@ type Arguments struct {
 // DefaultArguments holds defaults values.
 var DefaultArguments = Arguments{
 	IncludeTargetInfo: true,
-	IncludeScopeInfo:  true,
+	IncludeScopeInfo:  false,
 	GCFrequency:       5 * time.Minute,
 }
 
@@ -77,7 +77,7 @@ func New(o component.Options, c Arguments) (*Component, error) {
 
 	converter := convert.New(o.Logger, fanout, convert.Options{
 		IncludeTargetInfo: true,
-		IncludeScopeInfo:  true,
+		IncludeScopeInfo:  false,
 	})
 
 	res := &Component{

--- a/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
@@ -35,12 +35,12 @@ otelcol.exporter.prometheus "LABEL" {
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `include_target_info` | `boolean` | Whether to include `target_info` metrics. | `true` | no
-`include_scope_info` | `boolean` | Whether to include `otel_scope_info` metrics. | `true` | no
+`include_scope_info` | `boolean` | Whether to include `otel_scope_info` metrics. | `false` | no
 `gc_frequency` | `duration` | How often to clean up stale metrics from memory. | `"5m"` | no
 `forward_to` | `list(receiver)` | Where to forward converted Prometheus metrics. | | yes
 
-By default, OpenTelemetry resources are converted into `target_info` metrics,
-and OpenTelemetry instrumentation scopes are converted into `otel_scope_info`
+By default, OpenTelemetry resources are converted into `target_info` metrics. 
+OpenTelemetry instrumentation scopes are converted into `otel_scope_info`
 metrics. Set the `include_scope_info` and `include_target_info` arguments to
 `false`, respectively, to disable the custom metrics.
 
@@ -48,8 +48,7 @@ When `include_scope_info` is `true`, the instrumentation scope name and version
 are added as `otel_scope_name` and `otel_scope_version` labels to every
 converted metric sample.
 
-
-When `include_scope_info` is true, OpenTelemetry Collector resources are converted into `target_info` metrics.
+When `include_target_info` is true, OpenTelemetry Collector resources are converted into `target_info` metrics.
 
 ## Exported fields
 


### PR DESCRIPTION
The collector doesn't implement this yet and the metrics are not very useful.

See: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/24248

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] ~Config converters updated~