### PR TITLE
build: bump build image usage to 0.30.3

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -75,7 +75,7 @@ steps:
 - commands:
   - apt-get update -y && apt-get install -y libsystemd-dev
   - make lint
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Lint
 trigger:
   event:
@@ -93,7 +93,7 @@ steps:
   - ERR_MSG="Dashboard definitions are out of date. Please run 'make generate-dashboards'
     and commit changes!"
   - if [ ! -z "$(git status --porcelain)" ]; then echo $ERR_MSG >&2; exit 1; fi
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Regenerate dashboards
 trigger:
   event:
@@ -111,7 +111,7 @@ steps:
   - ERR_MSG="Custom Resource Definitions are out of date. Please run 'make generate-crds'
     and commit changes!"
   - if [ ! -z "$(git status --porcelain)" ]; then echo $ERR_MSG >&2; exit 1; fi
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Regenerate crds
 trigger:
   event:
@@ -129,7 +129,7 @@ steps:
   - ERR_MSG="The environment manifests are out of date. Please run 'make generate-manifests'
     and commit changes!"
   - if [ ! -z "$(git status --porcelain)" ]; then echo $ERR_MSG >&2; exit 1; fi
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Regenerate environment manifests
 trigger:
   event:
@@ -144,7 +144,7 @@ platform:
 steps:
 - commands:
   - make GO_TAGS="nodocker" test
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Run Go tests
 trigger:
   event:
@@ -159,7 +159,7 @@ platform:
 steps:
 - commands:
   - K8S_USE_DOCKER_NETWORK=1 make test
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Run Go tests
   volumes:
   - name: docker
@@ -182,7 +182,7 @@ platform:
 steps:
 - commands:
   - go test -tags="nodocker,nonetwork" ./...
-  image: grafana/agent-build-image:0.30.2-windows
+  image: grafana/agent-build-image:0.30.3-windows
   name: Run Go tests
 trigger:
   ref:
@@ -197,7 +197,7 @@ platform:
 steps:
 - commands:
   - make agent-image
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build container
   volumes:
   - name: docker
@@ -222,7 +222,7 @@ platform:
 steps:
 - commands:
   - make agentctl-image
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build container
   volumes:
   - name: docker
@@ -247,7 +247,7 @@ platform:
 steps:
 - commands:
   - make operator-image
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build container
   volumes:
   - name: docker
@@ -273,7 +273,7 @@ platform:
 steps:
 - commands:
   - '& "C:/Program Files/git/bin/bash.exe" ./tools/ci/docker-containers-windows agent'
-  image: grafana/agent-build-image:0.30.2-windows
+  image: grafana/agent-build-image:0.30.3-windows
   name: Build container
   volumes:
   - name: docker
@@ -299,7 +299,7 @@ platform:
 steps:
 - commands:
   - '& "C:/Program Files/git/bin/bash.exe" ./tools/ci/docker-containers-windows agentctl'
-  image: grafana/agent-build-image:0.30.2-windows
+  image: grafana/agent-build-image:0.30.3-windows
   name: Build container
   volumes:
   - name: docker
@@ -326,7 +326,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=amd64 GOARM=
     make agent
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -343,7 +343,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm64 GOARM=
     make agent
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -360,7 +360,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=ppc64le GOARM=
     make agent
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -377,7 +377,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=s390x GOARM=
     make agent
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -393,7 +393,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=darwin GOARCH=amd64 GOARM= make agent
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -409,7 +409,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=darwin GOARCH=arm64 GOARM= make agent
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -425,7 +425,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=windows GOARCH=amd64 GOARM= make agent
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -441,7 +441,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=freebsd GOARCH=amd64 GOARM= make agent
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -458,7 +458,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=amd64 GOARM=
     make agent-flow
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -475,7 +475,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm64 GOARM=
     make agent-flow
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -492,7 +492,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=ppc64le GOARM=
     make agent-flow
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -509,7 +509,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=s390x GOARM=
     make agent-flow
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -525,7 +525,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=darwin GOARCH=amd64 GOARM= make agent-flow
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -541,7 +541,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=darwin GOARCH=arm64 GOARM= make agent-flow
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -557,7 +557,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=windows GOARCH=amd64 GOARM= make agent-flow
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -573,7 +573,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=freebsd GOARCH=amd64 GOARM= make agent-flow
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -590,7 +590,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=amd64 GOARM=
     make agentctl
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -607,7 +607,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm64 GOARM=
     make agentctl
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -624,7 +624,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=ppc64le GOARM=
     make agentctl
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -641,7 +641,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=s390x GOARM=
     make agentctl
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -657,7 +657,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=darwin GOARCH=amd64 GOARM= make agentctl
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -673,7 +673,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=darwin GOARCH=arm64 GOARM= make agentctl
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -689,7 +689,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=windows GOARCH=amd64 GOARM= make agentctl
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -705,7 +705,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=freebsd GOARCH=amd64 GOARM= make agentctl
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -722,7 +722,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=amd64 GOARM=
     make operator
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -739,7 +739,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm64 GOARM=
     make operator
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -756,7 +756,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=ppc64le GOARM=
     make operator
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -773,7 +773,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=s390x GOARM=
     make operator
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -789,7 +789,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=darwin GOARCH=amd64 GOARM= make operator
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -805,7 +805,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=darwin GOARCH=arm64 GOARM= make operator
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -821,7 +821,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=windows GOARCH=amd64 GOARM= make operator
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -837,7 +837,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=freebsd GOARCH=amd64 GOARM= make operator
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -854,7 +854,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=amd64 GOARM=
     GOEXPERIMENT=boringcrypto make agent-boringcrypto
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -871,7 +871,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm64 GOARM=
     GOEXPERIMENT=boringcrypto make agent-boringcrypto
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -887,7 +887,7 @@ steps:
 - commands:
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   failure: ignore
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Configure QEMU
   volumes:
   - name: docker
@@ -907,7 +907,7 @@ steps:
       from_secret: docker_password
     GCR_CREDS:
       from_secret: gcr_admin
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Publish container
   volumes:
   - name: docker
@@ -931,7 +931,7 @@ steps:
 - commands:
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   failure: ignore
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Configure QEMU
   volumes:
   - name: docker
@@ -951,7 +951,7 @@ steps:
       from_secret: docker_password
     GCR_CREDS:
       from_secret: gcr_admin
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Publish container
   volumes:
   - name: docker
@@ -975,7 +975,7 @@ steps:
 - commands:
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   failure: ignore
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Configure QEMU
   volumes:
   - name: docker
@@ -995,7 +995,7 @@ steps:
       from_secret: docker_password
     GCR_CREDS:
       from_secret: gcr_admin
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Publish container
   volumes:
   - name: docker
@@ -1019,7 +1019,7 @@ steps:
 - commands:
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   failure: ignore
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Configure QEMU
   volumes:
   - name: docker
@@ -1039,7 +1039,7 @@ steps:
       from_secret: docker_password
     GCR_CREDS:
       from_secret: gcr_admin
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Publish container
   volumes:
   - name: docker
@@ -1063,7 +1063,7 @@ steps:
 - commands:
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   failure: ignore
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Configure QEMU
   volumes:
   - name: docker
@@ -1083,7 +1083,7 @@ steps:
       from_secret: docker_password
     GCR_CREDS:
       from_secret: gcr_admin
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Publish container
   volumes:
   - name: docker
@@ -1107,7 +1107,7 @@ steps:
 - commands:
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   failure: ignore
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Configure QEMU
   volumes:
   - name: docker
@@ -1127,7 +1127,7 @@ steps:
       from_secret: docker_password
     GCR_CREDS:
       from_secret: gcr_admin
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Publish container
   volumes:
   - name: docker
@@ -1156,7 +1156,7 @@ steps:
       from_secret: docker_login
     DOCKER_PASSWORD:
       from_secret: docker_password
-  image: grafana/agent-build-image:0.30.2-windows
+  image: grafana/agent-build-image:0.30.3-windows
   name: Build containers
   volumes:
   - name: docker
@@ -1185,7 +1185,7 @@ steps:
       from_secret: docker_login
     DOCKER_PASSWORD:
       from_secret: docker_password
-  image: grafana/agent-build-image:0.30.2-windows
+  image: grafana/agent-build-image:0.30.3-windows
   name: Build containers
   volumes:
   - name: docker
@@ -1306,7 +1306,7 @@ steps:
       from_secret: gpg_private_key
     GPG_PUBLIC_KEY:
       from_secret: gpg_public_key
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Publish release
   volumes:
   - name: docker
@@ -1331,7 +1331,7 @@ steps:
   - DOCKER_OPTS="" make dist/grafana-agentctl-linux-amd64
   - DOCKER_OPTS="" make dist.temp/grafana-agent-flow-linux-amd64
   - DOCKER_OPTS="" make test-packages
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Test Linux system packages
   volumes:
   - name: docker
@@ -1427,6 +1427,6 @@ kind: secret
 name: updater_private_key
 ---
 kind: signature
-hmac: 372648213124cf1280ee4f0d402324dcc80b8a3304ae7a8e877bbe766ccb4074
+hmac: 47d018f95267288b13edfd1bdabbab3bc60daa2674fda3ebeb713fac569586cb
 
 ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ Main (unreleased)
 
 - Allow converting labels to structured metadata with Loki's structured_metadata stage. (@gonzalesraul)
 
+### Other changes
+
+- Use Go 1.21.3 for builds. (@tpaschalis)
 
 v0.37.1 (2023-10-10)
 -----------------

--- a/cmd/grafana-agent-operator/Dockerfile
+++ b/cmd/grafana-agent-operator/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.30.2 as build
+FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.30.3 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/cmd/grafana-agent/Dockerfile
+++ b/cmd/grafana-agent/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.30.2 as build
+FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.30.3 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/cmd/grafana-agent/Dockerfile.windows
+++ b/cmd/grafana-agent/Dockerfile.windows
@@ -1,4 +1,4 @@
-FROM grafana/agent-build-image:0.30.2-windows as builder
+FROM grafana/agent-build-image:0.30.3-windows as builder
 ARG VERSION
 ARG RELEASE_BUILD=1
 

--- a/cmd/grafana-agentctl/Dockerfile
+++ b/cmd/grafana-agentctl/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.30.2 as build
+FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.30.3 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/cmd/grafana-agentctl/Dockerfile.windows
+++ b/cmd/grafana-agentctl/Dockerfile.windows
@@ -1,4 +1,4 @@
-FROM grafana/agent-build-image:0.30.2-windows as builder
+FROM grafana/agent-build-image:0.30.3-windows as builder
 ARG VERSION
 ARG RELEASE_BUILD=1
 

--- a/tools/crow/Dockerfile
+++ b/tools/crow/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.30.2 as build
+FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.30.3 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/tools/make/build-container.mk
+++ b/tools/make/build-container.mk
@@ -34,7 +34,7 @@
 # variable names should be passed through to the container.
 
 USE_CONTAINER       ?= 0
-BUILD_IMAGE_VERSION ?= 0.30.2
+BUILD_IMAGE_VERSION ?= 0.30.3
 BUILD_IMAGE         ?= grafana/agent-build-image:$(BUILD_IMAGE_VERSION)
 DOCKER_OPTS         ?= -it
 

--- a/tools/smoke/Dockerfile
+++ b/tools/smoke/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.30.2 as build
+FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.30.3 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS


### PR DESCRIPTION
This bumps the build-image to the newly pushed v0.30.3 tag which makes use of Go 1.21.3