### PR TITLE
ci: bump helm/chart-testing-action to latest release

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -22,7 +22,7 @@ jobs:
           path: source
 
       - name: Install chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: List changed charts
         id: list-changed

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -57,7 +57,7 @@ jobs:
           check-latest: true
 
       - name: Install chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: Determine changed charts
         id: list-changed


### PR DESCRIPTION
The current release being used, 2.4.0, doesn't work anymore.
