### PR TITLE
Update Agent documentation to use doc/reference instead of relrefs

### DIFF
--- a/docs/sources/flow/getting-started/migrating-from-promtail.md
+++ b/docs/sources/flow/getting-started/migrating-from-promtail.md
@@ -20,30 +20,16 @@ This topic describes how to:
 * Convert a Promtail configuration to a Flow Mode configuration.
 * Run a Promtail configuration natively using Grafana Agent Flow Mode.
 
-[Promtail]: /docs/loki/latest/clients/promtail/
-
 ## Components used in this topic
 
 * [local.file_match][]
 * [loki.source.file][]
 * [loki.write][]
 
-[local.file_match]: {{< relref "../reference/components/local.file_match.md" >}}
-[loki.source.file]: {{< relref "../reference/components/loki.source.file.md" >}}
-[loki.write]: {{< relref "../reference/components/loki.write.md" >}}
-
 ## Before you begin
 
 * You must have an existing Promtail configuration.
-* You must be familiar with the concept of [Components][] in Grafana Agent Flow
-  Mode.
-
-[Components]: {{< relref "../concepts/components.md" >}}
-[convert]: {{< relref "../reference/cli/convert.md" >}}
-[run]: {{< relref "../reference/cli/run.md" >}}
-[Start the agent]: {{< relref "../setup/start-agent.md" >}}
-[Flow Debugging]: {{< relref "../monitoring/debugging.md" >}}
-[debugging]: #debugging
+* You must be familiar with the concept of [Components][] in Grafana Agent Flow mode.
 
 ## Convert a Promtail configuration
 
@@ -84,7 +70,10 @@ features available in Grafana Agent Flow Mode.
    output the flow configuration using a best-effort conversion by including
    the `--bypass-errors` flag.
 
-   {{% admonition type="caution" %}}If you bypass the errors, the behavior of the converted configuration may not match the original Promtail configuration. Make sure you fully test the converted configuration before using it in a production environment.{{% /admonition %}}
+   {{% admonition type="caution" %}}
+   If you bypass the errors, the behavior of the converted configuration may not match the original Promtail configuration.
+   Make sure you fully test the converted configuration before using it in a production environment.
+   {{% /admonition %}}
 
    {{< code >}}
 
@@ -132,11 +121,11 @@ configuration. This allows you to try Flow Mode without modifying your existing
 Promtail configuration infrastructure.
 
 > In this task, we will use the [run][] CLI command to run Grafana Agent in Flow
-> Mode using a Promtail configuration.
+> mode using a Promtail configuration.
 
-[Start the Agent][] in flow mode and include the command line flag
+[Start the Agent][] in Flow mode and include the command line flag
 `--config.format=promtail`. Your configuration file must be a valid Promtail
-configuration file rather than a Flow Mode configuration file.
+configuration file rather than a Flow mode configuration file.
 
 ### Debugging
 
@@ -144,20 +133,23 @@ configuration file rather than a Flow Mode configuration file.
    a diagnostic report.
 
 1. Refer to the Grafana Agent [Flow Debugging][] for more information about
-   running Grafana Agent in Flow Mode.
+   running Grafana Agent in Flow mode.
 
-1. If your Promtail configuration cannot be converted and loaded directly into
+1. If your Promtail configuration can't be converted and loaded directly into
    Grafana Agent, diagnostic information is sent to `stderr`. You can bypass any
    non-critical issues and start the Agent by including the
    `--config.bypass-conversion-errors` flag in addition to
    `--config.format=promtail`.
 
-   {{% admonition type="caution" %}}If you bypass the errors, the behavior of the converted configuration may not match the original Promtail configuration. Do not use this flag in a production environment.{{%/admonition %}}
+   {{% admonition type="caution" %}}
+   If you bypass the errors, the behavior of the converted configuration may not match the original Promtail configuration.
+   Do not use this flag in a production environment.
+   {{%/admonition %}}
 
 ## Example
 
 This example demonstrates converting a Promtail configuration file to a Grafana
-Agent Flow Mode configuration file.
+Agent Flow mode configuration file.
 
 The following Promtail configuration file provides the input for the conversion:
 
@@ -174,8 +166,6 @@ scrape_configs:
 ```
 
 The convert command takes the YAML file as input and outputs a [River][] file.
-
-[River]: {{< relref "../config-language/_index.md" >}}
 
 {{< code >}}
 
@@ -214,17 +204,17 @@ loki.write "default" {
 
 ## Limitations
 
-Configuration conversion is done on a best-effort basis. The Agent will issue
+Configuration conversion is done on a best-effort basis. Grafana Agent will issue
 warnings or errors where the conversion can't be performed.
 
 Once the configuration is converted, we recommend that you review
-the Flow Mode configuration file created, and verify that it is correct
+the Flow Mode configuration file created, and verify that it's correct
 before starting to use it in a production environment.
 
 Furthermore, we recommend that you review the following checklist:
 
 * Check if you are using any extra command line arguments with Promtail which
-  are not present in your config file. For example, `-max-line-size`.
+  aren't present in your configuration file. For example, `-max-line-size`.
 * Check if you are setting any environment variables,
   whether [expanded in the config file][] itself or consumed directly by
   Promtail, such as `JAEGER_AGENT_HOST`.
@@ -240,6 +230,28 @@ Furthermore, we recommend that you review the following checklist:
 * Note that the Agent exposes the [Grafana Agent Flow UI][], which differs
   from Promtail's Web UI.
 
-[expanded in the config file]: /docs/loki/latest/clients/promtail/configuration/#use-environment-variables-in-the-configuration
-
-[Grafana Agent Flow UI]: {{< relref "../monitoring/debugging/#grafana-agent-flow-ui" >}}
+{{% docs/reference %}}
+[Promtail]: https://www.grafana.com/docs/loki/<LOKI_VERSION>/clients/promtail/
+[debugging]: #debugging
+[expanded in the config file]: https://www.grafana.com/docs/loki/<LOKI_VERSION>/clients/promtail/configuration/#use-environment-variables-in-the-configuration
+[local.file_match]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/local.file_match.md"
+[local.file_match]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/components/local.file_match.md"
+[loki.source.file]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.source.file.md"
+[loki.source.file]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/components/loki.source.file.md"
+[loki.write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.write.md"
+[loki.write]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/components/loki.write.md"
+[Components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
+[Components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/concepts/components.md"
+[convert]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/convert.md"
+[convert]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/cli/convert.md"
+[run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
+[run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/cli/run.md"
+[Start the agent]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/start-agent.md"
+[Start the agent]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/setup/start-agent.md"
+[Flow Debugging]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md"
+[Flow Debugging]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/monitoring/debugging.md"
+[River]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/config-language/_index.md"
+[River]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/config-language/_index.md"
+[Grafana Agent Flow UI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging#grafana-agent-flow-ui"
+[Grafana Agent Flow UI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/monitoring/debugging#grafana-agent-flow-ui"
+{{% /docs/reference %}}

--- a/docs/sources/flow/getting-started/migrating-from-static.md
+++ b/docs/sources/flow/getting-started/migrating-from-static.md
@@ -142,8 +142,6 @@ mode configuration file.
 
    {{% admonition type="caution" %}}If you bypass the errors, the behavior of the converted configuration may not match the original Grafana Agent Static mode configuration. Do not use this flag in a production environment.{{%/admonition %}}
 
-[debugging]: #debugging
-
 ## Example
 
 This example demonstrates converting a [Static] mode configuration file to a Flow mode configuration file.
@@ -323,6 +321,8 @@ Furthermore, we recommend that you review the following checklist:
 * The logs produced by Grafana Agent Flow mode will differ from those
   produced by Static mode.
 * Grafana Agent exposes the [Grafana Agent Flow UI][].
+
+[debugging]: #debugging
 
 {{% docs/reference %}}
 [prometheus.scrape]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape.md"

--- a/docs/sources/flow/getting-started/migrating-from-static.md
+++ b/docs/sources/flow/getting-started/migrating-from-static.md
@@ -322,9 +322,8 @@ Furthermore, we recommend that you review the following checklist:
   produced by Static mode.
 * Grafana Agent exposes the [Grafana Agent Flow UI][].
 
-[debugging]: #debugging
-
 {{% docs/reference %}}
+[debugging]: #debugging
 [prometheus.scrape]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape.md"
 [prometheus.scrape]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/components/prometheus.scrape.md"
 [prometheus.remote_write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write.md"

--- a/docs/sources/flow/getting-started/migrating-from-static.md
+++ b/docs/sources/flow/getting-started/migrating-from-static.md
@@ -31,24 +31,10 @@ This topic describes how to:
 * [loki.source.file][]
 * [loki.write][]
 
-[prometheus.scrape]: {{< relref "../reference/components/prometheus.scrape.md" >}}
-[prometheus.remote_write]: {{< relref "../reference/components/prometheus.remote_write.md" >}}
-[local.file_match]: {{< relref "../reference/components/local.file_match.md" >}}
-[loki.process]: {{< relref "../reference/components/loki.process.md" >}}
-[loki.source.file]: {{< relref "../reference/components/loki.source.file.md" >}}
-[loki.write]: {{< relref "../reference/components/loki.write.md" >}}
-
 ## Before you begin
 
 * You must have an existing Grafana Agent Static mode configuration.
 * You must be familiar with the [Components][] concept in Grafana Agent Flow mode.
-
-[Components]: {{< relref "../concepts/components.md" >}}
-[convert]: {{< relref "../reference/cli/convert.md" >}}
-[run]: {{< relref "../reference/cli/run.md" >}}
-[Start the agent]: {{< relref "../setup/start-agent.md" >}}
-[Flow Debugging]: {{< relref "../monitoring/debugging.md" >}}
-[debugging]: #debugging
 
 ## Convert a Static mode configuration
 
@@ -149,12 +135,14 @@ mode configuration file.
 1. Refer to the Grafana Agent [Flow Debugging][] for more information about
    running Grafana Agent in Flow mode.
 
-1. If your [Static] mode configuration cannot be converted and loaded directly into
+1. If your [Static] mode configuration can't be converted and loaded directly into
     Grafana Agent, diagnostic information is sent to `stderr`. You can use the `
     --config.bypass-conversion-errors` flag with `--config.format=static` to bypass any
     non-critical issues and start the Agent.
 
    {{% admonition type="caution" %}}If you bypass the errors, the behavior of the converted configuration may not match the original Grafana Agent Static mode configuration. Do not use this flag in a production environment.{{%/admonition %}}
+
+[debugging]: #debugging
 
 ## Example
 
@@ -217,8 +205,6 @@ logs:
 ```
 
 The convert command takes the YAML file as input and outputs a [River][] file.
-
-[River]: {{< relref "../config-language/_index.md" >}}
 
 {{< code >}}
 
@@ -307,7 +293,6 @@ loki.write "logs_varlogs" {
 	}
 	external_labels = {}
 }
-
 ```
 
 ## Limitations
@@ -339,12 +324,47 @@ Furthermore, we recommend that you review the following checklist:
   produced by Static mode.
 * Grafana Agent exposes the [Grafana Agent Flow UI][].
 
-[Integrations next]: {{< relref "../../static/configuration/integrations/integrations-next/_index.md" >}}
-[Traces]: {{< relref "../../static/configuration/traces-config.md" >}}
-[Agent Management]: {{< relref "../../static/configuration/agent-management.md" >}}
-[env]: {{< relref "../reference/stdlib/env.md" >}}
-[Prometheus Limitations]: {{< relref "migrating-from-prometheus.md/#limitations" >}}
-[Promtail Limitations]: {{< relref "migrating-from-promtail.md/#limitations" >}}
-[Metrics]: {{< relref "../../static/configuration/metrics-config.md" >}}
-[Logs]: {{< relref "../../static/configuration/logs-config.md" >}}
-[Grafana Agent Flow UI]: {{< relref "../monitoring/debugging/#grafana-agent-flow-ui" >}}
+{{% docs/reference %}}
+[prometheus.scrape]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape.md"
+[prometheus.scrape]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/components/prometheus.scrape.md"
+[prometheus.remote_write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write.md"
+[prometheus.remote_write]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/components/prometheus.remote_write.md"
+[local.file_match]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/local.file_match.md"
+[local.file_match]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/components/local.file_match.md"
+[loki.process]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.process.md"
+[loki.process]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/components/loki.process.md"
+[loki.source.file]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.source.file.md"
+[loki.source.file]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/components/loki.source.file.md"
+[loki.write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.write.md"
+[loki.write]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/components/loki.write.md"
+[Components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
+[Components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/concepts/components.md"
+[convert]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/convert.md"
+[convert]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/cli/convert.md"
+[run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
+[run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/cli/run.md"
+[Start the agent]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/start-agent.md"
+[Start the agent]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/setup/start-agent.md"
+[Flow Debugging]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md"
+[Flow Debugging]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/monitoring/debugging.md"
+[River]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/config-language/"
+[River]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/config-language/"
+[Integrations next]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static/configuration/integrations/integrations-next/_index.md"
+[Integrations next]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration/traces-config.md
+[Traces]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static/configuration/traces-config.md"
+[Traces]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration/traces-config.md"
+[Agent Management]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static/configuration/agent-management.md"
+[Agent Management]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration/agent-management.md"
+[env]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/stdlib/env.md"
+[env]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/stdlib/env.md"
+[Prometheus Limitations]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/migrating-from-prometheus.md#limitations"
+[Prometheus Limitations]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/getting-started/migrating-from-prometheus.md#limitations"
+[Promtail Limitations]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/migrating-from-promtail.md#limitations"
+[Promtail Limitations]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/getting-started/migrating-from-promtail.md#limitations"
+[Metrics]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static/configuration/metrics-config.md"
+[Metrics]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration/metrics-config.md"
+[Logs]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static/configuration/logs-config.md"
+[Logs]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static/logs-config.md"
+[Grafana Agent Flow UI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging#grafana-agent-flow-ui"
+[Grafana Agent Flow UI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/monitoring/debugging#grafana-agent-flow-ui"
+{{% /docs/reference %}}

--- a/docs/sources/flow/getting-started/opentelemetry-to-lgtm-stack.md
+++ b/docs/sources/flow/getting-started/opentelemetry-to-lgtm-stack.md
@@ -300,14 +300,13 @@ You can now check the pipeline graphically by visiting http://localhost:12345/gr
 
 ![](../../../assets/getting-started/otlp-lgtm-graph.png)
 
+{{% docs/reference %}}
 [OpenTelemetry]: https://opentelemetry.io
 [Grafana Loki]: /oss/loki/
 [Grafana Tempo]: https://grafana.com/oss/tempo/
 [GrafanaCloud Portal]: https://grafana.com/docs/grafana-cloud/account-management/cloud-portal/#your-grafana-cloud-stack 
 [Prometheus Remote Write]: https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage
 [Grafana Mimir]: https://grafana.com/oss/mimir/
-
-{{% docs/reference %}}
 [Collect open telemetry data]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-opentelemetry-data.md"
 [Collect open telemetry data]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/getting-started/collect-opentelemetry-data.md"
 [Components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"

--- a/docs/sources/flow/getting-started/opentelemetry-to-lgtm-stack.md
+++ b/docs/sources/flow/getting-started/opentelemetry-to-lgtm-stack.md
@@ -15,12 +15,9 @@ You can configure Grafana Agent Flow to collect [OpenTelemetry][]-compatible dat
 
 This topic describes how to:
 
-* Configure Agent to send your data to Loki
-* Configure Agent to send your data to Tempo
-* Configure Agent to send your data to Mimir or Prometheus Remote Write
-
-[OpenTelemetry]: https://opentelemetry.io
-
+* Configure Grafana Agent to send your data to Loki
+* Configure Grafana Agent to send your data to Tempo
+* Configure Grafana Agent to send your data to Mimir or Prometheus Remote Write
 
 ## Components used in this topic
 
@@ -33,15 +30,6 @@ This topic describes how to:
 * [otelcol.receiver.otlp][]
 * [prometheus.remote_write][]
 
-[loki.write]: {{< relref "../reference/components/loki.write.md" >}}
-[otelcol.auth.basic]: {{< relref "../reference/components/otelcol.auth.basic.md" >}}
-[otelcol.exporter.loki]: {{< relref "../reference/components/otelcol.exporter.loki.md" >}}
-[otelcol.exporter.otlp]: {{< relref "../reference/components/otelcol.exporter.otlp.md" >}}
-[otelcol.exporter.prometheus]: {{< relref "../reference/components/otelcol.exporter.prometheus.md" >}}
-[otelcol.processor.batch]: {{< relref "../reference/components/otelcol.processor.batch.md" >}}
-[otelcol.receiver.otlp]: {{< relref "../reference/components/otelcol.receiver.otlp.md" >}}
-[prometheus.remote_write]: {{< relref "../reference/components/prometheus.remote_write.md" >}}
-
 ## Before you begin
 
 * Ensure that you have basic familiarity with instrumenting applications with
@@ -52,11 +40,7 @@ This topic describes how to:
 * Be familiar with the concept of [Components][] in Grafana Agent Flow.
 * Complete the [Collect open telemetry data][] getting started guide. You will pick up from where that guide ended.
 
-[Collect open telemetry data]: {{< relref "./collect-opentelemetry-data.md" >}}
-
-[Components]: {{< relref "../concepts/components.md" >}}
-
-## The Pipeline
+## The pipeline
 
 You can start with the Grafana Agent Flow configuration you created in the previous getting started guide:
 
@@ -93,6 +77,7 @@ otelcol.exporter.otlp "default" {
 ```
 
 The pipeline currently looks like this:
+
 ```
 Metrics, Logs, Traces: OTLP Receiver → batch processor → OTLP Exporter
 ```
@@ -119,7 +104,7 @@ loki.write "default" {
 }
 ```
 
-To use Loki with basic-auth, which is required with GrafanaCloud Loki, you must configure the [loki.write][] component. You can get the Loki config from the Loki **Details** page in the [GrafanaCloud Portal][]:
+To use Loki with basic-auth, which is required with GrafanaCloud Loki, you must configure the [loki.write][] component. You can get the Loki configuration from the Loki **Details** page in the [GrafanaCloud Portal][]:
 
 ![](../../../assets/getting-started/loki-config.png)
 
@@ -140,11 +125,9 @@ loki.write "grafana_cloud_loki" {
 }
 ```
 
-[Grafana Loki]: /oss/loki/
-
 ## Grafana Tempo
 
-[Grafana Tempo][] is an open-source, easy-to-use, scalable distributed tracing backend. Tempo can ingest OTLP directly, and you can use the OTLP exporter to send the traces to Tempo.
+[Grafana Tempo][] is an open source, easy-to-use, scalable distributed tracing backend. Tempo can ingest OTLP directly, and you can use the OTLP exporter to send the traces to Tempo.
 
 ```river
 otelcol.exporter.otlp "default" {
@@ -154,7 +137,7 @@ otelcol.exporter.otlp "default" {
 }
 ```
 
-To use Tempo with basic-auth, which is required with GrafanaCloud Tempo, you must use the [otelcol.auth.basic][] component. You can get the Tempo config from the Tempo **Details** page in the [GrafanaCloud Portal][]:
+To use Tempo with basic-auth, which is required with GrafanaCloud Tempo, you must use the [otelcol.auth.basic][] component. You can get the Tempo configuration from the Tempo **Details** page in the [GrafanaCloud Portal][]:
 
 ![](../../../assets/getting-started/tempo-config.png)
 
@@ -172,9 +155,6 @@ otelcol.auth.basic "grafana_cloud_tempo" {
 }
 ```
 
-[Grafana Tempo]: https://grafana.com/oss/tempo/
-[GrafanaCloud Portal]: https://grafana.com/docs/grafana-cloud/account-management/cloud-portal/#your-grafana-cloud-stack 
-
 ## Grafana Mimir or Prometheus Remote Write
 
 [Prometheus Remote Write][] is a popular metrics transmission protocol supported by most metrics systems, including [Grafana Mimir][] and GrafanaCloud. To send from OTLP to Prometheus, we do a passthrough from the [otelcol.exporter.prometheus][] to the [prometheus.remote_write][] component. The Prometheus remote write component in Agent is a robust protocol implementation, including a Write Ahead Log for resiliency.
@@ -191,7 +171,7 @@ prometheus.remote_write "default" {
 }
 ```
 
-To use Prometheus with basic-auth, which is required with GrafanaCloud Prometheus, you have to configure the [prometheus.remote_write][] component. You can get the Prometheus config from the Prometheus **Details** page in the [GrafanaCloud Portal][]:
+To use Prometheus with basic-auth, which is required with GrafanaCloud Prometheus, you must configure the [prometheus.remote_write][] component. You can get the Prometheus configuration from the Prometheus **Details** page in the [GrafanaCloud Portal][]:
 
 ![](../../../assets/getting-started/prometheus-config.png)
 
@@ -211,9 +191,6 @@ prometheus.remote_write "grafana_cloud_prometheus" {
     }
 }
 ```
-
-[Prometheus Remote Write]: https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage
-[Grafana Mimir]: https://grafana.com/oss/mimir/
 
 ## Putting it all together
 
@@ -322,3 +299,33 @@ ts=2023-05-09T09:37:15.304234Z component=otelcol.receiver.otlp.default level=inf
 You can now check the pipeline graphically by visiting http://localhost:12345/graph
 
 ![](../../../assets/getting-started/otlp-lgtm-graph.png)
+
+[OpenTelemetry]: https://opentelemetry.io
+[Grafana Loki]: /oss/loki/
+[Grafana Tempo]: https://grafana.com/oss/tempo/
+[GrafanaCloud Portal]: https://grafana.com/docs/grafana-cloud/account-management/cloud-portal/#your-grafana-cloud-stack 
+[Prometheus Remote Write]: https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage
+[Grafana Mimir]: https://grafana.com/oss/mimir/
+
+{{% docs/reference %}}
+[Collect open telemetry data]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-opentelemetry-data.md"
+[Collect open telemetry data]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/getting-started/collect-opentelemetry-data.md"
+[Components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
+[Components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/concepts/components.md"
+[loki.write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.write.md"
+[loki.write]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/components/loki.write.md"
+[otelcol.auth.basic]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.auth.basic.md"
+[otelcol.auth.basic]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/components/otelcol.auth.basic.md"
+[otelcol.exporter.loki]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.loki.md"
+[otelcol.exporter.loki]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/components/otelcol.exporter.loki.md"
+[otelcol.exporter.otlp]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.otlp.md"
+[otelcol.exporter.otlp]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/components/otelcol.exporter.otlp.md"
+[otelcol.exporter.prometheus]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.prometheus.md"
+[otelcol.exporter.prometheus]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/components/otelcol.exporter.prometheus.md"
+[otelcol.processor.batch]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.processor.batch.md"
+[otelcol.processor.batch]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/components/otelcol.processor.batch.md"
+[otelcol.receiver.otlp]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.receiver.otlp.md"
+[otelcol.receiver.otlp]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/components/otelcol.receiver.otlp.md"
+[prometheus.remote_write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write.md"
+[prometheus.remote_write]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/components/prometheus.remote_write.md"
+{{% /docs/reference %}}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

The relref shortcode is being deprecated in favour of the `docs/reference` shortcode. The new shortcode allows us to have more control over the references and links and makes sure that topics mounted into more than one project can have working links within that project.

This PR starts the process of migrating the Flow documentation to use the `docs/reference` shortcodes as preparation for mounting Flow topics into the Cloud docs.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated