### PR TITLE
discovery.process: Accept failing username detection

### DIFF
--- a/component/discovery/process/discover.go
+++ b/component/discovery/process/discover.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/user"
 	"path"
 	"runtime"
 
@@ -116,16 +117,15 @@ func discover(l log.Logger, cfg *DiscoverConfig) ([]process, error) {
 		}
 		if cfg.Username {
 			username, err = p.Username()
-			if err != nil {
+			var uerr user.UnknownUserIdError
+			if err != nil && !errors.As(err, &uerr) {
 				loge(int(p.Pid), err)
-				continue
 			}
 		}
 		if cfg.UID {
 			uids, err := p.Uids()
 			if err != nil {
 				loge(int(p.Pid), err)
-				continue
 			}
 			if len(uids) > 0 {
 				uid = fmt.Sprintf("%d", uids[0])


### PR DESCRIPTION
Quite common with docker container UIDs not resolving on the host or in  another container.

This will basically move on in those cases, rather than dropping the whole process.

Unsure if this should also be a lower level log message, potentially only debug.