### PR TITLE
Dockertarget test: fix data race

### DIFF
--- a/component/loki/source/docker/internal/dockertarget/target_test.go
+++ b/component/loki/source/docker/internal/dockertarget/target_test.go
@@ -94,7 +94,10 @@ func TestDockerTarget(t *testing.T) {
 		assertExpectedLog(c, entryHandler, expectedLines)
 	}, 5*time.Second, 100*time.Millisecond, "Expected log lines were not found within the time limit.")
 
-	tgt.Stop()
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.False(t, tgt.Ready())
+	}, 5*time.Second, 20*time.Millisecond, "Expected target to finish processing within the time limit.")
+
 	entryHandler.Clear()
 	// restart target to simulate container restart
 	tgt.StartIfNotRunning()


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This test has a flaky test which sometimes triggers a data race warning: https://drone.grafana.net/grafana/agent/16422/1/2.

I could not reproduce the race locally.

I noticed that Stop() is already called in processLoop function which sets the readiness to false when it exits.
In the test I added a readiness check before performing a restart.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Tests updated