### PR TITLE
docs: move "Flow by example" folder to top of tutorials list

### DIFF
--- a/docs/sources/flow/tutorials/flow-by-example/_index.md
+++ b/docs/sources/flow/tutorials/flow-by-example/_index.md
@@ -7,7 +7,7 @@ aliases:
 canonical: https://grafana.com/docs/agent/latest/flow/tutorials/flow-by-example/
 description: Learn how to use Grafana Agent Flow
 title: Flow by example
-weight: 300
+weight: 100
 ---
 
 # Flow by example


### PR DESCRIPTION
Previously, "Flow by example" was sandwiched between two non-folder tutorials.

Before and after:

![image](https://github.com/grafana/agent/assets/630212/e8214c7b-d340-4d9e-a42a-08973cbe2617)
![image](https://github.com/grafana/agent/assets/630212/dec014b1-4158-4da4-8539-e3dff09cf842)
