### PR TITLE
common/relabel: update validation rules from Prometheus

### DIFF
--- a/component/common/relabel/relabel.go
+++ b/component/common/relabel/relabel.go
@@ -146,16 +146,13 @@ func (rc *Config) Validate() error {
 	if rc.Modulus == 0 && rc.Action == HashMod {
 		return fmt.Errorf("relabel configuration for hashmod requires non-zero modulus")
 	}
-	if (rc.Action == Replace || rc.Action == KeepEqual || rc.Action == DropEqual || rc.Action == HashMod || rc.Action == Lowercase || rc.Action == Uppercase) && rc.TargetLabel == "" {
+	if (rc.Action == Replace || rc.Action == HashMod || rc.Action == Lowercase || rc.Action == Uppercase || rc.Action == KeepEqual || rc.Action == DropEqual) && rc.TargetLabel == "" {
 		return fmt.Errorf("relabel configuration for %s action requires 'target_label' value", rc.Action)
 	}
-	if (rc.Action == KeepEqual || rc.Action == DropEqual) && rc.SourceLabels == nil {
-		return fmt.Errorf("relabel configuration for %s action requires 'source_labels' value", rc.Action)
-	}
-	if (rc.Action == Replace || rc.Action == Lowercase || rc.Action == Uppercase) && !relabelTarget.MatchString(rc.TargetLabel) {
+	if (rc.Action == Replace || rc.Action == Lowercase || rc.Action == Uppercase || rc.Action == KeepEqual || rc.Action == DropEqual) && !relabelTarget.MatchString(rc.TargetLabel) {
 		return fmt.Errorf("%q is invalid 'target_label' for %s action", rc.TargetLabel, rc.Action)
 	}
-	if (rc.Action == Lowercase || rc.Action == Uppercase) && rc.Replacement != DefaultRelabelConfig.Replacement {
+	if (rc.Action == Lowercase || rc.Action == Uppercase || rc.Action == KeepEqual || rc.Action == DropEqual) && rc.Replacement != DefaultRelabelConfig.Replacement {
 		return fmt.Errorf("'replacement' can not be set for %s action", rc.Action)
 	}
 	if rc.Action == LabelMap && !relabelTarget.MatchString(rc.Replacement) {

--- a/component/common/relabel/relabel_test.go
+++ b/component/common/relabel/relabel_test.go
@@ -39,26 +39,10 @@ func TestParseConfig(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "missing dropequal source",
-			cfg: `
-			action = "dropequal"
-			target_label = "foo"
-			`,
-			expectErr: true,
-		},
-		{
 			name: "missing keepequal target",
 			cfg: `
 			action = "keepequal"
 			source_labels = ["bar"]
-			`,
-			expectErr: true,
-		},
-		{
-			name: "missing keepequal source",
-			cfg: `
-			action = "keepequal"
-			target_label = "foo"
 			`,
 			expectErr: true,
 		},


### PR DESCRIPTION


#### PR Description
This PR updates the validation rules for all `*.relabel` blocks to be aligned with the validations in [upstream Prometheus](https://github.com/prometheus/prometheus/blob/a807dd16160f0816d5f03bfed72a5321372b0de4/model/relabel/relabel.go#L102-L153)'s UnmarshalYAML method.


#### Which issue(s) this PR fixes
Fixes #4837 

#### Notes to the Reviewer
I don't think there's something else to sync for loki.relabel since it's not _really_ using much of Promtail code


#### PR Checklist

- [ ] CHANGELOG.md updated (N/A)
- [ ] Documentation added (N/A) 
- [ ] Tests updated (N/A)
- [ ] Config converters updated (N?A)