### PR TITLE
Added Kubernetes service resolver to loadbalancing exporters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,9 @@ v0.37.4 (2023-11-06)
 - Fix a bug where reloading the configuration of a `loki.write` component lead
   to a panic. (@tpaschalis)
 
+- Added Kubernetes service resolver to static node's loadbalancing exporter 
+  and to Flow's `otelcol.exporter.loadbalancing`. (@ptodev)
+
 v0.37.3 (2023-10-26)
 -----------------
 

--- a/component/otelcol/exporter/loadbalancing/loadbalancing.go
+++ b/component/otelcol/exporter/loadbalancing/loadbalancing.go
@@ -213,12 +213,12 @@ type KubernetesResolver struct {
 
 var _ river.Defaulter = &KubernetesResolver{}
 
-// DefaultDNSResolver holds default values for K8sSvcResolver.
-var DefaultK8sSvcResolver = KubernetesResolver{}
-
 // SetToDefault implements river.Defaulter.
 func (args *KubernetesResolver) SetToDefault() {
-	*args = DefaultK8sSvcResolver
+	if args == nil {
+		args = &KubernetesResolver{}
+	}
+	args.Ports = []int32{4317}
 }
 
 func (k8sSvcResolver *KubernetesResolver) Convert() loadbalancingexporter.K8sSvcResolver {

--- a/component/otelcol/exporter/loadbalancing/loadbalancing.go
+++ b/component/otelcol/exporter/loadbalancing/loadbalancing.go
@@ -224,7 +224,7 @@ func (args *KubernetesResolver) SetToDefault() {
 func (k8sSvcResolver *KubernetesResolver) Convert() loadbalancingexporter.K8sSvcResolver {
 	return loadbalancingexporter.K8sSvcResolver{
 		Service: k8sSvcResolver.Service,
-		Ports:   k8sSvcResolver.Ports,
+		Ports:   append([]int32{}, k8sSvcResolver.Ports...),
 	}
 }
 

--- a/component/otelcol/exporter/loadbalancing/loadbalancing.go
+++ b/component/otelcol/exporter/loadbalancing/loadbalancing.go
@@ -139,6 +139,7 @@ func (otlpConfig OtlpConfig) Convert() otlpexporter.Config {
 type ResolverSettings struct {
 	Static *StaticResolver `river:"static,block,optional"`
 	DNS    *DNSResolver    `river:"dns,block,optional"`
+	K8sSvc *K8sSvcResolver `river:"k8s,block,optional"`
 }
 
 func (resolverSettings ResolverSettings) Convert() loadbalancingexporter.ResolverSettings {
@@ -152,6 +153,11 @@ func (resolverSettings ResolverSettings) Convert() loadbalancingexporter.Resolve
 	if resolverSettings.DNS != nil {
 		dnsResolver := resolverSettings.DNS.Convert()
 		res.DNS = &dnsResolver
+	}
+
+	if resolverSettings.K8sSvc != nil {
+		k8sSvcResolver := resolverSettings.K8sSvc.Convert()
+		res.K8sSvc = &k8sSvcResolver
 	}
 
 	return res
@@ -196,6 +202,29 @@ func (dnsResolver *DNSResolver) Convert() loadbalancingexporter.DNSResolver {
 		Port:     dnsResolver.Port,
 		Interval: dnsResolver.Interval,
 		Timeout:  dnsResolver.Timeout,
+	}
+}
+
+// K8sSvcResolver defines the configuration for the k8s resolver
+type K8sSvcResolver struct {
+	Service string  `river:"service,attr"`
+	Ports   []int32 `river:"ports,attr,optional"`
+}
+
+var _ river.Defaulter = &K8sSvcResolver{}
+
+// DefaultDNSResolver holds default values for K8sSvcResolver.
+var DefaultK8sSvcResolver = K8sSvcResolver{}
+
+// SetToDefault implements river.Defaulter.
+func (args *K8sSvcResolver) SetToDefault() {
+	*args = DefaultK8sSvcResolver
+}
+
+func (k8sSvcResolver *K8sSvcResolver) Convert() loadbalancingexporter.K8sSvcResolver {
+	return loadbalancingexporter.K8sSvcResolver{
+		Service: k8sSvcResolver.Service,
+		Ports:   k8sSvcResolver.Ports,
 	}
 }
 

--- a/component/otelcol/exporter/loadbalancing/loadbalancing.go
+++ b/component/otelcol/exporter/loadbalancing/loadbalancing.go
@@ -137,9 +137,9 @@ func (otlpConfig OtlpConfig) Convert() otlpexporter.Config {
 
 // ResolverSettings defines the configurations for the backend resolver
 type ResolverSettings struct {
-	Static *StaticResolver `river:"static,block,optional"`
-	DNS    *DNSResolver    `river:"dns,block,optional"`
-	K8sSvc *K8sSvcResolver `river:"k8s,block,optional"`
+	Static     *StaticResolver     `river:"static,block,optional"`
+	DNS        *DNSResolver        `river:"dns,block,optional"`
+	Kubernetes *KubernetesResolver `river:"kubernetes,block,optional"`
 }
 
 func (resolverSettings ResolverSettings) Convert() loadbalancingexporter.ResolverSettings {
@@ -155,9 +155,9 @@ func (resolverSettings ResolverSettings) Convert() loadbalancingexporter.Resolve
 		res.DNS = &dnsResolver
 	}
 
-	if resolverSettings.K8sSvc != nil {
-		k8sSvcResolver := resolverSettings.K8sSvc.Convert()
-		res.K8sSvc = &k8sSvcResolver
+	if resolverSettings.Kubernetes != nil {
+		kubernetesResolver := resolverSettings.Kubernetes.Convert()
+		res.K8sSvc = &kubernetesResolver
 	}
 
 	return res
@@ -205,23 +205,23 @@ func (dnsResolver *DNSResolver) Convert() loadbalancingexporter.DNSResolver {
 	}
 }
 
-// K8sSvcResolver defines the configuration for the k8s resolver
-type K8sSvcResolver struct {
+// KubernetesResolver defines the configuration for the k8s resolver
+type KubernetesResolver struct {
 	Service string  `river:"service,attr"`
 	Ports   []int32 `river:"ports,attr,optional"`
 }
 
-var _ river.Defaulter = &K8sSvcResolver{}
+var _ river.Defaulter = &KubernetesResolver{}
 
 // DefaultDNSResolver holds default values for K8sSvcResolver.
-var DefaultK8sSvcResolver = K8sSvcResolver{}
+var DefaultK8sSvcResolver = KubernetesResolver{}
 
 // SetToDefault implements river.Defaulter.
-func (args *K8sSvcResolver) SetToDefault() {
+func (args *KubernetesResolver) SetToDefault() {
 	*args = DefaultK8sSvcResolver
 }
 
-func (k8sSvcResolver *K8sSvcResolver) Convert() loadbalancingexporter.K8sSvcResolver {
+func (k8sSvcResolver *KubernetesResolver) Convert() loadbalancingexporter.K8sSvcResolver {
 	return loadbalancingexporter.K8sSvcResolver{
 		Service: k8sSvcResolver.Service,
 		Ports:   k8sSvcResolver.Ports,

--- a/component/otelcol/exporter/loadbalancing/loadbalancing_test.go
+++ b/component/otelcol/exporter/loadbalancing/loadbalancing_test.go
@@ -203,6 +203,58 @@ func TestConfigConversion(t *testing.T) {
 				Protocol:   defaultProtocol,
 			},
 		},
+		{
+			testName: "k8s with defaults",
+			agentCfg: `
+			resolver {
+				k8s {
+					service = "lb-svc.lb-ns"
+				}
+			}
+			protocol {
+				otlp {
+					client {}
+				}
+			}
+			`,
+			expected: loadbalancingexporter.Config{
+				Resolver: loadbalancingexporter.ResolverSettings{
+					Static: nil,
+					K8sSvc: &loadbalancingexporter.K8sSvcResolver{
+						Service: "lb-svc.lb-ns",
+					},
+				},
+				RoutingKey: "traceID",
+				Protocol:   defaultProtocol,
+			},
+		},
+		{
+			testName: "k8s with non-defaults",
+			agentCfg: `
+			resolver {
+				k8s {
+					service = "lb-svc.lb-ns"
+					ports = [55690, 55691]
+				}
+			}
+			protocol {
+				otlp {
+					client {}
+				}
+			}
+			`,
+			expected: loadbalancingexporter.Config{
+				Resolver: loadbalancingexporter.ResolverSettings{
+					Static: nil,
+					K8sSvc: &loadbalancingexporter.K8sSvcResolver{
+						Service: "lb-svc.lb-ns",
+						Ports:   []int32{55690, 55691},
+					},
+				},
+				RoutingKey: "traceID",
+				Protocol:   defaultProtocol,
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/component/otelcol/exporter/loadbalancing/loadbalancing_test.go
+++ b/component/otelcol/exporter/loadbalancing/loadbalancing_test.go
@@ -207,7 +207,7 @@ func TestConfigConversion(t *testing.T) {
 			testName: "k8s with defaults",
 			agentCfg: `
 			resolver {
-				k8s {
+				kubernetes {
 					service = "lb-svc.lb-ns"
 				}
 			}
@@ -232,7 +232,7 @@ func TestConfigConversion(t *testing.T) {
 			testName: "k8s with non-defaults",
 			agentCfg: `
 			resolver {
-				k8s {
+				kubernetes {
 					service = "lb-svc.lb-ns"
 					ports = [55690, 55691]
 				}

--- a/component/otelcol/exporter/loadbalancing/loadbalancing_test.go
+++ b/component/otelcol/exporter/loadbalancing/loadbalancing_test.go
@@ -222,6 +222,7 @@ func TestConfigConversion(t *testing.T) {
 					Static: nil,
 					K8sSvc: &loadbalancingexporter.K8sSvcResolver{
 						Service: "lb-svc.lb-ns",
+						Ports:   []int32{4317},
 					},
 				},
 				RoutingKey: "traceID",

--- a/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
@@ -149,7 +149,7 @@ The following arguments are supported:
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `service` | `string`       | Kubernetes service to resolve. |  | yes
-`ports`   | `list(number)` | Ports to use with the IP addresses resolved from `service`. | `["4317"]` | no
+`ports`   | `list(number)` | Ports to use with the IP addresses resolved from `service`. | `[4317]` | no
 
 If no namespace is specified inside `service`, an attempt will be made to infer the namespace for this Agent. 
 If this fails, the `default` namespace will be used.

--- a/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
@@ -81,7 +81,7 @@ Hierarchy | Block | Description | Required
 resolver | [resolver][] | Configures discovering the endpoints to export to. | yes
 resolver > static | [static][] | Static list of endpoints to export to. | no
 resolver > dns | [dns][] | DNS-sourced list of endpoints to export to. | no
-resolver > k8s | [k8s][] | Kubernetes-sourced list of endpoints to export to. | no
+resolver > kubernetes | [kubernetes][] | Kubernetes-sourced list of endpoints to export to. | no
 protocol | [protocol][] | Protocol settings. Only OTLP is supported at the moment. | no
 protocol > otlp | [otlp][] | Configures an OTLP exporter. | no
 protocol > otlp > client | [client][] | Configures the exporter gRPC client. | no
@@ -97,7 +97,7 @@ refers to a `static` block defined inside a `resolver` block.
 [resolver]: #resolver-block
 [static]: #static-block
 [dns]: #dns-block
-[k8s]: #k8s-block
+[kubernetes]: #kubernetes-block
 [protocol]: #protocol-block
 [otlp]: #otlp-block
 [client]: #client-block
@@ -139,9 +139,9 @@ Name | Type | Description | Default | Required
 `timeout`  | `duration` | Resolver timeout. | `"1s"`  | no
 `port`     | `string`   | Port to be used with the IP addresses resolved from the DNS hostname. | `"4317"` | no
 
-### k8s block
+### kubernetes block
 
-You can use the `k8s` block to load balance across the pods of a Kubernetes service. The Agent will be notified
+You can use the `kubernetes` block to load balance across the pods of a Kubernetes service. The Agent will be notified
 by the Kubernetes API whenever a new pod is added or removed from the service.
 
 The following arguments are supported:

--- a/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
@@ -141,7 +141,7 @@ Name | Type | Description | Default | Required
 
 ### k8s block
 
-The `k8s` block provides a way to load balance across the pods of a Kubernetes service. The Agent will be notified
+You can use the `k8s` block to load balance across the pods of a Kubernetes service. The Agent will be notified
 by the Kubernetes API whenever a new pod is added or removed from the service.
 
 The following arguments are supported:

--- a/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
@@ -81,6 +81,7 @@ Hierarchy | Block | Description | Required
 resolver | [resolver][] | Configures discovering the endpoints to export to. | yes
 resolver > static | [static][] | Static list of endpoints to export to. | no
 resolver > dns | [dns][] | DNS-sourced list of endpoints to export to. | no
+resolver > k8s | [k8s][] | Kubernetes-sourced list of endpoints to export to. | no
 protocol | [protocol][] | Protocol settings. Only OTLP is supported at the moment. | no
 protocol > otlp | [otlp][] | Configures an OTLP exporter. | no
 protocol > otlp > client | [client][] | Configures the exporter gRPC client. | no
@@ -96,6 +97,7 @@ refers to a `static` block defined inside a `resolver` block.
 [resolver]: #resolver-block
 [static]: #static-block
 [dns]: #dns-block
+[k8s]: #k8s-block
 [protocol]: #protocol-block
 [otlp]: #otlp-block
 [client]: #client-block
@@ -136,6 +138,23 @@ Name | Type | Description | Default | Required
 `interval` | `duration` | Resolver interval. | `"5s"` | no
 `timeout`  | `duration` | Resolver timeout. | `"1s"`  | no
 `port`     | `string`   | Port to be used with the IP addresses resolved from the DNS hostname. | `"4317"` | no
+
+### k8s block
+
+The `k8s` block provides a way to load balance across the pods of a Kubernetes service. The Agent will be notified
+by the Kubernetes API whenever a new pod is added or removed from the service.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`service` | `string`       | Kubernetes service to resolve. |  | yes
+`ports`   | `list(number)` | Ports to use with the IP addresses resolved from `service`. | `["4317"]` | no
+
+If no namespace is specified inside `service`, an attempt will be made to infer the namespace for this Agent. 
+If this fails, the `default` namespace will be used.
+
+Each of the ports listed in `ports` will be used with each of the IPs resolved from `service`. 
 
 ### protocol block
 

--- a/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
@@ -156,6 +156,9 @@ If this fails, the `default` namespace will be used.
 
 Each of the ports listed in `ports` will be used with each of the IPs resolved from `service`. 
 
+The "get", "list", and "watch" [roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-example)
+must be granted in Kubernetes for the resolver to work.
+
 ### protocol block
 
 The `protocol` block configures protocol-related settings for exporting.

--- a/docs/sources/static/configuration/traces-config.md
+++ b/docs/sources/static/configuration/traces-config.md
@@ -332,6 +332,9 @@ load_balancing:
       [ interval: <duration> | default = 5s ]
       # Resolver timeout
       [ timeout: <duration> | default = 1s ]
+    k8s:
+      service: <string>
+      [ ports: <int array> | default = 4317 ]
 
   # routing_key can be either "traceID" or "service":
   # * "service": exports spans based on their service name.

--- a/docs/sources/static/configuration/traces-config.md
+++ b/docs/sources/static/configuration/traces-config.md
@@ -332,7 +332,7 @@ load_balancing:
       [ interval: <duration> | default = 5s ]
       # Resolver timeout
       [ timeout: <duration> | default = 1s ]
-    k8s:
+    kubernetes:
       service: <string>
       [ ports: <int array> | default = 4317 ]
 

--- a/pkg/traces/config.go
+++ b/pkg/traces/config.go
@@ -589,7 +589,7 @@ func resolver(config map[string]interface{}) (map[string]interface{}, error) {
 		case dnsTagName, staticTagName:
 			resolverCfg[typ] = cfg
 		case kubernetesTagName:
-			resolverCfg[typ] = "k8s"
+			resolverCfg["k8s"] = cfg
 		default:
 			return nil, fmt.Errorf("unsupported resolver config type: %s", typ)
 		}

--- a/pkg/traces/config.go
+++ b/pkg/traces/config.go
@@ -64,9 +64,9 @@ const (
 	// defaultLoadBalancingPort is the default port the agent uses for internal load balancing
 	defaultLoadBalancingPort = "4318"
 	// agent's load balancing options
-	dnsTagName    = "dns"
-	staticTagName = "static"
-	k8sTagName    = "k8s"
+	dnsTagName        = "dns"
+	staticTagName     = "static"
+	kubernetesTagName = "kubernetes"
 
 	// sampling policies
 	alwaysSamplePolicy = "always_sample"
@@ -586,8 +586,10 @@ func resolver(config map[string]interface{}) (map[string]interface{}, error) {
 	resolverCfg := make(map[string]interface{})
 	for typ, cfg := range config {
 		switch typ {
-		case dnsTagName, staticTagName, k8sTagName:
+		case dnsTagName, staticTagName:
 			resolverCfg[typ] = cfg
+		case kubernetesTagName:
+			resolverCfg[typ] = "k8s"
 		default:
 			return nil, fmt.Errorf("unsupported resolver config type: %s", typ)
 		}

--- a/pkg/traces/config.go
+++ b/pkg/traces/config.go
@@ -66,6 +66,7 @@ const (
 	// agent's load balancing options
 	dnsTagName    = "dns"
 	staticTagName = "static"
+	k8sTagName    = "k8s"
 
 	// sampling policies
 	alwaysSamplePolicy = "always_sample"
@@ -585,7 +586,7 @@ func resolver(config map[string]interface{}) (map[string]interface{}, error) {
 	resolverCfg := make(map[string]interface{})
 	for typ, cfg := range config {
 		switch typ {
-		case dnsTagName, staticTagName:
+		case dnsTagName, staticTagName, k8sTagName:
 			resolverCfg[typ] = cfg
 		default:
 			return nil, fmt.Errorf("unsupported resolver config type: %s", typ)

--- a/pkg/traces/config_test.go
+++ b/pkg/traces/config_test.go
@@ -754,7 +754,7 @@ service:
 `,
 		},
 		{
-			name: "tail sampling config with load balancing",
+			name: "tail sampling config with DNS load balancing",
 			cfg: `
 receivers:
   jaeger:
@@ -815,6 +815,94 @@ exporters:
         port: 8282
         interval: 12m
         timeout: 76s
+processors:
+  tail_sampling:
+    decision_wait: 5s
+    policies:
+      - name: always_sample/0
+        type: always_sample
+      - name: string_attribute/1
+        type: string_attribute
+        string_attribute:
+          key: key
+          values:
+            - value1
+            - value2
+extensions: {}
+service:
+  pipelines:
+    traces/0:
+      exporters: ["loadbalancing"]
+      processors: []
+      receivers: ["jaeger", "push_receiver"]
+    traces/1:
+      exporters: ["otlp/0"]
+      processors: ["tail_sampling"]
+      receivers: ["otlp/lb"]
+`,
+		},
+		{
+			name: "tail sampling config with Kubernetes load balancing",
+			cfg: `
+receivers:
+  jaeger:
+    protocols:
+      grpc:
+remote_write:
+  - endpoint: example.com:12345
+tail_sampling:
+  policies:
+    - type: always_sample
+    - type: string_attribute
+      string_attribute:
+        key: key
+        values:
+          - value1
+          - value2
+load_balancing:
+  receiver_port: 8181
+  routing_key: service
+  exporter:
+    insecure: true
+  resolver:
+    kubernetes:
+      service: lb-svc.lb-ns
+      ports:
+      - 55690
+      - 55691
+`,
+			expectedConfig: `
+receivers:
+  jaeger:
+    protocols:
+      grpc:
+  push_receiver: {}
+  otlp/lb:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:8181"
+exporters:
+  otlp/0:
+    endpoint: example.com:12345
+    compression: gzip
+    retry_on_failure:
+      max_elapsed_time: 60s
+  loadbalancing:
+    routing_key: service
+    protocol:
+      otlp:
+        tls:
+          insecure: true
+        endpoint: noop
+        retry_on_failure:
+          max_elapsed_time: 60s
+        compression: none
+    resolver:
+      k8s:
+        service: lb-svc.lb-ns
+        ports:
+        - 55690
+        - 55691
 processors:
   tail_sampling:
     decision_wait: 5s


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This feature was [added](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/22776/files) to Collector version [v0.82.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.82.0), but it looks like we didn't update the components on our end to use it.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated