### PR TITLE
loki/wal: fix panic for duplicate registered metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,9 @@ Main (unreleased)
 
 - Fixed a bug where UDP syslog messages were never processed (@joshuapare)
 
+- Fix a bug where reloading the configuration of a `loki.write` component lead
+  to a panic. (@tpaschalis)
+
 ### Enhancements
 
 - The `loki.write` WAL now has snappy compression enabled by default. (@thepalbi)


### PR DESCRIPTION
#### PR Description
The original issue in #5414 is easily reproducible by changing the configuration of a `loki.write` component and hitting the reload endpoint, as the NewWatcherMetrics will attempt to re-register the same set of metrics.

#### Which issue(s) this PR fixes
Fixes #5414

#### Notes to the Reviewer
Another possible fix would be to create these metrics at the top-level, when creating a New component and propagate a pointer to the metrics struct down to here. Both solutions could work, but for now, this is what we've mainly been doing in loki.* components when forklifting Promtail code, so an argument can be made to leave this as-is for now to not trip off people when trying to bring new Promtail code in.

#### PR Checklist

- [X] CHANGELOG.md updated
- [ ] Documentation added (N/A)
- [ ] Tests updated (N/A)
