### PR TITLE
Promtail converter will now treat `global positions configuration is …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,8 @@ Main (unreleased)
 - The `instance` label of targets exposed by `prometheus.exporter.*` components
   is now more representative of what is being monitored. (@tpaschalis)
 
+- Promtail converter will now treat `global positions configuration is not supported` as a Warning instead of Error. (@erikbaranowski)
+
 ### Bugfixes
 
 - Fixed `otelcol.exporter.prometheus` label names for the `otel_scope_info`

--- a/converter/internal/promtailconvert/testdata/unsupported.diags
+++ b/converter/internal/promtailconvert/testdata/unsupported.diags
@@ -1,4 +1,4 @@
-(Error) global positions configuration is not supported - each Flow Mode's loki.source.file component has its own positions file in the component's data directory
+(Warning) global positions configuration is not supported - each Flow Mode's loki.source.file component has its own positions file in the component's data directory
 (Error) Promtail's WAL is currently not supported in Flow Mode
 (Error) limits_config is not yet supported in Flow Mode
 (Warning) If you have a tracing set up for Promtail, it cannot be migrated to Flow Mode automatically. Refer to the documentation on how to configure tracing in Flow Mode.

--- a/converter/internal/promtailconvert/validate.go
+++ b/converter/internal/promtailconvert/validate.go
@@ -11,7 +11,7 @@ func validateTopLevelConfig(cfg *promtailcfg.Config, diags *diag.Diagnostics) {
 	// The positions global config is not supported in Flow Mode.
 	if cfg.PositionsConfig != DefaultPositionsConfig() {
 		diags.Add(
-			diag.SeverityLevelError,
+			diag.SeverityLevelWarn,
 			"global positions configuration is not supported - each Flow Mode's loki.source.file component "+
 				"has its own positions file in the component's data directory",
 		)

--- a/converter/internal/staticconvert/testdata/promtail_prom.diags
+++ b/converter/internal/staticconvert/testdata/promtail_prom.diags
@@ -1,5 +1,5 @@
-(Error) global positions configuration is not supported - each Flow Mode's loki.source.file component has its own positions file in the component's data directory
+(Warning) global positions configuration is not supported - each Flow Mode's loki.source.file component has its own positions file in the component's data directory
 (Warning) server.log_level is not supported - Flow mode components may produce different logs
-(Error) global positions configuration is not supported - each Flow Mode's loki.source.file component has its own positions file in the component's data directory
+(Warning) global positions configuration is not supported - each Flow Mode's loki.source.file component has its own positions file in the component's data directory
 (Warning) server.log_level is not supported - Flow mode components may produce different logs
 (Warning) Please review your agent command line flags and ensure they are set in your Flow mode config file where necessary.

--- a/converter/internal/staticconvert/testdata/promtail_scrape.diags
+++ b/converter/internal/staticconvert/testdata/promtail_scrape.diags
@@ -1,3 +1,3 @@
-(Error) global positions configuration is not supported - each Flow Mode's loki.source.file component has its own positions file in the component's data directory
+(Warning) global positions configuration is not supported - each Flow Mode's loki.source.file component has its own positions file in the component's data directory
 (Warning) server.log_level is not supported - Flow mode components may produce different logs
 (Warning) Please review your agent command line flags and ensure they are set in your Flow mode config file where necessary.

--- a/converter/internal/staticconvert/testdata/sanitize.diags
+++ b/converter/internal/staticconvert/testdata/sanitize.diags
@@ -1,4 +1,4 @@
-(Error) global positions configuration is not supported - each Flow Mode's loki.source.file component has its own positions file in the component's data directory
+(Warning) global positions configuration is not supported - each Flow Mode's loki.source.file component has its own positions file in the component's data directory
 (Warning) server.log_level is not supported - Flow mode components may produce different logs
 (Warning) Please review your agent command line flags and ensure they are set in your Flow mode config file where necessary.
 (Error) unsupported wal_directory metrics config was provided. use the run command flag --storage.path for Flow mode instead.

--- a/converter/internal/staticconvert/testdata/unsupported.diags
+++ b/converter/internal/staticconvert/testdata/unsupported.diags
@@ -1,4 +1,4 @@
-(Error) global positions configuration is not supported - each Flow Mode's loki.source.file component has its own positions file in the component's data directory
+(Warning) global positions configuration is not supported - each Flow Mode's loki.source.file component has its own positions file in the component's data directory
 (Warning) server.log_level is not supported - Flow mode components may produce different logs
 (Error) unsupported integration which is not being scraped was provided: mssql.
 (Error) mapping_config is not supported in statsd_exporter integrations config


### PR DESCRIPTION
…not supported` as a Warning instead of Error.

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

Closes #4835

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [x] Config converters updated