### PR TITLE
pkg/integrations/cadvisor: minimize runner responsibilities

### DIFF
--- a/pkg/integrations/cadvisor/cadvisor.go
+++ b/pkg/integrations/cadvisor/cadvisor.go
@@ -116,12 +116,12 @@ func New(logger log.Logger, c *Config) (integrations.Integration, error) {
 
 	var collectorHTTPClient http.Client
 
-	cludedMetrics, err := c.GetIncludedMetrics()
+	includedMetrics, err := c.GetIncludedMetrics()
 	if err != nil {
-		return nil, fmt.Errorf("unable to determine cluded metrics: %w", err)
+		return nil, fmt.Errorf("unable to determine included metrics: %w", err)
 	}
 
-	rm, err := manager.New(memoryStorage, sysFs, manager.HousekeepingConfigFlags, cludedMetrics, &collectorHTTPClient, c.RawCgroupPrefixAllowlist, c.EnvMetadataAllowlist, c.PerfEventsConfig, time.Duration(c.ResctrlInterval))
+	rm, err := manager.New(memoryStorage, sysFs, manager.HousekeepingConfigFlags, includedMetrics, &collectorHTTPClient, c.RawCgroupPrefixAllowlist, c.EnvMetadataAllowlist, c.PerfEventsConfig, time.Duration(c.ResctrlInterval))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a manager: %w", err)
 	}
@@ -135,7 +135,7 @@ func New(logger log.Logger, c *Config) (integrations.Integration, error) {
 		containerLabelFunc = metrics.BaseContainerLabels(c.AllowlistedContainerLabels)
 	}
 
-	machCol := metrics.NewPrometheusMachineCollector(rm, cludedMetrics)
+	machCol := metrics.NewPrometheusMachineCollector(rm, includedMetrics)
 	// This is really just a concatenation of the defaults found at;
 	// https://github.com/google/cadvisor/tree/f89291a53b80b2c3659fff8954c11f1fc3de8a3b/cmd/internal/api/versions.go#L536-L540
 	// https://github.com/google/cadvisor/tree/f89291a53b80b2c3659fff8954c11f1fc3de8a3b/cmd/internal/http/handlers.go#L109-L110
@@ -145,7 +145,7 @@ func New(logger log.Logger, c *Config) (integrations.Integration, error) {
 		Count:     1,
 		Recursive: true,
 	}
-	contCol := metrics.NewPrometheusCollector(rm, containerLabelFunc, cludedMetrics, clock.RealClock{}, reqOpts)
+	contCol := metrics.NewPrometheusCollector(rm, containerLabelFunc, includedMetrics, clock.RealClock{}, reqOpts)
 
 	start := func(ctx context.Context) error {
 		<-ctx.Done()

--- a/pkg/integrations/cadvisor/cadvisor.go
+++ b/pkg/integrations/cadvisor/cadvisor.go
@@ -86,55 +86,56 @@ type Integration struct {
 	i *integrations.CollectorIntegration
 }
 
-// Run holds all the configuration logic for globals, as well as starting the resource manager and registering the collectors with the collector integration
-func (i *Integration) Run(ctx context.Context) error {
+// New creates a new cadvisor integration
+func New(logger log.Logger, c *Config) (integrations.Integration, error) {
+	c.logger = logger
 	// Do gross global configs. This works, so long as there is only one instance of the cAdvisor integration
 	// per host.
 
 	// klog
-	klog.SetLogger(i.c.logger)
+	klog.SetLogger(c.logger)
 
 	// Containerd
-	containerd.ArgContainerdEndpoint = &i.c.Containerd
-	containerd.ArgContainerdNamespace = &i.c.ContainerdNamespace
+	containerd.ArgContainerdEndpoint = &c.Containerd
+	containerd.ArgContainerdNamespace = &c.ContainerdNamespace
 
 	// Docker
-	docker.ArgDockerEndpoint = &i.c.Docker
-	docker.ArgDockerTLS = &i.c.DockerTLS
-	docker.ArgDockerCert = &i.c.DockerTLSCert
-	docker.ArgDockerKey = &i.c.DockerTLSKey
-	docker.ArgDockerCA = &i.c.DockerTLSCA
+	docker.ArgDockerEndpoint = &c.Docker
+	docker.ArgDockerTLS = &c.DockerTLS
+	docker.ArgDockerCert = &c.DockerTLSCert
+	docker.ArgDockerKey = &c.DockerTLSKey
+	docker.ArgDockerCA = &c.DockerTLSCA
 
 	// Raw
-	raw.DockerOnly = &i.c.DockerOnly
+	raw.DockerOnly = &c.DockerOnly
 
 	// Only using in-memory storage, with no backup storage for cadvisor stats
-	memoryStorage := memory.New(i.c.StorageDuration, []storage.StorageDriver{})
+	memoryStorage := memory.New(c.StorageDuration, []storage.StorageDriver{})
 
 	sysFs := sysfs.NewRealSysFs()
 
 	var collectorHTTPClient http.Client
 
-	includedMetrics, err := i.c.GetIncludedMetrics()
+	cludedMetrics, err := c.GetIncludedMetrics()
 	if err != nil {
-		return fmt.Errorf("unable to determine included metrics: %w", err)
+		return nil, fmt.Errorf("unable to determine cluded metrics: %w", err)
 	}
 
-	rm, err := manager.New(memoryStorage, sysFs, manager.HousekeepingConfigFlags, includedMetrics, &collectorHTTPClient, i.c.RawCgroupPrefixAllowlist, i.c.EnvMetadataAllowlist, i.c.PerfEventsConfig, time.Duration(i.c.ResctrlInterval))
+	rm, err := manager.New(memoryStorage, sysFs, manager.HousekeepingConfigFlags, cludedMetrics, &collectorHTTPClient, c.RawCgroupPrefixAllowlist, c.EnvMetadataAllowlist, c.PerfEventsConfig, time.Duration(c.ResctrlInterval))
 	if err != nil {
-		return fmt.Errorf("failed to create a manager: %w", err)
+		return nil, fmt.Errorf("failed to create a manager: %w", err)
 	}
 
 	if err := rm.Start(); err != nil {
-		return fmt.Errorf("failed to start manager: %w", err)
+		return nil, fmt.Errorf("failed to start manager: %w", err)
 	}
 
 	containerLabelFunc := metrics.DefaultContainerLabels
-	if !i.c.StoreContainerLabels {
-		containerLabelFunc = metrics.BaseContainerLabels(i.c.AllowlistedContainerLabels)
+	if !c.StoreContainerLabels {
+		containerLabelFunc = metrics.BaseContainerLabels(c.AllowlistedContainerLabels)
 	}
 
-	machCol := metrics.NewPrometheusMachineCollector(rm, includedMetrics)
+	machCol := metrics.NewPrometheusMachineCollector(rm, cludedMetrics)
 	// This is really just a concatenation of the defaults found at;
 	// https://github.com/google/cadvisor/tree/f89291a53b80b2c3659fff8954c11f1fc3de8a3b/cmd/internal/api/versions.go#L536-L540
 	// https://github.com/google/cadvisor/tree/f89291a53b80b2c3659fff8954c11f1fc3de8a3b/cmd/internal/http/handlers.go#L109-L110
@@ -144,26 +145,22 @@ func (i *Integration) Run(ctx context.Context) error {
 		Count:     1,
 		Recursive: true,
 	}
-	contCol := metrics.NewPrometheusCollector(rm, containerLabelFunc, includedMetrics, clock.RealClock{}, reqOpts)
-	integrations.WithCollectors(machCol, contCol)(i.i)
+	contCol := metrics.NewPrometheusCollector(rm, containerLabelFunc, cludedMetrics, clock.RealClock{}, reqOpts)
 
-	<-ctx.Done()
+	start := func(ctx context.Context) error {
+		<-ctx.Done()
 
-	if err := rm.Stop(); err != nil {
-		return fmt.Errorf("failed to stop manager: %w", err)
+		if err := rm.Stop(); err != nil {
+			return fmt.Errorf("failed to stop manager: %w", err)
+		}
+		return nil
 	}
-	return nil
-}
 
-// New creates a new cadvisor integration
-func New(logger log.Logger, c *Config) (integrations.Integration, error) {
-	c.logger = logger
+	ci := integrations.NewCollectorIntegration(
+		c.Name(),
+		integrations.WithRunner(start),
+		integrations.WithCollectors(machCol, contCol),
+	)
 
-	ci := integrations.NewCollectorIntegration(c.Name())
-	integration := Integration{
-		c: c,
-		i: ci,
-	}
-	integrations.WithRunner(integration.Run)(ci)
 	return ci, nil
 }

--- a/pkg/integrations/cadvisor/cadvisor.go
+++ b/pkg/integrations/cadvisor/cadvisor.go
@@ -80,12 +80,6 @@ func (c *Config) NewIntegration(logger log.Logger) (integrations.Integration, er
 	return New(logger, c)
 }
 
-// Integration implements the cadvisor integration
-type Integration struct {
-	c *Config
-	i *integrations.CollectorIntegration
-}
-
 // New creates a new cadvisor integration
 func New(logger log.Logger, c *Config) (integrations.Integration, error) {
 	c.logger = logger


### PR DESCRIPTION
#### PR Description
The current iteration of the cadvisor integration is not compatible with the way we're building `prometheus.exporter.*` components today.

The current code gets the HTTP handler for the metrics endpoint once at the start (after the exporter is created), and then calls to run the exporter itself.

https://github.com/grafana/agent/blob/363b169217812dec56dc1f2e9f27998fc7e07644/component/prometheus/exporter/exporter.go#L73-L80

The cadvisor integration behaves somewhat differently and updates its collectors within its custom `Run` method

https://github.com/grafana/agent/blob/363b169217812dec56dc1f2e9f27998fc7e07644/pkg/integrations/cadvisor/cadvisor.go#L148-L150


This means at the point where the component would fetch the handler, no collectors are registered and no metrics are available.

This PR serves to minimize the runner's responsibilities by only watching for the shutdown of the context to close the manager. As a tradeoff, it will spend some more time in the integration's initialization.

#### Which issue(s) this PR fixes
No issue filed. Updates https://github.com/grafana/agent/issues/3162

#### Notes to the Reviewer

I've diffed the metrics produced by the `cadvisor` integration on main and the current branch, and diffed them with a Python script created by @spartan0x117. As expected, there's no difference in the metrics being reported.


```
$ wc -l forked_metrics main_metrics
   2274 forked_metrics
   2274 main_metrics
   4548 total
$ python3 mischa.py
Found 1 keys not in main_metrics
Found 1 keys not in forked_metrics
Total: 2 keys not present both files
---------------------------------
Keys not in first file:
cadvisor_build_info{branch="refactor-cadvisor-integration",goarch="amd64",goos="linux",goversion="go1.21.1",revision="97ea39a0b",tags="unknown",version="refactor-cadvisor-integration-97ea39a"}
---------------------------------
Keys not in second file:
cadvisor_build_info{branch="main",goarch="amd64",goos="linux",goversion="go1.21.1",revision="363b16921",tags="unknown",version="main-363b169"}
```

I haven't performed more extensive testing, but the behavior should not be changing here.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated (N/A)
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
