### PR TITLE
fix: use official hashicorp consul image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Main (unreleased)
 
 - Fix issue with windows_exporter defaults not being set correctly. (@mattdurham)
 
+- Use official HashiCorp Consul image. (@tranngoclam)
+
 v0.38.0 (2023-11-21)
 --------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,6 @@ Main (unreleased)
 
 - Fix issue with windows_exporter defaults not being set correctly. (@mattdurham)
 
-- Use official HashiCorp Consul image. (@tranngoclam)
-
 v0.38.0 (2023-11-21)
 --------------------
 

--- a/example/docker-compose/docker-compose.yaml
+++ b/example/docker-compose/docker-compose.yaml
@@ -162,7 +162,7 @@ services:
 
   consul:
     profiles: [integrations,consul]
-    image: consul
+    image: hashicorp/consul
     ports:
       - "8500:8500"
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

- Use the official HashiCorp Consul image

from https://hub.docker.com/_/consul:

> Upcoming in Consul 1.16, we will stop publishing official Dockerhub images and publish only our Verified Publisher images. Users of Docker images should pull from [hashicorp/consul](https://hub.docker.com/r/hashicorp/consul) instead of [consul](https://hub.docker.com/_/consul). Verified Publisher images can be found at https://hub.docker.com/r/hashicorp/consul.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated