### PR TITLE
doc(prom/scrape): correct reference for `__param_` label in

### DIFF
--- a/docs/sources/flow/reference/components/prometheus.scrape.md
+++ b/docs/sources/flow/reference/components/prometheus.scrape.md
@@ -281,7 +281,7 @@ The following special labels can change the behavior of prometheus.scrape:
 * `__scheme__` is the name of the label that holds the scheme (http,https) on which to  scrape a target.
 * `__scrape_interval__` is the name of the label that holds the scrape interval used to scrape a target.
 * `__scrape_timeout__` is the name of the label that holds the scrape timeout used to scrape a target.
-* `__param__` is a prefix for labels that provide URL parameters used to scrape a target.
+* `__param_<name>` is a prefix for labels that provide URL parameters `<name>` used to scrape a target.
 
 Special labels added after a scrape
 * `__name__` is the label name indicating the metric name of a timeseries.

--- a/go.mod
+++ b/go.mod
@@ -541,7 +541,7 @@ require (
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Thanks to @Gusser93's discovery, the doc reference on `__param_` is incorrect. [Prometheus's doc for reference](https://github.com/prometheus/prometheus/blob/5d5303c746a4609520cd3d910fd445596fb86522/docs/configuration/configuration.md?plain=1#L3185)


#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #5995 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->