### PR TITLE
[release-v0.32] docs: pin version to removed folders

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Grafana Agent
 weight: 1
+cascade:
+  AGENT_RELEASE: v0.33.0
 ---
 
 # Grafana Agent

--- a/docs/sources/set-up/_index.md
+++ b/docs/sources/set-up/_index.md
@@ -16,14 +16,14 @@ To get started with Grafana Agent Operator, refer to the Operator-specific
 
 ## Installation options
 
-Grafana Agent is currently distributed in plain binary form, Docker container images, a Windows installer, a Homebrew package, and a Kubernetes install script. 
+Grafana Agent is currently distributed in plain binary form, Docker container images, a Windows installer, a Homebrew package, and a Kubernetes install script.
 
 The following architectures receive active support.
 
- - macOS: Intel Mac or Apple Silicon 
- - Windows: A x64 machine 
+ - macOS: Intel Mac or Apple Silicon
+ - Windows: A x64 machine
  - Linux: AMD64, ARM64, ARMv6, or ARMv7 machines
- - FreeBSD: A AMD64 machine 
+ - FreeBSD: A AMD64 machine
 
 In addition, best-effort support is provided for Linux: ppc64le.
 
@@ -31,8 +31,8 @@ Choose from the following platforms and installation options according to which 
 
 ### Kubernetes
 
-Deploy Kubernetes manifests from the [`kubernetes` directory](https://github.com/grafana/agent/tree/main/production/kubernetes).
-You can manually modify the Kubernetes manifests by downloading them. These manifests do not include Grafana Agent configuration files. 
+Deploy Kubernetes manifests from the [`kubernetes` directory](https://github.com/grafana/agent/tree/{{< param "AGENT_RELEASE" >}}/production/kubernetes).
+You can manually modify the Kubernetes manifests by downloading them. These manifests do not include Grafana Agent configuration files.
 
 For sample configuration files, refer to the Grafana Cloud Kubernetes quick start guide: https://grafana.com/docs/grafana-cloud/kubernetes/agent-k8s/.
 
@@ -64,4 +64,4 @@ Use the Grafana Agent [Kubernetes quickstarts](https://grafana.com/docs/grafana-
 
 ### Tanka
 
-For more information, refer to the [Tanka](https://tanka.dev) configurations in our [`production/`](https://github.com/grafana/agent/tree/main/production/tanka/grafana-agent) directory.
+For more information, refer to the [Tanka](https://tanka.dev) configurations in our [`production/`](https://github.com/grafana/agent/tree/{{< param "AGENT_RELEASE" >}}/production/tanka/grafana-agent) directory.


### PR DESCRIPTION
As part of #6077, folders referenced by older versions of documentation will no longer work when pointing to the main branch. These links are now being pinned to the agent version that the versioned documentation is associated with.