### PR TITLE
Add call to set the perflib query.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,8 @@ v0.39.0-rc.0 (2024-01-05)
 
 - Fix issue where `prometheus.exporter.kafka` would crash when configuring `sasl_password`. (@rfratto)
 
+- Fix performance issue where perf lib where clause was not being set, leading to timeouts in collecting metrics for windows_exporter. (@mattdurham)
+
 ### Other changes
 
 - Bump github.com/IBM/sarama from v1.41.2 to v1.42.1

--- a/pkg/integrations/windows_exporter/windows_exporter_windows.go
+++ b/pkg/integrations/windows_exporter/windows_exporter_windows.go
@@ -23,6 +23,11 @@ func New(logger log.Logger, c *Config) (integrations.Integration, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = winCol.SetPerfCounterQuery()
+	if err != nil {
+		return nil, err
+	}
+
 	return integrations.NewCollectorIntegration(c.Name(), integrations.WithCollectors(
 		// Hard-coded 4m timeout to represent the time a series goes stale.
 		// TODO: Make configurable if useful.


### PR DESCRIPTION
#### PR Description

The perflib query wasnt being set. It isnt upstream either but have a PR to fix their issue too. This means the perflib will try to grab everything which can lead to timeouts.

#### Which issue(s) this PR fixes

Fixes https://github.com/grafana/agent/issues/6036
Fixes https://github.com/grafana/agent/issues/6034
Fixes https://github.com/grafana/agent/issues/6004

#### Notes to the Reviewer

#### PR Checklist


- [x] CHANGELOG.md updated
