### PR TITLE
Fixing example in remote.kubernetes.secret.md to include nonsensitive()

### DIFF
--- a/docs/sources/flow/reference/components/remote.kubernetes.secret.md
+++ b/docs/sources/flow/reference/components/remote.kubernetes.secret.md
@@ -156,7 +156,7 @@ prometheus.remote_write "default" {
   endpoint {
     url = remote.kubernetes.configmap.endpoint.data["url"]
     basic_auth {
-      username = remote.kubernetes.configmap.endpoint.data["username"]
+      username = nonsensitive(remote.kubernetes.configmap.endpoint.data["username"])
       password = remote.kubernetes.secret.credentials.data["password"]
     }
   }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

The prometheus.remote_write > basic_auth > username is a string type and the agent will non start if the username is provided directly as a secret out of remote.kubernetes.secret as done in the example. nonsensitive() needs to be added to it for the config to be valid.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added