### PR TITLE
fix(prom/scrape): recreate internal scraper after reloaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@ v0.37.2 (2023-10-16)
   config not being included in the river output. (@erikbaranowski)
 
 - Fix issue with default values in `discovery.nomad`. (@marctc)
+
+- Fix issue where two scrape options `prometheus.scrape` component not getting
+  applied after agent got reloaded. (hainenber) 
   
 ### Enhancements
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Recreate internal scrapeManager of  `prometheus.scrape` Flow component and hence multiple options will be applied once getting reload signal

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #5536 

#### Notes to the Reviewer
Let me know if a unit test is required or current setup is enough to ensure no regression since this seems pretty convoluted to write a straightforward test.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [] Documentation added
- [ ] Tests updated
- [ ] Config converters updated