### PR TITLE
fix tls condition for kafka_exporter, issue #6048

### DIFF
--- a/pkg/integrations/kafka_exporter/kafka_exporter.go
+++ b/pkg/integrations/kafka_exporter/kafka_exporter.go
@@ -8,6 +8,7 @@ import (
 	"github.com/IBM/sarama"
 	kafka_exporter "github.com/davidmparrott/kafka_exporter/v2/exporter"
 	"github.com/go-kit/log"
+
 	"github.com/grafana/agent/pkg/integrations"
 	integrations_v2 "github.com/grafana/agent/pkg/integrations/v2"
 	"github.com/grafana/agent/pkg/integrations/v2/metricsutils"
@@ -131,8 +132,8 @@ func New(logger log.Logger, c *Config) (integrations.Integration, error) {
 	if len(c.KafkaURIs) == 0 || c.KafkaURIs[0] == "" {
 		return nil, fmt.Errorf("empty kafka_uris provided")
 	}
-	if c.UseTLS && (c.CertFile == "" || c.KeyFile == "") {
-		return nil, fmt.Errorf("tls is enabled but key pair was not provided")
+	if c.UseTLS && (c.CertFile == "" || c.KeyFile == "" || c.CAFile == "") {
+		return nil, fmt.Errorf("tls is enabled but key pair or ca certificate was not provided")
 	}
 	if c.UseSASL && (c.SASLPassword == "" || c.SASLUsername == "") {
 		return nil, fmt.Errorf("SASL is enabled but username or password was not provided")

--- a/pkg/integrations/kafka_exporter/kafka_exporter.go
+++ b/pkg/integrations/kafka_exporter/kafka_exporter.go
@@ -132,8 +132,10 @@ func New(logger log.Logger, c *Config) (integrations.Integration, error) {
 	if len(c.KafkaURIs) == 0 || c.KafkaURIs[0] == "" {
 		return nil, fmt.Errorf("empty kafka_uris provided")
 	}
-	if c.UseTLS && (c.CertFile == "" || c.KeyFile == "" || c.CAFile == "") {
-		return nil, fmt.Errorf("tls is enabled but key pair or ca certificate was not provided")
+	if c.UseTLS {
+		if c.CAFile != "" && (c.CertFile == "" || c.KeyFile == "") {
+			return nil, fmt.Errorf("tls is enabled but key pair was not provided")
+		}
 	}
 	if c.UseSASL && (c.SASLPassword == "" || c.SASLUsername == "") {
 		return nil, fmt.Errorf("SASL is enabled but username or password was not provided")

--- a/pkg/integrations/kafka_exporter/kafka_exporter.go
+++ b/pkg/integrations/kafka_exporter/kafka_exporter.go
@@ -133,8 +133,8 @@ func New(logger log.Logger, c *Config) (integrations.Integration, error) {
 		return nil, fmt.Errorf("empty kafka_uris provided")
 	}
 	if c.UseTLS {
-		if c.CAFile != "" && (c.CertFile == "" || c.KeyFile == "") {
-			return nil, fmt.Errorf("tls is enabled but key pair was not provided")
+		if c.CAFile == "" && (c.CertFile == "" || c.KeyFile == "") {
+			return nil, fmt.Errorf("tls is enabled but key pair or ca certificate was not provided")
 		}
 	}
 	if c.UseSASL && (c.SASLPassword == "" || c.SASLUsername == "") {


### PR DESCRIPTION
#### PR Description

try to fix issue 6048

#### Which issue(s) this PR fixes

https://github.com/grafana/alloy/issues/280

#### Notes to the Reviewer

original kafka exporter allow connect without cert&key pair only with root ca

(sorry, english is not my main language)

UP: checked, it's work

<img width="826" alt="image" src="https://github.com/grafana/agent/assets/862272/991a5e74-27c7-4ab6-955d-aed8497a91db">
