### PR TITLE
MSSQL Integration - Update documentation with extra windows authentication details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ Main (unreleased)
 
 - Use Go 1.22 for builds. (@rfratto)
 
+- Updated docs for MSSQL Integration to show additional authentication capabilities. (@StefanKurek)
+
 v0.39.2 (2024-1-31)
 --------------------
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.mssql.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mssql.md
@@ -51,6 +51,21 @@ If specified, the `query_config` argument must be a YAML document as string defi
 
 See [sql_exporter](https://github.com/burningalchemist/sql_exporter#collectors) for details on how to create a configuration.
 
+### Authentication
+By default, the `USERNAME` and `PASSWORD` used within the `connection_string` should correspond with a SQL Server username and password.
+
+If the Grafana Agent is running in the same Windows domain as the SQL Server, then the parameter `authenticator=winsspi` can be used within the `connection_string` without any additional credentials in order to authenticate.
+
+```conn
+sqlserver://@<HOST>:<PORT>?authenticator=winsspi
+```
+
+Otherwise if you would like to use Windows credentials to authenticate (instead of SQL Server credentials), you can use the parameter `authenticator=ntlm` within the `connection_string`. The `USERNAME` and `PASSWORD` would then be the Windows username and password (domain may need to be prefixed to the username).
+
+```conn
+sqlserver://<DOMAIN\USERNAME>:<PASSWORD>@<HOST>:<PORT>?authenticator=ntlm
+```
+
 ## Blocks
 
 The `prometheus.exporter.mssql` component does not support any blocks, and is configured

--- a/docs/sources/flow/reference/components/prometheus.exporter.mssql.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.mssql.md
@@ -52,15 +52,17 @@ If specified, the `query_config` argument must be a YAML document as string defi
 See [sql_exporter](https://github.com/burningalchemist/sql_exporter#collectors) for details on how to create a configuration.
 
 ### Authentication
-By default, the `USERNAME` and `PASSWORD` used within the `connection_string` should correspond with a SQL Server username and password.
+By default, the `USERNAME` and `PASSWORD` used within the `connection_string` argument corresponds to a SQL Server username and password.
 
-If the Grafana Agent is running in the same Windows domain as the SQL Server, then the parameter `authenticator=winsspi` can be used within the `connection_string` without any additional credentials in order to authenticate.
+If {{< param "PRODUCT_ROOT_NAME" >}} is running in the same Windows domain as the SQL Server, then you can use the parameter `authenticator=winsspi` within the `connection_string` to authenticate without any additional credentials.
 
 ```conn
 sqlserver://@<HOST>:<PORT>?authenticator=winsspi
 ```
 
-Otherwise if you would like to use Windows credentials to authenticate (instead of SQL Server credentials), you can use the parameter `authenticator=ntlm` within the `connection_string`. The `USERNAME` and `PASSWORD` would then be the Windows username and password (domain may need to be prefixed to the username).
+If you want to use Windows credentials to authenticate, instead of SQL Server credentials, you can use the parameter `authenticator=ntlm` within the `connection_string`. 
+The `USERNAME` and `PASSWORD` then corresponds to a Windows username and password.
+The Windows domain may need to be prefixed to the username with a trailing `\`.
 
 ```conn
 sqlserver://<DOMAIN\USERNAME>:<PASSWORD>@<HOST>:<PORT>?authenticator=ntlm

--- a/docs/sources/static/configuration/integrations/mssql-config.md
+++ b/docs/sources/static/configuration/integrations/mssql-config.md
@@ -97,15 +97,17 @@ Full reference of options:
 ```
 
 ### Authentication
-By default, the `USERNAME` and `PASSWORD` used within the `connection_string` should correspond with a SQL Server username and password.
+By default, the `USERNAME` and `PASSWORD` used within the `connection_string` argument corresponds to a SQL Server username and password.
 
-If the Grafana Agent is running in the same Windows domain as the SQL Server, then the parameter `authenticator=winsspi` can be used within the `connection_string` without any additional credentials in order to authenticate.
+If Grafana Agent is running in the same Windows domain as the SQL Server, then you can use the parameter `authenticator=winsspi` within the `connection_string` to authenticate without any additional credentials.
 
 ```conn
 sqlserver://@<HOST>:<PORT>?authenticator=winsspi
 ```
 
-Otherwise if you would like to use Windows credentials to authenticate (instead of SQL Server credentials), you can use the parameter `authenticator=ntlm` within the `connection_string`. The `USERNAME` and `PASSWORD` would then be the Windows username and password (domain may need to be prefixed to the username).
+If you want to use Windows credentials to authenticate, instead of SQL Server credentials, you can use the parameter `authenticator=ntlm` within the `connection_string`. 
+The `USERNAME` and `PASSWORD` then corresponds to a Windows username and password.
+The Windows domain may need to be prefixed to the username with a trailing `\`.
 
 ```conn
 sqlserver://<DOMAIN\USERNAME>:<PASSWORD>@<HOST>:<PORT>?authenticator=ntlm

--- a/docs/sources/static/configuration/integrations/mssql-config.md
+++ b/docs/sources/static/configuration/integrations/mssql-config.md
@@ -96,6 +96,21 @@ Full reference of options:
     [- <queries> ... ]]
 ```
 
+### Authentication
+By default, the `USERNAME` and `PASSWORD` used within the `connection_string` should correspond with a SQL Server username and password.
+
+If the Grafana Agent is running in the same Windows domain as the SQL Server, then the parameter `authenticator=winsspi` can be used within the `connection_string` without any additional credentials in order to authenticate.
+
+```conn
+sqlserver://@<HOST>:<PORT>?authenticator=winsspi
+```
+
+Otherwise if you would like to use Windows credentials to authenticate (instead of SQL Server credentials), you can use the parameter `authenticator=ntlm` within the `connection_string`. The `USERNAME` and `PASSWORD` would then be the Windows username and password (domain may need to be prefixed to the username).
+
+```conn
+sqlserver://<DOMAIN\USERNAME>:<PASSWORD>@<HOST>:<PORT>?authenticator=ntlm
+```
+
 ## Custom metrics
 You can use the optional `query_config` parameter to retrieve custom Prometheus metrics for a MSSQL instance.
 


### PR DESCRIPTION
#### PR Description
Updates MSSQL Integration documentation to explicitly mention some of the windows authentication options that can be used within the `connection_string` config param for both static and flow modes.

#### Which issue(s) this PR fixes
NA

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Documentation added