### PR TITLE
Add missing documentation for scheduled_task in Static docs

### DIFF
--- a/docs/sources/flow/reference/components/discovery.azure.md
+++ b/docs/sources/flow/reference/components/discovery.azure.md
@@ -36,14 +36,15 @@ Name                | Type       | Description                                  
 `enable_http2`      | `bool`     | Whether HTTP2 is supported for requests.                               | `true`               | no
 
 ## Blocks
+
 The following blocks are supported inside the definition of
 `discovery.azure`:
 
-Hierarchy | Block | Description | Required
---------- | ----- | ----------- | --------
-oauth | [oauth][] | OAuth configuration for Azure API. | no
-managed_identity | [managed_identity][] | Managed Identity configuration for Azure API. | no
-tls_config | [tls_config][] | TLS configuration for requests to the Azure API. | no
+Hierarchy        | Block                | Description                                      | Required
+-----------------|----------------------|--------------------------------------------------|---------
+oauth            | [oauth][]            | OAuth configuration for Azure API.               | no
+managed_identity | [managed_identity][] | Managed Identity configuration for Azure API.    | no
+tls_config       | [tls_config][]       | TLS configuration for requests to the Azure API. | no
 
 Exactly one of the `oauth` or `managed_identity` blocks must be specified.
 
@@ -51,23 +52,25 @@ Exactly one of the `oauth` or `managed_identity` blocks must be specified.
 [managed_identity]: #managed_identity-block
 [tls_config]: #tls_config-block
 
-### oauth block
+### oauth
+
 The `oauth` block configures OAuth authentication for the Azure API.
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`client_id` | `string` | OAuth client ID. | | yes
-`client_secret` | `string` | OAuth client secret. | | yes
-`tenant_id` | `string` | OAuth tenant ID. | | yes
+Name            | Type     | Description          | Default | Required
+----------------|----------|----------------------|---------|---------
+`client_id`     | `string` | OAuth client ID.     |         | yes
+`client_secret` | `string` | OAuth client secret. |         | yes
+`tenant_id`     | `string` | OAuth tenant ID.     |         | yes
 
-### managed_identity block
+### managed_identity
+
 The `managed_identity` block configures Managed Identity authentication for the Azure API.
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`client_id` | `string` | Managed Identity client ID. | | yes
+Name        | Type     | Description                 | Default | Required
+------------|----------|-----------------------------|---------|---------
+`client_id` | `string` | Managed Identity client ID. |         | yes
 
-### tls_config block
+### tls_config
 
 {{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
@@ -76,7 +79,7 @@ Name | Type | Description | Default | Required
 The following fields are exported and can be referenced by other components:
 
 Name      | Type                | Description
---------- | ------------------- | -----------
+----------|---------------------|--------------------------------------------------
 `targets` | `list(map(string))` | The set of targets discovered from the Azure API.
 
 Each target includes the following labels:
@@ -91,7 +94,7 @@ Each target includes the following labels:
 * `__meta_azure_machine_location`: The region the VM is in.
 * `__meta_azure_machine_private_ip`: The private IP address of the VM.
 * `__meta_azure_machine_public_ip`: The public IP address of the VM.
-* `__meta_azure_machine_tag_*`: A tag on the VM. There will be one label per tag.
+* `__meta_azure_machine_tag_*`: A tag on the VM. There must be one label per tag.
 * `__meta_azure_machine_scale_set`: The name of the scale set the VM is in.
 * `__meta_azure_machine_size`: The size of the VM.
 
@@ -99,28 +102,27 @@ Each discovered VM maps to a single target. The `__address__` label is set to th
 
 ## Component health
 
-`discovery.azure` is only reported as unhealthy when given an invalid
-configuration. In those cases, exported fields retain their last healthy
-values.
+`discovery.azure` is only reported as unhealthy when given an invalid configuration.
+In those cases, exported fields retain their last healthy values.
 
 ## Debug information
 
-`discovery.azure` does not expose any component-specific debug information.
+`discovery.azure` doesn't expose any component-specific debug information.
 
 ## Debug metrics
 
-`discovery.azure` does not expose any component-specific debug metrics.
+`discovery.azure` doesn't expose any component-specific debug metrics.
 
 ## Example
 
 ```river
 discovery.azure "example" {
   port = 80
-  subscription_id = AZURE_SUBSCRIPTION_ID
+  subscription_id = <AZURE_SUBSCRIPTION_ID>
   oauth {
-      client_id = AZURE_CLIENT_ID
-      client_secret = AZURE_CLIENT_SECRET
-      tenant_id = AZURE_TENANT_ID
+      client_id = <AZURE_CLIENT_ID>
+      client_secret = <AZURE_CLIENT_SECRET>
+      tenant_id = <AZURE_TENANT_ID>
   }
 }
 
@@ -131,20 +133,21 @@ prometheus.scrape "demo" {
 
 prometheus.remote_write "demo" {
   endpoint {
-    url = PROMETHEUS_REMOTE_WRITE_URL
+    url = <PROMETHEUS_REMOTE_WRITE_URL>
 
     basic_auth {
-      username = USERNAME
-      password = PASSWORD
+      username = <USERNAME>
+      password = <PASSWORD>
     }
   }
 }
 ```
+
 Replace the following:
-  - `AZURE_SUBSCRIPTION_ID`: Your Azure subscription ID.
-  - `AZURE_CLIENT_ID`: Your Azure client ID.
-  - `AZURE_CLIENT_SECRET`: Your Azure client secret.
-  - `AZURE_TENANT_ID`: Your Azure tenant ID.
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+  - `<AZURE_SUBSCRIPTION_ID>`: Your Azure subscription ID.
+  - `<AZURE_CLIENT_ID>`: Your Azure client ID.
+  - `<AZURE_CLIENT_SECRET>`: Your Azure client secret.
+  - `<AZURE_TENANT_ID>`: Your Azure tenant ID.
+  - `<PROMETHEUS_REMOTE_WRITE_URL>`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+  - `<USERNAME>`: The username to use for authentication to the remote_write API.
+  - `<PASSWORD>`: The password to use for authentication to the remote_write API.

--- a/docs/sources/flow/reference/components/discovery.consul.md
+++ b/docs/sources/flow/reference/components/discovery.consul.md
@@ -10,7 +10,7 @@ description: Learn about discovery.consul
 
 # discovery.consul
 
-`discovery.consul` allows retrieving scrape targets from [Consul's Catalog API][].
+`discovery.consul` allows you to retrieve scrape targets from [Consul's Catalog API][].
 
 [Consul's Catalog API]: https://www.consul.io/use-cases/discover-services
 
@@ -50,7 +50,7 @@ Name | Type | Description | Default | Required
 
  At most one of the following can be provided:
  - [`bearer_token` argument](#arguments).
- - [`bearer_token_file` argument](#arguments). 
+ - [`bearer_token_file` argument](#arguments).
  - [`basic_auth` block][basic_auth].
  - [`authorization` block][authorization].
  - [`oauth2` block][oauth2].
@@ -63,12 +63,12 @@ Name | Type | Description | Default | Required
 The following blocks are supported inside the definition of
 `discovery.consul`:
 
-Hierarchy | Block | Description | Required
---------- | ----- | ----------- | --------
-basic_auth | [basic_auth][] | Configure basic_auth for authenticating to the endpoint. | no
-authorization | [authorization][] | Configure generic authorization to the endpoint. | no
-oauth2 | [oauth2][] | Configure OAuth2 for authenticating to the endpoint. | no
-oauth2 > tls_config | [tls_config][] | Configure TLS settings for connecting to the endpoint. | no
+Hierarchy           | Block             | Description                                              | Required
+--------------------|-------------------|----------------------------------------------------------|---------
+basic_auth          | [basic_auth][]    | Configure basic_auth for authenticating to the endpoint. | no
+authorization       | [authorization][] | Configure generic authorization to the endpoint.         | no
+oauth2              | [oauth2][]        | Configure OAuth2 for authenticating to the endpoint.     | no
+oauth2 > tls_config | [tls_config][]    | Configure TLS settings for connecting to the endpoint.   | no
 
 The `>` symbol indicates deeper levels of nesting. For example,
 `oauth2 > tls_config` refers to a `tls_config` block defined inside
@@ -79,19 +79,19 @@ an `oauth2` block.
 [oauth2]: #oauth2-block
 [tls_config]: #tls_config-block
 
-### basic_auth block
+### basic_auth
 
 {{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT VERSION>" >}}
 
-### authorization block
+### authorization
 
 {{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT VERSION>" >}}
 
-### oauth2 block
+### oauth2
 
 {{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT VERSION>" >}}
 
-### tls_config block
+### tls_config
 
 {{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
 
@@ -99,39 +99,38 @@ an `oauth2` block.
 
 The following fields are exported and can be referenced by other components:
 
-Name | Type | Description
----- | ---- | -----------
+Name      | Type                | Description
+----------|---------------------|-----------------------------------------------------------
 `targets` | `list(map(string))` | The set of targets discovered from the Consul catalog API.
 
 Each target includes the following labels:
 
-* `__meta_consul_address`: the address of the target.
-* `__meta_consul_dc`: the datacenter name for the target.
-* `__meta_consul_health`: the health status of the service.
-* `__meta_consul_partition`: the admin partition name where the service is registered.
-* `__meta_consul_metadata_<key>`: each node metadata key value of the target.
-* `__meta_consul_node`: the node name defined for the target.
-* `__meta_consul_service_address`: the service address of the target.
-* `__meta_consul_service_id`: the service ID of the target.
-* `__meta_consul_service_metadata_<key>`: each service metadata key value of the target.
-* `__meta_consul_service_port`: the service port of the target.
-* `__meta_consul_service`: the name of the service the target belongs to.
-* `__meta_consul_tagged_address_<key>`: each node tagged address key value of the target.
-* `__meta_consul_tags`: the list of tags of the target joined by the tag separator.
+* `__meta_consul_address`: The address of the target.
+* `__meta_consul_dc`: The datacenter name for the target.
+* `__meta_consul_health`: The health status of the service.
+* `__meta_consul_partition`: The admin partition name where the service is registered.
+* `__meta_consul_metadata_<key>`: Each node metadata key value of the target.
+* `__meta_consul_node`: The node name defined for the target.
+* `__meta_consul_service_address`: The service address of the target.
+* `__meta_consul_service_id`: The service ID of the target.
+* `__meta_consul_service_metadata_<key>`: Each service metadata key value of the target.
+* `__meta_consul_service_port`: The service port of the target.
+* `__meta_consul_service`: The name of the service the target belongs to.
+* `__meta_consul_tagged_address_<key>`: Each node tagged address key value of the target.
+* `__meta_consul_tags`: The list of tags of the target joined by the tag separator.
 
 ## Component health
 
-`discovery.consul` is only reported as unhealthy when given an invalid
-configuration. In those cases, exported fields retain their last healthy
-values.
+`discovery.consul` is only reported as unhealthy when given an invalid configuration.
+In those cases, exported fields retain their last healthy values.
 
 ## Debug information
 
-`discovery.consul` does not expose any component-specific debug information.
+`discovery.consul` doesn't expose any component-specific debug information.
 
 ## Debug metrics
 
-`discovery.consul` does not expose any component-specific debug metrics.
+`discovery.consul` doesn't expose any component-specific debug metrics.
 
 ## Example
 
@@ -153,16 +152,16 @@ prometheus.scrape "demo" {
 
 prometheus.remote_write "demo" {
   endpoint {
-    url = PROMETHEUS_REMOTE_WRITE_URL
+    url = <PROMETHEUS_REMOTE_WRITE_URL>
 
     basic_auth {
-      username = USERNAME
-      password = PASSWORD
+      username = <USERNAME>
+      password = <PASSWORD>
     }
   }
 }
 ```
 Replace the following:
-  - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
-  - `USERNAME`: The username to use for authentication to the remote_write API.
-  - `PASSWORD`: The password to use for authentication to the remote_write API.
+  - `<PROMETHEUS_REMOTE_WRITE_URL>`: The URL of the Prometheus remote_write-compatible server to send metrics to.
+  - `<USERNAME>`: The username to use for authentication to the remote_write API.
+  - `<PASSWORD>`: The password to use for authentication to the remote_write API.

--- a/docs/sources/shared/flow/reference/components/authorization-block.md
+++ b/docs/sources/shared/flow/reference/components/authorization-block.md
@@ -9,11 +9,10 @@ description: Shared content, authorization block
 headless: true
 ---
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`type` | `string` | Authorization type, for example, "Bearer". | | no
-`credentials` | `secret` | Secret value. | | no
-`credentials_file` | `string` | File containing the secret value. | | no
+Name               | Type     | Description                                | Default | Required
+-------------------|----------|--------------------------------------------|---------|---------
+`type`             | `string` | Authorization type, for example, "Bearer". |         | no
+`credentials`      | `secret` | Secret value.                              |         | no
+`credentials_file` | `string` | File containing the secret value.          |         | no
 
-`credential` and `credentials_file` are mutually exclusive and only one can be
-provided inside of an `authorization` block.
+`credential` and `credentials_file` are mutually exclusive and only one can be provided inside of an `authorization` block.

--- a/docs/sources/shared/flow/reference/components/azuread-block.md
+++ b/docs/sources/shared/flow/reference/components/azuread-block.md
@@ -9,8 +9,8 @@ description: Shared content, azuread block
 headless: true
 ---
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
+Name    | Type     | Description      | Default         | Required
+--------|----------|------------------|-----------------|---------
 `cloud` | `string` | The Azure Cloud. | `"AzurePublic"` | no
 
 The supported values for `cloud` are:

--- a/docs/sources/shared/flow/reference/components/basic-auth-block.md
+++ b/docs/sources/shared/flow/reference/components/basic-auth-block.md
@@ -9,11 +9,10 @@ description: Shared content, basic auth block
 headless: true
 ---
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`username` | `string` | Basic auth username. | | no
-`password` | `secret` | Basic auth password. | | no
-`password_file` | `string` | File containing the basic auth password. | | no
+Name            | Type     | Description                              | Default | Required
+----------------|----------|------------------------------------------|---------|---------
+`username`      | `string` | Basic auth username.                     |         | no
+`password`      | `secret` | Basic auth password.                     |         | no
+`password_file` | `string` | File containing the basic auth password. |         | no
 
-`password` and `password_file` are mutually exclusive and only one can be
-provided inside of a `basic_auth` block.
+`password` and `password_file` are mutually exclusive and only one can be provided inside of a `basic_auth` block.

--- a/docs/sources/shared/flow/reference/components/exporter-component-exports.md
+++ b/docs/sources/shared/flow/reference/components/exporter-component-exports.md
@@ -12,7 +12,7 @@ headless: true
 The following fields are exported and can be referenced by other components.
 
 Name      | Type                | Description
---------- | ------------------- | -----------
+----------|---------------------|----------------------------------------------------------
 `targets` | `list(map(string))` | The targets that can be used to collect exporter metrics.
 
 For example, the `targets` can either be passed to a `discovery.relabel`

--- a/docs/sources/shared/flow/reference/components/extract-field-block.md
+++ b/docs/sources/shared/flow/reference/components/extract-field-block.md
@@ -11,20 +11,19 @@ headless: true
 
 The following attributes are supported:
 
-Name | Type           | Description                                                                                              | Default | Required
----- |----------------|----------------------------------------------------------------------------------------------------------|---------| --------
-`tag_name` | `string` | The name of the resource attribute that will be added to logs, metrics, or spans.      | `""` | no
-`key` | `string` | The annotation (or label) name. This must exactly match an annotation (or label) name.    |  `""` | no
-`key_regex` | `string` | A regular expression used to extract a key that matches the regex.                           | `""` | no
-`regex` | `string` | An optional field used to extract a sub-string from a complex field value.                      | `""` | no
-`from` | `string` | The source of the labels or annotations. Allowed values are `pod` and `namespace`.          | `pod`    | no
+Name        | Type     | Description                                                                        | Default | Required
+------------|----------|------------------------------------------------------------------------------------|---------|---------
+`tag_name`  | `string` | The name of the resource attribute added to logs, metrics, or spans.               | `""`    | no
+`key`       | `string` | The annotation or label name. This must exactly match an annotation or label name. | `""`    | no
+`key_regex` | `string` | A regular expression used to extract a key that matches the regular expression.    | `""`    | no
+`regex`     | `string` | An optional field used to extract a sub-string from a complex field value.         | `""`    | no
+`from`      | `string` | The source of the labels or annotations. Allowed values are `pod` and `namespace`. | `pod`   | no
 
 When `tag_name` is not specified, a default tag name will be used with the format:
 * `k8s.pod.annotations.<annotation key>`
 * `k8s.pod.labels.<label key>`
 
-For example, if `tag_name` is not specified and the key is `git_sha`, then the attribute name will be
-`k8s.pod.annotations.git_sha`.
+For example, if you don't specify the `tag_name` and the key is `git_sha`, then the attribute name is `k8s.pod.annotations.git_sha`.
 
 Either the `key` attribute or the `key_regex` attribute should be set, not both.
 When `key_regex` is present, `tag_name` supports back reference to both
@@ -34,7 +33,7 @@ For example, assume your pod spec contains the following labels:
 * `app.kubernetes.io/component: mysql`
 * `app.kubernetes.io/version: 5.7.21`
 
-If you'd like to add tags for all labels with prefix `app.kubernetes.io/` and trim the prefix, 
+If you'd like to add tags for all labels with prefix `app.kubernetes.io/` and trim the prefix,
 then you can specify the following extraction rules:
 
 ```river
@@ -47,6 +46,6 @@ extract {
 }
 ```
 
-These rules will add the `component` and `version` tags to the spans or metrics.
+These rules add the `component` and `version` tags to the spans or metrics.
 
-The `from` attribute can be set to either `"pod"` or `"namespace"`.
+You can set the `from` attribute to either `"pod"` or `"namespace"`.

--- a/docs/sources/shared/flow/reference/components/field-filter-block.md
+++ b/docs/sources/shared/flow/reference/components/field-filter-block.md
@@ -11,11 +11,11 @@ headless: true
 
 The following attributes are supported:
 
-Name | Type     | Description                                                                       | Default | Required
----- |----------|-----------------------------------------------------------------------------------|---------| --------
-`key` | `string` | The key or name of the field or labels that a filter can use. |         | yes
-`value` | `string` | The value associated with the key that a filter can use.    |         | yes
-`op` | `string` | The filter operation to apply on the given key: value pair.         | `equals` | no
+Name    | Type     | Description                                                   | Default  | Required
+--------|----------|---------------------------------------------------------------|----------|---------
+`key`   | `string` | The key or name of the field or labels that a filter can use. |          | yes
+`value` | `string` | The value associated with the key that a filter can use.      |          | yes
+`op`    | `string` | The filter operation to apply on the given key: value pair.   | `equals` | no
 
 For `op` the following values are allowed:
 * `equals`: The field value must be equal to the provided value.

--- a/docs/sources/shared/flow/reference/components/http-client-config-block.md
+++ b/docs/sources/shared/flow/reference/components/http-client-config-block.md
@@ -9,13 +9,13 @@ description: Shared content, http client config block
 headless: true
 ---
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`bearer_token` | `secret` | Bearer token to authenticate with. | | no
-`bearer_token_file` | `string` | File containing a bearer token to authenticate with. | | no
-`proxy_url` | `string` | HTTP proxy to proxy requests through. | | no
-`follow_redirects` | `bool` | Whether redirects returned by the server should be followed. | `true` | no
-`enable_http2` | `bool` | Whether HTTP2 is supported for requests. | `true` | no
+Name                | Type     | Description                                                  | Default | Required
+--------------------|----------|--------------------------------------------------------------|---------|---------
+`bearer_token`      | `secret` | Bearer token to authenticate with.                           |         | no
+`bearer_token_file` | `string` | File containing a bearer token to authenticate with.         |         | no
+`proxy_url`         | `string` | HTTP proxy to proxy requests through.                        |         | no
+`follow_redirects`  | `bool`   | Whether redirects returned by the server should be followed. | `true`  | no
+`enable_http2`      | `bool`   | Whether HTTP2 is supported for requests.                     | `true`  | no
 
 `bearer_token`, `bearer_token_file`, `basic_auth`, `authorization`, and
 `oauth2` are mutually exclusive and only one can be provided inside of a

--- a/docs/sources/shared/flow/reference/components/loki-server-grpc.md
+++ b/docs/sources/shared/flow/reference/components/loki-server-grpc.md
@@ -14,14 +14,14 @@ The `grpc` block configures the gRPC server.
 The following arguments can be used to configure the `grpc` block. Any omitted
 fields take their default values.
 
- Name                            | Type       | Description                                                                                                          | Default      | Required 
----------------------------------|------------|----------------------------------------------------------------------------------------------------------------------|--------------|----------
- `listen_address`                | `string`   | Network address on which the server will listen for new connections. Defaults to accepting all incoming connections. | `""`         | no       
- `listen_port`                   | `int`      | Port number on which the server will listen for new connections. Defaults to a random free port being assigned.      | `0`          | no       
- `conn_limit`                    | `int`      | Maximum number of simultaneous http connections. Defaults to no limit.                                               | `0`          | no       
- `max_connection_age`            | `duration` | The duration for the maximum amount of time a connection may exist before it will be closed.                         | `"infinity"` | no       
- `max_connection_age_grace`      | `duration` | An additive period after `max_connection_age` after which the connection will be forcibly closed.                    | `"infinity"` | no       
- `max_connection_idle`           | `duration` | The duration after which an idle connection should be closed.                                                        | `"infinity"` | no       
- `server_max_recv_msg_size`      | `int`      | Limit on the size of a gRPC message this server can receive (bytes).                                                 | `4MB`        | no       
- `server_max_send_msg_size`      | `int`      | Limit on the size of a gRPC message this server can send (bytes).                                                    | `4MB`        | no       
- `server_max_concurrent_streams` | `int`      | Limit on the number of concurrent streams for gRPC calls (0 = unlimited).                                            | `100`        | no       
+Name                            | Type       | Description                                                                                                          | Default      | Required
+--------------------------------|------------|----------------------------------------------------------------------------------------------------------------------|--------------|---------
+`listen_address`                | `string`   | Network address on which the server will listen for new connections. Defaults to accepting all incoming connections. | `""`         | no
+`listen_port`                   | `int`      | Port number on which the server will listen for new connections. Defaults to a random free port being assigned.      | `0`          | no
+`conn_limit`                    | `int`      | Maximum number of simultaneous http connections. Defaults to no limit.                                               | `0`          | no
+`max_connection_age`            | `duration` | The duration for the maximum amount of time a connection may exist before it will be closed.                         | `"infinity"` | no
+`max_connection_age_grace`      | `duration` | An additive period after `max_connection_age` after which the connection will be forcibly closed.                    | `"infinity"` | no
+`max_connection_idle`           | `duration` | The duration after which an idle connection should be closed.                                                        | `"infinity"` | no
+`server_max_recv_msg_size`      | `int`      | Limit on the size of a gRPC message this server can receive (bytes).                                                 | `4MB`        | no
+`server_max_send_msg_size`      | `int`      | Limit on the size of a gRPC message this server can send (bytes).                                                    | `4MB`        | no
+`server_max_concurrent_streams` | `int`      | Limit on the number of concurrent streams for gRPC calls (0 = unlimited).                                            | `100`        | no

--- a/docs/sources/shared/flow/reference/components/loki-server-http.md
+++ b/docs/sources/shared/flow/reference/components/loki-server-http.md
@@ -14,11 +14,11 @@ The `http` block configures the HTTP server.
 The following arguments can be used to configure the `http` block. Any omitted
 fields take their default values.
 
- Name                   | Type       | Description                                                                                                          | Default  | Required
-------------------------|------------|----------------------------------------------------------------------------------------------------------------------|----------|----------
- `listen_address`       | `string`   | Network address on which the server will listen for new connections. Defaults to accepting all incoming connections. | `""`     | no
- `listen_port`          | `int`      | Port number on which the server will listen for new connections.                                                     | `8080`   | no
- `conn_limit`           | `int`      | Maximum number of simultaneous http connections. Defaults to no limit.                                               | `0`      | no
- `server_read_timeout`  | `duration` | Read timeout for HTTP server.                                                                                        | `"30s"`  | no
- `server_write_timeout` | `duration` | Write timeout for HTTP server.                                                                                       | `"30s"`  | no
- `server_idle_timeout`  | `duration` | Idle timeout for HTTP server.                                                                                        | `"120s"` | no
+Name                   | Type       | Description                                                                                                          | Default  | Required
+-----------------------|------------|----------------------------------------------------------------------------------------------------------------------|----------|---------
+`listen_address`       | `string`   | Network address on which the server will listen for new connections. Defaults to accepting all incoming connections. | `""`     | no
+`listen_port`          | `int`      | Port number on which the server will listen for new connections.                                                     | `8080`   | no
+`conn_limit`           | `int`      | Maximum number of simultaneous http connections. Defaults to no limit.                                               | `0`      | no
+`server_read_timeout`  | `duration` | Read timeout for HTTP server.                                                                                        | `"30s"`  | no
+`server_write_timeout` | `duration` | Write timeout for HTTP server.                                                                                       | `"30s"`  | no
+`server_idle_timeout`  | `duration` | Idle timeout for HTTP server.                                                                                        | `"120s"` | no

--- a/docs/sources/shared/flow/reference/components/managed_identity-block.md
+++ b/docs/sources/shared/flow/reference/components/managed_identity-block.md
@@ -9,9 +9,9 @@ description: Shared content, managed_identity block
 headless: true
 ---
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`client_id` | `string` | Client ID of the managed identity which is used to authenticate. | | yes
+Name        | Type     | Description                                                      | Default | Required
+------------|----------|------------------------------------------------------------------|---------|---------
+`client_id` | `string` | Client ID of the managed identity which is used to authenticate. |         | yes
 
 `client_id` should be a valid [UUID][] in one of the supported formats:
 * `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`

--- a/docs/sources/shared/flow/reference/components/match-properties-block.md
+++ b/docs/sources/shared/flow/reference/components/match-properties-block.md
@@ -11,15 +11,15 @@ headless: true
 
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`match_type` | `string` | Controls how items to match against are interpreted. | | yes
-`services` | `list(string)` | A list of items to match the service name against. | `[]` | no
-`span_names` | `list(string)` | A list of items to match the span name against. | `[]` | no
-`log_bodies` | `list(string)` | A list of strings that the LogRecord's body field must match against. | `[]` | no
-`log_severity_texts` | `list(string)` | A list of strings that the LogRecord's severity text field must match against. | `[]` | no
-`metric_names` | `list(string)` | A list of strings to match the metric name against. | `[]` | no
-`span_kinds` | `list(string)` | A list of items to match the span kind against. | `[]` | no
+Name                 | Type           | Description                                                                    | Default | Required
+---------------------|----------------|--------------------------------------------------------------------------------|---------|---------
+`match_type`         | `string`       | Controls how items to match against are interpreted.                           |         | yes
+`services`           | `list(string)` | A list of items to match the service name against.                             | `[]`    | no
+`span_names`         | `list(string)` | A list of items to match the span name against.                                | `[]`    | no
+`log_bodies`         | `list(string)` | A list of strings that the LogRecord's body field must match against.          | `[]`    | no
+`log_severity_texts` | `list(string)` | A list of strings that the LogRecord's severity text field must match against. | `[]`    | no
+`metric_names`       | `list(string)` | A list of strings to match the metric name against.                            | `[]`    | no
+`span_kinds`         | `list(string)` | A list of items to match the span kind against.                                | `[]`    | no
 
 `match_type` is required and must be set to either `"regexp"` or `"strict"`.
 

--- a/docs/sources/shared/flow/reference/components/oauth2-block.md
+++ b/docs/sources/shared/flow/reference/components/oauth2-block.md
@@ -9,15 +9,15 @@ description: Shared content, oauth2 block
 headless: true
 ---
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`client_id` | `string` | OAuth2 client ID. | | no
-`client_secret` | `secret` | OAuth2 client secret. | | no
-`client_secret_file` | `string` | File containing the OAuth2 client secret. | | no
-`scopes` | `list(string)` | List of scopes to authenticate with. | | no
-`token_url` | `string` | URL to fetch the token from. | | no
-`endpoint_params` | `map(string)` | Optional parameters to append to the token URL. | | no
-`proxy_url` | `string` | Optional proxy URL for OAuth2 requests. | | no
+Name                 | Type           | Description                                     | Default | Required
+---------------------|----------------|-------------------------------------------------|---------|---------
+`client_id`          | `string`       | OAuth2 client ID.                               |         | no
+`client_secret`      | `secret`       | OAuth2 client secret.                           |         | no
+`client_secret_file` | `string`       | File containing the OAuth2 client secret.       |         | no
+`scopes`             | `list(string)` | List of scopes to authenticate with.            |         | no
+`token_url`          | `string`       | URL to fetch the token from.                    |         | no
+`endpoint_params`    | `map(string)`  | Optional parameters to append to the token URL. |         | no
+`proxy_url`          | `string`       | Optional proxy URL for OAuth2 requests.         |         | no
 
 `client_secret` and `client_secret_file` are mutually exclusive and only one
 can be provided inside of an `oauth2` block.

--- a/docs/sources/shared/flow/reference/components/otelcol-debug-metrics-block.md
+++ b/docs/sources/shared/flow/reference/components/otelcol-debug-metrics-block.md
@@ -13,8 +13,8 @@ The `debug_metrics` block configures the metrics that this component generates t
 
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
+Name                               | Type      | Description                                          | Default | Required
+-----------------------------------|-----------|------------------------------------------------------|---------|---------
 `disable_high_cardinality_metrics` | `boolean` | Whether to disable certain high cardinality metrics. | `false` | no
 
 `disable_high_cardinality_metrics` is the Grafana Agent equivalent to the

--- a/docs/sources/shared/flow/reference/components/otelcol-filter-attribute-block.md
+++ b/docs/sources/shared/flow/reference/components/otelcol-filter-attribute-block.md
@@ -16,10 +16,10 @@ This block specifies an attribute to match against:
 
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`key` | `string` | The attribute key. | | yes
-`value` | `any` | The attribute value to match against. | | no
+Name    | Type     | Description                           | Default | Required
+--------|----------|---------------------------------------|---------|---------
+`key`   | `string` | The attribute key.                    |         | yes
+`value` | `any`    | The attribute value to match against. |         | no
 
 If `value` is not set, any value will match.
 The type of `value` could be a number, a string, or a boolean.

--- a/docs/sources/shared/flow/reference/components/otelcol-filter-library-block.md
+++ b/docs/sources/shared/flow/reference/components/otelcol-filter-library-block.md
@@ -15,10 +15,10 @@ This block specifies properties to match the implementation library against:
 
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`name` | `string` | The attribute key. | | yes
-`version` | `string` | The version to match against. | null | no
+Name      | Type     | Description                   | Default | Required
+----------|----------|-------------------------------|---------|---------
+`name`    | `string` | The attribute key.            |         | yes
+`version` | `string` | The version to match against. | null    | no
 
-If `version` is unset, any version will match. If `version` is set to an empty string, it will only match 
+If `version` is unset, any version will match. If `version` is set to an empty string, it will only match
 a library version which is also an empty string.

--- a/docs/sources/shared/flow/reference/components/otelcol-filter-log-severity-block.md
+++ b/docs/sources/shared/flow/reference/components/otelcol-filter-log-severity-block.md
@@ -12,18 +12,18 @@ This block defines how to match based on a log record's SeverityNumber field.
 
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`min` | `string` | The lowest severity that may be matched. | | yes
-`match_undefined` | `bool` | Whether logs with "undefined" severity match. | | yes
+Name              | Type     | Description                                   | Default | Required
+------------------|----------|-----------------------------------------------|---------|---------
+`min`             | `string` | The lowest severity that may be matched.      |         | yes
+`match_undefined` | `bool`   | Whether logs with "undefined" severity match. |         | yes
 
 If `match_undefined` is true, entries with undefined severity will match.
 
-The severities supported by Otel are listed in the table below. 
+The severities supported by Otel are listed in the table below.
 The value for `min` should be one of the values in the "Log Severity" column.
 
 Log Severity | Severity number
------------- | ---------------
+-------------|----------------
 TRACE        | 1
 TRACE2       | 2
 TRACE3       | 3

--- a/docs/sources/shared/flow/reference/components/otelcol-filter-regexp-block.md
+++ b/docs/sources/shared/flow/reference/components/otelcol-filter-regexp-block.md
@@ -13,10 +13,10 @@ It configures a Least Recently Used (LRU) cache.
 
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`cache_enabled` | `bool` | Determines whether match results are LRU cached. | `false` | no
-`cache_max_num_entries` | `int` | The max number of entries of the LRU cache that stores match results. | `0` | no
+Name                    | Type   | Description                                                           | Default | Required
+------------------------|--------|-----------------------------------------------------------------------|---------|---------
+`cache_enabled`         | `bool` | Determines whether match results are LRU cached.                      | `false` | no
+`cache_max_num_entries` | `int`  | The max number of entries of the LRU cache that stores match results. | `0`     | no
 
 Enabling `cache_enabled` could make subsequent matches faster.
 Cache size is unlimited unless `cache_max_num_entries` is also specified.

--- a/docs/sources/shared/flow/reference/components/otelcol-filter-resource-block.md
+++ b/docs/sources/shared/flow/reference/components/otelcol-filter-resource-block.md
@@ -15,10 +15,10 @@ This block specifies items to match the resources against:
 
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`key` | `string` | The resource key. | | yes
-`value` | `any` | The resource value to match against. | | no
+Name    | Type     | Description                          | Default | Required
+--------|----------|--------------------------------------|---------|---------
+`key`   | `string` | The resource key.                    |         | yes
+`value` | `any`    | The resource value to match against. |         | no
 
 If `value` is not set, any value will match.
 The type of `value` could be a number, a string or a boolean.

--- a/docs/sources/shared/flow/reference/components/otelcol-grpc-authority.md
+++ b/docs/sources/shared/flow/reference/components/otelcol-grpc-authority.md
@@ -9,9 +9,9 @@ headless: true
 ---
 
 The `:authority` header in gRPC specifies the host to which the request is being sent.
-It is similar to the `Host` [header][HTTP host header] in HTTP requests. By default, 
-the value for `:authority` is derived from the endpoint URL used for the gRPC call. 
-Overriding `:authority` could be useful when routing traffic using a proxy like Envoy, which 
+It is similar to the `Host` [header][HTTP host header] in HTTP requests. By default,
+the value for `:authority` is derived from the endpoint URL used for the gRPC call.
+Overriding `:authority` could be useful when routing traffic using a proxy like Envoy, which
 [makes routing decisions][Envoy route matching] based on the value of the `:authority` header.
 
 [HTTP host header]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host

--- a/docs/sources/shared/flow/reference/components/otelcol-grpc-balancer-name.md
+++ b/docs/sources/shared/flow/reference/components/otelcol-grpc-balancer-name.md
@@ -9,11 +9,11 @@ headless: true
 ---
 
 The supported values for `balancer_name` are listed in the gRPC documentation on [Load balancing][]:
-* `pick_first`: Tries to connect to the first address, uses it for all RPCs if it connects, 
-  or tries the next address if it fails (and keeps doing that until one connection is successful). 
+* `pick_first`: Tries to connect to the first address, uses it for all RPCs if it connects,
+  or tries the next address if it fails (and keeps doing that until one connection is successful).
   Because of this, all the RPCs will be sent to the same backend.
-* `round_robin`: Connects to all the addresses it sees, and sends an RPC to each backend one at a time in order. 
-  For example, the first RPC is sent to backend-1, the second RPC is sent to backend-2, 
+* `round_robin`: Connects to all the addresses it sees, and sends an RPC to each backend one at a time in order.
+  For example, the first RPC is sent to backend-1, the second RPC is sent to backend-2,
   and the third RPC is sent to backend-1.
 
 [Load balancing]: https://github.com/grpc/grpc-go/blob/master/examples/features/load_balancing/README.md#pick_first

--- a/docs/sources/shared/flow/reference/components/otelcol-queue-block.md
+++ b/docs/sources/shared/flow/reference/components/otelcol-queue-block.md
@@ -11,11 +11,11 @@ headless: true
 
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`enabled` | `boolean` | Enables an in-memory buffer before sending data to the client. | `true` | no
-`num_consumers` | `number` | Number of readers to send batches written to the queue in parallel. | `10` | no
-`queue_size` | `number` | Maximum number of unwritten batches allowed in the queue at once. | `5000` | no
+Name            | Type      | Description                                                         | Default | Required
+----------------|-----------|---------------------------------------------------------------------|---------|---------
+`enabled`       | `boolean` | Enables an in-memory buffer before sending data to the client.      | `true`  | no
+`num_consumers` | `number`  | Number of readers to send batches written to the queue in parallel. | `10`    | no
+`queue_size`    | `number`  | Maximum number of unwritten batches allowed in the queue at once.   | `5000`  | no
 
 When `enabled` is `true`, data is first written to an in-memory buffer before
 sending it to the configured server. Batches sent to the component's `input`

--- a/docs/sources/shared/flow/reference/components/otelcol-retry-block.md
+++ b/docs/sources/shared/flow/reference/components/otelcol-retry-block.md
@@ -11,14 +11,14 @@ headless: true
 
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`enabled` | `boolean` | Enables retrying failed requests. | `true` | no
-`initial_interval` | `duration` | Initial time to wait before retrying a failed request. | `"5s"` | no
-`randomization_factor` | `number` | Factor to randomize wait time before retrying. | `0.5` | no
-`multiplier` | `number` | Factor to grow wait time before retrying. | `1.5` | no
-`max_interval` | `duration` | Maximum time to wait between retries. | `"30s"` | no
-`max_elapsed_time` | `duration` | Maximum amount of time to wait before discarding a failed batch. | `"5m"` | no
+Name                   | Type       | Description                                                      | Default | Required
+-----------------------|------------|------------------------------------------------------------------|---------|---------
+`enabled`              | `boolean`  | Enables retrying failed requests.                                | `true`  | no
+`initial_interval`     | `duration` | Initial time to wait before retrying a failed request.           | `"5s"`  | no
+`randomization_factor` | `number`   | Factor to randomize wait time before retrying.                   | `0.5`   | no
+`multiplier`           | `number`   | Factor to grow wait time before retrying.                        | `1.5`   | no
+`max_interval`         | `duration` | Maximum time to wait between retries.                            | `"30s"` | no
+`max_elapsed_time`     | `duration` | Maximum amount of time to wait before discarding a failed batch. | `"5m"`  | no
 
 When `enabled` is `true`, failed batches are retried after a given interval.
 The `initial_interval` argument specifies how long to wait before the first

--- a/docs/sources/shared/flow/reference/components/otelcol-tls-config-block.md
+++ b/docs/sources/shared/flow/reference/components/otelcol-tls-config-block.md
@@ -11,20 +11,20 @@ headless: true
 
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`ca_pem` | `string` | CA PEM-encoded text to validate the server with. | | no
-`ca_file` | `string` | Path to the CA file. | | no
-`cert_pem` | `string` | Certificate PEM-encoded text for client authentication. | | no
-`cert_file` | `string` | Path to the TLS certificate. | | no
-`key_pem` | `secret` | Key PEM-encoded text for client authentication. | | no
-`key_file` | `string` | Path to the TLS certificate key. | | no
-`min_version` | `string` | Minimum acceptable TLS version for connections. | `"TLS 1.2"` | no
-`max_version` | `string` | Maximum acceptable TLS version for connections. | `"TLS 1.3"` | no
-`reload_interval` | `duration` | The duration after which the certificate will be reloaded. | `"0s"` | no
-`insecure` | `boolean` | Disables TLS when connecting to the configured server. | | no
-`insecure_skip_verify` | `boolean` | Ignores insecure server TLS certificates. | | no
-`server_name` | `string` | Verifies the hostname of server certificates when set. | | no
+Name                   | Type       | Description                                                | Default     | Required
+-----------------------|------------|------------------------------------------------------------|-------------|---------
+`ca_pem`               | `string`   | CA PEM-encoded text to validate the server with.           |             | no
+`ca_file`              | `string`   | Path to the CA file.                                       |             | no
+`cert_pem`             | `string`   | Certificate PEM-encoded text for client authentication.    |             | no
+`cert_file`            | `string`   | Path to the TLS certificate.                               |             | no
+`key_pem`              | `secret`   | Key PEM-encoded text for client authentication.            |             | no
+`key_file`             | `string`   | Path to the TLS certificate key.                           |             | no
+`min_version`          | `string`   | Minimum acceptable TLS version for connections.            | `"TLS 1.2"` | no
+`max_version`          | `string`   | Maximum acceptable TLS version for connections.            | `"TLS 1.3"` | no
+`reload_interval`      | `duration` | The duration after which the certificate will be reloaded. | `"0s"`      | no
+`insecure`             | `boolean`  | Disables TLS when connecting to the configured server.     |             | no
+`insecure_skip_verify` | `boolean`  | Ignores insecure server TLS certificates.                  |             | no
+`server_name`          | `string`   | Verifies the hostname of server certificates when set.     |             | no
 
 If the server doesn't support TLS, the tls block must be provided with the
 `insecure` argument set to `true`. To disable `tls` for connections to the

--- a/docs/sources/shared/flow/reference/components/output-block-logs.md
+++ b/docs/sources/shared/flow/reference/components/output-block-logs.md
@@ -14,9 +14,9 @@ telemetry data to.
 
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`logs` | `list(otelcol.Consumer)` | List of consumers to send logs to. | `[]` | no
+Name   | Type                     | Description                        | Default | Required
+-------|--------------------------|------------------------------------|---------|---------
+`logs` | `list(otelcol.Consumer)` | List of consumers to send logs to. | `[]`    | no
 
 The `output` block must be specified, but all of its arguments are optional. By
 default, telemetry data is dropped. To send telemetry data to other components,

--- a/docs/sources/shared/flow/reference/components/output-block-metrics.md
+++ b/docs/sources/shared/flow/reference/components/output-block-metrics.md
@@ -13,9 +13,9 @@ telemetry data to.
 
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`metrics` | `list(otelcol.Consumer)` | List of consumers to send metrics to. | `[]` | no
+Name      | Type                     | Description                           | Default | Required
+----------|--------------------------|---------------------------------------|---------|---------
+`metrics` | `list(otelcol.Consumer)` | List of consumers to send metrics to. | `[]`    | no
 
 The `output` block must be specified, but all of its arguments are optional. By
 default, telemetry data is dropped. To send telemetry data to other components,

--- a/docs/sources/shared/flow/reference/components/output-block-traces.md
+++ b/docs/sources/shared/flow/reference/components/output-block-traces.md
@@ -14,9 +14,9 @@ telemetry data to.
 
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`traces` | `list(otelcol.Consumer)` | List of consumers to send traces to. | `[]` | no
+Name     | Type                     | Description                          | Default | Required
+---------|--------------------------|--------------------------------------|---------|---------
+`traces` | `list(otelcol.Consumer)` | List of consumers to send traces to. | `[]`    | no
 
 The `output` block must be specified, but all of its arguments are optional. By
 default, telemetry data is dropped. To send telemetry data to other components,

--- a/docs/sources/shared/flow/reference/components/output-block.md
+++ b/docs/sources/shared/flow/reference/components/output-block.md
@@ -14,11 +14,11 @@ telemetry data to.
 
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`metrics` | `list(otelcol.Consumer)` | List of consumers to send metrics to. | `[]` | no
-`logs` | `list(otelcol.Consumer)` | List of consumers to send logs to. | `[]` | no
-`traces` | `list(otelcol.Consumer)` | List of consumers to send traces to. | `[]` | no
+Name      | Type                     | Description                           | Default | Required
+----------|--------------------------|---------------------------------------|---------|---------
+`metrics` | `list(otelcol.Consumer)` | List of consumers to send metrics to. | `[]`    | no
+`logs`    | `list(otelcol.Consumer)` | List of consumers to send logs to.    | `[]`    | no
+`traces`  | `list(otelcol.Consumer)` | List of consumers to send traces to.  | `[]`    | no
 
 The `output` block must be specified, but all of its arguments are optional. By
 default, telemetry data is dropped. To send telemetry data to other components,

--- a/docs/sources/shared/flow/reference/components/sigv4-block.md
+++ b/docs/sources/shared/flow/reference/components/sigv4-block.md
@@ -9,13 +9,13 @@ description: Shared content, sigv4 block
 headless: true
 ---
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`region` | `string` | AWS region. | | no
-`access_key` | `string` | AWS API access key. | | no
-`secret_key` | `secret` | AWS API secret key.| | no
-`profile` | `string` | Named AWS profile used to authenticate. | | no
-`role_arn` | `string` | AWS Role ARN, an alternative to using AWS API keys. | | no
+Name         | Type     | Description                                         | Default | Required
+-------------|----------|-----------------------------------------------------|---------|---------
+`region`     | `string` | AWS region.                                         |         | no
+`access_key` | `string` | AWS API access key.                                 |         | no
+`secret_key` | `secret` | AWS API secret key.                                 |         | no
+`profile`    | `string` | Named AWS profile used to authenticate.             |         | no
+`role_arn`   | `string` | AWS Role ARN, an alternative to using AWS API keys. |         | no
 
 If `region` is left blank, the region from the default credentials chain is used.
 

--- a/docs/sources/shared/flow/reference/components/tls-config-block.md
+++ b/docs/sources/shared/flow/reference/components/tls-config-block.md
@@ -9,17 +9,17 @@ description: Shared content, tls config block
 headless: true
 ---
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`ca_pem` | `string` | CA PEM-encoded text to validate the server with. | | no
-`ca_file` | `string` | CA certificate to validate the server with. | | no
-`cert_pem` | `string` | Certificate PEM-encoded text for client authentication. | | no
-`cert_file` | `string` | Certificate file for client authentication. | | no
-`key_pem` | `secret` | Key PEM-encoded text for client authentication. | | no
-`key_file` | `string` | Key file for client authentication. | | no
-`server_name` | `string` | ServerName extension to indicate the name of the server. | | no
-`insecure_skip_verify` | `bool` | Disables validation of the server certificate. | | no
-`min_version` | `string` | Minimum acceptable TLS version. | | no
+Name                   | Type     | Description                                              | Default | Required
+-----------------------|----------|----------------------------------------------------------|---------|---------
+`ca_pem`               | `string` | CA PEM-encoded text to validate the server with.         |         | no
+`ca_file`              | `string` | CA certificate to validate the server with.              |         | no
+`cert_pem`             | `string` | Certificate PEM-encoded text for client authentication.  |         | no
+`cert_file`            | `string` | Certificate file for client authentication.              |         | no
+`key_pem`              | `secret` | Key PEM-encoded text for client authentication.          |         | no
+`key_file`             | `string` | Key file for client authentication.                      |         | no
+`server_name`          | `string` | ServerName extension to indicate the name of the server. |         | no
+`insecure_skip_verify` | `bool`   | Disables validation of the server certificate.           |         | no
+`min_version`          | `string` | Minimum acceptable TLS version.                          |         | no
 
 The following pairs of arguments are mutually exclusive and cannot both be set
 simultaneously:

--- a/docs/sources/static/configuration/integrations/windows-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/windows-exporter-config.md
@@ -153,4 +153,11 @@ Full reference of options:
     # Regexp of volumes to blacklist. Volume name must both match whitelist and not match blacklist to be included.
     # Maps to collector.logical_disk.volume-blacklist in windows_exporter
     [blacklist: <string> | default=".+"]
+
+  # Configuration for Windows Task Scheduler
+  scheduled_task:
+    # Regexp of tasks to include.
+    [include: <string> | default ".+"]
+    #Regexp of tasks to exclude.
+    [exclude: <string> | default ""]
 ```


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR adds the missing documentation for `scheduled_task` to https://grafana.com/docs/agent/latest/static/configuration/integrations/windows-exporter-config/

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #4341 

#### Notes to the Reviewer

I made a guess at what was required based n the documentation for flow and what I read in https://github.com/grafana/agent/blob/3d92001037b3a9915b1760a15683f3023a876b17/pkg/integrations/windows_exporter/config.go

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated