### PR TITLE
Docs for k8s event logs: clarify equivalent of Static mode's cache_path in Flow mode.

### DIFF
--- a/converter/internal/staticconvert/internal/build/eventhandler.go
+++ b/converter/internal/staticconvert/internal/build/eventhandler.go
@@ -20,9 +20,15 @@ func (b *IntegrationsConfigBuilder) appendEventHandlerV2(config *eventhandler_v2
 	}
 
 	b.diags.AddAll(common.ValidateSupported(common.NotDeepEquals, config.SendTimeout, eventhandler_v2.DefaultConfig.SendTimeout, "eventhandler send_timeout", "this field is not configurable in flow mode"))
-	b.diags.AddAll(common.ValidateSupported(common.NotDeepEquals, config.CachePath, eventhandler_v2.DefaultConfig.CachePath, "eventhandler cache_path", "this field is not configurable in flow mode"))
 	b.diags.AddAll(common.ValidateSupported(common.NotDeepEquals, config.InformerResync, eventhandler_v2.DefaultConfig.InformerResync, "eventhandler informer_resync", "this field is not configurable in flow mode"))
 	b.diags.AddAll(common.ValidateSupported(common.NotDeepEquals, config.FlushInterval, eventhandler_v2.DefaultConfig.FlushInterval, "eventhandler flush_interval", "this field is not configurable in flow mode"))
+
+	if config.CachePath != eventhandler_v2.DefaultConfig.CachePath {
+		b.diags.Add(
+			diag.SeverityLevelWarn,
+			"The eventhandler cache_path is unnecessary in flow mode because the storage path is governed by the --storage.path cmd argument and is always local to the component.",
+		)
+	}
 
 	receiver := getLogsReceiver(config)
 	if len(config.ExtraLabels) > 0 {

--- a/converter/internal/staticconvert/testdata-v2/unsupported.diags
+++ b/converter/internal/staticconvert/testdata-v2/unsupported.diags
@@ -1,6 +1,6 @@
 (Error) The converter does not support converting the provided eventhandler send_timeout config: this field is not configurable in flow mode
-(Error) The converter does not support converting the provided eventhandler cache_path config: this field is not configurable in flow mode
 (Error) The converter does not support converting the provided eventhandler informer_resync config: this field is not configurable in flow mode
 (Error) The converter does not support converting the provided eventhandler flush_interval config: this field is not configurable in flow mode
+(Warning) The eventhandler cache_path is unnecessary in flow mode because the storage path is governed by the --storage.path cmd argument and is always local to the component.
 (Warning) Please review your agent command line flags and ensure they are set in your Flow mode config file where necessary.
 (Error) The converter does not support converting the provided app_agent_receiver traces_instance config.

--- a/docs/sources/flow/reference/components/loki.source.docker.md
+++ b/docs/sources/flow/reference/components/loki.source.docker.md
@@ -126,9 +126,9 @@ configuration.
 * `loki_source_docker_target_parsing_errors_total` (gauge): Total number of parsing errors while receiving Docker messages.
 
 ## Component behavior
-The component uses its data path (a directory named after the domain's
-fully qualified name) to store its _positions file_. The positions file
-stores the read offsets so that if there is a component or Agent restart,
+The component uses its data path, a directory named after the domain's
+fully qualified name, to store its _positions file_. The positions file is used
+to store read offsets, so that if a component or {{< param "PRODUCT_ROOT_NAME" >}} restarts,
 `loki.source.docker` can pick up tailing from the same spot.
 
 If the target's argument contains multiple entries with the same container

--- a/docs/sources/flow/reference/components/loki.source.file.md
+++ b/docs/sources/flow/reference/components/loki.source.file.md
@@ -143,9 +143,9 @@ the component reads. All other labels starting with a double underscore are
 considered _internal_ and are removed from the log entries before they're
 passed to other `loki.*` components.
 
-The component uses its data path (a directory named after the domain's
-fully qualified name) to store its _positions file_. The positions file is used
-to store read offsets, so that in case of a component or Agent restart,
+The component uses its data path, a directory named after the domain's
+fully qualified name, to store its _positions file_. The positions file is used
+to store read offsets, so that if a component or {{< param "PRODUCT_ROOT_NAME" >}} restarts,
 `loki.source.file` can pick up tailing from the same spot.
 
 The data path is inside the directory configured by the `--storage.path` [command line argument][cmd-args].

--- a/docs/sources/flow/reference/components/loki.source.file.md
+++ b/docs/sources/flow/reference/components/loki.source.file.md
@@ -148,9 +148,13 @@ fully qualified name) to store its _positions file_. The positions file is used
 to store read offsets, so that in case of a component or Agent restart,
 `loki.source.file` can pick up tailing from the same spot.
 
+The data path is inside the directory configured by the `--storage.path` [command line argument][cmd-args].
+
 If a file is removed from the `targets` list, its positions file entry is also
 removed. When it's added back on, `loki.source.file` starts reading it from the
 beginning.
+
+[cmd-args]: {{< relref "../cli/run.md" >}}
 
 ## Examples
 

--- a/docs/sources/flow/reference/components/loki.source.kubernetes_events.md
+++ b/docs/sources/flow/reference/components/loki.source.kubernetes_events.md
@@ -152,6 +152,21 @@ events in each watched namespace.
 
 `loki.source.kubernetes_events` does not expose any component-specific debug metrics.
 
+## Component behavior
+
+The component uses its data path (a directory named after the domain's
+fully qualified name) to store its _positions file_. The positions file is used
+to store read offsets, so that in case of a component or Agent restart,
+`loki.source.kubernetes_events` can pick up tailing from the same spot.
+
+The data path is inside the directory configured by the `--storage.path` [command line argument][cmd-args].
+
+In the static mode's [eventhandler integration][eventhandler-integration], a `cache_path` argument was used in order to configure such a positions file.
+In Flow mode, this argument is no longer necessary.
+
+[cmd-args]: {{< relref "../cli/run.md" >}}
+[eventhandler-integration]: {{< relref "../../../static/configuration/integrations/integrations-next/eventhandler-config.md" >}}
+
 ## Example
 
 This example collects watches events in the `kube-system` namespace and

--- a/docs/sources/flow/reference/components/loki.source.kubernetes_events.md
+++ b/docs/sources/flow/reference/components/loki.source.kubernetes_events.md
@@ -154,7 +154,7 @@ events in each watched namespace.
 
 ## Component behavior
 
-The component uses its data path,  a directory named after the domain's
+The component uses its data path, a directory named after the domain's
 fully qualified name, to store its _positions file_. The positions file is used
 to store read offsets, so that if a component or {{< param "PRODUCT_ROOT_NAME" >}} restarts,
 `loki.source.kubernetes_events` can pick up tailing from the same spot.

--- a/docs/sources/flow/reference/components/loki.source.kubernetes_events.md
+++ b/docs/sources/flow/reference/components/loki.source.kubernetes_events.md
@@ -154,14 +154,14 @@ events in each watched namespace.
 
 ## Component behavior
 
-The component uses its data path (a directory named after the domain's
-fully qualified name) to store its _positions file_. The positions file is used
-to store read offsets, so that in case of a component or Agent restart,
+The component uses its data path,  a directory named after the domain's
+fully qualified name, to store its _positions file_. The positions file is used
+to store read offsets, so that if a component or {{< param "PRODUCT_ROOT_NAME" >}} restarts,
 `loki.source.kubernetes_events` can pick up tailing from the same spot.
 
 The data path is inside the directory configured by the `--storage.path` [command line argument][cmd-args].
 
-In the static mode's [eventhandler integration][eventhandler-integration], a `cache_path` argument was used in order to configure such a positions file.
+In the Static mode's [eventhandler integration][eventhandler-integration], a `cache_path` argument is used to configure a positions file.
 In Flow mode, this argument is no longer necessary.
 
 [cmd-args]: {{< relref "../cli/run.md" >}}


### PR DESCRIPTION
The static mode integration for k8s events has a `cache_path` argument which Flow mode doesn't have. These changes make it more clear to the users why such an argument is missing from Flow mode.