### PR TITLE
Update otelcol release instructions in README.md

### DIFF
--- a/docs/developer/release/README.md
+++ b/docs/developer/release/README.md
@@ -25,7 +25,6 @@ responsible for ownership of the following workflows:
 5. [Publish Release](./6-publish-release.md)
 6. [Test Release](./7-test-release.md)
 7. [Announce Release](./9-announce-release.md)
-8. [Update OTEL Contrib](./10-update-otel.md)
 
 ## Additional Release Candidate[s] Publish
 1. [Cherry Pick Commits](./2-cherry-pick-commits.md)
@@ -34,7 +33,6 @@ responsible for ownership of the following workflows:
 4. [Publish Release](./6-publish-release.md)
 5. [Test Release](./7-test-release.md)
 6. [Announce Release](./9-announce-release.md)
-7. [Update OTEL Contrib](./10-update-otel.md)
 
 ## Stable Release Publish
 1. [Cherry Pick Commits](./2-cherry-pick-commits.md)
@@ -55,7 +53,6 @@ responsible for ownership of the following workflows:
 5. [Update Release Branch](./5-update-release-branch.md) 
 6. [Update Helm Charts](./8-update-helm-charts.md)
 7. [Announce Release](./9-announce-release.md)
-8. [Update OTEL Contrib](./10-update-otel.md)
 
 ## Patch Release Publish (older version)
 - Not documented yet (but here are some hints)


### PR DESCRIPTION
The task of adding a link to grafana agent docs to OTEL docs (example: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/26104/files) should be performed only when we release a stable version:
* RCs are not yet recommended to use in prod, so no need to update
* Patch releases don't add new OTEL components, so no need

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
