### PR TITLE
Remove flaky test condition for static mode write handler

### DIFF
--- a/pkg/metrics/instance/instance_test.go
+++ b/pkg/metrics/instance/instance_test.go
@@ -281,7 +281,6 @@ func TestInstance_Recreate(t *testing.T) {
 		inst, err := New(prometheus.NewRegistry(), cfg, walDir, logger)
 		require.NoError(t, err)
 		runInstance(t, inst)
-		_ = inst.WriteHandler()
 
 		time.Sleep(1 * time.Second)
 	})

--- a/pkg/metrics/instance/instance_test.go
+++ b/pkg/metrics/instance/instance_test.go
@@ -281,6 +281,7 @@ func TestInstance_Recreate(t *testing.T) {
 		inst, err := New(prometheus.NewRegistry(), cfg, walDir, logger)
 		require.NoError(t, err)
 		runInstance(t, inst)
+		_ = inst.WriteHandler()
 
 		time.Sleep(1 * time.Second)
 	})
@@ -416,6 +417,5 @@ func runInstance(t *testing.T, i *Instance) {
 	t.Cleanup(func() { cancel() })
 	go require.NotPanics(t, func() {
 		_ = i.Run(ctx)
-		require.NotNil(t, i.WriteHandler())
 	})
 }


### PR DESCRIPTION
Last PR that fixed the static mode write handler introduced a flaky test.

I'm removing the offending condition so that we don't break everyone's macOS runners and see if it makes sense to introduce something else in its place in an upcoming PR.