### PR TITLE
fix(pkg/flow): cmt stmt in arg block is now parseable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,8 @@ Main (unreleased)
 
 - Fixed a bug where the BackOffLimit for the kubernetes tailer was always set to zero. (@anderssonw)
 
+- Fixed a bug where Flow agent fails to load `comment` statement in `argument` block. (@hainenber)
+
 ### Other changes
 
 - Use Go 1.21.1 for builds. (@rfratto)

--- a/pkg/flow/internal/controller/node_config_argument.go
+++ b/pkg/flow/internal/controller/node_config_argument.go
@@ -36,8 +36,9 @@ func NewArgumentConfigNode(block *ast.BlockStmt, globals ComponentGlobals) *Argu
 }
 
 type argumentBlock struct {
-	Optional bool `river:"optional,attr,optional"`
-	Default  any  `river:"default,attr,optional"`
+	Optional bool   `river:"optional,attr,optional"`
+	Default  any    `river:"default,attr,optional"`
+	Comment  string `river:"comment,attr,optional"`
 }
 
 // Evaluate implements BlockNode and updates the arguments for the managed config block

--- a/pkg/flow/module_test.go
+++ b/pkg/flow/module_test.go
@@ -25,6 +25,13 @@ const argumentConfig = `
 		default = "default_value"
 	}`
 
+const argumentWithFullOptsConfig = `
+	argument "foo" {
+		comment = "description of foo"
+		optional = true	
+		default = "default_value"
+	}`
+
 const exportStringConfig = `
 	export "username" {
 		value = "bob"
@@ -95,6 +102,10 @@ func TestModule(t *testing.T) {
 			name:                "Multiple exports but none are used but still exported",
 			exportModuleContent: exportStringConfig + exportDummy,
 			expectedExports:     []string{"username", "dummy"},
+		},
+		{
+			name:                "Argument block with comment is parseable",
+			exportModuleContent: argumentWithFullOptsConfig,
 		},
 	}
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #5321 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Tests updated