### PR TITLE
Label the stability of otelcol flow components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Main (unreleased)
   - `otelcol.connector.spanlogs` - creates logs from spans. It is the flow mode equivalent 
   to static mode's `automatic_logging` processor. (@ptodev)
 
+### Enhancements
+
+- Label the stability of most `otelcol` flow components in the Agent documentation.
+
 v0.36.0-rc.0 (2023-08-25)
 --------------------
 

--- a/docs/sources/flow/reference/components/otelcol.auth.basic.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.basic.md
@@ -1,5 +1,7 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.auth.basic/
+labels:
+  stage: beta
 title: otelcol.auth.basic
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.auth.bearer.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.bearer.md
@@ -1,5 +1,7 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.auth.bearer/
+labels:
+  stage: beta
 title: otelcol.auth.bearer
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.auth.headers.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.headers.md
@@ -1,5 +1,7 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.auth.headers/
+labels:
+  stage: experimental
 title: otelcol.auth.headers
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
@@ -1,5 +1,7 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.auth.oauth2/
+labels:
+  stage: beta
 title: otelcol.auth.oauth2
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.auth.sigv4.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.sigv4.md
@@ -1,5 +1,7 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.auth.sigv4/
+labels:
+  stage: beta
 title: otelcol.auth.sigv4
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.connector.spanlogs.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.spanlogs.md
@@ -1,5 +1,7 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.connector.spanlogs/
+labels:
+  stage: experimental
 title: otelcol.connector.spanlogs
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.connector.spanmetrics.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.spanmetrics.md
@@ -1,7 +1,7 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.connector.spanmetrics/
 labels:
-  stage: alpha
+  stage: experimental
 title: otelcol.connector.spanmetrics
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.jaeger.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.jaeger.md
@@ -1,5 +1,7 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.jaeger/
+labels:
+  stage: deprecated
 title: otelcol.exporter.jaeger
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.logging.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.logging.md
@@ -1,5 +1,7 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.logging/
+labels:
+  stage: experimental
 title: otelcol.exporter.logging
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.loki.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.loki.md
@@ -1,5 +1,7 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.loki/
+labels:
+  stage: beta
 title: otelcol.exporter.loki
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
@@ -1,5 +1,9 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.otlp/
+labels:
+  stage (metrics): stable
+  stage (traces): stable
+  stage (logs): beta
 title: otelcol.exporter.otlp
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlphttp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlphttp.md
@@ -1,5 +1,9 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.otlphttp/
+labels:
+  stage (metrics): stable
+  stage (traces): stable
+  stage (logs): beta
 title: otelcol.exporter.otlphttp
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.processor.attributes.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.attributes.md
@@ -1,5 +1,7 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.attributes/
+labels:
+  stage: beta
 title: otelcol.processor.attributes
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.processor.batch.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.batch.md
@@ -1,5 +1,7 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.batch/
+labels:
+  stage: beta
 title: otelcol.processor.batch
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.processor.discovery.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.discovery.md
@@ -1,5 +1,7 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.discovery/
+labels:
+  stage: beta
 title: otelcol.processor.discovery
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.processor.memory_limiter.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.memory_limiter.md
@@ -1,5 +1,7 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.memory_limiter/
+labels:
+  stage: beta
 title: otelcol.processor.memory_limiter
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.processor.span.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.span.md
@@ -1,7 +1,7 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.span/
 labels:
-  stage: alpha
+  stage: experimental
 title: otelcol.processor.span
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.jaeger.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.jaeger.md
@@ -1,5 +1,7 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.receiver.jaeger/
+labels:
+  stage: beta
 title: otelcol.receiver.jaeger
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.kafka.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.kafka.md
@@ -1,5 +1,7 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.receiver.kafka/
+labels:
+  stage: beta
 title: otelcol.receiver.kafka
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.opencensus.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.opencensus.md
@@ -1,5 +1,7 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.receiver.opencensus/
+labels:
+  stage: beta
 title: otelcol.receiver.opencensus
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.otlp.md
@@ -1,5 +1,9 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.receiver.otlp/
+labels:
+  stage (metrics): stable
+  stage (traces): stable
+  stage (logs): beta
 title: otelcol.receiver.otlp
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.receiver.zipkin.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.zipkin.md
@@ -1,5 +1,7 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.receiver.zipkin/
+labels:
+  stage: beta
 title: otelcol.receiver.zipkin
 ---
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

The stability level of otelcol components was not always present in the Agent docs. I updated them to match the stability indicated in the otel docs. However, a few things are not very clear:

* We [don't have](https://grafana.com/docs/agent/latest/stability/) a "deprecated" stability level. How should we label `otelcol.exporter.jaeger`?
* How should we label components with different stabilities for different signals (e.g. `otelcol.exporter.otlp`)?
* Would it be better to link to the Agent's stability page, simiarly to how Otel does it? E.g. in the [basic auth extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/basicauthextension#basic-authenticator), otel links to  [beta](https://github.com/open-telemetry/opentelemetry-collector#beta) stability description. Our links would go to [experimental](https://grafana.com/docs/agent/latest/stability/#experimental), [beta](https://grafana.com/docs/agent/latest/stability/#beta) and [stable](https://grafana.com/docs/agent/latest/stability/#stable). Personally, I think having the links is nice.

Links to otel docs:

- [basicauthextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/extension/basicauthextension)
- [bearertokenauthextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/extension/bearertokenauthextension)
- [headerssetterextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/extension/headerssetterextension)
- [oauth2clientauthextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/extension/oauth2clientauthextension)
- [sigv4authextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/extension/sigv4authextension)
- [spanmetricsconnector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/connector/spanmetricsconnector)
- [jaegerexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/exporter/jaegerexporter)
- [loggingexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.80.0/exporter/loggingexporter)
- [lokiexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/exporter/lokiexporter)
- [otlpexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.80.0/exporter/otlpexporter)
- [otlphttpexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.80.0/exporter/otlphttpexporter)
- [attributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/processor/attributesprocessor)
- [batchprocessor](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.80.0/processor/batchprocessor)
- [memorylimiterprocessor](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.80.0/processor/memorylimiterprocessor)
- [spanprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/processor/spanprocessor)
- [jaegerreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/receiver/jaegerreceiver)
- [kafkareceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/receiver/kafkareceiver)
- [opencensusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/receiver/opencensusreceiver)
- [otlpreceiver](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.80.0/receiver/otlpreceiver)
- [zipkinreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/receiver/zipkinreceiver)

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated