### PR TITLE
Fix sometimes flaky test

### DIFF
--- a/component/discovery/consulagent/promtail_consulagent_test.go
+++ b/component/discovery/consulagent/promtail_consulagent_test.go
@@ -33,8 +33,6 @@ import (
 
 //nolint:interfacer // this follows the pattern in prometheus service discovery
 func TestMain(m *testing.M) {
-	m.Run()
-	// Verify no leaks after tests run.
 	goleak.VerifyTestMain(m, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
 }
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

The test would be sometimes flaky due to race detection:
```
➜  agent git:(main) go test -race -count 1000 github.com/grafana/agent/component/discovery/consulagent -run TestAllServices
==================
WARNING: DATA RACE
Write at 0x00c000164a30 by goroutine 19386:
  runtime.recvDirect()
      /opt/homebrew/Cellar/go/1.21.0/libexec/src/runtime/chan.go:348 +0x7c
  github.com/grafana/agent/component/discovery/consulagent.TestAllServices.func1()
      /Users/piotr/workspace/agent/component/discovery/consulagent/promtail_consulagent_test.go:372 +0x58

Previous read at 0x00c000164a30 by goroutine 19395:
  runtime.chansend1()
      /opt/homebrew/Cellar/go/1.21.0/libexec/src/runtime/chan.go:146 +0x2c
  github.com/grafana/agent/component/discovery/consulagent.(*consulService).watch()
      /Users/piotr/workspace/agent/component/discovery/consulagent/promtail_consulagent.go:556 +0x19fc
  github.com/grafana/agent/component/discovery/consulagent.(*Discovery).watchService.func1()
      /Users/piotr/workspace/agent/component/discovery/consulagent/promtail_consulagent.go:444 +0x118

Goroutine 19386 (running) created at:
  github.com/grafana/agent/component/discovery/consulagent.TestAllServices()
      /Users/piotr/workspace/agent/component/discovery/consulagent/promtail_consulagent_test.go:370 +0x180
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.0/libexec/src/testing/testing.go:1595 +0x194
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.0/libexec/src/testing/testing.go:1648 +0x40

Goroutine 19395 (finished) created at:
  github.com/grafana/agent/component/discovery/consulagent.(*Discovery).watchService()
      /Users/piotr/workspace/agent/component/discovery/consulagent/promtail_consulagent.go:435 +0x4a4
  github.com/grafana/agent/component/discovery/consulagent.(*Discovery).watchServices()
      /Users/piotr/workspace/agent/component/discovery/consulagent/promtail_consulagent.go:376 +0x7fc
  github.com/grafana/agent/component/discovery/consulagent.(*Discovery).Run()
      /Users/piotr/workspace/agent/component/discovery/consulagent/promtail_consulagent.go:321 +0x168
  github.com/grafana/agent/component/discovery/consulagent.TestAllServices.func1()
      /Users/piotr/workspace/agent/component/discovery/consulagent/promtail_consulagent_test.go:371 +0x50
==================
--- FAIL: TestAllServices (0.01s)
    testing.go:1465: race detected during execution of test
FAIL
FAIL	github.com/grafana/agent/component/discovery/consulagent	14.489s
FAIL
```

This is because the service goroutine may still be trying to write to a channel that is being closed in the test, which can result in a panic and is detected as a race condition.

After this fix, we no longer have a race:
```
➜  agent git:(main) ✗ go test -race -count 100 github.com/grafana/agent/component/discovery/consulagent -run TestAllServices
ok  	github.com/grafana/agent/component/discovery/consulagent	3.778s
```

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated