### PR TITLE
flow: fix data race in new logger implementation

### DIFF
--- a/pkg/flow/logging/handler.go
+++ b/pkg/flow/logging/handler.go
@@ -58,7 +58,7 @@ func (h *handler) buildHandler() slog.Handler {
 	// Fast path: if our cached handler is still valid, immediately return it.
 	h.mut.RLock()
 	if h.currentFormat == expectFormat && h.inner != nil {
-		h.mut.RUnlock()
+		defer h.mut.RUnlock()
 		return h.inner
 	}
 	h.mut.RUnlock()


### PR DESCRIPTION
I [saw](https://drone.grafana.net/grafana/agent/12588/1/2) some builds from main fail with a reported data race.

I haven't been able to reproduce this yet, but I _think_ this due to trying to return (read) `h.inner` after releasing the lock, and coinciding with a new handler being set (write).


```
==================
WARNING: DATA RACE
Write at 0x00c0001a8f88 by goroutine 998:
  github.com/grafana/agent/pkg/flow/logging.(*handler).buildHandler()
      /drone/src/pkg/flow/logging/handler.go:147 +0x836
  github.com/grafana/agent/pkg/flow/logging.(*handler).Handle()
      /drone/src/pkg/flow/logging/handler.go:49 +0x51
  github.com/grafana/agent/internal/slogadapter.slogAdapter.Log()
      /drone/src/internal/slogadapter/gokit.go:71 +0x5d4
  github.com/grafana/agent/pkg/flow/logging.(*Logger).Log()
      /drone/src/pkg/flow/logging/logger.go:83 +0x86
  github.com/go-kit/log.(*context).Log()
      /go/pkg/mod/github.com/dannykopping/go-kit-log@v0.2.2-0.20221002180827-5591c1641b6b/log.go:168 +0x4ba
  github.com/grafana/agent/component/loki/process/stages.(*logfmtStage).Process()
      /drone/src/component/loki/process/stages/logfmt.go:122 +0x1416
  github.com/grafana/agent/component/loki/process/stages.(*stageProcessor).Run.stageProcessor.Run.func1()
      /drone/src/component/loki/process/stages/stage.go:94 +0x170
  github.com/grafana/agent/component/loki/process/stages.RunWith.func1()
      /drone/src/component/loki/process/stages/pipeline.go:82 +0x141

Previous read at 0x00c0001a8f88 by goroutine 1000:
  github.com/grafana/agent/pkg/flow/logging.(*handler).buildHandler()
      /drone/src/pkg/flow/logging/handler.go:62 +0x8f7
  github.com/grafana/agent/pkg/flow/logging.(*handler).Handle()
      /drone/src/pkg/flow/logging/handler.go:49 +0x51
  github.com/grafana/agent/internal/slogadapter.slogAdapter.Log()
      /drone/src/internal/slogadapter/gokit.go:71 +0x5d4
  github.com/grafana/agent/pkg/flow/logging.(*Logger).Log()
      /drone/src/pkg/flow/logging/logger.go:83 +0x86
  github.com/go-kit/log.(*context).Log()
      /go/pkg/mod/github.com/dannykopping/go-kit-log@v0.2.2-0.20221002180827-5591c1641b6b/log.go:168 +0x4ba
  github.com/grafana/agent/component/loki/process/stages.(*logfmtStage).Process()
      /drone/src/component/loki/process/stages/logfmt.go:93 +0xafc
  github.com/grafana/agent/component/loki/process/stages.(*stageProcessor).Run.stageProcessor.Run.func1()
      /drone/src/component/loki/process/stages/stage.go:94 +0x170
  github.com/grafana/agent/component/loki/process/stages.RunWith.func1()
      /drone/src/component/loki/process/stages/pipeline.go:82 +0x141

```

- [ ] CHANGELOG.md updated
- [ ] Documentation added (N/A)
- [ ] Tests updated 