### PR TITLE
feat(operations/helm) add support for extraObjects

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -15,6 +15,8 @@ Unreleased
 
 ### Enhancements
 
+- Add support for `extraObjects` to define additional manifests. (@timtalbot)
+
 - Add `kubectl.kubernetes.io/default-container: grafana-agent` annotation to allow various tools to choose `grafana-agent` container as default target (@aerfio)
 
 - Add support for topology spread constraints in helm chart. (@etiennep)

--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -10,12 +10,14 @@ internal API changes are not present.
 Unreleased
 ----------
 
+### Enhancements
+
+- Add support for `extraObjects` to define additional manifests. (@timtalbot)
+
 0.31.1 (2024-01-19)
 -------------------
 
 ### Enhancements
-
-- Add support for `extraObjects` to define additional manifests. (@timtalbot)
 
 - Add `kubectl.kubernetes.io/default-container: grafana-agent` annotation to allow various tools to choose `grafana-agent` container as default target (@aerfio)
 

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -95,6 +95,7 @@ use the older mode (called "static mode"), set the `agent.mode` value to
 | controller.volumeClaimTemplates | list | `[]` | volumeClaimTemplates to add when controller.type is 'statefulset'. |
 | controller.volumes.extra | list | `[]` | Extra volumes to add to the Grafana Agent pod. |
 | crds.create | bool | `true` | Whether to install CRDs for monitoring. |
+| extraObjects | list | `[]` | Add dynamic manifests via values. |
 | fullnameOverride | string | `nil` | Overrides the chart's computed fullname. Used to change the full prefix of resource names. |
 | global.image.pullSecrets | list | `[]` | Optional set of global image pull secrets. |
 | global.image.registry | string | `""` | Global image registry to use if it needs to be overriden for some specific use cases (e.g local registries, custom images, ...) |

--- a/operations/helm/charts/grafana-agent/ci/extra-manifests-values.yaml
+++ b/operations/helm/charts/grafana-agent/ci/extra-manifests-values.yaml
@@ -1,0 +1,7 @@
+extraObjects:
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: extra-cm-{{ .Release.Name }}
+    data: |
+      extra.yml: "extra-config: true"

--- a/operations/helm/charts/grafana-agent/templates/extra_manifests.yaml
+++ b/operations/helm/charts/grafana-agent/templates/extra_manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/operations/helm/charts/grafana-agent/values.yaml
+++ b/operations/helm/charts/grafana-agent/values.yaml
@@ -306,3 +306,4 @@ extraObjects: []
   #     name: extra-cm-{{ .Release.Name }}
   #   data: |
   #     extra.yml: "extra-config: true"
+  

--- a/operations/helm/charts/grafana-agent/values.yaml
+++ b/operations/helm/charts/grafana-agent/values.yaml
@@ -296,3 +296,13 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+
+# -- Add dynamic manifests via values.
+extraObjects: []
+  # extraObjects:
+  # - kind: ConfigMap
+  #   apiVersion: v1
+  #   metadata:
+  #     name: extra-cm-{{ .Release.Name }}
+  #   data: |
+  #     extra.yml: "extra-config: true"

--- a/operations/helm/tests/extra-manifests/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/extra-manifests/grafana-agent/templates/configmap.yaml
@@ -1,0 +1,42 @@
+---
+# Source: grafana-agent/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.river: |-
+    logging {
+    	level  = "info"
+    	format = "logfmt"
+    }
+    
+    discovery.kubernetes "pods" {
+    	role = "pod"
+    }
+    
+    discovery.kubernetes "nodes" {
+    	role = "node"
+    }
+    
+    discovery.kubernetes "services" {
+    	role = "service"
+    }
+    
+    discovery.kubernetes "endpoints" {
+    	role = "endpoints"
+    }
+    
+    discovery.kubernetes "endpointslices" {
+    	role = "endpointslice"
+    }
+    
+    discovery.kubernetes "ingresses" {
+    	role = "ingress"
+    }

--- a/operations/helm/tests/extra-manifests/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-manifests/grafana-agent/templates/controllers/daemonset.yaml
@@ -1,0 +1,75 @@
+---
+# Source: grafana-agent/templates/controllers/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  minReadySeconds: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana-agent
+      app.kubernetes.io/instance: grafana-agent
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-agent
+      labels:
+        app.kubernetes.io/name: grafana-agent
+        app.kubernetes.io/instance: grafana-agent
+    spec:
+      serviceAccountName: grafana-agent
+      containers:
+        - name: grafana-agent
+          image: docker.io/grafana/agent:v0.39.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - /etc/agent/config.river
+            - --storage.path=/tmp/agent
+            - --server.http.listen-addr=0.0.0.0:80
+            - --server.http.ui-path-prefix=/
+          env:
+            - name: AGENT_MODE
+              value: flow
+            - name: AGENT_DEPLOY_MODE
+              value: "helm"
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - containerPort: 80
+              name: http-metrics
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 80
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+        - name: config-reloader
+          image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
+          args:
+            - --volume-dir=/etc/agent
+            - --webhook-url=http://localhost:80/-/reload
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+          resources:
+            requests:
+              cpu: 1m
+              memory: 5Mi
+      dnsPolicy: ClusterFirst
+      volumes:
+        - name: config
+          configMap:
+            name: grafana-agent

--- a/operations/helm/tests/extra-manifests/grafana-agent/templates/extra_manifests.yaml
+++ b/operations/helm/tests/extra-manifests/grafana-agent/templates/extra_manifests.yaml
@@ -1,0 +1,8 @@
+---
+# Source: grafana-agent/templates/extra_manifests.yaml
+apiVersion: v1
+data: |
+  extra.yml: "extra-config: true"
+kind: ConfigMap
+metadata:
+  name: extra-cm-grafana-agent

--- a/operations/helm/tests/extra-manifests/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/extra-manifests/grafana-agent/templates/rbac.yaml
@@ -1,0 +1,117 @@
+---
+# Source: grafana-agent/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  # Rules which allow discovery.kubernetes to function.
+  - apiGroups:
+      - ""
+      - "discovery.k8s.io"
+      - "networking.k8s.io"
+    resources:
+      - endpoints
+      - endpointslices
+      - ingresses
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  # Rules for prometheus.kubernetes.*
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - podmonitors
+      - servicemonitors
+      - probes
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  # needed for remote.kubernetes.*
+  - apiGroups: [""]
+    resources:
+      - "configmaps"
+      - "secrets"
+    verbs:
+      - get
+      - list
+      - watch
+  # needed for otelcol.processor.k8sattributes
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+---
+# Source: grafana-agent/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: grafana-agent
+subjects:
+  - kind: ServiceAccount
+    name: grafana-agent
+    namespace: default

--- a/operations/helm/tests/extra-manifests/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/extra-manifests/grafana-agent/templates/service.yaml
@@ -1,0 +1,22 @@
+---
+# Source: grafana-agent/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+  ports:
+    - name: http-metrics
+      port: 80
+      targetPort: 80
+      protocol: "TCP"

--- a/operations/helm/tests/extra-manifests/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/extra-manifests/grafana-agent/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: grafana-agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-agent
+  namespace: default
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Adds support for an `extraObjects` field in chart values to add additional manifests with chart installation.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer
Following the model used by many charts including other Grafana ones to deploy extra objects with the chart. Thanks for your time!
#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated