### PR TITLE
update docs for otelcol.connector.host_info

### DIFF
--- a/component/otelcol/connector/host_info/host_metrics.go
+++ b/component/otelcol/connector/host_info/host_metrics.go
@@ -36,11 +36,11 @@ func (h *hostMetrics) metrics() (*pmetric.Metrics, int) {
 	defer h.mutex.RUnlock()
 
 	count := len(h.hosts)
-	var m *pmetric.Metrics
+	var pm *pmetric.Metrics
 
 	if count > 0 {
 		metrics := pmetric.NewMetrics()
-		m = &metrics
+		pm = &metrics
 
 		ilm := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
 		ilm.Scope().SetName(typeStr)
@@ -60,7 +60,7 @@ func (h *hostMetrics) metrics() (*pmetric.Metrics, int) {
 		}
 	}
 
-	return m, count
+	return pm, count
 }
 
 func (h *hostMetrics) reset() {

--- a/docs/sources/flow/reference/components/otelcol.connector.host_info.md
+++ b/docs/sources/flow/reference/components/otelcol.connector.host_info.md
@@ -34,6 +34,21 @@ otelcol.connector.host_info "LABEL" {
 | `host_identifiers`       | `list(string)` | Ordered list of resource attributes used to identify unique hosts. | `["host.id"]` | no       |
 | `metrics_flush_interval` | `duration`     | How often to flush generated metrics.                              | `"60s"`       | no       |
 
+## Blocks
+
+The following blocks are supported inside the definition of
+`otelcol.connector.host_info`:
+
+| Hierarchy | Block      | Description                                       | Required |
+| --------- | ---------- | ------------------------------------------------- | -------- |
+| output    | [output][] | Configures where to send received telemetry data. | yes      |
+
+[output]: #output-block
+
+### output block
+
+{{< docs/shared lookup="flow/reference/components/output-block-metrics.md" source="agent" version="<AGENT_VERSION>" >}}
+
 ## Exported fields
 
 The following fields are exported and can be referenced by other components:


### PR DESCRIPTION
#### PR Description

This updates the documentation to include the output block for the `otelcol.connector.host_info` component. 

#### Notes to the Reviewer

* This component was introduced in #6410
* I'm also fixing a shadowed variable the linter didn't catch

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated