### PR TITLE
helm: Fix the CHANGELOG header for v0.27.2

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -10,7 +10,7 @@ internal API changes are not present.
 Unreleased
 ----------
 
-0.27.1 (2023-11-07)
+0.27.2 (2023-11-07)
 ----------
 
 ### Enhancements


### PR DESCRIPTION
This fixes the changelog header to match the most recent [published version](https://artifacthub.io/packages/helm/grafana/grafana-agent).

![image](https://github.com/grafana/agent/assets/17771679/bbc061c7-26e0-4d15-86c8-3ba56ecdd7b9)