### PR TITLE
prometheus.operator.*, simplify cluster update logic.

### DIFF
--- a/component/prometheus/operator/common/component.go
+++ b/component/prometheus/operator/common/component.go
@@ -64,8 +64,7 @@ func (c *Component) Run(ctx context.Context) error {
 			c.reportHealth(err)
 		case <-c.onUpdate:
 			c.mut.Lock()
-			nextConfig := c.config
-			manager := newCrdManager(c.opts, c.opts.Logger, nextConfig, c.kind)
+			manager := newCrdManager(c.opts, c.opts.Logger, c.config, c.kind)
 			c.manager = manager
 			if cancel != nil {
 				cancel()

--- a/component/prometheus/operator/types.go
+++ b/component/prometheus/operator/types.go
@@ -1,7 +1,6 @@
 package operator
 
 import (
-	"reflect"
 	"time"
 
 	"github.com/grafana/agent/component/common/config"
@@ -28,10 +27,6 @@ type Arguments struct {
 	Clustering Clustering `river:"clustering,block,optional"`
 
 	RelabelConfigs []*flow_relabel.Config `river:"rule,block,optional"`
-}
-
-func (a *Arguments) Equals(b *Arguments) bool {
-	return reflect.DeepEqual(a, b)
 }
 
 // Clustering holds values that configure clustering-specific behavior.

--- a/component/prometheus/operator/types_test.go
+++ b/component/prometheus/operator/types_test.go
@@ -27,20 +27,3 @@ func TestRiverUnmarshal(t *testing.T) {
 	err := river.Unmarshal([]byte(exampleRiverConfig), &args)
 	require.NoError(t, err)
 }
-
-func TestEqual(t *testing.T) {
-	a := Arguments{
-		Namespaces: []string{"my-app"},
-		Clustering: Clustering{Enabled: true},
-	}
-	b := Arguments{
-		Namespaces: []string{"my-app"},
-		Clustering: Clustering{Enabled: true},
-	}
-	c := Arguments{
-		Namespaces: []string{"my-app", "other-app"},
-		Clustering: Clustering{Enabled: false},
-	}
-	require.True(t, a.Equals(&b))
-	require.False(t, a.Equals(&c))
-}


### PR DESCRIPTION
We previously had to discriminate between "argument" updates and "clustering" updates. Now that the notification mechanism for clustering is changed, this gets a bit simpler.

I don't think this needs a changelog.