### PR TITLE
"apt-get upgrade" in agentctl and operator docker images

### DIFF
--- a/cmd/grafana-agent-operator/Dockerfile
+++ b/cmd/grafana-agent-operator/Dockerfile
@@ -30,6 +30,7 @@ LABEL org.opencontainers.image.source="https://github.com/grafana/agent"
 RUN <<EOF
   apt-get update
   apt-get install -qy libsystemd-dev tzdata ca-certificates
+  apt-get upgrade -y
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 EOF
 

--- a/cmd/grafana-agentctl/Dockerfile
+++ b/cmd/grafana-agentctl/Dockerfile
@@ -31,7 +31,7 @@ LABEL org.opencontainers.image.source="https://github.com/grafana/agent"
 RUN <<EOF
   apt-get update
   apt-get install -qy libsystemd-dev tzdata ca-certificates
-
+  apt-get upgrade -y
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 EOF
 


### PR DESCRIPTION
#5463 updated the `grafana-agent` dockerfile, but not the other two docker files. This PR also updates the other two files for consistency, and also to make sure they are not flagged for CVEs.