### PR TITLE
Add support for retry on http429 to loki write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ Main (unreleased)
 
 - Flow: Added exemplar support for the `otelcol.exporter.prometheus`. (@wildum)
 
-- `loki.write` now supports retries on HTTP429. (@wildum)
+- `loki.write` now supports configuring retries on HTTP status code 429. (@wildum)
 
 - New Grafana Agent Flow components:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ Main (unreleased)
 
 - Flow: Added exemplar support for the `otelcol.exporter.prometheus`. (@wildum)
 
+- `loki.write` now supports retries on HTTP429. (@wildum)
+
 - New Grafana Agent Flow components:
 
   - `prometheus.exporter.gcp` - scrape GCP metrics. (@tburgessdev)

--- a/component/loki/write/types.go
+++ b/component/loki/write/types.go
@@ -27,6 +27,7 @@ type EndpointOptions struct {
 	MaxBackoff        time.Duration           `river:"max_backoff_period,attr,optional"`  // increase exponentially to this level
 	MaxBackoffRetries int                     `river:"max_backoff_retries,attr,optional"` // give up after this many; zero means infinite retries
 	TenantID          string                  `river:"tenant_id,attr,optional"`
+	RetryOnHTTP429    bool                    `river:"retry_on_http_429,attr,optional"`
 	HTTPClientConfig  *types.HTTPClientConfig `river:",squash"`
 }
 
@@ -44,6 +45,7 @@ func GetDefaultEndpointOptions() EndpointOptions {
 		MaxBackoff:        5 * time.Minute,
 		MaxBackoffRetries: 10,
 		HTTPClientConfig:  types.CloneDefaultHTTPClientConfig(),
+		RetryOnHTTP429:    true,
 	}
 
 	return defaultEndpointOptions
@@ -84,9 +86,10 @@ func (args Arguments) convertClientConfigs() []client.Config {
 				MaxBackoff: cfg.MaxBackoff,
 				MaxRetries: cfg.MaxBackoffRetries,
 			},
-			ExternalLabels: lokiflagext.LabelSet{LabelSet: toLabelSet(args.ExternalLabels)},
-			Timeout:        cfg.RemoteTimeout,
-			TenantID:       cfg.TenantID,
+			ExternalLabels:         lokiflagext.LabelSet{LabelSet: toLabelSet(args.ExternalLabels)},
+			Timeout:                cfg.RemoteTimeout,
+			TenantID:               cfg.TenantID,
+			DropRateLimitedBatches: !cfg.RetryOnHTTP429,
 		}
 		res = append(res, cc)
 	}

--- a/converter/internal/promtailconvert/internal/build/loki_write.go
+++ b/converter/internal/promtailconvert/internal/build/loki_write.go
@@ -38,14 +38,6 @@ func toLokiWriteArguments(config *client.Config, diags *diag.Diagnostics) *lokiw
 		)
 	}
 
-	// This is not supported yet - see https://github.com/grafana/agent/issues/4335.
-	if config.DropRateLimitedBatches {
-		diags.Add(
-			diag.SeverityLevelError,
-			"DropRateLimitedBatches is currently not supported in Grafana Agent Flow",
-		)
-	}
-
 	// Also deprecated in promtail.
 	if len(config.StreamLagLabels) != 0 {
 		diags.Add(
@@ -68,6 +60,7 @@ func toLokiWriteArguments(config *client.Config, diags *diag.Diagnostics) *lokiw
 				MaxBackoffRetries: config.BackoffConfig.MaxRetries,
 				RemoteTimeout:     config.Timeout,
 				TenantID:          config.TenantID,
+				RetryOnHTTP429:    !config.DropRateLimitedBatches,
 			},
 		},
 		ExternalLabels: convertFlagLabels(config.ExternalLabels),

--- a/converter/internal/promtailconvert/testdata/loki_write.river
+++ b/converter/internal/promtailconvert/testdata/loki_write.river
@@ -1,0 +1,19 @@
+loki.write "default" {
+	endpoint {
+		url            = "http://localhost/loki/api/v1/push"
+		batch_wait     = "10s"
+		batch_size     = "1KiB"
+		remote_timeout = "30s"
+		headers        = {
+			bird = "house",
+			fat  = "ball",
+		}
+		min_backoff_period  = "100ms"
+		max_backoff_period  = "10s"
+		max_backoff_retries = 20
+		tenant_id           = "sparrow"
+		retry_on_http_429   = false
+		proxy_url           = "http://proxy.example.com"
+	}
+	external_labels = {}
+}

--- a/converter/internal/promtailconvert/testdata/loki_write.river
+++ b/converter/internal/promtailconvert/testdata/loki_write.river
@@ -17,3 +17,10 @@ loki.write "default" {
 	}
 	external_labels = {}
 }
+
+loki.write "default_2" {
+	endpoint {
+		url = "http://localhost/loki/api/v1/push"
+	}
+	external_labels = {}
+}

--- a/converter/internal/promtailconvert/testdata/loki_write.yaml
+++ b/converter/internal/promtailconvert/testdata/loki_write.yaml
@@ -1,0 +1,17 @@
+clients:
+  - url: http://localhost/loki/api/v1/push
+    headers:
+      fat: ball
+      bird: house
+    tenant_id: sparrow
+    batchwait: 10s
+    batchsize: 1024
+    proxy_url: http://proxy.example.com
+    backoff_config:
+      min_period: 100ms
+      max_period: 10s
+      max_retries: 20
+    drop_rate_limited_batches: true
+    timeout: 30s
+tracing: {enabled: false}
+server: {register_instrumentation: false}

--- a/converter/internal/promtailconvert/testdata/loki_write.yaml
+++ b/converter/internal/promtailconvert/testdata/loki_write.yaml
@@ -13,5 +13,7 @@ clients:
       max_retries: 20
     drop_rate_limited_batches: true
     timeout: 30s
+  - url: http://localhost/loki/api/v1/push
+    drop_rate_limited_batches: false
 tracing: {enabled: false}
 server: {register_instrumentation: false}

--- a/converter/internal/promtailconvert/testdata/unsupported.diags
+++ b/converter/internal/promtailconvert/testdata/unsupported.diags
@@ -10,7 +10,6 @@
 (Warning) server.log_level is not supported - Flow mode components may produce different logs
 (Error) server.http_path_prefix is not supported
 (Warning) server.health_check_target disabling is not supported in Flow mode
-(Error) DropRateLimitedBatches is currently not supported in Grafana Agent Flow
 (Warning) stream_lag_labels is deprecated and the associated metric has been removed
 (Error) dockerswarm_sd_configs is not supported
 (Error) serverset_sd_configs is not supported

--- a/docs/sources/flow/reference/components/loki.write.md
+++ b/docs/sources/flow/reference/components/loki.write.md
@@ -102,6 +102,11 @@ Endpoints can be named for easier identification in debug metrics by using the
 `name` argument. If the `name` argument isn't provided, a name is generated
 based on a hash of the endpoint settings.
 
+The `retry_on_http_429` argument specifies whether `HTTP 429` status code
+responses should be treated as recoverable errors; other `HTTP 4xx` status code
+responses are never considered recoverable errors. When `retry_on_http_429` is
+enabled, the retry mechanism will be governed by the specified `backoff` configuration.
+
 ### basic_auth block
 
 {{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}

--- a/docs/sources/flow/reference/components/loki.write.md
+++ b/docs/sources/flow/reference/components/loki.write.md
@@ -80,6 +80,7 @@ Name                  | Type          | Description                           | 
 `proxy_url`           | `string`      | HTTP proxy to proxy requests through. | | no
 `follow_redirects`    | `bool`        | Whether redirects returned by the server should be followed. | `true` | no
 `enable_http2`        | `bool`        | Whether HTTP2 is supported for requests. | `true` | no
+`retry_on_http_429`   | `bool`        | Retry when an HTTP 429 status code is received. | `true` | no
 
  At most one of the following can be provided:
  - [`bearer_token` argument](#endpoint-block).

--- a/docs/sources/flow/reference/components/loki.write.md
+++ b/docs/sources/flow/reference/components/loki.write.md
@@ -105,7 +105,7 @@ based on a hash of the endpoint settings.
 The `retry_on_http_429` argument specifies whether `HTTP 429` status code
 responses should be treated as recoverable errors; other `HTTP 4xx` status code
 responses are never considered recoverable errors. When `retry_on_http_429` is
-enabled, the retry mechanism will be governed by the specified `backoff` configuration.
+enabled, the retry mechanism will be governed by the backoff configuration specified through `min_backoff_period`, `max_backoff_period ` and `max_backoff_retries` attributes.
 
 ### basic_auth block
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Add support for retry on http429 to loki write for static and flow mode. It was decided in the issue to go with the property RetryOnHTTP429 like in prometheus remote write rather than going for the DropRateLimitedBatches used in promtail.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #4335

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated