### PR TITLE
prometheus.scrape: add options for enabling native histograms scraping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ Main (unreleased)
   This will load all River files in the directory as a single configuration;
   component names must be unique across all loaded files. (@rfratto, @hainenber)
 
+- Flow: the `prometheus.scrape` component can now configure the scraping of
+  Prometheus native histograms. (@tpaschalis)
 
 ### Enhancements
 

--- a/component/prometheus/scrape/scrape.go
+++ b/component/prometheus/scrape/scrape.go
@@ -53,6 +53,8 @@ type Arguments struct {
 	HonorTimestamps bool `river:"honor_timestamps,attr,optional"`
 	// A set of query parameters with which the target is scraped.
 	Params url.Values `river:"params,attr,optional"`
+	// Whether to scrape a classic histogram that is also exposed as a native histogram.
+	ScrapeClassicHistograms bool `river:"scrape_classic_histogram,attr,optional"`
 	// How frequently to scrape the targets of this scrape config.
 	ScrapeInterval time.Duration `river:"scrape_interval,attr,optional"`
 	// The timeout for scraping targets of this config.
@@ -83,7 +85,8 @@ type Arguments struct {
 	HTTPClientConfig component_config.HTTPClientConfig `river:",squash"`
 
 	// Scrape Options
-	ExtraMetrics bool `river:"extra_metrics,attr,optional"`
+	ExtraMetrics              bool `river:"extra_metrics,attr,optional"`
+	EnableProtobufNegotiation bool `river:"enable_protobuf_negotiation,attr,optional"`
 
 	Clustering Clustering `river:"clustering,block,optional"`
 }
@@ -155,6 +158,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		HTTPClientOptions: []config_util.HTTPClientOption{
 			config_util.WithDialContextFunc(httpData.DialFunc),
 		},
+		EnableProtobufNegotiation: args.EnableProtobufNegotiation,
 	}
 	scraper := scrape.NewManager(scrapeOptions, o.Logger, flowAppendable)
 
@@ -284,6 +288,7 @@ func getPromScrapeConfigs(jobName string, c Arguments) *config.ScrapeConfig {
 	dec.HonorLabels = c.HonorLabels
 	dec.HonorTimestamps = c.HonorTimestamps
 	dec.Params = c.Params
+	dec.ScrapeClassicHistograms = c.ScrapeClassicHistograms
 	dec.ScrapeInterval = model.Duration(c.ScrapeInterval)
 	dec.ScrapeTimeout = model.Duration(c.ScrapeTimeout)
 	dec.MetricsPath = c.MetricsPath

--- a/docs/sources/flow/reference/components/prometheus.scrape.md
+++ b/docs/sources/flow/reference/components/prometheus.scrape.md
@@ -47,9 +47,11 @@ Name | Type | Description | Default | Required
 `forward_to`               | `list(MetricsReceiver)` | List of receivers to send scraped metrics to. | | yes
 `job_name`                 | `string`   | The job name to override the job label with. | component name | no
 `extra_metrics`            | `bool`     | Whether extra metrics should be generated for scrape targets. | `false` | no
+`enable_protobuf_negotiation` | `bool`     | Whether to enable protobuf negotiation with the client. | `false` | no
 `honor_labels`             | `bool`     | Indicator whether the scraped metrics should remain unmodified. | `false` | no
 `honor_timestamps`         | `bool`     | Indicator whether the scraped timestamps should be respected. | `true` | no
 `params`                   | `map(list(string))` | A set of query parameters with which the target is scraped. | | no
+`scrape_classic_histogram` | `bool`     | Whether to scrape a classic histogram that is also exposed as a native histogram. | `false` | no
 `scrape_interval`          | `duration` | How frequently to scrape the targets of this scrape config. | `"60s"` | no
 `scrape_timeout`           | `duration` | The timeout for scraping targets of this config. | `"10s"` | no
 `metrics_path`             | `string`   | The HTTP resource path on which to fetch metrics from targets. | `/metrics` | no
@@ -229,6 +231,12 @@ scrape target, either because it is not reachable, because the connection
 times out while scraping, or because the samples from the target could not be
 processed. When the target is behaving normally, the `up` metric is set to
 `1`.
+
+To enable scraping of Prometheus' native histograms over gRPC, the
+`enable_protobuf_negotiation` must be set to true. The
+`scrape_classic_histogram` argument controls whether the component should also
+scrape the 'classic' histogram equivalent of a native histogram, if it is
+present.
 
 [in-memory traffic]: {{< relref "../../concepts/component_controller.md#in-memory-traffic" >}}
 [run command]: {{< relref "../cli/run.md" >}}


### PR DESCRIPTION
#### PR Description
This PR adds a couple of new Arguments to the `prometheus.scrape` component to toggle scraping of Prometheus' native histograms over gRPC and conditionally allowing classic histograms being scraped in parallel.

#### Which issue(s) this PR fixes
Fixes #5136 

#### Notes to the Reviewer
Nothing for now.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [X] Documentation added
- [ ] Tests updated
