### PR TITLE
Misc. Docs Fixes

### DIFF
--- a/docs/sources/flow/reference/components/discovery.nerve.md
+++ b/docs/sources/flow/reference/components/discovery.nerve.md
@@ -1,3 +1,4 @@
+---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/discovery.nerve/
 title: discovery.nerve
 ---

--- a/docs/sources/flow/reference/components/prometheus.remote_write.md
+++ b/docs/sources/flow/reference/components/prometheus.remote_write.md
@@ -304,7 +304,7 @@ information.
 * `prometheus_remote_storage_exemplars_in_total` (counter): Exemplars read into
   remote storage.
 
-# Examples
+## Examples
 
 The following examples show you how to create `prometheus.remote_write` components that send metrics to different destinations.
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Fixes a few miscellaneous things in the docs:

- Changes the header level of the `Examples` section in the `prometheus.remote_write` docs, which was causing the section to be squashed into the previous one.

- Fixes the metadata for the `discovery.nerve` component docs.
