### PR TITLE
Add Deploy Mode to usage stats.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ Main (unreleased)
 
 - Fix issue in `prometheus.operator.*` where targets would be dropped if two crds share a common prefix in their names. (@Paul424, @captncraig)
 
+### Other changes
+
+- Add Agent Deploy Mode to usage report. (@captncraig)
+
 v0.38.0 (2023-11-21)
 --------------------
 

--- a/docs/sources/data-collection.md
+++ b/docs/sources/data-collection.md
@@ -30,6 +30,7 @@ The usage information includes the following details:
 * List of enabled feature flags ([Static] mode only).
 * List of enabled integrations ([Static] mode only).
 * List of enabled [components][] ([Flow] mode only).
+* Method used to deploy Grafana Agent (docker, helm, rpm, operator, etc.)
 
 This list may change over time. All newly reported data is documented in the CHANGELOG.
 

--- a/docs/sources/data-collection.md
+++ b/docs/sources/data-collection.md
@@ -30,7 +30,7 @@ The usage information includes the following details:
 * List of enabled feature flags ([Static] mode only).
 * List of enabled integrations ([Static] mode only).
 * List of enabled [components][] ([Flow] mode only).
-* Method used to deploy Grafana Agent (docker, helm, rpm, operator, etc.)
+* Method used to deploy Grafana Agent, for example Docker, Helm, RPM, or Operator.
 
 This list may change over time. All newly reported data is documented in the CHANGELOG.
 

--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -19,6 +19,7 @@ const (
 
 // settable by tests
 var goos = runtime.GOOS
+var executable = os.Executable
 
 func Get() string {
 	parenthesis := ""
@@ -58,7 +59,7 @@ func GetDeployMode() string {
 		return op
 	}
 	// try to detect if executable is in homebrew directory
-	if path, err := os.Executable(); err == nil && runtime.GOOS == "darwin" && strings.Contains(path, "brew") {
+	if path, err := executable(); err == nil && goos == "darwin" && strings.Contains(path, "brew") {
 		return "brew"
 	}
 	// fallback to binary

--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -27,7 +27,7 @@ func Get() string {
 		metadata = append(metadata, mode)
 	}
 	metadata = append(metadata, goos)
-	if op := getDeployMode(); op != "" {
+	if op := GetDeployMode(); op != "" {
 		metadata = append(metadata, op)
 	}
 	if len(metadata) > 0 {
@@ -49,12 +49,18 @@ func getRunMode() string {
 	}
 }
 
-func getDeployMode() string {
+// GetDeployMode returns our best-effort guess at the way Grafana Agent was deployed.
+func GetDeployMode() string {
 	op := os.Getenv(deployModeEnv)
 	// only return known modes. Use "binary" as a default catch-all.
 	switch op {
 	case "operator", "helm", "docker", "deb", "rpm", "brew":
 		return op
 	}
+	// try to detect if executable is in homebrew directory
+	if path, err := os.Executable(); err == nil && runtime.GOOS == "darwin" && strings.Contains(path, "brew") {
+		return "brew"
+	}
+	// fallback to binary
 	return "binary"
 }

--- a/internal/useragent/useragent_test.go
+++ b/internal/useragent/useragent_test.go
@@ -15,6 +15,7 @@ func TestUserAgent(t *testing.T) {
 		Expected   string
 		DeployMode string
 		GOOS       string
+		Exe        string
 	}{
 		{
 			Name:     "basic",
@@ -76,9 +77,21 @@ func TestUserAgent(t *testing.T) {
 			Expected:   "GrafanaAgent/v1.2.3 (flow; linux; helm)",
 			GOOS:       "linux",
 		},
+		{
+			Name:     "brew",
+			Mode:     "flow",
+			Expected: "GrafanaAgent/v1.2.3 (flow; darwin; brew)",
+			GOOS:     "darwin",
+			Exe:      "/opt/homebrew/bin/agent",
+		},
 	}
 	for _, tst := range tests {
 		t.Run(tst.Name, func(t *testing.T) {
+			if tst.Exe != "" {
+				executable = func() (string, error) { return tst.Exe, nil }
+			} else {
+				executable = func() (string, error) { return "/agent", nil }
+			}
 			goos = tst.GOOS
 			t.Setenv(deployModeEnv, tst.DeployMode)
 			t.Setenv(modeEnv, tst.Mode)

--- a/pkg/usagestats/stats.go
+++ b/pkg/usagestats/stats.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"runtime"
 	"time"
 
+	"github.com/grafana/agent/internal/useragent"
 	"github.com/prometheus/common/version"
 )
 
@@ -40,7 +40,7 @@ func sendReport(ctx context.Context, seed *AgentSeed, interval time.Time, metric
 		Arch:         runtime.GOARCH,
 		Interval:     interval,
 		Metrics:      metrics,
-		DeployMode:   getDeployMode(),
+		DeployMode:   useragent.GetDeployMode(),
 	}
 	out, err := json.MarshalIndent(report, "", " ")
 	if err != nil {
@@ -65,14 +65,4 @@ func sendReport(ctx context.Context, seed *AgentSeed, interval time.Time, metric
 		return fmt.Errorf("failed to send usage stats: %s  body: %s", resp.Status, string(data))
 	}
 	return nil
-}
-
-func getDeployMode() string {
-	op := os.Getenv("AGENT_DEPLOY_MODE")
-	// only return known modes. Use "binary" as a default catch-all.
-	switch op {
-	case "operator", "helm", "docker", "deb", "rpm", "brew":
-		return op
-	}
-	return "binary"
 }

--- a/pkg/usagestats/stats.go
+++ b/pkg/usagestats/stats.go
@@ -21,26 +21,26 @@ var (
 
 // Report is the payload to be sent to stats.grafana.org
 type Report struct {
-	UsageStatsID   string                 `json:"usageStatsId"`
-	CreatedAt      time.Time              `json:"createdAt"`
-	Interval       time.Time              `json:"interval"`
-	Version        string                 `json:"version"`
-	Metrics        map[string]interface{} `json:"metrics"`
-	Os             string                 `json:"os"`
-	Arch           string                 `json:"arch"`
-	DeploymentMode string                 `json:"deploymentMode"`
+	UsageStatsID string                 `json:"usageStatsId"`
+	CreatedAt    time.Time              `json:"createdAt"`
+	Interval     time.Time              `json:"interval"`
+	Version      string                 `json:"version"`
+	Metrics      map[string]interface{} `json:"metrics"`
+	Os           string                 `json:"os"`
+	Arch         string                 `json:"arch"`
+	DeployMode   string                 `json:"deployMode"`
 }
 
 func sendReport(ctx context.Context, seed *AgentSeed, interval time.Time, metrics map[string]interface{}) error {
 	report := Report{
-		UsageStatsID:   seed.UID,
-		CreatedAt:      seed.CreatedAt,
-		Version:        version.Version,
-		Os:             runtime.GOOS,
-		Arch:           runtime.GOARCH,
-		Interval:       interval,
-		Metrics:        metrics,
-		DeploymentMode: getDeployMode(),
+		UsageStatsID: seed.UID,
+		CreatedAt:    seed.CreatedAt,
+		Version:      version.Version,
+		Os:           runtime.GOOS,
+		Arch:         runtime.GOARCH,
+		Interval:     interval,
+		Metrics:      metrics,
+		DeployMode:   getDeployMode(),
 	}
 	out, err := json.MarshalIndent(report, "", " ")
 	if err != nil {


### PR DESCRIPTION
With 0.38.0 we added a deploy mode to the user agent, and added ways to set it, but we did not add it to the usage stats, which would be very useful. This adds it.

Also makes a best-effort attempt to detect homebrew installs, by looking t the executable path.