### PR TITLE
Set the otel feature gates in Flow mode earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,9 +112,6 @@ Main (unreleased)
 
 - Fixed a bug where converting `YACE` cloudwatch config to river skipped converting static jobs. (@berler)
 
-- Fixed a bug due to which debug metrics originating from OpenTelemetry components
-  were not visible on the Agent't `metrics` endpoint. (@ptodev)
-
 ### Other changes
 
 - Use Go 1.21.1 for builds. (@rfratto)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,9 @@ Main (unreleased)
 
 - Fixed a bug where converting `YACE` cloudwatch config to river skipped converting static jobs. (@berler)
 
+- Fixed a bug due to which debug metrics originating from OpenTelemetry components
+  were not visible on the Agent't `metrics` endpoint. (@ptodev)
+
 ### Other changes
 
 - Use Go 1.21.1 for builds. (@rfratto)

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -239,7 +239,10 @@ func (fr *flowRun) Run(configPath string) error {
 		Cluster:  clusterService.Data().(cluster.Cluster),
 	})
 
-	otelService := otel_service.New()
+	otelService := otel_service.New(l)
+	if otelService == nil {
+		return fmt.Errorf("failed to create otel service")
+	}
 
 	f := flow.New(flow.Options{
 		Logger:   l,


### PR DESCRIPTION
#### PR Description

Otel metrics were supposed to be integrated into Flow mode in #5045, but it was recently discovered that they were still not working. I think this is because I did some last minute refactoring, and must have forgotten to do a local test of the Agent to make sure the metrics are still visible. I suspect that I initially had the feature gate registration in `New` and moved it to `Run` later on.

This PR does the feature gate registration in the `New` function, because doing it in the `Run` function would be too late - the otel components would already have checked the feature gate by then.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated