### PR TITLE
chore(build): remove seemingly obsolete exclude directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -721,9 +721,6 @@ replace (
 	github.com/prometheus/node_exporter => github.com/grafana/node_exporter v0.18.1-grafana-r01.0.20231004161416-702318429731
 )
 
-// Excluding fixes a conflict in test packages and allows "go mod tidy" to run.
-exclude google.golang.org/grpc/examples v0.0.0-20200728065043-dfc0c05b2da9
-
 // Replacing for an internal fork which allows us to observe metrics produced by the Collector.
 // This is a temporary solution while a new configuration design is discussed for the collector. Related issues:
 // https://github.com/open-telemetry/opentelemetry-collector/issues/7532


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Remove seemingly obsolete `exclude` directive. After removal, I was able to run `go mod tidy` but I still don't know what test got failed due to this directive back then. @rfratto can you help recall this one? :D 

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->