### PR TITLE
Add new options to spanmetrics processor in static mode:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,10 @@ v0.37.2 (2023-10-16)
 
 - Allow Out of Order writing to the WAL for metrics. (@mattdurham)
 
+- Added new config options to spanmetrics processor in static mode (@ptodev):
+  - `aggregation_temporality`: configures whether to reset the metrics after flushing.
+  - `metrics_flush_interval`: configures how often to flush generated metrics.
+
 ### Other changes
 
 - Use Go 1.21.3 for builds. (@tpaschalis)

--- a/docs/sources/static/configuration/traces-config.md
+++ b/docs/sources/static/configuration/traces-config.md
@@ -157,7 +157,7 @@ remote_write:
 automatic_logging:
   # Indicates where the stream of log lines should go. Either supports writing
   # to a logs instance defined in this same config or to stdout.
-  [ backend: <string> | default = "stdout" | supported "stdout", "logs_instance" ]
+  [ backend: <string> | default = "stdout" | supported = "stdout", "logs_instance" ]
   # Indicates the logs instance to write logs to.
   # Required if backend is set to logs_instance.
   [ logs_instance_name: <string> ]
@@ -264,8 +264,13 @@ spanmetrics:
   [ metrics_instance: <string> ]
   # handler_endpoint defines the endpoint where the OTel prometheus exporter will be exposed.
   [ handler_endpoint: <string> ]
-  # dimensions_cache_size defines the size of cache for storing Dimensions
-  [ dimensions_cache_size: <int> ]
+  # dimensions_cache_size defines the size of cache for storing Dimensions.
+  [ dimensions_cache_size: <int> | default = 1000 ]
+  # aggregation_temporality configures whether to reset the metrics after flushing.
+  # It can be either AGGREGATION_TEMPORALITY_CUMULATIVE or AGGREGATION_TEMPORALITY_DELTA.
+  [ aggregation_temporality: <string> | default = "AGGREGATION_TEMPORALITY_CUMULATIVE" ]
+  # metrics_flush_interval configures how often to flush generated metrics.
+  [ metrics_flush_interval: <duration> | default = 15s ]
 
 # tail_sampling supports tail-based sampling of traces in the agent.
 #

--- a/pkg/traces/config.go
+++ b/pkg/traces/config.go
@@ -372,7 +372,7 @@ type SpanMetricsConfig struct {
 	AggregationTemporality string `yaml:"aggregation_temporality"`
 
 	// MetricsEmitInterval is the time period between when metrics are flushed
-	// or emitted to the configured MetricsExporter.
+	// or emitted to the configured MetricsInstance or HandlerEndpoint.
 	MetricsFlushInterval time.Duration `yaml:"metrics_flush_interval"`
 }
 

--- a/pkg/traces/config.go
+++ b/pkg/traces/config.go
@@ -365,6 +365,15 @@ type SpanMetricsConfig struct {
 	// DimensionsCacheSize defines the size of cache for storing Dimensions, which helps to avoid cache memory growing
 	// indefinitely over the lifetime of the collector.
 	DimensionsCacheSize int `yaml:"dimensions_cache_size"`
+
+	// Defines the aggregation temporality of the generated metrics. Can be either of:
+	// * "AGGREGATION_TEMPORALITY_CUMULATIVE"
+	// * "AGGREGATION_TEMPORALITY_DELTA"
+	AggregationTemporality string `yaml:"aggregation_temporality"`
+
+	// MetricsEmitInterval is the time period between when metrics are flushed
+	// or emitted to the configured MetricsExporter.
+	MetricsFlushInterval time.Duration `yaml:"metrics_flush_interval"`
 }
 
 // tailSamplingConfig is the configuration for tail-based sampling
@@ -738,6 +747,12 @@ func (c *InstanceConfig) otelConfig() (*otelcol.Config, error) {
 			"metrics_exporter":          exporterName,
 			"latency_histogram_buckets": c.SpanMetrics.LatencyHistogramBuckets,
 			"dimensions":                c.SpanMetrics.Dimensions,
+		}
+		if c.SpanMetrics.AggregationTemporality != "" {
+			spanMetrics["aggregation_temporality"] = c.SpanMetrics.AggregationTemporality
+		}
+		if c.SpanMetrics.MetricsFlushInterval != 0 {
+			spanMetrics["metrics_flush_interval"] = c.SpanMetrics.MetricsFlushInterval
 		}
 		if c.SpanMetrics.DimensionsCacheSize != 0 {
 			spanMetrics["dimensions_cache_size"] = c.SpanMetrics.DimensionsCacheSize

--- a/pkg/traces/config_test.go
+++ b/pkg/traces/config_test.go
@@ -546,6 +546,8 @@ spanmetrics:
     - name: http.status_code
   metrics_instance: traces
   dimensions_cache_size: 10000
+  aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+  metrics_flush_interval: 20s
 `,
 			expectedConfig: `
 receivers:
@@ -572,6 +574,8 @@ processors:
         default: GET
       - name: http.status_code
     dimensions_cache_size: 10000
+    aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+    metrics_flush_interval: 20s
 extensions: {}
 service:
   pipelines:
@@ -617,6 +621,9 @@ processors:
     metrics_exporter: prometheus
     latency_histogram_buckets: {}
     dimensions: {}
+    aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE
+    metrics_flush_interval: 15s
+    dimensions_cache_size: 1000
 
 extensions: {}
 service:


### PR DESCRIPTION
#### PR Description
Adding new config options to spanmetrics processor in static mode:
  - `aggregation_temporality`: configures whether to reset the metrics after flushing.
  - `metrics_flush_interval`: configures how often to flush generated metrics.

#### Which issue(s) this PR fixes

Fixes #4614

#### Notes to the Reviewer

This change is ok from a feature parity point of view because both of these config options are present in [otelcol.connector.spanmetrics](https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.connector.spanmetrics/).

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated