### PR TITLE
Add kubectl.kubernetes.io/default-container annotation to grafana-agent pod template

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -10,6 +10,10 @@ internal API changes are not present.
 Unreleased
 ----------
 
+### Enhancments
+
+- Add `kubectl.kubernetes.io/default-container: grafana-agent` annotation to allow various tools to choose `grafana-agent` container as default target
+
 0.31.0 (2024-01-10)
 -------------------
 

--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -12,7 +12,7 @@ Unreleased
 
 ### Enhancments
 
-- Add `kubectl.kubernetes.io/default-container: grafana-agent` annotation to allow various tools to choose `grafana-agent` container as default target
+- Add `kubectl.kubernetes.io/default-container: grafana-agent` annotation to allow various tools to choose `grafana-agent` container as default target (@aerfio)
 
 0.31.0 (2024-01-10)
 -------------------

--- a/operations/helm/charts/grafana-agent/ci/pod_annotations-values.yaml
+++ b/operations/helm/charts/grafana-agent/ci/pod_annotations-values.yaml
@@ -1,0 +1,4 @@
+# Test correct rendering of the pod annotations
+controller:
+  podAnnotations:
+    testAnnotationKey: testAnnotationValue

--- a/operations/helm/charts/grafana-agent/templates/controllers/_pod.yaml
+++ b/operations/helm/charts/grafana-agent/templates/controllers/_pod.yaml
@@ -1,9 +1,10 @@
 {{- define "grafana-agent.pod-template" -}}
 metadata:
-  {{- with .Values.controller.podAnnotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    kubectl.kubernetes.io/default-container: grafana-agent
+    {{- with .Values.controller.podAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "grafana-agent.selectorLabels" . | nindent 4 }}
     {{- with .Values.controller.podLabels }}

--- a/operations/helm/tests/additional-serviceaccount-label/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/additional-serviceaccount-label/grafana-agent/templates/controllers/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/clustering/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/clustering/grafana-agent/templates/controllers/statefulset.yaml
@@ -21,6 +21,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/controller-volumes-extra/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/controller-volumes-extra/grafana-agent/templates/controllers/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/controllers/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/create-deployment-autoscaling/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment-autoscaling/grafana-agent/templates/controllers/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
@@ -19,6 +19,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/create-statefulset-autoscaling/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset-autoscaling/grafana-agent/templates/controllers/statefulset.yaml
@@ -20,6 +20,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
@@ -21,6 +21,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/enable-servicemonitor/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/enable-servicemonitor/grafana-agent/templates/controllers/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/envFrom/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/envFrom/grafana-agent/templates/controllers/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/extra-env/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-env/grafana-agent/templates/controllers/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/faro-ingress/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/faro-ingress/grafana-agent/templates/controllers/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/global-image-registry/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-registry/grafana-agent/templates/controllers/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/initcontainers/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/initcontainers/grafana-agent/templates/controllers/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/local-image-pullsecrets/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/local-image-pullsecrets/grafana-agent/templates/controllers/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/local-image-registry/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/local-image-registry/grafana-agent/templates/controllers/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/nodeselectors-and-tolerations/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/nodeselectors-and-tolerations/grafana-agent/templates/controllers/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/pod_annotations/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/pod_annotations/grafana-agent/templates/configmap.yaml
@@ -1,0 +1,42 @@
+---
+# Source: grafana-agent/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.river: |-
+    logging {
+    	level  = "info"
+    	format = "logfmt"
+    }
+    
+    discovery.kubernetes "pods" {
+    	role = "pod"
+    }
+    
+    discovery.kubernetes "nodes" {
+    	role = "node"
+    }
+    
+    discovery.kubernetes "services" {
+    	role = "service"
+    }
+    
+    discovery.kubernetes "endpoints" {
+    	role = "endpoints"
+    }
+    
+    discovery.kubernetes "endpointslices" {
+    	role = "endpointslice"
+    }
+    
+    discovery.kubernetes "ingresses" {
+    	role = "ingress"
+    }

--- a/operations/helm/tests/pod_annotations/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/pod_annotations/grafana-agent/templates/controllers/daemonset.yaml
@@ -20,16 +20,12 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: grafana-agent
+        testAnnotationKey: testAnnotationValue
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent
     spec:
-      securityContext:
-        runAsGroup: 1000
-        runAsUser: 1000
       serviceAccountName: grafana-agent
-      imagePullSecrets:
-        - name: global-cred
       containers:
         - name: grafana-agent
           image: docker.io/grafana/agent:v0.39.0

--- a/operations/helm/tests/pod_annotations/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/pod_annotations/grafana-agent/templates/rbac.yaml
@@ -1,0 +1,117 @@
+---
+# Source: grafana-agent/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  # Rules which allow discovery.kubernetes to function.
+  - apiGroups:
+      - ""
+      - "discovery.k8s.io"
+      - "networking.k8s.io"
+    resources:
+      - endpoints
+      - endpointslices
+      - ingresses
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  # Rules for prometheus.kubernetes.*
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - podmonitors
+      - servicemonitors
+      - probes
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  # needed for remote.kubernetes.*
+  - apiGroups: [""]
+    resources:
+      - "configmaps"
+      - "secrets"
+    verbs:
+      - get
+      - list
+      - watch
+  # needed for otelcol.processor.k8sattributes
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+---
+# Source: grafana-agent/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: grafana-agent
+subjects:
+  - kind: ServiceAccount
+    name: grafana-agent
+    namespace: default

--- a/operations/helm/tests/pod_annotations/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/pod_annotations/grafana-agent/templates/service.yaml
@@ -1,0 +1,22 @@
+---
+# Source: grafana-agent/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+  ports:
+    - name: http-metrics
+      port: 80
+      targetPort: 80
+      protocol: "TCP"

--- a/operations/helm/tests/pod_annotations/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/pod_annotations/grafana-agent/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: grafana-agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-agent
+  namespace: default
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/sidecars/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/sidecars/grafana-agent/templates/controllers/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent

--- a/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: grafana-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
       labels:
         app.kubernetes.io/name: grafana-agent
         app.kubernetes.io/instance: grafana-agent


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Add `kubectl.kubernetes.io/default-container: grafana-agent` annotation to allow various tools to choose `grafana-agent` container as default target. Example of such tool: kubectl, k9s. Kuberentes docs describing this annotation: https://kubernetes.io/docs/reference/labels-annotations-taints/#kubectl-kubernetes-io-default-container

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated