### PR TITLE
helm: revert accidental version bump

### DIFF
--- a/operations/helm/charts/grafana-agent/Chart.yaml
+++ b/operations/helm/charts/grafana-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: grafana-agent
 description: 'Grafana Agent'
 type: application
-version: 0.21.1
+version: 0.21.0
 appVersion: 'v0.35.4'


### PR DESCRIPTION
PR https://github.com/grafana/agent/pull/5005 accidentally bumped the version of the Helm chart; we will be bumping this when we release a new Helm chart version instead.