### PR TITLE
Use types from discovery Hetzner when converting configs

### DIFF
--- a/component/discovery/hetzner/hetzner.go
+++ b/component/discovery/hetzner/hetzner.go
@@ -11,13 +11,6 @@ import (
 	prom_discovery "github.com/prometheus/prometheus/discovery/hetzner"
 )
 
-// TODO(marctc): hetzner role constants are not exported, we need to manual create them
-// Remove once this is merged: https://github.com/prometheus/prometheus/pull/12620
-const (
-	hetznerRoleRobot  string = "robot"
-	hetznerRoleHcloud string = "hcloud"
-)
-
 func init() {
 	component.Register(component.Registration{
 		Name:    "discovery.hetzner",
@@ -51,7 +44,7 @@ func (args *Arguments) SetToDefault() {
 // Validate implements river.Validator.
 func (args *Arguments) Validate() error {
 	switch args.Role {
-	case hetznerRoleRobot, hetznerRoleHcloud:
+	case string(prom_discovery.HetznerRoleRobot), string(prom_discovery.HetznerRoleHcloud):
 	default:
 		return fmt.Errorf("unknown role %s, must be one of robot or hcloud", args.Role)
 	}
@@ -65,13 +58,7 @@ func (args *Arguments) Convert() *prom_discovery.SDConfig {
 		RefreshInterval:  model.Duration(args.RefreshInterval),
 		Port:             args.Port,
 		HTTPClientConfig: *httpClient.Convert(),
-	}
-	// TODO(marctc): hetzner.role is not exported, we need to manual convert it
-	// Remove once this is merged: https://github.com/prometheus/prometheus/pull/12620
-	if args.Role == hetznerRoleRobot {
-		cfg.Role = "robot"
-	} else if args.Role == hetznerRoleHcloud {
-		cfg.Role = "hcloud"
+		Role:             prom_discovery.Role(args.Role),
 	}
 	return cfg
 }


### PR DESCRIPTION
#### PR Description

The type `hetzner.Role` and constants `HetznerRoleRobot` and `HetznerRoleHcloud` where not exported.
After upgrading Prometheus to last version, those are now exported, therefore we can cleanup the current
code to use the types from Prometheus.


#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated