### PR TITLE
otelcol.exporter.prometheus add_metrics_suffixes option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,9 @@ Main (unreleased)
   - `otelcol.receiver.kafka` has a new `version` argument to change the version of 
     the SASL Protocol for SASL authentication.
 
+- Added new config options to `otelcol.exporter.prometheus` in flow mode (@mar4uk):
+  - `add_metrics_suffixes`: configures whether to add type and unit suffixes to metrics names.
+
 v0.37.2 (2023-10-16)
 -----------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,7 @@ Main (unreleased)
     the SASL Protocol for SASL authentication.
 
 - Added new config options to `otelcol.exporter.prometheus` in flow mode (@mar4uk):
-  - `add_metrics_suffixes`: configures whether to add type and unit suffixes to metrics names.
+  - `add_metric_suffixes`: configures whether to add type and unit suffixes to metrics names.
 
 v0.37.2 (2023-10-16)
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,9 +88,9 @@ Main (unreleased)
   - `otelcol.receiver.kafka` has a new `version` argument to change the version of 
     the SASL Protocol for SASL authentication.
 
-- Added new config options to `otelcol.exporter.prometheus` in flow mode (@mar4uk):
-  - `add_metric_suffixes`: configures whether to add type and unit suffixes to metrics names.
-
+- Added an `add_metric_suffixes` option to `otelcol.exporter.prometheus` in flow mode, 
+  which configures whether to add type and unit suffixes to metrics names. (@mar4uk)
+  
 v0.37.2 (2023-10-16)
 -----------------
 

--- a/component/otelcol/exporter/prometheus/internal/convert/convert.go
+++ b/component/otelcol/exporter/prometheus/internal/convert/convert.go
@@ -288,7 +288,6 @@ func (conv *Converter) consumeMetric(app storage.Appender, memResource *memorySe
 }
 
 func (conv *Converter) consumeGauge(app storage.Appender, memResource *memorySeries, memScope *memorySeries, m pmetric.Metric) {
-	// TODO: should we make the param addMetricSuffixes configurable? For now we set the default value (true) to keep the same behavior as before
 	metricName := prometheus.BuildCompliantName(m, "", conv.opts.AddMetricSuffixes)
 
 	metricMD := conv.createOrUpdateMetadata(metricName, metadata.Metadata{

--- a/component/otelcol/exporter/prometheus/internal/convert/convert.go
+++ b/component/otelcol/exporter/prometheus/internal/convert/convert.go
@@ -64,7 +64,7 @@ type Options struct {
 	// labels from the scope in the metrics.
 	IncludeScopeLabels bool
 	// AddMetricSuffixes controls whether suffixes are added to metric names. Defaults to true.
-	AddMetricSuffixes bool `mapstructure:"add_metric_suffixes"`
+	AddMetricSuffixes bool
 }
 
 var _ consumer.Metrics = (*Converter)(nil)

--- a/component/otelcol/exporter/prometheus/internal/convert/convert.go
+++ b/component/otelcol/exporter/prometheus/internal/convert/convert.go
@@ -63,6 +63,8 @@ type Options struct {
 	// IncludeScopeLabels includes the otel_scope_name and otel_scope_version
 	// labels from the scope in the metrics.
 	IncludeScopeLabels bool
+	// AddMetricSuffixes controls whether suffixes are added to metric names. Defaults to true.
+	AddMetricSuffixes bool `mapstructure:"add_metric_suffixes"`
 }
 
 var _ consumer.Metrics = (*Converter)(nil)
@@ -287,7 +289,7 @@ func (conv *Converter) consumeMetric(app storage.Appender, memResource *memorySe
 
 func (conv *Converter) consumeGauge(app storage.Appender, memResource *memorySeries, memScope *memorySeries, m pmetric.Metric) {
 	// TODO: should we make the param addMetricSuffixes configurable? For now we set the default value (true) to keep the same behavior as before
-	metricName := prometheus.BuildCompliantName(m, "", true)
+	metricName := prometheus.BuildCompliantName(m, "", conv.opts.AddMetricSuffixes)
 
 	metricMD := conv.createOrUpdateMetadata(metricName, metadata.Metadata{
 		Type: textparse.MetricTypeGauge,
@@ -389,7 +391,7 @@ func getNumberDataPointValue(dp pmetric.NumberDataPoint) float64 {
 }
 
 func (conv *Converter) consumeSum(app storage.Appender, memResource *memorySeries, memScope *memorySeries, m pmetric.Metric) {
-	metricName := prometheus.BuildCompliantName(m, "", true)
+	metricName := prometheus.BuildCompliantName(m, "", conv.opts.AddMetricSuffixes)
 
 	// Excerpt from the spec:
 	//
@@ -447,7 +449,7 @@ func (conv *Converter) consumeSum(app storage.Appender, memResource *memorySerie
 }
 
 func (conv *Converter) consumeHistogram(app storage.Appender, memResource *memorySeries, memScope *memorySeries, m pmetric.Metric) {
-	metricName := prometheus.BuildCompliantName(m, "", true)
+	metricName := prometheus.BuildCompliantName(m, "", conv.opts.AddMetricSuffixes)
 
 	if m.Histogram().AggregationTemporality() != pmetric.AggregationTemporalityCumulative {
 		// Drop non-cumulative histograms for now, which is permitted by the spec.
@@ -606,7 +608,7 @@ func (conv *Converter) convertExemplar(otelExemplar pmetric.Exemplar, ts time.Ti
 }
 
 func (conv *Converter) consumeSummary(app storage.Appender, memResource *memorySeries, memScope *memorySeries, m pmetric.Metric) {
-	metricName := prometheus.BuildCompliantName(m, "", true)
+	metricName := prometheus.BuildCompliantName(m, "", conv.opts.AddMetricSuffixes)
 
 	metricMD := conv.createOrUpdateMetadata(metricName, metadata.Metadata{
 		Type: textparse.MetricTypeSummary,

--- a/component/otelcol/exporter/prometheus/prometheus.go
+++ b/component/otelcol/exporter/prometheus/prometheus.go
@@ -36,6 +36,7 @@ type Arguments struct {
 	IncludeScopeLabels bool                 `river:"include_scope_labels,attr,optional"`
 	GCFrequency        time.Duration        `river:"gc_frequency,attr,optional"`
 	ForwardTo          []storage.Appendable `river:"forward_to,attr"`
+	AddMetricSuffixes  bool                 `river:"add_metrics_suffixes,attr,optional"`
 }
 
 // DefaultArguments holds defaults values.
@@ -44,6 +45,7 @@ var DefaultArguments = Arguments{
 	IncludeScopeInfo:   false,
 	IncludeScopeLabels: true,
 	GCFrequency:        5 * time.Minute,
+	AddMetricSuffixes:  true,
 }
 
 // SetToDefault implements river.Defaulter.
@@ -86,6 +88,7 @@ func New(o component.Options, c Arguments) (*Component, error) {
 	converter := convert.New(o.Logger, fanout, convert.Options{
 		IncludeTargetInfo: true,
 		IncludeScopeInfo:  false,
+		AddMetricSuffixes: true,
 	})
 
 	res := &Component{

--- a/component/otelcol/exporter/prometheus/prometheus.go
+++ b/component/otelcol/exporter/prometheus/prometheus.go
@@ -85,11 +85,7 @@ func New(o component.Options, c Arguments) (*Component, error) {
 	ls := service.(labelstore.LabelStore)
 	fanout := prometheus.NewFanout(nil, o.ID, o.Registerer, ls)
 
-	converter := convert.New(o.Logger, fanout, convert.Options{
-		IncludeTargetInfo: true,
-		IncludeScopeInfo:  false,
-		AddMetricSuffixes: true,
-	})
+	converter := convert.New(o.Logger, fanout, convertArgumentsToConvertOptions(c))
 
 	res := &Component{
 		log:  o.Logger,
@@ -142,11 +138,7 @@ func (c *Component) Update(newConfig component.Arguments) error {
 	c.cfg = cfg
 
 	c.fanout.UpdateChildren(cfg.ForwardTo)
-	c.converter.UpdateOptions(convert.Options{
-		IncludeTargetInfo: cfg.IncludeTargetInfo,
-		IncludeScopeInfo:  cfg.IncludeScopeInfo,
-		AddMetricSuffixes: cfg.AddMetricSuffixes,
-	})
+	c.converter.UpdateOptions(convertArgumentsToConvertOptions(cfg))
 
 	// If our forward_to argument changed, we need to flush the metadata cache to
 	// ensure the new children have all the metadata they need.
@@ -155,4 +147,12 @@ func (c *Component) Update(newConfig component.Arguments) error {
 	// more intelligent here in the future.
 	c.converter.FlushMetadata()
 	return nil
+}
+
+func convertArgumentsToConvertOptions(args Arguments) convert.Options {
+	return convert.Options{
+		IncludeTargetInfo: args.IncludeTargetInfo,
+		IncludeScopeInfo:  args.IncludeScopeInfo,
+		AddMetricSuffixes: args.AddMetricSuffixes,
+	}
 }

--- a/component/otelcol/exporter/prometheus/prometheus.go
+++ b/component/otelcol/exporter/prometheus/prometheus.go
@@ -36,7 +36,7 @@ type Arguments struct {
 	IncludeScopeLabels bool                 `river:"include_scope_labels,attr,optional"`
 	GCFrequency        time.Duration        `river:"gc_frequency,attr,optional"`
 	ForwardTo          []storage.Appendable `river:"forward_to,attr"`
-	AddMetricSuffixes  bool                 `river:"add_metrics_suffixes,attr,optional"`
+	AddMetricSuffixes  bool                 `river:"add_metric_suffixes,attr,optional"`
 }
 
 // DefaultArguments holds defaults values.

--- a/component/otelcol/exporter/prometheus/prometheus.go
+++ b/component/otelcol/exporter/prometheus/prometheus.go
@@ -145,6 +145,7 @@ func (c *Component) Update(newConfig component.Arguments) error {
 	c.converter.UpdateOptions(convert.Options{
 		IncludeTargetInfo: cfg.IncludeTargetInfo,
 		IncludeScopeInfo:  cfg.IncludeScopeInfo,
+		AddMetricSuffixes: cfg.AddMetricSuffixes,
 	})
 
 	// If our forward_to argument changed, we need to flush the metadata cache to

--- a/component/otelcol/exporter/prometheus/prometheus_test.go
+++ b/component/otelcol/exporter/prometheus/prometheus_test.go
@@ -1,0 +1,75 @@
+package prometheus_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/component/otelcol/exporter/prometheus"
+	"github.com/grafana/river"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArguments_UnmarshalRiver(t *testing.T) {
+	tests := []struct {
+		testName string
+		cfg      string
+		expected prometheus.Arguments
+		errorMsg string
+	}{
+		{
+			testName: "Defaults",
+			cfg: `
+					forward_to = []
+				`,
+			expected: prometheus.Arguments{
+				IncludeTargetInfo:  true,
+				IncludeScopeInfo:   false,
+				IncludeScopeLabels: true,
+				GCFrequency:        5 * time.Minute,
+				AddMetricSuffixes:  true,
+				ForwardTo:          []storage.Appendable{},
+			},
+		},
+		{
+			testName: "ExplicitValues",
+			cfg: `
+					include_target_info = false
+					include_scope_info = true
+					include_scope_labels = false
+					gc_frequency = "1s"
+					add_metric_suffixes = false
+					forward_to = []
+				`,
+			expected: prometheus.Arguments{
+				IncludeTargetInfo:  false,
+				IncludeScopeInfo:   true,
+				IncludeScopeLabels: false,
+				GCFrequency:        1 * time.Second,
+				AddMetricSuffixes:  false,
+				ForwardTo:          []storage.Appendable{},
+			},
+		},
+		{
+			testName: "Zero GCFrequency",
+			cfg: `
+					gc_frequency = "0s"
+					forward_to = []
+				`,
+			errorMsg: "gc_frequency must be greater than 0",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			var args prometheus.Arguments
+			err := river.Unmarshal([]byte(tc.cfg), &args)
+			if tc.errorMsg != "" {
+				require.EqualError(t, err, tc.errorMsg)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, args)
+		})
+	}
+}

--- a/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
@@ -37,13 +37,14 @@ otelcol.exporter.prometheus "LABEL" {
 
 `otelcol.exporter.prometheus` supports the following arguments:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`include_target_info` | `boolean` | Whether to include `target_info` metrics. | `true` | no
-`include_scope_info` | `boolean` | Whether to include `otel_scope_info` metrics. | `false` | no
+Name | Type | Description                                               | Default | Required
+---- | ---- |-----------------------------------------------------------| ------- | --------
+`include_target_info` | `boolean` | Whether to include `target_info` metrics.                 | `true` | no
+`include_scope_info` | `boolean` | Whether to include `otel_scope_info` metrics.             | `false` | no
 `include_scope_labels` | `boolean` | Whether to include additional OTLP labels in all metrics. | `true` | no
-`gc_frequency` | `duration` | How often to clean up stale metrics from memory. | `"5m"` | no
-`forward_to` | `list(receiver)` | Where to forward converted Prometheus metrics. | | yes
+`add_metrics_suffixes` | `boolean` | Whether to add type and unit suffixes to metrics. | `true` | no
+`gc_frequency` | `duration` | How often to clean up stale metrics from memory.          | `"5m"` | no
+`forward_to` | `list(receiver)` | Where to forward converted Prometheus metrics.            | | yes
 
 By default, OpenTelemetry resources are converted into `target_info` metrics. 
 OpenTelemetry instrumentation scopes are converted into `otel_scope_info`

--- a/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
@@ -42,7 +42,7 @@ Name | Type | Description                                               | Defaul
 `include_target_info` | `boolean` | Whether to include `target_info` metrics.                 | `true` | no
 `include_scope_info` | `boolean` | Whether to include `otel_scope_info` metrics.             | `false` | no
 `include_scope_labels` | `boolean` | Whether to include additional OTLP labels in all metrics. | `true` | no
-`add_metrics_suffixes` | `boolean` | Whether to add type and unit suffixes to metrics. | `true` | no
+`add_metrics_suffixes` | `boolean` | Whether to add type and unit suffixes to metrics names.   | `true` | no
 `gc_frequency` | `duration` | How often to clean up stale metrics from memory.          | `"5m"` | no
 `forward_to` | `list(receiver)` | Where to forward converted Prometheus metrics.            | | yes
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
@@ -42,7 +42,7 @@ Name | Type | Description                                               | Defaul
 `include_target_info` | `boolean` | Whether to include `target_info` metrics.                 | `true` | no
 `include_scope_info` | `boolean` | Whether to include `otel_scope_info` metrics.             | `false` | no
 `include_scope_labels` | `boolean` | Whether to include additional OTLP labels in all metrics. | `true` | no
-`add_metrics_suffixes` | `boolean` | Whether to add type and unit suffixes to metrics names.   | `true` | no
+`add_metric_suffixes` | `boolean` | Whether to add type and unit suffixes to metrics names.   | `true` | no
 `gc_frequency` | `duration` | How often to clean up stale metrics from memory.          | `"5m"` | no
 `forward_to` | `list(receiver)` | Where to forward converted Prometheus metrics.            | | yes
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Added option add_metrics_suffixes. If set to false, type and unit suffixes will not be added to metrics. Default: true.
This option is needed for compatibility with https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusexporter

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->
https://github.com/grafana/agent/issues/5567

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated