### PR TITLE
Change Promtail Reference to Static Mode in migrating-from-static.md

### DIFF
--- a/docs/sources/flow/getting-started/migrating-from-static.md
+++ b/docs/sources/flow/getting-started/migrating-from-static.md
@@ -103,7 +103,7 @@ features available in Grafana Agent Flow mode.
     (Warning) Please review your agent command line flags and ensure they are set in your Flow mode config file where necessary.
     ```
 
-## Run a Promtail configuration
+## Run a Static mode configuration
 
 If you’re not ready to completely switch to a Flow mode configuration, you can run
 Grafana Agent using your existing Grafana Agent Static mode configuration.


### PR DESCRIPTION
Change Promtail Reference to Static Mode since the Doc does not reference Promtail.

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Replaces `Promtail` with `Static mode` in one of the Section Headers.

Section content refers to Static Mode

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist
