### PR TITLE
Update windows defaults to use upstream defaults except for enabled collectors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+
+### Bugfixes
+
+- Fix issue with windows_exporter defaults not being set correctly. (@mattdurham)
+
 v0.38.0 (2023-11-21)
 --------------------
 

--- a/component/prometheus/exporter/windows/config.go
+++ b/component/prometheus/exporter/windows/config.go
@@ -4,74 +4,7 @@ import (
 	"strings"
 
 	windows_integration "github.com/grafana/agent/pkg/integrations/windows_exporter"
-	col "github.com/prometheus-community/windows_exporter/pkg/collector"
 )
-
-// DefaultArguments holds non-zero default options for Arguments when it is
-// unmarshaled from YAML.
-//
-// Some defaults are populated from init functions in the github.com/grafana/agent/pkg/integrations/windows_exporter package.
-
-var DefaultArguments = Arguments{
-	EnabledCollectors: strings.Split(windows_integration.DefaultConfig.EnabledCollectors, ","),
-	Dfsr: DfsrConfig{
-		SourcesEnabled: strings.Split(col.ConfigDefaults.Dfsr.DfsrEnabledCollectors, ","),
-	},
-	Exchange: ExchangeConfig{
-		EnabledList: strings.Split(col.ConfigDefaults.Exchange.CollectorsEnabled, ","),
-	},
-	IIS: IISConfig{
-		AppBlackList:  col.ConfigDefaults.Iis.AppExclude,
-		AppWhiteList:  col.ConfigDefaults.Iis.AppInclude,
-		SiteBlackList: col.ConfigDefaults.Iis.SiteExclude,
-		SiteWhiteList: col.ConfigDefaults.Iis.SiteInclude,
-		AppInclude:    col.ConfigDefaults.Iis.AppInclude,
-		AppExclude:    col.ConfigDefaults.Iis.AppExclude,
-		SiteInclude:   col.ConfigDefaults.Iis.SiteInclude,
-		SiteExclude:   col.ConfigDefaults.Iis.SiteExclude,
-	},
-	LogicalDisk: LogicalDiskConfig{
-		BlackList: col.ConfigDefaults.LogicalDisk.VolumeExclude,
-		WhiteList: col.ConfigDefaults.LogicalDisk.VolumeInclude,
-		Include:   col.ConfigDefaults.LogicalDisk.VolumeInclude,
-		Exclude:   col.ConfigDefaults.LogicalDisk.VolumeExclude,
-	},
-	MSMQ: MSMQConfig{
-		Where: col.ConfigDefaults.Msmq.QueryWhereClause,
-	},
-	MSSQL: MSSQLConfig{
-		EnabledClasses: strings.Split(col.ConfigDefaults.Mssql.EnabledCollectors, ","),
-	},
-	Network: NetworkConfig{
-		BlackList: col.ConfigDefaults.Net.NicExclude,
-		WhiteList: col.ConfigDefaults.Net.NicInclude,
-		Include:   col.ConfigDefaults.Net.NicInclude,
-		Exclude:   col.ConfigDefaults.Net.NicExclude,
-	},
-	Process: ProcessConfig{
-		BlackList: col.ConfigDefaults.Process.ProcessExclude,
-		WhiteList: col.ConfigDefaults.Process.ProcessInclude,
-		Include:   col.ConfigDefaults.Process.ProcessInclude,
-		Exclude:   col.ConfigDefaults.Process.ProcessExclude,
-	},
-	ScheduledTask: ScheduledTaskConfig{
-		Include: col.ConfigDefaults.ScheduledTask.TaskInclude,
-		Exclude: col.ConfigDefaults.ScheduledTask.TaskExclude,
-	},
-	Service: ServiceConfig{
-		UseApi: "false",
-		Where:  col.ConfigDefaults.Service.ServiceWhereClause,
-	},
-	SMTP: SMTPConfig{
-		BlackList: col.ConfigDefaults.Smtp.ServerExclude,
-		WhiteList: col.ConfigDefaults.Smtp.ServerInclude,
-		Include:   col.ConfigDefaults.Smtp.ServerInclude,
-		Exclude:   col.ConfigDefaults.Smtp.ServerExclude,
-	},
-	TextFile: TextFileConfig{
-		TextFileDirectory: col.ConfigDefaults.Textfile.TextFileDirectories,
-	},
-}
 
 // Arguments is used for controlling for this exporter.
 type Arguments struct {
@@ -91,11 +24,6 @@ type Arguments struct {
 	Service       ServiceConfig       `river:"service,block,optional"`
 	SMTP          SMTPConfig          `river:"smtp,block,optional"`
 	TextFile      TextFileConfig      `river:"text_file,block,optional"`
-}
-
-// SetToDefault implements river.Defaulter.
-func (a *Arguments) SetToDefault() {
-	*a = DefaultArguments
 }
 
 // Convert converts the component's Arguments to the integration's Config.

--- a/component/prometheus/exporter/windows/config.go
+++ b/component/prometheus/exporter/windows/config.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	windows_integration "github.com/grafana/agent/pkg/integrations/windows_exporter"
+	col "github.com/prometheus-community/windows_exporter/pkg/collector"
 )
 
 // DefaultArguments holds non-zero default options for Arguments when it is
@@ -14,61 +15,61 @@ import (
 var DefaultArguments = Arguments{
 	EnabledCollectors: strings.Split(windows_integration.DefaultConfig.EnabledCollectors, ","),
 	Dfsr: DfsrConfig{
-		SourcesEnabled: strings.Split(windows_integration.DefaultConfig.Dfsr.SourcesEnabled, ","),
+		SourcesEnabled: strings.Split(col.ConfigDefaults.Dfsr.DfsrEnabledCollectors, ","),
 	},
 	Exchange: ExchangeConfig{
-		EnabledList: strings.Split(windows_integration.DefaultConfig.Exchange.EnabledList, ","),
+		EnabledList: strings.Split(col.ConfigDefaults.Exchange.CollectorsEnabled, ","),
 	},
 	IIS: IISConfig{
-		AppBlackList:  windows_integration.DefaultConfig.IIS.AppBlackList,
-		AppWhiteList:  windows_integration.DefaultConfig.IIS.AppWhiteList,
-		SiteBlackList: windows_integration.DefaultConfig.IIS.SiteBlackList,
-		SiteWhiteList: windows_integration.DefaultConfig.IIS.SiteWhiteList,
-		AppInclude:    windows_integration.DefaultConfig.IIS.AppInclude,
-		AppExclude:    windows_integration.DefaultConfig.IIS.AppExclude,
-		SiteInclude:   windows_integration.DefaultConfig.IIS.SiteInclude,
-		SiteExclude:   windows_integration.DefaultConfig.IIS.SiteExclude,
+		AppBlackList:  col.ConfigDefaults.Iis.AppExclude,
+		AppWhiteList:  col.ConfigDefaults.Iis.AppInclude,
+		SiteBlackList: col.ConfigDefaults.Iis.SiteExclude,
+		SiteWhiteList: col.ConfigDefaults.Iis.SiteInclude,
+		AppInclude:    col.ConfigDefaults.Iis.AppInclude,
+		AppExclude:    col.ConfigDefaults.Iis.AppExclude,
+		SiteInclude:   col.ConfigDefaults.Iis.SiteInclude,
+		SiteExclude:   col.ConfigDefaults.Iis.SiteExclude,
 	},
 	LogicalDisk: LogicalDiskConfig{
-		BlackList: windows_integration.DefaultConfig.LogicalDisk.BlackList,
-		WhiteList: windows_integration.DefaultConfig.LogicalDisk.WhiteList,
-		Include:   windows_integration.DefaultConfig.LogicalDisk.Include,
-		Exclude:   windows_integration.DefaultConfig.LogicalDisk.Exclude,
+		BlackList: col.ConfigDefaults.LogicalDisk.VolumeExclude,
+		WhiteList: col.ConfigDefaults.LogicalDisk.VolumeInclude,
+		Include:   col.ConfigDefaults.LogicalDisk.VolumeInclude,
+		Exclude:   col.ConfigDefaults.LogicalDisk.VolumeExclude,
 	},
 	MSMQ: MSMQConfig{
-		Where: windows_integration.DefaultConfig.MSMQ.Where,
+		Where: col.ConfigDefaults.Msmq.QueryWhereClause,
 	},
 	MSSQL: MSSQLConfig{
-		EnabledClasses: strings.Split(windows_integration.DefaultConfig.MSSQL.EnabledClasses, ","),
+		EnabledClasses: strings.Split(col.ConfigDefaults.Mssql.EnabledCollectors, ","),
 	},
 	Network: NetworkConfig{
-		BlackList: windows_integration.DefaultConfig.Network.BlackList,
-		WhiteList: windows_integration.DefaultConfig.Network.WhiteList,
-		Include:   windows_integration.DefaultConfig.Network.Include,
-		Exclude:   windows_integration.DefaultConfig.Network.Exclude,
+		BlackList: col.ConfigDefaults.Net.NicExclude,
+		WhiteList: col.ConfigDefaults.Net.NicInclude,
+		Include:   col.ConfigDefaults.Net.NicInclude,
+		Exclude:   col.ConfigDefaults.Net.NicExclude,
 	},
 	Process: ProcessConfig{
-		BlackList: windows_integration.DefaultConfig.Process.BlackList,
-		WhiteList: windows_integration.DefaultConfig.Process.WhiteList,
-		Include:   windows_integration.DefaultConfig.Process.Include,
-		Exclude:   windows_integration.DefaultConfig.Process.Exclude,
+		BlackList: col.ConfigDefaults.Process.ProcessExclude,
+		WhiteList: col.ConfigDefaults.Process.ProcessInclude,
+		Include:   col.ConfigDefaults.Process.ProcessInclude,
+		Exclude:   col.ConfigDefaults.Process.ProcessExclude,
 	},
 	ScheduledTask: ScheduledTaskConfig{
-		Include: windows_integration.DefaultConfig.ScheduledTask.Include,
-		Exclude: windows_integration.DefaultConfig.ScheduledTask.Exclude,
+		Include: col.ConfigDefaults.ScheduledTask.TaskInclude,
+		Exclude: col.ConfigDefaults.ScheduledTask.TaskExclude,
 	},
 	Service: ServiceConfig{
-		UseApi: windows_integration.DefaultConfig.Service.UseApi,
-		Where:  windows_integration.DefaultConfig.Service.Where,
+		UseApi: "false",
+		Where:  col.ConfigDefaults.Service.ServiceWhereClause,
 	},
 	SMTP: SMTPConfig{
-		BlackList: windows_integration.DefaultConfig.SMTP.BlackList,
-		WhiteList: windows_integration.DefaultConfig.SMTP.WhiteList,
-		Include:   windows_integration.DefaultConfig.SMTP.Include,
-		Exclude:   windows_integration.DefaultConfig.SMTP.Exclude,
+		BlackList: col.ConfigDefaults.Smtp.ServerExclude,
+		WhiteList: col.ConfigDefaults.Smtp.ServerInclude,
+		Include:   col.ConfigDefaults.Smtp.ServerInclude,
+		Exclude:   col.ConfigDefaults.Smtp.ServerExclude,
 	},
 	TextFile: TextFileConfig{
-		TextFileDirectory: windows_integration.DefaultConfig.TextFile.TextFileDirectory,
+		TextFileDirectory: col.ConfigDefaults.Textfile.TextFileDirectories,
 	},
 }
 

--- a/component/prometheus/exporter/windows/config_default_windows_test.go
+++ b/component/prometheus/exporter/windows/config_default_windows_test.go
@@ -1,10 +1,8 @@
 package windows
 
 import (
-	"strings"
 	"testing"
 
-	windows_integration "github.com/grafana/agent/pkg/integrations/windows_exporter"
 	"github.com/grafana/river"
 	"github.com/stretchr/testify/require"
 )
@@ -14,26 +12,26 @@ func TestRiverUnmarshalWithDefaultConfig(t *testing.T) {
 	err := river.Unmarshal([]byte(""), &args)
 	require.NoError(t, err)
 
-	require.Equal(t, strings.Split(windows_integration.DefaultConfig.EnabledCollectors, ","), args.EnabledCollectors)
-	require.Equal(t, strings.Split(windows_integration.DefaultConfig.Dfsr.SourcesEnabled, ","), args.Dfsr.SourcesEnabled)
-	require.Equal(t, strings.Split(windows_integration.DefaultConfig.Exchange.EnabledList, ","), args.Exchange.EnabledList)
-	require.Equal(t, windows_integration.DefaultConfig.IIS.AppExclude, args.IIS.AppExclude)
-	require.Equal(t, windows_integration.DefaultConfig.IIS.AppInclude, args.IIS.AppInclude)
-	require.Equal(t, windows_integration.DefaultConfig.IIS.SiteExclude, args.IIS.SiteExclude)
-	require.Equal(t, windows_integration.DefaultConfig.IIS.SiteInclude, args.IIS.SiteInclude)
-	require.Equal(t, windows_integration.DefaultConfig.LogicalDisk.Exclude, args.LogicalDisk.Exclude)
-	require.Equal(t, windows_integration.DefaultConfig.LogicalDisk.Include, args.LogicalDisk.Include)
-	require.Equal(t, windows_integration.DefaultConfig.MSMQ.Where, args.MSMQ.Where)
-	require.Equal(t, strings.Split(windows_integration.DefaultConfig.MSSQL.EnabledClasses, ","), args.MSSQL.EnabledClasses)
-	require.Equal(t, windows_integration.DefaultConfig.Network.Exclude, args.Network.Exclude)
-	require.Equal(t, windows_integration.DefaultConfig.Network.Include, args.Network.Include)
-	require.Equal(t, windows_integration.DefaultConfig.Process.Exclude, args.Process.Exclude)
-	require.Equal(t, windows_integration.DefaultConfig.Process.Include, args.Process.Include)
-	require.Equal(t, windows_integration.DefaultConfig.ScheduledTask.Exclude, args.ScheduledTask.Exclude)
-	require.Equal(t, windows_integration.DefaultConfig.ScheduledTask.Include, args.ScheduledTask.Include)
-	require.Equal(t, windows_integration.DefaultConfig.Service.UseApi, args.Service.UseApi)
-	require.Equal(t, windows_integration.DefaultConfig.Service.Where, args.Service.Where)
-	require.Equal(t, windows_integration.DefaultConfig.SMTP.Exclude, args.SMTP.Exclude)
-	require.Equal(t, windows_integration.DefaultConfig.SMTP.Include, args.SMTP.Include)
-	require.Equal(t, windows_integration.DefaultConfig.TextFile.TextFileDirectory, args.TextFile.TextFileDirectory)
+	require.Equal(t, DefaultArguments.EnabledCollectors, args.EnabledCollectors)
+	require.Equal(t, DefaultArguments.Dfsr.SourcesEnabled, args.Dfsr.SourcesEnabled)
+	require.Equal(t, DefaultArguments.Exchange.EnabledList, args.Exchange.EnabledList)
+	require.Equal(t, DefaultArguments.IIS.AppExclude, args.IIS.AppExclude)
+	require.Equal(t, DefaultArguments.IIS.AppInclude, args.IIS.AppInclude)
+	require.Equal(t, DefaultArguments.IIS.SiteExclude, args.IIS.SiteExclude)
+	require.Equal(t, DefaultArguments.IIS.SiteInclude, args.IIS.SiteInclude)
+	require.Equal(t, DefaultArguments.LogicalDisk.Exclude, args.LogicalDisk.Exclude)
+	require.Equal(t, DefaultArguments.LogicalDisk.Include, args.LogicalDisk.Include)
+	require.Equal(t, DefaultArguments.MSMQ.Where, args.MSMQ.Where)
+	require.Equal(t, DefaultArguments.MSSQL.EnabledClasses, args.MSSQL.EnabledClasses)
+	require.Equal(t, DefaultArguments.Network.Exclude, args.Network.Exclude)
+	require.Equal(t, DefaultArguments.Network.Include, args.Network.Include)
+	require.Equal(t, DefaultArguments.Process.Exclude, args.Process.Exclude)
+	require.Equal(t, DefaultArguments.Process.Include, args.Process.Include)
+	require.Equal(t, DefaultArguments.ScheduledTask.Exclude, args.ScheduledTask.Exclude)
+	require.Equal(t, DefaultArguments.ScheduledTask.Include, args.ScheduledTask.Include)
+	require.Equal(t, DefaultArguments.Service.UseApi, args.Service.UseApi)
+	require.Equal(t, DefaultArguments.Service.Where, args.Service.Where)
+	require.Equal(t, DefaultArguments.SMTP.Exclude, args.SMTP.Exclude)
+	require.Equal(t, DefaultArguments.SMTP.Include, args.SMTP.Include)
+	require.Equal(t, DefaultArguments.TextFile.TextFileDirectory, args.TextFile.TextFileDirectory)
 }

--- a/component/prometheus/exporter/windows/config_windows.go
+++ b/component/prometheus/exporter/windows/config_windows.go
@@ -1,6 +1,10 @@
 package windows
 
-import col "github.com/prometheus-community/windows_exporter/pkg/collector"
+import (
+	windows_integration "github.com/grafana/agent/pkg/integrations/windows_exporter"
+	col "github.com/prometheus-community/windows_exporter/pkg/collector"
+	"strings"
+)
 
 // DefaultArguments holds non-zero default options for Arguments when it is
 // unmarshaled from YAML.

--- a/component/prometheus/exporter/windows/config_windows.go
+++ b/component/prometheus/exporter/windows/config_windows.go
@@ -1,0 +1,71 @@
+package windows
+
+import col "github.com/prometheus-community/windows_exporter/pkg/collector"
+
+// DefaultArguments holds non-zero default options for Arguments when it is
+// unmarshaled from YAML.
+var DefaultArguments = Arguments{
+	EnabledCollectors: strings.Split(windows_integration.DefaultConfig.EnabledCollectors, ","),
+	Dfsr: DfsrConfig{
+		SourcesEnabled: strings.Split(col.ConfigDefaults.Dfsr.DfsrEnabledCollectors, ","),
+	},
+	Exchange: ExchangeConfig{
+		EnabledList: strings.Split(col.ConfigDefaults.Exchange.CollectorsEnabled, ","),
+	},
+	IIS: IISConfig{
+		AppBlackList:  col.ConfigDefaults.Iis.AppExclude,
+		AppWhiteList:  col.ConfigDefaults.Iis.AppInclude,
+		SiteBlackList: col.ConfigDefaults.Iis.SiteExclude,
+		SiteWhiteList: col.ConfigDefaults.Iis.SiteInclude,
+		AppInclude:    col.ConfigDefaults.Iis.AppInclude,
+		AppExclude:    col.ConfigDefaults.Iis.AppExclude,
+		SiteInclude:   col.ConfigDefaults.Iis.SiteInclude,
+		SiteExclude:   col.ConfigDefaults.Iis.SiteExclude,
+	},
+	LogicalDisk: LogicalDiskConfig{
+		BlackList: col.ConfigDefaults.LogicalDisk.VolumeExclude,
+		WhiteList: col.ConfigDefaults.LogicalDisk.VolumeInclude,
+		Include:   col.ConfigDefaults.LogicalDisk.VolumeInclude,
+		Exclude:   col.ConfigDefaults.LogicalDisk.VolumeExclude,
+	},
+	MSMQ: MSMQConfig{
+		Where: col.ConfigDefaults.Msmq.QueryWhereClause,
+	},
+	MSSQL: MSSQLConfig{
+		EnabledClasses: strings.Split(col.ConfigDefaults.Mssql.EnabledCollectors, ","),
+	},
+	Network: NetworkConfig{
+		BlackList: col.ConfigDefaults.Net.NicExclude,
+		WhiteList: col.ConfigDefaults.Net.NicInclude,
+		Include:   col.ConfigDefaults.Net.NicInclude,
+		Exclude:   col.ConfigDefaults.Net.NicExclude,
+	},
+	Process: ProcessConfig{
+		BlackList: col.ConfigDefaults.Process.ProcessExclude,
+		WhiteList: col.ConfigDefaults.Process.ProcessInclude,
+		Include:   col.ConfigDefaults.Process.ProcessInclude,
+		Exclude:   col.ConfigDefaults.Process.ProcessExclude,
+	},
+	ScheduledTask: ScheduledTaskConfig{
+		Include: col.ConfigDefaults.ScheduledTask.TaskInclude,
+		Exclude: col.ConfigDefaults.ScheduledTask.TaskExclude,
+	},
+	Service: ServiceConfig{
+		UseApi: "false",
+		Where:  col.ConfigDefaults.Service.ServiceWhereClause,
+	},
+	SMTP: SMTPConfig{
+		BlackList: col.ConfigDefaults.Smtp.ServerExclude,
+		WhiteList: col.ConfigDefaults.Smtp.ServerInclude,
+		Include:   col.ConfigDefaults.Smtp.ServerInclude,
+		Exclude:   col.ConfigDefaults.Smtp.ServerExclude,
+	},
+	TextFile: TextFileConfig{
+		TextFileDirectory: col.ConfigDefaults.Textfile.TextFileDirectories,
+	},
+}
+
+// SetToDefault implements river.Defaulter.
+func (a *Arguments) SetToDefault() {
+	*a = DefaultArguments
+}

--- a/converter/internal/staticconvert/internal/build/windows_exporter.go
+++ b/converter/internal/staticconvert/internal/build/windows_exporter.go
@@ -47,8 +47,8 @@ func toWindowsExporter(config *windows_exporter.Config) *windows.Arguments {
 		Network: windows.NetworkConfig{
 			BlackList: config.Network.BlackList,
 			WhiteList: config.Network.WhiteList,
-			Exclude:   config.Network.Include,
-			Include:   config.Network.Exclude,
+			Exclude:   config.Network.Exclude,
+			Include:   config.Network.Include,
 		},
 		Process: windows.ProcessConfig{
 			BlackList: config.Process.BlackList,

--- a/pkg/integrations/windows_exporter/config.go
+++ b/pkg/integrations/windows_exporter/config.go
@@ -5,70 +5,7 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	integrations_v2 "github.com/grafana/agent/pkg/integrations/v2"
 	"github.com/grafana/agent/pkg/integrations/v2/metricsutils"
-	col "github.com/prometheus-community/windows_exporter/pkg/collector"
 )
-
-// DefaultConfig holds the default settings for the windows_exporter integration.
-var DefaultConfig = Config{
-	EnabledCollectors: "cpu,cs,logical_disk,net,os,service,system",
-	Dfsr: DfsrConfig{
-		SourcesEnabled: col.ConfigDefaults.Dfsr.DfsrEnabledCollectors,
-	},
-	Exchange: ExchangeConfig{
-		EnabledList: col.ConfigDefaults.Exchange.CollectorsEnabled,
-	},
-	IIS: IISConfig{
-		AppBlackList:  col.ConfigDefaults.Iis.AppExclude,
-		AppWhiteList:  col.ConfigDefaults.Iis.AppInclude,
-		SiteBlackList: col.ConfigDefaults.Iis.SiteExclude,
-		SiteWhiteList: col.ConfigDefaults.Iis.SiteInclude,
-		AppInclude:    col.ConfigDefaults.Iis.AppInclude,
-		AppExclude:    col.ConfigDefaults.Iis.AppExclude,
-		SiteInclude:   col.ConfigDefaults.Iis.SiteInclude,
-		SiteExclude:   col.ConfigDefaults.Iis.SiteExclude,
-	},
-	LogicalDisk: LogicalDiskConfig{
-		BlackList: col.ConfigDefaults.LogicalDisk.VolumeExclude,
-		WhiteList: col.ConfigDefaults.LogicalDisk.VolumeInclude,
-		Include:   col.ConfigDefaults.LogicalDisk.VolumeInclude,
-		Exclude:   col.ConfigDefaults.LogicalDisk.VolumeExclude,
-	},
-	MSMQ: MSMQConfig{
-		Where: col.ConfigDefaults.Msmq.QueryWhereClause,
-	},
-	MSSQL: MSSQLConfig{
-		EnabledClasses: col.ConfigDefaults.Mssql.EnabledCollectors,
-	},
-	Network: NetworkConfig{
-		BlackList: col.ConfigDefaults.Net.NicExclude,
-		WhiteList: col.ConfigDefaults.Net.NicInclude,
-		Include:   col.ConfigDefaults.Net.NicInclude,
-		Exclude:   col.ConfigDefaults.Net.NicExclude,
-	},
-	Process: ProcessConfig{
-		BlackList: col.ConfigDefaults.Process.ProcessExclude,
-		WhiteList: col.ConfigDefaults.Process.ProcessInclude,
-		Include:   col.ConfigDefaults.Process.ProcessInclude,
-		Exclude:   col.ConfigDefaults.Process.ProcessExclude,
-	},
-	ScheduledTask: ScheduledTaskConfig{
-		Include: col.ConfigDefaults.ScheduledTask.TaskInclude,
-		Exclude: col.ConfigDefaults.ScheduledTask.TaskExclude,
-	},
-	Service: ServiceConfig{
-		UseApi: "false",
-		Where:  col.ConfigDefaults.Service.ServiceWhereClause,
-	},
-	SMTP: SMTPConfig{
-		BlackList: col.ConfigDefaults.Smtp.ServerExclude,
-		WhiteList: col.ConfigDefaults.Smtp.ServerInclude,
-		Include:   col.ConfigDefaults.Smtp.ServerInclude,
-		Exclude:   col.ConfigDefaults.Smtp.ServerExclude,
-	},
-	TextFile: TextFileConfig{
-		TextFileDirectory: col.ConfigDefaults.Textfile.TextFileDirectories,
-	},
-}
 
 func init() {
 	integrations.RegisterIntegration(&Config{})
@@ -92,14 +29,6 @@ type Config struct {
 	MSMQ          MSMQConfig          `yaml:"msmq,omitempty"`
 	LogicalDisk   LogicalDiskConfig   `yaml:"logical_disk,omitempty"`
 	ScheduledTask ScheduledTaskConfig `yaml:"scheduled_task,omitempty"`
-}
-
-// UnmarshalYAML implements yaml.Unmarshaler for Config.
-func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	*c = DefaultConfig
-
-	type plain Config
-	return unmarshal((*plain)(c))
 }
 
 // Name returns the name used, "windows_explorer"

--- a/pkg/integrations/windows_exporter/config.go
+++ b/pkg/integrations/windows_exporter/config.go
@@ -5,70 +5,68 @@ import (
 	"github.com/grafana/agent/pkg/integrations"
 	integrations_v2 "github.com/grafana/agent/pkg/integrations/v2"
 	"github.com/grafana/agent/pkg/integrations/v2/metricsutils"
+	col "github.com/prometheus-community/windows_exporter/pkg/collector"
 )
 
 // DefaultConfig holds the default settings for the windows_exporter integration.
 var DefaultConfig = Config{
-	// NOTE(rfratto): there is an init function in config_windows.go that
-	// populates defaults for collectors based on the exporter defaults.
 	EnabledCollectors: "cpu,cs,logical_disk,net,os,service,system",
-
 	Dfsr: DfsrConfig{
-		SourcesEnabled: "",
+		SourcesEnabled: col.ConfigDefaults.Dfsr.DfsrEnabledCollectors,
 	},
 	Exchange: ExchangeConfig{
-		EnabledList: "",
+		EnabledList: col.ConfigDefaults.Exchange.CollectorsEnabled,
 	},
 	IIS: IISConfig{
-		AppBlackList:  "",
-		AppWhiteList:  "",
-		SiteBlackList: "",
-		SiteWhiteList: "",
-		AppInclude:    "",
-		AppExclude:    "",
-		SiteInclude:   "",
-		SiteExclude:   "",
+		AppBlackList:  col.ConfigDefaults.Iis.AppExclude,
+		AppWhiteList:  col.ConfigDefaults.Iis.AppInclude,
+		SiteBlackList: col.ConfigDefaults.Iis.SiteExclude,
+		SiteWhiteList: col.ConfigDefaults.Iis.SiteInclude,
+		AppInclude:    col.ConfigDefaults.Iis.AppInclude,
+		AppExclude:    col.ConfigDefaults.Iis.AppExclude,
+		SiteInclude:   col.ConfigDefaults.Iis.SiteInclude,
+		SiteExclude:   col.ConfigDefaults.Iis.SiteExclude,
 	},
 	LogicalDisk: LogicalDiskConfig{
-		BlackList: "",
-		WhiteList: "",
-		Include:   "",
-		Exclude:   "",
+		BlackList: col.ConfigDefaults.LogicalDisk.VolumeExclude,
+		WhiteList: col.ConfigDefaults.LogicalDisk.VolumeInclude,
+		Include:   col.ConfigDefaults.LogicalDisk.VolumeInclude,
+		Exclude:   col.ConfigDefaults.LogicalDisk.VolumeExclude,
 	},
 	MSMQ: MSMQConfig{
-		Where: "",
+		Where: col.ConfigDefaults.Msmq.QueryWhereClause,
 	},
 	MSSQL: MSSQLConfig{
-		EnabledClasses: "",
+		EnabledClasses: col.ConfigDefaults.Mssql.EnabledCollectors,
 	},
 	Network: NetworkConfig{
-		BlackList: "",
-		WhiteList: "",
-		Include:   "",
-		Exclude:   "",
+		BlackList: col.ConfigDefaults.Net.NicExclude,
+		WhiteList: col.ConfigDefaults.Net.NicInclude,
+		Include:   col.ConfigDefaults.Net.NicInclude,
+		Exclude:   col.ConfigDefaults.Net.NicExclude,
 	},
 	Process: ProcessConfig{
-		BlackList: "",
-		WhiteList: "",
-		Include:   "",
-		Exclude:   "",
+		BlackList: col.ConfigDefaults.Process.ProcessExclude,
+		WhiteList: col.ConfigDefaults.Process.ProcessInclude,
+		Include:   col.ConfigDefaults.Process.ProcessInclude,
+		Exclude:   col.ConfigDefaults.Process.ProcessExclude,
 	},
 	ScheduledTask: ScheduledTaskConfig{
-		Include: "",
-		Exclude: "",
+		Include: col.ConfigDefaults.ScheduledTask.TaskInclude,
+		Exclude: col.ConfigDefaults.ScheduledTask.TaskExclude,
 	},
 	Service: ServiceConfig{
-		UseApi: "",
-		Where:  "",
+		UseApi: "false",
+		Where:  col.ConfigDefaults.Service.ServiceWhereClause,
 	},
 	SMTP: SMTPConfig{
-		BlackList: "",
-		WhiteList: "",
-		Include:   "",
-		Exclude:   "",
+		BlackList: col.ConfigDefaults.Smtp.ServerExclude,
+		WhiteList: col.ConfigDefaults.Smtp.ServerInclude,
+		Include:   col.ConfigDefaults.Smtp.ServerInclude,
+		Exclude:   col.ConfigDefaults.Smtp.ServerExclude,
 	},
 	TextFile: TextFileConfig{
-		TextFileDirectory: "",
+		TextFileDirectory: col.ConfigDefaults.Textfile.TextFileDirectories,
 	},
 }
 

--- a/pkg/integrations/windows_exporter/config_windows.go
+++ b/pkg/integrations/windows_exporter/config_windows.go
@@ -1,6 +1,9 @@
 package windows_exporter
 
-import "github.com/prometheus-community/windows_exporter/pkg/collector"
+import (
+	"github.com/prometheus-community/windows_exporter/pkg/collector"
+	col "github.com/prometheus-community/windows_exporter/pkg/collector"
+)
 
 func (c *Config) ToWindowsExporterConfig() collector.Config {
 	cfg := collector.ConfigDefaults
@@ -46,4 +49,74 @@ func coalesceString(v ...string) string {
 		}
 	}
 	return ""
+}
+
+// DefaultConfig holds the default settings for the windows_exporter integration.
+var DefaultConfig = Config{
+	EnabledCollectors: "cpu,cs,logical_disk,net,os,service,system",
+	Dfsr: DfsrConfig{
+		SourcesEnabled: col.ConfigDefaults.Dfsr.DfsrEnabledCollectors,
+	},
+	Exchange: ExchangeConfig{
+		EnabledList: col.ConfigDefaults.Exchange.CollectorsEnabled,
+	},
+	IIS: IISConfig{
+		AppBlackList:  col.ConfigDefaults.Iis.AppExclude,
+		AppWhiteList:  col.ConfigDefaults.Iis.AppInclude,
+		SiteBlackList: col.ConfigDefaults.Iis.SiteExclude,
+		SiteWhiteList: col.ConfigDefaults.Iis.SiteInclude,
+		AppInclude:    col.ConfigDefaults.Iis.AppInclude,
+		AppExclude:    col.ConfigDefaults.Iis.AppExclude,
+		SiteInclude:   col.ConfigDefaults.Iis.SiteInclude,
+		SiteExclude:   col.ConfigDefaults.Iis.SiteExclude,
+	},
+	LogicalDisk: LogicalDiskConfig{
+		BlackList: col.ConfigDefaults.LogicalDisk.VolumeExclude,
+		WhiteList: col.ConfigDefaults.LogicalDisk.VolumeInclude,
+		Include:   col.ConfigDefaults.LogicalDisk.VolumeInclude,
+		Exclude:   col.ConfigDefaults.LogicalDisk.VolumeExclude,
+	},
+	MSMQ: MSMQConfig{
+		Where: col.ConfigDefaults.Msmq.QueryWhereClause,
+	},
+	MSSQL: MSSQLConfig{
+		EnabledClasses: col.ConfigDefaults.Mssql.EnabledCollectors,
+	},
+	Network: NetworkConfig{
+		BlackList: col.ConfigDefaults.Net.NicExclude,
+		WhiteList: col.ConfigDefaults.Net.NicInclude,
+		Include:   col.ConfigDefaults.Net.NicInclude,
+		Exclude:   col.ConfigDefaults.Net.NicExclude,
+	},
+	Process: ProcessConfig{
+		BlackList: col.ConfigDefaults.Process.ProcessExclude,
+		WhiteList: col.ConfigDefaults.Process.ProcessInclude,
+		Include:   col.ConfigDefaults.Process.ProcessInclude,
+		Exclude:   col.ConfigDefaults.Process.ProcessExclude,
+	},
+	ScheduledTask: ScheduledTaskConfig{
+		Include: col.ConfigDefaults.ScheduledTask.TaskInclude,
+		Exclude: col.ConfigDefaults.ScheduledTask.TaskExclude,
+	},
+	Service: ServiceConfig{
+		UseApi: "false",
+		Where:  col.ConfigDefaults.Service.ServiceWhereClause,
+	},
+	SMTP: SMTPConfig{
+		BlackList: col.ConfigDefaults.Smtp.ServerExclude,
+		WhiteList: col.ConfigDefaults.Smtp.ServerInclude,
+		Include:   col.ConfigDefaults.Smtp.ServerInclude,
+		Exclude:   col.ConfigDefaults.Smtp.ServerExclude,
+	},
+	TextFile: TextFileConfig{
+		TextFileDirectory: col.ConfigDefaults.Textfile.TextFileDirectories,
+	},
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler for Config.
+func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultConfig
+
+	type plain Config
+	return unmarshal((*plain)(c))
 }


### PR DESCRIPTION
#### PR Description

This aligns the defaults of the windows exporter with the upstream, sadly its basically in two places yaml and river.

#### Which issue(s) this PR fixes

Fixes #5831 

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG.md updated
- [ x] Tests updated
