### PR TITLE
Demonstrate one potential implementation for `declare` 

### DIFF
--- a/component/registry.go
+++ b/component/registry.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/regexp"
+	"github.com/grafana/river/ast"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/exp/maps"
@@ -45,6 +46,10 @@ type Module interface {
 	// LoadConfig can be called multiple times, and called prior to
 	// [Module.Run].
 	LoadConfig(config []byte, args map[string]any) error
+
+	// LoadBody loads a River AST body into the Module. LoadBody can be called
+	// multiple times, and called prior to [Module.Run].
+	LoadBody(body ast.Body, args map[string]any) error
 
 	// Run starts the Module. No components within the Module
 	// will be run until Run is called.

--- a/pkg/flow/flow.go
+++ b/pkg/flow/flow.go
@@ -195,7 +195,7 @@ func newController(o controllerOptions) *Flow {
 			ControllerID:    o.ControllerID,
 			NewModuleController: func(id string) controller.ModuleController {
 				return newModuleController(&moduleControllerOptions{
-					ComponentRegistry: o.ComponentRegistry,
+					ComponentRegistry: f.loader.ComponentRegistry(),
 					ModuleRegistry:    o.ModuleRegistry,
 					Logger:            log,
 					Tracer:            tracer,

--- a/pkg/flow/internal/controller/component_references.go
+++ b/pkg/flow/internal/controller/component_references.go
@@ -34,6 +34,17 @@ func ComponentReferences(cn dag.Node, g *dag.Graph) ([]Reference, diag.Diagnosti
 	)
 
 	switch cn := cn.(type) {
+	case *DeclareNode:
+		// Special case: DeclareNode can have references to components inside its
+		// definition. However, since DeclareNode is run in its own dedicated
+		// controller without access to external components, we don't need to
+		// detect anything here.
+		//
+		// TODO(rfratto): Relax the restriction that declare components can't
+		// reference external compnoents, as it's mentioned in the RFC as a
+		// requirement. See grafana/agent#5547.
+		return []Reference{}, nil
+
 	case BlockNode:
 		if cn.Block() != nil {
 			traversals = expressionsFromBody(cn.Block().Body)

--- a/pkg/flow/internal/controller/component_registry.go
+++ b/pkg/flow/internal/controller/component_registry.go
@@ -1,27 +1,110 @@
 package controller
 
-import "github.com/grafana/agent/component"
+import (
+	"fmt"
 
-// ComponentRegistry is a collection of registered components.
+	"github.com/grafana/agent/component"
+	"github.com/grafana/river/ast"
+)
+
+// ComponentRegistry is a collection of components.
 type ComponentRegistry interface {
 	// Get looks up a component by name.
-	Get(name string) (component.Registration, bool)
+	Get(name string) (Component, bool)
 }
 
-// DefaultComponentRegistry is the default [ComponentRegistry] which gets
-// components registered to github.com/grafana/agent/component.
+// Component is a generic representation of a component.
+type Component struct {
+	kind    ComponentKind
+	builtin component.Registration
+	custom  CustomComponent
+}
+
+// Kind returns the Kind of component c is.
+func (c *Component) Kind() ComponentKind { return c.kind }
+
+// Builtin returns the registration for a built-in component. Builtin panics if
+// Kind() is not ComponentKindBuiltin.
+func (c *Component) Builtin() component.Registration {
+	if c.kind != ComponentKindBuiltin {
+		panic("Component.Builtin: component is not a builtin component")
+	}
+	return c.builtin
+}
+
+// Custom returns the custom component. Custom panics if Kind() is not
+// ComponentKindCustom.
+func (c *Component) Custom() CustomComponent {
+	if c.kind != ComponentKindCustom {
+		panic("Component.Builtin: component is not a custom component")
+	}
+	return c.custom
+}
+
+// ComponentKind represents a kind of component.
+type ComponentKind int
+
+const (
+	ComponentKindInvalid ComponentKind = iota // ComponentKindInvalid is an invalid ComponentKind.
+	ComponentKindBuiltin                      // ComponentKindBuiltin is a built-in component.
+	ComponentKindCustom                       // ComponentKindCustom is a custom component.
+)
+
+// String returns the string form of the ComponentKind.
+func (kind ComponentKind) String() string {
+	switch kind {
+	case ComponentKindInvalid:
+		return "invalid"
+	case ComponentKindBuiltin:
+		return "builtin"
+	case ComponentKindCustom:
+		return "custom"
+	default:
+		return fmt.Sprintf("ComponentKind(%d)", kind)
+	}
+}
+
+// CustomComponent represents the definition of a custom component either
+// through a declare statment or an import.
+type CustomComponent interface {
+	// Definition retrieves the definition for a CustomComponent.
+	//
+	// Definition may lazily retrieve a component definition from an imported
+	// module. If the custom component doesn't exist in the imported module,
+	// or the imported module hasn't been evaluated yet, Definition returns an
+	// error.
+	Definition() (ast.Body, error)
+}
+
+// DefaultComponentRegistry is the default [ComponentRegistry] which only gets
+// builtin components registered to github.com/grafana/agent/component.
 type DefaultComponentRegistry struct{}
 
 // Get retrieves a component using [component.Get].
-func (reg DefaultComponentRegistry) Get(name string) (component.Registration, bool) {
-	return component.Get(name)
+func (reg DefaultComponentRegistry) Get(name string) (Component, bool) {
+	builtinReg, ok := component.Get(name)
+	if !ok {
+		return Component{}, false
+	}
+
+	return Component{
+		kind:    ComponentKindBuiltin,
+		builtin: builtinReg,
+	}, true
 }
 
 // RegistryMap is a map which implements [ComponentRegistry].
 type RegistryMap map[string]component.Registration
 
 // Get retrieves a component using [component.Get].
-func (m RegistryMap) Get(name string) (component.Registration, bool) {
+func (m RegistryMap) Get(name string) (Component, bool) {
 	reg, ok := m[name]
-	return reg, ok
+	if !ok {
+		return Component{}, false
+	}
+
+	return Component{
+		kind:    ComponentKindBuiltin,
+		builtin: reg,
+	}, true
 }

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -385,6 +385,7 @@ func (l *Loader) populateConfigBlockNodes(args map[string]any, g *dag.Graph, con
 		nodeMap = NewConfigNodeMap()
 	)
 
+	// TODO(rfratto): Don't recreate the ConfigNode blocks every time we reload.
 	for _, block := range configBlocks {
 		node, newConfigNodeDiags := NewConfigNode(block, l.globals)
 		diags = append(diags, newConfigNodeDiags...)

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -456,7 +456,7 @@ func (l *Loader) populateComponentNodes(g *dag.Graph, componentBlocks []*ast.Blo
 			c.UpdateBlock(block)
 		} else {
 			componentName := block.GetBlockName()
-			registration, exists := l.componentReg.Get(componentName)
+			component, exists := l.componentReg.Get(componentName)
 			if !exists {
 				diags.Add(diag.Diagnostic{
 					Severity: diag.SeverityLevelError,
@@ -477,8 +477,12 @@ func (l *Loader) populateComponentNodes(g *dag.Graph, componentBlocks []*ast.Blo
 				continue
 			}
 
+			if kind := component.Kind(); kind != ComponentKindBuiltin {
+				panic(fmt.Sprintf("unexpected component kind %s", kind))
+			}
+
 			// Create a new component
-			c = NewBuiltinComponentNode(l.globals, registration, block)
+			c = NewBuiltinComponentNode(l.globals, component.Builtin(), block)
 		}
 
 		g.Add(c)

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -388,6 +388,10 @@ func (l *Loader) populateConfigBlockNodes(args map[string]any, g *dag.Graph, con
 	for _, block := range configBlocks {
 		node, newConfigNodeDiags := NewConfigNode(block, l.globals)
 		diags = append(diags, newConfigNodeDiags...)
+		if node == nil {
+			// NewConfigNode may have failed and returned nil.
+			continue
+		}
 
 		if g.GetByID(node.NodeID()) != nil {
 			configBlockStartPos := ast.StartPos(block).Position()

--- a/pkg/flow/internal/controller/node_config.go
+++ b/pkg/flow/internal/controller/node_config.go
@@ -12,6 +12,7 @@ const (
 	exportBlockID   = "export"
 	loggingBlockID  = "logging"
 	tracingBlockID  = "tracing"
+	declareBlockID  = "declare"
 )
 
 // NewConfigNode creates a new ConfigNode from an initial ast.BlockStmt.
@@ -26,6 +27,8 @@ func NewConfigNode(block *ast.BlockStmt, globals ComponentGlobals) (BlockNode, d
 		return NewLoggingConfigNode(block, globals), nil
 	case tracingBlockID:
 		return NewTracingConfigNode(block, globals), nil
+	case declareBlockID:
+		return NewDeclareNode(block), nil
 	default:
 		var diags diag.Diagnostics
 		diags.Add(diag.Diagnostic{
@@ -46,6 +49,7 @@ type ConfigNodeMap struct {
 	tracing     *TracingConfigNode
 	argumentMap map[string]*ArgumentConfigNode
 	exportMap   map[string]*ExportConfigNode
+	declareMap  map[string]*DeclareNode
 }
 
 // NewConfigNodeMap will create an initial ConfigNodeMap. Append must be called
@@ -56,6 +60,7 @@ func NewConfigNodeMap() *ConfigNodeMap {
 		tracing:     nil,
 		argumentMap: map[string]*ArgumentConfigNode{},
 		exportMap:   map[string]*ExportConfigNode{},
+		declareMap:  map[string]*DeclareNode{},
 	}
 }
 
@@ -73,6 +78,8 @@ func (nodeMap *ConfigNodeMap) Append(configNode BlockNode) diag.Diagnostics {
 		nodeMap.logging = n
 	case *TracingConfigNode:
 		nodeMap.tracing = n
+	case *DeclareNode:
+		nodeMap.declareMap[n.ComponentName()] = n
 	default:
 		diags.Add(diag.Diagnostic{
 			Severity: diag.SeverityLevelError,

--- a/pkg/flow/internal/controller/node_custom_component.go
+++ b/pkg/flow/internal/controller/node_custom_component.go
@@ -1,0 +1,312 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/pkg/flow/logging/level"
+	"github.com/grafana/river/ast"
+	"github.com/grafana/river/vm"
+)
+
+// CustomComponentNode is a controller node which manages a custom component.
+//
+// CustomComponentNode manages the underlying custom component and caches its
+// current arguments and exports.
+type CustomComponentNode struct {
+	id                ComponentID
+	label             string
+	componentName     string
+	nodeID            string // Cached from id.String() to avoid allocating new strings every time NodeID is called.
+	customComponent   CustomComponent
+	exportsType       reflect.Type
+	moduleController  ModuleController
+	onBlockNodeUpdate func(cn BlockNode) // Informs controller that we need to reevaluate dependants.
+	logger            log.Logger
+
+	mut    sync.RWMutex
+	block  *ast.BlockStmt
+	eval   *vm.Evaluator
+	module component.Module    // Inner managed component.
+	args   component.Arguments // Evaluated arguments for the managed component.
+
+	// NOTE(rfratto): health and exports have their own mutex because they may be
+	// set asynchronously while mut is still being held (i.e., when calling
+	// Evaluate and the managed component immediately creates new exports).
+
+	healthMut  sync.RWMutex
+	evalHealth component.Health // Health of the last evaluation.
+	runHealth  component.Health // Health of running the component.
+
+	exportsMut sync.RWMutex
+	exports    component.Exports // Evaluated exports for the managed component.
+}
+
+var _ ComponentNode = (*CustomComponentNode)(nil)
+
+// NewCustomComponentNode creates a new CustomComponentNode from an initial
+// ast.BlockStmt.
+//
+// The underlying managed custom component isn't created until Evaluate is called.
+func NewCustomComponentNode(globals ComponentGlobals, reg CustomComponent, b *ast.BlockStmt) *CustomComponentNode {
+	var (
+		id     = BlockComponentID(b)
+		nodeID = id.String()
+	)
+
+	initHealth := component.Health{
+		Health:     component.HealthTypeUnknown,
+		Message:    "custom component created",
+		UpdateTime: time.Now(),
+	}
+
+	// We need to generate a globally unique component ID to give to the
+	// component and for use with telemetry data which doesn't support
+	// reconstructing the global ID. For everything else (HTTP, data), we can
+	// just use the controller-local ID as those values are guaranteed to be
+	// globally unique.
+	globalID := nodeID
+	if globals.ControllerID != "" {
+		globalID = path.Join(globals.ControllerID, nodeID)
+	}
+
+	cn := &CustomComponentNode{
+		id:                id,
+		label:             b.Label,
+		nodeID:            nodeID,
+		componentName:     b.GetBlockName(),
+		customComponent:   reg,
+		exportsType:       reflect.TypeOf(map[string]any{}),
+		moduleController:  globals.NewModuleController(globalID),
+		onBlockNodeUpdate: globals.OnBlockNodeUpdate,
+		logger:            log.With(globals.Logger, "component", globalID),
+
+		block: b,
+		eval:  vm.New(b.Body),
+
+		// Prepopulate arguments and exports with their zero values.
+		args:    map[string]any{},
+		exports: map[string]any{},
+
+		evalHealth: initHealth,
+		runHealth:  initHealth,
+	}
+
+	return cn
+}
+
+// NodeID implements [dag.Node] and returns the unique ID for this node. The
+// NodeID is the string representation of the component's ID from its River
+// block.
+func (c *CustomComponentNode) NodeID() string { return c.nodeID }
+
+// Block implements [BlockNode] and returns the current block of the custom
+// component.
+func (c *CustomComponentNode) Block() *ast.BlockStmt {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+	return c.block
+}
+
+// Evaluate implements [BlockNode] and updates the arguments for the custom
+// component by re-evaluating its River block with the provided scope. A
+// controller for the custom component will be built the first time Evaluate is
+// called.
+//
+// Evaluate will return an error if the River block cannot be evaluated, if
+// decoding to arguments fails, or if the definition for the custom component
+// cannot be retrieved.
+func (c *CustomComponentNode) Evaluate(scope *vm.Scope) error {
+	err := c.evaluate(scope)
+
+	switch err {
+	case nil:
+		c.setEvalHealth(component.HealthTypeHealthy, "component evaluated")
+	default:
+		msg := fmt.Sprintf("component evaluation failed: %s", err)
+		c.setEvalHealth(component.HealthTypeUnhealthy, msg)
+	}
+
+	return err
+}
+
+func (c *CustomComponentNode) evaluate(scope *vm.Scope) error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	// BUG(rfratto): c.customComponent here relies on a single version of the
+	// graph and does not respect updates to the Loader's graph.
+	//
+	// If the definition of a component changes, we will not get the new change
+	// as c.customComponent is kept for the lifetime of our component node.
+	body, err := c.customComponent.Definition()
+	if err != nil {
+		return fmt.Errorf("failed to get definition of %s: %w", c.componentName, err)
+	}
+
+	var args map[string]any
+	if err := c.eval.Evaluate(scope, &args); err != nil {
+		return fmt.Errorf("decoding River: %w", err)
+	}
+
+	if c.module == nil {
+		mod, err := c.moduleController.NewModule("", func(exports map[string]any) { c.setExports(exports) })
+		if err != nil {
+			return fmt.Errorf("creating custom component controller: %w", err)
+		}
+		c.module = mod
+	}
+
+	if err := c.module.LoadBody(body, args); err != nil {
+		return fmt.Errorf("updating component: %w", err)
+	}
+
+	c.args = args
+	return nil
+}
+
+func (c *CustomComponentNode) Run(ctx context.Context) error {
+	c.mut.RLock()
+	managed := c.module
+	c.mut.RUnlock()
+
+	if managed == nil {
+		return ErrUnevaluated
+	}
+
+	c.setRunHealth(component.HealthTypeHealthy, "started component")
+	err := c.module.Run(ctx)
+
+	var exitMsg string
+	if err != nil {
+		level.Error(c.logger).Log("msg", "component exited with error", "err", err)
+		exitMsg = fmt.Sprintf("component shut down with error: %s", err)
+	} else {
+		level.Info(c.logger).Log("msg", "component exited")
+		exitMsg = "component shut down normally"
+	}
+
+	c.setRunHealth(component.HealthTypeExited, exitMsg)
+	return err
+}
+
+// CurrentHealth returns the current health of the CustomComponentNode.
+//
+// The health of a CustomComponent node is determined by combining:
+//
+//  1. Health from the call to Run().
+//  2. Health from the last call to Evaluate().
+func (c *CustomComponentNode) CurrentHealth() component.Health {
+	c.healthMut.RLock()
+	defer c.healthMut.RUnlock()
+
+	var (
+		runHealth  = c.runHealth
+		evalHealth = c.evalHealth
+	)
+
+	return component.LeastHealthy(runHealth, evalHealth)
+}
+
+// Arguments returns the current arguments of the custom component.
+func (c *CustomComponentNode) Arguments() component.Arguments {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+	return c.args
+}
+
+// Exports returns the current set of exports from the custom component.
+// Exports returns nil if the custom component does not have exports.
+func (c *CustomComponentNode) Exports() component.Exports {
+	c.exportsMut.RLock()
+	defer c.exportsMut.RUnlock()
+	return c.exports
+}
+
+// setExports is called whenever the custom module updates. e must be a
+// map[string]any.
+func (c *CustomComponentNode) setExports(e component.Exports) {
+	if reflect.TypeOf(e) != c.exportsType {
+		panic(fmt.Sprintf("Component %s changed Exports types from %T to %T", c.nodeID, c.exportsType, e))
+	}
+
+	// Some components may aggressively reexport values even though no exposed
+	// state has changed. This may be done for components which always supply
+	// exports whenever their arguments are evaluated without tracking internal
+	// state to see if anything actually changed.
+	//
+	// To avoid needlessly reevaluating components we'll ignore unchanged
+	// exports.
+	var changed bool
+
+	c.exportsMut.Lock()
+	if !reflect.DeepEqual(c.exports, e) {
+		changed = true
+		c.exports = e
+	}
+	c.exportsMut.Unlock()
+
+	if changed {
+		// Inform the controller that we have new exports.
+		c.onBlockNodeUpdate(c)
+	}
+}
+
+// Label returns the label for the custom component.
+func (c *CustomComponentNode) Label() string { return c.label }
+
+// ComponentName returns the component's name, corresponding to the River block
+// name without the label.
+func (c *CustomComponentNode) ComponentName() string { return c.componentName }
+
+// ID returns the component ID of the custom component from its River block.
+func (c *CustomComponentNode) ID() ComponentID { return c.id }
+
+// UpdateBlock updates the River block used to construct arguments for the
+// custom component. The new block isn't used until the next time Evaluate is
+// invoked.
+//
+// UpdateBlock will panic if the block does not match the component ID of the
+// CustomComponentNode assigned on creation.
+func (c *CustomComponentNode) UpdateBlock(b *ast.BlockStmt) {
+	if !BlockComponentID(b).Equals(c.id) {
+		panic("UpdateBlock called with a River block with a different component ID")
+	}
+
+	c.mut.Lock()
+	defer c.mut.Unlock()
+	c.block = b
+	c.eval = vm.New(b.Body)
+}
+
+// setEvalHealth sets the internal health from a call to Evaluate. See Health
+// for information on how overall health is calculated.
+func (c *CustomComponentNode) setEvalHealth(t component.HealthType, msg string) {
+	c.healthMut.Lock()
+	defer c.healthMut.Unlock()
+
+	c.evalHealth = component.Health{
+		Health:     t,
+		Message:    msg,
+		UpdateTime: time.Now(),
+	}
+}
+
+// setRunHealth sets the internal health from a call to Run. See Health for
+// information on how overall health is calculated.
+func (c *CustomComponentNode) setRunHealth(t component.HealthType, msg string) {
+	c.healthMut.Lock()
+	defer c.healthMut.Unlock()
+
+	c.runHealth = component.Health{
+		Health:     t,
+		Message:    msg,
+		UpdateTime: time.Now(),
+	}
+}

--- a/pkg/flow/internal/controller/node_declare.go
+++ b/pkg/flow/internal/controller/node_declare.go
@@ -53,3 +53,12 @@ func (cn *DeclareNode) NodeID() string { return cn.nodeID }
 
 // ComponentName returns the name of the component being declared.
 func (cn *DeclareNode) ComponentName() string { return cn.componentName }
+
+// Definition implements [CustomComponent] and returns the body of the declare
+// node.
+func (cn *DeclareNode) Definition() (ast.Body, error) {
+	cn.mut.RLock()
+	defer cn.mut.RUnlock()
+
+	return cn.block.Body, nil
+}

--- a/pkg/flow/internal/controller/node_declare.go
+++ b/pkg/flow/internal/controller/node_declare.go
@@ -1,0 +1,55 @@
+package controller
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/grafana/river/ast"
+	"github.com/grafana/river/vm"
+)
+
+// DeclareNode represents a declare block in the DAG.
+type DeclareNode struct {
+	nodeID        string // ID of the node.
+	componentName string // Name of the component being declared.
+
+	mut   sync.RWMutex
+	block *ast.BlockStmt // Definition of DeclareNode.
+}
+
+var _ BlockNode = (*DeclareNode)(nil)
+
+// NewDeclareNode creates a new DeclareNode with its definition.
+func NewDeclareNode(block *ast.BlockStmt) *DeclareNode {
+	if fullName := strings.Join(block.Name, "."); fullName != "declare" {
+		panic("controller: NewDeclareNode called with non-declare block.")
+	}
+	if block.Label == "" {
+		panic("controller: NewDeclareNode called with a block without a label")
+	}
+
+	return &DeclareNode{
+		nodeID:        fmt.Sprintf("declare.%s", block.Label),
+		componentName: block.Label,
+		block:         block,
+	}
+}
+
+// Evaluate does nothing for DeclareNode.
+func (cn *DeclareNode) Evaluate(scope *vm.Scope) error {
+	return nil
+}
+
+// Block implements BlockNode and returns the current block of the managed config node.
+func (cn *DeclareNode) Block() *ast.BlockStmt {
+	cn.mut.RLock()
+	defer cn.mut.RUnlock()
+	return cn.block
+}
+
+// NodeID implements dag.Node and returns the unique ID for the config node.
+func (cn *DeclareNode) NodeID() string { return cn.nodeID }
+
+// ComponentName returns the name of the component being declared.
+func (cn *DeclareNode) ComponentName() string { return cn.componentName }

--- a/pkg/flow/module.go
+++ b/pkg/flow/module.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/agent/pkg/flow/logging"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/grafana/agent/pkg/flow/tracing"
+	"github.com/grafana/river/ast"
 	"github.com/grafana/river/scanner"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/exp/maps"
@@ -130,6 +131,15 @@ func newModule(o *moduleOptions) *module {
 // LoadConfig parses River config and loads it.
 func (c *module) LoadConfig(config []byte, args map[string]any) error {
 	ff, err := ParseSource(c.o.ID, config)
+	if err != nil {
+		return err
+	}
+	return c.f.LoadSource(ff, args)
+}
+
+// LoadBody loads a pre-parsed River config.
+func (c *module) LoadBody(body ast.Body, args map[string]any) error {
+	ff, err := sourceFromBody(body)
 	if err != nil {
 		return err
 	}

--- a/pkg/flow/module_declare_test.go
+++ b/pkg/flow/module_declare_test.go
@@ -1,0 +1,222 @@
+package flow_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/agent/pkg/flow"
+	"github.com/grafana/agent/pkg/flow/internal/testcomponents"
+	"github.com/stretchr/testify/require"
+)
+
+type testCase struct {
+	name     string
+	config   string
+	expected int
+}
+
+func TestDeclare(t *testing.T) {
+	tt := []testCase{
+		{
+			name: "BasicDeclare",
+			config: `
+			declare "test" {
+				argument "input" {
+					optional = false
+				}
+			
+				testcomponents.passthrough "pt" {
+					input = argument.input.value
+					lag = "1ms"
+				}
+			
+				export "output" {
+					value = testcomponents.passthrough.pt.output
+				}
+			}
+			testcomponents.count "inc" {
+				frequency = "10ms"
+				max = 10
+			}
+		
+			test "myModule" {
+				input = testcomponents.count.inc.count
+			}
+		
+			testcomponents.summation "sum" {
+				input = test.myModule.output
+			}
+			`,
+			expected: 10,
+		},
+		{
+			name: "NestedDeclares",
+			config: `
+			declare "test" {
+				argument "input" {
+					optional = false
+				}
+				declare "nested" {
+					argument "input" {
+						optional = false
+					}
+					export "output" {
+						value = argument.input.value
+					}
+				}
+			
+				testcomponents.passthrough "pt" {
+					input = argument.input.value
+					lag = "1ms"
+				}
+				nested "default" {
+					input = testcomponents.passthrough.pt.output
+				}
+			
+				export "output" {
+					value = nested.default.output
+				}
+			}
+			testcomponents.count "inc" {
+				frequency = "10ms"
+				max = 10
+			}
+		
+			test "myModule" {
+				input = testcomponents.count.inc.count
+			}
+		
+			testcomponents.summation "sum" {
+				input = test.myModule.output
+			}
+			`,
+			expected: 10,
+		},
+		{
+			name: "DeclaredInParentDepth1",
+			config: `
+			declare "test" {
+				argument "input" {
+					optional = false
+				}
+			
+				testcomponents.passthrough "pt" {
+					input = argument.input.value
+					lag = "1ms"
+				}
+				rootDeclare "default" {
+					input = testcomponents.passthrough.pt.output
+				}
+			
+				export "output" {
+					value = rootDeclare.default.output
+				}
+			}
+			declare "rootDeclare" {
+				argument "input" {
+					optional = false
+				}
+				export "output" {
+					value = argument.input.value
+				}
+			}
+			testcomponents.count "inc" {
+				frequency = "10ms"
+				max = 10
+			}
+		
+			test "myModule" {
+				input = testcomponents.count.inc.count
+			}
+		
+			testcomponents.summation "sum" {
+				input = test.myModule.output
+			}
+			`,
+			expected: 10,
+		},
+		{
+			name: "DeclaredInParentDepth2",
+			config: `
+			declare "test" {
+				argument "input" {
+					optional = false
+				}
+			
+				testcomponents.passthrough "pt" {
+					input = argument.input.value
+					lag = "1ms"
+				}
+				declare "anotherDeclare" {
+					argument "input" {
+						optional = false
+					}
+					rootDeclare "default" {
+						input = argument.input.value
+					}
+					export "output" {
+						value = rootDeclare.default.output
+					}
+				}
+				anotherDeclare "myOtherDeclare" {
+					input = testcomponents.passthrough.pt.output
+				}
+			
+				export "output" {
+					value = anotherDeclare.myOtherDeclare.output
+				}
+			}
+			declare "rootDeclare" {
+				argument "input" {
+					optional = false
+				}
+				export "output" {
+					value = argument.input.value
+				}
+			}
+			testcomponents.count "inc" {
+				frequency = "10ms"
+				max = 10
+			}
+		
+			test "myModule" {
+				input = testcomponents.count.inc.count
+			}
+		
+			testcomponents.summation "sum" {
+				input = test.myModule.output
+			}
+			`,
+			expected: 10,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := flow.New(testOptions(t))
+			f, err := flow.ParseSource(t.Name(), []byte(tc.config))
+			require.NoError(t, err)
+			require.NotNil(t, f)
+
+			err = ctrl.LoadSource(f, nil)
+			require.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan struct{})
+			go func() {
+				ctrl.Run(ctx)
+				close(done)
+			}()
+			defer func() {
+				cancel()
+				<-done
+			}()
+
+			require.Eventually(t, func() bool {
+				export := getExport[testcomponents.SummationExports](t, ctrl, "", "testcomponents.summation.sum")
+				return export.LastAdded == tc.expected
+			}, 3*time.Second, 10*time.Millisecond)
+		})
+	}
+}

--- a/pkg/flow/source.go
+++ b/pkg/flow/source.go
@@ -37,6 +37,18 @@ func ParseSource(name string, bb []byte) (*Source, error) {
 		return nil, err
 	}
 
+	source, err := sourceFromBody(node.Body)
+	if err != nil {
+		return nil, err
+	}
+	source.sourceMap = map[string][]byte{name: bb}
+	source.hash = sha256.Sum256(bb)
+	return source, nil
+}
+
+// sourceFromBody creates a Source from an existing AST. This must only be used
+// internally as there will be no sourceMap or hash.
+func sourceFromBody(body ast.Body) (*Source, error) {
 	// Look for predefined non-components blocks (i.e., logging), and store
 	// everything else into a list of components.
 	//
@@ -47,7 +59,7 @@ func ParseSource(name string, bb []byte) (*Source, error) {
 		configs    []*ast.BlockStmt
 	)
 
-	for _, stmt := range node.Body {
+	for _, stmt := range body {
 		switch stmt := stmt.(type) {
 		case *ast.AttributeStmt:
 			return nil, diag.Diagnostic{
@@ -79,8 +91,6 @@ func ParseSource(name string, bb []byte) (*Source, error) {
 	return &Source{
 		components:   components,
 		configBlocks: configs,
-		sourceMap:    map[string][]byte{name: bb},
-		hash:         sha256.Sum256(bb),
 	}, nil
 }
 

--- a/pkg/flow/source.go
+++ b/pkg/flow/source.go
@@ -60,7 +60,7 @@ func ParseSource(name string, bb []byte) (*Source, error) {
 		case *ast.BlockStmt:
 			fullName := strings.Join(stmt.Name, ".")
 			switch fullName {
-			case "logging", "tracing", "argument", "export":
+			case "logging", "tracing", "argument", "export", "declare":
 				configs = append(configs, stmt)
 			default:
 				components = append(components, stmt)


### PR DESCRIPTION
**DO NOT MERGE; DEMONSTRATIVE PR ONLY**

> **NOTE**: This PR is meant to be reviewed commit-by-commit. 

This PR demonstrates one potential implementation for `declare` blocks as defined in #5547. The purpose of this PR is to compare/contrast approaches towards modelling the way declare blocks are scoped and how components are retrieved, with the other approach being in the [declare-new-modules branch](https://github.com/grafana/agent/tree/declare-new-modules) (which had a PR at #6253). 

The architecture of this implementation relies on the `ComponentRegistry` interface being used to look up built-in and custom components. The ComponentRegistry is passed around to child controllers, and child controllers create an interface implementation which extends the provided registry with custom component definitions in their local scope. 

Keep these things in mind when reviewing this PR: 

1. There is a [bug](https://github.com/rfratto/agent/blob/d56eb0096d855aeea38d4a971decc5fac959b2b5/pkg/flow/internal/controller/node_custom_component.go#L143-L147) left in the code. I don't think the bug detracts away from the discussion of evaluating this design, so I'm leaving it in for now. 

2. For this PR, `declare` blocks are not able to access top-level component exports, which is a behaviour described in #5547. This detail should likely not be implemented in any initial implementation for `declare`, and we should revisit the RFC to see if that capability should be scoped out entirely for now. 

3. The final commit copies the unit tests from #6253 to ensure that the same test cases pass. 