### PR TITLE
helm: enable clustering support for deployments and daemonsets

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -8,8 +8,11 @@ changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
 Unreleased
-
 ----------
+
+### Enhancements
+
+- Enable clustering for deployments and daemonsets. (@tpaschalis)
 
 0.22.0 (2023-08-30)
 -------------------

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -41,7 +41,7 @@ use the older mode (called "static mode"), set the `agent.mode` value to
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| agent.clustering.enabled | bool | `false` | Deploy agents in a cluster to allow for load distribution. Only applies when agent.mode=flow and controller.type=statefulset. |
+| agent.clustering.enabled | bool | `false` | Deploy agents in a cluster to allow for load distribution. Only applies when agent.mode=flow. |
 | agent.configMap.content | string | `""` | Content to assign to the new ConfigMap.  This is passed into `tpl` allowing for templating from values. |
 | agent.configMap.create | bool | `true` | Create a new ConfigMap for the config file. |
 | agent.configMap.key | string | `nil` | Key in ConfigMap to get config from. |

--- a/operations/helm/charts/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/charts/grafana-agent/templates/controllers/statefulset.yaml
@@ -1,7 +1,3 @@
-{{- if and (.Values.agent.clustering.enabled) (ne .Values.controller.type "statefulset") -}}
-{{ fail "Clustering may only be used with controller.type=statefulset." }}
-{{- end -}}
-
 {{- if eq .Values.controller.type "statefulset" }}
 apiVersion: apps/v1
 kind: StatefulSet

--- a/operations/helm/charts/grafana-agent/values.yaml
+++ b/operations/helm/charts/grafana-agent/values.yaml
@@ -40,7 +40,7 @@ agent:
 
   clustering:
     # -- Deploy agents in a cluster to allow for load distribution. Only
-    # applies when agent.mode=flow and controller.type=statefulset.
+    # applies when agent.mode=flow.
     enabled: false
 
   # -- Path to where Grafana Agent stores data (for example, the Write-Ahead Log).


### PR DESCRIPTION
Since we've merged support for periodically rejoining the list of peers, this enables clustering to work with deployments, daemonsets as well as statefulsets with maxUnavailablePods > 1.

We've already identified this can be noisy in large environments, but this will be mitigated with #4464 or similar.
As a drive-by, we fix the changelog of a previous release.

Fixes #4995.
