### PR TITLE
Re-enable stale bot (without closing issues or PRs)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           close-issue-reason: not_planned
           days-before-stale: 30
-          days-before-close: -1
+          days-before-close: -1 # never close automatically
           stale-issue-message: >
             This issue has been automatically marked as stale because it has
             not had any activity in the past 30 days. The issue will not be closed

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,9 +21,9 @@ jobs:
             automatically, but a label will be added to it for tracking purposes.
 
             
-            If the opened issue is a bug, check if newer versions of the Agent have
-            fixed the issue. If it is not, please let us know is this issue is still
-            relevant otherwise, feel free to close it.
+            If the opened issue is a bug, check if newer releases have fixed the 
+            issue. If the issue is no longer relevant, please feel free to close 
+            it.
 
             Thank you for your contributions!
           stale-pr-message: >

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -31,8 +31,8 @@ jobs:
             had any activity in the past 30 days. The PR will not be closed
             automatically, but a label will be added to it for tracking purposes.
 
-            If you do not have enough time to follow up on this PR or you think its is 
-            no long relevant, consider closing it and let us know.
+            If you do not have enough time to follow up on this PR or you think it's  
+            no longer relevant, consider closing it.
 
             Thank you for your contributions!
           stale-issue-label: stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v6.0.0
+      - uses: actions/stale@v8
         with:
           close-issue-reason: not_planned
           days-before-stale: 30

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,8 @@ jobs:
           days-before-close: -1
           stale-issue-message: >
             This issue has been automatically marked as stale because it has
-            not had any activity in the past 30 days.
+            not had any activity in the past 30 days. The issue will not be closed
+            automatically, but a label will be added to it for tracking purposes.
 
             
             If the opened issue is a bug, check if newer versions of the Agent have
@@ -27,11 +28,11 @@ jobs:
             Thank you for your contributions!
           stale-pr-message: >
             This PR has been automatically marked as stale because it has not
-            had any activity in the past 30 days.
+            had any activity in the past 30 days. The PR will not be closed
+            automatically, but a label will be added to it for tracking purposes.
 
-            If the PR could not move forward because it has not enough reviewers, please ping
-            the maintainers in order to get more reviews. If you do not have enough
-            time to follow up on this PR, consider closing it and let us know.
+            If you do not have enough time to follow up on this PR or you think its is 
+            no long relevant, consider closing it and let us know.
 
             Thank you for your contributions!
           stale-issue-label: stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,39 @@
+name: Stale check
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 0 * * *'
+permissions:
+  issues: write
+  pull-requests: write
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v6.0.0
+        with:
+          close-issue-reason: not_planned
+          days-before-stale: 30
+          days-before-close: -1
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has
+            not had any activity in the past 30 days.
+
+            
+            If the opened issue is a bug, check if newer versions of the Agent have
+            fixed the issue.
+
+            Thank you for your contributions!
+          stale-pr-message: >
+            This PR has been automatically marked as stale because it has not
+            had any activity in the past 30 days.
+
+            If the PR could not move forward because it has not enough reviewers, please ping
+            the maintainers in order to get more reviews. If you do not have enough
+            time to follow up on this PR, consider closing it and let us know.
+
+            Thank you for your contributions!
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: keepalive,proposal,outdated-dependency,dev-branch
+          exempt-pr-labels: keepalive,proposal,outdated-dependency,dev-branch

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,7 +21,8 @@ jobs:
 
             
             If the opened issue is a bug, check if newer versions of the Agent have
-            fixed the issue.
+            fixed the issue. If it is not, please let us know is this issue is still
+            relevant otherwise, feel free to close it.
 
             Thank you for your contributions!
           stale-pr-message: >


### PR DESCRIPTION
#### PR Description

This PR re-enables stale bot but without closing issues or PR marked
as stale. This would help us to identify if we have to follow up on issues or
PR and help contributors to follow up on opened issues or PR.