### PR TITLE
Wrong order for the split functions example

### DIFF
--- a/docs/sources/flow/reference/stdlib/split.md
+++ b/docs/sources/flow/reference/stdlib/split.md
@@ -19,12 +19,12 @@ split(list, separator)
 ## Examples
 
 ```river
-> split(",", "foo,bar,baz")
+> split("foo,bar,baz", "," )
 ["foo", "bar", "baz"]
 
-> split(",", "foo")
+> split("foo", ",")
 ["foo"]
 
-> split(",", "")
+> split("", ",")
 [""]
 ```


### PR DESCRIPTION
#### PR Description
Fixes split function documentation.

#### Which issue(s) this PR fixes
NA
#### Notes to the Reviewer
Fixes documentation for split function order examples.
#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated