### PR TITLE
[release-v0.35] Update `docs/shared` shortcode usage to use keyword argument interface and fix typos

### DIFF
--- a/docs/sources/flow/reference/components/prometheus.exporter.apache.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.apache.md
@@ -26,7 +26,7 @@ Name | Type | Description | Default | Required
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
@@ -59,7 +59,7 @@ Name | Type | Description | Default | Required
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.cloudwatch.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.cloudwatch.md
@@ -324,7 +324,7 @@ is exported to CloudWatch.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.consul.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.consul.md
@@ -36,7 +36,7 @@ Name | Type | Description | Default | Required
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.dnsmasq.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.dnsmasq.md
@@ -26,7 +26,7 @@ Name          | Type     | Description                          | Default       
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.elasticsearch.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.elasticsearch.md
@@ -52,7 +52,7 @@ Name | Type | Description | Default | Required
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.github.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.github.md
@@ -33,7 +33,7 @@ When provided, `api_token_file` takes precedence over `api_token`.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.kafka.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.kafka.md
@@ -46,7 +46,7 @@ Omitted fields take their default values.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.memcached.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.memcached.md
@@ -27,7 +27,7 @@ fully through arguments.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 `prometheus.exporter.memcached` is only reported as unhealthy if given

--- a/docs/sources/flow/reference/components/prometheus.exporter.mongodb.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mongodb.md
@@ -36,7 +36,7 @@ MongoDB node connection URI must be in the [`Standard Connection String Format`]
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.mssql.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mssql.md
@@ -42,7 +42,7 @@ fully through arguments.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.mysql.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mysql.md
@@ -139,7 +139,7 @@ The full list of supported collectors is:
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.oracledb.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.oracledb.md
@@ -39,7 +39,7 @@ fully through arguments.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.postgres.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.postgres.md
@@ -62,7 +62,7 @@ If `autodiscovery` is disabled, neither `database_allowlist` nor `database_denyl
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.process.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.process.md
@@ -65,7 +65,7 @@ Each regex in `cmdline` must match the corresponding argv for the process to be 
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.redis.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.redis.md
@@ -69,7 +69,7 @@ Note that setting `export_client_port` increases the cardinality of all Redis me
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.snmp.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.snmp.md
@@ -77,7 +77,7 @@ Name | Type | Description | Default | Required
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.snowflake.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.snowflake.md
@@ -38,7 +38,7 @@ fully through arguments.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.squid.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.squid.md
@@ -34,7 +34,7 @@ fully through arguments.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.statsd.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.statsd.md
@@ -51,7 +51,7 @@ fully through arguments.
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.unix.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.unix.md
@@ -234,7 +234,7 @@ name | type | description | default | required
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.windows.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.windows.md
@@ -182,7 +182,7 @@ When `text_file_directory` is set, only files with the extension `.prom` inside 
 
 ## Exported fields
 
-{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" >}}
+{{< docs/shared lookup="flow/reference/components/exporter-component-exports.md" source="agent" version="<AGENT VERSION>" >}}
 
 ## Component health
 


### PR DESCRIPTION
I honestly don't know how I missed them with the initial search and replace.

- Fix typos in `exporter-component-exports.md` shared include.
- Include version argument using `<AGENT VERSION>` variable syntax that is substituted during the website build for the version inferred from the including page.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
