### PR TITLE
Fix integration test cache

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,5 +1,11 @@
 name: Integration Tests
 on:
+  # Run tests on main just so the module and build cache can be saved and used
+  # in PRs. This speeds up the time it takes to test PRs dramatically.
+  # (More information on https://docs.github.com/en/enterprise-server@3.6/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
+  push:
+    branches:
+      - main
   pull_request:
 jobs:
   run_tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test
 on:
   # Run tests on main just so the module and build cache can be saved and used
   # in PRs. This speeds up the time it takes to test PRs dramatically.
+  # (More information on https://docs.github.com/en/enterprise-server@3.6/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
   push:
     branches:
       - main


### PR DESCRIPTION
The cache was correctly created on every PRs but the PRs could not access it because of [access restrictions](https://docs.github.com/en/enterprise-server@3.6/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache).

By building the cache on every push to the main branch, the cache should be available to all PRs. This speeds up the time to run the integration tests by 200%.