### PR TITLE
Disable high cardinality metrics in receivers.

### DIFF
--- a/component/otelcol/receiver/jaeger/jaeger.go
+++ b/component/otelcol/receiver/jaeger/jaeger.go
@@ -40,6 +40,13 @@ type Arguments struct {
 
 var _ receiver.Arguments = Arguments{}
 
+// SetToDefault implements river.Defaulter.
+func (args *Arguments) SetToDefault() {
+	*args = Arguments{
+		DebugMetrics: otelcol.DefaultDebugMetricsArguments,
+	}
+}
+
 // Validate implements river.Validator.
 func (args *Arguments) Validate() error {
 	if args.Protocols.GRPC == nil &&

--- a/component/otelcol/receiver/kafka/kafka.go
+++ b/component/otelcol/receiver/kafka/kafka.go
@@ -83,6 +83,7 @@ var DefaultArguments = Arguments{
 		ExtractHeaders: false,
 		Headers:        []string{},
 	},
+	DebugMetrics: otelcol.DefaultDebugMetricsArguments,
 }
 
 // SetToDefault implements river.Defaulter.

--- a/component/otelcol/receiver/opencensus/opencensus.go
+++ b/component/otelcol/receiver/opencensus/opencensus.go
@@ -47,6 +47,7 @@ var DefaultArguments = Arguments{
 		ReadBufferSize: 512 * units.Kibibyte,
 		// We almost write 0 bytes, so no need to tune WriteBufferSize.
 	},
+	DebugMetrics: otelcol.DefaultDebugMetricsArguments,
 }
 
 // SetToDefault implements river.Defaulter.

--- a/component/otelcol/receiver/opencensus/opencensus_test.go
+++ b/component/otelcol/receiver/opencensus/opencensus_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/receiver/opencensus"
 	"github.com/grafana/agent/pkg/flow/componenttest"
 	"github.com/grafana/agent/pkg/util"
@@ -96,4 +97,57 @@ func getFreeAddr(t *testing.T) string {
 	require.NoError(t, err)
 
 	return fmt.Sprintf("localhost:%d", portNumber)
+}
+
+func TestDebugMetricsConfig(t *testing.T) {
+	tests := []struct {
+		testName string
+		agentCfg string
+		expected otelcol.DebugMetricsArguments
+	}{
+		{
+			testName: "default",
+			agentCfg: `
+			output {}
+			`,
+			expected: otelcol.DebugMetricsArguments{
+				DisableHighCardinalityMetrics: true,
+			},
+		},
+		{
+			testName: "explicit_false",
+			agentCfg: `
+			debug_metrics {
+				disable_high_cardinality_metrics = false
+			}
+			output {}
+			`,
+			expected: otelcol.DebugMetricsArguments{
+				DisableHighCardinalityMetrics: false,
+			},
+		},
+		{
+			testName: "explicit_true",
+			agentCfg: `
+			debug_metrics {
+				disable_high_cardinality_metrics = true
+			}
+			output {}
+			`,
+			expected: otelcol.DebugMetricsArguments{
+				DisableHighCardinalityMetrics: true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			var args opencensus.Arguments
+			require.NoError(t, river.Unmarshal([]byte(tc.agentCfg), &args))
+			_, err := args.Convert()
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected, args.DebugMetricsConfig())
+		})
+	}
 }

--- a/component/otelcol/receiver/otlp/otlp.go
+++ b/component/otelcol/receiver/otlp/otlp.go
@@ -67,6 +67,13 @@ func (args *HTTPConfigArguments) Convert() *otlpreceiver.HTTPConfig {
 
 var _ receiver.Arguments = Arguments{}
 
+// SetToDefault implements river.Defaulter.
+func (args *Arguments) SetToDefault() {
+	*args = Arguments{
+		DebugMetrics: otelcol.DefaultDebugMetricsArguments,
+	}
+}
+
 // Convert implements receiver.Arguments.
 func (args Arguments) Convert() (otelcomponent.Config, error) {
 	return &otlpreceiver.Config{

--- a/component/otelcol/receiver/vcenter/vcenter.go
+++ b/component/otelcol/receiver/vcenter/vcenter.go
@@ -267,6 +267,7 @@ var (
 				VcenterVMName:                    ResourceAttributeConfig{Enabled: true},
 			},
 		},
+		DebugMetrics: otelcol.DefaultDebugMetricsArguments,
 	}
 )
 

--- a/component/otelcol/receiver/zipkin/zipkin.go
+++ b/component/otelcol/receiver/zipkin/zipkin.go
@@ -42,6 +42,7 @@ var DefaultArguments = Arguments{
 	HTTPServer: otelcol.HTTPServerArguments{
 		Endpoint: "0.0.0.0:9411",
 	},
+	DebugMetrics: otelcol.DefaultDebugMetricsArguments,
 }
 
 // SetToDefault implements river.Defaulter.

--- a/component/otelcol/receiver/zipkin/zipkin_test.go
+++ b/component/otelcol/receiver/zipkin/zipkin_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/receiver/zipkin"
 	"github.com/grafana/agent/pkg/flow/componenttest"
 	"github.com/grafana/agent/pkg/util"
@@ -83,4 +84,59 @@ func getFreeAddr(t *testing.T) string {
 	require.NoError(t, err)
 
 	return fmt.Sprintf("localhost:%d", portNumber)
+}
+
+func TestDebugMetricsConfig(t *testing.T) {
+	tests := []struct {
+		testName string
+		agentCfg string
+		expected otelcol.DebugMetricsArguments
+	}{
+		{
+			testName: "default",
+			agentCfg: `
+			output {}
+			`,
+			expected: otelcol.DebugMetricsArguments{
+				DisableHighCardinalityMetrics: true,
+			},
+		},
+		{
+			testName: "explicit_false",
+			agentCfg: `
+			debug_metrics {
+				disable_high_cardinality_metrics = false
+			}
+
+			output {}
+			`,
+			expected: otelcol.DebugMetricsArguments{
+				DisableHighCardinalityMetrics: false,
+			},
+		},
+		{
+			testName: "explicit_true",
+			agentCfg: `
+			debug_metrics {
+				disable_high_cardinality_metrics = true
+			}
+
+			output {}
+			`,
+			expected: otelcol.DebugMetricsArguments{
+				DisableHighCardinalityMetrics: true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			var args zipkin.Arguments
+			require.NoError(t, river.Unmarshal([]byte(tc.agentCfg), &args))
+			_, err := args.Convert()
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected, args.DebugMetricsConfig())
+		})
+	}
 }


### PR DESCRIPTION
High cardinality metrics were disabled by default in exporters in #6255, but I forgot to update the receivers. This PR will do that.