### PR TITLE
flow: change clustering interface to be a call to NotifyClusterChange

### DIFF
--- a/component/component.go
+++ b/component/component.go
@@ -119,5 +119,7 @@ type DebugComponent interface {
 type ClusteredComponent interface {
 	Component
 
-	ClusterUpdatesRegistration() bool
+	// NotifyClusterChange notifies the component that the state of the cluster
+	// has changed.
+	NotifyClusterChange()
 }

--- a/component/component.go
+++ b/component/component.go
@@ -121,5 +121,8 @@ type ClusteredComponent interface {
 
 	// NotifyClusterChange notifies the component that the state of the cluster
 	// has changed.
+	//
+	// Implementations of ClusteredComponent should ignore calls to this method
+	// if they are configured to not utilize clustering.
 	NotifyClusterChange()
 }

--- a/component/prometheus/operator/common/component.go
+++ b/component/prometheus/operator/common/component.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Component struct {
-	mut     sync.Mutex
+	mut     sync.RWMutex
 	config  *operator.Arguments
 	manager *crdManager
 
@@ -108,8 +108,8 @@ func (c *Component) Update(args component.Arguments) error {
 
 // NotifyClusterChange implements component.ClusterComponent.
 func (c *Component) NotifyClusterChange() {
-	c.mut.Lock()
-	defer c.mut.Unlock()
+	c.mut.RLock()
+	defer c.mut.RUnlock()
 
 	if !c.config.Clustering.Enabled {
 		return // no-op

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -96,16 +96,12 @@ func NewLoader(opts LoaderOptions) *Loader {
 		defer span.End()
 		for _, cmp := range l.Components() {
 			if cc, ok := cmp.managed.(component.ClusteredComponent); ok {
-				if cc.ClusterUpdatesRegistration() {
-					_, span := tracer.Start(spanCtx, "ClusteredComponentReevaluation", trace.WithSpanKind(trace.SpanKindInternal))
-					span.SetAttributes(attribute.String("node_id", cmp.NodeID()))
-					defer span.End()
+				_, span := tracer.Start(spanCtx, "NotifyClusterChange", trace.WithSpanKind(trace.SpanKindInternal))
+				span.SetAttributes(attribute.String("node_id", cmp.NodeID()))
 
-					err := cmp.Reevaluate()
-					if err != nil {
-						level.Error(l.log).Log("msg", "failed to reevaluate component", "componentID", cmp.NodeID(), "err", err)
-					}
-				}
+				cc.NotifyClusterChange()
+
+				span.End()
 			}
 		}
 		return true

--- a/pkg/flow/internal/controller/node_component.go
+++ b/pkg/flow/internal/controller/node_component.go
@@ -265,37 +265,6 @@ func (cn *ComponentNode) Evaluate(scope *vm.Scope) error {
 	return err
 }
 
-// Reevaluate calls Update on the managed component with its last used
-// arguments.Reevaluate does not build the component if it is not already built
-// and does not re-evaluate the River block itself.
-// Its only use case is for components opting-in to clustering where calling
-// Update with the same Arguments may result in different functionality.
-func (cn *ComponentNode) Reevaluate() error {
-	cn.mut.Lock()
-	defer cn.mut.Unlock()
-
-	cn.doingEval.Store(true)
-	defer cn.doingEval.Store(false)
-
-	if cn.managed == nil {
-		// We haven't built the managed component successfully yet.
-		return nil
-	}
-
-	// Update the existing managed component with the same arguments.
-	err := cn.managed.Update(cn.args)
-
-	switch err {
-	case nil:
-		cn.setEvalHealth(component.HealthTypeHealthy, "component evaluated")
-		return nil
-	default:
-		msg := fmt.Sprintf("component evaluation failed: %s", err)
-		cn.setEvalHealth(component.HealthTypeUnhealthy, msg)
-		return err
-	}
-}
-
 func (cn *ComponentNode) evaluate(scope *vm.Scope) error {
 	cn.mut.Lock()
 	defer cn.mut.Unlock()


### PR DESCRIPTION
Previously, components would opt in to clustering notifications through a call to ClusterUpdatesRegistration. Then, if that method returned true, they would be re-evaluated.

In preparation for the move to services, the clustering service would not be able to function the same way, as services are not permitted to trigger a re-evaluation of a component.

The new interface is a NotifyClusterChange method, which allows components to opt-in to whether they want to ignore that signal or not.

This is not reflected in the CHANGELOG as it is a no-op for users.