### PR TITLE
Fix changelog: enhancement added under the wrong version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Main (unreleased)
 - Flow: allow the HTTP server to be configured with TLS in the config file
   using the new `http` config block. (@rfratto)
 
+### Enhancements
+
+- Clustering: Allow advertise interfaces to be configurable. (@wildum)
+
 ### Other changes
 
 - Use Go 1.21.0 for builds. (@rfratto)
@@ -107,8 +111,6 @@ v0.36.0 (2023-08-30)
 - Support decoupled scraping in the cloudwatch_exporter integration (@dtrejod).
 
 - Agent Management: Enable proxying support (@spartan0x117)
-
-- Clustering: Allow advertise interfaces to be configurable. (@wildum)
 
 ### Bugfixes
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

The change was added under v0.36 but the code itself was not part of v0.36.
This PR moves it to the right part in changelog.md

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated