### PR TITLE
helm: reload controller with configmap

### DIFF
--- a/operations/helm/charts/grafana-agent/templates/controllers/_pod.yaml
+++ b/operations/helm/charts/grafana-agent/templates/controllers/_pod.yaml
@@ -3,6 +3,7 @@ metadata:
   {{- with .Values.controller.podAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
+    checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
   {{- end }}
   labels:
     {{- include "grafana-agent.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR adds the [checksum annotation](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments) so that workload resources are rolled out when the configmap changes without needing to rely on external controllers.

#### Which issue(s) this PR fixes

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated