### PR TITLE
SigV4 and AzureAD authentication support for `prometheus.remote_write`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ Main (unreleased)
 - Flow: the `prometheus.scrape` component can now configure the scraping of
   Prometheus native histograms. (@tpaschalis)
 
+- Flow: the `prometheus.remote_write` component now supports SigV4 and AzureAD authentication. (@ptodev)
+
 ### Enhancements
 
 - Clustering: allow advertise interfaces to be configurable, with the possibility to select all available interfaces. (@wildum)

--- a/component/prometheus/remotewrite/types.go
+++ b/component/prometheus/remotewrite/types.go
@@ -8,12 +8,16 @@ import (
 
 	types "github.com/grafana/agent/component/common/config"
 	flow_relabel "github.com/grafana/agent/component/common/relabel"
+	"github.com/grafana/river/rivertypes"
 
+	"github.com/google/uuid"
 	common "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
+	promsigv4 "github.com/prometheus/common/sigv4"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/storage/remote/azuread"
 )
 
 // Defaults for config blocks.
@@ -72,6 +76,8 @@ type EndpointOptions struct {
 	QueueOptions         *QueueOptions           `river:"queue_config,block,optional"`
 	MetadataOptions      *MetadataOptions        `river:"metadata_config,block,optional"`
 	WriteRelabelConfigs  []*flow_relabel.Config  `river:"write_relabel_config,block,optional"`
+	SigV4                *SigV4Config            `river:"sigv4,block,optional"`
+	AzureAD              *AzureADConfig          `river:"azuread,block,optional"`
 }
 
 // SetToDefault implements river.Defaulter.
@@ -83,12 +89,34 @@ func (r *EndpointOptions) SetToDefault() {
 	}
 }
 
+func isAuthSetInHttpClientConfig(cfg *types.HTTPClientConfig) bool {
+	return cfg.BasicAuth != nil ||
+		cfg.OAuth2 != nil ||
+		cfg.Authorization != nil ||
+		len(cfg.BearerToken) > 0 ||
+		len(cfg.BearerTokenFile) > 0
+}
+
 // Validate implements river.Validator.
 func (r *EndpointOptions) Validate() error {
 	// We must explicitly Validate because HTTPClientConfig is squashed and it won't run otherwise
 	if r.HTTPClientConfig != nil {
 		if err := r.HTTPClientConfig.Validate(); err != nil {
 			return err
+		}
+	}
+
+	const tooManyAuthErr = "at most one of sigv4, azuread, basic_auth, oauth2, bearer_token & bearer_token_file must be configured"
+
+	if r.SigV4 != nil {
+		if r.AzureAD != nil || isAuthSetInHttpClientConfig(r.HTTPClientConfig) {
+			return fmt.Errorf(tooManyAuthErr)
+		}
+	}
+
+	if r.AzureAD != nil {
+		if r.SigV4 != nil || isAuthSetInHttpClientConfig(r.HTTPClientConfig) {
+			return fmt.Errorf(tooManyAuthErr)
 		}
 	}
 
@@ -216,7 +244,8 @@ func convertConfigs(cfg Arguments) (*config.Config, error) {
 			HTTPClientConfig:    *rw.HTTPClientConfig.Convert(),
 			QueueConfig:         rw.QueueOptions.toPrometheusType(),
 			MetadataConfig:      rw.MetadataOptions.toPrometheusType(),
-			// TODO(rfratto): SigV4Config
+			SigV4Config:         rw.SigV4.toPrometheusType(),
+			AzureADConfig:       rw.AzureAD.toPrometheusType(),
 		})
 	}
 
@@ -235,4 +264,85 @@ func toLabels(in map[string]string) labels.Labels {
 	}
 	sort.Sort(res)
 	return res
+}
+
+// ManagedIdentityConfig is used to store managed identity config values
+type ManagedIdentityConfig struct {
+	// ClientID is the clientId of the managed identity that is being used to authenticate.
+	ClientID string `river:"client_id,attr"`
+}
+
+func (m ManagedIdentityConfig) toPrometheusType() azuread.ManagedIdentityConfig {
+	return azuread.ManagedIdentityConfig{
+		ClientID: m.ClientID,
+	}
+}
+
+type AzureADConfig struct {
+	// ManagedIdentity is the managed identity that is being used to authenticate.
+	ManagedIdentity ManagedIdentityConfig `river:"managed_identity,block"`
+
+	// Cloud is the Azure cloud in which the service is running. Example: AzurePublic/AzureGovernment/AzureChina.
+	Cloud string `river:"cloud,attr,optional"`
+}
+
+func (a *AzureADConfig) Validate() error {
+	if a.Cloud != azuread.AzureChina && a.Cloud != azuread.AzureGovernment && a.Cloud != azuread.AzurePublic {
+		return fmt.Errorf("must provide a cloud in the Azure AD config")
+	}
+
+	_, err := uuid.Parse(a.ManagedIdentity.ClientID)
+	if err != nil {
+		return fmt.Errorf("the provided Azure Managed Identity client_id provided is invalid")
+	}
+
+	return nil
+}
+
+// SetToDefault implements river.Defaulter.
+func (a *AzureADConfig) SetToDefault() {
+	*a = AzureADConfig{
+		Cloud: azuread.AzurePublic,
+	}
+}
+
+func (a *AzureADConfig) toPrometheusType() *azuread.AzureADConfig {
+	if a == nil {
+		return nil
+	}
+
+	mangedIdentity := a.ManagedIdentity.toPrometheusType()
+	return &azuread.AzureADConfig{
+		ManagedIdentity: &mangedIdentity,
+		Cloud:           a.Cloud,
+	}
+}
+
+type SigV4Config struct {
+	Region    string            `river:"region,attr,optional"`
+	AccessKey string            `river:"access_key,attr,optional"`
+	SecretKey rivertypes.Secret `river:"secret_key,attr,optional"`
+	Profile   string            `river:"profile,attr,optional"`
+	RoleARN   string            `river:"role_arn,attr,optional"`
+}
+
+func (s *SigV4Config) Validate() error {
+	if (s.AccessKey == "") != (s.SecretKey == "") {
+		return fmt.Errorf("must provide an AWS SigV4 access key and secret key if credentials are specified in the SigV4 config")
+	}
+	return nil
+}
+
+func (s *SigV4Config) toPrometheusType() *promsigv4.SigV4Config {
+	if s == nil {
+		return nil
+	}
+
+	return &promsigv4.SigV4Config{
+		Region:    s.Region,
+		AccessKey: s.AccessKey,
+		SecretKey: common.Secret(s.SecretKey),
+		Profile:   s.Profile,
+		RoleARN:   s.RoleARN,
+	}
 }

--- a/component/prometheus/remotewrite/types_test.go
+++ b/component/prometheus/remotewrite/types_test.go
@@ -277,5 +277,4 @@ func TestRiverConfig(t *testing.T) {
 			require.Equal(t, tc.expectedCfg, promCfg)
 		})
 	}
-
 }

--- a/component/prometheus/remotewrite/types_test.go
+++ b/component/prometheus/remotewrite/types_test.go
@@ -1,61 +1,281 @@
 package remotewrite
 
 import (
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/grafana/river"
+	commonconfig "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/sigv4"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/prometheus/prometheus/storage/remote/azuread"
 	"github.com/stretchr/testify/require"
 )
 
-func TestRiverConfig(t *testing.T) {
-	var exampleRiverConfig = `
-		external_labels = {
-			cluster = "local",
-		}
+func expectedCfg(transform func(c *config.Config)) *config.Config {
+	// Initialize this with the default expected config
+	res := &config.Config{
+		GlobalConfig: config.GlobalConfig{
+			ExternalLabels: labels.Labels{},
+		},
+		RemoteWriteConfigs: []*config.RemoteWriteConfig{
+			{
+				URL: &commonconfig.URL{
+					URL: &url.URL{
+						Scheme: "http",
+						Host:   "0.0.0.0:11111",
+						Path:   `/api/v1/write`,
+					},
+				},
+				RemoteTimeout:       model.Duration(30 * time.Second),
+				WriteRelabelConfigs: []*relabel.Config{},
+				SendExemplars:       true,
+				HTTPClientConfig: commonconfig.HTTPClientConfig{
+					FollowRedirects: true,
+					EnableHTTP2:     true,
+				},
+				QueueConfig: config.QueueConfig{
+					Capacity:          10000,
+					MaxShards:         50,
+					MinShards:         1,
+					MaxSamplesPerSend: 2000,
+					BatchSendDeadline: model.Duration(5 * time.Second),
+					MinBackoff:        model.Duration(30 * time.Millisecond),
+					MaxBackoff:        model.Duration(5 * time.Second),
+					RetryOnRateLimit:  true,
+				},
+				MetadataConfig: config.MetadataConfig{
+					Send:              true,
+					SendInterval:      model.Duration(1 * time.Minute),
+					MaxSamplesPerSend: 2000,
+				},
+			},
+		},
+	}
 
-		endpoint {
-			name           = "test-url"
-			url            = "http://0.0.0.0:11111/api/v1/write"
-			remote_timeout = "100ms"
-
-			queue_config {
-				batch_send_deadline = "100ms"
-			}
-
-			write_relabel_config {
-				source_labels = ["instance"]
-				target_label  = "instance"
-				action        = "lowercase"
-			}
-		}
-`
-
-	var args Arguments
-	err := river.Unmarshal([]byte(exampleRiverConfig), &args)
-	require.NoError(t, err)
+	if transform != nil {
+		transform(res)
+	}
+	return res
 }
 
-func TestBadRiverConfig(t *testing.T) {
-	var exampleRiverConfig = `
-		external_labels = {
-			cluster = "local",
-		}
-
-		endpoint {
-			name           = "test-url"
-			url            = "http://0.0.0.0:11111/api/v1/write"
-			remote_timeout = "100ms"
-			bearer_token = "token"
-			bearer_token_file = "/path/to/file.token"
-
-			queue_config {
-				batch_send_deadline = "100ms"
+func TestRiverConfig(t *testing.T) {
+	tests := []struct {
+		testName    string
+		cfg         string
+		expectedCfg *config.Config
+		errorMsg    string
+	}{
+		{
+			testName: "Endpoint_Defaults",
+			cfg: `
+			endpoint {
+				url = "http://0.0.0.0:11111/api/v1/write"
 			}
-		}
-`
+			`,
+			expectedCfg: expectedCfg(nil),
+		},
+		{
+			testName: "RelabelConfig",
+			cfg: `
+			external_labels = {
+				cluster = "local",
+			}
 
-	// Make sure the squashed HTTPClientConfig Validate function is being utilized correctly
-	var args Arguments
-	err := river.Unmarshal([]byte(exampleRiverConfig), &args)
-	require.ErrorContains(t, err, "at most one of bearer_token & bearer_token_file must be configured")
+			endpoint {
+				name           = "test-url"
+				url            = "http://0.0.0.0:11111/api/v1/write"
+				remote_timeout = "100ms"
+
+				queue_config {
+					batch_send_deadline = "100ms"
+				}
+
+				write_relabel_config {
+					source_labels = ["instance"]
+					target_label  = "instance"
+					action        = "lowercase"
+				}
+			}`,
+			expectedCfg: expectedCfg(func(c *config.Config) {
+				relabelCfg := &relabel.DefaultRelabelConfig
+				relabelCfg.SourceLabels = model.LabelNames{"instance"}
+				relabelCfg.TargetLabel = "instance"
+				relabelCfg.Action = "lowercase"
+
+				c.GlobalConfig.ExternalLabels = labels.FromMap(map[string]string{
+					"cluster": "local",
+				})
+				c.RemoteWriteConfigs[0].Name = "test-url"
+				c.RemoteWriteConfigs[0].RemoteTimeout = model.Duration(100 * time.Millisecond)
+				c.RemoteWriteConfigs[0].QueueConfig.BatchSendDeadline = model.Duration(100 * time.Millisecond)
+				c.RemoteWriteConfigs[0].WriteRelabelConfigs = []*relabel.Config{
+					relabelCfg,
+				}
+			}),
+		},
+		{
+			testName: "AzureAD_Defaults",
+			cfg: `
+			endpoint {
+				url  = "http://0.0.0.0:11111/api/v1/write"
+
+				azuread {
+					managed_identity {
+						client_id = "00000000-0000-0000-0000-000000000000"
+					}
+				}
+			}`,
+			expectedCfg: expectedCfg(func(c *config.Config) {
+				c.RemoteWriteConfigs[0].AzureADConfig = &azuread.AzureADConfig{
+					Cloud: "AzurePublic",
+					ManagedIdentity: &azuread.ManagedIdentityConfig{
+						ClientID: "00000000-0000-0000-0000-000000000000",
+					},
+				}
+			}),
+		},
+		{
+			testName: "AzureAD_Explicit",
+			cfg: `
+			endpoint {
+				url  = "http://0.0.0.0:11111/api/v1/write"
+
+				azuread {
+					cloud = "AzureChina"
+					managed_identity {
+						client_id = "00000000-0000-0000-0000-000000000000"
+					}
+				}
+			}`,
+			expectedCfg: expectedCfg(func(c *config.Config) {
+				c.RemoteWriteConfigs[0].AzureADConfig = &azuread.AzureADConfig{
+					Cloud: "AzureChina",
+					ManagedIdentity: &azuread.ManagedIdentityConfig{
+						ClientID: "00000000-0000-0000-0000-000000000000",
+					},
+				}
+			}),
+		},
+		{
+			testName: "SigV4_Defaults",
+			cfg: `
+			endpoint {
+				url  = "http://0.0.0.0:11111/api/v1/write"
+
+				sigv4 {}
+			}`,
+			expectedCfg: expectedCfg(func(c *config.Config) {
+				c.RemoteWriteConfigs[0].SigV4Config = &sigv4.SigV4Config{}
+			}),
+		},
+		{
+			testName: "SigV4_Explicit",
+			cfg: `
+			endpoint {
+				url  = "http://0.0.0.0:11111/api/v1/write"
+
+				sigv4 {
+					region     = "us-east-1"
+					access_key = "example_access_key"
+					secret_key = "example_secret_key"
+					profile    = "example_profile"
+					role_arn   = "example_role_arn"
+				}
+			}`,
+			expectedCfg: expectedCfg(func(c *config.Config) {
+				c.RemoteWriteConfigs[0].SigV4Config = &sigv4.SigV4Config{
+					Region:    "us-east-1",
+					AccessKey: "example_access_key",
+					SecretKey: commonconfig.Secret("example_secret_key"),
+					Profile:   "example_profile",
+					RoleARN:   "example_role_arn",
+				}
+			}),
+		},
+		{
+			testName: "TooManyAuth1",
+			cfg: `
+			endpoint {
+				url  = "http://0.0.0.0:11111/api/v1/write"
+
+				sigv4 {}
+				bearer_token = "token"
+			}`,
+			errorMsg: "at most one of sigv4, azuread, basic_auth, oauth2, bearer_token & bearer_token_file must be configured",
+		},
+		{
+			testName: "TooManyAuth2",
+			cfg: `
+			endpoint {
+				url  = "http://0.0.0.0:11111/api/v1/write"
+
+				sigv4 {}
+				azuread {
+					managed_identity {
+						client_id = "00000000-0000-0000-0000-000000000000"
+					}
+				}
+			}`,
+			errorMsg: "at most one of sigv4, azuread, basic_auth, oauth2, bearer_token & bearer_token_file must be configured",
+		},
+		{
+			testName: "BadAzureClientId",
+			cfg: `
+			endpoint {
+				url  = "http://0.0.0.0:11111/api/v1/write"
+
+				azuread {
+					managed_identity {
+						client_id = "bad_client_id"
+					}
+				}
+			}`,
+			errorMsg: "the provided Azure Managed Identity client_id provided is invalid",
+		},
+		{
+			// Make sure the squashed HTTPClientConfig Validate function is being utilized correctly
+			testName: "BadBearerConfig",
+			cfg: `
+			external_labels = {
+				cluster = "local",
+			}
+
+			endpoint {
+				name           = "test-url"
+				url            = "http://0.0.0.0:11111/api/v1/write"
+				remote_timeout = "100ms"
+				bearer_token = "token"
+				bearer_token_file = "/path/to/file.token"
+
+				queue_config {
+					batch_send_deadline = "100ms"
+				}
+			}`,
+			errorMsg: "at most one of bearer_token & bearer_token_file must be configured",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			var args Arguments
+			err := river.Unmarshal([]byte(tc.cfg), &args)
+
+			if tc.errorMsg != "" {
+				require.ErrorContains(t, err, tc.errorMsg)
+				return
+			}
+			require.NoError(t, err)
+
+			promCfg, err := convertConfigs(args)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expectedCfg, promCfg)
+		})
+	}
+
 }

--- a/converter/internal/prometheusconvert/testdata/scrape.river
+++ b/converter/internal/prometheusconvert/testdata/scrape.river
@@ -43,7 +43,7 @@ prometheus.remote_write "default" {
 	}
 
 	endpoint {
-		name = "remote-1"
+		name = "remote1"
 		url  = "http://remote-write-url1"
 
 		queue_config { }
@@ -68,5 +68,64 @@ prometheus.remote_write "default" {
 		queue_config { }
 
 		metadata_config { }
+	}
+
+	endpoint {
+		name = "remote3_sigv4_defaults"
+		url  = "http://localhost:9012/api/prom/push"
+
+		queue_config { }
+
+		metadata_config { }
+
+		sigv4 { }
+	}
+
+	endpoint {
+		name = "remote4_sigv4_explicit"
+		url  = "http://localhost:9012/api/prom/push"
+
+		queue_config { }
+
+		metadata_config { }
+
+		sigv4 {
+			region     = "us-east-1"
+			access_key = "fake_access_key"
+			secret_key = "fake_secret_key"
+			profile    = "fake_profile"
+			role_arn   = "fake_role_arn"
+		}
+	}
+
+	endpoint {
+		name = "remote5_azuread_defaults"
+		url  = "http://localhost:9012/api/prom/push"
+
+		queue_config { }
+
+		metadata_config { }
+
+		azuread {
+			managed_identity {
+				client_id = "00000000-0000-0000-0000-000000000000"
+			}
+		}
+	}
+
+	endpoint {
+		name = "remote6_azuread_explicit"
+		url  = "http://localhost:9012/api/prom/push"
+
+		queue_config { }
+
+		metadata_config { }
+
+		azuread {
+			managed_identity {
+				client_id = "00000000-0000-0000-0000-000000000000"
+			}
+			cloud = "AzureGovernment"
+		}
 	}
 }

--- a/converter/internal/prometheusconvert/testdata/scrape.yaml
+++ b/converter/internal/prometheusconvert/testdata/scrape.yaml
@@ -22,7 +22,7 @@ scrape_configs:
       - targets: ["localhost:9093"]
 
 remote_write:
-  - name: "remote-1"
+  - name: "remote1"
     url: "http://remote-write-url1"
     write_relabel_configs:
       - source_labels: [__address1__]
@@ -31,3 +31,25 @@ remote_write:
         target_label: __param_target2
   - name: "remote2"
     url: "http://remote-write-url2"
+  - name: "remote3_sigv4_defaults"
+    url: http://localhost:9012/api/prom/push
+    sigv4: {}
+  - name: "remote4_sigv4_explicit"
+    url: http://localhost:9012/api/prom/push
+    sigv4:
+      region: us-east-1
+      access_key: fake_access_key
+      secret_key: fake_secret_key
+      profile: fake_profile
+      role_arn: fake_role_arn
+  - name: "remote5_azuread_defaults"
+    url: http://localhost:9012/api/prom/push
+    azuread:
+      managed_identity:
+        client_id: 00000000-0000-0000-0000-000000000000
+  - name: "remote6_azuread_explicit"
+    url: http://localhost:9012/api/prom/push
+    azuread:
+      cloud: AzureGovernment
+      managed_identity:
+        client_id: 00000000-0000-0000-0000-000000000000

--- a/converter/internal/prometheusconvert/testdata/unsupported.diags
+++ b/converter/internal/prometheusconvert/testdata/unsupported.diags
@@ -7,7 +7,6 @@
 (Error) unsupported native_histogram_bucket_limit for scrape_configs
 (Error) unsupported storage config was provided
 (Error) unsupported tracing config was provided
-(Error) unsupported remote_write sigv4 config was provided
 (Error) unsupported HTTP Client config proxy_from_environment was provided
 (Error) unsupported HTTP Client config max_version was provided
 (Error) unsupported remote_read config was provided

--- a/converter/internal/prometheusconvert/testdata/unsupported.yaml
+++ b/converter/internal/prometheusconvert/testdata/unsupported.yaml
@@ -51,7 +51,5 @@ remote_write:
     proxy_from_environment: true
     tls_config:
       max_version: TLS13
-    sigv4:
-      region: us-east-1
   - name: "remote2"
     url: "http://remote-write-url2"

--- a/converter/internal/staticconvert/testdata/prom_remote_write.river
+++ b/converter/internal/staticconvert/testdata/prom_remote_write.river
@@ -42,3 +42,70 @@ prometheus.remote_write "metrics_test3" {
 		metadata_config { }
 	}
 }
+
+prometheus.remote_write "metrics_test4_sigv4_defaults" {
+	endpoint {
+		name = "test4_sigv4_defaults-c42e88"
+		url  = "http://localhost:9012/api/prom/push"
+
+		queue_config { }
+
+		metadata_config { }
+
+		sigv4 { }
+	}
+}
+
+prometheus.remote_write "metrics_test5_sigv4_explicit" {
+	endpoint {
+		name = "test5_sigv4_explicit-050ad5"
+		url  = "http://localhost:9012/api/prom/push"
+
+		queue_config { }
+
+		metadata_config { }
+
+		sigv4 {
+			region     = "us-east-1"
+			access_key = "fake_access_key"
+			secret_key = "fake_secret_key"
+			profile    = "fake_profile"
+			role_arn   = "fake_role_arn"
+		}
+	}
+}
+
+prometheus.remote_write "metrics_test6_azuread_defaults" {
+	endpoint {
+		name = "test6_azuread_defaults-50e17f"
+		url  = "http://localhost:9012/api/prom/push"
+
+		queue_config { }
+
+		metadata_config { }
+
+		azuread {
+			managed_identity {
+				client_id = "00000000-0000-0000-0000-000000000000"
+			}
+		}
+	}
+}
+
+prometheus.remote_write "metrics_test7_azuread_explicit" {
+	endpoint {
+		name = "test7_azuread_explicit-0f55f1"
+		url  = "http://localhost:9012/api/prom/push"
+
+		queue_config { }
+
+		metadata_config { }
+
+		azuread {
+			managed_identity {
+				client_id = "00000000-0000-0000-0000-000000000000"
+			}
+			cloud = "AzureGovernment"
+		}
+	}
+}

--- a/converter/internal/staticconvert/testdata/prom_remote_write.yaml
+++ b/converter/internal/staticconvert/testdata/prom_remote_write.yaml
@@ -16,4 +16,29 @@ metrics:
         - url: http://localhost:9012/api/prom/push
           queue_config:
             retry_on_http_429: false
-    
+    - name: "test4_sigv4_defaults"
+      remote_write:
+        - url: http://localhost:9012/api/prom/push
+          sigv4: {}
+    - name: "test5_sigv4_explicit"
+      remote_write:
+        - url: http://localhost:9012/api/prom/push
+          sigv4:
+            region: us-east-1
+            access_key: fake_access_key
+            secret_key: fake_secret_key
+            profile: fake_profile
+            role_arn: fake_role_arn
+    - name: "test6_azuread_defaults"
+      remote_write:
+        - url: http://localhost:9012/api/prom/push
+          azuread:
+            managed_identity:
+              client_id: 00000000-0000-0000-0000-000000000000
+    - name: "test7_azuread_explicit"
+      remote_write:
+        - url: http://localhost:9012/api/prom/push
+          azuread:
+            cloud: AzureGovernment
+            managed_identity:
+              client_id: 00000000-0000-0000-0000-000000000000

--- a/docs/sources/flow/reference/components/prometheus.remote_write.md
+++ b/docs/sources/flow/reference/components/prometheus.remote_write.md
@@ -54,6 +54,9 @@ endpoint > basic_auth | [basic_auth][] | Configure basic_auth for authenticating
 endpoint > authorization | [authorization][] | Configure generic authorization to the endpoint. | no
 endpoint > oauth2 | [oauth2][] | Configure OAuth2 for authenticating to the endpoint. | no
 endpoint > oauth2 > tls_config | [tls_config][] | Configure TLS settings for connecting to the endpoint. | no
+endpoint > sigv4 | [sigv4][] | Configure AWS Signature Verification 4 for authenticating to the endpoint. | no
+endpoint > azuread | [azuread][] | Configure AzureAD for authenticating to the endpoint. | no
+endpoint > azuread > managed_identity | [managed_identity][] | Configure Azure user-assigned managed identity. | yes
 endpoint > tls_config | [tls_config][] | Configure TLS settings for connecting to the endpoint. | no
 endpoint > queue_config | [queue_config][] | Configuration for how metrics are batched before sending. | no
 endpoint > metadata_config | [metadata_config][] | Configuration for how metric metadata is sent. | no
@@ -68,6 +71,9 @@ basic_auth` refers to a `basic_auth` block defined inside an
 [basic_auth]: #basic_auth-block
 [authorization]: #authorization-block
 [oauth2]: #oauth2-block
+[sigv4]: #sigv4-block
+[azuread]: #azuread-block
+[managed_identity]: #managed_identity-block
 [tls_config]: #tls_config-block
 [queue_config]: #queue_config-block
 [metadata_config]: #metadata_config-block
@@ -101,6 +107,8 @@ Name | Type | Description | Default | Required
  - [`basic_auth` block][basic_auth].
  - [`authorization` block][authorization].
  - [`oauth2` block][oauth2].
+ - [`sigv4` block][sigv4].
+ - [`azuread` block][azuread].
 
 When multiple `endpoint` blocks are provided, metrics are concurrently sent to all
 configured locations. Each endpoint has a _queue_ which is used to read metrics
@@ -127,6 +135,18 @@ metrics fails.
 ### oauth2 block
 
 {{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
+
+### sigv4 block
+
+{{< docs/shared lookup="flow/reference/components/sigv4-block.md" source="agent" version="<AGENT VERSION>" >}}
+
+### azuread block
+
+{{< docs/shared lookup="flow/reference/components/azuread-block.md" source="agent" version="<AGENT VERSION>" >}}
+
+### managed_identity block
+
+{{< docs/shared lookup="flow/reference/components/managed_identity-block.md" source="agent" version="<AGENT VERSION>" >}}
 
 ### tls_config block
 

--- a/docs/sources/shared/flow/reference/components/azuread-block.md
+++ b/docs/sources/shared/flow/reference/components/azuread-block.md
@@ -1,0 +1,19 @@
+---
+aliases:
+- /docs/agent/shared/flow/reference/components/azuread-block/
+- /docs/grafana-cloud/agent/shared/flow/reference/components/azuread-block/
+- /docs/grafana-cloud/monitor-infrastructure/agent/shared/flow/reference/components/azuread-block/
+- /docs/grafana-cloud/monitor-infrastructure/integrations/agent/shared/flow/reference/components/azuread-block/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/reference/components/azuread-block/
+description: Shared content, azuread block
+headless: true
+---
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`cloud` | `string` | The Azure Cloud. | `"AzurePublic"` | no
+
+The supported values for `cloud` are:
+* `"AzurePublic"`
+* `"AzureChina"`
+* `"AzureGovernment"`

--- a/docs/sources/shared/flow/reference/components/managed_identity-block.md
+++ b/docs/sources/shared/flow/reference/components/managed_identity-block.md
@@ -1,0 +1,22 @@
+---
+aliases:
+- /docs/agent/shared/flow/reference/components/managed_identity-block/
+- /docs/grafana-cloud/agent/shared/flow/reference/components/managed_identity-block/
+- /docs/grafana-cloud/monitor-infrastructure/agent/shared/flow/reference/components/managed_identity-block/
+- /docs/grafana-cloud/monitor-infrastructure/integrations/agent/shared/flow/reference/components/managed_identity-block/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/reference/components/managed_identity-block/
+description: Shared content, managed_identity block
+headless: true
+---
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`client_id` | `string` | Client ID of the managed identity which is used to authenticate. | | yes
+
+`client_id` should be a valid [UUID][] in one of the supported formats:
+* `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
+* `urn:uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` 
+* Microsoft encoding: `{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}`
+* Raw hex encoding: `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
+
+[UUID]: https://en.wikipedia.org/wiki/Universally_unique_identifier

--- a/docs/sources/shared/flow/reference/components/sigv4-block.md
+++ b/docs/sources/shared/flow/reference/components/sigv4-block.md
@@ -1,0 +1,24 @@
+---
+aliases:
+- /docs/agent/shared/flow/reference/components/sigv4-block/
+- /docs/grafana-cloud/agent/shared/flow/reference/components/sigv4-block/
+- /docs/grafana-cloud/monitor-infrastructure/agent/shared/flow/reference/components/sigv4-block/
+- /docs/grafana-cloud/monitor-infrastructure/integrations/agent/shared/flow/reference/components/sigv4-block/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/reference/components/sigv4-block/
+description: Shared content, sigv4 block
+headless: true
+---
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`region` | `string` | AWS region. | | no
+`access_key` | `string` | AWS API access key. | | no
+`secret_key` | `secret` | AWS API secret key.| | no
+`profile` | `string` | Named AWS profile used to authenticate. | | no
+`role_arn` | `string` | AWS Role ARN, an alternative to using AWS API keys. | | no
+
+If `region` is left blank, the region from the default credentials chain is used.
+
+If `access_key` is left blank, the environment variable `AWS_ACCESS_KEY_ID` is used.
+
+If `secret_key` is left blank, the environment variable `AWS_SECRET_ACCESS_KEY` is used.


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Adding SigV4 and AzureAD authentication support for `prometheus.remote_write`.

#### Which issue(s) this PR fixes

Fixes #5346

#### Notes to the Reviewer

Unlike other authentication methods, this one is not used in discovery processes since it's just specific to remote write.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated