### PR TITLE
loki.process: document limitation of stage.json

### DIFF
--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -382,6 +382,27 @@ following key-value pair to the set of extracted data.
 username: agent
 ```
 
+{{% admonition type="note" %}}
+Due to a limitation of the upstream jmespath library, defining an expression
+that contains a hyphen `-` needs to be wrapped in quotes so that it's not
+considered a numeric expression.
+{{% /admonition %}}
+
+In this case, you can use one of two syntaxes to circumvent this issue:
+```
+stage.json {
+  expressions = {
+    http_user_agent = "\"request_User-Agent\"",
+  }
+}
+
+stage.json {
+  expressions = {
+    http_user_agent = `"request_User-Agent"`,
+  }
+}
+```
+
 ### stage.label_drop block
 
 The `stage.label_drop` inner block configures a processing stage that drops labels

--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -383,9 +383,12 @@ username: agent
 ```
 
 {{% admonition type="note" %}}
-Due to a limitation of the upstream jmespath library, defining an expression
-that contains a hyphen `-` needs to be wrapped in quotes so that it's not
-considered a numeric expression.
+Due to a limitation of the upstream jmespath library, any string that contains
+a hyphen `-` needs to be wrapped in quotes so that it's not considered a
+numerical expression.
+
+Otherwise, you might get errors like:
+`Unexpected token at the end of the expression: tNumber`
 {{% /admonition %}}
 
 In this case, you can use one of two syntaxes to circumvent this issue:


### PR DESCRIPTION
#### PR Description
This PR documents a limitation of the jmespath library used to parse JSON expressions for the json stage of the loki.process component.

#### Which issue(s) this PR fixes
Fixes #5838

#### Notes to the Reviewer

#### PR Checklist

- [ ] CHANGELOG.md updated (N/A)
- [X] Documentation added
- [ ] Tests updated (N/A)
