### PR TITLE
Add an "exclude_event_message" argument to loki.source.windowsevent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,9 @@ Main (unreleased)
 - Added an `add_metric_suffixes` option to `otelcol.exporter.prometheus` in flow mode, 
   which configures whether to add type and unit suffixes to metrics names. (@mar4uk)
 
+- Added an `exclude_event_message` option to `loki.source.windowsevent` in flow mode,
+  which excludes the human-friendly event message from Windows event logs. (@ptodev)
+
 v0.37.3 (2023-10-26)
 -----------------
 

--- a/component/loki/source/windowsevent/arguments.go
+++ b/component/loki/source/windowsevent/arguments.go
@@ -16,6 +16,7 @@ type Arguments struct {
 	PollInterval         time.Duration       `river:"poll_interval,attr,optional"`
 	ExcludeEventData     bool                `river:"exclude_event_data,attr,optional"`
 	ExcludeUserdata      bool                `river:"exclude_user_data,attr,optional"`
+	ExcludeEventMessage  bool                `river:"exclude_event_message,attr,optional"`
 	UseIncomingTimestamp bool                `river:"use_incoming_timestamp,attr,optional"`
 	ForwardTo            []loki.LogsReceiver `river:"forward_to,attr"`
 	Labels               map[string]string   `river:"labels,attr,optional"`
@@ -30,6 +31,7 @@ func defaultArgs() Arguments {
 		PollInterval:         3 * time.Second,
 		ExcludeEventData:     false,
 		ExcludeUserdata:      false,
+		ExcludeEventMessage:  false,
 		UseIncomingTimestamp: false,
 	}
 }

--- a/component/loki/source/windowsevent/arguments.go
+++ b/component/loki/source/windowsevent/arguments.go
@@ -1,5 +1,9 @@
 package windowsevent
 
+// NOTE: The arguments here are based on commit bde6566
+// of Promtail's arguments in Loki's repository:
+// https://github.com/grafana/loki/blob/bde65667f7c88af17b7729e3621d7bd5d1d3b45f/clients/pkg/promtail/scrapeconfig/scrapeconfig.go#L211-L255
+
 import (
 	"time"
 

--- a/component/loki/source/windowsevent/component_test.go
+++ b/component/loki/source/windowsevent/component_test.go
@@ -42,6 +42,7 @@ func TestEventLogger(t *testing.T) {
 		PollInterval:         10 * time.Millisecond,
 		ExcludeEventData:     false,
 		ExcludeUserdata:      false,
+		ExcludeEventMessage:  false,
 		UseIncomingTimestamp: false,
 		ForwardTo:            []loki.LogsReceiver{rec},
 		Labels:               map[string]string{"job": "windows"},

--- a/component/loki/source/windowsevent/component_windows.go
+++ b/component/loki/source/windowsevent/component_windows.go
@@ -150,7 +150,7 @@ func convertConfig(arg Arguments) *scrapeconfig.WindowsEventsTargetConfig {
 		BookmarkPath:         arg.BookmarkPath,
 		PollInterval:         arg.PollInterval,
 		ExcludeEventData:     arg.ExcludeEventData,
-		ExcludeEventMessage:  false,
+		ExcludeEventMessage:  arg.ExcludeEventMessage,
 		ExcludeUserData:      arg.ExcludeUserdata,
 		Labels:               utils.ToLabelSet(arg.Labels),
 	}

--- a/converter/internal/promtailconvert/internal/build/windows_events.go
+++ b/converter/internal/promtailconvert/internal/build/windows_events.go
@@ -19,6 +19,7 @@ func (s *ScrapeConfigBuilder) AppendWindowsEventsConfig() {
 		PollInterval:         winCfg.PollInterval,
 		ExcludeEventData:     winCfg.ExcludeEventData,
 		ExcludeUserdata:      winCfg.ExcludeUserData,
+		ExcludeEventMessage:  winCfg.ExcludeEventMessage,
 		UseIncomingTimestamp: winCfg.UseIncomingTimestamp,
 		ForwardTo:            make([]loki.LogsReceiver, 0),
 		Labels:               convertPromLabels(winCfg.Labels),

--- a/converter/internal/promtailconvert/testdata/windowsevents.river
+++ b/converter/internal/promtailconvert/testdata/windowsevents.river
@@ -6,6 +6,7 @@ loki.source.windowsevent "fun" {
 	poll_interval          = "10s"
 	exclude_event_data     = true
 	exclude_user_data      = true
+	exclude_event_message  = true
 	use_incoming_timestamp = true
 	forward_to             = [loki.write.default.receiver]
 	labels                 = {

--- a/converter/internal/promtailconvert/testdata/windowsevents_relabel.river
+++ b/converter/internal/promtailconvert/testdata/windowsevents_relabel.river
@@ -16,6 +16,7 @@ loki.source.windowsevent "fun" {
 	poll_interval          = "10s"
 	exclude_event_data     = true
 	exclude_user_data      = true
+	exclude_event_message  = true
 	use_incoming_timestamp = true
 	forward_to             = [loki.relabel.fun.receiver]
 	labels                 = {}

--- a/docs/sources/flow/reference/components/loki.source.windowsevent.md
+++ b/docs/sources/flow/reference/components/loki.source.windowsevent.md
@@ -31,18 +31,19 @@ log entries to the list of receivers passed in `forward_to`.
 
 `loki.source.windowsevent` supports the following arguments:
 
-Name         | Type                 | Description                                                                    | Default                    | Required
------------- |----------------------|--------------------------------------------------------------------------------|----------------------------| --------
-`locale`    | `number`             | Locale ID for event rendering. 0 default is Windows Locale.                    | `0` | no
-`eventlog_name`    | `string`             | Event log to read from.                                                        |                            | See below.
-`xpath_query`    | `string`             | Event log to read from.                                                        | `"*"`                          | See below.
-`bookmark_path`    | `string`             | Keeps position in event log.                                            | `"DATA_PATH/bookmark.xml"`     | no
-`poll_interval`    | `duration`      | How often to poll the event log.                                               | `"3s"`                         | no
-`exclude_event_data`    | `bool`               | Exclude event data.                                                            | `false`                      | no
-`exclude_user_data`    | `bool`               | Exclude user data.                                                             | `false`                      | no
-`use_incoming_timestamp`    | `bool`               | When false, assigns the current timestamp to the log when it was processed. | `false`                      | no
-`forward_to` | `list(LogsReceiver)` | List of receivers to send log entries to.                                      |                            | yes
-`labels`     | `map(string)` | The labels to associate with incoming logs.                                           |                            | no 
+Name                     | Type                 | Description                                                                    | Default                    | Required
+------------------------ |----------------------|--------------------------------------------------------------------------------|----------------------------| --------
+`locale`                 | `number`             | Locale ID for event rendering. 0 default is Windows Locale.                    | `0`                        | no
+`eventlog_name`          | `string`             | Event log to read from.                                                        |                            | See below.
+`xpath_query`            | `string`             | Event log to read from.                                                        | `"*"`                      | See below.
+`bookmark_path`          | `string`             | Keeps position in event log.                                                   | `"DATA_PATH/bookmark.xml"` | no
+`poll_interval`          | `duration`           | How often to poll the event log.                                               | `"3s"`                     | no
+`exclude_event_data`     | `bool`               | Exclude event data.                                                            | `false`                    | no
+`exclude_user_data`      | `bool`               | Exclude user data.                                                             | `false`                    | no
+`exclude_event_message`  | `bool`               | Exclude the human-friendly event message.                                      | `false`                    | no
+`use_incoming_timestamp` | `bool`               | When false, assigns the current timestamp to the log when it was processed.    | `false`                    | no
+`forward_to`             | `list(LogsReceiver)` | List of receivers to send log entries to.                                      |                            | yes
+`labels`                 | `map(string)`        | The labels to associate with incoming logs.                                    |                            | no 
 
 
 > **NOTE**: `eventlog_name` is required if `xpath_query` does not specify the event log.


### PR DESCRIPTION
#### PR Description

Syncs the `loki.source.windowsevent` flow component with a [change](https://github.com/grafana/loki/pull/7462) done in promtail a few months ago. Interestingly, this config entry exists in the Agent codebase but was always set to false. I don't know why that is the case. Probably it was an oversight.

#### Which issue(s) this PR fixes

Fixes #4851

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated