### PR TITLE
Add auto-generated connected components in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ Main (unreleased)
 
 - `pyroscope.ebpf` support python on arm64 platforms. (@korniltsev)
 
+- Added links between compatible components in the documentation to make it
+  easier to discover them. (@thampiotr)
+
 ### Bugfixes
 
 - Update `pyroscope.ebpf` to fix a logical bug causing to profile to many kthreads instead of regular processes https://github.com/grafana/pyroscope/pull/2778 (@korniltsev)

--- a/Makefile
+++ b/Makefile
@@ -287,7 +287,7 @@ smoke-image:
 #
 
 .PHONY: generate generate-crds generate-drone generate-helm-docs generate-helm-tests generate-manifests generate-dashboards generate-protos generate-ui generate-versioned-files
-generate: generate-crds generate-drone generate-helm-docs generate-helm-tests generate-manifests generate-dashboards generate-protos generate-ui generate-versioned-files
+generate: generate-crds generate-drone generate-helm-docs generate-helm-tests generate-manifests generate-dashboards generate-protos generate-ui generate-versioned-files generate-docs
 
 generate-crds:
 ifeq ($(USE_CONTAINER),1)
@@ -350,6 +350,12 @@ else
 	sh ./tools/gen-versioned-files/gen-versioned-files.sh
 endif
 
+generate-docs:
+ifeq ($(USE_CONTAINER),1)
+	$(RERUN_IN_CONTAINER)
+else
+	go generate ./docs
+endif
 #
 # Other targets
 #

--- a/component/metadata/metadata.go
+++ b/component/metadata/metadata.go
@@ -1,0 +1,193 @@
+package metadata
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/grafana/agent/component"
+	_ "github.com/grafana/agent/component/all"
+	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/component/otelcol"
+	"github.com/grafana/agent/component/pyroscope"
+	"github.com/prometheus/prometheus/storage"
+)
+
+//TODO(thampiotr): Instead of metadata package reaching into registry, we'll migrate to using a YAML schema file that
+//				   contains information about all the available components. This file will be generated separately and
+//				   can be used by other tools.
+
+type Type struct {
+	Name string
+	// Returns true if provided args include this type (including nested structs)
+	existsInArgsFn func(args component.Arguments) bool
+	// Returns true if provided exports include this type (including nested structs)
+	existsInExportsFn func(exports component.Exports) bool
+}
+
+func (t Type) String() string {
+	return fmt.Sprintf("Type[%s]", t.Name)
+}
+
+var (
+	TypeTargets = Type{
+		Name: "Targets",
+		existsInArgsFn: func(args component.Arguments) bool {
+			return hasFieldOfType(args, reflect.TypeOf([]discovery.Target{}))
+		},
+		existsInExportsFn: func(exports component.Exports) bool {
+			return hasFieldOfType(exports, reflect.TypeOf([]discovery.Target{}))
+		},
+	}
+
+	TypeLokiLogs = Type{
+		Name: "Loki `LogsReceiver`",
+		existsInArgsFn: func(args component.Arguments) bool {
+			return hasFieldOfType(args, reflect.TypeOf([]loki.LogsReceiver{}))
+		},
+		existsInExportsFn: func(exports component.Exports) bool {
+			return hasFieldOfType(exports, reflect.TypeOf(loki.NewLogsReceiver()))
+		},
+	}
+
+	TypePromMetricsReceiver = Type{
+		Name: "Prometheus `MetricsReceiver`",
+		existsInArgsFn: func(args component.Arguments) bool {
+			return hasFieldOfType(args, reflect.TypeOf([]storage.Appendable{}))
+		},
+		existsInExportsFn: func(exports component.Exports) bool {
+			var a *storage.Appendable = nil
+			return hasFieldOfType(exports, reflect.TypeOf(a).Elem())
+		},
+	}
+
+	TypePyroProfilesReceiver = Type{
+		Name: "Pyroscope `ProfilesReceiver`",
+		existsInArgsFn: func(args component.Arguments) bool {
+			return hasFieldOfType(args, reflect.TypeOf([]pyroscope.Appendable{}))
+		},
+		existsInExportsFn: func(exports component.Exports) bool {
+			var a *pyroscope.Appendable = nil
+			return hasFieldOfType(exports, reflect.TypeOf(a).Elem())
+		},
+	}
+
+	TypeOTELReceiver = Type{
+		Name: "OpenTelemetry `otelcol.Consumer`",
+		existsInArgsFn: func(args component.Arguments) bool {
+			return hasFieldOfType(args, reflect.TypeOf([]otelcol.Consumer{}))
+		},
+		existsInExportsFn: func(exports component.Exports) bool {
+			var a *otelcol.Consumer = nil
+			return hasFieldOfType(exports, reflect.TypeOf(a).Elem())
+		},
+	}
+
+	AllTypes = []Type{
+		TypeTargets,
+		TypeLokiLogs,
+		TypePromMetricsReceiver,
+		TypePyroProfilesReceiver,
+		TypeOTELReceiver,
+	}
+)
+
+type Metadata struct {
+	accepts []Type
+	exports []Type
+}
+
+func (m Metadata) Empty() bool {
+	return len(m.accepts) == 0 && len(m.exports) == 0
+}
+
+func (m Metadata) AllTypesAccepted() []Type {
+	return m.accepts
+}
+
+func (m Metadata) AllTypesExported() []Type {
+	return m.exports
+}
+
+func (m Metadata) AcceptsType(t Type) bool {
+	for _, a := range m.accepts {
+		if a.Name == t.Name {
+			return true
+		}
+	}
+	return false
+}
+
+func (m Metadata) ExportsType(t Type) bool {
+	for _, o := range m.exports {
+		if o.Name == t.Name {
+			return true
+		}
+	}
+	return false
+}
+
+func ForComponent(name string) (Metadata, error) {
+	reg, ok := component.Get(name)
+	if !ok {
+		return Metadata{}, fmt.Errorf("could not find component %q", name)
+	}
+	return inferMetadata(reg.Args, reg.Exports), nil
+}
+
+func inferMetadata(args component.Arguments, exports component.Exports) Metadata {
+	m := Metadata{}
+	for _, t := range AllTypes {
+		if t.existsInArgsFn(args) {
+			m.accepts = append(m.accepts, t)
+		}
+		if t.existsInExportsFn(exports) {
+			m.exports = append(m.exports, t)
+		}
+	}
+	return m
+}
+
+func hasFieldOfType(obj interface{}, fieldType reflect.Type) bool {
+	objValue := reflect.ValueOf(obj)
+
+	// If the object is a pointer, dereference it
+	for objValue.Kind() == reflect.Ptr {
+		objValue = objValue.Elem()
+	}
+
+	// If the object is not a struct or interface, return false
+	if objValue.Kind() != reflect.Struct && objValue.Kind() != reflect.Interface {
+		return false
+	}
+
+	for i := 0; i < objValue.NumField(); i++ {
+		fv := objValue.Field(i)
+		ft := fv.Type()
+
+		// If the field type matches the given type, return true
+		if ft == fieldType {
+			return true
+		}
+
+		if fv.Kind() == reflect.Interface && fieldType.AssignableTo(ft) {
+			return true
+		}
+
+		// If the field is a struct, recursively check its fields
+		if fv.Kind() == reflect.Struct {
+			if hasFieldOfType(fv.Interface(), fieldType) {
+				return true
+			}
+		}
+
+		// If the field is a pointer, create a new instance of the pointer type and recursively check its fields
+		if fv.Kind() == reflect.Ptr {
+			if hasFieldOfType(reflect.New(ft.Elem()).Interface(), fieldType) {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/component/metadata/metadata_test.go
+++ b/component/metadata/metadata_test.go
@@ -1,0 +1,94 @@
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_inferMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected Metadata
+	}{
+		{
+			name:     "discovery.dns",
+			expected: Metadata{exports: []Type{TypeTargets}},
+		},
+		{
+			name: "discovery.relabel",
+			expected: Metadata{
+				accepts: []Type{TypeTargets},
+				exports: []Type{TypeTargets},
+			},
+		},
+		{
+			name:     "loki.echo",
+			expected: Metadata{exports: []Type{TypeLokiLogs}},
+		},
+		{
+			name: "loki.source.file",
+			expected: Metadata{
+				accepts: []Type{TypeTargets, TypeLokiLogs},
+			},
+		},
+		{
+			name: "loki.process",
+			expected: Metadata{
+				accepts: []Type{TypeLokiLogs},
+				exports: []Type{TypeLokiLogs},
+			},
+		},
+		{
+			name: "prometheus.relabel",
+			expected: Metadata{
+				accepts: []Type{TypePromMetricsReceiver},
+				exports: []Type{TypePromMetricsReceiver},
+			},
+		},
+		{
+			name: "prometheus.remote_write",
+			expected: Metadata{
+				accepts: []Type{},
+				exports: []Type{TypePromMetricsReceiver},
+			},
+		},
+		{
+			name: "otelcol.exporter.otlp",
+			expected: Metadata{
+				accepts: []Type{},
+				exports: []Type{TypeOTELReceiver},
+			},
+		},
+		{
+			name: "otelcol.processor.filter",
+			expected: Metadata{
+				accepts: []Type{TypeOTELReceiver},
+				exports: []Type{TypeOTELReceiver},
+			},
+		},
+		{
+			name: "faro.receiver",
+			expected: Metadata{
+				accepts: []Type{TypeLokiLogs, TypeOTELReceiver},
+				exports: []Type{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := ForComponent(tt.name)
+			require.NoError(t, err)
+
+			compareSlices := func(expected, actual []Type, name string) {
+				require.Equal(t, len(expected), len(actual), "expected %d %s types, got %d; expected: %v, actual: %v", len(expected), name, len(actual), expected, actual)
+				for i := range expected {
+					require.Equal(t, expected[i].Name, actual[i].Name, "expected %s type at %d to be %q, got %q", name, i, expected[i].Name, actual[i].Name)
+				}
+			}
+
+			compareSlices(tt.expected.AllTypesAccepted(), actual.AllTypesAccepted(), "accepted")
+			compareSlices(tt.expected.AllTypesExported(), actual.AllTypesExported(), "exported")
+		})
+	}
+}

--- a/component/pyroscope/ebpf/ebpf_placeholder.go
+++ b/component/pyroscope/ebpf/ebpf_placeholder.go
@@ -1,4 +1,4 @@
-//go:build linux && !arm64 && !amd64
+//go:build !linux || (linux && !arm64 && !amd64)
 
 package ebpf
 

--- a/component/pyroscope/ebpf/ebpf_placeholder.go
+++ b/component/pyroscope/ebpf/ebpf_placeholder.go
@@ -1,4 +1,4 @@
-//go:build !linux || (linux && !arm64 && !amd64)
+//go:build !(linux && (arm64 || amd64))
 
 package ebpf
 
@@ -26,7 +26,7 @@ type Component struct {
 }
 
 func New(opts component.Options, args Arguments) (component.Component, error) {
-	level.Warn(opts.Logger).Log("msg", "the pyroscope.ebpf component only works on linux; enabling it otherwise will do nothing")
+	level.Warn(opts.Logger).Log("msg", "the pyroscope.ebpf component only works on ARM64 and AMD64 Linux platforms; enabling it otherwise will do nothing")
 	return &Component{}, nil
 }
 

--- a/component/registry.go
+++ b/component/registry.go
@@ -10,6 +10,8 @@ import (
 	"github.com/grafana/regexp"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 )
 
 // The parsedName of a component is the parts of its name ("remote.http") split
@@ -201,4 +203,10 @@ func validatePrefixMatch(check parsedName, against map[string]parsedName) error 
 func Get(name string) (Registration, bool) {
 	r, ok := registered[name]
 	return r, ok
+}
+
+func AllNames() []string {
+	keys := maps.Keys(registered)
+	slices.Sort(keys)
+	return keys
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,10 @@ First, inside the `docs/` folder run `make check-cloudwatch-integration` to veri
 
 If the check fails, then the doc supported services list should be updated. For that, run `make generate-cloudwatch-integration` to get the updated list, which should replace the old one in [the docs](./sources/static/configuration/integrations/cloudwatch-exporter-config.md).
 
+## Update generated reference docs
+
+Some sections of Agent Flow reference documentation are automatically generated. To update them, run `make generate-docs`.
+
 ### Community Projects
 
 Below is a list of community-led projects for working with Grafana Agent. These projects are not maintained or supported by Grafana Labs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,11 +23,11 @@ If the check fails, then the doc supported services list should be updated. For 
 
 ## Update generated reference docs
 
-Some sections of Agent Flow reference documentation are automatically generated. To update them, run `make generate-docs`.
+Some sections of Grafana Agent Flow reference documentation are automatically generated. To update them, run `make generate-docs`.
 
 ### Community Projects
 
-Below is a list of community-led projects for working with Grafana Agent. These projects are not maintained or supported by Grafana Labs.
+The following is a list of community-led projects for working with Grafana Agent. These projects are not maintained or supported by Grafana Labs.
 
 #### Helm (Kubernetes Deployment)
 

--- a/docs/docs_updated_test.go
+++ b/docs/docs_updated_test.go
@@ -1,0 +1,70 @@
+package docs
+
+import (
+	"flag"
+	"strings"
+	"testing"
+
+	"github.com/grafana/agent/component"
+	_ "github.com/grafana/agent/component/all"
+	"github.com/grafana/agent/component/metadata"
+	"github.com/grafana/agent/docs/generator"
+	"github.com/stretchr/testify/require"
+)
+
+// Run the below generate command to automatically update the Markdown docs with generated content
+//go:generate go test -fix-tests -v
+
+var fixTestsFlag = flag.Bool("fix-tests", false, "update the test files with the current generated content")
+
+func TestLinksToTypesSectionsUpdated(t *testing.T) {
+	for _, name := range component.AllNames() {
+		t.Run(name, func(t *testing.T) {
+			runForGenerator(t, generator.NewLinksToTypesGenerator(name))
+		})
+	}
+}
+
+func TestCompatibleComponentsPageUpdated(t *testing.T) {
+	path := "sources/flow/reference/compatibility/_index.md"
+	for _, typ := range metadata.AllTypes {
+		t.Run(typ.Name, func(t *testing.T) {
+			t.Run("exporters", func(t *testing.T) {
+				runForGenerator(t, generator.NewExportersListGenerator(typ, path))
+			})
+			t.Run("consumers", func(t *testing.T) {
+				runForGenerator(t, generator.NewConsumersListGenerator(typ, path))
+			})
+		})
+	}
+}
+
+func runForGenerator(t *testing.T, g generator.DocsGenerator) {
+	if *fixTestsFlag {
+		err := g.Write()
+		require.NoError(t, err, "failed to write generated content for: %q", g.Name())
+		t.Log("updated the docs with generated content", g.Name())
+		return
+	}
+
+	generated, err := g.Generate()
+	require.NoError(t, err, "failed to generate: %q", g.Name())
+
+	if strings.TrimSpace(generated) == "" {
+		actual, err := g.Read()
+		require.Error(t, err, "expected error when reading existing generated docs for %q", g.Name())
+		require.Contains(t, err.Error(), "markers not found", "expected error to be about missing markers")
+		require.Empty(t, actual, "expected empty actual content for %q", g.Name())
+		return
+	}
+
+	actual, err := g.Read()
+	require.NoError(t, err, "failed to read existing generated docs for %q, try running 'go generate ./docs'", g.Name())
+	require.Contains(
+		t,
+		actual,
+		strings.TrimSpace(generated),
+		"outdated docs detected when running %q, try updating with 'go generate ./docs'",
+		g.Name(),
+	)
+}

--- a/docs/generator/compatible_components_page.go
+++ b/docs/generator/compatible_components_page.go
@@ -1,0 +1,102 @@
+package generator
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/grafana/agent/component/metadata"
+	"golang.org/x/exp/maps"
+)
+
+type CompatibleComponentsListGenerator struct {
+	filePath    string
+	t           metadata.Type
+	sectionName string
+	generateFn  func() string
+}
+
+func NewExportersListGenerator(t metadata.Type, filePath string) *CompatibleComponentsListGenerator {
+	return &CompatibleComponentsListGenerator{
+		filePath:    filePath,
+		t:           t,
+		sectionName: "exporters",
+		generateFn:  func() string { return listOfComponentsExporting(t) },
+	}
+}
+
+func NewConsumersListGenerator(t metadata.Type, filePath string) *CompatibleComponentsListGenerator {
+	return &CompatibleComponentsListGenerator{
+		filePath:    filePath,
+		t:           t,
+		sectionName: "consumers",
+		generateFn:  func() string { return listOfComponentsAccepting(t) },
+	}
+}
+
+func (c *CompatibleComponentsListGenerator) Name() string {
+	return fmt.Sprintf("generator of %s section for %q in %q", c.sectionName, c.t.Name, c.filePath)
+}
+
+func (c *CompatibleComponentsListGenerator) Generate() (string, error) {
+	return c.generateFn(), nil
+}
+
+func (c *CompatibleComponentsListGenerator) Read() (string, error) {
+	content, err := readBetweenMarkers(c.startMarker(), c.endMarker(), c.filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read existing content for %q: %w", c.Name(), err)
+	}
+	return content, err
+}
+
+func (c *CompatibleComponentsListGenerator) Write() error {
+	newSection, err := c.Generate()
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(newSection) == "" {
+		return nil
+	}
+	newSection = "\n" + newSection + "\n"
+	return writeBetweenMarkers(c.startMarker(), c.endMarker(), c.filePath, newSection, false)
+}
+
+func (c *CompatibleComponentsListGenerator) startMarker() string {
+	return fmt.Sprintf("<!-- START GENERATED SECTION: %s OF %s -->", strings.ToUpper(c.sectionName), c.t.Name)
+}
+
+func (c *CompatibleComponentsListGenerator) endMarker() string {
+	return fmt.Sprintf("<!-- END GENERATED SECTION: %s OF %s -->", strings.ToUpper(c.sectionName), c.t.Name)
+}
+
+func listOfComponentsAccepting(dataType metadata.Type) string {
+	return listOfLinksToComponents(allComponentsThatAccept(dataType))
+}
+
+func listOfComponentsExporting(dataType metadata.Type) string {
+	return listOfLinksToComponents(allComponentsThatExport(dataType))
+}
+
+func listOfLinksToComponents(components []string) string {
+	str := ""
+	groups := make(map[string][]string)
+
+	for _, component := range components {
+		parts := strings.SplitN(component, ".", 2)
+		namespace := parts[0]
+		groups[namespace] = append(groups[namespace], component)
+	}
+
+	sortedNamespaces := maps.Keys(groups)
+	sort.Strings(sortedNamespaces)
+
+	for _, namespace := range sortedNamespaces {
+		str += fmt.Sprintf("\n{{< collapse title=%q >}}\n", namespace)
+		for _, component := range groups[namespace] {
+			str += fmt.Sprintf("- [%[1]s]({{< relref \"../components/%[1]s.md\" >}})\n", component)
+		}
+		str += "{{< /collapse >}}\n"
+	}
+	return str
+}

--- a/docs/generator/docs_generator.go
+++ b/docs/generator/docs_generator.go
@@ -1,0 +1,86 @@
+package generator
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/metadata"
+)
+
+type DocsGenerator interface {
+	Name() string
+	Generate() (string, error)
+	Read() (string, error)
+	Write() error
+}
+
+func allComponentsThat(f func(meta metadata.Metadata) bool) []string {
+	var result []string
+	for _, name := range component.AllNames() {
+		meta, err := metadata.ForComponent(name)
+		if err != nil {
+			panic(err) // should never happen
+		}
+
+		if f(meta) {
+			result = append(result, name)
+		}
+	}
+	return result
+}
+
+func allComponentsThatExport(dataType metadata.Type) []string {
+	return allComponentsThat(func(meta metadata.Metadata) bool {
+		return meta.ExportsType(dataType)
+	})
+}
+
+func allComponentsThatAccept(dataType metadata.Type) []string {
+	return allComponentsThat(func(meta metadata.Metadata) bool {
+		return meta.AcceptsType(dataType)
+	})
+}
+
+func writeBetweenMarkers(startMarker string, endMarker string, filePath string, content string, appendIfMissing bool) error {
+	fileContents, err := os.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	replacement := append(append([]byte(startMarker), []byte(content)...), []byte(endMarker)...)
+
+	startIndex := bytes.Index(fileContents, []byte(startMarker))
+	endIndex := bytes.LastIndex(fileContents, []byte(endMarker))
+	var newFileContents []byte
+	if startIndex == -1 || endIndex == -1 {
+		if !appendIfMissing {
+			return fmt.Errorf("required markers %q and %q do not exist in %q", startMarker, endMarker, filePath)
+		}
+		// Append the new section to the end of the file
+		newFileContents = append(fileContents, replacement...)
+	} else {
+		// Replace the section with the new content
+		newFileContents = append(newFileContents, fileContents[:startIndex]...)
+		newFileContents = append(newFileContents, replacement...)
+		newFileContents = append(newFileContents, fileContents[endIndex+len(endMarker):]...)
+	}
+	err = os.WriteFile(filePath, newFileContents, 0644)
+	return err
+}
+
+func readBetweenMarkers(startMarker string, endMarker string, filePath string) (string, error) {
+	fileContents, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+
+	startIndex := bytes.Index(fileContents, []byte(startMarker))
+	endIndex := bytes.LastIndex(fileContents, []byte(endMarker))
+	if startIndex == -1 || endIndex == -1 {
+		return "", fmt.Errorf("markers not found: %q or %q", startMarker, endMarker)
+	}
+
+	return string(fileContents[startIndex+len(startMarker) : endIndex]), nil
+}

--- a/docs/generator/links_to_types.go
+++ b/docs/generator/links_to_types.go
@@ -1,0 +1,119 @@
+package generator
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/grafana/agent/component/metadata"
+)
+
+type LinksToTypesGenerator struct {
+	component string
+}
+
+func NewLinksToTypesGenerator(component string) *LinksToTypesGenerator {
+	return &LinksToTypesGenerator{component: component}
+}
+
+func (l *LinksToTypesGenerator) Name() string {
+	return fmt.Sprintf("generator of links to types for %q reference page", l.component)
+}
+
+func (l *LinksToTypesGenerator) Generate() (string, error) {
+	meta, err := metadata.ForComponent(l.component)
+	if err != nil {
+		return "", err
+	}
+	if meta.Empty() {
+		return "", nil
+	}
+
+	heading := "\n## Compatible components\n\n"
+	acceptingSection := acceptingComponentsSection(l.component, meta)
+	outputSection := outputComponentsSection(l.component, meta)
+
+	if acceptingSection == "" && outputSection == "" {
+		return "", nil
+	}
+
+	note := "\nNote that connecting some components may not be feasible or components may require further " +
+		"configuration to make the connection work correctly. " +
+		"Please refer to the linked documentation for more details.\n\n"
+
+	return heading + acceptingSection + outputSection + note, nil
+}
+
+func (l *LinksToTypesGenerator) Read() (string, error) {
+	content, err := readBetweenMarkers(l.startMarker(), l.endMarker(), l.pathToComponentMarkdown())
+	if err != nil {
+		return "", fmt.Errorf("failed to read existing content for %q: %w", l.Name(), err)
+	}
+	return content, err
+}
+
+func (l *LinksToTypesGenerator) Write() error {
+	newSection, err := l.Generate()
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(newSection) == "" {
+		return nil
+	}
+	newSection = "\n" + newSection + "\n"
+	return writeBetweenMarkers(l.startMarker(), l.endMarker(), l.pathToComponentMarkdown(), newSection, true)
+}
+
+func (l *LinksToTypesGenerator) startMarker() string {
+	return "<!-- START GENERATED COMPATIBLE COMPONENTS -->"
+}
+
+func (l *LinksToTypesGenerator) endMarker() string {
+	return "<!-- END GENERATED COMPATIBLE COMPONENTS -->"
+}
+
+func (l *LinksToTypesGenerator) pathToComponentMarkdown() string {
+	return fmt.Sprintf("sources/flow/reference/components/%s.md", l.component)
+}
+
+func outputComponentsSection(name string, meta metadata.Metadata) string {
+	section := ""
+	for _, outputDataType := range meta.AllTypesExported() {
+		if list := allComponentsThatAccept(outputDataType); len(list) > 0 {
+			section += fmt.Sprintf(
+				"- Components that consume [%s]({{< relref \"../compatibility/%s\" >}})\n",
+				outputDataType.Name,
+				anchorFor(outputDataType.Name, "consumers"),
+			)
+		}
+	}
+	if section != "" {
+		section = fmt.Sprintf("`%s` has exports that can be consumed by the following components:\n\n", name) + section
+	}
+	return section
+}
+
+func acceptingComponentsSection(componentName string, meta metadata.Metadata) string {
+	section := ""
+	for _, acceptedDataType := range meta.AllTypesAccepted() {
+		if list := allComponentsThatExport(acceptedDataType); len(list) > 0 {
+			section += fmt.Sprintf(
+				"- Components that export [%s]({{< relref \"../compatibility/%s\" >}})\n",
+				acceptedDataType.Name,
+				anchorFor(acceptedDataType.Name, "exporters"),
+			)
+		}
+	}
+	if section != "" {
+		section = fmt.Sprintf("`%s` can accept arguments from the following components:\n\n", componentName) + section + "\n"
+	}
+	return section
+}
+
+func anchorFor(parts ...string) string {
+	for i, s := range parts {
+		reg := regexp.MustCompile("[^a-z0-9-_]+")
+		parts[i] = reg.ReplaceAllString(strings.ReplaceAll(strings.ToLower(s), " ", "-"), "")
+	}
+	return "#" + strings.Join(parts, "-")
+}

--- a/docs/generator/links_to_types.go
+++ b/docs/generator/links_to_types.go
@@ -37,9 +37,14 @@ func (l *LinksToTypesGenerator) Generate() (string, error) {
 		return "", nil
 	}
 
-	note := "\nNote that connecting some components may not be feasible or components may require further " +
-		"configuration to make the connection work correctly. " +
-		"Please refer to the linked documentation for more details.\n\n"
+	note := `
+{{% admonition type="note" %}}
+
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
+`
 
 	return heading + acceptingSection + outputSection + note, nil
 }

--- a/docs/sources/flow/reference/compatibility/_index.md
+++ b/docs/sources/flow/reference/compatibility/_index.md
@@ -34,10 +34,8 @@ that can export or consume it.
 
 Targets are a `list(map(string))` - a [list]({{< relref "../../config-language/expressions/types_and_values/#naming-convention" >}}) of [maps]({{< relref "../../config-language/expressions/types_and_values/#naming-convention" >}}) with [string]({{< relref "../../config-language/expressions/types_and_values/#strings" >}}) values. As such,
 they can contain different key-value pairs and can be used with a wide range of
-components. Some components export Targets with key-value pairs specified in
-the reference documentation, while other components accept Targets as arguments.
-Some components require Targets to contain specific key-value pairs in order
-to work correctly. It is recommended to always check component reference for
+components. Some components require Targets to contain specific key-value pairs in order
+to work correctly, it is recommended to always check component reference for
 details when working with Targets.
 
 <!-- NOTE: this title is used as an anchor in links. Do not change. -->

--- a/docs/sources/flow/reference/compatibility/_index.md
+++ b/docs/sources/flow/reference/compatibility/_index.md
@@ -32,16 +32,15 @@ that can export or consume it.
 
 ## Targets
 
-Targets are a `list(map(string))` - a [list]({{< relref "../../config-language/expressions/types_and_values/#naming-convention" >}}) of [maps]({{< relref "../../config-language/expressions/types_and_values/#naming-convention" >}}) with [string]({{< relref "../../config-language/expressions/types_and_values/#strings" >}}) values. As such,
-they can contain different key-value pairs and can be used with a wide range of
-components. Some components require Targets to contain specific key-value pairs in order
-to work correctly, it is recommended to always check component reference for
+Targets are a `list(map(string))` - a [list]({{< relref "../../config-language/expressions/types_and_values/#naming-convention" >}}) of [maps]({{< relref "../../config-language/expressions/types_and_values/#naming-convention" >}}) with [string]({{< relref "../../config-language/expressions/types_and_values/#strings" >}}) values.
+They can contain different key-value pairs, and you can use them with a wide range of
+components. Some components require Targets to contain specific key-value pairs
+to work correctly. It is recommended to always check component references for
 details when working with Targets.
 
 <!-- NOTE: this title is used as an anchor in links. Do not change. -->
 ### Targets Exporters
-Below are components that _export_ Targets grouped by namespace. Click
-on the namespace to expand and see more detail.
+The following components, grouped by namespace, _export_ Targets.
 
 <!-- START GENERATED SECTION: EXPORTERS OF Targets -->
 
@@ -116,8 +115,7 @@ on the namespace to expand and see more detail.
 
 <!-- NOTE: this title is used as an anchor in links. Do not change. -->
 ### Targets Consumers
-Below are components that _consume_ Targets grouped by namespace. Click
-on the namespace to expand and see more detail.
+The following components, grouped by namespace, _consume_ Targets.
 
 <!-- START GENERATED SECTION: CONSUMERS OF Targets -->
 
@@ -161,8 +159,7 @@ following components to build your Prometheus metrics pipeline:
 
 <!-- NOTE: this title is used as an anchor in links. Do not change. -->
 ### Prometheus `MetricsReceiver` Exporters
-Below are components that _export_ Prometheus `MetricsReceiver`, grouped by namespace. Click
-on the namespace to expand and see more detail.
+The following components, grouped by namespace, _export_ Prometheus `MetricsReceiver`.
 
 <!-- START GENERATED SECTION: EXPORTERS OF Prometheus `MetricsReceiver` -->
 
@@ -179,8 +176,8 @@ on the namespace to expand and see more detail.
 
 <!-- NOTE: this title is used as an anchor in links. Do not change. -->
 ### Prometheus `MetricsReceiver` Consumers
-Below are components that _consume_ Prometheus `MetricsReceiver`, grouped by namespace. Click
-on the namespace to expand and see more detail.
+The following components, grouped by namespace, _consume_ Prometheus `MetricsReceiver`.
+ 
 
 <!-- START GENERATED SECTION: CONSUMERS OF Prometheus `MetricsReceiver` -->
 
@@ -210,8 +207,7 @@ following components to build your Loki logs pipeline:
 
 <!-- NOTE: this title is used as an anchor in links. Do not change. -->
 ### Loki `LogsReceiver` Exporters
-Below are components that _export_ Loki `LogsReceiver` grouped by namespace. Click
-on the namespace to expand and see more detail.
+The following components, grouped by namespace, _export_ Loki `LogsReceiver`.
 
 <!-- START GENERATED SECTION: EXPORTERS OF Loki `LogsReceiver` -->
 
@@ -230,8 +226,7 @@ on the namespace to expand and see more detail.
 
 <!-- NOTE: this title is used as an anchor in links. Do not change. -->
 ### Loki `LogsReceiver` Consumers
-Below are components that _consume_ Loki `LogsReceiver` grouped by namespace. Click
-on the namespace to expand and see more detail.
+The following components, grouped by namespace, _consume_ Loki `LogsReceiver`.
 
 <!-- START GENERATED SECTION: CONSUMERS OF Loki `LogsReceiver` -->
 
@@ -273,13 +268,12 @@ The OpenTelemetry data is sent between components using `otelcol.Consumer`s.
 `otelcol.Consumer`s are [capsules]({{< relref "../../config-language/expressions/types_and_values/#capsules" >}})
 that are exported by components that can receive OpenTelemetry data. Components that
 can consume OpenTelemetry data can be passed the `otelcol.Consumer` as an argument. Note that some components
-that use `otelcol.Consumer` only support a subset of telemetry signals, e.g. only traces. Check the component
+that use `otelcol.Consumer` only support a subset of telemetry signals, for example, only traces. Check the component
 reference pages for more details on what is supported. Use the following components to build your OpenTelemetry pipeline:
 
 <!-- NOTE: this title is used as an anchor in links. Do not change. -->
 ### OpenTelemetry `otelcol.Consumer` Exporters
-Below are components that _export_ OpenTelemetry `otelcol.Consumer`, grouped by namespace. Click
-on the namespace to expand and see more detail.
+The following components, grouped by namespace, _export_ OpenTelemetry `otelcol.Consumer`.
 
 <!-- START GENERATED SECTION: EXPORTERS OF OpenTelemetry `otelcol.Consumer` -->
 
@@ -309,8 +303,7 @@ on the namespace to expand and see more detail.
 
 <!-- NOTE: this title is used as an anchor in links. Do not change. -->
 ### OpenTelemetry `otelcol.Consumer` Consumers
-Below are components that _consume_ OpenTelemetry `otelcol.Consumer`, grouped by namespace. Click
-on the namespace to expand and see more detail.
+The following components, grouped by namespace, _consume_ OpenTelemetry `otelcol.Consumer`.
 
 <!-- START GENERATED SECTION: CONSUMERS OF OpenTelemetry `otelcol.Consumer` -->
 
@@ -356,8 +349,7 @@ following components to build your Pyroscope profiles pipeline:
 
 <!-- NOTE: this title is used as an anchor in links. Do not change. -->
 ### Pyroscope `ProfilesReceiver` Exporters
-Below are components that _export_ Pyroscope `ProfilesReceiver`, grouped by namespace. Click
-on the namespace to expand and see more detail.
+The following components, grouped by namespace, _export_ Pyroscope `ProfilesReceiver`.
 
 <!-- START GENERATED SECTION: EXPORTERS OF Pyroscope `ProfilesReceiver` -->
 
@@ -369,8 +361,7 @@ on the namespace to expand and see more detail.
 
 <!-- NOTE: this title is used as an anchor in links. Do not change. -->
 ### Pyroscope `ProfilesReceiver` Consumers
-Below are components that _consume_ Pyroscope `ProfilesReceiver`, grouped by namespace. Click
-on the namespace to expand and see more detail.
+The following components, grouped by namespace, _consume_ Pyroscope `ProfilesReceiver`.
 
 <!-- START GENERATED SECTION: CONSUMERS OF Pyroscope `ProfilesReceiver` -->
 

--- a/docs/sources/flow/reference/compatibility/_index.md
+++ b/docs/sources/flow/reference/compatibility/_index.md
@@ -1,0 +1,377 @@
+---
+aliases:
+- /docs/grafana-cloud/agent/flow/reference/compatible-components/
+- /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/compatible-components/
+- /docs/grafana-cloud/monitor-infrastructure/integrations/agent/flow/reference/compatible-components/
+- /docs/grafana-cloud/send-data/agent/flow/reference/compatible-components/
+canonical: https://grafana.com/docs/agent/latest/flow/reference/compatible-components/
+description: Learn about which components are compatible with each other in Grafana Agent Flow
+title: Compatible components
+weight: 400
+---
+
+# Compatible components
+
+This section provides an overview of _some_ of the possible connections between 
+compatible components in Grafana Agent Flow. 
+
+For each common telemetry data type, we provide a list of compatible components
+that can export or consume it.
+
+> Note that connecting some components may require further configuration to make
+> the connection work correctly. Please refer to the linked documentation for more
+> details.
+
+## Targets
+
+Targets are a `list(map(string))` - a [list]({{< relref "../../config-language/expressions/types_and_values/#naming-convention" >}}) of [maps]({{< relref "../../config-language/expressions/types_and_values/#naming-convention" >}}) with [string]({{< relref "../../config-language/expressions/types_and_values/#strings" >}}) values. As such,
+they can contain different key-value pairs and can be used with a wide range of
+components. Some components export Targets with key-value pairs specified in
+the reference documentation, while other components accept Targets as arguments.
+Some components require Targets to contain specific key-value pairs in order
+to work correctly. It is recommended to always check component reference for
+details when working with Targets.
+
+<!-- NOTE: this title is used as an anchor in links. Do not change. -->
+### Targets Exporters
+Below are components that _export_ Targets grouped by namespace. Click
+on the namespace to expand and see more detail.
+
+<!-- START GENERATED SECTION: EXPORTERS OF Targets -->
+
+{{< collapse title="discovery" >}}
+- [discovery.azure]({{< relref "../components/discovery.azure.md" >}})
+- [discovery.consul]({{< relref "../components/discovery.consul.md" >}})
+- [discovery.consulagent]({{< relref "../components/discovery.consulagent.md" >}})
+- [discovery.digitalocean]({{< relref "../components/discovery.digitalocean.md" >}})
+- [discovery.dns]({{< relref "../components/discovery.dns.md" >}})
+- [discovery.docker]({{< relref "../components/discovery.docker.md" >}})
+- [discovery.dockerswarm]({{< relref "../components/discovery.dockerswarm.md" >}})
+- [discovery.ec2]({{< relref "../components/discovery.ec2.md" >}})
+- [discovery.eureka]({{< relref "../components/discovery.eureka.md" >}})
+- [discovery.file]({{< relref "../components/discovery.file.md" >}})
+- [discovery.gce]({{< relref "../components/discovery.gce.md" >}})
+- [discovery.hetzner]({{< relref "../components/discovery.hetzner.md" >}})
+- [discovery.http]({{< relref "../components/discovery.http.md" >}})
+- [discovery.ionos]({{< relref "../components/discovery.ionos.md" >}})
+- [discovery.kubelet]({{< relref "../components/discovery.kubelet.md" >}})
+- [discovery.kubernetes]({{< relref "../components/discovery.kubernetes.md" >}})
+- [discovery.kuma]({{< relref "../components/discovery.kuma.md" >}})
+- [discovery.lightsail]({{< relref "../components/discovery.lightsail.md" >}})
+- [discovery.linode]({{< relref "../components/discovery.linode.md" >}})
+- [discovery.marathon]({{< relref "../components/discovery.marathon.md" >}})
+- [discovery.nerve]({{< relref "../components/discovery.nerve.md" >}})
+- [discovery.nomad]({{< relref "../components/discovery.nomad.md" >}})
+- [discovery.openstack]({{< relref "../components/discovery.openstack.md" >}})
+- [discovery.puppetdb]({{< relref "../components/discovery.puppetdb.md" >}})
+- [discovery.relabel]({{< relref "../components/discovery.relabel.md" >}})
+- [discovery.scaleway]({{< relref "../components/discovery.scaleway.md" >}})
+- [discovery.serverset]({{< relref "../components/discovery.serverset.md" >}})
+- [discovery.triton]({{< relref "../components/discovery.triton.md" >}})
+- [discovery.uyuni]({{< relref "../components/discovery.uyuni.md" >}})
+{{< /collapse >}}
+
+{{< collapse title="local" >}}
+- [local.file_match]({{< relref "../components/local.file_match.md" >}})
+{{< /collapse >}}
+
+{{< collapse title="prometheus" >}}
+- [prometheus.exporter.agent]({{< relref "../components/prometheus.exporter.agent.md" >}})
+- [prometheus.exporter.apache]({{< relref "../components/prometheus.exporter.apache.md" >}})
+- [prometheus.exporter.azure]({{< relref "../components/prometheus.exporter.azure.md" >}})
+- [prometheus.exporter.blackbox]({{< relref "../components/prometheus.exporter.blackbox.md" >}})
+- [prometheus.exporter.cadvisor]({{< relref "../components/prometheus.exporter.cadvisor.md" >}})
+- [prometheus.exporter.cloudwatch]({{< relref "../components/prometheus.exporter.cloudwatch.md" >}})
+- [prometheus.exporter.consul]({{< relref "../components/prometheus.exporter.consul.md" >}})
+- [prometheus.exporter.dnsmasq]({{< relref "../components/prometheus.exporter.dnsmasq.md" >}})
+- [prometheus.exporter.elasticsearch]({{< relref "../components/prometheus.exporter.elasticsearch.md" >}})
+- [prometheus.exporter.gcp]({{< relref "../components/prometheus.exporter.gcp.md" >}})
+- [prometheus.exporter.github]({{< relref "../components/prometheus.exporter.github.md" >}})
+- [prometheus.exporter.kafka]({{< relref "../components/prometheus.exporter.kafka.md" >}})
+- [prometheus.exporter.memcached]({{< relref "../components/prometheus.exporter.memcached.md" >}})
+- [prometheus.exporter.mongodb]({{< relref "../components/prometheus.exporter.mongodb.md" >}})
+- [prometheus.exporter.mssql]({{< relref "../components/prometheus.exporter.mssql.md" >}})
+- [prometheus.exporter.mysql]({{< relref "../components/prometheus.exporter.mysql.md" >}})
+- [prometheus.exporter.oracledb]({{< relref "../components/prometheus.exporter.oracledb.md" >}})
+- [prometheus.exporter.postgres]({{< relref "../components/prometheus.exporter.postgres.md" >}})
+- [prometheus.exporter.process]({{< relref "../components/prometheus.exporter.process.md" >}})
+- [prometheus.exporter.redis]({{< relref "../components/prometheus.exporter.redis.md" >}})
+- [prometheus.exporter.snmp]({{< relref "../components/prometheus.exporter.snmp.md" >}})
+- [prometheus.exporter.snowflake]({{< relref "../components/prometheus.exporter.snowflake.md" >}})
+- [prometheus.exporter.squid]({{< relref "../components/prometheus.exporter.squid.md" >}})
+- [prometheus.exporter.statsd]({{< relref "../components/prometheus.exporter.statsd.md" >}})
+- [prometheus.exporter.unix]({{< relref "../components/prometheus.exporter.unix.md" >}})
+- [prometheus.exporter.vsphere]({{< relref "../components/prometheus.exporter.vsphere.md" >}})
+- [prometheus.exporter.windows]({{< relref "../components/prometheus.exporter.windows.md" >}})
+{{< /collapse >}}
+
+<!-- END GENERATED SECTION: EXPORTERS OF Targets -->
+
+
+<!-- NOTE: this title is used as an anchor in links. Do not change. -->
+### Targets Consumers
+Below are components that _consume_ Targets grouped by namespace. Click
+on the namespace to expand and see more detail.
+
+<!-- START GENERATED SECTION: CONSUMERS OF Targets -->
+
+{{< collapse title="discovery" >}}
+- [discovery.relabel]({{< relref "../components/discovery.relabel.md" >}})
+{{< /collapse >}}
+
+{{< collapse title="local" >}}
+- [local.file_match]({{< relref "../components/local.file_match.md" >}})
+{{< /collapse >}}
+
+{{< collapse title="loki" >}}
+- [loki.source.docker]({{< relref "../components/loki.source.docker.md" >}})
+- [loki.source.file]({{< relref "../components/loki.source.file.md" >}})
+- [loki.source.kubernetes]({{< relref "../components/loki.source.kubernetes.md" >}})
+{{< /collapse >}}
+
+{{< collapse title="otelcol" >}}
+- [otelcol.processor.discovery]({{< relref "../components/otelcol.processor.discovery.md" >}})
+{{< /collapse >}}
+
+{{< collapse title="prometheus" >}}
+- [prometheus.scrape]({{< relref "../components/prometheus.scrape.md" >}})
+{{< /collapse >}}
+
+{{< collapse title="pyroscope" >}}
+- [pyroscope.ebpf]({{< relref "../components/pyroscope.ebpf.md" >}})
+- [pyroscope.scrape]({{< relref "../components/pyroscope.scrape.md" >}})
+{{< /collapse >}}
+
+<!-- END GENERATED SECTION: CONSUMERS OF Targets -->
+
+
+## Prometheus `MetricsReceiver`
+
+The Prometheus metrics are sent between components using `MetricsReceiver`s. 
+`MetricsReceiver`s are [capsules]({{< relref "../../config-language/expressions/types_and_values/#capsules" >}})
+that are exported by components that can receive Prometheus metrics. Components that
+can consume Prometheus metrics can be passed the `MetricsReceiver` as an argument. Use the
+following components to build your Prometheus metrics pipeline:
+
+<!-- NOTE: this title is used as an anchor in links. Do not change. -->
+### Prometheus `MetricsReceiver` Exporters
+Below are components that _export_ Prometheus `MetricsReceiver`, grouped by namespace. Click
+on the namespace to expand and see more detail.
+
+<!-- START GENERATED SECTION: EXPORTERS OF Prometheus `MetricsReceiver` -->
+
+{{< collapse title="otelcol" >}}
+- [otelcol.receiver.prometheus]({{< relref "../components/otelcol.receiver.prometheus.md" >}})
+{{< /collapse >}}
+
+{{< collapse title="prometheus" >}}
+- [prometheus.relabel]({{< relref "../components/prometheus.relabel.md" >}})
+- [prometheus.remote_write]({{< relref "../components/prometheus.remote_write.md" >}})
+{{< /collapse >}}
+
+<!-- END GENERATED SECTION: EXPORTERS OF Prometheus `MetricsReceiver` -->
+
+<!-- NOTE: this title is used as an anchor in links. Do not change. -->
+### Prometheus `MetricsReceiver` Consumers
+Below are components that _consume_ Prometheus `MetricsReceiver`, grouped by namespace. Click
+on the namespace to expand and see more detail.
+
+<!-- START GENERATED SECTION: CONSUMERS OF Prometheus `MetricsReceiver` -->
+
+{{< collapse title="otelcol" >}}
+- [otelcol.exporter.prometheus]({{< relref "../components/otelcol.exporter.prometheus.md" >}})
+{{< /collapse >}}
+
+{{< collapse title="prometheus" >}}
+- [prometheus.operator.podmonitors]({{< relref "../components/prometheus.operator.podmonitors.md" >}})
+- [prometheus.operator.probes]({{< relref "../components/prometheus.operator.probes.md" >}})
+- [prometheus.operator.servicemonitors]({{< relref "../components/prometheus.operator.servicemonitors.md" >}})
+- [prometheus.receive_http]({{< relref "../components/prometheus.receive_http.md" >}})
+- [prometheus.relabel]({{< relref "../components/prometheus.relabel.md" >}})
+- [prometheus.scrape]({{< relref "../components/prometheus.scrape.md" >}})
+{{< /collapse >}}
+
+<!-- END GENERATED SECTION: CONSUMERS OF Prometheus `MetricsReceiver` -->
+
+
+
+## Loki `LogsReceiver`
+
+`LogsReceiver` is a [capsule]({{< relref "../../config-language/expressions/types_and_values/#capsules" >}})
+that is exported by components that can receive Loki logs. Components that
+consume `LogsReceiver` as an argument typically send logs to it. Use the
+following components to build your Loki logs pipeline:
+
+<!-- NOTE: this title is used as an anchor in links. Do not change. -->
+### Loki `LogsReceiver` Exporters
+Below are components that _export_ Loki `LogsReceiver` grouped by namespace. Click
+on the namespace to expand and see more detail.
+
+<!-- START GENERATED SECTION: EXPORTERS OF Loki `LogsReceiver` -->
+
+{{< collapse title="loki" >}}
+- [loki.echo]({{< relref "../components/loki.echo.md" >}})
+- [loki.process]({{< relref "../components/loki.process.md" >}})
+- [loki.relabel]({{< relref "../components/loki.relabel.md" >}})
+- [loki.write]({{< relref "../components/loki.write.md" >}})
+{{< /collapse >}}
+
+{{< collapse title="otelcol" >}}
+- [otelcol.receiver.loki]({{< relref "../components/otelcol.receiver.loki.md" >}})
+{{< /collapse >}}
+
+<!-- END GENERATED SECTION: EXPORTERS OF Loki `LogsReceiver` -->
+
+<!-- NOTE: this title is used as an anchor in links. Do not change. -->
+### Loki `LogsReceiver` Consumers
+Below are components that _consume_ Loki `LogsReceiver` grouped by namespace. Click
+on the namespace to expand and see more detail.
+
+<!-- START GENERATED SECTION: CONSUMERS OF Loki `LogsReceiver` -->
+
+{{< collapse title="faro" >}}
+- [faro.receiver]({{< relref "../components/faro.receiver.md" >}})
+{{< /collapse >}}
+
+{{< collapse title="loki" >}}
+- [loki.process]({{< relref "../components/loki.process.md" >}})
+- [loki.relabel]({{< relref "../components/loki.relabel.md" >}})
+- [loki.source.api]({{< relref "../components/loki.source.api.md" >}})
+- [loki.source.awsfirehose]({{< relref "../components/loki.source.awsfirehose.md" >}})
+- [loki.source.azure_event_hubs]({{< relref "../components/loki.source.azure_event_hubs.md" >}})
+- [loki.source.cloudflare]({{< relref "../components/loki.source.cloudflare.md" >}})
+- [loki.source.docker]({{< relref "../components/loki.source.docker.md" >}})
+- [loki.source.file]({{< relref "../components/loki.source.file.md" >}})
+- [loki.source.gcplog]({{< relref "../components/loki.source.gcplog.md" >}})
+- [loki.source.gelf]({{< relref "../components/loki.source.gelf.md" >}})
+- [loki.source.heroku]({{< relref "../components/loki.source.heroku.md" >}})
+- [loki.source.journal]({{< relref "../components/loki.source.journal.md" >}})
+- [loki.source.kafka]({{< relref "../components/loki.source.kafka.md" >}})
+- [loki.source.kubernetes]({{< relref "../components/loki.source.kubernetes.md" >}})
+- [loki.source.kubernetes_events]({{< relref "../components/loki.source.kubernetes_events.md" >}})
+- [loki.source.podlogs]({{< relref "../components/loki.source.podlogs.md" >}})
+- [loki.source.syslog]({{< relref "../components/loki.source.syslog.md" >}})
+- [loki.source.windowsevent]({{< relref "../components/loki.source.windowsevent.md" >}})
+{{< /collapse >}}
+
+{{< collapse title="otelcol" >}}
+- [otelcol.exporter.loki]({{< relref "../components/otelcol.exporter.loki.md" >}})
+{{< /collapse >}}
+
+<!-- END GENERATED SECTION: CONSUMERS OF Loki `LogsReceiver` -->
+
+
+## OpenTelemetry `otelcol.Consumer`
+
+The OpenTelemetry data is sent between components using `otelcol.Consumer`s.
+`otelcol.Consumer`s are [capsules]({{< relref "../../config-language/expressions/types_and_values/#capsules" >}})
+that are exported by components that can receive OpenTelemetry data. Components that
+can consume OpenTelemetry data can be passed the `otelcol.Consumer` as an argument. Note that some components
+that use `otelcol.Consumer` only support a subset of telemetry signals, e.g. only traces. Check the component
+reference pages for more details on what is supported. Use the following components to build your OpenTelemetry pipeline:
+
+<!-- NOTE: this title is used as an anchor in links. Do not change. -->
+### OpenTelemetry `otelcol.Consumer` Exporters
+Below are components that _export_ OpenTelemetry `otelcol.Consumer`, grouped by namespace. Click
+on the namespace to expand and see more detail.
+
+<!-- START GENERATED SECTION: EXPORTERS OF OpenTelemetry `otelcol.Consumer` -->
+
+{{< collapse title="otelcol" >}}
+- [otelcol.connector.servicegraph]({{< relref "../components/otelcol.connector.servicegraph.md" >}})
+- [otelcol.connector.spanlogs]({{< relref "../components/otelcol.connector.spanlogs.md" >}})
+- [otelcol.connector.spanmetrics]({{< relref "../components/otelcol.connector.spanmetrics.md" >}})
+- [otelcol.exporter.loadbalancing]({{< relref "../components/otelcol.exporter.loadbalancing.md" >}})
+- [otelcol.exporter.logging]({{< relref "../components/otelcol.exporter.logging.md" >}})
+- [otelcol.exporter.loki]({{< relref "../components/otelcol.exporter.loki.md" >}})
+- [otelcol.exporter.otlp]({{< relref "../components/otelcol.exporter.otlp.md" >}})
+- [otelcol.exporter.otlphttp]({{< relref "../components/otelcol.exporter.otlphttp.md" >}})
+- [otelcol.exporter.prometheus]({{< relref "../components/otelcol.exporter.prometheus.md" >}})
+- [otelcol.processor.attributes]({{< relref "../components/otelcol.processor.attributes.md" >}})
+- [otelcol.processor.batch]({{< relref "../components/otelcol.processor.batch.md" >}})
+- [otelcol.processor.discovery]({{< relref "../components/otelcol.processor.discovery.md" >}})
+- [otelcol.processor.filter]({{< relref "../components/otelcol.processor.filter.md" >}})
+- [otelcol.processor.k8sattributes]({{< relref "../components/otelcol.processor.k8sattributes.md" >}})
+- [otelcol.processor.memory_limiter]({{< relref "../components/otelcol.processor.memory_limiter.md" >}})
+- [otelcol.processor.probabilistic_sampler]({{< relref "../components/otelcol.processor.probabilistic_sampler.md" >}})
+- [otelcol.processor.span]({{< relref "../components/otelcol.processor.span.md" >}})
+- [otelcol.processor.tail_sampling]({{< relref "../components/otelcol.processor.tail_sampling.md" >}})
+- [otelcol.processor.transform]({{< relref "../components/otelcol.processor.transform.md" >}})
+{{< /collapse >}}
+
+<!-- END GENERATED SECTION: EXPORTERS OF OpenTelemetry `otelcol.Consumer` -->
+
+<!-- NOTE: this title is used as an anchor in links. Do not change. -->
+### OpenTelemetry `otelcol.Consumer` Consumers
+Below are components that _consume_ OpenTelemetry `otelcol.Consumer`, grouped by namespace. Click
+on the namespace to expand and see more detail.
+
+<!-- START GENERATED SECTION: CONSUMERS OF OpenTelemetry `otelcol.Consumer` -->
+
+{{< collapse title="faro" >}}
+- [faro.receiver]({{< relref "../components/faro.receiver.md" >}})
+{{< /collapse >}}
+
+{{< collapse title="otelcol" >}}
+- [otelcol.connector.servicegraph]({{< relref "../components/otelcol.connector.servicegraph.md" >}})
+- [otelcol.connector.spanlogs]({{< relref "../components/otelcol.connector.spanlogs.md" >}})
+- [otelcol.connector.spanmetrics]({{< relref "../components/otelcol.connector.spanmetrics.md" >}})
+- [otelcol.processor.attributes]({{< relref "../components/otelcol.processor.attributes.md" >}})
+- [otelcol.processor.batch]({{< relref "../components/otelcol.processor.batch.md" >}})
+- [otelcol.processor.discovery]({{< relref "../components/otelcol.processor.discovery.md" >}})
+- [otelcol.processor.filter]({{< relref "../components/otelcol.processor.filter.md" >}})
+- [otelcol.processor.k8sattributes]({{< relref "../components/otelcol.processor.k8sattributes.md" >}})
+- [otelcol.processor.memory_limiter]({{< relref "../components/otelcol.processor.memory_limiter.md" >}})
+- [otelcol.processor.probabilistic_sampler]({{< relref "../components/otelcol.processor.probabilistic_sampler.md" >}})
+- [otelcol.processor.span]({{< relref "../components/otelcol.processor.span.md" >}})
+- [otelcol.processor.tail_sampling]({{< relref "../components/otelcol.processor.tail_sampling.md" >}})
+- [otelcol.processor.transform]({{< relref "../components/otelcol.processor.transform.md" >}})
+- [otelcol.receiver.jaeger]({{< relref "../components/otelcol.receiver.jaeger.md" >}})
+- [otelcol.receiver.kafka]({{< relref "../components/otelcol.receiver.kafka.md" >}})
+- [otelcol.receiver.loki]({{< relref "../components/otelcol.receiver.loki.md" >}})
+- [otelcol.receiver.opencensus]({{< relref "../components/otelcol.receiver.opencensus.md" >}})
+- [otelcol.receiver.otlp]({{< relref "../components/otelcol.receiver.otlp.md" >}})
+- [otelcol.receiver.prometheus]({{< relref "../components/otelcol.receiver.prometheus.md" >}})
+- [otelcol.receiver.vcenter]({{< relref "../components/otelcol.receiver.vcenter.md" >}})
+- [otelcol.receiver.zipkin]({{< relref "../components/otelcol.receiver.zipkin.md" >}})
+{{< /collapse >}}
+
+<!-- END GENERATED SECTION: CONSUMERS OF OpenTelemetry `otelcol.Consumer` -->
+
+
+
+## Pyroscope `ProfilesReceiver`
+
+The Pyroscope profiles are sent between components using `ProfilesReceiver`s.
+`ProfilesReceiver`s are [capsules]({{< relref "../../config-language/expressions/types_and_values/#capsules" >}})
+that are exported by components that can receive Pyroscope profiles. Components that
+can consume Pyroscope profiles can be passed the `ProfilesReceiver` as an argument. Use the
+following components to build your Pyroscope profiles pipeline:
+
+<!-- NOTE: this title is used as an anchor in links. Do not change. -->
+### Pyroscope `ProfilesReceiver` Exporters
+Below are components that _export_ Pyroscope `ProfilesReceiver`, grouped by namespace. Click
+on the namespace to expand and see more detail.
+
+<!-- START GENERATED SECTION: EXPORTERS OF Pyroscope `ProfilesReceiver` -->
+
+{{< collapse title="pyroscope" >}}
+- [pyroscope.write]({{< relref "../components/pyroscope.write.md" >}})
+{{< /collapse >}}
+
+<!-- END GENERATED SECTION: EXPORTERS OF Pyroscope `ProfilesReceiver` -->
+
+<!-- NOTE: this title is used as an anchor in links. Do not change. -->
+### Pyroscope `ProfilesReceiver` Consumers
+Below are components that _consume_ Pyroscope `ProfilesReceiver`, grouped by namespace. Click
+on the namespace to expand and see more detail.
+
+<!-- START GENERATED SECTION: CONSUMERS OF Pyroscope `ProfilesReceiver` -->
+
+{{< collapse title="pyroscope" >}}
+- [pyroscope.ebpf]({{< relref "../components/pyroscope.ebpf.md" >}})
+- [pyroscope.scrape]({{< relref "../components/pyroscope.scrape.md" >}})
+{{< /collapse >}}
+
+<!-- END GENERATED SECTION: CONSUMERS OF Pyroscope `ProfilesReceiver` -->
+

--- a/docs/sources/flow/reference/compatibility/_index.md
+++ b/docs/sources/flow/reference/compatibility/_index.md
@@ -15,12 +15,20 @@ weight: 400
 This section provides an overview of _some_ of the possible connections between 
 compatible components in Grafana Agent Flow. 
 
-For each common telemetry data type, we provide a list of compatible components
+For each common data type, we provide a list of compatible components
 that can export or consume it.
 
-> Note that connecting some components may require further configuration to make
-> the connection work correctly. Please refer to the linked documentation for more
-> details.
+{{% admonition type="note" %}}
+
+> The type of export may not be the only requirement for chaining components together.
+> The value of an attribute may matter as well as its type.
+> Please refer to each component's documentation for more details on what values are acceptable.
+>
+> For example:
+> * A Prometheus component may always expect an `"__address__"` label inside a list of targets.
+> * A `string` argument may only accept certain values like "traceID" or "spanID".
+
+{{% /admonition %}}
 
 ## Targets
 

--- a/docs/sources/flow/reference/components/discovery.azure.md
+++ b/docs/sources/flow/reference/components/discovery.azure.md
@@ -149,3 +149,16 @@ Replace the following:
   - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
   - `USERNAME`: The username to use for authentication to the remote_write API.
   - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.azure` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.azure.md
+++ b/docs/sources/flow/reference/components/discovery.azure.md
@@ -158,7 +158,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.consul.md
+++ b/docs/sources/flow/reference/components/discovery.consul.md
@@ -167,3 +167,16 @@ Replace the following:
   - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
   - `USERNAME`: The username to use for authentication to the remote_write API.
   - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.consul` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.consul.md
+++ b/docs/sources/flow/reference/components/discovery.consul.md
@@ -176,7 +176,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.consulagent.md
+++ b/docs/sources/flow/reference/components/discovery.consulagent.md
@@ -138,7 +138,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.consulagent.md
+++ b/docs/sources/flow/reference/components/discovery.consulagent.md
@@ -129,3 +129,16 @@ Replace the following:
 - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
 - `USERNAME`: The username to use for authentication to the remote_write API.
 - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.consulagent` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.digitalocean.md
+++ b/docs/sources/flow/reference/components/discovery.digitalocean.md
@@ -119,3 +119,16 @@ Replace the following:
   - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
   - `USERNAME`: The username to use for authentication to the remote_write API.
   - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.digitalocean` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.digitalocean.md
+++ b/docs/sources/flow/reference/components/discovery.digitalocean.md
@@ -128,7 +128,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.dns.md
+++ b/docs/sources/flow/reference/components/discovery.dns.md
@@ -103,7 +103,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.dns.md
+++ b/docs/sources/flow/reference/components/discovery.dns.md
@@ -94,3 +94,16 @@ Replace the following:
   - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
   - `USERNAME`: The username to use for authentication to the remote_write API.
   - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.dns` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.docker.md
+++ b/docs/sources/flow/reference/components/discovery.docker.md
@@ -215,3 +215,16 @@ Replace the following:
 
 > **NOTE**: This example requires the "Expose daemon on tcp://localhost:2375
 > without TLS" setting to be enabled in the Docker Engine settings.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.docker` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.docker.md
+++ b/docs/sources/flow/reference/components/discovery.docker.md
@@ -224,7 +224,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.dockerswarm.md
+++ b/docs/sources/flow/reference/components/discovery.dockerswarm.md
@@ -238,3 +238,16 @@ Replace the following:
 - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
 - `USERNAME`: The username to use for authentication to the remote_write API.
 - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.dockerswarm` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.dockerswarm.md
+++ b/docs/sources/flow/reference/components/discovery.dockerswarm.md
@@ -247,7 +247,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.ec2.md
+++ b/docs/sources/flow/reference/components/discovery.ec2.md
@@ -134,3 +134,16 @@ Replace the following:
   - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
   - `USERNAME`: The username to use for authentication to the remote_write API.
   - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.ec2` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.ec2.md
+++ b/docs/sources/flow/reference/components/discovery.ec2.md
@@ -143,7 +143,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.eureka.md
+++ b/docs/sources/flow/reference/components/discovery.eureka.md
@@ -140,3 +140,16 @@ Replace the following:
   - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
   - `USERNAME`: The username to use for authentication to the remote_write API.
   - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.eureka` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.eureka.md
+++ b/docs/sources/flow/reference/components/discovery.eureka.md
@@ -149,7 +149,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.file.md
+++ b/docs/sources/flow/reference/components/discovery.file.md
@@ -173,3 +173,16 @@ Replace the following:
   - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
   - `USERNAME`: The username to use for authentication to the remote_write API.
   - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.file` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.file.md
+++ b/docs/sources/flow/reference/components/discovery.file.md
@@ -182,7 +182,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.gce.md
+++ b/docs/sources/flow/reference/components/discovery.gce.md
@@ -122,7 +122,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.gce.md
+++ b/docs/sources/flow/reference/components/discovery.gce.md
@@ -113,3 +113,16 @@ Replace the following:
   - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
   - `USERNAME`: The username to use for authentication to the remote_write API.
   - `PASSWORD`: The password to use for authentication to the remote_write API.
+ 
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.gce` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.hetzner.md
+++ b/docs/sources/flow/reference/components/discovery.hetzner.md
@@ -185,7 +185,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.hetzner.md
+++ b/docs/sources/flow/reference/components/discovery.hetzner.md
@@ -176,3 +176,16 @@ Replace the following:
   - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
   - `USERNAME`: The username to use for authentication to the remote_write API.
   - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.hetzner` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.http.md
+++ b/docs/sources/flow/reference/components/discovery.http.md
@@ -168,3 +168,16 @@ discovery.http "dynamic_targets" {
   refresh_interval = "15s"
 }
 ```
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.http` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.http.md
+++ b/docs/sources/flow/reference/components/discovery.http.md
@@ -177,7 +177,11 @@ discovery.http "dynamic_targets" {
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.ionos.md
+++ b/docs/sources/flow/reference/components/discovery.ionos.md
@@ -140,3 +140,16 @@ Replace the following:
 - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
 - `USERNAME`: The username to use for authentication to the remote_write API.
 - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.ionos` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.ionos.md
+++ b/docs/sources/flow/reference/components/discovery.ionos.md
@@ -149,7 +149,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.kubelet.md
+++ b/docs/sources/flow/reference/components/discovery.kubelet.md
@@ -193,3 +193,16 @@ Replace the following:
   - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
   - `USERNAME`: The username to use for authentication to the remote_write API.
   - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.kubelet` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.kubelet.md
+++ b/docs/sources/flow/reference/components/discovery.kubelet.md
@@ -202,7 +202,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.kubernetes.md
+++ b/docs/sources/flow/reference/components/discovery.kubernetes.md
@@ -509,7 +509,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.kubernetes.md
+++ b/docs/sources/flow/reference/components/discovery.kubernetes.md
@@ -500,3 +500,16 @@ Replace the following:
   - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
   - `USERNAME`: The username to use for authentication to the remote_write API.
   - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.kubernetes` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.kuma.md
+++ b/docs/sources/flow/reference/components/discovery.kuma.md
@@ -144,7 +144,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.kuma.md
+++ b/docs/sources/flow/reference/components/discovery.kuma.md
@@ -135,3 +135,16 @@ Replace the following:
   - `USERNAME`: The username to use for authentication to the remote_write API.
   - `PASSWORD`: The password to use for authentication to the remote_write API.
 
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.kuma` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.lightsail.md
+++ b/docs/sources/flow/reference/components/discovery.lightsail.md
@@ -108,7 +108,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.lightsail.md
+++ b/docs/sources/flow/reference/components/discovery.lightsail.md
@@ -99,3 +99,16 @@ Replace the following:
   - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
   - `USERNAME`: The username to use for authentication to the remote_write API.
   - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.lightsail` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.linode.md
+++ b/docs/sources/flow/reference/components/discovery.linode.md
@@ -175,3 +175,16 @@ prometheus.remote_write "demo" {
 	}
 }
 ```
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.linode` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.linode.md
+++ b/docs/sources/flow/reference/components/discovery.linode.md
@@ -184,7 +184,11 @@ prometheus.remote_write "demo" {
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.marathon.md
+++ b/docs/sources/flow/reference/components/discovery.marathon.md
@@ -145,3 +145,16 @@ Replace the following:
 - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
 - `USERNAME`: The username to use for authentication to the remote_write API.
 - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.marathon` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.marathon.md
+++ b/docs/sources/flow/reference/components/discovery.marathon.md
@@ -154,7 +154,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.nerve.md
+++ b/docs/sources/flow/reference/components/discovery.nerve.md
@@ -97,3 +97,16 @@ Replace the following:
   - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
   - `USERNAME`: The username to use for authentication to the remote_write API.
   - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.nerve` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.nerve.md
+++ b/docs/sources/flow/reference/components/discovery.nerve.md
@@ -106,7 +106,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.nomad.md
+++ b/docs/sources/flow/reference/components/discovery.nomad.md
@@ -146,3 +146,16 @@ Replace the following:
   - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
   - `USERNAME`: The username to use for authentication to the remote_write API.
   - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.nomad` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.nomad.md
+++ b/docs/sources/flow/reference/components/discovery.nomad.md
@@ -155,7 +155,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.openstack.md
+++ b/docs/sources/flow/reference/components/discovery.openstack.md
@@ -157,3 +157,16 @@ Replace the following:
   - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
   - `USERNAME`: The username to use for authentication to the remote_write API.
   - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.openstack` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.openstack.md
+++ b/docs/sources/flow/reference/components/discovery.openstack.md
@@ -166,7 +166,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.puppetdb.md
+++ b/docs/sources/flow/reference/components/discovery.puppetdb.md
@@ -156,3 +156,16 @@ Replace the following:
   - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
   - `USERNAME`: The username to use for authentication to the remote_write API.
   - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.puppetdb` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.puppetdb.md
+++ b/docs/sources/flow/reference/components/discovery.puppetdb.md
@@ -165,7 +165,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.relabel.md
+++ b/docs/sources/flow/reference/components/discovery.relabel.md
@@ -123,3 +123,19 @@ discovery.relabel "keep_backend_only" {
 ```
 
 
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.relabel` can accept arguments from the following components:
+
+- Components that export [Targets]({{< relref "../compatibility/#targets-exporters" >}})
+
+`discovery.relabel` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.relabel.md
+++ b/docs/sources/flow/reference/components/discovery.relabel.md
@@ -135,7 +135,11 @@ discovery.relabel "keep_backend_only" {
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.scaleway.md
+++ b/docs/sources/flow/reference/components/discovery.scaleway.md
@@ -183,7 +183,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.scaleway.md
+++ b/docs/sources/flow/reference/components/discovery.scaleway.md
@@ -174,3 +174,16 @@ Replace the following:
 * `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
 * `USERNAME`: The username to use for authentication to the remote_write API.
 * `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.scaleway` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.serverset.md
+++ b/docs/sources/flow/reference/components/discovery.serverset.md
@@ -104,7 +104,11 @@ prometheus.remote_write "default" {
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.serverset.md
+++ b/docs/sources/flow/reference/components/discovery.serverset.md
@@ -95,3 +95,16 @@ prometheus.remote_write "default" {
 	}
 }
 ```
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.serverset` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.triton.md
+++ b/docs/sources/flow/reference/components/discovery.triton.md
@@ -138,7 +138,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.triton.md
+++ b/docs/sources/flow/reference/components/discovery.triton.md
@@ -129,3 +129,16 @@ Replace the following:
   - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
   - `USERNAME`: The username to use for authentication to the remote_write API.
   - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.triton` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.uyuni.md
+++ b/docs/sources/flow/reference/components/discovery.uyuni.md
@@ -132,7 +132,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/discovery.uyuni.md
+++ b/docs/sources/flow/reference/components/discovery.uyuni.md
@@ -124,3 +124,15 @@ Replace the following:
   - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
   - `USERNAME`: The username to use for authentication to the remote_write API.
   - `PASSWORD`: The password to use for authentication to the remote_write API.
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`discovery.uyuni` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/faro.receiver.md
+++ b/docs/sources/flow/reference/components/faro.receiver.md
@@ -278,7 +278,11 @@ Replace the following:
 - Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/faro.receiver.md
+++ b/docs/sources/flow/reference/components/faro.receiver.md
@@ -267,3 +267,18 @@ Replace the following:
 
 [loki.write]: {{< relref "./loki.write.md" >}}
 [otelcol.exporter.otlp]: {{< relref "./otelcol.exporter.otlp.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`faro.receiver` can accept arguments from the following components:
+
+- Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/local.file_match.md
+++ b/docs/sources/flow/reference/components/local.file_match.md
@@ -158,7 +158,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/local.file_match.md
+++ b/docs/sources/flow/reference/components/local.file_match.md
@@ -145,3 +145,20 @@ Replace the following:
   - `LOKI_URL`: The URL of the Loki server to send logs to.
   - `USERNAME`: The username to use for authentication to the Loki API.
   - `PASSWORD`: The password to use for authentication to the Loki API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`local.file_match` can accept arguments from the following components:
+
+- Components that export [Targets]({{< relref "../compatibility/#targets-exporters" >}})
+
+`local.file_match` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.echo.md
+++ b/docs/sources/flow/reference/components/loki.echo.md
@@ -76,7 +76,11 @@ loki.echo "example" { }
 
 - Components that consume [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.echo.md
+++ b/docs/sources/flow/reference/components/loki.echo.md
@@ -67,3 +67,16 @@ loki.source.file "logs" {
 
 loki.echo "example" { }
 ```
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`loki.echo` has exports that can be consumed by the following components:
+
+- Components that consume [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -1706,7 +1706,11 @@ loki.process "local" {
 
 - Components that consume [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -1694,3 +1694,19 @@ loki.process "local" {
   }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`loki.process` can accept arguments from the following components:
+
+- Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
+
+`loki.process` has exports that can be consumed by the following components:
+
+- Components that consume [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.relabel.md
+++ b/docs/sources/flow/reference/components/loki.relabel.md
@@ -124,7 +124,11 @@ loki.relabel "keep_error_only" {
 
 - Components that consume [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.relabel.md
+++ b/docs/sources/flow/reference/components/loki.relabel.md
@@ -112,3 +112,19 @@ loki.relabel "keep_error_only" {
 }
 ```
 
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`loki.relabel` can accept arguments from the following components:
+
+- Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
+
+`loki.relabel` has exports that can be consumed by the following components:
+
+- Components that consume [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.api.md
+++ b/docs/sources/flow/reference/components/loki.source.api.md
@@ -126,7 +126,11 @@ loki.source.api "loki_push_api" {
 - Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.api.md
+++ b/docs/sources/flow/reference/components/loki.source.api.md
@@ -117,3 +117,16 @@ loki.source.api "loki_push_api" {
 }
 ```
 
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`loki.source.api` can accept arguments from the following components:
+
+- Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.awsfirehose.md
+++ b/docs/sources/flow/reference/components/loki.source.awsfirehose.md
@@ -205,7 +205,11 @@ loki.relabel "logging_origin" {
 - Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.awsfirehose.md
+++ b/docs/sources/flow/reference/components/loki.source.awsfirehose.md
@@ -196,3 +196,16 @@ loki.relabel "logging_origin" {
   forward_to = []
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`loki.source.awsfirehose` can accept arguments from the following components:
+
+- Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.azure_event_hubs.md
+++ b/docs/sources/flow/reference/components/loki.source.azure_event_hubs.md
@@ -134,4 +134,16 @@ loki.write "example" {
 		url = "loki:3100/api/v1/push"
 	}
 }
-```
+```<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`loki.source.azure_event_hubs` can accept arguments from the following components:
+
+- Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.azure_event_hubs.md
+++ b/docs/sources/flow/reference/components/loki.source.azure_event_hubs.md
@@ -143,7 +143,11 @@ loki.write "example" {
 - Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.cloudflare.md
+++ b/docs/sources/flow/reference/components/loki.source.cloudflare.md
@@ -209,3 +209,16 @@ loki.write "local" {
   }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`loki.source.cloudflare` can accept arguments from the following components:
+
+- Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.cloudflare.md
+++ b/docs/sources/flow/reference/components/loki.source.cloudflare.md
@@ -218,7 +218,11 @@ loki.write "local" {
 - Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.docker.md
+++ b/docs/sources/flow/reference/components/loki.source.docker.md
@@ -164,7 +164,11 @@ loki.write "local" {
 - Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.docker.md
+++ b/docs/sources/flow/reference/components/loki.source.docker.md
@@ -153,3 +153,18 @@ loki.write "local" {
   }
 }
 ```
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`loki.source.docker` can accept arguments from the following components:
+
+- Components that export [Targets]({{< relref "../compatibility/#targets-exporters" >}})
+- Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.file.md
+++ b/docs/sources/flow/reference/components/loki.source.file.md
@@ -234,3 +234,18 @@ loki.write "local" {
 ```
 
 [IANA encoding]: https://www.iana.org/assignments/character-sets/character-sets.xhtml
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`loki.source.file` can accept arguments from the following components:
+
+- Components that export [Targets]({{< relref "../compatibility/#targets-exporters" >}})
+- Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.file.md
+++ b/docs/sources/flow/reference/components/loki.source.file.md
@@ -245,7 +245,11 @@ loki.write "local" {
 - Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.gcplog.md
+++ b/docs/sources/flow/reference/components/loki.source.gcplog.md
@@ -193,3 +193,16 @@ loki.write "local" {
   }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`loki.source.gcplog` can accept arguments from the following components:
+
+- Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.gcplog.md
+++ b/docs/sources/flow/reference/components/loki.source.gcplog.md
@@ -202,7 +202,11 @@ loki.write "local" {
 - Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.gelf.md
+++ b/docs/sources/flow/reference/components/loki.source.gelf.md
@@ -98,7 +98,11 @@ loki.write "endpoint" {
 - Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.gelf.md
+++ b/docs/sources/flow/reference/components/loki.source.gelf.md
@@ -89,3 +89,16 @@ loki.write "endpoint" {
   }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`loki.source.gelf` can accept arguments from the following components:
+
+- Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.heroku.md
+++ b/docs/sources/flow/reference/components/loki.source.heroku.md
@@ -144,3 +144,16 @@ loki.write "local" {
     }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`loki.source.heroku` can accept arguments from the following components:
+
+- Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.heroku.md
+++ b/docs/sources/flow/reference/components/loki.source.heroku.md
@@ -153,7 +153,11 @@ loki.write "local" {
 - Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.journal.md
+++ b/docs/sources/flow/reference/components/loki.source.journal.md
@@ -110,7 +110,11 @@ loki.write "endpoint" {
 - Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.journal.md
+++ b/docs/sources/flow/reference/components/loki.source.journal.md
@@ -101,3 +101,16 @@ loki.write "endpoint" {
   }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`loki.source.journal` can accept arguments from the following components:
+
+- Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.kafka.md
+++ b/docs/sources/flow/reference/components/loki.source.kafka.md
@@ -183,7 +183,11 @@ loki.write "local" {
 - Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.kafka.md
+++ b/docs/sources/flow/reference/components/loki.source.kafka.md
@@ -173,3 +173,17 @@ loki.write "local" {
   }
 }
 ```
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`loki.source.kafka` can accept arguments from the following components:
+
+- Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.kubernetes.md
+++ b/docs/sources/flow/reference/components/loki.source.kubernetes.md
@@ -210,7 +210,11 @@ loki.write "local" {
 - Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.kubernetes.md
+++ b/docs/sources/flow/reference/components/loki.source.kubernetes.md
@@ -199,3 +199,18 @@ loki.write "local" {
   }
 }
 ```
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`loki.source.kubernetes` can accept arguments from the following components:
+
+- Components that export [Targets]({{< relref "../compatibility/#targets-exporters" >}})
+- Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.kubernetes_events.md
+++ b/docs/sources/flow/reference/components/loki.source.kubernetes_events.md
@@ -180,7 +180,11 @@ loki.write "local" {
 - Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.kubernetes_events.md
+++ b/docs/sources/flow/reference/components/loki.source.kubernetes_events.md
@@ -171,3 +171,16 @@ loki.write "local" {
   }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`loki.source.kubernetes_events` can accept arguments from the following components:
+
+- Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.podlogs.md
+++ b/docs/sources/flow/reference/components/loki.source.podlogs.md
@@ -290,3 +290,16 @@ loki.write "local" {
   }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`loki.source.podlogs` can accept arguments from the following components:
+
+- Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.podlogs.md
+++ b/docs/sources/flow/reference/components/loki.source.podlogs.md
@@ -299,7 +299,11 @@ loki.write "local" {
 - Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.syslog.md
+++ b/docs/sources/flow/reference/components/loki.source.syslog.md
@@ -162,7 +162,11 @@ loki.write "local" {
 - Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.syslog.md
+++ b/docs/sources/flow/reference/components/loki.source.syslog.md
@@ -153,3 +153,16 @@ loki.write "local" {
 }
 ```
 
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`loki.source.syslog` can accept arguments from the following components:
+
+- Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.windowsevent.md
+++ b/docs/sources/flow/reference/components/loki.source.windowsevent.md
@@ -84,7 +84,11 @@ loki.write "endpoint" {
 - Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.source.windowsevent.md
+++ b/docs/sources/flow/reference/components/loki.source.windowsevent.md
@@ -75,3 +75,16 @@ loki.write "endpoint" {
     }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`loki.source.windowsevent` can accept arguments from the following components:
+
+- Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.write.md
+++ b/docs/sources/flow/reference/components/loki.write.md
@@ -233,3 +233,16 @@ loki.write "default" {
 `loki.write` uses [snappy](https://en.wikipedia.org/wiki/Snappy_(compression)) for compression.
 
 Any labels that start with `__` will be removed before sending to the endpoint.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`loki.write` has exports that can be consumed by the following components:
+
+- Components that consume [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/loki.write.md
+++ b/docs/sources/flow/reference/components/loki.write.md
@@ -242,7 +242,11 @@ Any labels that start with `__` will be removed before sending to the endpoint.
 
 - Components that consume [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.connector.servicegraph.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.servicegraph.md
@@ -219,4 +219,19 @@ Some of the metrics in Mimir may look like this:
 ```
 traces_service_graph_request_total{client="shop-backend",failed="false",server="article-service",client_http_method="DELETE",server_http_method="DELETE"}
 traces_service_graph_request_failed_total{client="shop-backend",client_http_method="POST",failed="false",server="auth-service",server_http_method="POST"}
-```
+```<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.connector.servicegraph` can accept arguments from the following components:
+
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+`otelcol.connector.servicegraph` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.connector.servicegraph.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.servicegraph.md
@@ -231,7 +231,11 @@ traces_service_graph_request_failed_total{client="shop-backend",client_http_meth
 
 - Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.connector.spanlogs.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.spanlogs.md
@@ -291,7 +291,11 @@ For an input trace like this...
 
 - Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.connector.spanlogs.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.spanlogs.md
@@ -279,3 +279,19 @@ For an input trace like this...
   ]
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.connector.spanlogs` can accept arguments from the following components:
+
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+`otelcol.connector.spanlogs` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.connector.spanmetrics.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.spanmetrics.md
@@ -295,3 +295,19 @@ prometheus.remote_write "mimir" {
   }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.connector.spanmetrics` can accept arguments from the following components:
+
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+`otelcol.connector.spanmetrics` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.connector.spanmetrics.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.spanmetrics.md
@@ -307,7 +307,11 @@ prometheus.remote_write "mimir" {
 
 - Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
@@ -301,3 +301,15 @@ otelcol.exporter.loadbalancing "default" {
     }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.exporter.loadbalancing` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
@@ -309,7 +309,11 @@ otelcol.exporter.loadbalancing "default" {
 
 - Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.exporter.logging.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.logging.md
@@ -107,3 +107,15 @@ otelcol.exporter.logging "default" {
     sampling_thereafter = 1
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.exporter.logging` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.exporter.logging.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.logging.md
@@ -115,7 +115,11 @@ otelcol.exporter.logging "default" {
 
 - Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.exporter.loki.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.loki.md
@@ -171,7 +171,11 @@ loki.write "local" {
 
 - Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.exporter.loki.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.loki.md
@@ -158,3 +158,20 @@ loki.write "local" {
 ```
 
 [Prometheus format](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels)
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.exporter.loki` can accept arguments from the following components:
+
+- Components that export [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-exporters" >}})
+
+`otelcol.exporter.loki` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
@@ -222,7 +222,11 @@ otelcol.auth.basic "grafana_cloud_tempo" {
 
 - Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlp.md
@@ -214,3 +214,15 @@ otelcol.auth.basic "grafana_cloud_tempo" {
     password = env("GRAFANA_CLOUD_API_KEY")
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.exporter.otlp` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlphttp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlphttp.md
@@ -163,7 +163,11 @@ otelcol.exporter.otlphttp "tempo" {
 
 - Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.exporter.otlphttp.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.otlphttp.md
@@ -155,3 +155,15 @@ otelcol.exporter.otlphttp "tempo" {
     }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.exporter.otlphttp` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
@@ -45,7 +45,7 @@ Name | Type | Description                                               | Defaul
 `include_scope_labels` | `boolean` | Whether to include additional OTLP labels in all metrics. | `true` | no
 `add_metric_suffixes` | `boolean` | Whether to add type and unit suffixes to metrics names.   | `true` | no
 `gc_frequency` | `duration` | How often to clean up stale metrics from memory.          | `"5m"` | no
-`forward_to` | `list(receiver)` | Where to forward converted Prometheus metrics.            | | yes
+`forward_to` | `list(MetricsReceiver)` | Where to forward converted Prometheus metrics.            | | yes
 `resource_to_telemetry_conversion` | `boolean` | Whether to convert OTel resource attributes to Prometheus labels. | `false` | no
 
 By default, OpenTelemetry resources are converted into `target_info` metrics. 
@@ -110,3 +110,19 @@ prometheus.remote_write "mimir" {
   }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.exporter.prometheus` can accept arguments from the following components:
+
+- Components that export [Prometheus `MetricsReceiver`]({{< relref "../compatibility/#prometheus-metricsreceiver-exporters" >}})
+
+`otelcol.exporter.prometheus` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
@@ -122,7 +122,11 @@ prometheus.remote_write "mimir" {
 
 - Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.processor.attributes.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.attributes.md
@@ -634,3 +634,19 @@ otelcol.processor.attributes "default" {
     }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.processor.attributes` can accept arguments from the following components:
+
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+`otelcol.processor.attributes` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.processor.attributes.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.attributes.md
@@ -646,7 +646,11 @@ otelcol.processor.attributes "default" {
 
 - Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.processor.batch.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.batch.md
@@ -227,3 +227,19 @@ otelcol.exporter.otlp "production" {
 ```
 
 [otelcol.exporter.otlp]: {{< relref "./otelcol.exporter.otlp.md" >}}
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.processor.batch` can accept arguments from the following components:
+
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+`otelcol.processor.batch` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.processor.batch.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.batch.md
@@ -239,7 +239,11 @@ otelcol.exporter.otlp "production" {
 
 - Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.processor.discovery.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.discovery.md
@@ -205,7 +205,11 @@ otelcol.processor.discovery "default" {
 
 - Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.processor.discovery.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.discovery.md
@@ -191,3 +191,21 @@ otelcol.processor.discovery "default" {
     }
 }
 ```
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.processor.discovery` can accept arguments from the following components:
+
+- Components that export [Targets]({{< relref "../compatibility/#targets-exporters" >}})
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+`otelcol.processor.discovery` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.processor.filter.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.filter.md
@@ -301,3 +301,19 @@ Some values in the River strings are [escaped][river-strings]:
 [HasAttrOnDataPoint]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/filterprocessor/README.md#hasattrondatapoint
 [OTTL booleans]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.85.0/pkg/ottl#booleans
 [OTTL math expressions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.85.0/pkg/ottl#math-expressions
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.processor.filter` can accept arguments from the following components:
+
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+`otelcol.processor.filter` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.processor.filter.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.filter.md
@@ -313,7 +313,11 @@ Some values in the River strings are [escaped][river-strings]:
 
 - Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.processor.k8sattributes.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.k8sattributes.md
@@ -422,7 +422,11 @@ prometheus.remote_write "mimir" {
 
 - Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.processor.k8sattributes.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.k8sattributes.md
@@ -410,3 +410,19 @@ prometheus.remote_write "mimir" {
   }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.processor.k8sattributes` can accept arguments from the following components:
+
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+`otelcol.processor.k8sattributes` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.processor.memory_limiter.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.memory_limiter.md
@@ -121,7 +121,11 @@ information.
 
 - Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.processor.memory_limiter.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.memory_limiter.md
@@ -109,3 +109,19 @@ configuration.
 
 `otelcol.processor.memory_limiter` does not expose any component-specific debug
 information.
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.processor.memory_limiter` can accept arguments from the following components:
+
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+`otelcol.processor.memory_limiter` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.processor.probabilistic_sampler.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.probabilistic_sampler.md
@@ -157,7 +157,11 @@ otelcol.processor.probabilistic_sampler "default" {
 
 - Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.processor.probabilistic_sampler.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.probabilistic_sampler.md
@@ -145,3 +145,19 @@ otelcol.processor.probabilistic_sampler "default" {
   }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.processor.probabilistic_sampler` can accept arguments from the following components:
+
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+`otelcol.processor.probabilistic_sampler` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.processor.span.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.span.md
@@ -400,7 +400,11 @@ otelcol.processor.span "default" {
 
 - Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.processor.span.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.span.md
@@ -388,3 +388,19 @@ otelcol.processor.span "default" {
   }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.processor.span` can accept arguments from the following components:
+
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+`otelcol.processor.span` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.processor.tail_sampling.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.tail_sampling.md
@@ -565,7 +565,11 @@ otelcol.exporter.otlp "production" {
 
 - Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.processor.tail_sampling.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.tail_sampling.md
@@ -553,3 +553,19 @@ otelcol.exporter.otlp "production" {
   }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.processor.tail_sampling` can accept arguments from the following components:
+
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+`otelcol.processor.tail_sampling` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.processor.transform.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.transform.md
@@ -590,3 +590,19 @@ each `"` with a `\"`, and each `\` with a `\\` inside a [normal][river-strings] 
 [OTTL metric context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/pkg/ottl/contexts/ottlmetric/README.md
 [OTTL datapoint context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/pkg/ottl/contexts/ottldatapoint/README.md
 [OTTL log context]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/pkg/ottl/contexts/ottllog/README.md
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.processor.transform` can accept arguments from the following components:
+
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+`otelcol.processor.transform` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.processor.transform.md
+++ b/docs/sources/flow/reference/components/otelcol.processor.transform.md
@@ -602,7 +602,11 @@ each `"` with a `\"`, and each `\` with a `\\` inside a [normal][river-strings] 
 
 - Components that consume [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.receiver.jaeger.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.jaeger.md
@@ -287,7 +287,11 @@ otelcol.exporter.otlp "default" {
 - Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.receiver.jaeger.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.jaeger.md
@@ -278,3 +278,16 @@ otelcol.exporter.otlp "default" {
 ## Technical details
 
 `otelcol.receiver.jaeger` supports [gzip](https://en.wikipedia.org/wiki/Gzip) for compression.
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.receiver.jaeger` can accept arguments from the following components:
+
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.receiver.kafka.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.kafka.md
@@ -330,3 +330,16 @@ otelcol.exporter.otlp "default" {
   }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.receiver.kafka` can accept arguments from the following components:
+
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.receiver.kafka.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.kafka.md
@@ -339,7 +339,11 @@ otelcol.exporter.otlp "default" {
 - Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.receiver.loki.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.loki.md
@@ -112,7 +112,11 @@ otelcol.exporter.otlp "default" {
 
 - Components that consume [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.receiver.loki.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.loki.md
@@ -99,3 +99,20 @@ otelcol.exporter.otlp "default" {
   }
 }
 ```
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.receiver.loki` can accept arguments from the following components:
+
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+`otelcol.receiver.loki` has exports that can be consumed by the following components:
+
+- Components that consume [Loki `LogsReceiver`]({{< relref "../compatibility/#loki-logsreceiver-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.receiver.opencensus.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.opencensus.md
@@ -219,7 +219,11 @@ otelcol.exporter.otlp "default" {
 - Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.receiver.opencensus.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.opencensus.md
@@ -210,3 +210,16 @@ otelcol.exporter.otlp "default" {
 	}
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.receiver.opencensus` can accept arguments from the following components:
+
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.receiver.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.otlp.md
@@ -248,3 +248,16 @@ otelcol.exporter.otlp "default" {
 ## Technical details
 
 `otelcol.receiver.otlp` supports [gzip](https://en.wikipedia.org/wiki/Gzip) for compression.
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.receiver.otlp` can accept arguments from the following components:
+
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.receiver.otlp.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.otlp.md
@@ -257,7 +257,11 @@ otelcol.exporter.otlp "default" {
 - Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.receiver.prometheus.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.prometheus.md
@@ -111,7 +111,11 @@ otelcol.exporter.otlp "default" {
 
 - Components that consume [Prometheus `MetricsReceiver`]({{< relref "../compatibility/#prometheus-metricsreceiver-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.receiver.prometheus.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.prometheus.md
@@ -58,7 +58,7 @@ The following fields are exported and can be referenced by other components:
 
 Name | Type | Description
 ---- | ---- | -----------
-`receiver` | `receiver` | A value that other components can use to send Prometheus metrics to.
+`receiver` | `MetricsReceiver` | A value that other components can use to send Prometheus metrics to.
 
 ## Component health
 
@@ -99,3 +99,19 @@ otelcol.exporter.otlp "default" {
   }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.receiver.prometheus` can accept arguments from the following components:
+
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+`otelcol.receiver.prometheus` has exports that can be consumed by the following components:
+
+- Components that consume [Prometheus `MetricsReceiver`]({{< relref "../compatibility/#prometheus-metricsreceiver-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.receiver.vcenter.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.vcenter.md
@@ -219,3 +219,16 @@ otelcol.exporter.otlp "default" {
     endpoint = env("OTLP_ENDPOINT")
   }
 }
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.receiver.vcenter` can accept arguments from the following components:
+
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.receiver.vcenter.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.vcenter.md
@@ -228,7 +228,11 @@ otelcol.exporter.otlp "default" {
 - Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.receiver.zipkin.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.zipkin.md
@@ -143,3 +143,16 @@ otelcol.exporter.otlp "default" {
   }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.receiver.zipkin` can accept arguments from the following components:
+
+- Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.receiver.zipkin.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.zipkin.md
@@ -152,7 +152,11 @@ otelcol.exporter.otlp "default" {
 - Components that export [OpenTelemetry `otelcol.Consumer`]({{< relref "../compatibility/#opentelemetry-otelcolconsumer-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.agent.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.agent.md
@@ -70,3 +70,17 @@ Replace the following:
   - `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.agent` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.agent.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.agent.md
@@ -80,7 +80,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.apache.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.apache.md
@@ -96,7 +96,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.apache.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.apache.md
@@ -87,3 +87,16 @@ Replace the following:
 - `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.apache` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.azure.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.azure.md
@@ -148,3 +148,16 @@ Replace the following:
 - `PROMETHEUS_REMOTE_WRITE_URL`: The URL of the Prometheus remote_write-compatible server to send metrics to.
 - `USERNAME`: The username to use for authentication to the remote_write API.
 - `PASSWORD`: The password to use for authentication to the remote_write API.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.azure` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.azure.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.azure.md
@@ -157,7 +157,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
@@ -189,3 +189,16 @@ Replace the following:
 
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.blackbox` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
@@ -198,7 +198,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.cadvisor.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.cadvisor.md
@@ -135,7 +135,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.cadvisor.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.cadvisor.md
@@ -126,3 +126,16 @@ Replace the following:
 - `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.cadvisor` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.cloudwatch.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.cloudwatch.md
@@ -452,3 +452,16 @@ discovery job, the `type` field of each `discovery_job` must match either the de
 - Namespace: `/aws/sagemaker/TransformJobs` or Alias: `sagemaker-transform`
 - Namespace: `/aws/sagemaker/InferenceRecommendationsJobs` or Alias: `sagemaker-inf-rec`
 - Namespace: `AWS/Sagemaker/ModelBuildingPipeline` or Alias: `sagemaker-model-building-pipeline`
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.cloudwatch` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.cloudwatch.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.cloudwatch.md
@@ -461,7 +461,11 @@ discovery job, the `type` field of each `discovery_job` must match either the de
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.consul.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.consul.md
@@ -106,7 +106,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.consul.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.consul.md
@@ -97,3 +97,16 @@ Replace the following:
 - `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.consul` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.dnsmasq.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.dnsmasq.md
@@ -96,7 +96,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.dnsmasq.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.dnsmasq.md
@@ -87,3 +87,16 @@ Replace the following:
 - `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.dnsmasq` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.elasticsearch.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.elasticsearch.md
@@ -111,3 +111,16 @@ Replace the following:
 - `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.elasticsearch` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.elasticsearch.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.elasticsearch.md
@@ -120,7 +120,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.gcp.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.gcp.md
@@ -182,7 +182,11 @@ prometheus.exporter.gcp "lb_subset_with_filter" {
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.gcp.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.gcp.md
@@ -173,3 +173,16 @@ prometheus.exporter.gcp "lb_subset_with_filter" {
         ]
 }
 ```
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.gcp` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.github.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.github.md
@@ -95,3 +95,16 @@ Replace the following:
 - `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.github` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.github.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.github.md
@@ -104,7 +104,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.kafka.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.kafka.md
@@ -107,3 +107,16 @@ Replace the following:
 - `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.kafka` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.kafka.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.kafka.md
@@ -116,7 +116,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.memcached.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.memcached.md
@@ -99,3 +99,16 @@ Replace the following:
 - `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.memcached` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.memcached.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.memcached.md
@@ -108,7 +108,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.mongodb.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mongodb.md
@@ -97,7 +97,11 @@ prometheus.remote_write "default" {
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.mongodb.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mongodb.md
@@ -88,3 +88,16 @@ prometheus.remote_write "default" {
 ```
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.mongodb` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.mssql.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mssql.md
@@ -330,3 +330,16 @@ queries:
         committed_target_kb * 1024 AS committed_memory_target_bytes
       FROM sys.dm_os_sys_info
 ```
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.mssql` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.mssql.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mssql.md
@@ -339,7 +339,11 @@ queries:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.mysql.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mysql.md
@@ -212,3 +212,16 @@ Replace the following:
 - `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.mysql` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.mysql.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mysql.md
@@ -221,7 +221,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.oracledb.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.oracledb.md
@@ -109,7 +109,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.oracledb.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.oracledb.md
@@ -100,3 +100,16 @@ Replace the following:
 - `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.oracledb` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.postgres.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.postgres.md
@@ -222,7 +222,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.postgres.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.postgres.md
@@ -213,3 +213,16 @@ Replace the following:
 - `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.postgres` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.process.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.process.md
@@ -133,3 +133,16 @@ Replace the following:
 - `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.process` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.process.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.process.md
@@ -142,7 +142,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.redis.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.redis.md
@@ -140,7 +140,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.redis.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.redis.md
@@ -131,3 +131,16 @@ Replace the following:
 - `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.redis` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.snmp.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.snmp.md
@@ -207,7 +207,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.snmp.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.snmp.md
@@ -198,3 +198,16 @@ Replace the following:
 - `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.snmp` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.snowflake.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.snowflake.md
@@ -101,3 +101,16 @@ Replace the following:
 - `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.snowflake` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.snowflake.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.snowflake.md
@@ -110,7 +110,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.squid.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.squid.md
@@ -102,7 +102,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.squid.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.squid.md
@@ -93,3 +93,16 @@ Replace the following:
 - `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.squid` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.statsd.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.statsd.md
@@ -135,7 +135,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.statsd.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.statsd.md
@@ -126,3 +126,16 @@ Replace the following:
 - `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.statsd` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.unix.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.unix.md
@@ -409,3 +409,16 @@ Replace the following:
 - `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.unix` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.unix.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.unix.md
@@ -418,7 +418,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.vsphere.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.vsphere.md
@@ -98,7 +98,11 @@ prometheus.remote_write "default" {
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.vsphere.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.vsphere.md
@@ -89,3 +89,16 @@ prometheus.remote_write "default" {
 ```
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.vsphere` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.windows.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.windows.md
@@ -307,3 +307,16 @@ Replace the following:
   - `PASSWORD`: The password to use for authentication to the remote_write API.
 
 [scrape]: {{< relref "./prometheus.scrape.md" >}}
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.exporter.windows` has exports that can be consumed by the following components:
+
+- Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.exporter.windows.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.windows.md
@@ -316,7 +316,11 @@ Replace the following:
 
 - Components that consume [Targets]({{< relref "../compatibility/#targets-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.operator.podmonitors.md
+++ b/docs/sources/flow/reference/components/prometheus.operator.podmonitors.md
@@ -256,3 +256,16 @@ prometheus.operator.podmonitors "pods" {
     }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.operator.podmonitors` can accept arguments from the following components:
+
+- Components that export [Prometheus `MetricsReceiver`]({{< relref "../compatibility/#prometheus-metricsreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.operator.podmonitors.md
+++ b/docs/sources/flow/reference/components/prometheus.operator.podmonitors.md
@@ -265,7 +265,11 @@ prometheus.operator.podmonitors "pods" {
 - Components that export [Prometheus `MetricsReceiver`]({{< relref "../compatibility/#prometheus-metricsreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.operator.probes.md
+++ b/docs/sources/flow/reference/components/prometheus.operator.probes.md
@@ -191,7 +191,7 @@ If {{< param "PRODUCT_NAME" >}} is _not_ running in clustered mode, then the blo
 
 ## Exported fields
 
-`prometheus.operator.probes` does not export any fields. It forwards all metrics it scrapes to the receiver configures with the `forward_to` argument.
+`prometheus.operator.probes` does not export any fields. It forwards all metrics it scrapes to the receivers configured with the `forward_to` argument.
 
 ## Component health
 
@@ -258,3 +258,16 @@ prometheus.operator.probes "probes" {
     }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.operator.probes` can accept arguments from the following components:
+
+- Components that export [Prometheus `MetricsReceiver`]({{< relref "../compatibility/#prometheus-metricsreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.operator.probes.md
+++ b/docs/sources/flow/reference/components/prometheus.operator.probes.md
@@ -267,7 +267,11 @@ prometheus.operator.probes "probes" {
 - Components that export [Prometheus `MetricsReceiver`]({{< relref "../compatibility/#prometheus-metricsreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.operator.servicemonitors.md
+++ b/docs/sources/flow/reference/components/prometheus.operator.servicemonitors.md
@@ -258,3 +258,16 @@ prometheus.operator.servicemonitors "services" {
     }
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.operator.servicemonitors` can accept arguments from the following components:
+
+- Components that export [Prometheus `MetricsReceiver`]({{< relref "../compatibility/#prometheus-metricsreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.operator.servicemonitors.md
+++ b/docs/sources/flow/reference/components/prometheus.operator.servicemonitors.md
@@ -267,7 +267,11 @@ prometheus.operator.servicemonitors "services" {
 - Components that export [Prometheus `MetricsReceiver`]({{< relref "../compatibility/#prometheus-metricsreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.receive_http.md
+++ b/docs/sources/flow/reference/components/prometheus.receive_http.md
@@ -138,7 +138,11 @@ prometheus.remote_write "local" {
 - Components that export [Prometheus `MetricsReceiver`]({{< relref "../compatibility/#prometheus-metricsreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.receive_http.md
+++ b/docs/sources/flow/reference/components/prometheus.receive_http.md
@@ -40,7 +40,7 @@ The component will start an HTTP server supporting the following endpoint:
 
 Name         | Type             | Description                           | Default | Required
 -------------|------------------|---------------------------------------|---------|---------
-`forward_to` | `list(receiver)` | List of receivers to send metrics to. |         | yes
+`forward_to` | `list(MetricsReceiver)` | List of receivers to send metrics to. |         | yes
 
 ## Blocks
 
@@ -129,3 +129,16 @@ prometheus.remote_write "local" {
 ## Technical details
 
 `prometheus.receive_http` uses [snappy](https://en.wikipedia.org/wiki/Snappy_(compression)) for compression.
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.receive_http` can accept arguments from the following components:
+
+- Components that export [Prometheus `MetricsReceiver`]({{< relref "../compatibility/#prometheus-metricsreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.relabel.md
+++ b/docs/sources/flow/reference/components/prometheus.relabel.md
@@ -180,7 +180,11 @@ The two resulting metrics are then propagated to each receiver defined in the
 
 - Components that consume [Prometheus `MetricsReceiver`]({{< relref "../compatibility/#prometheus-metricsreceiver-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.relabel.md
+++ b/docs/sources/flow/reference/components/prometheus.relabel.md
@@ -55,7 +55,7 @@ The following arguments are supported:
 
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`forward_to` | `list(receiver)` | Where the metrics should be forwarded to, after relabeling takes place. | | yes
+`forward_to` | `list(MetricsReceiver)` | Where the metrics should be forwarded to, after relabeling takes place. | | yes
 
 ## Blocks
 
@@ -77,7 +77,7 @@ The following fields are exported and can be referenced by other components:
 
 Name | Type | Description
 ---- | ---- | -----------
-`receiver` | `receiver` | The input receiver where samples are sent to be relabeled.
+`receiver` | `MetricsReceiver` | The input receiver where samples are sent to be relabeled.
 `rules`    | `RelabelRules` | The currently configured relabeling rules.
 
 ## Component health
@@ -168,3 +168,19 @@ metric_a{host = "cluster_a/production",  __address__ = "cluster_a", app = "backe
 
 The two resulting metrics are then propagated to each receiver defined in the
 `forward_to` argument.
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.relabel` can accept arguments from the following components:
+
+- Components that export [Prometheus `MetricsReceiver`]({{< relref "../compatibility/#prometheus-metricsreceiver-exporters" >}})
+
+`prometheus.relabel` has exports that can be consumed by the following components:
+
+- Components that consume [Prometheus `MetricsReceiver`]({{< relref "../compatibility/#prometheus-metricsreceiver-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.remote_write.md
+++ b/docs/sources/flow/reference/components/prometheus.remote_write.md
@@ -242,7 +242,7 @@ The following fields are exported and can be referenced by other components:
 
 Name | Type | Description
 ---- | ---- | -----------
-`receiver` | `receiver` | A value which other components can use to send metrics to.
+`receiver` | `MetricsReceiver` | A value which other components can use to send metrics to.
 
 ## Component health
 
@@ -405,3 +405,15 @@ Any labels that start with `__` will be removed before sending to the endpoint.
 
 {{< docs/shared source="agent" lookup="/wal-data-retention.md" version="<AGENT_VERSION>" >}}
 
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.remote_write` has exports that can be consumed by the following components:
+
+- Components that consume [Prometheus `MetricsReceiver`]({{< relref "../compatibility/#prometheus-metricsreceiver-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.remote_write.md
+++ b/docs/sources/flow/reference/components/prometheus.remote_write.md
@@ -413,7 +413,11 @@ Any labels that start with `__` will be removed before sending to the endpoint.
 
 - Components that consume [Prometheus `MetricsReceiver`]({{< relref "../compatibility/#prometheus-metricsreceiver-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.scrape.md
+++ b/docs/sources/flow/reference/components/prometheus.scrape.md
@@ -287,3 +287,18 @@ Special labels added after a scrape
 * `__name__` is the label name indicating the metric name of a timeseries.
 * `job` is the label name indicating the job from which a timeseries was scraped.
 * `instance` is the label name used for the instance label.
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`prometheus.scrape` can accept arguments from the following components:
+
+- Components that export [Targets]({{< relref "../compatibility/#targets-exporters" >}})
+- Components that export [Prometheus `MetricsReceiver`]({{< relref "../compatibility/#prometheus-metricsreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/prometheus.scrape.md
+++ b/docs/sources/flow/reference/components/prometheus.scrape.md
@@ -298,7 +298,11 @@ Special labels added after a scrape
 - Components that export [Prometheus `MetricsReceiver`]({{< relref "../compatibility/#prometheus-metricsreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/pyroscope.ebpf.md
+++ b/docs/sources/flow/reference/components/pyroscope.ebpf.md
@@ -288,3 +288,17 @@ pyroscope.ebpf "default" {
   targets      = discovery.relabel.local_containers.output
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`pyroscope.ebpf` can accept arguments from the following components:
+
+- Components that export [Targets]({{< relref "../compatibility/#targets-exporters" >}})
+- Components that export [Pyroscope `ProfilesReceiver`]({{< relref "../compatibility/#pyroscope-profilesreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/pyroscope.ebpf.md
+++ b/docs/sources/flow/reference/components/pyroscope.ebpf.md
@@ -298,7 +298,11 @@ pyroscope.ebpf "default" {
 - Components that export [Pyroscope `ProfilesReceiver`]({{< relref "../compatibility/#pyroscope-profilesreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/pyroscope.scrape.md
+++ b/docs/sources/flow/reference/components/pyroscope.scrape.md
@@ -428,3 +428,18 @@ http://localhost:12345/debug/pprof/goroutine
 http://localhost:12345/debug/pprof/profile?seconds=14
 http://localhost:12345/debug/fgprof?seconds=14
 ```
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`pyroscope.scrape` can accept arguments from the following components:
+
+- Components that export [Targets]({{< relref "../compatibility/#targets-exporters" >}})
+- Components that export [Pyroscope `ProfilesReceiver`]({{< relref "../compatibility/#pyroscope-profilesreceiver-exporters" >}})
+
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/pyroscope.scrape.md
+++ b/docs/sources/flow/reference/components/pyroscope.scrape.md
@@ -439,7 +439,11 @@ http://localhost:12345/debug/fgprof?seconds=14
 - Components that export [Pyroscope `ProfilesReceiver`]({{< relref "../compatibility/#pyroscope-profilesreceiver-exporters" >}})
 
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/pyroscope.write.md
+++ b/docs/sources/flow/reference/components/pyroscope.write.md
@@ -168,7 +168,11 @@ pyroscope.scrape "default" {
 
 - Components that consume [Pyroscope `ProfilesReceiver`]({{< relref "../compatibility/#pyroscope-profilesreceiver-consumers" >}})
 
-Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+{{% admonition type="note" %}}
 
+Connecting some components may not be sensible or components may require further configuration to make the 
+connection work correctly. Refer to the linked documentation for more details.
+
+{{% /admonition %}}
 
 <!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/pyroscope.write.md
+++ b/docs/sources/flow/reference/components/pyroscope.write.md
@@ -160,3 +160,15 @@ pyroscope.scrape "default" {
   forward_to = [pyroscope.write.staging.receiver]
 }
 ```
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`pyroscope.write` has exports that can be consumed by the following components:
+
+- Components that consume [Pyroscope `ProfilesReceiver`]({{< relref "../compatibility/#pyroscope-profilesreceiver-consumers" >}})
+
+Note that connecting some components may not be feasible or components may require further configuration to make the connection work correctly. Please refer to the linked documentation for more details.
+
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->


### PR DESCRIPTION
## Description

This PR adds:
* An auto-generated section "Compatible Components" on each component's reference page that lists the most common ways the components can be connected. The "most common ways" is determined by type of data being used: Targets, Prom metrics, Loki logs, Pyroscope profiles, OTEL.
* A new "Compatible Components" page which lists some of the most common data types used in telemetry pipelines and which components can be used to either export or consume these data types. 
* Code required to generate these pages.
* Tests that verify that the checked-in docs match with in-memory generated docs, so we can verify that they are being updated correctly. This test also allows to overwrite local files when developer wants to update the docs locally with the generated versions.

## Generation workflow

The docs can be re-generated using `make generate-docs`. 
There is a CI test that compares the current docs vs. the in-memory generated docs. If differences are found, the test fails and adequate error message is printed. This can be fixed by running `make generate-docs` and the changes should be reviewed as part of PR.

## Examples

Loki section on "Compatible Components" page. The list of `loki` namespace components is collapsed, cause it's long.
![image](https://github.com/grafana/agent/assets/17101802/363a3611-a531-455a-bb38-6d48c1727295)

And an example of "Compatible Components" section on "loki.process" reference page:
![image](https://github.com/grafana/agent/assets/17101802/06fa7334-cdc1-4f45-aa54-53656176a271)

Fixes: #4754