### PR TITLE
Allow out of order samples to be written to the WAL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Main (unreleased)
 
 - Allow converting labels to structured metadata with Loki's structured_metadata stage. (@gonzalesraul)
 
+- Allow Out of Order writing to the WAL for metrics. (@mattdurham)
+
 ### Other changes
 
 - Use Go 1.21.3 for builds. (@tpaschalis)

--- a/pkg/metrics/wal/wal.go
+++ b/pkg/metrics/wal/wal.go
@@ -699,11 +699,6 @@ func (a *appender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v flo
 	series.Lock()
 	defer series.Unlock()
 
-	if t < series.lastTs {
-		a.w.metrics.totalOutOfOrderSamples.Inc()
-		return 0, storage.ErrOutOfOrderSample
-	}
-
 	// NOTE(rfratto): always modify pendingSamples and sampleSeries together.
 	a.pendingSamples = append(a.pendingSamples, record.RefSample{
 		Ref: series.ref,
@@ -823,11 +818,6 @@ func (a *appender) AppendHistogram(ref storage.SeriesRef, l labels.Labels, t int
 
 	series.Lock()
 	defer series.Unlock()
-
-	if t < series.lastTs {
-		a.w.metrics.totalOutOfOrderSamples.Inc()
-		return 0, storage.ErrOutOfOrderSample
-	}
 
 	switch {
 	case h != nil:


### PR DESCRIPTION
#### PR Description

This copies the behavior of https://github.com/prometheus/prometheus/pull/12897 into our own tsdb. 

#### PR Checklist

- [X] CHANGELOG.md updated
- [NA] Documentation added
- [X] Tests updated
- [NA] Config converters updated