### PR TITLE
Clustering: Fall back to localhost if default interfaces not found

### DIFF
--- a/cmd/internal/flowmode/cluster_builder.go
+++ b/cmd/internal/flowmode/cluster_builder.go
@@ -2,7 +2,6 @@ package flowmode
 
 import (
 	"fmt"
-	"github.com/go-kit/log/level"
 	stdlog "log"
 	"net"
 	"os"
@@ -10,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/service/cluster"
 	"github.com/grafana/ckit/advertise"
 	"github.com/hashicorp/go-discover"

--- a/cmd/internal/flowmode/cluster_builder.go
+++ b/cmd/internal/flowmode/cluster_builder.go
@@ -62,8 +62,9 @@ func buildClusterService(opts clusterOptions) (*cluster.Service, error) {
 			if err != nil {
 				level.Warn(opts.Log).Log("msg", "could not find advertise address using default interface names, "+
 					"falling back to localhost", "err", err)
+			} else {
+				advertiseAddress = fmt.Sprintf("%s:%d", addr.String(), listenPort)
 			}
-			advertiseAddress = fmt.Sprintf("%s:%d", addr.String(), listenPort)
 		}
 		config.AdvertiseAddress = advertiseAddress
 	} else {

--- a/service/cluster/cluster.go
+++ b/service/cluster/cluster.go
@@ -123,7 +123,7 @@ func New(opts Options) (*Service, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cluster node: %w", err)
 	}
-	if opts.Metrics != nil {
+	if opts.EnableClustering && opts.Metrics != nil {
 		if err := opts.Metrics.Register(node.Metrics()); err != nil {
 			return nil, fmt.Errorf("failed to register metrics: %w", err)
 		}

--- a/service/cluster/cluster.go
+++ b/service/cluster/cluster.go
@@ -251,7 +251,7 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 		}
 	}
 
-	if s.opts.RejoinInterval > 0 {
+	if s.opts.EnableClustering && s.opts.RejoinInterval > 0 {
 		wg.Add(1)
 
 		go func() {

--- a/service/cluster/cluster.go
+++ b/service/cluster/cluster.go
@@ -239,7 +239,8 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 		return fmt.Errorf("failed to get peers to join: %w", err)
 	}
 
-	level.Info(s.log).Log("msg", "starting cluster node", "peers", peers, "advertise_addr", s.opts.AdvertiseAddress)
+	level.Info(s.log).Log("msg", "starting cluster node", "peers", strings.Join(peers, ","),
+		"advertise_addr", s.opts.AdvertiseAddress)
 
 	if err := s.node.Start(peers); err != nil {
 		level.Warn(s.log).Log("msg", "failed to connect to peers; bootstrapping a new cluster", "err", err)


### PR DESCRIPTION
#### PR Description

* Prevents a failure to start the agent with default config when the machine doesn't have eth0 or en0 interfaces.
* Does not register clustering metrics when clustering is not enabled
* Does not start the rejoining peers goroutine if clustering is not enabled, as it spams logs and uses resources
* Fixes the peers not printing in one log message

Before:
```
$ AGENT_MODE=flow ./grafana-agent-windows-amd64.exe run config.river
ts=2023-08-25T09:06:44.8303801Z level=info boringcryptoenabled=false
Error: determining advertise address: 2 errors occurred:
        * interface "eth0": route ip+net: no such network interface
        * interface "en0": route ip+net: no such network interface

```

After this change - tested different combinations of flags on Windows:
```
$ AGENT_MODE=flow ./grafana-agent-windows-amd64.exe run --cluster.advertise-address 192.168.29.1 config.river
ts=2023-08-25T11:17:54.9041495Z level=info boringcryptoenabled=false
ts=2023-08-25T11:17:54.9053436Z level=info msg="running usage stats reporter"
ts=2023-08-25T11:17:54.9054898Z level=info controller_id= trace_id=a2b05f906bb94ad96f66c03aa3654207 msg="starting complete graph evaluation"
ts=2023-08-25T11:17:54.9054898Z level=info controller_id= trace_id=a2b05f906bb94ad96f66c03aa3654207 msg="finished node evaluation" node_id=tracing duration=0s
ts=2023-08-25T11:17:54.9054898Z level=info controller_id= trace_id=a2b05f906bb94ad96f66c03aa3654207 msg="finished node evaluation" node_id=logging duration=0s
ts=2023-08-25T11:17:54.9054898Z level=info controller_id= trace_id=a2b05f906bb94ad96f66c03aa3654207 msg="finished node evaluation" node_id=http duration=0s
ts=2023-08-25T11:17:54.9054898Z level=info controller_id= trace_id=a2b05f906bb94ad96f66c03aa3654207 msg="finished node evaluation" node_id=cluster duration=0s
ts=2023-08-25T11:17:54.9054898Z level=info controller_id= trace_id=a2b05f906bb94ad96f66c03aa3654207 msg="finished node evaluation" node_id=ui duration=0s
ts=2023-08-25T11:17:54.9054898Z level=info controller_id= trace_id=a2b05f906bb94ad96f66c03aa3654207 msg="finished complete graph evaluation" duration=0s
ts=2023-08-25T11:17:54.9054898Z level=info msg="scheduling loaded components and services"
ts=2023-08-25T11:17:54.9054898Z level=info msg="starting cluster node" peers= advertise_addr=192.168.29.1:12345
ts=2023-08-25T11:17:54.9060687Z level=info msg="peers changed" new_peers=<HOSTNAME>
ts=2023-08-25T11:17:54.9072555Z level=info service=http msg="now listening for http traffic" addr=127.0.0.1:12345
interrupt received
ts=2023-08-25T11:18:03.1908029Z level=error msg="failed to start reporter" err="context canceled"
ts=2023-08-25T11:18:03.1908029Z level=info service=http msg="http server closed" addr=memory err="http: Server closed"
ts=2023-08-25T11:18:03.1908029Z level=info service=http msg="http server closed" addr=127.0.0.1:12345 err="http: Server closed"
```
Advert address provided and cluster enabled
```
$ AGENT_MODE=flow ./grafana-agent-windows-amd64.exe run --cluster.enabled --cluster.advertise-address 192.168.29.1 config.river
ts=2023-08-25T11:18:14.4713485Z level=info boringcryptoenabled=false
ts=2023-08-25T11:18:14.4719352Z level=info msg="running usage stats reporter"
ts=2023-08-25T11:18:14.4725142Z level=info controller_id= trace_id=abbcba47c7181d215986e616f67a2e9b msg="starting complete graph evaluation"
ts=2023-08-25T11:18:14.4725142Z level=info controller_id= trace_id=abbcba47c7181d215986e616f67a2e9b msg="finished node evaluation" node_id=http duration=0s
ts=2023-08-25T11:18:14.4725142Z level=info controller_id= trace_id=abbcba47c7181d215986e616f67a2e9b msg="finished node evaluation" node_id=cluster duration=0s
ts=2023-08-25T11:18:14.4725142Z level=info controller_id= trace_id=abbcba47c7181d215986e616f67a2e9b msg="finished node evaluation" node_id=ui duration=0s
ts=2023-08-25T11:18:14.4725142Z level=info controller_id= trace_id=abbcba47c7181d215986e616f67a2e9b msg="finished node evaluation" node_id=tracing duration=0s
ts=2023-08-25T11:18:14.4725142Z level=info controller_id= trace_id=abbcba47c7181d215986e616f67a2e9b msg="finished node evaluation" node_id=logging duration=0s
ts=2023-08-25T11:18:14.4725142Z level=info controller_id= trace_id=abbcba47c7181d215986e616f67a2e9b msg="finished complete graph evaluation" duration=0s
ts=2023-08-25T11:18:14.4725142Z level=info msg="scheduling loaded components and services"
ts=2023-08-25T11:18:14.4741958Z level=info service=http msg="now listening for http traffic" addr=127.0.0.1:12345
ts=2023-08-25T11:18:15.4842252Z level=info msg="starting cluster node" peers= advertise_addr=192.168.29.1:12345
ts=2023-08-25T11:18:15.4842252Z level=info msg="peers changed" new_peers=<HOSTNAME>
interrupt received
ts=2023-08-25T11:18:31.8859563Z level=error msg="failed to start reporter" err="context canceled"
ts=2023-08-25T11:18:31.8869413Z level=info service=http msg="http server closed" addr=memory err="http: Server closed"
ts=2023-08-25T11:18:31.8869413Z level=info service=http msg="http server closed" addr=127.0.0.1:12345 err="http: Server closed"
```
Advert address provided
```
$ AGENT_MODE=flow ./grafana-agent-windows-amd64.exe run --cluster.advertise-address 192.168.29.1 config.river
ts=2023-08-25T11:18:39.4608063Z level=info boringcryptoenabled=false
ts=2023-08-25T11:18:39.46137Z level=info msg="running usage stats reporter"
ts=2023-08-25T11:18:39.4619342Z level=info controller_id= trace_id=bdb9822bc873ac51f8dcd25ca1454d20 msg="starting complete graph evaluation"
ts=2023-08-25T11:18:39.4619342Z level=info controller_id= trace_id=bdb9822bc873ac51f8dcd25ca1454d20 msg="finished node evaluation" node_id=logging duration=0s
ts=2023-08-25T11:18:39.4619342Z level=info controller_id= trace_id=bdb9822bc873ac51f8dcd25ca1454d20 msg="finished node evaluation" node_id=http duration=0s
ts=2023-08-25T11:18:39.4619342Z level=info controller_id= trace_id=bdb9822bc873ac51f8dcd25ca1454d20 msg="finished node evaluation" node_id=ui duration=0s
ts=2023-08-25T11:18:39.4619342Z level=info controller_id= trace_id=bdb9822bc873ac51f8dcd25ca1454d20 msg="finished node evaluation" node_id=cluster duration=0s
ts=2023-08-25T11:18:39.4619342Z level=info controller_id= trace_id=bdb9822bc873ac51f8dcd25ca1454d20 msg="finished node evaluation" node_id=tracing duration=0s
ts=2023-08-25T11:18:39.4619342Z level=info controller_id= trace_id=bdb9822bc873ac51f8dcd25ca1454d20 msg="finished complete graph evaluation" duration=564.2µs
ts=2023-08-25T11:18:39.4619342Z level=info msg="scheduling loaded components and services"
ts=2023-08-25T11:18:39.4619342Z level=info msg="starting cluster node" peers= advertise_addr=192.168.29.1:12345
ts=2023-08-25T11:18:39.4619342Z level=info msg="peers changed" new_peers=<HOSTNAME>
ts=2023-08-25T11:18:39.4619342Z level=info msg="peers changed" new_peers=<HOSTNAME>
ts=2023-08-25T11:18:39.4635584Z level=info service=http msg="now listening for http traffic" addr=127.0.0.1:12345
interrupt received
ts=2023-08-25T11:18:51.9448291Z level=error msg="failed to start reporter" err="context canceled"
ts=2023-08-25T11:18:51.9448291Z level=info service=http msg="http server closed" addr=memory err="http: Server closed"
ts=2023-08-25T11:18:51.9448291Z level=info service=http msg="http server closed" addr=127.0.0.1:12345 err="http: Server closed"
```
Clustering enabled
```
$ AGENT_MODE=flow ./grafana-agent-windows-amd64.exe run --cluster.enabled config.river                  ts=2023-08-25T11:19:05.5719944Z level=info boringcryptoenabled=false
ts=2023-08-25T11:19:05.5778243Z level=warn msg="could not find advertise address using default interface names, falling back to localhost" err="2 errors occurred:\n\t* interface \"eth0\": route ip+net: no such network interface\n\t* interface \"en0\": route ip+net: no such network interface\n\n"
ts=2023-08-25T11:19:05.5788759Z level=info msg="running usage stats reporter"
ts=2023-08-25T11:19:05.5789069Z level=info controller_id= trace_id=e7c450eb138ec54e99858b5ba6872a03 msg="starting complete graph evaluation"
ts=2023-08-25T11:19:05.5789069Z level=info controller_id= trace_id=e7c450eb138ec54e99858b5ba6872a03 msg="finished node evaluation" node_id=http duration=0s
ts=2023-08-25T11:19:05.5789069Z level=info controller_id= trace_id=e7c450eb138ec54e99858b5ba6872a03 msg="finished node evaluation" node_id=cluster duration=0s
ts=2023-08-25T11:19:05.5789069Z level=info controller_id= trace_id=e7c450eb138ec54e99858b5ba6872a03 msg="finished node evaluation" node_id=ui duration=0s
ts=2023-08-25T11:19:05.5789069Z level=info controller_id= trace_id=e7c450eb138ec54e99858b5ba6872a03 msg="finished node evaluation" node_id=tracing duration=0s
ts=2023-08-25T11:19:05.5789069Z level=info controller_id= trace_id=e7c450eb138ec54e99858b5ba6872a03 msg="finished node evaluation" node_id=logging duration=0s
ts=2023-08-25T11:19:05.5789069Z level=info controller_id= trace_id=e7c450eb138ec54e99858b5ba6872a03 msg="finished complete graph evaluation" duration=0s
ts=2023-08-25T11:19:05.5789069Z level=info msg="scheduling loaded components and services"
ts=2023-08-25T11:19:05.580535Z level=info service=http msg="now listening for http traffic" addr=127.0.0.1:12345
ts=2023-08-25T11:19:06.589811Z level=info msg="starting cluster node" peers= advertise_addr=127.0.0.1:12345
ts=2023-08-25T11:19:06.589811Z level=info msg="peers changed" new_peers=<HOSTNAME>
interrupt received
ts=2023-08-25T11:19:09.7664295Z level=error msg="failed to start reporter" err="context canceled"
ts=2023-08-25T11:19:09.7664295Z level=info service=http msg="http server closed" addr=memory err="http: Server closed"
ts=2023-08-25T11:19:09.7664295Z level=info service=http msg="http server closed" addr=127.0.0.1:12345 err="http: Server closed"
```
Default config
```
$ AGENT_MODE=flow ./grafana-agent-windows-amd64.exe run config.river
ts=2023-08-25T11:19:15.1164515Z level=info boringcryptoenabled=false
ts=2023-08-25T11:19:15.1170089Z level=info msg="running usage stats reporter"
ts=2023-08-25T11:19:15.1175701Z level=info controller_id= trace_id=fe37c766e2d177bf11be9f8f6b9d52de msg="starting complete graph evaluation"
ts=2023-08-25T11:19:15.1175701Z level=info controller_id= trace_id=fe37c766e2d177bf11be9f8f6b9d52de msg="finished node evaluation" node_id=tracing duration=0s
ts=2023-08-25T11:19:15.1175701Z level=info controller_id= trace_id=fe37c766e2d177bf11be9f8f6b9d52de msg="finished node evaluation" node_id=logging duration=0s
ts=2023-08-25T11:19:15.1175701Z level=info controller_id= trace_id=fe37c766e2d177bf11be9f8f6b9d52de msg="finished node evaluation" node_id=http duration=0s
ts=2023-08-25T11:19:15.1175701Z level=info controller_id= trace_id=fe37c766e2d177bf11be9f8f6b9d52de msg="finished node evaluation" node_id=cluster duration=0s
ts=2023-08-25T11:19:15.1175701Z level=info controller_id= trace_id=fe37c766e2d177bf11be9f8f6b9d52de msg="finished node evaluation" node_id=ui duration=0s
ts=2023-08-25T11:19:15.1175701Z level=info controller_id= trace_id=fe37c766e2d177bf11be9f8f6b9d52de msg="finished complete graph evaluation" duration=561.2µs
ts=2023-08-25T11:19:15.1175701Z level=info msg="scheduling loaded components and services"
ts=2023-08-25T11:19:15.1175701Z level=info msg="starting cluster node" peers= advertise_addr=127.0.0.1:12345
ts=2023-08-25T11:19:15.1175701Z level=info msg="peers changed" new_peers=<HOSTNAME>
ts=2023-08-25T11:19:15.1175701Z level=info msg="peers changed" new_peers=<HOSTNAME>
ts=2023-08-25T11:19:15.1181391Z level=info service=http msg="now listening for http traffic" addr=127.0.0.1:12345
interrupt received
ts=2023-08-25T11:19:19.3906814Z level=error msg="failed to start reporter" err="context canceled"
ts=2023-08-25T11:19:19.3906814Z level=info service=http msg="http server closed" addr=127.0.0.1:12345 err="http: Server closed"
ts=2023-08-25T11:19:19.3906814Z level=info service=http msg="http server closed" addr=memory err="http: Server closed"
```

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated