### PR TITLE
Fix alert for Agent Management in mixin

### DIFF
--- a/production/grafana-agent-mixin/alerts.libsonnet
+++ b/production/grafana-agent-mixin/alerts.libsonnet
@@ -242,7 +242,7 @@ local _config = config._config;
           {
             alert: 'AgentRemoteConfigBadAPIRequests',
             expr: |||
-              100 * sum(rate(agent_remote_config_fetches_total{status_code="(4|5).."}[10m])) by (%(group_by_cluster)s)
+              100 * sum(rate(agent_remote_config_fetches_total{status_code=~"(4|5).."}[10m])) by (%(group_by_cluster)s)
                 /
               sum(rate(agent_remote_config_fetches_total[10m])) by (%(group_by_cluster)s)
                 > 5
@@ -260,7 +260,7 @@ local _config = config._config;
           {
             alert: 'AgentRemoteConfigBadAPIRequests',
             expr: |||
-              100 * sum(rate(agent_remote_config_fetches_total{status_code="(4|5).."}[10m])) by (%(group_by_cluster)s)
+              100 * sum(rate(agent_remote_config_fetches_total{status_code=~"(4|5).."}[10m])) by (%(group_by_cluster)s)
                 /
               sum(rate(agent_remote_config_fetches_total[10m])) by (%(group_by_cluster)s)
                 > 10


### PR DESCRIPTION
#### PR Description

The `AgentRemoteConfigBadAPIRequests` was using the wrong operator to evaluate the pattern.
