### PR TITLE
Add otel service as a dependency to module loaders.

### DIFF
--- a/component/module/file/file.go
+++ b/component/module/file/file.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/agent/component/module"
 	"github.com/grafana/agent/service/cluster"
 	"github.com/grafana/agent/service/http"
+	otel_service "github.com/grafana/agent/service/otel"
 	"github.com/grafana/river/rivertypes"
 )
 
@@ -19,7 +20,7 @@ func init() {
 		Name:          "module.file",
 		Args:          Arguments{},
 		Exports:       module.Exports{},
-		NeedsServices: []string{http.ServiceName, cluster.ServiceName},
+		NeedsServices: []string{http.ServiceName, cluster.ServiceName, otel_service.ServiceName},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/module/git/git.go
+++ b/component/module/git/git.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/agent/component/module/git/internal/vcs"
 	"github.com/grafana/agent/service/cluster"
 	"github.com/grafana/agent/service/http"
+	otel_service "github.com/grafana/agent/service/otel"
 )
 
 func init() {
@@ -22,7 +23,7 @@ func init() {
 		Name:          "module.git",
 		Args:          Arguments{},
 		Exports:       module.Exports{},
-		NeedsServices: []string{http.ServiceName, cluster.ServiceName},
+		NeedsServices: []string{http.ServiceName, cluster.ServiceName, otel_service.ServiceName},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/module/http/http.go
+++ b/component/module/http/http.go
@@ -11,6 +11,7 @@ import (
 	remote_http "github.com/grafana/agent/component/remote/http"
 	"github.com/grafana/agent/service/cluster"
 	http_service "github.com/grafana/agent/service/http"
+	otel_service "github.com/grafana/agent/service/otel"
 	"github.com/grafana/river/rivertypes"
 )
 
@@ -19,7 +20,7 @@ func init() {
 		Name:          "module.http",
 		Args:          Arguments{},
 		Exports:       module.Exports{},
-		NeedsServices: []string{http_service.ServiceName, cluster.ServiceName},
+		NeedsServices: []string{http_service.ServiceName, cluster.ServiceName, otel_service.ServiceName},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/module/string/string.go
+++ b/component/module/string/string.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/agent/component/module"
 	"github.com/grafana/agent/service/cluster"
 	"github.com/grafana/agent/service/http"
+	otel_service "github.com/grafana/agent/service/otel"
 	"github.com/grafana/river/rivertypes"
 )
 
@@ -15,7 +16,7 @@ func init() {
 		Name:          "module.string",
 		Args:          Arguments{},
 		Exports:       module.Exports{},
-		NeedsServices: []string{http.ServiceName, cluster.ServiceName},
+		NeedsServices: []string{http.ServiceName, cluster.ServiceName, otel_service.ServiceName},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/pkg/flow/module_caching_test.go
+++ b/pkg/flow/module_caching_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/agent/service"
 	cluster_service "github.com/grafana/agent/service/cluster"
 	http_service "github.com/grafana/agent/service/http"
+	otel_service "github.com/grafana/agent/service/otel"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
@@ -151,6 +152,9 @@ func testOptions(t *testing.T) flow.Options {
 	})
 	require.NoError(t, err)
 
+	otelService := otel_service.New(s)
+	require.NotNil(t, otelService)
+
 	return flow.Options{
 		Logger:   s,
 		DataPath: t.TempDir(),
@@ -158,6 +162,7 @@ func testOptions(t *testing.T) flow.Options {
 		Services: []service.Service{
 			http_service.New(http_service.Options{}),
 			clusterService,
+			otelService,
 		},
 	}
 }


### PR DESCRIPTION
#### PR Description

This is necessary so that modules can successfully load otelcol components which depend on the otel service. Those are almost all otelcol receivers and exporters.

I am not updating the changelog because we haven't released a version of the Agent with this bug.

I wish I could add tests to the CI for this, but I cannot see any test files which exist already for modules.

#### Notes to the Reviewer

I tested this change with this river file:

```
tracing {
	sampling_fraction = 1
	write_to          = [module.git.traces_otel_input.exports.input]
}

module.git "traces_otel_input" {
	repository = "https://github.com/grafana/agent-modules.git"
	revision   = "add_aaron_benton_code_owner"
	path       = "example/traces/otel_input/module.river"

	arguments {
		username = ""
		password = ""
		url      = ""
	}
}
```

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated