### PR TITLE
Blocks to show parents in docs headers.

### DIFF
--- a/docs/developer/writing-flow-component-documentation.md
+++ b/docs/developer/writing-flow-component-documentation.md
@@ -317,9 +317,14 @@ The Block section is a sub-section of Blocks describing an individual block
 supported by a component. There is one Block section per recognized block type
 within the component.
 
-The Block section starts with an `h3` header with the name of the block,
-followed by the word "block." Do not surround the name of the block in
-backticks in the header.
+The Block section starts with an `h3` header with the names of the block and its parents, 
+separated by ` > `. Do not surround the names of the blocks in backticks in the header.
+
+For example, if the section is for a block called `annotation`, which is contained inside 
+a block called `extract`, which is contained inside a block called `filter`, the header should be:
+```
+### filter > extract > annotation
+```
 
 Block sections are similar to Arguments section, where it is composed of:
 

--- a/docs/sources/flow/reference/components/otelcol.processor.k8sattributes.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.k8sattributes.md
@@ -69,10 +69,10 @@ Hierarchy | Block | Description | Required
 output | [output][] | Configures where to send received telemetry data. | yes
 extract | [extract][] | Rules for extracting data from Kubernetes. | no
 extract > annotation | [annotation][] | Creating resource attributes from Kubernetes annotations. | no
-extract > label | [extract_label][] | Creating resource attributes from Kubernetes labels. | no
+extract > label | [label][extract_label] | Creating resource attributes from Kubernetes labels. | no
 filter | [filter][] | Filters the data loaded from Kubernetes. | no
 filter > field | [field][] | Filter pods by generic Kubernetes fields. | no
-filter > label | [filter_label][] | Filter pods by Kubernetes labels. | no
+filter > label | [label][filter_label] | Filter pods by Kubernetes labels. | no
 pod_association | [pod_association][] | Rules to associate pod metadata with telemetry signals. | no
 pod_association > source | [source][] | Source information to identify a pod. | no
 exclude | [exclude][] | Exclude pods from being processed. | no
@@ -94,7 +94,7 @@ refers to an `annotation` block defined inside an `extract` block.
 [exclude]: #exclude-block
 [pod]: #pod-block
 
-### extract block
+### extract
 
 The `extract` block configures which metadata, annotations, and labels to extract from the pod.
 
@@ -138,19 +138,19 @@ By default, if `metadata` is not specified, the following fields are extracted a
 * `container.image.name` (requires one of the following additional attributes to be set: `container.id` or `k8s.container.name`)
 * `container.image.tag` (requires one of the following additional attributes to be set: `container.id` or `k8s.container.name`)
 
-### annotation block
+### extract > annotation
 
 The `annotation` block configures how to extract Kubernetes annotations.
 
 {{< docs/shared lookup="flow/reference/components/extract-field-block.md" source="agent" version="<AGENT VERSION>" >}}
 
-### label block {#extract-label-block}
+### extract > label {#extract-label-block}
 
 The `label` block configures how to extract Kubernetes labels.
 
 {{< docs/shared lookup="flow/reference/components/extract-field-block.md" source="agent" version="<AGENT VERSION>" >}}
 
-### filter block
+### filter
 
 The `filter` block configures which nodes to get data from and which fields and labels to fetch.
 
@@ -163,19 +163,19 @@ Name | Type     | Description                                                   
 
 If `node` is specified, then any pods not running on the specified node will be ignored by `otelcol.processor.k8sattributes`.
 
-### field block
+### filter > field
 
 The `field` block allows you to filter pods by generic Kubernetes fields.
 
 {{< docs/shared lookup="flow/reference/components/field-filter-block.md" source="agent" version="<AGENT VERSION>" >}}
 
-### label block {#filter-label-block}
+### filter > label {#filter-label-block}
 
 The `label` block allows you to filter pods by generic Kubernetes labels.
 
 {{< docs/shared lookup="flow/reference/components/field-filter-block.md" source="agent" version="<AGENT VERSION>" >}}
 
-### pod_association block
+### pod_association
 
 The `pod_association` block configures rules on how to associate logs/traces/metrics to pods.
 
@@ -204,7 +204,7 @@ pod_association {
 }
 ```
 
-### source block
+#### pod_association > source
 
 The `source` block configures a pod association rule. This is used by the `k8sattributes` processor to determine the
 pod associated with a telemetry signal.
@@ -220,11 +220,14 @@ Name | Type     | Description                                                   
 `name` | `string` | Name represents extracted key name. For example, `ip`, `pod_uid`, `k8s.pod.ip`           |  | no
 
 
-### exclude block
+### exclude
 
 The `exclude` block configures which pods to exclude from the processor.
 
-### pod block
+The `exclude` block does not support any arguments, and is configured
+fully through child blocks.
+
+### exclude > pod
 
 The `pod` block configures a pod to be excluded from the processor.
 
@@ -234,7 +237,7 @@ Name | Type     | Description         | Default | Required
 ---- |----------|---------------------| ------- | --------
 `name` | `string` | The name of the pod |  | yes
 
-### output block
+### output
 
 {{< docs/shared lookup="flow/reference/components/output-block.md" source="agent" version="<AGENT VERSION>" >}}
 


### PR DESCRIPTION
There are two issues with the current [best practices for writing flow components](https://github.com/grafana/agent/blob/main/docs/developer/writing-flow-component-documentation.md#block-section):

1. They do not say what to do in case two blocks have the same name.
2. It is hard to tell where each block fits in the config hierarchy just by looking at the table of contents on the right of the webpage

#5229 introduced the `otelcol.processor.k8sattributes` component which contains two blocks called "label". The best practices for writing flow components docs do not mention what to do in this case. If we follow them, we will end up with two blocks with the same name in the table of contents:

![Screenshot 2023-10-05 at 18 14 21](https://github.com/grafana/agent/assets/5834788/15e52123-71fc-4b42-b6f8-723ad408569c)

In this PR, I am proposing two changes:
* Including the parents of a block in the header. This makes it more clear which block this heading is referring to.
* Dropping the "block" word from the header. Every header under "Blocks" is a block, so having the word "block" in each heading is redundant.

This is what the table of contents looks like for `otelcol.processor.k8sattributes` after this change:

![Screenshot 2023-10-05 at 18 14 03](https://github.com/grafana/agent/assets/5834788/26176aa7-bcff-4229-a458-aca7107426dd)

I believe this looks much cleaner. There are only two issues which I can think of:
1. Obviously, it's a lot of work to update all the docs to follow this convention. For now we can just do it for `otelcol.processor.k8sattributes`, and we can also update other docs over time. I believe the long term gain in usability is worth the short term inconsistency.
2. The table of contents might look a bit off for deeply nested blocks. The name of the block goes on another line, and that line starts to look like a whole other block hierarchy. However, I think this is not such a bit problem, because when you mouse over you see that it's all one big link. Also, I don't expect deeply nested blocks to be common (but I have not checked if that's the case). It might be better if we somehow don't let an overflow to a new line though, and instead we could have a horizontal scrollbar like the one we have if a block name is too long (see point 3). I could raise a ticket with the website team to ask if it's possible?
![Screenshot 2023-10-05 at 18 34 26](https://github.com/grafana/agent/assets/5834788/ade98314-cbe4-4cc0-b1be-b4984feceab2)
![Screenshot 2023-10-05 at 18 34 34](https://github.com/grafana/agent/assets/5834788/f2c5e2a7-37e9-433a-8a30-651c07af4a10)

4. I also tried how it looks for blocks with very long names - we get a scrollbar, so I think that's all good:

![Screenshot 2023-10-05 at 18 35 06](https://github.com/grafana/agent/assets/5834788/7968b638-998d-4982-9207-694208e940f5)
