### PR TITLE
Improves Pyroscope's scrape sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ Main (unreleased)
 
 - Allow converting labels to structured metadata with Loki's structured_metadata stage. (@gonzalesraul)
 
+- Improved performance of `pyroscope.scrape` component when working with a large number of targets. (@cyriltovena)
+
 v0.37.2 (2023-10-16)
 -----------------
 

--- a/component/pyroscope/scrape/scrape.go
+++ b/component/pyroscope/scrape/scrape.go
@@ -97,12 +97,21 @@ type ProfilingConfig struct {
 	Custom            []CustomProfilingTarget `river:"profile.custom,block,optional"`
 
 	PprofPrefix string `river:"path_prefix,attr,optional"`
+
+	allTargets map[string]ProfilingTarget
 }
 
 // AllTargets returns the set of all standard and custom profiling targets,
 // regardless of whether they're enabled. The key in the map indicates the name
 // of the target.
-func (cfg ProfilingConfig) AllTargets() map[string]ProfilingTarget {
+func (cfg *ProfilingConfig) AllTargets() map[string]ProfilingTarget {
+	if cfg.allTargets == nil {
+		cfg.allTargets = cfg.buildAllTargets()
+	}
+	return cfg.allTargets
+}
+
+func (cfg ProfilingConfig) buildAllTargets() map[string]ProfilingTarget {
 	targets := map[string]ProfilingTarget{
 		pprofMemory:            cfg.Memory,
 		pprofBlock:             cfg.Block,
@@ -376,7 +385,7 @@ func (c *Component) DebugInfo() interface{} {
 			if st != nil {
 				res = append(res, scrape.TargetStatus{
 					JobName:            job,
-					URL:                st.URL().String(),
+					URL:                st.URL(),
 					Health:             string(st.Health()),
 					Labels:             st.discoveredLabels.Map(),
 					LastError:          lastError,

--- a/component/pyroscope/scrape/scrape.go
+++ b/component/pyroscope/scrape/scrape.go
@@ -97,21 +97,12 @@ type ProfilingConfig struct {
 	Custom            []CustomProfilingTarget `river:"profile.custom,block,optional"`
 
 	PprofPrefix string `river:"path_prefix,attr,optional"`
-
-	allTargets map[string]ProfilingTarget
 }
 
 // AllTargets returns the set of all standard and custom profiling targets,
 // regardless of whether they're enabled. The key in the map indicates the name
 // of the target.
 func (cfg *ProfilingConfig) AllTargets() map[string]ProfilingTarget {
-	if cfg.allTargets == nil {
-		cfg.allTargets = cfg.buildAllTargets()
-	}
-	return cfg.allTargets
-}
-
-func (cfg ProfilingConfig) buildAllTargets() map[string]ProfilingTarget {
 	targets := map[string]ProfilingTarget{
 		pprofMemory:            cfg.Memory,
 		pprofBlock:             cfg.Block,

--- a/component/pyroscope/scrape/scrape_loop.go
+++ b/component/pyroscope/scrape/scrape_loop.go
@@ -56,12 +56,12 @@ func newScrapePool(cfg Arguments, appendable pyroscope.Appendable, logger log.Lo
 func (tg *scrapePool) sync(groups []*targetgroup.Group) {
 	tg.mtx.Lock()
 	defer tg.mtx.Unlock()
-
+	allTarget := tg.config.ProfilingConfig.AllTargets()
 	level.Info(tg.logger).Log("msg", "syncing target groups", "job", tg.config.JobName)
 	var actives []*Target
 	tg.droppedTargets = tg.droppedTargets[:0]
 	for _, group := range groups {
-		targets, dropped, err := targetsFromGroup(group, tg.config)
+		targets, dropped, err := targetsFromGroup(group, tg.config, allTarget)
 		if err != nil {
 			level.Error(tg.logger).Log("msg", "creating targets failed", "err", err)
 			continue

--- a/component/pyroscope/scrape/scrape_loop.go
+++ b/component/pyroscope/scrape/scrape_loop.go
@@ -59,7 +59,7 @@ func (tg *scrapePool) sync(groups []*targetgroup.Group) {
 
 	level.Info(tg.logger).Log("msg", "syncing target groups", "job", tg.config.JobName)
 	var actives []*Target
-	tg.droppedTargets = []*Target{}
+	tg.droppedTargets = tg.droppedTargets[:0]
 	for _, group := range groups {
 		targets, dropped, err := targetsFromGroup(group, tg.config)
 		if err != nil {
@@ -75,12 +75,12 @@ func (tg *scrapePool) sync(groups []*targetgroup.Group) {
 	}
 
 	for _, t := range actives {
-		if _, ok := tg.activeTargets[t.hash()]; !ok {
+		if _, ok := tg.activeTargets[t.Hash()]; !ok {
 			loop := newScrapeLoop(t, tg.scrapeClient, tg.appendable, tg.config.ScrapeInterval, tg.config.ScrapeTimeout, tg.logger)
-			tg.activeTargets[t.hash()] = loop
+			tg.activeTargets[t.Hash()] = loop
 			loop.start()
 		} else {
-			tg.activeTargets[t.hash()].SetDiscoveredLabels(t.DiscoveredLabels())
+			tg.activeTargets[t.Hash()].SetDiscoveredLabels(t.DiscoveredLabels())
 		}
 	}
 
@@ -88,7 +88,7 @@ func (tg *scrapePool) sync(groups []*targetgroup.Group) {
 Outer:
 	for h, t := range tg.activeTargets {
 		for _, at := range actives {
-			if h == at.hash() {
+			if h == at.Hash() {
 				continue Outer
 			}
 		}
@@ -179,7 +179,7 @@ func newScrapeLoop(t *Target, scrapeClient *http.Client, appendable pyroscope.Ap
 		Target:       t,
 		logger:       logger,
 		scrapeClient: scrapeClient,
-		appender:     NewDeltaAppender(appendable.Appender(), t.labels),
+		appender:     NewDeltaAppender(appendable.Appender(), t.privateLabels),
 		interval:     interval,
 		timeout:      timeout,
 	}
@@ -222,7 +222,7 @@ func (t *scrapeLoop) scrape() {
 	)
 	defer cancel()
 
-	for _, l := range t.labels {
+	for _, l := range t.privateLabels {
 		if l.Name == ProfileName {
 			profileType = l.Value
 			break
@@ -238,7 +238,7 @@ func (t *scrapeLoop) scrape() {
 	if len(b) > 0 {
 		t.lastScrapeSize = len(b)
 	}
-	if err := t.appender.Append(context.Background(), t.labels, []*pyroscope.RawSample{{RawProfile: b}}); err != nil {
+	if err := t.appender.Append(context.Background(), t.privateLabels, []*pyroscope.RawSample{{RawProfile: b}}); err != nil {
 		level.Error(t.logger).Log("msg", "push failed", "labels", t.Labels().String(), "err", err)
 		t.updateTargetStatus(start, err)
 		return
@@ -262,7 +262,7 @@ func (t *scrapeLoop) updateTargetStatus(start time.Time, err error) {
 
 func (t *scrapeLoop) fetchProfile(ctx context.Context, profileType string, buf io.Writer) error {
 	if t.req == nil {
-		req, err := http.NewRequest("GET", t.URL().String(), nil)
+		req, err := http.NewRequest("GET", t.URL(), nil)
 		if err != nil {
 			return err
 		}

--- a/component/pyroscope/scrape/target.go
+++ b/component/pyroscope/scrape/target.go
@@ -347,7 +347,7 @@ func populateLabels(lset labels.Labels, cfg Arguments) (res, orig labels.Labels,
 }
 
 // targetsFromGroup builds targets based on the given TargetGroup and config.
-func targetsFromGroup(group *targetgroup.Group, cfg Arguments) ([]*Target, []*Target, error) {
+func targetsFromGroup(group *targetgroup.Group, cfg Arguments, targetTypes map[string]ProfilingTarget) ([]*Target, []*Target, error) {
 	var (
 		targets        = make([]*Target, 0, len(group.Targets))
 		droppedTargets = make([]*Target, 0, len(group.Targets))
@@ -404,7 +404,7 @@ func targetsFromGroup(group *targetgroup.Group, cfg Arguments) ([]*Target, []*Ta
 					params = url.Values{}
 				}
 
-				if pcfg, found := cfg.ProfilingConfig.AllTargets()[profType]; found && pcfg.Delta {
+				if pcfg, found := targetTypes[profType]; found && pcfg.Delta {
 					params.Add("seconds", strconv.Itoa(int((cfg.ScrapeInterval)/time.Second)-1))
 				}
 				targets = append(targets, NewTarget(lbls, origLabels, params))

--- a/component/pyroscope/scrape/target_test.go
+++ b/component/pyroscope/scrape/target_test.go
@@ -28,7 +28,7 @@ func Test_targetsFromGroup(t *testing.T) {
 		Labels: model.LabelSet{
 			"foo": "bar",
 		},
-	}, args)
+	}, args, args.ProfilingConfig.AllTargets())
 	expected := []*Target{
 		// unspecified
 		NewTarget(
@@ -68,7 +68,7 @@ func Test_targetsFromGroup(t *testing.T) {
 			}),
 			url.Values{"seconds": []string{"14"}}),
 
-		//specified
+		// specified
 		NewTarget(
 			labels.FromMap(map[string]string{
 				model.AddressLabel:    "localhost:9091",


### PR DESCRIPTION
This improves the sync method of Pyroscope scrapes based on some investigation.

The change is basically caching values of labels, url and hash of targets to avoid regenerating them when we sync and scrape profiles.

To ensure we're improving something I've added a benchmark.

Result:

```
benchstat before.txt after.txt
name     old time/op    new time/op    delta
Sync-16     796µs ±13%     167µs ± 3%  -79.06%  (p=0.008 n=5+5)

name     old alloc/op   new alloc/op   delta
Sync-16     609kB ± 0%     162kB ± 0%  -73.35%  (p=0.008 n=5+5)

name     old allocs/op  new allocs/op  delta
Sync-16     8.26k ± 0%     1.55k ± 0%  -81.29%  (p=0.008 n=5+5)
```

I'm sure there's more we can do.