### PR TITLE
feat(comp/loki): expose msg's offset as internal label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ Main (unreleased)
 - Added a `disable_high_cardinality_metrics` configuration flag to `otelcol`
   exporters and receivers to switch high cardinality debug metrics off.  (@glindstedt)
 
+- `loki.source.kafka` component now exposes internal label `__meta_kafka_offset`
+  to indicate offset of consumed message. (@hainenber)
+
 ### Other changes
 
 - Use Go 1.21.0 for builds. (@rfratto)

--- a/component/loki/source/internal/kafkatarget/kafkatarget.go
+++ b/component/loki/source/internal/kafkatarget/kafkatarget.go
@@ -68,6 +68,7 @@ func NewKafkaTarget(
 const (
 	defaultKafkaMessageKey  = "none"
 	labelKeyKafkaMessageKey = "__meta_kafka_message_key"
+	labelKeyKafkaOffset     = "__meta_kafka_message_offset"
 )
 
 func (t *KafkaTarget) run() {
@@ -80,10 +81,10 @@ func (t *KafkaTarget) run() {
 
 		// TODO: Possibly need to format after merging with discovered labels because we can specify multiple labels in source labels
 		// https://github.com/grafana/loki/pull/4745#discussion_r750022234
-		lbs := format([]labels.Label{{
-			Name:  labelKeyKafkaMessageKey,
-			Value: mk,
-		}}, t.relabelConfig)
+		lbs := format([]labels.Label{
+			{Name: labelKeyKafkaMessageKey, Value: mk},
+			{Name: labelKeyKafkaOffset, Value: fmt.Sprintf("%v", message.Offset)},
+		}, t.relabelConfig)
 
 		out := t.lbs.Clone()
 		if len(lbs) > 0 {

--- a/component/loki/source/internal/kafkatarget/kafkatarget_test.go
+++ b/component/loki/source/internal/kafkatarget/kafkatarget_test.go
@@ -227,7 +227,7 @@ func Test_TargetRun(t *testing.T) {
 					Timestamp: time.Unix(0, int64(i)),
 					Value:     []byte(fmt.Sprintf("%d", i)),
 					Key:       []byte(tt.inMessageKey),
-					Offset:    int64(tt.inMessageOffset),
+					Offset:    tt.inMessageOffset,
 				})
 			}
 			claim.Stop()

--- a/docs/sources/flow/reference/components/loki.source.kafka.md
+++ b/docs/sources/flow/reference/components/loki.source.kafka.md
@@ -56,6 +56,7 @@ before they're forwarded to the list of receivers in `forward_to`.
 In addition to custom labels, the following internal labels prefixed with `__` are available:
 
 - `__meta_kafka_message_key`
+- `__meta_kafka_message_offset`
 - `__meta_kafka_topic`
 - `__meta_kafka_partition`
 - `__meta_kafka_member_id`


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Expose message's offset in `loki.source.kafka` as internal label in the format of `__meta_kafka_message_offset`

#### Which issue(s) this PR fixes
Fixes #5079 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated