### PR TITLE
Update migrating-from-static.md

### DIFF
--- a/docs/sources/flow/getting-started/migrating-from-static.md
+++ b/docs/sources/flow/getting-started/migrating-from-static.md
@@ -83,13 +83,13 @@ features available in Grafana Agent Flow mode.
    {{% admonition type="caution" %}}If you bypass the errors, the behavior of the converted configuration may not match the original [Static] mode configuration. Make sure you fully test the converted configuration before using it in a production environment.{{% /admonition %}}
 
     ```bash
-    AGENT_MODE=flow; grafana-agent convert --source-format=static --bypass-errors --output=OUTPUT_CONFIG_PATH INPUT_CONFIG_PATH
+    AGENT_MODE=flow; grafana-agent-flow convert --source-format=static --bypass-errors --output=OUTPUT_CONFIG_PATH INPUT_CONFIG_PATH
     ```
 
 1. You can use the `--report` flag to output a diagnostic report.
 
     ```bash
-    AGENT_MODE=flow; grafana-agent convert --source-format=static --report=OUTPUT_REPORT_PATH --output=OUTPUT_CONFIG_PATH INPUT_CONFIG_PATH
+    AGENT_MODE=flow; grafana-agent-flow convert --source-format=static --report=OUTPUT_REPORT_PATH --output=OUTPUT_CONFIG_PATH INPUT_CONFIG_PATH
     ```
 
     * Replace `OUTPUT_REPORT_PATH` with the output path for the report.
@@ -199,7 +199,7 @@ The convert command takes the YAML file as input and outputs a [River][] file.
 [River]: {{< relref "../config-language/_index.md" >}}
 
 ```bash
-AGENT_MODE=flow; grafana-agent convert --source-format=static --output=OUTPUT_CONFIG_PATH INPUT_CONFIG_PATH
+AGENT_MODE=flow; grafana-agent-flow convert --source-format=static --output=OUTPUT_CONFIG_PATH INPUT_CONFIG_PATH
 ```
 
 The new Flow mode configuration file looks like this:


### PR DESCRIPTION
Running existing static to flow conversion with "grafana-agent" insinuated that I still needed the old agent. By default, the executable is named, "grafana-agent-flow" in the documentation and doesn't mention a need to rename the executable.

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated