### PR TITLE
Tweak clustering alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Main (unreleased)
   "Prometheus Components" and added charts for `prometheus.scrape` success rate
   and duration metrics. (@thampiotr)
 
+- Removed `ClusterLamportClockDrift` and `ClusterLamportClockStuck` alerts from
+  Grafana Agent Mixin to focus on alerting on symptoms. (@thampiotr)
+
+- Increased clustering alert periods to 10 minutes to improve the
+  signal-to-noise ratio in Grafana Agent Mixin. (@thampiotr)
+
 ### Bugfixes
 
 - Fix an issue in `remote.s3` where the exported content of an object would be an empty string if `remote.s3` failed to fully retrieve

--- a/operations/agent-flow-mixin/alerts/clustering.libsonnet
+++ b/operations/agent-flow-mixin/alerts/clustering.libsonnet
@@ -8,7 +8,7 @@ alert.newGroup(
       'ClusterNotConverging',
       'stddev by (cluster, namespace) (sum without (state) (cluster_node_peers)) != 0',
       'Cluster is not converging.',
-      '5m',
+      '10m',
     ),
 
     // Cluster has entered a split brain state.
@@ -23,15 +23,7 @@ alert.newGroup(
         count by (cluster, namespace) (cluster_node_info)
       |||,
       'Cluster nodes have entered a split brain state.',
-      '5m',
-    ),
-
-    // Standard Deviation of Lamport clock time between nodes is too high.
-    alert.newRule(
-      'ClusterLamportClockDrift',
-      'stddev by (cluster, namespace) (cluster_node_lamport_time) > 4 * sqrt(count by (cluster, namespace) (cluster_node_info))',
-      "Cluster nodes' lamport clocks are not converging.",
-      '5m'
+      '10m',
     ),
 
     // Nodes health score is not zero.
@@ -41,22 +33,7 @@ alert.newGroup(
         cluster_node_gossip_health_score > 0
       |||,
       'Cluster node is reporting a health score > 0.',
-      '5m',
-    ),
-
-    // Lamport clock of a node is not progressing at all.
-    //
-    // This only checks for nodes that have peers other than themselves; nodes
-    // with no external peers will not increase their lamport time because
-    // there is no cluster networking traffic.
-    alert.newRule(
-      'ClusterLamportClockStuck',
-      |||
-        sum by (cluster, namespace, instance) (rate(cluster_node_lamport_time[2m])) == 0
-        and on (cluster, namespace, instance) (cluster_node_peers > 1)
-      |||,
-      "Cluster nodes's lamport clocks is not progressing.",
-      '5m',
+      '10m',
     ),
 
     // Node tried to join the cluster with an already-present node name.
@@ -72,7 +49,7 @@ alert.newGroup(
       'ClusterNodeStuckTerminating',
       'sum by (cluster, namespace, instance) (cluster_node_peers{state="terminating"}) > 0',
       'Cluster node stuck in Terminating state.',
-      '5m',
+      '10m',
     ),
 
     // Nodes are not using the same configuration file.
@@ -84,10 +61,7 @@ alert.newGroup(
         ) > 1
       |||,
       'Cluster nodes are not using the same configuration file.',
-      '5m',
+      '10m',
     ),
-
-    // TODO(@tpaschalis) Alert on open transport streams once we investigate
-    // their behavior.
   ]
 )

--- a/operations/agent-flow-mixin/alerts/clustering.libsonnet
+++ b/operations/agent-flow-mixin/alerts/clustering.libsonnet
@@ -61,7 +61,7 @@ alert.newGroup(
         ) > 1
       |||,
       'Cluster nodes are not using the same configuration file.',
-      '10m',
+      '5m',
     ),
   ]
 )


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

- Removed `ClusterLamportClockDrift` and `ClusterLamportClockStuck` alerts from
  Grafana Agent Mixin to focus on alerting on symptoms.

- Increased clustering alert periods to 10 minutes to improve the
  signal-to-noise ratio in Grafana Agent Mixin.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

Based on internal team discussion.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated