### PR TITLE
Clarify blackbox exporter documentation

### DIFF
--- a/component/prometheus/exporter/blackbox/blackbox.go
+++ b/component/prometheus/exporter/blackbox/blackbox.go
@@ -106,10 +106,14 @@ func (a *Arguments) Validate() error {
 		return errors.New("config and config_file are mutually exclusive")
 	}
 
+	if a.ConfigFile == "" && a.Config.Value == "" {
+		return errors.New("config or config_file must be set")
+	}
+
 	var blackboxConfig blackbox_config.Config
 	err := yaml.UnmarshalStrict([]byte(a.Config.Value), &blackboxConfig)
 	if err != nil {
-		return fmt.Errorf("invalid backbox_exporter config: %s", err)
+		return fmt.Errorf("invalid blackbox_exporter config: %s", err)
 	}
 
 	return nil

--- a/component/prometheus/exporter/blackbox/blackbox_test.go
+++ b/component/prometheus/exporter/blackbox/blackbox_test.go
@@ -106,7 +106,7 @@ func TestUnmarshalRiverWithInlineConfigYaml(t *testing.T) {
 	require.Contains(t, "http_2xx", args.Targets[1].Module)
 }
 
-func TestUnmarshalRiverWithInvalidInlineConfig(t *testing.T) {
+func TestUnmarshalRiverWithInvalidConfig(t *testing.T) {
 	var tests = []struct {
 		testname      string
 		cfg           string
@@ -122,7 +122,7 @@ func TestUnmarshalRiverWithInvalidInlineConfig(t *testing.T) {
 				module = "http_2xx"
 			}
 			`,
-			`invalid backbox_exporter config: yaml: line 1: did not find expected ',' or '}'`,
+			`invalid blackbox_exporter config: yaml: line 1: did not find expected ',' or '}'`,
 		},
 		{
 			"Invalid property",
@@ -134,7 +134,7 @@ func TestUnmarshalRiverWithInvalidInlineConfig(t *testing.T) {
 				module = "http_2xx"
 			}
 			`,
-			"invalid backbox_exporter config: yaml: unmarshal errors:\n  line 1: field module not found in type config.plain",
+			"invalid blackbox_exporter config: yaml: unmarshal errors:\n  line 1: field module not found in type config.plain",
 		},
 		{
 			"Define config and config_file",
@@ -148,6 +148,16 @@ func TestUnmarshalRiverWithInvalidInlineConfig(t *testing.T) {
 			}
 			`,
 			`config and config_file are mutually exclusive`,
+		},
+		{
+			"Define neither config nor config_file",
+			`
+			target "target_a" {
+				address = "http://example.com"
+				module = "http_2xx"
+			}
+			`,
+			`config or config_file must be set`,
 		},
 	}
 	for _, tt := range tests {

--- a/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
@@ -17,6 +17,9 @@ The `prometheus.exporter.blackbox` component embeds
 
 ```river
 prometheus.exporter.blackbox "LABEL" {
+  target "example" {
+    address = "EXAMPLE_ADDRESS"
+  }
 }
 ```
 
@@ -90,7 +93,9 @@ debug metrics.
 ### Collect metrics using a blackbox exporter config file
 
 This example uses a [`prometheus.scrape` component][scrape] to collect metrics
-from `prometheus.exporter.blackbox`. It adds an extra label, `env="dev"`, to the metrics emitted by the `grafana` target. The `example` target does not have any added labels.
+from `prometheus.exporter.blackbox`. It adds an extra label, `env="dev"`, to the metrics emitted by the `grafana` target. The `example` target does not have any added labels. 
+
+The `config_file` argument is used to define which `blackbox_exporter` modules to use. You can use the [blackbox example config file](https://github.com/prometheus/blackbox_exporter/blob/master/example.yml).
 
 ```river
 prometheus.exporter.blackbox "example" {

--- a/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
@@ -34,6 +34,7 @@ Omitted fields take their default values.
 | `config`               | `string` or `secret` | blackbox_exporter configuration as inline string.                |          | no       |
 | `probe_timeout_offset` | `duration`           | Offset in seconds to subtract from timeout when probing targets. | `"0.5s"` | no       |
 
+Either `config_file` or `config` must be specified.
 The `config_file` argument points to a YAML file defining which blackbox_exporter modules to use.
 The `config` argument must be a YAML document as string defining which blackbox_exporter modules to use.
 `config` is typically loaded by using the exports of another component. For example,

--- a/docs/sources/static/configuration/integrations/blackbox-config.md
+++ b/docs/sources/static/configuration/integrations/blackbox-config.md
@@ -91,6 +91,7 @@ Full reference of options:
   [config_file: <string> | default = ""]
 
   # Embedded blackbox configuration. You can specify your modules here instead of an external config file.
+  # config_file or blackbox_config must be specified.
   # See https://github.com/prometheus/blackbox_exporter/blob/master/CONFIGURATION.md for more details how to specify your blackbox modules.
   blackbox_config:
     [- <modules> ... ]

--- a/pkg/integrations/blackbox_exporter/blackbox_exporter.go
+++ b/pkg/integrations/blackbox_exporter/blackbox_exporter.go
@@ -104,6 +104,10 @@ func LoadBlackboxConfig(log log.Logger, configFile string, targets []BlackboxTar
 
 // New creates a new blackbox_exporter integration
 func New(log log.Logger, c *Config) (integrations.Integration, error) {
+	if c.BlackboxConfigFile == "" && c.BlackboxConfig == nil {
+		return nil, fmt.Errorf("failed to load blackbox config; no config file or config block provided")
+	}
+
 	var blackbox_config blackbox_config.Config
 	err := yaml.Unmarshal(c.BlackboxConfig, &blackbox_config)
 	if err != nil {


### PR DESCRIPTION
#### PR Description

- Documentation for blackbox exporter contained some broken config examples. This PR fixes
them and clarifies some areas.
- Added validation for either specifying config file or blackbox module config content.
 
#### Which issue(s) this PR fixes

Fixes #5007 

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated