### PR TITLE
Correct link errors, 404s, and incorrect syntax in Agent documentation

### DIFF
--- a/docs/sources/flow/concepts/clustering.md
+++ b/docs/sources/flow/concepts/clustering.md
@@ -7,7 +7,7 @@ canonical: https://grafana.com/docs/agent/latest/flow/concepts/clustering/
 labels:
   stage: beta
 menuTitle: Clustering
-title: Grafana Agent clustering concepts
+title: Clustering (beta)
 description: Learn about Grafana Agent clustering concepts
 weight: 500
 ---

--- a/docs/sources/flow/concepts/configuration_language.md
+++ b/docs/sources/flow/concepts/configuration_language.md
@@ -104,4 +104,4 @@ This file has two blocks:
 River is documented in detail in [Configuration language][config-docs] section
 of the Grafana Agent Flow docs.
 
-[config-docs]: {{< relref "../config-language/" >}}
+[config-docs]: {{< relref "../config-language" >}}

--- a/docs/sources/flow/config-language/expressions/function_calls.md
+++ b/docs/sources/flow/config-language/expressions/function_calls.md
@@ -10,7 +10,7 @@ description: Learn about function calls
 weight: 400
 ---
 
-# Function Calls
+# Function calls
 Function calls is one more River feature that lets users build richer
 expressions.
 
@@ -31,4 +31,4 @@ env("HOME")
 json_decode(local.file.cfg.contents)["namespace"]
 ```
 
-[standard library]: {{< relref "../../reference/stdlib/_index.md" >}}
+[standard library]: {{< relref "../../reference/stdlib" >}}

--- a/docs/sources/flow/config-language/expressions/types_and_values.md
+++ b/docs/sources/flow/config-language/expressions/types_and_values.md
@@ -45,7 +45,7 @@ the following conventions for referring to types:
   descending units can be combined to add their values together; `"1h30m"` is
   the same as `"90m"`.
 
-[component reference]: {{< relref "../../reference/components/" >}}
+[component reference]: {{< relref "../../reference/components" >}}
 
 ## Numbers
 

--- a/docs/sources/flow/config-language/syntax.md
+++ b/docs/sources/flow/config-language/syntax.md
@@ -45,7 +45,7 @@ The following example sets the `log_level` attribute to `"debug"`.
 log_level = "debug"
 ```
 
-The `ATTRIBUTE_NAME` must be a valid River [identifier](#identifier).
+The `ATTRIBUTE_NAME` must be a valid River [identifier](#identifiers).
 
 The `ATTRIBUTE_VALUE` can be either a constant value of a valid River
 [type]({{< relref "./expressions/types_and_values.md" >}}) (eg. string,

--- a/docs/sources/flow/getting-started/configure-agent-clustering.md
+++ b/docs/sources/flow/getting-started/configure-agent-clustering.md
@@ -10,7 +10,7 @@ description: Learn how to configure Grafana Agent clustering in an existing inst
 weight: 400
 ---
 
-# Configure Grafana Agent clustering
+# Configure Grafana Agent clustering in an existing installation
 
 You can configure Grafana Agent to run with [clustering][] so that
 individual agents can work together for workload distribution and high

--- a/docs/sources/flow/getting-started/distribute-prometheus-scrape-load.md
+++ b/docs/sources/flow/getting-started/distribute-prometheus-scrape-load.md
@@ -5,7 +5,7 @@ aliases:
 - /docs/grafana-cloud/monitor-infrastructure/integrations/agent/flow/getting-started/distribute-prometheus-scrape-load/
 canonical: https://grafana.com/docs/agent/latest/flow/getting-started/distribute-prometheus-scrape-load/
 menuTitle: Distribute Prometheus metrics scrape load
-title: Distribute your Prometheus metrics scrape load
+title: Distribute Prometheus metrics scrape load
 description: Learn how to distribute your Prometheus metrics scrape load
 weight: 500
 ---

--- a/docs/sources/flow/getting-started/migrating-from-prometheus.md
+++ b/docs/sources/flow/getting-started/migrating-from-prometheus.md
@@ -4,15 +4,13 @@ aliases:
 - /docs/grafana-cloud/monitor-infrastructure/agent/flow/getting-started/migrating-from-prometheus/
 - /docs/grafana-cloud/monitor-infrastructure/integrations/agent/flow/getting-started/migrating-from-prometheus/
 canonical: https://grafana.com/docs/agent/latest/flow/getting-started/migrating-from-prometheus/
-description: Learn how to migrate your configuration from Prometheus to Grafana Agent
-  flow mode
 menuTitle: Migrate from Prometheus
-title: Migrate from Prometheus to Grafana Agent flow mode
-description: Learn how to migrate from Prometheus to Grafana Agent flow mode
+title: Migrate from Prometheus to Grafana Agent Flow
+description: Learn how to migrate from Prometheus to Grafana Agent Flow
 weight: 320
 ---
 
-# Migrate from Prometheus to Grafana Agent
+# Migrate from Prometheus to Grafana Agent Flow
 
 The built-in Grafana Agent convert command can migrate your [Prometheus][] configuration to a Grafana Agent flow configuration.
 

--- a/docs/sources/flow/getting-started/migrating-from-promtail.md
+++ b/docs/sources/flow/getting-started/migrating-from-promtail.md
@@ -4,15 +4,13 @@ aliases:
 - /docs/grafana-cloud/monitor-infrastructure/agent/flow/getting-started/migrating-from-promtail/
 - /docs/grafana-cloud/monitor-infrastructure/integrations/agent/flow/getting-started/migrating-from-promtail/
 canonical: https://grafana.com/docs/agent/latest/flow/getting-started/migrating-from-promtail/
-description: Learn how to migrate your configuration from Promtail to Grafana Agent
-  Flow Mode
 menuTitle: Migrate from Promtail
-title: Migrate from Promtail to Grafana Agent Flow mode
-description: Learn how to migrate from Promtail to Grafana Agent Flow mode
+title: Migrate from Promtail to Grafana Agent Flow
+description: Learn how to migrate from Promtail to Grafana Agent Flow
 weight: 330
 ---
 
-# Migrate from Promtail to Grafana Agent
+# Migrate from Promtail to Grafana Agent Flow
 
 The built-in Grafana Agent convert command can migrate your [Promtail][]
 configuration to a Grafana Agent flow configuration.
@@ -22,7 +20,7 @@ This topic describes how to:
 * Convert a Promtail configuration to a Flow Mode configuration.
 * Run a Promtail configuration natively using Grafana Agent Flow Mode.
 
-[Promtail]: https://grafana.com/docs/loki/latest/clients/promtail/
+[Promtail]: /docs/loki/latest/clients/promtail/
 
 ## Components used in this topic
 
@@ -207,6 +205,6 @@ Furthermore, we recommend that you review the following checklist:
 * Note that the Agent exposes the [Grafana Agent Flow UI][], which differs
   from Promtail's Web UI.
 
-[expanded in the config file]: https://grafana.com/docs/loki/latest/clients/promtail/configuration/#use-environment-variables-in-the-configuration
+[expanded in the config file]: /docs/loki/latest/clients/promtail/configuration/#use-environment-variables-in-the-configuration
 
-[Grafana Agent Flow UI]: https://grafana.com/docs/agent/latest/flow/monitoring/debugging/#grafana-agent-flow-ui
+[Grafana Agent Flow UI]: /docs/agent/latest/flow/monitoring/debugging/#grafana-agent-flow-ui

--- a/docs/sources/flow/getting-started/opentelemetry-to-lgtm-stack.md
+++ b/docs/sources/flow/getting-started/opentelemetry-to-lgtm-stack.md
@@ -140,7 +140,7 @@ loki.write "grafana_cloud_loki" {
 }
 ```
 
-[Grafana Loki]: https://grafana.com/oss/loki/
+[Grafana Loki]: /oss/loki/
 
 ## Grafana Tempo
 

--- a/docs/sources/flow/monitoring/debugging.md
+++ b/docs/sources/flow/monitoring/debugging.md
@@ -35,9 +35,9 @@ server, which defaults to listening at `http://localhost:12345`.
 > learn how to change the HTTP listen address, and pass the appropriate flag
 > when running Grafana Agent Flow.
 >
-> [install]: {{< relref "../setup/install/" >}}
+> [install]: {{< relref "../setup/install" >}}
 
-[grafana-agent run]: {{< relref "../reference/cli/run.md" >}}
+[grafana-agent run]: {{< relref "../reference/cli/run" >}}
 
 ### Home page
 
@@ -131,5 +131,5 @@ down and set its state to Terminating, but it has not completely gone away. Chec
 the clustering page to view the state of the peers and verify that the
 terminating Agent has been shut down.
 
-[logging]: {{< relref "../reference/config-blocks/logging.md" >}}
-[clustering]: {{< relref "../concepts/clustering.md" >}}
+[logging]: {{< relref "../reference/config-blocks/logging" >}}
+[clustering]: {{< relref "../concepts/clustering" >}}

--- a/docs/sources/flow/reference/cli/_index.md
+++ b/docs/sources/flow/reference/cli/_index.md
@@ -7,12 +7,12 @@ canonical: https://grafana.com/docs/agent/latest/flow/reference/cli/
 description: The Grafana Agent command line interface provides subcommands to perform
   various operations.
 menuTitle: Command-line interface
-title: The Grafana Agent command line interface
+title: The Grafana Agent command-line interface
 description: Learn about the Grafana Agent command line interface
 weight: 100
 ---
 
-# Command-line interface
+# The Grafana Agent command-line interface
 
 When in Flow mode, the `grafana-agent` binary exposes a command-line interface with
 subcommands to perform various operations.

--- a/docs/sources/flow/reference/cli/convert.md
+++ b/docs/sources/flow/reference/cli/convert.md
@@ -83,10 +83,10 @@ in [errors].
 ### Promtail
 
 Using the `--source-format=promtail` will convert the source configuration from
-[Promtail v2.8.x](https://grafana.com/docs/loki/v2.8.x/clients/promtail/)
+[Promtail v2.8.x](/docs/loki/v2.8.x/clients/promtail/)
 to Grafana Agent Flow configuration.
 
-Nearly all [Promtail features](https://grafana.com/docs/loki/v2.8.x/clients/promtail/configuration/)
+Nearly all [Promtail features](/docs/loki/v2.8.x/clients/promtail/configuration/)
 are supported and can be converted to Grafana Agent Flow config.
 
 If you have unsupported features in a source configuration, you will receive [errors] when you convert to a flow configuration. The converter will

--- a/docs/sources/flow/reference/components/discovery.http.md
+++ b/docs/sources/flow/reference/components/discovery.http.md
@@ -28,7 +28,9 @@ Example response body:
 ]
 ```
 
-It is possible to use additional fields in the JSON to pass parameters to [prometheus.scrape](../prometheus.scrape#technical-details) such as the `metricsPath` and `scrape_interval`.
+It is possible to use additional fields in the JSON to pass parameters to [prometheus.scrape][] such as the `metricsPath` and `scrape_interval`.
+
+[prometheus.scrape]: {{< relref "./prometheus.scrape.md#technical-details" >}}
 
 As an example, the following will provide a target with a custom `metricsPath`, scrape interval, and timeout value:
 
@@ -73,7 +75,7 @@ For example, the following will call a metrics path of `/health?target_data=prom
 
 ```
 
-For more information on the potential labels you can use, see the [prometheus.scrape technical details](../prometheus.scrape#technical-details) section, or the [Prometheus Configuration](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) documentation.
+For more information on the potential labels you can use, see the [prometheus.scrape technical details][prometheus.scrape] section, or the [Prometheus Configuration](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) documentation.
 
 ## Usage
 

--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -881,7 +881,7 @@ embedded labels are removed from the original log entry:
 }
 ```
 
-At query time, Loki's [`unpack` parser](https://grafana.com/docs/loki/latest/logql/log_queries/#unpack)
+At query time, Loki's [`unpack` parser](/docs/loki/latest/logql/log_queries/#unpack)
 can be used to access these embedded labels and replace the log line with the
 original one stored in the `_entry` field automatically.
 

--- a/docs/sources/flow/reference/components/loki.source.api.md
+++ b/docs/sources/flow/reference/components/loki.source.api.md
@@ -38,7 +38,7 @@ The component will start HTTP server on the configured port and address with the
 - `/api/v1/raw` - internally reroutes to `/loki/api/v1/raw`
 
 
-[promtail-push-api]: https://grafana.com/docs/loki/latest/clients/promtail/configuration/#loki_push_api
+[promtail-push-api]: /docs/loki/latest/clients/promtail/configuration/#loki_push_api
 
 ## Arguments
 

--- a/docs/sources/flow/reference/components/loki.source.gcplog.md
+++ b/docs/sources/flow/reference/components/loki.source.gcplog.md
@@ -80,7 +80,7 @@ fields take their default values.
 | `use_full_line`          | `bool`        | Send the full line from Cloud Logging even if `textPayload` is available. | `false` | no       |
 
 To make use of the `pull` strategy, the GCP project must have been
-[configured](https://grafana.com/docs/loki/next/clients/promtail/gcplog-cloud/)
+[configured](/docs/loki/next/clients/promtail/gcplog-cloud/)
 to forward its cloud resource logs onto a Pub/Sub topic for
 `loki.source.gcplog` to consume.
 

--- a/docs/sources/flow/reference/components/otelcol.connector.servicegraph.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.servicegraph.md
@@ -39,7 +39,7 @@ Service graphs are useful for a number of use-cases:
 Since `otelcol.connector.servicegraph` has to process both sides of an edge,
 it needs to process all spans of a trace to function properly.
 If spans of a trace are spread out over multiple Agent instances, spans cannot be paired reliably.
-A solution to this problem is using [otelcol.exporter.loadbalancing]({{< relref "otelcol.exporter.loadbalancing.md" >}})
+A solution to this problem is using [otelcol.exporter.loadbalancing]({{< relref "./otelcol.exporter.loadbalancing.md" >}})
 in front of Agent instances running `otelcol.connector.servicegraph`.
 
 ## Usage

--- a/docs/sources/flow/reference/components/otelcol.connector.servicegraph.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.servicegraph.md
@@ -14,7 +14,7 @@ description: Learn about otelcol.connector.servicegraph
 outputs metrics representing the relationship between various services in a system.
 A metric represents an edge in the service graph.
 Those metrics can then be used by a data visualization application (e.g. 
-[Grafana](https://grafana.com/docs/grafana/latest/explore/trace-integration/#service-graph))
+[Grafana](/docs/grafana/latest/explore/trace-integration/#service-graph))
 to draw the service graph.
 
 > **NOTE**: `otelcol.connector.servicegraph` is a wrapper over the upstream
@@ -39,7 +39,7 @@ Service graphs are useful for a number of use-cases:
 Since `otelcol.connector.servicegraph` has to process both sides of an edge,
 it needs to process all spans of a trace to function properly.
 If spans of a trace are spread out over multiple Agent instances, spans cannot be paired reliably.
-A solution to this problem is using [otelcol.exporter.loadbalancing](../otelcol.exporter.loadbalancing/)
+A solution to this problem is using [otelcol.exporter.loadbalancing]({{< relref "otelcol.exporter.loadbalancing.md" >}})
 in front of Agent instances running `otelcol.connector.servicegraph`.
 
 ## Usage

--- a/docs/sources/flow/reference/components/otelcol.connector.spanlogs.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.spanlogs.md
@@ -16,7 +16,7 @@ This allows you to automatically build a mechanism for trace discovery.
 
 > **NOTE**: `otelcol.connector.spanlogs` is a custom component unrelated
 > to any components from the OpenTelemetry Collector. It is based on the
-> `automatic_logging` component in the [traces]({{< relref "../../../static/configuration/traces-config">}}) subsystem of the Agent static mode.
+> `automatic_logging` component in the [traces]({{< relref "../../../static/configuration/traces-config" >}}) subsystem of the Agent static mode.
 
 You can specify multiple `otelcol.connector.spanlogs` components by giving them
 different labels.

--- a/docs/sources/flow/reference/components/otelcol.connector.spanlogs.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.spanlogs.md
@@ -16,9 +16,7 @@ This allows you to automatically build a mechanism for trace discovery.
 
 > **NOTE**: `otelcol.connector.spanlogs` is a custom component unrelated
 > to any components from the OpenTelemetry Collector. It is based on the
-> `automatic_logging` component in the
-> [traces](../../../../static/configuration/traces-config/)
-> subsystem of the Agent static mode.
+> `automatic_logging` component in the [traces]({{< relref "../../../static/configuration/traces-config">}}) subsystem of the Agent static mode.
 
 You can specify multiple `otelcol.connector.spanlogs` components by giving them
 different labels.

--- a/docs/sources/flow/reference/components/otelcol.processor.attributes.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.attributes.md
@@ -167,8 +167,8 @@ The `exclude` block provides an option to exclude data from being fed into the [
 
 {{% admonition type="note" %}}
 Signals excluded by the `exclude` block will still be propagated to downstream components as-is.
-If you would like to not propagate certain signals to downstream components, 
-consider a processor such as [otelcol.processor.tail_sampling](../otelcol.processor.tail_sampling/).
+If you would like to not propagate certain signals to downstream components,
+consider a processor such as [otelcol.processor.tail_sampling]({{< relref "./otelcol.processor.tail_sampling.md" >}}).
 {{% /admonition %}}
 
 {{< docs/shared lookup="flow/reference/components/match-properties-block.md" source="agent" version="<AGENT VERSION>" >}}

--- a/docs/sources/flow/reference/components/prometheus.exporter.agent.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.agent.md
@@ -1,6 +1,6 @@
 ---
 canonical: https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.agent/
-title: prometheus.exporter.agen
+title: prometheus.exporter.agent
 description: Learn about prometheus.exporter.agen
 ---
 

--- a/docs/sources/flow/reference/components/prometheus.operator.probes.md
+++ b/docs/sources/flow/reference/components/prometheus.operator.probes.md
@@ -14,7 +14,7 @@ description: Learn about prometheus.operator.probes
 
 {{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT VERSION>" >}}
 
-`prometheus.operator.probes` discovers [Probe](https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.Probe) resources in your kubernetes cluster and scrapes the targets they reference. This component performs three main functions:
+`prometheus.operator.probes` discovers [Probe](https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.Probe) resources in your Kubernetes cluster and scrapes the targets they reference. This component performs three main functions:
 
 1. Discover Probe resources from your Kubernetes cluster.
 2. Discover targets or ingresses that match those Probes.
@@ -184,7 +184,7 @@ fully consistent like hashmod sharding is).
 If the agent is _not_ running in clustered mode, then the block is a no-op, and
 `prometheus.operator.probes` scrapes every target it receives in its arguments.
 
-[clustered mode]: {{< relref "../cli/run.md#clustered-mode-experimental" >}}
+[clustered mode]: {{< relref "../cli/run.md#clustering-beta" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/reference/components/pyroscope.write.md
+++ b/docs/sources/flow/reference/components/pyroscope.write.md
@@ -15,12 +15,12 @@ description: Learn about pyroscope.write
 {{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT VERSION>" >}}
 
 `pyroscope.write` receives performance profiles from other components and forwards them
-to a series of user-supplied endpoints using [Pyroscope' Push API](https://grafana.com/oss/pyroscope/).
+to a series of user-supplied endpoints using [Pyroscope' Push API](/oss/pyroscope/).
 
 Multiple `pyroscope.write` components can be specified by giving them
 different labels.
 
-## Usage
+## Usage for Grafana Agent flow mode
 
 ```river
 pyroscope.write "LABEL" {

--- a/docs/sources/flow/reference/config-blocks/argument.md
+++ b/docs/sources/flow/reference/config-blocks/argument.md
@@ -4,7 +4,8 @@ aliases:
 - /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/config-blocks/argument/
 - /docs/grafana-cloud/monitor-infrastructure/integrations/agent/flow/reference/config-blocks/argument/
 canonical: https://grafana.com/docs/agent/latest/flow/reference/config-blocks/argument/
-title: argument
+title: argument block
+menuTitle: argument
 description: Learn about the argument configuration block
 ---
 

--- a/docs/sources/flow/reference/config-blocks/export.md
+++ b/docs/sources/flow/reference/config-blocks/export.md
@@ -4,7 +4,8 @@ aliases:
 - /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/config-blocks/export/
 - /docs/grafana-cloud/monitor-infrastructure/integrations/agent/flow/reference/config-blocks/export/
 canonical: https://grafana.com/docs/agent/latest/flow/reference/config-blocks/export/
-title: export
+title: export block
+menuTitle: export
 description: Learn about the export configuration block
 ---
 

--- a/docs/sources/flow/reference/config-blocks/http.md
+++ b/docs/sources/flow/reference/config-blocks/http.md
@@ -4,7 +4,8 @@ aliases:
 - /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/config-blocks/http/
 - /docs/grafana-cloud/monitor-infrastructure/integrations/agent/flow/reference/config-blocks/http/
 canonical: https://grafana.com/docs/agent/latest/flow/reference/config-blocks/http/
-title: http
+title: http block
+menuTitle: http
 description: Learn about the http configuration block
 ---
 

--- a/docs/sources/flow/reference/config-blocks/logging.md
+++ b/docs/sources/flow/reference/config-blocks/logging.md
@@ -4,7 +4,8 @@ aliases:
 - /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/config-blocks/logging/
 - /docs/grafana-cloud/monitor-infrastructure/integrations/agent/flow/reference/config-blocks/logging/
 canonical: https://grafana.com/docs/agent/latest/flow/reference/config-blocks/logging/
-title: logging
+title: logging block
+menuTitle: logging
 description: Learn about the logging configuration block
 ---
 

--- a/docs/sources/flow/reference/config-blocks/tracing.md
+++ b/docs/sources/flow/reference/config-blocks/tracing.md
@@ -4,7 +4,8 @@ aliases:
 - /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/config-blocks/tracing/
 - /docs/grafana-cloud/monitor-infrastructure/integrations/agent/flow/reference/config-blocks/tracing/
 canonical: https://grafana.com/docs/agent/latest/flow/reference/config-blocks/tracing/
-title: tracing
+title: tracing block
+menuTitle: tracing
 description: Learn about the tracing configuration block
 ---
 

--- a/docs/sources/flow/reference/stdlib/to_lower.md
+++ b/docs/sources/flow/reference/stdlib/to_lower.md
@@ -9,7 +9,7 @@ title: to_lower
 description: Learn about to_lower
 ---
 
-# lower
+# to_lower
 
 `to_lower` converts all uppercase letters in a string to lowercase.
 

--- a/docs/sources/flow/reference/stdlib/to_upper.md
+++ b/docs/sources/flow/reference/stdlib/to_upper.md
@@ -9,7 +9,7 @@ title: to_upper
 description: Learn about to_upper
 ---
 
-# upper
+# to_upper
 
 `to_upper` converts all lowercase letters in a string to uppercase.
 

--- a/docs/sources/flow/release-notes.md
+++ b/docs/sources/flow/release-notes.md
@@ -7,11 +7,11 @@ aliases:
 canonical: https://grafana.com/docs/agent/latest/flow/release-notes/
 description: Release notes for Grafana Agent flow mode
 menuTitle: Release notes
-title: Release notes for Grafana Agentflow mode
+title: Release notes for Grafana Agent flow mode
 weight: 999
 ---
 
-# Release notes
+# Release notes for Grafana Agent flow mode
 
 The release notes provide information about deprecations and breaking changes in Grafana Agent flow mode.
 

--- a/docs/sources/flow/setup/configure/configure-macos.md
+++ b/docs/sources/flow/setup/configure/configure-macos.md
@@ -69,7 +69,7 @@ the [UI for debugging][UI].
 
 To expose the UI to other machines, complete the following steps:
 
-1. Follow [Configure the Grafana Agent service](#configure-the-grafana-agent-flow-service)
+1. Follow [Configure the Grafana Agent service](#configure-the-grafana-agent-service)
    to edit command line flags passed to Grafana Agent, including the
    following customizations:
 

--- a/docs/sources/flow/setup/install/binary.md
+++ b/docs/sources/flow/setup/install/binary.md
@@ -22,7 +22,7 @@ Grafana Agent is distributed as a standalone binary for the following operating 
 
 ## Download Grafana Agent
 
-To download the Grafana Agent as a standalone binary, perform the following steps.
+To download Grafana Agent as a standalone binary, perform the following steps.
 
 1. Navigate to the current Grafana Agent [release](https://github.com/grafana/agent/releases) page.
 
@@ -43,4 +43,4 @@ To download the Grafana Agent as a standalone binary, perform the following step
 ## Next steps
 
 * [Start Grafana Agent]({{< relref "../start-agent#standalone-binary" >}})
-* [Configure Grafana Agent]({{< relref "../configure/" >}})
+* [Configure Grafana Agent]({{< relref "../configure" >}})

--- a/docs/sources/flow/setup/install/docker.md
+++ b/docs/sources/flow/setup/install/docker.md
@@ -55,7 +55,7 @@ Refer to the documentation for [run][] for more information about the options av
 
 {{% admonition type="note" %}}
 Make sure you pass `--server.http.listen-addr=0.0.0.0:12345` as an argument as shown in the example above.
-If you don't pass this argument, the [debugging UI](../../../monitoring/debugging#grafana-agent-flow-ui) won't be available outside of the Docker container.
+If you don't pass this argument, the [debugging UI]({{< relref "../../monitoring/debugging#grafana-agent-flow-ui" >}}) won't be available outside of the Docker container.
 {{% /admonition %}}
 
 [run]: {{< relref "../../reference/cli/run.md" >}}
@@ -80,7 +80,7 @@ Refer to the documentation for [run][] for more information about the options av
 
 {{% admonition type="note" %}}
 Make sure you pass `--server.http.listen-addr=0.0.0.0:12345` as an argument as shown in the example above.
-If you don't pass this argument, the [debugging UI](../../../monitoring/debugging#grafana-agent-flow-ui) won't be available outside of the Docker container.
+If you don't pass this argument, the [debugging UI]({{< relref "../../monitoring/debugging#grafana-agent-flow-ui" >}}) won't be available outside of the Docker container.
 {{% /admonition %}}
 
 [run]: {{< relref "../../reference/cli/run.md" >}}

--- a/docs/sources/flow/setup/install/linux.md
+++ b/docs/sources/flow/setup/install/linux.md
@@ -7,7 +7,7 @@ aliases:
 canonical: https://grafana.com/docs/agent/latest/flow/setup/install/linux/
 description: Learn how to install Grafana Agent in flow mode on Linux
 menuTitle: Linux
-title: Install Grafana Agent in flow mode on Linux
+title: Install or uninstall Grafana Agent in flow mode on Linux
 weight: 300
 ---
 

--- a/docs/sources/flow/setup/start-agent.md
+++ b/docs/sources/flow/setup/start-agent.md
@@ -10,7 +10,7 @@ title: Start, restart, and stop Grafana Agent in flow mode
 weight: 800
 ---
 
-# Start Grafana Agent in flow mode
+# Start, restart, and stop Grafana Agent in flow mode
 
 You can start, restart, and stop Grafana Agent after it is installed.
 
@@ -80,7 +80,7 @@ brew services start grafana-agent-flow
 
 Grafana Agent automatically runs when the system starts.
 
-Optional: Verify that the service is running:
+(Optional) Verify that the service is running:
 
 ```shell
 brew services info grafana-agent-flow
@@ -107,7 +107,7 @@ brew services stop grafana-agent-flow
 By default, logs are written to `$(brew --prefix)/var/log/grafana-agent-flow.log` and
 `$(brew --prefix)/var/log/grafana-agent-flow.err.log`.
 
-If you followed [Configure the Grafana Agent service](../setup/configure/configure-macos#configure-the-grafana-agent-service)
+If you followed [Configure the Grafana Agent service]({{< relref "./configure/configure-macos#configure-the-grafana-agent-service" >}})
 and changed the path where logs are written, refer to your current copy of the Grafana Agent formula to locate your log files.
 
 ## Windows

--- a/docs/sources/flow/tutorials/chaining.md
+++ b/docs/sources/flow/tutorials/chaining.md
@@ -13,7 +13,7 @@ weight: 400
 
 # Chain Prometheus components
 
-This tutorial shows how to use [multiple-inputs.river](../assets/flow_configs/multiple-inputs.river) to send data to several different locations. This tutorial uses the same base as [Filtering metrics]({{< relref "filtering-metrics.md">}}). 
+This tutorial shows how to use [multiple-inputs.river](/docs/agent/latest/flow/tutorials/assets/flow_configs/multiple-inputs.river) to send data to several different locations. This tutorial uses the same base as [Filtering metrics]({{< relref "./filtering-metrics">}}).
 
 A new concept introduced in Flow is chaining components together in a composable pipeline. This promotes the reusability of components while offering flexibility. 
 
@@ -23,7 +23,11 @@ A new concept introduced in Flow is chaining components together in a composable
 
 ## Run the example
 
-Run the following `curl https://raw.githubusercontent.com/grafana/agent/main/docs/sources/flow/tutorials/assets/runt.sh -O && bash ./runt.sh multiple-inputs.river`.
+Run the following 
+
+```bash
+curl https://raw.githubusercontent.com/grafana/agent/main/docs/sources/flow/tutorials/assets/runt.sh -O && bash ./runt.sh multiple-inputs.river
+```
 
 The `runt.sh` script does:
 

--- a/docs/sources/flow/tutorials/chaining.md
+++ b/docs/sources/flow/tutorials/chaining.md
@@ -13,7 +13,7 @@ weight: 400
 
 # Chain Prometheus components
 
-This tutorial shows how to use [multiple-inputs.river](/docs/agent/latest/flow/tutorials/assets/flow_configs/multiple-inputs.river) to send data to several different locations. This tutorial uses the same base as [Filtering metrics]({{< relref "./filtering-metrics">}}).
+This tutorial shows how to use [multiple-inputs.river](/docs/agent/latest/flow/tutorials/assets/flow_configs/multiple-inputs.river) to send data to several different locations. This tutorial uses the same base as [Filtering metrics]({{< relref "./filtering-metrics" >}}).
 
 A new concept introduced in Flow is chaining components together in a composable pipeline. This promotes the reusability of components while offering flexibility. 
 

--- a/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
+++ b/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
@@ -21,11 +21,15 @@ Grafana Agent is a telemetry collector with the primary goal of moving telemetry
 
 ## Run the example
 
-Run the following `curl https://raw.githubusercontent.com/grafana/agent/main/docs/sources/flow/tutorials/assets/runt.sh -O && bash ./runt.sh agent.river`.
+Run the following command in a terminal window:
+
+```bash
+curl https://raw.githubusercontent.com/grafana/agent/main/docs/sources/flow/tutorials/assets/runt.sh -O && bash ./runt.sh agent.river
+```
 
 The `runt.sh` script does:
 
-1. Downloads the configs necessary for Mimir, Grafana and the Grafana Agent.
+1. Downloads the configs necessary for Mimir, Grafana and Grafana Agent.
 2. Downloads the docker image for Grafana Agent explicitly.
 3. Runs the docker-compose up command to bring all the services up.
 
@@ -64,9 +68,9 @@ prometheus.scrape "default" {
 
 The `prometheus.scrape "default"` annotation indicates the name of the component, `prometheus.scrape`, and its label, `default`. All components must have a unique combination of name and if applicable label.
 
-The `targets` [attribute]({{< relref "../concepts/configuration_language/#attributes" >}}) is an [argument]({{< relref "../concepts/components.md">}}). `targets` is a list of labels that specify the target via the special key `__address__`. The scraper is targeting the Agent's `/metrics` endpoint. Both `http` and `/metrics` are implied but can be overridden.
+The `targets` [attribute]({{< relref "../concepts/configuration_language#attributes" >}}) is an [argument]({{< relref "../concepts/components" >}}). `targets` is a list of labels that specify the target via the special key `__address__`. The scraper is targeting the Agent's `/metrics` endpoint. Both `http` and `/metrics` are implied but can be overridden.
 
-The `forward_to` attribute is an argument that references the [export]({{< relref "../concepts/components.md">}}) of the `prometheus.remote_write.prom` component. This is where the scraper will send the metrics for further processing.
+The `forward_to` attribute is an argument that references the [export]({{< relref "../concepts/components" >}}) of the `prometheus.remote_write.prom` component. This is where the scraper will send the metrics for further processing.
 
 ## Remote Write component
 

--- a/docs/sources/flow/tutorials/filtering-metrics.md
+++ b/docs/sources/flow/tutorials/filtering-metrics.md
@@ -13,7 +13,7 @@ weight: 300
 
 # Filter Prometheus metrics
 
-In this tutorial, you'll add a new component [prometheus.relabel]({{< ref "../reference/components/prometheus.relabel.md" >}}) using [relabel.river](../assets/flow_configs/relabel.river) to filter metrics. This tutorial uses the same base as [Collecting Prometheus metrics]({{< relref "./collecting-prometheus-metrics.md">}}).
+In this tutorial, you'll add a new component [prometheus.relabel]({{< relref "../reference/components/prometheus.relabel.md" >}}) using [relabel.river](/docs/agent/latest/flow/tutorials/assets/flow_configs/relabel.river) to filter metrics. This tutorial uses the same base as [Collecting Prometheus metrics]({{< relref "./collecting-prometheus-metrics.md" >}}).
 
 ## Prerequisites
 
@@ -21,16 +21,22 @@ In this tutorial, you'll add a new component [prometheus.relabel]({{< ref "../re
 
 ## Run the example
 
-The `prometheus.relabel` component is used to drop, add, or filter metrics.  Run the following: `curl https://raw.githubusercontent.com/grafana/agent/main/docs/sources/flow/tutorials/assets/runt.sh -O && bash ./runt.sh relabel.river`.
+The `prometheus.relabel` component is used to drop, add, or filter metrics.
+
+Run the following:
+
+```bash
+curl https://raw.githubusercontent.com/grafana/agent/main/docs/sources/flow/tutorials/assets/runt.sh -O && bash ./runt.sh relabel.river
+```
 
 The `runt.sh` script does:
 
-1. Downloads the configs necessary for Mimir, Grafana and the Grafana Agent. 
+1. Downloads the configs necessary for Mimir, Grafana and Grafana Agent. 
 2. Downloads the docker image for Grafana Agent explicitly.
 3. Runs the docker-compose up command to bring all the services up.
 
 
-Allow the Grafana Agent to run for two minutes, then navigate to [Grafana](http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Mimir%22,%7B%22refId%22:%22A%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22agent_build_info%7B%7D%22%7D%5D) page and the `service` label will be there with the `api_server` value.
+Allow Grafana Agent to run for two minutes, then navigate to [Grafana](http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Mimir%22,%7B%22refId%22:%22A%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22agent_build_info%7B%7D%22%7D%5D) page and the `service` label will be there with the `api_server` value.
 
 ![Dashboard showing api_server](/media/docs/agent/screenshot-grafana-agent-filtering-metrics-filter.png)
 

--- a/docs/sources/operator/_index.md
+++ b/docs/sources/operator/_index.md
@@ -4,7 +4,8 @@ aliases:
 - /docs/grafana-cloud/monitor-infrastructure/agent/operator/
 - /docs/grafana-cloud/monitor-infrastructure/integrations/agent/operator/
 canonical: https://grafana.com/docs/agent/latest/operator/
-title: Static mode Kubernetes operator
+title: Static mode Kubernetes operator (Beta)
+menuTitle: Static mode Kubernetes operator
 description: Learn about the static mode Kubernetes operator
 weight: 300
 ---
@@ -35,7 +36,7 @@ If you are shipping your data to Grafana Cloud, use [Kubernetes Monitoring](/doc
 Kubernetes Monitoring provides a simplified approach and preconfigured dashboards and alerts.
 {{% /admonition %}}
 
-Grafana Agent Operator uses additonal custom resources to manage the deployment
+Grafana Agent Operator uses additional custom resources to manage the deployment
 and configuration of Grafana Agents running in static mode. In addition to the
 supported custom resources, you can also provide your own Service Discovery
 (SD) configurations to collect metrics from other types of sources.
@@ -50,11 +51,11 @@ The following sections describe how to use Grafana Agent Operator:
 | Topic | Describes |
 |---|---|
 | [Configure Kubernetes Monitoring using Agent Operator](/docs/grafana-cloud/monitor-infrastructure/kubernetes-monitoring/configuration/configure-infrastructure-manually/k8s-agent-operator/) | Use the Kubernetes Monitoring solution to set up monitoring of your Kubernetes cluster and to install preconfigured dashboards and alerts. |
-| [Install Grafana Agent Operator with Helm]({{< relref "./helm-getting-started/" >}}) | How to deploy the Grafana Agent Operator into your Kubernetes cluster using the grafana-agent-operator Helm chart. |
-| [Install Grafana Agent Operator]({{< relref "./getting-started/" >}}) | How to deploy the Grafana Agent Operator into your Kubernetes cluster without using Helm. |
-| [Deploy the Grafana Agent Operator resources]({{< relref "./deploy-agent-operator-resources/" >}}) | How to roll out the Grafana Agent Operator custom resources, needed to begin monitoring your cluster. Complete this procedure *after* installing Grafana Agent Operator&mdash;either with or without Helm. |
-| [Grafana Agent Operator architecture]({{< relref "./architecture/" >}}) | Learn about the resources used by Agent Operator to collect telemetry data and how it discovers the hierarchy of custom resources, continually reconciling the hierarchy.  |
-| [Set up Agent Operator integrations]({{< relref "./operator-integrations/" >}}) | Learn how to set up node-exporter and mysqld-exporter integrations. |
+| [Install Grafana Agent Operator with Helm]({{< relref "./helm-getting-started" >}}) | How to deploy the Grafana Agent Operator into your Kubernetes cluster using the grafana-agent-operator Helm chart. |
+| [Install Grafana Agent Operator]({{< relref "./getting-started" >}}) | How to deploy the Grafana Agent Operator into your Kubernetes cluster without using Helm. |
+| [Deploy the Grafana Agent Operator resources]({{< relref "./deploy-agent-operator-resources" >}}) | How to roll out the Grafana Agent Operator custom resources, needed to begin monitoring your cluster. Complete this procedure *after* installing Grafana Agent Operator&mdash;either with or without Helm. |
+| [Grafana Agent Operator architecture]({{< relref "./architecture" >}}) | Learn about the resources used by Agent Operator to collect telemetry data and how it discovers the hierarchy of custom resources, continually reconciling the hierarchy.  |
+| [Set up Agent Operator integrations]({{< relref "./operator-integrations" >}}) | Learn how to set up node-exporter and mysqld-exporter integrations. |
 
 [Kubernetes operator]: https://www.cncf.io/blog/2022/06/15/kubernetes-operators-what-are-they-some-examples/
 [static mode]: {{< relref "../static/" >}}

--- a/docs/sources/operator/architecture.md
+++ b/docs/sources/operator/architecture.md
@@ -119,7 +119,7 @@ The sharding mechanism is borrowed from the Prometheus Operator.
 
 The number of replicas can be defined, similarly to the number of shards. This
 creates deduplicate shards. This must be paired with a `remote_write` system that
-can perform HA deduplication. [Grafana Cloud](https://grafana.com/docs/grafana-cloud/) and [Mimir](https://grafana.com/docs/mimir/latest/) provide this out of the
+can perform HA deduplication. [Grafana Cloud](/docs/grafana-cloud/) and [Mimir](/docs/mimir/latest/) provide this out of the
 box, and the Grafana Agent Operator defaults support these two systems.
 
 The total number of created metrics pods will be the product of `numShards *

--- a/docs/sources/operator/deploy-agent-operator-resources.md
+++ b/docs/sources/operator/deploy-agent-operator-resources.md
@@ -13,8 +13,8 @@ weight: 120
 
 To start collecting telemetry data, you need to roll out Grafana Agent Operator custom resources into your Kubernetes cluster. Before you can create the custom resources, you must first apply the Agent Custom Resource Definitions (CRDs) and install Agent Operator, with or without Helm. If you haven't yet taken these steps, follow the instructions in one of the following topics:
 
-- [Install Agent Operator]({{< relref "./getting-started/" >}})
-- [Install Agent Operator with Helm]({{< relref "./helm-getting-started/" >}})
+- [Install Agent Operator]({{< relref "./getting-started" >}})
+- [Install Agent Operator with Helm]({{< relref "./helm-getting-started" >}})
 
 Follow the steps in this guide to roll out the Grafana Agent Operator custom resources to:
 
@@ -31,7 +31,7 @@ The hierarchy of custom resources is as follows:
   - `LogsInstance`
     - `PodLogs`
 
-To learn more about the custom resources Agent Operator provides and their hierarchy, see [Grafana Agent Operator architecture]({{< relref "./architecture/" >}}).
+To learn more about the custom resources Agent Operator provides and their hierarchy, see [Grafana Agent Operator architecture]({{< relref "./architecture" >}}).
 
 {{% admonition type="note" %}}
 Agent Operator is currently in [beta]({{< relref "../stability.md#beta" >}}) and its custom resources are subject to change.
@@ -39,11 +39,11 @@ Agent Operator is currently in [beta]({{< relref "../stability.md#beta" >}}) and
 
 ## Before you begin
 
-Before you begin, make sure that you have deployed the Grafana Agent Operator CRDs and installed Agent Operator into your cluster. See [Install Grafana Agent Operator with Helm]({{< relref "./helm-getting-started.md" >}}) or [Install Grafana Agent Operator]({{< relref "./getting-started.md" >}}) for instructions.
+Before you begin, make sure that you have deployed the Grafana Agent Operator CRDs and installed Agent Operator into your cluster. See [Install Grafana Agent Operator with Helm]({{< relref "./helm-getting-started" >}}) or [Install Grafana Agent Operator]({{< relref "./getting-started" >}}) for instructions.
 
 ## Deploy the GrafanaAgent resource
 
-In this section, you'll roll out a `GrafanaAgent` resource. See [Grafana Agent Operator architecture]({{< relref "./architecture.md" >}}) for a discussion of the resources in the `GrafanaAgent` resource hierarchy.
+In this section, you'll roll out a `GrafanaAgent` resource. See [Grafana Agent Operator architecture]({{< relref "./architecture" >}}) for a discussion of the resources in the `GrafanaAgent` resource hierarchy.
 
 {{% admonition type="note" %}}
 Due to the variety of possible deployment architectures, the official Agent Operator Helm chart does not provide built-in templates for the custom resources described in this guide. You must configure and deploy these manually as described in this section. We recommend templating and adding the following manifests to your own in-house Helm charts and GitOps flows.
@@ -230,7 +230,7 @@ To deploy a `MetricsInstance` resource:
       password: 'your_cloud_prometheus_API_key'
     ```
 
-If you're using Grafana Cloud, you can find your hosted Loki endpoint username and password by clicking **Details** on the Loki tile on the [Grafana Cloud Portal](https://grafana.com/profile/org). If you want to base64-encode these values yourself, use `data` instead of `stringData`.
+If you're using Grafana Cloud, you can find your hosted Loki endpoint username and password by clicking **Details** on the Loki tile on the [Grafana Cloud Portal](/profile/org). If you want to base64-encode these values yourself, use `data` instead of `stringData`.
 
 Once you've rolled out the `MetricsInstance` and its Secret, you can confirm that the `MetricsInstance` Agent is up and running using `kubectl get pod`. Since you haven't defined any monitors yet, this Agent doesn't have any scrape targets defined. In the next section, you'll create scrape targets for the cAdvisor and kubelet endpoints exposed by the `kubelet` service in the cluster.
 
@@ -359,7 +359,7 @@ To deploy the `LogsInstance` resource into your cluster:
           instance: primary
     ```
 
-    This `LogsInstance` picks up `PodLogs` resources with the `instance: primary` label. Be sure to set the Loki URL to the correct push endpoint. For Grafana Cloud, this will look similar to `logs-prod-us-central1.grafana.net/loki/api/v1/push`, however check the [Grafana Cloud Portal](https://grafana.com/profile/org) to confirm by clicking **Details** on the Loki tile.
+    This `LogsInstance` picks up `PodLogs` resources with the `instance: primary` label. Be sure to set the Loki URL to the correct push endpoint. For Grafana Cloud, this will look similar to `logs-prod-us-central1.grafana.net/loki/api/v1/push`, however check the [Grafana Cloud Portal](/profile/org) to confirm by clicking **Details** on the Loki tile.
 
     Also note that this example uses the `agent: grafana-agent-logs` label, which associates this `LogsInstance` with the `GrafanaAgent` resource defined earlier. This means that it will inherit requests, limits, affinities and other properties defined in the `GrafanaAgent` custom resource.
 
@@ -376,7 +376,7 @@ To deploy the `LogsInstance` resource into your cluster:
       password: 'your_password_here'
     ```
 
-    If you're using Grafana Cloud, you can find your hosted Loki endpoint username and password by clicking **Details** on the Loki tile on the [Grafana Cloud Portal](https://grafana.com/profile/org). If you want to base64-encode these values yourself, use `data` instead of `stringData`.
+    If you're using Grafana Cloud, you can find your hosted Loki endpoint username and password by clicking **Details** on the Loki tile on the [Grafana Cloud Portal](/profile/org). If you want to base64-encode these values yourself, use `data` instead of `stringData`.
 
 1. Copy the following `PodLogs` manifest to a file, then roll it to your cluster using `kubectl apply -f` followed by the filename. The manifest defines your logging targets. Agent Operator  turns this into Agent configuration for the logs subsystem, and rolls it out to the DaemonSet of logging Agents.
 
@@ -413,7 +413,7 @@ To deploy the `LogsInstance` resource into your cluster:
     - `job` (set to `PodLogs_namespace/PodLogs_name`)
     - `__path__` (the path to log files, set to `/var/log/pods/*$1/*.log` where `$1` is `__meta_kubernetes_pod_uid/__meta_kubernetes_pod_container_name`)
 
-    To learn more about this configuration format and other available labels, see the [Promtail Scraping](https://grafana.com/docs/loki/latest/clients/promtail/scraping/#promtail-scraping-service-discovery) documentation. Agent Operator loads this configuration into the `LogsInstance` agents automatically.
+    To learn more about this configuration format and other available labels, see the [Promtail Scraping](/docs/loki/latest/clients/promtail/scraping/#promtail-scraping-service-discovery) documentation. Agent Operator loads this configuration into the `LogsInstance` agents automatically.
 
 The DaemonSet of logging agents should be tailing your container logs, applying  default labels to the log lines, and shipping them to your remote Loki endpoint.
 

--- a/docs/sources/operator/getting-started.md
+++ b/docs/sources/operator/getting-started.md
@@ -13,7 +13,7 @@ weight: 110
 
 In this guide, you'll learn how to deploy [Grafana Agent Operator]({{< relref "./_index.md" >}}) into your Kubernetes cluster. This guide does not use Helm. To learn how to deploy Agent Operator using the [grafana-agent-operator Helm chart](https://github.com/grafana/helm-charts/tree/main/charts/agent-operator), see [Install Grafana Agent Operator with Helm]({{< relref "./helm-getting-started.md" >}}).
 
-> **Note**: If you are shipping your data to Grafana Cloud, use [Kubernetes Monitoring](https://grafana.com/docs/grafana-cloud/kubernetes-monitoring/) to set up Agent Operator. Kubernetes Monitoring provides a simplified approach and preconfigured dashboards and alerts.
+> **Note**: If you are shipping your data to Grafana Cloud, use [Kubernetes Monitoring](/docs/grafana-cloud/kubernetes-monitoring/) to set up Agent Operator. Kubernetes Monitoring provides a simplified approach and preconfigured dashboards and alerts.
 ## Before you begin
 
 To deploy Agent Operator, make sure that you have the following:
@@ -31,7 +31,7 @@ you need to deploy the
 to the cluster. These definitions describe the schema that the custom
 resources will conform to. This is also required for Grafana Agent Operator to run; it
 will fail if it can't find the Custom Resource Definitions of objects it is
-looking to use. To learn more about the custom resources Agent Operator provides and their hierarchy, see [Grafana Agent Operator architecture]({{< relref "./architecture/" >}}).
+looking to use. To learn more about the custom resources Agent Operator provides and their hierarchy, see [Grafana Agent Operator architecture]({{< relref "./architecture" >}}).
 
 You can find the set of Custom Resource Definitions for Grafana Agent Operator in the Grafana Agent repository under
 [production/operator/crds](https://github.com/grafana/agent/tree/main/production/operator/crds).
@@ -152,4 +152,4 @@ To install Agent Operator:
 
 ## Deploy the Grafana Agent Operator resources
 
-Agent Operator is now up and running. Next, you need to install a Grafana Agent for Agent Operator to run for you. To do so, follow the instructions in the [Deploy the Grafana Agent Operator resources]({{< relref "./deploy-agent-operator-resources.md" >}}) topic.
+Agent Operator is now up and running. Next, you need to install a Grafana Agent for Agent Operator to run for you. To do so, follow the instructions in the [Deploy the Grafana Agent Operator resources]({{< relref "./deploy-agent-operator-resources" >}}) topic.

--- a/docs/sources/operator/helm-getting-started.md
+++ b/docs/sources/operator/helm-getting-started.md
@@ -12,7 +12,7 @@ weight: 100
 
 In this guide, you'll learn how to deploy [Grafana Agent Operator]({{< relref "./_index.md" >}}) into your Kubernetes cluster using the [grafana-agent-operator Helm chart](https://github.com/grafana/helm-charts/tree/main/charts/agent-operator). To learn how to deploy Agent Operator without using Helm, see [Install Grafana Agent Operator]({{< relref "./getting-started.md" >}}).
 
-> **Note**: If you are shipping your data to Grafana Cloud, use [Kubernetes Monitoring](https://grafana.com/docs/grafana-cloud/kubernetes-monitoring/) to set up Agent Operator. Kubernetes Monitoring provides a simplified approach and preconfigured dashboards and alerts.
+> **Note**: If you are shipping your data to Grafana Cloud, use [Kubernetes Monitoring](/docs/grafana-cloud/kubernetes-monitoring/) to set up Agent Operator. Kubernetes Monitoring provides a simplified approach and preconfigured dashboards and alerts.
 
 ## Before you begin
 
@@ -54,7 +54,7 @@ To install the Agent Operator Helm chart:
     ```bash
     helm install my-release grafana/grafana-agent-operator -f values.yaml -n my-namespace
     ```
-    You can find a list of configurable template parameters in the [Helm chart repository](https://github.com/grafana/helm-charts/blob/main/charts/agent-operator/values.yaml).
+    You can find a list of configurable template parameters in the [Helm chart repository](/grafana/helm-charts/blob/main/charts/agent-operator/values.yaml).
 
 1. Once you've successfully deployed the Helm release, confirm that Agent Operator is up and running:
 
@@ -67,4 +67,4 @@ To install the Agent Operator Helm chart:
 
 ## Deploy the Grafana Agent Operator resources
 
- Agent Operator is now up and running. Next, you need to install a Grafana Agent for Agent Operator to run for you. To do so, follow the instructions in the [Deploy the Grafana Agent Operator resources]({{< relref "./deploy-agent-operator-resources.md" >}}) topic. To learn more about the custom resources Agent Operator provides and their hierarchy, see [Grafana Agent Operator architecture]({{< relref "./architecture/" >}}).
+ Agent Operator is now up and running. Next, you need to install a Grafana Agent for Agent Operator to run for you. To do so, follow the instructions in the [Deploy the Grafana Agent Operator resources]({{< relref "./deploy-agent-operator-resources.md" >}}) topic. To learn more about the custom resources Agent Operator provides and their hierarchy, see [Grafana Agent Operator architecture]({{< relref "./architecture" >}}).

--- a/docs/sources/shared/index.md
+++ b/docs/sources/shared/index.md
@@ -1,5 +1,4 @@
 ---
-aliases: null
 canonical: https://grafana.com/docs/agent/latest/shared/
 headless: true
 description: Shared content

--- a/docs/sources/static/api/_index.md
+++ b/docs/sources/static/api/_index.md
@@ -2,7 +2,7 @@
 aliases:
 - ../api/
 canonical: https://grafana.com/docs/agent/latest/static/api/
-title: Static mode API (Stable)
+title: Static mode APIs (Stable)
 menuTitle: Static mode API
 description: Learn about the Grafana Agent static mode API
 weight: 400

--- a/docs/sources/static/api/_index.md
+++ b/docs/sources/static/api/_index.md
@@ -2,7 +2,8 @@
 aliases:
 - ../api/
 canonical: https://grafana.com/docs/agent/latest/static/api/
-title: Static mode API
+title: Static mode API (Stable)
+menuTitle: Static mode API
 description: Learn about the Grafana Agent static mode API
 weight: 400
 ---
@@ -11,7 +12,7 @@ weight: 400
 
 The API for static mode is divided into several parts:
 
-- [Config Management API](#config-management-api)
+- [Config Management API](#config-management-api-beta)
 - [Agent API](#agent-api)
 - [Integrations API](#integrations-api-experimental)
 - [Ready/Healthy API](#ready--health-api)
@@ -459,7 +460,7 @@ GET /agent/api/v1/metrics/integrations/targets
 ```
 
 This endpoint returns all integrations for which autoscrape is enabled. The
-response is identical to [`/agent/api/v1/metrics/targets`](#list-current-scrape-targets).
+response is identical to [`/agent/api/v1/metrics/targets`](#list-current-scrape-targets-of-logs-subsystem).
 
 Status code: 200 on success.
 Response on success:

--- a/docs/sources/static/configuration/agent-management.md
+++ b/docs/sources/static/configuration/agent-management.md
@@ -89,7 +89,7 @@ snippets:
 
 ### grafana_agent_config
 
-This is a standard Grafana Agent [static mode configuration](https://grafana.com/docs/agent/latest/static/configuration/). Typically used to configure the server, remote_writes, and other global configuration.
+This is a standard Grafana Agent [static mode configuration](/docs/agent/latest/static/configuration/). Typically used to configure the server, remote_writes, and other global configuration.
 
 ### snippet_content
 
@@ -112,8 +112,8 @@ selector:
 > **Note:** More information on the following types can be found in their respective documentation pages:
 >
 > * [`scrape_config`](https://prometheus.io/docs/prometheus/2.45/configuration/configuration/#scrape_config)
-> * [`promtail.scrape_config`](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#scrape_configs)
-> * [`integrations_config`](https://grafana.com/docs/agent/latest/static/configuration/integrations)
+> * [`promtail.scrape_config`](/docs/loki/latest/clients/promtail/configuration/#scrape_configs)
+> * [`integrations_config`](/docs/agent/latest/static/configuration/integrations)
 
 > **Note:** Snippet selection is currently done in the API server. This behaviour is subject to change in the future.
 

--- a/docs/sources/static/configuration/integrations/gcp-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/gcp-exporter-config.md
@@ -141,7 +141,7 @@ Since the exporter gathers all of its data from [GCP monitoring APIs](https://cl
 
 ## Configuration Examples
 
-The following examples show working configurations. See the [Configuration Reference](#config-reference) for a full
+The following examples show working configurations. See the [Configuration Reference](#configuration-reference) for a full
 overview of the configuration options and what they do.
 
 ### Multiple prefixes

--- a/docs/sources/static/configuration/integrations/integrations-next/_index.md
+++ b/docs/sources/static/configuration/integrations/integrations-next/_index.md
@@ -2,7 +2,8 @@
 aliases:
 - ../../../configuration/integrations/integrations-next/
 canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/integrations-next/
-title: Integrations next
+title: Integrations next (Experimental)
+menuTitle: Integrations next
 description: Learn about integrations next
 weight: 100
 ---

--- a/docs/sources/static/configuration/integrations/integrations-next/eventhandler-config.md
+++ b/docs/sources/static/configuration/integrations/integrations-next/eventhandler-config.md
@@ -35,7 +35,7 @@ This integration uses Grafana Agent's embedded Loki-compatible `logs` subsystem
 to ship entries, and a logs client and sink must be configured to use the
 integration. Please see the sample Agent config below for an example
 configuration.
-[Pipelines](https://grafana.com/docs/loki/latest/clients/promtail/pipelines/)
+[Pipelines](/docs/loki/latest/clients/promtail/pipelines/)
 and relabel configuration are not yet supported, but these features will be
 added soon. You should use the `job=eventhandler cluster=...` labels to query
 your events (you can then use LogQL on top of the result set).

--- a/docs/sources/static/configuration/integrations/integrations-next/snmp-config.md
+++ b/docs/sources/static/configuration/integrations/integrations-next/snmp-config.md
@@ -2,8 +2,8 @@
 aliases:
 - ../../../../configuration/integrations/integrations-next/snmp-config/
 canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/integrations-next/snmp-config/
-title: snmp_exporter_config next
-description: Learn about snmp_exporter_config next
+title: snmp_config next
+description: Learn about snmp_config next
 ---
 
 # snmp config next

--- a/docs/sources/static/configuration/integrations/integrations-next/snmp-config.md
+++ b/docs/sources/static/configuration/integrations/integrations-next/snmp-config.md
@@ -2,8 +2,8 @@
 aliases:
 - ../../../../configuration/integrations/integrations-next/snmp-config/
 canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/integrations-next/snmp-config/
-title: snmp_config next
-description: Learn about snmp_config next
+title: snmp config next
+description: Learn about snmp config next
 ---
 
 # snmp config next

--- a/docs/sources/static/configuration/integrations/integrations-next/vsphere-config.md
+++ b/docs/sources/static/configuration/integrations/integrations-next/vsphere-config.md
@@ -2,7 +2,8 @@
 aliases:
 - ../../../../configuration/integrations/integrations-next/vsphere-config/
 canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/integrations-next/vsphere-config/
-title: vsphere_config next
+title: vsphere config (beta) next
+menuTitle: vsphere_config next
 description: Learn about vsphere_config next
 ---
 

--- a/docs/sources/static/configuration/integrations/snmp-config.md
+++ b/docs/sources/static/configuration/integrations/snmp-config.md
@@ -2,8 +2,8 @@
 aliases:
 - ../../../configuration/integrations/snmp-config/
 canonical: https://grafana.com/docs/agent/latest/static/configuration/integrations/snmp-config/
-title: snmp_exporter_config
-description: Learn about snmp_exporter_config
+title: snmp config
+description: Learn about snmp config
 ---
 
 # snmp config

--- a/docs/sources/static/configuration/logs-config.md
+++ b/docs/sources/static/configuration/logs-config.md
@@ -16,7 +16,7 @@ configured, except deprecated fields have been removed and the server_config is
 not supported.
 
 Refer to the
-[Promtail documentation](docs/loki/latest/clients/promtail/configuration/#clients)
+[Promtail documentation](/docs/loki/latest/clients/promtail/configuration/#clients)
 for the supported values for these fields.
 
 ```yaml

--- a/docs/sources/static/configuration/logs-config.md
+++ b/docs/sources/static/configuration/logs-config.md
@@ -16,7 +16,7 @@ configured, except deprecated fields have been removed and the server_config is
 not supported.
 
 Refer to the
-[Promtail documentation](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#clients)
+[Promtail documentation](docs/loki/latest/clients/promtail/configuration/#clients)
 for the supported values for these fields.
 
 ```yaml
@@ -54,7 +54,7 @@ clients:
 > **Note:** More information on the following types can be found on the
 > documentation for Promtail:
 >
-> * [`promtail.client_config`](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#clients)
+> * [`promtail.client_config`](/docs/loki/latest/clients/promtail/configuration/#clients)
 
 
 ## file_watch_config
@@ -108,10 +108,10 @@ scrape_configs:
 > **Note:** More information on the following types can be found on the
 > documentation for Promtail:
 >
-> * [`promtail.client_config`](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#clients)
-> * [`promtail.scrape_config`](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#scrape_configs)
-> * [`promtail.target_config`](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#target_config)
-> * [`promtail.limits_config`](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#limits_config)
+> * [`promtail.client_config`](/docs/loki/latest/clients/promtail/configuration/#clients)
+> * [`promtail.scrape_config`](/docs/loki/latest/clients/promtail/configuration/#scrape_configs)
+> * [`promtail.target_config`](/docs/loki/latest/clients/promtail/configuration/#target_config)
+> * [`promtail.limits_config`](/docs/loki/latest/clients/promtail/configuration/#limits_config)
 
 > **Note:** Backticks in values are not supported.
 

--- a/docs/sources/static/operation-guide/_index.md
+++ b/docs/sources/static/operation-guide/_index.md
@@ -9,13 +9,13 @@ weight: 700
 
 # Operation guide
 
-This guide helps you operate the Grafana Agent.
+This guide helps you operate Grafana Agent.
 
 ## Horizontal Scaling
 
 There are three options to horizontally scale your deployment of Grafana Agents:
 
-- [Host filtering](#host-filtering) requires you to run one Agent on every
+- [Host filtering](#host-filtering-beta) requires you to run one Agent on every
   machine you wish to collect metrics from. Agents will only collect metrics
   from the machines they run on.
 - [Hashmod sharding](#hashmod-sharding) allows you to roughly shard the

--- a/docs/sources/static/operation-guide/_index.md
+++ b/docs/sources/static/operation-guide/_index.md
@@ -18,7 +18,7 @@ There are three options to horizontally scale your deployment of Grafana Agents:
 - [Host filtering](#host-filtering-beta) requires you to run one Agent on every
   machine you wish to collect metrics from. Agents will only collect metrics
   from the machines they run on.
-- [Hashmod sharding](#hashmod-sharding) allows you to roughly shard the
+- [Hashmod sharding](#hashmod-sharding-stable) allows you to roughly shard the
   discovered set of targets by using hashmod/keep relabel rules.
 - The [scraping service][scrape] allows you to cluster Grafana
   Agents and have them distribute per-tenant configs throughout the cluster.

--- a/docs/sources/static/release-notes.md
+++ b/docs/sources/static/release-notes.md
@@ -140,7 +140,7 @@ See [Module and Auth Split Migration](https://github.com/prometheus/snmp_exporte
 ### Removal of Dynamic Configuration
 
 The experimental feature Dynamic Configuration has been removed. The use case of dynamic configuration will be replaced
-with [Modules](../../concepts/modules/) in Grafana Agent Flow.
+with [Modules]({{< relref "../flow/concepts/modules/" >}}) in Grafana Agent Flow.
 
 ### Breaking change: Removed and renamed tracing metrics
 
@@ -181,7 +181,7 @@ use the new binaries that are prefixed with `/bin/grafana*`.
 
 ### Deprecation of Dynamic Configuration
 
-[Dynamic Configuration](https://grafana.com/docs/agent/v0.33/cookbook/dynamic-configuration/) will be removed in v0.34.
+[Dynamic Configuration](/docs/agent/v0.33/cookbook/dynamic-configuration/) will be removed in v0.34.
 The use case of dynamic configuration will be replaced with Modules in Grafana Agent Flow.
 
 ## v0.32

--- a/docs/sources/static/release-notes.md
+++ b/docs/sources/static/release-notes.md
@@ -140,7 +140,7 @@ See [Module and Auth Split Migration](https://github.com/prometheus/snmp_exporte
 ### Removal of Dynamic Configuration
 
 The experimental feature Dynamic Configuration has been removed. The use case of dynamic configuration will be replaced
-with [Modules]({{< relref "../flow/concepts/modules/" >}}) in Grafana Agent Flow.
+with [Modules]({{< relref "../flow/concepts/modules" >}}) in Grafana Agent Flow.
 
 ### Breaking change: Removed and renamed tracing metrics
 

--- a/docs/sources/static/set-up/install/install-agent-on-windows.md
+++ b/docs/sources/static/set-up/install/install-agent-on-windows.md
@@ -28,7 +28,7 @@ To do a standard graphical install of Grafana Agent on Windows, perform the foll
 1. Double-click on `grafana-agent-installer.exe` to install Grafana Agent.
 
    Grafana Agent is installed into the default directory `C:\Program Files\Grafana Agent`.
-   The [windows_exporter integration](https://grafana.com/docs/agent/latest/static/configuration/integrations/windows-exporter-config) can be enabled with all default windows_exporter options.
+   The [windows_exporter integration](/docs/agent/latest/static/configuration/integrations/windows-exporter-config) can be enabled with all default windows_exporter options.
 
 ## Silent install
 
@@ -109,7 +109,7 @@ Grafana Agent can also be silently uninstalled by running `uninstall.exe /S` as 
 
 ## Push Windows logs to Grafana Loki
 
-Grafana Agent can use the embedded [promtail](https://grafana.com/docs/loki/latest/clients/promtail/) to push Windows Event Logs to [Grafana Loki](https://github.com/grafana/loki). Example configuration below:
+Grafana Agent can use the embedded [promtail](/docs/loki/latest/clients/promtail/) to push Windows Event Logs to [Grafana Loki](https://github.com/grafana/loki). Example configuration below:
 
 ```yaml
 server:
@@ -136,7 +136,7 @@ logs:
             job: windows
 ```
 
-Refer to [windows_events](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#windows_events) for additional configuration details.
+Refer to [windows_events](/docs/loki/latest/clients/promtail/configuration/#windows_events) for additional configuration details.
 
 ## Next steps
 

--- a/docs/sources/static/set-up/quick-starts.md
+++ b/docs/sources/static/set-up/quick-starts.md
@@ -14,11 +14,11 @@ The following quick starts help you get up and running with Grafana Agent. Youâ€
 
 ## Grafana Stack quick starts
 
-- [Send metrics to Mimir](https://grafana.com/docs/mimir/latest/get-started/) using Grafana Agent.
+- [Send metrics to Mimir](/docs/mimir/latest/get-started/) using Grafana Agent.
 
-- [Send traces to Tempo](https://grafana.com/docs/tempo/latest/getting-started/#2-pipeline-grafana-agent) using Grafana Agent.
+- [Send traces to Tempo](/docs/tempo/latest/getting-started/#2-pipeline-grafana-agent) using Grafana Agent.
 
-- [Send logs to Loki](https://grafana.com/docs/grafana-cloud/logs/collect-logs-with-agent/) using Grafana Agent.
+- [Send logs to Loki](/docs/grafana-cloud/logs/collect-logs-with-agent/) using Grafana Agent.
 
 ## Grafana Cloud quick starts
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR continues the work to fix or correct the errors reported by `make docs-validator`  Fixes include:

* Cleaning up the relref syntax and formatting
* Removing trailing `/` from reference URLs
* Correcting absolute and relative link paths
* Fixing broken link anchors (caused by formatting errors, moved topics, and changed heading text)

Related PR: https://github.com/grafana/agent/pull/5296 Add description metadata to Grafana Agent docs

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated