### PR TITLE
loki.process: fix deadlock in case of frequent Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Main (unreleased)
 - Added a `disable_high_cardinality_metrics` configuration flag to `otelcol` 
   exporters and receivers to switch high cardinality debug metrics off.  (@glindstedt)
 
+
 ### Other changes
 
 - Use Go 1.21.0 for builds. (@rfratto)
@@ -47,7 +48,10 @@ Main (unreleased)
 - Restart managed components of a module loader only on if module content
   changes or the last load failed. This was specifically impacting `module.git`
   each time it pulls. (@erikbaranowski)
+
 - Allow overriding default `User-Agent` for `http.remote` component (@hainenber)
+
+- Fix a deadlock candidate in the `loki.process` component. (@tpaschalis)
 
 v0.36.0 (2023-08-30)
 --------------------

--- a/component/loki/process/process.go
+++ b/component/loki/process/process.go
@@ -85,7 +85,6 @@ func (c *Component) Run(ctx context.Context) error {
 		if c.entryHandler != nil {
 			c.entryHandler.Stop()
 		}
-		close(c.processOut)
 		close(c.processIn)
 		c.mut.RUnlock()
 	}()

--- a/component/loki/process/process.go
+++ b/component/loki/process/process.go
@@ -49,11 +49,13 @@ type Component struct {
 
 	mut          sync.RWMutex
 	receiver     loki.LogsReceiver
-	fanout       []loki.LogsReceiver
 	processIn    chan<- loki.Entry
 	processOut   chan loki.Entry
 	entryHandler loki.EntryHandler
 	stages       []stages.StageConfig
+
+	fanoutMut sync.RWMutex
+	fanout    []loki.LogsReceiver
 }
 
 // New creates a new loki.process component.
@@ -100,6 +102,12 @@ func (c *Component) Run(ctx context.Context) error {
 func (c *Component) Update(args component.Arguments) error {
 	newArgs := args.(Arguments)
 
+	// Update c.fanout first in case anything else fails.
+	c.fanoutMut.Lock()
+	c.fanout = newArgs.ForwardTo
+	c.fanoutMut.Unlock()
+
+	// Then update the pipeline itself.
 	c.mut.Lock()
 	defer c.mut.Unlock()
 
@@ -119,8 +127,6 @@ func (c *Component) Update(args component.Arguments) error {
 		c.processIn = pipeline.Wrap(c.entryHandler).Chan()
 		c.stages = newArgs.Stages
 	}
-
-	c.fanout = newArgs.ForwardTo
 
 	return nil
 }
@@ -155,8 +161,10 @@ func (c *Component) handleOut(ctx context.Context, wg *sync.WaitGroup) {
 		case <-ctx.Done():
 			return
 		case entry := <-c.processOut:
-			c.mut.RLock()
-			for _, f := range c.fanout {
+			c.fanoutMut.RLock()
+			fanout := c.fanout
+			c.fanoutMut.RUnlock()
+			for _, f := range fanout {
 				select {
 				case <-ctx.Done():
 					return
@@ -164,7 +172,6 @@ func (c *Component) handleOut(ctx context.Context, wg *sync.WaitGroup) {
 					// no-op
 				}
 			}
-			c.mut.RUnlock()
 		}
 	}
 }

--- a/component/loki/process/process_test.go
+++ b/component/loki/process/process_test.go
@@ -482,5 +482,5 @@ func TestDeadlockWithFrequentUpdates(t *testing.T) {
 
 	// Run everything for a while
 	time.Sleep(1 * time.Second)
-	require.Less(t, time.Now().Sub(lastSend).Abs(), 1*time.Millisecond)
+	require.WithinDuration(t, time.Now(), lastSend, 5*time.Millisecond)
 }

--- a/component/loki/process/process_test.go
+++ b/component/loki/process/process_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"context"
 	"os"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 	"go.uber.org/goleak"
 )
 

--- a/component/loki/process/process_test.go
+++ b/component/loki/process/process_test.go
@@ -2,7 +2,6 @@ package process
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -435,15 +434,15 @@ func TestDeadlockWithFrequentUpdates(t *testing.T) {
 	defer cancel()
 	go c.Run(ctx)
 
+	var lastSend time.Time
 	// Drain received logs
 	go func() {
 		for {
-			// time.Sleep(10 * time.Millisecond)
 			select {
 			case <-ch1.Chan():
-				fmt.Println("Received from ch1")
+				lastSend = time.Now()
 			case <-ch2.Chan():
-				fmt.Println("Received from ch2")
+				lastSend = time.Now()
 			default:
 			}
 		}
@@ -481,6 +480,7 @@ func TestDeadlockWithFrequentUpdates(t *testing.T) {
 		}
 	}()
 
-	// Run everything for some time.
-	time.Sleep(10 * time.Second)
+	// Run everything for a while
+	time.Sleep(1 * time.Second)
+	require.Less(t, time.Now().Sub(lastSend).Abs(), 1*time.Millisecond)
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
This PR fixes a deadlock candidate in `loki.process` when Update was concurrently called with a log line being fanned out.

We've already fixed similar problems in other components, as #5061 mentions we should go through all of the loki components to look for similar issues.

#### Which issue(s) this PR fixes
No issue filed

#### Notes to the Reviewer
Let me know if you know of a better way to detect partial deadlocks here.

#### PR Checklist

- [X] CHANGELOG.md updated
- [ ] Documentation added (N/A)
- [X] Tests updated