### PR TITLE
Clarify that attribute processor does not drop signals

### DIFF
--- a/docs/sources/flow/reference/components/otelcol.processor.attributes.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.attributes.md
@@ -164,9 +164,11 @@ For example, adding a `span_names` filter could cause the component to error if 
 
 The `exclude` block provides an option to exclude data from being fed into the [action] blocks based on the properties of a span, log, or metric records.
 
-> **NOTE**: Signals excluded by the `exclude` block will still be propagated to downstream components.
-> If you would like to not propagate certain signals to downstream components, 
-> consider a processor such as [otelcol.processor.tail_sampling](../otelcol.processor.tail_sampling/).
+{{% admonition type="note" %}}
+Signals excluded by the `exclude` block will still be propagated to downstream components as-is.
+If you would like to not propagate certain signals to downstream components, 
+consider a processor such as [otelcol.processor.tail_sampling](../otelcol.processor.tail_sampling/).
+{{% /admonition %}}
 
 {{< docs/shared lookup="flow/reference/components/match-properties-block.md" source="agent" version="<AGENT VERSION>" >}}
 

--- a/docs/sources/flow/reference/components/otelcol.processor.attributes.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.attributes.md
@@ -164,6 +164,10 @@ For example, adding a `span_names` filter could cause the component to error if 
 
 The `exclude` block provides an option to exclude data from being fed into the [action] blocks based on the properties of a span, log, or metric records.
 
+> **NOTE**: Signals excluded by the `exclude` block will still be propagated to downstream components.
+> If you would like to not propagate certain signals to downstream components, 
+> consider a processor such as [otelcol.processor.tail_sampling](../otelcol.processor.tail_sampling/).
+
 {{< docs/shared lookup="flow/reference/components/match-properties-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 One of the following is also required:


### PR DESCRIPTION
#### PR Description

There has been some confusion regarding the attributes processor. It contains an `exclude` block, and people sometimes get confused that this means the data will be excluded in downstream components. This is not the case.

I mention the tail sampling processor as a processor which can do this. However, it only works for traces. It would have been nice to also point to similar processors for logs and metrics, but I don't think we have such components in Flow at the moment. I think the otel components for dropping metrics and logs are [metricstransform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor) and [probabilisticsampler processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/probabilisticsamplerprocessor).

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated