### PR TITLE
Fix elasticsearch flow component usage example

### DIFF
--- a/docs/sources/flow/reference/components/prometheus.exporter.elasticsearch.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.elasticsearch.md
@@ -77,14 +77,29 @@ from `prometheus.exporter.elasticsearch`:
 
 ```river
 prometheus.exporter.elasticsearch "example" {
-  address = "localhost:9200"
+  address = "http://localhost:9200"
 }
 
 // Configure a prometheus.scrape component to collect Elasticsearch metrics.
 prometheus.scrape "demo" {
   targets    = prometheus.exporter.elasticsearch.example.targets
-  forward_to = [ /* ... */ ]
+  forward_to = [prometheus.remote_write.demo.receiver]
+}
+
+prometheus.remote_write "demo" {
+  endpoint {
+    url = PROMETHEUS_REMOTE_WRITE_URL
+
+    basic_auth {
+      username = USERNAME
+      password = PASSWORD
+    }
+  }
 }
 ```
+Replace the following:
+  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+  - `USERNAME`: The username to use for authentication to the remote_write API.
+  - `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}


### PR DESCRIPTION
#### PR Description

`address` field for Elasticsearch component needs to have `http` as prefix, otherwise
doesn't work. This PR fixes the usage  example in the docs of the flow component.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated