### PR TITLE
feat(otelcol/exp/prom): add support for resource_to_telemetry_conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Main (unreleased)
   Previously, only `remote.*` and `local.*` components could be referenced
   without a circular dependency. (@rfratto)
 
+- Added support to convert resource attributes to Prometheus labels in `otelcol.exporter.prometheus`. (@hainenber)
+
 ### Bugfixes
 
 - Permit `X-Faro-Session-ID` header in CORS requests for the `faro.receiver`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ Main (unreleased)
   Previously, only `remote.*` and `local.*` components could be referenced
   without a circular dependency. (@rfratto)
 
-- Added support to convert resource attributes to Prometheus labels in `otelcol.exporter.prometheus`. (@hainenber)
+- Add a `resource_to_telemetry_conversion` argument to `otelcol.exporter.prometheus`
+  for converting resource attributes to Prometheus labels. (@hainenber)
 
 ### Bugfixes
 

--- a/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
+++ b/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
@@ -18,12 +18,13 @@ func TestConverter(t *testing.T) {
 		input  string
 		expect string
 
-		showTimestamps     bool
-		includeTargetInfo  bool
-		includeScopeInfo   bool
-		includeScopeLabels bool
-		addMetricSuffixes  bool
-		enableOpenMetrics  bool
+		showTimestamps                bool
+		includeTargetInfo             bool
+		includeScopeInfo              bool
+		includeScopeLabels            bool
+		addMetricSuffixes             bool
+		enableOpenMetrics             bool
+		resourceToTelemetryConversion bool
 	}{
 		{
 			name: "Gauge",
@@ -838,6 +839,233 @@ func TestConverter(t *testing.T) {
 			addMetricSuffixes: true,
 			enableOpenMetrics: true,
 		},
+		{
+			name: "Gauge: convert resource attributes to metric label",
+			input: `{
+				"resource_metrics": [{
+					"resource": {
+						"attributes": [{
+							"key": "service.name",
+							"value": { "stringValue": "myservice" }
+						}, {
+							"key": "service.instance.id",
+							"value": { "stringValue": "instance" }
+						}, {
+							"key": "raw",
+							"value": { "stringValue": "test" }
+						},{
+							"key": "foo.one",
+							"value": { "stringValue": "foo" }
+						}, {
+							"key": "bar.one",
+							"value": { "stringValue": "bar" }
+						}]
+					},
+					"scope_metrics": [{
+						"metrics": [{
+							"name": "test_metric_gauge",
+							"gauge": {
+								"data_points": [{
+									"as_double": 1234.56
+								}]
+							}
+						}]
+					}]
+				}]
+			}`,
+			expect: `
+				# TYPE test_metric_gauge gauge
+				test_metric_gauge{bar_one="bar",foo_one="foo",instance="instance",service_instance_id="instance",job="myservice",service_name="myservice",raw="test"} 1234.56
+			`,
+			enableOpenMetrics:             true,
+			resourceToTelemetryConversion: true,
+		},
+		{
+			name: "Summary: convert resource attributes to metric label",
+			input: `{
+				"resource_metrics": [{
+					"resource": {
+						"attributes": [{
+							"key": "service.name",
+							"value": { "stringValue": "myservice" }
+						}, {
+							"key": "service.instance.id",
+							"value": { "stringValue": "instance" }
+						}, {
+							"key": "raw",
+							"value": { "stringValue": "test" }
+						},{
+							"key": "foo.one",
+							"value": { "stringValue": "foo" }
+						}, {
+							"key": "bar.one",
+							"value": { "stringValue": "bar" }
+						}]
+					},
+					"scope_metrics": [{
+						"metrics": [{
+							"name": "test_metric_summary",
+							"unit": "seconds",
+							"summary": {
+								"data_points": [{
+									"start_time_unix_nano": 1000000000,
+									"time_unix_nano": 1000000000,
+									"count": 333,
+									"sum": 100,
+									"quantile_values": [
+										{ "quantile": 0, "value": 100 },
+										{ "quantile": 0.5, "value": 400 },
+										{ "quantile": 1, "value": 500 }
+									]
+								}]
+							}
+						}]
+					}]
+				}]
+			}`,
+			expect: `
+				# TYPE test_metric_summary summary
+				test_metric_summary{bar_one="bar",foo_one="foo",instance="instance",service_instance_id="instance",job="myservice",service_name="myservice",raw="test",quantile="0.0"} 100.0
+				test_metric_summary{bar_one="bar",foo_one="foo",instance="instance",service_instance_id="instance",job="myservice",service_name="myservice",raw="test",quantile="0.5"} 400.0
+				test_metric_summary{bar_one="bar",foo_one="foo",instance="instance",service_instance_id="instance",job="myservice",service_name="myservice",raw="test",quantile="1.0"} 500.0
+				test_metric_summary_sum{bar_one="bar",foo_one="foo",instance="instance",service_instance_id="instance",job="myservice",service_name="myservice",raw="test"} 100.0
+				test_metric_summary_count{bar_one="bar",foo_one="foo",instance="instance",service_instance_id="instance",job="myservice",service_name="myservice",raw="test"} 333
+			`,
+			enableOpenMetrics:             true,
+			resourceToTelemetryConversion: true,
+		},
+		{
+			name: "Histogram: convert resource attributes to metric label",
+			input: `{
+				"resource_metrics": [{
+					"resource": {
+						"attributes": [{
+							"key": "service.name",
+							"value": { "stringValue": "myservice" }
+						}, {
+							"key": "service.instance.id",
+							"value": { "stringValue": "instance" }
+						}, {
+							"key": "raw",
+							"value": { "stringValue": "test" }
+						},{
+							"key": "foo.one",
+							"value": { "stringValue": "foo" }
+						}, {
+							"key": "bar.one",
+							"value": { "stringValue": "bar" }
+						}]
+					},
+					"scope_metrics": [{
+						"metrics": [
+							{
+								"name": "test_metric_histogram",
+								"unit": "seconds",
+								"histogram": {
+									"aggregation_temporality": 2,
+									"data_points": [{
+										"start_time_unix_nano": 1000000000,
+										"time_unix_nano": 1000000000,
+										"count": 333,
+										"sum": 100,
+										"bucket_counts": [0, 111, 0, 222],
+										"explicit_bounds": [0.25, 0.5, 0.75, 1.0],
+										"exemplars":[
+											{
+												"time_unix_nano": 1000000001,
+												"as_double": 0.3,
+												"span_id": "aaaaaaaaaaaaaaaa",
+												"trace_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+											},
+											{
+												"time_unix_nano": 1000000003,
+												"as_double": 1.5,
+												"span_id": "cccccccccccccccc",
+												"trace_id": "cccccccccccccccccccccccccccccccc"
+											},
+											{
+												"time_unix_nano": 1000000002,
+												"as_double": 0.5,
+												"span_id": "bbbbbbbbbbbbbbbb",
+												"trace_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+											}
+										]
+									}]
+								}
+							}
+						]
+					}]
+				}]
+			}`,
+			expect: `
+				# TYPE test_metric_histogram histogram
+				test_metric_histogram_bucket{bar_one="bar",foo_one="foo",instance="instance",service_instance_id="instance",job="myservice",service_name="myservice",raw="test",le="0.25"} 0
+				test_metric_histogram_bucket{bar_one="bar",foo_one="foo",instance="instance",service_instance_id="instance",job="myservice",service_name="myservice",raw="test",le="0.5"} 111 # {span_id="aaaaaaaaaaaaaaaa",trace_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"} 0.3
+				test_metric_histogram_bucket{bar_one="bar",foo_one="foo",instance="instance",service_instance_id="instance",job="myservice",service_name="myservice",raw="test",le="0.75"} 111 # {span_id="bbbbbbbbbbbbbbbb",trace_id="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"} 0.5
+				test_metric_histogram_bucket{bar_one="bar",foo_one="foo",instance="instance",service_instance_id="instance",job="myservice",service_name="myservice",raw="test",le="1.0"} 333
+				test_metric_histogram_bucket{bar_one="bar",foo_one="foo",instance="instance",service_instance_id="instance",job="myservice",service_name="myservice",raw="test",le="+Inf"} 333 # {span_id="cccccccccccccccc",trace_id="cccccccccccccccccccccccccccccccc"} 1.5
+				test_metric_histogram_sum{bar_one="bar",foo_one="foo",instance="instance",service_instance_id="instance",job="myservice",service_name="myservice",raw="test"} 100.0
+				test_metric_histogram_count{bar_one="bar",foo_one="foo",instance="instance",service_instance_id="instance",job="myservice",service_name="myservice",raw="test"} 333
+			`,
+			enableOpenMetrics:             true,
+			resourceToTelemetryConversion: true,
+		},
+		{
+			name: "Monotonic sum: convert resource attributes to metric label",
+			input: `{
+				"resource_metrics": [{
+					"resource": {
+						"attributes": [{
+							"key": "service.name",
+							"value": { "stringValue": "myservice" }
+						}, {
+							"key": "service.instance.id",
+							"value": { "stringValue": "instance" }
+						}, {
+							"key": "raw",
+							"value": { "stringValue": "test" }
+						},{
+							"key": "foo.one",
+							"value": { "stringValue": "foo" }
+						}, {
+							"key": "bar.one",
+							"value": { "stringValue": "bar" }
+						}]
+					},
+					"scope_metrics": [{
+						"metrics": [
+							{
+								"name": "test_metric_mono_sum_total",
+								"unit": "seconds",
+								"sum": {
+									"aggregation_temporality": 2,
+									"is_monotonic": true,
+									"data_points": [{
+										"start_time_unix_nano": 1000000000,
+										"time_unix_nano": 1000000000,
+										"as_double": 15,
+										"exemplars":[
+											{
+												"time_unix_nano": 1000000001,
+												"as_double": 0.3,
+												"span_id": "aaaaaaaaaaaaaaaa",
+												"trace_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+											}
+										]
+									}]
+								}
+							}
+						]
+					}]
+				}]
+			}`,
+			expect: `
+				# TYPE test_metric_mono_sum counter
+				test_metric_mono_sum_total{bar_one="bar",foo_one="foo",instance="instance",service_instance_id="instance",job="myservice",service_name="myservice",raw="test"} 15.0 # {span_id="aaaaaaaaaaaaaaaa",trace_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"} 0.3
+			`,
+			enableOpenMetrics:             true,
+			resourceToTelemetryConversion: true,
+		},
 	}
 
 	decoder := &pmetric.JSONUnmarshaler{}
@@ -851,10 +1079,11 @@ func TestConverter(t *testing.T) {
 
 			l := util.TestLogger(t)
 			conv := convert.New(l, appenderAppendable{Inner: &app}, convert.Options{
-				IncludeTargetInfo:  tc.includeTargetInfo,
-				IncludeScopeInfo:   tc.includeScopeInfo,
-				IncludeScopeLabels: tc.includeScopeLabels,
-				AddMetricSuffixes:  tc.addMetricSuffixes,
+				IncludeTargetInfo:             tc.includeTargetInfo,
+				IncludeScopeInfo:              tc.includeScopeInfo,
+				IncludeScopeLabels:            tc.includeScopeLabels,
+				AddMetricSuffixes:             tc.addMetricSuffixes,
+				ResourceToTelemetryConversion: tc.resourceToTelemetryConversion,
 			})
 			require.NoError(t, conv.ConsumeMetrics(context.Background(), payload))
 

--- a/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
+++ b/component/otelcol/exporter/prometheus/internal/convert/convert_test.go
@@ -881,6 +881,47 @@ func TestConverter(t *testing.T) {
 			resourceToTelemetryConversion: true,
 		},
 		{
+			name: "Gauge: NOT convert resource attributes to metric label",
+			input: `{
+				"resource_metrics": [{
+					"resource": {
+						"attributes": [{
+							"key": "service.name",
+							"value": { "stringValue": "myservice" }
+						}, {
+							"key": "service.instance.id",
+							"value": { "stringValue": "instance" }
+						}, {
+							"key": "raw",
+							"value": { "stringValue": "test" }
+						},{
+							"key": "foo.one",
+							"value": { "stringValue": "foo" }
+						}, {
+							"key": "bar.one",
+							"value": { "stringValue": "bar" }
+						}]
+					},
+					"scope_metrics": [{
+						"metrics": [{
+							"name": "test_metric_gauge",
+							"gauge": {
+								"data_points": [{
+									"as_double": 1234.56
+								}]
+							}
+						}]
+					}]
+				}]
+			}`,
+			expect: `
+				# TYPE test_metric_gauge gauge
+				test_metric_gauge{instance="instance",job="myservice"} 1234.56
+			`,
+			enableOpenMetrics:             true,
+			resourceToTelemetryConversion: false,
+		},
+		{
 			name: "Summary: convert resource attributes to metric label",
 			input: `{
 				"resource_metrics": [{

--- a/component/otelcol/exporter/prometheus/prometheus.go
+++ b/component/otelcol/exporter/prometheus/prometheus.go
@@ -31,21 +31,23 @@ func init() {
 
 // Arguments configures the otelcol.exporter.prometheus component.
 type Arguments struct {
-	IncludeTargetInfo  bool                 `river:"include_target_info,attr,optional"`
-	IncludeScopeInfo   bool                 `river:"include_scope_info,attr,optional"`
-	IncludeScopeLabels bool                 `river:"include_scope_labels,attr,optional"`
-	GCFrequency        time.Duration        `river:"gc_frequency,attr,optional"`
-	ForwardTo          []storage.Appendable `river:"forward_to,attr"`
-	AddMetricSuffixes  bool                 `river:"add_metric_suffixes,attr,optional"`
+	IncludeTargetInfo             bool                 `river:"include_target_info,attr,optional"`
+	IncludeScopeInfo              bool                 `river:"include_scope_info,attr,optional"`
+	IncludeScopeLabels            bool                 `river:"include_scope_labels,attr,optional"`
+	GCFrequency                   time.Duration        `river:"gc_frequency,attr,optional"`
+	ForwardTo                     []storage.Appendable `river:"forward_to,attr"`
+	AddMetricSuffixes             bool                 `river:"add_metric_suffixes,attr,optional"`
+	ResourceToTelemetryConversion bool                 `river:"resource_to_telemetry_conversion,attr,optional"`
 }
 
 // DefaultArguments holds defaults values.
 var DefaultArguments = Arguments{
-	IncludeTargetInfo:  true,
-	IncludeScopeInfo:   false,
-	IncludeScopeLabels: true,
-	GCFrequency:        5 * time.Minute,
-	AddMetricSuffixes:  true,
+	IncludeTargetInfo:             true,
+	IncludeScopeInfo:              false,
+	IncludeScopeLabels:            true,
+	GCFrequency:                   5 * time.Minute,
+	AddMetricSuffixes:             true,
+	ResourceToTelemetryConversion: false,
 }
 
 // SetToDefault implements river.Defaulter.
@@ -151,8 +153,9 @@ func (c *Component) Update(newConfig component.Arguments) error {
 
 func convertArgumentsToConvertOptions(args Arguments) convert.Options {
 	return convert.Options{
-		IncludeTargetInfo: args.IncludeTargetInfo,
-		IncludeScopeInfo:  args.IncludeScopeInfo,
-		AddMetricSuffixes: args.AddMetricSuffixes,
+		IncludeTargetInfo:             args.IncludeTargetInfo,
+		IncludeScopeInfo:              args.IncludeScopeInfo,
+		AddMetricSuffixes:             args.AddMetricSuffixes,
+		ResourceToTelemetryConversion: args.ResourceToTelemetryConversion,
 	}
 }

--- a/component/otelcol/exporter/prometheus/prometheus_test.go
+++ b/component/otelcol/exporter/prometheus/prometheus_test.go
@@ -23,12 +23,13 @@ func TestArguments_UnmarshalRiver(t *testing.T) {
 					forward_to = []
 				`,
 			expected: prometheus.Arguments{
-				IncludeTargetInfo:  true,
-				IncludeScopeInfo:   false,
-				IncludeScopeLabels: true,
-				GCFrequency:        5 * time.Minute,
-				AddMetricSuffixes:  true,
-				ForwardTo:          []storage.Appendable{},
+				IncludeTargetInfo:             true,
+				IncludeScopeInfo:              false,
+				IncludeScopeLabels:            true,
+				GCFrequency:                   5 * time.Minute,
+				AddMetricSuffixes:             true,
+				ForwardTo:                     []storage.Appendable{},
+				ResourceToTelemetryConversion: false,
 			},
 		},
 		{
@@ -39,15 +40,17 @@ func TestArguments_UnmarshalRiver(t *testing.T) {
 					include_scope_labels = false
 					gc_frequency = "1s"
 					add_metric_suffixes = false
+					resource_to_telemetry_conversion = true
 					forward_to = []
 				`,
 			expected: prometheus.Arguments{
-				IncludeTargetInfo:  false,
-				IncludeScopeInfo:   true,
-				IncludeScopeLabels: false,
-				GCFrequency:        1 * time.Second,
-				AddMetricSuffixes:  false,
-				ForwardTo:          []storage.Appendable{},
+				IncludeTargetInfo:             false,
+				IncludeScopeInfo:              true,
+				IncludeScopeLabels:            false,
+				GCFrequency:                   1 * time.Second,
+				AddMetricSuffixes:             false,
+				ForwardTo:                     []storage.Appendable{},
+				ResourceToTelemetryConversion: true,
 			},
 		},
 		{

--- a/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
@@ -46,6 +46,7 @@ Name | Type | Description                                               | Defaul
 `add_metric_suffixes` | `boolean` | Whether to add type and unit suffixes to metrics names.   | `true` | no
 `gc_frequency` | `duration` | How often to clean up stale metrics from memory.          | `"5m"` | no
 `forward_to` | `list(receiver)` | Where to forward converted Prometheus metrics.            | | yes
+`resource_to_telemetry_conversion` | `boolean` | Whether to convert OTEL resource attribute to Prometheus-compatible datapoint attribute | `false` | no
 
 By default, OpenTelemetry resources are converted into `target_info` metrics. 
 OpenTelemetry instrumentation scopes are converted into `otel_scope_info`

--- a/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
@@ -46,7 +46,7 @@ Name | Type | Description                                               | Defaul
 `add_metric_suffixes` | `boolean` | Whether to add type and unit suffixes to metrics names.   | `true` | no
 `gc_frequency` | `duration` | How often to clean up stale metrics from memory.          | `"5m"` | no
 `forward_to` | `list(receiver)` | Where to forward converted Prometheus metrics.            | | yes
-`resource_to_telemetry_conversion` | `boolean` | Whether to convert OTel resource attributes to Prometheus-compatible datapoint attributes | `false` | no
+`resource_to_telemetry_conversion` | `boolean` | Whether to convert OTel resource attributes to Prometheus labels. | `false` | no
 
 By default, OpenTelemetry resources are converted into `target_info` metrics. 
 OpenTelemetry instrumentation scopes are converted into `otel_scope_info`

--- a/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
@@ -46,7 +46,7 @@ Name | Type | Description                                               | Defaul
 `add_metric_suffixes` | `boolean` | Whether to add type and unit suffixes to metrics names.   | `true` | no
 `gc_frequency` | `duration` | How often to clean up stale metrics from memory.          | `"5m"` | no
 `forward_to` | `list(receiver)` | Where to forward converted Prometheus metrics.            | | yes
-`resource_to_telemetry_conversion` | `boolean` | Whether to convert OTEL resource attribute to Prometheus-compatible datapoint attribute | `false` | no
+`resource_to_telemetry_conversion` | `boolean` | Whether to convert OTel resource attributes to Prometheus-compatible datapoint attributes | `false` | no
 
 By default, OpenTelemetry resources are converted into `target_info` metrics. 
 OpenTelemetry instrumentation scopes are converted into `otel_scope_info`


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Support conversion of OTEL's resource attributes to Prometheus-compatible datapoint attributes. Strongly inspired by [OTEL's contributor implementation](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/a80edda1860b50fde9a2e7d6d9df9152cc49e87c/pkg/resourcetotelemetry/resource_to_telemetry.go#L20)

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Closes #5631 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated