### PR TITLE
docs(pyroscope): fixes wrong memory profiling path

### DIFF
--- a/docs/sources/flow/reference/components/pyroscope.scrape.md
+++ b/docs/sources/flow/reference/components/pyroscope.scrape.md
@@ -156,7 +156,7 @@ It accepts the following arguments:
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `enabled` | `boolean` | Enable this profile type to be scraped. | `true` | no
-`path` | `string` | The path to the profile type on the target. | `"/debug/pprof/memory"` | no
+`path` | `string` | The path to the profile type on the target. | `"/debug/pprof/allocs"` | no
 `delta` | `boolean` | Whether to scrape the profile as a delta. | `false` | no
 
 When the `delta` argument is `true`, a `seconds` query parameter is


### PR DESCRIPTION
See this conversation https://raintank-corp.slack.com/archives/C03NCLB4GG7/p1698431277146729 for more context

cc @korniltsev
