### PR TITLE
Port loki/#10752 to Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Main (unreleased)
 
 - The `loki.write` WAL now has snappy compression enabled by default. (@thepalbi)
 
+- Allow converting labels to structured metadata with Loki's structured_metadata stage. (@gonzalesraul)
+
 v0.37.1 (2023-10-10)
 -----------------
 

--- a/component/loki/process/stages/structured_metadata.go
+++ b/component/loki/process/stages/structured_metadata.go
@@ -32,6 +32,26 @@ func (s *structuredMetadataStage) Run(in chan Entry) chan Entry {
 		processLabelsConfigs(s.logger, e.Extracted, s.cfgs, func(labelName model.LabelName, labelValue model.LabelValue) {
 			e.StructuredMetadata = append(e.StructuredMetadata, logproto.LabelAdapter{Name: string(labelName), Value: string(labelValue)})
 		})
-		return e
+		return s.extractFromLabels(e)
 	})
+}
+
+func (s *structuredMetadataStage) extractFromLabels(e Entry) Entry {
+	labels := e.Labels
+	foundLabels := []model.LabelName{}
+
+	for lName, lSrc := range s.cfgs.Values {
+		labelKey := model.LabelName(*lSrc)
+		if lValue, ok := labels[labelKey]; ok {
+			e.StructuredMetadata = append(e.StructuredMetadata, logproto.LabelAdapter{Name: lName, Value: string(lValue)})
+			foundLabels = append(foundLabels, labelKey)
+		}
+	}
+
+	// Remove found labels, do this after append to structure metadata
+	for _, fl := range foundLabels {
+		delete(labels, fl)
+	}
+	e.Labels = labels
+	return e
 }


### PR DESCRIPTION
#### PR Description
This PR upstreams the promtail changes from https://github.com/grafana/loki/pull/10752 into the Grafana Agent.

This is rather expected behavior, so no need to update the docs.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated