### PR TITLE
prometheus.operator.*: fix panic when port not defined in CRD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ Main (unreleased)
 
 - Fix issue on Windows where DNS short names were unresolvable. (@rfratto)
 
+- Fix panic in `prometheus.operator.*` when no Port supplied in Monitor crds. (@captncraig)
+
 v0.35.4 (2023-08-14)
 --------------------
 

--- a/component/prometheus/operator/configgen/config_gen_podmonitor.go
+++ b/component/prometheus/operator/configgen/config_gen_podmonitor.go
@@ -182,9 +182,8 @@ func (cg *ConfigGenerator) GeneratePodMonitorConfig(m *promopv1.PodMonitor, ep p
 			Regex:        regex,
 		})
 	} else if ep.TargetPort != nil { //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
-		if ep.TargetPort.StrVal != "" {
-			//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
-			regex, err := relabel.NewRegexp(ep.TargetPort.String())
+		if ep.TargetPort.StrVal != "" { //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
+			regex, err := relabel.NewRegexp(ep.TargetPort.String()) //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 			if err != nil {
 				return nil, fmt.Errorf("parsing TargetPort as regex: %w", err)
 			}

--- a/component/prometheus/operator/configgen/config_gen_podmonitor.go
+++ b/component/prometheus/operator/configgen/config_gen_podmonitor.go
@@ -182,28 +182,30 @@ func (cg *ConfigGenerator) GeneratePodMonitorConfig(m *promopv1.PodMonitor, ep p
 			Regex:        regex,
 		})
 	} else if ep.TargetPort != nil { //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
-		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
-		regex, err := relabel.NewRegexp(ep.TargetPort.String())
-		if err != nil {
-			return nil, fmt.Errorf("parsing TargetPort as regex: %w", err)
-		}
-		if ep.TargetPort.StrVal != "" { //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
+		if ep.TargetPort.StrVal != "" {
+			//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
+			regex, err := relabel.NewRegexp(ep.TargetPort.String())
+			if err != nil {
+				return nil, fmt.Errorf("parsing TargetPort as regex: %w", err)
+			}
+			if ep.TargetPort.StrVal != "" { //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
+				relabels.add(&relabel.Config{
+					SourceLabels: model.LabelNames{"__meta_kubernetes_pod_container_port_name"},
+					Action:       "keep",
+					Regex:        regex,
+				})
+			}
+		} else if ep.TargetPort.IntVal != 0 { //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
+			regex, err := relabel.NewRegexp(ep.TargetPort.String()) //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
+			if err != nil {
+				return nil, fmt.Errorf("parsing TargetPort as regex: %w", err)
+			}
 			relabels.add(&relabel.Config{
-				SourceLabels: model.LabelNames{"__meta_kubernetes_pod_container_port_name"},
+				SourceLabels: model.LabelNames{"__meta_kubernetes_pod_container_port_number"},
 				Action:       "keep",
 				Regex:        regex,
 			})
 		}
-	} else if ep.TargetPort.IntVal != 0 { //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
-		regex, err := relabel.NewRegexp(ep.TargetPort.String()) //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
-		if err != nil {
-			return nil, fmt.Errorf("parsing TargetPort as regex: %w", err)
-		}
-		relabels.add(&relabel.Config{
-			SourceLabels: model.LabelNames{"__meta_kubernetes_pod_container_port_number"},
-			Action:       "keep",
-			Regex:        regex,
-		})
 	}
 
 	// Relabel namespace and pod and service labels into proper labels.

--- a/component/prometheus/operator/configgen/config_gen_podmonitor_test.go
+++ b/component/prometheus/operator/configgen/config_gen_podmonitor_test.go
@@ -42,9 +42,7 @@ func TestGeneratePodMonitorConfig(t *testing.T) {
 					Name:      "podmonitor",
 				},
 			},
-			ep: promopv1.PodMetricsEndpoint{
-				Port: "metrics",
-			},
+			ep: promopv1.PodMetricsEndpoint{},
 			expectedRelabels: util.Untab(`
 				- target_label: __meta_foo
 				  replacement: bar
@@ -53,9 +51,6 @@ func TestGeneratePodMonitorConfig(t *testing.T) {
 				- source_labels: [__meta_kubernetes_pod_phase]
 				  regex: (Failed|Succeeded)
 				  action: drop
-				- source_labels: [__meta_kubernetes_pod_container_port_name]
-				  regex: metrics
-				  action: keep
 				- source_labels: [__meta_kubernetes_namespace]
 				  target_label: namespace
 				- source_labels: [__meta_kubernetes_pod_container_name]
@@ -64,8 +59,6 @@ func TestGeneratePodMonitorConfig(t *testing.T) {
 				  target_label: pod
 				- target_label: job
 				  replacement: operator/podmonitor
-				- target_label: endpoint
-				  replacement: metrics
 			`),
 			expected: &config.ScrapeConfig{
 				JobName:         "podMonitor/operator/podmonitor/0",

--- a/component/prometheus/operator/configgen/config_gen_servicemonitor.go
+++ b/component/prometheus/operator/configgen/config_gen_servicemonitor.go
@@ -168,9 +168,8 @@ func (cg *ConfigGenerator) GenerateServiceMonitorConfig(m *promopv1.ServiceMonit
 			Regex:        regex,
 		})
 	} else if ep.TargetPort != nil { //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
-		if ep.TargetPort.StrVal != "" {
-			//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
-			regex, err := relabel.NewRegexp(ep.TargetPort.String())
+		if ep.TargetPort.StrVal != "" { //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
+			regex, err := relabel.NewRegexp(ep.TargetPort.String()) //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 			if err != nil {
 				return nil, fmt.Errorf("parsing TargetPort as regex: %w", err)
 			}

--- a/component/prometheus/operator/configgen/config_gen_servicemonitor_test.go
+++ b/component/prometheus/operator/configgen/config_gen_servicemonitor_test.go
@@ -42,17 +42,12 @@ func TestGenerateServiceMonitorConfig(t *testing.T) {
 					Name:      "svcmonitor",
 				},
 			},
-			ep: promopv1.Endpoint{
-				Port: "metrics",
-			},
+			ep: promopv1.Endpoint{},
 			expectedRelabels: util.Untab(`
 				- target_label: __meta_foo
 				  replacement: bar
 				- source_labels: [job]
 				  target_label: __tmp_prometheus_job_name
-				- source_labels: [__meta_kubernetes_endpoint_port_name]
-				  regex: metrics
-				  action: keep
 				- source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
 				  regex: Node;(.*)
 				  target_label: node
@@ -76,9 +71,6 @@ func TestGenerateServiceMonitorConfig(t *testing.T) {
 				- source_labels: [__meta_kubernetes_service_name]
 				  target_label: job
 				  replacement: ${1}
-				- target_label: endpoint
-				  replacement: metrics
-				  action: replace
 			`),
 			expected: &config.ScrapeConfig{
 				JobName:         "serviceMonitor/operator/svcmonitor/0",


### PR DESCRIPTION
If you didn't define a port at all in your CRD, this would panic. That is not good.