### PR TITLE
ci: skip installing CRDs if the Kind cluster is not being installed

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -75,12 +75,14 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Add dependency chart repos
+        if: steps.list-changed.outputs.changed == 'true'
         run: |
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 
       - name: Install Prometheus Operator CRDs
+        if: steps.list-changed.outputs.changed == 'true'
         run: |
-          helm install my-prometheus-operator-crds prometheus-community/prometheus-operator-crds --version 6.0.0 
+          helm install my-prometheus-operator-crds prometheus-community/prometheus-operator-crds --version 6.0.0
 
       - name: Test charts
         run: ct install --config ./operations/helm/ct.yaml


### PR DESCRIPTION
The Kind cluster won't be installed if a PR doesn't modify the Helm chart, so the same condition should be applied to whether CRDs are installed.

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated