### PR TITLE
Enable compression in logs WAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Enhancements
+
+- The `loki.write` WAL now has snappy compression enabled by default. (@thepalbi)
+
+
 v0.37.0-rc.0 (2023-10-05)
 -----------------
 

--- a/component/common/loki/wal/wal.go
+++ b/component/common/loki/wal/wal.go
@@ -37,7 +37,7 @@ type wrapper struct {
 func New(cfg Config, log log.Logger, registerer prometheus.Registerer) (WAL, error) {
 	// TODO: We should fine-tune the WAL instantiated here to allow some buffering of written entries, but not written to disk
 	// yet. This will attest for the lack of buffering in the channel Writer exposes.
-	tsdbWAL, err := wlog.NewSize(log, registerer, cfg.Dir, wlog.DefaultSegmentSize, wlog.CompressionNone)
+	tsdbWAL, err := wlog.NewSize(log, registerer, cfg.Dir, wlog.DefaultSegmentSize, wlog.CompressionSnappy)
 	if err != nil {
 		return nil, fmt.Errorf("failde to create tsdb WAL: %w", err)
 	}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR enables compression the `loki.write` WAL. Both snappy and zstd are supported by the reader/writer side, and the reader side checks the compression of each record read (so no compat issues). Snappy was picked because since this it will be used in a WAL, rather than a wire-protocol, we strive more for cpu efficiency (snappy is cpu lighter) rather higher compression rate (which zstd does better, but at a higher CPU cost).

Enabling compression in WAL allowed us in our agents deployment to have a compression rate of ~2.

<img width="1497" alt="image" src="https://github.com/grafana/agent/assets/2617411/be1314cf-1130-4683-8893-34c6d96768d9">


#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
