### PR TITLE
pkg/metrics/wal: drop out-of-order exemplars

### DIFF
--- a/pkg/metrics/wal/wal.go
+++ b/pkg/metrics/wal/wal.go
@@ -760,7 +760,7 @@ func (a *appender) AppendExemplar(ref storage.SeriesRef, _ labels.Labels, e exem
 	// Otherwise, record the current exemplar as the latest.
 	// Prometheus' TSDB returns 0 when encountering duplicates, so we do the same here.
 	prevExemplar := a.w.series.GetLatestExemplar(s.ref)
-	if prevExemplar != nil && prevExemplar.Equals(e) {
+	if prevExemplar != nil && (prevExemplar.Equals(e) || prevExemplar.Ts > e.Ts) {
 		// Duplicate, don't return an error but don't accept the exemplar.
 		return 0, nil
 	}

--- a/pkg/metrics/wal/wal.go
+++ b/pkg/metrics/wal/wal.go
@@ -759,6 +759,10 @@ func (a *appender) AppendExemplar(ref storage.SeriesRef, _ labels.Labels, e exem
 	// Check for duplicate vs last stored exemplar for this series, and discard those.
 	// Otherwise, record the current exemplar as the latest.
 	// Prometheus' TSDB returns 0 when encountering duplicates, so we do the same here.
+	// TODO(@tpaschalis) The case of OOO exemplars is currently unique to
+	// Native Histograms. Prometheus is tracking a (possibly different) fix to
+	// this, we should revisit once they've settled on a solution.
+	// https://github.com/prometheus/prometheus/issues/12971
 	prevExemplar := a.w.series.GetLatestExemplar(s.ref)
 	if prevExemplar != nil && (prevExemplar.Equals(e) || prevExemplar.Ts > e.Ts) {
 		// Duplicate, don't return an error but don't accept the exemplar.

--- a/pkg/metrics/wal/wal_test.go
+++ b/pkg/metrics/wal/wal_test.go
@@ -163,6 +163,10 @@ func TestStorage_DuplicateExemplarsIgnored(t *testing.T) {
 	_, _ = app.AppendExemplar(sRef, nil, e)
 	_, _ = app.AppendExemplar(sRef, nil, e)
 
+	e.Ts = 24
+	_, _ = app.AppendExemplar(sRef, nil, e)
+	_, _ = app.AppendExemplar(sRef, nil, e)
+
 	require.NoError(t, app.Commit())
 	collector := walDataCollector{}
 	replayer := walReplayer{w: &collector}


### PR DESCRIPTION
#### PR Description

During my second or third week at Grafana, I wrote #1316 to avoid sending duplicate exemplars and putting extra load on remote write systems Now, almost two years after, it's fun having to revisit this code and reminiscing all the steps we've made to be here today. :) Just wanted to say thanks to everyone who helped on this journey. <3

Anyway, Native Histogram can have more than one exemplar on the same datapoint; if they don't have an explicit timestamp they inherit the scrape's timestamp, and this triggers the out-of-order warning on the remote write side.

Since OOO exemplars are not in the 'normal' code path, having remote writes reject them with a 4xx code makes the agent think that _all_ datapoints in that request were discarded (as there's no way for the protocol to relay partial success) leading to metrics such as `prometheus_remote_storage_samples_failed_total` report a false positive with a steady rate of failed samples and potentially masking _other_ issues with remote write connections.

Until there's consensus on how to handle this from the Prometheus side, we can put this workaround in place; instead of dropping only duplicate exemplars, we can also filter out the OOO ones.

#### Which issue(s) this PR fixes
Relates to: https://github.com/prometheus/prometheus/issues/12971

#### Notes to the Reviewer
Not adding a CHANGELOG entry as this shouldn't be a user-facing change.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated (N/A)
- [ ] Documentation added (N/A)
- [X] Tests updated