### PR TITLE
docs: fix write_relabel_config block reference

### DIFF
--- a/docs/sources/flow/reference/components/prometheus.remote_write.md
+++ b/docs/sources/flow/reference/components/prometheus.remote_write.md
@@ -211,7 +211,7 @@ Name | Type | Description | Default | Required
 
 ### write_relabel_config block
 
-{{< docs/shared lookup="flow/reference/components/rule-block.md" source="agent" version="<AGENT_VERSION>" >}}
+{{< docs/shared lookup="flow/reference/components/write_relabel_config.md" source="agent" version="<AGENT_VERSION>" >}}
 
 ### wal block
 

--- a/docs/sources/shared/flow/reference/components/write_relabel_config.md
+++ b/docs/sources/shared/flow/reference/components/write_relabel_config.md
@@ -1,0 +1,50 @@
+---
+aliases:
+- /docs/agent/shared/flow/reference/components/write-relabel-config-block/
+- /docs/grafana-cloud/agent/shared/flow/reference/components/write-relabel-config-block/
+- /docs/grafana-cloud/monitor-infrastructure/agent/shared/flow/reference/components/write-relabel-config-block/
+- /docs/grafana-cloud/monitor-infrastructure/integrations/agent/shared/flow/reference/components/write-relabel-config-block/
+- /docs/grafana-cloud/send-data/agent/shared/flow/reference/components/write-relabel-config-block/
+canonical: https://grafana.com/docs/agent/latest/shared/flow/reference/components/write-relabel-config-block/
+description: Shared content, write_relabel_config block
+headless: true
+---
+
+<!-- NOTE(@tpaschalis) This needs to be kept in sync with rule.md on the same
+directory since these pages don't support some type of templating. -->
+
+The `write_relabel_config` block contains the definition of any relabeling
+rules that can be applied to an input metric.
+If more than one `write_relabel_config` block is defined, the transformations
+are applied in top-down order.
+
+The following arguments can be used to configure a `write_relabel_config`.
+All arguments are optional. Omitted fields take their default values.
+
+Name            | Type           | Description                                                                                                                          | Default | Required
+----------------|----------------|--------------------------------------------------------------------------------------------------------------------------------------|---------|---------
+`action`        | `string`       | The relabeling action to perform.                                                                                                    | replace | no
+`modulus`       | `uint`         | A positive integer used to calculate the modulus of the hashed source label values.                                                  |         | no
+`regex`         | `string`       | A valid RE2 expression with support for parenthesized capture groups. Used to match the extracted value from the combination of the `source_label` and `separator` fields or filter labels during the `labelkeep/labeldrop/labelmap` actions. | `(.*)` | no
+`replacement`   | `string`       | The value against which a regular expression replace is performed, if the regular expression matches the extracted value. Supports previously captured groups. | `"$1"`      | no
+`separator`     | `string`       | The separator used to concatenate the values present in `source_labels`.                                                             | ;       | no
+`source_labels` | `list(string)` | The list of labels whose values are to be selected. Their content is concatenated using the `separator` and matched against `regex`. |         | no
+`target_label`  | `string`       | Label to which the resulting value will be written to.                                                                               |         | no
+
+You can use the following actions:
+
+* `drop`      - Drops metrics where `regex` matches the string extracted using the `source_labels` and `separator`.
+* `dropequal` - Drop targets for which the concatenated `source_labels` do match `target_label`.
+* `hashmod`   - Hashes the concatenated labels, calculates its modulo `modulus` and writes the result to the `target_label`.
+* `keep`      - Keeps metrics where `regex` matches the string extracted using the `source_labels` and `separator`.
+* `keepequal` - Drop targets for which the concatenated `source_labels` do not match `target_label`.
+* `labeldrop` - Matches `regex` against all label names. Any labels that match are removed from the metric's label set.
+* `labelkeep` - Matches `regex` against all label names. Any labels that don't match are removed from the metric's label set.
+* `labelmap`  - Matches `regex` against all label names. Any labels that match are renamed according to the contents of the `replacement` field.
+* `lowercase` - Sets `target_label` to the lowercase form of the concatenated `source_labels`.
+* `replace`   - Matches `regex` to the concatenated labels. If there's a match, it replaces the content of the `target_label` using the contents of the `replacement` field.
+* `uppercase` - Sets `target_label` to the uppercase form of the concatenated `source_labels`.
+
+{{< admonition type="note" >}}
+The regular expression capture groups can be referred to using either the `$CAPTURE_GROUP_NUMBER` or `${CAPTURE_GROUP_NUMBER}` notation.
+{{< /admonition >}}


### PR DESCRIPTION
![image](https://github.com/grafana/agent/assets/17771679/49b0750e-f9c5-4aa0-b557-14a9ee0daf33)

The documentation of the write_relabel_config block reuses the rule.md shared snippet which results in confusing documentation. Since there's no way to templatize these to appear with a different block names, we had some options:

a) Rename the `write_relabel_config` block to `rule`. This makes relabeling rules consistent across all components, but is a breaking change.
b) Inline the documentation for this block since it's not being used anywhere else.
c) Create a copy of the shared block with minimal changes so it's easier to compare and keep in sync.

I think that the short-term solution c) might be a good tradeoff while we think about renaming the block itself.

Fixes #5741