### PR TITLE
fix panic when prometheus.operator.* is not initialized for cluster updates

### DIFF
--- a/component/prometheus/operator/common/component.go
+++ b/component/prometheus/operator/common/component.go
@@ -105,7 +105,9 @@ func (c *Component) NotifyClusterChange() {
 		return // no-op
 	}
 
-	c.manager.ClusteringUpdated()
+	if c.manager != nil {
+		c.manager.ClusteringUpdated()
+	}
 }
 
 // DebugInfo returns debug information for this component.


### PR DESCRIPTION
Fixes #4879 