### PR TITLE
helm: move initContainers to inside controller for consistency with pod settings

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -10,6 +10,11 @@ internal API changes are not present.
 Unreleased
 ----------
 
+### Breaking changes
+
+- The `initContainers` setting has been moved to `controller.initContainers`
+  for consistency with other Pod-level settings. (@rfratto)
+
 ### Enhancements
 
 - Make CRDs optional through the `crds.create` setting. (@bentonam, @rfratto)

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -78,6 +78,7 @@ use the older mode (called "static mode"), set the `agent.mode` value to
 | controller.enableStatefulSetAutoDeletePVC | bool | `false` | Whether to enable automatic deletion of stale PVCs due to a scale down operation, when controller.type is 'statefulset'. |
 | controller.hostNetwork | bool | `false` | Configures Pods to use the host network. When set to true, the ports that will be used must be specified. |
 | controller.hostPID | bool | `false` | Configures Pods to use the host PID namespace. |
+| controller.initContainers | list | `[]` |  |
 | controller.nodeSelector | object | `{}` | nodeSelector to apply to Grafana Agent pods. |
 | controller.parallelRollout | bool | `true` | Whether to deploy pods in parallel. Only used when controller.type is 'statefulset'. |
 | controller.podAnnotations | object | `{}` | Extra pod annotations to add. |
@@ -109,7 +110,6 @@ use the older mode (called "static mode"), set the `agent.mode` value to
 | ingress.path | string | `"/"` |  |
 | ingress.pathType | string | `"Prefix"` |  |
 | ingress.tls | list | `[]` |  |
-| initContainers | list | `[]` |  |
 | nameOverride | string | `nil` | Overrides the chart's name. Used to change the infix in the resource names. |
 | rbac.create | bool | `true` | Whether to create RBAC resources for the agent. |
 | service.annotations | object | `{}` |  |

--- a/operations/helm/charts/grafana-agent/ci/initcontainers-values.yaml
+++ b/operations/helm/charts/grafana-agent/ci/initcontainers-values.yaml
@@ -1,26 +1,27 @@
-initContainers:
-- name: geo-ip
-  image: ghcr.io/maxmind/geoipupdate:v6.0
-  volumeMounts:
-    - name: geoip
-      mountPath: /etc/geoip
-  volumes:
-  - name: geoip
-    emptyDir: {}
-  env:
-  - name: GEOIPUPDATE_ACCOUNT_ID
-    value: "geoipupdate_account_id"
-  - name: GEOIPUPDATE_LICENSE_KEY
-    value: "geoipupdate_license_key"
-  - name: GEOIPUPDATE_EDITION_IDS
-    value: "GeoLite2-ASN GeoLite2-City GeoLite2-Country"
-  - name: GEOIPUPDATE_DB_DIR
-    value: "/etc/geoip"
 controller:
+  initContainers:
+  - name: geo-ip
+    image: ghcr.io/maxmind/geoipupdate:v6.0
+    volumeMounts:
+      - name: geoip
+        mountPath: /etc/geoip
+    volumes:
+    - name: geoip
+      emptyDir: {}
+    env:
+    - name: GEOIPUPDATE_ACCOUNT_ID
+      value: "geoipupdate_account_id"
+    - name: GEOIPUPDATE_LICENSE_KEY
+      value: "geoipupdate_license_key"
+    - name: GEOIPUPDATE_EDITION_IDS
+      value: "GeoLite2-ASN GeoLite2-City GeoLite2-Country"
+    - name: GEOIPUPDATE_DB_DIR
+      value: "/etc/geoip"
   volumes:
     extra:
       - name: geoip
         mountPath: /etc/geoip
+
 agent:
   mounts:
     extra:

--- a/operations/helm/charts/grafana-agent/templates/controllers/_pod.yaml
+++ b/operations/helm/charts/grafana-agent/templates/controllers/_pod.yaml
@@ -23,9 +23,9 @@ spec:
     {{- toYaml .Values.image.pullSecrets | nindent 4 }}
     {{- end }}
   {{- end }}
-  {{- if .Values.initContainers }}
+  {{- if .Values.controller.initContainers }}
   initContainers:
-    {{- with .Values.initContainers }}
+    {{- with .Values.controller.initContainers }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}

--- a/operations/helm/charts/grafana-agent/values.yaml
+++ b/operations/helm/charts/grafana-agent/values.yaml
@@ -18,11 +18,6 @@ global:
   # -- Security context to apply to the Grafana Agent pod.
   podSecurityContext: {}
 
-## The init containers to run.
-## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
-##
-initContainers: []
-
 crds:
   # -- Whether to install CRDs for monitoring.
   create: true
@@ -209,6 +204,11 @@ controller:
 
   # -- volumeClaimTemplates to add when controller.type is 'statefulset'.
   volumeClaimTemplates: []
+
+  ## -- Additional init containers to run.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+  ##
+  initContainers: []
 
 service:
   # -- Creates a Service for the controller's pods.


### PR DESCRIPTION
Other pod-level settings are determined by the `controller` group of settings, so initContainers should be inside of controller (`controller.initContainers`) rather than a top-level field.
