### PR TITLE
chore: migrate away from `aws-sdk-go` v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,8 @@ v0.40.0 (2024-02-27)
 - `grafana-agent` and `grafana-agent-flow` fallback to default X.509 trusted root certificates
   when the `GODEBUG=x509usefallbackroots=1` environment variable is set. (@hainenber)
 
+- Migrate away from EoL'ed `github.com/aws-sdk-go` v1. (@hainenber)
+
 v0.39.2 (2024-1-31)
 --------------------
 
@@ -189,7 +191,6 @@ v0.39.2 (2024-1-31)
 
 - An error will be returned in the converter from Static to Flow when `scrape_integration` is set
   to `true` but no `remote_write` is defined. (@erikbaranowski)
-
 
 v0.39.1 (2024-01-19)
 --------------------
@@ -204,7 +205,6 @@ v0.39.1 (2024-01-19)
 ### Bugfixes
 
 - Fix issue where installing the Windows Agent Flow installer would hang then crash. (@mattdurham)
-
 
 v0.39.0 (2024-01-09)
 --------------------

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/PuerkitoBio/rehttp v1.1.0
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
-	github.com/aws/aws-sdk-go v1.45.25
+	github.com/aws/aws-sdk-go v1.45.25 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.25.0
 	github.com/aws/aws-sdk-go-v2/config v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.49.0
@@ -283,7 +283,7 @@ require (
 	github.com/avvmoto/buf-readerat v0.0.0-20171115124131-a17c8cb89270 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.0 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.0 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.15.0 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.15.0
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.16.0 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.0 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.0 // indirect

--- a/internal/component/discovery/aws/lightsail.go
+++ b/internal/component/discovery/aws/lightsail.go
@@ -1,11 +1,12 @@
 package aws
 
 import (
+	"context"
 	"errors"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/ec2metadata"
-	"github.com/aws/aws-sdk-go/aws/session"
+	awsConfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/grafana/agent/internal/component"
 	"github.com/grafana/agent/internal/component/common/config"
 	"github.com/grafana/agent/internal/component/discovery"
@@ -71,16 +72,18 @@ func (args *LightsailArguments) SetToDefault() {
 // Validate implements river.Validator.
 func (args *LightsailArguments) Validate() error {
 	if args.Region == "" {
-		sess, err := session.NewSession()
+		cfgCtx := context.TODO()
+		cfg, err := awsConfig.LoadDefaultConfig(cfgCtx)
 		if err != nil {
 			return err
 		}
-		metadata := ec2metadata.New(sess)
-		region, err := metadata.Region()
+
+		client := imds.NewFromConfig(cfg)
+		region, err := client.GetRegion(cfgCtx, &imds.GetRegionInput{})
 		if err != nil {
 			return errors.New("Lightsail SD configuration requires a region")
 		}
-		args.Region = region
+		args.Region = region.Region
 	}
 	return nil
 }

--- a/internal/component/remote/s3/watcher.go
+++ b/internal/component/remote/s3/watcher.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 
 	"context"
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

`github.com/aws-sdk-go` has been announced to be in maintenance mode July 31, 2024. It's better to future-proof by moving to `aws-sdk-go-v2` and also 1 less dependency. 

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated