### PR TITLE
ci: use Apple silicon macOS runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go 1.21
       uses: actions/setup-go@v4
       with:
-        go-version: "1.21.0"
+        go-version: "1.21"
         cache: true
     - name: Test
       run: make GO_TAGS="nodocker" test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        platform: [macos-latest]
+        platform: [macos-latest-xlarge]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code


### PR DESCRIPTION
Use the new Apple silicon macOS runner when running macOS tests.

While these new runners are twice as expensive as the normal macOS runners, it is expected to be cost-neutral thanks to the speed increase.

For more information, see GitHub's announcement about the new runners: https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/