### PR TITLE
Agent Management: Small doc tweaks

### DIFF
--- a/docs/sources/static/configuration/agent-management.md
+++ b/docs/sources/static/configuration/agent-management.md
@@ -67,7 +67,7 @@ agent_management:
     labels:
       [ <labelname>: <labelvalue> ... ]
 
-    # Whether to use labels from the label management service. If enabled, labels from the API supersede the ones configured in the agent. The agent_id must be defined.
+    # Whether to use labels from the label management service. If enabled, labels from the API supersede the ones configured in the agent. The agent_id field must be defined.
     label_management_enabled: <bool> | default = false
 
     # Whether to accept HTTP 304 Not Modified responses from the API server. If enabled, the agent will use the cached configuration if the API server responds with HTTP 304 Not Modified. You can set this argument to `false` for debugging or testing.

--- a/docs/sources/static/configuration/agent-management.md
+++ b/docs/sources/static/configuration/agent-management.md
@@ -67,7 +67,7 @@ agent_management:
     labels:
       [ <labelname>: <labelvalue> ... ]
 
-    # Whether to use labels from the label management service. If enabled, labels from the API supersede the ones configured in the agent.
+    # Whether to use labels from the label management service. If enabled, labels from the API supersede the ones configured in the agent. The agent_id must be defined.
     label_management_enabled: <bool> | default = false
 
     # Whether to accept HTTP 304 Not Modified responses from the API server. If enabled, the agent will use the cached configuration if the API server responds with HTTP 304 Not Modified. You can set this argument to `false` for debugging or testing.
@@ -77,7 +77,7 @@ agent_management:
     agent_id: <string>
 ```
 
-## API (v2)
+## API
 
 Grafana Agents with Agent Management enabled continuously poll the API server for an up-to-date configuration. The API server is expected to implement a `GET /agent-management/api/agent/v2/namespace/:namespace/remote_config` HTTP endpoint returning a successful response with the following body format:
 

--- a/docs/sources/static/configuration/agent-management.md
+++ b/docs/sources/static/configuration/agent-management.md
@@ -70,11 +70,11 @@ agent_management:
     # Whether to use labels from the label management service. If enabled, labels from the API supersede the ones configured in the agent. The agent_id field must be defined.
     label_management_enabled: <bool> | default = false
 
-    # Whether to accept HTTP 304 Not Modified responses from the API server. If enabled, the agent will use the cached configuration if the API server responds with HTTP 304 Not Modified. You can set this argument to `false` for debugging or testing.
-    accept_http_not_modified: <bool> | default = true
-
     # A unique ID for the agent, which is used to identify the agent.
     agent_id: <string>
+
+    # Whether to accept HTTP 304 Not Modified responses from the API server. If enabled, the agent will use the cached configuration if the API server responds with HTTP 304 Not Modified. You can set this argument to `false` for debugging or testing.
+    accept_http_not_modified: <bool> | default = true
 ```
 
 ## API


### PR DESCRIPTION
#### PR Description

- Remove references to v2 in the API (this does not have much meaning to users).
- Specify that `agent_id` is required when label management is enabled.
