### PR TITLE
clustering: fix handling of empty join-addresses flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Main (unreleased)
 
 - Fixed an issue where `loki.process` validation for stage `metric.counter` was 
   allowing invalid combination of configuration options. (@thampiotr)
+
+- Fix the handling of the `--cluster.join-addresses` flag causing an invalid
+  comparison with the mutually-exclusive `--cluster.discover-peers`. (@tpaschalis)
   
 ### Enhancements
 

--- a/cmd/internal/flowmode/cluster_builder_test.go
+++ b/cmd/internal/flowmode/cluster_builder_test.go
@@ -1,0 +1,18 @@
+package flowmode
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildClusterService(t *testing.T) {
+	opts := clusterOptions{
+		JoinPeers:     []string{"foo", "bar"},
+		DiscoverPeers: "provider=aws key1=val1 key2=val2",
+	}
+
+	cs, err := buildClusterService(opts)
+	require.Nil(t, cs)
+	require.EqualError(t, err, "at most one of join peers and discover peers may be set")
+}

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -210,7 +210,7 @@ func (fr *flowRun) Run(configPath string) error {
 		NodeName:            fr.clusterNodeName,
 		AdvertiseAddress:    fr.clusterAdvAddr,
 		ListenAddress:       fr.httpListenAddr,
-		JoinPeers:           strings.Split(fr.clusterJoinAddr, ","),
+		JoinPeers:           splitPeers(fr.clusterJoinAddr, ","),
 		DiscoverPeers:       fr.clusterDiscoverPeers,
 		RejoinInterval:      fr.clusterRejoinInterval,
 		AdvertiseInterfaces: fr.clusterAdvInterfaces,
@@ -429,4 +429,11 @@ func interruptContext() (context.Context, context.CancelFunc) {
 	}()
 
 	return ctx, cancel
+}
+
+func splitPeers(s, sep string) []string {
+	if len(s) == 0 {
+		return []string{}
+	}
+	return strings.Split(s, sep)
 }


### PR DESCRIPTION
#### PR Description

We recently almost had this bite us when porting the cadvisor integration to a new component. 

`strings.Split` returns the input string itself if the separator is not found; this meant that for an empty flag, `strings.Split("", ",")` returned a 1-element slice with the empty string, and _not_ an empty slice.

#### Which issue(s) this PR fixes
Fixes #5449 

#### Notes to the Reviewer

Nothing to note.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [ ] Documentation added (N/A)
- [X] Tests updated
