### PR TITLE
ci: automate starting new release cycles when release branch is cut

### DIFF
--- a/.github/actions/next-release-cycle/Dockerfile
+++ b/.github/actions/next-release-cycle/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.21-alpine3.18
+
+COPY . /src
+WORKDIR /src
+
+RUN go build -o /bin/next-release-cycle .
+
+ENTRYPOINT ["/bin/next-release-cycle"]

--- a/.github/actions/next-release-cycle/action.yml
+++ b/.github/actions/next-release-cycle/action.yml
@@ -1,0 +1,14 @@
+name: Next release cycle
+description: Determine the next release cycle given an input.
+inputs:
+  branch-name:
+    description: Branch name of current release cycle.
+    required: true
+outputs:
+  next-cycle:
+    description: Next release cycle (formatted as a version number).
+runs:
+  using: 'docker'
+  image: Dockerfile
+  args:
+    - ${{ inputs.branch-name }}

--- a/.github/actions/next-release-cycle/go.mod
+++ b/.github/actions/next-release-cycle/go.mod
@@ -1,0 +1,10 @@
+module github.com/grafana/agent/.github/actions/next-release-cycle
+
+go 1.21.0
+
+require (
+	github.com/Masterminds/semver/v3 v3.2.1 // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/coreos/go-semver v0.3.1 // indirect
+	golang.org/x/mod v0.13.0 // indirect
+)

--- a/.github/actions/next-release-cycle/go.sum
+++ b/.github/actions/next-release-cycle/go.sum
@@ -1,0 +1,10 @@
+github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
+github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
+github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
+golang.org/x/mod v0.13.0 h1:I/DsJXRlw/8l/0c24sM9yb0T4z9liZTduXvdAWYiysY=
+golang.org/x/mod v0.13.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/.github/actions/next-release-cycle/main.go
+++ b/.github/actions/next-release-cycle/main.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	if len(os.Args) != 2 {
+		return fmt.Errorf("usage: next-release-cycle <branch-name>")
+	}
+
+	branchName := strings.TrimPrefix(os.Args[1], "release-")
+	log.Println("Determing release cycle after", branchName)
+
+	currentVersion, err := semver.NewVersion(branchName)
+	if err != nil {
+		return err
+	}
+
+	nextVersion := semver.New(
+		currentVersion.Major(),
+		currentVersion.Minor()+1,
+		0,
+		"",
+		"",
+	)
+	nextVersionText := "v" + nextVersion.String()
+
+	// Set the next cycle as a variable in the GitHub Actions environment.
+	if githubOutputFile := os.Getenv("GITHUB_OUTPUT"); githubOutputFile != "" {
+		setVariable := fmt.Sprintf("next-cycle=%s\n", nextVersionText)
+		if err := appendFile(githubOutputFile, []byte(setVariable)); err != nil {
+			return err
+		}
+	}
+
+	fmt.Fprintln(os.Stdout, nextVersionText)
+	return nil
+}
+
+// appendFile appends data to the file named name. If the file doesn't exist,
+// an error is returned.
+func appendFile(name string, data []byte) error {
+	f, err := os.OpenFile(name, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.Write(data)
+	return err
+}

--- a/.github/workflows/bump-release-cycle.yml
+++ b/.github/workflows/bump-release-cycle.yml
@@ -1,0 +1,50 @@
+name: Bump release cycle
+on:
+  workflow_dispatch: {}
+  create:
+    branches:
+      - 'release-v*'
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  bump-release-cycle:
+    if: ${{ startsWith(github.ref, 'refs/heads/release-v')}}
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check out main branch"
+        uses: "actions/checkout@v4"
+        with:
+          ref: main
+      - name: "Determine next release cycle"
+        id: next-release-cycle
+        uses: "./.github/actions/next-release-cycle"
+        with:
+          branch-name: ${{ github.ref_name }}
+      - name: "Update version files"
+        run: |
+          echo -n "${{ steps.next-release-cycle.outputs.next-cycle }}" > tools/gen-versioned-files/agent-version.txt
+          make generate-versioned-files
+          git add .
+
+      - name: "Open PR"
+        run: |
+          git config --local user.name "${GITHUB_ACTOR}"
+          git config --local user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+          NEXT_CYCLE=${{ steps.next-release-cycle.outputs.next-cycle }}
+
+          BRANCH=start-release-cycle-$NEXT_CYCLE
+          git checkout -b $BRANCH
+
+          git commit -F - <<EOF
+          Start release cycle $NEXT_CYCLE
+
+          Triggered by ${GITHUB_REF_NAME} being created.
+          EOF
+
+          git push origin HEAD
+
+          gh pr create -B main --fill --reviewer "${GITHUB_ACTOR}"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This commit introduces new automation to automatically bump the version in the main branch at the point a release branch is created.

For example, if branch release-v0.37 is pushed, this action will trigger and perform the following:

* Clone the repo off of the main branch.
* Determine the release cycle after release-v0.37 (v0.38.0).
* Update the version file and regenerate versioned templates for the next release cycle.
* Open a PR against the main branch.

This automation reduces the overhead of PRs like grafana/agent#5384, where it'll no longer be necessary to manually update the version file at the start of a new release cycle.

This action has been tested extensively on
<https://github.com/rfratto/agent> and was shown to work as expected:

https://github.com/grafana/agent/assets/630212/e2a1954e-05fd-4f33-a5ea-3974f426d680
