### PR TITLE
Update `docs/shared` shortcode usage to use keyword argument interface

### DIFF
--- a/docs/sources/flow/reference/components/discovery.azure.md
+++ b/docs/sources/flow/reference/components/discovery.azure.md
@@ -64,7 +64,7 @@ Name | Type | Description | Default | Required
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/discovery.consul.md
+++ b/docs/sources/flow/reference/components/discovery.consul.md
@@ -76,19 +76,19 @@ an `oauth2` block.
 
 ### basic_auth block
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### authorization block
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### oauth2 block
 
-{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/discovery.docker.md
+++ b/docs/sources/flow/reference/components/discovery.docker.md
@@ -83,19 +83,19 @@ documentation for the list of supported filters and their meaning.
 
 ### basic_auth block
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### authorization block
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### oauth2 block
 
-{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/discovery.eureka.md
+++ b/docs/sources/flow/reference/components/discovery.eureka.md
@@ -50,19 +50,19 @@ an `oauth2` block.
 
 ### basic_auth block
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### authorization block
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### oauth2 block
 
-{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/discovery.hetzner.md
+++ b/docs/sources/flow/reference/components/discovery.hetzner.md
@@ -68,19 +68,19 @@ an `oauth2` block.
 
 ### basic_auth block
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### authorization block
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### oauth2 block
 
-{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/discovery.http.md
+++ b/docs/sources/flow/reference/components/discovery.http.md
@@ -63,19 +63,19 @@ an `oauth2` block.
 
 ### basic_auth block
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### authorization block
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### oauth2 block
 
-{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/discovery.kubelet.md
+++ b/docs/sources/flow/reference/components/discovery.kubelet.md
@@ -58,11 +58,11 @@ tls_config | [tls_config][] | Configure TLS settings for connecting to the endpo
 
 ### authorization block
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/discovery.kubernetes.md
+++ b/docs/sources/flow/reference/components/discovery.kubernetes.md
@@ -316,19 +316,19 @@ Name | Type | Description | Default | Required
 
 ### basic_auth block
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### authorization block
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### oauth2 block
 
-{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/discovery.nomad.md
+++ b/docs/sources/flow/reference/components/discovery.nomad.md
@@ -65,19 +65,19 @@ an `oauth2` block.
 
 ### basic_auth block
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### authorization block
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### oauth2 block
 
-{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/discovery.openstack.md
+++ b/docs/sources/flow/reference/components/discovery.openstack.md
@@ -67,7 +67,7 @@ tls_config | [tls_config][] | TLS configuration for requests to the OpenStack AP
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/discovery.puppetdb.md
+++ b/docs/sources/flow/reference/components/discovery.puppetdb.md
@@ -70,19 +70,19 @@ an `oauth2` block.
 
 ### basic_auth block
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### authorization block
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### oauth2 block
 
-{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/discovery.relabel.md
+++ b/docs/sources/flow/reference/components/discovery.relabel.md
@@ -66,7 +66,7 @@ rule | [rule][] | Relabeling rules to apply to targets. | no
 
 ### rule block
 
-{{< docs/shared lookup="flow/reference/components/rule-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/rule-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/discovery.uyuni.md
+++ b/docs/sources/flow/reference/components/discovery.uyuni.md
@@ -48,7 +48,7 @@ tls_config | [tls_config][] | TLS configuration for requests to the Uyuni API. |
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/local.file.md
+++ b/docs/sources/flow/reference/components/local.file.md
@@ -35,7 +35,7 @@ Name | Type | Description | Default | Required
 
 [secret]: {{< relref "../../config-language/expressions/types_and_values.md#secrets" >}}
 
-{{< docs/shared lookup="flow/reference/components/local-file-arguments-text.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/local-file-arguments-text.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/loki.echo.md
+++ b/docs/sources/flow/reference/components/loki.echo.md
@@ -7,7 +7,7 @@ title: loki.echo
 
 # loki.echo
 
-{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT VERSION>" >}}
 
 `loki.echo` receives log entries from other `loki` components and prints them
 to the process' standard output (stdout).

--- a/docs/sources/flow/reference/components/loki.relabel.md
+++ b/docs/sources/flow/reference/components/loki.relabel.md
@@ -61,7 +61,7 @@ rule | [rule][] | Relabeling rules to apply to received log entries. | no
 
 ### rule block
 
-{{< docs/shared lookup="flow/reference/components/rule-block-logs.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/rule-block-logs.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/loki.source.api.md
+++ b/docs/sources/flow/reference/components/loki.source.api.md
@@ -63,7 +63,7 @@ The following blocks are supported inside the definition of `loki.source.api`:
 
 ### http
 
-{{< docs/shared lookup="flow/reference/components/loki-server-http.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/loki-server-http.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/loki.source.awsfirehose.md
+++ b/docs/sources/flow/reference/components/loki.source.awsfirehose.md
@@ -96,11 +96,11 @@ The following blocks are supported inside the definition of `loki.source.awsfire
 
 ### http
 
-{{< docs/shared lookup="flow/reference/components/loki-server-http.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/loki-server-http.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### grpc
 
-{{< docs/shared lookup="flow/reference/components/loki-server-grpc.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/loki-server-grpc.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/loki.source.gcplog.md
+++ b/docs/sources/flow/reference/components/loki.source.gcplog.md
@@ -112,11 +112,11 @@ The `labels` map is applied to every entry that passes through the component.
 
 ### http
 
-{{< docs/shared lookup="flow/reference/components/loki-server-http.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/loki-server-http.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### grpc
 
-{{< docs/shared lookup="flow/reference/components/loki-server-grpc.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/loki-server-grpc.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/loki.source.heroku.md
+++ b/docs/sources/flow/reference/components/loki.source.heroku.md
@@ -62,11 +62,11 @@ The following blocks are supported inside the definition of `loki.source.heroku`
 
 ### http
 
-{{< docs/shared lookup="flow/reference/components/loki-server-http.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/loki-server-http.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### grpc
 
-{{< docs/shared lookup="flow/reference/components/loki-server-grpc.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/loki-server-grpc.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Labels
 

--- a/docs/sources/flow/reference/components/loki.source.kafka.md
+++ b/docs/sources/flow/reference/components/loki.source.kafka.md
@@ -100,7 +100,7 @@ you must set the `tls_config` block. If `"sasl"` is used, you must set the `sasl
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### sasl_config block
 

--- a/docs/sources/flow/reference/components/loki.source.kubernetes.md
+++ b/docs/sources/flow/reference/components/loki.source.kubernetes.md
@@ -7,7 +7,7 @@ title: loki.source.kubernetes
 
 # loki.source.kubernetes
 
-{{< docs/shared lookup="flow/stability/experimental.md" source="agent" >}}
+{{< docs/shared lookup="flow/stability/experimental.md" source="agent" version="<AGENT VERSION>" >}}
 
 `loki.source.kubernetes` tails logs from Kubernetes containers using the
 Kubernetes API. It has the following benefits over `loki.source.file`:
@@ -116,19 +116,19 @@ Name | Type | Description | Default | Required
 
 ### basic_auth block
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### authorization block
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### oauth2 block
 
-{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/loki.source.kubernetes_events.md
+++ b/docs/sources/flow/reference/components/loki.source.kubernetes_events.md
@@ -114,19 +114,19 @@ Name | Type | Description | Default | Required
 
 ### basic_auth block
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### authorization block
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### oauth2 block
 
-{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/loki.source.podlogs.md
+++ b/docs/sources/flow/reference/components/loki.source.podlogs.md
@@ -7,7 +7,7 @@ title: loki.source.podlogs
 
 # loki.source.podlogs
 
-{{< docs/shared lookup="flow/stability/experimental.md" source="agent" >}}
+{{< docs/shared lookup="flow/stability/experimental.md" source="agent" version="<AGENT VERSION>" >}}
 
 `loki.source.podlogs` discovers `PodLogs` resources on Kubernetes and, using
 the Kubernetes API, tails logs from Kubernetes containers of Pods specified by
@@ -178,19 +178,19 @@ Name | Type | Description | Default | Required
 
 ### basic_auth block
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### authorization block
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### oauth2 block
 
-{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### selector block
 

--- a/docs/sources/flow/reference/components/loki.source.syslog.md
+++ b/docs/sources/flow/reference/components/loki.source.syslog.md
@@ -96,7 +96,7 @@ translated to internal labels in the form of
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/loki.write.md
+++ b/docs/sources/flow/reference/components/loki.write.md
@@ -109,19 +109,19 @@ enabled, the retry mechanism will be governed by the backoff configuration speci
 
 ### basic_auth block
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### authorization block
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### oauth2 block
 
-{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### wal block (experimental)
 

--- a/docs/sources/flow/reference/components/mimir.rules.kubernetes.md
+++ b/docs/sources/flow/reference/components/mimir.rules.kubernetes.md
@@ -7,7 +7,7 @@ title: mimir.rules.kubernetes
 
 # mimir.rules.kubernetes
 
-{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT VERSION>" >}}
 
 `mimir.rules.kubernetes` discovers `PrometheusRule` Kubernetes resources and
 loads them into a Mimir instance.
@@ -138,19 +138,19 @@ The `values` argument must not be provided when `operator` is set to `"Exists"` 
 
 ### basic_auth block
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### authorization block
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### oauth2 block
 
-{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/module.file.md
+++ b/docs/sources/flow/reference/components/module.file.md
@@ -7,7 +7,7 @@ title: module.file
 
 # module.file
 
-{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT VERSION>" >}}
 
 `module.file` is a *module loader* component. A module loader is a Grafana Agent Flow
 component which retrieves a [module][] and runs the components defined inside of it.
@@ -47,7 +47,7 @@ Name | Type | Description | Default | Required
 
 [secret]: {{< relref "../../config-language/expressions/types_and_values.md#secrets" >}}
 
-{{< docs/shared lookup="flow/reference/components/local-file-arguments-text.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/local-file-arguments-text.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Blocks
 

--- a/docs/sources/flow/reference/components/module.git.md
+++ b/docs/sources/flow/reference/components/module.git.md
@@ -7,7 +7,7 @@ title: module.git
 
 # module.git
 
-{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT VERSION>" >}}
 
 `module.git` is a *module loader* component. A module loader is a Grafana Agent Flow
 component which retrieves a [module][] and runs the components defined inside of it.
@@ -72,7 +72,7 @@ arguments | [arguments][] | Arguments to pass to the module. | no
 
 ### basic_auth block
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### ssh_key block
 

--- a/docs/sources/flow/reference/components/module.http.md
+++ b/docs/sources/flow/reference/components/module.http.md
@@ -7,7 +7,7 @@ title: module.http
 
 # module.http
 
-{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT VERSION>" >}}
 
 `module.http` is a [module loader][] component.
 

--- a/docs/sources/flow/reference/components/module.string.md
+++ b/docs/sources/flow/reference/components/module.string.md
@@ -7,7 +7,7 @@ title: module.string
 
 # module.string
 
-{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT VERSION>" >}}
 
 `module.string` is a *module loader* component. A module loader is a Grafana Agent Flow
 component which retrieves a [module][] and runs the components defined inside of it.

--- a/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
@@ -58,7 +58,7 @@ tls | [tls][] | TLS settings for the token client. | no
 The `tls` block configures TLS settings used for connecting to the token client. If the `tls` block isn't provided, 
 TLS won't be used for communication.
 
-{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.jaeger.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.jaeger.md
@@ -74,9 +74,9 @@ Name | Type | Description | Default | Required
 `balancer_name` | `string` | Which gRPC client-side load balancer to use for requests. | `pick_first` | no
 `auth` | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests. | | no
 
-{{< docs/shared lookup="flow/reference/components/otelcol-compression-field.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-compression-field.md" source="agent" version="<AGENT VERSION>" >}}
 
-{{< docs/shared lookup="flow/reference/components/otelcol-grpc-balancer-name.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-grpc-balancer-name.md" source="agent" version="<AGENT VERSION>" >}}
 
 An HTTP proxy can be configured through the following environment variables:
 
@@ -105,7 +105,7 @@ able to handle and proxy HTTP/2 traffic.
 The `tls` block configures TLS settings used for the connection to the gRPC
 server.
 
-{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### keepalive block
 
@@ -125,14 +125,14 @@ Name | Type | Description | Default | Required
 The `sending_queue` block configures an in-memory buffer of batches before data is sent
 to the gRPC server.
 
-{{< docs/shared lookup="flow/reference/components/otelcol-queue-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-queue-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### retry_on_failure block
 
 The `retry_on_failure` block configures how failed requests to the gRPC server are
 retried.
 
-{{< docs/shared lookup="flow/reference/components/otelcol-retry-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-retry-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
@@ -7,7 +7,7 @@ title: otelcol.exporter.loadbalancing
 
 # otelcol.exporter.loadbalancing
 
-{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT VERSION>" >}}
 
 `otelcol.exporter.loadbalancing` accepts logs and traces from other `otelcol` components
 and writes them over the network using the OpenTelemetry Protocol (OTLP) protocol. 
@@ -155,9 +155,9 @@ Name | Type | Description | Default | Required
 `balancer_name` | `string` | Which gRPC client-side load balancer to use for requests. | `pick_first` | no
 `auth` | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests. | | no
 
-{{< docs/shared lookup="flow/reference/components/otelcol-compression-field.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-compression-field.md" source="agent" version="<AGENT VERSION>" >}}
 
-{{< docs/shared lookup="flow/reference/components/otelcol-grpc-balancer-name.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-grpc-balancer-name.md" source="agent" version="<AGENT VERSION>" >}}
 
 You can configure an HTTP proxy with the following environment variables:
 
@@ -186,7 +186,7 @@ able to handle and proxy HTTP/2 traffic.
 The `tls` block configures TLS settings used for the connection to the gRPC
 server.
 
-{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### keepalive block
 
@@ -206,14 +206,14 @@ Name | Type | Description | Default | Required
 The `queue` block configures an in-memory buffer of batches before data is sent
 to the gRPC server.
 
-{{< docs/shared lookup="flow/reference/components/otelcol-queue-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-queue-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### retry block
 
 The `retry` block configures how failed requests to the gRPC server are
 retried.
 
-{{< docs/shared lookup="flow/reference/components/otelcol-retry-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-retry-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
@@ -72,9 +72,9 @@ Name | Type | Description | Default | Required
 `balancer_name` | `string` | Which gRPC client-side load balancer to use for requests. | `pick_first` | no
 `auth` | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests. | | no
 
-{{< docs/shared lookup="flow/reference/components/otelcol-compression-field.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-compression-field.md" source="agent" version="<AGENT VERSION>" >}}
 
-{{< docs/shared lookup="flow/reference/components/otelcol-grpc-balancer-name.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-grpc-balancer-name.md" source="agent" version="<AGENT VERSION>" >}}
 
 An HTTP proxy can be configured through the following environment variables:
 
@@ -103,7 +103,7 @@ able to handle and proxy HTTP/2 traffic.
 The `tls` block configures TLS settings used for the connection to the gRPC
 server.
 
-{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 > **NOTE**: `otelcol.exporter.otlp` uses gRPC, which does not allow you to send sensitive credentials (like `auth`) over insecure channels.
 > Sending sensitive credentials over insecure non-TLS connections is supported by non-gRPC exporters such as [otelcol.exporter.otlphttp][].
@@ -128,14 +128,14 @@ Name | Type | Description | Default | Required
 The `sending_queue` block configures an in-memory buffer of batches before data is sent
 to the gRPC server.
 
-{{< docs/shared lookup="flow/reference/components/otelcol-queue-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-queue-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### retry_on_failure block
 
 The `retry_on_failure` block configures how failed requests to the gRPC server are
 retried.
 
-{{< docs/shared lookup="flow/reference/components/otelcol-retry-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-retry-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlphttp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlphttp.md
@@ -79,28 +79,28 @@ Name | Type | Description | Default | Required
 `idle_conn_timeout`  | `duration`    | Time to wait before an idle connection closes itself. | `"90s"` | no
 `auth`               | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests. | | no
 
-{{< docs/shared lookup="flow/reference/components/otelcol-compression-field.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-compression-field.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls block
 
 The `tls` block configures TLS settings used for the connection to the HTTP
 server.
 
-{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### sending_queue block
 
 The `sending_queue` block configures an in-memory buffer of batches before data is sent
 to the HTTP server.
 
-{{< docs/shared lookup="flow/reference/components/otelcol-queue-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-queue-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### retry_on_failure block
 
 The `retry_on_failure` block configures how failed requests to the HTTP server are
 retried.
 
-{{< docs/shared lookup="flow/reference/components/otelcol-retry-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-retry-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/otelcol.extension.jaeger_remote_sampling.md
+++ b/docs/sources/flow/reference/components/otelcol.extension.jaeger_remote_sampling.md
@@ -7,7 +7,7 @@ title: otelcol.extension.jaeger_remote_sampling
 
 # otelcol.extension.jaeger_remote_sampling
 
-{{< docs/shared lookup="flow/stability/experimental.md" source="agent" >}}
+{{< docs/shared lookup="flow/stability/experimental.md" source="agent" version="<AGENT VERSION>" >}}
 
 `otelcol.extension.jaeger_remote_sampling` serves a specified Jaeger remote sampling
 document.
@@ -205,9 +205,9 @@ Name | Type | Description | Default | Required
 `balancer_name` | `string` | Which gRPC client-side load balancer to use for requests. | `pick_first` | no
 `auth` | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests. | | no
 
-{{< docs/shared lookup="flow/reference/components/otelcol-compression-field.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-compression-field.md" source="agent" version="<AGENT VERSION>" >}}
 
-{{< docs/shared lookup="flow/reference/components/otelcol-grpc-balancer-name.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-grpc-balancer-name.md" source="agent" version="<AGENT VERSION>" >}}
 
 An HTTP proxy can be configured through the following environment variables:
 
@@ -236,7 +236,7 @@ able to handle and proxy HTTP/2 traffic.
 The `tls` block configures TLS settings used for the connection to the gRPC
 server.
 
-{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### keepalive client block
 

--- a/docs/sources/flow/reference/components/otelcol.processor.attributes.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.attributes.md
@@ -143,7 +143,7 @@ The supported values for `action` are:
 
 The `include` block provides an option to include data being fed into the [action] blocks based on the properties of a span, log, or metric records.
 
-{{< docs/shared lookup="flow/reference/components/match-properties-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/match-properties-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 One of the following is also required:
 * For spans, one of `services`, `span_names`, `span_kinds`, [attribute][], [resource][], or [library][] must be specified 
@@ -160,7 +160,7 @@ For example, adding a `span_names` filter could cause the component to error if 
 
 The `exclude` block provides an option to exclude data from being fed into the [action] blocks based on the properties of a span, log, or metric records.
 
-{{< docs/shared lookup="flow/reference/components/match-properties-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/match-properties-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 One of the following is also required:
 * For spans, one of `services`, `span_names`, `span_kinds`, [attribute][], [resource][], or [library][] must be specified 
@@ -175,27 +175,27 @@ For example, adding a `span_names` filter could cause the component to error if 
 
 ### regexp block
 
-{{< docs/shared lookup="flow/reference/components/otelcol-filter-regexp-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-filter-regexp-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### attribute block
 
-{{< docs/shared lookup="flow/reference/components/otelcol-filter-attribute-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-filter-attribute-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### resource block
 
-{{< docs/shared lookup="flow/reference/components/otelcol-filter-resource-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-filter-resource-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### library block
 
-{{< docs/shared lookup="flow/reference/components/otelcol-filter-library-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-filter-library-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### log_severity block
 
-{{< docs/shared lookup="flow/reference/components/otelcol-filter-log-severity-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-filter-log-severity-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### output block
 
-{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/otelcol.processor.batch.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.batch.md
@@ -92,7 +92,7 @@ output | [output][] | Configures where to send received telemetry data. | yes
 
 ### output block
 
-{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/otelcol.processor.discovery.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.discovery.md
@@ -74,7 +74,7 @@ output | [output][] | Configures where to send received telemetry data. | yes
 
 ### output block
 
-{{< docs/shared lookup="flow/reference/components/output-block-traces.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/output-block-traces.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/otelcol.processor.memory_limiter.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.memory_limiter.md
@@ -81,7 +81,7 @@ output | [output][] | Configures where to send received telemetry data. | yes
 
 ### output block
 
-{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/otelcol.processor.span.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.span.md
@@ -181,23 +181,23 @@ with a non-empty value for a valid configuration.
 
 ### regexp block
 
-{{< docs/shared lookup="flow/reference/components/otelcol-filter-regexp-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-filter-regexp-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### attribute block
 
-{{< docs/shared lookup="flow/reference/components/otelcol-filter-attribute-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-filter-attribute-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### resource block
 
-{{< docs/shared lookup="flow/reference/components/otelcol-filter-resource-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-filter-resource-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### library block
 
-{{< docs/shared lookup="flow/reference/components/otelcol-filter-library-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-filter-library-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### output block
 
-{{< docs/shared lookup="flow/reference/components/output-block-traces.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/output-block-traces.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/otelcol.processor.tail_sampling.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.tail_sampling.md
@@ -7,7 +7,7 @@ title: otelcol.processor.tail_sampling
 
 # otelcol.processor.tail_sampling
 
-{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT VERSION>" >}}
 
 `otelcol.processor.tail_sampling` samples traces based on a set of defined
 policies. All spans for a given trace *must* be received by the same collector
@@ -302,7 +302,7 @@ Name | Type | Description | Default | Required
 
 ### output block
 
-{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.jaeger.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.jaeger.md
@@ -107,7 +107,7 @@ Name | Type | Description | Default | Required
 The `tls` block configures TLS settings used for a server. If the `tls` block
 isn't provided, TLS won't be used for connections to the server.
 
-{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### keepalive block
 
@@ -215,7 +215,7 @@ Name | Type | Description | Default | Required
 
 ### output block
 
-{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.kafka.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.kafka.md
@@ -154,7 +154,7 @@ The `tls` block configures TLS settings used for connecting to the Kafka
 brokers. If the `tls` block isn't provided, TLS won't be used for
 communication.
 
-{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### kerberos block
 
@@ -251,7 +251,7 @@ has no effect if `after_execution` is `false`.
 
 ### output block
 
-{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.loki.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.loki.md
@@ -7,7 +7,7 @@ title: otelcol.receiver.loki
 
 # otelcol.receiver.loki
 
-{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT VERSION>" >}}
 
 `otelcol.receiver.loki` receives Loki log entries, converts them to the
 OpenTelemetry logs format, and forwards them to other `otelcol.*` components.
@@ -43,7 +43,7 @@ output | [output][] | Configures where to send converted telemetry data. | yes
 
 ### output block
 
-{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.opencensus.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.opencensus.md
@@ -83,7 +83,7 @@ refers to a `tls` block defined inside a `grpc` block.
 The `tls` block configures TLS settings used for a server. If the `tls` block
 isn't provided, TLS won't be used for connections to the server.
 
-{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### keepalive block
 
@@ -123,7 +123,7 @@ Name | Type | Description | Default | Required
 
 ### output block
 
-{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.otlp.md
@@ -171,7 +171,7 @@ If `allowed_headers` includes `"*"`, all headers are permitted.
 
 ### output block
 
-{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.prometheus.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.prometheus.md
@@ -7,7 +7,7 @@ title: otelcol.receiver.prometheus
 
 # otelcol.receiver.prometheus
 
-{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT VERSION>" >}}
 
 `otelcol.receiver.prometheus` receives Prometheus metrics, converts them to the
 OpenTelemetry metrics format, and forwards them to other `otelcol.*`
@@ -44,7 +44,7 @@ output | [output][] | Configures where to send received telemetry data. | yes
 
 ### output block
 
-{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.zipkin.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.zipkin.md
@@ -63,7 +63,7 @@ refers to a `tls` block defined inside a `grpc` block.
 The `tls` block configures TLS settings used for a server. If the `tls` block
 isn't provided, TLS won't be used for connections to the server.
 
-{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### cors block
 
@@ -89,7 +89,7 @@ If `allowed_headers` includes `"*"`, all headers are permitted.
 
 ### output block
 
-{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.apache.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.apache.md
@@ -26,7 +26,7 @@ Name | Type | Description | Default | Required
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.apache.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.apache.md
@@ -26,7 +26,7 @@ Name | Type | Description | Default | Required
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
@@ -59,7 +59,7 @@ Name | Type | Description | Default | Required
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
@@ -59,7 +59,7 @@ Name | Type | Description | Default | Required
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.cloudwatch.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.cloudwatch.md
@@ -325,7 +325,7 @@ is exported to CloudWatch.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.cloudwatch.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.cloudwatch.md
@@ -325,7 +325,7 @@ is exported to CloudWatch.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.consul.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.consul.md
@@ -36,7 +36,7 @@ Name | Type | Description | Default | Required
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.consul.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.consul.md
@@ -36,7 +36,7 @@ Name | Type | Description | Default | Required
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.dnsmasq.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.dnsmasq.md
@@ -26,7 +26,7 @@ Name          | Type     | Description                          | Default       
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.dnsmasq.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.dnsmasq.md
@@ -26,7 +26,7 @@ Name          | Type     | Description                          | Default       
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.elasticsearch.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.elasticsearch.md
@@ -52,7 +52,7 @@ Name | Type | Description | Default | Required
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.elasticsearch.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.elasticsearch.md
@@ -52,7 +52,7 @@ Name | Type | Description | Default | Required
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.gcp.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.gcp.md
@@ -75,7 +75,7 @@ For `ingest_delay`, you can see the values for this in documented metrics as `Af
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.gcp.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.gcp.md
@@ -75,7 +75,7 @@ For `ingest_delay`, you can see the values for this in documented metrics as `Af
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.github.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.github.md
@@ -33,7 +33,7 @@ When provided, `api_token_file` takes precedence over `api_token`.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.github.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.github.md
@@ -33,7 +33,7 @@ When provided, `api_token_file` takes precedence over `api_token`.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.kafka.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.kafka.md
@@ -46,7 +46,7 @@ Omitted fields take their default values.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.kafka.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.kafka.md
@@ -46,7 +46,7 @@ Omitted fields take their default values.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.memcached.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.memcached.md
@@ -32,12 +32,12 @@ tls_config | [tls_config][] | TLS configuration for requests to the Memcached se
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 `prometheus.exporter.memcached` is only reported as unhealthy if given

--- a/docs/sources/flow/reference/components/prometheus.exporter.memcached.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.memcached.md
@@ -37,7 +37,7 @@ tls_config | [tls_config][] | TLS configuration for requests to the Memcached se
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 `prometheus.exporter.memcached` is only reported as unhealthy if given

--- a/docs/sources/flow/reference/components/prometheus.exporter.mongodb.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mongodb.md
@@ -39,7 +39,7 @@ For `tls_basic_auth_config_path`, check [`tls_config`](https://prometheus.io/doc
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.mongodb.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mongodb.md
@@ -39,7 +39,7 @@ For `tls_basic_auth_config_path`, check [`tls_config`](https://prometheus.io/doc
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.mssql.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mssql.md
@@ -42,7 +42,7 @@ fully through arguments.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.mssql.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mssql.md
@@ -42,7 +42,7 @@ fully through arguments.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.mysql.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mysql.md
@@ -139,7 +139,7 @@ The full list of supported collectors is:
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.mysql.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mysql.md
@@ -139,7 +139,7 @@ The full list of supported collectors is:
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.oracledb.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.oracledb.md
@@ -39,7 +39,7 @@ fully through arguments.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.oracledb.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.oracledb.md
@@ -39,7 +39,7 @@ fully through arguments.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.postgres.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.postgres.md
@@ -62,7 +62,7 @@ If `autodiscovery` is disabled, neither `database_allowlist` nor `database_denyl
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.postgres.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.postgres.md
@@ -62,7 +62,7 @@ If `autodiscovery` is disabled, neither `database_allowlist` nor `database_denyl
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.process.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.process.md
@@ -65,7 +65,7 @@ Each regex in `cmdline` must match the corresponding argv for the process to be 
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.process.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.process.md
@@ -65,7 +65,7 @@ Each regex in `cmdline` must match the corresponding argv for the process to be 
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.redis.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.redis.md
@@ -69,7 +69,7 @@ Note that setting `export_client_port` increases the cardinality of all Redis me
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.redis.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.redis.md
@@ -69,7 +69,7 @@ Note that setting `export_client_port` increases the cardinality of all Redis me
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.snmp.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.snmp.md
@@ -77,7 +77,7 @@ Name | Type | Description | Default | Required
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.snmp.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.snmp.md
@@ -77,7 +77,7 @@ Name | Type | Description | Default | Required
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.snowflake.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.snowflake.md
@@ -38,7 +38,7 @@ fully through arguments.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.snowflake.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.snowflake.md
@@ -38,7 +38,7 @@ fully through arguments.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.squid.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.squid.md
@@ -34,7 +34,7 @@ fully through arguments.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.squid.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.squid.md
@@ -34,7 +34,7 @@ fully through arguments.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.statsd.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.statsd.md
@@ -51,7 +51,7 @@ fully through arguments.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.statsd.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.statsd.md
@@ -51,7 +51,7 @@ fully through arguments.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.unix.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.unix.md
@@ -235,7 +235,7 @@ name | type | description | default | required
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.unix.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.unix.md
@@ -235,7 +235,7 @@ name | type | description | default | required
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.windows.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.windows.md
@@ -182,7 +182,7 @@ When `text_file_directory` is set, only files with the extension `.prom` inside 
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.windows.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.windows.md
@@ -182,7 +182,7 @@ When `text_file_directory` is set, only files with the extension `.prom` inside 
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.operator.podmonitors.md
+++ b/docs/sources/flow/reference/components/prometheus.operator.podmonitors.md
@@ -7,7 +7,7 @@ title: prometheus.operator.podmonitors
 
 # prometheus.operator.podmonitors
 
-{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT VERSION>" >}}
 
 `prometheus.operator.podmonitors` discovers [PodMonitor](https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.PodMonitor) resources in your kubernetes cluster and scrapes the targets they reference. This component performs three main functions:
 
@@ -93,23 +93,23 @@ Name | Type | Description | Default | Required
 
 ### basic_auth block
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### authorization block
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### oauth2 block
 
-{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### rule block
 
-{{< docs/shared lookup="flow/reference/components/rule-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/rule-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### selector block
 

--- a/docs/sources/flow/reference/components/prometheus.operator.probes.md
+++ b/docs/sources/flow/reference/components/prometheus.operator.probes.md
@@ -7,7 +7,7 @@ title: prometheus.operator.probes
 
 # prometheus.operator.probes
 
-{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT VERSION>" >}}
 
 `prometheus.operator.probes` discovers [Probe](https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.Probe) resources in your kubernetes cluster and scrapes the targets they reference. This component performs three main functions:
 
@@ -93,23 +93,23 @@ Name | Type | Description | Default | Required
 
 ### basic_auth block
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### authorization block
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### oauth2 block
 
-{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### rule block
 
-{{< docs/shared lookup="flow/reference/components/rule-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/rule-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### selector block
 

--- a/docs/sources/flow/reference/components/prometheus.operator.servicemonitors.md
+++ b/docs/sources/flow/reference/components/prometheus.operator.servicemonitors.md
@@ -7,7 +7,7 @@ title: prometheus.operator.servicemonitors
 
 # prometheus.operator.servicemonitors
 
-{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT VERSION>" >}}
 
 `prometheus.operator.servicemonitors` discovers [ServiceMonitor](https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.ServiceMonitor) resources in your kubernetes cluster and scrapes the targets they reference. This component performs three main functions:
 
@@ -93,23 +93,23 @@ Name | Type | Description | Default | Required
 
 ### basic_auth block
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### authorization block
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### oauth2 block
 
-{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### rule block
 
-{{< docs/shared lookup="flow/reference/components/rule-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/rule-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### selector block
 

--- a/docs/sources/flow/reference/components/prometheus.receive_http.md
+++ b/docs/sources/flow/reference/components/prometheus.receive_http.md
@@ -48,7 +48,7 @@ The following blocks are supported inside the definition of `prometheus.receive_
 
 ### http
 
-{{< docs/shared lookup="flow/reference/components/loki-server-http.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/loki-server-http.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/prometheus.relabel.md
+++ b/docs/sources/flow/reference/components/prometheus.relabel.md
@@ -63,7 +63,7 @@ rule | [rule][] | Relabeling rules to apply to received metrics. | no
 
 ### rule block
 
-{{< docs/shared lookup="flow/reference/components/rule-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/rule-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/prometheus.remote_write.md
+++ b/docs/sources/flow/reference/components/prometheus.remote_write.md
@@ -113,19 +113,19 @@ metrics fails.
 
 ### basic_auth block
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### authorization block
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### oauth2 block
 
-{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### queue_config block
 
@@ -175,7 +175,7 @@ Name | Type | Description | Default | Required
 
 ### write_relabel_config block
 
-{{< docs/shared lookup="flow/reference/components/rule-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/rule-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### wal block
 

--- a/docs/sources/flow/reference/components/prometheus.scrape.md
+++ b/docs/sources/flow/reference/components/prometheus.scrape.md
@@ -94,19 +94,19 @@ an `oauth2` block.
 
 ### basic_auth block
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### authorization block
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### oauth2 block
 
-{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### clustering (beta)
 

--- a/docs/sources/flow/reference/components/pyroscope.ebpf.md
+++ b/docs/sources/flow/reference/components/pyroscope.ebpf.md
@@ -7,7 +7,7 @@ title: pyroscope.ebpf
 
 # pyroscope.ebpf
 
-{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT VERSION>" >}}
 
 `pyroscope.ebpf` configures an ebpf profiling job for the current host. The collected performance profiles are forwarded
 to the list of receivers passed in `forward_to`.

--- a/docs/sources/flow/reference/components/pyroscope.scrape.md
+++ b/docs/sources/flow/reference/components/pyroscope.scrape.md
@@ -7,7 +7,7 @@ title: pyroscope.scrape
 
 # pyroscope.scrape
 
-{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT VERSION>" >}}
 
 `pyroscope.scrape` configures a [pprof] scraping job for a given set of
 `targets`. The scraped performance profiles are forwarded to the list of receivers passed in
@@ -117,19 +117,19 @@ an `oauth2` block.
 
 ### basic_auth block
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### authorization block
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### oauth2 block
 
-{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### profiling_config block
 

--- a/docs/sources/flow/reference/components/pyroscope.write.md
+++ b/docs/sources/flow/reference/components/pyroscope.write.md
@@ -7,7 +7,7 @@ title: pyroscope.write
 
 # pyroscope.write
 
-{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+{{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT VERSION>" >}}
 
 `pyroscope.write` receives performance profiles from other components and forwards them
 to a series of user-supplied endpoints using [Pyroscope' Push API](https://grafana.com/oss/phlare/).
@@ -96,19 +96,19 @@ configured locations.
 
 ### basic_auth block
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### authorization block
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### oauth2 block
 
-{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/remote.http.md
+++ b/docs/sources/flow/reference/components/remote.http.md
@@ -76,34 +76,34 @@ basic_auth` refers to an `basic_auth` block defined inside a `client` block.
 The `client` block configures settings used to connect to the HTTP
 server.
 
-{{< docs/shared lookup="flow/reference/components/http-client-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/http-client-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### basic_auth block
 
 The `basic_auth` block configures basic authentication to use when polling the
 configured URL.
 
-{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### authorization block
 
 The `authorization` block configures custom authorization to use when polling
 the configured URL.
 
-{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### oauth2 block
 
 The `oauth2` block configures OAuth2 authorization to use when polling the
 configured URL.
 
-{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 
 The `tls_config` block configures TLS settings for connecting to HTTPS servers.
 
-{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 


### PR DESCRIPTION
Previously, an empty version was inferred from the relative permalink for the page. Although the behavior was similar to the other version inference done in shortcodes like `docs/reference`, it did not allow specifying an empty version needed to include content from unversioned documentation.

For consistency with other shortcodes like `docs/reference`, the `docs/shared` shortcode version lookup has been replaced with the following behavior:

1. If `version=""`, use an empty version.
1. If `version="<SOMETHING VERSION>`, use version inference as described in https://grafana.com/docs/writers-toolkit/write/shortcodes/#docsreference-shortcode:~:text=The%20path%20to,becomes%20GRAFANA%20CLOUD..
1. If `version="ANYTHING ELSE"`, use that literal value.
