### PR TITLE
Agent Management: Honor 503 ServiceUnavailable Retry-After header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ Main (unreleased)
   `otelcol.exporter.otlp` and `otelcol.processor.batch`. There may also be metrics 
   from other components which are not documented yet. (@ptodev)
 
+- Agent Management: Honor 503 ServiceUnavailable `Retry-After` header. (@jcreixell)
+
 ### Other changes
 
 - Use Go 1.21.1 for builds. (@rfratto)

--- a/pkg/config/remote_config.go
+++ b/pkg/config/remote_config.go
@@ -112,7 +112,7 @@ func (p httpProvider) retrieve() ([]byte, error) {
 
 	instrumentation.InstrumentRemoteConfigFetch(response.StatusCode)
 
-	if response.StatusCode == http.StatusTooManyRequests {
+	if response.StatusCode == http.StatusTooManyRequests || response.StatusCode == http.StatusServiceUnavailable {
 		retryAfter := response.Header.Get("Retry-After")
 		if retryAfter == "" {
 			return nil, fmt.Errorf("server indicated to retry, but no Retry-After header was provided")


### PR DESCRIPTION
#### PR Description
  
In addition to `429 TooManyRequests`, remote servers may return `503 ServiceUnavailable` with a `Retry-After` header. This allows overloaded servers to apply back-pressure for a quick recovery.

#### PR Checklist

- [x] CHANGELOG.md updated
