### PR TITLE
wire up more integrations v1 exporters to integrations v2

### DIFF
--- a/converter/internal/staticconvert/internal/build/agent_exporter.go
+++ b/converter/internal/staticconvert/internal/build/agent_exporter.go
@@ -9,7 +9,7 @@ import (
 
 func (b *IntegrationsConfigBuilder) appendAgentExporter(config *agent_exporter.Config) discovery.Exports {
 	args := toAgentExporter(config)
-	return b.appendExporterBlock(args, config.Name(), "agent")
+	return b.appendExporterBlock(args, config.Name(), nil, "agent")
 }
 
 func toAgentExporter(config *agent_exporter.Config) *agent.Arguments {
@@ -18,7 +18,7 @@ func toAgentExporter(config *agent_exporter.Config) *agent.Arguments {
 
 func (b *IntegrationsConfigBuilder) appendAgentExporterV2(config *agent_exporter_v2.Config) discovery.Exports {
 	args := toAgentExporterV2(config)
-	return b.appendExporterBlock(args, config.Name(), "agent")
+	return b.appendExporterBlock(args, config.Name(), config.Common.InstanceKey, "agent")
 }
 
 func toAgentExporterV2(config *agent_exporter_v2.Config) *agent.Arguments {

--- a/converter/internal/staticconvert/internal/build/apache_exporter.go
+++ b/converter/internal/staticconvert/internal/build/apache_exporter.go
@@ -1,27 +1,31 @@
 package build
 
 import (
-	"fmt"
-
 	"github.com/grafana/agent/component/discovery"
 	"github.com/grafana/agent/component/prometheus/exporter/apache"
-	"github.com/grafana/agent/converter/internal/common"
 	"github.com/grafana/agent/pkg/integrations/apache_http"
+	apache_exporter_v2 "github.com/grafana/agent/pkg/integrations/v2/apache_http"
 )
 
 func (b *IntegrationsConfigBuilder) appendApacheExporter(config *apache_http.Config) discovery.Exports {
 	args := toApacheExporter(config)
-	compLabel := common.LabelForParts(b.globalCtx.LabelPrefix, config.Name())
-	b.f.Body().AppendBlock(common.NewBlockWithOverride(
-		[]string{"prometheus", "exporter", "apache"},
-		compLabel,
-		args,
-	))
-
-	return common.NewDiscoveryExports(fmt.Sprintf("prometheus.exporter.apache.%s.targets", compLabel))
+	return b.appendExporterBlock(args, config.Name(), nil, "apache")
 }
 
 func toApacheExporter(config *apache_http.Config) *apache.Arguments {
+	return &apache.Arguments{
+		ApacheAddr:         config.ApacheAddr,
+		ApacheHostOverride: config.ApacheHostOverride,
+		ApacheInsecure:     config.ApacheInsecure,
+	}
+}
+
+func (b *IntegrationsConfigBuilder) appendApacheExporterV2(config *apache_exporter_v2.Config) discovery.Exports {
+	args := toApacheExporterV2(config)
+	return b.appendExporterBlock(args, config.Name(), config.Common.InstanceKey, "apache")
+}
+
+func toApacheExporterV2(config *apache_exporter_v2.Config) *apache.Arguments {
 	return &apache.Arguments{
 		ApacheAddr:         config.ApacheAddr,
 		ApacheHostOverride: config.ApacheHostOverride,

--- a/converter/internal/staticconvert/internal/build/azure_exporter.go
+++ b/converter/internal/staticconvert/internal/build/azure_exporter.go
@@ -1,24 +1,14 @@
 package build
 
 import (
-	"fmt"
-
 	"github.com/grafana/agent/component/discovery"
 	"github.com/grafana/agent/component/prometheus/exporter/azure"
-	"github.com/grafana/agent/converter/internal/common"
 	"github.com/grafana/agent/pkg/integrations/azure_exporter"
 )
 
-func (b *IntegrationsConfigBuilder) appendAzureExporter(config *azure_exporter.Config) discovery.Exports {
+func (b *IntegrationsConfigBuilder) appendAzureExporter(config *azure_exporter.Config, instanceKey *string) discovery.Exports {
 	args := toAzureExporter(config)
-	compLabel := common.LabelForParts(b.globalCtx.LabelPrefix, config.Name())
-	b.f.Body().AppendBlock(common.NewBlockWithOverride(
-		[]string{"prometheus", "exporter", "azure"},
-		compLabel,
-		args,
-	))
-
-	return common.NewDiscoveryExports(fmt.Sprintf("prometheus.exporter.azure.%s.targets", compLabel))
+	return b.appendExporterBlock(args, config.Name(), instanceKey, "azure")
 }
 
 func toAzureExporter(config *azure_exporter.Config) *azure.Arguments {

--- a/converter/internal/staticconvert/internal/build/builder.go
+++ b/converter/internal/staticconvert/internal/build/builder.go
@@ -40,6 +40,7 @@ import (
 	agent_exporter_v2 "github.com/grafana/agent/pkg/integrations/v2/agent"
 	apache_exporter_v2 "github.com/grafana/agent/pkg/integrations/v2/apache_http"
 	common_v2 "github.com/grafana/agent/pkg/integrations/v2/common"
+	"github.com/grafana/agent/pkg/integrations/v2/metricsutils"
 	"github.com/grafana/agent/pkg/integrations/windows_exporter"
 	"github.com/grafana/river/scanner"
 	"github.com/grafana/river/token/builder"
@@ -148,7 +149,7 @@ func (b *IntegrationsConfigBuilder) appendV1Integrations() {
 		case *windows_exporter.Config:
 			exports = b.appendWindowsExporter(itg)
 		case *azure_exporter.Config:
-			exports = b.appendAzureExporter(itg)
+			exports = b.appendAzureExporter(itg, nil)
 		case *cadvisor.Config:
 			exports = b.appendCadvisorExporter(itg)
 		}
@@ -204,6 +205,14 @@ func (b *IntegrationsConfigBuilder) appendV2Integrations() {
 		case *apache_exporter_v2.Config:
 			exports = b.appendApacheExporterV2(itg)
 			commonConfig = itg.Common
+		case *metricsutils.ConfigShim:
+			commonConfig = itg.Common
+			switch v1_itg := itg.Orig.(type) {
+			case *azure_exporter.Config:
+				{
+					exports = b.appendAzureExporter(v1_itg, itg.Common.InstanceKey)
+				}
+			}
 		}
 
 		if len(exports.Targets) > 0 {

--- a/converter/internal/staticconvert/internal/build/builder.go
+++ b/converter/internal/staticconvert/internal/build/builder.go
@@ -38,6 +38,7 @@ import (
 	"github.com/grafana/agent/pkg/integrations/squid_exporter"
 	"github.com/grafana/agent/pkg/integrations/statsd_exporter"
 	agent_exporter_v2 "github.com/grafana/agent/pkg/integrations/v2/agent"
+	apache_exporter_v2 "github.com/grafana/agent/pkg/integrations/v2/apache_http"
 	common_v2 "github.com/grafana/agent/pkg/integrations/v2/common"
 	"github.com/grafana/agent/pkg/integrations/windows_exporter"
 	"github.com/grafana/river/scanner"
@@ -160,7 +161,7 @@ func (b *IntegrationsConfigBuilder) appendV1Integrations() {
 
 func (b *IntegrationsConfigBuilder) appendExporter(commonConfig *int_config.Common, name string, extraTargets []discovery.Target) {
 	scrapeConfig := prom_config.DefaultScrapeConfig
-	scrapeConfig.JobName = fmt.Sprintf("integrations/%s", name)
+	scrapeConfig.JobName = b.formatJobName(name, nil)
 	scrapeConfig.RelabelConfigs = commonConfig.RelabelConfigs
 	scrapeConfig.MetricRelabelConfigs = commonConfig.MetricRelabelConfigs
 	scrapeConfig.HTTPClientConfig.TLSConfig = b.cfg.Integrations.ConfigV1.TLSConfig
@@ -184,12 +185,7 @@ func (b *IntegrationsConfigBuilder) appendExporter(commonConfig *int_config.Comm
 	}
 
 	jobNameToCompLabelsFunc := func(jobName string) string {
-		labelSuffix := strings.TrimPrefix(jobName, "integrations/")
-		if labelSuffix == "" {
-			return b.globalCtx.LabelPrefix
-		}
-
-		return fmt.Sprintf("%s_%s", b.globalCtx.LabelPrefix, labelSuffix)
+		return b.jobNameToCompLabel(jobName)
 	}
 
 	b.diags.AddAll(prometheusconvert.AppendAllNested(b.f, promConfig, jobNameToCompLabelsFunc, extraTargets, b.globalCtx.RemoteWriteExports))
@@ -204,6 +200,9 @@ func (b *IntegrationsConfigBuilder) appendV2Integrations() {
 		switch itg := integration.(type) {
 		case *agent_exporter_v2.Config:
 			exports = b.appendAgentExporterV2(itg)
+			commonConfig = itg.Common
+		case *apache_exporter_v2.Config:
+			exports = b.appendApacheExporterV2(itg)
 			commonConfig = itg.Common
 		}
 
@@ -228,7 +227,7 @@ func (b *IntegrationsConfigBuilder) appendExporterV2(commonConfig *common_v2.Met
 
 	commonConfig.ApplyDefaults(b.cfg.Integrations.ConfigV2.Metrics.Autoscrape)
 	scrapeConfig := prom_config.DefaultScrapeConfig
-	scrapeConfig.JobName = fmt.Sprintf("integrations/%s", name)
+	scrapeConfig.JobName = b.formatJobName(name, commonConfig.InstanceKey)
 	scrapeConfig.RelabelConfigs = commonConfig.Autoscrape.RelabelConfigs
 	scrapeConfig.MetricRelabelConfigs = commonConfig.Autoscrape.MetricRelabelConfigs
 	scrapeConfig.ScrapeInterval = commonConfig.Autoscrape.ScrapeInterval
@@ -263,12 +262,7 @@ func (b *IntegrationsConfigBuilder) appendExporterV2(commonConfig *common_v2.Met
 	}
 
 	jobNameToCompLabelsFunc := func(jobName string) string {
-		labelSuffix := strings.TrimPrefix(jobName, "integrations/")
-		if labelSuffix == "" {
-			return b.globalCtx.LabelPrefix
-		}
-
-		return fmt.Sprintf("%s_%s", b.globalCtx.LabelPrefix, labelSuffix)
+		return b.jobNameToCompLabel(jobName)
 	}
 
 	// Need to pass in the remote write reference from the metrics config here:
@@ -283,8 +277,32 @@ func splitByCommaNullOnEmpty(s string) []string {
 	return strings.Split(s, ",")
 }
 
-func (b *IntegrationsConfigBuilder) appendExporterBlock(args component.Arguments, name string, exporterName string) discovery.Exports {
-	compLabel := common.LabelForParts(b.globalCtx.LabelPrefix, name)
+func (b *IntegrationsConfigBuilder) jobNameToCompLabel(jobName string) string {
+	labelSuffix := strings.TrimPrefix(jobName, "integrations/")
+	if labelSuffix == "" {
+		return b.globalCtx.LabelPrefix
+	}
+
+	return fmt.Sprintf("%s_%s", b.globalCtx.LabelPrefix, labelSuffix)
+}
+
+func (b *IntegrationsConfigBuilder) formatJobName(name string, instanceKey *string) string {
+	jobName := b.globalCtx.LabelPrefix
+	if instanceKey != nil {
+		jobName = fmt.Sprintf("%s/%s", jobName, *instanceKey)
+	} else {
+		jobName = fmt.Sprintf("%s/%s", jobName, name)
+	}
+
+	return jobName
+}
+
+func (b *IntegrationsConfigBuilder) appendExporterBlock(args component.Arguments, configName string, instanceKey *string, exporterName string) discovery.Exports {
+	compLabel, err := scanner.SanitizeIdentifier(b.formatJobName(configName, instanceKey))
+	if err != nil {
+		b.diags.Add(diag.SeverityLevelCritical, fmt.Sprintf("failed to sanitize job name: %s", err))
+	}
+
 	b.f.Body().AppendBlock(common.NewBlockWithOverride(
 		[]string{"prometheus", "exporter", exporterName},
 		compLabel,

--- a/converter/internal/staticconvert/internal/build/builder.go
+++ b/converter/internal/staticconvert/internal/build/builder.go
@@ -209,9 +209,7 @@ func (b *IntegrationsConfigBuilder) appendV2Integrations() {
 			commonConfig = itg.Common
 			switch v1_itg := itg.Orig.(type) {
 			case *azure_exporter.Config:
-				{
-					exports = b.appendAzureExporter(v1_itg, itg.Common.InstanceKey)
-				}
+				exports = b.appendAzureExporter(v1_itg, itg.Common.InstanceKey)
 			}
 		}
 

--- a/converter/internal/staticconvert/testdata-v2/integrations_v2.river
+++ b/converter/internal/staticconvert/testdata-v2/integrations_v2.river
@@ -32,3 +32,37 @@ prometheus.scrape "integrations_agent" {
 	forward_to = [prometheus.remote_write.metrics_default.receiver]
 	job_name   = "integrations/agent"
 }
+
+prometheus.exporter.apache "integrations_apache1" {
+	insecure = true
+}
+
+prometheus.scrape "integrations_apache1" {
+	targets    = prometheus.exporter.apache.integrations_apache1.targets
+	forward_to = [prometheus.remote_write.metrics_default.receiver]
+	job_name   = "integrations/apache1"
+}
+
+prometheus.exporter.apache "integrations_apache2" { }
+
+discovery.relabel "integrations_apache2" {
+	targets = prometheus.exporter.apache.integrations_apache2.targets
+
+	rule {
+		source_labels = ["__address__"]
+		target_label  = "test_label"
+		replacement   = "test_label_value"
+	}
+
+	rule {
+		source_labels = ["__address__"]
+		target_label  = "test_label_2"
+		replacement   = "test_label_value_2"
+	}
+}
+
+prometheus.scrape "integrations_apache2" {
+	targets    = discovery.relabel.integrations_apache2.output
+	forward_to = [prometheus.remote_write.metrics_default.receiver]
+	job_name   = "integrations/apache2"
+}

--- a/converter/internal/staticconvert/testdata-v2/integrations_v2.river
+++ b/converter/internal/staticconvert/testdata-v2/integrations_v2.river
@@ -9,6 +9,30 @@ prometheus.remote_write "metrics_default" {
 	}
 }
 
+prometheus.exporter.azure "integrations_azure1" {
+	subscriptions = ["subId"]
+	resource_type = "Microsoft.Dashboard/grafana"
+	metrics       = ["HttpRequestCount"]
+}
+
+prometheus.scrape "integrations_azure1" {
+	targets    = prometheus.exporter.azure.integrations_azure1.targets
+	forward_to = [prometheus.remote_write.metrics_default.receiver]
+	job_name   = "integrations/azure1"
+}
+
+prometheus.exporter.azure "integrations_azure2" {
+	subscriptions = ["subId"]
+	resource_type = "Microsoft.Dashboard/grafana"
+	metrics       = ["HttpRequestCount"]
+}
+
+prometheus.scrape "integrations_azure2" {
+	targets    = prometheus.exporter.azure.integrations_azure2.targets
+	forward_to = [prometheus.remote_write.metrics_default.receiver]
+	job_name   = "integrations/azure2"
+}
+
 prometheus.exporter.agent "integrations_agent" { }
 
 discovery.relabel "integrations_agent" {

--- a/converter/internal/staticconvert/testdata-v2/integrations_v2.yaml
+++ b/converter/internal/staticconvert/testdata-v2/integrations_v2.yaml
@@ -19,3 +19,16 @@ integrations:
       extra_labels:
         test_label: test_label_value
         test_label_2: test_label_value_2
+  azure_configs:
+    - instance: "azure1"
+      subscriptions:
+        - "subId"
+      resource_type: "Microsoft.Dashboard/grafana"
+      metrics:
+        - "HttpRequestCount"
+    - instance: "azure2"
+      subscriptions:
+        - "subId"
+      resource_type: "Microsoft.Dashboard/grafana"
+      metrics:
+        - "HttpRequestCount"

--- a/converter/internal/staticconvert/testdata-v2/integrations_v2.yaml
+++ b/converter/internal/staticconvert/testdata-v2/integrations_v2.yaml
@@ -7,9 +7,15 @@ metrics:
 
 integrations:
   agent:
-    instance: "default"
     autoscrape:
       metrics_instance: "default"
     extra_labels:
       test_label: test_label_value
       test_label_2: test_label_value_2
+  apache_http_configs:
+    - instance: "apache1"
+      insecure: true
+    - instance: "apache2"
+      extra_labels:
+        test_label: test_label_value
+        test_label_2: test_label_value_2

--- a/converter/internal/staticconvert/validate.go
+++ b/converter/internal/staticconvert/validate.go
@@ -34,6 +34,7 @@ import (
 	"github.com/grafana/agent/pkg/integrations/statsd_exporter"
 	v2 "github.com/grafana/agent/pkg/integrations/v2"
 	agent_exporter_v2 "github.com/grafana/agent/pkg/integrations/v2/agent"
+	apache_exporter_v2 "github.com/grafana/agent/pkg/integrations/v2/apache_http"
 	"github.com/grafana/agent/pkg/integrations/windows_exporter"
 	"github.com/grafana/agent/pkg/logs"
 	"github.com/grafana/agent/pkg/metrics"
@@ -161,6 +162,7 @@ func validateIntegrationsV2(integrationsConfig *v2.SubsystemOptions) diag.Diagno
 	for _, integration := range integrationsConfig.Configs {
 		switch itg := integration.(type) {
 		case *agent_exporter_v2.Config:
+		case *apache_exporter_v2.Config:
 		default:
 			diags.Add(diag.SeverityLevelError, fmt.Sprintf("The converter does not support converting the provided %s integration.", itg.Name()))
 		}

--- a/converter/internal/staticconvert/validate.go
+++ b/converter/internal/staticconvert/validate.go
@@ -35,6 +35,7 @@ import (
 	v2 "github.com/grafana/agent/pkg/integrations/v2"
 	agent_exporter_v2 "github.com/grafana/agent/pkg/integrations/v2/agent"
 	apache_exporter_v2 "github.com/grafana/agent/pkg/integrations/v2/apache_http"
+	"github.com/grafana/agent/pkg/integrations/v2/metricsutils"
 	"github.com/grafana/agent/pkg/integrations/windows_exporter"
 	"github.com/grafana/agent/pkg/logs"
 	"github.com/grafana/agent/pkg/metrics"
@@ -163,6 +164,12 @@ func validateIntegrationsV2(integrationsConfig *v2.SubsystemOptions) diag.Diagno
 		switch itg := integration.(type) {
 		case *agent_exporter_v2.Config:
 		case *apache_exporter_v2.Config:
+		case *metricsutils.ConfigShim:
+			switch v1_itg := itg.Orig.(type) {
+			case *azure_exporter.Config:
+			default:
+				diags.Add(diag.SeverityLevelError, fmt.Sprintf("The converter does not support converting the provided %s integration.", v1_itg.Name()))
+			}
 		default:
 			diags.Add(diag.SeverityLevelError, fmt.Sprintf("The converter does not support converting the provided %s integration.", itg.Name()))
 		}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

There are 2 categories of new exporter types that were wired in so I'm looking for feedback before copying the pattern to the rest.

1. apache exporter is the first case where multiple instances are allowed. I made some changes in the first commit on this PR to allow this to work smoothly
2. azure exporter is the first case that relies on a v1 integrations shim. I made changes to set this up for this exporter and future ones. See the 2nd commit for this implementation

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [x] Config converters updated