### PR TITLE
helm: allow overriding hpa behavior

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -14,6 +14,8 @@ Unreleased
 
 - Update `rbac` to include necessary rules for the `otelcol.processor.k8sattributes` component. (@rlankfo)
 
+- Allow setting behavior for horizontal pod autoscaler. (@captncraig)
+
 0.29.0 (2023-11-30)
 -------------------
 

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -70,6 +70,7 @@ use the older mode (called "static mode"), set the `agent.mode` value to
 | configReloader.resources | object | `{"requests":{"cpu":"1m","memory":"5Mi"}}` | Resource requests and limits to apply to the config reloader container. |
 | configReloader.securityContext | object | `{}` | Security context to apply to the Grafana configReloader container. |
 | controller.affinity | object | `{}` | Affinity configuration for pods. |
+| controller.autoscaling.behavior | object | `{}` | Behavior section of the HPA spec. Used if you want to customize scale up or down behavior from the defaults. |
 | controller.autoscaling.enabled | bool | `false` | Creates a HorizontalPodAutoscaler for controller type deployment. |
 | controller.autoscaling.maxReplicas | int | `5` | The upper limit for the number of replicas to which the autoscaler can scale up. |
 | controller.autoscaling.minReplicas | int | `1` | The lower limit for the number of replicas to which the autoscaler can scale down. |

--- a/operations/helm/charts/grafana-agent/ci/create-statefulset-autoscaling-values.yaml
+++ b/operations/helm/charts/grafana-agent/ci/create-statefulset-autoscaling-values.yaml
@@ -3,6 +3,9 @@ controller:
   type: statefulset
   autoscaling:
     enabled: true
+    behavior: 
+      scaleDown:
+        selectPolicy: Disabled
 agent:
   resources:
     requests:

--- a/operations/helm/charts/grafana-agent/templates/hpa.yaml
+++ b/operations/helm/charts/grafana-agent/templates/hpa.yaml
@@ -22,6 +22,10 @@ spec:
     apiVersion: apps/v1
     kind: {{ .Values.controller.type  }}
     name: {{ include "grafana-agent.fullname" . }}
+  {{- with .Values.controller.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.controller.autoscaling }}
   minReplicas: {{ .minReplicas }}
   maxReplicas: {{ .maxReplicas }}

--- a/operations/helm/charts/grafana-agent/values.yaml
+++ b/operations/helm/charts/grafana-agent/values.yaml
@@ -200,6 +200,8 @@ controller:
     targetCPUUtilizationPercentage: 0
     # -- Average Memory utilization across all relevant pods, a percentage of the requested value of the resource for the pods. Setting `targetMemoryUtilizationPercentage` to 0 will disable Memory scaling.
     targetMemoryUtilizationPercentage: 80
+    # -- Behavior section of the HPA spec. Used if you want to customize scale up or down behavior from the defaults.
+    behavior: {}
 
   # -- Affinity configuration for pods.
   affinity: {}

--- a/operations/helm/tests/create-statefulset-autoscaling/grafana-agent/templates/hpa.yaml
+++ b/operations/helm/tests/create-statefulset-autoscaling/grafana-agent/templates/hpa.yaml
@@ -15,6 +15,9 @@ spec:
     apiVersion: apps/v1
     kind: statefulset
     name: grafana-agent
+  behavior:
+    scaleDown:
+      selectPolicy: Disabled
   minReplicas: 1
   maxReplicas: 5
   metrics:


### PR DESCRIPTION
This allows you to set the behavior for the hpa. Could be useful if you want to change scaling parameters.