### PR TITLE
otelcolconvert: automatically sync DebugMetrics with Flow defaults

### DIFF
--- a/converter/internal/common/river_utils.go
+++ b/converter/internal/common/river_utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/grafana/river"
 	"github.com/grafana/river/parser"
 	"github.com/grafana/river/printer"
 	"github.com/grafana/river/scanner"
@@ -123,4 +124,17 @@ func SanitizeIdentifierPanics(in string) string {
 		panic(err)
 	}
 	return out
+}
+
+// DefaultValue returns the default value for a given type. If *T implements
+// river.Defaulter, a value will be returned with defaults applied. If *T does
+// not implement river.Defaulter, the zero value of T is returned.
+//
+// T must not be a pointer type.
+func DefaultValue[T any]() T {
+	var val T
+	if defaulter, ok := any(&val).(river.Defaulter); ok {
+		defaulter.SetToDefault()
+	}
+	return val
 }

--- a/converter/internal/common/river_utils_test.go
+++ b/converter/internal/common/river_utils_test.go
@@ -1,0 +1,26 @@
+package common_test
+
+import (
+	"testing"
+
+	"github.com/grafana/agent/converter/internal/common"
+	"github.com/grafana/river"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultValue(t *testing.T) {
+	var explicitDefault defaultingType
+	explicitDefault.SetToDefault()
+
+	require.Equal(t, explicitDefault, common.DefaultValue[defaultingType]())
+}
+
+type defaultingType struct {
+	Number int
+}
+
+var _ river.Defaulter = (*defaultingType)(nil)
+
+func (dt *defaultingType) SetToDefault() {
+	dt.Number = 42
+}

--- a/converter/internal/otelcolconvert/converter_jaegerreceiver.go
+++ b/converter/internal/otelcolconvert/converter_jaegerreceiver.go
@@ -54,6 +54,8 @@ func toJaegerReceiver(state *state, id component.InstanceID, cfg *jaegerreceiver
 			ThriftCompact: toJaegerThriftCompactArguments(cfg.ThriftCompact),
 		},
 
+		DebugMetrics: common.DefaultValue[jaeger.Arguments]().DebugMetrics,
+
 		Output: &otelcol.ConsumerArguments{
 			Traces: toTokenizedConsumers(nextTraces),
 		},

--- a/converter/internal/otelcolconvert/converter_kafkareceiver.go
+++ b/converter/internal/otelcolconvert/converter_kafkareceiver.go
@@ -65,6 +65,8 @@ func toKafkaReceiver(state *state, id component.InstanceID, cfg *kafkareceiver.C
 		MessageMarking:   toKafkaMessageMarking(cfg.MessageMarking),
 		HeaderExtraction: toKafkaHeaderExtraction(cfg.HeaderExtraction),
 
+		DebugMetrics: common.DefaultValue[kafka.Arguments]().DebugMetrics,
+
 		Output: &otelcol.ConsumerArguments{
 			Metrics: toTokenizedConsumers(nextMetrics),
 			Logs:    toTokenizedConsumers(nextLogs),

--- a/converter/internal/otelcolconvert/converter_opencensusreceiver.go
+++ b/converter/internal/otelcolconvert/converter_opencensusreceiver.go
@@ -50,6 +50,8 @@ func toOpencensusReceiver(state *state, id component.InstanceID, cfg *opencensus
 		CorsAllowedOrigins: cfg.CorsOrigins,
 		GRPC:               *toGRPCServerArguments(&cfg.GRPCServerSettings),
 
+		DebugMetrics: common.DefaultValue[opencensus.Arguments]().DebugMetrics,
+
 		Output: &otelcol.ConsumerArguments{
 			Metrics: toTokenizedConsumers(nextMetrics),
 			Traces:  toTokenizedConsumers(nextTraces),

--- a/converter/internal/otelcolconvert/converter_otlpexporter.go
+++ b/converter/internal/otelcolconvert/converter_otlpexporter.go
@@ -52,7 +52,7 @@ func toOtelcolExporterOTLP(cfg *otlpexporter.Config) *otlp.Arguments {
 		Queue: toQueueArguments(cfg.QueueSettings),
 		Retry: toRetryArguments(cfg.RetrySettings),
 
-		DebugMetrics: otelcol.DefaultDebugMetricsArguments,
+		DebugMetrics: common.DefaultValue[otlp.Arguments]().DebugMetrics,
 
 		Client: otlp.GRPCClientArguments(toGRPCClientArguments(cfg.GRPCClientSettings)),
 	}

--- a/converter/internal/otelcolconvert/converter_otlpreceiver.go
+++ b/converter/internal/otelcolconvert/converter_otlpreceiver.go
@@ -54,6 +54,8 @@ func toOtelcolReceiverOTLP(state *state, id component.InstanceID, cfg *otlprecei
 		GRPC: (*otlp.GRPCServerArguments)(toGRPCServerArguments(cfg.GRPC)),
 		HTTP: toHTTPConfigArguments(cfg.HTTP),
 
+		DebugMetrics: common.DefaultValue[otlp.Arguments]().DebugMetrics,
+
 		Output: &otelcol.ConsumerArguments{
 			Metrics: toTokenizedConsumers(nextMetrics),
 			Logs:    toTokenizedConsumers(nextLogs),

--- a/converter/internal/otelcolconvert/converter_zipkinreceiver.go
+++ b/converter/internal/otelcolconvert/converter_zipkinreceiver.go
@@ -47,6 +47,8 @@ func toZipkinReceiver(state *state, id component.InstanceID, cfg *zipkinreceiver
 		ParseStringTags: cfg.ParseStringTags,
 		HTTPServer:      *toHTTPServerArguments(&cfg.HTTPServerSettings),
 
+		DebugMetrics: common.DefaultValue[zipkin.Arguments]().DebugMetrics,
+
 		Output: &otelcol.ConsumerArguments{
 			Traces: toTokenizedConsumers(nextTraces),
 		},


### PR DESCRIPTION
Follow up on https://github.com/grafana/agent/pull/6464#discussion_r1498140245