### PR TITLE
Add extra_labels object to BlackboxTarget block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Main (unreleased)
 - Add a `file_watch` block in `loki.source.file` to configure how often to poll files from disk for changes via `min_poll_frequency` and `max_poll_frequency`.
   In static mode it can be configured in the global `file_watch_config` via `min_poll_frequency` and `max_poll_frequency`.  (@wildum)
 
+- Flow: In `prometheus.exporter.blackbox`, allow setting extra labels for individual targets. (@spartan0x117)
+
 ### Enhancements
 
 - Clustering: allow advertise interfaces to be configurable, with the possibility to select all available interfaces. (@wildum)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Main (unreleased)
 - Add a `file_watch` block in `loki.source.file` to configure how often to poll files from disk for changes via `min_poll_frequency` and `max_poll_frequency`.
   In static mode it can be configured in the global `file_watch_config` via `min_poll_frequency` and `max_poll_frequency`.  (@wildum)
 
-- Flow: In `prometheus.exporter.blackbox`, allow setting extra labels for individual targets. (@spartan0x117)
+- Flow: In `prometheus.exporter.blackbox`, allow setting labels for individual targets. (@spartan0x117)
 
 ### Enhancements
 

--- a/component/prometheus/exporter/blackbox/blackbox.go
+++ b/component/prometheus/exporter/blackbox/blackbox.go
@@ -38,10 +38,11 @@ func buildBlackboxTargets(baseTarget discovery.Target, args component.Arguments)
 	a := args.(Arguments)
 	for _, tgt := range a.Targets {
 		target := make(discovery.Target)
-		for k, v := range baseTarget {
+		// Set extra labels first, meaning that any other labels will override
+		for k, v := range tgt.ExtraLabels {
 			target[k] = v
 		}
-		for k, v := range tgt.ExtraLabels {
+		for k, v := range baseTarget {
 			target[k] = v
 		}
 

--- a/component/prometheus/exporter/blackbox/blackbox.go
+++ b/component/prometheus/exporter/blackbox/blackbox.go
@@ -39,7 +39,7 @@ func buildBlackboxTargets(baseTarget discovery.Target, args component.Arguments)
 	for _, tgt := range a.Targets {
 		target := make(discovery.Target)
 		// Set extra labels first, meaning that any other labels will override
-		for k, v := range tgt.ExtraLabels {
+		for k, v := range tgt.Labels {
 			target[k] = v
 		}
 		for k, v := range baseTarget {
@@ -66,10 +66,10 @@ var DefaultArguments = Arguments{
 
 // BlackboxTarget defines a target to be used by the exporter.
 type BlackboxTarget struct {
-	Name        string            `river:",label"`
-	Target      string            `river:"address,attr"`
-	Module      string            `river:"module,attr,optional"`
-	ExtraLabels map[string]string `river:"extra_labels,attr,optional"`
+	Name   string            `river:",label"`
+	Target string            `river:"address,attr"`
+	Module string            `river:"module,attr,optional"`
+	Labels map[string]string `river:"labels,attr,optional"`
 }
 
 type TargetBlock []BlackboxTarget

--- a/component/prometheus/exporter/blackbox/blackbox.go
+++ b/component/prometheus/exporter/blackbox/blackbox.go
@@ -41,6 +41,9 @@ func buildBlackboxTargets(baseTarget discovery.Target, args component.Arguments)
 		for k, v := range baseTarget {
 			target[k] = v
 		}
+		for k, v := range tgt.ExtraLabels {
+			target[k] = v
+		}
 
 		target["job"] = target["job"] + "/" + tgt.Name
 		target["__param_target"] = tgt.Target
@@ -62,9 +65,10 @@ var DefaultArguments = Arguments{
 
 // BlackboxTarget defines a target to be used by the exporter.
 type BlackboxTarget struct {
-	Name   string `river:",label"`
-	Target string `river:"address,attr"`
-	Module string `river:"module,attr,optional"`
+	Name        string            `river:",label"`
+	Target      string            `river:"address,attr"`
+	Module      string            `river:"module,attr,optional"`
+	ExtraLabels map[string]string `river:"extra_labels,attr,optional"`
 }
 
 type TargetBlock []BlackboxTarget

--- a/component/prometheus/exporter/blackbox/blackbox_test.go
+++ b/component/prometheus/exporter/blackbox/blackbox_test.go
@@ -178,7 +178,7 @@ func TestBuildBlackboxTargetsWithExtraLabels(t *testing.T) {
 			Name:   "target_a",
 			Target: "http://example.com",
 			Module: "http_2xx",
-			ExtraLabels: map[string]string{
+			Labels: map[string]string{
 				"env": "test",
 				"foo": "bar",
 			},
@@ -204,7 +204,7 @@ func TestBuildBlackboxTargetsWithExtraLabels(t *testing.T) {
 	require.Equal(t, "bar", targets[0]["foo"])
 
 	// Check that the extra labels do not override existing labels
-	baseArgs.Targets[0].ExtraLabels = map[string]string{
+	baseArgs.Targets[0].Labels = map[string]string{
 		"job":      "test",
 		"instance": "test-instance",
 	}

--- a/component/prometheus/exporter/blackbox/blackbox_test.go
+++ b/component/prometheus/exporter/blackbox/blackbox_test.go
@@ -202,4 +202,15 @@ func TestBuildBlackboxTargetsWithExtraLabels(t *testing.T) {
 
 	require.Equal(t, "test", targets[0]["env"])
 	require.Equal(t, "bar", targets[0]["foo"])
+
+	// Check that the extra labels do not override existing labels
+	baseArgs.Targets[0].ExtraLabels = map[string]string{
+		"job": "test",
+		"instance": "test-instance",
+	}
+	args = component.Arguments(baseArgs)
+	targets = buildBlackboxTargets(baseTarget, args)
+	require.Equal(t, 1, len(targets))
+	require.Equal(t, "integrations/blackbox/target_a", targets[0]["job"])
+	require.Equal(t, "prometheus.exporter.blackbox.default", targets[0]["instance"])
 }

--- a/component/prometheus/exporter/blackbox/blackbox_test.go
+++ b/component/prometheus/exporter/blackbox/blackbox_test.go
@@ -170,3 +170,36 @@ func TestBuildBlackboxTargets(t *testing.T) {
 	require.Equal(t, "http://example.com", targets[0]["__param_target"])
 	require.Equal(t, "http_2xx", targets[0]["__param_module"])
 }
+
+func TestBuildBlackboxTargetsWithExtraLabels(t *testing.T) {
+	baseArgs := Arguments{
+		ConfigFile: "modules.yml",
+		Targets: TargetBlock{{
+			Name:   "target_a",
+			Target: "http://example.com",
+			Module: "http_2xx",
+			ExtraLabels: map[string]string{
+				"env": "test",
+				"foo": "bar",
+			},
+		}},
+		ProbeTimeoutOffset: 1.0,
+	}
+	baseTarget := discovery.Target{
+		model.SchemeLabel:                   "http",
+		model.MetricsPathLabel:              "component/prometheus.exporter.blackbox.default/metrics",
+		"instance":                          "prometheus.exporter.blackbox.default",
+		"job":                               "integrations/blackbox",
+		"__meta_agent_integration_name":     "blackbox",
+		"__meta_agent_integration_instance": "prometheus.exporter.blackbox.default",
+	}
+	args := component.Arguments(baseArgs)
+	targets := buildBlackboxTargets(baseTarget, args)
+	require.Equal(t, 1, len(targets))
+	require.Equal(t, "integrations/blackbox/target_a", targets[0]["job"])
+	require.Equal(t, "http://example.com", targets[0]["__param_target"])
+	require.Equal(t, "http_2xx", targets[0]["__param_module"])
+
+	require.Equal(t, "test", targets[0]["env"])
+	require.Equal(t, "bar", targets[0]["foo"])
+}

--- a/component/prometheus/exporter/blackbox/blackbox_test.go
+++ b/component/prometheus/exporter/blackbox/blackbox_test.go
@@ -205,7 +205,7 @@ func TestBuildBlackboxTargetsWithExtraLabels(t *testing.T) {
 
 	// Check that the extra labels do not override existing labels
 	baseArgs.Targets[0].ExtraLabels = map[string]string{
-		"job": "test",
+		"job":      "test",
 		"instance": "test-instance",
 	}
 	args = component.Arguments(baseArgs)

--- a/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
@@ -83,7 +83,7 @@ debug metrics.
 ### Collect metrics using a blackbox exporter config file
 
 This example uses a [`prometheus.scrape` component][scrape] to collect metrics
-from `prometheus.exporter.blackbox`. It adds an extra label, `env="dev"`, to the metrics emitted by the `grafana` target. The `example` target does not have any extra labels.
+from `prometheus.exporter.blackbox`. It adds an extra label, `env="dev"`, to the metrics emitted by the `grafana` target. The `example` target does not have any added labels.
 
 ```river
 prometheus.exporter.blackbox "example" {
@@ -97,7 +97,7 @@ prometheus.exporter.blackbox "example" {
   target "grafana" {
     address = "http://grafana.com"
     module  = "http_2xx"
-    extra_labels = {
+    labels = {
       "env": "dev",
     }
   }
@@ -143,7 +143,7 @@ prometheus.exporter.blackbox "example" {
   target "grafana" {
     address = "http://grafana.com"
     module  = "http_2xx"
-    extra_labels = {
+    labels = {
       "env": "dev",
     }
   }

--- a/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
@@ -83,7 +83,7 @@ debug metrics.
 ### Collect metrics using a blackbox exporter config file
 
 This example uses a [`prometheus.scrape` component][scrape] to collect metrics
-from `prometheus.exporter.blackbox`:
+from `prometheus.exporter.blackbox`. It adds an extra label `env="dev"` to the metrics emitted by the `grafana` target. The `example` target will not have any extra labels.
 
 ```river
 prometheus.exporter.blackbox "example" {
@@ -97,6 +97,9 @@ prometheus.exporter.blackbox "example" {
   target "grafana" {
     address = "http://grafana.com"
     module  = "http_2xx"
+    extra_labels = {
+      "env": "dev",
+    }
   }
 }
 
@@ -131,48 +134,6 @@ This example is the same above with using an embedded configuration:
 ```river
 prometheus.exporter.blackbox "example" {
   config = "{ modules: { http_2xx: { prober: http, timeout: 5s } } }"
-
-  target "example" {
-    address = "http://example.com"
-    module  = "http_2xx"
-  }
-
-  target "grafana" {
-    address = "http://grafana.com"
-    module  = "http_2xx"
-  }
-}
-
-// Configure a prometheus.scrape component to collect Blackbox metrics.
-prometheus.scrape "demo" {
-  targets    = prometheus.exporter.blackbox.example.targets
-  forward_to = [prometheus.remote_write.demo.receiver]
-}
-
-prometheus.remote_write "demo" {
-  endpoint {
-    url = PROMETHEUS_REMOTE_WRITE_URL
-
-    basic_auth {
-      username = USERNAME
-      password = PASSWORD
-    }
-  }
-}
-```
-
-Replace the following:
-
-- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-- `USERNAME`: The username to use for authentication to the remote_write API.
-- `PASSWORD`: The password to use for authentication to the remote_write API.
-
-### Collect metrics using a blackbox exporter config file with extra labels
-
-This example will add an extra label `env="dev"` to the metrics emitted by the `grafana` target. The `example` target will not have any extra labels.
-
-prometheus.exporter.blackbox "example" {
-  config_file = "blackbox_modules.yml"
 
   target "example" {
     address = "http://example.com"

--- a/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
@@ -167,4 +167,50 @@ Replace the following:
 - `USERNAME`: The username to use for authentication to the remote_write API.
 - `PASSWORD`: The password to use for authentication to the remote_write API.
 
+### Collect metrics using a blackbox exporter config file with extra labels
+
+This example will add an extra label `env="dev"` to the metrics emitted by the `grafana` target. The `example` target will not have any extra labels.
+
+prometheus.exporter.blackbox "example" {
+  config_file = "blackbox_modules.yml"
+
+  target "example" {
+    address = "http://example.com"
+    module  = "http_2xx"
+  }
+
+  target "grafana" {
+    address = "http://grafana.com"
+    module  = "http_2xx"
+    extra_labels = {
+      "env": "dev",
+    }
+  }
+}
+
+// Configure a prometheus.scrape component to collect Blackbox metrics.
+prometheus.scrape "demo" {
+  targets    = prometheus.exporter.blackbox.example.targets
+  forward_to = [prometheus.remote_write.demo.receiver]
+}
+
+prometheus.remote_write "demo" {
+  endpoint {
+    url = PROMETHEUS_REMOTE_WRITE_URL
+
+    basic_auth {
+      username = USERNAME
+      password = PASSWORD
+    }
+  }
+}
+```
+
+Replace the following:
+
+- `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+- `USERNAME`: The username to use for authentication to the remote_write API.
+- `PASSWORD`: The password to use for authentication to the remote_write API.
+
+
 [scrape]: {{< relref "./prometheus.scrape.md" >}}

--- a/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
@@ -83,7 +83,7 @@ debug metrics.
 ### Collect metrics using a blackbox exporter config file
 
 This example uses a [`prometheus.scrape` component][scrape] to collect metrics
-from `prometheus.exporter.blackbox`. It adds an extra label `env="dev"` to the metrics emitted by the `grafana` target. The `example` target will not have any extra labels.
+from `prometheus.exporter.blackbox`. It adds an extra label, `env="dev"`, to the metrics emitted by the `grafana` target. The `example` target does not have any extra labels.
 
 ```river
 prometheus.exporter.blackbox "example" {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Adds a `labels` object to `prometheus.exporter.blackbox`'s `target` block. This allows setting labels individually per target.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [X] Documentation added
- [X] Tests updated
- [ ] Config converters updated