### PR TITLE
loki.process: make test condition less sensitive

### DIFF
--- a/component/loki/process/process_test.go
+++ b/component/loki/process/process_test.go
@@ -482,5 +482,5 @@ func TestDeadlockWithFrequentUpdates(t *testing.T) {
 
 	// Run everything for a while
 	time.Sleep(1 * time.Second)
-	require.WithinDuration(t, time.Now(), lastSend.Load().(time.Time), 5*time.Millisecond)
+	require.WithinDuration(t, time.Now(), lastSend.Load().(time.Time), 300*time.Millisecond)
 }


### PR DESCRIPTION
This fixes the flaky `TestDeadlockWithFrequentUpdates` test we introduced recently.

Turns out, while the deadlock happens _very_ quickly (so lastSend.Load was always ~900ms behind on my machine), the CI runners can be much slower in sending logs.