### PR TITLE
docs: remove implication that flow mode doesn't have feature parity from about page

### DIFF
--- a/docs/sources/about.md
+++ b/docs/sources/about.md
@@ -58,9 +58,6 @@ You should run Static mode when:
 
 * **Grafana Cloud integrations**: You need to use Grafana Agent with Grafana Cloud integrations.
 
-* **Complete list of integrations**: You need to use a Static mode [integration][integrations] which is not yet
-  available as a [component][components] in Flow mode.
-
 ### Static mode Kubernetes operator
 
 The [Static mode Kubernetes operator][] is a variant of Grafana Agent first
@@ -86,8 +83,6 @@ vendor neutrality, ease-of-use, improved debuggability, and ability to adapt to
 the needs of power users by adopting a configuration-as-code model.
 
 Flow mode is considered to be the future of the Grafana Agent project.
-Eventually, all functionality of Static mode and the Static mode Kubernetes
-operator will be added into Flow mode.
 
 You should run Flow mode when:
 


### PR DESCRIPTION
Flow mode has feature parity with static mode and operator in v0.37. This removes references implying it doesn't. 