### PR TITLE
Cherry picks for v0.37.2

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -126,7 +126,7 @@ steps:
 - commands:
   - apt-get update -y && apt-get install -y libsystemd-dev
   - make lint
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Lint
 trigger:
   event:
@@ -144,7 +144,7 @@ steps:
   - ERR_MSG="Dashboard definitions are out of date. Please run 'make generate-dashboards'
     and commit changes!"
   - if [ ! -z "$(git status --porcelain)" ]; then echo $ERR_MSG >&2; exit 1; fi
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Regenerate dashboards
 trigger:
   event:
@@ -162,7 +162,7 @@ steps:
   - ERR_MSG="Custom Resource Definitions are out of date. Please run 'make generate-crds'
     and commit changes!"
   - if [ ! -z "$(git status --porcelain)" ]; then echo $ERR_MSG >&2; exit 1; fi
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Regenerate crds
 trigger:
   event:
@@ -180,7 +180,7 @@ steps:
   - ERR_MSG="The environment manifests are out of date. Please run 'make generate-manifests'
     and commit changes!"
   - if [ ! -z "$(git status --porcelain)" ]; then echo $ERR_MSG >&2; exit 1; fi
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Regenerate environment manifests
 trigger:
   event:
@@ -195,7 +195,7 @@ platform:
 steps:
 - commands:
   - make GO_TAGS="nodocker" test
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Run Go tests
 trigger:
   event:
@@ -210,7 +210,7 @@ platform:
 steps:
 - commands:
   - K8S_USE_DOCKER_NETWORK=1 make test
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Run Go tests
   volumes:
   - name: docker
@@ -233,7 +233,7 @@ platform:
 steps:
 - commands:
   - go test -tags="nodocker,nonetwork" ./...
-  image: grafana/agent-build-image:0.30.2-windows
+  image: grafana/agent-build-image:0.30.3-windows
   name: Run Go tests
 trigger:
   ref:
@@ -248,7 +248,7 @@ platform:
 steps:
 - commands:
   - make agent-image
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build container
   volumes:
   - name: docker
@@ -273,7 +273,7 @@ platform:
 steps:
 - commands:
   - make agentctl-image
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build container
   volumes:
   - name: docker
@@ -298,7 +298,7 @@ platform:
 steps:
 - commands:
   - make operator-image
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build container
   volumes:
   - name: docker
@@ -324,7 +324,7 @@ platform:
 steps:
 - commands:
   - '& "C:/Program Files/git/bin/bash.exe" ./tools/ci/docker-containers-windows agent'
-  image: grafana/agent-build-image:0.30.2-windows
+  image: grafana/agent-build-image:0.30.3-windows
   name: Build container
   volumes:
   - name: docker
@@ -350,7 +350,7 @@ platform:
 steps:
 - commands:
   - '& "C:/Program Files/git/bin/bash.exe" ./tools/ci/docker-containers-windows agentctl'
-  image: grafana/agent-build-image:0.30.2-windows
+  image: grafana/agent-build-image:0.30.3-windows
   name: Build container
   volumes:
   - name: docker
@@ -377,7 +377,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=amd64 GOARM=
     make agent
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -394,7 +394,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm64 GOARM=
     make agent
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -411,7 +411,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=ppc64le GOARM=
     make agent
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -428,7 +428,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=s390x GOARM=
     make agent
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -444,7 +444,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=darwin GOARCH=amd64 GOARM= make agent
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -460,7 +460,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=darwin GOARCH=arm64 GOARM= make agent
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -476,7 +476,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=windows GOARCH=amd64 GOARM= make agent
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -492,7 +492,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=freebsd GOARCH=amd64 GOARM= make agent
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -509,7 +509,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=amd64 GOARM=
     make agent-flow
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -526,7 +526,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm64 GOARM=
     make agent-flow
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -543,7 +543,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=ppc64le GOARM=
     make agent-flow
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -560,7 +560,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=s390x GOARM=
     make agent-flow
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -576,7 +576,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=darwin GOARCH=amd64 GOARM= make agent-flow
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -592,7 +592,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=darwin GOARCH=arm64 GOARM= make agent-flow
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -608,7 +608,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=windows GOARCH=amd64 GOARM= make agent-flow
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -624,7 +624,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=freebsd GOARCH=amd64 GOARM= make agent-flow
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -641,7 +641,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=amd64 GOARM=
     make agentctl
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -658,7 +658,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm64 GOARM=
     make agentctl
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -675,7 +675,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=ppc64le GOARM=
     make agentctl
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -692,7 +692,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=s390x GOARM=
     make agentctl
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -708,7 +708,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=darwin GOARCH=amd64 GOARM= make agentctl
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -724,7 +724,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=darwin GOARCH=arm64 GOARM= make agentctl
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -740,7 +740,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=windows GOARCH=amd64 GOARM= make agentctl
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -756,7 +756,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=freebsd GOARCH=amd64 GOARM= make agentctl
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -773,7 +773,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=amd64 GOARM=
     make operator
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -790,7 +790,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm64 GOARM=
     make operator
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -807,7 +807,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=ppc64le GOARM=
     make operator
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -824,7 +824,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=s390x GOARM=
     make operator
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -840,7 +840,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=darwin GOARCH=amd64 GOARM= make operator
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -856,7 +856,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=darwin GOARCH=arm64 GOARM= make operator
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -872,7 +872,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=windows GOARCH=amd64 GOARM= make operator
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -888,7 +888,7 @@ steps:
 - commands:
   - make generate-ui
   - GO_TAGS="builtinassets" GOOS=freebsd GOARCH=amd64 GOARM= make operator
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -905,7 +905,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=amd64 GOARM=
     GOEXPERIMENT=boringcrypto make agent-boringcrypto
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -922,7 +922,7 @@ steps:
   - make generate-ui
   - GO_TAGS="builtinassets promtail_journal_enabled" GOOS=linux GOARCH=arm64 GOARM=
     GOEXPERIMENT=boringcrypto make agent-boringcrypto
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Build
 trigger:
   event:
@@ -938,7 +938,7 @@ steps:
 - commands:
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   failure: ignore
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Configure QEMU
   volumes:
   - name: docker
@@ -958,7 +958,7 @@ steps:
       from_secret: docker_password
     GCR_CREDS:
       from_secret: gcr_admin
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Publish container
   volumes:
   - name: docker
@@ -982,7 +982,7 @@ steps:
 - commands:
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   failure: ignore
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Configure QEMU
   volumes:
   - name: docker
@@ -1002,7 +1002,7 @@ steps:
       from_secret: docker_password
     GCR_CREDS:
       from_secret: gcr_admin
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Publish container
   volumes:
   - name: docker
@@ -1026,7 +1026,7 @@ steps:
 - commands:
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   failure: ignore
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Configure QEMU
   volumes:
   - name: docker
@@ -1046,7 +1046,7 @@ steps:
       from_secret: docker_password
     GCR_CREDS:
       from_secret: gcr_admin
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Publish container
   volumes:
   - name: docker
@@ -1070,7 +1070,7 @@ steps:
 - commands:
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   failure: ignore
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Configure QEMU
   volumes:
   - name: docker
@@ -1090,7 +1090,7 @@ steps:
       from_secret: docker_password
     GCR_CREDS:
       from_secret: gcr_admin
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Publish container
   volumes:
   - name: docker
@@ -1114,7 +1114,7 @@ steps:
 - commands:
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   failure: ignore
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Configure QEMU
   volumes:
   - name: docker
@@ -1134,7 +1134,7 @@ steps:
       from_secret: docker_password
     GCR_CREDS:
       from_secret: gcr_admin
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Publish container
   volumes:
   - name: docker
@@ -1158,7 +1158,7 @@ steps:
 - commands:
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   failure: ignore
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Configure QEMU
   volumes:
   - name: docker
@@ -1178,7 +1178,7 @@ steps:
       from_secret: docker_password
     GCR_CREDS:
       from_secret: gcr_admin
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Publish container
   volumes:
   - name: docker
@@ -1207,7 +1207,7 @@ steps:
       from_secret: docker_login
     DOCKER_PASSWORD:
       from_secret: docker_password
-  image: grafana/agent-build-image:0.30.2-windows
+  image: grafana/agent-build-image:0.30.3-windows
   name: Build containers
   volumes:
   - name: docker
@@ -1236,7 +1236,7 @@ steps:
       from_secret: docker_login
     DOCKER_PASSWORD:
       from_secret: docker_password
-  image: grafana/agent-build-image:0.30.2-windows
+  image: grafana/agent-build-image:0.30.3-windows
   name: Build containers
   volumes:
   - name: docker
@@ -1357,7 +1357,7 @@ steps:
       from_secret: gpg_private_key
     GPG_PUBLIC_KEY:
       from_secret: gpg_public_key
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Publish release
   volumes:
   - name: docker
@@ -1382,7 +1382,7 @@ steps:
   - DOCKER_OPTS="" make dist/grafana-agentctl-linux-amd64
   - DOCKER_OPTS="" make dist.temp/grafana-agent-flow-linux-amd64
   - DOCKER_OPTS="" make test-packages
-  image: grafana/agent-build-image:0.30.2
+  image: grafana/agent-build-image:0.30.3
   name: Test Linux system packages
   volumes:
   - name: docker
@@ -1478,6 +1478,6 @@ kind: secret
 name: updater_private_key
 ---
 kind: signature
-hmac: d9fd1e02c62a58f2f6ccd7c87108f53d0a701dd5d44e81366ff825edb9401ae6
+hmac: f0a76b1eb8a86fd7cd800855df42655a2bd799d35b505acea3b722ff5644ba5d
 
 ...

--- a/cmd/grafana-agent-operator/Dockerfile
+++ b/cmd/grafana-agent-operator/Dockerfile
@@ -30,6 +30,7 @@ LABEL org.opencontainers.image.source="https://github.com/grafana/agent"
 RUN <<EOF
   apt-get update
   apt-get install -qy libsystemd-dev tzdata ca-certificates
+  apt-get upgrade -y
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 EOF
 

--- a/cmd/grafana-agent-operator/Dockerfile
+++ b/cmd/grafana-agent-operator/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.30.2 as build
+FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.30.3 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/cmd/grafana-agent/Dockerfile
+++ b/cmd/grafana-agent/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.30.2 as build
+FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.30.3 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/cmd/grafana-agent/Dockerfile
+++ b/cmd/grafana-agent/Dockerfile
@@ -38,7 +38,7 @@ LABEL org.opencontainers.image.source="https://github.com/grafana/agent"
 RUN <<EOF
   apt-get update
   apt-get install -qy libsystemd-dev tzdata ca-certificates
-
+  apt-get upgrade -y
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 EOF
 

--- a/cmd/grafana-agent/Dockerfile.windows
+++ b/cmd/grafana-agent/Dockerfile.windows
@@ -1,4 +1,4 @@
-FROM grafana/agent-build-image:0.30.2-windows as builder
+FROM grafana/agent-build-image:0.30.3-windows as builder
 ARG VERSION
 ARG RELEASE_BUILD=1
 

--- a/cmd/grafana-agentctl/Dockerfile
+++ b/cmd/grafana-agentctl/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.30.2 as build
+FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.30.3 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/cmd/grafana-agentctl/Dockerfile
+++ b/cmd/grafana-agentctl/Dockerfile
@@ -31,7 +31,7 @@ LABEL org.opencontainers.image.source="https://github.com/grafana/agent"
 RUN <<EOF
   apt-get update
   apt-get install -qy libsystemd-dev tzdata ca-certificates
-
+  apt-get upgrade -y
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 EOF
 

--- a/cmd/grafana-agentctl/Dockerfile.windows
+++ b/cmd/grafana-agentctl/Dockerfile.windows
@@ -1,4 +1,4 @@
-FROM grafana/agent-build-image:0.30.2-windows as builder
+FROM grafana/agent-build-image:0.30.3-windows as builder
 ARG VERSION
 ARG RELEASE_BUILD=1
 

--- a/cmd/internal/flowmode/cluster_builder_test.go
+++ b/cmd/internal/flowmode/cluster_builder_test.go
@@ -1,0 +1,18 @@
+package flowmode
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildClusterService(t *testing.T) {
+	opts := clusterOptions{
+		JoinPeers:     []string{"foo", "bar"},
+		DiscoverPeers: "provider=aws key1=val1 key2=val2",
+	}
+
+	cs, err := buildClusterService(opts)
+	require.Nil(t, cs)
+	require.EqualError(t, err, "at most one of join peers and discover peers may be set")
+}

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -210,7 +210,7 @@ func (fr *flowRun) Run(configPath string) error {
 		NodeName:            fr.clusterNodeName,
 		AdvertiseAddress:    fr.clusterAdvAddr,
 		ListenAddress:       fr.httpListenAddr,
-		JoinPeers:           strings.Split(fr.clusterJoinAddr, ","),
+		JoinPeers:           splitPeers(fr.clusterJoinAddr, ","),
 		DiscoverPeers:       fr.clusterDiscoverPeers,
 		RejoinInterval:      fr.clusterRejoinInterval,
 		AdvertiseInterfaces: fr.clusterAdvInterfaces,
@@ -429,4 +429,11 @@ func interruptContext() (context.Context, context.CancelFunc) {
 	}()
 
 	return ctx, cancel
+}
+
+func splitPeers(s, sep string) []string {
+	if len(s) == 0 {
+		return []string{}
+	}
+	return strings.Split(s, sep)
 }

--- a/component/prometheus/exporter/blackbox/blackbox.go
+++ b/component/prometheus/exporter/blackbox/blackbox.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/agent/component/prometheus/exporter"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/blackbox_exporter"
+	"github.com/grafana/agent/pkg/util"
 	"github.com/grafana/river/rivertypes"
 )
 
@@ -92,7 +93,6 @@ type Arguments struct {
 	Config             rivertypes.OptionalSecret `river:"config,attr,optional"`
 	Targets            TargetBlock               `river:"target,block"`
 	ProbeTimeoutOffset time.Duration             `river:"probe_timeout_offset,attr,optional"`
-	ConfigStruct       blackbox_config.Config
 }
 
 // SetToDefault implements river.Defaulter.
@@ -106,7 +106,8 @@ func (a *Arguments) Validate() error {
 		return errors.New("config and config_file are mutually exclusive")
 	}
 
-	err := yaml.UnmarshalStrict([]byte(a.Config.Value), &a.ConfigStruct)
+	var blackboxConfig blackbox_config.Config
+	err := yaml.UnmarshalStrict([]byte(a.Config.Value), &blackboxConfig)
 	if err != nil {
 		return fmt.Errorf("invalid backbox_exporter config: %s", err)
 	}
@@ -118,7 +119,7 @@ func (a *Arguments) Validate() error {
 func (a *Arguments) Convert() *blackbox_exporter.Config {
 	return &blackbox_exporter.Config{
 		BlackboxConfigFile: a.ConfigFile,
-		BlackboxConfig:     a.ConfigStruct,
+		BlackboxConfig:     util.RawYAML(a.Config.Value),
 		BlackboxTargets:    a.Targets.Convert(),
 		ProbeTimeoutOffset: a.ProbeTimeoutOffset.Seconds(),
 	}

--- a/converter/internal/staticconvert/internal/build/blackbox_exporter.go
+++ b/converter/internal/staticconvert/internal/build/blackbox_exporter.go
@@ -26,11 +26,13 @@ func (b *IntegrationsV1ConfigBuilder) appendBlackboxExporter(config *blackbox_ex
 
 func toBlackboxExporter(config *blackbox_exporter.Config) *blackbox.Arguments {
 	return &blackbox.Arguments{
-		ConfigFile:         config.BlackboxConfigFile,
-		Config:             rivertypes.OptionalSecret{},
+		ConfigFile: config.BlackboxConfigFile,
+		Config: rivertypes.OptionalSecret{
+			IsSecret: false,
+			Value:    string(config.BlackboxConfig),
+		},
 		Targets:            toBlackboxTargets(config.BlackboxTargets),
 		ProbeTimeoutOffset: time.Duration(config.ProbeTimeoutOffset),
-		ConfigStruct:       config.BlackboxConfig,
 	}
 }
 

--- a/converter/internal/staticconvert/testdata/integrations.river
+++ b/converter/internal/staticconvert/testdata/integrations.river
@@ -25,6 +25,8 @@ prometheus.remote_write "integrations" {
 }
 
 prometheus.exporter.blackbox "integrations_blackbox" {
+	config = "modules:\n  http_2xx:\n    prober: http\n    timeout: 5s\n    http:\n      method: POST\n      headers:\n        Content-Type: application/json\n      body: '{}'\n      preferred_ip_protocol: ip4\n"
+
 	target "example" {
 		address = "http://example.com"
 		module  = "http_2xx"

--- a/go.mod
+++ b/go.mod
@@ -676,8 +676,8 @@ replace (
 // * There is a release of Prometheus which contains
 // prometheus/prometheus#12677 and prometheus/prometheus#12729.
 // We use the last v1-related tag as the replace statement does not work for v2
-// tags without the v2 suffix to the module root
-replace github.com/prometheus/prometheus => github.com/grafana/prometheus v1.8.2-0.20231003113207-17e15326a784 // grafana:prometheus:v0.46.0-retry-improvements
+// tags without the v2 suffix to the module root.
+replace github.com/prometheus/prometheus => github.com/grafana/prometheus v1.8.2-0.20231016083943-46550094220d // grafana:prometheus:v0.47.2-retry-improvements
 
 replace gopkg.in/yaml.v2 => github.com/rfratto/go-yaml v0.0.0-20211119180816-77389c3526dc
 

--- a/go.sum
+++ b/go.sum
@@ -1071,8 +1071,8 @@ github.com/grafana/perflib_exporter v0.1.1-0.20230511173423-6166026bd090 h1:Ko80
 github.com/grafana/perflib_exporter v0.1.1-0.20230511173423-6166026bd090/go.mod h1:MinSWm88jguXFFrGsP56PtleUb4Qtm4tNRH/wXNXRTI=
 github.com/grafana/postgres_exporter v0.8.1-0.20210722175051-db35d7c2f520 h1:HnFWqxhoSF3WC7sKAdMZ+SRXvHLVZlZ3sbQjuUlTqkw=
 github.com/grafana/postgres_exporter v0.8.1-0.20210722175051-db35d7c2f520/go.mod h1:+HPXgiOV0InDHcZ2jNijL1SOKvo0eEPege5fQA0+ICI=
-github.com/grafana/prometheus v1.8.2-0.20231003113207-17e15326a784 h1:B8AAFKq7WQPUYdoGwWjgxFARn5XodYlKJNHCYUopah8=
-github.com/grafana/prometheus v1.8.2-0.20231003113207-17e15326a784/go.mod h1:10L5IJE5CEsjee1FnOcVswYXlPIscDWWt3IJ2UDYrz4=
+github.com/grafana/prometheus v1.8.2-0.20231016083943-46550094220d h1:hr0QEXSfpdakWdHw2sZeT/5GnGwIkHnNO0YBkfRj5zk=
+github.com/grafana/prometheus v1.8.2-0.20231016083943-46550094220d/go.mod h1:J/bmOSjgH7lFxz2gZhrWEZs2i64vMS+HIuZfmYNhJ/M=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.3 h1:eunWpv1B3Z7ZK9o4499EmQGlY+CsDmSZ4FbxjRx37uk=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.3/go.mod h1:1HSPtjU8vLG0jE9JrTdzjgFqdJ/VgN7fvxBNq3luJko=
 github.com/grafana/pyroscope/api v0.2.0 h1:TzOxL0s6SiaLEy944ZAKgHcx/JDRJXu4O8ObwkqR6p4=

--- a/pkg/integrations/blackbox_exporter/blackbox_exporter.go
+++ b/pkg/integrations/blackbox_exporter/blackbox_exporter.go
@@ -9,9 +9,11 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/config"
+	"github.com/grafana/agent/pkg/util"
 	blackbox_config "github.com/prometheus/blackbox_exporter/config"
 	"github.com/prometheus/blackbox_exporter/prober"
 	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/yaml.v3"
 )
 
 // DefaultConfig holds the default settings for the blackbox_exporter integration.
@@ -39,10 +41,10 @@ type BlackboxTarget struct {
 
 // Config configures the Blackbox integration.
 type Config struct {
-	BlackboxConfigFile string                 `yaml:"config_file,omitempty"`
-	BlackboxTargets    []BlackboxTarget       `yaml:"blackbox_targets"`
-	BlackboxConfig     blackbox_config.Config `yaml:"blackbox_config,omitempty"`
-	ProbeTimeoutOffset float64                `yaml:"probe_timeout_offset,omitempty"`
+	BlackboxConfigFile string           `yaml:"config_file,omitempty"`
+	BlackboxTargets    []BlackboxTarget `yaml:"blackbox_targets"`
+	BlackboxConfig     util.RawYAML     `yaml:"blackbox_config,omitempty"`
+	ProbeTimeoutOffset float64          `yaml:"probe_timeout_offset,omitempty"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler for Config.
@@ -50,7 +52,13 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	*c = DefaultConfig
 
 	type plain Config
-	return unmarshal((*plain)(c))
+	err := unmarshal((*plain)(c))
+	if err != nil {
+		return err
+	}
+
+	var blackbox_config blackbox_config.Config
+	return yaml.Unmarshal(c.BlackboxConfig, &blackbox_config)
 }
 
 // Name returns the name of the integration.
@@ -96,7 +104,13 @@ func LoadBlackboxConfig(log log.Logger, configFile string, targets []BlackboxTar
 
 // New creates a new blackbox_exporter integration
 func New(log log.Logger, c *Config) (integrations.Integration, error) {
-	modules, err := LoadBlackboxConfig(log, c.BlackboxConfigFile, c.BlackboxTargets, &c.BlackboxConfig)
+	var blackbox_config blackbox_config.Config
+	err := yaml.Unmarshal(c.BlackboxConfig, &blackbox_config)
+	if err != nil {
+		return nil, err
+	}
+
+	modules, err := LoadBlackboxConfig(log, c.BlackboxConfigFile, c.BlackboxTargets, &blackbox_config)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/crow/Dockerfile
+++ b/tools/crow/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.30.2 as build
+FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.30.3 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/tools/make/build-container.mk
+++ b/tools/make/build-container.mk
@@ -34,7 +34,7 @@
 # variable names should be passed through to the container.
 
 USE_CONTAINER       ?= 0
-BUILD_IMAGE_VERSION ?= 0.30.2
+BUILD_IMAGE_VERSION ?= 0.30.3
 BUILD_IMAGE         ?= grafana/agent-build-image:$(BUILD_IMAGE_VERSION)
 DOCKER_OPTS         ?= -it
 

--- a/tools/smoke/Dockerfile
+++ b/tools/smoke/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.30.2 as build
+FROM --platform=$BUILDPLATFORM grafana/agent-build-image:0.30.3 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS


### PR DESCRIPTION
This PR cherry-picks multiple commits to prepare for a v0.37.2 patch release:

* Bumps our Prometheus dependency to v2.47.2 along with our retry improvements to fix two bugs with native histograms
* Bumps Go to v1.21.3 to resolve the recent HTTP/2 CVE
* Updates our Ubuntu packages to the latest
* Fixes a bug in clustering's handle of the `--cluster.join-addresses` CLI flag.
* Fixes an issue with the converter and the blackbox exporter