### PR TITLE
otelcolconvert: support converting span processor

### DIFF
--- a/component/otelcol/config_filter.go
+++ b/component/otelcol/config_filter.go
@@ -269,6 +269,33 @@ var severityLevels = map[SeverityLevel]plog.SeverityNumber{
 	"FATAL4": 24,
 }
 
+var severityNumbers = map[plog.SeverityNumber]SeverityLevel{
+	1:  "TRACE",
+	2:  "TRACE2",
+	3:  "TRACE3",
+	4:  "TRACE4",
+	5:  "DEBUG",
+	6:  "DEBUG2",
+	7:  "DEBUG3",
+	8:  "DEBUG4",
+	9:  "INFO",
+	10: "INFO2",
+	11: "INFO3",
+	12: "INFO4",
+	13: "WARN",
+	14: "WARN2",
+	15: "WARN3",
+	16: "WARN4",
+	17: "ERROR",
+	18: "ERROR2",
+	19: "ERROR3",
+	20: "ERROR4",
+	21: "FATAL",
+	22: "FATAL2",
+	23: "FATAL3",
+	24: "FATAL4",
+}
+
 // UnmarshalText implements encoding.TextUnmarshaler for SeverityLevel.
 func (sl *SeverityLevel) UnmarshalText(text []byte) error {
 	agentSevLevelStr := SeverityLevel(text)
@@ -277,4 +304,12 @@ func (sl *SeverityLevel) UnmarshalText(text []byte) error {
 		return nil
 	}
 	return fmt.Errorf("unrecognized severity level %q", string(text))
+}
+
+func LookupSeverityNumber(num plog.SeverityNumber) (SeverityLevel, error) {
+	if lvl, exists := severityNumbers[num]; exists {
+		return lvl, nil
+	}
+
+	return "", fmt.Errorf("unrecognized severity number %q", num)
 }

--- a/converter/internal/otelcolconvert/converter_helpers.go
+++ b/converter/internal/otelcolconvert/converter_helpers.go
@@ -54,6 +54,10 @@ func encodeMapstruct(v any) map[string]any {
 	return res
 }
 
+// encodeMapslice uses mapstruct fields to convert the given argument into a
+// []map[string]any. This is useful for being able to convert configuration
+// sections for OpenTelemetry components where the configuration type is hidden
+// in an internal package.
 func encodeMapslice(v any) []map[string]any {
 	var res []map[string]any
 	if err := mapstructure.Decode(v, &res); err != nil {
@@ -62,6 +66,10 @@ func encodeMapslice(v any) []map[string]any {
 	return res
 }
 
+// encodeString uses mapstruct fields to convert the given argument into a
+// string. This is useful for being able to convert configuration
+// sections for OpenTelemetry components where the configuration type is hidden
+// in an internal package.
 func encodeString(v any) string {
 	var res string
 	if err := mapstructure.Decode(v, &res); err != nil {

--- a/converter/internal/otelcolconvert/converter_helpers.go
+++ b/converter/internal/otelcolconvert/converter_helpers.go
@@ -53,3 +53,19 @@ func encodeMapstruct(v any) map[string]any {
 	}
 	return res
 }
+
+func encodeMapslice(v any) []map[string]any {
+	var res []map[string]any
+	if err := mapstructure.Decode(v, &res); err != nil {
+		panic(err)
+	}
+	return res
+}
+
+func encodeString(v any) string {
+	var res string
+	if err := mapstructure.Decode(v, &res); err != nil {
+		panic(err)
+	}
+	return res
+}

--- a/converter/internal/otelcolconvert/converter_spanprocessor.go
+++ b/converter/internal/otelcolconvert/converter_spanprocessor.go
@@ -44,20 +44,20 @@ func toSpanProcessor(state *state, id component.InstanceID, cfg *spanprocessor.C
 		nextTraces = state.Next(id, component.DataTypeTraces)
 	)
 
-	setStatus := &span.Status{}
-	if cfg.SetStatus == nil {
-		setStatus = nil
-	} else {
-		setStatus.Code = cfg.SetStatus.Code
-		setStatus.Description = cfg.SetStatus.Description
+	var setStatus *span.Status
+	if cfg.SetStatus != nil {
+		setStatus = &span.Status{
+			Code:        cfg.SetStatus.Code,
+			Description: cfg.SetStatus.Description,
+		}
 	}
 
-	toAttributes := &span.ToAttributes{}
-	if cfg.Rename.ToAttributes == nil {
-		toAttributes = nil
-	} else {
-		toAttributes.Rules = cfg.Rename.ToAttributes.Rules
-		toAttributes.BreakAfterMatch = cfg.Rename.ToAttributes.BreakAfterMatch
+	var toAttributes *span.ToAttributes
+	if cfg.Rename.ToAttributes != nil {
+		toAttributes = &span.ToAttributes{
+			Rules:           cfg.Rename.ToAttributes.Rules,
+			BreakAfterMatch: cfg.Rename.ToAttributes.BreakAfterMatch,
+		}
 	}
 
 	return &span.Arguments{

--- a/converter/internal/otelcolconvert/converter_spanprocessor.go
+++ b/converter/internal/otelcolconvert/converter_spanprocessor.go
@@ -1,0 +1,139 @@
+package otelcolconvert
+
+import (
+	"fmt"
+
+	"github.com/grafana/agent/component/otelcol"
+	"github.com/grafana/agent/component/otelcol/processor/span"
+	"github.com/grafana/agent/converter/diag"
+	"github.com/grafana/agent/converter/internal/common"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor"
+	"go.opentelemetry.io/collector/component"
+)
+
+func init() {
+	converters = append(converters, spanProcessorConverter{})
+}
+
+type spanProcessorConverter struct{}
+
+func (spanProcessorConverter) Factory() component.Factory { return spanprocessor.NewFactory() }
+
+func (spanProcessorConverter) InputComponentName() string { return "otelcol.processor.span" }
+
+func (spanProcessorConverter) ConvertAndAppend(state *state, id component.InstanceID, cfg component.Config) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	label := state.FlowComponentLabel()
+
+	args := toSpanProcessor(state, id, cfg.(*spanprocessor.Config))
+	block := common.NewBlockWithOverride([]string{"otelcol", "processor", "span"}, label, args)
+
+	diags.Add(
+		diag.SeverityLevelInfo,
+		fmt.Sprintf("Converted %s into %s", stringifyInstanceID(id), stringifyBlock(block)),
+	)
+
+	state.Body().AppendBlock(block)
+	return diags
+}
+
+func toSpanProcessor(state *state, id component.InstanceID, cfg *spanprocessor.Config) *span.Arguments {
+	var (
+		nextTraces = state.Next(id, component.DataTypeTraces)
+	)
+
+	var setStatus *span.Status
+	if cfg.SetStatus != nil {
+		setStatus := &span.Status{}
+		setStatus.Code = cfg.SetStatus.Code
+		setStatus.Description = cfg.SetStatus.Description
+	}
+
+	var toAttributes *span.ToAttributes
+	if cfg.Rename.ToAttributes != nil {
+		toAttributes := &span.ToAttributes{}
+		toAttributes.Rules = cfg.Rename.ToAttributes.Rules
+		toAttributes.BreakAfterMatch = cfg.Rename.ToAttributes.BreakAfterMatch
+	}
+
+	return &span.Arguments{
+		Match: otelcol.MatchConfig{
+			Include: toMatchProperties(encodeMapstruct(cfg.Include)),
+			Exclude: toMatchProperties(encodeMapstruct(cfg.Exclude)),
+		},
+		Name: span.Name{
+			FromAttributes: cfg.Rename.FromAttributes,
+			Separator:      cfg.Rename.Separator,
+			ToAttributes:   toAttributes,
+		},
+		SetStatus: setStatus,
+		Output: &otelcol.ConsumerArguments{
+			Traces: toTokenizedConsumers(nextTraces),
+		},
+	}
+}
+
+func toMatchProperties(cfg map[string]any) *otelcol.MatchProperties {
+	if cfg == nil {
+		return nil
+	}
+
+	var regexpConfig *otelcol.RegexpConfig
+	if cfg["regexp_config"] != nil {
+		regexpConfig.CacheEnabled = cfg["regexp_config"].(map[string]any)["cache_enabled"].(bool)
+		regexpConfig.CacheMaxNumEntries = cfg["regexp_config"].(map[string]any)["cache_max_num_entries"].(int)
+	}
+
+	var ls *otelcol.LogSeverityNumberMatchProperties
+	if cfg["log_severity"] != nil {
+		ls.Min = otelcol.SeverityLevel(cfg["log_severity"].(map[string]any)["min"].(string))
+		ls.MatchUndefined = cfg["log_severity"].(map[string]any)["match_undefined"].(bool)
+	}
+	a := cfg["attributes"]
+	attributes := toOtelcolAttributes(encodeMapslice(a))
+	r := cfg["resources"]
+	resources := toOtelcolAttributes(encodeMapslice(r))
+	l := cfg["libraries"]
+	libraries := toOtelcolInstrumentationLibrary(encodeMapslice(l))
+
+	return &otelcol.MatchProperties{
+		MatchType:        encodeString(cfg["match_type"]),
+		RegexpConfig:     regexpConfig,
+		Services:         cfg["services"].([]string),
+		SpanNames:        cfg["span_names"].([]string),
+		LogBodies:        cfg["log_bodies"].([]string),
+		LogSeverityTexts: cfg["log_severity_texts"].([]string),
+		LogSeverity:      ls,
+		MetricNames:      cfg["metric_names"].([]string),
+		Attributes:       attributes,
+		Resources:        resources,
+		Libraries:        libraries,
+		SpanKinds:        cfg["span_kinds"].([]string),
+	}
+}
+
+func toOtelcolAttributes(in []map[string]any) []otelcol.Attribute {
+	res := make([]otelcol.Attribute, 0, len(in))
+
+	for _, a := range in {
+		res = append(res, otelcol.Attribute{
+			Key:   a["key"].(string),
+			Value: a["value"],
+		})
+	}
+
+	return res
+}
+
+func toOtelcolInstrumentationLibrary(in []map[string]any) []otelcol.InstrumentationLibrary {
+	res := make([]otelcol.InstrumentationLibrary, 0, len(in))
+
+	for _, l := range in {
+		res = append(res, otelcol.InstrumentationLibrary{
+			Name:    l["name"].(string),
+			Version: l["version"].(*string),
+		})
+	}
+	return res
+}

--- a/converter/internal/otelcolconvert/testdata/span.river
+++ b/converter/internal/otelcolconvert/testdata/span.river
@@ -1,0 +1,23 @@
+otelcol.receiver.otlp "default" {
+	grpc { }
+
+	http { }
+
+	output {
+		metrics = [otelcol.exporter.otlp.default.input]
+		logs    = [otelcol.exporter.otlp.default.input]
+		traces  = [otelcol.processor.span.default.input]
+	}
+}
+
+otelcol.processor.span "default" {
+	output {
+		traces = [otelcol.exporter.otlp.default.input]
+	}
+}
+
+otelcol.exporter.otlp "default" {
+	client {
+		endpoint = "database:4317"
+	}
+}

--- a/converter/internal/otelcolconvert/testdata/span.yaml
+++ b/converter/internal/otelcolconvert/testdata/span.yaml
@@ -1,0 +1,33 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+exporters:
+  otlp:
+    # Our defaults have drifted from upstream, so we explicitly set our
+    # defaults below (balancer_name and queue_size).
+    endpoint: database:4317
+    balancer_name: pick_first
+    sending_queue:
+      queue_size: 5000
+
+processors:
+  span:
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlp]
+    logs:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlp]
+    traces:
+      receivers: [otlp]
+      processors: [span]
+      exporters: [otlp]
+

--- a/converter/internal/otelcolconvert/testdata/span_full.river
+++ b/converter/internal/otelcolconvert/testdata/span_full.river
@@ -1,0 +1,72 @@
+otelcol.receiver.otlp "default" {
+	grpc { }
+
+	http { }
+
+	output {
+		metrics = [otelcol.exporter.otlp.default.input]
+		logs    = [otelcol.exporter.otlp.default.input]
+		traces  = [otelcol.processor.span.default.input]
+	}
+}
+
+otelcol.processor.span "default" {
+	include {
+		match_type         = "strict"
+		span_names         = ["span1", "span2"]
+		log_bodies         = ["lb1", "lb2"]
+		log_severity_texts = ["ls1", "ls2"]
+
+		attribute {
+			key   = "key1"
+			value = "value1"
+		}
+		span_kinds = ["spankind1", "spankind2"]
+	}
+
+	exclude {
+		match_type = "regex"
+		services   = ["svc1", "svc2"]
+
+		log_severity {
+			min             = "TRACE2"
+			match_undefined = false
+		}
+		metric_names = ["mn1", "mn2"]
+
+		resource {
+			key   = "key1"
+			value = "value1"
+		}
+
+		library {
+			name    = "name1"
+			version = "version1"
+		}
+	}
+
+	name {
+		from_attributes = ["db.svc", "operation"]
+		separator       = "::"
+
+		to_attributes {
+			rules             = ["^\\/api\\/v1\\/document\\/(?P<documentId>.*)\\/update$"]
+			break_after_match = true
+		}
+	}
+
+	status {
+		code        = "Error"
+		description = "some error description"
+	}
+
+	output {
+		traces = [otelcol.exporter.otlp.default.input]
+	}
+}
+
+otelcol.exporter.otlp "default" {
+	client {
+		endpoint = "database:4317"
+	}
+}

--- a/converter/internal/otelcolconvert/testdata/span_full.yaml
+++ b/converter/internal/otelcolconvert/testdata/span_full.yaml
@@ -1,0 +1,67 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+exporters:
+  otlp:
+    # Our defaults have drifted from upstream, so we explicitly set our
+    # defaults below (balancer_name and queue_size).
+    endpoint: database:4317
+    balancer_name: pick_first
+    sending_queue:
+      queue_size: 5000
+
+processors:
+  # Since this processor has deeply nested attributes, we're adding a more
+  # fleshed out testdata case to make sure we're hitting all the possible
+  # conversion code paths.
+  span:
+    name:
+      from_attributes: ["db.svc", "operation"]
+      separator: "::"
+      to_attributes:
+        break_after_match: true
+        rules:
+          - ^\/api\/v1\/document\/(?P<documentId>.*)\/update$
+    status:
+      code: Error
+      description: "some error description"
+    include:
+      match_type: "strict"
+      attributes:
+        - key: "key1"
+          value: "value1"
+      span_names: ["span1", "span2"]
+      span_kinds: ["spankind1", "spankind2"]
+      log_bodies: ["lb1", "lb2"]
+      log_severity_texts: ["ls1", "ls2"]
+    exclude:
+      match_type: "regex"
+      services: ["svc1", "svc2"]
+      resources:
+        - key: "key1"
+          value: "value1"
+      libraries:
+        - name: "name1"
+          version: "version1"
+      log_severity_number:
+        min: 2
+        match_undefined: false
+      metric_names: ["mn1", "mn2"]
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlp]
+    logs:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlp]
+    traces:
+      receivers: [otlp]
+      processors: [span]
+      exporters: [otlp]


### PR DESCRIPTION
Closes #6455

I had to add a few more encode helper methods to access internal slice/string types.

I was worried about the number of nested fields, but I used all the options with a span.yaml like the following and got eveything ported over to the River config without any panics.

<details>

```
receivers:
  otlp:
    protocols:
      grpc:
      http:

exporters:
  otlp:
    # Our defaults have drifted from upstream, so we explicitly set our
    # defaults below (balancer_name and queue_size).
    endpoint: database:4317
    balancer_name: pick_first
    sending_queue:
      queue_size: 5000

processors:
  span:
    name:
      from_attributes: ["db.svc", "operation"]
      separator: "::"
      to_attributes:
        rules:
          - ^\/api\/v1\/document\/(?P<documentId>.*)\/update$
    status:
      code: Error
      description: "some error description"
    include:
      match_type: "strict"
      attributes:
        - key: "key1"
          value: "value1"
      span_names: ["span1", "span2"]
      span_kinds: ["spankind1", "spankind2"]
      log_bodies: ["lb1", "lb2"]
      log_severity_texts: ["ls1", "ls2"]
    exclude:
      match_type: "regex"
      services: ["svc1", "svc2"]
      resources:
        - key: "key1"
          value: "value1"
      libraries:
        - name: "name1"
          version: "version1"
      log_severity_number:
        min: 1
        match_undefined: false
      metric_names: ["mn1", "mn2"]

service:
  pipelines:
    metrics:
      receivers: [otlp]
      processors: []
      exporters: [otlp]
    logs:
      receivers: [otlp]
      processors: []
      exporters: [otlp]
    traces:
      receivers: [otlp]
      processors: [span]
      exporters: [otlp]
```

</details>