### PR TITLE
Replace < with % in var references in headings

### DIFF
--- a/docs/sources/flow/_index.md
+++ b/docs/sources/flow/_index.md
@@ -14,7 +14,7 @@ cascade:
   PRODUCT_ROOT_NAME: Grafana Agent
 ---
 
-# {{< param "PRODUCT_NAME" >}}
+# {{% param "PRODUCT_NAME" %}}
 
 {{< param "PRODUCT_NAME" >}} is a _component-based_ revision of {{< param "PRODUCT_ROOT_NAME" >}} with a focus on ease-of-use,
 debuggability, and ability to adapt to the needs of power users.
@@ -67,7 +67,7 @@ prometheus.remote_write "default" {
 }
 ```
 
-## {{< param "PRODUCT_ROOT_NAME" >}} configuration generator
+## {{% param "PRODUCT_ROOT_NAME" %}} configuration generator
 
 The {{< param "PRODUCT_ROOT_NAME" >}} [configuration generator](https://grafana.github.io/agent-configurator/) will help you get a head start on creating flow code.
 

--- a/docs/sources/flow/getting-started/_index.md
+++ b/docs/sources/flow/getting-started/_index.md
@@ -12,7 +12,7 @@ title: Get started with Grafana Agent Flow
 weight: 200
 ---
 
-# Get started with {{< param "PRODUCT_NAME" >}}
+# Get started with {{% param "PRODUCT_NAME" %}}
 
 This section details guides for getting started with {{< param "PRODUCT_NAME" >}}.
 

--- a/docs/sources/flow/getting-started/configure-agent-clustering.md
+++ b/docs/sources/flow/getting-started/configure-agent-clustering.md
@@ -11,7 +11,7 @@ title: Configure Grafana Agent clustering in an existing installation
 weight: 400
 ---
 
-# Configure {{< param "PRODUCT_NAME" >}} clustering in an existing installation
+# Configure {{% param "PRODUCT_NAME" %}} clustering in an existing installation
 
 You can configure {{< param "PRODUCT_NAME" >}} to run with [clustering][] so that individual {{< param "PRODUCT_ROOT_NAME" >}}s can work together for workload distribution and high availability.
 
@@ -20,7 +20,7 @@ You can configure {{< param "PRODUCT_NAME" >}} to run with [clustering][] so tha
 
 This topic describes how to add clustering to an existing installation.
 
-## Configure {{< param "PRODUCT_NAME" >}} clustering with Helm Chart
+## Configure {{% param "PRODUCT_NAME" %}} clustering with Helm Chart
 
 This section guides you through enabling clustering when {{< param "PRODUCT_NAME" >}} is installed on Kubernetes using the {{< param "PRODUCT_ROOT_NAME" >}} [Helm chart][install-helm].
 

--- a/docs/sources/flow/getting-started/migrating-from-operator.md
+++ b/docs/sources/flow/getting-started/migrating-from-operator.md
@@ -9,7 +9,7 @@ title: Migrating from Grafana Agent Operator to Grafana Agent Flow
 weight: 320
 ---
 
-# Migrating from Grafana Agent Operator to {{< param "PRODUCT_NAME" >}}
+# Migrating from Grafana Agent Operator to {{% param "PRODUCT_NAME" %}}
 
 With the release of {{< param "PRODUCT_NAME" >}}, Grafana Agent Operator is no longer the recommended way to deploy {{< param "PRODUCT_ROOT_NAME" >}} in Kubernetes.
 Some of the Operator functionality has moved into {{< param "PRODUCT_NAME" >}} itself, and the Helm Chart has replaced the remaining functionality.
@@ -21,7 +21,7 @@ Some of the Operator functionality has moved into {{< param "PRODUCT_NAME" >}} i
 
 This guide provides some steps to get started with {{< param "PRODUCT_NAME" >}} for users coming from Grafana Agent Operator.
 
-## Deploy {{< param "PRODUCT_NAME" >}} with Helm
+## Deploy {{% param "PRODUCT_NAME" %}} with Helm
 
 1. Create a `values.yaml` file, which contains options for deploying your {{< param "PRODUCT_ROOT_NAME" >}}.
    You can start with the [default values][] and customize as you see fit, or start with this snippet, which should be a good starting point for what the Operator does.
@@ -64,7 +64,7 @@ This guide provides some steps to get started with {{< param "PRODUCT_NAME" >}} 
 
     This command uses the `--set-file` flag to pass the configuration file as a Helm value so that you can continue to edit it as a regular River file.
 
-## Convert `MetricsIntances` to {{< param "PRODUCT_NAME" >}} components
+## Convert `MetricsIntances` to {{% param "PRODUCT_NAME" %}} components
 
 A `MetricsInstance` resource primarily defines:
 

--- a/docs/sources/flow/getting-started/migrating-from-prometheus.md
+++ b/docs/sources/flow/getting-started/migrating-from-prometheus.md
@@ -11,7 +11,7 @@ title: Migrate from Prometheus to Grafana Agent Flow
 weight: 320
 ---
 
-# Migrate from Prometheus to {{< param "PRODUCT_NAME" >}}
+# Migrate from Prometheus to {{% param "PRODUCT_NAME" %}}
 
 The built-in {{< param "PRODUCT_ROOT_NAME" >}} convert command can migrate your [Prometheus][] configuration to a {{< param "PRODUCT_NAME" >}} configuration.
 

--- a/docs/sources/flow/getting-started/migrating-from-promtail.md
+++ b/docs/sources/flow/getting-started/migrating-from-promtail.md
@@ -11,7 +11,7 @@ title: Migrate from Promtail to Grafana Agent Flow
 weight: 330
 ---
 
-# Migrate from Promtail to {{< param "PRODUCT_NAME" >}}
+# Migrate from Promtail to {{% param "PRODUCT_NAME" %}}
 
 The built-in {{< param "PRODUCT_ROOT_NAME" >}} convert command can migrate your [Promtail][] configuration to a {{< param "PRODUCT_NAME" >}} configuration.
 

--- a/docs/sources/flow/getting-started/migrating-from-static.md
+++ b/docs/sources/flow/getting-started/migrating-from-static.md
@@ -11,7 +11,7 @@ title: Migrate Grafana Agent Static to Grafana Agent Flow
 weight: 340
 ---
 
-# Migrate from {{< param "PRODUCT_ROOT_NAME" >}} Static to {{< param "PRODUCT_NAME" >}}
+# Migrate from {{% param "PRODUCT_ROOT_NAME" %}} Static to {{% param "PRODUCT_NAME" %}}
 
 The built-in {{< param "PRODUCT_ROOT_NAME" >}} convert command can migrate your [Static][] configuration to a {{< param "PRODUCT_NAME" >}} configuration.
 

--- a/docs/sources/flow/monitoring/_index.md
+++ b/docs/sources/flow/monitoring/_index.md
@@ -11,7 +11,7 @@ menuTitle: Monitoring
 weight: 500
 ---
 
-# Monitoring {{< param "PRODUCT_NAME" >}}
+# Monitoring {{% param "PRODUCT_NAME" %}}
 
 This section details various ways to monitor and debug {{< param "PRODUCT_NAME" >}}.
 

--- a/docs/sources/flow/monitoring/debugging.md
+++ b/docs/sources/flow/monitoring/debugging.md
@@ -17,7 +17,7 @@ Follow these steps to debug issues with {{< param "PRODUCT_NAME" >}}:
 1. Use the {{< param "PRODUCT_NAME" >}} UI to debug issues.
 1. If the {{< param "PRODUCT_NAME" >}} UI doesn't help with debugging an issue, logs can be examined instead.
 
-## {{< param "PRODUCT_NAME" >}} UI
+## {{% param "PRODUCT_NAME" %}} UI
 
 {{< param "PRODUCT_NAME" >}} includes an embedded UI viewable from the {{< param "PRODUCT_ROOT_NAME" >}} HTTP server, which defaults to listening at `http://localhost:12345`.
 

--- a/docs/sources/flow/reference/_index.md
+++ b/docs/sources/flow/reference/_index.md
@@ -11,7 +11,7 @@ title: Grafana Agent Flow Reference
 weight: 600
 ---
 
-# {{< param "PRODUCT_NAME" >}} Reference
+# {{% param "PRODUCT_NAME" %}} Reference
 
 This section provides reference-level documentation for the various parts of {{< param "PRODUCT_NAME" >}}:
 

--- a/docs/sources/flow/reference/cli/_index.md
+++ b/docs/sources/flow/reference/cli/_index.md
@@ -11,7 +11,7 @@ title: The Grafana Agent command-line interface
 weight: 100
 ---
 
-# The {{< param "PRODUCT_ROOT_NAME" >}} command-line interface
+# The {{% param "PRODUCT_ROOT_NAME" %}} command-line interface
 
 When in Flow mode, the `grafana-agent` binary exposes a command-line interface with
 subcommands to perform various operations.

--- a/docs/sources/flow/release-notes.md
+++ b/docs/sources/flow/release-notes.md
@@ -12,7 +12,7 @@ title: Release notes for Grafana Agent Flow
 weight: 999
 ---
 
-# Release notes for {{< param "PRODUCT_NAME" >}}
+# Release notes for {{% param "PRODUCT_NAME" %}}
 
 The release notes provide information about deprecations and breaking changes in {{< param "PRODUCT_NAME" >}}.
 
@@ -372,7 +372,7 @@ The change was made in PR [#18070](https://github.com/open-telemetry/opentelemet
 The `remote_sampling` block in `otelcol.receiver.jaeger` has been an undocumented no-op configuration for some time, and has now been removed.
 Customers are advised to use `otelcol.extension.jaeger_remote_sampling` instead.
 
-### Deprecation: `otelcol.exporter.jaeger` has been deprecated and will be removed in {{< param "PRODUCT_NAME" >}} v0.38.0.
+### Deprecation: `otelcol.exporter.jaeger` has been deprecated and will be removed in {{% param "PRODUCT_NAME" %}} v0.38.0.
 
 This is because Jaeger supports OTLP directly and OpenTelemetry Collector is also removing its
 [Jaeger receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/jaegerexporter).

--- a/docs/sources/flow/setup/_index.md
+++ b/docs/sources/flow/setup/_index.md
@@ -11,7 +11,7 @@ title: Set up Grafana Agent Flow
 weight: 50
 ---
 
-# Set up {{< param "PRODUCT_NAME" >}}
+# Set up {{% param "PRODUCT_NAME" %}}
 
 This section includes information that helps you install and configure {{< param "PRODUCT_NAME" >}}.
 

--- a/docs/sources/flow/setup/configure/_index.md
+++ b/docs/sources/flow/setup/configure/_index.md
@@ -11,7 +11,7 @@ title: Configure Grafana Agent Flow
 weight: 150
 ---
 
-# Configure {{< param "PRODUCT_NAME" >}}
+# Configure {{% param "PRODUCT_NAME" %}}
 
 You can configure {{< param "PRODUCT_NAME" >}} after it is installed. The default River configuration file for {{< param "PRODUCT_NAME" >}} is located at:
 

--- a/docs/sources/flow/setup/configure/configure-kubernetes.md
+++ b/docs/sources/flow/setup/configure/configure-kubernetes.md
@@ -11,7 +11,7 @@ title: Configure Grafana Agent Flow on Kubernetes
 weight: 200
 ---
 
-# Configure {{< param "PRODUCT_NAME" >}} on Kubernetes
+# Configure {{% param "PRODUCT_NAME" %}} on Kubernetes
 
 To configure {{< param "PRODUCT_NAME" >}} on Kubernetes, perform the following steps:
 

--- a/docs/sources/flow/setup/configure/configure-linux.md
+++ b/docs/sources/flow/setup/configure/configure-linux.md
@@ -11,7 +11,7 @@ title: Configure Grafana Agent Flow on Linux
 weight: 300
 ---
 
-# Configure {{< param "PRODUCT_NAME" >}} on Linux
+# Configure {{% param "PRODUCT_NAME" %}} on Linux
 
 To configure {{< param "PRODUCT_NAME" >}} on Linux, perform the following steps:
 

--- a/docs/sources/flow/setup/configure/configure-macos.md
+++ b/docs/sources/flow/setup/configure/configure-macos.md
@@ -11,7 +11,7 @@ title: Configure Grafana Agent Flow on macOS
 weight: 400
 ---
 
-# Configure {{< param "PRODUCT_NAME" >}} on macOS
+# Configure {{% param "PRODUCT_NAME" %}} on macOS
 
 To configure {{< param "PRODUCT_NAME" >}} on macOS, perform the following steps:
 
@@ -23,7 +23,7 @@ To configure {{< param "PRODUCT_NAME" >}} on macOS, perform the following steps:
    brew services restart grafana-agent-flow
    ```
 
-## Configure the {{< param "PRODUCT_NAME" >}} service
+## Configure the {{% param "PRODUCT_NAME" %}} service
 
 {{% admonition type="note" %}}
 Due to limitations in Homebrew, customizing the service used by

--- a/docs/sources/flow/setup/configure/configure-windows.md
+++ b/docs/sources/flow/setup/configure/configure-windows.md
@@ -11,7 +11,7 @@ title: Configure Grafana Agent Flow on Windows
 weight: 500
 ---
 
-# Configure {{< param "PRODUCT_NAME" >}} on Windows
+# Configure {{% param "PRODUCT_NAME" %}} on Windows
 
 To configure {{< param "PRODUCT_NAME" >}} on Windows, perform the following steps:
 

--- a/docs/sources/flow/setup/install/_index.md
+++ b/docs/sources/flow/setup/install/_index.md
@@ -12,7 +12,7 @@ title: Install Grafana Agent Flow
 weight: 50
 ---
 
-# Install {{< param "PRODUCT_NAME" >}}
+# Install {{% param "PRODUCT_NAME" %}}
 
 You can install {{< param "PRODUCT_NAME" >}} on Docker, Kubernetes, Linux, macOS, or Windows.
 

--- a/docs/sources/flow/setup/install/binary.md
+++ b/docs/sources/flow/setup/install/binary.md
@@ -12,7 +12,7 @@ title: Install Grafana Agent  Flow as a standalone binary
 weight: 600
 ---
 
-# Install {{< param "PRODUCT_NAME" >}} as a standalone binary
+# Install {{% param "PRODUCT_NAME" %}} as a standalone binary
 
 {{< param "PRODUCT_NAME" >}} is distributed as a standalone binary for the following operating systems and architectures:
 
@@ -21,7 +21,7 @@ weight: 600
 * macOS: AMD64 (Intel), ARM64 (Apple Silicon)
 * FreeBSD: AMD64
 
-## Download {{< param "PRODUCT_ROOT_NAME" >}}
+## Download {{% param "PRODUCT_ROOT_NAME" %}}
 
 To download {{< param "PRODUCT_NAME" >}} as a standalone binary, perform the following steps.
 

--- a/docs/sources/flow/setup/install/docker.md
+++ b/docs/sources/flow/setup/install/docker.md
@@ -12,7 +12,7 @@ title: Run Grafana Agent Flow in a Docker container
 weight: 100
 ---
 
-# Run {{< param "PRODUCT_NAME" >}} in a Docker container
+# Run {{% param "PRODUCT_NAME" %}} in a Docker container
 
 {{< param "PRODUCT_NAME" >}} is available as a Docker container image on the following platforms:
 

--- a/docs/sources/flow/setup/install/kubernetes.md
+++ b/docs/sources/flow/setup/install/kubernetes.md
@@ -12,7 +12,7 @@ title: Deploy Grafana Agent Flow on Kubernetes
 weight: 200
 ---
 
-# Deploy {{< param "PRODUCT_NAME" >}} on Kubernetes
+# Deploy {{% param "PRODUCT_NAME" %}} on Kubernetes
 
 {{< param "PRODUCT_NAME" >}} can be deployed on Kubernetes by using the Helm chart for {{< param "PRODUCT_ROOT_NAME" >}}.
 

--- a/docs/sources/flow/setup/install/linux.md
+++ b/docs/sources/flow/setup/install/linux.md
@@ -12,7 +12,7 @@ title: Install Grafana Agent Flow on Linux
 weight: 300
 ---
 
-# Install or uninstall {{< param "PRODUCT_NAME" >}} on Linux
+# Install or uninstall {{% param "PRODUCT_NAME" %}} on Linux
 
 You can install {{< param "PRODUCT_NAME" >}} as a systemd service on Linux.
 

--- a/docs/sources/flow/setup/install/macos.md
+++ b/docs/sources/flow/setup/install/macos.md
@@ -12,7 +12,7 @@ title: Install Grafana Agent Flow on macOS
 weight: 400
 ---
 
-# Install {{< param "PRODUCT_NAME" >}} on macOS
+# Install {{% param "PRODUCT_NAME" %}} on macOS
 
 You can install {{< param "PRODUCT_NAME" >}} on macOS with Homebrew .
 

--- a/docs/sources/flow/setup/install/windows.md
+++ b/docs/sources/flow/setup/install/windows.md
@@ -12,7 +12,7 @@ title: Install Grafana Agent Flow on Windows
 weight: 500
 ---
 
-# Install {{< param "PRODUCT_NAME" >}} on Windows
+# Install {{% param "PRODUCT_NAME" %}} on Windows
 
 You can install {{< param "PRODUCT_NAME" >}} on Windows as a standard graphical install, or as a silent install.
 

--- a/docs/sources/flow/setup/start-agent.md
+++ b/docs/sources/flow/setup/start-agent.md
@@ -11,7 +11,7 @@ title: Start, restart, and stop Grafana Agent Flow
 weight: 800
 ---
 
-# Start, restart, and stop {{< param "PRODUCT_NAME" >}}
+# Start, restart, and stop {{% param "PRODUCT_NAME" %}}
 
 You can start, restart, and stop {{< param "PRODUCT_NAME" >}} after it is installed.
 
@@ -21,7 +21,7 @@ You can start, restart, and stop {{< param "PRODUCT_NAME" >}} after it is instal
 
 [systemd]: https://systemd.io/
 
-### Start {{< param "PRODUCT_NAME" >}}
+### Start {{% param "PRODUCT_NAME" %}}
 
 To start {{< param "PRODUCT_NAME" >}}, run the following command in a terminal window:
 
@@ -35,7 +35,7 @@ sudo systemctl start grafana-agent-flow
 sudo systemctl status grafana-agent-flow
 ```
 
-### Configure {{< param "PRODUCT_NAME" >}} to start at boot
+### Configure {{% param "PRODUCT_NAME" %}} to start at boot
 
 To automatically run {{< param "PRODUCT_NAME" >}} when the system starts, run the following command in a terminal window:
 
@@ -43,7 +43,7 @@ To automatically run {{< param "PRODUCT_NAME" >}} when the system starts, run th
 sudo systemctl enable grafana-agent-flow.service
 ```
 
-### Restart {{< param "PRODUCT_NAME" >}}
+### Restart {{% param "PRODUCT_NAME" %}}
 
 To restart {{< param "PRODUCT_NAME" >}}, run the following command in a terminal window:
 
@@ -51,7 +51,7 @@ To restart {{< param "PRODUCT_NAME" >}}, run the following command in a terminal
 sudo systemctl restart grafana-agent-flow
 ```
 
-### Stop {{< param "PRODUCT_NAME" >}}
+### Stop {{% param "PRODUCT_NAME" %}}
 
 To stop {{< param "PRODUCT_NAME" >}}, run the following command in a terminal window:
 
@@ -59,7 +59,7 @@ To stop {{< param "PRODUCT_NAME" >}}, run the following command in a terminal wi
 sudo systemctl stop grafana-agent-flow
 ```
 
-### View {{< param "PRODUCT_NAME" >}} logs on Linux
+### View {{% param "PRODUCT_NAME" %}} logs on Linux
 
 To view {{< param "PRODUCT_NAME" >}} log files, run the following command in a terminal window:
 
@@ -71,7 +71,7 @@ sudo journalctl -u grafana-agent-flow
 
 {{< param "PRODUCT_NAME" >}} is installed as a launchd service on macOS.
 
-### Start {{< param "PRODUCT_NAME" >}}
+### Start {{% param "PRODUCT_NAME" %}}
 
 To start {{< param "PRODUCT_NAME" >}}, run the following command in a terminal window:
 
@@ -87,7 +87,7 @@ brew services start grafana-agent-flow
 brew services info grafana-agent-flow
 ```
 
-### Restart {{< param "PRODUCT_NAME" >}}
+### Restart {{% param "PRODUCT_NAME" %}}
 
 To restart {{< param "PRODUCT_NAME" >}}, run the following command in a terminal window:
 
@@ -95,7 +95,7 @@ To restart {{< param "PRODUCT_NAME" >}}, run the following command in a terminal
 brew services restart grafana-agent-flow
 ```
 
-### Stop {{< param "PRODUCT_NAME" >}}
+### Stop {{% param "PRODUCT_NAME" %}}
 
 To stop {{< param "PRODUCT_NAME" >}}, run the following command in a terminal window:
 
@@ -103,7 +103,7 @@ To stop {{< param "PRODUCT_NAME" >}}, run the following command in a terminal wi
 brew services stop grafana-agent-flow
 ```
 
-### View {{< param "PRODUCT_NAME" >}} logs on macOS
+### View {{% param "PRODUCT_NAME" %}} logs on macOS
 
 By default, logs are written to `$(brew --prefix)/var/log/grafana-agent-flow.log` and
 `$(brew --prefix)/var/log/grafana-agent-flow.err.log`.
@@ -125,7 +125,7 @@ To verify that {{< param "PRODUCT_NAME" >}} is running as a Windows Service:
 
 1. Scroll down to find the **{{< param "PRODUCT_NAME" >}}** service and verify that the **Status** is **Running**.
 
-### View {{< param "PRODUCT_NAME" >}} logs
+### View {{% param "PRODUCT_NAME" %}} logs
 
 When running on Windows, {{< param "PRODUCT_NAME" >}} writes its logs to Windows Event
 Logs with an event source name of **{{< param "PRODUCT_NAME" >}}**.
@@ -146,7 +146,7 @@ To view the logs, perform the following steps:
 
 If you downloaded the standalone binary, you must run {{< param "PRODUCT_NAME" >}} from a terminal or command window.
 
-### Start {{< param "PRODUCT_NAME" >}} on Linux, macOS, or FreeBSD
+### Start {{% param "PRODUCT_NAME" %}} on Linux, macOS, or FreeBSD
 
 To start {{< param "PRODUCT_NAME" >}} on Linux, macOS, or FreeBSD, run the following command in a terminal window:
 
@@ -159,7 +159,7 @@ Replace the following:
 * _`<BINARY_PATH>`_: The path to the {{< param "PRODUCT_NAME" >}} binary file.
 * _`<CONFIG_PATH>`_: The path to the {{< param "PRODUCT_NAME" >}} configuration file.
 
-### Start {{< param "PRODUCT_NAME" >}} on Windows
+### Start {{% param "PRODUCT_NAME" %}} on Windows
 
 To start {{< param "PRODUCT_NAME" >}} on Windows, run the following commands in a command prompt:
 
@@ -173,7 +173,7 @@ Replace the following:
 * _`<BINARY_PATH>`_: The path to the {{< param "PRODUCT_NAME" >}} binary file.
 * _`<CONFIG_PATH>`_: The path to the {{< param "PRODUCT_NAME" >}} configuration file.
 
-### Set up {{< param "PRODUCT_NAME" >}} as a Linux systemd service
+### Set up {{% param "PRODUCT_NAME" %}} as a Linux systemd service
 
 You can set up and manage the standalone binary for {{< param "PRODUCT_NAME" >}} as a Linux systemd service.
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

The table of contents is generated during Markdown processing and shortcodes with `{{< VAR_NAME >}}` syntax haven't been rendered at that point.

Recent changes to use a cascading variable for the Grafana Agent Flow product name use the `{{< VAR_NAME >}}` shortcode in many of the headings. The result is the heading anchor link URLs contain `hahahugoshortcodes0hbhb` in place of `Grafana Agent Flow`

To fix this we have to use `{{% VAR_NAME %}}` shortcode syntax in the headings only. This tells Hugo to render the shortcode before the markdown... and...  anchor link URLs look normal.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated