### PR TITLE
fix(agentctl): prevent panic when validating integration-included cfg file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ Main (unreleased)
   changes or the last load failed. This was specifically impacting `module.git`
   each time it pulls. (@erikbaranowski)
 - Allow overriding default `User-Agent` for `http.remote` component (@hainenber)
+- Fix panic when running `grafana-agentctl config-check` against config files
+  having `integrations` block (both V1 and V2). (@hainenber)
 
 v0.36.0 (2023-08-30)
 --------------------

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -522,3 +522,26 @@ func TestConfig_EmptyServerConfigFails(t *testing.T) {
 	_, err := Load(fs, []string{"--config.file", "./testdata/server_empty.yml"}, logger)
 	require.Error(t, err)
 }
+
+func TestConfig_ValidateConfigWithIntegrationV1(t *testing.T) {
+	input := util.Untab(`
+integrations:
+	agent:
+		enabled: true
+`)
+	var cfg Config
+	require.NoError(t, LoadBytes([]byte(input), false, &cfg))
+	require.NoError(t, cfg.Validate(nil))
+}
+
+func TestConfig_ValidateConfigWithIntegrationV2(t *testing.T) {
+	input := util.Untab(`
+integrations:
+	agent:
+		autoscrape:
+			enabled: true
+`)
+	var cfg Config
+	require.NoError(t, LoadBytes([]byte(input), false, &cfg))
+	require.NoError(t, cfg.Validate(nil))
+}

--- a/pkg/config/integrations.go
+++ b/pkg/config/integrations.go
@@ -85,10 +85,15 @@ func (c VersionedIntegrations) IsZero() bool {
 
 // ApplyDefaults applies defaults to the subsystem based on globals.
 func (c *VersionedIntegrations) ApplyDefaults(sflags *server.Flags, mcfg *metrics.Config) error {
-	if c.version != integrationsVersion2 {
+	switch {
+	case c.version != integrationsVersion2 && c.ConfigV1 != nil:
 		return c.ConfigV1.ApplyDefaults(sflags, mcfg)
+	case c.configV2 != nil:
+		return c.configV2.ApplyDefaults(mcfg)
+	default:
+		// No-op
+		return nil
 	}
-	return c.configV2.ApplyDefaults(mcfg)
 }
 
 // setVersion completes the deferred unmarshal and unmarshals the raw YAML into


### PR DESCRIPTION
Also add unit tests to prevent regression.

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Prevent panic when validating integration-included cfg file by performing nil check

#### Which issue(s) this PR fixes

 Fixes #5047 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- ~~[ ] Documentation added~~
- [x] Tests updated
- ~~[ ] Config converters updated~~