### PR TITLE
Fix scraped targets metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,9 @@ Main (unreleased)
 
 - Fix `loki.source.file` race condition in cleaning up metrics when stopping to tail files. (@thampiotr)
 
+- Fixed the `agent_prometheus_scrape_targets_gauge` incorrectly reporting all discovered targets 
+  instead of targets that belong to current instance when clustering is enabled. (@thampiotr)
+
 v0.36.1 (2023-09-06)
 --------------------
 

--- a/component/prometheus/scrape/scrape.go
+++ b/component/prometheus/scrape/scrape.go
@@ -217,6 +217,7 @@ func (c *Component) Run(ctx context.Context) error {
 			// 'clustered' targets implementation every time.
 			ct := discovery.NewDistributedTargets(cl, c.cluster, tgs)
 			promTargets := c.componentTargetsToProm(jobName, ct.Get())
+			c.targetsGauge.Set(float64(len(promTargets)))
 
 			select {
 			case targetSetsChan <- promTargets:
@@ -251,7 +252,6 @@ func (c *Component) Update(args component.Arguments) error {
 	default:
 	}
 
-	c.targetsGauge.Set(float64(len(c.args.Targets)))
 	return nil
 }
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

* When hashmod sharding was on, the metric was reporting # of targets after the ones that don't belong to local instance are dropped - because the targets were dropped in the relabel component
* When clustering is enabled, the metric will always report all the discovered targets, not just the ones that belong to local instance. Tracking whether targets are evenly balanced across instances is not possible using this metric.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
