### PR TITLE
Clarify usage of resource_to_telemetry_conversion

### DIFF
--- a/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
@@ -58,6 +58,18 @@ When `include_scope_labels` is `true`  the `otel_scope_name` and
 
 When `include_target_info` is true, OpenTelemetry Collector resources are converted into `target_info` metrics.
 
+{{% admonition type="note" %}}
+
+OTLP metrics tend to have a lot of resource attributes. 
+Setting `resource_to_telemetry_conversion` to `true` would convert all of them to Prometheus labels, which may not be what you want.
+Instead of using `resource_to_telemetry_conversion`, most users need to use `otelcol.processor.transform` 
+to convert OTLP resource attributes to OTLP metric datapoint attributes prior to using `otelcol.exporter.prometheus`. 
+See [Creating Prometheus labels from OTLP resource attributes][] for an example.
+
+[Creating Prometheus labels from OTLP resource attributes]: #creating-prometheus-labels-from-otlp-resource-attributes
+
+{{% /admonition %}}
+
 ## Exported fields
 
 The following fields are exported and can be referenced by other components:
@@ -87,6 +99,8 @@ information.
 
 ## Example
 
+## Basic usage
+
 This example accepts metrics over OTLP and forwards it using
 `prometheus.remote_write`:
 
@@ -109,6 +123,54 @@ prometheus.remote_write "mimir" {
   }
 }
 ```
+
+## Creating Prometheus labels from OTLP resource attributes
+
+This example uses `otelcol.processor.transform` to add extra `key1` and `key2` OTLP metric datapoint attributes from the
+`key1` and `key2` OTLP resource attributes. 
+
+`otelcol.exporter.prometheus` then converts `key1` and `key2` to Prometheus labels along with any other OTLP metric datapoint attributes.
+
+This avoids the need to set `resource_to_telemetry_conversion` to `true`,
+which could have created too many unnecessary metric labels.
+
+```river
+otelcol.receiver.otlp "default" {
+  grpc {}
+
+  output {
+    metrics = [otelcol.processor.transform.default.input]
+  }
+}
+
+otelcol.processor.transform "default" {
+  error_mode = "ignore"
+
+  metric_statements {
+    context = "datapoint"
+
+    statements = [
+      `set(attributes["key1"], resource.attributes["key1"])`,
+      `set(attributes["key2"], resource.attributes["key2"])`,
+    ]
+  }
+
+  output {
+    metrics = [otelcol.exporter.prometheus.default.input]
+  }
+}
+
+otelcol.exporter.prometheus "default" {
+  forward_to = [prometheus.remote_write.mimir.receiver]
+}
+
+prometheus.remote_write "mimir" {
+  endpoint {
+    url = "http://mimir:9009/api/v1/push"
+  }
+}
+```
+
 <!-- START GENERATED COMPATIBLE COMPONENTS -->
 
 ## Compatible components

--- a/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.prometheus.md
@@ -60,10 +60,10 @@ When `include_target_info` is true, OpenTelemetry Collector resources are conver
 
 {{% admonition type="note" %}}
 
-OTLP metrics tend to have a lot of resource attributes. 
+OTLP metrics can have a lot of resource attributes. 
 Setting `resource_to_telemetry_conversion` to `true` would convert all of them to Prometheus labels, which may not be what you want.
 Instead of using `resource_to_telemetry_conversion`, most users need to use `otelcol.processor.transform` 
-to convert OTLP resource attributes to OTLP metric datapoint attributes prior to using `otelcol.exporter.prometheus`. 
+to convert OTLP resource attributes to OTLP metric datapoint attributes before using `otelcol.exporter.prometheus`. 
 See [Creating Prometheus labels from OTLP resource attributes][] for an example.
 
 [Creating Prometheus labels from OTLP resource attributes]: #creating-prometheus-labels-from-otlp-resource-attributes
@@ -124,7 +124,7 @@ prometheus.remote_write "mimir" {
 }
 ```
 
-## Creating Prometheus labels from OTLP resource attributes
+## Create Prometheus labels from OTLP resource attributes
 
 This example uses `otelcol.processor.transform` to add extra `key1` and `key2` OTLP metric datapoint attributes from the
 `key1` and `key2` OTLP resource attributes. 


### PR DESCRIPTION
Fixes #5986

`resource_to_telemetry_conversion` is generally not what the users want to use. This makes it a bit more clear.

We can also backport this to v0.39, once it's available.