### PR TITLE
Fix wrong Y axis on new chart

### DIFF
--- a/operations/agent-flow-mixin/dashboards/prometheus.libsonnet
+++ b/operations/agent-flow-mixin/dashboards/prometheus.libsonnet
@@ -20,7 +20,7 @@ local scrapePanels(y_offset) = [
   // Scrape success rate
   (
     panel.new(title='Scrape success rate in $cluster', type='timeseries') +
-    panel.withUnit('percent') +
+    panel.withUnit('percentunit') +
     panel.withDescription(|||
       Percentage of targets successfully scraped by prometheus.scrape
       components.
@@ -36,7 +36,7 @@ local scrapePanels(y_offset) = [
     panel.withQueries([
       panel.newQuery(
         expr=|||
-          100 * sum(up{cluster="$cluster"})
+          sum(up{cluster="$cluster"})
           /
           count (up{cluster="$cluster"})
         |||,

--- a/operations/agent-flow-mixin/dashboards/prometheus.libsonnet
+++ b/operations/agent-flow-mixin/dashboards/prometheus.libsonnet
@@ -19,7 +19,7 @@ local scrapePanels(y_offset) = [
 
   // Scrape success rate
   (
-    panel.new(title='Scrape success rate', type='timeseries') +
+    panel.new(title='Scrape success rate in $cluster', type='timeseries') +
     panel.withUnit('percent') +
     panel.withDescription(|||
       Percentage of targets successfully scraped by prometheus.scrape
@@ -36,7 +36,7 @@ local scrapePanels(y_offset) = [
     panel.withQueries([
       panel.newQuery(
         expr=|||
-          sum(up{cluster="$cluster"})
+          100 * sum(up{cluster="$cluster"})
           /
           count (up{cluster="$cluster"})
         |||,
@@ -47,7 +47,7 @@ local scrapePanels(y_offset) = [
 
   // Scrape duration
   (
-    panel.new(title='Scrape duration', type='timeseries') +
+    panel.new(title='Scrape duration in $cluster', type='timeseries') +
     panel.withUnit('s') +
     panel.withDescription(|||
       Duration of successful scrapes by prometheus.scrape components,


### PR DESCRIPTION
This is an unreleased feature, so no need to update the changelog. 
* The % Y axis used a fraction not multiplied by 100.
* Added the `in <cluster>` to make it a bit more clear how the chart doesn't take into account other dash template variables from drop-downs.

![image](https://github.com/grafana/agent/assets/17101802/cf9e6036-2209-4638-a02b-78dc60e40bea)
