### PR TITLE
Chore: Respects Retry-After header for both 429 and 5xx status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Main (unreleased)
   have been standardized. The first fields will always be `ts`, `level`, and
   `msg`, followed by non-common fields. Previously, the position of `msg` was
   not consistent. (@rfratto)
+- Agent Management: Respects Retry-After header for both 429 and 5xx status codes. (@ying-jeanne)
 
 v0.36.1 (2023-09-06)
 --------------------

--- a/pkg/config/remote_config.go
+++ b/pkg/config/remote_config.go
@@ -112,7 +112,7 @@ func (p httpProvider) retrieve() ([]byte, error) {
 
 	instrumentation.InstrumentRemoteConfigFetch(response.StatusCode)
 
-	if response.StatusCode == http.StatusTooManyRequests {
+	if response.StatusCode/100 == 5 || response.StatusCode == http.StatusTooManyRequests {
 		retryAfter := response.Header.Get("Retry-After")
 		if retryAfter == "" {
 			return nil, fmt.Errorf("server indicated to retry, but no Retry-After header was provided")


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer
Agent will now consider and adhere to the Retry-After header in response to both 429 and 5xx status codes.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated