### PR TITLE
Remove integration-tests from windows unit tests in drone

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -181,7 +181,7 @@ platform:
   version: "1809"
 steps:
 - commands:
-  - go test -tags="nodocker,nonetwork" ./...
+  - go test -tags="nodocker,nonetwork" $(go list ./... | grep -v integration-tests)
   image: grafana/agent-build-image:0.30.3-windows
   name: Run Go tests
 trigger:


### PR DESCRIPTION
Looking at recent builds on main I noticed that the windows unit tests were trying to run the integration tests (https://drone.grafana.net/grafana/agent/14196/2/2).
Integration tests are not meant to run in drone for now but in github actions. This PR should fix the problem.