### PR TITLE
docs: fix old instances of prometheus.exporter.unix not needing a label

### DIFF
--- a/docs/sources/flow/concepts/configuration_language.md
+++ b/docs/sources/flow/concepts/configuration_language.md
@@ -73,10 +73,6 @@ The most common expression is to reference the exports of a component like
 formed by merging the component's name (e.g., `local.file`), label (e.g.,
 `password_file`), and export name (e.g., `content`), delimited by period.
 
-For components that don't use labels, like
-`prometheus.exporter.unix`, only combine the component name with
-export name: `prometheus.exporter.unix.targets`.
-
 ## Blocks
 
 _Blocks_ are used to configure components and groups of attributes. Each block

--- a/docs/sources/flow/config-language/components.md
+++ b/docs/sources/flow/config-language/components.md
@@ -24,7 +24,7 @@ re-evaluating their arguments and providing their exports.
 ## Configuring components
 Components are created by defining a top-level River block. All components
 are identified by their name, describing what the component is responsible for,
-while some allow or require to provide an extra user-specified _label_.
+and a user-specified _label_.
 
 The [components docs]({{< relref "../reference/components/_index.md" >}}) contain a list
 of all available components. Each one has a complete reference page, so getting

--- a/docs/sources/flow/reference/components/module.file.md
+++ b/docs/sources/flow/reference/components/module.file.md
@@ -131,10 +131,10 @@ module.file "metrics" {
   }
 }
 
-prometheus.exporter.unix { }
+prometheus.exporter.unix "default" { }
 
 prometheus.scrape "local_agent" {
-  targets         = prometheus.exporter.unix.targets
+  targets         = prometheus.exporter.unix.default.targets
   forward_to      = [module.file.metrics.exports.prometheus_remote_write.receiver]
   scrape_interval = "10s"
 }

--- a/docs/sources/flow/reference/components/module.http.md
+++ b/docs/sources/flow/reference/components/module.http.md
@@ -116,9 +116,9 @@ unhealthy, and the health includes the error from loading the module.
 ## Example
 
 In this example, the `module.http` component loads a module from a locally running
-HTTP server, polling for changes once every minute. 
+HTTP server, polling for changes once every minute.
 
-The module sets up a Redis exporter and exports the list of targets to the parent config to scrape 
+The module sets up a Redis exporter and exports the list of targets to the parent config to scrape
 and remote write.
 
 
@@ -130,10 +130,10 @@ module.http "remote_module" {
   poll_frequency   = "1m"
 }
 
-prometheus.exporter.unix { }
+prometheus.exporter.unix "default" { }
 
 prometheus.scrape "local_agent" {
-  targets         = concat(prometheus.exporter.unix.targets, module.http.remote_module.exports.targets)
+  targets         = concat(prometheus.exporter.unix.default.targets, module.http.remote_module.exports.targets)
   forward_to      = [module.http.metrics.exports.prometheus_remote_write.receiver]
   scrape_interval = "10s"
 }

--- a/docs/sources/flow/reference/components/module.string.md
+++ b/docs/sources/flow/reference/components/module.string.md
@@ -129,10 +129,10 @@ module.string "metrics" {
   }
 }
 
-prometheus.exporter.unix { }
+prometheus.exporter.unix "default" { }
 
 prometheus.scrape "local_agent" {
-  targets         = prometheus.exporter.unix.targets
+  targets         = prometheus.exporter.unix.default.targets
   forward_to      = [module.string.metrics.exports.prometheus_remote_write.receiver]
   scrape_interval = "10s"
 }

--- a/docs/sources/flow/reference/components/otelcol.exporter.logging.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.logging.md
@@ -41,7 +41,7 @@ Name | Type | Description | Default | Required
 `sampling_initial`    | `int`    | Number of messages initially logged each second. | `2` | no
 `sampling_thereafter` | `int`    | Sampling rate after the initial messages are logged. | `500` | no
 
-The `verbosity` argument must be one of `"basic"`, `"normal"`, or `"detailed"`. 
+The `verbosity` argument must be one of `"basic"`, `"normal"`, or `"detailed"`.
 
 ## Blocks
 
@@ -87,22 +87,22 @@ information.
 This example scrapes prometheus unix metrics and writes them to the console:
 
 ```river
-prometheus.exporter.unix { }
+prometheus.exporter.unix "default" { }
 
 prometheus.scrape "default" {
-	targets    = prometheus.exporter.unix.targets
-	forward_to = [otelcol.receiver.prometheus.default.receiver]
+    targets    = prometheus.exporter.unix.default.targets
+    forward_to = [otelcol.receiver.prometheus.default.receiver]
 }
 
 otelcol.receiver.prometheus "default" {
-	output {
-		metrics = [otelcol.exporter.logging.default.input]
-	}
+    output {
+        metrics = [otelcol.exporter.logging.default.input]
+    }
 }
 
 otelcol.exporter.logging "default" {
-	verbosity           = "detailed"
-	sampling_initial    = 1
-	sampling_thereafter = 1
+    verbosity           = "detailed"
+    sampling_initial    = 1
+    sampling_thereafter = 1
 }
 ```

--- a/docs/sources/flow/tutorials/assets/flow_configs/example.river
+++ b/docs/sources/flow/tutorials/assets/flow_configs/example.river
@@ -1,9 +1,9 @@
-prometheus.exporter.unix {
-set_collectors = ["cpu", "diskstats"]
+prometheus.exporter.unix "default" {
+	set_collectors = ["cpu", "diskstats"]
 }
 
 prometheus.scrape "my_scrape_job" {
-	targets    = prometheus.exporter.unix.targets
+	targets    = prometheus.exporter.unix.default.targets
 	forward_to = [prometheus.remote_write.default.receiver]
 }
 

--- a/docs/sources/flow/tutorials/chaining.md
+++ b/docs/sources/flow/tutorials/chaining.md
@@ -15,7 +15,7 @@ weight: 400
 
 This tutorial shows how to use [multiple-inputs.river](/docs/agent/latest/flow/tutorials/assets/flow_configs/multiple-inputs.river) to send data to several different locations. This tutorial uses the same base as [Filtering metrics]({{< relref "./filtering-metrics" >}}).
 
-A new concept introduced in Flow is chaining components together in a composable pipeline. This promotes the reusability of components while offering flexibility. 
+A new concept introduced in Flow is chaining components together in a composable pipeline. This promotes the reusability of components while offering flexibility.
 
 ## Prerequisites
 
@@ -23,7 +23,7 @@ A new concept introduced in Flow is chaining components together in a composable
 
 ## Run the example
 
-Run the following 
+Run the following
 
 ```bash
 curl https://raw.githubusercontent.com/grafana/agent/main/docs/sources/flow/tutorials/assets/runt.sh -O && bash ./runt.sh multiple-inputs.river
@@ -31,7 +31,7 @@ curl https://raw.githubusercontent.com/grafana/agent/main/docs/sources/flow/tuto
 
 The `runt.sh` script does:
 
-1. Downloads the configs necessary for Mimir, Grafana and the Grafana Agent. 
+1. Downloads the configs necessary for Mimir, Grafana and the Grafana Agent.
 2. Downloads the docker image for Grafana Agent explicitly.
 3. Runs the docker-compose up command to bring all the services up.
 
@@ -43,37 +43,37 @@ There are two scrapes each sending metrics to one filter. Note the `job` label l
 
 ```river
 prometheus.scrape "agent" {
-	targets    = [{"__address__" = "localhost:12345"}]
-	forward_to = [prometheus.relabel.service.receiver]
+    targets    = [{"__address__" = "localhost:12345"}]
+    forward_to = [prometheus.relabel.service.receiver]
 }
 
-prometheus.exporter.unix {
-	set_collectors = ["cpu", "diskstats"]
+prometheus.exporter.unix "default" {
+    set_collectors = ["cpu", "diskstats"]
 }
 
 prometheus.scrape "unix" {
-	targets    = prometheus.exporter.unix.targets
-	forward_to = [prometheus.relabel.service.receiver]
+    targets    = prometheus.exporter.unix.default.targets
+    forward_to = [prometheus.relabel.service.receiver]
 }
 
 prometheus.relabel "service" {
-	rule {
-		source_labels = ["__name__"]
-		regex         = "(.+)"
-		replacement   = "api_server"
-		target_label  = "service"
-	}
-	forward_to = [prometheus.remote_write.prom.receiver]
+    rule {
+        source_labels = ["__name__"]
+        regex         = "(.+)"
+        replacement   = "api_server"
+        target_label  = "service"
+    }
+    forward_to = [prometheus.remote_write.prom.receiver]
 }
 
 prometheus.remote_write "prom" {
-	endpoint {
-		url = "http://mimir:9009/api/v1/push"
-	}
+    endpoint {
+        url = "http://mimir:9009/api/v1/push"
+    }
 }
 ```
 
-In the above Flow block, `prometheus.relabel.service` is being forwarded metrics from two sources `prometheus.scrape.agent` and `prometheus.exporter.unix`. This allows for a single relabel component to be used with any number of inputs.
+In the above Flow block, `prometheus.relabel.service` is being forwarded metrics from two sources `prometheus.scrape.agent` and `prometheus.exporter.unix.default`. This allows for a single relabel component to be used with any number of inputs.
 
 ## Adding another relabel
 


### PR DESCRIPTION
PR #5361 removed the concept of "singleton components" (components which must not have a user-specified label), and thus made prometheus.exporter.unix require a label.

However, documentation referring to the old form of this component was not updated to include a label.

Related to #5542.