### PR TITLE
clustering: configure threshold for ClusterLamportClockDrift alert

### DIFF
--- a/operations/agent-flow-mixin/alerts/clustering.libsonnet
+++ b/operations/agent-flow-mixin/alerts/clustering.libsonnet
@@ -29,7 +29,7 @@ alert.newGroup(
     // Standard Deviation of Lamport clock time between nodes is too high.
     alert.newRule(
       'ClusterLamportClockDrift',
-      'stddev by (cluster, namespace) (cluster_node_lamport_time) > 4',
+      'stddev by (cluster, namespace) (cluster_node_lamport_time) > 4 * sqrt(count by (cluster, namespace) (cluster_node_info))',
       "Cluster nodes' lamport clocks are not converging.",
       '5m'
     ),


### PR DESCRIPTION
We've noticed the `ClusterLamportClockDrift` to be exceptionally sensitive with bigger cluster sizes; this makes sense given gossip's random nature, it's not hard for nodes to temporarily be more than 4 messages apart.

I propose that we gently scale the arbitrary threshold value that we chose to correlate with cluster size; this would still 
```
1 node    = 4 * 0   = 0
2 nodes   = 4 * 1.4 = 6
4 nodes   = 4 * 2   = 8
8 nodes   = 4 * 2.8 = 11.3
25 nodes  = 4 * 5   = 20
100 nodes = 4 * 10  = 40  
```

I've looked at some internal metrics and it looks like the scaled metric better correlates with instances where we _did_ have issues with the network communication of cluster nodes.