### PR TITLE
fix(agentctl): set exit code 1 on non-runnable command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,8 @@ Main (unreleased)
 
 ### Bugfixes
 
+- Set exit code 1 on grafana-agentctl non-runnable command. (@fgouteroux)
+
 - Fixed an issue where `loki.process` validation for stage `metric.counter` was
   allowing invalid combination of configuration options. (@thampiotr)
 

--- a/cmd/grafana-agentctl/main.go
+++ b/cmd/grafana-agentctl/main.go
@@ -64,7 +64,9 @@ func main() {
 		testLogs(),
 	)
 
-	_ = cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }
 
 func configSyncCmd() *cobra.Command {


### PR DESCRIPTION
#### PR Description

Set exit code 1 (instead of 0) on grafana-agentctl non-runnable command.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated