### PR TITLE
fix: Documentation references of client_auth in flow http client.

### DIFF
--- a/docs/sources/flow/reference/config-blocks/http.md
+++ b/docs/sources/flow/reference/config-blocks/http.md
@@ -71,7 +71,7 @@ Name | Type | Description | Default | Required
 `key_file` | `string` | Path to the server TLS key on disk. | `""` | conditionally
 `client_ca_pem` | `string` | PEM data of the client CA to validate requests against. | `""` | no
 `client_ca_file` | `string` | Path to the client CA file on disk to validate requests against. | `""` | no
-`client_auth` | `string` | Client authentication to use. | `"NoClientCert"` | no
+`client_auth_type` | `string` | Client authentication to use. | `"NoClientCert"` | no
 `cipher_suites` | `list(string)` | Set of cipher suites to use. | `[]` | no
 `curve_preferences` | `list(string)` | Set of elliptic curves to use in a handshake. | `[]` | no
 `min_version` | `string` | Oldest TLS version to accept from clients. | `""` | no
@@ -88,12 +88,12 @@ configured at a time:
 * `key_pem` and `key_file`
 * `client_ca_pem` and `client_ca_file`
 
-The `client_auth` argument determines whether to validate client certificates.
+The `client_auth_type` argument determines whether to validate client certificates.
 The default value, `NoClientCert`, indicates that the client certificate is not
 validated. The `client_ca_pem` and `client_ca_file` arguments may only
-be configured when `client_auth` is not `NoClientCert`.
+be configured when `client_auth_type` is not `NoClientCert`.
 
-The following values are accepted for `client_auth`:
+The following values are accepted for `client_auth_type`:
 
 * `NoClientCert`: client certificates are neither requested nor validated.
 * `RequestClientCert`: requests clients to send an optional certificate. Certificates provided by clients are not validated.
@@ -102,7 +102,7 @@ The following values are accepted for `client_auth`:
 * `RequireAndVerifyClientCert`: requires clients to send a valid certificate.
 
 The `client_ca_pem` or `client_ca_file` arguments may be used to perform client
-certificate validation. These arguments may only be provided when `client_auth`
+certificate validation. These arguments may only be provided when `client_auth_type`
 is not set to `NoClientCert`.
 
 The `cipher_suites` argument determines what cipher suites to use. If not


### PR DESCRIPTION
#### PR Description
The flow `http` module docs referenced the `client_auth` configuration incorrectly. Referencing the code directly you'll see the [configuration](https://github.com/rfratto/agent/blob/0bd12997ae23e5f09ca76fa0dfcf4a8e6c99b25e/service/http/tls.go#L22) is actually `client_auth_type`

Trying to start the server with `client_auth` in the `tls` block results in the following error:
```
decoding River: /var/lib/grafana-agent/config/agent.river:12:5: unrecognized attribute name "client_auth"
```

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated