### PR TITLE
Improve river config validation in prometheus.scrape 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ Main (unreleased)
 - `loki.source.kafka` component now exposes internal label `__meta_kafka_offset`
   to indicate offset of consumed message. (@hainenber)
 
+- Flow: improve river config validation step in `prometheus.scrape` by comparing `scrape_timeout` with `scrape_interval`. (@wildum)
+
 ### Other changes
 
 - Use Go 1.21.1 for builds. (@rfratto)

--- a/component/prometheus/scrape/scrape.go
+++ b/component/prometheus/scrape/scrape.go
@@ -109,6 +109,10 @@ func (arg *Arguments) SetToDefault() {
 
 // Validate implements river.Validator.
 func (arg *Arguments) Validate() error {
+	if arg.ScrapeTimeout > arg.ScrapeInterval {
+		return fmt.Errorf("scrape_timeout (%s) greater than scrape_interval (%s) for scrape config with job name %q", arg.ScrapeTimeout, arg.ScrapeInterval, arg.JobName)
+	}
+
 	// We must explicitly Validate because HTTPClientConfig is squashed and it won't run otherwise
 	return arg.HTTPClientConfig.Validate()
 }

--- a/component/prometheus/scrape/scrape_test.go
+++ b/component/prometheus/scrape/scrape_test.go
@@ -204,3 +204,16 @@ func TestCustomDialer(t *testing.T) {
 	err = scrapeTrigger.Wait(1 * time.Minute)
 	require.NoError(t, err, "custom dialer was not used")
 }
+
+func TestValidateScrapeConfig(t *testing.T) {
+	var exampleRiverConfig = `
+	targets         = [{ "target1" = "target1" }]
+	forward_to      = []
+	scrape_interval = "10s"
+	scrape_timeout  = "20s"
+	job_name        = "local"
+`
+	var args Arguments
+	err := river.Unmarshal([]byte(exampleRiverConfig), &args)
+	require.ErrorContains(t, err, "scrape_timeout (20s) greater than scrape_interval (10s) for scrape config with job name \"local\"")
+}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Extend the validation check by comparing the value of scrape timeout with scrape interval to detect an eventual misconfiguration before trying to scrape.

The check is similar to the one in [Prometheus](https://github.com/prometheus/prometheus/blob/24d7e5bd49dd26a45c2123a897c6cac5ac7c47f0/config/config.go#L549-L569)

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #3696 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Tests updated