### PR TITLE
Prevent hot loop retry on full worker queue

### DIFF
--- a/pkg/flow/internal/worker/worker_pool.go
+++ b/pkg/flow/internal/worker/worker_pool.go
@@ -6,31 +6,35 @@ import (
 	"math/rand"
 	"runtime"
 	"sync"
+	"time"
 )
 
 type Pool interface {
 	// Stop stops the worker pool. It does not wait to drain any internal queues, but it does wait for the currently
 	// running tasks to complete. It must only be called once.
 	Stop()
-	// Submit submits a function to be executed by the worker pool on a random worker. Error is returned if the pool
-	// is unable to accept extra work.
-	Submit(func()) error
-	// SubmitWithKey submits a function to be executed by the worker pool, ensuring that only one
+	// TrySubmit submits a function fn to be executed by the worker pool on a random worker. Error is returned if the
+	// pool is unable to accept extra work within the provided timeout.
+	TrySubmit(fn func(), timeout time.Duration) error
+	// TrySubmitWithKey submits a function to be executed by the worker pool, ensuring that only one
 	// job with given key can be queued at the time. Adding a job with a key that is already queued is a no-op (even if
-	// the submitted function is different). Error is returned if the pool is unable to accept extra work - the caller
-	// can decide how to handle this situation.
-	SubmitWithKey(string, func()) error
+	// the submitted function is different). Error is returned if the pool is unable to accept extra work within the
+	// provided timeout - the caller can decide how to handle this situation.
+	TrySubmitWithKey(key string, fn func(), timeout time.Duration) error
 	// QueueSize returns the number of tasks currently queued.
 	QueueSize() int
+	// DefaultTimeout returns the default timeout that can be used with TrySubmit and TrySubmitWithKey.
+	DefaultTimeout() time.Duration
 }
 
 // shardedWorkerPool is a Pool that distributes work across a fixed number of workers, using a hash of the key to
 // determine which worker to use. This, to an extent, defends the pool from a slow task hogging all the workers.
 type shardedWorkerPool struct {
-	workersCount int
-	workQueues   []chan func()
-	quit         chan struct{}
-	allStopped   sync.WaitGroup
+	workersCount   int
+	workQueues     []chan func()
+	quit           chan struct{}
+	allStopped     sync.WaitGroup
+	defaultTimeout time.Duration
 
 	lock sync.Mutex
 	set  map[string]struct{}
@@ -38,14 +42,16 @@ type shardedWorkerPool struct {
 
 var _ Pool = (*shardedWorkerPool)(nil)
 
+// NewDefaultWorkerPool creates a new worker pool suitable for use in Flow controllers. Since Flow retries component
+// dependency updates, the timeout used will mostly determine how often we'll log an error when the queue is full.
 func NewDefaultWorkerPool() Pool {
-	return NewShardedWorkerPool(runtime.NumCPU(), 1024)
+	return NewShardedWorkerPool(runtime.NumCPU(), 1024, 10*time.Second)
 }
 
 // NewShardedWorkerPool creates a new worker pool with the given number of workers and queue size for each worker.
 // The queued tasks are sharded across the workers using a hash of the key. The pool is automatically started and
 // ready to accept work. To prevent resource leak, Stop() must be called when the pool is no longer needed.
-func NewShardedWorkerPool(workersCount int, queueSize int) Pool {
+func NewShardedWorkerPool(workersCount int, queueSize int, defaultTimeout time.Duration) Pool {
 	if workersCount <= 0 {
 		panic(fmt.Sprintf("workersCount must be positive, got %d", workersCount))
 	}
@@ -54,20 +60,21 @@ func NewShardedWorkerPool(workersCount int, queueSize int) Pool {
 		queues[i] = make(chan func(), queueSize)
 	}
 	pool := &shardedWorkerPool{
-		workersCount: workersCount,
-		workQueues:   queues,
-		quit:         make(chan struct{}),
-		set:          make(map[string]struct{}),
+		workersCount:   workersCount,
+		workQueues:     queues,
+		quit:           make(chan struct{}),
+		set:            make(map[string]struct{}),
+		defaultTimeout: defaultTimeout,
 	}
 	pool.start()
 	return pool
 }
 
-func (w *shardedWorkerPool) Submit(f func()) error {
-	return w.SubmitWithKey(fmt.Sprintf("%d", rand.Int()), f)
+func (w *shardedWorkerPool) TrySubmit(f func(), timeout time.Duration) error {
+	return w.TrySubmitWithKey(fmt.Sprintf("%d", rand.Int()), f, timeout)
 }
 
-func (w *shardedWorkerPool) SubmitWithKey(key string, f func()) error {
+func (w *shardedWorkerPool) TrySubmitWithKey(key string, f func(), timeout time.Duration) error {
 	wrapped := func() {
 		// NOTE: we intentionally remove from the queue before executing the function. This means that while a task is
 		// executing, another task with the same key can be added to the queue, potentially even by the task itself.
@@ -78,19 +85,30 @@ func (w *shardedWorkerPool) SubmitWithKey(key string, f func()) error {
 		f()
 	}
 	queue := w.workQueues[w.workerFor(key)]
+	deadline := time.Now().Add(timeout)
 
-	w.lock.Lock()
-	defer w.lock.Unlock()
-	if _, exists := w.set[key]; exists {
-		return nil // only queue one job for given key
-	}
+	for {
+		w.lock.Lock()
+		if _, exists := w.set[key]; exists {
+			w.lock.Unlock()
+			return nil // Allow only queue one job for given key
+		}
 
-	select {
-	case queue <- wrapped:
-		w.set[key] = struct{}{}
-		return nil
-	default:
-		return fmt.Errorf("worker queue is full")
+		select {
+		case queue <- wrapped:
+			w.set[key] = struct{}{}
+			w.lock.Unlock()
+			return nil // We successfully queued the task
+		default:
+			if time.Now().After(deadline) {
+				w.lock.Unlock()
+				// We've timed out trying to queue the task
+				return fmt.Errorf("timed out adding a task to worker queue with key %q after %q", key, timeout)
+			}
+		}
+		// Couldn't queue the task, release the lock and let other goroutines work on the tasks
+		w.lock.Unlock()
+		runtime.Gosched()
 	}
 }
 
@@ -98,6 +116,10 @@ func (w *shardedWorkerPool) QueueSize() int {
 	w.lock.Lock()
 	defer w.lock.Unlock()
 	return len(w.set)
+}
+
+func (w *shardedWorkerPool) DefaultTimeout() time.Duration {
+	return w.defaultTimeout
 }
 
 func (w *shardedWorkerPool) Stop() {

--- a/pkg/flow/internal/worker/worker_pool_test.go
+++ b/pkg/flow/internal/worker/worker_pool_test.go
@@ -9,11 +9,13 @@ import (
 	"go.uber.org/goleak"
 )
 
+var defaultTestTimeout = 10 * time.Millisecond
+
 func TestWorkerPool(t *testing.T) {
 	t.Run("worker pool", func(t *testing.T) {
 		t.Run("should start and stop cleanly", func(t *testing.T) {
 			defer goleak.VerifyNone(t)
-			pool := NewShardedWorkerPool(4, 1)
+			pool := NewShardedWorkerPool(4, 1, defaultTestTimeout)
 			require.Equal(t, 0, pool.QueueSize())
 			defer pool.Stop()
 		})
@@ -22,30 +24,30 @@ func TestWorkerPool(t *testing.T) {
 			defer goleak.VerifyNone(t)
 
 			require.Panics(t, func() {
-				NewShardedWorkerPool(0, 0)
+				NewShardedWorkerPool(0, 0, defaultTestTimeout)
 			})
 
 			require.Panics(t, func() {
-				NewShardedWorkerPool(-1, 0)
+				NewShardedWorkerPool(-1, 0, defaultTestTimeout)
 			})
 		})
 
 		t.Run("should reject invalid buffer size", func(t *testing.T) {
 			defer goleak.VerifyNone(t)
 			require.Panics(t, func() {
-				NewShardedWorkerPool(1, -1)
+				NewShardedWorkerPool(1, -1, defaultTestTimeout)
 			})
 		})
 
 		t.Run("should process a single task", func(t *testing.T) {
 			defer goleak.VerifyNone(t)
 			done := make(chan struct{})
-			pool := NewShardedWorkerPool(4, 1)
+			pool := NewShardedWorkerPool(4, 1, defaultTestTimeout)
 			defer pool.Stop()
 
-			err := pool.Submit(func() {
+			err := pool.TrySubmit(func() {
 				done <- struct{}{}
-			})
+			}, pool.DefaultTimeout())
 			require.NoError(t, err)
 			select {
 			case <-done:
@@ -59,12 +61,12 @@ func TestWorkerPool(t *testing.T) {
 		t.Run("should process a single task with key", func(t *testing.T) {
 			defer goleak.VerifyNone(t)
 			done := make(chan struct{})
-			pool := NewShardedWorkerPool(4, 1)
+			pool := NewShardedWorkerPool(4, 1, defaultTestTimeout)
 			defer pool.Stop()
 
-			err := pool.SubmitWithKey("testKey", func() {
+			err := pool.TrySubmitWithKey("testKey", func() {
 				done <- struct{}{}
-			})
+			}, pool.DefaultTimeout())
 			require.NoError(t, err)
 			select {
 			case <-done:
@@ -77,18 +79,18 @@ func TestWorkerPool(t *testing.T) {
 
 		t.Run("should not queue duplicated keys", func(t *testing.T) {
 			defer goleak.VerifyNone(t)
-			pool := NewShardedWorkerPool(4, 10)
+			pool := NewShardedWorkerPool(4, 10, defaultTestTimeout)
 			defer pool.Stop()
 			tasksDone := atomic.Int32{}
 
 			// First task will block the worker
 			blockFirstTask := make(chan struct{})
 			firstTaskRunning := make(chan struct{})
-			err := pool.SubmitWithKey("k1", func() {
+			err := pool.TrySubmitWithKey("k1", func() {
 				firstTaskRunning <- struct{}{}
 				<-blockFirstTask
 				tasksDone.Inc()
-			})
+			}, pool.DefaultTimeout())
 			require.NoError(t, err)
 
 			// Wait for the first task to be running already and blocking the worker
@@ -96,16 +98,16 @@ func TestWorkerPool(t *testing.T) {
 			require.Equal(t, 0, pool.QueueSize())
 
 			// Second task will be queued
-			err = pool.SubmitWithKey("k1", func() {
+			err = pool.TrySubmitWithKey("k1", func() {
 				tasksDone.Inc()
-			})
+			}, pool.DefaultTimeout())
 			require.NoError(t, err)
 			require.Equal(t, 1, pool.QueueSize())
 
 			// Third task will be skipped, as we already have k1 in the queue
-			err = pool.SubmitWithKey("k1", func() {
+			err = pool.TrySubmitWithKey("k1", func() {
 				tasksDone.Inc()
-			})
+			}, pool.DefaultTimeout())
 			require.NoError(t, err)
 
 			// No tasks done yet as we're blocking the first task
@@ -125,28 +127,28 @@ func TestWorkerPool(t *testing.T) {
 
 		t.Run("should concurrently process for different keys", func(t *testing.T) {
 			defer goleak.VerifyNone(t)
-			pool := NewShardedWorkerPool(4, 10)
+			pool := NewShardedWorkerPool(4, 10, defaultTestTimeout)
 			defer pool.Stop()
 			tasksDone := atomic.Int32{}
 
 			// First task will block the worker
 			blockFirstTask := make(chan struct{})
 			firstTaskRunning := make(chan struct{})
-			err := pool.SubmitWithKey("k1", func() {
+			err := pool.TrySubmitWithKey("k1", func() {
 				firstTaskRunning <- struct{}{}
 				<-blockFirstTask
 				tasksDone.Inc()
-			})
+			}, pool.DefaultTimeout())
 			require.NoError(t, err)
 
 			// Wait for the first task to be running already and blocking the worker
 			<-firstTaskRunning
 
 			// Second and third tasks will complete as it has a key that will hash to a different shard
-			err = pool.SubmitWithKey("k2", func() { tasksDone.Inc() })
+			err = pool.TrySubmitWithKey("k2", func() { tasksDone.Inc() }, pool.DefaultTimeout())
 			require.NoError(t, err)
 
-			err = pool.SubmitWithKey("k3", func() { tasksDone.Inc() })
+			err = pool.TrySubmitWithKey("k3", func() { tasksDone.Inc() }, pool.DefaultTimeout())
 			require.NoError(t, err)
 
 			// Ensure the k2 and k3 tasks are done
@@ -161,21 +163,21 @@ func TestWorkerPool(t *testing.T) {
 			}, 3*time.Second, 5*time.Millisecond)
 		})
 
-		t.Run("should reject when queue is full", func(t *testing.T) {
+		t.Run("should reject when queue is full and times out waiting", func(t *testing.T) {
 			defer goleak.VerifyNone(t)
 			// Pool with one worker and queue size of 1 - all work goes to one queue
-			pool := NewShardedWorkerPool(1, 1)
+			pool := NewShardedWorkerPool(1, 1, defaultTestTimeout)
 			defer pool.Stop()
 			tasksDone := atomic.Int32{}
 
 			// First task will block the worker
 			blockFirstTask := make(chan struct{})
 			firstTaskRunning := make(chan struct{})
-			err := pool.SubmitWithKey("k1", func() {
+			err := pool.TrySubmitWithKey("k1", func() {
 				firstTaskRunning <- struct{}{}
 				<-blockFirstTask
 				tasksDone.Inc()
-			})
+			}, pool.DefaultTimeout())
 			require.NoError(t, err)
 			defer func() { blockFirstTask <- struct{}{} }()
 
@@ -184,14 +186,57 @@ func TestWorkerPool(t *testing.T) {
 			require.Equal(t, 0, pool.QueueSize())
 
 			// Second task will be queued
-			err = pool.SubmitWithKey("k2", func() { tasksDone.Inc() })
+			err = pool.TrySubmitWithKey("k2", func() { tasksDone.Inc() }, pool.DefaultTimeout())
 			require.NoError(t, err)
 			require.Equal(t, 1, pool.QueueSize())
 
 			// Third task cannot be accepted, because the queue is full
-			err = pool.SubmitWithKey("k3", func() { tasksDone.Inc() })
-			require.ErrorContains(t, err, "queue is full")
+			err = pool.TrySubmitWithKey("k3", func() { tasksDone.Inc() }, pool.DefaultTimeout())
+			require.ErrorContains(t, err, "timed out adding a task to worker queue")
 			require.Equal(t, 1, pool.QueueSize())
+		})
+
+		t.Run("should process when queue frees up within the timeout", func(t *testing.T) {
+			defer goleak.VerifyNone(t)
+			// Pool with one worker and queue size of 1 - all work goes to one queue
+			pool := NewShardedWorkerPool(1, 1, defaultTestTimeout)
+			defer pool.Stop()
+			tasksDone := atomic.Int32{}
+
+			// First task will block the worker
+			blockFirstTask := make(chan struct{})
+			firstTaskRunning := make(chan struct{})
+			err := pool.TrySubmitWithKey("k1", func() {
+				firstTaskRunning <- struct{}{}
+				<-blockFirstTask
+				tasksDone.Inc()
+			}, pool.DefaultTimeout())
+			require.NoError(t, err)
+
+			// Wait for the first task to be running already and blocking the worker
+			<-firstTaskRunning
+			require.Equal(t, 0, pool.QueueSize())
+
+			// Second task will be queued
+			err = pool.TrySubmitWithKey("k2", func() { tasksDone.Inc() }, pool.DefaultTimeout())
+			require.NoError(t, err)
+			require.Equal(t, 1, pool.QueueSize())
+
+			// Third task cannot be accepted right away with default timeout
+			err = pool.TrySubmitWithKey("k3", func() { tasksDone.Inc() }, pool.DefaultTimeout())
+			require.ErrorContains(t, err, "timed out adding a task to worker queue")
+			require.Equal(t, 1, pool.QueueSize())
+
+			// Unblock first task after some delay
+			go func() {
+				time.Sleep(10 * time.Millisecond)
+				blockFirstTask <- struct{}{}
+			}()
+
+			// If we submit the third task again with a longer timeout, it will eventually be accepted, as we allowed the
+			// first task to complete above.
+			err = pool.TrySubmitWithKey("k3", func() { tasksDone.Inc() }, time.Second)
+			require.NoError(t, err)
 		})
 	})
 }

--- a/pkg/flow/module_test.go
+++ b/pkg/flow/module_test.go
@@ -236,7 +236,7 @@ func testModuleControllerOptions(t *testing.T) *moduleControllerOptions {
 		DataPath:       t.TempDir(),
 		Reg:            prometheus.NewRegistry(),
 		ModuleRegistry: newModuleRegistry(),
-		WorkerPool:     worker.NewShardedWorkerPool(1, 100),
+		WorkerPool:     worker.NewShardedWorkerPool(1, 100, time.Minute),
 	}
 }
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This prevents a hot retry loop in the unlikely event of worker queue getting full. The symptom of hot retry loop would be a lot of log lines saying `failed to submit node for evaluation - the agent is likely overloaded and cannot keep up with evaluating components` - as it could be observed when running a test dedicated to reproducing this situation - `TestController_Updates_WithQueueFull`. 

#### Notes to the Reviewer

* `Flow` passes updated components to `loader`'s `EvaluateDependencies`, which submits the component's direct dependencies for evaluation to the worker pool.
* In unlikely event that the pool is full, e.g. we have a component that runs into a deadlock, we would currently log an error and return the parent component back to `Flow` for a retry. But `Flow` would attempt retry right away, leading to a hot loop using CPU and printing a lot of logs.
* In this PR I add a `timeout` parameter to worker pool's submit functions, which will attempt to queue the task until the `timeout` duration passes. As a result, we'll block for some time before failing when the queue is completely full, and the hot retry loop will be prevented, as well as the error log line will be printed less frequently.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated