### PR TITLE
otelcol.connector.servicegraph: update default store ttl value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ Main (unreleased)
 
 - Fixes `loki.source.docker` a behavior that synced an incomplete list of targets to the tailer manager. (@FerdinandvHagen)
 
+- Fixes `otelcol.connector.servicegraph` store ttl default value from 2ms to 2s. (@rlankfo)
+
 ### Other changes
 
 - Bump github.com/IBM/sarama from v1.41.2 to v1.42.1

--- a/component/otelcol/connector/servicegraph/servicegraph.go
+++ b/component/otelcol/connector/servicegraph/servicegraph.go
@@ -91,7 +91,7 @@ var DefaultArguments = Arguments{
 	Dimensions: []string{},
 	Store: StoreConfig{
 		MaxItems: 1000,
-		TTL:      2 * time.Millisecond,
+		TTL:      2 * time.Second,
 	},
 	CacheLoop:           1 * time.Minute,
 	StoreExpirationLoop: 2 * time.Second,

--- a/component/otelcol/connector/servicegraph/servicegraph_test.go
+++ b/component/otelcol/connector/servicegraph/servicegraph_test.go
@@ -44,7 +44,7 @@ func TestArguments_UnmarshalRiver(t *testing.T) {
 				Dimensions: []string{},
 				Store: servicegraphprocessor.StoreConfig{
 					MaxItems: 1000,
-					TTL:      2 * time.Millisecond,
+					TTL:      2 * time.Second,
 				},
 				CacheLoop:           1 * time.Minute,
 				StoreExpirationLoop: 2 * time.Second,

--- a/docs/sources/flow/reference/components/otelcol.connector.servicegraph.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.servicegraph.md
@@ -135,7 +135,7 @@ The `store` block configures the in-memory store for spans.
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `max_items` | `number` | Maximum number of items to keep in the store. | `1000` | no
-`ttl` | `duration` | The time to live for spans in the store. | `"2ms"` | no
+`ttl` | `duration` | The time to live for spans in the store. | `"2s"` | no
 
 ### output block
 


### PR DESCRIPTION
Signed-off-by: Robbie Lankford <robert.lankford@grafana.com>

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR updates the default store ttl for this component from 2ms to 2s.

#### Which issue(s) this PR fixes

See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29723

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated