### PR TITLE
chore: add contextual attributes to faro measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,14 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
-Main (unreleased)
------------------
+## Main (unreleased)
 
 ### Features
 
 - New Grafana Agent Flow components:
 
   - `otelcol.connector.spanlogs` - creates logs from spans. It is the flow mode equivalent
-  to static mode's `automatic_logging` processor. (@ptodev)
+    to static mode's `automatic_logging` processor. (@ptodev)
 
 - Flow: allow the HTTP server to be configured with TLS in the config file
   using the new `http` config block. (@rfratto)
@@ -23,9 +22,9 @@ Main (unreleased)
 ### Other changes
 
 - Use Go 1.21.0 for builds. (@rfratto)
+- Read contextual attributes from Faro measurements (@codecapitano)
 
-v0.36.0-rc.3 (2023-08-28)
---------------------
+## v0.36.0-rc.3 (2023-08-28)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -48,7 +47,7 @@ v0.36.0-rc.3 (2023-08-28)
 - Add [godeltaprof](https://github.com/grafana/godeltaprof) profiling types (`godeltaprof_memory`, `godeltaprof_mutex`, `godeltaprof_block`) to `pyroscope.scrape` component
 
 - Flow: Allow the `logging` configuration block to tee the Agent's logs to one
-  or more loki.* components. (@tpaschalis)
+  or more loki.\* components. (@tpaschalis)
 
 - Added support for `promtail` configuration conversion in `grafana-agent convert` and `grafana-agent run` commands. (@thampiotr)
 
@@ -154,8 +153,7 @@ v0.36.0-rc.3 (2023-08-28)
 
 - Agent Management: Fix issue where an integration defined multiple times could lead to undefined behaviour. (@jcreixell)
 
-v0.35.4 (2023-08-14)
---------------------
+## v0.35.4 (2023-08-14)
 
 ### Bugfixes
 
@@ -165,8 +163,7 @@ v0.35.4 (2023-08-14)
 
 - Clarify usage documentation surrounding `loki.source.file` (@joshuapare)
 
-v0.35.3 (2023-08-09)
---------------------
+## v0.35.3 (2023-08-09)
 
 ### Bugfixes
 
@@ -183,8 +180,7 @@ v0.35.3 (2023-08-09)
 - Fix graceful termination when receiving SIGTERM/CTRL_SHUTDOWN_EVENT
   signals. (@tpaschalis)
 
-v0.35.2 (2023-07-27)
---------------------
+## v0.35.2 (2023-07-27)
 
 ### Bugfixes
 
@@ -207,8 +203,7 @@ v0.35.2 (2023-07-27)
   `grafana-agentctl test-logs` functions as expected when testing tailing the
   systemd journal. (@rfratto)
 
-v0.35.1 (2023-07-25)
---------------------
+## v0.35.1 (2023-07-25)
 
 ### Bugfixes
 
@@ -216,8 +211,7 @@ v0.35.1 (2023-07-25)
   Users of the static mode's service graph processor are also advised to upgrade,
   although the bug should theoretically not affect them. (@ptodev)
 
-v0.35.0 (2023-07-18)
---------------------
+## v0.35.0 (2023-07-18)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -243,7 +237,9 @@ v0.35.0 (2023-07-18)
   (@rfratto)
 
 - In the traces subsystem for Static mode, some metrics are removed and others are renamed. (@ptodev)
+
   - Removed metrics:
+
     - "blackbox_exporter_config_last_reload_success_timestamp_seconds" (gauge)
     - "blackbox_exporter_config_last_reload_successful" (gauge)
     - "blackbox_module_unknown_total" (counter)
@@ -369,6 +365,7 @@ v0.35.0 (2023-07-18)
 - Allow `prometheus.exporter.snmp` and SNMP integration to be configured passing a YAML block. (@marctc)
 
 - Some metrics have been added to the traces subsystem for Static mode. (@ptodev)
+
   - "traces_processor_batch_batch_send_size" (histogram)
   - "traces_processor_batch_batch_size_trigger_send_total" (counter)
   - "traces_processor_batch_metadata_cardinality" (gauge)
@@ -384,7 +381,6 @@ v0.35.0 (2023-07-18)
 
 - Fix issue where `remote.http` incorrectly had a status of "Unknown" until the
   period specified by the polling frquency elapsed. (@rfratto)
-
 
 - Add signing region to remote.s3 component for use with custom endpoints so that Authorization Headers work correctly when
   proxying requests. (@mattdurham)
@@ -422,8 +418,7 @@ v0.35.0 (2023-07-18)
 
 - Clustering for Grafana Agent in flow mode has graduated from experimental to beta.
 
-v0.34.3 (2023-06-27)
---------------------
+## v0.34.3 (2023-06-27)
 
 ### Bugfixes
 
@@ -431,8 +426,7 @@ v0.34.3 (2023-06-27)
 - Enforce sha256 digest signing for rpms enabling installation on FIPS-enabled OSes. (@kfriedrich123)
 - Fix panic from improper startup ordering in `prometheus.operator.servicemonitors`. (@captncraig)
 
-v0.34.2 (2023-06-20)
---------------------
+## v0.34.2 (2023-06-20)
 
 ### Enhancements
 
@@ -449,8 +443,7 @@ v0.34.2 (2023-06-20)
 
 - Mongodb integration has been disabled for the time being due to licensing issues. (@jcreixell)
 
-v0.34.1 (2023-06-12)
---------------------
+## v0.34.1 (2023-06-12)
 
 ### Bugfixes
 
@@ -471,8 +464,7 @@ v0.34.1 (2023-06-12)
 
 - Add logging to failed requests in `remote.http`. (@rfratto)
 
-v0.34.0 (2023-06-08)
---------------------
+## v0.34.0 (2023-06-08)
 
 ### Breaking changes
 
@@ -489,6 +481,7 @@ v0.34.0 (2023-06-08)
 ### Features
 
 - New Grafana Agent Flow components:
+
   - `loki.source.api` - receive Loki log entries over HTTP (e.g. from other agents). (@thampiotr)
   - `prometheus.operator.servicemonitors` discovers ServiceMonitor resources in your Kubernetes cluster and scrape
     the targets they reference. (@captncraig, @marctc, @jcreixell)
@@ -605,8 +598,7 @@ v0.34.0 (2023-06-08)
 - Change the Docker base image for Linux containers to `ubuntu:lunar`.
   (@rfratto)
 
-v0.33.2 (2023-05-11)
---------------------
+## v0.33.2 (2023-05-11)
 
 ### Bugfixes
 
@@ -642,8 +634,7 @@ v0.33.2 (2023-05-11)
 - The `phlare.scrape` Flow component `fetch profile failed` log has been set to
   `debug` instead of `error`. (@erikbaranowski)
 
-v0.33.1 (2023-05-01)
---------------------
+## v0.33.1 (2023-05-01)
 
 ### Bugfixes
 
@@ -667,8 +658,7 @@ v0.33.1 (2023-05-01)
 
 - Support Bundles report the status of discovered log targets. (@tpaschalis)
 
-v0.33.0 (2023-04-25)
---------------------
+## v0.33.0 (2023-04-25)
 
 ### Breaking changes
 
@@ -677,12 +667,12 @@ v0.33.0 (2023-04-25)
   compiler issues are resolved and 32-bit ARM builds are stable. (@rfratto)
 
 - Agent Management: `agent_management.api_url` config field has been replaced by
-`agent_management.host`. The API path and version is now defined by the Agent. (@jcreixell)
+  `agent_management.host`. The API path and version is now defined by the Agent. (@jcreixell)
 
 - Agent Management: `agent_management.protocol` config field now allows defining "http" and "https" explicitly. Previously, "http" was previously used for both, with the actual protocol used inferred from the api url, which led to confusion. When upgrading, make sure to set to "https" when replacing `api_url` with `host`. (@jcreixell)
 
 - Agent Management: `agent_management.remote_config_cache_location` config field has been replaced by
-`agent_management.remote_configuration.cache_location`. (@jcreixell)
+  `agent_management.remote_configuration.cache_location`. (@jcreixell)
 
 - Remove deprecated symbolic links to to `/bin/agent*` in Docker containers,
   as planned in v0.31. (@tpaschalis)
@@ -725,7 +715,7 @@ v0.33.0 (2023-04-25)
     the targets they reference. (@captncraig, @marctc, @jcreixell)
   - `prometheus.exporter.windows` collects metrics from a Windows instance. (@jkroepke)
   - `prometheus.exporter.memcached` collects metrics from a Memcached server. (@spartan0x117)
-  - `loki.source.azure_event_hubs` reads messages from Azure Event Hub using Kafka and forwards them to other   `loki` components. (@akselleirv)
+  - `loki.source.azure_event_hubs` reads messages from Azure Event Hub using Kafka and forwards them to other `loki` components. (@akselleirv)
 
 - Add support for Flow-specific system packages:
 
@@ -860,8 +850,7 @@ v0.33.0 (2023-04-25)
 - Update prometheus.remote_write defaults to match new prometheus
   remote-write defaults. (@erikbaranowski)
 
-v0.32.1 (2023-03-06)
---------------------
+## v0.32.1 (2023-03-06)
 
 ### Bugfixes
 
@@ -876,8 +865,7 @@ v0.32.1 (2023-03-06)
   defaulted incorrectly to the container name, causing tailers to never
   restart. (@rfratto)
 
-v0.32.0 (2023-02-28)
---------------------
+## v0.32.0 (2023-02-28)
 
 ### Breaking changes
 
@@ -1026,8 +1014,7 @@ v0.32.0 (2023-02-28)
   - `phlare.scrape` is explicitly marked as beta.
   - `phlare.write` is explicitly marked as beta.
 
-v0.31.3 (2023-02-13)
---------------------
+## v0.31.3 (2023-02-13)
 
 ### Bugfixes
 
@@ -1038,16 +1025,14 @@ v0.31.3 (2023-02-13)
 - `loki.source.cloudflare`: fix issue where `api_token` argument was not marked
   as a sensitive field. (@rfratto)
 
-v0.31.2 (2023-02-08)
---------------------
+## v0.31.2 (2023-02-08)
 
 ### Other changes
 
 - In the Agent Operator, upgrade the `prometheus-config-reloader` dependency
   from version 0.47.0 to version 0.62.0. (@ptodev)
 
-v0.31.1 (2023-02-06)
---------------------
+## v0.31.1 (2023-02-06)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -1062,8 +1047,7 @@ v0.31.1 (2023-02-06)
 - Support Go 1.20 for builds. Official release binaries are still produced
   using Go 1.19. (@rfratto)
 
-v0.31.0 (2023-01-31)
---------------------
+## v0.31.0 (2023-01-31)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -1158,8 +1142,7 @@ v0.31.0 (2023-01-31)
 
 - New windows containers for agent and agentctl. These can be found moving forward with the ${Version}-windows tags for grafana/agent and grafana/agentctl docker images (@erikbaranowski)
 
-v0.30.2 (2023-01-11)
---------------------
+## v0.30.2 (2023-01-11)
 
 ### Bugfixes
 
@@ -1175,8 +1158,7 @@ v0.30.2 (2023-01-11)
 - Operator: Fix the handling of the enableHttp2 field as a boolean in
   `pod_monitor` and `service_monitor` templates. (@tpaschalis)
 
-v0.30.1 (2022-12-23)
---------------------
+## v0.30.1 (2022-12-23)
 
 ### Bugfixes
 
@@ -1184,8 +1166,7 @@ v0.30.1 (2022-12-23)
 
 - Fix issue where some traces' metrics where not collected. (@marctc)
 
-v0.30.0 (2022-12-20)
---------------------
+## v0.30.0 (2022-12-20)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -1290,8 +1271,7 @@ v0.30.0 (2022-12-20)
 
 - Grafana Agent Flow has graduated from experimental to beta.
 
-v0.29.0 (2022-11-08)
---------------------
+## v0.29.0 (2022-11-08)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -1416,8 +1396,7 @@ v0.29.0 (2022-11-08)
 
 - Use Go 1.19.3 for builds. (@rfratto)
 
-v0.28.1 (2022-11-03)
---------------------
+## v0.28.1 (2022-11-03)
 
 ### Security
 
@@ -1426,8 +1405,7 @@ v0.28.1 (2022-11-03)
   vulnerable to these issues, but the base image has been updated to remove the
   report from image scanners. (@rfratto)
 
-v0.28.0 (2022-09-29)
---------------------
+## v0.28.0 (2022-09-29)
 
 ### Features
 
@@ -1452,8 +1430,7 @@ v0.28.0 (2022-09-29)
 
 - Add metrics for config reloads and config hash (@jcreixell)
 
-v0.27.1 (2022-09-09)
---------------------
+## v0.27.1 (2022-09-09)
 
 > **NOTE**: ARMv6 Docker images are no longer being published.
 >
@@ -1467,8 +1444,7 @@ v0.27.1 (2022-09-09)
 
 - Switch docker image base from debian to ubuntu. (@captncraig)
 
-v0.27.0 (2022-09-01)
---------------------
+## v0.27.0 (2022-09-01)
 
 ### Features
 
@@ -1494,7 +1470,7 @@ v0.27.0 (2022-09-01)
 ### Bugfixes
 
 - Tracing: Fixed issue with the PromSD processor using the `connection` method to discover the IP
-  address.  It was failing to match because the port number was included in the address string. (@jphx)
+  address. It was failing to match because the port number was included in the address string. (@jphx)
 
 - Register prometheus discovery metrics. (@mattdurham)
 
@@ -1512,8 +1488,7 @@ v0.27.0 (2022-09-01)
 
 - It is now possible to compile Grafana Agent using Go 1.19. (@rfratto)
 
-v0.26.1 (2022-07-25)
---------------------
+## v0.26.1 (2022-07-25)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -1529,8 +1504,7 @@ v0.26.1 (2022-07-25)
 
 - Build the Linux/AMD64 artifacts using the opt-out flag for the ebpf_exporter. (@tpaschalis)
 
-v0.26.0 (2022-07-18)
---------------------
+## v0.26.0 (2022-07-18)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -1562,8 +1536,7 @@ v0.26.0 (2022-07-18)
 
 - Fix mongodb exporter so that it now collects all metrics. (@mattdurham)
 
-v0.25.1 (2022-06-16)
---------------------
+## v0.25.1 (2022-06-16)
 
 ### Bugfixes
 
@@ -1571,8 +1544,7 @@ v0.25.1 (2022-06-16)
 
 - Unwrap replayWAL error before attempting corruption repair. (@rlankfo)
 
-v0.25.0 (2022-06-06)
---------------------
+## v0.25.0 (2022-06-06)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -1618,7 +1590,7 @@ v0.25.0 (2022-06-06)
 
 ### Bugfixes
 
-- Scraping service was not honoring the new server grpc flags `server.grpc.address`.  (@mattdurham)
+- Scraping service was not honoring the new server grpc flags `server.grpc.address`. (@mattdurham)
 
 ### Other changes
 
@@ -1628,15 +1600,14 @@ v0.25.0 (2022-06-06)
 - Use Go 1.18 for builds. (@rfratto)
 
 - Add `metrics` prefix to the url of list instances endpoint (`GET
-  /agent/api/v1/instances`) and list targets endpoint (`GET
-  /agent/api/v1/metrics/targets`). (@marctc)
+/agent/api/v1/instances`) and list targets endpoint (`GET
+/agent/api/v1/metrics/targets`). (@marctc)
 
 - Add extra identifying labels (`job`, `instance`, `agent_hostname`) to eventhandler integration. (@hjet)
 
 - Add `extra_labels` configuration to eventhandler integration. (@hjet)
 
-v0.24.2 (2022-05-02)
---------------------
+## v0.24.2 (2022-05-02)
 
 ### Bugfixes
 
@@ -1646,8 +1617,7 @@ v0.24.2 (2022-05-02)
 
 - Update version of node_exporter to include additional metrics for osx. (@v-zhuravlev)
 
-v0.24.1 (2022-04-14)
---------------------
+## v0.24.1 (2022-04-14)
 
 ### Bugfixes
 
@@ -1672,8 +1642,7 @@ v0.24.1 (2022-04-14)
 - Embed timezone data to enable Promtail pipelines using the `location` field
   on Windows machines. (@tpaschalis)
 
-v0.24.0 (2022-04-07)
---------------------
+## v0.24.0 (2022-04-07)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -1804,7 +1773,7 @@ v0.24.0 (2022-04-07)
   custom Secrets will now be mounted at
   `/var/lib/grafana-agent/extra-secrets/<secret name>` and custom ConfigMaps
   will now be mounted at `/var/lib/grafana-agent/extra-configmaps/<configmap
-  name>`. This is not a breaking change as it was previously impossible to
+name>`. This is not a breaking change as it was previously impossible to
   properly provide these custom mounts. (@rfratto)
 
 - Flags accidentally prefixed with `-metrics.service..` (two `.` in a row) have
@@ -1818,8 +1787,7 @@ v0.24.0 (2022-04-07)
   will now default to `data-agent/`, the same default WAL directory as
   Prometheus Agent. (@rfratto)
 
-v0.23.0 (2022-02-10)
---------------------
+## v0.23.0 (2022-02-10)
 
 ### Enhancements
 
@@ -1864,8 +1832,7 @@ v0.23.0 (2022-02-10)
 
 - Disable `machine-id` journal vol by default in sample logs manifest (@hjet)
 
-v0.22.0 (2022-01-13)
---------------------
+## v0.22.0 (2022-01-13)
 
 > This release has deprecations. Please read entries carefully and consult
 > the [upgrade guide][] for specific instructions.
@@ -1952,8 +1919,7 @@ v0.22.0 (2022-01-13)
 
 - Remove log-level flag from systemd unit file (@jpkrohling)
 
-v0.21.2 (2021-12-08)
---------------------
+## v0.21.2 (2021-12-08)
 
 ### Security fixes
 
@@ -1967,8 +1933,7 @@ v0.21.2 (2021-12-08)
   `--config.enable-read-api` flag at the command line to opt in to these
   endpoints.
 
-v0.21.1 (2021-11-18)
---------------------
+## v0.21.1 (2021-11-18)
 
 ### Bugfixes
 
@@ -1987,8 +1952,7 @@ v0.21.1 (2021-11-18)
 - Metrics: Only run WAL cleaner when metrics are being used and a WAL is
   configured. (@rfratto)
 
-v0.21.0 (2021-11-17)
---------------------
+## v0.21.0 (2021-11-17)
 
 ### Enhancements
 
@@ -2022,8 +1986,7 @@ v0.21.0 (2021-11-17)
 
 - Traces: Changed service graphs store implementation to improve CPU performance (@mapno)
 
-v0.20.1 (2021-12-08)
---------------------
+## v0.20.1 (2021-12-08)
 
 > _NOTE_: The fixes in this patch are only present in v0.20.1 and >=v0.21.2.
 
@@ -2039,8 +2002,7 @@ v0.20.1 (2021-12-08)
   `--config.enable-read-api` flag at the command line to opt in to these
   endpoints.
 
-v0.20.0 (2021-10-28)
---------------------
+## v0.20.0 (2021-10-28)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -2072,7 +2034,7 @@ v0.20.0 (2021-10-28)
 
 - Updated elasticsearch_exporter to v1.2.1 (@gaantunes)
 
-- Add remote write to silent Windows Installer  (@mattdurham)
+- Add remote write to silent Windows Installer (@mattdurham)
 
 - Updated mongodb_exporter to v0.20.7 (@rfratto)
 
@@ -2113,8 +2075,7 @@ v0.20.0 (2021-10-28)
 - The windows_exporter now disables the textfile collector by default.
   (@rfratto)
 
-v0.19.0 (2021-09-29)
---------------------
+## v0.19.0 (2021-09-29)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -2176,7 +2137,7 @@ v0.19.0 (2021-09-29)
 - Allow reloading configuration using `SIGHUP` signal. (@tharun208)
 
 - Add HOSTNAME environment variable to service file to allow for expanding the
-  $HOSTNAME variable in agent config.  (@dfrankel33)
+  $HOSTNAME variable in agent config. (@dfrankel33)
 
 - Update jsonnet-libs to 1.21 for Kubernetes 1.21+ compatability. (@MurzNN)
 
@@ -2216,8 +2177,7 @@ v0.19.0 (2021-09-29)
 
 - Standardize scrape_interval to 1m in examples. (@mattdurham)
 
-v0.18.4 (2021-09-14)
---------------------
+## v0.18.4 (2021-09-14)
 
 ### Enhancements
 
@@ -2231,8 +2191,7 @@ v0.18.4 (2021-09-14)
 - Scraping service: Ensure that a reshard is scheduled every reshard
   interval. (@rfratto)
 
-v0.18.3 (2021-09-08)
---------------------
+## v0.18.3 (2021-09-08)
 
 ### Bugfixes
 
@@ -2253,22 +2212,19 @@ v0.18.3 (2021-09-08)
 - Scraping service: prevent more than one refresh from being queued at a time.
   (@rfratto)
 
-v0.18.2 (2021-08-12)
---------------------
+## v0.18.2 (2021-08-12)
 
 ### Bugfixes
 
 - Honor the prefix and remove prefix from consul list results (@mattdurham)
 
-v0.18.1 (2021-08-09)
---------------------
+## v0.18.1 (2021-08-09)
 
 ### Bugfixes
 
 - Reduce number of consul calls when ran in scrape service mode (@mattdurham)
 
-v0.18.0 (2021-07-29)
---------------------
+## v0.18.0 (2021-07-29)
 
 ### Features
 
@@ -2287,8 +2243,7 @@ v0.18.0 (2021-07-29)
 
 - Enabled flag for integrations is not being honored. (@mattdurham)
 
-v0.17.0 (2021-07-15)
---------------------
+## v0.17.0 (2021-07-15)
 
 ### Features
 
@@ -2300,16 +2255,14 @@ v0.17.0 (2021-07-15)
 - Fix race condition that may occur and result in a panic when initializing
   scraping service cluster. (@rfratto)
 
-v0.16.1 (2021-06-22)
---------------------
+## v0.16.1 (2021-06-22)
 
 ### Bugfixes
 
 - Fix issue where replaying a WAL caused incorrect metrics to be sent over
   remote write. (@rfratto)
 
-v0.16.0 (2021-06-17)
---------------------
+## v0.16.0 (2021-06-17)
 
 ### Features
 
@@ -2330,8 +2283,7 @@ v0.16.0 (2021-06-17)
   that target had gone down for long enough that its series were removed from
   the in-memory cache (2 GC cycles). (@rfratto)
 
-v0.15.0 (2021-06-03)
---------------------
+## v0.15.0 (2021-06-03)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -2372,8 +2324,7 @@ v0.15.0 (2021-06-03)
 
 - Intentionally order tracing processors. (@joe-elliott)
 
-v0.14.0 (2021-05-24)
---------------------
+## v0.14.0 (2021-05-24)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -2416,7 +2367,7 @@ v0.14.0 (2021-05-24)
   against the main HTTP server. Instead, two new command-line flags have been
   added: `--reload-addr` and `--reload-port`. These will launch a
   `/-/reload`-only HTTP server that can be used to safely reload the Agent's
-  state.  (@rfratto)
+  state. (@rfratto)
 
 - Add a /-/config endpoint. This endpoint will return the current configuration
   file with defaults applied that the Agent has loaded from disk. (@rfratto)
@@ -2488,8 +2439,7 @@ v0.14.0 (2021-05-24)
 
 - Add `tempo_spanmetrics` namespace in spanmetrics (@mapno)
 
-v0.13.1 (2021-04-09)
---------------------
+## v0.13.1 (2021-04-09)
 
 ### Bugfixes
 
@@ -2497,8 +2447,7 @@ v0.13.1 (2021-04-09)
   label set with duplicate labels, mirroring the behavior of Prometheus.
   (@rfratto)
 
-v0.13.0 (2021-02-25)
---------------------
+## v0.13.0 (2021-02-25)
 
 > The primary branch name has changed from `master` to `main`. You may have to
 > update your local checkouts of the repository to point at the new branch name.
@@ -2537,8 +2486,7 @@ v0.13.0 (2021-02-25)
 - Add the ability to read and serve HTTPS integration metrics when given a set
   certificates (@mattdurham)
 
-v0.12.0 (2021-02-05)
---------------------
+## v0.12.0 (2021-02-05)
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -2574,7 +2522,7 @@ v0.12.0 (2021-02-05)
 - Scraping service: Unhealthy Agents in the ring will no longer cause job
   distribution to fail. (@rfratto)
 
-- Scraping service: Cortex ring metrics (prefixed with cortex_ring_) will now
+- Scraping service: Cortex ring metrics (prefixed with cortex*ring*) will now
   be registered for tracking the state of the hash ring. (@rfratto)
 
 - Scraping service: instance config ownership is now determined by the hash of
@@ -2592,8 +2540,7 @@ v0.12.0 (2021-02-05)
 - `agentctl config-check` will now work correctly when the supplied config file
   contains integrations. (@hoenn)
 
-v0.11.0 (2021-01-20)
---------------------
+## v0.11.0 (2021-01-20)
 
 ### Features
 
@@ -2621,8 +2568,7 @@ v0.11.0 (2021-01-20)
 - The K8s manifests will no longer include the `default/kubernetes` job twice
   in both the DaemonSet and the Deployment. (@rfratto)
 
-v0.10.0 (2021-01-13)
---------------------
+## v0.10.0 (2021-01-13)
 
 ### Features
 
@@ -2659,16 +2605,14 @@ v0.10.0 (2021-01-13)
   This was prevented by accidentally writing to a readonly volume mount.
   (@rfratto)
 
-v0.9.1 (2021-01-04)
--------------------
+## v0.9.1 (2021-01-04)
 
 ### Enhancements
 
 - agentctl will now be installed by the rpm and deb packages as
   `grafana-agentctl`. (@rfratto)
 
-v0.9.0 (2020-12-10)
--------------------
+## v0.9.0 (2020-12-10)
 
 ### Features
 
@@ -2717,8 +2661,7 @@ v0.9.0 (2020-12-10)
 - The User-Agent header sent for logs will now be `GrafanaCloudAgent/<version>`
   (@rfratto)
 
-v0.8.0 (2020-11-06)
--------------------
+## v0.8.0 (2020-11-06)
 
 ### Features
 
@@ -2744,8 +2687,7 @@ v0.8.0 (2020-11-06)
   rather than just logging a generic message saying that retrieving the config
   has failed. (@rfratto)
 
-v0.7.2 (2020-10-29)
--------------------
+## v0.7.2 (2020-10-29)
 
 ### Enhancements
 
@@ -2768,15 +2710,13 @@ v0.7.2 (2020-10-29)
 - Fix issue where the `push_config` for Tempo field was expected to be
   `remote_write`. `push_config` now works as expected. (@rfratto)
 
-v0.7.1 (2020-10-23)
--------------------
+## v0.7.1 (2020-10-23)
 
 ### Bugfixes
 
 - Fix issue where ARM binaries were not published with the GitHub release.
 
-v0.7.0 (2020-10-23)
--------------------
+## v0.7.0 (2020-10-23)
 
 ### Features
 
@@ -2818,8 +2758,7 @@ v0.7.0 (2020-10-23)
   computed by remote_write. This change should not negatively affect existing
   users. (@rfratto)
 
-v0.6.1 (2020-04-11)
--------------------
+## v0.6.1 (2020-04-11)
 
 ### Bugfixes
 
@@ -2832,8 +2771,7 @@ v0.6.1 (2020-04-11)
 - Fix deadlock that slowly prevents the Agent from scraping targets at a high
   scrape volume. (@rfratto)
 
-v0.6.0 (2020-09-04)
--------------------
+## v0.6.0 (2020-09-04)
 
 ### Breaking Changes
 
@@ -2882,7 +2820,7 @@ v0.6.0 (2020-09-04)
 - The subsystems of the Agent (`prometheus`, `loki`) are now made optional.
   Enabling integrations also implicitly enables the associated subsystem. For
   example, enabling the `agent` or `node_exporter` integration will force the
-  `prometheus` subsystem to be enabled.  (@rfratto)
+  `prometheus` subsystem to be enabled. (@rfratto)
 
 ### Bugfixes
 
@@ -2906,8 +2844,7 @@ v0.6.0 (2020-09-04)
 - Fix a panic that may occur during shutdown if the WAL is closed in the middle
   of the WAL being truncated. (@rfratto)
 
-v0.5.0 (2020-08-12)
--------------------
+## v0.5.0 (2020-08-12)
 
 ### Features
 
@@ -2944,8 +2881,7 @@ v0.5.0 (2020-08-12)
   needing to manually set the blocklist and allowlist of filesystems.
   (@rfratto)
 
-v0.4.0 (2020-06-18)
--------------------
+## v0.4.0 (2020-06-18)
 
 ### Features
 
@@ -2972,8 +2908,7 @@ v0.4.0 (2020-06-18)
 - Enable agent host_filter in the Tanka configs, which was disabled by default
   by mistake. (@rfratto)
 
-v0.3.2 (2020-05-29)
--------------------
+## v0.3.2 (2020-05-29)
 
 ### Features
 
@@ -3013,8 +2948,7 @@ v0.3.2 (2020-05-29)
   correctly show the pod name of the Agent instead of the exporter name.
   (@rfratto)
 
-v0.3.1 (2020-05-20)
--------------------
+## v0.3.1 (2020-05-20)
 
 ### Features
 
@@ -3034,8 +2968,7 @@ v0.3.1 (2020-05-20)
 - `agentctl` and the config API will now validate that the YAML they receive
   are valid instance configs. (@rfratto)
 
-v0.3.0 (2020-05-13)
--------------------
+## v0.3.0 (2020-05-13)
 
 ### Features
 
@@ -3062,8 +2995,7 @@ v0.3.0 (2020-05-13)
 - The Grafana Agent Tanka Mixins now are placed in an "Agent" folder within
   Grafana. (@cyriltovena)
 
-v0.2.0 (2020-04-09)
--------------------
+## v0.2.0 (2020-04-09)
 
 ### Features
 
@@ -3073,6 +3005,7 @@ v0.2.0 (2020-04-09)
   (@gotjosh)
 
   These metrics are available to monitor metadata being sent:
+
   - `prometheus_remote_storage_succeeded_metadata_total`
   - `prometheus_remote_storage_failed_metadata_total`
   - `prometheus_remote_storage_retried_metadata_total`
@@ -3092,8 +3025,7 @@ v0.2.0 (2020-04-09)
 - Enabling host_filter will now allow metrics from node role Kubernetes service
   discovery to be scraped properly (e.g., cAdvisor, Kubelet). (@rfratto)
 
-v0.1.1 (2020-03-16)
--------------------
+## v0.1.1 (2020-03-16)
 
 ### Other changes
 
@@ -3103,8 +3035,7 @@ v0.1.1 (2020-03-16)
 
 - Pass through release tag to `docker build` (@rfratto)
 
-v0.1.0 (2020-03-16)
--------------------
+## v0.1.0 (2020-03-16)
 
 > First release!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,15 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
-## Main (unreleased)
+Main (unreleased)
+-----------------
 
 ### Features
 
 - New Grafana Agent Flow components:
 
   - `otelcol.connector.spanlogs` - creates logs from spans. It is the flow mode equivalent
-    to static mode's `automatic_logging` processor. (@ptodev)
+  to static mode's `automatic_logging` processor. (@ptodev)
 
 - Flow: allow the HTTP server to be configured with TLS in the config file
   using the new `http` config block. (@rfratto)
@@ -24,7 +25,8 @@ internal API changes are not present.
 - Use Go 1.21.0 for builds. (@rfratto)
 - Read contextual attributes from Faro measurements (@codecapitano)
 
-## v0.36.0-rc.3 (2023-08-28)
+v0.36.0-rc.3 (2023-08-28)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -47,7 +49,7 @@ internal API changes are not present.
 - Add [godeltaprof](https://github.com/grafana/godeltaprof) profiling types (`godeltaprof_memory`, `godeltaprof_mutex`, `godeltaprof_block`) to `pyroscope.scrape` component
 
 - Flow: Allow the `logging` configuration block to tee the Agent's logs to one
-  or more loki.\* components. (@tpaschalis)
+  or more loki.* components. (@tpaschalis)
 
 - Added support for `promtail` configuration conversion in `grafana-agent convert` and `grafana-agent run` commands. (@thampiotr)
 
@@ -75,6 +77,7 @@ internal API changes are not present.
   - `otelcol.processor.discovery` adds resource attributes to spans, where the attributes
     keys and values are sourced from `discovery.*` components. (@ptodev)
   - `otelcol.connector.spanmetrics` - creates OpenTelemetry metrics from traces. (@ptodev)
+
 
 ### Enhancements
 
@@ -153,7 +156,8 @@ internal API changes are not present.
 
 - Agent Management: Fix issue where an integration defined multiple times could lead to undefined behaviour. (@jcreixell)
 
-## v0.35.4 (2023-08-14)
+v0.35.4 (2023-08-14)
+--------------------
 
 ### Bugfixes
 
@@ -163,7 +167,8 @@ internal API changes are not present.
 
 - Clarify usage documentation surrounding `loki.source.file` (@joshuapare)
 
-## v0.35.3 (2023-08-09)
+v0.35.3 (2023-08-09)
+--------------------
 
 ### Bugfixes
 
@@ -180,7 +185,8 @@ internal API changes are not present.
 - Fix graceful termination when receiving SIGTERM/CTRL_SHUTDOWN_EVENT
   signals. (@tpaschalis)
 
-## v0.35.2 (2023-07-27)
+v0.35.2 (2023-07-27)
+--------------------
 
 ### Bugfixes
 
@@ -203,7 +209,8 @@ internal API changes are not present.
   `grafana-agentctl test-logs` functions as expected when testing tailing the
   systemd journal. (@rfratto)
 
-## v0.35.1 (2023-07-25)
+v0.35.1 (2023-07-25)
+--------------------
 
 ### Bugfixes
 
@@ -211,7 +218,8 @@ internal API changes are not present.
   Users of the static mode's service graph processor are also advised to upgrade,
   although the bug should theoretically not affect them. (@ptodev)
 
-## v0.35.0 (2023-07-18)
+v0.35.0 (2023-07-18)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -237,9 +245,7 @@ internal API changes are not present.
   (@rfratto)
 
 - In the traces subsystem for Static mode, some metrics are removed and others are renamed. (@ptodev)
-
   - Removed metrics:
-
     - "blackbox_exporter_config_last_reload_success_timestamp_seconds" (gauge)
     - "blackbox_exporter_config_last_reload_successful" (gauge)
     - "blackbox_module_unknown_total" (counter)
@@ -365,7 +371,6 @@ internal API changes are not present.
 - Allow `prometheus.exporter.snmp` and SNMP integration to be configured passing a YAML block. (@marctc)
 
 - Some metrics have been added to the traces subsystem for Static mode. (@ptodev)
-
   - "traces_processor_batch_batch_send_size" (histogram)
   - "traces_processor_batch_batch_size_trigger_send_total" (counter)
   - "traces_processor_batch_metadata_cardinality" (gauge)
@@ -381,6 +386,7 @@ internal API changes are not present.
 
 - Fix issue where `remote.http` incorrectly had a status of "Unknown" until the
   period specified by the polling frquency elapsed. (@rfratto)
+
 
 - Add signing region to remote.s3 component for use with custom endpoints so that Authorization Headers work correctly when
   proxying requests. (@mattdurham)
@@ -418,7 +424,8 @@ internal API changes are not present.
 
 - Clustering for Grafana Agent in flow mode has graduated from experimental to beta.
 
-## v0.34.3 (2023-06-27)
+v0.34.3 (2023-06-27)
+--------------------
 
 ### Bugfixes
 
@@ -426,7 +433,8 @@ internal API changes are not present.
 - Enforce sha256 digest signing for rpms enabling installation on FIPS-enabled OSes. (@kfriedrich123)
 - Fix panic from improper startup ordering in `prometheus.operator.servicemonitors`. (@captncraig)
 
-## v0.34.2 (2023-06-20)
+v0.34.2 (2023-06-20)
+--------------------
 
 ### Enhancements
 
@@ -443,7 +451,8 @@ internal API changes are not present.
 
 - Mongodb integration has been disabled for the time being due to licensing issues. (@jcreixell)
 
-## v0.34.1 (2023-06-12)
+v0.34.1 (2023-06-12)
+--------------------
 
 ### Bugfixes
 
@@ -464,7 +473,8 @@ internal API changes are not present.
 
 - Add logging to failed requests in `remote.http`. (@rfratto)
 
-## v0.34.0 (2023-06-08)
+v0.34.0 (2023-06-08)
+--------------------
 
 ### Breaking changes
 
@@ -481,7 +491,6 @@ internal API changes are not present.
 ### Features
 
 - New Grafana Agent Flow components:
-
   - `loki.source.api` - receive Loki log entries over HTTP (e.g. from other agents). (@thampiotr)
   - `prometheus.operator.servicemonitors` discovers ServiceMonitor resources in your Kubernetes cluster and scrape
     the targets they reference. (@captncraig, @marctc, @jcreixell)
@@ -598,7 +607,8 @@ internal API changes are not present.
 - Change the Docker base image for Linux containers to `ubuntu:lunar`.
   (@rfratto)
 
-## v0.33.2 (2023-05-11)
+v0.33.2 (2023-05-11)
+--------------------
 
 ### Bugfixes
 
@@ -634,7 +644,8 @@ internal API changes are not present.
 - The `phlare.scrape` Flow component `fetch profile failed` log has been set to
   `debug` instead of `error`. (@erikbaranowski)
 
-## v0.33.1 (2023-05-01)
+v0.33.1 (2023-05-01)
+--------------------
 
 ### Bugfixes
 
@@ -658,7 +669,8 @@ internal API changes are not present.
 
 - Support Bundles report the status of discovered log targets. (@tpaschalis)
 
-## v0.33.0 (2023-04-25)
+v0.33.0 (2023-04-25)
+--------------------
 
 ### Breaking changes
 
@@ -667,12 +679,12 @@ internal API changes are not present.
   compiler issues are resolved and 32-bit ARM builds are stable. (@rfratto)
 
 - Agent Management: `agent_management.api_url` config field has been replaced by
-  `agent_management.host`. The API path and version is now defined by the Agent. (@jcreixell)
+`agent_management.host`. The API path and version is now defined by the Agent. (@jcreixell)
 
 - Agent Management: `agent_management.protocol` config field now allows defining "http" and "https" explicitly. Previously, "http" was previously used for both, with the actual protocol used inferred from the api url, which led to confusion. When upgrading, make sure to set to "https" when replacing `api_url` with `host`. (@jcreixell)
 
 - Agent Management: `agent_management.remote_config_cache_location` config field has been replaced by
-  `agent_management.remote_configuration.cache_location`. (@jcreixell)
+`agent_management.remote_configuration.cache_location`. (@jcreixell)
 
 - Remove deprecated symbolic links to to `/bin/agent*` in Docker containers,
   as planned in v0.31. (@tpaschalis)
@@ -715,7 +727,7 @@ internal API changes are not present.
     the targets they reference. (@captncraig, @marctc, @jcreixell)
   - `prometheus.exporter.windows` collects metrics from a Windows instance. (@jkroepke)
   - `prometheus.exporter.memcached` collects metrics from a Memcached server. (@spartan0x117)
-  - `loki.source.azure_event_hubs` reads messages from Azure Event Hub using Kafka and forwards them to other `loki` components. (@akselleirv)
+  - `loki.source.azure_event_hubs` reads messages from Azure Event Hub using Kafka and forwards them to other   `loki` components. (@akselleirv)
 
 - Add support for Flow-specific system packages:
 
@@ -850,7 +862,8 @@ internal API changes are not present.
 - Update prometheus.remote_write defaults to match new prometheus
   remote-write defaults. (@erikbaranowski)
 
-## v0.32.1 (2023-03-06)
+v0.32.1 (2023-03-06)
+--------------------
 
 ### Bugfixes
 
@@ -865,7 +878,8 @@ internal API changes are not present.
   defaulted incorrectly to the container name, causing tailers to never
   restart. (@rfratto)
 
-## v0.32.0 (2023-02-28)
+v0.32.0 (2023-02-28)
+--------------------
 
 ### Breaking changes
 
@@ -1014,7 +1028,8 @@ internal API changes are not present.
   - `phlare.scrape` is explicitly marked as beta.
   - `phlare.write` is explicitly marked as beta.
 
-## v0.31.3 (2023-02-13)
+v0.31.3 (2023-02-13)
+--------------------
 
 ### Bugfixes
 
@@ -1025,14 +1040,16 @@ internal API changes are not present.
 - `loki.source.cloudflare`: fix issue where `api_token` argument was not marked
   as a sensitive field. (@rfratto)
 
-## v0.31.2 (2023-02-08)
+v0.31.2 (2023-02-08)
+--------------------
 
 ### Other changes
 
 - In the Agent Operator, upgrade the `prometheus-config-reloader` dependency
   from version 0.47.0 to version 0.62.0. (@ptodev)
 
-## v0.31.1 (2023-02-06)
+v0.31.1 (2023-02-06)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -1047,7 +1064,8 @@ internal API changes are not present.
 - Support Go 1.20 for builds. Official release binaries are still produced
   using Go 1.19. (@rfratto)
 
-## v0.31.0 (2023-01-31)
+v0.31.0 (2023-01-31)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -1142,7 +1160,8 @@ internal API changes are not present.
 
 - New windows containers for agent and agentctl. These can be found moving forward with the ${Version}-windows tags for grafana/agent and grafana/agentctl docker images (@erikbaranowski)
 
-## v0.30.2 (2023-01-11)
+v0.30.2 (2023-01-11)
+--------------------
 
 ### Bugfixes
 
@@ -1158,7 +1177,8 @@ internal API changes are not present.
 - Operator: Fix the handling of the enableHttp2 field as a boolean in
   `pod_monitor` and `service_monitor` templates. (@tpaschalis)
 
-## v0.30.1 (2022-12-23)
+v0.30.1 (2022-12-23)
+--------------------
 
 ### Bugfixes
 
@@ -1166,7 +1186,8 @@ internal API changes are not present.
 
 - Fix issue where some traces' metrics where not collected. (@marctc)
 
-## v0.30.0 (2022-12-20)
+v0.30.0 (2022-12-20)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -1271,7 +1292,8 @@ internal API changes are not present.
 
 - Grafana Agent Flow has graduated from experimental to beta.
 
-## v0.29.0 (2022-11-08)
+v0.29.0 (2022-11-08)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -1396,7 +1418,8 @@ internal API changes are not present.
 
 - Use Go 1.19.3 for builds. (@rfratto)
 
-## v0.28.1 (2022-11-03)
+v0.28.1 (2022-11-03)
+--------------------
 
 ### Security
 
@@ -1405,7 +1428,8 @@ internal API changes are not present.
   vulnerable to these issues, but the base image has been updated to remove the
   report from image scanners. (@rfratto)
 
-## v0.28.0 (2022-09-29)
+v0.28.0 (2022-09-29)
+--------------------
 
 ### Features
 
@@ -1430,7 +1454,8 @@ internal API changes are not present.
 
 - Add metrics for config reloads and config hash (@jcreixell)
 
-## v0.27.1 (2022-09-09)
+v0.27.1 (2022-09-09)
+--------------------
 
 > **NOTE**: ARMv6 Docker images are no longer being published.
 >
@@ -1444,7 +1469,8 @@ internal API changes are not present.
 
 - Switch docker image base from debian to ubuntu. (@captncraig)
 
-## v0.27.0 (2022-09-01)
+v0.27.0 (2022-09-01)
+--------------------
 
 ### Features
 
@@ -1470,7 +1496,7 @@ internal API changes are not present.
 ### Bugfixes
 
 - Tracing: Fixed issue with the PromSD processor using the `connection` method to discover the IP
-  address. It was failing to match because the port number was included in the address string. (@jphx)
+  address.  It was failing to match because the port number was included in the address string. (@jphx)
 
 - Register prometheus discovery metrics. (@mattdurham)
 
@@ -1488,7 +1514,8 @@ internal API changes are not present.
 
 - It is now possible to compile Grafana Agent using Go 1.19. (@rfratto)
 
-## v0.26.1 (2022-07-25)
+v0.26.1 (2022-07-25)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -1504,7 +1531,8 @@ internal API changes are not present.
 
 - Build the Linux/AMD64 artifacts using the opt-out flag for the ebpf_exporter. (@tpaschalis)
 
-## v0.26.0 (2022-07-18)
+v0.26.0 (2022-07-18)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -1536,7 +1564,8 @@ internal API changes are not present.
 
 - Fix mongodb exporter so that it now collects all metrics. (@mattdurham)
 
-## v0.25.1 (2022-06-16)
+v0.25.1 (2022-06-16)
+--------------------
 
 ### Bugfixes
 
@@ -1544,7 +1573,8 @@ internal API changes are not present.
 
 - Unwrap replayWAL error before attempting corruption repair. (@rlankfo)
 
-## v0.25.0 (2022-06-06)
+v0.25.0 (2022-06-06)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -1590,7 +1620,7 @@ internal API changes are not present.
 
 ### Bugfixes
 
-- Scraping service was not honoring the new server grpc flags `server.grpc.address`. (@mattdurham)
+- Scraping service was not honoring the new server grpc flags `server.grpc.address`.  (@mattdurham)
 
 ### Other changes
 
@@ -1600,14 +1630,15 @@ internal API changes are not present.
 - Use Go 1.18 for builds. (@rfratto)
 
 - Add `metrics` prefix to the url of list instances endpoint (`GET
-/agent/api/v1/instances`) and list targets endpoint (`GET
-/agent/api/v1/metrics/targets`). (@marctc)
+  /agent/api/v1/instances`) and list targets endpoint (`GET
+  /agent/api/v1/metrics/targets`). (@marctc)
 
 - Add extra identifying labels (`job`, `instance`, `agent_hostname`) to eventhandler integration. (@hjet)
 
 - Add `extra_labels` configuration to eventhandler integration. (@hjet)
 
-## v0.24.2 (2022-05-02)
+v0.24.2 (2022-05-02)
+--------------------
 
 ### Bugfixes
 
@@ -1617,7 +1648,8 @@ internal API changes are not present.
 
 - Update version of node_exporter to include additional metrics for osx. (@v-zhuravlev)
 
-## v0.24.1 (2022-04-14)
+v0.24.1 (2022-04-14)
+--------------------
 
 ### Bugfixes
 
@@ -1642,7 +1674,8 @@ internal API changes are not present.
 - Embed timezone data to enable Promtail pipelines using the `location` field
   on Windows machines. (@tpaschalis)
 
-## v0.24.0 (2022-04-07)
+v0.24.0 (2022-04-07)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -1773,7 +1806,7 @@ internal API changes are not present.
   custom Secrets will now be mounted at
   `/var/lib/grafana-agent/extra-secrets/<secret name>` and custom ConfigMaps
   will now be mounted at `/var/lib/grafana-agent/extra-configmaps/<configmap
-name>`. This is not a breaking change as it was previously impossible to
+  name>`. This is not a breaking change as it was previously impossible to
   properly provide these custom mounts. (@rfratto)
 
 - Flags accidentally prefixed with `-metrics.service..` (two `.` in a row) have
@@ -1787,7 +1820,8 @@ name>`. This is not a breaking change as it was previously impossible to
   will now default to `data-agent/`, the same default WAL directory as
   Prometheus Agent. (@rfratto)
 
-## v0.23.0 (2022-02-10)
+v0.23.0 (2022-02-10)
+--------------------
 
 ### Enhancements
 
@@ -1832,7 +1866,8 @@ name>`. This is not a breaking change as it was previously impossible to
 
 - Disable `machine-id` journal vol by default in sample logs manifest (@hjet)
 
-## v0.22.0 (2022-01-13)
+v0.22.0 (2022-01-13)
+--------------------
 
 > This release has deprecations. Please read entries carefully and consult
 > the [upgrade guide][] for specific instructions.
@@ -1919,7 +1954,8 @@ name>`. This is not a breaking change as it was previously impossible to
 
 - Remove log-level flag from systemd unit file (@jpkrohling)
 
-## v0.21.2 (2021-12-08)
+v0.21.2 (2021-12-08)
+--------------------
 
 ### Security fixes
 
@@ -1933,7 +1969,8 @@ name>`. This is not a breaking change as it was previously impossible to
   `--config.enable-read-api` flag at the command line to opt in to these
   endpoints.
 
-## v0.21.1 (2021-11-18)
+v0.21.1 (2021-11-18)
+--------------------
 
 ### Bugfixes
 
@@ -1952,7 +1989,8 @@ name>`. This is not a breaking change as it was previously impossible to
 - Metrics: Only run WAL cleaner when metrics are being used and a WAL is
   configured. (@rfratto)
 
-## v0.21.0 (2021-11-17)
+v0.21.0 (2021-11-17)
+--------------------
 
 ### Enhancements
 
@@ -1986,7 +2024,8 @@ name>`. This is not a breaking change as it was previously impossible to
 
 - Traces: Changed service graphs store implementation to improve CPU performance (@mapno)
 
-## v0.20.1 (2021-12-08)
+v0.20.1 (2021-12-08)
+--------------------
 
 > _NOTE_: The fixes in this patch are only present in v0.20.1 and >=v0.21.2.
 
@@ -2002,7 +2041,8 @@ name>`. This is not a breaking change as it was previously impossible to
   `--config.enable-read-api` flag at the command line to opt in to these
   endpoints.
 
-## v0.20.0 (2021-10-28)
+v0.20.0 (2021-10-28)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -2034,7 +2074,7 @@ name>`. This is not a breaking change as it was previously impossible to
 
 - Updated elasticsearch_exporter to v1.2.1 (@gaantunes)
 
-- Add remote write to silent Windows Installer (@mattdurham)
+- Add remote write to silent Windows Installer  (@mattdurham)
 
 - Updated mongodb_exporter to v0.20.7 (@rfratto)
 
@@ -2075,7 +2115,8 @@ name>`. This is not a breaking change as it was previously impossible to
 - The windows_exporter now disables the textfile collector by default.
   (@rfratto)
 
-## v0.19.0 (2021-09-29)
+v0.19.0 (2021-09-29)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -2137,7 +2178,7 @@ name>`. This is not a breaking change as it was previously impossible to
 - Allow reloading configuration using `SIGHUP` signal. (@tharun208)
 
 - Add HOSTNAME environment variable to service file to allow for expanding the
-  $HOSTNAME variable in agent config. (@dfrankel33)
+  $HOSTNAME variable in agent config.  (@dfrankel33)
 
 - Update jsonnet-libs to 1.21 for Kubernetes 1.21+ compatability. (@MurzNN)
 
@@ -2177,7 +2218,8 @@ name>`. This is not a breaking change as it was previously impossible to
 
 - Standardize scrape_interval to 1m in examples. (@mattdurham)
 
-## v0.18.4 (2021-09-14)
+v0.18.4 (2021-09-14)
+--------------------
 
 ### Enhancements
 
@@ -2191,7 +2233,8 @@ name>`. This is not a breaking change as it was previously impossible to
 - Scraping service: Ensure that a reshard is scheduled every reshard
   interval. (@rfratto)
 
-## v0.18.3 (2021-09-08)
+v0.18.3 (2021-09-08)
+--------------------
 
 ### Bugfixes
 
@@ -2212,19 +2255,22 @@ name>`. This is not a breaking change as it was previously impossible to
 - Scraping service: prevent more than one refresh from being queued at a time.
   (@rfratto)
 
-## v0.18.2 (2021-08-12)
+v0.18.2 (2021-08-12)
+--------------------
 
 ### Bugfixes
 
 - Honor the prefix and remove prefix from consul list results (@mattdurham)
 
-## v0.18.1 (2021-08-09)
+v0.18.1 (2021-08-09)
+--------------------
 
 ### Bugfixes
 
 - Reduce number of consul calls when ran in scrape service mode (@mattdurham)
 
-## v0.18.0 (2021-07-29)
+v0.18.0 (2021-07-29)
+--------------------
 
 ### Features
 
@@ -2243,7 +2289,8 @@ name>`. This is not a breaking change as it was previously impossible to
 
 - Enabled flag for integrations is not being honored. (@mattdurham)
 
-## v0.17.0 (2021-07-15)
+v0.17.0 (2021-07-15)
+--------------------
 
 ### Features
 
@@ -2255,14 +2302,16 @@ name>`. This is not a breaking change as it was previously impossible to
 - Fix race condition that may occur and result in a panic when initializing
   scraping service cluster. (@rfratto)
 
-## v0.16.1 (2021-06-22)
+v0.16.1 (2021-06-22)
+--------------------
 
 ### Bugfixes
 
 - Fix issue where replaying a WAL caused incorrect metrics to be sent over
   remote write. (@rfratto)
 
-## v0.16.0 (2021-06-17)
+v0.16.0 (2021-06-17)
+--------------------
 
 ### Features
 
@@ -2283,7 +2332,8 @@ name>`. This is not a breaking change as it was previously impossible to
   that target had gone down for long enough that its series were removed from
   the in-memory cache (2 GC cycles). (@rfratto)
 
-## v0.15.0 (2021-06-03)
+v0.15.0 (2021-06-03)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -2324,7 +2374,8 @@ name>`. This is not a breaking change as it was previously impossible to
 
 - Intentionally order tracing processors. (@joe-elliott)
 
-## v0.14.0 (2021-05-24)
+v0.14.0 (2021-05-24)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -2367,7 +2418,7 @@ name>`. This is not a breaking change as it was previously impossible to
   against the main HTTP server. Instead, two new command-line flags have been
   added: `--reload-addr` and `--reload-port`. These will launch a
   `/-/reload`-only HTTP server that can be used to safely reload the Agent's
-  state. (@rfratto)
+  state.  (@rfratto)
 
 - Add a /-/config endpoint. This endpoint will return the current configuration
   file with defaults applied that the Agent has loaded from disk. (@rfratto)
@@ -2439,7 +2490,8 @@ name>`. This is not a breaking change as it was previously impossible to
 
 - Add `tempo_spanmetrics` namespace in spanmetrics (@mapno)
 
-## v0.13.1 (2021-04-09)
+v0.13.1 (2021-04-09)
+--------------------
 
 ### Bugfixes
 
@@ -2447,7 +2499,8 @@ name>`. This is not a breaking change as it was previously impossible to
   label set with duplicate labels, mirroring the behavior of Prometheus.
   (@rfratto)
 
-## v0.13.0 (2021-02-25)
+v0.13.0 (2021-02-25)
+--------------------
 
 > The primary branch name has changed from `master` to `main`. You may have to
 > update your local checkouts of the repository to point at the new branch name.
@@ -2486,7 +2539,8 @@ name>`. This is not a breaking change as it was previously impossible to
 - Add the ability to read and serve HTTPS integration metrics when given a set
   certificates (@mattdurham)
 
-## v0.12.0 (2021-02-05)
+v0.12.0 (2021-02-05)
+--------------------
 
 > **BREAKING CHANGES**: This release has breaking changes. Please read entries
 > carefully and consult the [upgrade guide][] for specific instructions.
@@ -2522,7 +2576,7 @@ name>`. This is not a breaking change as it was previously impossible to
 - Scraping service: Unhealthy Agents in the ring will no longer cause job
   distribution to fail. (@rfratto)
 
-- Scraping service: Cortex ring metrics (prefixed with cortex*ring*) will now
+- Scraping service: Cortex ring metrics (prefixed with cortex_ring_) will now
   be registered for tracking the state of the hash ring. (@rfratto)
 
 - Scraping service: instance config ownership is now determined by the hash of
@@ -2540,7 +2594,8 @@ name>`. This is not a breaking change as it was previously impossible to
 - `agentctl config-check` will now work correctly when the supplied config file
   contains integrations. (@hoenn)
 
-## v0.11.0 (2021-01-20)
+v0.11.0 (2021-01-20)
+--------------------
 
 ### Features
 
@@ -2568,7 +2623,8 @@ name>`. This is not a breaking change as it was previously impossible to
 - The K8s manifests will no longer include the `default/kubernetes` job twice
   in both the DaemonSet and the Deployment. (@rfratto)
 
-## v0.10.0 (2021-01-13)
+v0.10.0 (2021-01-13)
+--------------------
 
 ### Features
 
@@ -2605,14 +2661,16 @@ name>`. This is not a breaking change as it was previously impossible to
   This was prevented by accidentally writing to a readonly volume mount.
   (@rfratto)
 
-## v0.9.1 (2021-01-04)
+v0.9.1 (2021-01-04)
+-------------------
 
 ### Enhancements
 
 - agentctl will now be installed by the rpm and deb packages as
   `grafana-agentctl`. (@rfratto)
 
-## v0.9.0 (2020-12-10)
+v0.9.0 (2020-12-10)
+-------------------
 
 ### Features
 
@@ -2661,7 +2719,8 @@ name>`. This is not a breaking change as it was previously impossible to
 - The User-Agent header sent for logs will now be `GrafanaCloudAgent/<version>`
   (@rfratto)
 
-## v0.8.0 (2020-11-06)
+v0.8.0 (2020-11-06)
+-------------------
 
 ### Features
 
@@ -2687,7 +2746,8 @@ name>`. This is not a breaking change as it was previously impossible to
   rather than just logging a generic message saying that retrieving the config
   has failed. (@rfratto)
 
-## v0.7.2 (2020-10-29)
+v0.7.2 (2020-10-29)
+-------------------
 
 ### Enhancements
 
@@ -2710,13 +2770,15 @@ name>`. This is not a breaking change as it was previously impossible to
 - Fix issue where the `push_config` for Tempo field was expected to be
   `remote_write`. `push_config` now works as expected. (@rfratto)
 
-## v0.7.1 (2020-10-23)
+v0.7.1 (2020-10-23)
+-------------------
 
 ### Bugfixes
 
 - Fix issue where ARM binaries were not published with the GitHub release.
 
-## v0.7.0 (2020-10-23)
+v0.7.0 (2020-10-23)
+-------------------
 
 ### Features
 
@@ -2758,7 +2820,8 @@ name>`. This is not a breaking change as it was previously impossible to
   computed by remote_write. This change should not negatively affect existing
   users. (@rfratto)
 
-## v0.6.1 (2020-04-11)
+v0.6.1 (2020-04-11)
+-------------------
 
 ### Bugfixes
 
@@ -2771,7 +2834,8 @@ name>`. This is not a breaking change as it was previously impossible to
 - Fix deadlock that slowly prevents the Agent from scraping targets at a high
   scrape volume. (@rfratto)
 
-## v0.6.0 (2020-09-04)
+v0.6.0 (2020-09-04)
+-------------------
 
 ### Breaking Changes
 
@@ -2820,7 +2884,7 @@ name>`. This is not a breaking change as it was previously impossible to
 - The subsystems of the Agent (`prometheus`, `loki`) are now made optional.
   Enabling integrations also implicitly enables the associated subsystem. For
   example, enabling the `agent` or `node_exporter` integration will force the
-  `prometheus` subsystem to be enabled. (@rfratto)
+  `prometheus` subsystem to be enabled.  (@rfratto)
 
 ### Bugfixes
 
@@ -2844,7 +2908,8 @@ name>`. This is not a breaking change as it was previously impossible to
 - Fix a panic that may occur during shutdown if the WAL is closed in the middle
   of the WAL being truncated. (@rfratto)
 
-## v0.5.0 (2020-08-12)
+v0.5.0 (2020-08-12)
+-------------------
 
 ### Features
 
@@ -2881,7 +2946,8 @@ name>`. This is not a breaking change as it was previously impossible to
   needing to manually set the blocklist and allowlist of filesystems.
   (@rfratto)
 
-## v0.4.0 (2020-06-18)
+v0.4.0 (2020-06-18)
+-------------------
 
 ### Features
 
@@ -2908,7 +2974,8 @@ name>`. This is not a breaking change as it was previously impossible to
 - Enable agent host_filter in the Tanka configs, which was disabled by default
   by mistake. (@rfratto)
 
-## v0.3.2 (2020-05-29)
+v0.3.2 (2020-05-29)
+-------------------
 
 ### Features
 
@@ -2948,7 +3015,8 @@ name>`. This is not a breaking change as it was previously impossible to
   correctly show the pod name of the Agent instead of the exporter name.
   (@rfratto)
 
-## v0.3.1 (2020-05-20)
+v0.3.1 (2020-05-20)
+-------------------
 
 ### Features
 
@@ -2968,7 +3036,8 @@ name>`. This is not a breaking change as it was previously impossible to
 - `agentctl` and the config API will now validate that the YAML they receive
   are valid instance configs. (@rfratto)
 
-## v0.3.0 (2020-05-13)
+v0.3.0 (2020-05-13)
+-------------------
 
 ### Features
 
@@ -2995,7 +3064,8 @@ name>`. This is not a breaking change as it was previously impossible to
 - The Grafana Agent Tanka Mixins now are placed in an "Agent" folder within
   Grafana. (@cyriltovena)
 
-## v0.2.0 (2020-04-09)
+v0.2.0 (2020-04-09)
+-------------------
 
 ### Features
 
@@ -3005,7 +3075,6 @@ name>`. This is not a breaking change as it was previously impossible to
   (@gotjosh)
 
   These metrics are available to monitor metadata being sent:
-
   - `prometheus_remote_storage_succeeded_metadata_total`
   - `prometheus_remote_storage_failed_metadata_total`
   - `prometheus_remote_storage_retried_metadata_total`
@@ -3025,7 +3094,8 @@ name>`. This is not a breaking change as it was previously impossible to
 - Enabling host_filter will now allow metrics from node role Kubernetes service
   discovery to be scraped properly (e.g., cAdvisor, Kubelet). (@rfratto)
 
-## v0.1.1 (2020-03-16)
+v0.1.1 (2020-03-16)
+-------------------
 
 ### Other changes
 
@@ -3035,7 +3105,8 @@ name>`. This is not a breaking change as it was previously impossible to
 
 - Pass through release tag to `docker build` (@rfratto)
 
-## v0.1.0 (2020-03-16)
+v0.1.0 (2020-03-16)
+-------------------
 
 > First release!
 

--- a/pkg/integrations/v2/app_agent_receiver/logs_exporter_test.go
+++ b/pkg/integrations/v2/app_agent_receiver/logs_exporter_test.go
@@ -99,7 +99,7 @@ func TestExportLogs(t *testing.T) {
 		prommodel.LabelName("app"):  prommodel.LabelValue("frontend"),
 		prommodel.LabelName("kind"): prommodel.LabelValue("measurement"),
 	}, inst.Entries[3].Labels)
-	expectedLine = "timestamp=\"2021-09-30 10:46:17.68 +0000 UTC\" kind=measurement ttfb=14.000000 ttfcp=22.120000 ttfp=20.120000 traceID=abcd spanID=def sdk_name=grafana-frontend-agent sdk_version=1.0.0 app_name=testapp app_release=0.8.2 app_version=abcdefg app_environment=production user_email=geralt@kaermorhen.org user_id=123 user_username=domasx2 user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false view_name=foobar"
+	expectedLine = "timestamp=\"2021-09-30 10:46:17.68 +0000 UTC\" kind=measurement ttfb=14.000000 ttfcp=22.120000 ttfp=20.120000 traceID=abcd spanID=def context_hello=world sdk_name=grafana-frontend-agent sdk_version=1.0.0 app_name=testapp app_release=0.8.2 app_version=abcdefg app_environment=production user_email=geralt@kaermorhen.org user_id=123 user_username=domasx2 user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false view_name=foobar"
 	require.Equal(t, expectedLine, inst.Entries[3].Line)
 
 	// event 1

--- a/pkg/integrations/v2/app_agent_receiver/payload.go
+++ b/pkg/integrations/v2/app_agent_receiver/payload.go
@@ -217,7 +217,6 @@ type Measurement struct {
 	Timestamp time.Time          `json:"timestamp,omitempty"`
 	Trace     TraceContext       `json:"trace,omitempty"`
 	Context   MeasurementContext `json:"context,omitempty"`
-	Type      string             `json:"type,omitempty"`
 }
 
 // KeyVal representation of the exception object

--- a/pkg/integrations/v2/app_agent_receiver/payload.go
+++ b/pkg/integrations/v2/app_agent_receiver/payload.go
@@ -207,11 +207,17 @@ func (l Log) KeyVal() *KeyVal {
 	return kv
 }
 
+// ExceptionContext is a string to string map structure that
+// represents the context of a log message
+type MeasurementContext map[string]string
+
 // Measurement holds the data for user provided measurements
 type Measurement struct {
 	Values    map[string]float64 `json:"values,omitempty"`
 	Timestamp time.Time          `json:"timestamp,omitempty"`
 	Trace     TraceContext       `json:"trace,omitempty"`
+	Context   MeasurementContext `json:"context,omitempty"`
+	Type      string             `json:"type,omitempty"`
 }
 
 // KeyVal representation of the exception object
@@ -230,6 +236,7 @@ func (m Measurement) KeyVal() *KeyVal {
 		KeyValAdd(kv, k, fmt.Sprintf("%f", m.Values[k]))
 	}
 	MergeKeyVal(kv, m.Trace.KeyVal())
+	MergeKeyValWithPrefix(kv, KeyValFromMap(m.Context), "context_")
 	return kv
 }
 

--- a/pkg/integrations/v2/app_agent_receiver/payload.go
+++ b/pkg/integrations/v2/app_agent_receiver/payload.go
@@ -207,7 +207,7 @@ func (l Log) KeyVal() *KeyVal {
 	return kv
 }
 
-// ExceptionContext is a string to string map structure that
+// MeasurementContext is a string to string map structure that
 // represents the context of a log message
 type MeasurementContext map[string]string
 

--- a/pkg/integrations/v2/app_agent_receiver/payload_test.go
+++ b/pkg/integrations/v2/app_agent_receiver/payload_test.go
@@ -128,13 +128,12 @@ func TestUnmarshalPayloadJSON(t *testing.T) {
 				"ttfcp": 22.12,
 				"ttfb":  14,
 			},
-			Type:      "page load",
 			Timestamp: now,
 			Trace: TraceContext{
 				TraceID: "abcd",
 				SpanID:  "def",
 			},
-			Context: map[string]string{
+			Context: MeasurementContext{
 				"hello": "world",
 			},
 		},

--- a/pkg/integrations/v2/app_agent_receiver/payload_test.go
+++ b/pkg/integrations/v2/app_agent_receiver/payload_test.go
@@ -118,4 +118,25 @@ func TestUnmarshalPayloadJSON(t *testing.T) {
 			Timestamp: now,
 		},
 	}, payload.Events)
+
+	require.Len(t, payload.Measurements, 1)
+
+	require.Equal(t, []Measurement{
+		{
+			Values: map[string]float64{
+				"ttfp":  20.12,
+				"ttfcp": 22.12,
+				"ttfb":  14,
+			},
+			Type:      "page load",
+			Timestamp: now,
+			Trace: TraceContext{
+				TraceID: "abcd",
+				SpanID:  "def",
+			},
+			Context: map[string]string{
+				"hello": "world",
+			},
+		},
+	}, payload.Measurements)
 }

--- a/pkg/integrations/v2/app_agent_receiver/testdata/payload.json
+++ b/pkg/integrations/v2/app_agent_receiver/testdata/payload.json
@@ -224,6 +224,9 @@
       "trace": {
         "trace_id": "abcd",
         "span_id": "def"
+      },
+      "context": {
+        "hello": "world"
       }
     }
   ],


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
In the Faro Web-SDK we added an option to provide additional contextual attributes to the measurements payload.
To enable this we need to update the agent as well.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer
Just for reference here are the PRs which make the needed changes to the Faro Receiver and the Faro Web-SDK.
* [PR Receiver](https://github.com/grafana/app-o11y-kwl-endpoint/pull/262)
* [PR Docs](https://github.com/grafana/website/pull/15059)

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Tests updated