### PR TITLE
Fix a cross reference link in a note in the Agent root topic (v0.37)

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -21,7 +21,7 @@ form programmable observability **pipelines** for telemetry collection,
 processing, and delivery.
 
 {{% admonition type="note" %}}
-This page focuses mainly on [Flow mode][], the Terraform-inspired variant of Grafana Agent.
+This page focuses mainly on [Flow mode](https://grafana.com/docs/agent/<AGENT VERSION>/flow/), the Terraform-inspired variant of Grafana Agent.
 
 For information on other variants of Grafana Agent, refer to [Introduction to Grafana Agent]({{< relref "./about.md" >}}).
 {{% /admonition %}}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR fixes a failing cross reference link from a note.

Restoring the original relref results in a broken link when this topic is mounted into the Grafana Cloud docs. Converting the link to a fully qualified link ensures the link will work in Agent docs and in Cloud docs. Refer to: https://grafana.com/docs/writers-toolkit/write/references/#choose-the-correct-link

Followup PR to https://github.com/grafana/agent/pull/5464

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated