### PR TITLE
[Agent Management] Support External Labels from API

### DIFF
--- a/pkg/config/agent_management_remote_config_test.go
+++ b/pkg/config/agent_management_remote_config_test.go
@@ -181,6 +181,36 @@ integration_configs:
 		require.Equal(t, 5*time.Second, c.Integrations.ConfigV1.IntegrationRestartBackoff)
 	})
 
+	t.Run("no external labels provided", func(t *testing.T) {
+		rc := RemoteConfig{
+			BaseConfig: BaseConfigContent(baseConfig),
+			Snippets:   allSnippets,
+		}
+		c, err := rc.BuildAgentConfig()
+		require.NoError(t, err)
+		require.Equal(t, 1, len(c.Logs.Configs))
+		require.Empty(t, c.Metrics.Global.Prometheus.ExternalLabels)
+	})
+
+	t.Run("no external labels provided in remote config", func(t *testing.T) {
+		baseConfig := `
+server:
+    log_level: debug
+metrics:
+    global:
+        external_labels:
+            foo: bar`
+		rc := RemoteConfig{
+			BaseConfig: BaseConfigContent(baseConfig),
+			Snippets:   allSnippets,
+		}
+		c, err := rc.BuildAgentConfig()
+		require.NoError(t, err)
+		require.Equal(t, 1, len(c.Logs.Configs))
+		require.Equal(t, 1, len(c.Metrics.Global.Prometheus.ExternalLabels))
+		require.Contains(t, c.Metrics.Global.Prometheus.ExternalLabels, labels.Label{Name: "foo", Value: "bar"})
+	})
+
 	t.Run("external labels provided", func(t *testing.T) {
 		rc := RemoteConfig{
 			BaseConfig: BaseConfigContent(baseConfig),

--- a/pkg/config/agentmanagement_remote_config.go
+++ b/pkg/config/agentmanagement_remote_config.go
@@ -125,6 +125,10 @@ func appendSnippets(c *Config, snippets []Snippet) error {
 }
 
 func appendExternalLabels(c *Config, externalLabels map[string]string) {
+	// Avoid doing anything if there are no external labels
+	if len(externalLabels) == 0 {
+		return
+	}
 	// Start off with the existing external labels, which will only be added to (not replaced)
 	newExternalLabels := c.Metrics.Global.Prometheus.ExternalLabels.Map()
 	for k, v := range externalLabels {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Adds support for optional response from the API (`agent_metadata: {external_labels: {...}}`). External labels supplied by the API in this way will only add to (not override) any existing external labels.

- [X] Tests updated
