### PR TITLE
Add discovery.relabel_script to relabel with scripting

### DIFF
--- a/component/all/all.go
+++ b/component/all/all.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/grafana/agent/component/discovery/openstack"                      // Import discovery.openstack
 	_ "github.com/grafana/agent/component/discovery/puppetdb"                       // Import discovery.puppetdb
 	_ "github.com/grafana/agent/component/discovery/relabel"                        // Import discovery.relabel
+	_ "github.com/grafana/agent/component/discovery/relabel_script"                 // Import discovery.relabel_script
 	_ "github.com/grafana/agent/component/discovery/scaleway"                       // Import discovery.scaleway
 	_ "github.com/grafana/agent/component/discovery/serverset"                      // Import discovery.serverset
 	_ "github.com/grafana/agent/component/discovery/triton"                         // Import discovery.triton

--- a/component/discovery/relabel_script/relabel_script.go
+++ b/component/discovery/relabel_script/relabel_script.go
@@ -1,0 +1,255 @@
+package relabel_script
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/pkg/flow/logging/level"
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:    "discovery.relabel_script",
+		Args:    Arguments{},
+		Exports: Exports{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			return New(opts, args.(Arguments))
+		},
+	})
+}
+
+type Arguments struct {
+	// Targets contains the input 'targets' passed by a service discovery component.
+	Targets []discovery.Target `river:"targets,attr"`
+	// Script contains a Python (Starlark dialect) script to run that will relabel the targets.
+	// The script must contain a function with the signature: `def relabel_targets(targets)` that takes a list of
+	// dictionaries representing the targets and returns a new list of dictionaries for the user-modified targets.
+	Script string `river:"script,attr,optional"`
+	// ScriptFile contains the path to a Starlark (Python dialect) script to run that will relabel the targets. See
+	// Script for details on the script format.
+	ScriptFile string `river:"script_file,attr,optional"`
+}
+
+func (a Arguments) Validate() error {
+	if a.Script == "" && a.ScriptFile == "" {
+		return fmt.Errorf("script or script_file must be set")
+	}
+	if a.Script != "" && a.ScriptFile != "" {
+		return fmt.Errorf("only one of script or script_file can be set")
+	}
+	return nil
+}
+
+type Exports struct {
+	Output []discovery.Target `river:"output,attr"`
+}
+
+type Component struct {
+	opts component.Options
+
+	mut              sync.RWMutex
+	currentScript    string
+	thread           *starlark.Thread
+	relabelTargetsFn starlark.Value
+}
+
+var _ component.Component = (*Component)(nil)
+
+func New(o component.Options, args Arguments) (*Component, error) {
+	c := &Component{opts: o}
+
+	// Call to Update() to set the output once at the start
+	if err := c.Update(args); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+func (c *Component) Run(ctx context.Context) error {
+	<-ctx.Done()
+	c.thread.Cancel("component exiting")
+	return nil
+}
+
+func (c *Component) Update(args component.Arguments) error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	newArgs := args.(Arguments)
+
+	if err := c.updateScript(newArgs); err != nil {
+		return err
+	}
+
+	targets, err := c.doRelabel(newArgs.Targets)
+	if err != nil {
+		return err
+	}
+
+	c.opts.OnStateChange(Exports{
+		Output: targets,
+	})
+
+	return nil
+}
+
+func (c *Component) doRelabel(targets []discovery.Target) ([]discovery.Target, error) {
+	sTargets, err := c.toStarlarkTargets(targets)
+	if err != nil {
+		return nil, fmt.Errorf("error converting targets to Starlark: %w", err)
+	}
+
+	value, err := starlark.Call(c.thread, c.relabelTargetsFn, starlark.Tuple{starlark.NewList(sTargets)}, nil)
+	if err != nil {
+		finalErr := err
+		if evalError, ok := err.(*starlark.EvalError); ok {
+			finalErr = fmt.Errorf("error calling relabel_targets function in script: %w\n%v\nscript:\n%v", err, evalError.Backtrace(), numberLines(c.currentScript))
+		}
+		return nil, finalErr
+	}
+
+	return c.toFlowTargets(value)
+}
+
+func (c *Component) updateScript(newArgs Arguments) error {
+	newScript := ""
+	if newArgs.Script != "" {
+		newScript = newArgs.Script
+	} else if newArgs.ScriptFile != "" {
+		scriptBytes, err := os.ReadFile(newArgs.ScriptFile)
+		if err != nil {
+			return fmt.Errorf("error loading script file: %w", err)
+		}
+		newScript = string(scriptBytes)
+	} else {
+		// Should never happen thanks to validation
+		return fmt.Errorf("script or script_file must be set")
+	}
+
+	if newScript == c.currentScript {
+		return nil
+	}
+	var opts = syntax.FileOptions{Set: true, While: true, TopLevelControl: true, Recursion: true}
+
+	printFn := func(_ *starlark.Thread, msg string) {
+		level.Info(c.opts.Logger).Log("subcomponent", "script", "msg", msg)
+	}
+	c.thread = &starlark.Thread{Name: c.opts.ID, Print: printFn}
+	compiled, err := starlark.ExecFileOptions(&opts, c.thread, c.opts.ID, dedent(newScript), nil)
+	if err != nil {
+		return fmt.Errorf("error compiling script: %w\nscript:\n%s", err, numberLines(newScript))
+	}
+
+	fn, ok := compiled["relabel_targets"]
+	if !ok {
+		return fmt.Errorf("script does not contain a relabel_targets function: %s", newScript)
+	}
+	if sfn, ok := fn.(*starlark.Function); ok {
+		if sfn.NumParams() != 1 {
+			return fmt.Errorf("the relabel_targets function must accept exactly 1 argument: %s", newScript)
+		}
+	} else {
+		return fmt.Errorf("script must define relabel_targets as a function: %s", newScript)
+	}
+	c.relabelTargetsFn = fn
+	c.currentScript = newScript
+	return nil
+}
+
+// dedent removes the common leading whitespace from all lines in the script. This is to allow users to indent their
+// scripts for readability in their River config file, without causing syntax errors.
+func dedent(script string) string {
+	lines := strings.Split(script, "\n")
+	emptyLinesToSkip := map[int]struct{}{}
+	smallestDedent := math.MaxInt
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			emptyLinesToSkip[i] = struct{}{}
+			continue
+		}
+		dedentCount := len(line) - len(strings.TrimLeft(line, " \t"))
+		if dedentCount < smallestDedent {
+			smallestDedent = dedentCount
+		}
+	}
+	if smallestDedent == 0 {
+		return script // Script is already dedented
+	}
+	for i, line := range lines {
+		if _, ok := emptyLinesToSkip[i]; ok {
+			continue
+		}
+		lines[i] = line[smallestDedent:]
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (c *Component) toFlowTargets(value starlark.Value) ([]discovery.Target, error) {
+	listVal, ok := value.(*starlark.List)
+	if !ok {
+		return nil, fmt.Errorf("relabel_targets function in script did not return "+
+			"a list of dictionaries compatible with targets: %+v", value)
+	}
+
+	newTargets := make([]discovery.Target, 0, listVal.Len())
+
+	it := listVal.Iterate()
+	defer it.Done()
+
+	var val starlark.Value
+	for it.Next(&val) {
+		dictVal, ok := val.(*starlark.Dict)
+		if !ok {
+			level.Error(c.opts.Logger).Log("msg", "skipping invalid target: relabel_targets function must return a list of dictionaries", "invalid_list_element", fmt.Sprintf("%+v", val))
+			continue
+		}
+		newTarget := make(discovery.Target)
+		for _, k := range dictVal.Keys() {
+			v, _, _ := dictVal.Get(k)
+			if key, ok := k.(starlark.String); ok {
+				newTarget[string(key)] = strings.Trim(v.String(), "\"")
+			} else {
+				level.Error(c.opts.Logger).Log("msg", "skipping invalid target label: relabel_targets function must return a list of dictionaries with string keys", "invalid_key", fmt.Sprintf("%+v", k))
+				continue
+			}
+		}
+		if len(newTarget) > 0 {
+			newTargets = append(newTargets, newTarget)
+		}
+	}
+
+	return newTargets, nil
+}
+
+func (c *Component) toStarlarkTargets(targets []discovery.Target) ([]starlark.Value, error) {
+	sTargets := make([]starlark.Value, len(targets))
+	for i, target := range targets {
+		st := starlark.NewDict(len(target))
+		for k, v := range target {
+			err := st.SetKey(starlark.String(k), starlark.String(v))
+			if err != nil {
+				return nil, err
+			}
+		}
+		sTargets[i] = st
+	}
+	return sTargets, nil
+}
+
+func numberLines(script string) string {
+	lines := strings.Split(script, "\n")
+	for i := range lines {
+		lines[i] = fmt.Sprintf("%d: %s", i+1, lines[i])
+	}
+	return strings.Join(lines, "\n")
+}

--- a/component/discovery/relabel_script/relabel_script_test.go
+++ b/component/discovery/relabel_script/relabel_script_test.go
@@ -1,0 +1,383 @@
+package relabel_script
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/pkg/flow/componenttest"
+	"github.com/grafana/agent/pkg/util"
+	"github.com/grafana/river"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+)
+
+var exampleTargets = []discovery.Target{
+	{
+		"__address__": "node01:12345",
+		"job":         "observability/agent",
+		"cluster":     "europe-south-1",
+	},
+	{
+		"__address__": "node02:12345",
+		"job":         "observability/loki",
+		"cluster":     "europe-south-1",
+	},
+	{
+		"__address__": "node03:12345",
+		"job":         "observability/mimir",
+		"cluster":     "europe-south-1",
+	},
+}
+
+func TestScript(t *testing.T) {
+	testCases := []struct {
+		name           string
+		script         string
+		scriptFile     string
+		targets        []discovery.Target
+		expected       []discovery.Target
+		expectedRunErr error
+	}{
+		{
+			name:           "empty script",
+			script:         ``,
+			expectedRunErr: fmt.Errorf("script or script_file must be set"),
+		},
+		{
+			name:           "file does not exist",
+			scriptFile:     "does_not_exist.py",
+			expectedRunErr: fmt.Errorf("error loading script file: open does_not_exist.py: no such file or directory"),
+		},
+		{
+			name: "identity script with empty targets",
+			script: `
+				def relabel_targets(targets):
+					return targets
+			`,
+			targets:  []discovery.Target{},
+			expected: []discovery.Target{},
+		},
+		{
+			name:           "broken script",
+			script:         `int wrongLanguage() { return 0; }`,
+			expectedRunErr: fmt.Errorf("error compiling script"),
+		},
+		{
+			name: "exception in script prints nice error message",
+			script: `
+				def relabel_targets(targets):
+					return targets[100]
+			`,
+			expectedRunErr: fmt.Errorf(
+				"error calling relabel_targets function in script: index 100 out of range: empty list\n" +
+					"Traceback (most recent call last):\n" +
+					"  discovery.relabel_script.test:3:16: in relabel_targets\n" +
+					"Error: index 100 out of range: empty list\n" +
+					"script:\n" +
+					"1: \n" +
+					"2: \t\t\t\tdef relabel_targets(targets):\n" +
+					"3: \t\t\t\t\treturn targets[100]\n" +
+					"4: ",
+			),
+		},
+		{
+			name:           "script missing the relabel_targets function",
+			script:         `print("hello world")`,
+			expectedRunErr: fmt.Errorf("script does not contain a relabel_targets function"),
+		},
+		{
+			name:           "script relabel_targets function got no args",
+			script:         `def relabel_targets(): pass`,
+			expectedRunErr: fmt.Errorf("the relabel_targets function must accept exactly 1 argument"),
+		},
+		{
+			name:           "script relabel_targets function got two args",
+			script:         `def relabel_targets(a, b): pass`,
+			expectedRunErr: fmt.Errorf("the relabel_targets function must accept exactly 1 argument"),
+		},
+		{
+			name:           "script relabel_targets is not a function",
+			script:         `relabel_targets = 1`,
+			expectedRunErr: fmt.Errorf("script must define relabel_targets as a function"),
+		},
+		{
+			name: "return not a list",
+			script: `
+				def relabel_targets(targets):
+					return 1
+			`,
+			targets:        exampleTargets,
+			expectedRunErr: fmt.Errorf("relabel_targets function in script did not return a list of dictionaries"),
+		},
+		{
+			name: "return list of non-dict",
+			script: `
+				def relabel_targets(targets):
+					return [1, 2, 3]
+			`,
+			targets:  exampleTargets,
+			expected: []discovery.Target{},
+		},
+		{
+			name: "convert wrong value types to string",
+			script: `
+				def relabel_targets(targets):
+					return [{"__address__": 1}, {"__address__": 3.14}, {"__address__": [1, 2, 3]}]
+			`,
+			targets: exampleTargets,
+			expected: []discovery.Target{
+				{"__address__": "1"}, {"__address__": "3.14"}, {"__address__": "[1, 2, 3]"},
+			},
+		},
+		{
+			name: "ignore keys with wrong type",
+			script: `
+				def relabel_targets(targets):
+					return [{"__address__": 1, 123: 1}, {"__address__": 2, 3.14: "hello"}, {"__address__": 3, True: False}]
+			`,
+			targets: exampleTargets,
+			expected: []discovery.Target{
+				{"__address__": "1"}, {"__address__": "2"}, {"__address__": "3"},
+			},
+		},
+		{
+			name: "script trying to do dodgy things",
+			script: `
+				import os
+				os.mkdir("/tmp/agent")
+				os.rmdir("/tmp/agent")
+			`,
+			expectedRunErr: fmt.Errorf("error compiling script: discovery.relabel_script.test:2:7: got illegal token, want primary expression"),
+		},
+		{
+			name: "pass through",
+			script: `
+				def relabel_targets(targets):
+					return targets
+			`,
+			targets:  exampleTargets,
+			expected: exampleTargets,
+		},
+		{
+			name: "add pod and namespace",
+			script: `
+				def relabel_targets(targets):
+					for t in targets:
+						namespace, pod = t["job"].split("/")
+						t["namespace"] = namespace
+						t["pod"] = pod
+					return targets
+			`,
+			targets: exampleTargets,
+			expected: []discovery.Target{
+				{
+					"__address__": "node01:12345",
+					"job":         "observability/agent",
+					"cluster":     "europe-south-1",
+					"namespace":   "observability",
+					"pod":         "agent",
+				},
+				{
+					"__address__": "node02:12345",
+					"job":         "observability/loki",
+					"cluster":     "europe-south-1",
+					"namespace":   "observability",
+					"pod":         "loki",
+				},
+				{
+					"__address__": "node03:12345",
+					"job":         "observability/mimir",
+					"cluster":     "europe-south-1",
+					"namespace":   "observability",
+					"pod":         "mimir",
+				},
+			},
+		},
+		{
+			name:       "simple relabel file - add pod and namespace",
+			scriptFile: "testdata/simple_relabel.py",
+			targets:    exampleTargets,
+			expected: []discovery.Target{
+				{
+					"__address__": "node01:12345",
+					"job":         "observability/agent",
+					"cluster":     "europe-south-1",
+					"namespace":   "observability",
+					"pod":         "agent",
+				},
+				{
+					"__address__": "node02:12345",
+					"job":         "observability/loki",
+					"cluster":     "europe-south-1",
+					"namespace":   "observability",
+					"pod":         "loki",
+				},
+				{
+					"__address__": "node03:12345",
+					"job":         "observability/mimir",
+					"cluster":     "europe-south-1",
+					"namespace":   "observability",
+					"pod":         "mimir",
+				},
+			},
+		},
+		{
+			name: "correlate and join targets demo",
+			script: `
+				def relabel_targets(targets):
+					joined = {}
+					for t in targets:
+						if t["__address__"].startswith("mysql://"):
+							key = t["__address__"].split("/")[2]
+						else:
+							key = t.pop("__address__", None)
+							t["__host_address__"] = key
+
+						joined[key] = joined[key] | t if key in joined else t
+					return list(joined.values())
+`,
+			targets: []discovery.Target{
+				{
+					"__address__": "mysql://node01/something",
+					"job":         "db/mysql",
+				},
+				{
+					"__address__": "node01",
+					"size":        "xs",
+					"cluster":     "europe-south-1",
+				},
+				{
+					"__address__": "node02",
+					"size":        "xxs",
+					"cluster":     "europe-middle-1",
+				},
+				{
+					"__address__": "mysql://node02/something",
+					"job":         "db/mysql",
+				},
+			},
+			expected: []discovery.Target{
+				{
+					"__address__":      "mysql://node01/something",
+					"__host_address__": "node01",
+					"job":              "db/mysql",
+					"size":             "xs",
+					"cluster":          "europe-south-1",
+				},
+				{
+					"__host_address__": "node02",
+					"__address__":      "mysql://node02/something",
+					"size":             "xxs",
+					"cluster":          "europe-middle-1",
+					"job":              "db/mysql",
+				},
+			},
+		},
+	}
+	t.Parallel()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputTargets := deepCopyTargets(tc.targets)
+
+			args := Arguments{
+				Targets:    inputTargets,
+				Script:     tc.script,
+				ScriptFile: tc.scriptFile,
+			}
+
+			ctrl, err := componenttest.NewControllerFromID(util.TestLogger(t), "discovery.relabel_script")
+			require.NoError(t, err)
+
+			var (
+				runErr  error
+				runDone = make(chan struct{})
+			)
+			go func() {
+				runErr = ctrl.Run(componenttest.TestContext(t), args)
+				close(runDone)
+			}()
+
+			// Check for error if needed
+			if tc.expectedRunErr != nil {
+				<-runDone
+				require.Error(t, runErr)
+				assert.Contains(t, runErr.Error(), tc.expectedRunErr.Error())
+				return
+			}
+
+			// Otherwise, verify exports
+			require.NoError(t, ctrl.WaitRunning(time.Second), "component never started")
+			require.NoError(t, ctrl.WaitExports(time.Second), "component never exported anything")
+
+			require.EventuallyWithT(t, func(t *assert.CollectT) {
+				exports := ctrl.Exports().(Exports)
+				assert.NotNil(t, exports)
+				assert.Equal(t, tc.targets, inputTargets, "input targets were modified")
+				assert.Equal(t, tc.expected, exports.Output, "expected export does not match actual export")
+			}, 3*time.Second, 10*time.Millisecond, "component never reached the desired state")
+		})
+	}
+}
+
+func TestScriptWithParsing(t *testing.T) {
+	// Note script is not full "dedented" - has leading indentation.
+	script := `
+		def relabel_targets(targets):
+			for t in targets:
+				print('got target: ', t)
+			return targets
+`
+	cfg := `
+targets = [
+	{
+		__address__ = "127.0.0.1:12345",
+		namespace = "agent",
+		pod = "agent",
+	},
+	{
+		__address__ = "127.0.0.1:8888",
+		namespace = "loki",
+		pod = "loki",
+	},
+]
+script = ` + "`" + script + "`" + `
+	`
+	var args Arguments
+	require.NoError(t, river.Unmarshal([]byte(cfg), &args))
+
+	ctrl, err := componenttest.NewControllerFromID(util.TestLogger(t), "discovery.relabel_script")
+	require.NoError(t, err)
+
+	go func() { require.NoError(t, ctrl.Run(componenttest.TestContext(t), args)) }()
+
+	require.NoError(t, ctrl.WaitRunning(time.Second), "component never started")
+	require.NoError(t, ctrl.WaitExports(time.Second), "component never exported anything")
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		exports := ctrl.Exports().(Exports)
+		assert.NotNil(t, exports)
+		assert.Contains(t, exports.Output, discovery.Target{
+			"__address__": "127.0.0.1:12345",
+			"namespace":   "agent",
+			"pod":         "agent",
+		})
+		assert.Contains(t, exports.Output, discovery.Target{
+			"__address__": "127.0.0.1:8888",
+			"namespace":   "loki",
+			"pod":         "loki",
+		})
+	}, 3*time.Second, 10*time.Millisecond, "component never reached the desired state")
+}
+
+func deepCopyTargets(targets []discovery.Target) []discovery.Target {
+	inputCopy := make([]discovery.Target, len(targets))
+	for i, tg := range targets {
+		tCopy := make(discovery.Target, len(tg))
+		maps.Copy(tCopy, tg)
+		inputCopy[i] = tCopy
+	}
+	return inputCopy
+}

--- a/component/discovery/relabel_script/testdata/simple_relabel.py
+++ b/component/discovery/relabel_script/testdata/simple_relabel.py
@@ -1,0 +1,6 @@
+def relabel_targets(targets):
+	for t in targets:
+		namespace, pod = t["job"].split("/")
+		t["namespace"] = namespace
+		t["pod"] = pod
+	return targets

--- a/go.mod
+++ b/go.mod
@@ -617,6 +617,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.87.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver v0.87.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v0.42.0
+	go.starlark.net v0.0.0-20231121155337-90ade8b19d09
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2421,6 +2421,8 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
 go.starlark.net v0.0.0-20200901195727-6e684ef5eeee/go.mod h1:f0znQkUKRrkk36XxWbGjMqQM8wGv/xHBVE2qc3B5oFU=
+go.starlark.net v0.0.0-20231121155337-90ade8b19d09 h1:hzy3LFnSN8kuQK8h9tHl4ndF6UruMj47OqwqsS+/Ai4=
+go.starlark.net v0.0.0-20231121155337-90ade8b19d09/go.mod h1:LcLNIzVOMp4oV+uusnpk+VU+SzXaJakUuBjoCSWH5dM=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Adds a new `discovery.relabel_script` component that allows to relabel targets using a Python script (to be exact, it's a limited [Starlark dialect](https://github.com/google/starlark-go), that is used, for example, in Bazel).
* This allows to combine different discovery targets into one target, so we can, for example, enrich targets we discover in one place with extra labels discovered in another place if we join them in a script.
* It makes some target manipulations much simpler to read and understand.
* Thanks to multiline strings support in River, the config files look pretty decent. Could also add support for pulling a script from a file.
* Does not require users to learn some new (future) River scripting syntax, Python is a popular language many users will know
* Does not require the Agent to implement complex River features to provide more built-in functions and closures. However, it also does not prevent us from doing it in the future.

#### Notes to the Reviewer
* Docs are TODO
* With VSCode plugin it looks like this:
   ![image](https://github.com/grafana/agent/assets/17101802/0bfb37c4-3ed7-4bbb-9d89-0059baaba0f2)
   I may have old version that doesn't support multiline strings? But it also doesn't break entirely.

Some more info about [Starlark can be found here](https://github.com/bazelbuild/starlark/). The important part are Starlark's design principles, which I believe align well with our use case:
![image](https://github.com/grafana/agent/assets/17101802/146db20c-7267-402e-9b5b-363368c2dd84)

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [x] Config converters updated