### PR TITLE
ci: autolock closed issues and PRs after 30 days

### DIFF
--- a/.github/workflows/autolock.yml
+++ b/.github/workflows/autolock.yml
@@ -1,0 +1,25 @@
+name: Lock closed issues and PRs
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+  discussions: write
+
+concurrency:
+  group: lock-threads
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v5
+        with:
+          pr-inactive-days: 30
+          issue-inactive-days: 30
+          add-issue-labels: 'frozen-due-to-age'
+          add-pr-labels: 'frozen-due-to-age'
+          process-only: 'issues, prs'


### PR DESCRIPTION
Old issues and PRs occasionally get comments well after they have been closed. These comments can lead to community frustration, as closed issues and PRs aren't actively monitored.

This commit introduces a new CI job to automatically lock closed issues and PRs after 30 days of inactivity. A `frozen-due-to-age` label is added to denote why the issue has been locked.

This CI job is deliberately configured to silently close issues without adding a comment to avoid notification noise for maintainers; adding a label takes the place of a comment.