### PR TITLE
Add an otelcol.connector.spanmetrics component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Main (unreleased)
   - `discovery.puppetdb` - service discovery from PuppetDB. (@captncraig)
   - `otelcol.processor.discovery` adds resource attributes to spans, where the attributes 
   keys and values are sourced from `discovery.*` components. (@ptodev)
+  - `otelcol.connector.spanmetrics` - creates OpenTelemetry metrics from traces. (@ptodev)
 
 - Update `YACE` to `v0.54.0`, which includes bugfixes for FIPS support. (@ashrayjain)
 

--- a/component/all/all.go
+++ b/component/all/all.go
@@ -52,6 +52,7 @@ import (
 	_ "github.com/grafana/agent/component/otelcol/auth/headers"                     // Import otelcol.auth.headers
 	_ "github.com/grafana/agent/component/otelcol/auth/oauth2"                      // Import otelcol.auth.oauth2
 	_ "github.com/grafana/agent/component/otelcol/auth/sigv4"                       // Import otelcol.auth.sigv4
+	_ "github.com/grafana/agent/component/otelcol/connector/spanmetrics"            // Import otelcol.connector.spanmetrics
 	_ "github.com/grafana/agent/component/otelcol/exporter/jaeger"                  // Import otelcol.exporter.jaeger
 	_ "github.com/grafana/agent/component/otelcol/exporter/loadbalancing"           // Import otelcol.exporter.loadbalancing
 	_ "github.com/grafana/agent/component/otelcol/exporter/logging"                 // Import otelcol.exporter.logging

--- a/component/otelcol/connector/connector.go
+++ b/component/otelcol/connector/connector.go
@@ -1,0 +1,206 @@
+// Package connector exposes utilities to create a Flow component from
+// OpenTelemetry Collector connectors.
+package connector
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otelcol"
+	"github.com/grafana/agent/component/otelcol/internal/fanoutconsumer"
+	"github.com/grafana/agent/component/otelcol/internal/lazycollector"
+	"github.com/grafana/agent/component/otelcol/internal/lazyconsumer"
+	"github.com/grafana/agent/component/otelcol/internal/scheduler"
+	"github.com/grafana/agent/pkg/build"
+	"github.com/grafana/agent/pkg/util/zapadapter"
+	"github.com/prometheus/client_golang/prometheus"
+	otelcomponent "go.opentelemetry.io/collector/component"
+	otelconnector "go.opentelemetry.io/collector/connector"
+	otelextension "go.opentelemetry.io/collector/extension"
+	sdkprometheus "go.opentelemetry.io/otel/exporters/prometheus"
+	"go.opentelemetry.io/otel/sdk/metric"
+
+	_ "github.com/grafana/agent/component/otelcol/internal/featuregate" // Enable needed feature gates
+)
+
+const (
+	ConnectorTracesToTraces = iota
+	ConnectorTracesToMetrics
+	ConnectorTracesToLogs
+	ConnectorMetricsToTraces
+	ConnectorMetricsToMetrics
+	ConnectorMetricsToLogs
+	ConnectorLogsToTraces
+	ConnectorLogsToMetrics
+	ConnectorLogsToLogs
+)
+
+// Arguments is an extension of component.Arguments which contains necessary
+// settings for OpenTelemetry Collector connectors.
+type Arguments interface {
+	component.Arguments
+
+	// Convert converts the Arguments into an OpenTelemetry Collector connector
+	// configuration.
+	Convert() (otelcomponent.Config, error)
+
+	// Extensions returns the set of extensions that the configured component is
+	// allowed to use.
+	Extensions() map[otelcomponent.ID]otelextension.Extension
+
+	// Exporters returns the set of exporters that are exposed to the configured
+	// component.
+	Exporters() map[otelcomponent.DataType]map[otelcomponent.ID]otelcomponent.Component
+
+	// NextConsumers returns the set of consumers to send data to.
+	NextConsumers() *otelcol.ConsumerArguments
+
+	ConnectorType() int
+}
+
+// Connector is a Flow component shim which manages an OpenTelemetry Collector
+// connector component.
+type Connector struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	opts     component.Options
+	factory  otelconnector.Factory
+	consumer *lazyconsumer.Consumer
+
+	sched     *scheduler.Scheduler
+	collector *lazycollector.Collector
+}
+
+var (
+	_ component.Component       = (*Connector)(nil)
+	_ component.HealthComponent = (*Connector)(nil)
+)
+
+// New creates a new Flow component which encapsulates an OpenTelemetry
+// Collector connector. args must hold a value of the argument type registered
+// with the Flow component.
+//
+// The registered component must be registered to export the
+// otelcol.ConsumerExports type, otherwise New will panic.
+func New(opts component.Options, f otelconnector.Factory, args Arguments) (*Connector, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	consumer := lazyconsumer.New(ctx)
+
+	// Create a lazy collector where metrics from the upstream component will be
+	// forwarded.
+	collector := lazycollector.New()
+	opts.Registerer.MustRegister(collector)
+
+	// Immediately set our state with our consumer. The exports will never change
+	// throughout the lifetime of our component.
+	//
+	// This will panic if the wrapping component is not registered to export
+	// otelcol.ConsumerExports.
+	opts.OnStateChange(otelcol.ConsumerExports{Input: consumer})
+
+	p := &Connector{
+		ctx:    ctx,
+		cancel: cancel,
+
+		opts:     opts,
+		factory:  f,
+		consumer: consumer,
+
+		sched:     scheduler.New(opts.Logger),
+		collector: collector,
+	}
+	if err := p.Update(args); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+// Run starts the Connector component.
+func (p *Connector) Run(ctx context.Context) error {
+	defer p.cancel()
+	return p.sched.Run(ctx)
+}
+
+// Update implements component.Component. It will convert the Arguments into
+// configuration for OpenTelemetry Collector connector configuration and manage
+// the underlying OpenTelemetry Collector connector.
+func (p *Connector) Update(args component.Arguments) error {
+	pargs := args.(Arguments)
+
+	host := scheduler.NewHost(
+		p.opts.Logger,
+		scheduler.WithHostExtensions(pargs.Extensions()),
+		scheduler.WithHostExporters(pargs.Exporters()),
+	)
+
+	reg := prometheus.NewRegistry()
+	p.collector.Set(reg)
+
+	promExporter, err := sdkprometheus.New(sdkprometheus.WithRegisterer(reg), sdkprometheus.WithoutTargetInfo())
+	if err != nil {
+		return err
+	}
+
+	settings := otelconnector.CreateSettings{
+		TelemetrySettings: otelcomponent.TelemetrySettings{
+			Logger: zapadapter.New(p.opts.Logger),
+
+			TracerProvider: p.opts.Tracer,
+			MeterProvider:  metric.NewMeterProvider(metric.WithReader(promExporter)),
+		},
+
+		BuildInfo: otelcomponent.BuildInfo{
+			Command:     os.Args[0],
+			Description: "Grafana Agent",
+			Version:     build.Version,
+		},
+	}
+
+	connectorConfig, err := pargs.Convert()
+	if err != nil {
+		return err
+	}
+
+	next := pargs.NextConsumers()
+
+	// Create instances of the connector from our factory for each of our
+	// supported telemetry signals.
+	var components []otelcomponent.Component
+
+	var tracesConnector otelconnector.Traces
+	var metricsConnector otelconnector.Metrics
+	var logsConnector otelconnector.Logs
+
+	switch pargs.ConnectorType() {
+	case ConnectorTracesToMetrics:
+		if len(next.Traces) > 0 || len(next.Logs) > 0 {
+			return errors.New("this connector can only output metrics")
+		}
+
+		if len(next.Metrics) > 0 {
+			nextMetrics := fanoutconsumer.Metrics(next.Metrics)
+			tracesConnector, err = p.factory.CreateTracesToMetrics(p.ctx, settings, connectorConfig, nextMetrics)
+			if err != nil && !errors.Is(err, otelcomponent.ErrDataTypeIsNotSupported) {
+				return err
+			} else if tracesConnector != nil {
+				components = append(components, tracesConnector)
+			}
+		}
+	default:
+		return errors.New("unsupported connector type")
+	}
+
+	// Schedule the components to run once our component is running.
+	p.sched.Schedule(host, components...)
+	p.consumer.SetConsumers(tracesConnector, metricsConnector, logsConnector)
+	return nil
+}
+
+// CurrentHealth implements component.HealthComponent.
+func (p *Connector) CurrentHealth() component.Health {
+	return p.sched.CurrentHealth()
+}

--- a/component/otelcol/connector/spanmetrics/spanmetrics.go
+++ b/component/otelcol/connector/spanmetrics/spanmetrics.go
@@ -1,0 +1,160 @@
+// Package spanmetrics provides an otelcol.connector.spanmetrics component.
+package spanmetrics
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otelcol"
+	"github.com/grafana/agent/component/otelcol/connector"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector"
+	otelcomponent "go.opentelemetry.io/collector/component"
+	otelextension "go.opentelemetry.io/collector/extension"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:    "otelcol.connector.spanmetrics",
+		Args:    Arguments{},
+		Exports: otelcol.ConsumerExports{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			fact := spanmetricsconnector.NewFactory()
+			return connector.New(opts, fact, args.(Arguments))
+		},
+	})
+}
+
+// Arguments configures the otelcol.connector.spanmetrics component.
+type Arguments struct {
+	// Dimensions defines the list of additional dimensions on top of the provided:
+	// - service.name
+	// - span.kind
+	// - span.kind
+	// - status.code
+	// The dimensions will be fetched from the span's attributes. Examples of some conventionally used attributes:
+	// https://github.com/open-telemetry/opentelemetry-collector/blob/main/model/semconv/opentelemetry.go.
+	Dimensions []Dimension `river:"dimension,block,optional"`
+
+	// DimensionsCacheSize defines the size of cache for storing Dimensions, which helps to avoid cache memory growing
+	// indefinitely over the lifetime of the collector.
+	DimensionsCacheSize int `river:"dimensions_cache_size,attr,optional"`
+
+	AggregationTemporality string `river:"aggregation_temporality,attr,optional"`
+
+	Histogram HistogramConfig `river:"histogram,block"`
+
+	// MetricsEmitInterval is the time period between when metrics are flushed or emitted to the downstream components.
+	MetricsFlushInterval time.Duration `river:"metrics_flush_interval,attr,optional"`
+
+	// Namespace is the namespace of the metrics emitted by the connector.
+	Namespace string `river:"namespace,attr,optional"`
+
+	// Output configures where to send processed data. Required.
+	Output *otelcol.ConsumerArguments `river:"output,block"`
+}
+
+var (
+	_ river.Validator     = (*Arguments)(nil)
+	_ river.Defaulter     = (*Arguments)(nil)
+	_ connector.Arguments = (*Arguments)(nil)
+)
+
+const (
+	AggregationTemporalityCumulative = "CUMULATIVE"
+	AggregationTemporalityDelta      = "DELTA"
+)
+
+// DefaultArguments holds default settings for Arguments.
+var DefaultArguments = Arguments{
+	DimensionsCacheSize:    1000,
+	AggregationTemporality: AggregationTemporalityCumulative,
+	MetricsFlushInterval:   15 * time.Second,
+}
+
+// SetToDefault implements river.Defaulter.
+func (args *Arguments) SetToDefault() {
+	*args = DefaultArguments
+}
+
+// Validate implements river.Validator.
+func (args *Arguments) Validate() error {
+	if args.DimensionsCacheSize <= 0 {
+		return fmt.Errorf(
+			"invalid cache size: %v, the maximum number of the items in the cache should be positive",
+			args.DimensionsCacheSize)
+	}
+
+	if args.MetricsFlushInterval <= 0 {
+		return fmt.Errorf("metrics_flush_interval must be greater than 0")
+	}
+
+	switch args.AggregationTemporality {
+	case AggregationTemporalityCumulative, AggregationTemporalityDelta:
+		// Valid
+	default:
+		return fmt.Errorf("invalid aggregation_temporality: %v", args.AggregationTemporality)
+	}
+
+	return nil
+}
+
+func convertAggregationTemporality(temporality string) (string, error) {
+	switch temporality {
+	case AggregationTemporalityCumulative:
+		return "AGGREGATION_TEMPORALITY_CUMULATIVE", nil
+	case AggregationTemporalityDelta:
+		return "AGGREGATION_TEMPORALITY_DELTA", nil
+	default:
+		return "", fmt.Errorf("invalid aggregation_temporality: %v", temporality)
+	}
+}
+
+// Convert implements connector.Arguments.
+func (args Arguments) Convert() (otelcomponent.Config, error) {
+	dimensions := make([]spanmetricsconnector.Dimension, 0, len(args.Dimensions))
+	for _, d := range args.Dimensions {
+		dimensions = append(dimensions, d.Convert())
+	}
+
+	histogram, err := args.Histogram.Convert()
+	if err != nil {
+		return nil, err
+	}
+
+	aggregationTemporality, err := convertAggregationTemporality(args.AggregationTemporality)
+	if err != nil {
+		return nil, err
+	}
+
+	return &spanmetricsconnector.Config{
+		Dimensions:             dimensions,
+		DimensionsCacheSize:    args.DimensionsCacheSize,
+		AggregationTemporality: aggregationTemporality,
+		Histogram:              *histogram,
+		MetricsFlushInterval:   args.MetricsFlushInterval,
+		Namespace:              args.Namespace,
+	}, nil
+}
+
+// Extensions implements connector.Arguments.
+func (args Arguments) Extensions() map[otelcomponent.ID]otelextension.Extension {
+	return nil
+}
+
+// Exporters implements connector.Arguments.
+func (args Arguments) Exporters() map[otelcomponent.DataType]map[otelcomponent.ID]otelcomponent.Component {
+	return nil
+}
+
+// NextConsumers implements connector.Arguments.
+func (args Arguments) NextConsumers() *otelcol.ConsumerArguments {
+	return args.Output
+}
+
+// ConnectorType() int implements connector.Arguments.
+func (Arguments) ConnectorType() int {
+	return connector.ConnectorTracesToMetrics
+}

--- a/component/otelcol/connector/spanmetrics/spanmetrics.go
+++ b/component/otelcol/connector/spanmetrics/spanmetrics.go
@@ -31,7 +31,7 @@ func init() {
 type Arguments struct {
 	// Dimensions defines the list of additional dimensions on top of the provided:
 	// - service.name
-	// - span.kind
+	// - span.name
 	// - span.kind
 	// - status.code
 	// The dimensions will be fetched from the span's attributes. Examples of some conventionally used attributes:

--- a/component/otelcol/connector/spanmetrics/spanmetrics_test.go
+++ b/component/otelcol/connector/spanmetrics/spanmetrics_test.go
@@ -1,0 +1,316 @@
+package spanmetrics_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/component/otelcol/connector/spanmetrics"
+	"github.com/grafana/agent/pkg/river"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector"
+	"github.com/stretchr/testify/require"
+)
+
+func getStringPtr(str string) *string {
+	newStr := str
+	return &newStr
+}
+
+func TestArguments_UnmarshalRiver(t *testing.T) {
+	tests := []struct {
+		testName string
+		cfg      string
+		expected spanmetricsconnector.Config
+		errorMsg string
+	}{
+		{
+			testName: "defaultConfigExplicitHistogram",
+			cfg: `
+			histogram {
+				explicit {}
+			}
+
+			output {}
+			`,
+			expected: spanmetricsconnector.Config{
+				Dimensions:             []spanmetricsconnector.Dimension{},
+				DimensionsCacheSize:    1000,
+				AggregationTemporality: "AGGREGATION_TEMPORALITY_CUMULATIVE",
+				Histogram: spanmetricsconnector.HistogramConfig{
+					Unit:        0,
+					Exponential: nil,
+					Explicit: &spanmetricsconnector.ExplicitHistogramConfig{
+						Buckets: []time.Duration{
+							2 * time.Millisecond,
+							4 * time.Millisecond,
+							6 * time.Millisecond,
+							8 * time.Millisecond,
+							10 * time.Millisecond,
+							50 * time.Millisecond,
+							100 * time.Millisecond,
+							200 * time.Millisecond,
+							400 * time.Millisecond,
+							800 * time.Millisecond,
+							1 * time.Second,
+							1400 * time.Millisecond,
+							2 * time.Second,
+							5 * time.Second,
+							10 * time.Second,
+							15 * time.Second,
+						},
+					},
+				},
+				MetricsFlushInterval: 15 * time.Second,
+				Namespace:            "",
+			},
+		},
+		{
+			testName: "defaultConfigExponentialHistogram",
+			cfg: `
+			histogram {
+				exponential {}
+			}
+
+			output {}
+			`,
+			expected: spanmetricsconnector.Config{
+				Dimensions:             []spanmetricsconnector.Dimension{},
+				DimensionsCacheSize:    1000,
+				AggregationTemporality: "AGGREGATION_TEMPORALITY_CUMULATIVE",
+				Histogram: spanmetricsconnector.HistogramConfig{
+					Unit:        0,
+					Exponential: &spanmetricsconnector.ExponentialHistogramConfig{MaxSize: 160},
+					Explicit:    nil,
+				},
+				MetricsFlushInterval: 15 * time.Second,
+				Namespace:            "",
+			},
+		},
+		{
+			testName: "explicitConfig",
+			cfg: `
+			dimension {
+				name = "http.status_code"
+			}
+			dimension {
+				name = "http.method"
+				default = "GET"
+			}
+			dimensions_cache_size = 333
+			aggregation_temporality = "DELTA"
+			histogram {
+				unit = "s"
+				explicit {
+					buckets = ["333ms", "777s", "999h"]
+				}
+			}
+			metrics_flush_interval = "33s"
+			namespace = "test.namespace"
+
+			output {}
+			`,
+			expected: spanmetricsconnector.Config{
+				Dimensions: []spanmetricsconnector.Dimension{
+					{Name: "http.status_code", Default: nil},
+					{Name: "http.method", Default: getStringPtr("GET")},
+				},
+				DimensionsCacheSize:    333,
+				AggregationTemporality: "AGGREGATION_TEMPORALITY_DELTA",
+				Histogram: spanmetricsconnector.HistogramConfig{
+					Unit:        1,
+					Exponential: nil,
+					Explicit: &spanmetricsconnector.ExplicitHistogramConfig{
+						Buckets: []time.Duration{
+							333 * time.Millisecond,
+							777 * time.Second,
+							999 * time.Hour,
+						},
+					},
+				},
+				MetricsFlushInterval: 33 * time.Second,
+				Namespace:            "test.namespace",
+			},
+		},
+		{
+			testName: "exponentialHistogramMs",
+			cfg: `
+			histogram {
+				unit = "ms"
+				exponential {
+					max_size = 123
+				}
+			}
+
+			output {}
+			`,
+			expected: spanmetricsconnector.Config{
+				Dimensions:             []spanmetricsconnector.Dimension{},
+				DimensionsCacheSize:    1000,
+				AggregationTemporality: "AGGREGATION_TEMPORALITY_CUMULATIVE",
+				Histogram: spanmetricsconnector.HistogramConfig{
+					Unit:        0,
+					Exponential: &spanmetricsconnector.ExponentialHistogramConfig{MaxSize: 123},
+					Explicit:    nil,
+				},
+				MetricsFlushInterval: 15 * time.Second,
+				Namespace:            "",
+			},
+		},
+		{
+			testName: "invalidAggregationTemporality",
+			cfg: `
+			aggregation_temporality = "badVal"
+
+			histogram {
+				explicit {}
+			}
+
+			output {}
+			`,
+			errorMsg: `invalid aggregation_temporality: badVal`,
+		},
+		{
+			testName: "invalidDimensionCache1",
+			cfg: `
+			dimensions_cache_size = -1
+
+			histogram {
+				explicit {}
+			}
+
+			output {}
+			`,
+			errorMsg: `invalid cache size: -1, the maximum number of the items in the cache should be positive`,
+		},
+		{
+			testName: "invalidDimensionCache2",
+			cfg: `
+			dimensions_cache_size = 0
+
+			histogram {
+				explicit {}
+			}
+
+			output {}
+			`,
+			errorMsg: `invalid cache size: 0, the maximum number of the items in the cache should be positive`,
+		},
+		{
+			testName: "invalidMetricsFlushInterval1",
+			cfg: `
+			metrics_flush_interval = "0s"
+
+			histogram {
+				explicit {}
+			}
+
+			output {}
+			`,
+			errorMsg: `metrics_flush_interval must be greater than 0`,
+		},
+		{
+			testName: "invalidMetricsFlushInterval2",
+			cfg: `
+			metrics_flush_interval = "-1s"
+
+			histogram {
+				explicit {}
+			}
+
+			output {}
+			`,
+			errorMsg: `metrics_flush_interval must be greater than 0`,
+		},
+		{
+			testName: "invalidDuplicateHistogramConfig",
+			cfg: `
+			histogram {
+				explicit {
+					buckets = ["333ms", "777s", "999h"]
+				}
+				exponential {
+					max_size = 123
+				}
+			}
+
+			output {}
+			`,
+			errorMsg: `only one of exponential or explicit histogram configuration can be specified`,
+		},
+		{
+			testName: "invalidHistogramExplicitUnit",
+			cfg: `
+			histogram {
+				explicit {
+					buckets = ["333fakeunit", "777s", "999h"]
+				}
+			}
+
+			output {}
+			`,
+			errorMsg: `4:17: "333fakeunit" time: unknown unit "fakeunit" in duration "333fakeunit"`,
+		},
+		{
+			testName: "invalidHistogramExponentialSize",
+			cfg: `
+			histogram {
+				exponential {
+					max_size = -1
+				}
+			}
+
+			output {}
+			`,
+			errorMsg: `max_size must be greater than 0`,
+		},
+		{
+			testName: "invalidHistogramUnit",
+			cfg: `
+			histogram {
+				unit = "badUnit"
+				explicit {}
+			}
+
+			output {}
+			`,
+			errorMsg: `unknown unit "badUnit", allowed units are "ms" and "s"`,
+		},
+		{
+			testName: "invalidHistogramNoConfig",
+			cfg: `
+			histogram {}
+
+			output {}
+			`,
+			errorMsg: `either exponential or explicit histogram configuration must be specified`,
+		},
+		{
+			testName: "invalidNoHistogram",
+			cfg: `
+			output {}
+			`,
+			errorMsg: `missing required block "histogram"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			var args spanmetrics.Arguments
+			err := river.Unmarshal([]byte(tc.cfg), &args)
+			if tc.errorMsg != "" {
+				require.ErrorContains(t, err, tc.errorMsg)
+				return
+			}
+
+			require.NoError(t, err)
+
+			actualPtr, err := args.Convert()
+			require.NoError(t, err)
+
+			actual := actualPtr.(*spanmetricsconnector.Config)
+
+			require.NoError(t, actual.Validate())
+
+			require.Equal(t, tc.expected, *actual)
+		})
+	}
+}

--- a/component/otelcol/connector/spanmetrics/types.go
+++ b/component/otelcol/connector/spanmetrics/types.go
@@ -37,7 +37,7 @@ const (
 // The unit is a private type in an internal Otel package,
 // so we need to convert it to a map and then back to the internal type.
 // ConvertMetricUnit matches the Unit type in this internal package:
-// "github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector/internal/metrics/unit.go"
+// https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.80.0/connector/spanmetricsconnector/internal/metrics/unit.go
 func ConvertMetricUnit(unit string) (map[string]interface{}, error) {
 	switch unit {
 	case MetricsUnitMilliseconds:

--- a/component/otelcol/connector/spanmetrics/types.go
+++ b/component/otelcol/connector/spanmetrics/types.go
@@ -1,0 +1,187 @@
+package spanmetrics
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/grafana/agent/pkg/river"
+	"github.com/mitchellh/mapstructure"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector"
+)
+
+// Dimension defines the dimension name and optional default value if the Dimension is missing from a span attribute.
+type Dimension struct {
+	Name    string  `river:"name,attr"`
+	Default *string `river:"default,attr,optional"`
+}
+
+func (d Dimension) Convert() spanmetricsconnector.Dimension {
+	res := spanmetricsconnector.Dimension{
+		Name: d.Name,
+	}
+
+	if d.Default != nil {
+		str := strings.Clone(*d.Default)
+		res.Default = &str
+	}
+
+	return res
+}
+
+const (
+	MetricsUnitMilliseconds string = "ms"
+	MetricsUnitSeconds      string = "s"
+)
+
+// The unit is a private type in an internal Otel package,
+// so we need to convert it to a map and then back to the internal type.
+// ConvertMetricUnit matches the Unit type in this internal package:
+// "github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector/internal/metrics/unit.go"
+func ConvertMetricUnit(unit string) (map[string]interface{}, error) {
+	switch unit {
+	case MetricsUnitMilliseconds:
+		return map[string]interface{}{
+			"unit": 0,
+		}, nil
+	case MetricsUnitSeconds:
+		return map[string]interface{}{
+			"unit": 1,
+		}, nil
+	default:
+		return nil, fmt.Errorf(
+			"unknown unit %q, allowed units are %q and %q",
+			unit, MetricsUnitMilliseconds, MetricsUnitSeconds)
+	}
+}
+
+type HistogramConfig struct {
+	Unit        string                      `river:"unit,attr,optional"`
+	Exponential *ExponentialHistogramConfig `river:"exponential,block,optional"`
+	Explicit    *ExplicitHistogramConfig    `river:"explicit,block,optional"`
+}
+
+var (
+	_ river.Defaulter = (*HistogramConfig)(nil)
+	_ river.Validator = (*HistogramConfig)(nil)
+)
+
+var DefaultHistogramConfig = HistogramConfig{
+	Unit:        MetricsUnitMilliseconds,
+	Exponential: nil,
+	Explicit:    nil,
+}
+
+func (hc *HistogramConfig) SetToDefault() {
+	*hc = DefaultHistogramConfig
+}
+
+func (hc *HistogramConfig) Validate() error {
+	switch hc.Unit {
+	case MetricsUnitMilliseconds, MetricsUnitSeconds:
+		// Valid
+	default:
+		return fmt.Errorf(
+			"unknown unit %q, allowed units are %q and %q",
+			hc.Unit, MetricsUnitMilliseconds, MetricsUnitSeconds)
+	}
+
+	if hc.Exponential != nil && hc.Explicit != nil {
+		return fmt.Errorf("only one of exponential or explicit histogram configuration can be specified")
+	}
+
+	if hc.Exponential == nil && hc.Explicit == nil {
+		return fmt.Errorf("either exponential or explicit histogram configuration must be specified")
+	}
+
+	return nil
+}
+
+func (hc HistogramConfig) Convert() (*spanmetricsconnector.HistogramConfig, error) {
+	input, err := ConvertMetricUnit(hc.Unit)
+	if err != nil {
+		return nil, err
+	}
+
+	var result spanmetricsconnector.HistogramConfig
+	err = mapstructure.Decode(input, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	if hc.Exponential != nil {
+		result.Exponential = hc.Exponential.Convert()
+	}
+
+	if hc.Explicit != nil {
+		result.Explicit = hc.Explicit.Convert()
+	}
+
+	return &result, nil
+}
+
+type ExponentialHistogramConfig struct {
+	MaxSize int32 `river:"max_size,attr,optional"`
+}
+
+var (
+	_ river.Defaulter = (*ExponentialHistogramConfig)(nil)
+	_ river.Validator = (*ExponentialHistogramConfig)(nil)
+)
+
+// SetToDefault implements river.Defaulter.
+func (ehc *ExponentialHistogramConfig) SetToDefault() {
+	ehc.MaxSize = 160
+}
+
+// Validate implements river.Validator.
+func (ehc *ExponentialHistogramConfig) Validate() error {
+	if ehc.MaxSize <= 0 {
+		return fmt.Errorf("max_size must be greater than 0")
+	}
+
+	return nil
+}
+
+func (ehc ExponentialHistogramConfig) Convert() *spanmetricsconnector.ExponentialHistogramConfig {
+	return &spanmetricsconnector.ExponentialHistogramConfig{
+		MaxSize: ehc.MaxSize,
+	}
+}
+
+type ExplicitHistogramConfig struct {
+	// Buckets is the list of durations representing explicit histogram buckets.
+	Buckets []time.Duration `river:"buckets,attr,optional"`
+}
+
+var (
+	_ river.Defaulter = (*ExplicitHistogramConfig)(nil)
+)
+
+func (hc *ExplicitHistogramConfig) SetToDefault() {
+	hc.Buckets = []time.Duration{
+		2 * time.Millisecond,
+		4 * time.Millisecond,
+		6 * time.Millisecond,
+		8 * time.Millisecond,
+		10 * time.Millisecond,
+		50 * time.Millisecond,
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		400 * time.Millisecond,
+		800 * time.Millisecond,
+		1 * time.Second,
+		1400 * time.Millisecond,
+		2 * time.Second,
+		5 * time.Second,
+		10 * time.Second,
+		15 * time.Second,
+	}
+}
+
+func (hc ExplicitHistogramConfig) Convert() *spanmetricsconnector.ExplicitHistogramConfig {
+	// Copy the values in the buckets slice so that we don't mutate the original.
+	return &spanmetricsconnector.ExplicitHistogramConfig{
+		Buckets: append([]time.Duration{}, hc.Buckets...),
+	}
+}

--- a/docs/sources/flow/reference/components/otelcol.connector.spanmetrics.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.spanmetrics.md
@@ -1,0 +1,267 @@
+---
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.connector.spanmetrics/
+title: otelcol.connector.spanmetrics
+---
+
+# otelcol.connector.spanmetrics
+
+`otelcol.connector.spanmetrics` accepts span data from other `otelcol` components and 
+aggregates Request, Error and Duration (R.E.D) OpenTelemetry metrics from the spans:
+
+* **Request** counts are computed as the number of spans seen per unique set of dimensions, 
+including Errors. Multiple metrics can be aggregated if, for instance, a user wishes to 
+view call counts just on `service.name`` and `span.name``.
+
+* **Error** counts are computed from the Request counts which have an `Error` status code metric dimension.
+
+* **Duration** is computed from the difference between the span start and end times and inserted 
+into the relevant duration histogram time bucket for each unique set dimensions.
+
+> **NOTE**: `otelcol.connector.spanmetrics` is a wrapper over the upstream
+> OpenTelemetry Collector `spanmetrics` connector. Bug reports or feature requests
+> will be redirected to the upstream repository, if necessary.
+
+Multiple `otelcol.connector.spanmetrics` components can be specified by giving them
+different labels.
+
+## Usage
+
+```river
+otelcol.connector.spanmetrics "LABEL" {
+  histogram {
+    ...
+  }
+
+  output {
+    metrics = [...]
+  }
+}
+```
+
+## Arguments
+
+`otelcol.connector.spanmetrics` supports the following arguments:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`dimensions_cache_size` | `number` | How many dimensions to cache. | `1000` | no
+`aggregation_temporality` | `string` | Configures whether to reset the metrics after flushing. | `"CUMULATIVE"` | no
+`metrics_flush_interval` | `duration` | How often to flush generated metrics. | `"15s"` | no
+`namespace` | `string` | Metric namespace. | `""` | no
+
+Adjusting `dimensions_cache_size` can improve the Agent process' memory usage.
+
+The supported values for `aggregation_temporality` are:
+* `"CUMULATIVE"`: The metrics will **not** be reset after they are flushed.
+* `"DELTA"`: The metrics will be reset after they are flushed.
+
+If `namespace` is set, the generated metric name will be added a `namespace.` prefix.
+
+## Blocks
+
+The following blocks are supported inside the definition of
+`otelcol.connector.spanmetrics`:
+
+Hierarchy | Block | Description | Required
+--------- | ----- | ----------- | --------
+dimension | [dimension][] | Dimensions to be added in addition to the default ones. | no
+histogram | [histogram][] | Configures the histogram derived from spans durations. | yes
+histogram > exponential | [exponential][] | Configuration for a histogram with exponential buckets. | no
+histogram > explicit | [explicit][] | Configuration for a histogram with explicit buckets. | no
+output | [output][] | Configures where to send telemetry data. | yes
+
+It is necessary to specify either a "[exponential][]" or an "[explicit][]" block:
+* Specifying both an "[exponential][]" and an "[explicit][]" block is not allowed.
+* Specifying neither an "[exponential][]" nor an "[explicit][]" block is not allowed.
+
+[dimension]: #dimension-block
+[histogram]: #histogram-block
+[exponential]: #exponential-block
+[explicit]: #explicit-block
+[output]: #output-block
+
+### dimension block
+
+The `dimension` block configures dimensions to be added in addition to the default ones.
+
+The default dimensions are:
+* `service.name`
+* `span.name`
+* `span.kind`
+* `status.code`
+
+The default dimensions are always added. If no additional dimensions are specified, 
+only the default ones will be added.
+
+The following attributes are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`name` | `string` | Span attribute or resource attribute to look up. |  | yes
+`default` | `string` | Value to use if the attribute is missing. | null | no
+
+`otelcol.connector.spanmetrics` will look for the `name` attribute in the span's 
+collection of attributes. If it is not found, the resource attributes will be checked.
+
+If the attribute is missing in both the span and resource attributes:
+* If `default` is not set, the dimension will be omitted.
+* If `default` is set, the dimension will be added and its value will be set to the value of `default`.
+
+### histogram block
+
+The `histogram` block configures the histogram derived from spans' durations.
+
+The following attributes are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`unit` | `string` | Configures the histogram units. | `"ms"` | no
+
+The supported values for `aggregation_temporality` are:
+* `"ms"`: milliseconds
+* `"s"`: seconds
+
+### exponential block
+
+The `exponential` block configures a histogram with exponential buckets.
+
+The following attributes are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`max_size` | `number` | Maximum number of buckets per positive or negative number range. | `160` | no
+
+### explicit block
+
+The `explicit` block configures a histogram with explicit buckets.
+
+The following attributes are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`buckets` | `list(duration)` | List of histogram buckets. | `["2ms", "4ms", "6ms", "8ms", "10ms", "50ms", "100ms", "200ms", "400ms", "800ms", "1s", "1400ms", "2s", "5s", "10s", "15s"]` | no
+
+### output block
+
+{{< docs/shared lookup="flow/reference/components/output-block-metrics.md" source="agent" >}}
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+Name | Type | Description
+---- | ---- | -----------
+`input` | `otelcol.Consumer` | A value that other components can use to send telemetry data to.
+
+`input` accepts `otelcol.Consumer` traces telemetry data. It does not accept metrics and logs.
+
+## Component health
+
+`otelcol.connector.spanmetrics` is only reported as unhealthy if given an invalid
+configuration.
+
+## Debug information
+
+`otelcol.connector.spanmetrics` does not expose any component-specific debug
+information.
+
+## Examples
+
+### Explicit histogram and extra dimensions
+
+In the example below, `http.status_code` and `http.method` are additional dimensions on top of:
+* `service.name`
+* `span.name`
+* `span.kind`
+* `status.code`
+
+```river
+otelcol.receiver.otlp "default" {
+  http {}
+  grpc {}
+
+  output {
+    traces  = [otelcol.connector.spanmetrics.default.input]
+  }
+}
+
+otelcol.connector.spanmetrics "default" {
+  // Since a default is not provided, the http.status_code dimension will be omitted
+  // if the span does not contain http.status_code.
+  dimension {
+    name = "http.status_code"
+  }
+
+  // If the span is missing http.method, the connector will insert
+  // the http.method dimension with value 'GET'.
+  dimension {
+    name = "http.method"
+    default = "GET"
+  }
+
+  dimensions_cache_size = 333
+
+  aggregation_temporality = "DELTA"
+
+  histogram {
+    unit = "s"
+    explicit {
+      buckets = ["333ms", "777s", "999h"]
+    }
+  }
+
+  // The period on which all metrics (whose dimension keys remain in cache) will be emitted.
+  metrics_flush_interval = "33s"
+  
+  namespace = "test.namespace"
+
+  output {
+    metrics = [otelcol.exporter.otlp.production.input]
+  }
+}
+
+otelcol.exporter.otlp "production" {
+  client {
+    endpoint = env("OTLP_SERVER_ENDPOINT")
+  }
+}
+```
+
+### Sending metrics via a Prometheus remote write
+
+In order for a `target_info` metric to be generated, the incoming spans resource scope 
+attributes must contain `service.name` and `service.instance.id` attributes.
+
+The `target_info` metric will be generated for each resource scope, while OpenTelemetry
+metric names and attributes will be normalized to be compliant with Prometheus naming rules. 
+
+```river
+otelcol.receiver.otlp "default" {
+  http {}
+  grpc {}
+
+  output {
+    traces  = [otelcol.connector.spanmetrics.default.input]
+  }
+}
+
+otelcol.connector.spanmetrics "default" {
+  histogram {
+    exponential {}
+  }
+  
+  output {
+    metrics = [otelcol.exporter.prometheus.default.input]
+  }
+}
+
+otelcol.exporter.prometheus "default" {
+  forward_to = [prometheus.remote_write.mimir.receiver]
+}
+
+prometheus.remote_write "mimir" {
+  endpoint {
+    url = "http://mimir:9009/api/v1/push"
+  }
+}
+```

--- a/docs/sources/shared/flow/reference/components/output-block-metrics.md
+++ b/docs/sources/shared/flow/reference/components/output-block-metrics.md
@@ -1,0 +1,18 @@
+---
+aliases:
+- ../../otelcol/output-block-metrics/
+headless: true
+---
+
+The `output` block configures a set of components to forward resulting
+telemetry data to.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`metrics` | `list(otelcol.Consumer)` | List of consumers to send metrics to. | `[]` | no
+
+The `output` block must be specified, but all of its arguments are optional. By
+default, telemetry data is dropped. To send telemetry data to other components,
+configure the `metrics` argument accordingly.

--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,7 @@ require (
 	github.com/oklog/run v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/oliver006/redis_exporter v1.51.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.80.0
@@ -626,6 +627,7 @@ require (
 	github.com/drone/envsubst v1.0.3 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
 	github.com/leoluk/perflib_exporter v0.2.0 // indirect
+	github.com/lightstep/go-expohisto v1.0.0 // indirect
 	github.com/metalmatze/signal v0.0.0-20210307161603-1c9aa721a97a // indirect
 	github.com/prometheus-community/prom-label-proxy v0.6.0 // indirect
 	github.com/sercand/kuberesolver/v4 v4.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2419,6 +2419,8 @@ github.com/lib/pq v1.10.1/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
 github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lightstep/go-expohisto v1.0.0 h1:UPtTS1rGdtehbbAF7o/dhkWLTDI73UifG8LbfQI7cA4=
+github.com/lightstep/go-expohisto v1.0.0/go.mod h1:xDXD0++Mu2FOaItXtdDfksfgxfV0z1TMPa+e/EUd0cs=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/linode/linodego v0.7.1/go.mod h1:ga11n3ivecUrPCHN0rANxKmfWBJVkOXfLMZinAbj2sY=
@@ -2731,6 +2733,8 @@ github.com/onsi/gomega v1.22.1/go.mod h1:x6n7VNe4hw0vkyYUM4mjIXx3JbLiPaBPNgB7PRQ
 github.com/onsi/gomega v1.23.0/go.mod h1:Z/NWtiqwBrwUt4/2loMmHL63EDLnYHmVbuBpDr2vQAg=
 github.com/onsi/gomega v1.27.7 h1:fVih9JD6ogIiHUN6ePK7HJidyEDpWGVB5mzM7cWNXoU=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
+github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.80.0 h1:j6Zo+MvskAAc5LNMHqeqjti3hxQZPBkqoK956wHhDdY=
+github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.80.0/go.mod h1:mv3/RQWBvNvB4IFnB9oqGe147e2KsLiFT5nkovkH/2o=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter v0.80.0 h1:/cUNpmtNRN+AhONVb5gzkqZv6w3GtB1hhpc73ngi9Z8=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter v0.80.0/go.mod h1:4LXWf8cF542j/HgU1nmeZDbCoNnHBKhv1EpqjiAOGJY=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.80.0 h1:Qrx5qe7nhwDLL8lKWyfKL8GaZasiLtH6LER5IILlUo4=


### PR DESCRIPTION
#### PR Description

This component adds an `otelcol.connector.spanmetrics` flow component, based on the Collector's, [spanmetrics connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/connector/spanmetricsconnector).

#### Which issue(s) this PR fixes

Fixes #2295

#### Notes to the Reviewer

This PR is the first time we port a "connector" component:
* Only a `TracesToMetrics` connector is supported at the moment. I don't want to over-engineer the code before we have consensus on how to handle connectors in the Agent.
* If a component is configured to send non-traces data to `otelcol.connector.spanmetrics` there won't be an error message on startup. E.g. `logs = [otelcol.connector.spanmetrics.default.input]` won't generate an error message. I am not sure if there would be an error message later on, when logs/metrics are actually received by `otelcol.connector.spanmetrics`.
* There is only an error message if `otelcol.connector.spanmetrics` is configured to send logs/traces:

  > Failed to build component: building component: this connector can only output metrics

* I think we should merge the PR as-is, and I can raise a separate issue for how we should handle connectors so that we can discuss it separately.

The name of the flow component is `otelcol.connector.spanmetrics` instead of `otelcol.processor.spanmetrics`
* In Collector, and in Agent's "otelcol" components, a "processor" has always implied that logs/metrics/traces data is handled independently. For example, if a processor accepts both metrics and traces, those two signals won't be mixed with each other.
* A "connector" implies that one type of signal is created from another type.
  * E.g. `otelcol.connector.spanmetrics` creates metrics out of traces
  * It is possible to create a TracesToTraces, MetricsToMetrics and LogsToLogs connectors, which muddies the definitions a bit.
* In Agent flow, a "connector" is not so badly needed since flow is more flexible than the Collector's graph.
* However, I chose to name this a "connector" in flow, to make these indications to the user:
  * `otelcol.processor` components are components which handle logs/metrics/traces independently and don't mix them.
  * `otelcol.conector` components can accept one type of signal and transform it to a different type.
* If we'd called this `otelcol.processor.spanmetrics`, then it'd raise the question of "what other processors mix different types of signals". IMO calling this component a "connector" avoids that discussion and makes it clear from the name that this component will mix signals of different types.

The feature parity with [static mode](https://grafana.com/docs/agent/latest/static/configuration/traces-config/) is not exactly 1 to 1:
* Static mode uses the [spanmetrics processor,](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/processor/spanmetricsprocessor) whereas in flow we will use the [spanmetrics connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/connector/spanmetricsconnector).
* Some [breaking changes](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/connector/spanmetricsconnector#span-to-metrics-processor-to-span-to-metrics-connector) were done to the connector to make it more Otel-native.
* I believe that none of these breaking changes would be an issue for static mode users looking to migrate to flow. If customers want to make their metrics look more like the processor's then it should be possible to do it with Prometheus relabelling rules.

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated