### PR TITLE
Fix the CI step blocking the CD pipeline to publish technical documentation

### DIFF
--- a/.github/workflows/publish-documentation-next.yml
+++ b/.github/workflows/publish-documentation-next.yml
@@ -15,8 +15,12 @@ jobs:
       - name: "Check out code"
         uses: actions/checkout@v3
       - name: "Build technical documentation"
-        run: |
-          docker run -v ${PWD}/docs/sources:/hugo/content/docs/agent/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
+        run: >
+          docker run
+          --volume "${PWD}/docs/sources:/hugo/content/docs/agent/latest"
+          --env HUGO_REFLINKSERRORLEVEL=ERROR
+          --rm grafana/docs-base:latest
+          /bin/bash -c 'echo -e "---\\nredirectURL: /docs/agent/latest/\\ntype: redirect\\nversioned: true\\n---\\n" > /hugo/content/docs/agent/_index.md && make hugo' 
 
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-documentation-versioned.yml
+++ b/.github/workflows/publish-documentation-versioned.yml
@@ -16,8 +16,12 @@ jobs:
       - name: "Check out code"
         uses: actions/checkout@v3
       - name: "Build technical documentation"
-        run: |
-          docker run -v ${PWD}/docs/sources:/hugo/content/docs/agent/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
+        run: >
+          docker run
+          --volume "${PWD}/docs/sources:/hugo/content/docs/agent/latest"
+          --env HUGO_REFLINKSERRORLEVEL=ERROR
+          --rm grafana/docs-base:latest
+          /bin/bash -c 'echo -e "---\\nredirectURL: /docs/agent/latest/\\ntype: redirect\\nversioned: true\\n---\\n" > /hugo/content/docs/agent/_index.md && make hugo' 
 
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The PR CI was already fixed in https://github.com/grafana/agent/pull/4814 but I neglected to update the CD pipelines.

Reviewers should be able to see that the publish build steps match the ones in PR CI again: https://github.com/grafana/agent/blob/main/.github/workflows/check_docs.yml#L9-L15