### PR TITLE
Set retry_on_http_429 to true by default prometheus.remote_write queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Main (unreleased)
 - `otelcol.exporter.prometheus`: Set `include_scope_info` to `false` by default. You can set 
   it to `true` to preserve previous behavior. (@gouthamve)
 
+- `prometheus.remote_write`: Set `retry_on_http_429` to `true` by default in the `queue_config` block.
+  You can set it to `false` to preserve previous behavior. (@wildum)
+
 ### Enhancements
 
 - Integrations: include `direct_connect`, `discovering_mode` and `tls_basic_auth_config_path` fields for MongoDB configuration. (@gaantunes)

--- a/component/prometheus/remotewrite/types.go
+++ b/component/prometheus/remotewrite/types.go
@@ -30,7 +30,7 @@ var (
 		BatchSendDeadline: 5 * time.Second,
 		MinBackoff:        30 * time.Millisecond,
 		MaxBackoff:        5 * time.Second,
-		RetryOnHTTP429:    false,
+		RetryOnHTTP429:    true,
 	}
 
 	DefaultMetadataOptions = MetadataOptions{

--- a/converter/internal/prometheusconvert/testdata/azure.river
+++ b/converter/internal/prometheusconvert/testdata/azure.river
@@ -53,7 +53,9 @@ prometheus.remote_write "default" {
 		url            = "http://remote-write-url1"
 		send_exemplars = false
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}

--- a/converter/internal/prometheusconvert/testdata/consul.river
+++ b/converter/internal/prometheusconvert/testdata/consul.river
@@ -33,7 +33,9 @@ prometheus.remote_write "default" {
 		url            = "http://remote-write-url1"
 		send_exemplars = false
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}

--- a/converter/internal/prometheusconvert/testdata/digitalocean.river
+++ b/converter/internal/prometheusconvert/testdata/digitalocean.river
@@ -31,7 +31,9 @@ prometheus.remote_write "default" {
 		url            = "http://remote-write-url1"
 		send_exemplars = false
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}

--- a/converter/internal/prometheusconvert/testdata/discovery.river
+++ b/converter/internal/prometheusconvert/testdata/discovery.river
@@ -76,7 +76,9 @@ prometheus.remote_write "default" {
 		url            = "http://remote-write-url1"
 		send_exemplars = false
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}

--- a/converter/internal/prometheusconvert/testdata/discovery_relabel.river
+++ b/converter/internal/prometheusconvert/testdata/discovery_relabel.river
@@ -76,7 +76,9 @@ prometheus.remote_write "default" {
 		url            = "http://remote-write-url1"
 		send_exemplars = false
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}

--- a/converter/internal/prometheusconvert/testdata/dns.river
+++ b/converter/internal/prometheusconvert/testdata/dns.river
@@ -32,7 +32,9 @@ prometheus.remote_write "default" {
 		url            = "http://remote-write-url1"
 		send_exemplars = false
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}

--- a/converter/internal/prometheusconvert/testdata/docker.river
+++ b/converter/internal/prometheusconvert/testdata/docker.river
@@ -29,7 +29,9 @@ prometheus.remote_write "default" {
 		url            = "http://remote-write-url1"
 		send_exemplars = false
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}

--- a/converter/internal/prometheusconvert/testdata/ec2.river
+++ b/converter/internal/prometheusconvert/testdata/ec2.river
@@ -35,7 +35,9 @@ prometheus.remote_write "default" {
 		url            = "http://remote-write-url1"
 		send_exemplars = false
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}

--- a/converter/internal/prometheusconvert/testdata/file.river
+++ b/converter/internal/prometheusconvert/testdata/file.river
@@ -30,7 +30,9 @@ prometheus.remote_write "default" {
 		url            = "http://remote-write-url1"
 		send_exemplars = false
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}

--- a/converter/internal/prometheusconvert/testdata/gce.river
+++ b/converter/internal/prometheusconvert/testdata/gce.river
@@ -33,7 +33,9 @@ prometheus.remote_write "default" {
 		url            = "http://remote-write-url1"
 		send_exemplars = false
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}

--- a/converter/internal/prometheusconvert/testdata/kubernetes.river
+++ b/converter/internal/prometheusconvert/testdata/kubernetes.river
@@ -29,7 +29,9 @@ prometheus.remote_write "default" {
 		url            = "http://remote-write-url1"
 		send_exemplars = false
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}

--- a/converter/internal/prometheusconvert/testdata/lightsail.river
+++ b/converter/internal/prometheusconvert/testdata/lightsail.river
@@ -35,7 +35,9 @@ prometheus.remote_write "default" {
 		url            = "http://remote-write-url1"
 		send_exemplars = false
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}

--- a/converter/internal/prometheusconvert/testdata/metric_relabel.river
+++ b/converter/internal/prometheusconvert/testdata/metric_relabel.river
@@ -46,7 +46,9 @@ prometheus.remote_write "default" {
 		url            = "http://remote-write-url1"
 		send_exemplars = false
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}
@@ -56,7 +58,9 @@ prometheus.remote_write "default" {
 		url            = "http://remote-write-url2"
 		send_exemplars = false
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}

--- a/converter/internal/prometheusconvert/testdata/scrape.river
+++ b/converter/internal/prometheusconvert/testdata/scrape.river
@@ -47,7 +47,9 @@ prometheus.remote_write "default" {
 		url            = "http://remote-write-url1"
 		send_exemplars = false
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 
@@ -67,7 +69,9 @@ prometheus.remote_write "default" {
 		url            = "http://remote-write-url2"
 		send_exemplars = false
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}

--- a/converter/internal/prometheusconvert/testdata/unsupported.river
+++ b/converter/internal/prometheusconvert/testdata/unsupported.river
@@ -33,7 +33,9 @@ prometheus.remote_write "default" {
 		url            = "http://remote-write-url1"
 		send_exemplars = false
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}
@@ -43,7 +45,9 @@ prometheus.remote_write "default" {
 		url            = "http://remote-write-url2"
 		send_exemplars = false
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}

--- a/converter/internal/staticconvert/testdata/integrations.river
+++ b/converter/internal/staticconvert/testdata/integrations.river
@@ -12,7 +12,9 @@ prometheus.remote_write "integrations" {
 	endpoint {
 		url = "http://localhost:9009/api/prom/push"
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}

--- a/converter/internal/staticconvert/testdata/prom_remote_write.river
+++ b/converter/internal/staticconvert/testdata/prom_remote_write.river
@@ -3,7 +3,9 @@ prometheus.remote_write "metrics_test1" {
 		name = "test1-ca06cf"
 		url  = "http://localhost:9009/api/prom/push"
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}
@@ -11,7 +13,7 @@ prometheus.remote_write "metrics_test1" {
 
 prometheus.remote_write "metrics_test2" {
 	endpoint {
-		name = "test2-85b8a7"
+		name = "test2-625ad5"
 		url  = "http://localhost:9010/api/prom/push"
 
 		queue_config { }
@@ -25,7 +27,9 @@ prometheus.remote_write "metrics_test3" {
 		name = "test3-c8fbbe"
 		url  = "http://localhost:9011/api/prom/push"
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}
@@ -34,7 +38,9 @@ prometheus.remote_write "metrics_test3" {
 		name = "test3-41df1c"
 		url  = "http://localhost:9012/api/prom/push"
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}

--- a/converter/internal/staticconvert/testdata/prom_remote_write.yaml
+++ b/converter/internal/staticconvert/testdata/prom_remote_write.yaml
@@ -7,6 +7,8 @@ metrics:
     - name: "test2"
       remote_write:
         - url: http://localhost:9010/api/prom/push
+          queue_config:
+            retry_on_http_429: true
     - name: "test3"
       remote_write:
         - url: http://localhost:9011/api/prom/push

--- a/converter/internal/staticconvert/testdata/prom_scrape.river
+++ b/converter/internal/staticconvert/testdata/prom_scrape.river
@@ -107,6 +107,7 @@ prometheus.remote_write "metrics_agent" {
 			max_shards          = 10
 			batch_send_deadline = "3m0s"
 			max_backoff         = "10s"
+			retry_on_http_429   = false
 		}
 
 		metadata_config { }

--- a/converter/internal/staticconvert/testdata/promtail_prom.river
+++ b/converter/internal/staticconvert/testdata/promtail_prom.river
@@ -23,7 +23,9 @@ prometheus.remote_write "metrics_name" {
 		name = "name-ca06cf"
 		url  = "http://localhost:9009/api/prom/push"
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}

--- a/converter/internal/staticconvert/testdata/sanitize.river
+++ b/converter/internal/staticconvert/testdata/sanitize.river
@@ -8,7 +8,9 @@ prometheus.remote_write "metrics_integrations" {
 			password = "token"
 		}
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}

--- a/converter/internal/staticconvert/testdata/unsupported.river
+++ b/converter/internal/staticconvert/testdata/unsupported.river
@@ -11,7 +11,9 @@ prometheus.remote_write "metrics_agent" {
 		name = "agent-72cf3f"
 		url  = "https://prometheus-us-central1.grafana.net/api/prom/push"
 
-		queue_config { }
+		queue_config {
+			retry_on_http_429 = false
+		}
 
 		metadata_config { }
 	}

--- a/docs/sources/flow/reference/components/prometheus.remote_write.md
+++ b/docs/sources/flow/reference/components/prometheus.remote_write.md
@@ -138,7 +138,7 @@ Name | Type | Description | Default | Required
 `batch_send_deadline` | `duration` | Maximum time samples will wait in the buffer before sending. | `"5s"` | no
 `min_backoff` | `duration` | Initial retry delay. The backoff time gets doubled for each retry. | `"30ms"` | no
 `max_backoff` | `duration` | Maximum retry delay. | `"5s"` | no
-`retry_on_http_429` | `bool` | Retry when an HTTP 429 status code is received. | `false` | no
+`retry_on_http_429` | `bool` | Retry when an HTTP 429 status code is received. | `true` | no
 
 Each queue then manages a number of concurrent _shards_ which is responsible
 for sending a fraction of data to their respective endpoints. The number of

--- a/docs/sources/flow/release-notes.md
+++ b/docs/sources/flow/release-notes.md
@@ -32,8 +32,8 @@ Other release notes for the different Grafana Agent variants are contained on se
 The default value of `retry_on_http_429` is changed from `false` to `true` for the `queue_config` block in `prometheus.remote_write`
 so that the agent can retry sending and avoid data being lost for metric pipelines by default.
 
-No action is required is you were setting the `retry_on_http_429` explicitly.
-If you did not set it explicitly, but you would like to *not* retry on HTTP 429, you should set it to `false` as you upgrade to this version.
+* If you set the `retry_on_http_429` explicitly - no action is required.
+* If you do not set `retry_on_http_429` explicitly and you do *not* want to retry on HTTP 429, make sure you set it to `false` as you upgrade to this new version.
 
 ## Breaking change: `loki.source.file` no longer automatically extracts logs from compressed files
 

--- a/docs/sources/flow/release-notes.md
+++ b/docs/sources/flow/release-notes.md
@@ -27,6 +27,14 @@ Other release notes for the different Grafana Agent variants are contained on se
 
 ## v0.36
 
+## Breaking change: The default value of `retry_on_http_429` is changed to `true` for the `queue_config` in `prometheus.remote_write`
+
+The default value of `retry_on_http_429` is changed from `false` to `true` for the `queue_config` block in `prometheus.remote_write`
+so that the agent can retry sending and avoid data being lost for metric pipelines by default.
+
+No action is required is you were setting the `retry_on_http_429` explicitly.
+If you did not set it explicitly, but you would like to *not* retry on HTTP 429, you should set it to `false` as you upgrade to this version.
+
 ## Breaking change: `loki.source.file` no longer automatically extracts logs from compressed files
 
 `loki.source.file` component will no longer automatically detect and decompress


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Set retry_on_http_429 to true by default in the queue config block of prometheus.remote_write.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #4441 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added