### PR TITLE
Upgrade docker images to ubuntu mantic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,6 @@ Main (unreleased)
     - renamed 3 metrics starting with `mysql_perf_schema_transaction_` to start with `mysql_perf_schema_transactions_` to be consistent with column names.
     - exposing only server's own stats by matching `MEMBER_ID` with `@@server_uuid` resulting "member_id" label to be dropped.
 
-### Other changes
-
-- Bump `mysqld_exporter` version to v0.15.0. (@marctc)
-
 ### Features
 
 - Added a new `stage.decolorize` stage to `loki.process` component which 
@@ -40,6 +36,12 @@ Main (unreleased)
 
 - Added a new `stage.eventlogmessage` stage to `loki.process` component which
   allows to extract data from Windows Event Log. (@thampiotr)
+
+### Enhancements
+
+- The `loki.write` WAL now has snappy compression enabled by default. (@thepalbi)
+
+- Allow converting labels to structured metadata with Loki's structured_metadata stage. (@gonzalesraul)
 
 ### Bugfixes
 
@@ -53,11 +55,11 @@ Main (unreleased)
 
 - Fixed an issue where native histogram time series were being dropped silently.  (@krajorama)
 
-### Enhancements
+### Other changes
 
-- The `loki.write` WAL now has snappy compression enabled by default. (@thepalbi)
+- Bump `mysqld_exporter` version to v0.15.0. (@marctc)
 
-- Allow converting labels to structured metadata with Loki's structured_metadata stage. (@gonzalesraul)
+- Change the Docker base image for Linux containers to ubuntu:mantic. (@ptodev)
 
 v0.37.2 (2023-10-16)
 -----------------

--- a/cmd/grafana-agent-operator/Dockerfile
+++ b/cmd/grafana-agent-operator/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} \
     make operator
 
-FROM ubuntu:lunar
+FROM ubuntu:mantic
 
 LABEL org.opencontainers.image.source="https://github.com/grafana/agent"
 
@@ -30,7 +30,6 @@ LABEL org.opencontainers.image.source="https://github.com/grafana/agent"
 RUN <<EOF
   apt-get update
   apt-get install -qy libsystemd-dev tzdata ca-certificates
-  apt-get upgrade -y
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 EOF
 

--- a/cmd/grafana-agent/Dockerfile
+++ b/cmd/grafana-agent/Dockerfile
@@ -30,7 +30,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     GOEXPERIMENT=${GOEXPERIMENT} \
     make agent
 
-FROM ubuntu:lunar
+FROM ubuntu:mantic
 
 LABEL org.opencontainers.image.source="https://github.com/grafana/agent"
 
@@ -38,7 +38,6 @@ LABEL org.opencontainers.image.source="https://github.com/grafana/agent"
 RUN <<EOF
   apt-get update
   apt-get install -qy libsystemd-dev tzdata ca-certificates
-  apt-get upgrade -y
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 EOF
 

--- a/cmd/grafana-agentctl/Dockerfile
+++ b/cmd/grafana-agentctl/Dockerfile
@@ -23,7 +23,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     GO_TAGS="netgo promtail_journal_enabled" \
     make agentctl
 
-FROM ubuntu:lunar
+FROM ubuntu:mantic
 
 LABEL org.opencontainers.image.source="https://github.com/grafana/agent"
 
@@ -31,7 +31,6 @@ LABEL org.opencontainers.image.source="https://github.com/grafana/agent"
 RUN <<EOF
   apt-get update
   apt-get install -qy libsystemd-dev tzdata ca-certificates
-  apt-get upgrade -y
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 EOF
 


### PR DESCRIPTION
#### PR Description

Upgrading our docker files to ubuntu mantic. 

Also, this PR removes the `apt-get upgrade -y` because it makes our docker builds more non-deterministic. 

#### Notes to the Reviewer

`apt-get upgrade -y` was introduced recently as a temporary measure to make sure we are not using a particular library which had a known vulnerability.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated