### PR TITLE
add nsis check for environment var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Main (unreleased)
 - Fix a duplicate metrics registration panic when sending metrics to an static
   mode metric instance's write handler. (@tpaschalis)
 
+- Fix issue where installing the Windows Agent Flow installer would hang then crash. (@mattdurham)
+
 ### Other changes
 
 - Removed support for Windows 2012 in line with Microsoft end of life. (@mattdurham)

--- a/packaging/grafana-agent-flow/windows/install_script.nsis
+++ b/packaging/grafana-agent-flow/windows/install_script.nsis
@@ -152,10 +152,14 @@ Function InitializeRegistry
     Pop $0 # Ignore return result
   ${EndIf}
 
-  # Define the environment key, which holds environment variables to pass to the
-  # service.
-  nsExec::ExecToLog 'Reg.exe add "${REGKEY}" /reg:64 /v Environment /t REG_MULTI_SZ /d "$Environment"'
-  Pop $0 # Ignore return result
+  nsExec::ExecToLog 'Reg.exe query "${REGKEY}" /reg:64 /v Environment'
+  Pop $0
+  ${If} $0 == 1
+    # Define the environment key, which holds environment variables to pass to the
+    # service.
+    nsExec::ExecToLog 'Reg.exe add "${REGKEY}" /reg:64 /v Environment /t REG_MULTI_SZ /d "$Environment"'
+    Pop $0 # Ignore return result
+  ${EndIf}
 
   Return
 FunctionEnd


### PR DESCRIPTION
#### PR Description

Previously if the environment var existed the installer would fail. Likely in asking for confirmation to overwrite. This follows the pattern of Arguments reg key

#### Which issue(s) this PR fixes

Fixes #6179

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG.md updated