### PR TITLE
Update prometheus.exporter.windows.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,7 +169,7 @@ Main (unreleased)
 
 - `prometheus.operator.probes` no longer ignores relabeling `rule` blocks. (@sberz)
 
-- Ducumentation updated to correct default path from `prometheus.exporter.windows` `text_file` block (@timo1707)
+- Documentation updated to correct default path from `prometheus.exporter.windows` `text_file` block (@timo1707)
 
 v0.36.2 (2023-09-22)
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,8 @@ Main (unreleased)
 
 - `prometheus.operator.probes` no longer ignores relabeling `rule` blocks. (@sberz)
 
+- Ducumentation updated to correct default path from prometheus.exporter.windows text_file block (@timo1707)
+
 v0.36.2 (2023-09-22)
 --------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,7 +169,7 @@ Main (unreleased)
 
 - `prometheus.operator.probes` no longer ignores relabeling `rule` blocks. (@sberz)
 
-- Ducumentation updated to correct default path from prometheus.exporter.windows text_file block (@timo1707)
+- Ducumentation updated to correct default path from `prometheus.exporter.windows` `text_file` block (@timo1707)
 
 v0.36.2 (2023-09-22)
 --------------------

--- a/docs/sources/flow/reference/components/prometheus.exporter.windows.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.windows.md
@@ -180,7 +180,7 @@ For a server name to be included, it must match the regular expression specified
 ### text_file block
 Name | Type     | Description | Default | Required
 ---- |----------| ----------- | ------- | --------
-`text_file_directory` | `string` | The directory containing the files to be ingested. | `C:\Program Files\windows_exporter\textfile_inputs` | no
+`text_file_directory` | `string` | The directory containing the files to be ingested. | `C:\Program Files\Grafana Agent Flow\textfile_inputs` | no
 
 When `text_file_directory` is set, only files with the extension `.prom` inside the specified directory are read. Each `.prom` file found must end with an empty line feed to work properly.
 


### PR DESCRIPTION
changed the default text_file_directory value

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The current default value from the [text_file](https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.windows/#textfile-block) block points to the default prometheus exporter directory.
This PR changes the documentation to the `textfile_inputs` directory from `Grafana Agent Flow`

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added