### PR TITLE
operations/helm: change StatefulSets to deploy in Parallel

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -10,7 +10,7 @@ internal API changes are not present.
 Unreleased
 ----------
 
-0.24.0 (2023-09-07)
+0.24.0 (2023-09-08)
 -------------------
 
 ### Enhancements

--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -10,12 +10,21 @@ internal API changes are not present.
 Unreleased
 ----------
 
-0.23.0 (2023-08-30)
+0.24.0 (2023-09-07)
 -------------------
 
-- Update Grafana Agent version to v0.36.1. (@erikbaranowski)
+### Enhancements
+
+- StatefulSets will now use `podManagementPolicy: Parallel` by default. To
+  disable this behavior, set `controller.parallelRollout` to `false`.
+  (@rfratto)
+
+0.23.0 (2023-09-06)
+-------------------
 
 ### Enhancements
+
+- Update Grafana Agent version to v0.36.1. (@erikbaranowski)
 
 - Enable clustering for deployments and daemonsets. (@tpaschalis)
 
@@ -28,7 +37,6 @@ Unreleased
 -------------------
 
 - Condition parameter minReadySeconds on StatefulSet, Deployment, and DaemonSet to Kubernetes v1.22 clusters.
-
 
 0.21.0 (2023-08-15)
 -------------------

--- a/operations/helm/charts/grafana-agent/Chart.yaml
+++ b/operations/helm/charts/grafana-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: grafana-agent
 description: 'Grafana Agent'
 type: application
-version: 0.23.0
+version: 0.24.0
 appVersion: 'v0.36.1'

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -1,6 +1,6 @@
 # Grafana Agent Helm chart
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.23.0](https://img.shields.io/badge/Version-0.23.0-informational?style=flat-square) ![AppVersion: v0.36.1](https://img.shields.io/badge/AppVersion-v0.36.1-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.24.0](https://img.shields.io/badge/Version-0.24.0-informational?style=flat-square) ![AppVersion: v0.36.1](https://img.shields.io/badge/AppVersion-v0.36.1-informational?style=flat-square)
 
 Helm chart for deploying [Grafana Agent][] to Kubernetes.
 
@@ -78,6 +78,7 @@ use the older mode (called "static mode"), set the `agent.mode` value to
 | controller.hostNetwork | bool | `false` | Configures Pods to use the host network. When set to true, the ports that will be used must be specified. |
 | controller.hostPID | bool | `false` | Configures Pods to use the host PID namespace. |
 | controller.nodeSelector | object | `{}` | nodeSelector to apply to Grafana Agent pods. |
+| controller.parallelRollout | bool | `true` | Whether to deploy pods in parallel. Only used when controller.type is 'statefulset'. |
 | controller.podAnnotations | object | `{}` | Extra pod annotations to add. |
 | controller.podLabels | object | `{}` | Extra pod labels to add. |
 | controller.priorityClassName | string | `""` | priorityClassName to apply to Grafana Agent pods. |

--- a/operations/helm/charts/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/charts/grafana-agent/templates/controllers/statefulset.yaml
@@ -9,6 +9,9 @@ spec:
   {{- if not .Values.controller.autoscaling.enabled }}
   replicas: {{ .Values.controller.replicas }}
   {{- end }}
+  {{- if .Values.controller.parallelRollout }}
+  podManagementPolicy: Parallel
+  {{- end }}
   {{- if ge (int .Capabilities.KubeVersion.Minor) 22 }}
   minReadySeconds: 10
   {{- end }}

--- a/operations/helm/charts/grafana-agent/values.yaml
+++ b/operations/helm/charts/grafana-agent/values.yaml
@@ -146,6 +146,10 @@ controller:
   # -- Number of pods to deploy. Ignored when controller.type is 'daemonset'.
   replicas: 1
 
+  # -- Whether to deploy pods in parallel. Only used when controller.type is
+  # 'statefulset'.
+  parallelRollout: true
+
   # -- Configures Pods to use the host network. When set to true, the ports that will be used must be specified.
   hostNetwork: false
 

--- a/operations/helm/tests/clustering/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/clustering/grafana-agent/templates/controllers/statefulset.yaml
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 3
+  podManagementPolicy: Parallel
   minReadySeconds: 10
   serviceName: grafana-agent
   selector:

--- a/operations/helm/tests/create-statefulset-autoscaling/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset-autoscaling/grafana-agent/templates/controllers/statefulset.yaml
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 spec:
+  podManagementPolicy: Parallel
   minReadySeconds: 10
   serviceName: grafana-agent
   selector:

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  podManagementPolicy: Parallel
   minReadySeconds: 10
   serviceName: grafana-agent
   selector:


### PR DESCRIPTION
Now that Flow mode cluster nodes will rejoin the cluster in the background, we can speed up the default rollout by changing StatefulSets to deploy in Parallel.
