### PR TITLE
prometheus.exporter.*: validate scrape configs while generating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ Main (unreleased)
 - Fix an issue with static mode and `promtail` converters, where static targets 
   did not correctly default to `localhost` when not provided. (@thampiotr)
 
+- Fix validation issue with ServiceMonitors when scrape timeout is greater than interval. (@captncraig)
+
 ### Enhancements
 
 - The `loki.write` WAL now has snappy compression enabled by default. (@thepalbi)

--- a/component/prometheus/operator/common/crdmanager.go
+++ b/component/prometheus/operator/common/crdmanager.go
@@ -495,15 +495,15 @@ func (c *crdManager) addProbe(p *promopv1.Probe) {
 		// TODO(jcreixell): Generate Kubernetes event to inform of this error when running `kubectl get <probe>`.
 		level.Error(c.logger).Log("name", p.Name, "err", err, "msg", "error generating scrapeconfig from probe")
 	}
+	if err != nil {
+		c.addDebugInfo(p.Namespace, p.Name, err)
+		return
+	}
 	c.mut.Lock()
 	c.discoveryConfigs[pmc.JobName] = pmc.ServiceDiscoveryConfigs
 	c.scrapeConfigs[pmc.JobName] = pmc
 	c.mut.Unlock()
 
-	if err != nil {
-		c.addDebugInfo(p.Namespace, p.Name, err)
-		return
-	}
 	if err = c.apply(); err != nil {
 		level.Error(c.logger).Log("name", p.Name, "err", err, "msg", "error applying scrape configs from "+c.kind)
 	}

--- a/component/prometheus/operator/common/crdmanager.go
+++ b/component/prometheus/operator/common/crdmanager.go
@@ -494,8 +494,6 @@ func (c *crdManager) addProbe(p *promopv1.Probe) {
 	if err != nil {
 		// TODO(jcreixell): Generate Kubernetes event to inform of this error when running `kubectl get <probe>`.
 		level.Error(c.logger).Log("name", p.Name, "err", err, "msg", "error generating scrapeconfig from probe")
-	}
-	if err != nil {
 		c.addDebugInfo(p.Namespace, p.Name, err)
 		return
 	}

--- a/component/prometheus/operator/configgen/config_gen_podmonitor.go
+++ b/component/prometheus/operator/configgen/config_gen_podmonitor.go
@@ -277,5 +277,5 @@ func (cg *ConfigGenerator) GeneratePodMonitorConfig(m *promopv1.PodMonitor, ep p
 	cfg.LabelNameLengthLimit = uint(m.Spec.LabelNameLengthLimit)
 	cfg.LabelValueLengthLimit = uint(m.Spec.LabelValueLengthLimit)
 
-	return cfg, nil
+	return cfg, cfg.Validate(cg.ScrapeOptions.GlobalConfig())
 }

--- a/component/prometheus/operator/configgen/config_gen_probe.go
+++ b/component/prometheus/operator/configgen/config_gen_probe.go
@@ -230,5 +230,5 @@ func (cg *ConfigGenerator) GenerateProbeConfig(m *promopv1.Probe) (cfg *config.S
 	}
 	cfg.MetricRelabelConfigs = metricRelabels.configs
 
-	return cfg, nil
+	return cfg, cfg.Validate(cg.ScrapeOptions.GlobalConfig())
 }

--- a/component/prometheus/operator/configgen/config_gen_servicemonitor.go
+++ b/component/prometheus/operator/configgen/config_gen_servicemonitor.go
@@ -301,5 +301,5 @@ func (cg *ConfigGenerator) GenerateServiceMonitorConfig(m *promopv1.ServiceMonit
 	cfg.LabelNameLengthLimit = uint(m.Spec.LabelNameLengthLimit)
 	cfg.LabelValueLengthLimit = uint(m.Spec.LabelValueLengthLimit)
 
-	return cfg, nil
+	return cfg, cfg.Validate(cg.ScrapeOptions.GlobalConfig())
 }

--- a/component/prometheus/operator/configgen/config_gen_servicemonitor_test.go
+++ b/component/prometheus/operator/configgen/config_gen_servicemonitor_test.go
@@ -283,8 +283,8 @@ func TestGenerateServiceMonitorConfig(t *testing.T) {
 				FollowRedirects: &falseVal,
 				ProxyURL:        &proxyURL,
 				Scheme:          "https",
-				ScrapeTimeout:   "17m",
-				Interval:        "1s",
+				ScrapeTimeout:   "17s",
+				Interval:        "12m",
 				HonorLabels:     true,
 				HonorTimestamps: &falseVal,
 				FilterRunning:   &falseVal,
@@ -377,8 +377,8 @@ func TestGenerateServiceMonitorConfig(t *testing.T) {
 				Params: url.Values{
 					"a": []string{"b"},
 				},
-				ScrapeInterval: model.Duration(time.Second),
-				ScrapeTimeout:  model.Duration(17 * time.Minute),
+				ScrapeInterval: model.Duration(12 * time.Minute),
+				ScrapeTimeout:  model.Duration(17 * time.Second),
 				MetricsPath:    "/foo",
 				Scheme:         "https",
 				HTTPClientConfig: commonConfig.HTTPClientConfig{

--- a/component/prometheus/operator/types.go
+++ b/component/prometheus/operator/types.go
@@ -7,6 +7,8 @@ import (
 	"github.com/grafana/agent/component/common/kubernetes"
 	flow_relabel "github.com/grafana/agent/component/common/relabel"
 	"github.com/grafana/agent/component/prometheus/scrape"
+	"github.com/prometheus/common/model"
+	promconfig "github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/storage"
 	apiv1 "k8s.io/api/core/v1"
 )
@@ -44,6 +46,13 @@ type ScrapeOptions struct {
 
 	// DefaultScrapeTimeout is the default timeout to scrape targets.
 	DefaultScrapeTimeout time.Duration `river:"default_scrape_timeout,attr,optional"`
+}
+
+func (s *ScrapeOptions) GlobalConfig() promconfig.GlobalConfig {
+	cfg := promconfig.DefaultGlobalConfig
+	cfg.ScrapeInterval = model.Duration(s.DefaultScrapeInterval)
+	cfg.ScrapeTimeout = model.Duration(s.DefaultScrapeTimeout)
+	return cfg
 }
 
 var DefaultArguments = Arguments{


### PR DESCRIPTION
Fixes #5324 

Calls the `Validate` function on the generated scrape config after generating, to make sure the Scrape Manager will be happy with it before we try.

timeout > interval is just one of the things it catches.