### PR TITLE
fix flaky wal_test.go for windows

### DIFF
--- a/pkg/metrics/wal/wal_test.go
+++ b/pkg/metrics/wal/wal_test.go
@@ -403,6 +403,8 @@ func TestStorage_Corruption(t *testing.T) {
 	s, err := NewStorage(log.NewNopLogger(), nil, walDir)
 	require.NoError(t, err)
 	require.NotNil(t, s)
+
+	require.NoError(t, s.Close())
 }
 
 func TestGlobalReferenceID_Normal(t *testing.T) {


### PR DESCRIPTION
In the last PR, we didn't handle closing of the WAL, which lead to failing tests on Windows.