### PR TITLE
Fix some build errors related to mounted content

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -21,7 +21,7 @@ form programmable observability **pipelines** for telemetry collection,
 processing, and delivery.
 
 {{% admonition type="note" %}}
-This page focuses mainly on [Flow mode]({{< relref "./flow" >}}), the Terraform-inspired variant of Grafana Agent.
+This page focuses mainly on [Flow mode][], the Terraform-inspired variant of Grafana Agent.
 
 For information on other variants of Grafana Agent, refer to [Introduction to Grafana Agent]({{< relref "./about.md" >}}).
 {{% /admonition %}}
@@ -56,8 +56,6 @@ Grafana Agent can collect, transform, and send data to:
 * **Batteries included**: Integrate with systems like MySQL, Kubernetes, and
   Apache to get telemetry that's immediately useful.
 
-[UI]: {{< relref "./flow/monitoring/debugging.md#grafana-agent-flow-ui" >}}
-
 ## Getting started
 
 * Choose a [variant][variants] of Grafana Agent to run.
@@ -65,11 +63,6 @@ Grafana Agent can collect, transform, and send data to:
   * [Static mode][]
   * [Static mode Kubernetes operator][]
   * [Flow mode][]
-
-[variants]: {{< relref "./about.md" >}}
-[Static mode]: {{< relref "./static" >}}
-[Static mode Kubernetes operator]: {{< relref "./operator" >}}
-[Flow mode]: {{< relref "./flow" >}}
 
 ## Supported platforms
 
@@ -106,3 +99,20 @@ one minor release is moved.
 Patch and security releases may be created at any time.
 
 [Milestones]: https://github.com/grafana/agent/milestones
+
+{{% docs/reference %}}
+[variants]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/about"
+[variants]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/about"
+
+[Static mode]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static"
+[Static mode]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static"
+
+[Static mode Kubernetes operator]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/operator"
+[Static mode Kubernetes operator]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/operator"
+
+[Flow mode]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow"
+[Flow mode]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow"
+
+[UI]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/monitoring/debugging.md#grafana-agent-flow-ui"
+[UI]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/monitoring/debugging.md#grafana-agent-flow-ui"
+{{% /docs/reference %}}

--- a/docs/sources/about.md
+++ b/docs/sources/about.md
@@ -19,13 +19,20 @@ such as Prometheus and OpenTelemetry.
 
 Grafana Agent is available in three different variants:
 
-* [Static mode][]: The default, original variant of Grafana Agent.
-* [Static mode Kubernetes operator][]: Variant which manages agents running in Static mode.
-* [Flow mode][]: The newer, more flexible re-imagining variant of Grafana Agent.
+- [Static mode][]: The default, original variant of Grafana Agent.
+- [Static mode Kubernetes operator][]: Variant which manages agents running in Static mode.
+- [Flow mode][]: The newer, more flexible re-imagining variant of Grafana Agent.
 
-[Static mode]: {{< relref "./static/" >}}
-[Static mode Kubernetes operator]: {{< relref "./operator/" >}}
-[Flow mode]: {{< relref "./flow/" >}}
+{{% docs/reference %}}
+[Static mode]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static"
+[Static mode]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static"
+
+[Static mode Kubernetes operator]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/operator"
+[Static mode Kubernetes operator]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/operator"
+
+[Flow mode]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow"
+[Flow mode]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow"
+{{% /docs/reference %}}
 
 ## Stability
 
@@ -107,6 +114,10 @@ You should run Flow mode when:
 [BoringCrypto](https://pkg.go.dev/crypto/internal/boring) is an **EXPERIMENTAL** feature for building Grafana Agent
 binaries and images with BoringCrypto enabled. Builds and Docker images for Linux arm64/amd64 are made available.
 
-[integrations]: {{< relref "./static/configuration/integrations/" >}}
-[components]: {{< relref "./flow/reference/components/" >}}
+{{% docs/reference %}}
+[integrations]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/integrations"
+[integrations]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration/integrations"
 
+[components]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/reference/components"
+[components]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/reference/components"
+{{% /docs/reference %}}

--- a/docs/sources/operator/release-notes.md
+++ b/docs/sources/operator/release-notes.md
@@ -19,16 +19,19 @@ The release notes provide information about deprecations and breaking changes in
 
 For a complete list of changes to Grafana Agent, with links to pull requests and related issues when available, refer to the [Changelog](https://github.com/grafana/agent/blob/main/CHANGELOG.md).
 
-{{% admonition type="note" %}}
-These release notes are specific to the Static mode Kubernetes Operator.
-Other release notes for the different Grafana Agent variants are contained on separate pages:
+> **Note:** These release notes are specific to the Static mode Kubernetes Operator.
+> Other release notes for the different Grafana Agent variants are contained on separate pages:
+>
+> - [Static mode release notes][release-notes-static]
+> - [Flow mode release notes][release-notes-flow]
 
-* [Static mode release notes][release-notes-static]
-* [Flow mode release notes][release-notes-flow]
+{{% docs/reference %}}
+[release-notes-static]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/release-notes"
+[release-notes-static]: "/docs/agent/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static/release-notes"
 
-[release-notes-static]: {{< relref "../static/release-notes.md" >}}
-[release-notes-flow]: {{< relref "../flow/release-notes.md" >}}
-{{% /admonition %}}
+[release-notes-flow]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/release-notes"
+[release-notes-flow]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/release-notes"
+{{% /docs/reference %}}
 
 ## v0.33
 

--- a/docs/sources/static/configuration/create-config-file.md
+++ b/docs/sources/static/configuration/create-config-file.md
@@ -186,5 +186,5 @@ integrations:
 
 {{% docs/reference %}}
 [configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration"
-[configure]: "/docs/grafana-cloud/ -> ./configuration"
+[configure]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration"
 {{% /docs/reference %}}

--- a/docs/sources/static/configuration/flags.md
+++ b/docs/sources/static/configuration/flags.md
@@ -146,9 +146,11 @@ YAML configuration when the `-server.http.tls-enabled` flag is used.
 
 {{% docs/reference %}}
 [retrieving]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration#remote-configuration-experimental"
-[retrieving]: "/docs/grafana-cloud/ -> ./configuration#remote-configuration-experimental"
+[retrieving]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration#remote-configuration-experimental"
+
 [revamp]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/integrations/integrations-next/"
-[revamp]: "/docs/grafana-cloud/ -> ./integrations/integrations-next/"
+[revamp]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration/integrations/integrations-next"
+
 [management]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/agent-management"
-[management]: "/docs/grafana-cloud/ -> ./agent-management"
+[management]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration/agent-management"
 {{% /docs/reference %}}

--- a/docs/sources/static/release-notes.md
+++ b/docs/sources/static/release-notes.md
@@ -24,8 +24,12 @@ For a complete list of changes to Grafana Agent, with links to pull requests and
 {{% docs/reference %}}
 [release-notes-operator]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/operator/release-notes"
 [release-notes-operator]: "/docs/grafana-cloud/ -> ../operator/release-notes"
+
 [release-notes-flow]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/release-notes"
-[release-notes-flow]: "/docs/grafana-cloud/ -> ../flow/release-notes"
+[release-notes-flow]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/release-notes"
+
+[Modules]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/concepts/modules"
+[Modules]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/concepts/modules"
 {{% /docs/reference %}}
 
 ## v0.37
@@ -140,7 +144,7 @@ See [Module and Auth Split Migration](https://github.com/prometheus/snmp_exporte
 ### Removal of Dynamic Configuration
 
 The experimental feature Dynamic Configuration has been removed. The use case of dynamic configuration will be replaced
-with [Modules]({{< relref "../flow/concepts/modules" >}}) in Grafana Agent Flow.
+with [Modules][] in Grafana Agent Flow.
 
 ### Breaking change: Removed and renamed tracing metrics
 

--- a/docs/sources/static/set-up/install/install-agent-binary.md
+++ b/docs/sources/static/set-up/install/install-agent-binary.md
@@ -54,7 +54,7 @@ To download the Grafana Agent as a standalone binary, perform the following step
 [linux]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-linux"
 [linux]: "/docs/grafana-cloud/ -> ./install-agent-linux"
 [macos]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-macos"
-[macos]: "/docs/grafana-cloud/ -> ./install-agent-mac-os"
+[macos]: "/docs/grafana-cloud/ -> ./install-agent-macos"
 [windows]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-on-windows"
 [windows]: "/docs/grafana-cloud/ -> ./install-agent-on-windows"
 [start]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/start-agent#standalone-binary"


### PR DESCRIPTION
Primarily arising from Flow content not being mounted in Grafana Cloud.

Some were typos or incorrect relative paths.

Links for this PR and the [backport](https://github.com/grafana/agent/pull/5353) tested in https://github.com/grafana/website/pull/15708.
