### PR TITLE
feat(mimir/ruler/k8s): configurable path prefix for Mimir's Prometheus API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Main (unreleased)
 - Expose `physical_disk` collector from `windows_exporter` v0.24.0 to 
   Flow configuration. (@hainenber)
 
+- Add argument to configure path prefix for Mimir's Prometheus API endpoint. (@hainenber)
+
 ### Bugfixes
 
 - Fix an issue in `remote.s3` where the exported content of an object would be an empty string if `remote.s3` failed to fully retrieve

--- a/component/mimir/rules/kubernetes/rules.go
+++ b/component/mimir/rules/kubernetes/rules.go
@@ -261,10 +261,11 @@ func (c *Component) init() error {
 	httpClient := c.args.HTTPClientConfig.Convert()
 
 	c.mimirClient, err = mimirClient.New(c.log, mimirClient.Config{
-		ID:               c.args.TenantID,
-		Address:          c.args.Address,
-		UseLegacyRoutes:  c.args.UseLegacyRoutes,
-		HTTPClientConfig: *httpClient,
+		ID:                   c.args.TenantID,
+		Address:              c.args.Address,
+		UseLegacyRoutes:      c.args.UseLegacyRoutes,
+		PrometheusHTTPPrefix: c.args.PrometheusHTTPPrefix,
+		HTTPClientConfig:     *httpClient,
 	}, c.metrics.mimirClientTiming)
 	if err != nil {
 		return err

--- a/component/mimir/rules/kubernetes/types.go
+++ b/component/mimir/rules/kubernetes/types.go
@@ -11,6 +11,7 @@ type Arguments struct {
 	Address              string                  `river:"address,attr"`
 	TenantID             string                  `river:"tenant_id,attr,optional"`
 	UseLegacyRoutes      bool                    `river:"use_legacy_routes,attr,optional"`
+	PrometheusHTTPPrefix string                  `river:"prometheus_http_prefix,attr,optional"`
 	HTTPClientConfig     config.HTTPClientConfig `river:",squash"`
 	SyncInterval         time.Duration           `river:"sync_interval,attr,optional"`
 	MimirNameSpacePrefix string                  `river:"mimir_namespace_prefix,attr,optional"`
@@ -23,6 +24,7 @@ var DefaultArguments = Arguments{
 	SyncInterval:         30 * time.Second,
 	MimirNameSpacePrefix: "agent",
 	HTTPClientConfig:     config.DefaultHTTPClientConfig,
+	PrometheusHTTPPrefix: "/prometheus",
 }
 
 // SetToDefault implements river.Defaulter.

--- a/docs/sources/flow/reference/components/mimir.rules.kubernetes.md
+++ b/docs/sources/flow/reference/components/mimir.rules.kubernetes.md
@@ -47,18 +47,19 @@ mimir.rules.kubernetes "LABEL" {
 
 `mimir.rules.kubernetes` supports the following arguments:
 
-Name                     | Type       | Description                                                                     | Default | Required
--------------------------|------------|---------------------------------------------------------------------------------|---------|---------
-`address`                | `string`   | URL of the Mimir ruler.                                                         |         | yes
-`tenant_id`              | `string`   | Mimir tenant ID.                                                                |         | no
-`use_legacy_routes`      | `bool`     | Whether to use deprecated ruler API endpoints.                                  | false   | no
-`sync_interval`          | `duration` | Amount of time between reconciliations with Mimir.                              | "30s"   | no
-`mimir_namespace_prefix` | `string`   | Prefix used to differentiate multiple {{< param "PRODUCT_NAME" >}} deployments. | "agent" | no
-`bearer_token`           | `secret`   | Bearer token to authenticate with.                                              |         | no
-`bearer_token_file`      | `string`   | File containing a bearer token to authenticate with.                            |         | no
-`proxy_url`              | `string`   | HTTP proxy to proxy requests through.                                           |         | no
-`follow_redirects`       | `bool`     | Whether redirects returned by the server should be followed.                    | `true`  | no
-`enable_http2`           | `bool`     | Whether HTTP2 is supported for requests.                                        | `true`  | no
+| Name                     | Type       | Description                                                                     | Default       | Required |
+| ------------------------ | ---------- | ------------------------------------------------------------------------------- | ------------- | -------- |
+| `address`                | `string`   | URL of the Mimir ruler.                                                         |               | yes      |
+| `tenant_id`              | `string`   | Mimir tenant ID.                                                                |               | no       |
+| `use_legacy_routes`      | `bool`     | Whether to use deprecated ruler API endpoints.                                  | false         | no       |
+| `prometheus_http_prefix` | `string`   | Path prefix for Mimir's Prometheus endpoint.                                    | `/prometheus` | no       |
+| `sync_interval`          | `duration` | Amount of time between reconciliations with Mimir.                              | "30s"         | no       |
+| `mimir_namespace_prefix` | `string`   | Prefix used to differentiate multiple {{< param "PRODUCT_NAME" >}} deployments. | "agent"       | no       |
+| `bearer_token`           | `secret`   | Bearer token to authenticate with.                                              |               | no       |
+| `bearer_token_file`      | `string`   | File containing a bearer token to authenticate with.                            |               | no       |
+| `proxy_url`              | `string`   | HTTP proxy to proxy requests through.                                           |               | no       |
+| `follow_redirects`       | `bool`     | Whether redirects returned by the server should be followed.                    | `true`        | no       |
+| `enable_http2`           | `bool`     | Whether HTTP2 is supported for requests.                                        | `true`        | no       |
 
  At most one of the following can be provided:
  - [`bearer_token` argument](#arguments).

--- a/pkg/mimir/client/client.go
+++ b/pkg/mimir/client/client.go
@@ -20,22 +20,18 @@ import (
 	"github.com/prometheus/prometheus/model/rulefmt"
 )
 
-const (
-	rulerAPIPath  = "/prometheus/config/v1/rules"
-	legacyAPIPath = "/api/v1/rules"
-)
-
 var (
-	ErrNoConfig         = errors.New("No config exists for this user")
+	ErrNoConfig         = errors.New("no config exists for this user")
 	ErrResourceNotFound = errors.New("requested resource not found")
 )
 
 // Config is used to configure a MimirClient.
 type Config struct {
-	ID               string
-	Address          string
-	UseLegacyRoutes  bool
-	HTTPClientConfig config.HTTPClientConfig
+	ID                   string
+	Address              string
+	UseLegacyRoutes      bool
+	HTTPClientConfig     config.HTTPClientConfig
+	PrometheusHTTPPrefix string
 }
 
 type Interface interface {
@@ -65,9 +61,12 @@ func New(logger log.Logger, cfg Config, timingHistogram *prometheus.HistogramVec
 		return nil, err
 	}
 
-	path := rulerAPIPath
+	path, err := url.JoinPath(cfg.PrometheusHTTPPrefix, "/config/v1/rules")
+	if err != nil {
+		return nil, err
+	}
 	if cfg.UseLegacyRoutes {
-		path = legacyAPIPath
+		path = "/api/v1/rules"
 	}
 
 	collector := instrument.NewHistogramCollector(timingHistogram)

--- a/pkg/mimir/client/client_test.go
+++ b/pkg/mimir/client/client_test.go
@@ -79,6 +79,13 @@ func TestBuildURL(t *testing.T) {
 			url:       "http://mimir.local/apathto",
 			resultURL: "http://mimir.local/apathto/prometheus/config/v1/rules/last-char-slash%2F",
 		},
+		{
+			name:      "builds the correct URL with a customized prometheus_http_prefix",
+			path:      "/mimir/config/v1/rules",
+			method:    http.MethodPost,
+			url:       "http://mimir.local/",
+			resultURL: "http://mimir.local/mimir/config/v1/rules",
+		},
 	}
 
 	for _, tt := range tc {

--- a/pkg/mimir/client/rules_test.go
+++ b/pkg/mimir/client/rules_test.go
@@ -22,49 +22,63 @@ func TestMimirClient_X(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := New(log.NewNopLogger(), Config{
-		Address: ts.URL,
-	}, prometheus.NewHistogramVec(prometheus.HistogramOpts{}, instrument.HistogramCollectorBuckets))
-	require.NoError(t, err)
-
 	for _, tc := range []struct {
-		test       string
-		namespace  string
-		name       string
-		expURLPath string
+		test                 string
+		namespace            string
+		name                 string
+		prometheusHTTPPrefix string
+		expURLPath           string
 	}{
 		{
-			test:       "regular-characters",
-			namespace:  "my-namespace",
-			name:       "my-name",
-			expURLPath: "/prometheus/config/v1/rules/my-namespace/my-name",
+			test:                 "regular-characters",
+			namespace:            "my-namespace",
+			name:                 "my-name",
+			expURLPath:           "/prometheus/config/v1/rules/my-namespace/my-name",
+			prometheusHTTPPrefix: "/prometheus",
 		},
 		{
-			test:       "special-characters-spaces",
-			namespace:  "My: Namespace",
-			name:       "My: Name",
-			expURLPath: "/prometheus/config/v1/rules/My:%20Namespace/My:%20Name",
+			test:                 "special-characters-spaces",
+			namespace:            "My: Namespace",
+			name:                 "My: Name",
+			prometheusHTTPPrefix: "/prometheus",
+			expURLPath:           "/prometheus/config/v1/rules/My:%20Namespace/My:%20Name",
 		},
 		{
-			test:       "special-characters-slashes",
-			namespace:  "My/Namespace",
-			name:       "My/Name",
-			expURLPath: "/prometheus/config/v1/rules/My%2FNamespace/My%2FName",
+			test:                 "special-characters-slashes",
+			namespace:            "My/Namespace",
+			name:                 "My/Name",
+			prometheusHTTPPrefix: "/prometheus",
+			expURLPath:           "/prometheus/config/v1/rules/My%2FNamespace/My%2FName",
 		},
 		{
-			test:       "special-characters-slash-first",
-			namespace:  "My/Namespace",
-			name:       "/first-char-slash",
-			expURLPath: "/prometheus/config/v1/rules/My%2FNamespace/%2Ffirst-char-slash",
+			test:                 "special-characters-slash-first",
+			namespace:            "My/Namespace",
+			name:                 "/first-char-slash",
+			prometheusHTTPPrefix: "/prometheus",
+			expURLPath:           "/prometheus/config/v1/rules/My%2FNamespace/%2Ffirst-char-slash",
 		},
 		{
-			test:       "special-characters-slash-last",
-			namespace:  "My/Namespace",
-			name:       "last-char-slash/",
-			expURLPath: "/prometheus/config/v1/rules/My%2FNamespace/last-char-slash%2F",
+			test:                 "special-characters-slash-last",
+			namespace:            "My/Namespace",
+			name:                 "last-char-slash/",
+			prometheusHTTPPrefix: "/prometheus",
+			expURLPath:           "/prometheus/config/v1/rules/My%2FNamespace/last-char-slash%2F",
+		},
+		{
+			test:                 "regular-characters-with-customized-prometheus-http-prefix",
+			namespace:            "My/Namespace",
+			name:                 "last-char-slash/",
+			prometheusHTTPPrefix: "/mimir",
+			expURLPath:           "/mimir/config/v1/rules/My%2FNamespace/last-char-slash%2F",
 		},
 	} {
 		t.Run(tc.test, func(t *testing.T) {
+			client, err := New(log.NewNopLogger(), Config{
+				Address:              ts.URL,
+				PrometheusHTTPPrefix: tc.prometheusHTTPPrefix,
+			}, prometheus.NewHistogramVec(prometheus.HistogramOpts{}, instrument.HistogramCollectorBuckets))
+			require.NoError(t, err)
+
 			ctx := context.Background()
 			require.NoError(t, client.DeleteRuleGroup(ctx, tc.namespace, tc.name))
 


### PR DESCRIPTION


<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #6162 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated