### PR TITLE
fix(http): allow override default user-agent header for http.remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Main (unreleased)
 - Restart managed components of a module loader only on if module content
   changes or the last load failed. This was specifically impacting `module.git`
   each time it pulls. (@erikbaranowski)
+- Allow overriding default `User-Agent` for `http.remote` component (@hainenber)
 
 v0.36.0 (2023-08-30)
 --------------------

--- a/component/remote/http/http.go
+++ b/component/remote/http/http.go
@@ -261,10 +261,16 @@ func (c *Component) Update(args component.Arguments) (err error) {
 	newArgs := args.(Arguments)
 	c.args = newArgs
 
+	// Override default UserAgent if another is provided in "headers" section
+	customUserAgent, exist := c.args.Headers["User-Agent"]
+	if !exist {
+		customUserAgent = userAgent
+	}
+
 	cli, err := prom_config.NewClientFromConfig(
 		*newArgs.Client.Convert(),
 		c.opts.ID,
-		prom_config.WithUserAgent(userAgent),
+		prom_config.WithUserAgent(customUserAgent),
 	)
 	if err != nil {
 		return err

--- a/component/remote/http/http_test.go
+++ b/component/remote/http/http_test.go
@@ -26,7 +26,7 @@ func Test(t *testing.T) {
 	srv := httptest.NewServer(&handler)
 	defer srv.Close()
 
-	handler.SetHandler(func(w http.ResponseWriter, _ *http.Request) {
+	handler.SetHandler(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "Hello, world!")
 	})
 
@@ -38,6 +38,7 @@ func Test(t *testing.T) {
 		method = "%s"
         headers = {
             "x-custom" = "value",
+			"User-Agent" = "custom_useragent",
         }
 
 		poll_frequency = "50ms" 
@@ -76,6 +77,8 @@ func Test(t *testing.T) {
 		fmt.Fprintln(w, "Testing!")
 		fmt.Fprintf(w, "Method: %s\n", r.Method)
 		fmt.Fprintf(w, "Header: %s\n", r.Header.Get("x-custom"))
+
+		require.Equal(t, "custom_useragent", r.Header.Get("User-Agent"))
 	})
 	require.NoError(t, ctrl.WaitExports(time.Second), "component didn't update exports")
 	requireExports(http_component.Exports{


### PR DESCRIPTION
Fixes #4042

Allow user to override default `User-Agent` header for `http.remote` component.