### PR TITLE
Benchmark for the queue

### DIFF
--- a/pkg/flow/internal/worker/worker_pool.go
+++ b/pkg/flow/internal/worker/worker_pool.go
@@ -166,7 +166,10 @@ func (w *workQueue) emitNextTask() {
 		return
 	}
 
-	// Remove the task from waiting and add it to running set
+	// Remove the task from waiting and add it to running set.
+	// NOTE: Even though we remove an element from the middle of a collection, we use a slice instead of a linked list.
+	// This code is NOT identified as a performance hot spot and given that in large agents we observe max number of
+	// tasks queued to be ~10, the slice is actually faster because it does not allocate memory. See BenchmarkQueue.
 	w.waitingOrder = append(w.waitingOrder[:index], w.waitingOrder[index+1:]...)
 	task = w.waiting[key]
 	delete(w.waiting, key)

--- a/pkg/flow/internal/worker/worker_pool_test.go
+++ b/pkg/flow/internal/worker/worker_pool_test.go
@@ -282,27 +282,27 @@ func TestWorkerPool(t *testing.T) {
 }
 
 func BenchmarkQueue(b *testing.B) {
-	/* The slice-based implementation is faster when queue size is less than 300 elements, as it doesn't allocate:
+	/* The slice-based implementation is faster when queue size is less than 100 elements, as it doesn't allocate:
 
-	BenchmarkQueue/slice_10_elements-8         	266251536	        4.427 ns/op        0 B/op	       0 allocs/op
-	BenchmarkQueue/list_10_elements-8          	38036170	        31.20 ns/op	      56 B/op	       1 allocs/op
-	BenchmarkQueue/slice_100_elements-8        	85725766	        14.29 ns/op	       0 B/op	       0 allocs/op
-	BenchmarkQueue/list_100_elements-8         	37889650	        31.17 ns/op	      56 B/op	       1 allocs/op
-	BenchmarkQueue/slice_300_elements-8        	40504732	        29.55 ns/op	       0 B/op	       0 allocs/op
-	BenchmarkQueue/list_300_elements-8         	38032604	        31.20 ns/op	      56 B/op	       1 allocs/op
-	BenchmarkQueue/slice_1000_elements-8       	12571960	        95.50 ns/op	       0 B/op	       0 allocs/op
-	BenchmarkQueue/list_1000_elements-8        	37922080	        31.07 ns/op	      56 B/op	       2 allocs/op
-	BenchmarkQueue/slice_10000_elements-8      	 1000000	      1026 ns/op	       0 B/op	       0 allocs/op
-	BenchmarkQueue/list_10000_elements-8       	34379028	        34.24 ns/op	      56 B/op	       1 allocs/op
+	BenchmarkQueue/slice_10_elements-8         	179793877	         7.119 ns/op	   0 B/op	       0 allocs/op
+	BenchmarkQueue/list_10_elements-8          	48129548	        24.75 ns/op	      48 B/op	       1 allocs/op
+	BenchmarkQueue/slice_50_elements-8         	100000000	        11.52 ns/op	       0 B/op	       0 allocs/op
+	BenchmarkQueue/list_50_elements-8          	52150766	        22.81 ns/op	      48 B/op	       1 allocs/op
+	BenchmarkQueue/slice_100_elements-8        	57941505	        20.71 ns/op	       0 B/op	       0 allocs/op
+	BenchmarkQueue/list_100_elements-8         	51232423	        22.95 ns/op	      48 B/op	       1 allocs/op
+	BenchmarkQueue/slice_500_elements-8        	12610141	        95.32 ns/op	       0 B/op	       0 allocs/op
+	BenchmarkQueue/list_500_elements-8         	51342938	        22.84 ns/op	      48 B/op	       1 allocs/op
+	BenchmarkQueue/slice_1000_elements-8       	 6416760	       187.6 ns/op	       0 B/op	       0 allocs/op
+	BenchmarkQueue/list_1000_elements-8        	51942148	        22.92 ns/op	      48 B/op	       1 allocs/op
 	*/
 
-	queueSizes := []int{10, 100, 300, 1000, 10000}
+	queueSizes := []int{10, 50, 100, 500, 1000}
 	for _, queueSize := range queueSizes {
 		elementsStr := fmt.Sprintf("%d elements", queueSize)
 		b.Run("slice "+elementsStr, func(b *testing.B) {
-			var slice []int
+			var slice []string
 			for i := 0; i < queueSize; i++ {
-				slice = append(slice, i)
+				slice = append(slice, fmt.Sprintf("some.component.name.%d", i))
 			}
 
 			b.ResetTimer()
@@ -310,7 +310,7 @@ func BenchmarkQueue(b *testing.B) {
 				// simulate what the `workQueue` does with its `waitingOrder` field.
 
 				// add to queue
-				slice = append(slice, i)
+				slice = append(slice, "some.component.name")
 
 				// iterate to an arbitrary element
 				ind := 0
@@ -326,7 +326,7 @@ func BenchmarkQueue(b *testing.B) {
 		b.Run("list "+elementsStr, func(b *testing.B) {
 			l := list.New()
 			for i := 0; i < queueSize; i++ {
-				l.PushBack(i)
+				l.PushBack(fmt.Sprintf("some.component.name.%d", i))
 			}
 
 			b.ResetTimer()
@@ -334,7 +334,7 @@ func BenchmarkQueue(b *testing.B) {
 				// simulate what the `workQueue` does with its `waitingOrder` field.
 
 				// add to queue
-				l.PushBack(i)
+				l.PushBack("some.component.name")
 
 				// iterate to an arbitrary element
 				toRemove := l.Front()


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

As discussed in [this thread](https://github.com/grafana/agent/pull/5751#discussion_r1389791081), the worker_pool queue could use linked list instead of slice. I was curious about performance and wrote a quick benchmark, which shows that as long as there are less than 100 elements in the queue, the slice implementation is faster. Given our use case, it's unlikely we'll have 100+ elements and the queue size is capped at 1024, where the performance of a slice is still going to be good-enough (~1 microsecond).

