### PR TITLE
Update scraping-service.md

### DIFF
--- a/docs/sources/static/configuration/scraping-service.md
+++ b/docs/sources/static/configuration/scraping-service.md
@@ -180,8 +180,9 @@ Information returned by the `/debug/ring` endpoint includes:
 - The list of Agents in the cluster along with their respective tokens
   used for sharding.
 - The list of configuration files in the KV store and their associated hash values used for lookup in the ring.
-- The unique instance ID assigned to each instance of the Agent running in the cluster. The instance ID is a unique identifier assigned to each running instance of the Agent within the cluster.
-The exact details of the instance ID generation might be specific to the implementation of the Grafana Agent.
+- The unique instance ID assigned to each instance of the Agent running in the cluster.
+   The instance ID is a unique identifier assigned to each running instance of the Agent within the cluster.
+   The exact details of the instance ID generation might be specific to the implementation of the Grafana Agent.
 - The time of the "Last Heartbeat" of each instance. The Last Heartbeat is the last time the instance was active in the ring.
 
 {{% docs/reference %}}

--- a/docs/sources/static/configuration/scraping-service.md
+++ b/docs/sources/static/configuration/scraping-service.md
@@ -179,7 +179,7 @@ You can access this endpoint by making an HTTP request to the Agent's API server
 Information returned by the `/debug/ring` endpoint includes:
 
 - The list of Agents in the cluster, and their respective tokens used for sharding.
-- The list of configuration files in the KV store and their associated hash values used for lookup in the ring.
+- The list of configuration files in the KV store and associated hash values used for lookup in the ring.
 - The unique instance ID assigned to each instance of the Agent running in the cluster.
    The instance ID is a unique identifier assigned to each running instance of the Agent within the cluster.
    The exact details of the instance ID generation might be specific to the implementation of the Grafana Agent.

--- a/docs/sources/static/configuration/scraping-service.md
+++ b/docs/sources/static/configuration/scraping-service.md
@@ -171,7 +171,8 @@ are planned for the future.
 ## Debug Ring endpoint
 
 You can use the `/debug/ring` endpoint to troubleshoot issues with the scraping service in Scraping Service Mode. 
-It provides information about the Distributed Hash Ring and the current distribution of configurations among Agents in the cluster and gives you the ability to forget an instance in the ring manually.   
+It provides information about the Distributed Hash Ring and the current distribution of configurations among Agents in the cluster.
+It also allows you to forget an instance in the ring manually.
 
 You can access this endpoint by making an HTTP request to the Agent's API server.
 

--- a/docs/sources/static/configuration/scraping-service.md
+++ b/docs/sources/static/configuration/scraping-service.md
@@ -168,6 +168,24 @@ container with the `grafana/agentctl` image. Tanka configurations that
 utilize `grafana/agentctl` and sync a set of configurations to the API
 are planned for the future.
 
+## Debug Ring endpoint
+
+You can use the `/debug/ring` endpoint to troubleshoot issues with the scraping service in Scraping Service Mode. 
+It provides information about the Distributed Hash Ring and the current distribution of configurations among Agents in the cluster and gives you the ability to forget an instance in the ring manually.   
+
+You can access this endpoint by making an HTTP request to the Agent's API server.
+
+Information returned by the `/debug/ring` endpoint includes:
+
+- The list of Agents in the cluster along with their respective tokens
+  used for sharding.
+- The list of configuration files in the KV store and their associated hash values used for lookup in the ring.
+- The unique instance ID assigned to each instance of the Agent running in the cluster. The instance ID is a unique identifier assigned to each running instance of the Agent within the cluster.
+The exact details of the instance ID generation might be specific to the implementation of the Grafana Agent.
+- The time of the "Last Heartbeat" of each instance. The Last Heartbeat is the last time the instance was active in the ring.
+
+
+  
 {{% docs/reference %}}
 [api]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static/api"
 [api]: "/docs/grafana-cloud/ -> ../api"

--- a/docs/sources/static/configuration/scraping-service.md
+++ b/docs/sources/static/configuration/scraping-service.md
@@ -184,8 +184,6 @@ Information returned by the `/debug/ring` endpoint includes:
 The exact details of the instance ID generation might be specific to the implementation of the Grafana Agent.
 - The time of the "Last Heartbeat" of each instance. The Last Heartbeat is the last time the instance was active in the ring.
 
-
-  
 {{% docs/reference %}}
 [api]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static/api"
 [api]: "/docs/grafana-cloud/ -> ../api"

--- a/docs/sources/static/configuration/scraping-service.md
+++ b/docs/sources/static/configuration/scraping-service.md
@@ -178,8 +178,7 @@ You can access this endpoint by making an HTTP request to the Agent's API server
 
 Information returned by the `/debug/ring` endpoint includes:
 
-- The list of Agents in the cluster along with their respective tokens
-  used for sharding.
+- The list of Agents in the cluster, and their respective tokens used for sharding.
 - The list of configuration files in the KV store and their associated hash values used for lookup in the ring.
 - The unique instance ID assigned to each instance of the Agent running in the cluster.
    The instance ID is a unique identifier assigned to each running instance of the Agent within the cluster.


### PR DESCRIPTION
Fixes # grafana/support-escalations#6830

I'm adding information on the /debug/ring endpoint.  This is based on this PR: https://github.com/grafana/agent/pull/4577 which had been abandoned.

I'm only backporting back to 0.37. Afaik we only support 2 versions back, but this was added in 0.33

