### PR TITLE
add `nil_to_zero` YACE config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ Main (unreleased)
 
 - Flow: In `prometheus.exporter.blackbox`, allow setting labels for individual targets. (@spartan0x117)
 
+- Add optional `nil_to_zero` config flag for `YACE` which can be set in the `static`, `discovery`, or `metric` config blocks. (@berler)
+
 ### Enhancements
 
 - Clustering: allow advertise interfaces to be configurable, with the possibility to select all available interfaces. (@wildum)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@ Main (unreleased)
 
 - Fixed a bug where documented default settings in `otelcol.exporter.loadbalancing` were never set. (@rfratto)
 
+- Fixed a bug where converting `YACE` cloudwatch config to river skipped converting static jobs. (@berler)
+
 v0.36.1 (2023-09-06)
 --------------------
 

--- a/converter/internal/staticconvert/internal/build/cloudwatch_exporter.go
+++ b/converter/internal/staticconvert/internal/build/cloudwatch_exporter.go
@@ -52,6 +52,7 @@ func toDiscoveryJob(job *cloudwatch_exporter.DiscoveryJob) cloudwatch.DiscoveryJ
 		Type:                      job.Type,
 		DimensionNameRequirements: job.DimensionNameRequirements,
 		Metrics:                   toMetrics(job.Metrics),
+		NilToZero:                 job.NilToZero,
 	}
 }
 
@@ -92,5 +93,6 @@ func toMetric(metric cloudwatch_exporter.Metric) cloudwatch.Metric {
 		Statistics: metric.Statistics,
 		Period:     metric.Period,
 		Length:     metric.Length,
+		NilToZero:  metric.NilToZero,
 	}
 }

--- a/converter/internal/staticconvert/internal/build/cloudwatch_exporter.go
+++ b/converter/internal/staticconvert/internal/build/cloudwatch_exporter.go
@@ -29,7 +29,7 @@ func toCloudwatchExporter(config *cloudwatch_exporter.Config) *cloudwatch.Argume
 		Debug:                 config.Debug,
 		DiscoveryExportedTags: config.Discovery.ExportedTags,
 		Discovery:             toDiscoveryJobs(config.Discovery.Jobs),
-		Static:                []cloudwatch.StaticJob{},
+		Static:                toStaticJobs(config.Static),
 	}
 }
 
@@ -56,6 +56,29 @@ func toDiscoveryJob(job *cloudwatch_exporter.DiscoveryJob) cloudwatch.DiscoveryJ
 	}
 }
 
+func toStaticJobs(jobs []cloudwatch_exporter.StaticJob) []cloudwatch.StaticJob {
+	var out []cloudwatch.StaticJob
+	for _, job := range jobs {
+		out = append(out, toStaticJob(&job))
+	}
+	return out
+}
+
+func toStaticJob(job *cloudwatch_exporter.StaticJob) cloudwatch.StaticJob {
+	return cloudwatch.StaticJob{
+		Name: job.Name,
+		Auth: cloudwatch.RegionAndRoles{
+			Regions: job.Regions,
+			Roles:   toRoles(job.Roles),
+		},
+		CustomTags: toTags(job.CustomTags),
+		Namespace:  job.Namespace,
+		Dimensions: toDimensions(job.Dimensions),
+		Metrics:    toMetrics(job.Metrics),
+		NilToZero:  job.NilToZero,
+	}
+}
+
 func toRoles(roles []cloudwatch_exporter.Role) []cloudwatch.Role {
 	var out []cloudwatch.Role
 	for _, role := range roles {
@@ -75,6 +98,14 @@ func toTags(tags []cloudwatch_exporter.Tag) cloudwatch.Tags {
 	out := make(cloudwatch.Tags, 0)
 	for _, tag := range tags {
 		out[tag.Key] = tag.Value
+	}
+	return out
+}
+
+func toDimensions(dimensions []cloudwatch_exporter.Dimension) cloudwatch.Dimensions {
+	out := make(cloudwatch.Dimensions)
+	for _, dimension := range dimensions {
+		out[dimension.Name] = dimension.Value
 	}
 	return out
 }

--- a/converter/internal/staticconvert/testdata/integrations.river
+++ b/converter/internal/staticconvert/testdata/integrations.river
@@ -116,6 +116,29 @@ prometheus.exporter.cloudwatch "integrations_cloudwatch_exporter" {
 		nil_to_zero = true
 	}
 
+	static "single_ec2_instance" {
+		regions     = ["us-east-2"]
+		custom_tags = {}
+		namespace   = "AWS/EC2"
+		dimensions  = {
+			InstanceId = "i-0e43cee369aa44b52",
+		}
+
+		metric {
+			name        = "CPUUtilization"
+			statistics  = ["Average"]
+			period      = "5m0s"
+			nil_to_zero = false
+		}
+
+		metric {
+			name       = "NetworkPacketsIn"
+			statistics = ["Average"]
+			period     = "5m0s"
+		}
+		nil_to_zero = true
+	}
+
 	decoupled_scraping { }
 }
 

--- a/converter/internal/staticconvert/testdata/integrations.river
+++ b/converter/internal/staticconvert/testdata/integrations.river
@@ -102,9 +102,10 @@ prometheus.exporter.cloudwatch "integrations_cloudwatch_exporter" {
 		type        = "AWS/EC2"
 
 		metric {
-			name       = "CPUUtilization"
-			statistics = ["Average"]
-			period     = "5m0s"
+			name        = "CPUUtilization"
+			statistics  = ["Average"]
+			period      = "5m0s"
+			nil_to_zero = false
 		}
 
 		metric {
@@ -112,6 +113,7 @@ prometheus.exporter.cloudwatch "integrations_cloudwatch_exporter" {
 			statistics = ["Average"]
 			period     = "5m0s"
 		}
+		nil_to_zero = true
 	}
 
 	decoupled_scraping { }

--- a/converter/internal/staticconvert/testdata/integrations.yaml
+++ b/converter/internal/staticconvert/testdata/integrations.yaml
@@ -37,11 +37,13 @@ integrations:
         - type: AWS/EC2
           regions:
             - us-east-2
+          nil_to_zero: true
           metrics:
             - name: CPUUtilization
               period: 5m
               statistics:
                 - Average
+              nil_to_zero: false
             - name: NetworkPacketsIn
               period: 5m
               statistics:

--- a/converter/internal/staticconvert/testdata/integrations.yaml
+++ b/converter/internal/staticconvert/testdata/integrations.yaml
@@ -48,6 +48,25 @@ integrations:
               period: 5m
               statistics:
                 - Average
+    static:
+      - name: single_ec2_instance
+        regions:
+          - us-east-2
+        namespace: AWS/EC2
+        dimensions:
+          - name: InstanceId
+            value: i-0e43cee369aa44b52
+        nil_to_zero: true
+        metrics:
+          - name: CPUUtilization
+            period: 5m
+            statistics:
+              - Average
+            nil_to_zero: false
+          - name: NetworkPacketsIn
+            period: 5m
+            statistics:
+              - Average
   consul_exporter:
     enabled: true
   dnsmasq_exporter:

--- a/docs/sources/flow/reference/components/prometheus.exporter.cloudwatch.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.cloudwatch.md
@@ -267,13 +267,13 @@ metrics.
 Follow [this guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/viewing_metrics_with_cloudwatch.html)
 on how to explore metrics, to easily pick the ones you need.
 
-| Name          | Type           | Description                                                        | Default                                                                                                             | Required |
-| ------------- | -------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- | -------- |
-| `name`        | `string`       | Metric name.                                                       |                                                                                                                     | yes      |
-| `statistics`  | `list(string)` | List of statistics to scrape. Ex: `"Minimum"`, `"Maximum"`, etc.   |                                                                                                                     | yes      |
-| `period`      | `duration`     | See [period][] section below.                                      |                                                                                                                     | yes      |
-| `length`      | `duration`     | See [period][] section below.                                      | Calculated based on `period`. See [period][] for details.                                                           | no       |
-| `nil_to_zero` | `bool`         | When `true`, `NaN` metric values are converted to 0.               | The value of `nil_to_zero` in the parent [static][] or [discovery][] block (`true` if not set in the parent block). | no       |
+| Name          | Type           | Description                                                               | Default                                                                                                             | Required |
+| ------------- | -------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | -------- |
+| `name`        | `string`       | Metric name.                                                              |                                                                                                                     | yes      |
+| `statistics`  | `list(string)` | List of statistics to scrape. For example, `"Minimum"`, `"Maximum"`, etc. |                                                                                                                     | yes      |
+| `period`      | `duration`     | See [period][] section below.                                             |                                                                                                                     | yes      |
+| `length`      | `duration`     | See [period][] section below.                                             | Calculated based on `period`. See [period][] for details.                                                           | no       |
+| `nil_to_zero` | `bool`         | When `true`, `NaN` metric values are converted to 0.                      | The value of `nil_to_zero` in the parent [static][] or [discovery][] block (`true` if not set in the parent block). | no       |
 
 [period]: #period-and-length
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.cloudwatch.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.cloudwatch.md
@@ -198,6 +198,7 @@ different `search_tags`.
 | `custom_tags`                 | `map(string)`  | Custom tags to be added as a list of key / value pairs. When exported to Prometheus format, the label name follows the following format: `custom_tag_{key}`.                                                                                               | `{}`    | no       |
 | `search_tags`                 | `map(string)`  | List of key / value pairs to use for tag filtering (all must match). Value can be a regex.                                                                                                                                                                 | `{}`    | no       |
 | `dimension_name_requirements` | `list(string)` | List of metric dimensions to query. Before querying metric values, the total list of metrics will be filtered to only those that contain exactly this list of dimensions. An empty or undefined list results in all dimension combinations being included. | `{}`    | no       |
+| `nil_to_zero`                 | `bool`         | When `true`, `NaN` metric values are converted to 0. Individual metrics can override this value in the [metric][] block.                                                                                                                                   | `true`  | no       |
 
 [supported-services]: #supported-services-in-discovery-jobs
 
@@ -252,6 +253,7 @@ You can configure the `static` block one or multiple times to scrape metrics wit
 | `namespace`   | `string`       | CloudWatch metric namespace.                                                                                                                                 |         | yes      |
 | `dimensions`  | `map(string)`  | CloudWatch metric dimensions as a list of name / value pairs. Must uniquely define all metrics in this job.                                                  |         | yes      |
 | `custom_tags` | `map(string)`  | Custom tags to be added as a list of key / value pairs. When exported to Prometheus format, the label name follows the following format: `custom_tag_{key}`. | `{}`    | no       |
+| `nil_to_zero` | `bool`         | When `true`, `NaN` metric values are converted to 0. Individual metrics can override this value in the [metric][] block.                                     | `true`  | no       |
 
 All dimensions must be specified when scraping single metrics like the example above. For example, `AWS/Logs` metrics
 require `Resource`, `Service`, `Class`, and `Type` dimensions to be specified. The same applies to CloudWatch custom
@@ -265,12 +267,13 @@ metrics.
 Follow [this guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/viewing_metrics_with_cloudwatch.html)
 on how to explore metrics, to easily pick the ones you need.
 
-| Name         | Type           | Description                                                      | Default                                                   | Required |
-| ------------ | -------------- | ---------------------------------------------------------------- | --------------------------------------------------------- | -------- |
-| `name`       | `string`       | Metric name.                                                     |                                                           | yes      |
-| `statistics` | `list(string)` | List of statistics to scrape. Ex: `"Minimum"`, `"Maximum"`, etc. |                                                           | yes      |
-| `period`     | `duration`     | See [period][] section below.                                    |                                                           | yes      |
-| `length`     | `duration`     | See [period][] section below.                                    | Calculated based on `period`. See [period][] for details. | no       |
+| Name          | Type           | Description                                                        | Default                                                                                                             | Required |
+| ------------- | -------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- | -------- |
+| `name`        | `string`       | Metric name.                                                       |                                                                                                                     | yes      |
+| `statistics`  | `list(string)` | List of statistics to scrape. Ex: `"Minimum"`, `"Maximum"`, etc.   |                                                                                                                     | yes      |
+| `period`      | `duration`     | See [period][] section below.                                      |                                                                                                                     | yes      |
+| `length`      | `duration`     | See [period][] section below.                                      | Calculated based on `period`. See [period][] for details.                                                           | no       |
+| `nil_to_zero` | `bool`         | When `true`, `NaN` metric values are converted to 0.               | The value of `nil_to_zero` in the parent [static][] or [discovery][] block (`true` if not set in the parent block). | no       |
 
 [period]: #period-and-length
 

--- a/docs/sources/static/configuration/integrations/cloudwatch-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/cloudwatch-exporter-config.md
@@ -177,15 +177,18 @@ discovery:
     - type: AWS/EC2
       regions:
         - us-east-2
+      nil_to_zero: true
       metrics:
         - name: CPUUtilization
           period: 5m
           statistics:
             - Average
+          nil_to_zero: true
         - name: NetworkPacketsIn
           period: 5m
           statistics:
             - Average
+          nil_to_zero: true
 ```
 
 Configuration reference:
@@ -211,6 +214,9 @@ Configuration reference:
   # Optional: List of metric dimensions to query. Before querying metric values, the total list of metrics will be filtered to only those that contain exactly this list of dimensions. An empty or undefined list results in all dimension combinations being included.
   dimension_name_requirements: [ <string> ]
 
+  # Optional: Flag that controls if `NaN` metric values are converted to 0. Default `true`. This can be overridden in the config of each metric.
+  nil_to_zero: <bool>
+
   # Required: List of metric definitions to scrape.
   metrics: [ <metric> ]
 ```
@@ -234,15 +240,18 @@ static:
     dimensions:
       - name: InstanceId
         value: i-0e43cee369aa44b52
+    nil_to_zero: true
     metrics:
       - name: CPUUtilization
         period: 5m
         statistics:
           - Average
+        nil_to_zero: true
       - name: NetworkPacketsIn
         period: 5m
         statistics:
           - Average
+        nil_to_zero: true
 ```
 
 All dimensions need to be specified when scraping single metrics like the example above. For example `AWS/Logs` metrics
@@ -270,6 +279,9 @@ Configuration reference:
   # Optional: Custom tags to be added as a list of Key/Value pairs. When exported, the label name follows the following format:
   # `custom_tag_{Key}`.
   custom_tags: [ <aws_tag> ]
+
+  # Optional: Flag that controls if `NaN` metric values are converted to 0. Default `true`. This can be overridden in the config of each metric.
+  nil_to_zero: <bool>
 
   # Required: List of metric definitions to scrape.
   metrics: [ <metric> ]
@@ -328,6 +340,10 @@ pick the ones you need.
 
   # Optional: See the `period and length` section below.
   length: [ <duration> | default = calculated based on `period` ]
+
+  # Optional: Flag that controls if `NaN` metric values are converted to 0.
+  # When not set, the value defaults to the setting in the parent static or discovery block (`true` if not set in the parent block).
+  nil_to_zero: <bool>
 ```
 
 ### Period and length

--- a/pkg/integrations/cloudwatch_exporter/config_test.go
+++ b/pkg/integrations/cloudwatch_exporter/config_test.go
@@ -122,6 +122,66 @@ static:
           - Average
 `
 
+// for testing nilToZero at the DiscoveryJob, StaticJob, and Metric level
+const configString3 = `
+sts_region: us-east-2
+discovery:
+  exported_tags:
+    AWS/EC2:
+      - name
+      - type
+  jobs:
+    - type: AWS/EC2
+      search_tags:
+        - key: instance_type
+          value: spot
+      regions:
+        - us-east-2
+      roles:
+        - role_arn: arn:aws:iam::878167871295:role/yace_testing
+      custom_tags:
+        - key: alias
+          value: tesis
+      nil_to_zero: false
+      metrics:
+        - name: CPUUtilization
+          period: 5m
+          statistics:
+            - Maximum
+            - Average
+    - type: s3
+      regions:
+        - us-east-2
+      roles:
+        - role_arn: arn:aws:iam::878167871295:role/yace_testing
+      dimension_name_requirements:
+        - BucketName
+      nil_to_zero: true
+      metrics:
+        - name: BucketSizeBytes
+          period: 5m
+          length: 1h
+          nil_to_zero: false
+          statistics:
+            - Sum
+static:
+  - regions:
+      - us-east-2
+    name: custom_tesis_metrics
+    namespace: CoolApp
+    dimensions:
+      - name: PURCHASES_SERVICE
+        value: CoolService
+      - name: APP_VERSION
+        value: 1.0
+    nil_to_zero: false
+    metrics:
+      - name: KPIs
+        period: 5m
+        statistics:
+          - Average
+`
+
 var falsePtr = false
 var truePtr = true
 
@@ -161,7 +221,7 @@ var expectedConfig = yaceConf.ScrapeConf{
 						Period:                 300,
 						Length:                 300,
 						Delay:                  0,
-						NilToZero:              &nilToZero,
+						NilToZero:              &defaultNilToZero,
 						AddCloudwatchTimestamp: &addCloudwatchTimestamp,
 					},
 				},
@@ -171,7 +231,7 @@ var expectedConfig = yaceConf.ScrapeConf{
 					Length:                 0,
 					Delay:                  0,
 					AddCloudwatchTimestamp: &falsePtr,
-					NilToZero:              &nilToZero,
+					NilToZero:              &defaultNilToZero,
 				},
 			},
 			{
@@ -193,7 +253,7 @@ var expectedConfig = yaceConf.ScrapeConf{
 						Period:                 300,
 						Length:                 3600, // 1 hour
 						Delay:                  0,
-						NilToZero:              &nilToZero,
+						NilToZero:              &defaultNilToZero,
 						AddCloudwatchTimestamp: &addCloudwatchTimestamp,
 					},
 				},
@@ -203,7 +263,7 @@ var expectedConfig = yaceConf.ScrapeConf{
 					Length:                 0,
 					Delay:                  0,
 					AddCloudwatchTimestamp: &falsePtr,
-					NilToZero:              &nilToZero,
+					NilToZero:              &defaultNilToZero,
 				},
 			},
 		},
@@ -232,7 +292,122 @@ var expectedConfig = yaceConf.ScrapeConf{
 					Length:                 300,
 					Statistics:             []string{"Average"},
 					Delay:                  0,
-					NilToZero:              &nilToZero,
+					NilToZero:              &defaultNilToZero,
+					AddCloudwatchTimestamp: &addCloudwatchTimestamp,
+				},
+			},
+		},
+	},
+}
+
+var expectedConfig3 = yaceConf.ScrapeConf{
+	APIVersion: "v1alpha1",
+	StsRegion:  "us-east-2",
+	Discovery: yaceConf.Discovery{
+		ExportedTagsOnMetrics: map[string][]string{
+			"AWS/EC2": {"name", "type"},
+		},
+		Jobs: []*yaceConf.Job{
+			{
+				Type:    "AWS/EC2",
+				Regions: []string{"us-east-2"},
+				Roles: []yaceConf.Role{
+					{
+						RoleArn: "arn:aws:iam::878167871295:role/yace_testing",
+					},
+				},
+				CustomTags: []yaceModel.Tag{
+					{
+						Key:   "alias",
+						Value: "tesis",
+					},
+				},
+				SearchTags: []yaceModel.Tag{
+					{
+						Key:   "instance_type",
+						Value: "spot",
+					},
+				},
+				Metrics: []*yaceConf.Metric{
+					{
+						Name:       "CPUUtilization",
+						Statistics: []string{"Maximum", "Average"},
+						// Defaults get configured from general settings
+						Period:                 300,
+						Length:                 300,
+						Delay:                  0,
+						NilToZero:              &falsePtr,
+						AddCloudwatchTimestamp: &addCloudwatchTimestamp,
+					},
+				},
+				RoundingPeriod: nil,
+				JobLevelMetricFields: yaceConf.JobLevelMetricFields{
+					Period:                 0,
+					Length:                 0,
+					Delay:                  0,
+					AddCloudwatchTimestamp: &falsePtr,
+					NilToZero:              &falsePtr,
+				},
+			},
+			{
+				Type:    "s3",
+				Regions: []string{"us-east-2"},
+				Roles: []yaceConf.Role{
+					{
+						RoleArn: "arn:aws:iam::878167871295:role/yace_testing",
+					},
+				},
+				SearchTags:                []yaceModel.Tag{},
+				CustomTags:                []yaceModel.Tag{},
+				DimensionNameRequirements: []string{"BucketName"},
+				Metrics: []*yaceConf.Metric{
+					{
+						Name:       "BucketSizeBytes",
+						Statistics: []string{"Sum"},
+						// Defaults get configured from general settings
+						Period:                 300,
+						Length:                 3600, // 1 hour
+						Delay:                  0,
+						NilToZero:              &falsePtr,
+						AddCloudwatchTimestamp: &addCloudwatchTimestamp,
+					},
+				},
+				RoundingPeriod: nil,
+				JobLevelMetricFields: yaceConf.JobLevelMetricFields{
+					Period:                 0,
+					Length:                 0,
+					Delay:                  0,
+					AddCloudwatchTimestamp: &falsePtr,
+					NilToZero:              &truePtr,
+				},
+			},
+		},
+	},
+	Static: []*yaceConf.Static{
+		{
+			Name:       "custom_tesis_metrics",
+			Regions:    []string{"us-east-2"},
+			Roles:      []yaceConf.Role{{}},
+			Namespace:  "CoolApp",
+			CustomTags: []yaceModel.Tag{},
+			Dimensions: []yaceConf.Dimension{
+				{
+					Name:  "PURCHASES_SERVICE",
+					Value: "CoolService",
+				},
+				{
+					Name:  "APP_VERSION",
+					Value: "1.0",
+				},
+			},
+			Metrics: []*yaceConf.Metric{
+				{
+					Name:                   "KPIs",
+					Period:                 300,
+					Length:                 300,
+					Statistics:             []string{"Average"},
+					Delay:                  0,
+					NilToZero:              &falsePtr,
 					AddCloudwatchTimestamp: &addCloudwatchTimestamp,
 				},
 			},
@@ -259,6 +434,18 @@ func TestTranslateConfigToYACEConfig(t *testing.T) {
 
 	require.EqualValues(t, expectedConfig, yaceConf)
 	require.EqualValues(t, falsePtr, fipsEnabled2)
+}
+
+func TestTranslateNilToZeroConfigToYACEConfig(t *testing.T) {
+	c := Config{}
+	err := yaml.Unmarshal([]byte(configString3), &c)
+	require.NoError(t, err, "failed to unmarshal config")
+
+	yaceConf, fipsEnabled, err := ToYACEConfig(&c)
+	require.NoError(t, err, "failed to translate to YACE configuration")
+
+	require.EqualValues(t, expectedConfig3, yaceConf)
+	require.EqualValues(t, truePtr, fipsEnabled)
 }
 
 func TestCloudwatchExporterConfigInstanceKey(t *testing.T) {


### PR DESCRIPTION
#### PR Description

Adds `nil_to_zero` config flag so `YACE` can be configured instead of hard-coding `true`.

#### Which issue(s) this PR fixes

Fixes #5075

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated