### PR TITLE
loki.source.docker: reduce labels-related resource usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@ Main (unreleased)
 
 - Fix issue where getting the support bundle failed due to using an HTTP Client that was not able to access the agent in-memory address. (@spartan0x117)
 
+- Fix an issue that lead the `loki.source.docker` container to use excessive
+  CPU and memory. (@tpaschalis)
+
 v0.35.4 (2023-08-14)
 --------------------
 

--- a/component/loki/source/docker/docker.go
+++ b/component/loki/source/docker/docker.go
@@ -243,7 +243,7 @@ func (c *Component) DebugInfo() interface{} {
 	for _, tgt := range c.manager.targets() {
 		details := tgt.Details().(map[string]string)
 		res.TargetsInfo = append(res.TargetsInfo, targetInfo{
-			Labels:     tgt.Labels().String(),
+			Labels:     tgt.LabelsStr(),
 			ID:         details["id"],
 			LastError:  details["error"],
 			IsRunning:  details["running"],

--- a/component/loki/source/docker/internal/dockertarget/target.go
+++ b/component/loki/source/docker/internal/dockertarget/target.go
@@ -43,6 +43,7 @@ type Target struct {
 	positions     positions.Positions
 	containerName string
 	labels        model.LabelSet
+	labelsStr     string
 	relabelConfig []*relabel.Config
 	metrics       *Metrics
 
@@ -55,7 +56,8 @@ type Target struct {
 
 // NewTarget starts a new target to read logs from a given container ID.
 func NewTarget(metrics *Metrics, logger log.Logger, handler loki.EntryHandler, position positions.Positions, containerID string, labels model.LabelSet, relabelConfig []*relabel.Config, client client.APIClient) (*Target, error) {
-	pos, err := position.Get(positions.CursorKey(containerID), labels.String())
+	labelsStr := labels.String()
+	pos, err := position.Get(positions.CursorKey(containerID), labelsStr)
 	if err != nil {
 		return nil, err
 	}
@@ -71,6 +73,7 @@ func NewTarget(metrics *Metrics, logger log.Logger, handler loki.EntryHandler, p
 		positions:     position,
 		containerName: containerID,
 		labels:        labels,
+		labelsStr:     labelsStr,
 		relabelConfig: relabelConfig,
 		metrics:       metrics,
 
@@ -231,7 +234,7 @@ func (t *Target) process(r io.Reader, logStream string) {
 		// problematic if we have the same container with a different set of
 		// labels (e.g. duplicated and relabeled), but this shouldn't be the
 		// case anyway.
-		t.positions.Put(positions.CursorKey(t.containerName), t.labels.String(), ts.Unix())
+		t.positions.Put(positions.CursorKey(t.containerName), t.labelsStr, ts.Unix())
 	}
 }
 
@@ -259,9 +262,9 @@ func (t *Target) Ready() bool {
 	return t.running.Load()
 }
 
-// Labels reports the target's labels.
-func (t *Target) Labels() model.LabelSet {
-	return t.labels
+// LabelsStr returns the target's original labels string representation.
+func (t *Target) LabelsStr() string {
+	return t.labelsStr
 }
 
 // Name reports the container name.
@@ -287,7 +290,7 @@ func (t *Target) Details() interface{} {
 	return map[string]string{
 		"id":       t.containerName,
 		"error":    errMsg,
-		"position": t.positions.GetString(positions.CursorKey(t.containerName), t.labels.String()),
+		"position": t.positions.GetString(positions.CursorKey(t.containerName), t.labelsStr),
 		"running":  strconv.FormatBool(t.running.Load()),
 	}
 }

--- a/component/loki/source/docker/runner.go
+++ b/component/loki/source/docker/runner.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana/agent/component/common/loki/positions"
 	dt "github.com/grafana/agent/component/loki/source/docker/internal/dockertarget"
 	"github.com/grafana/agent/pkg/runner"
-	"github.com/prometheus/common/model"
 )
 
 // A manager manages a set of running tailers.
@@ -81,8 +80,6 @@ type tailer struct {
 	log    log.Logger
 	opts   *options
 	target *dt.Target
-
-	lset model.LabelSet
 }
 
 // newTailer returns a new tailer which tails logs from the target specified by
@@ -92,8 +89,6 @@ func newTailer(l log.Logger, task *tailerTask) *tailer {
 		log:    log.WithPrefix(l, "target", task.target.Name()),
 		opts:   task.options,
 		target: task.target,
-
-		lset: task.target.Labels(),
 	}
 }
 

--- a/component/loki/source/docker/runner.go
+++ b/component/loki/source/docker/runner.go
@@ -73,7 +73,7 @@ func (tt *tailerTask) Equals(other runner.Task) bool {
 
 	// Slow path: check individual fields which are part of the task.
 	return tt.options == otherTask.options &&
-		tt.target.Labels().String() == otherTask.target.Labels().String()
+		tt.target.LabelsStr() == otherTask.target.LabelsStr()
 }
 
 // A tailer tails the logs of a docker container. It is created by a [Manager].
@@ -177,7 +177,7 @@ func entryForTarget(t *dt.Target) positions.Entry {
 	// entry when it can't find it.
 	return positions.Entry{
 		Path:   positions.CursorKey(t.Name()),
-		Labels: t.Labels().String(),
+		Labels: t.LabelsStr(),
 	}
 }
 


### PR DESCRIPTION
#### PR Description
This PR refactors the usage of labels on the `loki.source.docker` containers to reduce CPU usage by ~84% and memory usage by ~91% (`main` vs `fix`)

![Screenshot 2023-08-21 at 16 29 26](https://github.com/grafana/agent/assets/17771679/e87fe7b3-476e-420e-aa48-2f04c85376d9)
![Screenshot 2023-08-21 at 16 29 03](https://github.com/grafana/agent/assets/17771679/08aeb6f5-f180-40bb-aafb-ebc7aa140bf1)


#### Which issue(s) this PR fixes
Fixes #4777

#### Notes to the Reviewer
I've verified this by using our pyroscope components and checking the profiles on Grafana Cloud with a config like the following

```
pyroscope.scrape "local" {
  targets    = [
    {"__address__" = "localhost:12346", "service_name"="main"},
    {"__address__" = "localhost:12347", "service_name"="fix"},
  ]
  forward_to = [pyroscope.write.grafanacloud.receiver]

  profiling_config {
    profile.process_cpu {
      enabled = true
    }
  }
}

pyroscope.write "grafanacloud" {
  endpoint {
    url = "<url>"
    basic_auth {
      username = "<user>"
      password = "<pass>"
    }
  }
  external_labels = {
    "env" = "tpaschalis-comparison",
  }
}
```

#### PR Checklist
- [X] CHANGELOG.md updated
- [ ] Documentation added (N/A)
- [ ] Tests updated 