### PR TITLE
Fix header weight for "Debug metrics"

### DIFF
--- a/docs/sources/flow/reference/components/discovery.azure.md
+++ b/docs/sources/flow/reference/components/discovery.azure.md
@@ -107,7 +107,7 @@ values.
 
 `discovery.azure` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.azure` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.consul.md
+++ b/docs/sources/flow/reference/components/discovery.consul.md
@@ -129,7 +129,7 @@ values.
 
 `discovery.consul` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.consul` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.consulagent.md
+++ b/docs/sources/flow/reference/components/discovery.consulagent.md
@@ -85,7 +85,7 @@ values.
 
 `discovery.consulagent` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 - `discovery_consulagent_rpc_failures_total` (Counter): The number of Consul Agent RPC call failures.
 - `discovery_consulagent_rpc_duration_seconds` (SummaryVec): The duration of a Consul Agent RPC call in seconds.

--- a/docs/sources/flow/reference/components/discovery.digitalocean.md
+++ b/docs/sources/flow/reference/components/discovery.digitalocean.md
@@ -85,7 +85,7 @@ values.
 
 `discovery.digitalocean` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.digitalocean` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.dns.md
+++ b/docs/sources/flow/reference/components/discovery.dns.md
@@ -58,7 +58,7 @@ values.
 
 `discovery.dns` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.dns` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.docker.md
+++ b/docs/sources/flow/reference/components/discovery.docker.md
@@ -145,7 +145,7 @@ values.
 
 `discovery.docker` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.docker` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.dockerswarm.md
+++ b/docs/sources/flow/reference/components/discovery.dockerswarm.md
@@ -191,7 +191,7 @@ values.
 
 `discovery.dockerswarm` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.dockerswarm` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.ec2.md
+++ b/docs/sources/flow/reference/components/discovery.ec2.md
@@ -102,7 +102,7 @@ values.
 
 `discovery.ec2` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.ec2` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.eureka.md
+++ b/docs/sources/flow/reference/components/discovery.eureka.md
@@ -108,7 +108,7 @@ values.
 
 `discovery.eureka` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.eureka` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.file.md
+++ b/docs/sources/flow/reference/components/discovery.file.md
@@ -63,7 +63,7 @@ values.
 
 `discovery.file` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.file` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.gce.md
+++ b/docs/sources/flow/reference/components/discovery.gce.md
@@ -80,7 +80,7 @@ values.
 
 `discovery.gce` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.gce` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.hetzner.md
+++ b/docs/sources/flow/reference/components/discovery.hetzner.md
@@ -141,7 +141,7 @@ values.
 
 `discovery.hetzner` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.hetzner` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.http.md
+++ b/docs/sources/flow/reference/components/discovery.http.md
@@ -153,7 +153,7 @@ values.
 
 `discovery.http` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 * `prometheus_sd_http_failures_total` (counter): Total number of refresh failures.
 

--- a/docs/sources/flow/reference/components/discovery.ionos.md
+++ b/docs/sources/flow/reference/components/discovery.ionos.md
@@ -106,7 +106,7 @@ values.
 
 `discovery.ionos` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.ionos` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.kubelet.md
+++ b/docs/sources/flow/reference/components/discovery.kubelet.md
@@ -126,7 +126,7 @@ values.
 
 `discovery.kubelet` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.kubelet` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.kubernetes.md
+++ b/docs/sources/flow/reference/components/discovery.kubernetes.md
@@ -353,7 +353,7 @@ values.
 
 `discovery.kubernetes` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.kubernetes` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.kuma.md
+++ b/docs/sources/flow/reference/components/discovery.kuma.md
@@ -105,7 +105,7 @@ values.
 
 `discovery.kuma` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.kuma` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.lightsail.md
+++ b/docs/sources/flow/reference/components/discovery.lightsail.md
@@ -67,7 +67,7 @@ values.
 
 `discovery.lightsail` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.lightsail` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.linode.md
+++ b/docs/sources/flow/reference/components/discovery.linode.md
@@ -113,7 +113,7 @@ values.
 
 `discovery.linode` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.linode` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.marathon.md
+++ b/docs/sources/flow/reference/components/discovery.marathon.md
@@ -109,7 +109,7 @@ values.
 
 `discovery.marathon` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.marathon` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.nerve.md
+++ b/docs/sources/flow/reference/components/discovery.nerve.md
@@ -63,7 +63,7 @@ values.
 
 `discovery.nerve` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.nerve` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.nomad.md
+++ b/docs/sources/flow/reference/components/discovery.nomad.md
@@ -114,7 +114,7 @@ values.
 
 `discovery.nomad` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.nomad` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.openstack.md
+++ b/docs/sources/flow/reference/components/discovery.openstack.md
@@ -122,7 +122,7 @@ values.
 
 `discovery.openstack` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.openstack` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.puppetdb.md
+++ b/docs/sources/flow/reference/components/discovery.puppetdb.md
@@ -120,7 +120,7 @@ values.
 
 `discovery.puppetdb` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.puppetdb` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.relabel.md
+++ b/docs/sources/flow/reference/components/discovery.relabel.md
@@ -92,7 +92,7 @@ values.
 
 `discovery.relabel` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.relabel` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.scaleway.md
+++ b/docs/sources/flow/reference/components/discovery.scaleway.md
@@ -131,7 +131,7 @@ values.
 
 `discovery.scaleway` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.scaleway` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.serverset.md
+++ b/docs/sources/flow/reference/components/discovery.serverset.md
@@ -61,7 +61,7 @@ values.
 
 `discovery.serverset` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.serverset` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.triton.md
+++ b/docs/sources/flow/reference/components/discovery.triton.md
@@ -92,7 +92,7 @@ values.
 
 `discovery.triton` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.triton` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/discovery.uyuni.md
+++ b/docs/sources/flow/reference/components/discovery.uyuni.md
@@ -88,7 +88,7 @@ values.
 
 `discovery.uyuni` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `discovery.uyuni` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/faro.receiver.md
+++ b/docs/sources/flow/reference/components/faro.receiver.md
@@ -193,7 +193,7 @@ start.
 
 `faro.receiver` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `faro.receiver` exposes the following metrics for monitoring the component:
 

--- a/docs/sources/flow/reference/components/local.file.md
+++ b/docs/sources/flow/reference/components/local.file.md
@@ -68,7 +68,7 @@ component.
 
 `local.file` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 * `agent_local_file_timestamp_last_accessed_unix_seconds` (gauge): The
   timestamp, in Unix seconds, that the file was last successfully accessed.

--- a/docs/sources/flow/reference/components/local.file_match.md
+++ b/docs/sources/flow/reference/components/local.file_match.md
@@ -59,7 +59,7 @@ values.
 
 `local.file_match` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `local.file_match` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/module.file.md
+++ b/docs/sources/flow/reference/components/module.file.md
@@ -108,7 +108,7 @@ unhealthy and the health includes the error from loading the module.
 
 `module.file` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `module.file` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/module.git.md
+++ b/docs/sources/flow/reference/components/module.git.md
@@ -132,7 +132,7 @@ and most recent load of the module was successful.
 * The full SHA of the currently checked out revision.
 * The most recent error when trying to fetch the repository, if any.
 
-### Debug metrics
+## Debug metrics
 
 `module.git` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/module.http.md
+++ b/docs/sources/flow/reference/components/module.http.md
@@ -109,7 +109,7 @@ unhealthy, and the health includes the error from loading the module.
 
 `module.http` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `module.http` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/module.string.md
+++ b/docs/sources/flow/reference/components/module.string.md
@@ -102,7 +102,7 @@ unhealthy and the health includes the error from loading the module.
 
 `module.string` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `module.string` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/prometheus.operator.podmonitors.md
+++ b/docs/sources/flow/reference/components/prometheus.operator.podmonitors.md
@@ -201,8 +201,9 @@ scrape job on the component's debug endpoint, including discovered labels, and t
 
 It also exposes some debug information for each PodMonitor it has discovered, including any errors found while reconciling the scrape configuration from the PodMonitor.
 
-### Debug metrics
+## Debug metrics
 
+`prometheus.operator.podmonitors` does not expose any component-specific debug metrics.
 
 ## Example
 

--- a/docs/sources/flow/reference/components/prometheus.operator.probes.md
+++ b/docs/sources/flow/reference/components/prometheus.operator.probes.md
@@ -201,8 +201,9 @@ scrape job on the component's debug endpoint, including discovered labels, and t
 
 It also exposes some debug information for each Probe it has discovered, including any errors found while reconciling the scrape configuration from the Probe.
 
-### Debug metrics
+## Debug metrics
 
+`prometheus.operator.probes` does not expose any component-specific debug metrics.
 
 ## Example
 

--- a/docs/sources/flow/reference/components/prometheus.operator.servicemonitors.md
+++ b/docs/sources/flow/reference/components/prometheus.operator.servicemonitors.md
@@ -201,8 +201,9 @@ scrape job on the component's debug endpoint, including discovered labels, and t
 
 It also exposes some debug information for each ServiceMonitor it has discovered, including any errors found while reconciling the scrape configuration from the ServiceMonitor.
 
-### Debug metrics
+## Debug metrics
 
+`prometheus.operator.servicemonitors` does not expose any component-specific debug metrics.
 
 ## Example
 

--- a/docs/sources/flow/reference/components/prometheus.remote_write.md
+++ b/docs/sources/flow/reference/components/prometheus.remote_write.md
@@ -254,7 +254,7 @@ values.
 `prometheus.remote_write` does not expose any component-specific debug
 information.
 
-### Debug metrics
+## Debug metrics
 
 * `agent_wal_storage_active_series` (gauge): Current number of active series
   being tracked by the WAL.

--- a/docs/sources/flow/reference/components/remote.http.md
+++ b/docs/sources/flow/reference/components/remote.http.md
@@ -129,7 +129,7 @@ request of the specified URL succeeds.
 
 `remote.http` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `remote.http` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/remote.kubernetes.configmap.md
+++ b/docs/sources/flow/reference/components/remote.kubernetes.configmap.md
@@ -121,7 +121,7 @@ Instances of `remote.kubernetes.configmap` report as healthy if the most recent 
 
 `remote.kubernetes.configmap` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `remote.kubernetes.configmap` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/remote.kubernetes.secret.md
+++ b/docs/sources/flow/reference/components/remote.kubernetes.secret.md
@@ -133,7 +133,7 @@ Instances of `remote.kubernetes.secret` report as healthy if the most recent att
 
 `remote.kubernetes.secret` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `remote.kubernetes.secret` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/remote.s3.md
+++ b/docs/sources/flow/reference/components/remote.s3.md
@@ -87,7 +87,7 @@ the watched file was successful.
 
 `remote.s3` does not expose any component-specific debug information.
 
-### Debug metrics
+## Debug metrics
 
 `remote.s3` does not expose any component-specific debug metrics.
 

--- a/docs/sources/flow/reference/components/remote.vault.md
+++ b/docs/sources/flow/reference/components/remote.vault.md
@@ -300,7 +300,7 @@ secret around:
 * Whether the token is renewable.
 * Warnings from Vault from when the token was retrieved.
 
-### Debug metrics
+## Debug metrics
 
 `remote.vault` exposes the following metrics:
 


### PR DESCRIPTION
In the Flow component docs, some of the "Debug metric" headers have the wrong weight. This PR brings them in line with the team's [best practices](https://github.com/grafana/agent/blob/main/docs/developer/writing-flow-component-documentation.md).