### PR TITLE
feat(module/git): allow module.git use cached content when failed to fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,8 @@ Main (unreleased)
 
 - Updated windows exporter to use prometheus-community/windows_exporter commit 1836cd1. (@mattdurham)
 
+- Allow agent to start with `module.git` config if cached before. (@hainenber)
+
 ### Bugfixes
 
 - Set exit code 1 on grafana-agentctl non-runnable command. (@fgouteroux)

--- a/component/module/git/git.go
+++ b/component/module/git/git.go
@@ -198,11 +198,12 @@ func (c *Component) Update(args component.Arguments) (err error) {
 	var updateVcsErr vcs.UpdateFailedError
 	if c.repo == nil || !reflect.DeepEqual(repoOpts, c.repoOpts) {
 		r, err := vcs.NewGitRepo(context.Background(), repoPath, repoOpts)
-		if errors.As(err, &updateVcsErr) {
-			level.Error(c.log).Log("msg", "failed to update repository", "err", err)
-		}
 		if err != nil {
-			return err
+			if errors.As(err, &updateVcsErr) {
+				level.Error(c.log).Log("msg", "failed to update repository", "err", err)
+			} else {
+				return err
+			}
 		}
 		c.repo = r
 		c.repoOpts = repoOpts

--- a/component/module/git/git.go
+++ b/component/module/git/git.go
@@ -201,6 +201,7 @@ func (c *Component) Update(args component.Arguments) (err error) {
 		if err != nil {
 			if errors.As(err, &updateVcsErr) {
 				level.Error(c.log).Log("msg", "failed to update repository", "err", err)
+				c.updateHealth(err)
 			} else {
 				return err
 			}
@@ -231,6 +232,7 @@ func (c *Component) pollFile(ctx context.Context, args Arguments) error {
 	if err := c.repo.Update(ctx); err != nil {
 		if errors.As(err, &updateVcsErr) {
 			level.Error(c.log).Log("msg", "failed to update repository", "err", err)
+			c.updateHealth(err)
 		} else {
 			return err
 		}

--- a/component/module/git/git.go
+++ b/component/module/git/git.go
@@ -98,7 +98,6 @@ func New(o component.Options, args Arguments) (*Component, error) {
 	if err := c.Update(args); err != nil {
 		if errors.As(err, &vcs.UpdateFailedError{}) {
 			level.Error(c.log).Log("msg", "failed to update repository", "err", err)
-			c.updateHealth(err)
 		} else {
 			return nil, err
 		}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Allow `module.git` loader to use cached contents when failed to fetch during startup/update. This should be transient as the next poll interval, if fetch failure got resolved, the Git content will be up-to-date.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #5708

#### Notes to the Reviewer
Do let me know if something more format is needed, like a unit test or so.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Tests updated