### PR TITLE
loki.source.docker: deduplicate matching container IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,11 @@ Main (unreleased)
 - Add `max_cache_size` to `prometheus.relabel` to allow configurability instead of hard coded 100,000. (@mattdurham)
 
 - Add support for `http_sd_config` within a `scrape_config` for prometheus to flow config conversion. (@erikbaranowski)
+
 - `discovery.lightsail` now supports additional parameters for configuring HTTP client settings. (@ptodev)
+
+- `loki.source.docker` now deduplicates targets which report the same container
+  ID. (@tpaschalis)
 
 ### Bugfixes
 

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ lint: agentlint
 # more without -race for packages that have known race detection issues.
 test:
 	$(GO_ENV) go test $(GO_FLAGS) -race $(shell go list ./... | grep -v /integration-tests/)
-	$(GO_ENV) go test $(GO_FLAGS) ./pkg/integrations/node_exporter ./pkg/logs ./pkg/operator ./pkg/util/k8s ./component/otelcol/processor/tail_sampling ./component/loki/source/file
+	$(GO_ENV) go test $(GO_FLAGS) ./pkg/integrations/node_exporter ./pkg/logs ./pkg/operator ./pkg/util/k8s ./component/otelcol/processor/tail_sampling ./component/loki/source/file ./component/loki/source/docker
 
 test-packages:
 	docker pull $(BUILD_IMAGE)

--- a/component/loki/source/docker/docker.go
+++ b/component/loki/source/docker/docker.go
@@ -215,6 +215,7 @@ func (c *Component) Update(args component.Arguments) error {
 
 	// Convert input targets into targets to give to tailer.
 	targets := make([]*dt.Target, 0, len(newArgs.Targets))
+	seenTargets := make(map[string]struct{}, len(newArgs.Targets))
 
 	for _, target := range newArgs.Targets {
 		containerID, ok := target[dockerLabelContainerID]
@@ -222,6 +223,10 @@ func (c *Component) Update(args component.Arguments) error {
 			level.Debug(c.opts.Logger).Log("msg", "docker target did not include container ID label:"+dockerLabelContainerID)
 			continue
 		}
+		if _, seen := seenTargets[containerID]; seen {
+			continue
+		}
+		seenTargets[containerID] = struct{}{}
 
 		var labels = make(model.LabelSet)
 		for k, v := range target {

--- a/component/loki/source/docker/docker_test.go
+++ b/component/loki/source/docker/docker_test.go
@@ -5,9 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/pkg/flow/componenttest"
 	"github.com/grafana/agent/pkg/util"
 	"github.com/grafana/river"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,4 +34,31 @@ func Test(t *testing.T) {
 	}()
 
 	require.NoError(t, ctrl.WaitRunning(time.Minute))
+}
+
+func TestDuplicateTargets(t *testing.T) {
+	// Use host that works on all platforms (including Windows).
+	var cfg = `
+		host       = "tcp://127.0.0.1:9375"
+		targets    = [
+			{__meta_docker_container_id = "foo", __meta_docker_port_private = "8080"},
+			{__meta_docker_container_id = "foo", __meta_docker_port_private = "8080"},
+			{__meta_docker_container_id = "bar", __meta_docker_port_private = "8080"},
+		]
+		forward_to = []
+	`
+
+	var args Arguments
+	err := river.Unmarshal([]byte(cfg), &args)
+	require.NoError(t, err)
+
+	cmp, err := New(component.Options{
+		ID:         "loki.source.docker.test",
+		Logger:     util.TestFlowLogger(t),
+		Registerer: prometheus.NewRegistry(),
+		DataPath:   t.TempDir(),
+	}, args)
+	require.NoError(t, err)
+
+	require.Len(t, cmp.manager.tasks, 2)
 }

--- a/component/loki/source/docker/docker_test.go
+++ b/component/loki/source/docker/docker_test.go
@@ -44,7 +44,7 @@ func TestDuplicateTargets(t *testing.T) {
 		host       = "tcp://127.0.0.1:9376"
 		targets    = [
 			{__meta_docker_container_id = "foo", __meta_docker_port_private = "8080"},
-			{__meta_docker_container_id = "foo", __meta_docker_port_private = "8080"},
+			{__meta_docker_container_id = "foo", __meta_docker_port_private = "8081},
 		]
 		forward_to = []
 	`

--- a/component/loki/source/docker/docker_test.go
+++ b/component/loki/source/docker/docker_test.go
@@ -44,7 +44,7 @@ func TestDuplicateTargets(t *testing.T) {
 		host       = "tcp://127.0.0.1:9376"
 		targets    = [
 			{__meta_docker_container_id = "foo", __meta_docker_port_private = "8080"},
-			{__meta_docker_container_id = "foo", __meta_docker_port_private = "8081},
+			{__meta_docker_container_id = "foo", __meta_docker_port_private = "8081"},
 		]
 		forward_to = []
 	`

--- a/docs/sources/flow/reference/components/loki.source.docker.md
+++ b/docs/sources/flow/reference/components/loki.source.docker.md
@@ -131,11 +131,11 @@ fully qualified name) to store its _positions file_. The positions file
 stores the read offsets so that if there is a component or Agent restart,
 `loki.source.docker` can pick up tailing from the same spot.
 
-In case the targets argument contains multiple entries with the same container
+If the target's argument contains multiple entries with the same container
 ID (for example as a result of `discovery.docker` picking up multiple exposed
-ports or networks) `loki.source.docker` will deduplicate them, and only keep
+ports or networks), `loki.source.docker` will deduplicate them, and only keep
 the first of each container ID instances, based on the
-`__meta_docker_container_id` label.  As such, the Docker daemon will be queried
+`__meta_docker_container_id` label.  As such, the Docker daemon is queried
 for each container ID only once, and only one target will be available in the
 component's debug info.
 

--- a/docs/sources/flow/reference/components/loki.source.docker.md
+++ b/docs/sources/flow/reference/components/loki.source.docker.md
@@ -131,9 +131,9 @@ fully qualified name) to store its _positions file_. The positions file
 stores the read offsets so that if there is a component or Agent restart,
 `loki.source.docker` can pick up tailing from the same spot.
 
-In case the targets Argument contains multiple targets with the same container
-ID, for example as a result of `discovery.docker` picking up multiple exposed
-ports or networks, `loki.source.docker` will deduplicate these, keeping only
+In case the targets argument contains multiple entries with the same container
+ID (for example as a result of `discovery.docker` picking up multiple exposed
+ports or networks) `loki.source.docker` will deduplicate them, and only keep
 the first of each container ID instances.
 
 ## Example

--- a/docs/sources/flow/reference/components/loki.source.docker.md
+++ b/docs/sources/flow/reference/components/loki.source.docker.md
@@ -131,6 +131,11 @@ fully qualified name) to store its _positions file_. The positions file
 stores the read offsets so that if there is a component or Agent restart,
 `loki.source.docker` can pick up tailing from the same spot.
 
+In case the targets Argument contains multiple targets with the same container
+ID, for example as a result of `discovery.docker` picking up multiple exposed
+ports or networks, `loki.source.docker` will deduplicate these, keeping only
+the first of each container ID instances.
+
 ## Example
 
 This example collects log entries from the files specified in the `targets`

--- a/docs/sources/flow/reference/components/loki.source.docker.md
+++ b/docs/sources/flow/reference/components/loki.source.docker.md
@@ -134,7 +134,10 @@ stores the read offsets so that if there is a component or Agent restart,
 In case the targets argument contains multiple entries with the same container
 ID (for example as a result of `discovery.docker` picking up multiple exposed
 ports or networks) `loki.source.docker` will deduplicate them, and only keep
-the first of each container ID instances.
+the first of each container ID instances, based on the
+`__meta_docker_container_id` label.  As such, the Docker daemon will be queried
+for each container ID only once, and only one target will be available in the
+component's debug info.
 
 ## Example
 


### PR DESCRIPTION
#### PR Description
The `discovery.docker` component was initially built with Prometheus service discovery in mind; this means that it will report a different target for each port, network and network interface that a container exposes/belongs to, so that it can be scraped accordingly.

This means, that when `discovery.docker` is used as an input to loki.source.docker, it will set up unnecessary load on the Docker API by trying to fetch logs for the same container ID multiple times. This PR makes it so that during a component Update, the targets are deduplicated based on the container ID, keeping only the first one.

#### Which issue(s) this PR fixes
Related to: #4403

I'd like to gather some more evidence until we say this fixes #4403 outright, so keeping this PR in draft in the meantime.

#### Notes to the Reviewer

I've run a simplistic benchmark with a chatty container that exposes two ports, and as expected, the CPU time spent on reading logs is ~half here.
![image](https://github.com/grafana/agent/assets/17771679/03a96dcf-32ba-4d1b-9653-dbbba1d335df)

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [X] Documentation added
- [X] Tests updated