### PR TITLE
Update cross reference syntax in Agent static mode documentation (#4814)

### DIFF
--- a/.github/workflows/check_docs.yml
+++ b/.github/workflows/check_docs.yml
@@ -7,5 +7,9 @@ jobs:
     - name: "Check out code"
       uses: "actions/checkout@v3"
     - name: "Build technical documentation"
-      run: |
-        docker run -v ${PWD}/docs/sources:/hugo/content/docs/agent/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
+      run: >
+        docker run
+        --volume "${PWD}/docs/sources:/hugo/content/docs/agent/latest"
+        --env HUGO_REFLINKSERRORLEVEL=ERROR
+        --rm grafana/docs-base:latest
+        /bin/bash -c 'echo -e "---\\nredirectURL: /docs/agent/latest/\\ntype: redirect\\nversioned: true\\n---\\n" > /hugo/content/docs/agent/_index.md && make hugo'

--- a/docs/sources/flow/release-notes.md
+++ b/docs/sources/flow/release-notes.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/agent/latest/flow/upgrade-guide/
+canonical: https://grafana.com/docs/agent/latest/flow/release-notes/
 description: Release notes for Grafana Agent flow mode
 title: Release notes for Grafana Agentflow mode
 menuTitle: Release notes

--- a/docs/sources/static/_index.md
+++ b/docs/sources/static/_index.md
@@ -18,7 +18,7 @@ Static mode is composed of different _subsystems_:
   traces and forwarding them to Grafana Tempo or any OpenTelemetry-compatible
   endpoint.
 
-Static mode is [configured][] with a YAML file.
+Static mode is [configured][configure] with a YAML file.
 
 Static mode works with:
 
@@ -31,10 +31,6 @@ use Grafana Agent to meet your goals.
 
 You can [set up][] and [configure][] Grafana Agent in static mode manually, or
 you can follow the common workflows described in this topic.
-
-[set up]: {{< relref "./set-up" >}}
-[configure]: {{< relref "./configuration/" >}}
-[configured]: {{< relref "./configuration/" >}}
 
 ## Topics
 
@@ -66,12 +62,10 @@ Grafana Cloud integration workflows and the Kubernetes Monitoring solution are t
 
 | Topic | Description |
 |---|---|
-| [Install or uninstall Grafana Agent][] | Install or uninstall Grafana Agent. |
+| [Install or uninstall Grafana Agent][install] | Install or uninstall Grafana Agent. |
 | [Troubleshoot Cloud Integrations installation on Linux](/docs/grafana-cloud/monitor-infrastructure/integrations/install-troubleshoot-linux/) | Troubleshoot common errors when executing the Grafana Agent installation script on Linux.  |
 | [Troubleshoot Cloud Integrations installation on Mac](/docs/grafana-cloud/monitor-infrastructure/integrations/install-troubleshoot-mac/) | Troubleshoot common errors when executing the Grafana Agent installation script on Mac.  |
 | [Troubleshoot Cloud Integrations installation on Windows](/docs/grafana-cloud/monitor-infrastructure/integrations/install-troubleshoot-windows/) | Troubleshoot common errors when executing the Grafana Agent installation script on Windows.  |
-
-[Install or uninstall Grafana Agent]: {{< relref "./set-up/install/" >}}
 
 ### Use Grafana Agent to send logs to Grafana Loki
 
@@ -87,3 +81,12 @@ Logs are included when you [set up a Cloud integration](/docs/grafana-cloud/data
 |---|---|
 | [Set up and use tracing](/docs/grafana-cloud/data-configuration/traces/set-up-and-use-tempo/) |  Install Grafana Agent to collect traces for use with Grafana Tempo, included with your [Grafana Cloud account](/docs/grafana-cloud/account-management/cloud-portal/). |
 | [Use Grafana Agent as a tracing pipeline](/docs/tempo/latest/configuration/grafana-agent/) | Grafana Agent can be configured to run a set of tracing pipelines to collect data from your applications and write it to Grafana Tempo. Pipelines are built using OpenTelemetry, and consist of receivers, processors, and exporters. |
+
+{{% docs/reference %}}
+[set up]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up"
+[set up]: "/docs/grafana-cloud/ -> ./set-up"
+[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration"
+[configure]: "/docs/grafana-cloud/ -> ./configuration"
+[install]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install"
+[install]: "/docs/grafana-cloud/ -> ./set-up/install"
+{{% /docs/reference %}}

--- a/docs/sources/static/api/_index.md
+++ b/docs/sources/static/api/_index.md
@@ -18,10 +18,12 @@ API endpoints are stable unless otherwise noted.
 
 ## Config management API (Beta)
 
-Grafana Agent exposes a config management REST API for managing instance configurations when it is running in [scraping service mode]({{< relref "../configuration/scraping-service/" >}}).
+Grafana Agent exposes a config management REST API for managing instance configurations when it is running in [scraping service mode][scrape].
 
-(Note that scraping service mode is a requirement for the config management
-API, however this is not a prerequisite for the Agent API or Ready/Healthy API)
+{{% admonition type="note" %}}
+The scraping service mode is a requirement for the config management
+API, however this is not a prerequisite for the Agent API or Ready/Healthy API.
+{{% /admonition %}}
 
 The following endpoints are exposed:
 
@@ -115,17 +117,18 @@ with the same name already exists, then it will be completely overwritten.
 URL-encoded names are stored in decoded form. e.g., `hello%2Fworld` will
 represent the config named `hello/world`.
 
-The request body passed to this endpoint must match the format of
-[metrics_instance_config]({{< relref "../configuration/metrics-config" >}})
+The request body passed to this endpoint must match the format of [metrics_instance_config][metrics]
 defined in the Configuration Reference. The name field of the configuration is
 ignored and the name in the URL takes precedence. The request body must be
 formatted as YAML.
 
-**WARNING**: By default, all instance configuration files that read
+{{% admonition type="warning" %}}
+By default, all instance configuration files that read
 credentials from a file on disk will be rejected. This prevents malicious users
 from reading the contents of arbitrary files as passwords and sending their
 contents to fake remote_write endpoints. To change the behavior, set
 `dangerous_allow_reading_files` to true in the `scraping_service` block.
+{{% /admonition %}}
 
 Status code: 201 with a new config, 200 on updated config.
 Response on success:
@@ -165,7 +168,10 @@ Response on success:
 ```
 GET /agent/api/v1/metrics/instances
 ```
-*note:* deprecated alias is `/agent/api/v1/instances`
+
+{{% admonition type="note" %}}
+The deprecated alias is `/agent/api/v1/instances`
+{{% /admonition %}}
 
 Status code: 200 on success.
 Response on success:
@@ -184,7 +190,10 @@ Response on success:
 ```
 GET /agent/api/v1/metrics/targets
 ```
-*note:* deprecated alias is `/agent/api/v1/targets`
+
+{{% admonition type="note" %}}
+The deprecated alias is `/agent/api/v1/targets`
+{{% /admonition %}}
 
 This endpoint collects all metrics subsystem targets known to the Agent across all
 running instances. Only targets being scraped from the local Agent will be returned. If
@@ -395,7 +404,7 @@ A support bundle contains the following data:
 ## Integrations API (Experimental)
 
 > **WARNING**: This API is currently only available when the experimental
-> [integrations revamp]({{< relref "../configuration/integrations/integrations-next" >}})
+> [integrations revamp][integrations]
 > is enabled. Both the revamp and this API are subject to change while they
 > are still experimental.
 
@@ -406,8 +415,7 @@ GET /agent/api/v1/metrics/integrations/sd
 ```
 
 This endpoint returns all running metrics-based integrations. It conforms to
-the Prometheus [http_sd_config
-API](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_sd_config).
+the Prometheus [http_sd_config API](https://prometheus.io/docs/prometheus/2.45/configuration/configuration/#http_sd_config).
 Targets include integrations regardless of autoscrape being enabled; this
 allows for manually configuring scrape jobs to collect metrics from an
 integration running on an external agent.
@@ -507,3 +515,12 @@ Response:
 ```
 Agent is Healthy.
 ```
+
+{{% docs/reference %}}
+[scrape]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/scraping-service"
+[scrape]: "/docs/grafana-cloud/ -> ../configuration/scraping-service
+[metrics]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/metrics-config"
+[metrics]: "/docs/grafana-cloud/ -> ../configuration/metrics-config"
+[integrations]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/integrations/integrations-next"
+[integrations]: "/docs/grafana-cloud/ -> ../configuration/integrations/integrations-next"
+{{% /docs/reference %}}

--- a/docs/sources/static/configuration/_index.md
+++ b/docs/sources/static/configuration/_index.md
@@ -10,7 +10,7 @@ aliases:
 The configuration of static mode is split across two places:
 
 * A YAML file
-* [Command-line flags]({{< relref "./flags.md" >}})
+* [Command-line flags][flags]
 
 The YAML file is used to configure settings which are dynamic and can be
 changed at runtime. The command-line flags then configure things which cannot
@@ -18,11 +18,11 @@ change at runtime, such as the listen port for the HTTP server.
 
 This file describes the YAML configuration, which is usually in a file named `config.yaml`.
 
-- [server_config]({{< relref "./server-config" >}})
-- [metrics_config]({{< relref "./metrics-config" >}})
-- [logs_config]({{< relref "./logs-config.md" >}})
-- [traces_config]({{< relref "./traces-config" >}})
-- [integrations_config]({{< relref "./integrations/_index.md" >}})
+- [server_config][server]
+- [metrics_config][metrics]
+- [logs_config][logs]
+- [traces_config][traces]
+- [integrations_config][integrations]
 
 The configuration of Grafana Agent is "stable," but subject to breaking changes
 as individual features change. Breaking changes to configuration will be
@@ -75,8 +75,7 @@ which may be slightly unexpected.
 
 ## Reloading (beta)
 
-The configuration file can be reloaded at runtime. Read the [API
-documentation]({{< relref "../api#reload-configuration-file-beta" >}}) for more information.
+The configuration file can be reloaded at runtime. Read the [API documentation][api] for more information.
 
 This functionality is in beta, and may have issues. Please open GitHub issues
 for any problems you encounter.
@@ -134,4 +133,23 @@ The following flags will configure basic auth for requests made to HTTP/S remote
 - `-config.url.basic-auth-user <user>`: the basic auth username
 - `-config.url.basic-auth-password-file <file>`: path to a file containing the basic auth password
 
-Note that this beta feature is subject to change in future releases.
+{{% admonition type="note" %}}
+This beta feature is subject to change in future releases.
+{{% /admonition %}}
+
+{{% docs/reference %}}
+[flags]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/flags"
+[flags]: "/docs/grafana-cloud/ -> ./flags"
+[server]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/server-config"
+[server]: "/docs/grafana-cloud/ -> ./server-config"
+[metrics]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/metrics-config"
+[metrics]: "/docs/grafana-cloud/ -> ./metrics-config"
+[logs]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/logs-config"
+[logs]: "/docs/grafana-cloud/ -> ./logs-config"
+[traces]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/traces-config"
+[traces]: "/docs/grafana-cloud/ -> ./traces-config"
+[integrations]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/integrations"
+[integrations]: "/docs/grafana-cloud/ -> ./integrations"
+[api]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/api#reload-configuration-file-beta"
+[api]: "/docs/grafana-cloud/ -> ../api#reload-configuration-file-beta"
+{{% /docs/reference %}}

--- a/docs/sources/static/configuration/create-config-file.md
+++ b/docs/sources/static/configuration/create-config-file.md
@@ -60,8 +60,7 @@ the Grafana Agent is running on. This label helps to uniquely identify the
 source of metrics if you are running multiple Grafana Agents across multiple
 machines.
 
-Full configuration options can be found in the
-[configuration reference]({{< relref "../configuration/_index.md" >}}).
+Full configuration options can be found in the [configuration reference][configure].
 
 ## Prometheus config/migrating from Prometheus
 
@@ -106,7 +105,7 @@ metrics:
 ```
 
 Like with integrations, full configuration options can be found in the
-[configuration]({{< relref "../configuration/_index.md" >}}).
+[configuration][configure].
 
 ## Loki Config/Migrating from Promtail
 
@@ -182,3 +181,8 @@ integrations:
   node_exporter:
     enabled: true
 ```
+
+{{% docs/reference %}}
+[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration"
+[configure]: "/docs/grafana-cloud/ -> ./configuration"
+{{% /docs/reference %}}

--- a/docs/sources/static/configuration/flags.md
+++ b/docs/sources/static/configuration/flags.md
@@ -29,10 +29,10 @@ names to enable.
 
 Valid feature names are:
 
-* `remote-configs`: Enable [retrieving]({{< relref "./_index.md#remote-configuration-experimental" >}}) config files over HTTP/HTTPS
-* `integrations-next`: Enable [revamp]({{< relref "./integrations/integrations-next/" >}}) of the integrations subsystem
-* `extra-scrape-metrics`: When enabled, additional time series  are exposed for each metrics instance scrape. See [Extra scrape metrics](https://prometheus.io/docs/prometheus/latest/feature_flags/#extra-scrape-metrics).
-* `agent-management`: Enable support for [agent management]({{< relref "./agent-management" >}}).
+* `remote-configs`: Enable [retrieving][retrieving] config files over HTTP/HTTPS
+* `integrations-next`: Enable [revamp][revamp] of the integrations subsystem
+* `extra-scrape-metrics`: When enabled, additional time series  are exposed for each metrics instance scrape. See [Extra scrape metrics](https://prometheus.io/docs/prometheus/2.45/feature_flags/#extra-scrape-metrics).
+* `agent-management`: Enable support for [agent management][management].
 
 ## Report information usage
 
@@ -141,3 +141,12 @@ YAML configuration when the `-server.http.tls-enabled` flag is used.
 ## Metrics
 
 * `-metrics.wal-directory`: Directory to store the metrics Write-Ahead Log in
+
+{{% docs/reference %}}
+[retrieving]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration#remote-configuration-experimental"
+[retrieving]: "/docs/grafana-cloud/ -> ./configuration#remote-configuration-experimental"
+[revamp]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/integrations/integrations-next/"
+[revamp]: "/docs/grafana-cloud/ -> ./integrations/integrations-next/"
+[management]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/agent-management"
+[management]: "/docs/grafana-cloud/ -> ./agent-management"
+{{% /docs/reference %}}

--- a/docs/sources/static/configuration/metrics-config.md
+++ b/docs/sources/static/configuration/metrics-config.md
@@ -64,8 +64,7 @@ configs:
 
 ## scraping_service_config
 
-The `scraping_service` block configures the
-[scraping service]({{< relref "scraping-service/" >}}), an operational
+The `scraping_service` block configures the [scraping service][scrape], an operational
 mode where configurations are stored centrally in a KV store and a cluster of
 agents distributes discovery and scrape load between nodes.
 
@@ -331,6 +330,11 @@ remote_write:
 > **Note:** More information on the following types can be found on the Prometheus
 > website:
 >
-> * [`relabel_config`](https://prometheus.io/docs/prometheus/2.42/configuration/configuration/#relabel_config)
-> * [`scrape_config`](https://prometheus.io/docs/prometheus/2.42/configuration/configuration/#scrape_config)
-> * [`remote_write`](https://prometheus.io/docs/prometheus/2.42/configuration/configuration/#remote_write)
+> * [`relabel_config`](https://prometheus.io/docs/prometheus/2.45/configuration/configuration/#relabel_config)
+> * [`scrape_config`](https://prometheus.io/docs/prometheus/2.45/configuration/configuration/#scrape_config)
+> * [`remote_write`](https://prometheus.io/docs/prometheus/2.45/configuration/configuration/#remote_write)
+
+{{% docs/reference %}}
+[scrape]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/scraping-service"
+[scrape]: "/docs/grafana-cloud/ -> ./scraping-service"
+{{% /docs/reference %}}

--- a/docs/sources/static/configuration/scraping-service.md
+++ b/docs/sources/static/configuration/scraping-service.md
@@ -13,7 +13,7 @@ that allows for clustering a set of Agent processes and distributing scrape load
 across them.
 
 Determining what to scrape is done by writing instance configuration files to an
-[API]({{< relref "../api" >}}), which then stores the configuration files in a KV store backend.
+[API][api], which then stores the configuration files in a KV store backend.
 All agents in the cluster **must** use the same KV store so they see the same set
 of config files.
 
@@ -43,7 +43,7 @@ remote_write:
 
 The full set of supported options for an instance configuration file is
 available in the
-[`metrics-config.md` file]({{< relref "metrics-config" >}}).
+[`metrics-config.md` file][metrics].
 
 Having multiple instance configuration files is necessary for sharding; each
 config file is distributed to a particular agent on the cluster based on the
@@ -167,3 +167,10 @@ Entries in the API not in the synced directory will be deleted.
 container with the `grafana/agentctl` image. Tanka configurations that
 utilize `grafana/agentctl` and sync a set of configurations to the API
 are planned for the future.
+
+{{% docs/reference %}}
+[api]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/api"
+[api]: "/docs/grafana-cloud/ -> ../api"
+[metrics]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/metrics-config"
+[metrics]: "/docs/grafana-cloud/ -> ./metrics-config"
+{{% /docs/reference %}}

--- a/docs/sources/static/configuration/traces-config.md
+++ b/docs/sources/static/configuration/traces-config.md
@@ -13,9 +13,11 @@ configures its own tracing pipeline. Having multiple configs allows you to
 configure multiple distinct pipelines, each of which collects spans and sends
 them to a different location.
 
-Note that if using multiple configs, you must manually set port numbers for
+{{% admonition type="note" %}}
+If you are using multiple configs, you must manually set port numbers for
 each receiver, otherwise they will all try to use the same port and fail to
 start.
+{{% /admonition %}}
 
 ```yaml
 configs:
@@ -375,13 +377,12 @@ service_graphs:
       [ - <int> ... ]
 ```
 
-> **Note:** More information on the following types can be found on the
-> documentation for their respective projects:
->
-* [`attributes.config`: OpenTelemetry-Collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/b2327211df976e0a57ef0425493448988772a16b/processor/attributesprocessor)
-* [`batch.config`: OpenTelemetry-Collector](https://github.com/open-telemetry/opentelemetry-collector/tree/1f5dd9f9a566a937ec15093ca3bc377fba86f5f9/processor/batchprocessor)
-* [`otlpexporter.sending_queue`: OpenTelemetry-Collector](https://github.com/open-telemetry/opentelemetry-collector/tree/1f5dd9f9a566a937ec15093ca3bc377fba86f5f9/exporter/otlpexporter)
-* [`otlpexporter.retry_on_failure`: OpenTelemetry-Collector](https://github.com/open-telemetry/opentelemetry-collector/tree/1f5dd9f9a566a937ec15093ca3bc377fba86f5f9/exporter/otlpexporter)
+More information on the following types can be found on the documentation for their respective projects:
+
+* [`attributes.config`: OpenTelemetry-Collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/processor/attributesprocessor)
+* [`batch.config`: OpenTelemetry-Collector](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.80.0/processor/batchprocessor)
+* [`otlpexporter.sending_queue`: OpenTelemetry-Collector](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.80.0/exporter/otlpexporter)
+* [`otlpexporter.retry_on_failure`: OpenTelemetry-Collector](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.80.0/exporter/otlpexporter)
 * `receivers`:
   * [`jaegerreceiver`: OpenTelemetry-Collector-Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/b2327211df976e0a57ef0425493448988772a16b/receiver/jaegerreceiver)
   * [`kafkareceiver`: OpenTelemetry-Collector-Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/b2327211df976e0a57ef0425493448988772a16b/receiver/kafkareceiver)

--- a/docs/sources/static/operation-guide/_index.md
+++ b/docs/sources/static/operation-guide/_index.md
@@ -14,12 +14,12 @@ This guide helps you operate the Grafana Agent.
 There are three options to horizontally scale your deployment of Grafana Agents:
 
 - [Host filtering](#host-filtering) requires you to run one Agent on every
-   machine you wish to collect metrics from. Agents will only collect metrics
-   from the machines they run on.
+  machine you wish to collect metrics from. Agents will only collect metrics
+  from the machines they run on.
 - [Hashmod sharding](#hashmod-sharding) allows you to roughly shard the
-   discovered set of targets by using hashmod/keep relabel rules.
-- The [scraping service]({{< relref "../configuration/scraping-service/" >}}) allows you to cluster Grafana
-   Agents and have them distribute per-tenant configs throughout the cluster.
+  discovered set of targets by using hashmod/keep relabel rules.
+- The [scraping service][scrape] allows you to cluster Grafana
+  Agents and have them distribute per-tenant configs throughout the cluster.
 
 Each has their own set of tradeoffs:
 
@@ -53,7 +53,7 @@ Each has their own set of tradeoffs:
     - Smallest load on SD compared to host filtering, as only one Agent is
       responsible for a config.
   - Cons
-    - Centralized configs must discover a [minimal set of targets]({{< relref "../configuration/scraping-service#best-practices" >}})
+    - Centralized configs must discover a [minimal set of targets][targets]
       to distribute evenly.
     - Requires running a separate KV store to store the centralized configs.
     - Managing centralized configs adds operational burden over managing a config
@@ -77,8 +77,8 @@ running the Grafana Agent on GKE, you would have a DaemonSet with
 for scraping other targets that are not running on a cluster node, such as the
 Kubernetes control plane API.
 
-If you want to scale your scrape load without host filtering, you may use the
-[scraping service]({{< relref "../configuration/scraping-service/" >}}) instead.
+If you want to scale your scrape load without host filtering, you can use the
+[scraping service][scrape] instead.
 
 The host name of the Agent is determined by reading `$HOSTNAME`. If `$HOSTNAME`
 isn't defined, the Agent will use Go's [os.Hostname](https://golang.org/pkg/os/#Hostname)
@@ -109,8 +109,7 @@ logic; only `host_filter_relabel_configs` will work.
 
 If the determined hostname matches any of the meta labels, the discovered target
 is allowed. Otherwise, the target is ignored, and will not show up in the
-[targets
-API]({{< relref "../api#list-current-scrape-targets" >}}).
+[targets API][api].
 
 ## Hashmod sharding (Stable)
 
@@ -155,10 +154,9 @@ Instances allow for fine grained control of what data gets scraped and where it
 gets sent. Users can easily define two Instances that scrape different subsets
 of metrics and send them to two completely different remote_write systems.
 
-Instances are especially relevant to the [scraping service
-mode]({{< relref "../configuration/scraping-service/" >}}), where breaking up your scrape configs into
-multiple Instances is required for sharding and balancing scrape load across a
-cluster of Agents.
+Instances are especially relevant to the [scraping service mode][scrape],
+where breaking up your scrape configs into multiple Instances is required for 
+sharding and balancing scrape load across a cluster of Agents.
 
 ## Instance sharing (Stable)
 
@@ -175,10 +173,8 @@ first six characters of the group name and the first six characters of the hash
 from that `remote_write` config separated by a `-`.
 
 The shared instances mode is the new default, and the previous behavior is
-deprecated. If you wish to restore the old behavior, set `instance_mode:
-distinct` in the
-[`metrics_config`]({{< relref "../configuration/metrics-config" >}}) block of
-your config file.
+deprecated. If you wish to restore the old behavior, set `instance_mode: distinct`
+in the [`metrics_config`][metrics] block of your config file.
 
 Shared instances are completely transparent to the user with the exception of
 exposed metrics. With `instance_mode: shared`, metrics for Prometheus components
@@ -190,6 +186,16 @@ individual Instance config. It is recommended to use the default of
 `instance_mode: shared` unless you don't mind the performance hit and really
 need granular metrics.
 
-Users can use the [targets API]({{< relref "../api#list-current-scrape-targets" >}})
-to see all scraped targets, and the name of the shared instance they were
-assigned to.
+Users can use the [targets API][api] to see all scraped targets, and the name 
+of the shared instance they were assigned to.
+
+{{% docs/reference %}}
+[scrape]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/scraping-service"
+[scrape]: "/docs/grafana-cloud/ -> ../configuration/scraping-service"
+[targets]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/scraping-service#best-practices"
+[targets]: "/docs/grafana-cloud/ -> ../configuration/scraping-service#best-practices"
+[api]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/api#agent-api"
+[api]: "/docs/grafana-cloud/ -> ../api#agent-api"
+[metrics]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/metrics-config"
+[metrics]: "/docs/grafana-cloud/ -> ../configuration/metrics-config"
+{{% /docs/reference %}}

--- a/docs/sources/static/release-notes.md
+++ b/docs/sources/static/release-notes.md
@@ -17,16 +17,18 @@ The release notes provide information about deprecations and breaking changes in
 
 For a complete list of changes to Grafana Agent, with links to pull requests and related issues when available, refer to the [Changelog](https://github.com/grafana/agent/blob/main/CHANGELOG.md).
 
-{{% admonition type="note" %}}
-These release notes are specific to Grafana Agent static mode. 
-Other release notes for the different Grafana Agent variants are contained on separate pages:
+> **Note:** These release notes are specific to Grafana Agent static mode. 
+> Other release notes for the different Grafana Agent variants are contained on separate pages:
+>
+> * [Static mode Kubernetes operator release notes][release-notes-operator]
+> * [Flow mode release notes][release-notes-flow]
 
-* [Static mode Kubernetes operator release notes][release-notes-operator]
-* [Flow mode release notes][release-notes-flow]
-
-[release-notes-operator]: {{< relref "../operator/release-notes.md" >}}
-[release-notes-flow]: {{< relref "../flow/release-notes.md" >}}
-{{% /admonition %}}
+{{% docs/reference %}}
+[release-notes-operator]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/operator/release-notes"
+[release-notes-operator]: "/docs/grafana-cloud/ -> ../operator/release-notes"
+[release-notes-flow]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/release-notes"
+[release-notes-flow]: "/docs/grafana-cloud/ -> ../flow/release-notes"
+{{% /docs/reference %}}
 
 ### Removal of Dynamic Configuration
 

--- a/docs/sources/static/set-up/install/install-agent-binary.md
+++ b/docs/sources/static/set-up/install/install-agent-binary.md
@@ -21,9 +21,9 @@ ppc64le builds are considered secondary release targets and do not have the same
 
 The binary executable will run Grafana Agent in standalone mode. If you want to run Grafana Agent as a service, refer to the installation instructions for:
 
-* [Linux]({{< relref "./install-agent-linux.md" >}})
-* [macOS]({{< relref "./install-agent-macos.md" >}})
-* [Windows]({{< relref "./install-agent-on-windows.md" >}})
+* [Linux][linux]
+* [macOS][macos]
+* [Windows][windows]
 
 ## Download Grafana Agent
 
@@ -45,5 +45,18 @@ To download the Grafana Agent as a standalone binary, perform the following step
 
 ## Next steps
 
-- [Start Grafana Agent]({{< relref "../start-agent/" >}})
-- [Configure Grafana Agent]({{< relref "../../configuration/create-config-file/" >}})
+* [Start Grafana Agent][start]
+* [Configure Grafana Agent][configure]
+
+{{% docs/reference %}}
+[linux]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-linux"
+[linux]: "/docs/grafana-cloud/ -> ./install-agent-linux"
+[macos]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-macos"
+[macos]: "/docs/grafana-cloud/ -> ./install-agent-mac-os"
+[windows]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-on-windows"
+[windows]: "/docs/grafana-cloud/ -> ./install-agent-on-windows"
+[start]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/start-agent#standalone-binary"
+[start]: "/docs/grafana-cloud/ -> ../start-agent#standalone-binary"
+[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration"
+[configure]: "/docs/grafana-cloud/ -> ../../configuration"
+{{% /docs/reference %}}

--- a/docs/sources/static/set-up/install/install-agent-docker.md
+++ b/docs/sources/static/set-up/install/install-agent-docker.md
@@ -20,7 +20,7 @@ Grafana Agent is available as a Docker container image on the following platform
 ## Before you begin
 
 * Install [Docker][] on your computer.
-* Create and save a Grafana Agent YAML [configuration file]({{< relref "../../configuration/create-config-file/" >}}) on your computer.
+* Create and save a Grafana Agent YAML [configuration file][configure] on your computer.
 
 [Docker]: https://docker.io
 
@@ -63,5 +63,12 @@ For the flags to work correctly, you must expose the paths on your Windows host 
 
 ## Next steps
 
-- [Start Grafana Agent]({{< relref "../start-agent/" >}})
-- [Configure Grafana Agent]({{< relref "../../configuration/" >}})
+- [Start Grafana Agent][start]
+- [Configure Grafana Agent][configure]
+
+{{% docs/reference %}}
+[start]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/start-agent"
+[start]: "/docs/grafana-cloud/ -> ../start-agent"
+[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/create-config-file"
+[configure]: "/docs/grafana-cloud/ -> ../../configuration/create-config-file"
+{{% /docs/reference %}}

--- a/docs/sources/static/set-up/install/install-agent-linux.md
+++ b/docs/sources/static/set-up/install/install-agent-linux.md
@@ -211,5 +211,12 @@ Logs of Grafana Agent can be found by running the following command in a termina
 
 ## Next steps
 
-- [Start Grafana Agent]({{< relref "../start-agent/" >}})
-- [Configure Grafana Agent]({{< relref "../../configuration/" >}})
+- [Start Grafana Agent][start]
+- [Configure Grafana Agent][configure]
+
+{{% docs/reference %}}
+[start]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/start-agent"
+[start]: "/docs/grafana-cloud/ -> ../start-agent"
+[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/create-config-file"
+[configure]: "/docs/grafana-cloud/ -> ../../configuration/create-config-file"
+{{% /docs/reference %}}

--- a/docs/sources/static/set-up/install/install-agent-macos.md
+++ b/docs/sources/static/set-up/install/install-agent-macos.md
@@ -70,7 +70,7 @@ brew uninstall grafana-agent
     touch $(brew --prefix)/etc/grafana-agent/config.yml
     ```
 
-1. Edit `$(brew --prefix)/etc/grafana-agent/config.yml` and add the configuration blocks for your specific telemetry needs. Refer to [Configure Grafana Agent]({{< relref "../../configuration/" >}}) for more information.
+1. Edit `$(brew --prefix)/etc/grafana-agent/config.yml` and add the configuration blocks for your specific telemetry needs. Refer to [Configure Grafana Agent][configure] for more information.
 
 {{% admonition type="note" %}}
 To send your data to Grafana Cloud, set up Grafana Agent using the Grafana Cloud integration. Refer to [how to install an integration](/docs/grafana-cloud/data-configuration/integrations/install-and-manage-integrations/) and [macOS integration](/docs/grafana-cloud/data-configuration/integrations/integration-reference/integration-macos-node/).
@@ -78,5 +78,12 @@ To send your data to Grafana Cloud, set up Grafana Agent using the Grafana Cloud
 
 ## Next steps
 
-- [Start Grafana Agent]({{< relref "../start-agent/" >}})
-- [Configure Grafana Agent]({{< relref "../../configuration/" >}})
+- [Start Grafana Agent][start]
+- [Configure Grafana Agent][configure]
+
+{{% docs/reference %}}
+[start]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/start-agent"
+[start]: "/docs/grafana-cloud/ -> ../start-agent"
+[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/create-config-file"
+[configure]: "/docs/grafana-cloud/ -> ../../configuration/create-config-file"
+{{% /docs/reference %}}

--- a/docs/sources/static/set-up/install/install-agent-on-windows.md
+++ b/docs/sources/static/set-up/install/install-agent-on-windows.md
@@ -138,5 +138,12 @@ Refer to [windows_events](https://grafana.com/docs/loki/latest/clients/promtail/
 
 ## Next steps
 
-- [Start Grafana Agent]({{< relref "../start-agent/" >}})
-- [Configure Grafana Agent]({{< relref "../../configuration/" >}})
+- [Start Grafana Agent][start]
+- [Configure Grafana Agent][[configure]]
+
+{{% docs/reference %}}
+[start]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/start-agent"
+[start]: "/docs/grafana-cloud/ -> ../start-agent"
+[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/create-config-file"
+[configure]: "/docs/grafana-cloud/ -> ../../configuration/create-config-file"
+{{% /docs/reference %}}

--- a/docs/sources/static/set-up/start-agent.md
+++ b/docs/sources/static/set-up/start-agent.md
@@ -102,8 +102,7 @@ brew services stop grafana-agent
 By default, logs are written to `$(brew --prefix)/var/log/grafana-agent.log` and
 `$(brew --prefix)/var/log/grafana-agent.err.log`.
 
-If you followed [Configure the Grafana Agent service](../setup/configure/configure-macos.md#configure-the-grafana-agent-service)
-and changed the path where logs are written, refer to your current copy of the Grafana Agent formula to locate your log files.
+If you followed [Configure][configure] steps in the macOS install instructions and changed the path where logs are written, refer to your current copy of the Grafana Agent formula to locate your log files.
 
 ## Windows
 
@@ -152,3 +151,8 @@ Replace the following:
 
 * `BINARY_PATH`: The path to the Grafana Agent binary file
 * `CONFIG_FILE`: The path to the Grafana Agent configuration file.
+
+{{% docs/reference %}}
+[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-macos#configure"
+[configure]: "/docs/grafana-cloud/ -> ./install/install-agent-macos/#configure"
+{{% /docs/reference %}}


### PR DESCRIPTION
* First pass at updating references

* Remove note admonition

* Adjust ref syntax

* Trying different syntax

* Restory syntax to documented style

* Ensure that Hugo knows the documentation is versioned

Allows interpoloation of the `<GRAFANA VERSION>` variable used in the `docs/reference` shortcode.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

* Use more appropriate version variable

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

* Update cross references in setup

* Update install cross references

* Update cross refs in api and operations

* First pass at updating conf refs

* Fix remaining cross refs

* Convert to relative links for cloud

* Fix URL sytnax

---------

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
Co-authored-by: Jack Baldry <jack.baldry@grafana.com>
(cherry picked from commit 0cd4d262ed65f1999f5d142fd5470ac1fdcc0e38)

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated