### PR TITLE
Adjust the latency_fanout with some very unscientific values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Main (unreleased)
 
 - `service_name` label is inferred from discovery meta labels in `pyroscope.java` (@korniltsev)
 
-- Changed default buckets for `agent_prometheus_fanout_latency` to `.005, .01, .05, .1, .5, 1, 5, 10, 60, 90, 600`s. (@mattdurham)
+- Changed default buckets for `agent_prometheus_fanout_latency` to `.005, .01, .05, .1, .5, 1, 5, 10, 60, 90, 300`s. (@mattdurham)
 
 ### Bugfixes
 

--- a/component/prometheus/fanout.go
+++ b/component/prometheus/fanout.go
@@ -36,7 +36,7 @@ func NewFanout(children []storage.Appendable, componentID string, register prome
 	wl := prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:    "agent_prometheus_fanout_latency",
 		Help:    "Write latency for sending to direct and indirect components",
-		Buckets: []float64{.005, .01, .05, .1, .5, 1, 5, 10, 60, 90, 600},
+		Buckets: []float64{.005, .01, .05, .1, .5, 1, 5, 10, 60, 90, 300},
 	})
 	_ = register.Register(wl)
 


### PR DESCRIPTION
#### PR Description

#### Which issue(s) this PR fixes

The default buckets ended at 10 seconds and the write path can take much longer than that. Chose 300s (5m) as the max since anything above that hits the staleness marker and would be a really bad indicator.

#### Notes to the Reviewer

#### PR Checklist


- [x] CHANGELOG.md updatedad