### PR TITLE
Ignore order or OTLP resources in tests.

### DIFF
--- a/component/otelcol/processor/processortest/compare_signals.go
+++ b/component/otelcol/processor/processortest/compare_signals.go
@@ -1,0 +1,46 @@
+package processortest
+
+import (
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/plogtest"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pmetrictest"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/ptracetest"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+func CompareMetrics(t *testing.T, expected, actual pmetric.Metrics) {
+	err := pmetrictest.CompareMetrics(
+		expected,
+		actual,
+		pmetrictest.IgnoreResourceMetricsOrder(),
+		pmetrictest.IgnoreMetricDataPointsOrder(),
+		pmetrictest.IgnoreMetricsOrder(),
+		pmetrictest.IgnoreScopeMetricsOrder(),
+		pmetrictest.IgnoreSummaryDataPointValueAtQuantileSliceOrder(),
+		pmetrictest.IgnoreTimestamp(),
+		pmetrictest.IgnoreStartTimestamp(),
+	)
+	require.NoError(t, err)
+}
+
+func CompareLogs(t *testing.T, expected, actual plog.Logs) {
+	err := plogtest.CompareLogs(
+		expected,
+		actual,
+	)
+	require.NoError(t, err)
+}
+
+func CompareTraces(t *testing.T, expected, actual ptrace.Traces) {
+	err := ptracetest.CompareTraces(
+		expected,
+		actual,
+		ptracetest.IgnoreResourceSpansOrder(),
+		ptracetest.IgnoreScopeSpansOrder(),
+	)
+	require.NoError(t, err)
+}

--- a/component/otelcol/processor/processortest/compare_signals_test.go
+++ b/component/otelcol/processor/processortest/compare_signals_test.go
@@ -1,0 +1,36 @@
+package processortest
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+func Test_ScopeMetricsOrder(t *testing.T) {
+	metric1 := pmetric.NewMetrics()
+	metric1_res := metric1.ResourceMetrics().AppendEmpty()
+	metric1_res.ScopeMetrics().AppendEmpty().Scope().SetName("scope1")
+	metric1_res.ScopeMetrics().AppendEmpty().Scope().SetName("scope2")
+
+	metric2 := pmetric.NewMetrics()
+	metric2_res := metric2.ResourceMetrics().AppendEmpty()
+	metric2_res.ScopeMetrics().AppendEmpty().Scope().SetName("scope2")
+	metric2_res.ScopeMetrics().AppendEmpty().Scope().SetName("scope1")
+
+	CompareMetrics(t, metric1, metric2)
+}
+
+func Test_ScopeSpansAttributesOrder(t *testing.T) {
+	trace1 := ptrace.NewTraces()
+	trace1_span_attr := trace1.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Scope().Attributes()
+	trace1_span_attr.PutStr("key1", "val1")
+	trace1_span_attr.PutStr("key2", "val2")
+
+	trace2 := ptrace.NewTraces()
+	trace2_span_attr := trace2.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Scope().Attributes()
+	trace2_span_attr.PutStr("key2", "val2")
+	trace2_span_attr.PutStr("key1", "val1")
+
+	CompareTraces(t, trace1, trace2)
+}

--- a/component/otelcol/processor/processortest/processortest.go
+++ b/component/otelcol/processor/processortest/processortest.go
@@ -75,16 +75,16 @@ func TestRunProcessor(c ProcessorRunConfig) {
 //
 
 type traceToLogSignal struct {
-	logCh              chan plog.Logs
-	inputTrace         ptrace.Traces
-	expectedOuutputLog plog.Logs
+	logCh             chan plog.Logs
+	inputTrace        ptrace.Traces
+	expectedOutputLog plog.Logs
 }
 
 func NewTraceToLogSignal(inputJson string, expectedOutputJson string) Signal {
 	return &traceToLogSignal{
-		logCh:              make(chan plog.Logs),
-		inputTrace:         CreateTestTraces(inputJson),
-		expectedOuutputLog: CreateTestLogs(expectedOutputJson),
+		logCh:             make(chan plog.Logs),
+		inputTrace:        CreateTestTraces(inputJson),
+		expectedOutputLog: CreateTestLogs(expectedOutputJson),
 	}
 }
 
@@ -101,10 +101,8 @@ func (s traceToLogSignal) CheckOutput(t *testing.T) {
 	select {
 	case <-time.After(time.Second):
 		require.FailNow(t, "failed waiting for logs")
-	case tr := <-s.logCh:
-		trStr := marshalLogs(tr)
-		expStr := marshalLogs(s.expectedOuutputLog)
-		require.JSONEq(t, expStr, trStr)
+	case actualLog := <-s.logCh:
+		CompareLogs(t, s.expectedOutputLog, actualLog)
 	}
 }
 
@@ -113,17 +111,17 @@ func (s traceToLogSignal) CheckOutput(t *testing.T) {
 //
 
 type traceToMetricSignal struct {
-	metricCh              chan pmetric.Metrics
-	inputTrace            ptrace.Traces
-	expectedOuutputMetric pmetric.Metrics
+	metricCh             chan pmetric.Metrics
+	inputTrace           ptrace.Traces
+	expectedOutputMetric pmetric.Metrics
 }
 
 // Any timestamps inside expectedOutputJson should be set to 0.
 func NewTraceToMetricSignal(inputJson string, expectedOutputJson string) Signal {
 	return &traceToMetricSignal{
-		metricCh:              make(chan pmetric.Metrics),
-		inputTrace:            CreateTestTraces(inputJson),
-		expectedOuutputMetric: CreateTestMetrics(expectedOutputJson),
+		metricCh:             make(chan pmetric.Metrics),
+		inputTrace:           CreateTestTraces(inputJson),
+		expectedOutputMetric: CreateTestMetrics(expectedOutputJson),
 	}
 }
 
@@ -133,57 +131,6 @@ func (s traceToMetricSignal) MakeOutput() *otelcol.ConsumerArguments {
 
 func (s traceToMetricSignal) ConsumeInput(ctx context.Context, consumer otelcol.Consumer) error {
 	return consumer.ConsumeTraces(ctx, s.inputTrace)
-}
-
-// Set the timestamp of all data points to 0.
-// This helps avoid flaky tests due to timestamps.
-func setMetricTimestampToZero(metrics pmetric.Metrics) {
-	// Loop over all resource metrics
-	for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
-		rm := metrics.ResourceMetrics().At(i)
-		// Loop over all metric scopes.
-		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
-			sm := rm.ScopeMetrics().At(j)
-			// Loop over all metrics.
-			for k := 0; k < sm.Metrics().Len(); k++ {
-				m := sm.Metrics().At(k)
-				switch m.Type() {
-				case pmetric.MetricTypeSum:
-					// Loop over all data points.
-					for l := 0; l < m.Sum().DataPoints().Len(); l++ {
-						// Set the timestamp to 0 to avoid flaky tests.
-						dp := m.Sum().DataPoints().At(l)
-						dp.SetTimestamp(0)
-						dp.SetStartTimestamp(0)
-					}
-				case pmetric.MetricTypeGauge:
-					// Loop over all data points.
-					for l := 0; l < m.Gauge().DataPoints().Len(); l++ {
-						// Set the timestamp to 0 to avoid flaky tests.
-						dp := m.Gauge().DataPoints().At(l)
-						dp.SetTimestamp(0)
-						dp.SetStartTimestamp(0)
-					}
-				case pmetric.MetricTypeHistogram:
-					// Loop over all data points.
-					for l := 0; l < m.Histogram().DataPoints().Len(); l++ {
-						// Set the timestamp to 0 to avoid flaky tests.
-						dp := m.Histogram().DataPoints().At(l)
-						dp.SetTimestamp(0)
-						dp.SetStartTimestamp(0)
-					}
-				case pmetric.MetricTypeSummary:
-					// Loop over all data points.
-					for l := 0; l < m.Summary().DataPoints().Len(); l++ {
-						// Set the timestamp to 0 to avoid flaky tests.
-						dp := m.Summary().DataPoints().At(l)
-						dp.SetTimestamp(0)
-						dp.SetStartTimestamp(0)
-					}
-				}
-			}
-		}
-	}
 }
 
 // Wait for the component to finish and check its output.
@@ -196,14 +143,8 @@ func (s traceToMetricSignal) CheckOutput(t *testing.T) {
 	select {
 	case <-time.After(timeout):
 		require.FailNow(t, "failed waiting for metrics")
-	case tr := <-s.metricCh:
-		setMetricTimestampToZero(tr)
-		trStr := marshalMetrics(tr)
-
-		expStr := marshalMetrics(s.expectedOuutputMetric)
-		// Set a field from the json to an empty string to avoid flaky tests containing timestamps.
-
-		require.JSONEq(t, expStr, trStr)
+	case actualMetric := <-s.metricCh:
+		CompareMetrics(t, s.expectedOutputMetric, actualMetric)
 	}
 }
 
@@ -212,16 +153,16 @@ func (s traceToMetricSignal) CheckOutput(t *testing.T) {
 //
 
 type traceSignal struct {
-	traceCh              chan ptrace.Traces
-	inputTrace           ptrace.Traces
-	expectedOuutputTrace ptrace.Traces
+	traceCh             chan ptrace.Traces
+	inputTrace          ptrace.Traces
+	expectedOutputTrace ptrace.Traces
 }
 
 func NewTraceSignal(inputJson string, expectedOutputJson string) Signal {
 	return &traceSignal{
-		traceCh:              make(chan ptrace.Traces),
-		inputTrace:           CreateTestTraces(inputJson),
-		expectedOuutputTrace: CreateTestTraces(expectedOutputJson),
+		traceCh:             make(chan ptrace.Traces),
+		inputTrace:          CreateTestTraces(inputJson),
+		expectedOutputTrace: CreateTestTraces(expectedOutputJson),
 	}
 }
 
@@ -238,10 +179,8 @@ func (s traceSignal) CheckOutput(t *testing.T) {
 	select {
 	case <-time.After(time.Second):
 		require.FailNow(t, "failed waiting for traces")
-	case tr := <-s.traceCh:
-		trStr := marshalTraces(tr)
-		expStr := marshalTraces(s.expectedOuutputTrace)
-		require.JSONEq(t, expStr, trStr)
+	case actualTrace := <-s.traceCh:
+		CompareTraces(t, s.expectedOutputTrace, actualTrace)
 	}
 }
 
@@ -254,15 +193,6 @@ func CreateTestTraces(traceJson string) ptrace.Traces {
 		panic(err)
 	}
 	return data
-}
-
-func marshalTraces(trace ptrace.Traces) string {
-	marshaler := &ptrace.JSONMarshaler{}
-	data, err := marshaler.MarshalTraces(trace)
-	if err != nil {
-		panic(err)
-	}
-	return string(data)
 }
 
 // makeTracesOutput returns ConsumerArguments which will forward traces to the
@@ -289,16 +219,16 @@ func makeTracesOutput(ch chan ptrace.Traces) *otelcol.ConsumerArguments {
 //
 
 type logSignal struct {
-	logCh              chan plog.Logs
-	inputLog           plog.Logs
-	expectedOuutputLog plog.Logs
+	logCh             chan plog.Logs
+	inputLog          plog.Logs
+	expectedOutputLog plog.Logs
 }
 
 func NewLogSignal(inputJson string, expectedOutputJson string) Signal {
 	return &logSignal{
-		logCh:              make(chan plog.Logs),
-		inputLog:           CreateTestLogs(inputJson),
-		expectedOuutputLog: CreateTestLogs(expectedOutputJson),
+		logCh:             make(chan plog.Logs),
+		inputLog:          CreateTestLogs(inputJson),
+		expectedOutputLog: CreateTestLogs(expectedOutputJson),
 	}
 }
 
@@ -315,10 +245,8 @@ func (s logSignal) CheckOutput(t *testing.T) {
 	select {
 	case <-time.After(time.Second):
 		require.FailNow(t, "failed waiting for logs")
-	case tr := <-s.logCh:
-		trStr := marshalLogs(tr)
-		expStr := marshalLogs(s.expectedOuutputLog)
-		require.JSONEq(t, expStr, trStr)
+	case actualLog := <-s.logCh:
+		CompareLogs(t, s.expectedOutputLog, actualLog)
 	}
 }
 
@@ -352,30 +280,21 @@ func CreateTestLogs(logJson string) plog.Logs {
 	return data
 }
 
-func marshalLogs(log plog.Logs) string {
-	marshaler := &plog.JSONMarshaler{}
-	data, err := marshaler.MarshalLogs(log)
-	if err != nil {
-		panic(err)
-	}
-	return string(data)
-}
-
 //
 // Metrics
 //
 
 type metricSignal struct {
-	metricCh              chan pmetric.Metrics
-	inputMetric           pmetric.Metrics
-	expectedOuutputMetric pmetric.Metrics
+	metricCh             chan pmetric.Metrics
+	inputMetric          pmetric.Metrics
+	expectedOutputMetric pmetric.Metrics
 }
 
 func NewMetricSignal(inputJson string, expectedOutputJson string) Signal {
 	return &metricSignal{
-		metricCh:              make(chan pmetric.Metrics),
-		inputMetric:           CreateTestMetrics(inputJson),
-		expectedOuutputMetric: CreateTestMetrics(expectedOutputJson),
+		metricCh:             make(chan pmetric.Metrics),
+		inputMetric:          CreateTestMetrics(inputJson),
+		expectedOutputMetric: CreateTestMetrics(expectedOutputJson),
 	}
 }
 
@@ -392,10 +311,8 @@ func (s metricSignal) CheckOutput(t *testing.T) {
 	select {
 	case <-time.After(time.Second):
 		require.FailNow(t, "failed waiting for logs")
-	case tr := <-s.metricCh:
-		trStr := marshalMetrics(tr)
-		expStr := marshalMetrics(s.expectedOuutputMetric)
-		require.JSONEq(t, expStr, trStr)
+	case actualMetric := <-s.metricCh:
+		CompareMetrics(t, s.expectedOutputMetric, actualMetric)
 	}
 }
 
@@ -427,13 +344,4 @@ func CreateTestMetrics(metricJson string) pmetric.Metrics {
 		panic(err)
 	}
 	return data
-}
-
-func marshalMetrics(metrics pmetric.Metrics) string {
-	marshaler := &pmetric.JSONMarshaler{}
-	data, err := marshaler.MarshalMetrics(metrics)
-	if err != nil {
-		panic(err)
-	}
-	return string(data)
 }

--- a/go.mod
+++ b/go.mod
@@ -109,6 +109,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling v0.87.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension v0.87.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.87.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.87.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.87.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki v0.87.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.87.0


### PR DESCRIPTION
This fixes occurrences of flaky tests such as [this one](https://github.com/grafana/agent/actions/runs/7488444309/job/20382930718?pr=6111#step:4:246) and [this one](https://drone.grafana.net/grafana/agent/15864/5/2). I am also attaching printouts of those two failed tests, in case the links are no longer valid one day:
[flaky_test_1.txt](https://github.com/grafana/agent/files/14027178/flaky_test_1.txt)
[flaky_test_2.txt](https://github.com/grafana/agent/files/14027180/flaky_test_2.txt)
