### PR TITLE
Improve loggers performance

### DIFF
--- a/pkg/flow/logging/level/level.go
+++ b/pkg/flow/logging/level/level.go
@@ -1,0 +1,51 @@
+package level
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/agent/pkg/flow/logging"
+)
+
+const (
+	levelKey = "level"
+)
+
+// Error returns a logger that includes a Key/ErrorValue pair.
+func Error(logger log.Logger) log.Logger {
+	return toLevel(logger, "error", slog.LevelError)
+}
+
+// Warn returns a logger that includes a Key/WarnValue pair.
+func Warn(logger log.Logger) log.Logger {
+	return toLevel(logger, "warn", slog.LevelWarn)
+}
+
+// Info returns a logger that includes a Key/InfoValue pair.
+func Info(logger log.Logger) log.Logger {
+	return toLevel(logger, "info", slog.LevelInfo)
+}
+
+// Debug returns a logger that includes a Key/DebugValue pair.
+func Debug(logger log.Logger) log.Logger {
+	return toLevel(logger, "debug", slog.LevelDebug)
+}
+
+func toLevel(logger log.Logger, level string, slogLevel slog.Level) log.Logger {
+	switch l := logger.(type) {
+	case logging.EnabledAware:
+		if !l.Enabled(context.Background(), slogLevel) {
+			return disabledLogger
+		}
+	}
+	return log.WithPrefix(logger, levelKey, level)
+}
+
+var disabledLogger = &noopLogger{}
+
+type noopLogger struct{}
+
+func (d *noopLogger) Log(_ ...interface{}) error {
+	return nil
+}

--- a/pkg/flow/logging/logger.go
+++ b/pkg/flow/logging/logger.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -13,6 +14,10 @@ import (
 	"github.com/prometheus/common/model"
 )
 
+type EnabledAware interface {
+	Enabled(context.Context, slog.Level) bool
+}
+
 // Logger is the logging subsystem of Flow. It supports being dynamically
 // updated at runtime.
 type Logger struct {
@@ -22,6 +27,13 @@ type Logger struct {
 	format  *formatVar     // Current configured format.
 	writer  *writerVar     // Current configured multiwriter (inner + write_to).
 	handler *handler       // Handler which handles logs.
+}
+
+var _ EnabledAware = (*Logger)(nil)
+
+// Enabled implements EnabledAware interface.
+func (l *Logger) Enabled(ctx context.Context, level slog.Level) bool {
+	return l.handler.Enabled(ctx, level)
 }
 
 // New creates a New logger with the default log level and format.

--- a/pkg/flow/logging/logger_test.go
+++ b/pkg/flow/logging/logger_test.go
@@ -9,6 +9,7 @@ import (
 
 	gokitlevel "github.com/go-kit/log/level"
 	"github.com/grafana/agent/pkg/flow/logging"
+	flowlevel "github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,13 +18,15 @@ $ go test -count=1 -benchmem ./pkg/flow/logging -run ^$ -bench BenchmarkLogging_
 goos: darwin
 goarch: arm64
 pkg: github.com/grafana/agent/pkg/flow/logging
-BenchmarkLogging_NoLevel_Prints-8             	  811214	      1687 ns/op	     368 B/op	      11 allocs/op
-BenchmarkLogging_NoLevel_Drops-8              	 4061053	       293.4 ns/op	      40 B/op	       4 allocs/op
-BenchmarkLogging_GoKitLevel_Drops_Sprintf-8   	 2811063	       426.4 ns/op	     400 B/op	       9 allocs/op
-BenchmarkLogging_GoKitLevel_Drops-8           	 2567967	       468.0 ns/op	     504 B/op	       9 allocs/op
-BenchmarkLogging_GoKitLevel_Prints-8          	  710380	      1686 ns/op	     849 B/op	      16 allocs/op
-BenchmarkLogging_Slog_Drops-8                 	78973346	        15.33 ns/op	       8 B/op	       0 allocs/op
-BenchmarkLogging_Slog_Prints-8                	 1000000	      1128 ns/op	      32 B/op	       2 allocs/op
+BenchmarkLogging_NoLevel_Prints-8             	  797337	      1492 ns/op	     368 B/op	      11 allocs/op
+BenchmarkLogging_NoLevel_Drops-8              	44667505	        27.06 ns/op	       8 B/op	       0 allocs/op
+BenchmarkLogging_GoKitLevel_Drops_Sprintf-8   	 3569900	       336.1 ns/op	     320 B/op	       8 allocs/op
+BenchmarkLogging_GoKitLevel_Drops-8           	 6698175	       180.7 ns/op	     472 B/op	       5 allocs/op
+BenchmarkLogging_GoKitLevel_Prints-8          	  705537	      1688 ns/op	     849 B/op	      16 allocs/op
+BenchmarkLogging_Slog_Drops-8                 	79589450	        15.10 ns/op	       8 B/op	       0 allocs/op
+BenchmarkLogging_Slog_Prints-8                	 1000000	      1127 ns/op	      32 B/op	       2 allocs/op
+BenchmarkLogging_FlowLevel_Drops-8            	20856249	        55.64 ns/op	     168 B/op	       2 allocs/op
+BenchmarkLogging_FlowLevel_Prints-8           	  701811	      1713 ns/op	     849 B/op	      16 allocs/op
 */
 
 const testStr = "this is a test string"
@@ -98,6 +101,26 @@ func BenchmarkLogging_Slog_Prints(b *testing.B) {
 	testErr := fmt.Errorf("test error")
 	for i := 0; i < b.N; i++ {
 		logger.Info("test message", "i", i, "err", testErr, "str", testStr, "duration", time.Second)
+	}
+}
+
+func BenchmarkLogging_FlowLevel_Drops(b *testing.B) {
+	logger, err := logging.New(io.Discard, debugLevelOptions())
+	require.NoError(b, err)
+
+	testErr := fmt.Errorf("test error")
+	for i := 0; i < b.N; i++ {
+		flowlevel.Debug(logger).Log("msg", "test message", "i", i, "err", testErr, "str", testStr, "duration", time.Second)
+	}
+}
+
+func BenchmarkLogging_FlowLevel_Prints(b *testing.B) {
+	logger, err := logging.New(io.Discard, debugLevelOptions())
+	require.NoError(b, err)
+
+	testErr := fmt.Errorf("test error")
+	for i := 0; i < b.N; i++ {
+		flowlevel.Info(logger).Log("msg", "test message", "i", i, "err", testErr, "str", testStr, "duration", time.Second)
 	}
 }
 

--- a/pkg/flow/logging/logger_test.go
+++ b/pkg/flow/logging/logger_test.go
@@ -1,0 +1,115 @@
+package logging_test
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	gokitlevel "github.com/go-kit/log/level"
+	"github.com/grafana/agent/pkg/flow/logging"
+	"github.com/stretchr/testify/require"
+)
+
+/* Most recent performance results on M2 Macbook Air:
+$ go test -count=1 -benchmem ./pkg/flow/logging -run ^$ -bench BenchmarkLogging_
+goos: darwin
+goarch: arm64
+pkg: github.com/grafana/agent/pkg/flow/logging
+BenchmarkLogging_NoLevel_Prints-8             	  811214	      1687 ns/op	     368 B/op	      11 allocs/op
+BenchmarkLogging_NoLevel_Drops-8              	 4061053	       293.4 ns/op	      40 B/op	       4 allocs/op
+BenchmarkLogging_GoKitLevel_Drops_Sprintf-8   	 2811063	       426.4 ns/op	     400 B/op	       9 allocs/op
+BenchmarkLogging_GoKitLevel_Drops-8           	 2567967	       468.0 ns/op	     504 B/op	       9 allocs/op
+BenchmarkLogging_GoKitLevel_Prints-8          	  710380	      1686 ns/op	     849 B/op	      16 allocs/op
+BenchmarkLogging_Slog_Drops-8                 	78973346	        15.33 ns/op	       8 B/op	       0 allocs/op
+BenchmarkLogging_Slog_Prints-8                	 1000000	      1128 ns/op	      32 B/op	       2 allocs/op
+*/
+
+const testStr = "this is a test string"
+
+func BenchmarkLogging_NoLevel_Prints(b *testing.B) {
+	logger, err := logging.New(io.Discard, debugLevelOptions())
+	require.NoError(b, err)
+
+	testErr := fmt.Errorf("test error")
+	for i := 0; i < b.N; i++ {
+		logger.Log("msg", "test message", "i", i, "err", testErr, "str", testStr, "duration", time.Second)
+	}
+}
+
+func BenchmarkLogging_NoLevel_Drops(b *testing.B) {
+	logger, err := logging.New(io.Discard, warnLevelOptions())
+	require.NoError(b, err)
+
+	testErr := fmt.Errorf("test error")
+	for i := 0; i < b.N; i++ {
+		logger.Log("msg", "test message", "i", i, "err", testErr, "str", testStr, "duration", time.Second)
+	}
+}
+
+func BenchmarkLogging_GoKitLevel_Drops_Sprintf(b *testing.B) {
+	logger, err := logging.New(io.Discard, debugLevelOptions())
+	require.NoError(b, err)
+
+	testErr := fmt.Errorf("test error")
+	for i := 0; i < b.N; i++ {
+		gokitlevel.Debug(logger).Log("msg", fmt.Sprintf("test message %d, error=%v, str=%s, duration=%v", i, testErr, testStr, time.Second))
+	}
+}
+
+func BenchmarkLogging_GoKitLevel_Drops(b *testing.B) {
+	logger, err := logging.New(io.Discard, debugLevelOptions())
+	require.NoError(b, err)
+
+	testErr := fmt.Errorf("test error")
+	for i := 0; i < b.N; i++ {
+		gokitlevel.Debug(logger).Log("msg", "test message", "i", i, "err", testErr, "str", testStr, "duration", time.Second)
+	}
+}
+
+func BenchmarkLogging_GoKitLevel_Prints(b *testing.B) {
+	logger, err := logging.New(io.Discard, debugLevelOptions())
+	require.NoError(b, err)
+
+	testErr := fmt.Errorf("test error")
+	testStr := "this is a test string"
+	for i := 0; i < b.N; i++ {
+		gokitlevel.Warn(logger).Log("msg", "test message", "i", i, "err", testErr, "str", testStr, "duration", time.Second)
+	}
+}
+
+func BenchmarkLogging_Slog_Drops(b *testing.B) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
+	testErr := fmt.Errorf("test error")
+	for i := 0; i < b.N; i++ {
+		logger.Debug("test message", "i", i, "err", testErr, "str", testStr, "duration", time.Second)
+	}
+}
+
+func BenchmarkLogging_Slog_Prints(b *testing.B) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
+	testErr := fmt.Errorf("test error")
+	for i := 0; i < b.N; i++ {
+		logger.Info("test message", "i", i, "err", testErr, "str", testStr, "duration", time.Second)
+	}
+}
+
+func debugLevelOptions() logging.Options {
+	opts := logging.Options{}
+	opts.SetToDefault()
+	opts.Level = logging.LevelInfo
+	return opts
+}
+
+func warnLevelOptions() logging.Options {
+	opts := debugLevelOptions()
+	opts.Level = logging.LevelWarn
+	return opts
+}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

It's recommended too review the first two commits of this PR separately:
* [First one](https://github.com/grafana/agent/pull/5452/commits/c9d638b3917ecac138afe53c60339100842a00ce) adds benchmarks and includes the results in a comment
* [Second one](https://github.com/grafana/agent/pull/5452/commits/3ed08cfd5598a7d3f336f7af529083d314b5db62) adds a few optimisations for the logging and includes the new benchmark results in a comment.

Summary of optimisations:
* Look for the log level first in log adapter to avoid costly allocations if the record will not be logged
* Implement our own `level` package that can replace gokit's `level.Debug(logger)...` - our `level` package is level-aware and will be checking whether given level is enabled in the underlying logger (if it can, opportunistically. The idea is that we can replace the import with our own `level` and should get performance boost. 

In the long run we should still move to `slog` as it's more performant and simpler.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated