### PR TITLE
Add beta label to remotecfg

### DIFF
--- a/docs/sources/flow/reference/config-blocks/remotecfg.md
+++ b/docs/sources/flow/reference/config-blocks/remotecfg.md
@@ -10,7 +10,7 @@ menuTitle: remotecfg
 title: remotecfg block
 ---
 
-# remotecfg block
+# remotecfg block (beta)
 
 `remotecfg` is an optional configuration block that enables {{< param "PRODUCT_NAME" >}}
 to fetch and load the configuration from a remote endpoint.
@@ -20,7 +20,12 @@ configuration file.
 The [API definition][] for managing and fetching configuration that the
 `remotecfg` block uses is available under the Apache 2.0 license.
 
+> **BETA**: The `remotecfg` enables beta functionality.
+> Beta features are subject to breaking changes, and may be replaced with
+> equivalent functionality that cover the same use case.
+
 [API definition]: https://github.com/grafana/agent-remote-config
+[beta]: {{< relref "../../../stability.md#beta" >}}
 
 ## Example
 


### PR DESCRIPTION
#### PR Description
This PR marks a `beta` label to the newly added remotecfg block as its stability level was not explicitly mentioned.

I'm opting not to reuse the same doc snippet that components use since its verbiage doesn't exactly fit our use case here.