### PR TITLE
Explain tracing load balancing in more detail

### DIFF
--- a/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
@@ -297,9 +297,9 @@ All spans for a given `service.name` must go to the same spanmetrics Agent.
   * At worst, it could lead to an inaccurate data due to overlapping samples for the metric series.
 
 However, there are ways to scale `otelcol.connector.spanmetrics` without the need for a load balancer:
-1. Each Agent could add an attribute such as `agent.id` in order to make its series unique.
+1. Each Agent could add an attribute such as `collector.id` in order to make its series unique.
   * A `sum by` PromQL query could be used to aggregate the metrics from different Agents.
-  * An extra `agent.id` attribute has a downside that the metrics stored in the database will have higher {{< term "cardinality" >}}cardinality{{< /term >}}.
+  * An extra `collector.id` attribute has a downside that the metrics stored in the database will have higher {{< term "cardinality" >}}cardinality{{< /term >}}.
 2. Spanmetrics could be generated in the backend database instead of the Agent.
   * For example, span metrics can be [generated][tempo-spanmetrics] in Grafana Cloud by the Tempo traces database.
 
@@ -320,10 +320,10 @@ It is challenging to scale `otelcol.connector.servicegraph` over multiple Agent 
     they will generate the same service graph metric series.
   * If the series from two Agents are the same, this will lead to issues 
     when writing them to the backend database.
-  * Users could differentiate the series by adding an attribute such as `"agent.id"`.
+  * Users could differentiate the series by adding an attribute such as `"collector.id"`.
       * Unfortunately, there is currently no method in the Agent to aggregate those series from different Agents and merge them into one series.
     * A PromQL query could be used to aggregate the metrics from different Agents.
-    * If the metrics are stored in Grafana Mimir, cardinality issues due to `"agent.id"` labels can be solved using [Adaptive Metrics][adaptive-metrics].
+    * If the metrics are stored in Grafana Mimir, cardinality issues due to `"collector.id"` labels can be solved using [Adaptive Metrics][adaptive-metrics].
 
 A simpler, more scalable alternative to generating service graph metrics in the Agent is to generate them entirely in the backend database. 
 For example, service graphs can be [generated][tempo-servicegraphs] in Grafana Cloud by the Tempo traces database.

--- a/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.loadbalancing.md
@@ -291,16 +291,16 @@ All spans for a given `service.name` must go to the same spanmetrics Agent.
 * This can be done by configuring `otelcol.exporter.loadbalancing` with `routing_key = "service"`.
 * If this is not done, metrics generated from spans might be incorrect.
   * For example, if similar spans for the same `service.name` end up on different Agent instances,
-    the two Agents will have identical metic series for calculating span latency, errors, and number of requests.
+    the two Agents will have identical metric series for calculating span latency, errors, and number of requests.
   * When both Agents attempt to remote write the metrics to a database such as Mimir,
-    the series with clash with each other.
-  * At best this will lead to an error in the Agent and a rejected remote write. 
-  * At worst, it could lead to an inaccurate data dure to overlapping samples for the metric series.
+    the series may clash with each other.
+  * At best this will lead to an error in the Agent and a rejected write to the metrics database. 
+  * At worst, it could lead to an inaccurate data due to overlapping samples for the metric series.
 
 However, there are ways to scale `otelcol.connector.spanmetrics` without the need for a load balancer:
 1. Each Agent could add an attribute such as `agent.id` in order to make its series unique.
   * A `sum by` PromQL query could be used to aggregate the metrics from different Agents.
-  * An extra `agent.id` attribute has a downside that the metrics stored in the database will have extra cardinality.
+  * An extra `agent.id` attribute has a downside that the metrics stored in the database will have higher cardinality.
 2. Spanmetrics could be generated in the backend database instead of the Agent.
   * For example, span metrics can be [generated][tempo-spanmetrics] in Grafana Cloud by the Tempo traces database.
 
@@ -329,7 +329,7 @@ Unfortunately, there is generally no reliable way to scale `otelcol.connector.se
 There are ways to work around this:
   1. Each Agent could add an attribute such as `agent.id` in order to make its series unique.
     * A PromQL query could be used to aggregate the metrics from different Agents.
-    * An extra `agent.id` attribute has a downside that the metrics stored in the database will have extra cardinality.
+    * An extra `agent.id` attribute has a downside that the metrics stored in the database will have higher cardinality.
   2. A simpler, more scalable alternative to generating service graph metrics 
     in the Agent is to do them in the backend database. 
     * For example service graphs can be [generated][tempo-servicegraphs] in Grafana Cloud by the Tempo traces database.
@@ -419,7 +419,7 @@ otelcol.exporter.loadbalancing "default" {
 }
 ```
 
-Below is an example Kubernetes configuration which sets up two sets of Agents:
+Below is an example Kubernetes configuration which configures two sets of Agents:
 * A pool of "load balancer" Agents:
   * Spans are received from instrumented applications via `otelcol.receiver.otlp`
   * Spans are then exported via `otelcol.exporter.loadbalancing`.

--- a/docs/sources/flow/setup/deploy-agent.md
+++ b/docs/sources/flow/setup/deploy-agent.md
@@ -20,8 +20,8 @@ all necessary telemetry signals in the same Agent process. For example,
 a single Agent can process all of the incoming metrics, logs, traces, and profiles.
 
 However, if the load on the Agents is big, it may be beneficial to
-process different telemetry signals in different sets of Agents:
-* This provides bettor stability due to the isolation between processes.
+process different telemetry signals in different deployments of Agents:
+* This provides better stability due to the isolation between processes.
   * For example, an overloaded Agent processing traces won't impact an Agent processing metrics.
 * Different types of signal collection require different methods for scaling:
   * "Pull" components such as `prometheus.scrape` and `pyroscope.scrape` are scaled using hashmod sharing or clustering. 
@@ -57,11 +57,11 @@ Examples of stateful components:
 <!-- TODO: link to the otelcol.exporter.loadbalancing docs for more info -->
 
 A "stateless component" does not need to aggregate specific spans in 
-order to work correctly - it can work correctly even it only has 
+order to work correctly - it can work correctly even if it only has 
 some of the spans of a trace.
 
 Stateless Agents can be scaled without using `otelcol.exporter.loadbalancing`.
-You could use an off the shelf load balancer, or simply do a round-robin load balancing.
+You could use an off-the-shelf load balancer to, for example, do a round-robin load balancing.
 
 Examples of stateless components:
 * `otelcol.processor.probabilistic_sampler`

--- a/docs/sources/flow/setup/deploy-agent.md
+++ b/docs/sources/flow/setup/deploy-agent.md
@@ -13,14 +13,12 @@ weight: 900
 
 {{< docs/shared source="agent" lookup="/deploy-agent.md" version="<AGENT_VERSION>" >}}
 
-## Scaling Grafana Agent
+## Processing different types of telemetry in different Agent instances
 
-If the load on the Agents is small, it is recommended to process
-all necessary telemetry signals in the same Agent process. For example, 
-a single Agent can process all of the incoming metrics, logs, traces, and profiles.
+If the load on the Agents is small, it is recommended to process all necessary telemetry signals in the same Agent process. 
+For example, a single Agent can process all of the incoming metrics, logs, traces, and profiles.
 
-However, if the load on the Agents is big, it may be beneficial to
-process different telemetry signals in different deployments of Agents:
+However, if the load on the Agents is big, it may be beneficial to process different telemetry signals in different deployments of Agents:
 * This provides better stability due to the isolation between processes.
   * For example, an overloaded Agent processing traces won't impact an Agent processing metrics.
 * Different types of signal collection require different methods for scaling:
@@ -29,14 +27,17 @@ process different telemetry signals in different deployments of Agents:
 
 ### Traces
 
-<!-- TODO: Link to https://opentelemetry.io/docs/collector/scaling/ ? -->
+Scaling Agent instances for tracing is very similar to [scaling OpenTelemetry Collector][scaling-collector] instances.
+This is because most Flow components used for tracing are based on components from the Collector.
+
+[scaling-collector]: https://opentelemetry.io/docs/collector/scaling/
 
 #### When to scale
 
-<!-- 
-TODO: Include information from https://opentelemetry.io/docs/collector/scaling/#when-to-scale
-Unfortunately the Agent doesn't have many of the metrics they mention because they're instrumented with OpenCensus and not OpenTelemetry.
--->
+To decide whether scaling is necessary, check metrics such as:
+* `receiver_refused_spans_ratio_total` from receivers such as `otelcol.receiver.otlp`.
+* `processor_refused_spans_ratio_total` from processors such as `otelcol.processor.batch`.
+* `exporter_send_failed_spans_ratio_total` from exporters such as `otelcol.exporter.otlp` and `otelcol.exporter.loadbalancing`.
 
 #### Stateful and stateless components
 
@@ -56,9 +57,8 @@ Examples of stateful components:
 
 <!-- TODO: link to the otelcol.exporter.loadbalancing docs for more info -->
 
-A "stateless component" does not need to aggregate specific spans in 
-order to work correctly - it can work correctly even if it only has 
-some of the spans of a trace.
+A "stateless component" does not need to aggregate specific spans in order to work correctly - 
+it can work correctly even if it only has some of the spans of a trace.
 
 Stateless Agents can be scaled without using `otelcol.exporter.loadbalancing`.
 You could use an off-the-shelf load balancer to, for example, do a round-robin load balancing.

--- a/docs/sources/flow/setup/deploy-agent.md
+++ b/docs/sources/flow/setup/deploy-agent.md
@@ -13,3 +13,58 @@ weight: 900
 
 {{< docs/shared source="agent" lookup="/deploy-agent.md" version="<AGENT_VERSION>" >}}
 
+## Scaling Grafana Agent
+
+If the load on the Agents is small, it is recommended to process
+all necessary telemetry signals in the same Agent process. For example, 
+a single Agent can process all of the incoming metrics, logs, traces, and profiles.
+
+However, if the load on the Agents is big, it may be beneficial to
+process different telemetry signals in different sets of Agents:
+* This provides bettor stability due to the isolation between processes.
+  * For example, an overloaded Agent processing traces won't impact an Agent processing metrics.
+* Different types of signal collection require different methods for scaling:
+  * "Pull" components such as `prometheus.scrape` and `pyroscope.scrape` are scaled using hashmod sharing or clustering. 
+  * "Push" components such as `otelcol.receiver.otlp` are scaled by placing a load balancer in front of them.
+
+### Traces
+
+<!-- TODO: Link to https://opentelemetry.io/docs/collector/scaling/ ? -->
+
+#### When to scale
+
+<!-- 
+TODO: Include information from https://opentelemetry.io/docs/collector/scaling/#when-to-scale
+Unfortunately the Agent doesn't have many of the metrics they mention because they're instrumented with OpenCensus and not OpenTelemetry.
+-->
+
+#### Stateful and stateless components
+
+In the context of tracing, a "stateful component" is a component 
+which needs to aggregate certain spans in order to work correctly.
+A "stateless Agent" is an Agent which does not contain stateful components.
+
+Scaling stateful Agents is more difficult, because spans must be forwarded to a 
+specific Agent according to a span property such as trace ID or a `service.name` attribute.
+This can be done using `otelcol.exporter.loadbalancing`.
+
+Examples of stateful components:
+
+* `otelcol.processor.tail_sampling`
+* `otelcol.connector.spanmetrics`
+* `otelcol.connector.servicegraph`
+
+<!-- TODO: link to the otelcol.exporter.loadbalancing docs for more info -->
+
+A "stateless component" does not need to aggregate specific spans in 
+order to work correctly - it can work correctly even it only has 
+some of the spans of a trace.
+
+Stateless Agents can be scaled without using `otelcol.exporter.loadbalancing`.
+You could use an off the shelf load balancer, or simply do a round-robin load balancing.
+
+Examples of stateless components:
+* `otelcol.processor.probabilistic_sampler`
+* `otelcol.processor.transform`
+* `otelcol.processor.attributes`
+* `otelcol.processor.span`

--- a/docs/sources/flow/setup/deploy-agent.md
+++ b/docs/sources/flow/setup/deploy-agent.md
@@ -62,7 +62,7 @@ Examples of stateful components:
 A "stateless component" does not need to aggregate specific spans to work correctly - 
 it can work correctly even if it only has some of the spans of a trace.
 
-Stateless {{< param "PRODUCT_ROOT_NAME" >}} can be scaled without using `otelcol.exporter.loadbalancing`.
+A stateless {{< param "PRODUCT_ROOT_NAME" >}} can be scaled without using `otelcol.exporter.loadbalancing`.
 For example, you could use an off-the-shelf load balancer to do a round-robin load balancing.
 
 Examples of stateless components:

--- a/docs/sources/flow/setup/deploy-agent.md
+++ b/docs/sources/flow/setup/deploy-agent.md
@@ -13,22 +13,24 @@ weight: 900
 
 {{< docs/shared source="agent" lookup="/deploy-agent.md" version="<AGENT_VERSION>" >}}
 
-## Processing different types of telemetry in different Agent instances
+## Processing different types of telemetry in different {{< param "PRODUCT_ROOT_NAME" >}} instances
 
-If the load on the Agents is small, it is recommended to process all necessary telemetry signals in the same Agent process. 
-For example, a single Agent can process all of the incoming metrics, logs, traces, and profiles.
+If the load on {{< param "PRODUCT_ROOT_NAME" >}} is small, it is recommended to process all necessary telemetry signals in the same {{< param "PRODUCT_ROOT_NAME" >}} process. 
+For example, a single {{< param "PRODUCT_ROOT_NAME" >}} can process all of the incoming metrics, logs, traces, and profiles.
 
-However, if the load on the Agents is big, it may be beneficial to process different telemetry signals in different deployments of Agents:
-* This provides better stability due to the isolation between processes.
-  * For example, an overloaded Agent processing traces won't impact an Agent processing metrics.
-* Different types of signal collection require different methods for scaling:
-  * "Pull" components such as `prometheus.scrape` and `pyroscope.scrape` are scaled using hashmod sharing or clustering. 
-  * "Push" components such as `otelcol.receiver.otlp` are scaled by placing a load balancer in front of them.
+However, if the load on the {{< param "PRODUCT_ROOT_NAME" >}}s is big, it may be beneficial to process different telemetry signals in different deployments of {{< param "PRODUCT_ROOT_NAME" >}}s.
+
+This provides better stability due to the isolation between processes.
+For example, an overloaded {{< param "PRODUCT_ROOT_NAME" >}} processing traces won't impact an {{< param "PRODUCT_ROOT_NAME" >}} processing metrics.
+Different types of signal collection require different methods for scaling:
+
+* "Pull" components such as `prometheus.scrape` and `pyroscope.scrape` are scaled using hashmod sharing or clustering. 
+* "Push" components such as `otelcol.receiver.otlp` are scaled by placing a load balancer in front of them.
 
 ### Traces
 
-Scaling Agent instances for tracing is very similar to [scaling OpenTelemetry Collector][scaling-collector] instances.
-This is because most Flow components used for tracing are based on components from the Collector.
+Scaling {{< param "PRODUCT_ROOT_NAME" >}} instances for tracing is very similar to [scaling OpenTelemetry Collector][scaling-collector] instances.
+This similarity is because most {{< param "PRODUCT_NAME" >}} components used for tracing are based on components from the OTel Collector.
 
 [scaling-collector]: https://opentelemetry.io/docs/collector/scaling/
 
@@ -42,12 +44,12 @@ To decide whether scaling is necessary, check metrics such as:
 #### Stateful and stateless components
 
 In the context of tracing, a "stateful component" is a component 
-which needs to aggregate certain spans in order to work correctly.
-A "stateless Agent" is an Agent which does not contain stateful components.
+that needs to aggregate certain spans to work correctly.
+A "stateless {{< param "PRODUCT_ROOT_NAME" >}}" is a {{< param "PRODUCT_ROOT_NAME" >}} which does not contain stateful components.
 
-Scaling stateful Agents is more difficult, because spans must be forwarded to a 
-specific Agent according to a span property such as trace ID or a `service.name` attribute.
-This can be done using `otelcol.exporter.loadbalancing`.
+Scaling stateful {{< param "PRODUCT_ROOT_NAME" >}}s is more difficult, because spans must be forwarded to a 
+specific {{< param "PRODUCT_ROOT_NAME" >}} according to a span property such as trace ID or a `service.name` attribute.
+You can forward spans with `otelcol.exporter.loadbalancing`.
 
 Examples of stateful components:
 
@@ -57,11 +59,11 @@ Examples of stateful components:
 
 <!-- TODO: link to the otelcol.exporter.loadbalancing docs for more info -->
 
-A "stateless component" does not need to aggregate specific spans in order to work correctly - 
+A "stateless component" does not need to aggregate specific spans to work correctly - 
 it can work correctly even if it only has some of the spans of a trace.
 
-Stateless Agents can be scaled without using `otelcol.exporter.loadbalancing`.
-You could use an off-the-shelf load balancer to, for example, do a round-robin load balancing.
+Stateless {{< param "PRODUCT_ROOT_NAME" >}} can be scaled without using `otelcol.exporter.loadbalancing`.
+For example, you could use an off-the-shelf load balancer to do a round-robin load balancing.
 
 Examples of stateless components:
 * `otelcol.processor.probabilistic_sampler`

--- a/docs/sources/static/configuration/traces-config.md
+++ b/docs/sources/static/configuration/traces-config.md
@@ -333,19 +333,27 @@ tail_sampling:
 # exported an additional time between agents.
 load_balancing:
   # resolver configures the resolution strategy for the involved backends
-  # It can be static, with a fixed list of hostnames, or DNS, with a hostname
-  # (and port) that will resolve to all IP addresses.
+  # It can be either "static", "dns" or "kubernetes".
   resolver:
     static:
+      # A fixed list of hostnames.
       hostnames:
         [ - <string> ... ]
     dns:
+      # DNS hostname from which to resolve IP addresses.
       hostname: <string>
+      # Port number to use with the resolved IP address when exporting spans.
       [ port: <int> | default = 4317 ]
       # Resolver interval
       [ interval: <duration> | default = 5s ]
       # Resolver timeout
       [ timeout: <duration> | default = 1s ]
+    # The kubernetes resolver receives IP addresses of a Kubernetes service 
+    # from the Kubernetes API. It does not require polling. The Kubernetes API
+    # notifies the Agent when a new pod is available and when an old pod has exited.
+    #
+    # For the kubernetes resolver to work, Agent must be running under
+    # a system account with "list", "watch" and "get" permissions.
     kubernetes:
       service: <string>
       [ ports: <int array> | default = 4317 ]

--- a/docs/sources/static/configuration/traces-config.md
+++ b/docs/sources/static/configuration/traces-config.md
@@ -316,8 +316,8 @@ tail_sampling:
 # Agent instances need to be able to communicate with each other via gRPC.
 #
 # When load_balancing is enabled:
-# 1. When an Agent receives spans from the configures "receivers".
-# 2. If the "attributes" processor is configured, it will be ran on the spans.
+# 1. When an Agent receives spans from the configured "receivers".
+# 2. If the "attributes" processor is configured, it will run through all the spans.
 # 3. The spans will be exported using the "load_balancing" configuration to any of the Agent instances.
 #    This may or may not be the same Agent which has already received the span.
 # 4. The Agent which received the span from the loadbalancer will run these processors, 

--- a/docs/sources/static/configuration/traces-config.md
+++ b/docs/sources/static/configuration/traces-config.md
@@ -308,13 +308,27 @@ tail_sampling:
 # It ensures that all spans of a trace are sampled in the same instance.
 # It works by exporting spans based on their traceID via consistent hashing.
 #
-# Enabling this feature is required for tail_sampling to correctly work when
-# different agent instances can receive spans for the same trace.
+# Enabling this feature is required for "tail_sampling", "spanmetrics", and "service_graphs"
+# to correctly work when spans are ingested by multiple agent instances.
 #
 # Load balancing works by layering two pipelines and consistently exporting
 # spans belonging to a trace to the same agent instance.
 # Agent instances need to be able to communicate with each other via gRPC.
 #
+# When load_balancing is enabled:
+# 1. When an Agent receives spans from the configures "receivers".
+# 2. If the "attributes" processor is configured, it will be ran on the spans.
+# 3. The spans will be exported using the "load_balancing" configuration to any of the Agent instances.
+#    This may or may not be the same Agent which has already received the span.
+# 4. The Agent which received the span from the loadbalancer will run these processors, 
+#    in this order, if they are configured:
+#    1. "spanmetrics"
+#    2. "service_graphs"
+#    3. "tail_sampling"
+#    4. "automatic_logging"
+#    5. "batch"
+# 5. The spans are then remote written using the "remote_write" configuration.
+# 
 # Load balancing significantly increases CPU usage. This is because spans are
 # exported an additional time between agents.
 load_balancing:

--- a/docs/sources/static/set-up/deploy-agent.md
+++ b/docs/sources/static/set-up/deploy-agent.md
@@ -11,3 +11,190 @@ weight: 300
 
 {{< docs/shared source="agent" lookup="/deploy-agent.md" version="<AGENT_VERSION>" >}}
 
+## For scalable ingestion of traces
+
+For small workloads, it is normal to have just one Agent handle all incoming
+spans with no need of load balancing. However, for large workloads there it
+is desirable to spread out the load of ingesting spans over multiple Agent
+instances.
+
+To scale the Agent for trace ingestion, do the following:
+1. Set up the `load_balancing` section of the Agent's `traces` config.
+2. Start multiple Agent instances, all with the same configuration, so that:
+   * Each Agent load balances using the same strategy.
+   * Each Agent processes spans in the same way.
+3. The cluster of Agents is now setup for load balancing. It works as follows:
+   1. Any of the Agents can receive spans from instrumented applications via the configured `receivers`.
+   2. When an Agent firstly receives spans, it will forward them to any of the Agents in the cluster according to the `load_balancing` configuration.
+
+<!-- For more detail, send people over to the load_balancing section in traces_config -->
+
+### tail_sampling
+Agents configured with `tail_sampling` must have all spans for 
+a given trace in order to work correctly. If some of the spans for a trace end up
+in a different Agent, `tail_sampling` will not sample correctly.
+
+### spanmetrics
+<!-- TODO: Also talk about span metrics -->
+
+### service_graphs
+<!-- TODO: Also talk about service_graphs -->
+
+### Example Kubernetes configuration
+{{< collapse title="Example Kubernetes configuration with DNS load balancing" >}}
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: grafana-cloud-monitoring
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: agent-traces
+  namespace: grafana-cloud-monitoring
+spec:
+  ports:
+  - name: agent-traces-otlp-grpc
+    port: 9411
+    protocol: TCP
+    targetPort: 9411
+  selector:
+    name: agent-traces
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k6-trace-generator
+  namespace: grafana-cloud-monitoring
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      name: k6-trace-generator
+  template:
+    metadata:
+      labels:
+        name: k6-trace-generator
+    spec:
+      containers:
+      - env:
+        - name: ENDPOINT
+          value: agent-traces-headless.grafana-cloud-monitoring.svc.cluster.local:9411
+        image: ghcr.io/grafana/xk6-client-tracing:v0.0.2
+        imagePullPolicy: IfNotPresent
+        name: k6-trace-generator
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-traces
+  namespace: grafana-cloud-monitoring
+spec:
+  minReadySeconds: 10
+  replicas: 3
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      name: agent-traces
+  template:
+    metadata:
+      labels:
+        name: agent-traces
+    spec:
+      containers:
+      - args:
+        - -config.file=/etc/agent/agent.yaml
+        command:
+        - /bin/grafana-agent
+        image: grafana/agent:v0.38.0
+        imagePullPolicy: IfNotPresent
+        name: agent-traces
+        ports:
+        - containerPort: 9411
+          name: otlp-grpc
+          protocol: TCP
+        - containerPort: 34621
+          name: agent-lb
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /etc/agent
+          name: agent-traces
+      volumes:
+      - configMap:
+          name: agent-traces
+        name: agent-traces
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: agent-traces-headless
+  namespace: grafana-cloud-monitoring
+spec:
+  clusterIP: None
+  ports:
+  - name: agent-lb
+    port: 34621
+    protocol: TCP
+    targetPort: agent-lb
+  selector:
+    name: agent-traces
+  type: ClusterIP
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-traces
+  namespace: grafana-cloud-monitoring
+data:
+  agent.yaml: |
+    traces:
+      configs:
+      - name: default
+        load_balancing:
+          exporter:
+            insecure: true
+          resolver:
+            dns:
+              hostname: agent-traces-headless.grafana-cloud-monitoring.svc.cluster.local
+              port: 34621
+              timeout: 5s
+              interval: 60s
+          receiver_port: 34621
+        receivers:
+          otlp:
+            protocols:
+              grpc:
+                endpoint: 0.0.0.0:9411
+        remote_write:
+        - basic_auth:
+            username: 111111
+            password: pass
+          endpoint: tempo-prod-06-prod-gb-south-0.grafana.net:443
+          retry_on_failure:
+            enabled: false
+```
+{{< /collapse >}}
+
+{{< collapse title="Example Kubernetes configuration with Kubernetes load balancing" >}}
+
+<!-- TODO: Fill in the Kubernetes yaml once I have a working configuration -->
+```yaml
+```
+
+{{< /collapse >}}
+
+You need to fill in correct OTLP credentials prior to running the above example.
+The example above can be started by using k3d:
+<!-- TODO: Link to the k3d page -->
+```bash
+k3d cluster create grafana-agent-lb-test
+kubectl apply -f kubernetes_config.yaml
+```
+
+To delete the cluster, run:
+```bash
+k3d cluster delete grafana-agent-lb-test
+```


### PR DESCRIPTION
When load balancing traces over multiple Agent instances, there are lots of potential issues that our users need to watch out for. These docs updates go into detail and provide examples. 

Some things are still not complete:

- I still have to add some more info regarding Static mode.
- Ideally we could also add pictures with the architecture.
- I need to make a working Static config which uses the Kubernetes resolver.
- I'm still not sure if the locations in the docs which I edited are the most appropriate ones. Especially the "Deploy Grafana Agent" page.