### PR TITLE
prometheus.exporter.kafka: fix for  config option is ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Main (unreleased)
 - Fix an issue in `remote.s3` where the exported content of an object would be an empty string if `remote.s3` failed to fully retrieve
   the file in a single read call. (@grafana/agent-squad)
 
+- Utilize the `instance` Argument of `prometheus.exporter.kafka` when set. (@akhmatov-s)
+
 ### Other changes
 
 - Removed support for Windows 2012 in line with Microsoft end of life. (@mattdurham)

--- a/component/prometheus/exporter/kafka/kafka.go
+++ b/component/prometheus/exporter/kafka/kafka.go
@@ -90,6 +90,7 @@ func createExporter(opts component.Options, args component.Arguments, defaultIns
 
 func (a *Arguments) Convert() *kafka_exporter.Config {
 	return &kafka_exporter.Config{
+		Instance:                a.Instance,
 		KafkaURIs:               a.KafkaURIs,
 		UseSASL:                 a.UseSASL,
 		UseSASLHandshake:        a.UseSASLHandshake,

--- a/component/prometheus/exporter/kafka/kafka_test.go
+++ b/component/prometheus/exporter/kafka/kafka_test.go
@@ -83,6 +83,7 @@ func TestRiverConvert(t *testing.T) {
 	}
 	converted := orig.Convert()
 	expected := kafka_exporter.Config{
+		Instance:                "example",
 		KafkaURIs:               []string{"localhost:9092", "localhost:19092"},
 		KafkaVersion:            "2.0.0",
 		MetadataRefreshInterval: "1m",

--- a/pkg/integrations/kafka_exporter/kafka_exporter.go
+++ b/pkg/integrations/kafka_exporter/kafka_exporter.go
@@ -28,6 +28,9 @@ var DefaultConfig = Config{
 
 // Config controls kafka_exporter
 type Config struct {
+	// The instance label for metrics.
+	Instance string `yaml:"instance,omitempty"`
+
 	// Address array (host:port) of Kafka server
 	KafkaURIs []string `yaml:"kafka_uris,omitempty"`
 
@@ -104,12 +107,11 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 func (c *Config) Name() string {
 	return "kafka_exporter"
 }
-
 // InstanceKey returns the hostname:port of the first Kafka node, if any. If
 // there is not exactly one Kafka node, the user must manually provide
 // their own value for instance key in the common config.
 func (c *Config) InstanceKey(agentKey string) (string, error) {
-	if len(c.KafkaURIs) != 1 {
+	if c.Instance == "" && len(c.KafkaURIs) > 1 {
 		return "", fmt.Errorf("an automatic value for `instance` cannot be determined from %d kafka servers, manually provide one for this integration", len(c.KafkaURIs))
 	}
 

--- a/pkg/integrations/kafka_exporter/kafka_exporter.go
+++ b/pkg/integrations/kafka_exporter/kafka_exporter.go
@@ -107,15 +107,19 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 func (c *Config) Name() string {
 	return "kafka_exporter"
 }
+
 // InstanceKey returns the hostname:port of the first Kafka node, if any. If
 // there is not exactly one Kafka node, the user must manually provide
 // their own value for instance key in the common config.
 func (c *Config) InstanceKey(agentKey string) (string, error) {
+	if len(c.KafkaURIs) == 1 {
+		return c.KafkaURIs[0], nil
+	}
 	if c.Instance == "" && len(c.KafkaURIs) > 1 {
 		return "", fmt.Errorf("an automatic value for `instance` cannot be determined from %d kafka servers, manually provide one for this integration", len(c.KafkaURIs))
 	}
 
-	return c.KafkaURIs[0], nil
+	return c.Instance, nil
 }
 
 // NewIntegration creates a new elasticsearch_exporter


### PR DESCRIPTION
#### PR Description
prometheus.exporter.kafka `instance` option is ignored in river.config.

#### Which issue(s) this PR fixes
I'm trying to start grafana-agent with a simple config, where kafka_uris has more than 1 node:
```
prometheus.exporter.kafka "LABEL" {
    kafka_uris = ["kafka1:9092", "kafka2:9092"]
    instance = "test-instance"
}
```
Getting error message:

```
Error: /etc/agent/config.river:1:1: Failed to build component: building component: an automatic value for `instance` cannot be determined from 2 kafka servers, manually provide one for this integration

1 |   prometheus.exporter.kafka "LABEL" {
  |  _^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2 | |     kafka_uris = ["kafka1:9092", "kafka2:9092"]
3 | |     instance = "test-instance"
4 | | }
  | |_^
5 |
```

`instance` option is ignored.

The proposed PR fixes things for me.