### PR TITLE
clarify loki source file doesn't handle discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ Main (unreleased)
 
 - Fix issue where corrupt WAL segments lead to crash looping. (@tpaschalis)
 
+- Clarify usage documentation surrounding `loki.source.file` (@joshuapare)
+
 v0.35.3 (2023-08-09)
 --------------------
 

--- a/docs/sources/flow/reference/components/loki.source.file.md
+++ b/docs/sources/flow/reference/components/loki.source.file.md
@@ -11,7 +11,9 @@ title: loki.source.file
 Multiple `loki.source.file` components can be specified by giving them
 different labels.
 
-> **NOTE:**  `loki.source.file` does not handle file discovery. See the [File Globbing](#file-globbing) example below for usage with `local.file_match`.
+{{% admonition type="note" %}}
+`loki.source.file` does not handle file discovery. You can use `local.file_match` for file discovery. Refer to the [File Globbing](#file-globbing) example for more information.
+{{% /admonition %}}
 
 ## Usage
 

--- a/docs/sources/flow/reference/components/loki.source.file.md
+++ b/docs/sources/flow/reference/components/loki.source.file.md
@@ -11,6 +11,8 @@ title: loki.source.file
 Multiple `loki.source.file` components can be specified by giving them
 different labels.
 
+> **NOTE:**  `loki.source.file` does not handle file discovery. See the [File Globbing](#file-globbing) example below for usage with `local.file_match`.
+
 ## Usage
 
 ```river


### PR DESCRIPTION
Fixes #3954

Clarify that `loki.source.file` doesn't handle discovery, and link to the example in the docs that shows usage with the correct component.

- [x] CHANGELOG.md updated
- [x] Documentation added