### PR TITLE
pkg/metrics: fix a panic when accepting network remote write requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Main (unreleased)
 
 - Utilize the `instance` Argument of `prometheus.exporter.kafka` when set. (@akhmatov-s)
 
+- Fix a duplicate metrics registration panic when sending metrics to an static
+  mode metric instance's write handler. (@tpaschalis)
+
 ### Other changes
 
 - Removed support for Windows 2012 in line with Microsoft end of life. (@mattdurham)

--- a/pkg/metrics/agent_test.go
+++ b/pkg/metrics/agent_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"sync"
 	"testing"
 	"time"
@@ -283,6 +284,10 @@ func (i *fakeInstance) TargetsActive() map[string][]*scrape.Target {
 
 func (i *fakeInstance) StorageDirectory() string {
 	return ""
+}
+
+func (i *fakeInstance) WriteHandler() http.Handler {
+	return nil
 }
 
 func (i *fakeInstance) Appender(ctx context.Context) storage.Appender {

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -13,7 +13,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/scrape"
-	"github.com/prometheus/prometheus/storage/remote"
 )
 
 // WireAPI adds API routes to the provided mux router.
@@ -151,8 +150,7 @@ func (a *Agent) PushMetricsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	handler := remote.NewWriteHandler(a.logger, a.reg, managedInstance)
-	handler.ServeHTTP(w, r)
+	managedInstance.WriteHandler().ServeHTTP(w, r)
 }
 
 // getInstanceName uses gorilla/mux's route variables to extract the

--- a/pkg/metrics/instance/instance_test.go
+++ b/pkg/metrics/instance/instance_test.go
@@ -416,5 +416,6 @@ func runInstance(t *testing.T, i *Instance) {
 	t.Cleanup(func() { cancel() })
 	go require.NotPanics(t, func() {
 		_ = i.Run(ctx)
+		require.NotNil(t, i.WriteHandler())
 	})
 }

--- a/pkg/metrics/instance/manager.go
+++ b/pkg/metrics/instance/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"sync"
 	"time"
 
@@ -66,6 +67,7 @@ type ManagedInstance interface {
 	TargetsActive() map[string][]*scrape.Target
 	StorageDirectory() string
 	Appender(ctx context.Context) storage.Appender
+	WriteHandler() http.Handler
 }
 
 // BasicManagerConfig controls the operations of a BasicManager.

--- a/pkg/metrics/instance/manager_test.go
+++ b/pkg/metrics/instance/manager_test.go
@@ -3,6 +3,7 @@ package instance
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"testing"
 
@@ -104,6 +105,7 @@ type mockInstance struct {
 	TargetsActiveFunc    func() map[string][]*scrape.Target
 	StorageDirectoryFunc func() string
 	AppenderFunc         func() storage.Appender
+	WriteHandlerFunc     func() http.Handler
 }
 
 func (m mockInstance) Run(ctx context.Context) error {
@@ -139,6 +141,13 @@ func (m mockInstance) StorageDirectory() string {
 		return m.StorageDirectoryFunc()
 	}
 	panic("StorageDirectoryFunc not provided")
+}
+
+func (m mockInstance) WriteHandler() http.Handler {
+	if m.WriteHandlerFunc != nil {
+		return m.WriteHandlerFunc()
+	}
+	panic("GetWriteHandlerFunc not provided")
 }
 
 func (m mockInstance) Appender(_ context.Context) storage.Appender {

--- a/pkg/metrics/instance/noop.go
+++ b/pkg/metrics/instance/noop.go
@@ -2,6 +2,7 @@ package instance
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
@@ -35,6 +36,11 @@ func (NoOpInstance) TargetsActive() map[string][]*scrape.Target {
 // StorageDirectory implements Instance.
 func (NoOpInstance) StorageDirectory() string {
 	return ""
+}
+
+// WriteHandler implements Instance.
+func (NoOpInstance) WriteHandler() http.Handler {
+	return nil
 }
 
 // Appender implements Instance


### PR DESCRIPTION
#### PR Description
This PR circumvents a duplicate metrics registration panic that appeared in v0.37 in static mode.

> NOTE: This PR can be more easily reviewed commit-by-commit.

When calling the `/agent/api/v1/metrics/instance/{instance}/write` endpoint to push metrics directly into a metrics instance's WAL in static mode, the PushMetricsHandler used to recreate the prometheus write handler every time.

Since a metrics was introduced to keep track of invalid samples in the upstream Prometheus code meant that on every subsequent call, a panic was raised.

The fix here is to create and store the write handler once when the metrics instance is first initialized and introducing a new method on the Instance interface to fetch it whenever metrics are pushed. A test has been amended to make sure that re-creating a metrics instance under the same name does not result in a panic.

#### Which issue(s) this PR fixes

Fixes #6110

#### Notes to the Reviewer

Nothing else for now.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [ ] Documentation added (N/A)
- [X] Tests updated 
- [ ] Config converters updated