### PR TITLE
Label spanmetrics connector as alpha

### DIFF
--- a/docs/sources/flow/reference/components/otelcol.connector.spanmetrics.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.spanmetrics.md
@@ -1,5 +1,7 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.connector.spanmetrics/
+labels:
+  stage: alpha
 title: otelcol.connector.spanmetrics
 ---
 


### PR DESCRIPTION
Apparently the component is labeled as "alpha" on the [OpenTelemetry docs](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector), so it should be labeled as such in the Agent docs too.