### PR TITLE
Docs: Clarify which Vault "remote.vault" connects to

### DIFF
--- a/docs/sources/flow/reference/components/remote.vault.md
+++ b/docs/sources/flow/reference/components/remote.vault.md
@@ -11,12 +11,13 @@ description: Learn about remote.vault
 
 # remote.vault
 
-`remote.vault` connect to Vault to retrieve secrets. It can retrieve a secret
-using the [KV v2][] secrets engine.
+`remote.vault` connects to a [HashiCorp Vault][Vault] server to retrieve secrets.
+It can retrieve a secret using the [KV v2][] secrets engine.
 
 Multiple `remote.vault` components can be specified by giving them different
 labels.
 
+[Vault]: https://www.vaultproject.io/
 [KV v2]: https://www.vaultproject.io/docs/secrets/kv/kv-v2
 
 ## Usage


### PR DESCRIPTION
I'm surprised that "HashiCorp" is not mentioned in the docs for `remote.vault`. "Vault" is a term which is so overused in the security space, that probably even the component should have been called `remote.hashicorp_vault`.