### PR TITLE
[release-v0.36] docs: pin version to removed folders

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -7,6 +7,8 @@ canonical: https://grafana.com/docs/agent/latest/
 title: Grafana Agent
 description: Grafana Agent is a flexible, performant, vendor-neutral, telemetry collector
 weight: 350
+cascade:
+  AGENT_RELEASE: v0.36.0
 ---
 
 # Grafana Agent

--- a/docs/sources/static/set-up/install/install-agent-kubernetes.md
+++ b/docs/sources/static/set-up/install/install-agent-kubernetes.md
@@ -16,9 +16,9 @@ To deploy Grafana Agent in static mode on Kubernetes, perform the following step
 
 1. Download one of the following manifests from GitHub and save it as `manifest.yaml`:
 
-   - Metric collection (StatefulSet): [agent-bare.yaml](https://github.com/grafana/agent/blob/main/production/kubernetes/agent-bare.yaml)
-   - Log collection (DaemonSet): [agent-loki.yaml](https://github.com/grafana/agent/blob/main/production/kubernetes/agent-loki.yaml)
-   - Trace collection (Deployment): [agent-traces.yaml](https://github.com/grafana/agent/blob/main/production/kubernetes/agent-traces.yaml)
+   - Metric collection (StatefulSet): [agent-bare.yaml](https://github.com/grafana/agent/blob/{{< param "AGENT_RELEASE" >}}/production/kubernetes/agent-bare.yaml)
+   - Log collection (DaemonSet): [agent-loki.yaml](https://github.com/grafana/agent/blob/{{< param "AGENT_RELEASE" >}}/production/kubernetes/agent-loki.yaml)
+   - Trace collection (Deployment): [agent-traces.yaml](https://github.com/grafana/agent/blob/{{< param "AGENT_RELEASE" >}}/production/kubernetes/agent-traces.yaml)
 
 1. Edit the downloaded `manifest.yaml` and replace the placeholders with information relevant to your Kubernetes deployment.
 


### PR DESCRIPTION
As part of #6077, folders referenced by older versions of documentation will no longer work when pointing to the main branch. These links are now being pinned to the agent version that the versioned documentation is associated with.

This PR will be backported all the way to v0.25, but each backport will require a small amount of changes to modify the cascade variable. 