### PR TITLE
include source config suffix in converter test names

### DIFF
--- a/converter/internal/test_common/testing.go
+++ b/converter/internal/test_common/testing.go
@@ -45,7 +45,7 @@ func TestDirectory(t *testing.T, folderPath string, sourceSuffix string, loadFlo
 		}
 
 		if strings.HasSuffix(path, sourceSuffix) {
-			tc := getTestCaseName(path, sourceSuffix)
+			tc := filepath.Base(path)
 			t.Run(tc, func(t *testing.T) {
 				riverFile := strings.TrimSuffix(path, sourceSuffix) + flowSuffix
 				diagsFile := strings.TrimSuffix(path, sourceSuffix) + diagsSuffix
@@ -76,12 +76,6 @@ func getSourceContents(t *testing.T, path string) []byte {
 	sourceBytes, err := os.ReadFile(path)
 	require.NoError(t, err)
 	return sourceBytes
-}
-
-// getTestCaseName gets the test case name based on the path and source suffix.
-func getTestCaseName(path string, sourceSuffix string) string {
-	caseName := filepath.Base(path)
-	return strings.TrimSuffix(caseName, sourceSuffix)
 }
 
 // getExpectedDiags will retrieve any expected diags for the test.


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR is to help with clarity for when a test fail to show the full name of the source config for the test.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated