### PR TITLE
Implement WAL replay and markers for `loki.write`

### DIFF
--- a/component/common/loki/client/batch.go
+++ b/component/common/loki/client/batch.go
@@ -19,6 +19,12 @@ const (
 	errMaxStreamsLimitExceeded = "streams limit exceeded, streams: %d exceeds limit: %d, stream: '%s'"
 )
 
+// SentDataMarkerHandler is a slice of the MarkerHandler interface, that the batch interacts with to report the event that
+// all data in the batch has been delivered or a client failed to do so.
+type SentDataMarkerHandler interface {
+	UpdateSentData(segmentId, dataCount int)
+}
+
 // batch holds pending log streams waiting to be sent to Loki, and it's used
 // to reduce the number of push requests to Loki aggregating multiple log streams
 // and entries in a single batch request. In case of multi-tenant Promtail, log
@@ -53,16 +59,6 @@ func newBatch(maxStreams int, entries ...loki.Entry) *batch {
 	return b
 }
 
-type SendDataMarkerHandler interface {
-	UpdateSentData(segmentId, dataCount int)
-}
-
-func (b *batch) reportAsSentData(h SendDataMarkerHandler) {
-	for seg, data := range b.segmentCounter {
-		h.UpdateSentData(seg, data)
-	}
-}
-
 // add an entry to the batch
 func (b *batch) add(entry loki.Entry) error {
 	b.totalBytes += len(entry.Line)
@@ -86,7 +82,8 @@ func (b *batch) add(entry loki.Entry) error {
 	return nil
 }
 
-// add an entry to the batch
+// addFromWAL adds an entry to the batch, tracking that the data being added comes from segment segmentNum read from the
+// WAL.
 func (b *batch) addFromWAL(lbs model.LabelSet, entry logproto.Entry, segmentNum int) error {
 	b.totalBytes += len(entry.Line)
 
@@ -188,10 +185,19 @@ func (b *batch) createPushRequest() (*logproto.PushRequest, int) {
 	return &req, entriesCount
 }
 
-func (b *batch) countForSegment(segment int) {
-	if curr, ok := b.segmentCounter[segment]; ok {
-		b.segmentCounter[segment] = curr + 1
+// countForSegment tracks that one data item has been read from a certain WAL segment.
+func (b *batch) countForSegment(segmentNum int) {
+	if curr, ok := b.segmentCounter[segmentNum]; ok {
+		b.segmentCounter[segmentNum] = curr + 1
 		return
 	}
-	b.segmentCounter[segment] = 1
+	b.segmentCounter[segmentNum] = 1
+}
+
+// reportAsSentData will report for all segments whose data is part of this batch, the amount of that data as sent to
+// the provided SentDataMarkerHandler
+func (b *batch) reportAsSentData(h SentDataMarkerHandler) {
+	for seg, data := range b.segmentCounter {
+		h.UpdateSentData(seg, data)
+	}
 }

--- a/component/common/loki/client/batch.go
+++ b/component/common/loki/client/batch.go
@@ -37,10 +37,11 @@ type batch struct {
 
 func newBatch(maxStreams int, entries ...loki.Entry) *batch {
 	b := &batch{
-		streams:    map[string]*logproto.Stream{},
-		totalBytes: 0,
-		createdAt:  time.Now(),
-		maxStreams: maxStreams,
+		streams:        map[string]*logproto.Stream{},
+		totalBytes:     0,
+		createdAt:      time.Now(),
+		maxStreams:     maxStreams,
+		segmentCounter: map[int]int{},
 	}
 
 	// Add entries to the batch

--- a/component/common/loki/client/batch.go
+++ b/component/common/loki/client/batch.go
@@ -53,6 +53,16 @@ func newBatch(maxStreams int, entries ...loki.Entry) *batch {
 	return b
 }
 
+type SendDataMarkerHandler interface {
+	UpdateSentData(segmentId, dataCount int)
+}
+
+func (b *batch) reportAsSentData(h SendDataMarkerHandler) {
+	for seg, data := range b.segmentCounter {
+		h.UpdateSentData(seg, data)
+	}
+}
+
 // add an entry to the batch
 func (b *batch) add(entry loki.Entry) error {
 	b.totalBytes += len(entry.Line)

--- a/component/common/loki/client/internal/marker_encoding.go
+++ b/component/common/loki/client/internal/marker_encoding.go
@@ -30,7 +30,7 @@ func EncodeMarkerV1(segment uint64) ([]byte, error) {
 	return bs, nil
 }
 
-// DecodeMarkerV1
+// DecodeMarkerV1 decodes the segment number from a segment marker, encoded with EncodeMarkerV1.
 func DecodeMarkerV1(bs []byte) (uint64, error) {
 	// first check that read byte stream has expected length
 	if len(bs) != 14 {

--- a/component/common/loki/client/internal/marker_encoding.go
+++ b/component/common/loki/client/internal/marker_encoding.go
@@ -1,0 +1,55 @@
+package internal
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+)
+
+var (
+	markerHeaderV1 = []byte{'0', '1'}
+)
+
+// EncodeMarkerV1 encodes the segment number, from whom we need to create a marker, in the marker file format,
+// which in v1 includes the segment number and a trailing CRC code of the first 10 bytes.
+func EncodeMarkerV1(segment uint64) ([]byte, error) {
+	// marker format v1
+	// marker [ 0 , 1 ] - HEADER, which is used to track version
+	// marker [ 2 , 9 ] - encoded unit 64 which is the content of the marker, the last "consumed" segment
+	// marker [ 10, 13 ] - CRC32 of the first 10 bytes of the marker, using IEEE polynomial
+	bs := make([]byte, 14)
+	// write header with marker format version
+	bs[0] = markerHeaderV1[0]
+	bs[1] = markerHeaderV1[1]
+	// write actual marked segment number
+	binary.BigEndian.PutUint64(bs[2:10], segment)
+	// checksum is the IEEE CRC32 checksum of the first 10 bytes of the marker record
+	checksum := crc32.ChecksumIEEE(bs[0:10])
+	binary.BigEndian.PutUint32(bs[10:], checksum)
+
+	return bs, nil
+}
+
+// DecodeMarkerV1
+func DecodeMarkerV1(bs []byte) (uint64, error) {
+	// first check that read byte stream has expected length
+	if len(bs) != 14 {
+		return 0, fmt.Errorf("bad length %d", len(bs))
+	}
+
+	// check CRC first
+	expectedCrc := crc32.ChecksumIEEE(bs[0:10])
+	gotCrc := binary.BigEndian.Uint32(bs[len(bs)-4:])
+	if expectedCrc != gotCrc {
+		return 0, fmt.Errorf("corrupted WAL marker")
+	}
+
+	// check expected version header
+	header := bs[:2]
+	if !(header[0] == markerHeaderV1[0] && header[1] == markerHeaderV1[1]) {
+		return 0, fmt.Errorf("wrong WAL marker header")
+	}
+
+	// lastly, decode marked segment number
+	return binary.BigEndian.Uint64(bs[2:10]), nil
+}

--- a/component/common/loki/client/internal/marker_encoding_test.go
+++ b/component/common/loki/client/internal/marker_encoding_test.go
@@ -1,0 +1,49 @@
+package internal
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestMarkerEncodingV1(t *testing.T) {
+	t.Run("encode and decode", func(t *testing.T) {
+		segment := uint64(123)
+		bs, err := EncodeMarkerV1(segment)
+		require.NoError(t, err)
+
+		gotSegment, err := DecodeMarkerV1(bs)
+		require.NoError(t, err)
+		require.Equal(t, segment, gotSegment)
+	})
+
+	t.Run("decoding errors", func(t *testing.T) {
+		t.Run("bad checksum", func(t *testing.T) {
+			segment := uint64(123)
+			bs, err := EncodeMarkerV1(segment)
+			require.NoError(t, err)
+
+			// change last byte
+			bs[13] = '5'
+
+			_, err = DecodeMarkerV1(bs)
+			require.Error(t, err)
+		})
+
+		t.Run("bad length", func(t *testing.T) {
+			_, err := DecodeMarkerV1(make([]byte, 15))
+			require.Error(t, err)
+		})
+
+		t.Run("bad header", func(t *testing.T) {
+			segment := uint64(123)
+			bs, err := EncodeMarkerV1(segment)
+			require.NoError(t, err)
+
+			// change first header byte
+			bs[0] = '5'
+
+			_, err = DecodeMarkerV1(bs)
+			require.Error(t, err)
+		})
+	})
+}

--- a/component/common/loki/client/internal/marker_encoding_test.go
+++ b/component/common/loki/client/internal/marker_encoding_test.go
@@ -1,8 +1,9 @@
 package internal
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestMarkerEncodingV1(t *testing.T) {

--- a/component/common/loki/client/internal/marker_file_handler.go
+++ b/component/common/loki/client/internal/marker_file_handler.go
@@ -46,12 +46,6 @@ func NewMarkerFileHandler(logger log.Logger, walDir string) (MarkerFileHandler, 
 	if err := os.MkdirAll(markerDir, MarkerFolderMode); err != nil {
 		return nil, fmt.Errorf("error creating segment marker folder %q: %w", markerDir, err)
 	}
-	// If marker folder exists, and has other perms, change them
-	if stat, err := os.Stat(markerDir); err == nil && stat.Mode().Perm() != MarkerFolderMode {
-		if err := os.Chmod(markerDir, MarkerFolderMode); err != nil {
-			return nil, err
-		}
-	}
 
 	mfh := &markerFileHandler{
 		logger:                    logger,

--- a/component/common/loki/client/internal/marker_file_handler.go
+++ b/component/common/loki/client/internal/marker_file_handler.go
@@ -1,0 +1,88 @@
+package internal
+
+import (
+	"fmt"
+	"github.com/grafana/agent/component/common/loki/wal"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/prometheus/tsdb/fileutil"
+)
+
+type MarkerFileHandler interface {
+	wal.Marker
+	MarkSegment(segment int)
+}
+
+type markerFileHandler struct {
+	logger log.Logger
+
+	lastMarkedSegmentFilePath string
+}
+
+var (
+	_ MarkerFileHandler = (*markerFileHandler)(nil)
+)
+
+func NewMarkerFileHandler(logger log.Logger, walDir, markerId string) (MarkerFileHandler, error) {
+	markerDir := filepath.Join(walDir, "remote", markerId)
+
+	dir := filepath.Join(walDir, "remote", markerId)
+	if err := os.MkdirAll(dir, 0o777); err != nil {
+		return nil, fmt.Errorf("error creating segment marker folder %q: %w", dir, err)
+	}
+
+	mfh := &markerFileHandler{
+		logger:                    logger,
+		lastMarkedSegmentFilePath: filepath.Join(markerDir, "segment"),
+	}
+
+	return mfh, nil
+}
+
+// LastMarkedSegment implements wlog.Marker.
+func (mfh *markerFileHandler) LastMarkedSegment() int {
+	bb, err := os.ReadFile(mfh.lastMarkedSegmentFilePath)
+	if os.IsNotExist(err) {
+		level.Warn(mfh.logger).Log("msg", "marker segment file does not exist", "file", mfh.lastMarkedSegmentFilePath)
+		return -1
+	} else if err != nil {
+		level.Error(mfh.logger).Log("msg", "could not access segment marker file", "file", mfh.lastMarkedSegmentFilePath, "err", err)
+		return -1
+	}
+
+	savedSegment, err := strconv.Atoi(string(bb))
+	if err != nil {
+		level.Error(mfh.logger).Log("msg", "could not read segment marker file", "file", mfh.lastMarkedSegmentFilePath, "err", err)
+		return -1
+	}
+
+	if savedSegment < 0 {
+		level.Error(mfh.logger).Log("msg", "invalid segment number inside marker file", "file", mfh.lastMarkedSegmentFilePath, "segment number", savedSegment)
+		return -1
+	}
+
+	return savedSegment
+}
+
+// MarkSegment implements MarkerHandler.
+func (mfh *markerFileHandler) MarkSegment(segment int) {
+	var (
+		segmentText = strconv.Itoa(segment)
+		tmp         = mfh.lastMarkedSegmentFilePath + ".tmp"
+	)
+
+	if err := os.WriteFile(tmp, []byte(segmentText), 0o666); err != nil {
+		level.Error(mfh.logger).Log("msg", "could not create segment marker file", "file", tmp, "err", err)
+		return
+	}
+	if err := fileutil.Replace(tmp, mfh.lastMarkedSegmentFilePath); err != nil {
+		level.Error(mfh.logger).Log("msg", "could not replace segment marker file", "file", mfh.lastMarkedSegmentFilePath, "err", err)
+		return
+	}
+
+	level.Debug(mfh.logger).Log("msg", "updated segment marker file", "file", mfh.lastMarkedSegmentFilePath, "segment", segment)
+}

--- a/component/common/loki/client/internal/marker_file_handler.go
+++ b/component/common/loki/client/internal/marker_file_handler.go
@@ -13,7 +13,9 @@ import (
 
 const (
 	MarkerFolderName = "remote"
-	MarkerFileName   = "segment"
+	MarkerFileName   = "segment_marker"
+
+	MarkerFileMode os.FileMode = 0o600
 )
 
 // MarkerFileHandler is a file-backed wal.Marker, that also allows one to write to the backing store as particular
@@ -39,7 +41,7 @@ var (
 func NewMarkerFileHandler(logger log.Logger, walDir string) (MarkerFileHandler, error) {
 	markerDir := filepath.Join(walDir, MarkerFolderName)
 	// attempt to create dir if doesn't exist
-	if err := os.MkdirAll(markerDir, 0o777); err != nil {
+	if err := os.MkdirAll(markerDir, MarkerFileMode); err != nil {
 		return nil, fmt.Errorf("error creating segment marker folder %q: %w", markerDir, err)
 	}
 

--- a/component/common/loki/client/internal/marker_file_handler.go
+++ b/component/common/loki/client/internal/marker_file_handler.go
@@ -17,14 +17,17 @@ const (
 	MarkerFileName   = "segment"
 )
 
+// MarkerFileHandler is a file-backed wal.Marker, that also allows one to write to the backing store as particular
+// segment number as the last one marked.
 type MarkerFileHandler interface {
 	wal.Marker
+
+	// MarkSegment writes in the backing file-store that a particular segment is the last one marked.
 	MarkSegment(segment int)
 }
 
 type markerFileHandler struct {
-	logger log.Logger
-
+	logger                    log.Logger
 	lastMarkedSegmentFilePath string
 }
 
@@ -32,6 +35,7 @@ var (
 	_ MarkerFileHandler = (*markerFileHandler)(nil)
 )
 
+// NewMarkerFileHandler creates a new markerFileHandler.
 func NewMarkerFileHandler(logger log.Logger, walDir string) (MarkerFileHandler, error) {
 	markerDir := filepath.Join(walDir, MarkerFolderName)
 	// attempt to create dir if doesn't exist

--- a/component/common/loki/client/internal/marker_file_handler.go
+++ b/component/common/loki/client/internal/marker_file_handler.go
@@ -12,6 +12,11 @@ import (
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 )
 
+const (
+	MarkerFolderName = "remote"
+	MarkerFileName   = "segment"
+)
+
 type MarkerFileHandler interface {
 	wal.Marker
 	MarkSegment(segment int)
@@ -28,7 +33,7 @@ var (
 )
 
 func NewMarkerFileHandler(logger log.Logger, walDir string) (MarkerFileHandler, error) {
-	markerDir := filepath.Join(walDir, "remote")
+	markerDir := filepath.Join(walDir, MarkerFolderName)
 	// attempt to create dir if doesn't exist
 	if err := os.MkdirAll(markerDir, 0o777); err != nil {
 		return nil, fmt.Errorf("error creating segment marker folder %q: %w", markerDir, err)
@@ -36,7 +41,7 @@ func NewMarkerFileHandler(logger log.Logger, walDir string) (MarkerFileHandler, 
 
 	mfh := &markerFileHandler{
 		logger:                    logger,
-		lastMarkedSegmentFilePath: filepath.Join(markerDir, "segment"),
+		lastMarkedSegmentFilePath: filepath.Join(markerDir, MarkerFileName),
 	}
 
 	return mfh, nil

--- a/component/common/loki/client/internal/marker_file_handler.go
+++ b/component/common/loki/client/internal/marker_file_handler.go
@@ -46,12 +46,12 @@ func NewMarkerFileHandler(logger log.Logger, walDir string) (MarkerFileHandler, 
 	if err := os.MkdirAll(markerDir, MarkerFolderMode); err != nil {
 		return nil, fmt.Errorf("error creating segment marker folder %q: %w", markerDir, err)
 	}
-	// do we need this bit below?
-	//if stat, err := os.Stat(markerDir); err == nil && stat.Mode().Perm() != MarkerFileMode {
-	//	if err := os.Chmod(markerDir, MarkerFileMode); err != nil {
-	//		return nil, err
-	//	}
-	//}
+	// If marker folder exists, and has other perms, change them
+	if stat, err := os.Stat(markerDir); err == nil && stat.Mode().Perm() != MarkerFolderMode {
+		if err := os.Chmod(markerDir, MarkerFolderMode); err != nil {
+			return nil, err
+		}
+	}
 
 	mfh := &markerFileHandler{
 		logger:                    logger,

--- a/component/common/loki/client/internal/marker_file_handler.go
+++ b/component/common/loki/client/internal/marker_file_handler.go
@@ -27,12 +27,11 @@ var (
 	_ MarkerFileHandler = (*markerFileHandler)(nil)
 )
 
-func NewMarkerFileHandler(logger log.Logger, walDir, markerId string) (MarkerFileHandler, error) {
-	markerDir := filepath.Join(walDir, "remote", markerId)
-
-	dir := filepath.Join(walDir, "remote", markerId)
-	if err := os.MkdirAll(dir, 0o777); err != nil {
-		return nil, fmt.Errorf("error creating segment marker folder %q: %w", dir, err)
+func NewMarkerFileHandler(logger log.Logger, walDir string) (MarkerFileHandler, error) {
+	markerDir := filepath.Join(walDir, "remote")
+	// attempt to create dir if doesn't exist
+	if err := os.MkdirAll(markerDir, 0o777); err != nil {
+		return nil, fmt.Errorf("error creating segment marker folder %q: %w", markerDir, err)
 	}
 
 	mfh := &markerFileHandler{

--- a/component/common/loki/client/internal/marker_file_handler.go
+++ b/component/common/loki/client/internal/marker_file_handler.go
@@ -3,12 +3,13 @@ package internal
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/agent/component/common/loki/wal"
 	"github.com/natefinch/atomic"
-	"os"
-	"path/filepath"
 )
 
 const (

--- a/component/common/loki/client/internal/marker_file_handler.go
+++ b/component/common/loki/client/internal/marker_file_handler.go
@@ -15,7 +15,8 @@ const (
 	MarkerFolderName = "remote"
 	MarkerFileName   = "segment_marker"
 
-	MarkerFileMode os.FileMode = 0o600
+	MarkerFolderMode os.FileMode = 0o700
+	MarkerFileMode   os.FileMode = 0o600
 )
 
 // MarkerFileHandler is a file-backed wal.Marker, that also allows one to write to the backing store as particular
@@ -41,9 +42,15 @@ var (
 func NewMarkerFileHandler(logger log.Logger, walDir string) (MarkerFileHandler, error) {
 	markerDir := filepath.Join(walDir, MarkerFolderName)
 	// attempt to create dir if doesn't exist
-	if err := os.MkdirAll(markerDir, MarkerFileMode); err != nil {
+	if err := os.MkdirAll(markerDir, MarkerFolderMode); err != nil {
 		return nil, fmt.Errorf("error creating segment marker folder %q: %w", markerDir, err)
 	}
+	// do we need this bit below?
+	//if stat, err := os.Stat(markerDir); err == nil && stat.Mode().Perm() != MarkerFileMode {
+	//	if err := os.Chmod(markerDir, MarkerFileMode); err != nil {
+	//		return nil, err
+	//	}
+	//}
 
 	mfh := &markerFileHandler{
 		logger:                    logger,

--- a/component/common/loki/client/internal/marker_file_handler_test.go
+++ b/component/common/loki/client/internal/marker_file_handler_test.go
@@ -15,7 +15,7 @@ func TestMarkerFileHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	// write first something to marker
-	markerFile := path.Join(dir, "remote", "segment")
+	markerFile := path.Join(dir, MarkerFolderName, MarkerFileName)
 	err = os.WriteFile(markerFile, []byte("10"), 0o666)
 	require.NoError(t, err)
 

--- a/component/common/loki/client/internal/marker_file_handler_test.go
+++ b/component/common/loki/client/internal/marker_file_handler_test.go
@@ -2,7 +2,7 @@ package internal
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -15,7 +15,7 @@ func TestMarkerFileHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	// write first something to marker
-	markerFile := path.Join(dir, MarkerFolderName, MarkerFileName)
+	markerFile := filepath.Join(dir, MarkerFolderName, MarkerFileName)
 	err = os.WriteFile(markerFile, []byte("10"), 0o666)
 	require.NoError(t, err)
 

--- a/component/common/loki/client/internal/marker_file_handler_test.go
+++ b/component/common/loki/client/internal/marker_file_handler_test.go
@@ -63,19 +63,4 @@ func TestMarkerFileHandler(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, MarkerFileMode, stats.Mode().Perm())
 	})
-
-	t.Run("marker folder perms are fixed when existing and different", func(t *testing.T) {
-		dir := getTempDir(t)
-		markerFolder := filepath.Join(dir, MarkerFolderName)
-
-		// most permisive
-		require.NoError(t, os.MkdirAll(markerFolder, os.FileMode(0777)))
-
-		_, err := NewMarkerFileHandler(logger, dir)
-		require.NoError(t, err)
-
-		stats, err := os.Stat(filepath.Join(dir, MarkerFolderName))
-		require.NoError(t, err)
-		require.Equal(t, MarkerFolderMode, stats.Mode().Perm(), "marker folder perms should have been changed")
-	})
 }

--- a/component/common/loki/client/internal/marker_file_handler_test.go
+++ b/component/common/loki/client/internal/marker_file_handler_test.go
@@ -63,4 +63,19 @@ func TestMarkerFileHandler(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, MarkerFileMode, stats.Mode().Perm())
 	})
+
+	t.Run("marker folder perms are fixed when existing and different", func(t *testing.T) {
+		dir := getTempDir(t)
+		markerFolder := filepath.Join(dir, MarkerFolderName)
+
+		// most permisive
+		require.NoError(t, os.MkdirAll(markerFolder, os.FileMode(0777)))
+
+		_, err := NewMarkerFileHandler(logger, dir)
+		require.NoError(t, err)
+
+		stats, err := os.Stat(filepath.Join(dir, MarkerFolderName))
+		require.NoError(t, err)
+		require.Equal(t, MarkerFolderMode, stats.Mode().Perm(), "marker folder perms should have been changed")
+	})
 }

--- a/component/common/loki/client/internal/marker_file_handler_test.go
+++ b/component/common/loki/client/internal/marker_file_handler_test.go
@@ -1,0 +1,30 @@
+package internal
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarkerFileHandler(t *testing.T) {
+	dir := t.TempDir()
+	fh, err := NewMarkerFileHandler(log.NewNopLogger(), dir)
+	require.NoError(t, err)
+
+	// write first something to marker
+	markerFile := path.Join(dir, "remote", "segment")
+	err = os.WriteFile(markerFile, []byte("10"), 0o666)
+	require.NoError(t, err)
+
+	require.Equal(t, 10, fh.LastMarkedSegment())
+
+	// mark segment and re-check
+	fh.MarkSegment(12)
+	require.Equal(t, 12, fh.LastMarkedSegment())
+	bs, err := os.ReadFile(markerFile)
+	require.NoError(t, err)
+	require.Equal(t, "12", string(bs))
+}

--- a/component/common/loki/client/internal/marker_handler.go
+++ b/component/common/loki/client/internal/marker_handler.go
@@ -2,12 +2,13 @@ package internal
 
 import (
 	"fmt"
-	"github.com/go-kit/log"
-	"github.com/grafana/agent/component/common/loki/wal"
-	"github.com/grafana/agent/pkg/flow/logging/level"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/agent/component/common/loki/wal"
+	"github.com/grafana/agent/pkg/flow/logging/level"
 )
 
 type MarkerHandler interface {

--- a/component/common/loki/client/internal/marker_handler.go
+++ b/component/common/loki/client/internal/marker_handler.go
@@ -1,0 +1,112 @@
+package internal
+
+import (
+	"github.com/grafana/agent/component/common/loki/wal"
+)
+
+type MarkerHandler interface {
+	wal.Marker
+
+	UpdateReceivedData(segmentId, dataCount int) // Data queued for sending
+	UpdateSentData(segmentId, dataCount int)     // Data which was sent or given up on sending
+
+	Stop()
+}
+
+type markerHandler struct {
+	markerFileHandler MarkerFileHandler
+	lastMarkedSegment int
+	dataIOUpdate      chan data
+	quit              chan struct{}
+}
+
+// TODO: Rename this struct
+type data struct {
+	segmentId int
+	dataCount int
+}
+
+var (
+	_ MarkerHandler = (*markerHandler)(nil)
+)
+
+func NewMarkerHandler(mfh MarkerFileHandler) MarkerHandler {
+	mh := &markerHandler{
+		lastMarkedSegment: -1, // Segment ID last marked on disk.
+		markerFileHandler: mfh,
+		//TODO: What is a good size for the channel?
+		dataIOUpdate: make(chan data, 100),
+		quit:         make(chan struct{}),
+	}
+
+	// Load the last marked segment from disk (if it exists).
+	if lastSegment := mh.markerFileHandler.LastMarkedSegment(); lastSegment >= 0 {
+		mh.lastMarkedSegment = lastSegment
+	}
+
+	//TODO: Should this be in a separate Start() function?
+	go mh.updatePendingData()
+
+	return mh
+}
+
+func (mh *markerHandler) LastMarkedSegment() int {
+	return mh.markerFileHandler.LastMarkedSegment()
+}
+
+func (mh *markerHandler) UpdateReceivedData(segmentId, dataCount int) {
+	mh.dataIOUpdate <- data{
+		segmentId: segmentId,
+		dataCount: dataCount,
+	}
+}
+
+func (mh *markerHandler) UpdateSentData(segmentId, dataCount int) {
+	mh.dataIOUpdate <- data{
+		segmentId: segmentId,
+		dataCount: -1 * dataCount,
+	}
+}
+
+func (mh *markerHandler) Stop() {
+	// Firstly stop the Marker Handler, because it might want to use the Marker File Handler.
+	mh.quit <- struct{}{}
+}
+
+// updatePendingData updates a counter for how much data is yet to be sent from each segment.
+// "dataCount" will be added to the segment with ID "dataSegment".
+func (mh *markerHandler) updatePendingData() {
+	batchSegmentCount := make(map[int]int)
+
+	for {
+		select {
+		case <-mh.quit:
+			return
+		case dataUpdate := <-mh.dataIOUpdate:
+			batchSegmentCount[dataUpdate.segmentId] += dataUpdate.dataCount
+		}
+
+		markableSegment := -1
+		for segment, count := range batchSegmentCount {
+			//TODO: If count is less than 0, then log an error and remove the entry from the map?
+			if count != 0 {
+				continue
+			}
+
+			//TODO: Is it save to assume that just because a segment is 0 inside the map,
+			//      all samples from it have been processed?
+			if segment > markableSegment {
+				markableSegment = segment
+			}
+
+			// Clean up the pending map: the current segment has been completely
+			// consumed and doesn't need to be considered for marking again.
+			delete(batchSegmentCount, segment)
+		}
+
+		if markableSegment > mh.lastMarkedSegment {
+			mh.markerFileHandler.MarkSegment(markableSegment)
+			mh.lastMarkedSegment = markableSegment
+		}
+	}
+}

--- a/component/common/loki/client/internal/marker_handler_test.go
+++ b/component/common/loki/client/internal/marker_handler_test.go
@@ -43,3 +43,95 @@ func TestMarkerHandler(t *testing.T) {
 		require.Equal(t, 11, mockMFH.LastMarkedSegment())
 	})
 }
+
+func TestFindLastMarkableSegment(t *testing.T) {
+	t.Run("all segments with count zero, highest numbered should be marked", func(t *testing.T) {
+		now := time.Now()
+		data := map[int]countDataItem{
+			1: {
+				count:      0,
+				lastUpdate: now,
+			},
+			2: {
+				count:      0,
+				lastUpdate: now,
+			},
+			3: {
+				count:      0,
+				lastUpdate: now,
+			},
+			4: {
+				count:      0,
+				lastUpdate: now,
+			},
+		}
+		require.Equal(t, 4, FindMarkableSegment(data, time.Minute))
+	})
+
+	t.Run("all segments with count zero, and one too old, highest numbered should be marked", func(t *testing.T) {
+		now := time.Now()
+		data := map[int]countDataItem{
+			1: {
+				count:      0,
+				lastUpdate: now,
+			},
+			2: {
+				count:      0,
+				lastUpdate: now,
+			},
+			3: {
+				count:      10,
+				lastUpdate: now.Add(-2 * time.Minute),
+			},
+			4: {
+				count:      0,
+				lastUpdate: now,
+			},
+		}
+		require.Equal(t, 4, FindMarkableSegment(data, time.Minute))
+	})
+	t.Run("should find the zeroed segment before the last non-zero", func(t *testing.T) {
+		now := time.Now()
+		data := map[int]countDataItem{
+			1: {
+				count:      0,
+				lastUpdate: now,
+			},
+			2: {
+				count:      0,
+				lastUpdate: now,
+			},
+			3: {
+				count:      10,
+				lastUpdate: now,
+			},
+			4: {
+				count:      0,
+				lastUpdate: now,
+			},
+		}
+		require.Equal(t, 2, FindMarkableSegment(data, time.Minute))
+	})
+	t.Run("should return -1 when no segment is markable", func(t *testing.T) {
+		now := time.Now()
+		data := map[int]countDataItem{
+			1: {
+				count:      11,
+				lastUpdate: now,
+			},
+			2: {
+				count:      5,
+				lastUpdate: now,
+			},
+			3: {
+				count:      10,
+				lastUpdate: now,
+			},
+			4: {
+				count:      2,
+				lastUpdate: now,
+			},
+		}
+		require.Equal(t, -1, FindMarkableSegment(data, time.Minute))
+	})
+}

--- a/component/common/loki/client/internal/marker_handler_test.go
+++ b/component/common/loki/client/internal/marker_handler_test.go
@@ -1,11 +1,11 @@
 package internal
 
 import (
-	"github.com/go-kit/log"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 )
 

--- a/component/common/loki/client/internal/marker_handler_test.go
+++ b/component/common/loki/client/internal/marker_handler_test.go
@@ -1,0 +1,45 @@
+package internal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mockMarkerFileHandler struct {
+	lastMarkedSegment int
+}
+
+func (m *mockMarkerFileHandler) LastMarkedSegment() int {
+	return m.lastMarkedSegment
+}
+
+func (m *mockMarkerFileHandler) MarkSegment(segment int) {
+	m.lastMarkedSegment = segment
+}
+
+func TestMarkerHandler(t *testing.T) {
+	t.Run("returns last marked segment from file handler on start", func(t *testing.T) {
+		mockMFH := &mockMarkerFileHandler{lastMarkedSegment: 10}
+		mh := NewMarkerHandler(mockMFH)
+		defer mh.Stop()
+
+		require.Equal(t, 10, mh.LastMarkedSegment())
+	})
+
+	t.Run("last marked segment is updated when sends complete", func(t *testing.T) {
+		mockMFH := &mockMarkerFileHandler{lastMarkedSegment: 10}
+		mh := NewMarkerHandler(mockMFH)
+		defer mh.Stop()
+
+		mh.UpdateReceivedData(11, 10)
+		mh.UpdateSentData(11, 5)
+		mh.UpdateSentData(11, 5)
+
+		require.Eventually(t, func() bool {
+			return mh.LastMarkedSegment() == 11
+		}, time.Second, time.Millisecond*100, "expected last marked segment to catch up")
+		require.Equal(t, 11, mockMFH.LastMarkedSegment())
+	})
+}

--- a/component/common/loki/client/internal/metrics.go
+++ b/component/common/loki/client/internal/metrics.go
@@ -1,0 +1,35 @@
+package internal
+
+import "github.com/prometheus/client_golang/prometheus"
+
+type MarkerMetrics struct {
+	lastMarkedSegment *prometheus.GaugeVec
+}
+
+func NewMarkerMetrics(reg prometheus.Registerer) *MarkerMetrics {
+	m := &MarkerMetrics{
+		lastMarkedSegment: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "loki_write",
+				Subsystem: "wal_marker",
+				Name:      "last_marked_segment",
+				Help:      "Last marked WAL segment.",
+			},
+			[]string{"id"},
+		),
+	}
+	if reg != nil {
+		reg.MustRegister(m.lastMarkedSegment)
+	}
+	return m
+}
+
+// WithCurriedId returns a curried version of MarkerMetrics, with the id label pre-filled. This is a helper that avoids
+// having to move the id around where it's unnecessary, and won't change inside the consumer of the metrics.
+func (m *MarkerMetrics) WithCurriedId(id string) *MarkerMetrics {
+	return &MarkerMetrics{
+		lastMarkedSegment: m.lastMarkedSegment.MustCurryWith(map[string]string{
+			"id": id,
+		}),
+	}
+}

--- a/component/common/loki/client/manager.go
+++ b/component/common/loki/client/manager.go
@@ -91,7 +91,7 @@ func NewManager(metrics *Metrics, logger log.Logger, limits limit.Config, reg pr
 			// add some context information for the logger the watcher uses
 			wlog := log.With(logger, "client", clientName)
 
-			markerFileHandler, err := internal.NewMarkerFileHandler(logger, walCfg.Dir, "")
+			markerFileHandler, err := internal.NewMarkerFileHandler(logger, walCfg.Dir)
 			if err != nil {
 				return nil, err
 			}

--- a/component/common/loki/client/manager.go
+++ b/component/common/loki/client/manager.go
@@ -95,7 +95,7 @@ func NewManager(metrics *Metrics, logger log.Logger, limits limit.Config, reg pr
 			if err != nil {
 				return nil, err
 			}
-			markerHandler := internal.NewMarkerHandler(markerFileHandler)
+			markerHandler := internal.NewMarkerHandler(markerFileHandler, walCfg.MaxSegmentAge, logger)
 
 			queue, err := NewQueue(metrics, cfg, limits.MaxStreams, limits.MaxLineSize.Val(), limits.MaxLineSizeTruncate, logger, markerHandler)
 			if err != nil {

--- a/component/common/loki/client/manager.go
+++ b/component/common/loki/client/manager.go
@@ -3,11 +3,11 @@ package client
 import (
 	"crypto/sha256"
 	"fmt"
-	"github.com/grafana/agent/component/common/loki/client/internal"
 	"strings"
 	"sync"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/agent/component/common/loki/client/internal"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/prometheus/client_golang/prometheus"
 

--- a/component/common/loki/client/queue_client.go
+++ b/component/common/loki/client/queue_client.go
@@ -36,6 +36,7 @@ type StoppableWriteTo interface {
 type MarkerHandler interface {
 	UpdateReceivedData(segmentId, dataCount int) // Data queued for sending
 	UpdateSentData(segmentId, dataCount int)     // Data which was sent or given up on sending
+	Stoppable
 }
 
 // queuedBatch is a batch specific to a tenant, that is considered ready to be sent.
@@ -568,6 +569,8 @@ func (c *queueClient) Stop() {
 
 	// stop request after drain times out or exits
 	c.cancel()
+
+	c.markerHandler.Stop()
 }
 
 // StopNow stops the client without retries or draining the send queue
@@ -577,6 +580,7 @@ func (c *queueClient) StopNow() {
 	close(c.quit)
 	c.sendQueue.closeNow()
 	c.wg.Wait()
+	c.markerHandler.Stop()
 }
 
 func (c *queueClient) processLabels(lbs model.LabelSet) (model.LabelSet, string) {

--- a/component/common/loki/client/queue_client.go
+++ b/component/common/loki/client/queue_client.go
@@ -33,6 +33,8 @@ type StoppableWriteTo interface {
 	StopNow()
 }
 
+// MarkerHandler re-defines the interface of internal.MarkerHandler that the queue client interacts with, to contribute
+// to the feedback loop of when data from a segment is read from the WAL, or delivered.
 type MarkerHandler interface {
 	UpdateReceivedData(segmentId, dataCount int) // Data queued for sending
 	UpdateSentData(segmentId, dataCount int)     // Data which was sent or given up on sending

--- a/component/common/loki/client/queue_client.go
+++ b/component/common/loki/client/queue_client.go
@@ -272,7 +272,7 @@ func (c *queueClient) StoreSeries(series []record.RefSeries, segment int) {
 	}
 }
 
-func (c *queueClient) AppendEntries(entries wal.RefEntries, _ int) error {
+func (c *queueClient) AppendEntries(entries wal.RefEntries, segment int) error {
 	c.seriesLock.RLock()
 	l, ok := c.series[entries.Ref]
 	c.seriesLock.RUnlock()

--- a/component/common/loki/client/queue_client.go
+++ b/component/common/loki/client/queue_client.go
@@ -95,6 +95,8 @@ func (q *queue) run() {
 			// Since inside the actual send operation a context with time out is used, we should exceed that timeout
 			// instead of cancelling this send operations, since that batch has been taken out of the queue.
 			q.client.sendBatch(context.Background(), qb.TenantID, qb.Batch)
+			// mark segment data for that batch as sent, even if the send operation failed
+			qb.Batch.reportAsSentData(q.client.markerHandler)
 		}
 	}
 }
@@ -117,6 +119,8 @@ func (q *queue) closeAndDrain(ctx context.Context) {
 			// drain uses the same timeout, so if a timeout was applied to the parent context, it can cancel the underlying
 			// send operation preemptively.
 			q.client.sendBatch(ctx, qb.TenantID, qb.Batch)
+			// mark segment data for that batch as sent, even if the send operation failed
+			qb.Batch.reportAsSentData(q.client.markerHandler)
 		case <-ctx.Done():
 			level.Warn(q.logger).Log("msg", "timeout exceeded while draining send queue")
 			return

--- a/component/common/loki/client/queue_client_test.go
+++ b/component/common/loki/client/queue_client_test.go
@@ -135,7 +135,7 @@ func TestQueueClient(t *testing.T) {
 			logger := log.NewLogfmtLogger(os.Stdout)
 
 			m := NewMetrics(reg)
-			qc, err := NewQueue(m, cfg, 0, 0, false, logger)
+			qc, err := NewQueue(m, cfg, 0, 0, false, logger, nilMarkerHandler{})
 			require.NoError(t, err)
 
 			//labels := model.LabelSet{"app": "test"}
@@ -265,7 +265,7 @@ func runQueueClientBenchCase(b *testing.B, bc testCase) {
 	logger := log.NewLogfmtLogger(os.Stdout)
 
 	m := NewMetrics(reg)
-	qc, err := NewQueue(m, cfg, 0, 0, false, logger)
+	qc, err := NewQueue(m, cfg, 0, 0, false, logger, nilMarkerHandler{})
 	require.NoError(b, err)
 
 	//labels := model.LabelSet{"app": "test"}

--- a/component/common/loki/client/queue_client_test.go
+++ b/component/common/loki/client/queue_client_test.go
@@ -220,7 +220,7 @@ func BenchmarkClientImplementations(b *testing.B) {
 					markerFileHandler, err := internal.NewMarkerFileHandler(nopLogger, dir)
 					require.NoError(b, err)
 
-					markerHandler := internal.NewMarkerHandler(markerFileHandler, time.Minute, nopLogger)
+					markerHandler := internal.NewMarkerHandler(markerFileHandler, time.Minute, nopLogger, internal.NewMarkerMetrics(nil).WithCurriedId("test"))
 
 					return markerHandler
 				})

--- a/component/common/loki/client/queue_client_test.go
+++ b/component/common/loki/client/queue_client_test.go
@@ -43,6 +43,17 @@ type testCase struct {
 	expectedRWReqsCount int64
 }
 
+type nilMarkerHandler struct{}
+
+func (n nilMarkerHandler) UpdateReceivedData(segmentId, dataCount int) {
+}
+
+func (n nilMarkerHandler) UpdateSentData(segmentId, dataCount int) {
+}
+
+func (n nilMarkerHandler) Stop() {
+}
+
 func TestQueueClient(t *testing.T) {
 	for name, tc := range map[string]testCase{
 		"small test": {

--- a/component/common/loki/wal/watcher.go
+++ b/component/common/loki/wal/watcher.go
@@ -25,6 +25,10 @@ const (
 	debug = false
 )
 
+var (
+	ErrIgnorable = fmt.Errorf("ignore me") // ignorable error used when Watcher is replaying WAL segments
+)
+
 // Based in the implementation of prometheus WAL watcher
 // https://github.com/prometheus/prometheus/blob/main/tsdb/wlog/watcher.go. Includes some changes to make it suitable
 // for log WAL entries, but also, the writeTo surface has been implemented according to the actions necessary for
@@ -61,6 +65,17 @@ type WriteTo interface {
 	AppendEntries(entries wal.RefEntries, segmentNum int) error
 }
 
+// Marker allows the Watcher to start from a specific segment in the WAL.
+// Implementers can use this interface to save and restore save points.
+type Marker interface {
+	// LastMarkedSegment should return the last segment stored in the marker.
+	// Must return nil if there is no mark.
+	//
+	// The Watcher will start reading the first segment whose value is greater
+	// than the return value.
+	LastMarkedSegment() int
+}
+
 type Watcher struct {
 	// id identifies the Watcher. Used when one Watcher is instantiated per remote write client, to be able to track to whom
 	// the metric/log line corresponds.
@@ -74,25 +89,29 @@ type Watcher struct {
 	logger     log.Logger
 	MaxSegment int
 
-	metrics     *WatcherMetrics
-	minReadFreq time.Duration
-	maxReadFreq time.Duration
+	metrics      *WatcherMetrics
+	minReadFreq  time.Duration
+	maxReadFreq  time.Duration
+	marker       Marker
+	savedSegment int
 }
 
 // NewWatcher creates a new Watcher.
-func NewWatcher(walDir, id string, metrics *WatcherMetrics, writeTo WriteTo, logger log.Logger, config WatchConfig) *Watcher {
+func NewWatcher(walDir, id string, metrics *WatcherMetrics, writeTo WriteTo, logger log.Logger, config WatchConfig, marker Marker) *Watcher {
 	return &Watcher{
-		walDir:      walDir,
-		id:          id,
-		actions:     writeTo,
-		readNotify:  make(chan struct{}),
-		quit:        make(chan struct{}),
-		done:        make(chan struct{}),
-		MaxSegment:  -1,
-		logger:      logger,
-		metrics:     metrics,
-		minReadFreq: config.MinReadFrequency,
-		maxReadFreq: config.MaxReadFrequency,
+		walDir:       walDir,
+		id:           id,
+		actions:      writeTo,
+		readNotify:   make(chan struct{}),
+		quit:         make(chan struct{}),
+		done:         make(chan struct{}),
+		MaxSegment:   -1,
+		marker:       marker,
+		savedSegment: -1,
+		logger:       logger,
+		metrics:      metrics,
+		minReadFreq:  config.MinReadFrequency,
+		maxReadFreq:  config.MaxReadFrequency,
 	}
 }
 
@@ -107,6 +126,11 @@ func (w *Watcher) Start() {
 func (w *Watcher) mainLoop() {
 	defer close(w.done)
 	for !isClosed(w.quit) {
+		if w.marker != nil {
+			w.savedSegment = w.marker.LastMarkedSegment()
+			level.Debug(w.logger).Log("msg", "last saved segment", "segment", w.savedSegment)
+		}
+
 		if err := w.run(); err != nil {
 			level.Error(w.logger).Log("msg", "error tailing WAL", "err", err)
 		}
@@ -128,6 +152,16 @@ func (w *Watcher) run() error {
 	}
 
 	currentSegment := lastSegment
+
+	// TODO(thepalbi): taking as convention that the segment number stored in the marker is the last read completely
+	if nextToSavedSegment, err := w.findSegmentForIndex(w.savedSegment); w.savedSegment != -1 && err == nil {
+		// if the marker contains a valid segment number stored, and we correctly find the segment that follows that one,
+		// start tailing from there.
+		currentSegment = nextToSavedSegment
+	} else {
+		level.Debug(w.logger).Log("msg", fmt.Sprintf("failed to find segment for saved index %d", w.savedSegment), "err", err)
+	}
+
 	level.Debug(w.logger).Log("msg", "Tailing WAL", "currentSegment", currentSegment, "lastSegment", lastSegment)
 	for !isClosed(w.quit) {
 		w.metrics.currentSegment.WithLabelValues(w.id).Set(float64(currentSegment))
@@ -135,7 +169,7 @@ func (w *Watcher) run() error {
 
 		// On start, we have a pointer to what is the latest segment. On subsequent calls to this function,
 		// currentSegment will have been incremented, and we should open that segment.
-		if err := w.watch(currentSegment); err != nil {
+		if err := w.watch(currentSegment, currentSegment >= lastSegment); err != nil && !errors.Is(err, ErrIgnorable) {
 			return err
 		}
 
@@ -150,10 +184,27 @@ func (w *Watcher) run() error {
 	return nil
 }
 
+// findSegmentForIndex finds the first segment greater than or equal to index.
+func (w *Watcher) findSegmentForIndex(index int) (int, error) {
+	// TODO(thepalbi): is segs in order?
+	segs, err := readSegmentNumbers(w.walDir)
+	if err != nil {
+		return -1, err
+	}
+
+	for _, r := range segs {
+		if r > index {
+			return r, nil
+		}
+	}
+
+	return -1, errors.New("failed to find segment for index")
+}
+
 // watch will start reading from the segment identified by segmentNum. If an EOF is reached, it will keep
 // reading for more WAL records with a wlog.LiveReader. Periodically, it will check if there's a new segment, and if positive
 // read the remaining from the current one and return.
-func (w *Watcher) watch(segmentNum int) error {
+func (w *Watcher) watch(segmentNum int, tail bool) error {
 	segment, err := wlog.OpenReadSegment(wlog.SegmentName(w.walDir, segmentNum))
 	if err != nil {
 		return err
@@ -166,6 +217,18 @@ func (w *Watcher) watch(segmentNum int) error {
 
 	segmentTicker := time.NewTicker(segmentCheckPeriod)
 	defer segmentTicker.Stop()
+
+	// If we're replaying the segment we need to know the size of the file to know
+	// when to return from watch and move on to the next segment.
+	size := int64(math.MaxInt64)
+	if !tail {
+		segmentTicker.Stop()
+		var err error
+		size, err = getSegmentSize(w.walDir, segmentNum)
+		if err != nil {
+			return fmt.Errorf("error getting segment size: %w", err)
+		}
+	}
 
 	for {
 		select {
@@ -212,7 +275,18 @@ func (w *Watcher) watch(segmentNum int) error {
 		// read from open segment routine
 		ok, err := w.readSegment(reader, segmentNum)
 		if debug {
-			level.Warn(w.logger).Log("msg", "Error reading segment inside readTicker", "segment", segmentNum, "read", reader.Offset(), "err", err)
+			level.Warn(w.logger).Log("msg", "Error reading segment inside read ticker or notification", "segment", segmentNum, "read", reader.Offset(), "err", err)
+		}
+
+		// Ignore all errors reading to end of segment whilst replaying the WAL. If error, log a warning accordingly. If not,
+		// return with an ignorable error.
+		if !tail {
+			if err != nil && errors.Unwrap(err) != io.EOF {
+				level.Warn(w.logger).Log("msg", "Ignoring error reading to end of segment, may have dropped data", "segment", segmentNum, "err", err)
+			} else if reader.Offset() != size {
+				level.Warn(w.logger).Log("msg", "Expected to have read whole segment, may have dropped data", "segment", segmentNum, "read", reader.Offset(), "size", size)
+			}
+			return ErrIgnorable
 		}
 
 		// io.EOF error are non-fatal since we are tailing the wal
@@ -348,4 +422,14 @@ func readSegmentNumbers(dir string) ([]int, error) {
 		refs = append(refs, k)
 	}
 	return refs, nil
+}
+
+// Get size of segment.
+func getSegmentSize(dir string, index int) (int64, error) {
+	i := int64(-1)
+	fi, err := os.Stat(wlog.SegmentName(dir, index))
+	if err == nil {
+		i = fi.Size()
+	}
+	return i, err
 }

--- a/component/common/loki/wal/watcher_metrics.go
+++ b/component/common/loki/wal/watcher_metrics.go
@@ -8,6 +8,7 @@ type WatcherMetrics struct {
 	droppedWriteNotifications *prometheus.CounterVec
 	segmentRead               *prometheus.CounterVec
 	currentSegment            *prometheus.GaugeVec
+	replaySegment             *prometheus.GaugeVec
 	watchersRunning           *prometheus.GaugeVec
 }
 
@@ -55,6 +56,15 @@ func NewWatcherMetrics(reg prometheus.Registerer) *WatcherMetrics {
 				Subsystem: "wal_watcher",
 				Name:      "current_segment",
 				Help:      "Current segment the WAL watcher is reading records from.",
+			},
+			[]string{"id"},
+		),
+		replaySegment: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "loki_write",
+				Subsystem: "wal_watcher",
+				Name:      "replay_segment",
+				Help:      "Segment the WAL watcher will start replaying the WAL from on startup.",
 			},
 			[]string{"id"},
 		),

--- a/component/common/loki/wal/watcher_test.go
+++ b/component/common/loki/wal/watcher_test.go
@@ -52,6 +52,26 @@ func (t *testWriteTo) AppendEntries(entries wal.RefEntries, _ int) error {
 	return nil
 }
 
+func (t *testWriteTo) AssertContainsLines(tst *testing.T, lines ...string) {
+	seen := map[string]bool{}
+	for _, l := range lines {
+		seen[l] = false
+	}
+	for _, e := range t.ReadEntries.StartIterate() {
+		if _, ok := seen[e.Line]; ok {
+			seen[e.Line] = true
+		}
+	}
+	t.ReadEntries.DoneIterate()
+
+	allSeen := true
+	for _, wasSeen := range seen {
+		allSeen = allSeen && wasSeen
+	}
+
+	require.True(tst, allSeen, "expected all entries to have been received")
+}
+
 // watcherTestResources contains all resources necessary to test an individual Watcher functionality
 type watcherTestResources struct {
 	writeEntry             func(entry loki.Entry)
@@ -301,6 +321,12 @@ var cases = map[string]watcherTest{
 	},
 }
 
+type noMarker struct{}
+
+func (n noMarker) LastMarkedSegment() int {
+	return -1
+}
+
 // TestWatcher is the main test function, that works as framework to test different scenarios of the Watcher. It bootstraps
 // necessary test components.
 func TestWatcher(t *testing.T) {
@@ -317,7 +343,7 @@ func TestWatcher(t *testing.T) {
 				ReadEntries: utils.NewSyncSlice[loki.Entry](),
 			}
 			// create new watcher, and defer stop
-			watcher := NewWatcher(dir, "test", metrics, writeTo, logger, DefaultWatchConfig)
+			watcher := NewWatcher(dir, "test", metrics, writeTo, logger, DefaultWatchConfig, noMarker{})
 			defer watcher.Stop()
 			wl, err := New(Config{
 				Enabled: true,
@@ -354,4 +380,112 @@ func TestWatcher(t *testing.T) {
 			)
 		})
 	}
+}
+
+type mockMarker struct {
+	LastMarkedSegmentFunc func() int
+}
+
+func (m mockMarker) LastMarkedSegment() int {
+	return m.LastMarkedSegmentFunc()
+}
+
+func TestWatcher_Replay(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	logger := level.NewFilter(log.NewLogfmtLogger(os.Stdout), level.AllowDebug())
+	dir := t.TempDir()
+	metrics := NewWatcherMetrics(reg)
+	writeTo := &testWriteTo{
+		series:      map[uint64]model.LabelSet{},
+		logger:      logger,
+		ReadEntries: utils.NewSyncSlice[loki.Entry](),
+	}
+	// create new watcher, and defer stop
+	watcher := NewWatcher(dir, "test", metrics, writeTo, logger, DefaultWatchConfig, mockMarker{
+		LastMarkedSegmentFunc: func() int {
+			// when starting watcher, read from segment 0
+			return 0
+		},
+	})
+	defer watcher.Stop()
+	wl, err := New(Config{
+		Enabled: true,
+		Dir:     dir,
+	}, logger, reg)
+	require.NoError(t, err)
+	defer wl.Close()
+
+	ew := newEntryWriter()
+
+	labels := model.LabelSet{
+		"app": "test",
+	}
+
+	// First, write to segment 0. This will be the last "marked" segment
+	err = ew.WriteEntry(loki.Entry{
+		Labels: labels,
+		Entry: logproto.Entry{
+			Timestamp: time.Now(),
+			Line:      "this line should appear in received entries",
+		},
+	}, wl, logger)
+	require.NoError(t, err)
+
+	// cut segment and sync
+	_, err = wl.NextSegment()
+	require.NoError(t, err)
+
+	// Now, write to segment 1, this will be a segment not marked, hence replayed
+
+	segment1Lines := []string{
+		"before 1",
+		"before 2",
+		"before 3",
+	}
+
+	for _, line := range segment1Lines {
+		err = ew.WriteEntry(loki.Entry{
+			Labels: labels,
+			Entry: logproto.Entry{
+				Timestamp: time.Now(),
+				Line:      line,
+			},
+		}, wl, logger)
+		require.NoError(t, err)
+	}
+
+	// cut segment and sync
+	_, err = wl.NextSegment()
+	require.NoError(t, err)
+
+	// Finally, write some data to the last segment, this will be the write head
+
+	segment2Lines := []string{
+		"after 1",
+		"after 2",
+		"after 3",
+	}
+
+	for _, line := range segment2Lines {
+		err = ew.WriteEntry(loki.Entry{
+			Labels: labels,
+			Entry: logproto.Entry{
+				Timestamp: time.Now(),
+				Line:      line,
+			},
+		}, wl, logger)
+		require.NoError(t, err)
+	}
+
+	// sync wal, and start watcher
+	require.NoError(t, wl.Sync())
+
+	// start watcher
+	watcher.Start()
+
+	require.Eventually(t, func() bool {
+		return writeTo.ReadEntries.Length() == 6 // wait for watcher to catch up with both segments
+	}, time.Second*10, time.Second, "timed out waiting for watcher to catch up")
+	writeTo.AssertContainsLines(t, segment1Lines...)
+	writeTo.AssertContainsLines(t, segment2Lines...)
 }

--- a/component/common/loki/wal/watcher_test.go
+++ b/component/common/loki/wal/watcher_test.go
@@ -3,6 +3,7 @@ package wal
 import (
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -488,4 +489,23 @@ func TestWatcher_Replay(t *testing.T) {
 	}, time.Second*10, time.Second, "timed out waiting for watcher to catch up")
 	writeTo.AssertContainsLines(t, segment1Lines...)
 	writeTo.AssertContainsLines(t, segment2Lines...)
+}
+
+func Test(t *testing.T) {
+	ch := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		ch <- struct{}{}
+	}()
+	go func() {
+		defer wg.Done()
+		ch <- struct{}{}
+	}()
+
+	<-ch
+	close(ch)
+	wg.Wait()
 }

--- a/component/common/loki/wal/watcher_test.go
+++ b/component/common/loki/wal/watcher_test.go
@@ -3,7 +3,6 @@ package wal
 import (
 	"fmt"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -489,23 +488,4 @@ func TestWatcher_Replay(t *testing.T) {
 	}, time.Second*10, time.Second, "timed out waiting for watcher to catch up")
 	writeTo.AssertContainsLines(t, segment1Lines...)
 	writeTo.AssertContainsLines(t, segment2Lines...)
-}
-
-func Test(t *testing.T) {
-	ch := make(chan struct{})
-	var wg sync.WaitGroup
-
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		ch <- struct{}{}
-	}()
-	go func() {
-		defer wg.Done()
-		ch <- struct{}{}
-	}()
-
-	<-ch
-	close(ch)
-	wg.Wait()
 }

--- a/go.mod
+++ b/go.mod
@@ -635,6 +635,7 @@ require (
 	github.com/leoluk/perflib_exporter v0.2.0 // indirect
 	github.com/lightstep/go-expohisto v1.0.0 // indirect
 	github.com/metalmatze/signal v0.0.0-20210307161603-1c9aa721a97a // indirect
+	github.com/natefinch/atomic v1.0.1 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.87.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka v0.87.0 // indirect
 	github.com/openshift/api v3.9.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -1672,6 +1672,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
+github.com/natefinch/atomic v1.0.1 h1:ZPYKxkqQOx3KZ+RsbnP/YsgvxWQPGxjC0oBt2AhwV0A=
+github.com/natefinch/atomic v1.0.1/go.mod h1:N/D/ELrljoqDyT3rZrsUmtsuzvHkeB/wWjHV22AZRbM=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=
 github.com/nats-io/jwt v1.2.2/go.mod h1:/xX356yQA6LuXI9xWW7mZNpxgF2mBmGecH+Fj34sP5Q=


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR branches of https://github.com/grafana/agent/pull/5434, and applies the work done in https://github.com/ptodev/prometheus/pull/1 to improve two things:
1. WAL replay is implemented for `loki.write`, so upon an agent restart, it will replay "not sent" data saved in the WAL segments that are alive
2. Implement a "markers" mechanism that keeps track of which was the last consumed segment, consumed being read and delivered to the RW destination. This mechanisms works by creating a feedback loop between the side that reads from the WAL, and the side that sends batches.

#### TODOs
- [ ] Add tests for corrupted marker files https://github.com/grafana/agent/pull/5590#discussion_r1372979663

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated