### PR TITLE
`otelcol.auth.oauth2`: Change the type of the `client_secret` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,9 @@ Main (unreleased)
 
 - Update Prometheus dependency to v2.46.0. (@tpaschalis)
 
+- The `client_secret` config argument in the `otelcol.auth.oauth2` component is 
+  now of type `secret` instead of type `string`. (@ptodev)
+
 ### Bugfixes
 
 - Fixed `otelcol.exporter.prometheus` label names for the `otel_scope_info`

--- a/component/otelcol/auth/oauth2/oauth2.go
+++ b/component/otelcol/auth/oauth2/oauth2.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/auth"
 	otel_service "github.com/grafana/agent/service/otel"
+	"github.com/grafana/river/rivertypes"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension"
 	otelcomponent "go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configopaque"
@@ -31,7 +32,7 @@ func init() {
 // Arguments configures the otelcol.auth.oauth2 component.
 type Arguments struct {
 	ClientID       string                     `river:"client_id,attr"`
-	ClientSecret   string                     `river:"client_secret,attr"`
+	ClientSecret   rivertypes.Secret          `river:"client_secret,attr"`
 	TokenURL       string                     `river:"token_url,attr"`
 	EndpointParams url.Values                 `river:"endpoint_params,attr,optional"`
 	Scopes         []string                   `river:"scopes,attr,optional"`

--- a/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
@@ -39,7 +39,7 @@ otelcol.auth.oauth2 "LABEL" {
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `client_id` | `string` | The client identifier issued to the client. | | yes
-`client_secret` | `string` | The secret string associated with the client identifier. | | yes
+`client_secret` | `secret` | The secret string associated with the client identifier. | | yes
 `token_url` | `string` | The server endpoint URL from which to get tokens. | | yes
 `endpoint_params` | `map(list(string))` | Additional parameters that are sent to the token endpoint. | `{}` | no
 `scopes` | `list(string)` | Requested permissions associated for the client. | `[]` | no


### PR DESCRIPTION
Changing the type of the `client_secret` argument of the `otelcol.auth.oauth2` component from `string` to `secret`. It should not have been a `string` in the first place... this is an oversight from the time when the component was created.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated