### PR TITLE
Introduce remotecfg service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Main (unreleased)
 
 - Expose track_timestamps_staleness on Prometheus scraping, to fix the issue where container metrics live for 5 minutes after the container disappears. (@ptodev)
 
+- Introduce the `remotecfg` service that enables loading configuration from a
+  remote endpoint. (@tpaschalis) 
+  
 ### Enhancements
 
 - Include line numbers in profiles produced by `pyrsocope.java` component. (@korniltsev)

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -33,6 +33,7 @@ import (
 	httpservice "github.com/grafana/agent/service/http"
 	"github.com/grafana/agent/service/labelstore"
 	otel_service "github.com/grafana/agent/service/otel"
+	remotecfgservice "github.com/grafana/agent/service/remotecfg"
 	uiservice "github.com/grafana/agent/service/ui"
 	"github.com/grafana/ckit/advertise"
 	"github.com/grafana/ckit/peer"
@@ -243,6 +244,14 @@ func (fr *flowRun) Run(configPath string) error {
 		EnablePProf:      fr.enablePprof,
 	})
 
+	remoteCfgService, err := remotecfgservice.New(remotecfgservice.Options{
+		Logger:      log.With(l, "service", "remotecfg"),
+		StoragePath: fr.storagePath,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create the remotecfg service: %w", err)
+	}
+
 	uiService := uiservice.New(uiservice.Options{
 		UIPrefix: fr.uiPrefix,
 		Cluster:  clusterService.Data().(cluster.Cluster),
@@ -267,6 +276,7 @@ func (fr *flowRun) Run(configPath string) error {
 			clusterService,
 			otelService,
 			labelService,
+			remoteCfgService,
 		},
 	})
 

--- a/docs/sources/flow/reference/config-blocks/remotecfg.md
+++ b/docs/sources/flow/reference/config-blocks/remotecfg.md
@@ -13,7 +13,7 @@ title: remotecfg block
 # remotecfg block
 
 `remotecfg` is an optional configuration block that enables {{< param "PRODUCT_NAME" >}}
-to fetch and load configuration from a remote endpoint.
+to fetch and load the configuration from a remote endpoint.
 `remotecfg` is specified without a label and can only be provided once per
 configuration file.
 
@@ -44,13 +44,13 @@ The following arguments are supported:
 
 Name             | Type                 | Description                                      | Default     | Required
 -----------------|----------------------|--------------------------------------------------|-------------|---------
-`url`            | `string`             | The address of the API to poll for configuration | `""`        | no
-`id`             | `string`             | A self-reported ID                               | `see below` | no
-`metadata`       | `map(string)`        | A set of self-reported metadata                  | `{}`        | no
-`poll_frequency` | `duration`           | How often to poll the API for new configuration  | `"1m"`      | no
+`url`            | `string`             | The address of the API to poll for configuration. | `""`        | no
+`id`             | `string`             | A self-reported ID.                               | `see below` | no
+`metadata`       | `map(string)`        | A set of self-reported metadata.                  | `{}`        | no
+`poll_frequency` | `duration`           | How often to poll the API for new configuration.  | `"1m"`      | no
 
-If not set, the self-reported `id` that the Agent uses is a randomly generated,
-anonymous unique ID (UUID) that is stored on the Agent's storage path as
+If not set, the self-reported `id` that {{< param "PRODUCT_ROOT_NAME" >}} uses is a randomly generated,
+anonymous unique ID (UUID) that is stored in {{< param "PRODUCT_ROOT_NAME" >}}'s storage path as
 `agent_seed.json` so that it can persist across restarts.
 
 ## Blocks

--- a/docs/sources/flow/reference/config-blocks/remotecfg.md
+++ b/docs/sources/flow/reference/config-blocks/remotecfg.md
@@ -28,8 +28,8 @@ The [API definition][] for managing and fetching configuration that the
 remotecfg {
 	url = "SERVICE_URL"
 	basic_auth {
-		username      = USERNAME
-		password_file = PASSWORD_FILE
+		username      = "USERNAME"
+		password_file = "PASSWORD_FILE"
 	}
 
 	id             = constants.hostname
@@ -42,8 +42,8 @@ remotecfg {
 
 The following arguments are supported:
 
-Name             | Type                 | Description                                      | Default     | Required
------------------|----------------------|--------------------------------------------------|-------------|---------
+Name             | Type                 | Description                                       | Default     | Required
+-----------------|----------------------|---------------------------------------------------|-------------|---------
 `url`            | `string`             | The address of the API to poll for configuration. | `""`        | no
 `id`             | `string`             | A self-reported ID.                               | `see below` | no
 `metadata`       | `map(string)`        | A set of self-reported metadata.                  | `{}`        | no
@@ -54,6 +54,9 @@ If the `url` is not set, then the service block is a no-op.
 If not set, the self-reported `id` that the Agent uses is a randomly generated,
 anonymous unique ID (UUID) that is stored as an `agent_seed.json` file in the
 Agent's storage path so that it can persist across restarts.
+
+The `id` and `metadata` fields are used in the periodic request sent to the
+remote endpoint so that the API can decide what configuration to serve.
 
 ## Blocks
 

--- a/docs/sources/flow/reference/config-blocks/remotecfg.md
+++ b/docs/sources/flow/reference/config-blocks/remotecfg.md
@@ -33,8 +33,8 @@ remotecfg {
 	}
 
 	id             = constants.hostname
-	metadata       = {"cluster" = "dev-us-central-0", "namespace" = "agent-otlp"}
-	poll_frequency = "10m"
+	metadata       = {"cluster" = "dev", "namespace" = "otlp-dev"}
+	poll_frequency = "5m"
 }
 ```
 
@@ -49,9 +49,11 @@ Name             | Type                 | Description                           
 `metadata`       | `map(string)`        | A set of self-reported metadata.                  | `{}`        | no
 `poll_frequency` | `duration`           | How often to poll the API for new configuration.  | `"1m"`      | no
 
-If not set, the self-reported `id` that {{< param "PRODUCT_ROOT_NAME" >}} uses is a randomly generated,
-anonymous unique ID (UUID) that is stored in {{< param "PRODUCT_ROOT_NAME" >}}'s storage path as
-`agent_seed.json` so that it can persist across restarts.
+If the `url` is not set, then the service block is a no-op.
+
+If not set, the self-reported `id` that the Agent uses is a randomly generated,
+anonymous unique ID (UUID) that is stored as an `agent_seed.json` file in the
+Agent's storage path so that it can persist across restarts.
 
 ## Blocks
 

--- a/docs/sources/flow/reference/config-blocks/remotecfg.md
+++ b/docs/sources/flow/reference/config-blocks/remotecfg.md
@@ -47,7 +47,7 @@ Name             | Type                 | Description                           
 `url`            | `string`             | The address of the API to poll for configuration | `""`        | no
 `id`             | `string`             | A self-reported ID                               | `see below` | no
 `metadata`       | `map(string)`        | A set of self-reported metadata                  | `{}`        | no
-`poll_frequency` | `duration`           | How often to poll the API for new configuration  | `"1m"       | no
+`poll_frequency` | `duration`           | How often to poll the API for new configuration  | `"1m"`      | no
 
 If not set, the self-reported `id` that the Agent uses is a randomly generated,
 anonymous unique ID (UUID) that is stored on the Agent's storage path as

--- a/docs/sources/flow/reference/config-blocks/remotecfg.md
+++ b/docs/sources/flow/reference/config-blocks/remotecfg.md
@@ -1,0 +1,92 @@
+---
+aliases:
+- /docs/grafana-cloud/agent/flow/reference/config-blocks/remotecfg/
+- /docs/grafana-cloud/monitor-infrastructure/agent/flow/reference/config-blocks/remotecfg/
+- /docs/grafana-cloud/monitor-infrastructure/integrations/agent/flow/reference/config-blocks/remotecfg/
+- /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/remotecfg/
+canonical: remotecfgs://grafana.com/docs/agent/latest/flow/reference/config-blocks/remotecfg/
+description: Learn about the remotecfg configuration block
+menuTitle: remotecfg
+title: remotecfg block
+---
+
+# remotecfg block
+
+`remotecfg` is an optional configuration block that enables {{< param "PRODUCT_NAME" >}}
+to fetch and load configuration from a remote endpoint.
+`remotecfg` is specified without a label and can only be provided once per
+configuration file.
+
+The [API definition][] for managing and fetching configuration that the
+`remotecfg` block uses is available under the Apache 2.0 license.
+
+[API definition]: https://github.com/grafana/agent-remote-config
+
+## Example
+
+```river
+remotecfg {
+	url = "SERVICE_URL"
+	basic_auth {
+		username      = USERNAME
+		password_file = PASSWORD_FILE
+	}
+
+	id             = constants.hostname
+	metadata       = {"cluster" = "dev-us-central-0", "namespace" = "agent-otlp"}
+	poll_frequency = "10m"
+}
+```
+
+## Arguments
+
+The following arguments are supported:
+
+Name             | Type                 | Description                                      | Default     | Required
+-----------------|----------------------|--------------------------------------------------|-------------|---------
+`url`            | `string`             | The address of the API to poll for configuration | `""`        | no
+`id`             | `string`             | A self-reported ID                               | `see below` | no
+`metadata`       | `map(string)`        | A set of self-reported metadata                  | `{}`        | no
+`poll_frequency` | `duration`           | How often to poll the API for new configuration  | `"1m"       | no
+
+If not set, the self-reported `id` that the Agent uses is a randomly generated,
+anonymous unique ID (UUID) that is stored on the Agent's storage path as
+`agent_seed.json` so that it can persist across restarts.
+
+## Blocks
+
+The following blocks are supported inside the definition of `remotecfg`:
+
+Hierarchy | Block | Description | Required
+--------- | ----- | ----------- | --------
+basic_auth | [basic_auth][] | Configure basic_auth for authenticating to the endpoint. | no
+authorization | [authorization][] | Configure generic authorization to the endpoint. | no
+oauth2 | [oauth2][] | Configure OAuth2 for authenticating to the endpoint. | no
+oauth2 > tls_config | [tls_config][] | Configure TLS settings for connecting to the endpoint. | no
+tls_config | [tls_config][] | Configure TLS settings for connecting to the endpoint. | no
+
+The `>` symbol indicates deeper levels of nesting. For example,
+`oauth2 > tls_config` refers to a `tls_config` block defined inside
+an `oauth2` block.
+
+[basic_auth]: #basic_auth-block
+[authorization]: #authorization-block
+[oauth2]: #oauth2-block
+[tls_config]: #tls_config-block
+
+### basic_auth block
+
+{{< docs/shared lookup="flow/reference/components/basic-auth-block.md" source="agent" version="<AGENT_VERSION>" >}}
+
+### authorization block
+
+{{< docs/shared lookup="flow/reference/components/authorization-block.md" source="agent" version="<AGENT_VERSION>" >}}
+
+### oauth2 block
+
+{{< docs/shared lookup="flow/reference/components/oauth2-block.md" source="agent" version="<AGENT_VERSION>" >}}
+
+### tls_config block
+
+{{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT_VERSION>" >}}
+

--- a/go.mod
+++ b/go.mod
@@ -608,6 +608,7 @@ require github.com/ianlancetaylor/demangle v0.0.0-20230524184225-eabc099b10ab
 require (
 	connectrpc.com/connect v1.14.0
 	github.com/githubexporter/github-exporter v0.0.0-20231025122338-656e7dc33fe7
+	github.com/grafana/agent-remote-config v0.0.2
 	github.com/grafana/jfr-parser/pprof v0.0.0-20240126072739-986e71dc0361
 	github.com/natefinch/atomic v1.0.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.87.0

--- a/go.sum
+++ b/go.sum
@@ -1044,6 +1044,8 @@ github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/gosnmp/gosnmp v1.36.0 h1:1Si+MImHcKIqFc3/kJEs2LOULP1nlFKlzPFyrMOk5Qk=
 github.com/gosnmp/gosnmp v1.36.0/go.mod h1:iLcZxN2MxKhH0jPQDVMZaSNypw1ykqVi27O79koQj6w=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
+github.com/grafana/agent-remote-config v0.0.2 h1:s3FKgVzfY5Ij+xG0wVKgVvtDrh/Bz0ZvB3D5MM7LJxU=
+github.com/grafana/agent-remote-config v0.0.2/go.mod h1:amyG3pVNXKcMo+kNN46yhnAXAz/m/9Ew9MRf53n7XBg=
 github.com/grafana/cadvisor v0.0.0-20231110094609-5f7917925dea h1:Q5f5/nJJ0SbusZjA6F6XkJuHDbl2/PqdTGw6wHsuccA=
 github.com/grafana/cadvisor v0.0.0-20231110094609-5f7917925dea/go.mod h1:XjiOCFjmxXIWwauV5p39Mr2Yxlpyk72uKQH1UZvd4fQ=
 github.com/grafana/ckit v0.0.0-20230906125525-c046c99a5c04 h1:tG8Qxq4dN1WqakMmsPaxaH4+OQhYg5HVsarw5acLBX8=

--- a/pkg/flow/flow_services.go
+++ b/pkg/flow/flow_services.go
@@ -3,6 +3,7 @@ package flow
 import (
 	"github.com/grafana/agent/pkg/flow/internal/controller"
 	"github.com/grafana/agent/pkg/flow/internal/dag"
+	"github.com/grafana/agent/pkg/flow/internal/worker"
 	"github.com/grafana/agent/service"
 )
 
@@ -51,4 +52,23 @@ func serviceConsumersForGraph(graph *dag.Graph, serviceName string, includePeerS
 	}
 
 	return consumers
+}
+
+// NewController returns a new, unstarted, isolated Flow controller so that
+// services can instantiate their own components.
+func (f *Flow) NewController(id string) service.Controller {
+	return newController(controllerOptions{
+		Options: Options{
+			ControllerID:    id,
+			Logger:          f.opts.Logger,
+			Tracer:          f.opts.Tracer,
+			DataPath:        f.opts.DataPath,
+			Reg:             f.opts.Reg,
+			OnExportsChange: f.opts.OnExportsChange,
+			Services:        f.opts.Services,
+		},
+		IsModule:       true,
+		ModuleRegistry: newModuleRegistry(),
+		WorkerPool:     worker.NewDefaultWorkerPool(),
+	})
 }

--- a/pkg/flow/flow_services.go
+++ b/pkg/flow/flow_services.go
@@ -82,7 +82,11 @@ type serviceController struct {
 }
 
 func (sc serviceController) Run(ctx context.Context) { sc.f.Run(ctx) }
-func (sc serviceController) LoadSource(source any, args map[string]any) error {
-	return sc.f.LoadSource(source.(*Source), args)
+func (sc serviceController) LoadSource(b []byte, args map[string]any) error {
+	source, err := ParseSource("", b)
+	if err != nil {
+		return err
+	}
+	return sc.f.LoadSource(source, args)
 }
 func (sc serviceController) Ready() bool { return sc.f.Ready() }

--- a/pkg/flow/flow_services.go
+++ b/pkg/flow/flow_services.go
@@ -67,8 +67,8 @@ func (f *Flow) NewController(id string) service.Controller {
 				Tracer:          f.opts.Tracer,
 				DataPath:        f.opts.DataPath,
 				Reg:             f.opts.Reg,
-				OnExportsChange: f.opts.OnExportsChange,
 				Services:        f.opts.Services,
+				OnExportsChange: nil, // NOTE(@tpaschalis, @wildum) The isolated controller shouldn't be able to export any values.
 			},
 			IsModule:       true,
 			ModuleRegistry: newModuleRegistry(),

--- a/service/http/http_test.go
+++ b/service/http/http_test.go
@@ -215,3 +215,5 @@ func (fakeHost) ListComponents(moduleID string, opts component.InfoOptions) ([]*
 }
 
 func (fakeHost) GetServiceConsumers(serviceName string) []service.Consumer { return nil }
+
+func (fakeHost) NewController(id string) service.Controller { return nil }

--- a/service/remotecfg/noop.go
+++ b/service/remotecfg/noop.go
@@ -1,0 +1,41 @@
+package remotecfg
+
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+	agentv1 "github.com/grafana/agent-remote-config/api/gen/proto/go/agent/v1"
+)
+
+type noopClient struct{}
+
+// GetConfig returns the agent's configuration.
+func (c noopClient) GetConfig(context.Context, *connect.Request[agentv1.GetConfigRequest]) (*connect.Response[agentv1.GetConfigResponse], error) {
+	return nil, errors.New("noop client")
+}
+
+// GetAgent returns information about the agent.
+func (c noopClient) GetAgent(context.Context, *connect.Request[agentv1.GetAgentRequest]) (*connect.Response[agentv1.Agent], error) {
+	return nil, errors.New("noop client")
+}
+
+// ListAgents returns information about all agents.
+func (c noopClient) ListAgents(context.Context, *connect.Request[agentv1.ListAgentsRequest]) (*connect.Response[agentv1.Agents], error) {
+	return nil, errors.New("noop client")
+}
+
+// CreateAgent registers a new agent.
+func (c noopClient) CreateAgent(context.Context, *connect.Request[agentv1.CreateAgentRequest]) (*connect.Response[agentv1.Agent], error) {
+	return nil, errors.New("noop client")
+}
+
+// UpdateAgent updates an existing agent.
+func (c noopClient) UpdateAgent(context.Context, *connect.Request[agentv1.UpdateAgentRequest]) (*connect.Response[agentv1.Agent], error) {
+	return nil, errors.New("noop client")
+}
+
+// DeleteAgent deletes an existing agent.
+func (c noopClient) DeleteAgent(context.Context, *connect.Request[agentv1.DeleteAgentRequest]) (*connect.Response[agentv1.DeleteAgentResponse], error) {
+	return nil, errors.New("noop client")
+}

--- a/service/remotecfg/remotecfg.go
+++ b/service/remotecfg/remotecfg.go
@@ -1,0 +1,139 @@
+package remotecfg
+
+import (
+	"context"
+	"fmt"
+	"hash"
+	"hash/fnv"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/agent/component/common/config"
+	"github.com/grafana/agent/internal/agentseed"
+	"github.com/grafana/agent/service"
+)
+
+var fnvHash hash.Hash32 = fnv.New32()
+
+func getHash(in string) string {
+	fnvHash.Write([]byte(in))
+	defer fnvHash.Reset()
+
+	return fmt.Sprintf("%x", fnvHash.Sum(nil))
+}
+
+// Service implements a service for remote configuration.
+type Service struct {
+	opts Options
+	args Arguments
+
+	ctrl service.Controller
+}
+
+// ServiceName defines the name used for the remotecfg service.
+const ServiceName = "remotecfg"
+
+// Options are used to configure the remotecfg service. Options are
+// constant for the lifetime of the remotecfg service.
+type Options struct {
+	Logger      log.Logger // Where to send logs.
+	StoragePath string     // Where to cache configuration on-disk.
+}
+
+// Arguments holds runtime settings for the remotecfg service.
+type Arguments struct {
+	URL              string                   `river:"url,attr,optional"`
+	ID               string                   `river:"id,attr,optional"`
+	Metadata         map[string]string        `river:"metadata,attr,optional"`
+	PollFrequency    time.Duration            `river:"poll_frequency,attr,optional"`
+	HTTPClientConfig *config.HTTPClientConfig `river:",squash"`
+}
+
+// GetDefaultArguments populates the default values for the Arguments struct.
+func GetDefaultArguments() Arguments {
+	return Arguments{
+		ID:               agentseed.Get().UID,
+		Metadata:         make(map[string]string),
+		PollFrequency:    1 * time.Minute,
+		HTTPClientConfig: config.CloneDefaultHTTPClientConfig(),
+	}
+}
+
+// SetToDefault implements river.Defaulter.
+func (a *Arguments) SetToDefault() {
+	*a = GetDefaultArguments()
+}
+
+// Validate implements river.Validator.
+func (a *Arguments) Validate() error {
+	// We must explicitly Validate because HTTPClientConfig is squashed and it
+	// won't run otherwise
+	if a.HTTPClientConfig != nil {
+		return a.HTTPClientConfig.Validate()
+	}
+
+	return nil
+}
+
+// Data includes information associated with the remotecfg service.
+type Data struct {
+}
+
+// New returns a new instance of the remotecfg service.
+func New(opts Options) (*Service, error) {
+	basePath := filepath.Join(opts.StoragePath, ServiceName)
+	err := os.MkdirAll(basePath, 0750)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Service{
+		opts: opts,
+	}, nil
+}
+
+// Data returns an instance of [Data]. Calls to Data are cachable by the
+// caller.
+//
+// Data must only be called after parsing command-line flags.
+func (s *Service) Data() any {
+	return map[string]string{}
+}
+
+// Definition returns the definition of the remotecfg service.
+func (s *Service) Definition() service.Definition {
+	return service.Definition{
+		Name:       ServiceName,
+		ConfigType: Arguments{},
+		DependsOn:  nil, // remotecfg has no dependencies.
+	}
+}
+
+var _ service.Service = (*Service)(nil)
+
+// Run implements [service.Service] and starts the remotecfg service. It will
+// run until the provided context is canceled or there is a fatal error.
+func (s *Service) Run(ctx context.Context, host service.Host) error {
+	s.ctrl = host.NewController(ServiceName)
+
+	go func() {
+		s.ctrl.Run(ctx)
+	}()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+	}
+}
+
+// Update implements [service.Service] and applies settings.
+func (s *Service) Update(newConfig any) error {
+	newArgs := newConfig.(Arguments)
+	s.args = newArgs
+
+	return nil
+}

--- a/service/remotecfg/remotecfg.go
+++ b/service/remotecfg/remotecfg.go
@@ -248,7 +248,7 @@ func (s *Service) fetch() {
 	}
 
 	err = s.parseAndLoad(b1)
-	if err != nil {
+	if err != nil && err2 != nil {
 		err = s.parseAndLoad(b2)
 	}
 

--- a/service/remotecfg/remotecfg.go
+++ b/service/remotecfg/remotecfg.go
@@ -272,7 +272,6 @@ func (s *Service) parseAndLoad(b []byte) error {
 
 	s.setCfgHash(getHash(b))
 	return nil
-
 }
 
 func (s *Service) getCfgHash() string {

--- a/service/remotecfg/remotecfg.go
+++ b/service/remotecfg/remotecfg.go
@@ -105,8 +105,9 @@ func New(opts Options) (*Service, error) {
 	}
 
 	return &Service{
-		opts:   opts,
-		ticker: time.NewTicker(math.MaxInt64),
+		opts:     opts,
+		asClient: noopClient{},
+		ticker:   time.NewTicker(math.MaxInt64),
 	}, nil
 }
 
@@ -257,8 +258,8 @@ func (s *Service) Update(newConfig any) error {
 		s.mut.Lock()
 		defer s.mut.Unlock()
 		s.ticker.Reset(math.MaxInt64)
-		s.asClient = nil
-		s.args.HTTPClientConfig = nil
+		s.asClient = noopClient{}
+		s.args.HTTPClientConfig = config.CloneDefaultHTTPClientConfig()
 		s.currentConfigHash = ""
 		return nil
 	}

--- a/service/remotecfg/remotecfg.go
+++ b/service/remotecfg/remotecfg.go
@@ -15,12 +15,12 @@ import (
 	"connectrpc.com/connect"
 	"github.com/go-kit/log"
 	agentv1 "github.com/grafana/agent-remote-config/api/gen/proto/go/agent/v1"
+	"github.com/grafana/agent-remote-config/api/gen/proto/go/agent/v1/agentv1connect"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/internal/agentseed"
 	"github.com/grafana/agent/pkg/flow"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/grafana/agent/service"
-	"github.com/grafana/agentre-remote-config/api/gen/proto/go/agent/v1/agentv1connect"
 	commonconfig "github.com/prometheus/common/config"
 )
 

--- a/service/remotecfg/remotecfg.go
+++ b/service/remotecfg/remotecfg.go
@@ -248,7 +248,7 @@ func (s *Service) fetch() {
 	}
 
 	err = s.parseAndLoad(b1)
-	if err != nil && err2 != nil {
+	if err != nil && err2 == nil {
 		err = s.parseAndLoad(b2)
 	}
 

--- a/service/remotecfg/remotecfg.go
+++ b/service/remotecfg/remotecfg.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/agent-remote-config/api/gen/proto/go/agent/v1/agentv1connect"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/internal/agentseed"
-	"github.com/grafana/agent/pkg/flow"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/grafana/agent/service"
 	"github.com/grafana/river"
@@ -290,12 +289,8 @@ func (s *Service) parseAndLoad(b []byte) error {
 	if len(b) == 0 {
 		return nil
 	}
-	src, err := flow.ParseSource(ServiceName, b)
-	if err != nil {
-		return err
-	}
 
-	err = ctrl.LoadSource(src, nil)
+	err := ctrl.LoadSource(b, nil)
 	if err != nil {
 		return err
 	}

--- a/service/remotecfg/remotecfg.go
+++ b/service/remotecfg/remotecfg.go
@@ -172,6 +172,8 @@ func (s *Service) Update(newConfig any) error {
 		s.asClient = noopClient{}
 		s.args.HTTPClientConfig = config.CloneDefaultHTTPClientConfig()
 		s.mut.Unlock()
+
+		s.setCfgHash("")
 		return nil
 	}
 

--- a/service/remotecfg/remotecfg.go
+++ b/service/remotecfg/remotecfg.go
@@ -145,7 +145,9 @@ var _ service.Service = (*Service)(nil)
 func (s *Service) Run(ctx context.Context, host service.Host) error {
 	s.ctrl = host.NewController(ServiceName)
 
-	// TODO(@tpaschalis) Fix synchronization issue between Run and Update.
+	// TODO(@tpaschalis) This call to Update makes sure that initialFetch is
+	// ran _after_ the new controller has been spawned, which is not the case
+	// during the initial call.
 	s.Update(s.args)
 
 	// Run the service's own controller.
@@ -231,7 +233,7 @@ func (s *Service) Update(newConfig any) error {
 
 	// If we've already called Run, then immediately trigger an API call with
 	// the updated Arguments, and/or fall back to the updated cache location.
-	if s.ctrl != nil {
+	if s.ctrl != nil && s.ctrl.Ready() {
 		s.initialFetch()
 	}
 

--- a/service/remotecfg/remotecfg.go
+++ b/service/remotecfg/remotecfg.go
@@ -281,7 +281,7 @@ func (s *Service) getCachedConfig() ([]byte, error) {
 	return os.ReadFile(p)
 }
 
-func (s *Service) setCachedConfig(b []byte) error {
+func (s *Service) setCachedConfig(b []byte) {
 	s.mut.RLock()
 	p := s.dataPath
 	s.mut.RUnlock()
@@ -290,7 +290,6 @@ func (s *Service) setCachedConfig(b []byte) error {
 	if err != nil {
 		level.Error(s.opts.Logger).Log("msg", "failed to flush remote configuration contents the on-disk cache", "err", err)
 	}
-	return nil
 }
 
 func (s *Service) parseAndLoad(b []byte) error {

--- a/service/remotecfg/remotecfg_test.go
+++ b/service/remotecfg/remotecfg_test.go
@@ -166,7 +166,7 @@ func (f fakeHost) NewController(id string) service.Controller {
 		Tracer:          nil,
 		DataPath:        "",
 		Reg:             prometheus.NewRegistry(),
-		OnExportsChange: func(map[string]interface{}) { return },
+		OnExportsChange: func(map[string]interface{}) {},
 		Services:        []service.Service{},
 	})
 

--- a/service/remotecfg/remotecfg_test.go
+++ b/service/remotecfg/remotecfg_test.go
@@ -170,7 +170,7 @@ func (f fakeHost) NewController(id string) service.Controller {
 		Services:        []service.Service{},
 	})
 
-	return ctrl
+	return serviceController{ctrl}
 }
 
 type agentClient struct {
@@ -199,3 +199,13 @@ func (ag agentClient) DeleteAgent(context.Context, *connect.Request[agentv1.Dele
 func (ag agentClient) ListAgents(context.Context, *connect.Request[agentv1.ListAgentsRequest]) (*connect.Response[agentv1.Agents], error) {
 	return nil, nil
 }
+
+type serviceController struct {
+	f *flow.Flow
+}
+
+func (sc serviceController) Run(ctx context.Context) { sc.f.Run(ctx) }
+func (sc serviceController) LoadSource(source any, args map[string]any) error {
+	return sc.f.LoadSource(source.(*flow.Source), args)
+}
+func (sc serviceController) Ready() bool { return sc.f.Ready() }

--- a/service/remotecfg/remotecfg_test.go
+++ b/service/remotecfg/remotecfg_test.go
@@ -205,7 +205,8 @@ type serviceController struct {
 }
 
 func (sc serviceController) Run(ctx context.Context) { sc.f.Run(ctx) }
-func (sc serviceController) LoadSource(source any, args map[string]any) error {
-	return sc.f.LoadSource(source.(*flow.Source), args)
+func (sc serviceController) LoadSource(b []byte, args map[string]any) error {
+	source, _ := flow.ParseSource("", b)
+	return sc.f.LoadSource(source, args)
 }
 func (sc serviceController) Ready() bool { return sc.f.Ready() }

--- a/service/remotecfg/remotecfg_test.go
+++ b/service/remotecfg/remotecfg_test.go
@@ -206,7 +206,10 @@ type serviceController struct {
 
 func (sc serviceController) Run(ctx context.Context) { sc.f.Run(ctx) }
 func (sc serviceController) LoadSource(b []byte, args map[string]any) error {
-	source, _ := flow.ParseSource("", b)
+	source, err := flow.ParseSource("", b)
+	if err != nil {
+		return err
+	}
 	return sc.f.LoadSource(source, args)
 }
 func (sc serviceController) Ready() bool { return sc.f.Ready() }

--- a/service/remotecfg/remotecfg_test.go
+++ b/service/remotecfg/remotecfg_test.go
@@ -1,0 +1,198 @@
+package remotecfg
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	agentv1 "github.com/grafana/agent-remote-config/api/gen/proto/go/agent/v1"
+	"github.com/grafana/agent/component"
+	_ "github.com/grafana/agent/component/loki/process"
+	"github.com/grafana/agent/pkg/flow"
+	"github.com/grafana/agent/pkg/flow/componenttest"
+	"github.com/grafana/agent/pkg/flow/logging"
+	"github.com/grafana/agent/pkg/util"
+	"github.com/grafana/agent/service"
+	"github.com/grafana/river"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOnDiskCache(t *testing.T) {
+	ctx := componenttest.TestContext(t)
+	url := "https://example.com/"
+
+	// The contents of the on-disk cache.
+	cacheContents := `loki.process "default" { forward_to = [] }`
+	cacheHash := getHash(cacheContents)
+
+	// Create a new service.
+	env, err := newTestEnvironment(t)
+	require.NoError(t, err)
+	require.NoError(t, env.ApplyConfig(fmt.Sprintf(`
+		url = "%s"
+	`, url)))
+
+	client := &agentClient{}
+	env.svc.asClient = client
+
+	// Mock client to return an unparseable response.
+	client.getConfigFunc = buildGetConfigHandler("unparseable river config")
+
+	// Write the cache contents, and run the service.
+	err = os.WriteFile(env.svc.dataPath, []byte(cacheContents), 0644)
+	require.NoError(t, err)
+
+	go func() {
+		require.NoError(t, env.Run(ctx))
+	}()
+
+	// As the API response was unparseable, verify that the service has loaded
+	// the on-disk cache contents.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, cacheHash, env.svc.currentConfigHash)
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestAPIResponse(t *testing.T) {
+	ctx := componenttest.TestContext(t)
+	url := "https://example.com/"
+	cfg1 := `loki.process "default" { forward_to = [] }`
+	cfg2 := `loki.process "updated" { forward_to = [] }`
+
+	// Create a new service.
+	env, err := newTestEnvironment(t)
+	require.NoError(t, err)
+	require.NoError(t, env.ApplyConfig(fmt.Sprintf(`
+		url            = "%s"
+		poll_frequency = "10ms"
+	`, url)))
+
+	client := &agentClient{}
+	env.svc.asClient = client
+
+	// Mock client to return a valid response.
+	client.getConfigFunc = buildGetConfigHandler(cfg1)
+
+	// Run the service.
+	go func() {
+		require.NoError(t, env.Run(ctx))
+	}()
+
+	// As the API response was successful, verify that the service has loaded
+	// the valid response.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, getHash(cfg1), env.svc.currentConfigHash)
+	}, time.Second, 10*time.Millisecond)
+
+	// Update the response returned by the API.
+	client.getConfigFunc = buildGetConfigHandler(cfg2)
+
+	// Verify that the service has loaded the updated response.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, getHash(cfg2), env.svc.currentConfigHash)
+	}, time.Second, 10*time.Millisecond)
+}
+
+func buildGetConfigHandler(in string) func(context.Context, *connect.Request[agentv1.GetConfigRequest]) (*connect.Response[agentv1.GetConfigResponse], error) {
+	return func(context.Context, *connect.Request[agentv1.GetConfigRequest]) (*connect.Response[agentv1.GetConfigResponse], error) {
+		rsp := &connect.Response[agentv1.GetConfigResponse]{
+			Msg: &agentv1.GetConfigResponse{
+				Content: in,
+			},
+		}
+		return rsp, nil
+	}
+}
+
+type testEnvironment struct {
+	t   *testing.T
+	svc *Service
+}
+
+func newTestEnvironment(t *testing.T) (*testEnvironment, error) {
+	svc, err := New(Options{
+		Logger:      util.TestLogger(t),
+		StoragePath: t.TempDir(),
+	})
+	svc.asClient = nil
+	require.NoError(t, err)
+
+	return &testEnvironment{
+		t:   t,
+		svc: svc,
+	}, nil
+}
+
+func (env *testEnvironment) ApplyConfig(config string) error {
+	var args Arguments
+	if err := river.Unmarshal([]byte(config), &args); err != nil {
+		return err
+	}
+	return env.svc.Update(args)
+}
+
+func (env *testEnvironment) Run(ctx context.Context) error {
+	return env.svc.Run(ctx, fakeHost{})
+}
+
+type fakeHost struct{}
+
+var _ service.Host = (fakeHost{})
+
+func (fakeHost) GetComponent(id component.ID, opts component.InfoOptions) (*component.Info, error) {
+	return nil, fmt.Errorf("no such component %s", id)
+}
+
+func (fakeHost) ListComponents(moduleID string, opts component.InfoOptions) ([]*component.Info, error) {
+	if moduleID == "" {
+		return nil, nil
+	}
+	return nil, fmt.Errorf("no such module %q", moduleID)
+}
+
+func (fakeHost) GetServiceConsumers(serviceName string) []service.Consumer { return nil }
+
+func (f fakeHost) NewController(id string) service.Controller {
+	logger, _ := logging.New(io.Discard, logging.DefaultOptions)
+	ctrl := flow.New(flow.Options{
+		ControllerID:    ServiceName,
+		Logger:          logger,
+		Tracer:          nil,
+		DataPath:        "",
+		Reg:             prometheus.NewRegistry(),
+		OnExportsChange: func(map[string]interface{}) { return },
+		Services:        []service.Service{},
+	})
+
+	return ctrl
+}
+
+type agentClient struct {
+	getConfigFunc func(context.Context, *connect.Request[agentv1.GetConfigRequest]) (*connect.Response[agentv1.GetConfigResponse], error)
+}
+
+func (ag agentClient) GetConfig(ctx context.Context, req *connect.Request[agentv1.GetConfigRequest]) (*connect.Response[agentv1.GetConfigResponse], error) {
+	if ag.getConfigFunc != nil {
+		return ag.getConfigFunc(ctx, req)
+	}
+
+	panic("getConfigFunc not set")
+}
+func (ag agentClient) GetAgent(context.Context, *connect.Request[agentv1.GetAgentRequest]) (*connect.Response[agentv1.GetAgentResponse], error) {
+	return nil, nil
+}
+func (ag agentClient) CreateAgent(context.Context, *connect.Request[agentv1.CreateAgentRequest]) (*connect.Response[agentv1.CreateAgentResponse], error) {
+	return nil, nil
+}
+func (ag agentClient) UpdateAgent(context.Context, *connect.Request[agentv1.UpdateAgentRequest]) (*connect.Response[agentv1.UpdateAgentResponse], error) {
+	return nil, nil
+}
+func (ag agentClient) DeleteAgent(context.Context, *connect.Request[agentv1.DeleteAgentRequest]) (*connect.Response[agentv1.DeleteAgentResponse], error) {
+	return nil, nil
+}

--- a/service/remotecfg/remotecfg_test.go
+++ b/service/remotecfg/remotecfg_test.go
@@ -29,7 +29,7 @@ func TestOnDiskCache(t *testing.T) {
 
 	// The contents of the on-disk cache.
 	cacheContents := `loki.process "default" { forward_to = [] }`
-	cacheHash := getHash(cacheContents)
+	cacheHash := getHash([]byte(cacheContents))
 
 	// Create a new service.
 	env, err := newTestEnvironment(t)
@@ -87,7 +87,7 @@ func TestAPIResponse(t *testing.T) {
 	// As the API response was successful, verify that the service has loaded
 	// the valid response.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, getHash(cfg1), env.svc.currentConfigHash)
+		assert.Equal(c, getHash([]byte(cfg1)), env.svc.currentConfigHash)
 	}, time.Second, 10*time.Millisecond)
 
 	// Update the response returned by the API.
@@ -95,7 +95,9 @@ func TestAPIResponse(t *testing.T) {
 
 	// Verify that the service has loaded the updated response.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, getHash(cfg2), env.svc.currentConfigHash)
+		env.svc.mut.RLock()
+		assert.Equal(c, getHash([]byte(cfg2)), env.svc.currentConfigHash)
+		env.svc.mut.RUnlock()
 	}, time.Second, 10*time.Millisecond)
 }
 
@@ -184,15 +186,18 @@ func (ag agentClient) GetConfig(ctx context.Context, req *connect.Request[agentv
 
 	panic("getConfigFunc not set")
 }
-func (ag agentClient) GetAgent(context.Context, *connect.Request[agentv1.GetAgentRequest]) (*connect.Response[agentv1.GetAgentResponse], error) {
+func (ag agentClient) GetAgent(context.Context, *connect.Request[agentv1.GetAgentRequest]) (*connect.Response[agentv1.Agent], error) {
 	return nil, nil
 }
-func (ag agentClient) CreateAgent(context.Context, *connect.Request[agentv1.CreateAgentRequest]) (*connect.Response[agentv1.CreateAgentResponse], error) {
+func (ag agentClient) CreateAgent(context.Context, *connect.Request[agentv1.CreateAgentRequest]) (*connect.Response[agentv1.Agent], error) {
 	return nil, nil
 }
-func (ag agentClient) UpdateAgent(context.Context, *connect.Request[agentv1.UpdateAgentRequest]) (*connect.Response[agentv1.UpdateAgentResponse], error) {
+func (ag agentClient) UpdateAgent(context.Context, *connect.Request[agentv1.UpdateAgentRequest]) (*connect.Response[agentv1.Agent], error) {
 	return nil, nil
 }
 func (ag agentClient) DeleteAgent(context.Context, *connect.Request[agentv1.DeleteAgentRequest]) (*connect.Response[agentv1.DeleteAgentResponse], error) {
+	return nil, nil
+}
+func (ag agentClient) ListAgents(context.Context, *connect.Request[agentv1.ListAgentsRequest]) (*connect.Response[agentv1.Agents], error) {
 	return nil, nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -54,6 +54,17 @@ type Host interface {
 	// GetServiceConsumers gets the list of services which depend on a service by
 	// name.
 	GetServiceConsumers(serviceName string) []Consumer
+
+	// NewController returns an unstarted, isolated Controller that a Service
+	// can use to instantiate its own components.
+	NewController(id string) Controller
+}
+
+// Controller is implemented by flow.Flow.
+type Controller interface {
+	Run(ctx context.Context)
+	LoadSource(source any, args map[string]any) error
+	Ready() bool
 }
 
 type Consumer struct {

--- a/service/service.go
+++ b/service/service.go
@@ -63,7 +63,7 @@ type Host interface {
 // Controller is implemented by flow.Flow.
 type Controller interface {
 	Run(ctx context.Context)
-	LoadSource(source any, args map[string]any) error
+	LoadSource(source []byte, args map[string]any) error
 	Ready() bool
 }
 


### PR DESCRIPTION
#### PR Description
This PR introduces a new service that makes it possible for Grafana Agent to run configuration fetched via a remote endpoint.

The PR is more easily reviewable going commit-by-commit.

#### Which issue(s) this PR fixes
No issue filed.

#### Notes to the Reviewer

My main concern is whether the instantiation of the new controller makes sense, both now and long term with the upcoming redesign of Modules.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated