### PR TITLE
Correct the example syntax in the loki.source.kafka reference topic

### DIFF
--- a/docs/sources/flow/reference/components/loki.source.kafka.md
+++ b/docs/sources/flow/reference/components/loki.source.kafka.md
@@ -147,21 +147,22 @@ This example consumes Kafka events from the specified brokers and topics
 then forwards them to a `loki.write` component using the Kafka timestamp.
 
 ```river
-loki.relabel "kafka" {
-  rule {
-    source_labels = ["__meta_kafka_topic"]
-    target_label  = "topic"
-  }
-}
-
-
 loki.source.kafka "local" {
   brokers                = ["localhost:9092"]
   topics                 = ["quickstart-events"]
   labels                 = {component = "loki.source.kafka"}
-  forward_to             = [loki.write.local.receiver]
+  forward_to             = [loki.relabel.kafka.receiver]
   use_incoming_timestamp = true
   relabel_rules          = loki.relabel.kafka.rules
+}
+
+loki.relabel "kafka" {
+  forward_to      = [loki.write.local.receiver]
+
+  rule {
+    source_labels = ["__meta_kafka_topic"]
+    target_label  = "topic"
+  }
 }
 
 loki.write "local" {
@@ -170,4 +171,3 @@ loki.write "local" {
   }
 }
 ```
-


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR updates the example in https://grafana.com/docs/agent/latest/flow/reference/components/loki.source.kafka/ and adds in a missing `forward_to` argument, fixes another `forward_to` destination, and puts the blocks into a more logical/readable order.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #5044 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated