### PR TITLE
Add readyness API to net.server

### DIFF
--- a/component/common/net/config.go
+++ b/component/common/net/config.go
@@ -34,6 +34,10 @@ type ServerConfig struct {
 
 	// GracefulShutdownTimeout configures a timeout to gracefully shut down the server.
 	GracefulShutdownTimeout time.Duration `river:"graceful_shutdown_timeout,attr,optional"`
+
+	// EnableServerAPI registers in the server the `/server` api, that allows one to check the readyness state of the server,
+	// and toggle it if necessary. This is useful for example, for Kubernetes readyness probes.
+	EnableServerAPI bool `river:"enable_server_api,attr,optional"`
 }
 
 // HTTPConfig configures the HTTP dskit started by dskit.Server.
@@ -135,5 +139,6 @@ func DefaultServerConfig() *ServerConfig {
 			ServerMaxRecvMsg:           size4MB,
 		},
 		GracefulShutdownTimeout: 30 * time.Second,
+		EnableServerAPI:         false,
 	}
 }


### PR DESCRIPTION
#### PR Description

This PR adds an opt-in readyness API for the `common/net/server.go`. The idea is that if one hosts a set of agents in something like kubernetes, where readyness probes can be defined, this will allow the toggling of the readyness state. This comes useful for manually draining a pod, for example, if using `loki.source` components that expose a network server. The draining procude would be, assumming agents are hosted in a statefulset.

1. find the highest numbered pod
1. toggle the readyness state with the `PUT /server/toggle_ready` endpoint
1. wait, using metrics, for the desired draining state (for example, using WAL metrics for `loki.source` and `loki.write`)
1. Downscale statefulset so that this pod can be evicted


#### Which issue(s) this PR fixes

Part of https://github.com/grafana/cloud-onboarding/issues/5407

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
