### PR TITLE
feat!(exporter/blackbox): use required name attr instead label for target block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Breaking changes
+
+- `target` block in `prometheus.exporter.blackbox` requires mandatory `name`
+  attribute instead of label block previously. (@hainenber)
+
 ### Enhancements
 
 - Flow Windows service: Support environment variables. (@jkroepke)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ Main (unreleased)
 
 ### Breaking changes
 
-- `target` block in `prometheus.exporter.blackbox` requires mandatory `name`
-  attribute instead of label block previously. (@hainenber)
+- The `target` block in `prometheus.exporter.blackbox` requires a mandatory `name`
+  argument instead of a block label. (@hainenber)
 
 ### Enhancements
 

--- a/component/prometheus/exporter/blackbox/blackbox.go
+++ b/component/prometheus/exporter/blackbox/blackbox.go
@@ -67,7 +67,7 @@ var DefaultArguments = Arguments{
 
 // BlackboxTarget defines a target to be used by the exporter.
 type BlackboxTarget struct {
-	Name   string            `river:",label"`
+	Name   string            `river:"name,attr"`
 	Target string            `river:"address,attr"`
 	Module string            `river:"module,attr,optional"`
 	Labels map[string]string `river:"labels,attr,optional"`

--- a/component/prometheus/exporter/blackbox/blackbox_test.go
+++ b/component/prometheus/exporter/blackbox/blackbox_test.go
@@ -16,11 +16,13 @@ import (
 func TestUnmarshalRiver(t *testing.T) {
 	riverCfg := `
 		config_file = "modules.yml"
-		target "target_a" {
+		target {
+			name = "target_a"
 			address = "http://example.com"
 			module = "http_2xx"
 		}
-		target "target_b" {
+		target {
+			name = "target-b"
 			address = "http://grafana.com"
 			module = "http_2xx"
 		}
@@ -35,7 +37,7 @@ func TestUnmarshalRiver(t *testing.T) {
 	require.Contains(t, "target_a", args.Targets[0].Name)
 	require.Contains(t, "http://example.com", args.Targets[0].Target)
 	require.Contains(t, "http_2xx", args.Targets[0].Module)
-	require.Contains(t, "target_b", args.Targets[1].Name)
+	require.Contains(t, "target-b", args.Targets[1].Name)
 	require.Contains(t, "http://grafana.com", args.Targets[1].Target)
 	require.Contains(t, "http_2xx", args.Targets[1].Module)
 }
@@ -44,11 +46,13 @@ func TestUnmarshalRiverWithInlineConfig(t *testing.T) {
 	riverCfg := `
 		config = "{ modules: { http_2xx: { prober: http, timeout: 5s } } }"
 
-		target "target_a" {
+		target {
+			name = "target_a"
 			address = "http://example.com"
 			module = "http_2xx"
 		}
-		target "target_b" {
+		target {
+			name = "target-b"
 			address = "http://grafana.com"
 			module = "http_2xx"
 		}
@@ -68,7 +72,7 @@ func TestUnmarshalRiverWithInlineConfig(t *testing.T) {
 	require.Contains(t, "target_a", args.Targets[0].Name)
 	require.Contains(t, "http://example.com", args.Targets[0].Target)
 	require.Contains(t, "http_2xx", args.Targets[0].Module)
-	require.Contains(t, "target_b", args.Targets[1].Name)
+	require.Contains(t, "target-b", args.Targets[1].Name)
 	require.Contains(t, "http://grafana.com", args.Targets[1].Target)
 	require.Contains(t, "http_2xx", args.Targets[1].Module)
 }
@@ -77,11 +81,13 @@ func TestUnmarshalRiverWithInlineConfigYaml(t *testing.T) {
 	riverCfg := `
 		config = "modules:\n  http_2xx:\n    prober: http\n    timeout: 5s\n"
 
-		target "target_a" {
+		target {
+			name = "target_a" 
 			address = "http://example.com"
 			module = "http_2xx"
 		}
-		target "target_b" {
+		target {
+			name = "target-b"
 			address = "http://grafana.com"
 			module = "http_2xx"
 		}
@@ -101,7 +107,7 @@ func TestUnmarshalRiverWithInlineConfigYaml(t *testing.T) {
 	require.Contains(t, "target_a", args.Targets[0].Name)
 	require.Contains(t, "http://example.com", args.Targets[0].Target)
 	require.Contains(t, "http_2xx", args.Targets[0].Module)
-	require.Contains(t, "target_b", args.Targets[1].Name)
+	require.Contains(t, "target-b", args.Targets[1].Name)
 	require.Contains(t, "http://grafana.com", args.Targets[1].Target)
 	require.Contains(t, "http_2xx", args.Targets[1].Module)
 }
@@ -117,7 +123,8 @@ func TestUnmarshalRiverWithInvalidConfig(t *testing.T) {
 			`
 			config = "{ modules: { http_2xx: { prober: http, timeout: 5s }"
 
-			target "target_a" {
+			target {
+				name = "target_a"
 				address = "http://example.com"
 				module = "http_2xx"
 			}
@@ -129,7 +136,8 @@ func TestUnmarshalRiverWithInvalidConfig(t *testing.T) {
 			`
 			config = "{ module: { http_2xx: { prober: http, timeout: 5s } } }"
 
-			target "target_a" {
+			target {
+				name = "target_a"
 				address = "http://example.com"
 				module = "http_2xx"
 			}
@@ -142,7 +150,8 @@ func TestUnmarshalRiverWithInvalidConfig(t *testing.T) {
 			config_file = "config"
 			config = "{ modules: { http_2xx: { prober: http, timeout: 5s } } }"
 
-			target "target_a" {
+			target {
+				name = "target-a"
 				address = "http://example.com"
 				module = "http_2xx"
 			}
@@ -152,12 +161,23 @@ func TestUnmarshalRiverWithInvalidConfig(t *testing.T) {
 		{
 			"Define neither config nor config_file",
 			`
-			target "target_a" {
+			target {
+				name = "target-a"
 				address = "http://example.com"
 				module = "http_2xx"
 			}
 			`,
 			`config or config_file must be set`,
+		},
+		{
+			"Specify label for target block instead of name attribute",
+			`
+			target "target_a" {
+				address = "http://example.com"
+				module = "http_2xx"
+			}
+			`,
+			`2:4: block "target" does not support specifying labels`,
 		},
 	}
 	for _, tt := range tests {

--- a/converter/internal/staticconvert/internal/build/blackbox_exporter.go
+++ b/converter/internal/staticconvert/internal/build/blackbox_exporter.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/grafana/agent/component/discovery"
 	"github.com/grafana/agent/component/prometheus/exporter/blackbox"
-	"github.com/grafana/agent/converter/internal/common"
 	"github.com/grafana/agent/pkg/integrations/blackbox_exporter"
 	blackbox_exporter_v2 "github.com/grafana/agent/pkg/integrations/v2/blackbox_exporter"
 	"github.com/grafana/river/rivertypes"
@@ -57,7 +56,7 @@ func toBlackboxTargets(blackboxTargets []blackbox_exporter.BlackboxTarget) black
 
 func toBlackboxTarget(target blackbox_exporter.BlackboxTarget) blackbox.BlackboxTarget {
 	return blackbox.BlackboxTarget{
-		Name:   common.SanitizeIdentifierPanics(target.Name),
+		Name:   target.Name,
 		Target: target.Target,
 		Module: target.Module,
 	}

--- a/converter/internal/staticconvert/testdata-v2/integrations_v2.river
+++ b/converter/internal/staticconvert/testdata-v2/integrations_v2.river
@@ -475,7 +475,7 @@ prometheus.exporter.blackbox "integrations_blackbox" {
 	config = "modules:\n  http_2xx:\n    prober: http\n    timeout: 5s\n    http:\n      method: POST\n      headers:\n        Content-Type: application/json\n      body: '{}'\n      preferred_ip_protocol: ip4\n"
 
 	target {
-		name 	= "example"
+		name    = "example"
 		address = "http://example.com"
 		module  = "http_2xx"
 	}

--- a/converter/internal/staticconvert/testdata-v2/integrations_v2.river
+++ b/converter/internal/staticconvert/testdata-v2/integrations_v2.river
@@ -474,7 +474,8 @@ prometheus.scrape "integrations_apache2" {
 prometheus.exporter.blackbox "integrations_blackbox" {
 	config = "modules:\n  http_2xx:\n    prober: http\n    timeout: 5s\n    http:\n      method: POST\n      headers:\n        Content-Type: application/json\n      body: '{}'\n      preferred_ip_protocol: ip4\n"
 
-	target "example" {
+	target {
+		name 	= "example"
 		address = "http://example.com"
 		module  = "http_2xx"
 	}

--- a/converter/internal/staticconvert/testdata/integrations.river
+++ b/converter/internal/staticconvert/testdata/integrations.river
@@ -41,7 +41,8 @@ prometheus.scrape "integrations_apache_http" {
 prometheus.exporter.blackbox "integrations_blackbox" {
 	config = "modules:\n  http_2xx:\n    prober: http\n    timeout: 5s\n    http:\n      method: POST\n      headers:\n        Content-Type: application/json\n      body: '{}'\n      preferred_ip_protocol: ip4\n"
 
-	target "example" {
+	target {
+		name    = "example"
 		address = "http://example.com"
 		module  = "http_2xx"
 	}

--- a/docs/developer/writing-exporter-flow-components.md
+++ b/docs/developer/writing-exporter-flow-components.md
@@ -40,7 +40,7 @@ prometheus.exporter.blackbox "example" {
 	config_file = "blackbox_modules.yml"
 	
 	target {
-    name    = "example"
+		name    = "example"
 		address = "http://example.com"
 		module  = "http_2xx"
 	}

--- a/docs/developer/writing-exporter-flow-components.md
+++ b/docs/developer/writing-exporter-flow-components.md
@@ -39,7 +39,8 @@ The river config would look like this:
 prometheus.exporter.blackbox "example" { 
 	config_file = "blackbox_modules.yml"
 	
-	target "example" {
+	target {
+    name    = "example"
 		address = "http://example.com"
 		module  = "http_2xx"
 	}

--- a/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.blackbox.md
@@ -18,7 +18,8 @@ The `prometheus.exporter.blackbox` component embeds
 
 ```river
 prometheus.exporter.blackbox "LABEL" {
-  target "example" {
+  target {
+    name    = "example"
     address = "EXAMPLE_ADDRESS"
   }
 }
@@ -60,10 +61,11 @@ The following blocks are supported inside the definition of
 ### target block
 
 The `target` block defines an individual blackbox target.
-The `target` block may be specified multiple times to define multiple targets. The label of the block is required and will be used in the target's `job` label.
+The `target` block may be specified multiple times to define multiple targets. `name` attribute is required and will be used in the target's `job` label.
 
 | Name      | Type             | Description                         | Default | Required |
 | --------- | ---------------- | ----------------------------------- | ------- | -------- |
+| `name`    | `string`         | The name of the target to probe.    |         | yes      |
 | `address` | `string`         | The address of the target to probe. |         | yes      |
 | `module`  | `string`         | Blackbox module to use to probe.    | `""`    | no       |
 | `labels`  | `map(string)`    | Labels to add to the target.        |         | no       |
@@ -103,12 +105,14 @@ The `config_file` argument is used to define which `blackbox_exporter` modules t
 prometheus.exporter.blackbox "example" {
   config_file = "blackbox_modules.yml"
 
-  target "example" {
+  target {
+    name    = "example"
     address = "http://example.com"
     module  = "http_2xx"
   }
 
-  target "grafana" {
+  target {
+    name    = "grafana" 
     address = "http://grafana.com"
     module  = "http_2xx"
     labels = {
@@ -149,12 +153,14 @@ This example is the same above with using an embedded configuration:
 prometheus.exporter.blackbox "example" {
   config = "{ modules: { http_2xx: { prober: http, timeout: 5s } } }"
 
-  target "example" {
+  target {
+    name    = "example"
     address = "http://example.com"
     module  = "http_2xx"
   }
 
-  target "grafana" {
+  target {
+    name    = "grafana"
     address = "http://grafana.com"
     module  = "http_2xx"
     labels = {

--- a/docs/sources/flow/release-notes.md
+++ b/docs/sources/flow/release-notes.md
@@ -29,6 +29,47 @@ Other release notes for the different {{< param "PRODUCT_ROOT_NAME" >}} variants
 [release-notes-operator]: {{< relref "../operator/release-notes.md" >}}
 {{% /admonition %}}
 
+
+## v0.39
+
+### Breaking change: label for `target` block in `prometheus.exporter.blackbox` is removed
+
+Previously in `prometheus.exporter.blackbox`, the `target` block requires a label which is used in job's name. 
+In this version, user needs to be specify `name` attribute instead, which allow less restrictive naming.
+
+Old configuration example:
+
+```river
+prometheus.exporter.blackbox "example" {
+  config_file = "blackbox_modules.yml"
+
+  target "grafana" {
+    address = "http://grafana.com"
+    module  = "http_2xx"
+    labels = {
+      "env": "dev",
+    }
+  }
+}
+```
+
+New configuration example:
+
+```river
+prometheus.exporter.blackbox "example" {
+  config_file = "blackbox_modules.yml"
+
+  target {
+    name     = "grafana"
+    address = "http://grafana.com"
+    module  = "http_2xx"
+    labels = {
+      "env": "dev",
+    }
+  }
+}
+```
+
 ## v0.38
 
 ### Breaking change: `otelcol.exporter.jaeger` component removed


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #5940 

#### Notes to the Reviewer
Should this be a breaking change? I gave it some thoughts and unless we specify an interface to allow interchangeability (which is awkward, IMO), breaking change it is since `label` block is mandatory atm.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated