### PR TITLE
Allow x-faro-session-id header for faro receiver

### DIFF
--- a/component/faro/receiver/handler.go
+++ b/component/faro/receiver/handler.go
@@ -69,7 +69,7 @@ func (h *handler) Update(args ServerArguments) {
 	if len(args.CORSAllowedOrigins) > 0 {
 		h.cors = cors.New(cors.Options{
 			AllowedOrigins: args.CORSAllowedOrigins,
-			AllowedHeaders: []string{apiKeyHeader, "content-type"},
+			AllowedHeaders: []string{apiKeyHeader, "content-type", "x-faro-session-id"},
 		})
 	} else {
 		h.cors = nil // Disable cors.


### PR DESCRIPTION
#### PR Description

#### Which issue(s) this PR fixes

Faro introduced a header identifying the session id to collectors. This header needs to be whitelisted by the agent receiver to support people self-hosting.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated


Fixes: https://github.com/grafana/faro-web-sdk/issues/386