### PR TITLE
Remove description from the Windows Program Display Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Main (unreleased)
 
 - Use Go 1.21.0 for builds. (@rfratto)
 - Read contextual attributes from Faro measurements (@codecapitano)
+- Rename Grafana Agent service in windows app and features to not include the description
 
 v0.36.0 (2023-08-30)
 --------------------

--- a/packaging/grafana-agent-flow/windows/install_script.nsis
+++ b/packaging/grafana-agent-flow/windows/install_script.nsis
@@ -13,7 +13,6 @@ Unicode true
 !include ./macros.nsis
 
 !define APPNAME     "Grafana Agent Flow"
-!define DESCRIPTION "Vendor-neutral programmable observability pipelines."
 !define HELPURL     "https://grafana.com/docs/agent/latest/flow/"
 !define UPDATEURL   "https://github.com/grafana/agent/releases"
 !define ABOUTURL    "https://github.com/grafana/agent"
@@ -60,7 +59,7 @@ Section "install"
   # overwriting existing registry entries since we want it to be relevant to
   # the current installed version.
   !define UNINSTALLKEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"
-  WriteRegStr   HKLM "${UNINSTALLKEY}" "DisplayName"          '${APPNAME} ${VERSION} - ${DESCRIPTION}'
+  WriteRegStr   HKLM "${UNINSTALLKEY}" "DisplayName"          '${APPNAME} ${VERSION}'
   WriteRegStr   HKLM "${UNINSTALLKEY}" "UninstallString"      '"$INSTDIR\uninstall.exe"'
   WriteRegStr   HKLM "${UNINSTALLKEY}" "QuietUninstallString" '"$INSTDIR\uninstall.exe" /S'
   WriteRegStr   HKLM "${UNINSTALLKEY}" "InstallLocation"      '"$INSTDIR"'

--- a/packaging/grafana-agent/windows/install_script.nsis
+++ b/packaging/grafana-agent/windows/install_script.nsis
@@ -3,7 +3,6 @@ Unicode true
 # adds uninstall information to the registry for Add/Remove Programs
 
 !define APPNAME "Grafana Agent"
-!define DESCRIPTION "The Grafana Agent collects observability data and sends it to a compatible remote write endpoint"
 # These will be displayed by the "Click here for support information" link in "Add/Remove Programs"
 !define HELPURL "https://github.com/grafana/agent/discussions" # "Support Information" link
 !define UPDATEURL "https://github.com/grafana/agent/releases" # "Product Updates" link
@@ -109,7 +108,7 @@ Function Install
     writeUninstaller "$INSTDIR\uninstall.exe"
 
     # Registry information for add/remove programs
-    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "DisplayName" "${APPNAME} ${VERSION} - ${DESCRIPTION}"
+    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "DisplayName" "${APPNAME} ${VERSION}"
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "QuietUninstallString" "$\"$INSTDIR\uninstall.exe$\" /S"
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "InstallLocation" "$\"$INSTDIR$\""


### PR DESCRIPTION


<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The current name is very long and its not best practice to put an entire description in the displayname. 

(For more info here: https://learn.microsoft.com/en-us/windows/win32/msi/uninstall-registry-key)

#### Notes to the Reviewer
This is mainly annoying in automatic deployments as it causes people to have to list the full description in there.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x ] CHANGELOG.md updated