### PR TITLE
chore: re-enable K8s-related unit tests

### DIFF
--- a/component/remote/vault/vault_test.go
+++ b/component/remote/vault/vault_test.go
@@ -143,9 +143,6 @@ func Test_PollSecrets(t *testing.T) {
 }
 
 func getTestVaultServer(t *testing.T) *vaultapi.Client {
-	// TODO: this is broken with go 1.20.6
-	// waiting on https://github.com/testcontainers/testcontainers-go/issues/1359
-	t.Skip()
 	ctx := componenttest.TestContext(t)
 	l := util.TestLogger(t)
 

--- a/pkg/operator/build_hierarchy_test.go
+++ b/pkg/operator/build_hierarchy_test.go
@@ -27,9 +27,6 @@ import (
 // Test_buildHierarchy checks that an entire resource hierarchy can be
 // discovered.
 func Test_buildHierarchy(t *testing.T) {
-	// TODO: this is broken with go 1.20.6
-	// waiting on https://github.com/testcontainers/testcontainers-go/issues/1359
-	t.Skip()
 	var wg sync.WaitGroup
 	defer wg.Wait()
 

--- a/pkg/operator/hierarchy/hierarchy_test.go
+++ b/pkg/operator/hierarchy/hierarchy_test.go
@@ -21,9 +21,6 @@ import (
 // TestNotifier tests that notifier properly handles events for changed
 // objects.
 func TestNotifier(t *testing.T) {
-	// TODO: this is broken with go 1.20.6
-	// waiting on https://github.com/testcontainers/testcontainers-go/issues/1359
-	t.Skip()
 	l := log.NewNopLogger()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)

--- a/pkg/operator/kubelet_test.go
+++ b/pkg/operator/kubelet_test.go
@@ -22,9 +22,6 @@ import (
 
 // TestKubelet tests the Kubelet reconciler.
 func TestKubelet(t *testing.T) {
-	// TODO: this is broken with go 1.20.6
-	// waiting on https://github.com/testcontainers/testcontainers-go/issues/1359
-	t.Skip()
 	l := util.TestLogger(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -140,9 +140,6 @@ func ReconcileTest(ctx context.Context, t *testing.T, inFile, outFile string) {
 // NewTestCluster creates a new testing cluster. The cluster will be removed
 // when the test completes.
 func NewTestCluster(ctx context.Context, t *testing.T, l log.Logger) *k8s.Cluster {
-	// TODO: this is broken with go 1.20.6
-	// waiting on https://github.com/testcontainers/testcontainers-go/issues/1359
-	t.Skip()
 	t.Helper()
 
 	cluster, err := k8s.NewCluster(ctx, k8s.Options{})

--- a/pkg/util/k8s/k8s_test.go
+++ b/pkg/util/k8s/k8s_test.go
@@ -12,9 +12,6 @@ import (
 )
 
 func TestCluster(t *testing.T) {
-	// TODO: this is broken with go 1.20.6
-	// waiting on https://github.com/testcontainers/testcontainers-go/issues/1359
-	t.Skip()
 	ctx := context.Background()
 
 	cluster, err := NewCluster(ctx, Options{})


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
The [commented issue](https://github.com/testcontainers/testcontainers-go/issues/1359) has been fixed in testcontainers-go v0.25.0, which is already present in `go.mod`

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
N/A

#### Notes to the Reviewer
N/A

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

N/A