### PR TITLE
pkg/metrics/wal: remove deleted series from WAL sooner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Main (unreleased)
 
 - Clustering: Allow advertise interfaces to be configurable. (@wildum)
 
+- Deleted series will now be removed from the WAL sooner, allowing Prometheus
+  remote_write to free memory associated with removed series sooner. (@rfratto)
+
 ### Other changes
 
 - Use Go 1.21.0 for builds. (@rfratto)

--- a/pkg/metrics/wal/wal.go
+++ b/pkg/metrics/wal/wal.go
@@ -534,7 +534,7 @@ func (w *Storage) Truncate(mint int64) error {
 	// The checkpoint is written and segments before it is truncated, so we no
 	// longer need to track deleted series that are before it.
 	for ref, segment := range w.deleted {
-		if segment < first {
+		if segment <= last {
 			delete(w.deleted, ref)
 			w.metrics.totalRemovedSeries.Inc()
 		}


### PR DESCRIPTION
This change causes deleted series to be deleted earlier based on the last segment involved in the checkpoint rather than the first segment involved in the checkpoint.

This will then cause the next truncate to be more aggressive with dropped series, which should help free memory associated with deleted series in remote_write sooner.

Mirrors prometheus/prometheus#12297 from @bboreham.
