### PR TITLE
add cluster and namespace to unhealthy components

### DIFF
--- a/operations/agent-flow-mixin/alerts/controller.libsonnet
+++ b/operations/agent-flow-mixin/alerts/controller.libsonnet
@@ -14,7 +14,7 @@ alert.newGroup(
     // Unhealthy components detected.
     alert.newRule(
       'UnhealthyComponents',
-      'sum(agent_component_controller_running_components{health_type!="healthy"}) > 0',
+      'sum by (cluster, namespace) (agent_component_controller_running_components{health_type!="healthy"}) > 0',
       'Unhealthy Flow components detected.',
       '15m',
     ),


### PR DESCRIPTION
This alert was missing cluster and namespace