### PR TITLE
Prohibit the configuration of services within modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Breaking changes
+
+- Prohibit the configuration of services within modules. (@wildum)
+
 ### Features
 
 - A new `discovery.process` component for discovering Linux OS processes on the current host. (@korniltsev)

--- a/docs/sources/flow/release-notes.md
+++ b/docs/sources/flow/release-notes.md
@@ -29,6 +29,13 @@ Other release notes for the different {{< param "PRODUCT_ROOT_NAME" >}} variants
 [release-notes-operator]: {{< relref "../operator/release-notes.md" >}}
 {{% /admonition %}}
 
+## v0.40
+
+### Breaking change: Prohibit the configuration of services within modules.
+
+Previously it was possible to configure the HTTP service via the [HTTP config block](https://grafana.com/docs/agent/v0.39/flow/reference/config-blocks/http/) inside of a module.
+This functionality is now only available in the main configuration.
+
 ## v0.39
 
 ### Breaking change: `otelcol.receiver.prometheus` will drop all `otel_scope_info` metrics when converting them to OTLP

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -345,6 +345,17 @@ func (l *Loader) populateServiceNodes(g *dag.Graph, serviceBlocks []*ast.BlockSt
 	// Now, assign blocks to services.
 	for _, block := range serviceBlocks {
 		blockID := BlockComponentID(block).String()
+
+		if l.isModule() {
+			diags.Add(diag.Diagnostic{
+				Severity: diag.SeverityLevelError,
+				Message:  fmt.Sprintf("service blocks not allowed inside a module: %q", blockID),
+				StartPos: ast.StartPos(block).Position(),
+				EndPos:   ast.EndPos(block).Position(),
+			})
+			continue
+		}
+
 		node := g.GetByID(blockID).(*ServiceNode)
 
 		// Blocks assigned to services are reset to nil in the previous loop.

--- a/pkg/flow/module_test.go
+++ b/pkg/flow/module_test.go
@@ -7,8 +7,10 @@ import (
 	"time"
 
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/pkg/flow/internal/controller"
 	"github.com/grafana/agent/pkg/flow/internal/worker"
 	"github.com/grafana/agent/pkg/flow/logging"
+	"github.com/grafana/agent/service"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
@@ -43,6 +45,9 @@ const exportDummy = `
 		value = "bob"
 	}`
 
+const serviceConfig = `
+	testservice {}`
+
 func TestModule(t *testing.T) {
 	tt := []struct {
 		name                  string
@@ -71,6 +76,12 @@ func TestModule(t *testing.T) {
 			argumentModuleContent: argumentConfig + tracingConfig,
 			exportModuleContent:   exportStringConfig,
 			expectedErrorContains: "tracing block not allowed inside a module",
+		},
+		{
+			name:                  "Service blocks not allowed in module config",
+			argumentModuleContent: argumentConfig + serviceConfig,
+			exportModuleContent:   exportStringConfig,
+			expectedErrorContains: "service blocks not allowed inside a module: \"testservice\"",
 		},
 		{
 			name:                  "Argument not defined in module source",
@@ -245,12 +256,19 @@ func testModuleControllerOptions(t *testing.T) *moduleControllerOptions {
 	s, err := logging.New(os.Stderr, logging.DefaultOptions)
 	require.NoError(t, err)
 
+	services := []service.Service{
+		&testService{},
+	}
+
+	serviceMap := controller.NewServiceMap(services)
+
 	return &moduleControllerOptions{
 		Logger:         s,
 		DataPath:       t.TempDir(),
 		Reg:            prometheus.NewRegistry(),
 		ModuleRegistry: newModuleRegistry(),
 		WorkerPool:     worker.NewFixedWorkerPool(1, 100),
+		ServiceMap:     serviceMap,
 	}
 }
 
@@ -305,5 +323,25 @@ func (t *testModule) Run(ctx context.Context) error {
 }
 
 func (t *testModule) Update(_ component.Arguments) error {
+	return nil
+}
+
+type testService struct{}
+
+func (t *testService) Definition() service.Definition {
+	return service.Definition{
+		Name: "testservice",
+	}
+}
+
+func (t *testService) Run(ctx context.Context, host service.Host) error {
+	return nil
+}
+
+func (t *testService) Update(newConfig any) error {
+	return nil
+}
+
+func (t *testService) Data() any {
 	return nil
 }


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Services should only be configurable within the main config. A module should not have the possibility to modify the behavior of a service running at root level. In this PR, I added a check to prevent this from happening.

#### Which issue(s) this PR fixes

Fixes #6174

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Tests updated