### PR TITLE
Clustering: add max initial join peers flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Main (unreleased)
   - `otelcol.connector.spanlogs` - creates logs from spans. It is the flow mode equivalent
   to static mode's `automatic_logging` processor. (@ptodev)
 
+- Clustering: add new flag `--cluster.max-initial-join-peers` to limit the number of peers the system joins upon initialization. (@wildum)
+
 ### Other changes
 
 - Use Go 1.21.0 for builds. (@rfratto)

--- a/cmd/internal/flowmode/cluster_builder.go
+++ b/cmd/internal/flowmode/cluster_builder.go
@@ -23,14 +23,15 @@ type clusterOptions struct {
 	Metrics prometheus.Registerer
 	Tracer  trace.TracerProvider
 
-	EnableClustering    bool
-	NodeName            string
-	AdvertiseAddress    string
-	ListenAddress       string
-	JoinPeers           []string
-	DiscoverPeers       string
-	RejoinInterval      time.Duration
-	AdvertiseInterfaces []string
+	EnableClustering        bool
+	NodeName                string
+	AdvertiseAddress        string
+	ListenAddress           string
+	JoinPeers               []string
+	DiscoverPeers           string
+	RejoinInterval          time.Duration
+	AdvertiseInterfaces     []string
+	ClusterMaxInitJoinPeers int
 }
 
 func buildClusterService(opts clusterOptions) (*cluster.Service, error) {
@@ -41,10 +42,11 @@ func buildClusterService(opts clusterOptions) (*cluster.Service, error) {
 		Metrics: opts.Metrics,
 		Tracer:  opts.Tracer,
 
-		EnableClustering: opts.EnableClustering,
-		NodeName:         opts.NodeName,
-		AdvertiseAddress: opts.AdvertiseAddress,
-		RejoinInterval:   opts.RejoinInterval,
+		EnableClustering:        opts.EnableClustering,
+		NodeName:                opts.NodeName,
+		AdvertiseAddress:        opts.AdvertiseAddress,
+		RejoinInterval:          opts.RejoinInterval,
+		ClusterMaxInitJoinPeers: opts.ClusterMaxInitJoinPeers,
 	}
 
 	if config.NodeName == "" {

--- a/docs/sources/flow/reference/cli/run.md
+++ b/docs/sources/flow/reference/cli/run.md
@@ -51,6 +51,7 @@ The following flags are supported:
 * `--cluster.rejoin-interval`: How often to rejoin the list of peers (default `"60s"`).
 * `--cluster.advertise-address`: Address to advertise to other cluster nodes (default `""`).
 * `--cluster.advertise-interfaces`: List of interfaces used to infer an address to advertise. The first one available in the list will be selected (default `"eth0,en0"`).
+* `--cluster.max-initial-join-peers`: Number of initial peers to join from the discovered set (default `5`).
 * `--config.format`: The format of the source file. Supported formats: `flow`, `prometheus`, `promtail` (default `"flow"`).
 * `--config.bypass-conversion-errors`: Enable bypassing errors when converting (default `false`).
 
@@ -133,6 +134,9 @@ state.
 The first node that is used to bootstrap a new cluster (also known as
 the "seed node") can either omit the flags that specify peers to join or can
 try to connect to itself.
+
+To accelerate startup time, you can use the `--cluster.max-initial-join-peers` flag
+to limit the number of peers the system joins upon initialization.
 
 ### Clustering states
 

--- a/service/cluster/cluster_test.go
+++ b/service/cluster/cluster_test.go
@@ -1,0 +1,67 @@
+package cluster
+
+import (
+	"reflect"
+	"testing"
+)
+
+type MockedRand struct{}
+
+// Shuffle reverse the array for a predictable outcome.
+func (m *MockedRand) Shuffle(n int, swap func(i, j int)) {
+	for i := 0; i < n/2; i++ {
+		swap(i, n-i-1)
+	}
+}
+
+func mockDiscoverPeers(peers []string, err error) func() ([]string, error) {
+	return func() ([]string, error) {
+		return peers, err
+	}
+}
+
+func TestGetPeers(t *testing.T) {
+	tests := []struct {
+		name              string
+		opts              Options
+		expectedPeers     []string
+		expectedError     error
+		discoverPeersMock func() ([]string, error)
+	}{
+		{
+			name:          "Test clustering disabled",
+			opts:          Options{EnableClustering: false},
+			expectedPeers: nil,
+		},
+		{
+			name:          "Test no max peers limit",
+			opts:          Options{EnableClustering: true, ClusterMaxInitJoinPeers: 0, DiscoverPeers: mockDiscoverPeers([]string{"A", "B"}, nil)},
+			expectedPeers: []string{"A", "B"},
+		},
+		{
+			name:          "Test max higher than number of peers",
+			opts:          Options{EnableClustering: true, ClusterMaxInitJoinPeers: 5, DiscoverPeers: mockDiscoverPeers([]string{"A", "B", "C"}, nil)},
+			expectedPeers: []string{"A", "B", "C"},
+		},
+		{
+			name:          "Test max peers limit with shuffling",
+			opts:          Options{EnableClustering: true, ClusterMaxInitJoinPeers: 2, DiscoverPeers: mockDiscoverPeers([]string{"A", "B", "C"}, nil)},
+			expectedPeers: []string{"C", "B"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := &Service{
+				opts:    test.opts,
+				randGen: &MockedRand{},
+			}
+
+			peers, _ := s.getPeers()
+
+			if !reflect.DeepEqual(peers, test.expectedPeers) {
+				t.Errorf("Expected peers %v, got %v", test.expectedPeers, peers)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

On startup an agent with clustering enabled will try to join every peers from the discovered set. This action can be costly for clusters of significant sizes.

The flag max-initial-join-peers will allow the users to limit the number of peers an agent should join upon initialisation. The subset of peers is randomly selected amongst the discovered set. 

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
 Fixes #4464 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated