### PR TITLE
Logs WAL marker encoding and atomic swap

### DIFF
--- a/component/common/loki/client/internal/marker_encoding.go
+++ b/component/common/loki/client/internal/marker_encoding.go
@@ -1,0 +1,55 @@
+package internal
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+)
+
+var (
+	markerHeaderV1 = []byte{'0', '1'}
+)
+
+// EncodeMarkerV1 encodes the segment number, from whom we need to create a marker, in the marker file format,
+// which in v1 includes the segment number and a trailing CRC code of the first 10 bytes.
+func EncodeMarkerV1(segment uint64) ([]byte, error) {
+	// marker format v1
+	// marker [ 0 , 1 ] - HEADER, which is used to track version
+	// marker [ 2 , 9 ] - encoded unit 64 which is the content of the marker, the last "consumed" segment
+	// marker [ 10, 13 ] - CRC32 of the first 10 bytes of the marker, using IEEE polynomial
+	bs := make([]byte, 14)
+	// write header with marker format version
+	bs[0] = markerHeaderV1[0]
+	bs[1] = markerHeaderV1[1]
+	// write actual marked segment number
+	binary.BigEndian.PutUint64(bs[2:10], segment)
+	// checksum is the IEEE CRC32 checksum of the first 10 bytes of the marker record
+	checksum := crc32.ChecksumIEEE(bs[0:10])
+	binary.BigEndian.PutUint32(bs[10:], checksum)
+
+	return bs, nil
+}
+
+// DecodeMarkerV1
+func DecodeMarkerV1(bs []byte) (uint64, error) {
+	// first check that read byte stream has expected length
+	if len(bs) != 14 {
+		return 0, fmt.Errorf("bad length %d", len(bs))
+	}
+
+	// check CRC first
+	expectedCrc := crc32.ChecksumIEEE(bs[0:10])
+	gotCrc := binary.BigEndian.Uint32(bs[len(bs)-4:])
+	if expectedCrc != gotCrc {
+		return 0, fmt.Errorf("bad checksum")
+	}
+
+	// check expected version header
+	header := bs[:2]
+	if !(header[0] == markerHeaderV1[0] && header[1] == markerHeaderV1[1]) {
+		return 0, fmt.Errorf("wrong marker header")
+	}
+
+	// lastly, decode marked segment number
+	return binary.BigEndian.Uint64(bs[2:10]), nil
+}

--- a/component/common/loki/client/internal/marker_encoding.go
+++ b/component/common/loki/client/internal/marker_encoding.go
@@ -41,13 +41,13 @@ func DecodeMarkerV1(bs []byte) (uint64, error) {
 	expectedCrc := crc32.ChecksumIEEE(bs[0:10])
 	gotCrc := binary.BigEndian.Uint32(bs[len(bs)-4:])
 	if expectedCrc != gotCrc {
-		return 0, fmt.Errorf("bad checksum")
+		return 0, fmt.Errorf("corrupted WAL marker")
 	}
 
 	// check expected version header
 	header := bs[:2]
 	if !(header[0] == markerHeaderV1[0] && header[1] == markerHeaderV1[1]) {
-		return 0, fmt.Errorf("wrong marker header")
+		return 0, fmt.Errorf("wrong WAL marker header")
 	}
 
 	// lastly, decode marked segment number

--- a/component/common/loki/client/internal/marker_encoding_test.go
+++ b/component/common/loki/client/internal/marker_encoding_test.go
@@ -1,0 +1,49 @@
+package internal
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestMarkerEncodingV1(t *testing.T) {
+	t.Run("encode and decode", func(t *testing.T) {
+		segment := uint64(123)
+		bs, err := EncodeMarkerV1(segment)
+		require.NoError(t, err)
+
+		gotSegment, err := DecodeMarkerV1(bs)
+		require.NoError(t, err)
+		require.Equal(t, segment, gotSegment)
+	})
+
+	t.Run("decoding errors", func(t *testing.T) {
+		t.Run("bad checksum", func(t *testing.T) {
+			segment := uint64(123)
+			bs, err := EncodeMarkerV1(segment)
+			require.NoError(t, err)
+
+			// change last byte
+			bs[13] = '5'
+
+			_, err = DecodeMarkerV1(bs)
+			require.Error(t, err)
+		})
+
+		t.Run("bad length", func(t *testing.T) {
+			_, err := DecodeMarkerV1(make([]byte, 15))
+			require.Error(t, err)
+		})
+
+		t.Run("bad header", func(t *testing.T) {
+			segment := uint64(123)
+			bs, err := EncodeMarkerV1(segment)
+			require.NoError(t, err)
+
+			// change first header byte
+			bs[0] = '5'
+
+			_, err = DecodeMarkerV1(bs)
+			require.Error(t, err)
+		})
+	})
+}

--- a/component/common/loki/client/internal/marker_file_handler.go
+++ b/component/common/loki/client/internal/marker_file_handler.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/prometheus/prometheus/tsdb/fileutil"
 )
 
 const (
@@ -28,6 +27,7 @@ type MarkerFileHandler interface {
 
 type markerFileHandler struct {
 	logger                    log.Logger
+	lastMarkedSegmentDir      string
 	lastMarkedSegmentFilePath string
 }
 
@@ -45,6 +45,7 @@ func NewMarkerFileHandler(logger log.Logger, walDir string) (MarkerFileHandler, 
 
 	mfh := &markerFileHandler{
 		logger:                    logger,
+		lastMarkedSegmentDir:      filepath.Join(markerDir),
 		lastMarkedSegmentFilePath: filepath.Join(markerDir, MarkerFileName),
 	}
 
@@ -78,19 +79,48 @@ func (mfh *markerFileHandler) LastMarkedSegment() int {
 
 // MarkSegment implements MarkerHandler.
 func (mfh *markerFileHandler) MarkSegment(segment int) {
-	var (
-		segmentText = strconv.Itoa(segment)
-		tmp         = mfh.lastMarkedSegmentFilePath + ".tmp"
-	)
-
-	if err := os.WriteFile(tmp, []byte(segmentText), 0o666); err != nil {
-		level.Error(mfh.logger).Log("msg", "could not create segment marker file", "file", tmp, "err", err)
+	encodedMarker, err := EncodeMarkerV1(uint64(segment))
+	if err != nil {
+		level.Error(mfh.logger).Log("msg", "failed to encode marker when marking segment", "err", err)
 		return
 	}
-	if err := fileutil.Replace(tmp, mfh.lastMarkedSegmentFilePath); err != nil {
+
+	if err := mfh.swapMarkerFile(encodedMarker); err != nil {
 		level.Error(mfh.logger).Log("msg", "could not replace segment marker file", "file", mfh.lastMarkedSegmentFilePath, "err", err)
 		return
 	}
 
 	level.Debug(mfh.logger).Log("msg", "updated segment marker file", "file", mfh.lastMarkedSegmentFilePath, "segment", segment)
+}
+
+func (mfh *markerFileHandler) swapMarkerFile(bs []byte) error {
+	tempFile, err := os.CreateTemp(mfh.lastMarkedSegmentDir, "segment*")
+	if err != nil {
+		return err
+	}
+
+	// upon exit attempt to close the temporal file handler and remove the file
+	defer func() {
+		if err := tempFile.Close(); err != nil {
+			level.Warn(mfh.logger).Log("msg", "failed to close temporary marker file handler")
+			// TODO: should we try to remove the temporal file either way
+			return
+		}
+		if err := os.Remove(tempFile.Name()); err != nil {
+			level.Warn(mfh.logger).Log("msg", "failed to remove temporary marker file")
+		}
+	}()
+
+	written, err := tempFile.Write(bs)
+	if err != nil {
+		return fmt.Errorf("failed to write to temporal marker file: %w", err)
+	} else if written != len(bs) {
+		return fmt.Errorf("failed to write whole marker. written %d, expected %d", written, len(bs))
+	}
+
+	if err := os.Rename(tempFile.Name(), mfh.lastMarkedSegmentFilePath); err != nil {
+		return fmt.Errorf("failed to swap marker files: %w", err)
+	}
+
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -635,6 +635,7 @@ require (
 	github.com/leoluk/perflib_exporter v0.2.0 // indirect
 	github.com/lightstep/go-expohisto v1.0.0 // indirect
 	github.com/metalmatze/signal v0.0.0-20210307161603-1c9aa721a97a // indirect
+	github.com/natefinch/atomic v1.0.1 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.87.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka v0.87.0 // indirect
 	github.com/openshift/api v3.9.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -1672,6 +1672,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
+github.com/natefinch/atomic v1.0.1 h1:ZPYKxkqQOx3KZ+RsbnP/YsgvxWQPGxjC0oBt2AhwV0A=
+github.com/natefinch/atomic v1.0.1/go.mod h1:N/D/ELrljoqDyT3rZrsUmtsuzvHkeB/wWjHV22AZRbM=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=
 github.com/nats-io/jwt v1.2.2/go.mod h1:/xX356yQA6LuXI9xWW7mZNpxgF2mBmGecH+Fj34sP5Q=


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR into https://github.com/grafana/agent/pull/5590 proposes a marker file format for `loki.write`. Also, it introduces a lib that allows us to write marker's atomically both in UNIX and Windows OSes.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated