### PR TITLE
Update version string everywhere for v0.36.0-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,7 @@ Main (unreleased)
 
 - Use Go 1.21.0 for builds. (@rfratto)
 
-v0.36.0-rc.1 (2023-08-28)
---------------------
-
-### Bugfixes
-
-- Fix GitHub authentication on Drone pipeline.
-
-v0.36.0-rc.0 (2023-08-25)
+v0.36.0-rc.3 (2023-08-28)
 --------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries

--- a/docs/sources/operator/deploy-agent-operator-resources.md
+++ b/docs/sources/operator/deploy-agent-operator-resources.md
@@ -58,7 +58,7 @@ To deploy the `GrafanaAgent` resource:
       labels:
         app: grafana-agent
     spec:
-      image: grafana/agent:v0.36.0-rc.1
+      image: grafana/agent:v0.36.0-rc.3
       integrations:
         selector:
           matchLabels:

--- a/docs/sources/operator/getting-started.md
+++ b/docs/sources/operator/getting-started.md
@@ -74,7 +74,7 @@ To install Agent Operator:
           serviceAccountName: grafana-agent-operator
           containers:
           - name: operator
-            image: grafana/agent-operator:v0.36.0-rc.1
+            image: grafana/agent-operator:v0.36.0-rc.3
             args:
             - --kubelet-service=default/kubelet
     ---

--- a/docs/sources/static/configuration/integrations/node-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/node-exporter-config.md
@@ -29,7 +29,7 @@ docker run \
   -v "/proc:/host/proc:ro,rslave" \
   -v /tmp/agent:/etc/agent \
   -v /path/to/config.yaml:/etc/agent-config/agent.yaml \
-  grafana/agent:v0.36.0-rc.1 \
+  grafana/agent:v0.36.0-rc.3 \
   --config.file=/etc/agent-config/agent.yaml
 ```
 
@@ -69,7 +69,7 @@ metadata:
   name: agent
 spec:
   containers:
-  - image: grafana/agent:v0.36.0-rc.1
+  - image: grafana/agent:v0.36.0-rc.3
     name: agent
     args:
     - --config.file=/etc/agent-config/agent.yaml

--- a/docs/sources/static/configuration/integrations/process-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/process-exporter-config.md
@@ -21,7 +21,7 @@ docker run \
   -v "/proc:/proc:ro" \
   -v /tmp/agent:/etc/agent \
   -v /path/to/config.yaml:/etc/agent-config/agent.yaml \
-  grafana/agent:v0.36.0-rc.1 \
+  grafana/agent:v0.36.0-rc.3 \
   --config.file=/etc/agent-config/agent.yaml
 ```
 
@@ -38,7 +38,7 @@ metadata:
   name: agent
 spec:
   containers:
-  - image: grafana/agent:v0.36.0-rc.1
+  - image: grafana/agent:v0.36.0-rc.3
     name: agent
     args:
     - --config.file=/etc/agent-config/agent.yaml

--- a/docs/sources/static/set-up/install/install-agent-docker.md
+++ b/docs/sources/static/set-up/install/install-agent-docker.md
@@ -33,7 +33,7 @@ To run a Grafana Agent Docker container on Linux, run the following command in a
 docker run \
   -v WAL_DATA_DIRECTORY:/etc/agent/data \
   -v CONFIG_FILE_PATH:/etc/agent/agent.yaml \
-  grafana/agent:v0.36.0-rc.1
+  grafana/agent:v0.36.0-rc.3
 ```
 
 Replace `CONFIG_FILE_PATH` with the configuration file path on your Linux host system.
@@ -50,7 +50,7 @@ To run a Grafana Agent Docker container on Windows, run the following command in
 docker run ^
   -v WAL_DATA_DIRECTORY:C:\etc\grafana-agent\data ^
   -v CONFIG_FILE_PATH:C:\etc\grafana-agent ^
-  grafana/agent:v0.36.0-rc.1-windows
+  grafana/agent:v0.36.0-rc.3-windows
 ```
 
 Replace the following:

--- a/pkg/operator/defaults.go
+++ b/pkg/operator/defaults.go
@@ -2,7 +2,7 @@ package operator
 
 // Supported versions of the Grafana Agent.
 var (
-	DefaultAgentVersion   = "v0.36.0-rc.1"
+	DefaultAgentVersion   = "v0.36.0-rc.3"
 	DefaultAgentBaseImage = "grafana/agent"
 	DefaultAgentImage     = DefaultAgentBaseImage + ":" + DefaultAgentVersion
 )

--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -83,7 +83,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.36.0-rc.1
+        image: grafana/agent:v0.36.0-rc.3
         imagePullPolicy: IfNotPresent
         name: grafana-agent
         ports:

--- a/production/kubernetes/agent-loki.yaml
+++ b/production/kubernetes/agent-loki.yaml
@@ -65,7 +65,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.36.0-rc.1
+        image: grafana/agent:v0.36.0-rc.3
         imagePullPolicy: IfNotPresent
         name: grafana-agent-logs
         ports:

--- a/production/kubernetes/agent-traces.yaml
+++ b/production/kubernetes/agent-traces.yaml
@@ -114,7 +114,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: grafana/agent:v0.36.0-rc.1
+        image: grafana/agent:v0.36.0-rc.3
         imagePullPolicy: IfNotPresent
         name: grafana-agent-traces
         ports:

--- a/production/kubernetes/build/lib/version.libsonnet
+++ b/production/kubernetes/build/lib/version.libsonnet
@@ -1,1 +1,1 @@
-'grafana/agent:v0.36.0-rc.1'
+'grafana/agent:v0.36.0-rc.3'

--- a/production/kubernetes/build/templates/operator/main.jsonnet
+++ b/production/kubernetes/build/templates/operator/main.jsonnet
@@ -23,8 +23,8 @@ local ksm = import 'kube-state-metrics/kube-state-metrics.libsonnet';
   local this = self,
 
   _images:: {
-    agent: 'grafana/agent:v0.36.0-rc.1',
-    agent_operator: 'grafana/agent-operator:v0.36.0-rc.1',
+    agent: 'grafana/agent:v0.36.0-rc.3',
+    agent_operator: 'grafana/agent-operator:v0.36.0-rc.3',
     ksm: 'registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0',
   },
 

--- a/production/kubernetes/install-bare.sh
+++ b/production/kubernetes/install-bare.sh
@@ -25,7 +25,7 @@ check_installed() {
 check_installed curl
 check_installed envsubst
 
-MANIFEST_BRANCH=v0.36.0-rc.1
+MANIFEST_BRANCH=v0.36.0-rc.3
 MANIFEST_URL=${MANIFEST_URL:-https://raw.githubusercontent.com/grafana/agent/${MANIFEST_BRANCH}/production/kubernetes/agent-bare.yaml}
 NAMESPACE=${NAMESPACE:-default}
 

--- a/production/operator/templates/agent-operator.yaml
+++ b/production/operator/templates/agent-operator.yaml
@@ -372,7 +372,7 @@ spec:
       containers:
       - args:
         - --kubelet-service=default/kubelet
-        image: grafana/agent-operator:v0.36.0-rc.1
+        image: grafana/agent-operator:v0.36.0-rc.3
         imagePullPolicy: IfNotPresent
         name: grafana-agent-operator
       serviceAccount: grafana-agent-operator
@@ -436,7 +436,7 @@ metadata:
   name: grafana-agent
   namespace: ${NAMESPACE}
 spec:
-  image: grafana/agent:v0.36.0-rc.1
+  image: grafana/agent:v0.36.0-rc.3
   integrations:
     selector:
       matchLabels:

--- a/production/tanka/grafana-agent/v1/main.libsonnet
+++ b/production/tanka/grafana-agent/v1/main.libsonnet
@@ -15,8 +15,8 @@ local service = k.core.v1.service;
 (import './lib/traces.libsonnet') +
 {
   _images:: {
-    agent: 'grafana/agent:v0.36.0-rc.1',
-    agentctl: 'grafana/agentctl:v0.36.0-rc.1',
+    agent: 'grafana/agent:v0.36.0-rc.3',
+    agentctl: 'grafana/agentctl:v0.36.0-rc.3',
   },
 
   // new creates a new DaemonSet deployment of the grafana-agent. By default,

--- a/production/tanka/grafana-agent/v2/internal/base.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/base.libsonnet
@@ -11,8 +11,8 @@ function(name='grafana-agent', namespace='') {
   local this = self,
 
   _images:: {
-    agent: 'grafana/agent:v0.36.0-rc.1',
-    agentctl: 'grafana/agentctl:v0.36.0-rc.1',
+    agent: 'grafana/agent:v0.36.0-rc.3',
+    agentctl: 'grafana/agentctl:v0.36.0-rc.3',
   },
   _config:: {
     name: name,

--- a/production/tanka/grafana-agent/v2/internal/syncer.libsonnet
+++ b/production/tanka/grafana-agent/v2/internal/syncer.libsonnet
@@ -14,7 +14,7 @@ function(
 ) {
   local _config = {
     api: error 'api must be set',
-    image: 'grafana/agentctl:v0.36.0-rc.1',
+    image: 'grafana/agentctl:v0.36.0-rc.3',
     schedule: '*/5 * * * *',
     configs: [],
   } + config,


### PR DESCRIPTION
Update version references for v0.36.0-rc.3

We're skipping over rc.2 as the tag was used to verify that the drone pipeline changes were working properly prior to updating code references.