### PR TITLE
Update broken macos link start-agent.md

### DIFF
--- a/docs/sources/flow/setup/start-agent.md
+++ b/docs/sources/flow/setup/start-agent.md
@@ -103,7 +103,7 @@ brew services stop grafana-agent-flow
 By default, logs are written to `$(brew --prefix)/var/log/grafana-agent-flow.log` and
 `$(brew --prefix)/var/log/grafana-agent-flow.err.log`.
 
-If you followed [Configure the Grafana Agent service](../setup/configure/configure-macos.md#configure-the-grafana-agent-service)
+If you followed [Configure the Grafana Agent service](../setup/configure/configure-macos/#configure-the-grafana-agent-service)
 and changed the path where logs are written, refer to your current copy of the Grafana Agent formula to locate your log files.
 
 ## Windows


### PR DESCRIPTION
Currently the link is redirecting to https://grafana.com/docs/agent/latest/flow/setup/setup/configure/configure-macos.md#configure-the-grafana-agent-service which does not exist.

It should resolve to https://grafana.com/docs/agent/latest/flow/setup/configure/configure-macos/#configure-the-grafana-agent-service which does exist.

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated