### PR TITLE
Fix broken `docs/shared` usage

### DIFF
--- a/docs/sources/flow/reference/components/otelcol.connector.spanlogs.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.spanlogs.md
@@ -9,10 +9,10 @@ title: otelcol.connector.spanlogs
 components and outputs logs telemetry data for each span, root, or process.
 This allows you to automatically build a mechanism for trace discovery.
 
-> **NOTE**: `otelcol.connector.spanlogs` is a custom component unrelated 
-> to any components from the OpenTelemetry Collector. It is based on the 
-> `automatic_logging` component in the 
-> [traces](../../../static/configuration/traces-config.md) 
+> **NOTE**: `otelcol.connector.spanlogs` is a custom component unrelated
+> to any components from the OpenTelemetry Collector. It is based on the
+> `automatic_logging` component in the
+> [traces](../../../static/configuration/traces-config.md)
 > subsystem of the Agent static mode.
 
 You can specify multiple `otelcol.connector.spanlogs` components by giving them
@@ -32,14 +32,14 @@ otelcol.connector.spanlogs "LABEL" {
 
 `otelcol.connector.spanlogs` supports the following arguments:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`spans` | `bool` | Log one line per span. | `false` | no
-`roots` | `bool` | Log one line for every root span of a trace. | `false` | no
-`processes` | `bool` | Log one line for every process. | `false` | no
-`span_attributes` | `list(string)` | Additional span attributes to log. | `[]` | no
-`process_attributes` | `list(string)` | Additional process attributes to log. | `[]` | no
-`labels` | `list(string)` | A list of keys that will be logged as labels. | `[]` | no
+| Name                 | Type           | Description                                   | Default | Required |
+| -------------------- | -------------- | --------------------------------------------- | ------- | -------- |
+| `spans`              | `bool`         | Log one line per span.                        | `false` | no       |
+| `roots`              | `bool`         | Log one line for every root span of a trace.  | `false` | no       |
+| `processes`          | `bool`         | Log one line for every process.               | `false` | no       |
+| `span_attributes`    | `list(string)` | Additional span attributes to log.            | `[]`    | no       |
+| `process_attributes` | `list(string)` | Additional process attributes to log.         | `[]`    | no       |
+| `labels`             | `list(string)` | A list of keys that will be logged as labels. | `[]`    | no       |
 
 The values listed in `labels` should be the values of either span or process attributes.
 
@@ -50,10 +50,10 @@ The values listed in `labels` should be the values of either span or process att
 The following blocks are supported inside the definition of
 `otelcol.connector.spanlogs`:
 
-Hierarchy | Block | Description | Required
---------- | ----- | ----------- | --------
-overrides | [overrides][] | Overrides for keys in the log body. | no
-output | [output][] | Configures where to send received telemetry data. | yes
+| Hierarchy | Block         | Description                                       | Required |
+| --------- | ------------- | ------------------------------------------------- | -------- |
+| overrides | [overrides][] | Overrides for keys in the log body.               | no       |
+| output    | [output][]    | Configures where to send received telemetry data. | yes      |
 
 [output]: #output-block
 [overrides]: #overrides-block
@@ -64,26 +64,26 @@ The `overrides` block configures overrides for keys that will be logged in the b
 
 The following attributes are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`logs_instance_tag` | `string` | Indicates if the log line is for a span, root, or process. | `traces` | no
-`service_key` | `string` | Log key for the service name of the resource. | `svc` | no
-`span_name_key` | `string` | Log key for the name of the span. | `span` | no
-`status_key` | `string` | Log key for the status of the span. | `status` | no
-`duration_key` | `string` | Log key for the duration of the span. | `dur` | no
-`trace_id_key` | `string` | Log key for the trace ID of the span. | `tid` | no
+| Name                | Type     | Description                                                | Default  | Required |
+| ------------------- | -------- | ---------------------------------------------------------- | -------- | -------- |
+| `logs_instance_tag` | `string` | Indicates if the log line is for a span, root, or process. | `traces` | no       |
+| `service_key`       | `string` | Log key for the service name of the resource.              | `svc`    | no       |
+| `span_name_key`     | `string` | Log key for the name of the span.                          | `span`   | no       |
+| `status_key`        | `string` | Log key for the status of the span.                        | `status` | no       |
+| `duration_key`      | `string` | Log key for the duration of the span.                      | `dur`    | no       |
+| `trace_id_key`      | `string` | Log key for the trace ID of the span.                      | `tid`    | no       |
 
 ### output block
 
-{{< docs/shared lookup="flow/reference/components/output-block-logs.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/output-block-logs.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 
 The following fields are exported and can be referenced by other components:
 
-Name | Type | Description
----- | ---- | -----------
-`input` | `otelcol.Consumer` | A value that other components can use to send telemetry data to.
+| Name    | Type               | Description                                                      |
+| ------- | ------------------ | ---------------------------------------------------------------- |
+| `input` | `otelcol.Consumer` | A value that other components can use to send telemetry data to. |
 
 `input` accepts `otelcol.Consumer` data for any telemetry signal (metrics,
 logs, or traces).
@@ -154,45 +154,55 @@ For an input trace like this...
 
 ```json
 {
-    "resourceSpans": [{
-        "resource": {
-            "attributes": [{
-                "key": "service.name",
-                "value": { "stringValue": "TestSvcName" }
-            },
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": { "stringValue": "TestSvcName" }
+          },
+          {
+            "key": "res_attribute1",
+            "value": { "intValue": "78" }
+          },
+          {
+            "key": "unused_res_attribute1",
+            "value": { "stringValue": "str" }
+          },
+          {
+            "key": "res_account_id",
+            "value": { "intValue": "2245" }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
             {
-                "key": "res_attribute1",
-                "value": { "intValue": "78" }
-            },
-            {
-                "key": "unused_res_attribute1",
-                "value": { "stringValue": "str" }
-            },
-            {
-                "key": "res_account_id",
-                "value": { "intValue": "2245" }
-            }]
-        },
-        "scopeSpans": [{
-            "spans": [{
-                "trace_id": "7bba9f33312b3dbb8b2c2c62bb7abe2d",
-                "span_id": "086e83747d0e381e",
-                "name": "TestSpan",
-                "attributes": [{
-                    "key": "attribute1",
-                    "value": { "intValue": "78" }
+              "trace_id": "7bba9f33312b3dbb8b2c2c62bb7abe2d",
+              "span_id": "086e83747d0e381e",
+              "name": "TestSpan",
+              "attributes": [
+                {
+                  "key": "attribute1",
+                  "value": { "intValue": "78" }
                 },
                 {
-                    "key": "unused_attribute1",
-                    "value": { "intValue": "78" }
+                  "key": "unused_attribute1",
+                  "value": { "intValue": "78" }
                 },
                 {
-                    "key": "account_id",
-                    "value": { "intValue": "2245" }
-                }]
-            }]
-        }]
-    }]
+                  "key": "account_id",
+                  "value": { "intValue": "2245" }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }
 ```
 
@@ -200,50 +210,68 @@ For an input trace like this...
 
 ```json
 {
-    "resourceLogs": [{
-        "scopeLogs": [{
-            "log_records": [{
-                "body": { "stringValue": "span=TestSpan dur=0ns attribute1=78 svc=TestSvcName res_attribute1=78 tid=7bba9f33312b3dbb8b2c2c62bb7abe2d" },
-                "attributes": [{
-                    "key": "traces",
-                    "value": { "stringValue": "span" }
+  "resourceLogs": [
+    {
+      "scopeLogs": [
+        {
+          "log_records": [
+            {
+              "body": {
+                "stringValue": "span=TestSpan dur=0ns attribute1=78 svc=TestSvcName res_attribute1=78 tid=7bba9f33312b3dbb8b2c2c62bb7abe2d"
+              },
+              "attributes": [
+                {
+                  "key": "traces",
+                  "value": { "stringValue": "span" }
                 },
                 {
-                    "key": "attribute1",
-                    "value": { "intValue": "78" }
+                  "key": "attribute1",
+                  "value": { "intValue": "78" }
                 },
                 {
-                    "key": "res_attribute1",
-                    "value": { "intValue": "78" }
-                }]
+                  "key": "res_attribute1",
+                  "value": { "intValue": "78" }
+                }
+              ]
             },
             {
-                "body": { "stringValue": "span=TestSpan dur=0ns attribute1=78 svc=TestSvcName res_attribute1=78 tid=7bba9f33312b3dbb8b2c2c62bb7abe2d" },
-                "attributes": [{
-                    "key": "traces",
-                    "value": { "stringValue": "root" }
+              "body": {
+                "stringValue": "span=TestSpan dur=0ns attribute1=78 svc=TestSvcName res_attribute1=78 tid=7bba9f33312b3dbb8b2c2c62bb7abe2d"
+              },
+              "attributes": [
+                {
+                  "key": "traces",
+                  "value": { "stringValue": "root" }
                 },
                 {
-                    "key": "attribute1",
-                    "value": { "intValue": "78" }
+                  "key": "attribute1",
+                  "value": { "intValue": "78" }
                 },
                 {
-                    "key": "res_attribute1",
-                    "value": { "intValue": "78" }
-                }]
+                  "key": "res_attribute1",
+                  "value": { "intValue": "78" }
+                }
+              ]
             },
             {
-                "body": { "stringValue": "svc=TestSvcName res_attribute1=78 tid=7bba9f33312b3dbb8b2c2c62bb7abe2d" },
-                "attributes": [{
-                    "key": "traces",
-                    "value": { "stringValue": "process" }
+              "body": {
+                "stringValue": "svc=TestSvcName res_attribute1=78 tid=7bba9f33312b3dbb8b2c2c62bb7abe2d"
+              },
+              "attributes": [
+                {
+                  "key": "traces",
+                  "value": { "stringValue": "process" }
                 },
                 {
-                    "key": "res_attribute1",
-                    "value": { "intValue": "78" }
-                }]
-            }]
-        }]
-    }]
+                  "key": "res_attribute1",
+                  "value": { "intValue": "78" }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }
 ```

--- a/docs/sources/flow/reference/components/otelcol.connector.spanmetrics.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.spanmetrics.md
@@ -7,17 +7,17 @@ title: otelcol.connector.spanmetrics
 
 # otelcol.connector.spanmetrics
 
-`otelcol.connector.spanmetrics` accepts span data from other `otelcol` components and 
+`otelcol.connector.spanmetrics` accepts span data from other `otelcol` components and
 aggregates Request, Error and Duration (R.E.D) OpenTelemetry metrics from the spans:
 
-* **Request** counts are computed as the number of spans seen per unique set of dimensions, 
-including Errors. Multiple metrics can be aggregated if, for instance, a user wishes to 
-view call counts just on `service.name`` and `span.name``.
+- **Request** counts are computed as the number of spans seen per unique set of dimensions,
+  including Errors. Multiple metrics can be aggregated if, for instance, a user wishes to
+  view call counts just on `service.name`` and `span.name``.
 
-* **Error** counts are computed from the Request counts which have an `Error` status code metric dimension.
+- **Error** counts are computed from the Request counts which have an `Error` status code metric dimension.
 
-* **Duration** is computed from the difference between the span start and end times and inserted 
-into the relevant duration histogram time bucket for each unique set dimensions.
+- **Duration** is computed from the difference between the span start and end times and inserted
+  into the relevant duration histogram time bucket for each unique set dimensions.
 
 > **NOTE**: `otelcol.connector.spanmetrics` is a wrapper over the upstream
 > OpenTelemetry Collector `spanmetrics` connector. Bug reports or feature requests
@@ -44,18 +44,19 @@ otelcol.connector.spanmetrics "LABEL" {
 
 `otelcol.connector.spanmetrics` supports the following arguments:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`dimensions_cache_size` | `number` | How many dimensions to cache. | `1000` | no
-`aggregation_temporality` | `string` | Configures whether to reset the metrics after flushing. | `"CUMULATIVE"` | no
-`metrics_flush_interval` | `duration` | How often to flush generated metrics. | `"15s"` | no
-`namespace` | `string` | Metric namespace. | `""` | no
+| Name                      | Type       | Description                                             | Default        | Required |
+| ------------------------- | ---------- | ------------------------------------------------------- | -------------- | -------- |
+| `dimensions_cache_size`   | `number`   | How many dimensions to cache.                           | `1000`         | no       |
+| `aggregation_temporality` | `string`   | Configures whether to reset the metrics after flushing. | `"CUMULATIVE"` | no       |
+| `metrics_flush_interval`  | `duration` | How often to flush generated metrics.                   | `"15s"`        | no       |
+| `namespace`               | `string`   | Metric namespace.                                       | `""`           | no       |
 
 Adjusting `dimensions_cache_size` can improve the Agent process' memory usage.
 
 The supported values for `aggregation_temporality` are:
-* `"CUMULATIVE"`: The metrics will **not** be reset after they are flushed.
-* `"DELTA"`: The metrics will be reset after they are flushed.
+
+- `"CUMULATIVE"`: The metrics will **not** be reset after they are flushed.
+- `"DELTA"`: The metrics will be reset after they are flushed.
 
 If `namespace` is set, the generated metric name will be added a `namespace.` prefix.
 
@@ -64,17 +65,18 @@ If `namespace` is set, the generated metric name will be added a `namespace.` pr
 The following blocks are supported inside the definition of
 `otelcol.connector.spanmetrics`:
 
-Hierarchy | Block | Description | Required
---------- | ----- | ----------- | --------
-dimension | [dimension][] | Dimensions to be added in addition to the default ones. | no
-histogram | [histogram][] | Configures the histogram derived from spans durations. | yes
-histogram > exponential | [exponential][] | Configuration for a histogram with exponential buckets. | no
-histogram > explicit | [explicit][] | Configuration for a histogram with explicit buckets. | no
-output | [output][] | Configures where to send telemetry data. | yes
+| Hierarchy               | Block           | Description                                             | Required |
+| ----------------------- | --------------- | ------------------------------------------------------- | -------- |
+| dimension               | [dimension][]   | Dimensions to be added in addition to the default ones. | no       |
+| histogram               | [histogram][]   | Configures the histogram derived from spans durations.  | yes      |
+| histogram > exponential | [exponential][] | Configuration for a histogram with exponential buckets. | no       |
+| histogram > explicit    | [explicit][]    | Configuration for a histogram with explicit buckets.    | no       |
+| output                  | [output][]      | Configures where to send telemetry data.                | yes      |
 
 It is necessary to specify either a "[exponential][]" or an "[explicit][]" block:
-* Specifying both an "[exponential][]" and an "[explicit][]" block is not allowed.
-* Specifying neither an "[exponential][]" nor an "[explicit][]" block is not allowed.
+
+- Specifying both an "[exponential][]" and an "[explicit][]" block is not allowed.
+- Specifying neither an "[exponential][]" nor an "[explicit][]" block is not allowed.
 
 [dimension]: #dimension-block
 [histogram]: #histogram-block
@@ -87,27 +89,29 @@ It is necessary to specify either a "[exponential][]" or an "[explicit][]" block
 The `dimension` block configures dimensions to be added in addition to the default ones.
 
 The default dimensions are:
-* `service.name`
-* `span.name`
-* `span.kind`
-* `status.code`
 
-The default dimensions are always added. If no additional dimensions are specified, 
+- `service.name`
+- `span.name`
+- `span.kind`
+- `status.code`
+
+The default dimensions are always added. If no additional dimensions are specified,
 only the default ones will be added.
 
 The following attributes are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`name` | `string` | Span attribute or resource attribute to look up. |  | yes
-`default` | `string` | Value to use if the attribute is missing. | null | no
+| Name      | Type     | Description                                      | Default | Required |
+| --------- | -------- | ------------------------------------------------ | ------- | -------- |
+| `name`    | `string` | Span attribute or resource attribute to look up. |         | yes      |
+| `default` | `string` | Value to use if the attribute is missing.        | null    | no       |
 
-`otelcol.connector.spanmetrics` will look for the `name` attribute in the span's 
+`otelcol.connector.spanmetrics` will look for the `name` attribute in the span's
 collection of attributes. If it is not found, the resource attributes will be checked.
 
 If the attribute is missing in both the span and resource attributes:
-* If `default` is not set, the dimension will be omitted.
-* If `default` is set, the dimension will be added and its value will be set to the value of `default`.
+
+- If `default` is not set, the dimension will be omitted.
+- If `default` is set, the dimension will be added and its value will be set to the value of `default`.
 
 ### histogram block
 
@@ -115,13 +119,14 @@ The `histogram` block configures the histogram derived from spans' durations.
 
 The following attributes are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`unit` | `string` | Configures the histogram units. | `"ms"` | no
+| Name   | Type     | Description                     | Default | Required |
+| ------ | -------- | ------------------------------- | ------- | -------- |
+| `unit` | `string` | Configures the histogram units. | `"ms"`  | no       |
 
 The supported values for `aggregation_temporality` are:
-* `"ms"`: milliseconds
-* `"s"`: seconds
+
+- `"ms"`: milliseconds
+- `"s"`: seconds
 
 ### exponential block
 
@@ -129,9 +134,9 @@ The `exponential` block configures a histogram with exponential buckets.
 
 The following attributes are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`max_size` | `number` | Maximum number of buckets per positive or negative number range. | `160` | no
+| Name       | Type     | Description                                                      | Default | Required |
+| ---------- | -------- | ---------------------------------------------------------------- | ------- | -------- |
+| `max_size` | `number` | Maximum number of buckets per positive or negative number range. | `160`   | no       |
 
 ### explicit block
 
@@ -139,21 +144,21 @@ The `explicit` block configures a histogram with explicit buckets.
 
 The following attributes are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`buckets` | `list(duration)` | List of histogram buckets. | `["2ms", "4ms", "6ms", "8ms", "10ms", "50ms", "100ms", "200ms", "400ms", "800ms", "1s", "1400ms", "2s", "5s", "10s", "15s"]` | no
+| Name      | Type             | Description                | Default                                                                                                                      | Required |
+| --------- | ---------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `buckets` | `list(duration)` | List of histogram buckets. | `["2ms", "4ms", "6ms", "8ms", "10ms", "50ms", "100ms", "200ms", "400ms", "800ms", "1s", "1400ms", "2s", "5s", "10s", "15s"]` | no       |
 
 ### output block
 
-{{< docs/shared lookup="flow/reference/components/output-block-metrics.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/output-block-metrics.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Exported fields
 
 The following fields are exported and can be referenced by other components:
 
-Name | Type | Description
----- | ---- | -----------
-`input` | `otelcol.Consumer` | A value that other components can use to send telemetry data to.
+| Name    | Type               | Description                                                      |
+| ------- | ------------------ | ---------------------------------------------------------------- |
+| `input` | `otelcol.Consumer` | A value that other components can use to send telemetry data to. |
 
 `input` accepts `otelcol.Consumer` traces telemetry data. It does not accept metrics and logs.
 
@@ -172,10 +177,11 @@ information.
 ### Explicit histogram and extra dimensions
 
 In the example below, `http.status_code` and `http.method` are additional dimensions on top of:
-* `service.name`
-* `span.name`
-* `span.kind`
-* `status.code`
+
+- `service.name`
+- `span.name`
+- `span.kind`
+- `status.code`
 
 ```river
 otelcol.receiver.otlp "default" {
@@ -214,7 +220,7 @@ otelcol.connector.spanmetrics "default" {
 
   // The period on which all metrics (whose dimension keys remain in cache) will be emitted.
   metrics_flush_interval = "33s"
-  
+
   namespace = "test.namespace"
 
   output {
@@ -231,11 +237,11 @@ otelcol.exporter.otlp "production" {
 
 ### Sending metrics via a Prometheus remote write
 
-In order for a `target_info` metric to be generated, the incoming spans resource scope 
+In order for a `target_info` metric to be generated, the incoming spans resource scope
 attributes must contain `service.name` and `service.instance.id` attributes.
 
 The `target_info` metric will be generated for each resource scope, while OpenTelemetry
-metric names and attributes will be normalized to be compliant with Prometheus naming rules. 
+metric names and attributes will be normalized to be compliant with Prometheus naming rules.
 
 ```river
 otelcol.receiver.otlp "default" {
@@ -251,7 +257,7 @@ otelcol.connector.spanmetrics "default" {
   histogram {
     exponential {}
   }
-  
+
   output {
     metrics = [otelcol.exporter.prometheus.default.input]
   }

--- a/docs/sources/flow/reference/components/prometheus.exporter.apache.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.apache.md
@@ -4,6 +4,7 @@ title: prometheus.exporter.apache
 ---
 
 # prometheus.exporter.apache
+
 The `prometheus.exporter.apache` component embeds
 [apache_exporter](https://github.com/Lusitaniae/apache_exporter) for collecting mod_status statistics from an apache server.
 
@@ -15,18 +16,19 @@ prometheus.exporter.apache "LABEL" {
 ```
 
 ## Arguments
+
 The following arguments can be used to configure the exporter's behavior.
 All arguments are optional. Omitted fields take their default values.
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`scrape_uri`    | `string` | URI to Apache stub status page. | `http://localhost/server-status?auto` | no
-`host_override` | `string` | Override for HTTP Host header.  | | no
-`insecure`      | `bool`   | Ignore server certificate if using https. | false | no
+| Name            | Type     | Description                               | Default                               | Required |
+| --------------- | -------- | ----------------------------------------- | ------------------------------------- | -------- |
+| `scrape_uri`    | `string` | URI to Apache stub status page.           | `http://localhost/server-status?auto` | no       |
+| `host_override` | `string` | Override for HTTP Host header.            |                                       | no       |
+| `insecure`      | `bool`   | Ignore server certificate if using https. | false                                 | no       |
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 
@@ -71,9 +73,11 @@ prometheus.remote_write "demo" {
   }
 }
 ```
+
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
@@ -4,6 +4,7 @@ title: prometheus.exporter.blackbox
 ---
 
 # prometheus.exporter.blackbox
+
 The `prometheus.exporter.blackbox` component embeds
 [`blackbox_exporter`](https://github.com/prometheus/blackbox_exporter). `blackbox_exporter` lets you collect blackbox metrics (probes) and expose them as Prometheus metrics.
 
@@ -15,14 +16,15 @@ prometheus.exporter.blackbox "LABEL" {
 ```
 
 ## Arguments
+
 The following arguments can be used to configure the exporter's behavior.
 Omitted fields take their default values.
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`config_file`                 | `string`       | blackbox_exporter configuration file path. | | no
-`config`                      | `string` or `secret`       | blackbox_exporter configuration as inline string.  | |no
-`probe_timeout_offset`        | `duration`     | Offset in seconds to subtract from timeout when probing targets.  | `"0.5s"` | no
+| Name                   | Type                 | Description                                                      | Default  | Required |
+| ---------------------- | -------------------- | ---------------------------------------------------------------- | -------- | -------- |
+| `config_file`          | `string`             | blackbox_exporter configuration file path.                       |          | no       |
+| `config`               | `string` or `secret` | blackbox_exporter configuration as inline string.                |          | no       |
+| `probe_timeout_offset` | `duration`           | Offset in seconds to subtract from timeout when probing targets. | `"0.5s"` | no       |
 
 The `config_file` argument points to a YAML file defining which blackbox_exporter modules to use.
 The `config` argument must be a YAML document as string defining which blackbox_exporter modules to use.
@@ -32,17 +34,16 @@ The `config` argument must be a YAML document as string defining which blackbox_
 - `remote.http.LABEL.content`
 - `remote.s3.LABEL.content`
 
-
-See [blackbox_exporter]( https://github.com/prometheus/blackbox_exporter/blob/master/example.yml) for details on how to generate a config file.
+See [blackbox_exporter](https://github.com/prometheus/blackbox_exporter/blob/master/example.yml) for details on how to generate a config file.
 
 ## Blocks
 
 The following blocks are supported inside the definition of
 `prometheus.exporter.blackbox` to configure collector-specific options:
 
-Hierarchy | Name | Description | Required
---------- | ---- | ----------- | --------
-target | [target][] | Configures a blackbox target. | yes
+| Hierarchy | Name       | Description                   | Required |
+| --------- | ---------- | ----------------------------- | -------- |
+| target    | [target][] | Configures a blackbox target. | yes      |
 
 [target]: #target-block
 
@@ -51,15 +52,15 @@ target | [target][] | Configures a blackbox target. | yes
 The `target` block defines an individual blackbox target.
 The `target` block may be specified multiple times to define multiple targets.
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`name` | `string` | Name of the target. | | yes
-`address` | `string` | The address of the target to probe. | | yes
-`module`| `string` | Blackbox module to use to probe. | `""` | no
+| Name      | Type     | Description                         | Default | Required |
+| --------- | -------- | ----------------------------------- | ------- | -------- |
+| `name`    | `string` | Name of the target.                 |         | yes      |
+| `address` | `string` | The address of the target to probe. |         | yes      |
+| `module`  | `string` | Blackbox module to use to probe.    | `""`    | no       |
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 
@@ -116,10 +117,12 @@ prometheus.remote_write "demo" {
   }
 }
 ```
+
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 ### Collect metrics using an embedded configuration
 
@@ -157,9 +160,11 @@ prometheus.remote_write "demo" {
   }
 }
 ```
+
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.exporter.cloudwatch.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.cloudwatch.md
@@ -10,11 +10,10 @@ embeds [`yet-another-cloudwatch-exporter`](https://github.com/nerdswords/yet-ano
 collect [CloudWatch metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/WhatIsCloudWatch.html),
 translate them to a prometheus-compatible format and remote write them.
 
-This component lets you scrape CloudWatch metrics in a set of configurations we call *jobs*. There are
+This component lets you scrape CloudWatch metrics in a set of configurations we call _jobs_. There are
 two kinds of jobs: [discovery][] and [static][].
 
 [discovery]: #discovery-block
-
 [static]: #static-block
 
 ## Authentication
@@ -120,7 +119,7 @@ You can use the following arguments to configure the exporter's behavior.
 Omitted fields take their default values.
 
 | Name                      | Type                | Description                                                                                                                                                                                                                             | Default | Required |
-|---------------------------|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|----------|
+| ------------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
 | `sts_region`              | `string`            | AWS region to use when calling [STS][] for retrieving account information.                                                                                                                                                              |         | yes      |
 | `fips_disabled`           | `bool`              | Disable use of FIPS endpoints. Set 'true' when running outside of USA regions.                                                                                                                                                          | `true`  | no       |
 | `debug`                   | `bool`              | Enable debug logging on CloudWatch exporter internals.                                                                                                                                                                                  | `false` | no       |
@@ -133,14 +132,14 @@ Omitted fields take their default values.
 You can use the following blocks in`prometheus.exporter.cloudwatch` to configure collector-specific options:
 
 | Hierarchy          | Name                   | Description                                                                                                                             | Required |
-|--------------------|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|----------|
-| discovery          | [discovery][]          | Configures a discovery job. Multiple jobs can be configured.                                                                            | no*      |
+| ------------------ | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| discovery          | [discovery][]          | Configures a discovery job. Multiple jobs can be configured.                                                                            | no\*     |
 | discovery > role   | [role][]               | Configures the IAM roles the job should assume to scrape metrics. Defaults to the role configured in the environment the agent runs on. | no       |
 | discovery > metric | [metric][]             | Configures the list of metrics the job should scrape. Multiple metrics can be defined inside one job.                                   | yes      |
-| static             | [static][]             | Configures a static job. Multiple jobs can be configured.                                                                               | no*      |
+| static             | [static][]             | Configures a static job. Multiple jobs can be configured.                                                                               | no\*     |
 | static > role      | [role][]               | Configures the IAM roles the job should assume to scrape metrics. Defaults to the role configured in the environment the agent runs on. | no       |
 | static > metric    | [metric][]             | Configures the list of metrics the job should scrape. Multiple metrics can be defined inside one job.                                   | yes      |
-| decoupled_scraping | [decoupled_scraping][] | Configures the decoupled scraping feature to retrieve metrics on a schedule and return the cached metrics.                                        | no       |
+| decoupled_scraping | [decoupled_scraping][] | Configures the decoupled scraping feature to retrieve metrics on a schedule and return the cached metrics.                              | no       |
 
 {{% admonition type="note" %}}
 The `static` and `discovery` blocks are marked as not required, but you must configure at least one static or discovery
@@ -148,13 +147,9 @@ job.
 {{% /admonition %}}
 
 [discovery]: #discovery-block
-
 [static]: #static-block
-
 [metric]: #metric-block
-
 [role]: #role-block
-
 [decoupled_scraping]: #decoupled-scraping-block
 
 ## discovery block
@@ -192,13 +187,13 @@ prometheus.exporter.cloudwatch "discover_instances" {
 You can configure the `discovery` block one or multiple times to scrape metrics from different services or with
 different `search_tags`.
 
-| Name                           | Type           | Description                                                                                                                                                                                                                                                | Default | Required |
-|--------------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|----------|
-| `regions`                      | `list(string)` | List of AWS regions.                                                                                                                                                                                                                                       |         | yes      |
-| `type`                         | `string`       | Cloudwatch service alias (`"alb"`, `"ec2"`, etc) or namespace name (`"AWS/EC2"`, `"AWS/S3"`, etc). See [supported-services][] for a complete list.                                                                                                         |         | yes      |
-| `custom_tags`                  | `map(string)`  | Custom tags to be added as a list of key / value pairs. When exported to Prometheus format, the label name follows the following format: `custom_tag_{key}`.                                                                                               | `{}`    | no       |
-| `search_tags`                  | `map(string)`  | List of key / value pairs to use for tag filtering (all must match). Value can be a regex.                                                                                                                                                                 | `{}`    | no       |
-| `dimension_name_requirements`  | `list(string)` | List of metric dimensions to query. Before querying metric values, the total list of metrics will be filtered to only those that contain exactly this list of dimensions. An empty or undefined list results in all dimension combinations being included. | `{}`    | no       |
+| Name                          | Type           | Description                                                                                                                                                                                                                                                | Default | Required |
+| ----------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
+| `regions`                     | `list(string)` | List of AWS regions.                                                                                                                                                                                                                                       |         | yes      |
+| `type`                        | `string`       | Cloudwatch service alias (`"alb"`, `"ec2"`, etc) or namespace name (`"AWS/EC2"`, `"AWS/S3"`, etc). See [supported-services][] for a complete list.                                                                                                         |         | yes      |
+| `custom_tags`                 | `map(string)`  | Custom tags to be added as a list of key / value pairs. When exported to Prometheus format, the label name follows the following format: `custom_tag_{key}`.                                                                                               | `{}`    | no       |
+| `search_tags`                 | `map(string)`  | List of key / value pairs to use for tag filtering (all must match). Value can be a regex.                                                                                                                                                                 | `{}`    | no       |
+| `dimension_name_requirements` | `list(string)` | List of metric dimensions to query. Before querying metric values, the total list of metrics will be filtered to only those that contain exactly this list of dimensions. An empty or undefined list results in all dimension combinations being included. | `{}`    | no       |
 
 [supported-services]: #supported-services-in-discovery-jobs
 
@@ -248,7 +243,7 @@ static "LABEL" {
 You can configure the `static` block one or multiple times to scrape metrics with different sets of `dimensions`.
 
 | Name          | Type           | Description                                                                                                                                                  | Default | Required |
-|---------------|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|----------|
+| ------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- | -------- |
 | `regions`     | `list(string)` | List of AWS regions.                                                                                                                                         |         | yes      |
 | `namespace`   | `string`       | CloudWatch metric namespace.                                                                                                                                 |         | yes      |
 | `dimensions`  | `map(string)`  | CloudWatch metric dimensions as a list of name / value pairs. Must uniquely define all metrics in this job.                                                  |         | yes      |
@@ -267,7 +262,7 @@ Follow [this guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitori
 on how to explore metrics, to easily pick the ones you need.
 
 | Name         | Type           | Description                                                      | Default                                                   | Required |
-|--------------|----------------|------------------------------------------------------------------|-----------------------------------------------------------|----------|
+| ------------ | -------------- | ---------------------------------------------------------------- | --------------------------------------------------------- | -------- |
 | `name`       | `string`       | Metric name.                                                     |                                                           | yes      |
 | `statistics` | `list(string)` | List of statistics to scrape. Ex: `"Minimum"`, `"Maximum"`, etc. |                                                           | yes      |
 | `period`     | `duration`     | See [period][] section below.                                    |                                                           | yes      |
@@ -288,7 +283,7 @@ See [Granting a user permissions to switch roles](https://docs.aws.amazon.com/IA
 in the AWS IAM documentation for more information about how to configure this.
 
 | Name          | Type     | Description                                                           | Default | Required |
-|---------------|----------|-----------------------------------------------------------------------|---------|----------|
+| ------------- | -------- | --------------------------------------------------------------------- | ------- | -------- |
 | `role_arn`    | `string` | AWS IAM Role ARN the exporter should assume to perform AWS API calls. |         | yes      |
 | `external_id` | `string` | External ID used when calling STS AssumeRole API. See [details][].    | `""`    | no       |
 
@@ -336,13 +331,13 @@ The decoupled scraping feature reduces the number of API requests sent to AWS.
 This feature also prevents component scrape timeouts when you gather high volumes of CloudWatch metrics
 
 | Name              | Type     | Description                                                             | Default | Required |
-|-------------------|----------|-------------------------------------------------------------------------|---------|----------|
+| ----------------- | -------- | ----------------------------------------------------------------------- | ------- | -------- |
 | `enabled`         | `bool`   | Controls whether the decoupled scraping featured is enabled             | false   | no       |
 | `scrape_interval` | `string` | Controls how frequently to asynchronously gather new CloudWatch metrics | 5m      | no       |
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 
@@ -365,7 +360,6 @@ debug metrics.
 See the examples described under each [discovery][] and [static] sections.
 
 [discovery]: #discovery-block
-
 [static]: #static-block
 
 ## Supported services in discovery jobs
@@ -454,6 +448,3 @@ discovery job, the `type` field of each `discovery_job` must match either the de
 - Namespace: `/aws/sagemaker/TransformJobs` or Alias: `sagemaker-transform`
 - Namespace: `/aws/sagemaker/InferenceRecommendationsJobs` or Alias: `sagemaker-inf-rec`
 - Namespace: `AWS/Sagemaker/ModelBuildingPipeline` or Alias: `sagemaker-model-building-pipeline`
-
-
-

--- a/docs/sources/flow/reference/components/prometheus.exporter.consul.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.consul.md
@@ -4,6 +4,7 @@ title: prometheus.exporter.consul
 ---
 
 # prometheus.exporter.consul
+
 The `prometheus.exporter.consul` component embeds
 [consul_exporter](https://github.com/prometheus/consul_exporter) for collecting metrics from a consul install.
 
@@ -15,28 +16,29 @@ prometheus.exporter.consul "LABEL" {
 ```
 
 ## Arguments
+
 The following arguments can be used to configure the exporter's behavior.
 All arguments are optional. Omitted fields take their default values.
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`server`                  | `string`   | Address (host and port) of the Consul instance we should connect to. This could be a local agent (localhost:8500, for instance), or the address of a Consul server. | `http://localhost:8500` | no
-`ca_file`                 | `string`   | File path to a PEM-encoded certificate authority used to validate the authenticity of a server certificate.  | | no
-`cert_file`               | `string`   | File path to a PEM-encoded certificate used with the private key to verify the exporter's authenticity. | | no
-`key_file`                | `string`   | File path to a PEM-encoded private key used with the certificate to verify the exporter's authenticity. | | no
-`server_name`             | `string`   | When provided, this overrides the hostname for the TLS certificate. It can be used to ensure that the certificate name matches the hostname we declare. | | no
-`timeout`                 | `duration` | Timeout on HTTP requests to consul.  | 500ms | no
-`insecure_skip_verify`    | `bool`     | Disable TLS host verification. | false | no
-`concurrent_request_limit`| `string`   | Limit the maximum number of concurrent requests to consul, 0 means no limit. | | no
-`allow_stale`             | `bool`     | Allows any Consul server (non-leader) to service a read. | `true` | no
-`require_consistent`      | `bool`     | Forces the read to be fully consistent. | | no
-`kv_prefix`               | `string`   | Prefix under which to look for KV pairs. | | no
-`kv_filter`               | `string`   | Only store keys that match this regex pattern. | `.*` | no
-`generate_health_summary` | `bool`     | Collects information about each registered service and exports `consul_catalog_service_node_healthy`. | `true` | no
+| Name                       | Type       | Description                                                                                                                                                         | Default                 | Required |
+| -------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | -------- |
+| `server`                   | `string`   | Address (host and port) of the Consul instance we should connect to. This could be a local agent (localhost:8500, for instance), or the address of a Consul server. | `http://localhost:8500` | no       |
+| `ca_file`                  | `string`   | File path to a PEM-encoded certificate authority used to validate the authenticity of a server certificate.                                                         |                         | no       |
+| `cert_file`                | `string`   | File path to a PEM-encoded certificate used with the private key to verify the exporter's authenticity.                                                             |                         | no       |
+| `key_file`                 | `string`   | File path to a PEM-encoded private key used with the certificate to verify the exporter's authenticity.                                                             |                         | no       |
+| `server_name`              | `string`   | When provided, this overrides the hostname for the TLS certificate. It can be used to ensure that the certificate name matches the hostname we declare.             |                         | no       |
+| `timeout`                  | `duration` | Timeout on HTTP requests to consul.                                                                                                                                 | 500ms                   | no       |
+| `insecure_skip_verify`     | `bool`     | Disable TLS host verification.                                                                                                                                      | false                   | no       |
+| `concurrent_request_limit` | `string`   | Limit the maximum number of concurrent requests to consul, 0 means no limit.                                                                                        |                         | no       |
+| `allow_stale`              | `bool`     | Allows any Consul server (non-leader) to service a read.                                                                                                            | `true`                  | no       |
+| `require_consistent`       | `bool`     | Forces the read to be fully consistent.                                                                                                                             |                         | no       |
+| `kv_prefix`                | `string`   | Prefix under which to look for KV pairs.                                                                                                                            |                         | no       |
+| `kv_filter`                | `string`   | Only store keys that match this regex pattern.                                                                                                                      | `.*`                    | no       |
+| `generate_health_summary`  | `bool`     | Collects information about each registered service and exports `consul_catalog_service_node_healthy`.                                                               | `true`                  | no       |
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 
@@ -81,9 +83,11 @@ prometheus.remote_write "demo" {
   }
 }
 ```
+
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.exporter.dnsmasq.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.dnsmasq.md
@@ -4,6 +4,7 @@ title: prometheus.exporter.dnsmasq
 ---
 
 # prometheus.exporter.dnsmasq
+
 The `prometheus.exporter.dnsmasq` component embeds
 [dnsmasq_exporter](https://github.com/google/dnsmasq_exporter) for collecting statistics from a dnsmasq server.
 
@@ -15,18 +16,19 @@ prometheus.exporter.dnsmasq "LABEL" {
 ```
 
 ## Arguments
+
 The following arguments can be used to configure the exporter's behavior.
 All arguments are optional. Omitted fields take their default values.
 
-Name          | Type     | Description                          | Default                          | Required
-------------- | -------- | ------------------------------------ | -------------------------------- | --------
-`address`     | `string` | The address of the dnsmasq server.   | `"localhost:53"`                 | no
-`leases_file` | `string` | The path to the dnsmasq leases file. | `"/var/lib/misc/dnsmasq.leases"` | no
-`expose_leases` | `bool` | Expose dnsmasq leases as metrics (high cardinality). | `false` | no
+| Name            | Type     | Description                                          | Default                          | Required |
+| --------------- | -------- | ---------------------------------------------------- | -------------------------------- | -------- |
+| `address`       | `string` | The address of the dnsmasq server.                   | `"localhost:53"`                 | no       |
+| `leases_file`   | `string` | The path to the dnsmasq leases file.                 | `"/var/lib/misc/dnsmasq.leases"` | no       |
+| `expose_leases` | `bool`   | Expose dnsmasq leases as metrics (high cardinality). | `false`                          | no       |
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 
@@ -71,9 +73,11 @@ prometheus.remote_write "demo" {
   }
 }
 ```
+
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.exporter.elasticsearch.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.elasticsearch.md
@@ -4,6 +4,7 @@ title: prometheus.exporter.elasticsearch
 ---
 
 # prometheus.exporter.elasticsearch
+
 The `prometheus.exporter.elasticsearch` component embeds
 [elasticsearch_exporter](https://github.com/prometheus-community/elasticsearch_exporter) for
 the collection of metrics from ElasticSearch servers.
@@ -25,34 +26,33 @@ prometheus.exporter.elasticsearch "LABEL" {
 ```
 
 ## Arguments
+
 You can use the following arguments to configure the exporter's behavior.
 Omitted fields take their default values.
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`address` | `string` | HTTP API address of an Elasticsearch node. | `"http://localhost:9200"` | no
-`timeout` | `duration` | Timeout for trying to get stats from Elasticsearch. | `"5s"` | no
-`all` | `bool` | Export stats for all nodes in the cluster. If used, this flag will override the flag `node`. | | no
-`node` | `string` | Node's name of which metrics should be exposed |  | no
-`indices` | bool | Export stats for indices in the cluster. |  | no
-`indices_settings` | bool | Export stats for settings of all indices of the cluster. |  | no
-`cluster_settings` | bool | Export stats for cluster settings. |  | no
-`shards` | bool | Export stats for shards in the cluster (implies indices). |  | no
-`snapshots` | bool | Export stats for the cluster snapshots. |  | no
-`clusterinfo_interval` | `duration` | Cluster info update interval for the cluster label. | `"5m"` | no
-`ca` | `string` | Path to PEM file that contains trusted Certificate Authorities for the Elasticsearch connection. |  | no
-`client_private_key` | `string` | Path to PEM file that contains the private key for client auth when connecting to Elasticsearch. |  | no
-`client_cert` | `string` | Path to PEM file that contains the corresponding cert for the private key to connect to Elasticsearch. |  | no
-`ssl_skip_verify` | `bool` | Skip SSL verification when connecting to Elasticsearch. | | no
-`aliases` | `bool` | Include informational aliases metrics. |  | no
-`data_streams` | `bool` | Export stats for Data Streams. |  | no
-`slm` | `bool` | Export stats for SLM (Snapshot Lifecycle Management). |  | no
-
-
+| Name                   | Type       | Description                                                                                            | Default                   | Required |
+| ---------------------- | ---------- | ------------------------------------------------------------------------------------------------------ | ------------------------- | -------- |
+| `address`              | `string`   | HTTP API address of an Elasticsearch node.                                                             | `"http://localhost:9200"` | no       |
+| `timeout`              | `duration` | Timeout for trying to get stats from Elasticsearch.                                                    | `"5s"`                    | no       |
+| `all`                  | `bool`     | Export stats for all nodes in the cluster. If used, this flag will override the flag `node`.           |                           | no       |
+| `node`                 | `string`   | Node's name of which metrics should be exposed                                                         |                           | no       |
+| `indices`              | bool       | Export stats for indices in the cluster.                                                               |                           | no       |
+| `indices_settings`     | bool       | Export stats for settings of all indices of the cluster.                                               |                           | no       |
+| `cluster_settings`     | bool       | Export stats for cluster settings.                                                                     |                           | no       |
+| `shards`               | bool       | Export stats for shards in the cluster (implies indices).                                              |                           | no       |
+| `snapshots`            | bool       | Export stats for the cluster snapshots.                                                                |                           | no       |
+| `clusterinfo_interval` | `duration` | Cluster info update interval for the cluster label.                                                    | `"5m"`                    | no       |
+| `ca`                   | `string`   | Path to PEM file that contains trusted Certificate Authorities for the Elasticsearch connection.       |                           | no       |
+| `client_private_key`   | `string`   | Path to PEM file that contains the private key for client auth when connecting to Elasticsearch.       |                           | no       |
+| `client_cert`          | `string`   | Path to PEM file that contains the corresponding cert for the private key to connect to Elasticsearch. |                           | no       |
+| `ssl_skip_verify`      | `bool`     | Skip SSL verification when connecting to Elasticsearch.                                                |                           | no       |
+| `aliases`              | `bool`     | Include informational aliases metrics.                                                                 |                           | no       |
+| `data_streams`         | `bool`     | Export stats for Data Streams.                                                                         |                           | no       |
+| `slm`                  | `bool`     | Export stats for SLM (Snapshot Lifecycle Management).                                                  |                           | no       |
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 
@@ -97,9 +97,11 @@ prometheus.remote_write "demo" {
   }
 }
 ```
+
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.exporter.gcp.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.gcp.md
@@ -57,7 +57,7 @@ Please note that if you are supplying a list of strings for the `extra_filters` 
 {{% /admonition %}}
 
 | Name                      | Type           | Description                                                                                                                                                                                                                                                               | Default | Required |
-|---------------------------|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|----------|
+| ------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
 | `project_ids`             | `list(string)` | Configure the GCP Project(s) to scrape for metrics.                                                                                                                                                                                                                       |         | yes      |
 | `metrics_prefixes`        | `list(string)` | One or more values from the supported [GCP Metrics](https://cloud.google.com/monitoring/api/metrics_gcp). These can be as targeted or loose as needed.                                                                                                                    |         | yes      |
 | `extra_filters`           | `list(string)` | Used to further refine the resources you would like to collect metrics from. Please note that any string value within a particular filter string must be enclosed in escaped double-quotes. The structure for these filters is `<targeted_metric_prefix>:<filter_query>`. | `[]`    | no       |
@@ -75,7 +75,7 @@ For `ingest_delay`, you can see the values for this in documented metrics as `Af
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.github.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.github.md
@@ -4,6 +4,7 @@ title: prometheus.exporter.github
 ---
 
 # prometheus.exporter.github
+
 The `prometheus.exporter.github` component embeds
 [github_exporter](https://github.com/infinityworks/github-exporter) for collecting statistics from GitHub.
 
@@ -15,17 +16,18 @@ prometheus.exporter.github "LABEL" {
 ```
 
 ## Arguments
+
 The following arguments can be used to configure the exporter's behavior.
 All arguments are optional. Omitted fields take their default values.
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`api_url`    | `string` | The full URI of the GitHub API. | `https://api.github.com` | no
-`repositories` | `list(string)` | GitHub repositories for which to collect metrics. | | no
-`organizations` | `list(string)` | GitHub organizations for which to collect metrics. | | no
-`users` | `list(string)` | A list of GitHub users for which to collect metrics. | | no
-`api_token`    | `secret` | API token to use to authenticate against GitHub. | | no
-`api_token_file`    | `string` | File containing API token to use to authenticate against GitHub. | | no
+| Name             | Type           | Description                                                      | Default                  | Required |
+| ---------------- | -------------- | ---------------------------------------------------------------- | ------------------------ | -------- |
+| `api_url`        | `string`       | The full URI of the GitHub API.                                  | `https://api.github.com` | no       |
+| `repositories`   | `list(string)` | GitHub repositories for which to collect metrics.                |                          | no       |
+| `organizations`  | `list(string)` | GitHub organizations for which to collect metrics.               |                          | no       |
+| `users`          | `list(string)` | A list of GitHub users for which to collect metrics.             |                          | no       |
+| `api_token`      | `secret`       | API token to use to authenticate against GitHub.                 |                          | no       |
+| `api_token_file` | `string`       | File containing API token to use to authenticate against GitHub. |                          | no       |
 
 GitHub uses an aggressive rate limit for unauthenticated requests based on IP address. To allow more API requests, it is recommended to configure either `api_token` or `api_token_file` to authenticate against GitHub.
 
@@ -33,7 +35,7 @@ When provided, `api_token_file` takes precedence over `api_token`.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 
@@ -79,9 +81,11 @@ prometheus.remote_write "demo" {
   }
 }
 ```
+
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.exporter.kafka.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.kafka.md
@@ -4,6 +4,7 @@ title: prometheus.exporter.kafka
 ---
 
 # prometheus.exporter.kafka
+
 The `prometheus.exporter.kafka` component embeds
 [kafka_exporter](https://github.com/davidmparrott/kafka_exporter) for collecting metrics from a kafka server.
 
@@ -16,11 +17,12 @@ prometheus.exporter.kafka "LABEL" {
 ```
 
 ## Arguments
+
 You can use the following arguments to configure the exporter's behavior.
 Omitted fields take their default values.
 
 | Name                        | Type            | Description                                                                                                                                                                        | Default | Required |
-|-----------------------------|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|----------|
+| --------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
 | `kafka_uris`                | `array(string)` | Address array (host:port) of Kafka server.                                                                                                                                         |         | yes      |
 | `instance`                  | `string`        | The`instance`label for metrics, default is the hostname:port of the first kafka_uris. You must manually provide the instance value if there is more than one string in kafka_uris. |         | no       |
 | `use_sasl`                  | `bool`          | Connect using SASL/PLAIN.                                                                                                                                                          |         | no       |
@@ -32,10 +34,10 @@ Omitted fields take their default values.
 | `ca_file`                   | `string`        | The optional certificate authority file for TLS client authentication.                                                                                                             |         | no       |
 | `cert_file`                 | `string`        | The optional certificate file for TLS client authentication.                                                                                                                       |         | no       |
 | `key_file`                  | `string`        | The optional key file for TLS client authentication.                                                                                                                               |         | no       |
-| `insecure_skip_verify`      | `bool`          | If set to true, the server's certificate will not be checked for validity. This makes your HTTPS connections insecure.                                                                |         | no       |
+| `insecure_skip_verify`      | `bool`          | If set to true, the server's certificate will not be checked for validity. This makes your HTTPS connections insecure.                                                             |         | no       |
 | `kafka_version`             | `string`        | Kafka broker version.                                                                                                                                                              | `2.0.0` | no       |
-| `use_zookeeper_lag`         | `bool`          | If set to true, use a group from zookeeper.                                                                                                                                         |         | no       |
-| `zookeeper_uris`            | `array(string)` | Address array (hosts) of zookeeper server.                                                                                                                                        |         | no       |
+| `use_zookeeper_lag`         | `bool`          | If set to true, use a group from zookeeper.                                                                                                                                        |         | no       |
+| `zookeeper_uris`            | `array(string)` | Address array (hosts) of zookeeper server.                                                                                                                                         |         | no       |
 | `kafka_cluster_name`        | `string`        | Kafka cluster name.                                                                                                                                                                |         | no       |
 | `metadata_refresh_interval` | `duration`      | Metadata refresh interval.                                                                                                                                                         | `1m`    | no       |
 | `allow_concurrency`         | `bool`          | If set to true, all scrapes trigger Kafka operations. Otherwise, they will share results. WARNING: Disable this on large clusters.                                                 | `true`  | no       |
@@ -46,7 +48,7 @@ Omitted fields take their default values.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 
@@ -91,9 +93,11 @@ prometheus.remote_write "demo" {
   }
 }
 ```
+
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.exporter.memcached.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.memcached.md
@@ -4,29 +4,33 @@ title: prometheus.exporter.memcached
 ---
 
 # prometheus.exporter.memcached
+
 The `prometheus.exporter.memcached` component embeds
 [memcached_exporter](https://github.com/prometheus/memcached_exporter) for collecting metrics from a Memcached server.
 
 ## Usage
+
 ```river
 prometheus.exporter.memcached "LABEL" {
 }
 ```
 
 ## Arguments
+
 The following arguments are supported:
 
-Name             | Type       | Description                                         | Default               | Required |
----------------- | ---------- | --------------------------------------------------- | --------------------- | -------- |
-`address`        | `string`   | The Memcached server address.                       | `"localhost:11211"`   | no       |
-`timeout`        | `duration` | The timeout for connecting to the Memcached server. | `"1s"`                | no       |
+| Name      | Type       | Description                                         | Default             | Required |
+| --------- | ---------- | --------------------------------------------------- | ------------------- | -------- |
+| `address` | `string`   | The Memcached server address.                       | `"localhost:11211"` | no       |
+| `timeout` | `duration` | The timeout for connecting to the Memcached server. | `"1s"`              | no       |
 
 ## Blocks
+
 The following blocks are supported inside the definition of `prometheus.exporter.memcached`:
 
-Hierarchy | Block | Description | Required
---------- | ----- | ----------- | --------
-tls_config | [tls_config][] | TLS configuration for requests to the Memcached server. | no
+| Hierarchy  | Block          | Description                                             | Required |
+| ---------- | -------------- | ------------------------------------------------------- | -------- |
+| tls_config | [tls_config][] | TLS configuration for requests to the Memcached server. | no       |
 
 [tls_config]: #tls_config-block
 
@@ -34,21 +38,23 @@ tls_config | [tls_config][] | TLS configuration for requests to the Memcached se
 
 {{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
-
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
+
 `prometheus.exporter.memcached` is only reported as unhealthy if given
 an invalid configuration. In those cases, exported fields retain their last
 healthy values.
 
 ## Debug information
+
 `prometheus.exporter.memcached` does not expose any component-specific
 debug information.
 
 ## Debug metrics
+
 `prometheus.exporter.memcached` does not expose any component-specific
 debug metrics.
 
@@ -79,9 +85,11 @@ prometheus.remote_write "demo" {
   }
 }
 ```
+
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.exporter.mongodb.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mongodb.md
@@ -4,6 +4,7 @@ title: prometheus.exporter.mongodb
 ---
 
 # prometheus.exporter.mongodb
+
 The `prometheus.exporter.mongodb` component embeds percona's [`mongodb_exporter`](https://github.com/percona/mongodb_exporter).
 
 {{% admonition type="note" %}}
@@ -11,7 +12,7 @@ For this integration to work properly, you must have connect each node of your M
 That's because this exporter does not collect metrics from multiple nodes.
 {{% /admonition %}}
 
-We strongly recommend configuring a separate user for the Grafana Agent, giving it only the strictly mandatory security privileges necessary for monitoring your node. 
+We strongly recommend configuring a separate user for the Grafana Agent, giving it only the strictly mandatory security privileges necessary for monitoring your node.
 Refer to the [Percona documentation](https://github.com/percona/mongodb_exporter#permissions) for more information.
 
 ## Usage
@@ -23,15 +24,16 @@ prometheus.exporter.mongodb "LABEL" {
 ```
 
 ## Arguments
+
 You can use the following arguments to configure the exporter's behavior.
 Omitted fields take their default values.
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`mongodb_uri` | `string` | MongoDB node connection URI. | | yes
-`direct_connect` | `boolean` | Whether or not a direct connect should be made. Direct connections are not valid if multiple hosts are specified or an SRV URI is used. | false | no
-`discovering_mode` | `boolean` | Wheter or not to enable autodiscover collections. | false | no
-`tls_basic_auth_config_path` | `string` | Path to the file having Prometheus TLS config for basic auth. Only enable if you want to use TLS based authentication. | | no
+| Name                         | Type      | Description                                                                                                                             | Default | Required |
+| ---------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
+| `mongodb_uri`                | `string`  | MongoDB node connection URI.                                                                                                            |         | yes      |
+| `direct_connect`             | `boolean` | Whether or not a direct connect should be made. Direct connections are not valid if multiple hosts are specified or an SRV URI is used. | false   | no       |
+| `discovering_mode`           | `boolean` | Wheter or not to enable autodiscover collections.                                                                                       | false   | no       |
+| `tls_basic_auth_config_path` | `string`  | Path to the file having Prometheus TLS config for basic auth. Only enable if you want to use TLS based authentication.                  |         | no       |
 
 MongoDB node connection URI must be in the [`Standard Connection String Format`](https://docs.mongodb.com/manual/reference/connection-string/#std-label-connections-standard-connection-string-format)
 
@@ -39,7 +41,7 @@ For `tls_basic_auth_config_path`, check [`tls_config`](https://prometheus.io/doc
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.mssql.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mssql.md
@@ -4,6 +4,7 @@ title: prometheus.exporter.mssql
 ---
 
 # prometheus.exporter.mssql
+
 The `prometheus.exporter.mssql` component embeds
 [sql_exporter](https://github.com/burningalchemist/sql_exporter) for collecting stats from a Microsoft SQL Server.
 
@@ -15,22 +16,20 @@ prometheus.exporter.mssql "LABEL" {
 }
 ```
 
-
 ## Arguments
 
 The following arguments can be used to configure the exporter's behavior.
 Omitted fields take their default values.
 
 | Name                   | Type       | Description                                                       | Default | Required |
-|------------------------|------------|-------------------------------------------------------------------|---------|----------|
+| ---------------------- | ---------- | ----------------------------------------------------------------- | ------- | -------- |
 | `connection_string`    | `secret`   | The connection string used to connect to an Microsoft SQL Server. |         | yes      |
 | `max_idle_connections` | `int`      | Maximum number of idle connections to any one target.             | `3`     | no       |
 | `max_open_connections` | `int`      | Maximum number of open connections to any one target.             | `3`     | no       |
 | `timeout`              | `duration` | The query timeout in seconds.                                     | `"10s"` | no       |
 
-
-
 [The sql_exporter examples](https://github.com/burningalchemist/sql_exporter/blob/master/examples/azure-sql-mi/sql_exporter.yml#L21) show the format of the `connection_string` argument:
+
 ```conn
 sqlserver://USERNAME_HERE:PASSWORD_HERE@SQLMI_HERE_ENDPOINT.database.windows.net:1433?encrypt=true&hostNameInCertificate=%2A.SQL_MI_DOMAIN_HERE.database.windows.net&trustservercertificate=true
 ```
@@ -42,7 +41,7 @@ fully through arguments.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 
@@ -87,9 +86,11 @@ prometheus.remote_write "demo" {
   }
 }
 ```
+
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.exporter.mysql.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mysql.md
@@ -4,6 +4,7 @@ title: prometheus.exporter.mysql
 ---
 
 # prometheus.exporter.mysql
+
 The `prometheus.exporter.mysql` component embeds
 [mysqld_exporter](https://github.com/prometheus/mysqld_exporter) for collecting stats from a MySQL server.
 
@@ -15,25 +16,23 @@ prometheus.exporter.mysql "LABEL" {
 }
 ```
 
-
 ## Arguments
+
 The following arguments can be used to configure the exporter's behavior.
 All arguments are optional. Omitted fields take their default values.
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`data_source_name`                                | `secret`       | [Data Source Name](https://github.com/go-sql-driver/mysql#dsn-data-source-name) for the MySQL server to connect to. | | yes
-`enable_collectors`                               | `list(string)` | A list of [collectors][] to enable on top of the default set.  | | no
-`disable_collectors`                              | `list(string)` | A list of [collectors][] to disable from the default set. | | no
-`set_collectors`                                  | `list(string)` | A list of [collectors][] to run. Fully overrides the default set. | | no
-`lock_wait_timeout`                               | `int`          | Timeout, in seconds, to acquire a metadata lock. | `2`| no
-`log_slow_filter`                                 | `bool`         | Used to avoid queries from scrapes being logged in the slow query log. | `false` | no
-
+| Name                 | Type           | Description                                                                                                         | Default | Required |
+| -------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
+| `data_source_name`   | `secret`       | [Data Source Name](https://github.com/go-sql-driver/mysql#dsn-data-source-name) for the MySQL server to connect to. |         | yes      |
+| `enable_collectors`  | `list(string)` | A list of [collectors][] to enable on top of the default set.                                                       |         | no       |
+| `disable_collectors` | `list(string)` | A list of [collectors][] to disable from the default set.                                                           |         | no       |
+| `set_collectors`     | `list(string)` | A list of [collectors][] to run. Fully overrides the default set.                                                   |         | no       |
+| `lock_wait_timeout`  | `int`          | Timeout, in seconds, to acquire a metadata lock.                                                                    | `2`     | no       |
+| `log_slow_filter`    | `bool`         | Used to avoid queries from scrapes being logged in the slow query log.                                              | `false` | no       |
 
 Set a `lock_wait_timeout` on the connection to avoid potentially long wait times for metadata locks. View more detailed documentation on `lock_wait_timeout` [in the MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_lock_wait_timeout).
 
 > **NOTE**: `log_slow_filter` is not supported by Oracle MySQL.
-
 
 [collectors]: #supported-collectors
 
@@ -42,14 +41,14 @@ Set a `lock_wait_timeout` on the connection to avoid potentially long wait times
 The following blocks are supported inside the definition of
 `prometheus.exporter.mysql` to configure collector-specific options:
 
-Hierarchy | Name | Description | Required
---------- | ---- | ----------- | --------
-info_schema.processlist      | [info_schema.processlist][] | Configures the `info_schema.processlist` collector. | no
-info_schema.tables           | [info_schema.tables][] | Configures the `info_schema.tables` collector. | no
-perf_schema.eventsstatements | [perf_schema.eventsstatements][] | Configures the `perf_schema.eventsstatements` collector. | no
-perf_schema.file_instances   | [perf_schema.file_instances][] | Configures the `perf_schema.file_instances` collector. | no
-heartbeat                    | [heartbeat][] | Configures the `heartbeat` collector. | no
-mysql.user                   | [mysql.user][] | Configures the `mysql.user` collector. | no
+| Hierarchy                    | Name                             | Description                                              | Required |
+| ---------------------------- | -------------------------------- | -------------------------------------------------------- | -------- |
+| info_schema.processlist      | [info_schema.processlist][]      | Configures the `info_schema.processlist` collector.      | no       |
+| info_schema.tables           | [info_schema.tables][]           | Configures the `info_schema.tables` collector.           | no       |
+| perf_schema.eventsstatements | [perf_schema.eventsstatements][] | Configures the `perf_schema.eventsstatements` collector. | no       |
+| perf_schema.file_instances   | [perf_schema.file_instances][]   | Configures the `perf_schema.file_instances` collector.   | no       |
+| heartbeat                    | [heartbeat][]                    | Configures the `heartbeat` collector.                    | no       |
+| mysql.user                   | [mysql.user][]                   | Configures the `mysql.user` collector.                   | no       |
 
 [info_schema.processlist]: #info_schemaprocesslist-block
 [info_schema.tables]: #info_schematables-block
@@ -58,88 +57,93 @@ mysql.user                   | [mysql.user][] | Configures the `mysql.user` coll
 [heartbeat]: #heartbeat-block
 [mysql.user]: #mysqluser-block
 
-
 ### info_schema.processlist block
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`min_time`                      | `int`          | Minimum time a thread must be in each state to be counted. | `0` | no
-`processes_by_user`             | `bool`         | Enable collecting the number of processes by user. | `true` | no
-`processes_by_host`             | `bool`         | Enable collecting the number of processes by host. | `true` | no
 
+| Name                | Type   | Description                                                | Default | Required |
+| ------------------- | ------ | ---------------------------------------------------------- | ------- | -------- |
+| `min_time`          | `int`  | Minimum time a thread must be in each state to be counted. | `0`     | no       |
+| `processes_by_user` | `bool` | Enable collecting the number of processes by user.         | `true`  | no       |
+| `processes_by_host` | `bool` | Enable collecting the number of processes by host.         | `true`  | no       |
 
 ### info_schema.tables block
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`info_schema_tables_databases`  | `string`       | Regular expression to match databases to collect table stats for. | `"*"` | no
+
+| Name                           | Type     | Description                                                       | Default | Required |
+| ------------------------------ | -------- | ----------------------------------------------------------------- | ------- | -------- |
+| `info_schema_tables_databases` | `string` | Regular expression to match databases to collect table stats for. | `"*"`   | no       |
 
 ### perf_schema.eventsstatements block
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`limit`                         | `int`          | Limit the number of events statements digests, in descending order by `last_seen`. | `250` | no
-`time_limit`                    | `int`          | Limit how old, in seconds, the `last_seen` events statements can be. | `86400` | no
-`text_limit`                    | `int`          | Maximum length of the normalized statement text. | `120` | no
+
+| Name         | Type  | Description                                                                        | Default | Required |
+| ------------ | ----- | ---------------------------------------------------------------------------------- | ------- | -------- |
+| `limit`      | `int` | Limit the number of events statements digests, in descending order by `last_seen`. | `250`   | no       |
+| `time_limit` | `int` | Limit how old, in seconds, the `last_seen` events statements can be.               | `86400` | no       |
+| `text_limit` | `int` | Maximum length of the normalized statement text.                                   | `120`   | no       |
 
 ### perf_schema.file_instances block
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`filter`                        | `string`       | Regular expression to select rows in `performance_schema.file_summary_by_instance`. | `".*"` | no
-`remove_prefix`                 | `string`       | Prefix to trim away from `file_name`.  | `"/var/lib/mysql"` | no
+
+| Name            | Type     | Description                                                                         | Default            | Required |
+| --------------- | -------- | ----------------------------------------------------------------------------------- | ------------------ | -------- |
+| `filter`        | `string` | Regular expression to select rows in `performance_schema.file_summary_by_instance`. | `".*"`             | no       |
+| `remove_prefix` | `string` | Prefix to trim away from `file_name`.                                               | `"/var/lib/mysql"` | no       |
 
 View more detailed documentation on the tables used in `perf_schema_file_instances_filter` and `perf_schema_file_instances_remove_prefix` [in the MySQL documentation](https://dev.mysql.com/doc/mysql-perfschema-excerpt/8.0/en/performance-schema-file-summary-tables.html).
 
 ### heartbeat block
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`database`                      | `string`       | Database to collect heartbeat data from. | `"heartbeat"` | no
-`table`                         | `string`       | Table to collect heartbeat data from. | `"heartbeat"` | no
-`utc`                           | `bool`         | Use UTC for timestamps of the current server (`pt-heartbeat` is called with `--utc`). | `false` | no
+
+| Name       | Type     | Description                                                                           | Default       | Required |
+| ---------- | -------- | ------------------------------------------------------------------------------------- | ------------- | -------- |
+| `database` | `string` | Database to collect heartbeat data from.                                              | `"heartbeat"` | no       |
+| `table`    | `string` | Table to collect heartbeat data from.                                                 | `"heartbeat"` | no       |
+| `utc`      | `bool`   | Use UTC for timestamps of the current server (`pt-heartbeat` is called with `--utc`). | `false`       | no       |
 
 ### mysql.user block
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`privileges`                    | `bool`         | Enable collecting user privileges from `mysql.user`. | `false` | no
+
+| Name         | Type   | Description                                          | Default | Required |
+| ------------ | ------ | ---------------------------------------------------- | ------- | -------- |
+| `privileges` | `bool` | Enable collecting user privileges from `mysql.user`. | `false` | no       |
 
 ### Supported Collectors
+
 The full list of supported collectors is:
 
-| Name                                             | Description | Enabled by default |
-| ------------------------------------------------ | ----------- | ------------------ |
-| auto_increment.columns                           | Collect `auto_increment` columns and max values from `information_schema`. | no |
-| binlog_size                                      | Collect the current size of all registered `binlog` files. | no |
-| engine_innodb_status                             | Collect metrics from `SHOW ENGINE INNODB STATUS`. | no |
-| engine_tokudb_status                             | Collect metrics from `SHOW ENGINE TOKUDB STATUS`. | no |
-| global_status                                    | Collect metrics from `SHOW GLOBAL STATUS`. | yes |
-| global_variables                                 | Collect metrics from `SHOW GLOBAL VARIABLES`. | yes |
-| heartbeat                                        | Collect metrics from heartbeat database and tables. | no |
-| info_schema.clientstats                          | If running with userstat=1, enable to collect client statistics. | no |
-| info_schema.innodb_cmpmem                        | Collect metrics from `information_schema.innodb_cmpmem`. | yes |
-| info_schema.innodb_metrics                       | Collect metrics from `information_schema.innodb_metrics`. | yes |
-| info_schema.innodb_tablespaces                   | Collect metrics from `information_schema.innodb_sys_tablespaces`. | no |
-| info_schema.processlist                          | Collect current thread state counts from the `information_schema.processlist`. | no |
-| info_schema.query_response_time                  | Collect query response time distribution if `query_response_time_stats` is ON. | yes |
-| info_schema.replica_host                         | Collect metrics from `information_schema.replica_host_status`. | no |
-| info_schema.schemastats                          | If running with userstat=1, enable to collect schema statistics. | no |
-| info_schema.tables                               | Collect metrics from `information_schema.tables`. | no |
-| info_schema.tablestats                           | If running with userstat=1, enable to collect table statistics. | no |
-| info_schema.userstats                            | If running with userstat=1, enable to collect user statistics. | no |
-| mysql.user                                       | Collect data from `mysql.user`. | no |
-| perf_schema.eventsstatements                     | Collect metrics from `performance_schema.events_statements_summary_by_digest`. | no |
-| perf_schema.eventsstatementssum                  | Collect metrics of grand sums from `performance_schema.events_statements_summary_by_digest`. | no |
-| perf_schema.eventswaits                          | Collect metrics from `performance_schema.events_waits_summary_global_by_event_name`. | no |
-| perf_schema.file_events                          | Collect metrics from `performance_schema.file_summary_by_event_name`. | no |
-| perf_schema.file_instances                       | Collect metrics from `performance_schema.file_summary_by_instance`. | no |
-| perf_schema.indexiowaits                         | Collect metrics from `performance_schema.table_io_waits_summary_by_index_usage`. | no |
-| perf_schema.replication_applier_status_by_worker | Collect metrics from `performance_schema.replication_applier_status_by_worker`. | no |
-| perf_schema.replication_group_member_stats       | Collect metrics from `performance_schema.replication_group_member_stats`. | no |
-| perf_schema.replication_group_members            | Collect metrics from `performance_schema.replication_group_members`. | no |
-| perf_schema.tableiowaits                         | Collect metrics from `performance_schema.table_io_waits_summary_by_table`. | no |
-| perf_schema.tablelocks                           | Collect metrics from `performance_schema.table_lock_waits_summary_by_table`. | no |
-| slave_hosts                                      | Scrape information from `SHOW SLAVE HOSTS`. | no |
-| slave_status                                     | Scrape information from `SHOW SLAVE STATUS`. | yes |
+| Name                                             | Description                                                                                  | Enabled by default |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------- | ------------------ |
+| auto_increment.columns                           | Collect `auto_increment` columns and max values from `information_schema`.                   | no                 |
+| binlog_size                                      | Collect the current size of all registered `binlog` files.                                   | no                 |
+| engine_innodb_status                             | Collect metrics from `SHOW ENGINE INNODB STATUS`.                                            | no                 |
+| engine_tokudb_status                             | Collect metrics from `SHOW ENGINE TOKUDB STATUS`.                                            | no                 |
+| global_status                                    | Collect metrics from `SHOW GLOBAL STATUS`.                                                   | yes                |
+| global_variables                                 | Collect metrics from `SHOW GLOBAL VARIABLES`.                                                | yes                |
+| heartbeat                                        | Collect metrics from heartbeat database and tables.                                          | no                 |
+| info_schema.clientstats                          | If running with userstat=1, enable to collect client statistics.                             | no                 |
+| info_schema.innodb_cmpmem                        | Collect metrics from `information_schema.innodb_cmpmem`.                                     | yes                |
+| info_schema.innodb_metrics                       | Collect metrics from `information_schema.innodb_metrics`.                                    | yes                |
+| info_schema.innodb_tablespaces                   | Collect metrics from `information_schema.innodb_sys_tablespaces`.                            | no                 |
+| info_schema.processlist                          | Collect current thread state counts from the `information_schema.processlist`.               | no                 |
+| info_schema.query_response_time                  | Collect query response time distribution if `query_response_time_stats` is ON.               | yes                |
+| info_schema.replica_host                         | Collect metrics from `information_schema.replica_host_status`.                               | no                 |
+| info_schema.schemastats                          | If running with userstat=1, enable to collect schema statistics.                             | no                 |
+| info_schema.tables                               | Collect metrics from `information_schema.tables`.                                            | no                 |
+| info_schema.tablestats                           | If running with userstat=1, enable to collect table statistics.                              | no                 |
+| info_schema.userstats                            | If running with userstat=1, enable to collect user statistics.                               | no                 |
+| mysql.user                                       | Collect data from `mysql.user`.                                                              | no                 |
+| perf_schema.eventsstatements                     | Collect metrics from `performance_schema.events_statements_summary_by_digest`.               | no                 |
+| perf_schema.eventsstatementssum                  | Collect metrics of grand sums from `performance_schema.events_statements_summary_by_digest`. | no                 |
+| perf_schema.eventswaits                          | Collect metrics from `performance_schema.events_waits_summary_global_by_event_name`.         | no                 |
+| perf_schema.file_events                          | Collect metrics from `performance_schema.file_summary_by_event_name`.                        | no                 |
+| perf_schema.file_instances                       | Collect metrics from `performance_schema.file_summary_by_instance`.                          | no                 |
+| perf_schema.indexiowaits                         | Collect metrics from `performance_schema.table_io_waits_summary_by_index_usage`.             | no                 |
+| perf_schema.replication_applier_status_by_worker | Collect metrics from `performance_schema.replication_applier_status_by_worker`.              | no                 |
+| perf_schema.replication_group_member_stats       | Collect metrics from `performance_schema.replication_group_member_stats`.                    | no                 |
+| perf_schema.replication_group_members            | Collect metrics from `performance_schema.replication_group_members`.                         | no                 |
+| perf_schema.tableiowaits                         | Collect metrics from `performance_schema.table_io_waits_summary_by_table`.                   | no                 |
+| perf_schema.tablelocks                           | Collect metrics from `performance_schema.table_lock_waits_summary_by_table`.                 | no                 |
+| slave_hosts                                      | Scrape information from `SHOW SLAVE HOSTS`.                                                  | no                 |
+| slave_status                                     | Scrape information from `SHOW SLAVE STATUS`.                                                 | yes                |
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 
@@ -185,9 +189,11 @@ prometheus.remote_write "demo" {
   }
 }
 ```
+
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.exporter.oracledb.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.oracledb.md
@@ -4,6 +4,7 @@ title: prometheus.exporter.oracledb
 ---
 
 # prometheus.exporter.oracledb
+
 The `prometheus.exporter.oracledb` component embeds
 [oracledb_exporter](https://github.com/iamseth/oracledb_exporter) for collecting statistics from a OracleDB server.
 
@@ -21,13 +22,14 @@ The following arguments can be used to configure the exporter's behavior.
 Omitted fields take their default values.
 
 | Name                | Type     | Description                                                  | Default | Required |
-|---------------------|----------|--------------------------------------------------------------|---------|----------|
+| ------------------- | -------- | ------------------------------------------------------------ | ------- | -------- |
 | `connection_string` | `secret` | The connection string used to connect to an Oracle Database. |         | yes      |
 | `max_idle_conns`    | `int`    | Number of maximum idle connections in the connection pool.   | `0`     | no       |
 | `max_open_conns`    | `int`    | Number of maximum open connections in the connection pool.   | `10`    | no       |
 | `query_timeout`     | `int`    | The query timeout in seconds.                                | `5`     | no       |
 
 [The oracledb_exporter running documentation](https://github.com/iamseth/oracledb_exporter/tree/master#running) shows the format and provides examples of the `connection_string` argument:
+
 ```conn
 oracle://user:pass@server/service_name[?OPTION1=VALUE1[&OPTIONn=VALUEn]...]
 ```
@@ -39,7 +41,7 @@ fully through arguments.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 
@@ -84,9 +86,11 @@ prometheus.remote_write "demo" {
   }
 }
 ```
+
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.exporter.postgres.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.postgres.md
@@ -6,6 +6,7 @@ title: prometheus.exporter.postgres
 ---
 
 # prometheus.exporter.postgres
+
 The `prometheus.exporter.postgres` component embeds
 [postgres_exporter](https://github.com/prometheus-community/postgres_exporter) for collecting metrics from a postgres database.
 
@@ -21,14 +22,15 @@ prometheus.exporter.postgres "LABEL" {
 ```
 
 ## Arguments
+
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`data_source_names`                  | `list(secret)`      | Specifies the Postgres server(s) to connect to.  |         | yes
-`disable_settings_metrics`           | `bool`              | Disables collection of metrics from pg_settings. | `false` | no
-`disable_default_metrics`            | `bool`              | When `true`, only exposes metrics supplied from `custom_queries_config_path`. | `false` | no
-`custom_queries_config_path`         | `string`            | Path to YAML file containing custom queries to expose as metrics. | "" | no
+| Name                         | Type           | Description                                                                   | Default | Required |
+| ---------------------------- | -------------- | ----------------------------------------------------------------------------- | ------- | -------- |
+| `data_source_names`          | `list(secret)` | Specifies the Postgres server(s) to connect to.                               |         | yes      |
+| `disable_settings_metrics`   | `bool`         | Disables collection of metrics from pg_settings.                              | `false` | no       |
+| `disable_default_metrics`    | `bool`         | When `true`, only exposes metrics supplied from `custom_queries_config_path`. | `false` | no       |
+| `custom_queries_config_path` | `string`       | Path to YAML file containing custom queries to expose as metrics.             | ""      | no       |
 
 The format for connection strings in `data_source_names` can be found in the [official postgresql documentation](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING).
 
@@ -37,24 +39,26 @@ See examples for the `custom_queries_config_path` file in the [postgres_exporter
 **NOTE**: There are a number of environment variables that are not recommended for use, as they will affect _all_ `prometheus.exporter.postgres` components. A full list can be found in the [postgres_exporter repository](https://github.com/prometheus-community/postgres_exporter#environment-variables).
 
 ## Blocks
+
 The following blocks are supported:
 
-Hierarchy                    | Block             | Description                         | Required |
----------------------------- | ----------------- | ----------------------------------- | -------- |
-autodiscovery                | [autodiscovery][] | Database discovery settings.        | no       |
+| Hierarchy     | Block             | Description                  | Required |
+| ------------- | ----------------- | ---------------------------- | -------- |
+| autodiscovery | [autodiscovery][] | Database discovery settings. | no       |
 
 [autodiscovery]: #autodiscovery-block
 
 ### autodiscovery block
+
 The `autodiscovery` block configures discovery of databases, outside of any specified in `data_source_names`.
 
 The following arguments are supported:
 
-Name                 | Type           | Description                                                   | Default | Required |
--------------------- | -------------- | ------------------------------------------------------------- | ------- | -------- |
-`enabled`            | `bool`         | Whether to autodiscover other databases                       | `false` | no       |
-`database_allowlist` | `list(string)` | List of databases to filter for, meaning only these databases will be scraped. | | no
-`database_denylist`  | `list(string)` | List of databases to filter out, meaning all other databases will be scraped. | | no
+| Name                 | Type           | Description                                                                    | Default | Required |
+| -------------------- | -------------- | ------------------------------------------------------------------------------ | ------- | -------- |
+| `enabled`            | `bool`         | Whether to autodiscover other databases                                        | `false` | no       |
+| `database_allowlist` | `list(string)` | List of databases to filter for, meaning only these databases will be scraped. |         | no       |
+| `database_denylist`  | `list(string)` | List of databases to filter out, meaning all other databases will be scraped.  |         | no       |
 
 If `enabled` is set to `true` and no allowlist or denylist is specified, the exporter will scrape from all databases.
 
@@ -62,7 +66,7 @@ If `autodiscovery` is disabled, neither `database_allowlist` nor `database_denyl
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 
@@ -109,11 +113,12 @@ prometheus.remote_write "demo" {
   }
 }
 ```
-Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
 
+Replace the following:
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 ### Collect custom metrics from an allowlisted set of databases
 
@@ -154,14 +159,16 @@ prometheus.remote_write "demo" {
 ```
 
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 ### Collect metrics from all databases except for a denylisted database
 
 This example uses a `prometheus.exporter.postgres` component to collect custom metrics from all databases except
 for the `secrets` database.
+
 ```river
 prometheus.exporter.postgres "example" {
   data_source_names = ["postgresql://username:password@localhost:5432/database_name?sslmode=disable"]
@@ -194,8 +201,9 @@ prometheus.remote_write "demo" {
 ```
 
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.exporter.process.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.process.md
@@ -4,6 +4,7 @@ title: prometheus.exporter.process
 ---
 
 # prometheus.exporter.process
+
 The `prometheus.exporter.process` component embeds
 [process_exporter](https://github.com/ncabatoff/process-exporter) for collecting process stats from `/proc`.
 
@@ -15,43 +16,47 @@ prometheus.exporter.process "LABEL" {
 ```
 
 ## Arguments
+
 The following arguments can be used to configure the exporter's behavior.
 All arguments are optional. Omitted fields take their default values.
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`procfs_path`       | `string`                 | procfs mountpoint. | `/proc` | no
-`track_children`    | `bool`                   | Whether to track a process' children. | `true` | no
-`track_threads`     | `bool`                   | Report metrics for a process' individual threads.  | `true` | no
-`gather_smaps`      | `bool`                   | Gather metrics from the smaps file for a process. | `true` | no
-`recheck_on_scrape` | `bool`                   | Recheck process names on each scrape. | `true` | no
+| Name                | Type     | Description                                       | Default | Required |
+| ------------------- | -------- | ------------------------------------------------- | ------- | -------- |
+| `procfs_path`       | `string` | procfs mountpoint.                                | `/proc` | no       |
+| `track_children`    | `bool`   | Whether to track a process' children.             | `true`  | no       |
+| `track_threads`     | `bool`   | Report metrics for a process' individual threads. | `true`  | no       |
+| `gather_smaps`      | `bool`   | Gather metrics from the smaps file for a process. | `true`  | no       |
+| `recheck_on_scrape` | `bool`   | Recheck process names on each scrape.             | `true`  | no       |
 
 ## Blocks
+
 The following blocks are supported inside the definition of `prometheus.exporter.process`:
 
-Hierarchy        | Block      | Description | Required
----------------- | ---------- | ----------- | --------
-matcher          | [matcher][]  | A collection of matching rules to use for deciding which processes to monitor. | no
+| Hierarchy | Block       | Description                                                                    | Required |
+| --------- | ----------- | ------------------------------------------------------------------------------ | -------- |
+| matcher   | [matcher][] | A collection of matching rules to use for deciding which processes to monitor. | no       |
 
 [matcher]: #matcher-block
 
 ### matcher block
+
 Each `matcher` block config can match multiple processes, which will be tracked as a single process "group."
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`name`       | `string`        | The name to use for identifying the process group name in the metric. | `"{{.ExeBase}}"` | no
-`comm`       | `list(string)`  | A list of strings that match the base executable name for a process, truncated to 15 characters.  | | no
-`exe`        | `list(string)`  | A list of strings that match `argv[0]` for a process. | | no
-`cmdline`    | `list(string)`  | A list of regular expressions applied to the `argv` of the process. | | no
+| Name      | Type           | Description                                                                                      | Default          | Required |
+| --------- | -------------- | ------------------------------------------------------------------------------------------------ | ---------------- | -------- |
+| `name`    | `string`       | The name to use for identifying the process group name in the metric.                            | `"{{.ExeBase}}"` | no       |
+| `comm`    | `list(string)` | A list of strings that match the base executable name for a process, truncated to 15 characters. |                  | no       |
+| `exe`     | `list(string)` | A list of strings that match `argv[0]` for a process.                                            |                  | no       |
+| `cmdline` | `list(string)` | A list of regular expressions applied to the `argv` of the process.                              |                  | no       |
 
 The `name` argument can use the following template variables. By default it uses the base path of the executable:
-- `{{.Comm}}`:      Basename of the original executable from /proc/\<pid\>/stat.
-- `{{.ExeBase}}`:   Basename of the executable from argv[0].
-- `{{.ExeFull}}`:   Fully qualified path of the executable.
-- `{{.Username}}`:  Username of the effective user.
-- `{{.Matches}}`:   Map containing all regex capture groups resulting from matching a process with the cmdline rule group.
-- `{{.PID}}`:       PID of the process. Note that the PID is copied from the first executable found.
+
+- `{{.Comm}}`: Basename of the original executable from /proc/\<pid\>/stat.
+- `{{.ExeBase}}`: Basename of the executable from argv[0].
+- `{{.ExeFull}}`: Fully qualified path of the executable.
+- `{{.Username}}`: Username of the effective user.
+- `{{.Matches}}`: Map containing all regex capture groups resulting from matching a process with the cmdline rule group.
+- `{{.PID}}`: PID of the process. Note that the PID is copied from the first executable found.
 - `{{.StartTime}}`: The start time of the process. This is useful when combined with PID as PIDS get reused over time.
 - `{{.Cgroups}}`: The cgroups, if supported, of the process (`/proc/self/cgroup`). This is particularly useful for identifying to which container a process belongs.
 
@@ -65,7 +70,7 @@ Each regex in `cmdline` must match the corresponding argv for the process to be 
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 
@@ -114,9 +119,11 @@ prometheus.remote_write "demo" {
   }
 }
 ```
+
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.exporter.redis.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.redis.md
@@ -4,6 +4,7 @@ title: prometheus.exporter.redis
 ---
 
 # prometheus.exporter.redis
+
 The `prometheus.exporter.redis` component embeds
 [redis_exporter](https://github.com/oliver006/redis_exporter) for collecting metrics from a Redis database.
 
@@ -16,41 +17,42 @@ prometheus.exporter.redis "LABEL" {
 ```
 
 ## Arguments
+
 The following arguments can be used to configure the exporter's behavior.
 Omitted fields take their default values.
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`redis_addr`                  | `string`       | Address (host and port) of the Redis instance to connect to.  | | yes
-`redis_user`                  | `string`       | User name to use for authentication (Redis ACL for Redis 6.0 and newer).  | | no
-`redis_password`              | `secret`       | Password of the Redis instance. | | no
-`redis_password_file`         | `string`       | Path of a file containing a password.  | | no
-`redis_password_map_file`     | `string`       | Path of a JSON file containing a map of Redis URIs to passwords. | | no
-`namespace`                   | `string`       | Namespace for the metrics.  | `"redis"` | no
-`config_command`              | `string`       | What to use for the CONFIG command. | `"CONFIG"` | no
-`check_keys`                  | `list(string)` | List of key-patterns to export value and length/size, searched for with SCAN. | | no
-`check_key_groups`            | `list(string)` | List of Lua regular expressions (regex) for grouping keys. | | no
-`check_key_groups_batch_size` | `int`          | Check key or key groups batch size hint for the underlying SCAN. | `10000` | no
-`max_distinct_key_groups`     | `int`          | The maximum number of distinct key groups with the most memory utilization to present as distinct metrics per database. | `100` | no
-`check_single_keys`           | `list(string)` | List of single keys to export value and length/size. | | no
-`check_streams`               | `list(string)` | List of stream-patterns to export info about streams, groups, and consumers to search for with SCAN. | | no
-`check_single_streams`        | `list(string)` | List of single streams to export info about streams, groups, and consumers. | | no
-`count_keys`                  | `list(string)` | List of individual keys to export counts for. | | no
-`script_path`                 | `string`       | Path to Lua Redis script for collecting extra metrics. | | no
-`script_paths`                | `list(string)` | List of paths to Lua Redis scripts for collecting extra metrics. | | no
-`connection_timeout`          | `duration`     | Timeout for connection to Redis instance (in Golang duration format). | `"15s"` | no
-`tls_client_key_file`         | `string`       | Name of the client key file (including full path) if the server requires TLS client authentication. | | no
-`tls_client_cert_file`        | `string`       | Name of the client certificate file (including full path) if the server requires TLS client authentication. | | no
-`tls_ca_cert_file`            | `string`       | Name of the CA certificate file (including full path) if the server requires TLS client authentication. | | no
-`set_client_name`             | `bool`         | Whether to set client name to `redis_exporter`. | `true` | no
-`is_tile38`                   | `bool`         | Whether to scrape Tile38-specific metrics. | | no
-`is_cluster`                  | `bool`         | Whether the connection is to a Redis cluster. | | no
-`export_client_list`          | `bool`         | Whether to scrape Client List specific metrics. | | no
-`export_client_port`          | `bool`         | Whether to include the client's port when exporting the client list. | | no
-`redis_metrics_only`          | `bool`         | Whether to just export metrics or to also export go runtime metrics. | | no
-`ping_on_connect`             | `bool`         | Whether to ping the Redis instance after connecting. | | no
-`incl_system_metrics`         | `bool`         | Whether to include system metrics (e.g. `redis_total_system_memory_bytes`). | | no
-`skip_tls_verification`       | `bool`         | Whether to to skip TLS verification. | | no
+| Name                          | Type           | Description                                                                                                             | Default    | Required |
+| ----------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------- | ---------- | -------- |
+| `redis_addr`                  | `string`       | Address (host and port) of the Redis instance to connect to.                                                            |            | yes      |
+| `redis_user`                  | `string`       | User name to use for authentication (Redis ACL for Redis 6.0 and newer).                                                |            | no       |
+| `redis_password`              | `secret`       | Password of the Redis instance.                                                                                         |            | no       |
+| `redis_password_file`         | `string`       | Path of a file containing a password.                                                                                   |            | no       |
+| `redis_password_map_file`     | `string`       | Path of a JSON file containing a map of Redis URIs to passwords.                                                        |            | no       |
+| `namespace`                   | `string`       | Namespace for the metrics.                                                                                              | `"redis"`  | no       |
+| `config_command`              | `string`       | What to use for the CONFIG command.                                                                                     | `"CONFIG"` | no       |
+| `check_keys`                  | `list(string)` | List of key-patterns to export value and length/size, searched for with SCAN.                                           |            | no       |
+| `check_key_groups`            | `list(string)` | List of Lua regular expressions (regex) for grouping keys.                                                              |            | no       |
+| `check_key_groups_batch_size` | `int`          | Check key or key groups batch size hint for the underlying SCAN.                                                        | `10000`    | no       |
+| `max_distinct_key_groups`     | `int`          | The maximum number of distinct key groups with the most memory utilization to present as distinct metrics per database. | `100`      | no       |
+| `check_single_keys`           | `list(string)` | List of single keys to export value and length/size.                                                                    |            | no       |
+| `check_streams`               | `list(string)` | List of stream-patterns to export info about streams, groups, and consumers to search for with SCAN.                    |            | no       |
+| `check_single_streams`        | `list(string)` | List of single streams to export info about streams, groups, and consumers.                                             |            | no       |
+| `count_keys`                  | `list(string)` | List of individual keys to export counts for.                                                                           |            | no       |
+| `script_path`                 | `string`       | Path to Lua Redis script for collecting extra metrics.                                                                  |            | no       |
+| `script_paths`                | `list(string)` | List of paths to Lua Redis scripts for collecting extra metrics.                                                        |            | no       |
+| `connection_timeout`          | `duration`     | Timeout for connection to Redis instance (in Golang duration format).                                                   | `"15s"`    | no       |
+| `tls_client_key_file`         | `string`       | Name of the client key file (including full path) if the server requires TLS client authentication.                     |            | no       |
+| `tls_client_cert_file`        | `string`       | Name of the client certificate file (including full path) if the server requires TLS client authentication.             |            | no       |
+| `tls_ca_cert_file`            | `string`       | Name of the CA certificate file (including full path) if the server requires TLS client authentication.                 |            | no       |
+| `set_client_name`             | `bool`         | Whether to set client name to `redis_exporter`.                                                                         | `true`     | no       |
+| `is_tile38`                   | `bool`         | Whether to scrape Tile38-specific metrics.                                                                              |            | no       |
+| `is_cluster`                  | `bool`         | Whether the connection is to a Redis cluster.                                                                           |            | no       |
+| `export_client_list`          | `bool`         | Whether to scrape Client List specific metrics.                                                                         |            | no       |
+| `export_client_port`          | `bool`         | Whether to include the client's port when exporting the client list.                                                    |            | no       |
+| `redis_metrics_only`          | `bool`         | Whether to just export metrics or to also export go runtime metrics.                                                    |            | no       |
+| `ping_on_connect`             | `bool`         | Whether to ping the Redis instance after connecting.                                                                    |            | no       |
+| `incl_system_metrics`         | `bool`         | Whether to include system metrics (e.g. `redis_total_system_memory_bytes`).                                             |            | no       |
+| `skip_tls_verification`       | `bool`         | Whether to to skip TLS verification.                                                                                    |            | no       |
 
 If `redis_password_file` is defined, it will take precedence over `redis_password`.
 
@@ -69,7 +71,7 @@ Note that setting `export_client_port` increases the cardinality of all Redis me
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 
@@ -114,9 +116,11 @@ prometheus.remote_write "demo" {
   }
 }
 ```
+
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.exporter.snmp.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.snmp.md
@@ -4,6 +4,7 @@ title: prometheus.exporter.snmp
 ---
 
 # prometheus.exporter.snmp
+
 The `prometheus.exporter.snmp` component embeds
 [`snmp_exporter`](https://github.com/prometheus/snmp_exporter). `snmp_exporter` lets you collect SNMP data and expose them as Prometheus metrics.
 
@@ -20,13 +21,14 @@ prometheus.exporter.snmp "LABEL" {
 ```
 
 ## Arguments
+
 The following arguments can be used to configure the exporter's behavior.
 Omitted fields take their default values.
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`config_file` | `string`       | SNMP configuration file defining custom modules. | | no
-`config` | `string` or `secret`       | SNMP configuration as inline string.  | |no
+| Name          | Type                 | Description                                      | Default | Required |
+| ------------- | -------------------- | ------------------------------------------------ | ------- | -------- |
+| `config_file` | `string`             | SNMP configuration file defining custom modules. |         | no       |
+| `config`      | `string` or `secret` | SNMP configuration as inline string.             |         | no       |
 
 The `config_file` argument points to a YAML file defining which snmp_exporter modules to use. See [snmp_exporter](https://github.com/prometheus/snmp_exporter#generating-configuration) for details on how to generate a config file.
 
@@ -42,10 +44,10 @@ The `config` argument must be a YAML document as string defining which SNMP modu
 The following blocks are supported inside the definition of
 `prometheus.exporter.snmp` to configure collector-specific options:
 
-Hierarchy | Name | Description | Required
---------- | ---- | ----------- | --------
-target | [target][] | Configures an SNMP target. | yes
-walk_param | [walk_param][] | SNMP connection profiles to override default SNMP settings. | no
+| Hierarchy  | Name           | Description                                                 | Required |
+| ---------- | -------------- | ----------------------------------------------------------- | -------- |
+| target     | [target][]     | Configures an SNMP target.                                  | yes      |
+| walk_param | [walk_param][] | SNMP connection profiles to override default SNMP settings. | no       |
 
 [target]: #target-block
 [walk_param]: #walk_param-block
@@ -55,29 +57,29 @@ walk_param | [walk_param][] | SNMP connection profiles to override default SNMP 
 The `target` block defines an individual SNMP target.
 The `target` block may be specified multiple times to define multiple targets.
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`name` | `string` | Name of a snmp_target. | | yes
-`address` | `string` | The address of SNMP device. | | yes
-`module`| `string` | SNMP module to use for polling. | `""` | no
-`auth` | `string` | SNMP authentication profile to use. | `""` | no
-`walk_params`| `string` | Config to use for this target. | `""` | no
+| Name          | Type     | Description                         | Default | Required |
+| ------------- | -------- | ----------------------------------- | ------- | -------- |
+| `name`        | `string` | Name of a snmp_target.              |         | yes      |
+| `address`     | `string` | The address of SNMP device.         |         | yes      |
+| `module`      | `string` | SNMP module to use for polling.     | `""`    | no       |
+| `auth`        | `string` | SNMP authentication profile to use. | `""`    | no       |
+| `walk_params` | `string` | Config to use for this target.      | `""`    | no       |
 
 ### walk_param block
 
 The `walk_param` block defines an individual SNMP connection profile that can be used to override default SNMP settings.
 The `walk_param` block may be specified multiple times to define multiple SNMP connection profiles.
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`name` | `string` | Name of the module to override. | | no
-`max_repetitions`| `int` | How many objects to request with GET/GETBULK. | `25` | no
-`retries`| `int` | How many times to retry a failed request. | `3` | no
-`timeout`| `duration` | Timeout for each individual SNMP request. |  | no
+| Name              | Type       | Description                                   | Default | Required |
+| ----------------- | ---------- | --------------------------------------------- | ------- | -------- |
+| `name`            | `string`   | Name of the module to override.               |         | no       |
+| `max_repetitions` | `int`      | How many objects to request with GET/GETBULK. | `25`    | no       |
+| `retries`         | `int`      | How many times to retry a failed request.     | `3`     | no       |
+| `timeout`         | `duration` | Timeout for each individual SNMP request.     |         | no       |
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 
@@ -133,7 +135,6 @@ prometheus.scrape "demo" {
 
 This example is the same above with using an embedded configuration (with secrets):
 
-
 ```river
 local.file "snmp_config" {
     path      = "snmp_modules.yml"
@@ -180,9 +181,11 @@ prometheus.remote_write "demo" {
     }
 }
 ```
+
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.exporter.snowflake.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.snowflake.md
@@ -4,6 +4,7 @@ title: prometheus.exporter.snowflake
 ---
 
 # prometheus.exporter.snowflake
+
 The `prometheus.exporter.snowflake` component embeds
 [snowflake_exporter](https://github.com/grafana/snowflake-prometheus-exporter) for collecting warehouse, database, table, and replication statistics from a Snowflake account via HTTP for Prometheus consumption.
 
@@ -24,7 +25,7 @@ The following arguments can be used to configure the exporter's behavior.
 Omitted fields take their default values.
 
 | Name           | Type     | Description                                           | Default          | Required |
-|----------------|----------|-------------------------------------------------------|------------------|----------|
+| -------------- | -------- | ----------------------------------------------------- | ---------------- | -------- |
 | `account_name` | `string` | The account to collect metrics for.                   |                  | yes      |
 | `username`     | `string` | The username for the user used when querying metrics. |                  | yes      |
 | `password`     | `secret` | The password for the user used when querying metrics. |                  | yes      |
@@ -38,7 +39,7 @@ fully through arguments.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 
@@ -86,9 +87,11 @@ prometheus.remote_write "demo" {
   }
 }
 ```
+
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.exporter.squid.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.squid.md
@@ -4,6 +4,7 @@ title: prometheus.exporter.squid
 ---
 
 # prometheus.exporter.squid
+
 The `prometheus.exporter.squid` component embeds
 [squid_exporter](https://github.com/boynux/squid-exporter) for collecting metrics from a squid instance.
 
@@ -20,12 +21,11 @@ prometheus.exporter.squid "LABEL" {
 You can use the following arguments to configure the exporter's behavior.
 Omitted fields take their default values.
 
-| Name           | Type     | Description                                           | Default          | Required |
-|----------------|----------|-------------------------------------------------------|------------------|----------|
-| `address`      | `string` | The squid address to collect metrics from.            |                  | yes      |
-| `username`     | `string` | The username for the user used when querying metrics. |                  | no       |
-| `password`     | `secret` | The password for the user used when querying metrics. |                  | no       |
-
+| Name       | Type     | Description                                           | Default | Required |
+| ---------- | -------- | ----------------------------------------------------- | ------- | -------- |
+| `address`  | `string` | The squid address to collect metrics from.            |         | yes      |
+| `username` | `string` | The username for the user used when querying metrics. |         | no       |
+| `password` | `secret` | The password for the user used when querying metrics. |         | no       |
 
 ## Blocks
 
@@ -34,7 +34,7 @@ fully through arguments.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 
@@ -79,9 +79,11 @@ prometheus.remote_write "demo" {
   }
 }
 ```
+
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.exporter.statsd.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.statsd.md
@@ -4,6 +4,7 @@ title: prometheus.exporter.statsd
 ---
 
 # prometheus.exporter.statsd
+
 The `prometheus.exporter.statsd` component embeds
 [statsd_exporter](https://github.com/prometheus/statsd_exporter) for collecting StatsD-style metrics and exporting them as Prometheus metrics.
 
@@ -15,28 +16,29 @@ prometheus.exporter.statsd "LABEL" {
 ```
 
 ## Arguments
+
 The following arguments can be used to configure the exporter's behavior.
 All arguments are optional. Omitted fields take their default values.
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`listen_udp`                                      | `string`       | The UDP address on which to receive statsd metric lines. Use "" to disable it. | `:9125` | no
-`listen_tcp`                                      | `string`       | The TCP address on which to receive statsd metric lines. Use "" to disable it. | `:9125` | no
-`listen_unixgram`                                 | `string`       | The Unixgram socket path to receive statsd metric lines in datagram. Use "" to disable it. | | no
-`unix_socket_mode`                                | `string`       | The permission mode of the unix socket. | `755` | no
-`mapping_config_path`                             | `string`       | The path to a YAML mapping file used to translate specific dot-separated StatsD metrics into labeled Prometheus metrics. | | no
-`read_buffer`                                     | `int`          | Size (in bytes) of the operating system's transmit read buffer associated with the UDP or Unixgram connection. | | no
-`cache_size`                                      | `int`          | Maximum size of your metric mapping cache. Relies on least recently used replacement policy if max size is reached. | `1000` | no
-`cache_type`                                      | `string`       | Metric mapping cache type. Valid options are "lru" and "random". | `lru` | no
-`event_queue_size`                                | `int`          | Size of internal queue for processing events. | `10000` | no
-`event_flush_threshold`                           | `int`          | Number of events to hold in queue before flushing. | `1000`| no
-`event_flush_interval`                            | `string`       | Maximum time between event queue flushes. | `200ms`| no
-`parse_dogstatsd_tags`                            | `string`       | Parse DogStatsd style tags. | `true`| no
-`parse_influxdb_tags`                             | `string`       | Parse InfluxDB style tags. | `true`| no
-`parse_librato_tags`                              | `string`       | Parse Librato style tags. | `true`| no
-`parse_signalfx_tags`                             | `string`       | Parse SignalFX style tags. | `true`| no
-`relay_addr`                                      | `string`       | Relay address configuration (UDP endpoint in the format 'host:port'). | | no
-`relay_packet_length`                             | `int`          | Maximum relay output packet length to avoid fragmentation. | `1400` | no
+| Name                    | Type     | Description                                                                                                              | Default | Required |
+| ----------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------ | ------- | -------- |
+| `listen_udp`            | `string` | The UDP address on which to receive statsd metric lines. Use "" to disable it.                                           | `:9125` | no       |
+| `listen_tcp`            | `string` | The TCP address on which to receive statsd metric lines. Use "" to disable it.                                           | `:9125` | no       |
+| `listen_unixgram`       | `string` | The Unixgram socket path to receive statsd metric lines in datagram. Use "" to disable it.                               |         | no       |
+| `unix_socket_mode`      | `string` | The permission mode of the unix socket.                                                                                  | `755`   | no       |
+| `mapping_config_path`   | `string` | The path to a YAML mapping file used to translate specific dot-separated StatsD metrics into labeled Prometheus metrics. |         | no       |
+| `read_buffer`           | `int`    | Size (in bytes) of the operating system's transmit read buffer associated with the UDP or Unixgram connection.           |         | no       |
+| `cache_size`            | `int`    | Maximum size of your metric mapping cache. Relies on least recently used replacement policy if max size is reached.      | `1000`  | no       |
+| `cache_type`            | `string` | Metric mapping cache type. Valid options are "lru" and "random".                                                         | `lru`   | no       |
+| `event_queue_size`      | `int`    | Size of internal queue for processing events.                                                                            | `10000` | no       |
+| `event_flush_threshold` | `int`    | Number of events to hold in queue before flushing.                                                                       | `1000`  | no       |
+| `event_flush_interval`  | `string` | Maximum time between event queue flushes.                                                                                | `200ms` | no       |
+| `parse_dogstatsd_tags`  | `string` | Parse DogStatsd style tags.                                                                                              | `true`  | no       |
+| `parse_influxdb_tags`   | `string` | Parse InfluxDB style tags.                                                                                               | `true`  | no       |
+| `parse_librato_tags`    | `string` | Parse Librato style tags.                                                                                                | `true`  | no       |
+| `parse_signalfx_tags`   | `string` | Parse SignalFX style tags.                                                                                               | `true`  | no       |
+| `relay_addr`            | `string` | Relay address configuration (UDP endpoint in the format 'host:port').                                                    |         | no       |
+| `relay_packet_length`   | `int`    | Maximum relay output packet length to avoid fragmentation.                                                               | `1400`  | no       |
 
 At least one of `listen_udp`, `listen_tcp`, or `listen_unixgram` should be enabled.
 For details on how to use the mapping config file, please check the official
@@ -51,7 +53,7 @@ fully through arguments.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 
@@ -110,9 +112,11 @@ prometheus.remote_write "demo" {
   }
 }
 ```
+
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.exporter.unix.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.unix.md
@@ -4,6 +4,7 @@ title: prometheus.exporter.unix
 ---
 
 # prometheus.exporter.unix
+
 The `prometheus.exporter.unix` component embeds
 [node_exporter](https://github.com/prometheus/node_exporter) which exposes a
 wide variety of hardware and OS metrics for \*nix-based systems.
@@ -23,19 +24,20 @@ prometheus.exporter.unix {
 ```
 
 ## Arguments
+
 The following arguments can be used to configure the exporter's behavior.
 All arguments are optional. Omitted fields take their default values.
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`set_collectors`           | `list(string)` | Overrides the default set of enabled collectors with the collectors listed. | | no
-`enable_collectors`        | `list(string)` | Collectors to mark as enabled.  | | no
-`disable_collectors`       | `list(string)` | Collectors to mark as disabled. | | no
-`include_exporter_metrics` | `boolean`      | Whether metrics about the exporter itself should be reported. | false | no
-`procfs_path`              | `string`       | The procfs mountpoint. | `/proc` | no
-`sysfs_path`               | `string`       | The sysfs mountpoint.  | `/sys`   | no
-`rootfs_path`              | `string`       | Specify a prefix for accessing the host filesystem. | `/` | no
-`udev_data_path`           | `string`       | The udev data path.  | `/run/udev/data` | no
+| Name                       | Type           | Description                                                                 | Default          | Required |
+| -------------------------- | -------------- | --------------------------------------------------------------------------- | ---------------- | -------- |
+| `set_collectors`           | `list(string)` | Overrides the default set of enabled collectors with the collectors listed. |                  | no       |
+| `enable_collectors`        | `list(string)` | Collectors to mark as enabled.                                              |                  | no       |
+| `disable_collectors`       | `list(string)` | Collectors to mark as disabled.                                             |                  | no       |
+| `include_exporter_metrics` | `boolean`      | Whether metrics about the exporter itself should be reported.               | false            | no       |
+| `procfs_path`              | `string`       | The procfs mountpoint.                                                      | `/proc`          | no       |
+| `sysfs_path`               | `string`       | The sysfs mountpoint.                                                       | `/sys`           | no       |
+| `rootfs_path`              | `string`       | Specify a prefix for accessing the host filesystem.                         | `/`              | no       |
+| `udev_data_path`           | `string`       | The udev data path.                                                         | `/run/udev/data` | no       |
 
 `set_collectors` defines a hand-picked list of enabled-by-default
 collectors. If set, anything not provided in that list is disabled by
@@ -53,27 +55,27 @@ of conflicts, it takes precedence over `enable_collectors`.
 The following blocks are supported inside the definition of
 `prometheus.exporter.unix` to configure collector-specific options:
 
-Hierarchy | Name | Description | Required
---------- | ---- | ----------- | --------
-bcache | [bcache][] | Configures the bcache collector. | no
-cpu | [cpu][] | Configures the cpu collector. | no
-disk | [disk][] | Configures the diskstats collector. | no
-ethtool | [ethtool][] | Configures the ethtool collector. | no
-filesystem | [filesystem][] | Configures the filesystem collector. | no
-ipvs | [ipvs][] | Configures the ipvs collector. | no
-ntp | [ntp][] | Configures the ntp collector. | no
-netclass | [netclass][] | Configures the netclass collector. | no
-netdev | [netdev][] | Configures the netdev collector. | no
-netstat | [netstat][] | Configures the netstat collector. | no
-perf | [perf][] | Configures the perf collector. | no
-powersupply | [powersupply][] | Configures the powersupply collector. | no
-runit | [runit][] | Configures the runit collector. | no
-supervisord | [supervisord][] | Configures the supervisord collector. | no
-sysctl | [sysctl][] | Configures the sysctl collector. | no
-systemd | [systemd][] | Configures the systemd collector. | no
-tapestats | [tapestats][] | Configures the tapestats collector. | no
-textfile | [textfile][] | Configures the textfile collector. | no
-vmstat | [vmstat][] | Configures the vmstat collector. | no
+| Hierarchy   | Name            | Description                           | Required |
+| ----------- | --------------- | ------------------------------------- | -------- |
+| bcache      | [bcache][]      | Configures the bcache collector.      | no       |
+| cpu         | [cpu][]         | Configures the cpu collector.         | no       |
+| disk        | [disk][]        | Configures the diskstats collector.   | no       |
+| ethtool     | [ethtool][]     | Configures the ethtool collector.     | no       |
+| filesystem  | [filesystem][]  | Configures the filesystem collector.  | no       |
+| ipvs        | [ipvs][]        | Configures the ipvs collector.        | no       |
+| ntp         | [ntp][]         | Configures the ntp collector.         | no       |
+| netclass    | [netclass][]    | Configures the netclass collector.    | no       |
+| netdev      | [netdev][]      | Configures the netdev collector.      | no       |
+| netstat     | [netstat][]     | Configures the netstat collector.     | no       |
+| perf        | [perf][]        | Configures the perf collector.        | no       |
+| powersupply | [powersupply][] | Configures the powersupply collector. | no       |
+| runit       | [runit][]       | Configures the runit collector.       | no       |
+| supervisord | [supervisord][] | Configures the supervisord collector. | no       |
+| sysctl      | [sysctl][]      | Configures the sysctl collector.      | no       |
+| systemd     | [systemd][]     | Configures the systemd collector.     | no       |
+| tapestats   | [tapestats][]   | Configures the tapestats collector.   | no       |
+| textfile    | [textfile][]    | Configures the textfile collector.    | no       |
+| vmstat      | [vmstat][]      | Configures the vmstat collector.      | no       |
 
 [bcache]: #bcache-block
 [cpu]: #cpu-block
@@ -96,37 +98,42 @@ vmstat | [vmstat][] | Configures the vmstat collector. | no
 [vmstat]: #vmstat-block
 
 ### bcache block
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`priority_stats` | `boolean` |  Enable exposing of expensive bcache priority stats. | false | no
+
+| Name             | Type      | Description                                         | Default | Required |
+| ---------------- | --------- | --------------------------------------------------- | ------- | -------- |
+| `priority_stats` | `boolean` | Enable exposing of expensive bcache priority stats. | false   | no       |
 
 ### cpu block
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`guest`         | `boolean` | Enable the `node_cpu_guest_seconds_total` metric. | true | no
-`info`          | `boolean` | Enable the `cpu_info metric` for the cpu collector. | true | no
-`bugs_include`  | `string`  | Regexp of `bugs` field in cpu info to filter. | | no
-`flags_include` | `string`  | Regexp of `flags` field in cpu info to filter. | | no
+
+| Name            | Type      | Description                                         | Default | Required |
+| --------------- | --------- | --------------------------------------------------- | ------- | -------- |
+| `guest`         | `boolean` | Enable the `node_cpu_guest_seconds_total` metric.   | true    | no       |
+| `info`          | `boolean` | Enable the `cpu_info metric` for the cpu collector. | true    | no       |
+| `bugs_include`  | `string`  | Regexp of `bugs` field in cpu info to filter.       |         | no       |
+| `flags_include` | `string`  | Regexp of `flags` field in cpu info to filter.      |         | no       |
 
 ### disk block
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`device_exclude` | `string` | Regexp of devices to exclude for diskstats. | `"^(ram\|loop\|fd\|(h\|s\|v\|xv)d[a-z]\|nvme\\d+n\\d+p)\\d+$"` | no
-`device_include` | `string` | Regexp of devices to include for diskstats. If set, `device_exclude` is ignored.  | | no
+
+| Name             | Type     | Description                                                                      | Default                                                        | Required |
+| ---------------- | -------- | -------------------------------------------------------------------------------- | -------------------------------------------------------------- | -------- |
+| `device_exclude` | `string` | Regexp of devices to exclude for diskstats.                                      | `"^(ram\|loop\|fd\|(h\|s\|v\|xv)d[a-z]\|nvme\\d+n\\d+p)\\d+$"` | no       |
+| `device_include` | `string` | Regexp of devices to include for diskstats. If set, `device_exclude` is ignored. |                                                                | no       |
 
 ### ethtool block
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`device_exclude` | `string` | Regexp of ethtool devices to exclude (mutually exclusive with `device_include`). | | no
-`device_include` | `string` | Regexp of ethtool devices to include (mutually exclusive with `device_exclude`). | | no
-`metrics_include`| `string` | Regexp of ethtool stats to include. | `.*` | no
+
+| Name              | Type     | Description                                                                      | Default | Required |
+| ----------------- | -------- | -------------------------------------------------------------------------------- | ------- | -------- |
+| `device_exclude`  | `string` | Regexp of ethtool devices to exclude (mutually exclusive with `device_include`). |         | no       |
+| `device_include`  | `string` | Regexp of ethtool devices to include (mutually exclusive with `device_exclude`). |         | no       |
+| `metrics_include` | `string` | Regexp of ethtool stats to include.                                              | `.*`    | no       |
 
 ### filesystem block
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`fs_types_exclude`     | `string`   | Regexp of filesystem types to ignore for filesystem collector.| (_see below_ )| no
-`mount_points_exclude` | `string`   | Regexp of mount points to ignore for filesystem collector. | `"^/(dev\|proc\|sys\|var/lib/docker/.+)($\|/)"` | no
-`mount_timeout`        | `duration` | How long to wait for a mount to respond before marking it as stale. | `"5s"` | no
+
+| Name                   | Type       | Description                                                         | Default                                         | Required |
+| ---------------------- | ---------- | ------------------------------------------------------------------- | ----------------------------------------------- | -------- |
+| `fs_types_exclude`     | `string`   | Regexp of filesystem types to ignore for filesystem collector.      | (_see below_ )                                  | no       |
+| `mount_points_exclude` | `string`   | Regexp of mount points to ignore for filesystem collector.          | `"^/(dev\|proc\|sys\|var/lib/docker/.+)($\|/)"` | no       |
+| `mount_timeout`        | `duration` | How long to wait for a mount to respond before marking it as stale. | `"5s"`                                          | no       |
 
 `fs_types_exclude` defaults to the following regular expression string:
 
@@ -135,37 +142,42 @@ Name | Type | Description | Default | Required
 ```
 
 ### ipvs block
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`backend_labels` | `list(string)` | Array of IPVS backend stats labels. | `[local_address, local_port, remote_address, remote_port, proto, local_mark]` | no
+
+| Name             | Type           | Description                         | Default                                                                       | Required |
+| ---------------- | -------------- | ----------------------------------- | ----------------------------------------------------------------------------- | -------- |
+| `backend_labels` | `list(string)` | Array of IPVS backend stats labels. | `[local_address, local_port, remote_address, remote_port, proto, local_mark]` | no       |
 
 ### ntp block
-name | type | description | default | required
----- | ---- | ----------- | ------- | --------
-`server`                 | `string`   | NTP server to use for the collector. | `"127.0.0.1"` | no
-`server_is_local`        | `boolean`  | Certifies that the server address is not a public ntp server. | false | no
-`ip_ttl`                 | `int`      | TTL to use while sending NTP query. | 1 | no
-`local_offset_tolerance` | `duration` | Offset between local clock and local ntpd time to tolerate. | `"1ms"` | no
-`max_distance`           | `duration` | Max accumulated distance to the root. | `"3466080us"` | no
-`protocol_version`       | `int`      | NTP protocol version. | 4 | no
+
+| name                     | type       | description                                                   | default       | required |
+| ------------------------ | ---------- | ------------------------------------------------------------- | ------------- | -------- |
+| `server`                 | `string`   | NTP server to use for the collector.                          | `"127.0.0.1"` | no       |
+| `server_is_local`        | `boolean`  | Certifies that the server address is not a public ntp server. | false         | no       |
+| `ip_ttl`                 | `int`      | TTL to use while sending NTP query.                           | 1             | no       |
+| `local_offset_tolerance` | `duration` | Offset between local clock and local ntpd time to tolerate.   | `"1ms"`       | no       |
+| `max_distance`           | `duration` | Max accumulated distance to the root.                         | `"3466080us"` | no       |
+| `protocol_version`       | `int`      | NTP protocol version.                                         | 4             | no       |
 
 ### netclass block
-name | type | description | default | required
----- | ---- | ----------- | ------- | --------
-`ignore_invalid_speed_device` | `boolean` | Ignore net devices with invalid speed values. | false | no
-`ignored_devices`             | `string`  | Regexp of net devices to ignore for netclass collector. | `"^$"` | no
+
+| name                          | type      | description                                             | default | required |
+| ----------------------------- | --------- | ------------------------------------------------------- | ------- | -------- |
+| `ignore_invalid_speed_device` | `boolean` | Ignore net devices with invalid speed values.           | false   | no       |
+| `ignored_devices`             | `string`  | Regexp of net devices to ignore for netclass collector. | `"^$"`  | no       |
 
 ### netdev block
-name | type | description | default | required
----- | ---- | ----------- | ------- | --------
-`address_info`   | `boolean` | Enable collecting address-info for every device. | false | no
-`device_exclude` | `string`  | Regexp of net devices to exclude (mutually exclusive with `device_include`). |  | no
-`device_include` | `string`  | Regexp of net devices to include (mutually exclusive with `device_exclude`). |  | no
+
+| name             | type      | description                                                                  | default | required |
+| ---------------- | --------- | ---------------------------------------------------------------------------- | ------- | -------- |
+| `address_info`   | `boolean` | Enable collecting address-info for every device.                             | false   | no       |
+| `device_exclude` | `string`  | Regexp of net devices to exclude (mutually exclusive with `device_include`). |         | no       |
+| `device_include` | `string`  | Regexp of net devices to include (mutually exclusive with `device_exclude`). |         | no       |
 
 ### netstat block
-name | type | description | default | required
----- | ---- | ----------- | ------- | --------
-`fields` | `string` | Regexp of fields to return for netstat collector. | _(see below)_ | no
+
+| name     | type     | description                                       | default       | required |
+| -------- | -------- | ------------------------------------------------- | ------------- | -------- |
+| `fields` | `string` | Regexp of fields to return for netstat collector. | _(see below)_ | no       |
 
 `fields` defaults to the following regular expression string:
 
@@ -174,68 +186,77 @@ name | type | description | default | required
 ```
 
 ### perf block
-name | type | description | default | required
----- | ---- | ----------- | ------- | --------
-`cpus`                        | `string`       | List of CPUs from which perf metrics should be collected. | | no
-`tracepoint`                  | `list(string)` | Array of perf tracepoints that should be collected. | | no
-`disable_hardware_profilers`  | `boolean`      | Disable perf hardware profilers. | false | no
-`hardware_profilers`          | `list(string)` | Perf hardware profilers that should be collected. | | no
-`disable_software_profilers`  | `boolean`      | Disable perf software profilers. | false | no
-`software_profilers`          | `list(string)` | Perf software profilers that should be collected. | | no
-`disable_cache_profilers`     | `boolean`      | Disable perf cache profilers. | false | no
-`cache_profilers`             | `list(string)` | Perf cache profilers that should be collected. | | no
+
+| name                         | type           | description                                               | default | required |
+| ---------------------------- | -------------- | --------------------------------------------------------- | ------- | -------- |
+| `cpus`                       | `string`       | List of CPUs from which perf metrics should be collected. |         | no       |
+| `tracepoint`                 | `list(string)` | Array of perf tracepoints that should be collected.       |         | no       |
+| `disable_hardware_profilers` | `boolean`      | Disable perf hardware profilers.                          | false   | no       |
+| `hardware_profilers`         | `list(string)` | Perf hardware profilers that should be collected.         |         | no       |
+| `disable_software_profilers` | `boolean`      | Disable perf software profilers.                          | false   | no       |
+| `software_profilers`         | `list(string)` | Perf software profilers that should be collected.         |         | no       |
+| `disable_cache_profilers`    | `boolean`      | Disable perf cache profilers.                             | false   | no       |
+| `cache_profilers`            | `list(string)` | Perf cache profilers that should be collected.            |         | no       |
 
 ### powersupply block
-name | type | description | default | required
----- | ---- | ----------- | ------- | --------
-`ignored_supplies` | `string` | Regexp of power supplies to ignore for the powersupplyclass collector. | `"^$"` | no
+
+| name               | type     | description                                                            | default | required |
+| ------------------ | -------- | ---------------------------------------------------------------------- | ------- | -------- |
+| `ignored_supplies` | `string` | Regexp of power supplies to ignore for the powersupplyclass collector. | `"^$"`  | no       |
 
 ### runit block
-name | type | description | default | required
----- | ---- | ----------- | ------- | --------
-`service_dir` | `string` | Path to runit service directory. | `"/etc/service"` | no
+
+| name          | type     | description                      | default          | required |
+| ------------- | -------- | -------------------------------- | ---------------- | -------- |
+| `service_dir` | `string` | Path to runit service directory. | `"/etc/service"` | no       |
 
 ### supervisord block
-name | type | description | default | required
----- | ---- | ----------- | ------- | --------
-`url` | `string` | XML RPC endpoint for the supervisord collector. | `"http://localhost:9001/RPC2"` | no
+
+| name  | type     | description                                     | default                        | required |
+| ----- | -------- | ----------------------------------------------- | ------------------------------ | -------- |
+| `url` | `string` | XML RPC endpoint for the supervisord collector. | `"http://localhost:9001/RPC2"` | no       |
 
 Setting `SUPERVISORD_URL` in the environment overrides the default value.
 An explicit value in the block takes precedence over the environment variable.
 
 ### sysctl block
-name | type | description | default | required
----- | ---- | ----------- | ------- | --------
-`include` | `list(string)` | Numeric sysctl values to expose. | `[]` | no
-`include_info` | `list(string)` | String sysctl values to expose. | `[]` | no
+
+| name           | type           | description                      | default | required |
+| -------------- | -------------- | -------------------------------- | ------- | -------- |
+| `include`      | `list(string)` | Numeric sysctl values to expose. | `[]`    | no       |
+| `include_info` | `list(string)` | String sysctl values to expose.  | `[]`    | no       |
 
 ### systemd block
-name | type | description | default | required
----- | ---- | ----------- | ------- | --------
-`enable_restarts` | `boolean` | Enables service unit metric `service_restart_total` | false | no
-`start_time`      | `boolean` | Enables service unit metric `unit_start_time_seconds` | false | no
-`task_metrics`    | `boolean` | Enables service unit task metrics `unit_tasks_current` and `unit_tasks_max.` | false | no
-`unit_exclude`    | `string`  | Regexp of systemd units to exclude. Units must both match include and not match exclude to be collected. | `".+\\.(automount\|device\|mount\|scope\|slice)"` | no
-`unit_include`    | `string`  | Regexp of systemd units to include. Units must both match include and not match exclude to be collected. | `".+"` | no
+
+| name              | type      | description                                                                                              | default                                           | required |
+| ----------------- | --------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | -------- |
+| `enable_restarts` | `boolean` | Enables service unit metric `service_restart_total`                                                      | false                                             | no       |
+| `start_time`      | `boolean` | Enables service unit metric `unit_start_time_seconds`                                                    | false                                             | no       |
+| `task_metrics`    | `boolean` | Enables service unit task metrics `unit_tasks_current` and `unit_tasks_max.`                             | false                                             | no       |
+| `unit_exclude`    | `string`  | Regexp of systemd units to exclude. Units must both match include and not match exclude to be collected. | `".+\\.(automount\|device\|mount\|scope\|slice)"` | no       |
+| `unit_include`    | `string`  | Regexp of systemd units to include. Units must both match include and not match exclude to be collected. | `".+"`                                            | no       |
 
 ### tapestats block
-name | type | description | default | required
----- | ---- | ----------- | ------- | --------
-`ignored_devices` | `string` | Regexp of tapestats devices to ignore. | `"^$"` | no
+
+| name              | type     | description                            | default | required |
+| ----------------- | -------- | -------------------------------------- | ------- | -------- |
+| `ignored_devices` | `string` | Regexp of tapestats devices to ignore. | `"^$"`  | no       |
 
 ### textfile block
-name | type | description | default | required
----- | ---- | ----------- | ------- | --------
-`directory` | `string` | Directory to read `*.prom` files from for the textfile collector. |  | no
+
+| name        | type     | description                                                       | default | required |
+| ----------- | -------- | ----------------------------------------------------------------- | ------- | -------- |
+| `directory` | `string` | Directory to read `*.prom` files from for the textfile collector. |         | no       |
 
 ### vmstat block
-name | type | description | default | required
----- | ---- | ----------- | ------- | --------
-`fields` | `string` | Regexp of fields to return for the vmstat collector. | `"^(oom_kill\|pgpg\|pswp\|pg.*fault).*"` | no
+
+| name     | type     | description                                          | default                                  | required |
+| -------- | -------- | ---------------------------------------------------- | ---------------------------------------- | -------- |
+| `fields` | `string` | Regexp of fields to return for the vmstat collector. | `"^(oom_kill\|pgpg\|pswp\|pg.*fault).*"` | no       |
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 
@@ -254,6 +275,7 @@ debug information.
 debug metrics.
 
 ## Collectors list
+
 The following table lists the available collectors that `node_exporter` brings
 bundled in. Some collectors only work on specific operating systems; enabling a
 collector that is not supported by the host OS where Flow is running
@@ -263,82 +285,83 @@ Users can choose to enable a subset of collectors to limit the amount of
 metrics exposed by the `prometheus.exporter.unix` component,
 or disable collectors that are expensive to run.
 
-| Name             | Description | OS | Enabled by default |
-| ---------------- | ----------- | -- | ------------------ |
-| `arp`              | Exposes ARP statistics from `/proc/net/arp`. | Linux | yes |
-| `bcache`           | Exposes bcache statistics from `/sys/fs/bcache`. | Linux | yes |
-| `bonding`          | Exposes the number of configured and active slaves of Linux bonding interfaces. | Linux | yes |
-| `boottime`         | Exposes system boot time derived from the `kern.boottime sysctl`. | Darwin, Dragonfly, FreeBSD, NetBSD, OpenBSD, Solaris | yes |
-| `btrfs`            | Exposes statistics on btrfs. | Linux | yes |
-| `buddyinfo`        | Exposes statistics of memory fragments as reported by `/proc/buddyinfo`. | Linux | no |
-| `conntrack`        | Shows conntrack statistics (does nothing if no `/proc/sys/net/netfilter/` present). | Linux | yes |
-| `cpu`              | Exposes CPU statistics. | Darwin, Dragonfly, FreeBSD, Linux, Solaris, NetBSD | yes |
-| `cpufreq`          | Exposes CPU frequency statistics. | Linux, Solaris | yes |
-| `devstat`          | Exposes device statistics. | Dragonfly, FreeBSD | no |
-| `diskstats`        | Exposes disk I/O statistics. | Darwin, Linux, OpenBSD | yes |
-| `dmi`              | Exposes DMI information. | Linux | yes |
-| `drbd`             | Exposes Distributed Replicated Block Device statistics (to version 8.4). | Linux | no |
-| `drm`              | Exposes GPU card info from `/sys/class/drm/card?/device`. | Linux | no |
-| `edac`             | Exposes error detection and correction statistics. | Linux | yes |
-| `entropy`          | Exposes available entropy. | Linux | yes |
-| `ethtool`          | Exposes ethtool stats. | Linux | no |
-| `exec`             | Exposes execution statistics. | Dragonfly, FreeBSD | yes |
-| `fibrechannel`     | Exposes FibreChannel statistics. | Linux | yes |
-| `filefd`           | Exposes file descriptor statistics from `/proc/sys/fs/file-nr`. | Linux | yes |
-| `filesystem`       | Exposes filesystem statistics, such as disk space used. | Darwin, Dragonfly, FreeBSD, Linux, OpenBSD | yes |
-| `hwmon`            | Exposes hardware monitoring and sensor data from `/sys/class/hwmon`. | Linux | yes |
-| `infiniband`       | Exposes network statistics specific to InfiniBand and Intel OmniPath configurations. | Linux | yes |
-| `interrupts`       | Exposes detailed interrupts statistics. | Linux, OpenBSD | no |
-| `ipvs`             | Exposes IPVS status from `/proc/net/ip_vs` and stats from `/proc/net/ip_vs_stats`. | Linux | yes |
-| `ksmd`             | Exposes kernel and system statistics from `/sys/kernel/mm/ksm`. | Linux | no |
-| `lnstat`           | Exposes Linux network cache stats. | Linux | no |
-| `loadavg`          | Exposes load average. | Darwin, Dragonfly, FreeBSD, Linux, NetBSD, OpenBSD, Solaris | yes |
-| `logind`           | Exposes session counts from logind. | Linux | no |
-| `mdadm`            | Exposes statistics about devices in `/proc/mdstat` (does nothing if no `/proc/mdstat` present). | Linux | yes |
-| `meminfo`          | Exposes memory statistics. | Darwin, Dragonfly, FreeBSD, Linux, OpenBSD, NetBSD | yes |
-| `meminfo_numa`     | Exposes memory statistics from `/proc/meminfo_numa`. | Linux | no |
-| `mountstats`       | Exposes filesystem statistics from `/proc/self/mountstats`. Exposes detailed NFS client statistics. | Linux | no |
-| `netclass`         | Exposes network interface info from `/sys/class/net`. | Linux | yes |
-| `netdev`           | Exposes network interface statistics such as bytes transferred. | Darwin, Dragonfly, FreeBSD, Linux, OpenBSD | yes |
-| `netisr`           | Exposes netisr statistics. | FreeBSD | yes |
-| `netstat`          | Exposes network statistics from `/proc/net/netstat`. This is the same information as `netstat -s`. | Linux | yes |
-| `network_route`    | Exposes network route statistics. | Linux | no |
-| `nfs`              | Exposes NFS client statistics from `/proc/net/rpc/nfs`. This is the same information as `nfsstat -c`. | Linux | yes |
-| `nfsd`             | Exposes NFS kernel server statistics from `/proc/net/rpc/nfsd`. This is the same information as `nfsstat -s`. | Linux | yes |
-| `ntp`              | Exposes local NTP daemon health to check time. | any | no |
-| `nvme`             | Exposes NVMe statistics. | Linux | yes |
-| `os`               | Exposes os-release information. | Linux | yes |
-| `perf`             | Exposes perf based metrics (Warning: Metrics are dependent on kernel configuration and settings). | Linux | no |
-| `powersupplyclass` | Collects information on power supplies. | any | yes |
-| `pressure`         | Exposes pressure stall statistics from `/proc/pressure/`. | Linux (kernel 4.20+ and/or CONFIG_PSI) | yes |
-| `processes`        | Exposes aggregate process statistics from /proc. | Linux | no |
-| `qdisc`            | Exposes queuing discipline statistics. | Linux | no |
-| `rapl`             | Exposes various statistics from `/sys/class/powercap`. | Linux | yes |
-| `runit`            | Exposes service status from runit. | any | no |
-| `schedstat`        | Exposes task scheduler statistics from `/proc/schedstat`. | Linux | yes |
-| `sockstat`         | Exposes various statistics from `/proc/net/sockstat`. | Linux | yes |
-| `softirqs`         | Exposes detailed softirq statistics from `/proc/softirqs`. | Linux | no |
-| `softnet`          | Exposes statistics from `/proc/net/softnet_stat`. | Linux | yes |
-| `stat`             | Exposes various statistics from `/proc/stat`. This includes boot time, forks and interrupts. | Linux | yes |
-| `supervisord`      | Exposes service status from supervisord. | any | no |
-| `sysctl`           | Expose sysctl values from `/proc/sys`. | Linux | no |
-| `systemd`          | Exposes service and system status from systemd. | Linux | no |
-| `tapestats`        | Exposes tape device stats. | Linux | yes |
-| `tcpstat`          | Exposes TCP connection status information from `/proc/net/tcp` and `/proc/net/tcp6`. (Warning: The current version has potential performance issues in high load situations.) | Linux | no |
-| `textfile`         | Collects metrics from files in a directory matching the filename pattern `*.prom`. The files must be using the text format defined here: https://prometheus.io/docs/instrumenting/exposition_formats/. | any | yes |
-| `thermal`          | Exposes thermal statistics. | Darwin | yes |
-| `thermal_zone`     | Exposes thermal zone & cooling device statistics from `/sys/class/thermal`. | Linux | yes |
-| `time`             | Exposes the current system time. | any | yes |
-| `timex`            | Exposes selected `adjtimex(2)` system call stats. | Linux | yes |
-| `udp_queues`       | Exposes UDP total lengths of the `rx_queue` and `tx_queue` from `/proc/net/udp` and `/proc/net/udp6`. | Linux | yes |
-| `uname`            | Exposes system information as provided by the uname system call. | Darwin, FreeBSD, Linux, OpenBSD, NetBSD | yes |
-| `vmstat`           | Exposes statistics from `/proc/vmstat`. | Linux | yes |
-| `wifi`             | Exposes WiFi device and station statistics. | Linux | no |
-| `xfs`              | Exposes XFS runtime statistics. | Linux (kernel 4.4+) | yes |
-| `zfs`              | Exposes ZFS performance statistics. | Linux, Solaris | yes |
-| `zoneinfo`         | Exposes zone stats. | Linux | no |
+| Name               | Description                                                                                                                                                                                            | OS                                                          | Enabled by default |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- | ------------------ |
+| `arp`              | Exposes ARP statistics from `/proc/net/arp`.                                                                                                                                                           | Linux                                                       | yes                |
+| `bcache`           | Exposes bcache statistics from `/sys/fs/bcache`.                                                                                                                                                       | Linux                                                       | yes                |
+| `bonding`          | Exposes the number of configured and active slaves of Linux bonding interfaces.                                                                                                                        | Linux                                                       | yes                |
+| `boottime`         | Exposes system boot time derived from the `kern.boottime sysctl`.                                                                                                                                      | Darwin, Dragonfly, FreeBSD, NetBSD, OpenBSD, Solaris        | yes                |
+| `btrfs`            | Exposes statistics on btrfs.                                                                                                                                                                           | Linux                                                       | yes                |
+| `buddyinfo`        | Exposes statistics of memory fragments as reported by `/proc/buddyinfo`.                                                                                                                               | Linux                                                       | no                 |
+| `conntrack`        | Shows conntrack statistics (does nothing if no `/proc/sys/net/netfilter/` present).                                                                                                                    | Linux                                                       | yes                |
+| `cpu`              | Exposes CPU statistics.                                                                                                                                                                                | Darwin, Dragonfly, FreeBSD, Linux, Solaris, NetBSD          | yes                |
+| `cpufreq`          | Exposes CPU frequency statistics.                                                                                                                                                                      | Linux, Solaris                                              | yes                |
+| `devstat`          | Exposes device statistics.                                                                                                                                                                             | Dragonfly, FreeBSD                                          | no                 |
+| `diskstats`        | Exposes disk I/O statistics.                                                                                                                                                                           | Darwin, Linux, OpenBSD                                      | yes                |
+| `dmi`              | Exposes DMI information.                                                                                                                                                                               | Linux                                                       | yes                |
+| `drbd`             | Exposes Distributed Replicated Block Device statistics (to version 8.4).                                                                                                                               | Linux                                                       | no                 |
+| `drm`              | Exposes GPU card info from `/sys/class/drm/card?/device`.                                                                                                                                              | Linux                                                       | no                 |
+| `edac`             | Exposes error detection and correction statistics.                                                                                                                                                     | Linux                                                       | yes                |
+| `entropy`          | Exposes available entropy.                                                                                                                                                                             | Linux                                                       | yes                |
+| `ethtool`          | Exposes ethtool stats.                                                                                                                                                                                 | Linux                                                       | no                 |
+| `exec`             | Exposes execution statistics.                                                                                                                                                                          | Dragonfly, FreeBSD                                          | yes                |
+| `fibrechannel`     | Exposes FibreChannel statistics.                                                                                                                                                                       | Linux                                                       | yes                |
+| `filefd`           | Exposes file descriptor statistics from `/proc/sys/fs/file-nr`.                                                                                                                                        | Linux                                                       | yes                |
+| `filesystem`       | Exposes filesystem statistics, such as disk space used.                                                                                                                                                | Darwin, Dragonfly, FreeBSD, Linux, OpenBSD                  | yes                |
+| `hwmon`            | Exposes hardware monitoring and sensor data from `/sys/class/hwmon`.                                                                                                                                   | Linux                                                       | yes                |
+| `infiniband`       | Exposes network statistics specific to InfiniBand and Intel OmniPath configurations.                                                                                                                   | Linux                                                       | yes                |
+| `interrupts`       | Exposes detailed interrupts statistics.                                                                                                                                                                | Linux, OpenBSD                                              | no                 |
+| `ipvs`             | Exposes IPVS status from `/proc/net/ip_vs` and stats from `/proc/net/ip_vs_stats`.                                                                                                                     | Linux                                                       | yes                |
+| `ksmd`             | Exposes kernel and system statistics from `/sys/kernel/mm/ksm`.                                                                                                                                        | Linux                                                       | no                 |
+| `lnstat`           | Exposes Linux network cache stats.                                                                                                                                                                     | Linux                                                       | no                 |
+| `loadavg`          | Exposes load average.                                                                                                                                                                                  | Darwin, Dragonfly, FreeBSD, Linux, NetBSD, OpenBSD, Solaris | yes                |
+| `logind`           | Exposes session counts from logind.                                                                                                                                                                    | Linux                                                       | no                 |
+| `mdadm`            | Exposes statistics about devices in `/proc/mdstat` (does nothing if no `/proc/mdstat` present).                                                                                                        | Linux                                                       | yes                |
+| `meminfo`          | Exposes memory statistics.                                                                                                                                                                             | Darwin, Dragonfly, FreeBSD, Linux, OpenBSD, NetBSD          | yes                |
+| `meminfo_numa`     | Exposes memory statistics from `/proc/meminfo_numa`.                                                                                                                                                   | Linux                                                       | no                 |
+| `mountstats`       | Exposes filesystem statistics from `/proc/self/mountstats`. Exposes detailed NFS client statistics.                                                                                                    | Linux                                                       | no                 |
+| `netclass`         | Exposes network interface info from `/sys/class/net`.                                                                                                                                                  | Linux                                                       | yes                |
+| `netdev`           | Exposes network interface statistics such as bytes transferred.                                                                                                                                        | Darwin, Dragonfly, FreeBSD, Linux, OpenBSD                  | yes                |
+| `netisr`           | Exposes netisr statistics.                                                                                                                                                                             | FreeBSD                                                     | yes                |
+| `netstat`          | Exposes network statistics from `/proc/net/netstat`. This is the same information as `netstat -s`.                                                                                                     | Linux                                                       | yes                |
+| `network_route`    | Exposes network route statistics.                                                                                                                                                                      | Linux                                                       | no                 |
+| `nfs`              | Exposes NFS client statistics from `/proc/net/rpc/nfs`. This is the same information as `nfsstat -c`.                                                                                                  | Linux                                                       | yes                |
+| `nfsd`             | Exposes NFS kernel server statistics from `/proc/net/rpc/nfsd`. This is the same information as `nfsstat -s`.                                                                                          | Linux                                                       | yes                |
+| `ntp`              | Exposes local NTP daemon health to check time.                                                                                                                                                         | any                                                         | no                 |
+| `nvme`             | Exposes NVMe statistics.                                                                                                                                                                               | Linux                                                       | yes                |
+| `os`               | Exposes os-release information.                                                                                                                                                                        | Linux                                                       | yes                |
+| `perf`             | Exposes perf based metrics (Warning: Metrics are dependent on kernel configuration and settings).                                                                                                      | Linux                                                       | no                 |
+| `powersupplyclass` | Collects information on power supplies.                                                                                                                                                                | any                                                         | yes                |
+| `pressure`         | Exposes pressure stall statistics from `/proc/pressure/`.                                                                                                                                              | Linux (kernel 4.20+ and/or CONFIG_PSI)                      | yes                |
+| `processes`        | Exposes aggregate process statistics from /proc.                                                                                                                                                       | Linux                                                       | no                 |
+| `qdisc`            | Exposes queuing discipline statistics.                                                                                                                                                                 | Linux                                                       | no                 |
+| `rapl`             | Exposes various statistics from `/sys/class/powercap`.                                                                                                                                                 | Linux                                                       | yes                |
+| `runit`            | Exposes service status from runit.                                                                                                                                                                     | any                                                         | no                 |
+| `schedstat`        | Exposes task scheduler statistics from `/proc/schedstat`.                                                                                                                                              | Linux                                                       | yes                |
+| `sockstat`         | Exposes various statistics from `/proc/net/sockstat`.                                                                                                                                                  | Linux                                                       | yes                |
+| `softirqs`         | Exposes detailed softirq statistics from `/proc/softirqs`.                                                                                                                                             | Linux                                                       | no                 |
+| `softnet`          | Exposes statistics from `/proc/net/softnet_stat`.                                                                                                                                                      | Linux                                                       | yes                |
+| `stat`             | Exposes various statistics from `/proc/stat`. This includes boot time, forks and interrupts.                                                                                                           | Linux                                                       | yes                |
+| `supervisord`      | Exposes service status from supervisord.                                                                                                                                                               | any                                                         | no                 |
+| `sysctl`           | Expose sysctl values from `/proc/sys`.                                                                                                                                                                 | Linux                                                       | no                 |
+| `systemd`          | Exposes service and system status from systemd.                                                                                                                                                        | Linux                                                       | no                 |
+| `tapestats`        | Exposes tape device stats.                                                                                                                                                                             | Linux                                                       | yes                |
+| `tcpstat`          | Exposes TCP connection status information from `/proc/net/tcp` and `/proc/net/tcp6`. (Warning: The current version has potential performance issues in high load situations.)                          | Linux                                                       | no                 |
+| `textfile`         | Collects metrics from files in a directory matching the filename pattern `*.prom`. The files must be using the text format defined here: https://prometheus.io/docs/instrumenting/exposition_formats/. | any                                                         | yes                |
+| `thermal`          | Exposes thermal statistics.                                                                                                                                                                            | Darwin                                                      | yes                |
+| `thermal_zone`     | Exposes thermal zone & cooling device statistics from `/sys/class/thermal`.                                                                                                                            | Linux                                                       | yes                |
+| `time`             | Exposes the current system time.                                                                                                                                                                       | any                                                         | yes                |
+| `timex`            | Exposes selected `adjtimex(2)` system call stats.                                                                                                                                                      | Linux                                                       | yes                |
+| `udp_queues`       | Exposes UDP total lengths of the `rx_queue` and `tx_queue` from `/proc/net/udp` and `/proc/net/udp6`.                                                                                                  | Linux                                                       | yes                |
+| `uname`            | Exposes system information as provided by the uname system call.                                                                                                                                       | Darwin, FreeBSD, Linux, OpenBSD, NetBSD                     | yes                |
+| `vmstat`           | Exposes statistics from `/proc/vmstat`.                                                                                                                                                                | Linux                                                       | yes                |
+| `wifi`             | Exposes WiFi device and station statistics.                                                                                                                                                            | Linux                                                       | no                 |
+| `xfs`              | Exposes XFS runtime statistics.                                                                                                                                                                        | Linux (kernel 4.4+)                                         | yes                |
+| `zfs`              | Exposes ZFS performance statistics.                                                                                                                                                                    | Linux, Solaris                                              | yes                |
+| `zoneinfo`         | Exposes zone stats.                                                                                                                                                                                    | Linux                                                       | no                 |
 
 ## Running on Docker/Kubernetes
+
 When running Flow in a Docker container, you need to bind mount the filesystem,
 procfs, and sysfs from the host machine, as well as set the corresponding
 arguments for the component to work.
@@ -372,9 +395,11 @@ prometheus.remote_write "demo" {
   }
 }
 ```
+
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.exporter.windows.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.windows.md
@@ -182,7 +182,7 @@ When `text_file_directory` is set, only files with the extension `.prom` inside 
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporters-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 


### PR DESCRIPTION
In most cases the include was a typo and some were missing the special `<AGENT VERSION>` parameter.

All in all, this should fix 124 build errors in the site after backporting.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
