### PR TITLE
integrations/eventhandler: remove double-logging of events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Main (unreleased)
 - Deleted series will now be removed from the WAL sooner, allowing Prometheus
   remote_write to free memory associated with removed series sooner. (@rfratto)
 
-- Added a `disable_high_cardinality_metrics` configuration flag to `otelcol` 
+- Added a `disable_high_cardinality_metrics` configuration flag to `otelcol`
   exporters and receivers to switch high cardinality debug metrics off.  (@glindstedt)
 
 ### Other changes
@@ -61,6 +61,10 @@ Main (unreleased)
   having `integrations` block (both V1 and V2). (@hainenber)
 
 - Fix a deadlock candidate in the `loki.process` component. (@tpaschalis)
+
+- Fix an issue in the `eventhandler` integration where events would be
+  double-logged: once by sending the event to Loki, and once by including the
+  event in the Grafana Agent logs. Now, events are only ever sent to Loki. (@rfratto)
 
 v0.36.0 (2023-08-30)
 --------------------

--- a/pkg/integrations/v2/eventhandler/eventhandler.go
+++ b/pkg/integrations/v2/eventhandler/eventhandler.go
@@ -188,7 +188,6 @@ func (eh *EventHandler) handleEvent(event *v1.Event) error {
 		err = fmt.Errorf("msg=%s entry=%s", "error handing entry off to promtail", entry)
 		return err
 	}
-	level.Info(eh.Log).Log("msg", "Shipped entry", "eventRV", event.ResourceVersion, "eventMsg", event.Message)
 
 	// update cache with new "last" event
 	err = eh.updateLastEvent(event, eventTs)


### PR DESCRIPTION
This removes the info-level log line indicating that an event is logged. When agent logs are being collected, this makes the event appear as if it was double-collected, as the event appears both in the logs sent directly to Loki and in the agent logs.