### PR TITLE
Fix non-unique ID used in worker pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ Main (unreleased)
 
 - Fix issue causing duplicate logs when a docker target is restarted. (@captncraig)
 
+- Fix an issue where blocks having the same type and the same label across
+  modules could result in missed updates. (@thampiotr)
+
 ### Other changes
 
 - Removed support for Windows 2012 in line with Microsoft end of life. (@mattdurham)

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
 	"sync"
 	"time"
 
@@ -592,7 +593,8 @@ func (l *Loader) EvaluateDependants(ctx context.Context, updatedNodes []*Compone
 			err                error
 		)
 		for retryBackoff.Ongoing() {
-			err = l.workerPool.SubmitWithKey(nodeRef.NodeID(), func() {
+			globalUniqueKey := path.Join(l.globals.ControllerID, nodeRef.NodeID())
+			err = l.workerPool.SubmitWithKey(globalUniqueKey, func() {
 				l.concurrentEvalFn(nodeRef, dependantCtx, tracer, parentRef)
 			})
 			if err != nil {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

* Add a test in the first commit
* Add a fix in the second commit

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

Fixes #6199

#### Notes to the Reviewer

Wrote a slightly different, smaller test than the draft branch mentioned on the issue.

Before the fix, running `go test ./pkg/flow/ -count 10 -test.run "TestUpdates_TwoModules*"` would usually catch the bug:
```
--- FAIL: TestUpdates_TwoModules_SameCompNames (3.01s)
    module_caching_test.go:200:
        	Error Trace:	/Users/piotr/workspace/agent/pkg/flow/module_caching_test.go:200
        	Error:      	Condition never satisfied
        	Test:       	TestUpdates_TwoModules_SameCompNames
FAIL
FAIL	github.com/grafana/agent/pkg/flow	19.395s
FAIL
```

After the fix, it doesn't fail.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Tests updated