### PR TITLE
wal: fix detection of corruption errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ Main (unreleased)
 
 - Fix issue on Windows where DNS short names were unresolvable. (@rfratto)
 
+- Fix issue where corrupt WAL segments lead to crash looping. (@tpaschalis)
+
 v0.35.3 (2023-08-09)
 --------------------
 

--- a/pkg/metrics/wal/wal.go
+++ b/pkg/metrics/wal/wal.go
@@ -451,7 +451,7 @@ func (w *Storage) loadWAL(r *wlog.Reader, multiRef map[chunks.HeadSeriesRef]chun
 		return err
 	default:
 		if r.Err() != nil {
-			return fmt.Errorf("read records: %w", err)
+			return fmt.Errorf("read records: %w", r.Err())
 		}
 		return nil
 	}

--- a/pkg/metrics/wal/wal_test.go
+++ b/pkg/metrics/wal/wal_test.go
@@ -3,6 +3,8 @@ package wal
 import (
 	"context"
 	"math"
+	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 	"time"
@@ -386,6 +388,19 @@ func TestStorage_TruncateAfterClose(t *testing.T) {
 
 	require.NoError(t, s.Close())
 	require.Error(t, ErrWALClosed, s.Truncate(0))
+}
+
+func TestStorage_Corruption(t *testing.T) {
+	walDir := t.TempDir()
+
+	// Write a corrupt segment
+	err := os.Mkdir(filepath.Join(walDir, "wal"), 0755)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(walDir, "wal", "00000000"), []byte("hello world"), 0644)
+
+	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
+	require.NoError(t, err)
+	require.NotNil(t, s)
 }
 
 func TestGlobalReferenceID_Normal(t *testing.T) {

--- a/pkg/metrics/wal/wal_test.go
+++ b/pkg/metrics/wal/wal_test.go
@@ -397,7 +397,9 @@ func TestStorage_Corruption(t *testing.T) {
 	err := os.Mkdir(filepath.Join(walDir, "wal"), 0755)
 	require.NoError(t, err)
 	err = os.WriteFile(filepath.Join(walDir, "wal", "00000000"), []byte("hello world"), 0644)
+	require.NoError(t, err)
 
+	// The storage should be initialized correctly anyway.
 	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
 	require.NoError(t, err)
 	require.NotNil(t, s)


### PR DESCRIPTION
#### PR Description
This PR fixes a sneaky bug that makes WAL loading more brittle in cases of corruption.

I saw this initially when the Agent was crashlooping on building the component with a message like:
```
Failed to build component: building component: read records: %!w(<nil>)
```

The underlying issue is that we're returning a new `errors.(*errorString)` but we're never wrapping the original `r.Err()` of type `*wlog.CorruptionErr`.

When the return value of loadWAL bubbles up to wal.NewStorage, it never has the chance of being detected as the correct error type to avoid failure to build the storage.

https://github.com/grafana/agent/blob/dc3cdde444ad605c68a0728edcb0a926e04ba50c/pkg/metrics/wal/wal.go#L179-L185


#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer
I also noticed that the agent would crashloop in case a segment was missing. If we have the following segments and delete the first one
```
data-agent/prometheus.remote_write.default/wal/00000000
data-agent/prometheus.remote_write.default/wal/00000001
data-agent/prometheus.remote_write.default/wal/00000002
data-agent/prometheus.remote_write.default/wal/00000003
```

the agent will still crash loop with the following. I think we should also work for a fix on this.
```
Error: /Users/tpaschalis/river-configs/component-logger.river:30:1: Failed to build component: building component: open WAL segment 0: open data-agent/prometheus.remote_write.default/wal/00000000: no such file or directory
```

#### PR Checklist

- [X] CHANGELOG.md updated
- [ ] Documentation added (N/A)
- [X] Tests updated
