### PR TITLE
slogadapter: check for log level being enabled

### DIFF
--- a/internal/slogadapter/gokit.go
+++ b/internal/slogadapter/gokit.go
@@ -68,5 +68,8 @@ func (sa slogAdapter) Log(kvps ...interface{}) error {
 		})
 	}
 
+	if !sa.h.Enabled(context.Background(), rec.Level) {
+		return nil
+	}
 	return sa.h.Handle(context.Background(), rec)
 }

--- a/internal/slogadapter/gokit_test.go
+++ b/internal/slogadapter/gokit_test.go
@@ -1,0 +1,38 @@
+package slogadapter
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/go-kit/log/level"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFiltersLogs(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			// Drop timestamps for reproducible tests.
+			if a.Key == slog.TimeKey {
+				return slog.Attr{}
+			}
+
+			return a
+		},
+	})
+
+	l := GoKit(h)
+	level.Debug(l).Log("msg", "debug level log")
+	level.Info(l).Log("msg", "info level log")
+	level.Warn(l).Log("msg", "warn level log")
+	level.Error(l).Log("msg", "error level log")
+
+	expect := `level=WARN msg="warn level log"
+level=ERROR msg="error level log"
+`
+
+	require.Equal(t, expect, buf.String())
+}


### PR DESCRIPTION
The custom log.Logger implementation wrapping around a slog.Handler must check to see if a level is enabled before logging log lines.