### PR TITLE
simple clustering support for loki.source.kubernetes_events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@ Main (unreleased)
 - Grafana Agent Operator: `config-reloader` container no longer runs as root.
   (@rootmout)
 
+- `loki.source.kubernetes_events` now supports clustering. (@captncraig)
+
 ### Bugfixes
 
 - Fixed an issue where `loki.process` validation for stage `metric.counter` was

--- a/docs/sources/flow/reference/components/loki.source.kubernetes_events.md
+++ b/docs/sources/flow/reference/components/loki.source.kubernetes_events.md
@@ -80,6 +80,7 @@ client > authorization | [authorization][] | Configure generic authorization to 
 client > oauth2 | [oauth2][] | Configure OAuth2 for authenticating to the endpoint. | no
 client > oauth2 > tls_config | [tls_config][] | Configure TLS settings for connecting to the endpoint. | no
 client > tls_config | [tls_config][] | Configure TLS settings for connecting to the endpoint. | no
+clustering | [clustering][] | Configure the component for when the Agent is running in clustered mode. | no
 
 The `>` symbol indicates deeper levels of nesting. For example, `client >
 basic_auth` refers to a `basic_auth` block defined
@@ -90,6 +91,7 @@ inside a `client` block.
 [authorization]: #authorization-block
 [oauth2]: #oauth2-block
 [tls_config]: #tls_config-block
+[clustering]: #clustering-beta
 
 ### client block
 
@@ -132,6 +134,25 @@ Name | Type | Description | Default | Required
 ### tls_config block
 
 {{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT VERSION>" >}}
+
+### clustering (beta)
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`enabled` | `bool` | Distribute event collection with other cluster nodes. | | yes
+
+When the agent is [using clustering][], and `enabled` is set to true, then this
+`loki.source.kubernetes_events` component instance opts-in to participating in the
+cluster to distribute the load of event collection between all cluster nodes. If namespaces
+are specified in the arguments, each namespace's events will be watched by a single
+member of the cluster. Otherwise, a single node will be chosen to handle all events in order
+to avoid duplication.
+
+If the agent is _not_ running in clustered mode, then the block is a no-op and
+`loki.source.kubernetes_events` collects logs from every namespace in its
+arguments.
+
+[using clustering]: {{< relref "../../concepts/clustering.md" >}}
 
 ## Exported fields
 


### PR DESCRIPTION
This implements clustering by simply distributing each namespace (or the only namespace for all when `""` is given) to a different node.

As I submit this I realize there could be a problem since the positions will be stored locally, so if the clustering changes, the new owner could try to catch up. That may need a little thought.