### PR TITLE
Sync cri stage in loki.process with promtail.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ Main (unreleased)
 
 - Add optional `nil_to_zero` config flag for `YACE` which can be set in the `static`, `discovery`, or `metric` config blocks. (@berler)
 
+- The `cri` stage in `loki.process` can now be configured to limit line size.
+
 ### Enhancements
 
 - Clustering: allow advertise interfaces to be configurable, with the possibility to select all available interfaces. (@wildum)

--- a/component/loki/process/stages/extensions.go
+++ b/component/loki/process/stages/extensions.go
@@ -13,8 +13,6 @@ import (
 	"github.com/grafana/river"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
-
-	"github.com/grafana/loki/pkg/util/flagext"
 )
 
 const (
@@ -28,9 +26,9 @@ type DockerConfig struct{}
 // CRIConfig is an empty struct that is used to enable a pre-defined pipeline
 // for decoding entries that are using the CRI logging format.
 type CRIConfig struct {
-	MaxPartialLines            int              `river:"max_partial_lines,attr,optional"`
-	MaxPartialLineSize         flagext.ByteSize `river:"max_partial_line_size,attr,optional"`
-	MaxPartialLineSizeTruncate bool             `river:"max_partial_line_size_truncate,attr,optional"`
+	MaxPartialLines            int    `river:"max_partial_lines,attr,optional"`
+	MaxPartialLineSize         uint64 `river:"max_partial_line_size,attr,optional"`
+	MaxPartialLineSizeTruncate bool   `river:"max_partial_line_size_truncate,attr,optional"`
 }
 
 var (
@@ -163,8 +161,8 @@ func (c *cri) Run(entry chan Entry) chan Entry {
 }
 
 func (c *cri) ensureTruncateIfRequired(e *Entry) {
-	if c.cfg.MaxPartialLineSizeTruncate && len(e.Line) > c.cfg.MaxPartialLineSize.Val() {
-		e.Line = e.Line[:c.cfg.MaxPartialLineSize.Val()]
+	if c.cfg.MaxPartialLineSizeTruncate && len(e.Line) > int(c.cfg.MaxPartialLineSize) {
+		e.Line = e.Line[:c.cfg.MaxPartialLineSize]
 	}
 }
 

--- a/component/loki/process/stages/extensions.go
+++ b/component/loki/process/stages/extensions.go
@@ -36,7 +36,7 @@ var (
 	_ river.Validator = (*CRIConfig)(nil)
 )
 
-// DefaultCRIConfig applies the default values on
+// DefaultCRIConfig contains the default CRIConfig values.
 var DefaultCRIConfig = CRIConfig{
 	MaxPartialLines:            100,
 	MaxPartialLineSize:         0,

--- a/component/loki/process/stages/extensions_test.go
+++ b/component/loki/process/stages/extensions_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/pkg/util/flagext"
 	util_log "github.com/grafana/loki/pkg/util/log"
 )
 
@@ -100,15 +101,18 @@ type testEntry struct {
 
 func TestCRI_tags(t *testing.T) {
 	cases := []struct {
-		name            string
-		lines           []string
-		expected        []string
-		maxPartialLines int
-		entries         []testEntry
-		err             error
+		name                       string
+		lines                      []string
+		expected                   []string
+		maxPartialLines            int
+		maxPartialLineSize         flagext.ByteSize
+		maxPartialLineSizeTruncate bool
+		entries                    []testEntry
+		err                        error
 	}{
 		{
-			name: "tag F",
+			name:            "tag F",
+			maxPartialLines: 100,
 			entries: []testEntry{
 				{line: "2019-05-07T18:57:50.904275087+00:00 stdout F some full line", labels: model.LabelSet{"foo": "bar"}},
 				{line: "2019-05-07T18:57:55.904275087+00:00 stdout F log", labels: model.LabelSet{"foo": "bar"}},
@@ -116,7 +120,8 @@ func TestCRI_tags(t *testing.T) {
 			expected: []string{"some full line", "log"},
 		},
 		{
-			name: "tag P multi-stream",
+			name:            "tag P multi-stream",
+			maxPartialLines: 100,
 			entries: []testEntry{
 				{line: "2019-05-07T18:57:50.904275087+00:00 stdout P partial line 1 ", labels: model.LabelSet{"foo": "bar"}},
 				{line: "2019-05-07T18:57:50.904275087+00:00 stdout P partial line 2 ", labels: model.LabelSet{"foo": "bar2"}},
@@ -141,7 +146,7 @@ func TestCRI_tags(t *testing.T) {
 				{line: "2019-05-07T18:57:55.904275087+00:00 stdout F another full log", labels: model.LabelSet{"label1": "val3"}},
 				{line: "2019-05-07T18:57:55.904275087+00:00 stdout F yet an another full log", labels: model.LabelSet{"label1": "val4"}},
 			},
-			maxPartialLines: 2,
+			maxPartialLines: 3,
 			expected: []string{
 				"partial line 1 partial line 3 ",
 				"partial line 2 ",
@@ -167,19 +172,35 @@ func TestCRI_tags(t *testing.T) {
 				"another full log",
 			},
 		},
+		{
+			name: "tag P multi-stream with truncation",
+			entries: []testEntry{
+				{line: "2019-05-07T18:57:50.904275087+00:00 stdout P partial line 1 ", labels: model.LabelSet{"foo": "bar"}},
+				{line: "2019-05-07T18:57:50.904275087+00:00 stdout P partial", labels: model.LabelSet{"foo": "bar2"}},
+				{line: "2019-05-07T18:57:55.904275087+00:00 stdout F log finished", labels: model.LabelSet{"foo": "bar"}},
+				{line: "2019-05-07T18:57:55.904275087+00:00 stdout F full", labels: model.LabelSet{"foo": "bar2"}},
+			},
+			maxPartialLines:            100,
+			maxPartialLineSizeTruncate: true,
+			maxPartialLineSize:         11,
+			expected: []string{
+				"partial lin",
+				"partialfull",
+			},
+		},
 	}
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := NewCRI(util_log.Logger, prometheus.DefaultRegisterer)
+			cfg := CRIConfig{
+				MaxPartialLines:            tt.maxPartialLines,
+				MaxPartialLineSize:         tt.maxPartialLineSize,
+				MaxPartialLineSizeTruncate: tt.maxPartialLineSizeTruncate,
+			}
+			p, err := NewCRI(util_log.Logger, cfg, prometheus.DefaultRegisterer)
 			require.NoError(t, err)
 
 			got := make([]string, 0)
-
-			// tweak `maxPartialLines`
-			if tt.maxPartialLines != 0 {
-				p.(*cri).maxPartialLines = tt.maxPartialLines
-			}
 
 			for _, entry := range tt.entries {
 				out := processEntries(p, newEntry(nil, entry.labels, entry.line, time.Now()))
@@ -258,7 +279,8 @@ func TestNewCri(t *testing.T) {
 		tt := tt
 		t.Run(tName, func(t *testing.T) {
 			t.Parallel()
-			p, err := NewCRI(util_log.Logger, prometheus.DefaultRegisterer)
+			cfg := DefaultCRIConfig
+			p, err := NewCRI(util_log.Logger, cfg, prometheus.DefaultRegisterer)
 			if err != nil {
 				t.Fatalf("failed to create CRI parser: %s", err)
 			}

--- a/component/loki/process/stages/extensions_test.go
+++ b/component/loki/process/stages/extensions_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/loki/pkg/util/flagext"
 	util_log "github.com/grafana/loki/pkg/util/log"
 )
 
@@ -105,7 +104,7 @@ func TestCRI_tags(t *testing.T) {
 		lines                      []string
 		expected                   []string
 		maxPartialLines            int
-		maxPartialLineSize         flagext.ByteSize
+		maxPartialLineSize         uint64
 		maxPartialLineSizeTruncate bool
 		entries                    []testEntry
 		err                        error

--- a/component/loki/process/stages/stage.go
+++ b/component/loki/process/stages/stage.go
@@ -121,7 +121,7 @@ func New(logger log.Logger, jobName *string, cfg StageConfig, registerer prometh
 			return nil, err
 		}
 	case cfg.CRIConfig != nil:
-		s, err = NewCRI(logger, registerer)
+		s, err = NewCRI(logger, *cfg.CRIConfig, registerer)
 		if err != nil {
 			return nil, err
 		}

--- a/converter/internal/promtailconvert/testdata/pipeline_stages_cri_empty.river
+++ b/converter/internal/promtailconvert/testdata/pipeline_stages_cri_empty.river
@@ -1,0 +1,26 @@
+discovery.kubernetes "example" {
+	role            = "pod"
+	kubeconfig_file = "/home/toby/.kube/config"
+}
+
+local.file_match "example" {
+	path_targets = discovery.kubernetes.example.targets
+}
+
+loki.process "example" {
+	forward_to = [loki.write.default.receiver]
+
+	stage.cri { }
+}
+
+loki.source.file "example" {
+	targets    = local.file_match.example.targets
+	forward_to = [loki.process.example.receiver]
+}
+
+loki.write "default" {
+	endpoint {
+		url = "http://localhost/loki/api/v1/push"
+	}
+	external_labels = {}
+}

--- a/converter/internal/promtailconvert/testdata/pipeline_stages_cri_empty.yaml
+++ b/converter/internal/promtailconvert/testdata/pipeline_stages_cri_empty.yaml
@@ -1,0 +1,12 @@
+clients:
+  - url: http://localhost/loki/api/v1/push
+scrape_configs:
+  - job_name: example
+    pipeline_stages:
+      - cri: { }
+    kubernetes_sd_configs:
+      - role: pod
+        kubeconfig_file: /home/toby/.kube/config
+
+tracing: { enabled: false }
+server: { register_instrumentation: false }

--- a/converter/internal/promtailconvert/testdata/pipeline_stages_part2.river
+++ b/converter/internal/promtailconvert/testdata/pipeline_stages_part2.river
@@ -13,8 +13,8 @@ loki.process "example" {
 	stage.docker { }
 
 	stage.cri {
-		max_partial_lines = 223
-		max_partial_line_size = 26214
+		max_partial_lines              = 223
+		max_partial_line_size          = 26214
 		max_partial_line_size_truncate = true
 	}
 

--- a/converter/internal/promtailconvert/testdata/pipeline_stages_part2.river
+++ b/converter/internal/promtailconvert/testdata/pipeline_stages_part2.river
@@ -12,7 +12,11 @@ loki.process "example" {
 
 	stage.docker { }
 
-	stage.cri { }
+	stage.cri {
+		max_partial_lines = 223
+		max_partial_line_size = 26214
+		max_partial_line_size_truncate = true
+	}
 
 	stage.label_drop {
 		values = ["foo", "bar", "baz"]

--- a/converter/internal/promtailconvert/testdata/pipeline_stages_part2.yaml
+++ b/converter/internal/promtailconvert/testdata/pipeline_stages_part2.yaml
@@ -4,7 +4,10 @@ scrape_configs:
   - job_name: example
     pipeline_stages:
       - docker: { }
-      - cri: { }
+      - cri:
+          max_partial_lines: 223
+          max_partial_line_size: 26214
+          max_partial_line_size_truncate: true
       - labeldrop:
           - foo
           - bar

--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -109,11 +109,14 @@ the CRI logging format.
 
 The following arguments are supported:
 
-| Name                             | Type       | Description                                                                                    | Default        | Required |
-| -------------------------------- | ---------- | ---------------------------------------------------------------------------------------------- | -------------- | -------- |
-| `max_partial_lines`              | `number`   | Max buffer size to hold partial lines.                                                         | `100`          | no       |
-| `max_partial_line_size`          | `number`   | Max line size to hold a single partial line, if `max_partial_line_size_truncate` is `true`.    | `0`            | no       |
-| `max_partial_line_size_truncate` | `bool`     | Allows to pretruncate partial lines before storing in partial buffer.                          | `false`        | no       |
+| Name                             | Type       | Description                                                          | Default        | Required |
+| -------------------------------- | ---------- | -------------------------------------------------------------------- | -------------- | -------- |
+| `max_partial_lines`              | `number`   | Maximum number of partial lines to hold in memory.                   | `100`          | no       |
+| `max_partial_line_size`          | `number`   | Maximum number of characters which a partial line can have.          | `0`            | no       |
+| `max_partial_line_size_truncate` | `bool`     | Truncate partial lines that are longer than `max_partial_line_size`. | `false`        | no       |
+
+`max_partial_line_size` is only taken into account if 
+`max_partial_line_size_truncate` is set to `true`.
 
 ```river
 stage.cri {}
@@ -375,7 +378,7 @@ The following arguments are supported:
 | Name                  | Type     | Description                                                                      | Default | Required |
 | --------------------- | -------- | -------------------------------------------------------------------------------- | ------- | -------- |
 | `rate`                | `number` | The maximum rate of lines per second that the stage forwards.                    |         | yes      |
-| `burst`               | `number` | The cap in the quantity of burst lines that the stage forwards.                  |         | yes      |
+| `burst`               | `number` | The maximum number of burst lines that the stage forwards.                       |         | yes      |
 | `by_label_name`       | `string` | The label to use when rate-limiting on a label name.                             | `""`    | no       |
 | `drop`                | `bool`   | Whether to discard or backpressure lines that exceed the rate limit.             | `false` | no       |
 | `max_distinct_labels` | `number` | The number of unique values to keep track of when rate-limiting `by_label_name`. | `10000` | no       |

--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -107,8 +107,13 @@ file.
 The `stage.cri` inner block enables a predefined pipeline which reads log lines using
 the CRI logging format.
 
-The `stage.cri` block does not support any arguments or inner blocks, so it is always
-empty.
+The following arguments are supported:
+
+| Name                             | Type       | Description                                                                                    | Default        | Required |
+| -------------------------------- | ---------- | ---------------------------------------------------------------------------------------------- | -------------- | -------- |
+| `max_partial_lines`              | `number`   | Max buffer size to hold partial lines.                                                         | `100`          | no       |
+| `max_partial_line_size`          | `number`   | Max line size to hold a single partial line, if `max_partial_line_size_truncate` is `true`.    | `0`            | no       |
+| `max_partial_line_size_truncate` | `bool`     | Allows to pretruncate partial lines before storing in partial buffer.                          | `false`        | no       |
 
 ```river
 stage.cri {}
@@ -369,11 +374,11 @@ The following arguments are supported:
 
 | Name                  | Type     | Description                                                                      | Default | Required |
 | --------------------- | -------- | -------------------------------------------------------------------------------- | ------- | -------- |
-| `rate`                | `int`    | The maximum rate of lines per second that the stage forwards.                    |         | yes      |
-| `burst`               | `int`    | The cap in the quantity of burst lines that the stage forwards.                  |         | yes      |
+| `rate`                | `number` | The maximum rate of lines per second that the stage forwards.                    |         | yes      |
+| `burst`               | `number` | The cap in the quantity of burst lines that the stage forwards.                  |         | yes      |
 | `by_label_name`       | `string` | The label to use when rate-limiting on a label name.                             | `""`    | no       |
 | `drop`                | `bool`   | Whether to discard or backpressure lines that exceed the rate limit.             | `false` | no       |
-| `max_distinct_labels` | `int`    | The number of unique values to keep track of when rate-limiting `by_label_name`. | `10000` | no       |
+| `max_distinct_labels` | `number` | The number of unique values to keep track of when rate-limiting `by_label_name`. | `10000` | no       |
 
 The rate limiting is implemented as a "token bucket" of size `burst`, initially
 full and refilled at `rate` tokens per second. Each received log entry consumes one token from the bucket. When `drop` is set to true, incoming entries
@@ -740,7 +745,7 @@ The following arguments are supported:
 | --------------- | ---------- | -------------------------------------------------- | ------- | -------- |
 | `firstline`     | `string`   | Name from extracted data to use for the log entry. |         | yes      |
 | `max_wait_time` | `duration` | The maximum time to wait for a multiline block.    | `"3s"`  | no       |
-| `max_lines`     | `int`      | The maximum number of lines a block can have.      | `128`   | no       |
+| `max_lines`     | `number`   | The maximum number of lines a block can have.      | `128`   | no       |
 
 
 A new block is identified by the RE2 regular expression passed in `firstline`.


### PR DESCRIPTION
#### PR Description

There is a [new feature](https://github.com/grafana/loki/pull/9508) in promtail - this PR is adding it to `loki.process`.

#### Which issue(s) this PR fixes

Fixes #4883

#### Notes to the Reviewer

* I updated the promtail config converter test file, but I'm not sure if that's all I need to do for the converters?
* I updated the docs to say "number" instead of "int", to make it more consistent with the River [Types and values](https://grafana.com/docs/agent/latest/flow/config-language/expressions/types_and_values/) documentation.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated