### PR TITLE
Proposal how to paralelise graph evaluation

### DIFF
--- a/pkg/flow/flow.go
+++ b/pkg/flow/flow.go
@@ -227,15 +227,18 @@ func (f *Flow) Run(ctx context.Context) {
 			// We need to pop _everything_ from the queue and evaluate each of them.
 			// If we only pop a single element, other components may sit waiting for
 			// evaluation forever.
+
+			// NOTE: sending all the updated nodes at once to EvaluateDependencies
+			//TODO(thampiotr): fix tests and other callers
+			var allUpdated []*controller.ComponentNode
 			for {
 				updated := f.updateQueue.TryDequeue()
 				if updated == nil {
 					break
 				}
-
-				level.Debug(f.log).Log("msg", "handling component with updated state", "node_id", updated.NodeID())
-				f.loader.EvaluateDependencies(updated)
+				allUpdated = append(allUpdated, updated)
 			}
+			f.loader.EvaluateDependencies(allUpdated)
 
 		case <-f.loadFinished:
 			level.Info(f.log).Log("msg", "scheduling loaded components and services")

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -570,7 +570,15 @@ func (l *Loader) OriginalGraph() *dag.Graph {
 // The provided parentContext can be used to provide global variables and
 // functions to components. A child context will be constructed from the parent
 // to expose values of other components.
-func (l *Loader) EvaluateDependencies(c *ComponentNode) {
+func (l *Loader) EvaluateDependencies(nodes []*ComponentNode) {
+
+	//TODO(thampiotr): parallelize the nodes evaluation as follows:
+	// 1. Use disjoint sets / union-find to partition the graph into disjoint subgraphs
+	//    - this can be cached and takes O(V+E) to build
+	// 2. Partition all the nodes that need evaluation by the disjoint graph they're part of - (N * O(1) lookup = O(N))
+	// 2. Evaluate the partitions of nodes in parallel using a limited number of goroutines
+	// 3. Block waiting for all goroutines to finish - the slow subgraphs will no longer block the faster subgraphs
+
 	tracer := l.tracer.Tracer("")
 
 	l.mut.RLock()


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR is just a bunch of comments to draft an idea for parallelising graph evaluation.

Currently graph evaluation is single-threaded - each component update is processed fully, before another one can be attempted. But we already have a loop that empties the entire queue of updates before continuing.

This can be parallelised by taking all the queued updates and when there are 2 or more disjoint subgraphs - splitting them into subsets and walking the disjoint subgraphs in parallel. 

