### PR TITLE
Fix comment in remote_write.go

### DIFF
--- a/component/prometheus/remotewrite/remote_write.go
+++ b/component/prometheus/remotewrite/remote_write.go
@@ -193,7 +193,7 @@ func (c *Component) Run(ctx context.Context) error {
 				ts = 0
 			}
 
-			// Network issues can prevent the result of getRemoteWriteTimestamp from
+			// Network issues can prevent the result of LowestSentTimestamp from
 			// changing. We don't want data in the WAL to grow forever, so we set a cap
 			// on the maximum age data can be. If our ts is older than this cutoff point,
 			// we'll shift it forward to start deleting very stale data.


### PR DESCRIPTION
#### PR Description

This comment was copied from `instance.go` where there's `getRemoteWriteTimestamp` function. We don't have in this file, so this PR updates the comment.