### PR TITLE
Relax flow updates test assertions

### DIFF
--- a/pkg/flow/flow_updates_test.go
+++ b/pkg/flow/flow_updates_test.go
@@ -70,11 +70,8 @@ func TestController_Updates(t *testing.T) {
 	require.Equal(t, "10", in.(testcomponents.PassthroughConfig).Input)
 	require.Equal(t, "10", out.(testcomponents.PassthroughExports).Output)
 
-	in, out = getFields(t, ctrl.loader.Graph(), "testcomponents.summation.sum")
+	in, _ = getFields(t, ctrl.loader.Graph(), "testcomponents.summation.sum")
 	require.Equal(t, 10, in.(testcomponents.SummationConfig).Input)
-
-	// Since the lag is minimal, all updates will arrive to the final node.
-	require.Equal(t, 55, out.(testcomponents.SummationExports).Sum)
 }
 
 func TestController_Updates_WithQueueFull(t *testing.T) {
@@ -295,11 +292,8 @@ func TestController_Updates_WithOtherLaggingPipeline(t *testing.T) {
 	require.Equal(t, "10", in.(testcomponents.PassthroughConfig).Input)
 	require.Equal(t, "10", out.(testcomponents.PassthroughExports).Output)
 
-	in, out = getFields(t, ctrl.loader.Graph(), "testcomponents.summation.sum")
+	in, _ = getFields(t, ctrl.loader.Graph(), "testcomponents.summation.sum")
 	require.Equal(t, 10, in.(testcomponents.SummationConfig).Input)
-
-	// Since the actual lag should be minimal, all updates should arrive to the final node.
-	require.Equal(t, 55, out.(testcomponents.SummationExports).Sum)
 }
 
 func TestController_Updates_WithLaggingComponent(t *testing.T) {
@@ -367,11 +361,8 @@ func TestController_Updates_WithLaggingComponent(t *testing.T) {
 	require.Equal(t, "10", in.(testcomponents.PassthroughConfig).Input)
 	require.Equal(t, "10", out.(testcomponents.PassthroughExports).Output)
 
-	in, out = getFields(t, ctrl.loader.Graph(), "testcomponents.summation.sum")
+	in, _ = getFields(t, ctrl.loader.Graph(), "testcomponents.summation.sum")
 	require.Equal(t, 10, in.(testcomponents.SummationConfig).Input)
-
-	// Since the actual lag should be minimal, all updates should arrive to the final node.
-	require.Equal(t, 55, out.(testcomponents.SummationExports).Sum)
 }
 
 func newTestController(t *testing.T) *Flow {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Fixes flaky test on Windows and potentially other slower machines (which can pause for 7+ ms).

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

In current component updates tests that were added in https://github.com/grafana/agent/pull/5280 we have a `count` components which count `0, 1, ..., 10` every `10ms` and a `summation` component that adds up all the numbers it receives from `count` through other components that simulate a total lag of e.g. `3ms`. 

The test waits for the last update - `10` - to arrive to the `summation` component and then performs a bunch of assertions. This is the hard guarantee we need to provide - that the latest update always arrives. 

However, current and previous (before https://github.com/grafana/agent/pull/5280) implementations of Flow allow for intermediate updates to be skipped, if there is already an update queued for given component - see `component.Queue` as an example. Despite lack of this guarantee, the tests were asserting that all the updates arrive (checking that the sum is `55`). This is working as long as there are no pauses on the machine. Since the test pipeline has a lag of `3ms` and a new count is emitted every `10ms`, a machine pause as short as `7ms` could lead to some updates being missed. This appears to be the cause of these tests failing recently on Windows CI and the changes below should fix it. 

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated