### PR TITLE
drone: include gcr registry credentials (#4962)

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1321,6 +1321,8 @@ depends_on:
 - Publish Linux crow container
 - Publish Windows agent container
 - Publish Windows agentctl container
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: Publish release
 platform:
@@ -1476,6 +1478,6 @@ kind: secret
 name: updater_private_key
 ---
 kind: signature
-hmac: 4e46433a52fe5de7de0667c779539a2da5ffcf28bea4b357c5e9e8feda8e9fd7
+hmac: e909f33b560fd51cd1ad3c5a37e124afef335fe064f5c78a985b3f7bdd816859
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1478,6 +1478,6 @@ kind: secret
 name: updater_private_key
 ---
 kind: signature
-hmac: e909f33b560fd51cd1ad3c5a37e124afef335fe064f5c78a985b3f7bdd816859
+hmac: bbc1b5483052b9570167f52dcc1b17fe17c1a0ab2f0e81f27e540e1e7a6689e3
 
 ...

--- a/.drone/pipelines/publish.jsonnet
+++ b/.drone/pipelines/publish.jsonnet
@@ -152,6 +152,7 @@ linux_containers_jobs + windows_containers_jobs + [
       ref: ['refs/tags/v*'],
     },
     depends_on: job_names(linux_containers_jobs + windows_containers_jobs),
+    image_pull_secrets: ['dockerconfigjson'],
     steps: [
       {
         name: 'Generate GitHub token',


### PR DESCRIPTION
After verifying that the custom image works and allows releases to be published using a GitHub token, I'm bringing the change back to `main` to be available for future releases.