### PR TITLE
Add an error diag to the converter from static to flow when `scrape_i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ Main (unreleased)
 - Fix an issue where blocks having the same type and the same label across
   modules could result in missed updates. (@thampiotr)
 
+- Add an error diag to the converter from static to flow when `scrape_integration` is set
+  to true but no remote_write is defined. (@erikbaranowski)
+
 ### Other changes
 
 - Removed support for Windows 2012 in line with Microsoft end of life. (@mattdurham)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,8 @@ Main (unreleased)
 - Fix an issue where blocks having the same type and the same label across
   modules could result in missed updates. (@thampiotr)
 
-- Add an error diag to the converter from static to flow when `scrape_integration` is set
-  to true but no remote_write is defined. (@erikbaranowski)
+- An error will be returned in the converter from Static to Flow when `scrape_integration` is set
+  to `true` but no `remote_write` is defined. (@erikbaranowski)
 
 ### Other changes
 

--- a/converter/internal/staticconvert/internal/build/builder.go
+++ b/converter/internal/staticconvert/internal/build/builder.go
@@ -205,7 +205,7 @@ func (b *IntegrationsConfigBuilder) appendExporter(commonConfig *int_config.Comm
 	}
 
 	if len(b.cfg.Integrations.ConfigV1.PrometheusRemoteWrite) == 0 {
-		b.diags.Add(diag.SeverityLevelError, "The converter does not support handling integrations with are not connected to a remote_write.")
+		b.diags.Add(diag.SeverityLevelError, "The converter does not support handling integrations which are not connected to a remote_write.")
 	}
 
 	jobNameToCompLabelsFunc := func(jobName string) string {

--- a/converter/internal/staticconvert/internal/build/builder.go
+++ b/converter/internal/staticconvert/internal/build/builder.go
@@ -204,6 +204,10 @@ func (b *IntegrationsConfigBuilder) appendExporter(commonConfig *int_config.Comm
 		RemoteWriteConfigs: b.cfg.Integrations.ConfigV1.PrometheusRemoteWrite,
 	}
 
+	if len(b.cfg.Integrations.ConfigV1.PrometheusRemoteWrite) == 0 {
+		b.diags.Add(diag.SeverityLevelError, "The converter does not support handling integrations with are not connected to a remote_write.")
+	}
+
 	jobNameToCompLabelsFunc := func(jobName string) string {
 		return b.jobNameToCompLabel(jobName)
 	}

--- a/converter/internal/staticconvert/testdata/integrations_no_rw.diags
+++ b/converter/internal/staticconvert/testdata/integrations_no_rw.diags
@@ -1,0 +1,2 @@
+(Error) The converter does not support handling integrations with are not connected to a remote_write.
+(Warning) Please review your agent command line flags and ensure they are set in your Flow mode config file where necessary.

--- a/converter/internal/staticconvert/testdata/integrations_no_rw.diags
+++ b/converter/internal/staticconvert/testdata/integrations_no_rw.diags
@@ -1,2 +1,2 @@
-(Error) The converter does not support handling integrations with are not connected to a remote_write.
+(Error) The converter does not support handling integrations which are not connected to a remote_write.
 (Warning) Please review your agent command line flags and ensure they are set in your Flow mode config file where necessary.

--- a/converter/internal/staticconvert/testdata/integrations_no_rw.yaml
+++ b/converter/internal/staticconvert/testdata/integrations_no_rw.yaml
@@ -1,0 +1,4 @@
+integrations:
+  node_exporter:
+    scrape_integration: true
+    enabled: true


### PR DESCRIPTION
…ntegration` is set to true but no remote_write is defined.

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [x] Config converters updated