### PR TITLE
faro: include measurement type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ Main (unreleased)
 - Fixed a bug in River where passing a non-string key to an object (such as
   `{}[true]`) would incorrectly report that a number type was expected instead. (@rfratto)
 
+- Include Faro Measurement `type` field in `faro.receiver` Flow component and legacy `app_agent_receiver` integration. (@rlankfo)
+
 ### Enhancements
 
 - The `loki.write` WAL now has snappy compression enabled by default. (@thepalbi)

--- a/component/faro/receiver/internal/payload/payload.go
+++ b/component/faro/receiver/internal/payload/payload.go
@@ -213,6 +213,7 @@ type MeasurementContext map[string]string
 
 // Measurement holds the data for user provided measurements
 type Measurement struct {
+	Type      string             `json:"type,omitempty"`
 	Values    map[string]float64 `json:"values,omitempty"`
 	Timestamp time.Time          `json:"timestamp,omitempty"`
 	Trace     TraceContext       `json:"trace,omitempty"`
@@ -225,6 +226,7 @@ func (m Measurement) KeyVal() *KeyVal {
 
 	KeyValAdd(kv, "timestamp", m.Timestamp.String())
 	KeyValAdd(kv, "kind", "measurement")
+	KeyValAdd(kv, "type", m.Type)
 
 	keys := make([]string, 0, len(m.Values))
 	for k := range m.Values {

--- a/component/faro/receiver/internal/payload/payload_test.go
+++ b/component/faro/receiver/internal/payload/payload_test.go
@@ -123,6 +123,7 @@ func TestUnmarshalPayloadJSON(t *testing.T) {
 
 	require.Equal(t, []Measurement{
 		{
+			Type: "foobar",
 			Values: map[string]float64{
 				"ttfp":  20.12,
 				"ttfcp": 22.12,

--- a/component/faro/receiver/testdata/payload.json
+++ b/component/faro/receiver/testdata/payload.json
@@ -214,12 +214,12 @@
   ],
   "measurements": [
     {
+      "type": "foobar",
       "values": {
         "ttfp": 20.12,
         "ttfcp": 22.12,
         "ttfb": 14
       },
-      "type": "page load",
       "timestamp": "2021-09-30T10:46:17.680Z",
       "trace": {
         "trace_id": "abcd",

--- a/pkg/integrations/v2/app_agent_receiver/payload.go
+++ b/pkg/integrations/v2/app_agent_receiver/payload.go
@@ -213,6 +213,7 @@ type MeasurementContext map[string]string
 
 // Measurement holds the data for user provided measurements
 type Measurement struct {
+	Type      string             `json:"type,omitempty"`
 	Values    map[string]float64 `json:"values,omitempty"`
 	Timestamp time.Time          `json:"timestamp,omitempty"`
 	Trace     TraceContext       `json:"trace,omitempty"`

--- a/pkg/integrations/v2/app_agent_receiver/payload_test.go
+++ b/pkg/integrations/v2/app_agent_receiver/payload_test.go
@@ -123,6 +123,7 @@ func TestUnmarshalPayloadJSON(t *testing.T) {
 
 	require.Equal(t, []Measurement{
 		{
+			Type: "foobar",
 			Values: map[string]float64{
 				"ttfp":  20.12,
 				"ttfcp": 22.12,

--- a/pkg/integrations/v2/app_agent_receiver/testdata/payload.json
+++ b/pkg/integrations/v2/app_agent_receiver/testdata/payload.json
@@ -214,12 +214,12 @@
   ],
   "measurements": [
     {
+      "type": "foobar",
       "values": {
         "ttfp": 20.12,
         "ttfcp": 22.12,
         "ttfb": 14
       },
-      "type": "page load",
       "timestamp": "2021-09-30T10:46:17.680Z",
       "trace": {
         "trace_id": "abcd",


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This includes the measurement `type` field for Faro payloads in the flow component or the legacy integration.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->
Fixes https://github.com/grafana/agent/issues/5667

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated