### PR TITLE
build-image: bump to go 1.21.3

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -23,7 +23,7 @@ FROM alpine:3.17 as helm
 RUN apk add --no-cache helm
 
 # Dependency: Go and Go dependencies
-FROM golang:1.21.1-bullseye as golang
+FROM golang:1.21.3-bullseye as golang
 
 # Keep in sync with cmd/grafana-agent-operator/DEVELOPERS.md
 ENV CONTROLLER_GEN_VERSION v0.9.2

--- a/build-image/windows/Dockerfile
+++ b/build-image/windows/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/golang:1.21.1-windowsservercore-1809
+FROM library/golang:1.21.3-windowsservercore-1809
 
 SHELL ["powershell", "-command"]
 


### PR DESCRIPTION
Makes build-image use Go 1.21.3.