### PR TITLE
Fix flaky test metrics pkg

### DIFF
--- a/pkg/metrics/instance/instance_integration_test.go
+++ b/pkg/metrics/instance/instance_integration_test.go
@@ -193,9 +193,14 @@ remote_write: []
 	require.NoError(t, err)
 
 	instCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	done := make(chan struct{})
+	defer func() {
+		cancel()
+		<-done
+	}()
 	go func() {
 		err := inst.Run(instCtx)
+		close(done)
 		require.NoError(t, err)
 	}()
 

--- a/pkg/metrics/instance/instance_integration_test.go
+++ b/pkg/metrics/instance/instance_integration_test.go
@@ -73,9 +73,14 @@ remote_write: []
 	require.NoError(t, err)
 
 	instCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	done := make(chan struct{})
+	defer func() {
+		cancel()
+		<-done
+	}()
 	go func() {
 		err := inst.Run(instCtx)
+		close(done)
 		require.NoError(t, err)
 	}()
 
@@ -142,9 +147,14 @@ remote_write: []
 	require.NoError(t, err)
 
 	instCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	done := make(chan struct{})
+	defer func() {
+		cancel()
+		<-done
+	}()
 	go func() {
 		err := inst.Run(instCtx)
+		close(done)
 		require.NoError(t, err)
 	}()
 

--- a/pkg/metrics/instance/instance_integration_test.go
+++ b/pkg/metrics/instance/instance_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -73,14 +74,16 @@ remote_write: []
 	require.NoError(t, err)
 
 	instCtx, cancel := context.WithCancel(context.Background())
-	done := make(chan struct{})
+	var wg sync.WaitGroup
 	defer func() {
 		cancel()
-		<-done
+		wg.Wait()
 	}()
+
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		err := inst.Run(instCtx)
-		close(done)
 		require.NoError(t, err)
 	}()
 
@@ -147,14 +150,16 @@ remote_write: []
 	require.NoError(t, err)
 
 	instCtx, cancel := context.WithCancel(context.Background())
-	done := make(chan struct{})
+	var wg sync.WaitGroup
 	defer func() {
 		cancel()
-		<-done
+		wg.Wait()
 	}()
+
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		err := inst.Run(instCtx)
-		close(done)
 		require.NoError(t, err)
 	}()
 
@@ -203,14 +208,16 @@ remote_write: []
 	require.NoError(t, err)
 
 	instCtx, cancel := context.WithCancel(context.Background())
-	done := make(chan struct{})
+	var wg sync.WaitGroup
 	defer func() {
 		cancel()
-		<-done
+		wg.Wait()
 	}()
+
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		err := inst.Run(instCtx)
-		close(done)
 		require.NoError(t, err)
 	}()
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

This test would sometimes not pass on windows, making our main build fail (see https://drone.grafana.net/grafana/agent/16444/2/2).

When testing I also noticed that when running it many times on Mac it would also fail.

The fix makes sure that the context is properly canceled before exiting the test