### PR TITLE
upgrade packages in dockerfile

### DIFF
--- a/cmd/grafana-agent/Dockerfile
+++ b/cmd/grafana-agent/Dockerfile
@@ -30,7 +30,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     GOEXPERIMENT=${GOEXPERIMENT} \
     make agent
 
-FROM ubuntu:lunar
+FROM ubuntu:mantic
 
 LABEL org.opencontainers.image.source="https://github.com/grafana/agent"
 

--- a/cmd/grafana-agent/Dockerfile
+++ b/cmd/grafana-agent/Dockerfile
@@ -30,7 +30,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     GOEXPERIMENT=${GOEXPERIMENT} \
     make agent
 
-FROM ubuntu:mantic
+FROM ubuntu:lunar
 
 LABEL org.opencontainers.image.source="https://github.com/grafana/agent"
 
@@ -38,7 +38,7 @@ LABEL org.opencontainers.image.source="https://github.com/grafana/agent"
 RUN <<EOF
   apt-get update
   apt-get install -qy libsystemd-dev tzdata ca-certificates
-
+  apt-get upgrade -y
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 EOF
 


### PR DESCRIPTION
This resolves a number of (afaik unexploitable) cves.

Mantic does not have definitions yet, but there are updated libc6 packages. This runs `apt-get upgrade -y` in the dockerfile.