### PR TITLE
Update the otelcol.processor.span stability to alpha

### DIFF
--- a/docs/sources/flow/reference/components/otelcol.processor.span.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.span.md
@@ -1,5 +1,7 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.span/
+labels:
+  stage: alpha
 title: otelcol.processor.span
 ---
 


### PR DESCRIPTION
The span processor's stability is [labeled](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/processor/spanprocessor) as "alpha". Our docs should match that.