### PR TITLE
Add a otelcol.connector.servicegraph component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ Main (unreleased)
 
   - `otelcol.connector.spanlogs` creates logs from spans. It is the flow mode equivalent
   to static mode's `automatic_logging` processor. (@ptodev)
-  - `discovery.consulagent` - discovers scrape targets from Consul Agent. (@wildum)
+  - `otelcol.connector.servicegraph` creates service graph metrics from spans. It is the
+  flow mode equivalent to static mode's `service_graphs` processor. (@ptodev)
+  - `discovery.consulagent` discovers scrape targets from Consul Agent. (@wildum)
   - `discovery.kuma` discovers scrape targets from the Kuma control plane. (@tpaschalis)
   - `discovery.marathon` discovers scrape targets from Marathon servers. (@wildum)
   - `discovery.ionos` discovers scrape targets from the IONOS Cloud API. (@wildum)

--- a/component/all/all.go
+++ b/component/all/all.go
@@ -60,6 +60,7 @@ import (
 	_ "github.com/grafana/agent/component/otelcol/auth/headers"                     // Import otelcol.auth.headers
 	_ "github.com/grafana/agent/component/otelcol/auth/oauth2"                      // Import otelcol.auth.oauth2
 	_ "github.com/grafana/agent/component/otelcol/auth/sigv4"                       // Import otelcol.auth.sigv4
+	_ "github.com/grafana/agent/component/otelcol/connector/servicegraph"           // Import otelcol.connector.servicegraph
 	_ "github.com/grafana/agent/component/otelcol/connector/spanlogs"               // Import otelcol.connector.spanlogs
 	_ "github.com/grafana/agent/component/otelcol/connector/spanmetrics"            // Import otelcol.connector.spanmetrics
 	_ "github.com/grafana/agent/component/otelcol/exporter/jaeger"                  // Import otelcol.exporter.jaeger

--- a/component/otelcol/connector/servicegraph/servicegraph.go
+++ b/component/otelcol/connector/servicegraph/servicegraph.go
@@ -30,7 +30,6 @@ func init() {
 // Arguments configures the otelcol.connector.servicegraph component.
 type Arguments struct {
 	// LatencyHistogramBuckets is the list of durations representing latency histogram buckets.
-	// See defaultLatencyHistogramBucketsMs in processor.go for the default value.
 	LatencyHistogramBuckets []time.Duration `river:"latency_histogram_buckets,attr,optional"`
 
 	// Dimensions defines the list of additional dimensions on top of the provided:

--- a/component/otelcol/connector/servicegraph/servicegraph.go
+++ b/component/otelcol/connector/servicegraph/servicegraph.go
@@ -1,0 +1,178 @@
+package servicegraph
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/otelcol"
+	"github.com/grafana/agent/component/otelcol/connector"
+	"github.com/grafana/river"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/servicegraphprocessor"
+	otelcomponent "go.opentelemetry.io/collector/component"
+	otelextension "go.opentelemetry.io/collector/extension"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:    "otelcol.connector.servicegraph",
+		Args:    Arguments{},
+		Exports: otelcol.ConsumerExports{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			fact := servicegraphconnector.NewFactory()
+			return connector.New(opts, fact, args.(Arguments))
+		},
+	})
+}
+
+// Arguments configures the otelcol.connector.servicegraph component.
+type Arguments struct {
+	// LatencyHistogramBuckets is the list of durations representing latency histogram buckets.
+	// See defaultLatencyHistogramBucketsMs in processor.go for the default value.
+	LatencyHistogramBuckets []time.Duration `river:"latency_histogram_buckets,attr,optional"`
+
+	// Dimensions defines the list of additional dimensions on top of the provided:
+	// - client
+	// - server
+	// - failed
+	// - connection_type
+	// The dimensions will be fetched from the span's attributes. Examples of some conventionally used attributes:
+	// https://github.com/open-telemetry/opentelemetry-collector/blob/main/model/semconv/opentelemetry.go.
+	Dimensions []string `river:"dimensions,attr,optional"`
+
+	// Store contains the config for the in-memory store used to find requests between services by pairing spans.
+	Store StoreConfig `river:"store,block,optional"`
+	// CacheLoop is the time to cleans the cache periodically.
+	CacheLoop time.Duration `river:"cache_loop,attr,optional"`
+	// CacheLoop is the time to expire old entries from the store periodically.
+	StoreExpirationLoop time.Duration `river:"store_expiration_loop,attr,optional"`
+	// VirtualNodePeerAttributes the list of attributes need to match, the higher the front, the higher the priority.
+	//TODO: Ad VirtualNodePeerAttributes when it's no longer controlled by
+	// the "processor.servicegraph.virtualNode" feature gate.
+	// VirtualNodePeerAttributes []string `river:"virtual_node_peer_attributes,attr,optional"`
+
+	// Output configures where to send processed data. Required.
+	Output *otelcol.ConsumerArguments `river:"output,block"`
+}
+
+type StoreConfig struct {
+	// MaxItems is the maximum number of items to keep in the store.
+	MaxItems int `river:"max_items,attr,optional"`
+	// TTL is the time to live for items in the store.
+	TTL time.Duration `river:"ttl,attr,optional"`
+}
+
+var (
+	_ river.Validator = (*Arguments)(nil)
+	_ river.Defaulter = (*Arguments)(nil)
+)
+
+// DefaultArguments holds default settings for Arguments.
+var DefaultArguments = Arguments{
+	LatencyHistogramBuckets: []time.Duration{
+		2 * time.Millisecond,
+		4 * time.Millisecond,
+		6 * time.Millisecond,
+		8 * time.Millisecond,
+		10 * time.Millisecond,
+		50 * time.Millisecond,
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		400 * time.Millisecond,
+		800 * time.Millisecond,
+		1 * time.Second,
+		1400 * time.Millisecond,
+		2 * time.Second,
+		5 * time.Second,
+		10 * time.Second,
+		15 * time.Second,
+	},
+	Dimensions: []string{},
+	Store: StoreConfig{
+		MaxItems: 1000,
+		TTL:      2 * time.Millisecond,
+	},
+	CacheLoop:           1 * time.Minute,
+	StoreExpirationLoop: 2 * time.Second,
+	//TODO: Ad VirtualNodePeerAttributes when it's no longer controlled by
+	// the "processor.servicegraph.virtualNode" feature gate.
+	// VirtualNodePeerAttributes: []string{
+	// 	semconv.AttributeDBName,
+	// 	semconv.AttributeNetSockPeerAddr,
+	// 	semconv.AttributeNetPeerName,
+	// 	semconv.AttributeRPCService,
+	// 	semconv.AttributeNetSockPeerName,
+	// 	semconv.AttributeNetPeerName,
+	// 	semconv.AttributeHTTPURL,
+	// 	semconv.AttributeHTTPTarget,
+	// },
+}
+
+// SetToDefault implements river.Defaulter.
+func (args *Arguments) SetToDefault() {
+	*args = DefaultArguments
+}
+
+// Validate implements river.Validator.
+func (args *Arguments) Validate() error {
+	if args.CacheLoop <= 0 {
+		return fmt.Errorf("cache_loop must be greater than 0")
+	}
+
+	if args.StoreExpirationLoop <= 0 {
+		return fmt.Errorf("store_expiration_loop must be greater than 0")
+	}
+
+	if args.Store.MaxItems <= 0 {
+		return fmt.Errorf("store.max_items must be greater than 0")
+	}
+
+	if args.Store.TTL <= 0 {
+		return fmt.Errorf("store.ttl must be greater than 0")
+	}
+
+	return nil
+}
+
+// Convert implements connector.Arguments.
+func (args Arguments) Convert() (otelcomponent.Config, error) {
+	return &servicegraphprocessor.Config{
+		// Never set a metric exporter.
+		// The consumer of metrics will be set via Otel's Connector API.
+		//
+		// MetricsExporter:         "",
+		LatencyHistogramBuckets: args.LatencyHistogramBuckets,
+		Dimensions:              args.Dimensions,
+		Store: servicegraphprocessor.StoreConfig{
+			MaxItems: args.Store.MaxItems,
+			TTL:      args.Store.TTL,
+		},
+		CacheLoop:           args.CacheLoop,
+		StoreExpirationLoop: args.StoreExpirationLoop,
+		//TODO: Ad VirtualNodePeerAttributes when it's no longer controlled by
+		// the "processor.servicegraph.virtualNode" feature gate.
+		// VirtualNodePeerAttributes: args.VirtualNodePeerAttributes,
+	}, nil
+}
+
+// Extensions implements connector.Arguments.
+func (args Arguments) Extensions() map[otelcomponent.ID]otelextension.Extension {
+	return nil
+}
+
+// Exporters implements connector.Arguments.
+func (args Arguments) Exporters() map[otelcomponent.DataType]map[otelcomponent.ID]otelcomponent.Component {
+	return nil
+}
+
+// NextConsumers implements connector.Arguments.
+func (args Arguments) NextConsumers() *otelcol.ConsumerArguments {
+	return args.Output
+}
+
+// ConnectorType() int implements connector.Arguments.
+func (Arguments) ConnectorType() int {
+	return connector.ConnectorTracesToMetrics
+}

--- a/component/otelcol/connector/servicegraph/servicegraph.go
+++ b/component/otelcol/connector/servicegraph/servicegraph.go
@@ -44,12 +44,12 @@ type Arguments struct {
 
 	// Store contains the config for the in-memory store used to find requests between services by pairing spans.
 	Store StoreConfig `river:"store,block,optional"`
-	// CacheLoop is the time to cleans the cache periodically.
+	// CacheLoop defines how often to clean the cache of stale series.
 	CacheLoop time.Duration `river:"cache_loop,attr,optional"`
-	// CacheLoop is the time to expire old entries from the store periodically.
+	// StoreExpirationLoop defines how often to expire old entries from the store.
 	StoreExpirationLoop time.Duration `river:"store_expiration_loop,attr,optional"`
 	// VirtualNodePeerAttributes the list of attributes need to match, the higher the front, the higher the priority.
-	//TODO: Ad VirtualNodePeerAttributes when it's no longer controlled by
+	//TODO: Add VirtualNodePeerAttributes when it's no longer controlled by
 	// the "processor.servicegraph.virtualNode" feature gate.
 	// VirtualNodePeerAttributes []string `river:"virtual_node_peer_attributes,attr,optional"`
 
@@ -96,7 +96,7 @@ var DefaultArguments = Arguments{
 	},
 	CacheLoop:           1 * time.Minute,
 	StoreExpirationLoop: 2 * time.Second,
-	//TODO: Ad VirtualNodePeerAttributes when it's no longer controlled by
+	//TODO: Add VirtualNodePeerAttributes when it's no longer controlled by
 	// the "processor.servicegraph.virtualNode" feature gate.
 	// VirtualNodePeerAttributes: []string{
 	// 	semconv.AttributeDBName,
@@ -151,7 +151,7 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 		},
 		CacheLoop:           args.CacheLoop,
 		StoreExpirationLoop: args.StoreExpirationLoop,
-		//TODO: Ad VirtualNodePeerAttributes when it's no longer controlled by
+		//TODO: Add VirtualNodePeerAttributes when it's no longer controlled by
 		// the "processor.servicegraph.virtualNode" feature gate.
 		// VirtualNodePeerAttributes: args.VirtualNodePeerAttributes,
 	}, nil

--- a/component/otelcol/connector/servicegraph/servicegraph_test.go
+++ b/component/otelcol/connector/servicegraph/servicegraph_test.go
@@ -48,7 +48,7 @@ func TestArguments_UnmarshalRiver(t *testing.T) {
 				},
 				CacheLoop:           1 * time.Minute,
 				StoreExpirationLoop: 2 * time.Second,
-				//TODO: Ad VirtualNodePeerAttributes when it's no longer controlled by
+				//TODO: Add VirtualNodePeerAttributes when it's no longer controlled by
 				// the "processor.servicegraph.virtualNode" feature gate.
 				// VirtualNodePeerAttributes: []string{
 				// 				"db.name",

--- a/component/otelcol/connector/servicegraph/servicegraph_test.go
+++ b/component/otelcol/connector/servicegraph/servicegraph_test.go
@@ -1,0 +1,156 @@
+package servicegraph_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/component/otelcol/connector/servicegraph"
+	"github.com/grafana/river"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/servicegraphprocessor"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArguments_UnmarshalRiver(t *testing.T) {
+	tests := []struct {
+		testName string
+		cfg      string
+		expected servicegraphprocessor.Config
+		errorMsg string
+	}{
+		{
+			testName: "Defaults",
+			cfg: `
+				output {}
+			`,
+			expected: servicegraphprocessor.Config{
+				LatencyHistogramBuckets: []time.Duration{
+					2 * time.Millisecond,
+					4 * time.Millisecond,
+					6 * time.Millisecond,
+					8 * time.Millisecond,
+					10 * time.Millisecond,
+					50 * time.Millisecond,
+					100 * time.Millisecond,
+					200 * time.Millisecond,
+					400 * time.Millisecond,
+					800 * time.Millisecond,
+					1 * time.Second,
+					1400 * time.Millisecond,
+					2 * time.Second,
+					5 * time.Second,
+					10 * time.Second,
+					15 * time.Second,
+				},
+				Dimensions: []string{},
+				Store: servicegraphprocessor.StoreConfig{
+					MaxItems: 1000,
+					TTL:      2 * time.Millisecond,
+				},
+				CacheLoop:           1 * time.Minute,
+				StoreExpirationLoop: 2 * time.Second,
+				//TODO: Ad VirtualNodePeerAttributes when it's no longer controlled by
+				// the "processor.servicegraph.virtualNode" feature gate.
+				// VirtualNodePeerAttributes: []string{
+				// 				"db.name",
+				// 				"net.sock.peer.addr",
+				// 				"net.peer.name",
+				// 				"rpc.service",
+				// 				"net.sock.peer.name",
+				// 				"net.peer.name",
+				// 				"http.url",
+				// 				"http.target",
+				// 			},
+			},
+		},
+		{
+			testName: "ExplicitValues",
+			cfg: `
+					dimensions = ["foo", "bar"]
+					latency_histogram_buckets = ["2ms", "4s", "6h"]
+					store {
+						max_items = 333
+						ttl = "12h"
+					}
+					cache_loop = "55m"
+					store_expiration_loop = "77s"
+
+					output {}
+				`,
+			expected: servicegraphprocessor.Config{
+				LatencyHistogramBuckets: []time.Duration{
+					2 * time.Millisecond,
+					4 * time.Second,
+					6 * time.Hour,
+				},
+				Dimensions: []string{"foo", "bar"},
+				Store: servicegraphprocessor.StoreConfig{
+					MaxItems: 333,
+					TTL:      12 * time.Hour,
+				},
+				CacheLoop:           55 * time.Minute,
+				StoreExpirationLoop: 77 * time.Second,
+				//TODO: Ad VirtualNodePeerAttributes when it's no longer controlled by
+				// the "processor.servicegraph.virtualNode" feature gate.
+				// VirtualNodePeerAttributes: []string{"attr1", "attr2"},
+			},
+		},
+		{
+			testName: "InvalidCacheLoop",
+			cfg: `
+					cache_loop = "0s"
+					output {}
+				`,
+			errorMsg: "cache_loop must be greater than 0",
+		},
+		{
+			testName: "InvalidStoreExpirationLoop",
+			cfg: `
+					store_expiration_loop = "0s"
+					output {}
+				`,
+			errorMsg: "store_expiration_loop must be greater than 0",
+		},
+		{
+			testName: "InvalidStoreMaxItems",
+			cfg: `
+					store {
+						max_items = 0
+					}
+
+					output {}
+				`,
+			errorMsg: "store.max_items must be greater than 0",
+		},
+		{
+			testName: "InvalidStoreTTL",
+			cfg: `
+					store {
+						ttl = "0s"
+					}
+
+					output {}
+				`,
+			errorMsg: "store.ttl must be greater than 0",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			var args servicegraph.Arguments
+			err := river.Unmarshal([]byte(tc.cfg), &args)
+			if tc.errorMsg != "" {
+				require.ErrorContains(t, err, tc.errorMsg)
+				return
+			}
+
+			require.NoError(t, err)
+
+			actualPtr, err := args.Convert()
+			require.NoError(t, err)
+
+			actual := actualPtr.(*servicegraphprocessor.Config)
+
+			require.Equal(t, tc.expected, *actual)
+		})
+	}
+}

--- a/docs/sources/flow/reference/components/otelcol.connector.servicegraph.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.servicegraph.md
@@ -57,7 +57,7 @@ otelcol.connector.servicegraph "LABEL" {
 
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`latency_histogram_buckets` | `list(duration)` | Buckets for latency histogram metrics. | `["2ms","4ms","6ms","8ms","10ms","50ms","100ms","200ms","400ms","800ms","1s","1400ms","2s","5s","10s","15s"]` | no
+`latency_histogram_buckets` | `list(duration)` | Buckets for latency histogram metrics. | `["2ms", "4ms", "6ms", "8ms", "10ms", "50ms", "100ms", "200ms", "400ms", "800ms", "1s", "1400ms", "2s", "5s", "10s", "15s"]` | no
 `dimensions` | `list(string)` | A list of dimensions to add with the default dimensions. | `[]` | no
 `cache_loop` | `duration` | Configures how often to delete series which have not been updated. | `"1m"` | no
 `store_expiration_loop` | `duration` | The time to expire old entries from the store periodically. | `"2s"` | no

--- a/docs/sources/flow/reference/components/otelcol.connector.servicegraph.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.servicegraph.md
@@ -38,7 +38,7 @@ Service graphs are useful for a number of use-cases:
 Since `otelcol.connector.servicegraph` has to process both sides of an edge,
 it needs to process all spans of a trace to function properly.
 If spans of a trace are spread out over multiple Agent instances, spans cannot be paired reliably.
-A solution to this problem is using [otelcol.exporter.loadbalancing](./otelcol.exporter.loadbalancing.md)
+A solution to this problem is using [otelcol.exporter.loadbalancing](../otelcol.exporter.loadbalancing/)
 in front of Agent instances running `otelcol.connector.servicegraph`.
 
 ## Usage

--- a/docs/sources/flow/reference/components/otelcol.connector.servicegraph.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.servicegraph.md
@@ -1,0 +1,218 @@
+---
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.connector.servicegraph/
+labels:
+  stage: experimental
+title: otelcol.connector.servicegraph
+---
+
+# otelcol.connector.servicegraph
+
+{{< docs/shared lookup="flow/stability/experimental.md" source="agent" >}}
+
+`otelcol.connector.servicegraph` accepts span data from other `otelcol` components and 
+outputs metrics representing the relationship between various services in a system.
+A metric represents an edge in the service graph.
+Those metrics can then be used by a data visualization application (e.g. 
+[Grafana](https://grafana.com/docs/grafana/latest/explore/trace-integration/#service-graph))
+to draw the service graph.
+
+> **NOTE**: `otelcol.connector.servicegraph` is a wrapper over the upstream
+> OpenTelemetry Collector `servicegraph` connector. Bug reports or feature requests
+> will be redirected to the upstream repository, if necessary.
+
+Multiple `otelcol.connector.servicegraph` components can be specified by giving them
+different labels.
+
+This component is based on [Grafana Tempo's service graph processor](https://github.com/grafana/tempo/tree/main/modules/generator/processor/servicegraphs).
+
+Service graphs are useful for a number of use-cases:
+
+* Infer the topology of a distributed system. As distributed systems grow, they become more complex. 
+  Service graphs can help you understand the structure of the system.
+* Provide a high level overview of the health of your system.
+  Service graphs show error rates, latencies, and other relevant data.
+* Provide a historic view of a system’s topology.
+  Distributed systems change very frequently,
+  and service graphs offer a way of seeing how these systems have evolved over time.
+
+Since `otelcol.connector.servicegraph` has to process both sides of an edge,
+it needs to process all spans of a trace to function properly.
+If spans of a trace are spread out over multiple Agent instances, spans cannot be paired reliably.
+A solution to this problem is using [otelcol.exporter.loadbalancing](./otelcol.exporter.loadbalancing.md)
+in front of Agent instances running `otelcol.connector.servicegraph`.
+
+## Usage
+
+```river
+otelcol.connector.servicegraph "LABEL" {
+  output {
+    metrics = [...]
+  }
+}
+```
+
+## Arguments
+
+`otelcol.connector.servicegraph` supports the following arguments:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`latency_histogram_buckets` | `list(duration)` | Buckets for latency histogram metrics. | `["2ms","4ms","6ms","8ms","10ms","50ms","100ms","200ms","400ms","800ms","1s","1400ms","2s","5s","10s","15s"]` | no
+`dimensions` | `list(string)` | A list of dimensions to add with the default dimensions. | `[]` | no
+`cache_loop` | `duration` | Configures how often to delete series which have not been updated. | `"1m"` | no
+`store_expiration_loop` | `duration` | The time to expire old entries from the store periodically. | `"2s"` | no
+
+Service graphs work by inspecting traces and looking for spans with 
+parent-children relationship that represent a request.
+`otelcol.connector.servicegraph` uses OpenTelemetry semantic conventions 
+to detect a myriad of requests.
+The following requests are currently supported:
+
+* A direct request between two services, where the outgoing and the incoming span
+  must have a [Span Kind][] value of `client` and `server` respectively.
+* A request across a messaging system, where the outgoing and the incoming span 
+  must have a [Span Kind][] value of `producer` and `consumer` respectively.
+* A database request, where spans have a [Span Kind][] with a value of `client`,
+  as well as an attribute with a key of `db.name`.
+
+Every span which can be paired up to form a request is kept in an in-memory store:
+* If the TTL of the span expires before it can be paired, it is deleted from the store. 
+  TTL is configured in the [store][] block.
+* If the span is paired prior to its expiration, a metric is recorded and the span is deleted from the store.
+
+The following metrics are emitted by the processor:
+
+| Metric                                      | Type      | Labels                          | Description                                                  |
+|---------------------------------------------|-----------|---------------------------------|--------------------------------------------------------------|
+| traces_service_graph_request_total          | Counter   | client, server, connection_type | Total count of requests between two nodes                    |
+| traces_service_graph_request_failed_total   | Counter   | client, server, connection_type | Total count of failed requests between two nodes             |
+| traces_service_graph_request_server_seconds | Histogram | client, server, connection_type | Time for a request between two nodes as seen from the server |
+| traces_service_graph_request_client_seconds | Histogram | client, server, connection_type | Time for a request between two nodes as seen from the client |
+| traces_service_graph_unpaired_spans_total   | Counter   | client, server, connection_type | Total count of unpaired spans                                |
+| traces_service_graph_dropped_spans_total    | Counter   | client, server, connection_type | Total count of dropped spans                                 |
+
+Duration is measured both from the client and the server sides.
+
+The `latency_histogram_buckets` argument controls the buckets for 
+`traces_service_graph_request_server_seconds` and `traces_service_graph_request_client_seconds`.
+
+Each emitted metrics series have a `client` and a `server` label corresponding with the 
+service doing the request and the service receiving the request. The value of the label 
+is derived from the `service.name` resource attribute of the two spans.
+
+The `connection_type` label may not be set. If it is set, its value will be either `messaging_system` or `database`.
+
+Additional labels can be included using the `dimensions` configuration option:
+* Those labels will have a prefix to mark where they originate (client or server span kinds).
+  The `client_` prefix relates to the dimensions coming from spans with a [Span Kind][] of `client`.
+  The `server_` prefix relates to the dimensions coming from spans with a [Span Kind][] of `server`.
+* Firstly the resource attributes will be searched. If the attribute is not found, 
+  the span attributes will be searched.
+
+[Span Kind]: https://opentelemetry.io/docs/concepts/signals/traces/#span-kind
+
+## Blocks
+
+The following blocks are supported inside the definition of
+`otelcol.connector.servicegraph`:
+
+Hierarchy | Block | Description | Required
+--------- | ----- | ----------- | --------
+store | [store][] | Configures the in-memory store for spans. | no
+output | [output][] | Configures where to send telemetry data. | yes
+
+[store]: #store-block
+[output]: #output-block
+
+### store block
+
+The `store` block configures the in-memory store for spans.
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`max_items` | `number` | Maximum number of items to keep in the store. | `1000` | no
+`ttl` | `duration` | The time to live for spans in the store. | `"2ms"` | no
+
+### output block
+
+{{< docs/shared lookup="flow/reference/components/output-block-metrics.md" source="agent" >}}
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+Name | Type | Description
+---- | ---- | -----------
+`input` | `otelcol.Consumer` | A value that other components can use to send telemetry data to.
+
+`input` accepts `otelcol.Consumer` traces telemetry data. It does not accept metrics and logs.
+
+## Component health
+
+`otelcol.connector.servicegraph` is only reported as unhealthy if given an invalid
+configuration.
+
+## Debug information
+
+`otelcol.connector.servicegraph` does not expose any component-specific debug
+information.
+
+## Example
+
+The example below accepts traces, creates service graph metrics from them, and writes the metrics to Mimir.
+The traces are written to Tempo.
+
+`otelcol.connector.servicegraph` also adds a label to each metric with the value of the "http.method"
+span/resource attribute.
+
+```river
+otelcol.receiver.otlp "default" {
+  grpc {
+    endpoint = "0.0.0.0:4320"
+  }
+  
+  output {
+    traces  = [otelcol.connector.servicegraph.default.input,otelcol.exporter.otlp.grafana_cloud_tempo.input]
+  }
+}
+
+otelcol.connector.servicegraph "default" {
+  dimensions = ["http.method"]
+  output {
+    metrics = [otelcol.exporter.prometheus.default.input]
+  }
+}
+
+otelcol.exporter.prometheus "default" {
+  forward_to = [prometheus.remote_write.mimir.receiver]
+}
+
+prometheus.remote_write "mimir" {
+  endpoint {
+    url = "https://prometheus-xxx.grafana.net/api/prom/push"
+    
+    basic_auth {
+      username = env("PROMETHEUS_USERNAME")
+      password = env("GRAFANA_CLOUD_API_KEY")
+    }
+  }
+}
+
+otelcol.exporter.otlp "grafana_cloud_tempo" {
+  client {
+    endpoint = "https://tempo-xxx.grafana.net/tempo"
+    auth     = otelcol.auth.basic.grafana_cloud_tempo.handler
+  }
+}
+
+otelcol.auth.basic "grafana_cloud_tempo" {
+  username = env("TEMPO_USERNAME")
+  password = env("GRAFANA_CLOUD_API_KEY")
+}
+```
+
+Some of the metrics in Mimir may look like this:
+```
+traces_service_graph_request_total{client="shop-backend",failed="false",server="article-service",client_http_method="DELETE",server_http_method="DELETE"}
+traces_service_graph_request_failed_total{client="shop-backend",client_http_method="POST",failed="false",server="auth-service",server_http_method="POST"}
+```

--- a/docs/sources/flow/reference/components/otelcol.connector.spanlogs.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.spanlogs.md
@@ -9,10 +9,10 @@ title: otelcol.connector.spanlogs
 components and outputs logs telemetry data for each span, root, or process.
 This allows you to automatically build a mechanism for trace discovery.
 
-> **NOTE**: `otelcol.connector.spanlogs` is a custom component unrelated
-> to any components from the OpenTelemetry Collector. It is based on the
-> `automatic_logging` component in the
-> [traces](../../../static/configuration/traces-config.md)
+> **NOTE**: `otelcol.connector.spanlogs` is a custom component unrelated 
+> to any components from the OpenTelemetry Collector. It is based on the 
+> `automatic_logging` component in the 
+> [traces](../../../static/configuration/traces-config) 
 > subsystem of the Agent static mode.
 
 You can specify multiple `otelcol.connector.spanlogs` components by giving them

--- a/docs/sources/flow/reference/components/otelcol.connector.spanlogs.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.spanlogs.md
@@ -12,7 +12,7 @@ This allows you to automatically build a mechanism for trace discovery.
 > **NOTE**: `otelcol.connector.spanlogs` is a custom component unrelated 
 > to any components from the OpenTelemetry Collector. It is based on the 
 > `automatic_logging` component in the 
-> [traces](../../../static/configuration/traces-config) 
+> [traces](../../../../static/configuration/traces-config/) 
 > subsystem of the Agent static mode.
 
 You can specify multiple `otelcol.connector.spanlogs` components by giving them

--- a/go.mod
+++ b/go.mod
@@ -100,6 +100,7 @@ require (
 	github.com/oklog/run v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/oliver006/redis_exporter v1.51.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.80.0
@@ -115,6 +116,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.80.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/servicegraphprocessor v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.80.0

--- a/go.sum
+++ b/go.sum
@@ -2263,6 +2263,8 @@ github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/onsi/gomega v1.27.7 h1:fVih9JD6ogIiHUN6ePK7HJidyEDpWGVB5mzM7cWNXoU=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
+github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector v0.80.0 h1:fJF/5xzmnrXVKIMan4Q54toP8brqiGmaNTLQGrYnfro=
+github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector v0.80.0/go.mod h1:YepdDwedXtA3g7Q3bnDVJ07Onjn8AusMdwsH+f3phco=
 github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.80.0 h1:j6Zo+MvskAAc5LNMHqeqjti3hxQZPBkqoK956wHhDdY=
 github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.80.0/go.mod h1:mv3/RQWBvNvB4IFnB9oqGe147e2KsLiFT5nkovkH/2o=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter v0.80.0 h1:/cUNpmtNRN+AhONVb5gzkqZv6w3GtB1hhpc73ngi9Z8=
@@ -2313,6 +2315,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin 
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.80.0/go.mod h1:WvSStezNID55991drm0t9CJ+1beZPEozE29sgvlYtuo=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.80.0 h1:YHlUyWkXHu9Nf2Snic3x4Qv0S1dlgfvxBIRmk2N53Fk=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.80.0/go.mod h1:9uoUdWeHgN/c98VL9hPtDbdmqqHjQs8sF8W6P5MtUKA=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/servicegraphprocessor v0.80.0 h1:G8Ci9J7alCklki1akVDBmT40qzxJyNS0nRm47KknWd0=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/servicegraphprocessor v0.80.0/go.mod h1:qfUn0nunL4zbubziCbr6ectmvrGYfEinRGydmrvdkyE=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor v0.80.0 h1:+aUgA8hzbaBGyraAy7WGjyzq0zLvvTAaq0q0RO934HM=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor v0.80.0/go.mod h1:cjPA2Zcmy6ZSiKe1+gFGGjN4wgRRcPFwYuL/AnM6nIo=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.80.0 h1:E0eTh3rgRm38HQ3YX7y+IsSCsAsN1oy31aLAGzBW0jY=


### PR DESCRIPTION
#### PR Description

The new `otelcol.connector.servicegraph` component is based on the [servicegraphconnector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/connector/servicegraphconnector), which on the other hand is based on [servicegraphprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.80.0/processor/servicegraphprocessor).

#### Which issue(s) this PR fixes

Fixes #2300
Fixes #2213

#### Notes to the Reviewer

There is one config parameter for the servicegraph connector which we cannot yet support in flow - `virtual_node_peer_attributes`. It is behind a `processor.servicegraph.virtualNode` feature gate in the Collector. In the Agent we don't yet support enabling Otel feature gates. I will try to submit a PR to the Collector to either remove that feature gate or enable it by default, and the next time we upgrade Otel in the Agent we can add the `virtual_node_peer_attributes ` argument.
#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated