### PR TITLE
Rename component stability from "alpha" to "experimental".

### DIFF
--- a/docs/sources/flow/reference/components/otelcol.connector.spanmetrics.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.spanmetrics.md
@@ -11,6 +11,8 @@ title: otelcol.connector.spanmetrics
 
 # otelcol.connector.spanmetrics
 
+{{< docs/shared lookup="flow/stability/experimental.md" source="agent" version="<AGENT VERSION>" >}}
+
 `otelcol.connector.spanmetrics` accepts span data from other `otelcol` components and
 aggregates Request, Error and Duration (R.E.D) OpenTelemetry metrics from the spans:
 

--- a/docs/sources/flow/reference/components/otelcol.connector.spanmetrics.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.spanmetrics.md
@@ -5,7 +5,7 @@ aliases:
 - /docs/grafana-cloud/monitor-infrastructure/integrations/agent/flow/reference/components/otelcol.connector.spanmetrics/
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.connector.spanmetrics/
 labels:
-  stage: alpha
+  stage: experimental
 title: otelcol.connector.spanmetrics
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.processor.span.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.span.md
@@ -5,7 +5,7 @@ aliases:
 - /docs/grafana-cloud/monitor-infrastructure/integrations/agent/flow/reference/components/otelcol.processor.span/
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.span/
 labels:
-  stage: alpha
+  stage: experimental
 title: otelcol.processor.span
 ---
 

--- a/docs/sources/flow/reference/components/otelcol.processor.span.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.span.md
@@ -11,6 +11,8 @@ title: otelcol.processor.span
 
 # otelcol.processor.span
 
+{{< docs/shared lookup="flow/stability/experimental.md" source="agent" version="<AGENT VERSION>" >}}
+
 `otelcol.processor.span` accepts traces telemetry data from other `otelcol`
 components and modifies the names and attributes of the spans.
 It also supports the ability to filter input data to determine if 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#4934 and #4936 named the component stability of `otelcol.processor.span` and `otelcol.connector.spanmetrics` as "alpha". This is an Otel Collector term, and should be replaced by the [Agent's](https://grafana.com/docs/agent/latest/stability/) "experimental" label.

The Agent has a policy of not downgrading stability. I think this change doesn't count as downgrading, because it's reasonable to expect that something labeled "alpha" is not stable.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated