### PR TITLE
Append, rather than set, '/pods' to the path in discovery.kubelet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,8 @@ v0.39.0-rc.0 (2024-01-05)
 - `discovery.lightsail` now supports additional parameters for configuring HTTP client settings. (@ptodev)
 - Add `sample_age_limit` to remote_write config to drop samples older than a specified duration. (@marctc)
 
+- Handle paths in the Kubelet URL for `discovery.kubelet`. (@petewall)
+
 ### Bugfixes
 
 - Update `pyroscope.ebpf` to fix a logical bug causing to profile to many kthreads instead of regular processes https://github.com/grafana/pyroscope/pull/2778 (@korniltsev)

--- a/component/discovery/kubelet/kubelet.go
+++ b/component/discovery/kubelet/kubelet.go
@@ -130,10 +130,9 @@ func NewKubeletDiscovery(args Arguments) (*Discovery, error) {
 		Timeout:   30 * time.Second,
 	}
 	// Append the path to the kubelet pods endpoint
-	args.URL.Path = args.URL.Path + "/pods"
 	return &Discovery{
 		client:           client,
-		url:              args.URL.String(),
+		url:              args.URL.String() + "/pods",
 		targetNamespaces: args.Namespaces,
 	}, nil
 }

--- a/component/discovery/kubelet/kubelet.go
+++ b/component/discovery/kubelet/kubelet.go
@@ -129,8 +129,8 @@ func NewKubeletDiscovery(args Arguments) (*Discovery, error) {
 		Transport: transport,
 		Timeout:   30 * time.Second,
 	}
-	// ensure the path is the kubelet pods endpoint
-	args.URL.Path = "/pods"
+	// Append the path to the kubelet pods endpoint
+	args.URL.Path = args.URL.Path + "/pods"
 	return &Discovery{
 		client:           client,
 		url:              args.URL.String(),

--- a/component/discovery/kubelet/kubelet_test.go
+++ b/component/discovery/kubelet/kubelet_test.go
@@ -111,7 +111,7 @@ func TestDiscoveryPodWithoutPod(t *testing.T) {
 func TestWithDefaultKubeletHost(t *testing.T) {
 	kubeletDiscovery, err := NewKubeletDiscovery(DefaultConfig)
 	require.NoError(t, err)
-	require.Equal(t, kubeletDiscovery.url, "https://localhost:10250/pods")
+	require.Equal(t, "https://localhost:10250/pods", kubeletDiscovery.url)
 }
 
 func TestWithCustomPath(t *testing.T) {
@@ -122,5 +122,5 @@ func TestWithCustomPath(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.Equal(t, kubeletDiscovery.url, "https://kubernetes.default.svc.cluster.local:443/api/v1/nodes/cluster-node-1/proxy/pods")
+	require.Equal(t, "https://kubernetes.default.svc.cluster.local:443/api/v1/nodes/cluster-node-1/proxy/pods", kubeletDiscovery.url)
 }

--- a/component/discovery/kubelet/kubelet_test.go
+++ b/component/discovery/kubelet/kubelet_test.go
@@ -1,12 +1,14 @@
 package kubelet
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/river"
 	"github.com/stretchr/testify/require"
 )
@@ -104,4 +106,21 @@ func TestDiscoveryPodWithoutPod(t *testing.T) {
 	_, err = kubeletDiscovery.refresh(podList1)
 	require.NoError(t, err)
 	require.Len(t, kubeletDiscovery.discoveredPodSources, 2)
+}
+
+func TestWithDefaultKubeletHost(t *testing.T) {
+	kubeletDiscovery, err := NewKubeletDiscovery(DefaultConfig)
+	require.NoError(t, err)
+	require.Equal(t, kubeletDiscovery.url, "https://localhost:10250/pods")
+}
+
+func TestWithCustomPath(t *testing.T) {
+	kubeletProxyUrl, _ := url.Parse("https://kubernetes.default.svc.cluster.local:443/api/v1/nodes/cluster-node-1/proxy")
+	kubeletDiscovery, err := NewKubeletDiscovery(Arguments{
+		URL: config.URL{
+			URL: kubeletProxyUrl,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, kubeletDiscovery.url, "https://kubernetes.default.svc.cluster.local:443/api/v1/nodes/cluster-node-1/proxy/pods")
 }

--- a/docs/sources/flow/reference/components/discovery.kubelet.md
+++ b/docs/sources/flow/reference/components/discovery.kubelet.md
@@ -33,13 +33,13 @@ discovery.kubelet "LABEL" {
 
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`url` | `string` | URL of the Kubelet server. | | no
-`bearer_token` | `secret` | Bearer token to authenticate with. | | no
-`bearer_token_file` | `string` | File containing a bearer token to authenticate with. | | no
-`refresh_interval` | `duration` | How often the Kubelet should be polled for scrape targets | `5s` | no
-`namespaces` | `list(string)` | A list of namespaces to extract target pods from | | no
+Name | Type | Description | Default  | Required
+---- | ---- | ----------- |----------| --------
+`url` | `string` | URL of the Kubelet server. | https://localhost:10250    | no
+`bearer_token` | `secret` | Bearer token to authenticate with. |          | no
+`bearer_token_file` | `string` | File containing a bearer token to authenticate with. |          | no
+`refresh_interval` | `duration` | How often the Kubelet should be polled for scrape targets | `5s`     | no
+`namespaces` | `list(string)` | A list of namespaces to extract target pods from |          | no
 
 One of the following authentication methods must be provided if kubelet authentication is enabled
  - [`bearer_token` argument](#arguments).

--- a/docs/sources/flow/reference/components/discovery.kubelet.md
+++ b/docs/sources/flow/reference/components/discovery.kubelet.md
@@ -33,13 +33,13 @@ discovery.kubelet "LABEL" {
 
 The following arguments are supported:
 
-Name | Type | Description | Default  | Required
----- | ---- | ----------- |----------| --------
-`url` | `string` | URL of the Kubelet server. | https://localhost:10250    | no
-`bearer_token` | `secret` | Bearer token to authenticate with. |          | no
-`bearer_token_file` | `string` | File containing a bearer token to authenticate with. |          | no
-`refresh_interval` | `duration` | How often the Kubelet should be polled for scrape targets | `5s`     | no
-`namespaces` | `list(string)` | A list of namespaces to extract target pods from |          | no
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`url` | `string` | URL of the Kubelet server. | https://localhost:10250 | no
+`bearer_token` | `secret` | Bearer token to authenticate with. | | no
+`bearer_token_file` | `string` | File containing a bearer token to authenticate with. | | no
+`refresh_interval` | `duration` | How often the Kubelet should be polled for scrape targets | `5s` | no
+`namespaces` | `list(string)` | A list of namespaces to extract target pods from | | no
 
 One of the following authentication methods must be provided if kubelet authentication is enabled
  - [`bearer_token` argument](#arguments).

--- a/docs/sources/flow/reference/components/discovery.kubelet.md
+++ b/docs/sources/flow/reference/components/discovery.kubelet.md
@@ -49,7 +49,7 @@ One of the following authentication methods must be provided if kubelet authenti
 The `namespaces` list limits the namespaces to discover resources in. If
 omitted, all namespaces are searched.
 
-`discovery.kubelet` appends a `/pods` path to url to request the available pods.
+`discovery.kubelet` appends a `/pods` path to `url` to request the available pods.
 You can have additional paths in the `url`.
 For example, if `url` is `https://kubernetes.default.svc.cluster.local:443/api/v1/nodes/cluster-node-1/proxy`, then `discovery.kubelet` sends a request on `https://kubernetes.default.svc.cluster.local:443/api/v1/nodes/cluster-node-1/proxy/pods`
 

--- a/docs/sources/flow/reference/components/discovery.kubelet.md
+++ b/docs/sources/flow/reference/components/discovery.kubelet.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`url` | `string` | URL of the Kubelet server. | https://localhost:10250 | no
+`url` | `string` | URL of the Kubelet server. | "https://localhost:10250" | no
 `bearer_token` | `secret` | Bearer token to authenticate with. | | no
 `bearer_token_file` | `string` | File containing a bearer token to authenticate with. | | no
 `refresh_interval` | `duration` | How often the Kubelet should be polled for scrape targets | `5s` | no

--- a/docs/sources/flow/reference/components/discovery.kubelet.md
+++ b/docs/sources/flow/reference/components/discovery.kubelet.md
@@ -49,6 +49,10 @@ One of the following authentication methods must be provided if kubelet authenti
 The `namespaces` list limits the namespaces to discover resources in. If
 omitted, all namespaces are searched.
 
+`discovery.kubelet` appends a `/pods` path to url to request the available pods.
+You can have additional paths in the `url`.
+For example, if `url` is `https://kubernetes.default.svc.cluster.local:443/api/v1/nodes/cluster-node-1/proxy`, then `discovery.kubelet` sends a request on `https://kubernetes.default.svc.cluster.local:443/api/v1/nodes/cluster-node-1/proxy/pods`
+
 ## Blocks
 
 The following blocks are supported inside the definition of


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Previously, any paths added to the `url` argument of `discovery.kubelet` was overwritten with `/pods`. This prevented using urls to the Kubelet that required paths (e.g. using an API server proxy). This change appends `/pods` to the end of the URL, rather than assigning it as the path.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #5625

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [X] Documentation added
- [X] Tests updated
- [ ] Config converters updated