### PR TITLE
go.mod: cherry-pick improvements to Prometheus' retry behaviour

### DIFF
--- a/component/prometheus/receive_http/receive_http_test.go
+++ b/component/prometheus/receive_http/receive_http_test.go
@@ -373,7 +373,7 @@ func request(ctx context.Context, rawRemoteWriteURL string, req *prompb.WriteReq
 	}
 
 	compressed := snappy.Encode(buf, buf)
-	return client.Store(ctx, compressed)
+	return client.Store(ctx, compressed, 0)
 }
 
 func testOptions(t *testing.T) component.Options {

--- a/go.mod
+++ b/go.mod
@@ -666,11 +666,13 @@ replace (
 	k8s.io/klog/v2 => github.com/simonpasquier/klog-gokit/v3 v3.3.0
 )
 
-// TODO(rfratto): remove replace directive once:
+// TODO(tpaschalis): remove replace directive once:
 //
-// * We remove our dependency on Cortex, which forces Prometheus to an older
-//   version since Go thinks v1 is newer than v0.
-replace github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.45.0
+// * There is a release of Prometheus which contains
+// prometheus/prometheus#12677 and prometheus/prometheus#12729.
+// We use the last v1-related tag as the replace statement does not work for v2
+// tags without the v2 suffix to the module root
+replace github.com/prometheus/prometheus => github.com/grafana/prometheus v1.8.2-0.20231002111159-38991b77eb53 // grafana:prometheus:v0.45.0-retry-improvements
 
 replace gopkg.in/yaml.v2 => github.com/rfratto/go-yaml v0.0.0-20211119180816-77389c3526dc
 

--- a/go.sum
+++ b/go.sum
@@ -1102,6 +1102,8 @@ github.com/grafana/perflib_exporter v0.1.1-0.20230511173423-6166026bd090 h1:Ko80
 github.com/grafana/perflib_exporter v0.1.1-0.20230511173423-6166026bd090/go.mod h1:MinSWm88jguXFFrGsP56PtleUb4Qtm4tNRH/wXNXRTI=
 github.com/grafana/postgres_exporter v0.8.1-0.20210722175051-db35d7c2f520 h1:HnFWqxhoSF3WC7sKAdMZ+SRXvHLVZlZ3sbQjuUlTqkw=
 github.com/grafana/postgres_exporter v0.8.1-0.20210722175051-db35d7c2f520/go.mod h1:+HPXgiOV0InDHcZ2jNijL1SOKvo0eEPege5fQA0+ICI=
+github.com/grafana/prometheus v1.8.2-0.20231002111159-38991b77eb53 h1:nX3bUvvnjugac9y7RyxNAG/yNLGR8xSExqwWwVFQ1yk=
+github.com/grafana/prometheus v1.8.2-0.20231002111159-38991b77eb53/go.mod h1:jC5hyO8ItJBnDWGecbEucMyXjzxGv9cxsxsjS9u5s1w=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.3 h1:eunWpv1B3Z7ZK9o4499EmQGlY+CsDmSZ4FbxjRx37uk=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.3/go.mod h1:1HSPtjU8vLG0jE9JrTdzjgFqdJ/VgN7fvxBNq3luJko=
 github.com/grafana/pyroscope/api v0.2.0 h1:TzOxL0s6SiaLEy944ZAKgHcx/JDRJXu4O8ObwkqR6p4=
@@ -2042,8 +2044,6 @@ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0ua
 github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB/chUwxUZY=
 github.com/prometheus/procfs v0.11.0 h1:5EAgkfkMl659uZPbe9AS2N68a7Cc1TJbPEuGzFuRbyk=
 github.com/prometheus/procfs v0.11.0/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
-github.com/prometheus/prometheus v0.45.0 h1:O/uG+Nw4kNxx/jDPxmjsSDd+9Ohql6E7ZSY1x5x/0KI=
-github.com/prometheus/prometheus v0.45.0/go.mod h1:jC5hyO8ItJBnDWGecbEucMyXjzxGv9cxsxsjS9u5s1w=
 github.com/prometheus/snmp_exporter v0.23.0 h1:v+NUGGSj2a8QaLC4+cWAlTNWoI0qEZ8cEuJmtpVhsew=
 github.com/prometheus/snmp_exporter v0.23.0/go.mod h1:vdODeAhHaSbDD2B4yngJgkWkAB393LuCGJUbK8AFfFU=
 github.com/prometheus/statsd_exporter v0.22.7/go.mod h1:N/TevpjkIh9ccs6nuzY3jQn9dFqnUakOjnEuMPJJJnI=


### PR DESCRIPTION
You can see the diff with the branch (and pinned commit SHA) on the following link. Once the next Prometheus release is out with the two fixes, we can stop using the Prometheus replace directive altogether since we also removed our Cortex dependency.

https://github.com/prometheus/prometheus/compare/v2.45.0...grafana:prometheus:v0.45.0-retry-improvements?expand=1