### PR TITLE
Restrict unix integration-test to run on linux only

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -12,6 +12,8 @@ Execute the integration tests using the following command:
 
 `go run .`
 
+**_NOTE:_** The tests don't run on Windows. If you want to run the tests on Linux, you need to set the environment variable OTEL_EXPORTER_ENDPOINT=172.17.0.1:4318.
+
 ### Flags
 
 * `--skip-build`: Run the integration tests without building the agent (default: `false`)

--- a/integration-tests/tests/unix/unix_metrics_test.go
+++ b/integration-tests/tests/unix/unix_metrics_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build linux
 
 package main
 

--- a/integration-tests/utils.go
+++ b/integration-tests/utils.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 )
 
@@ -122,6 +123,10 @@ func reportResults() {
 	// If the channel would not be closed, the for loop would wait forever.
 	close(logChan)
 	for log := range logChan {
+		if strings.Contains(log.TestOutput, "build constraints exclude all Go files") {
+			fmt.Printf("Test %q is not applicable for this OS, ignoring\n", log.TestDir)
+			continue
+		}
 		fmt.Printf("Failure detected in %s:\n", log.TestDir)
 		fmt.Println("Test output:", log.TestOutput)
 		fmt.Println("Agent logs:", log.AgentLog)


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

The test does not run on darwin OS because of the component prometheus.exporter.unix not exporting the expected metrics.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated