### PR TITLE
Change the default value of disable_high_cardinality_metrics to "true".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Main (unreleased)
 
 - Prohibit the configuration of services within modules. (@wildum)
 
+- For `otelcol.exporter` components, change the default value of `disable_high_cardinality_metrics` to `true`. (@ptodev)
+
 ### Features
 
 - A new `discovery.process` component for discovering Linux OS processes on the current host. (@korniltsev)

--- a/component/otelcol/config_debug_metrics.go
+++ b/component/otelcol/config_debug_metrics.go
@@ -7,7 +7,7 @@ type DebugMetricsArguments struct {
 
 // DefaultDebugMetricsArguments holds default settings for DebugMetricsArguments.
 var DefaultDebugMetricsArguments = DebugMetricsArguments{
-	DisableHighCardinalityMetrics: false,
+	DisableHighCardinalityMetrics: true,
 }
 
 // SetToDefault implements river.Defaulter.

--- a/component/otelcol/exporter/loadbalancing/loadbalancing.go
+++ b/component/otelcol/exporter/loadbalancing/loadbalancing.go
@@ -59,7 +59,8 @@ var (
 		Protocol: Protocol{
 			OTLP: DefaultOTLPConfig,
 		},
-		RoutingKey: "traceID",
+		RoutingKey:   "traceID",
+		DebugMetrics: otelcol.DefaultDebugMetricsArguments,
 	}
 
 	DefaultOTLPConfig = OtlpConfig{

--- a/component/otelcol/exporter/logging/logging.go
+++ b/component/otelcol/exporter/logging/logging.go
@@ -41,6 +41,7 @@ var DefaultArguments = Arguments{
 	Verbosity:          configtelemetry.LevelNormal,
 	SamplingInitial:    2,
 	SamplingThereafter: 500,
+	DebugMetrics:       otelcol.DefaultDebugMetricsArguments,
 }
 
 // SetToDefault implements river.Defaulter.

--- a/component/otelcol/exporter/otlp/otlp.go
+++ b/component/otelcol/exporter/otlp/otlp.go
@@ -43,10 +43,11 @@ var _ exporter.Arguments = Arguments{}
 
 // DefaultArguments holds default values for Arguments.
 var DefaultArguments = Arguments{
-	Timeout: otelcol.DefaultTimeout,
-	Queue:   otelcol.DefaultQueueArguments,
-	Retry:   otelcol.DefaultRetryArguments,
-	Client:  DefaultGRPCClientArguments,
+	Timeout:      otelcol.DefaultTimeout,
+	Queue:        otelcol.DefaultQueueArguments,
+	Retry:        otelcol.DefaultRetryArguments,
+	Client:       DefaultGRPCClientArguments,
+	DebugMetrics: otelcol.DefaultDebugMetricsArguments,
 }
 
 // SetToDefault implements river.Defaulter.

--- a/component/otelcol/exporter/otlphttp/otlphttp.go
+++ b/component/otelcol/exporter/otlphttp/otlphttp.go
@@ -48,9 +48,10 @@ var _ exporter.Arguments = Arguments{}
 
 // DefaultArguments holds default values for Arguments.
 var DefaultArguments = Arguments{
-	Queue:  otelcol.DefaultQueueArguments,
-	Retry:  otelcol.DefaultRetryArguments,
-	Client: DefaultHTTPClientArguments,
+	Queue:        otelcol.DefaultQueueArguments,
+	Retry:        otelcol.DefaultRetryArguments,
+	Client:       DefaultHTTPClientArguments,
+	DebugMetrics: otelcol.DefaultDebugMetricsArguments,
 }
 
 // SetToDefault implements river.Defaulter.

--- a/component/otelcol/exporter/otlphttp/otlphttp_test.go
+++ b/component/otelcol/exporter/otlphttp/otlphttp_test.go
@@ -114,3 +114,62 @@ func createTestTraces() ptrace.Traces {
 	}
 	return data
 }
+
+func TestDebugMetricsConfig(t *testing.T) {
+	tests := []struct {
+		testName string
+		agentCfg string
+		expected otelcol.DebugMetricsArguments
+	}{
+		{
+			testName: "default",
+			agentCfg: `
+			client {
+				endpoint = "http://tempo:4317"
+			}
+			`,
+			expected: otelcol.DebugMetricsArguments{
+				DisableHighCardinalityMetrics: true,
+			},
+		},
+		{
+			testName: "explicit_false",
+			agentCfg: `
+			client {
+				endpoint = "http://tempo:4317"
+			}
+			debug_metrics {
+				disable_high_cardinality_metrics = false
+			}
+			`,
+			expected: otelcol.DebugMetricsArguments{
+				DisableHighCardinalityMetrics: false,
+			},
+		},
+		{
+			testName: "explicit_true",
+			agentCfg: `
+			client {
+				endpoint = "http://tempo:4317"
+			}
+			debug_metrics {
+				disable_high_cardinality_metrics = true
+			}
+			`,
+			expected: otelcol.DebugMetricsArguments{
+				DisableHighCardinalityMetrics: true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			var args otlphttp.Arguments
+			require.NoError(t, river.Unmarshal([]byte(tc.agentCfg), &args))
+			_, err := args.Convert()
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected, args.DebugMetricsConfig())
+		})
+	}
+}

--- a/docs/sources/flow/release-notes.md
+++ b/docs/sources/flow/release-notes.md
@@ -36,6 +36,11 @@ Other release notes for the different {{< param "PRODUCT_ROOT_NAME" >}} variants
 Previously it was possible to configure the HTTP service via the [HTTP config block](https://grafana.com/docs/agent/v0.39/flow/reference/config-blocks/http/) inside of a module.
 This functionality is now only available in the main configuration.
 
+### Breaking change: Change the default value of `disable_high_cardinality_metrics` to `true`.
+
+The `disable_high_cardinality_metrics` configuration argument is used by `otelcol.exporter` components such as `otelcol.exporter.otlp`.
+If you need to see high cardinality metrics containing labels such as IP addresses and port numbers, you now have to explicitly set `disable_high_cardinality_metrics` to `false`.
+
 ## v0.39
 
 ### Breaking change: `otelcol.receiver.prometheus` will drop all `otel_scope_info` metrics when converting them to OTLP

--- a/docs/sources/shared/flow/reference/components/otelcol-debug-metrics-block.md
+++ b/docs/sources/shared/flow/reference/components/otelcol-debug-metrics-block.md
@@ -16,7 +16,7 @@ The following arguments are supported:
 
 Name                               | Type      | Description                                          | Default | Required
 -----------------------------------|-----------|------------------------------------------------------|---------|---------
-`disable_high_cardinality_metrics` | `boolean` | Whether to disable certain high cardinality metrics. | `false` | no
+`disable_high_cardinality_metrics` | `boolean` | Whether to disable certain high cardinality metrics. | `true`  | no
 
 `disable_high_cardinality_metrics` is the Grafana Agent equivalent to the `telemetry.disableHighCardinalityMetrics` feature gate in the OpenTelemetry Collector.
 It removes attributes that could cause high cardinality metrics.


### PR DESCRIPTION
In #4769, I suggested that `disable_high_cardinality_metrics` default to `false` for a few reasons:

- Agent Flow was already showing high cardinality metrics, and removing them would have been a breaking change.
- OTel Collector enables these high cardinality metrics by default.

Unfortunately, it seems that those high cardinality metrics seem to really cause an understandable inconvenience for users. In the spirit of providing good defaults, it'd be best to exclude such metrics by default.

This will also simplify Static mode -> Flow converters, because high cardinality metrics are already disabled by default in Static mode.

I suspect that one day OTel Collector will have to also exclude these metrics by default. At the moment it's not a huge issue for the Collector, because you'd have to have a `telemetry.useOtelForInternalMetrics` feature gate enabled first.

cc @glindstedt