### PR TITLE
loki.source.api: fix a bug where incoming structured metadata and parsed are ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Main (unreleased)
 
 - Fix an issue where JSON string array elements were not parsed correctly in `loki.source.cloudflare`. (@thampiotr)
 
+- Fix a bug where structured metadata and parsed field are not passed further in `loki.source.api` (@marchellodev)
+
 ### Other changes
 
 - Clustering for Grafana Agent in Flow mode has graduated from beta to stable.

--- a/internal/component/loki/source/api/internal/lokipush/push_api_server.go
+++ b/internal/component/loki/source/api/internal/lokipush/push_api_server.go
@@ -185,7 +185,9 @@ func (s *PushAPIServer) handleLoki(w http.ResponseWriter, r *http.Request) {
 			e := loki.Entry{
 				Labels: filtered.Clone(),
 				Entry: logproto.Entry{
-					Line: entry.Line,
+					Line:               entry.Line,
+					StructuredMetadata: entry.StructuredMetadata,
+					Parsed:             entry.Parsed,
 				},
 			}
 			if keepTimestamp {


### PR DESCRIPTION

#### PR Description

This pull-request fixes a bug in loki.source.api, where incoming structured metadata and parsed fields are not passed further.

#### Which issue(s) this PR fixes

Fixes #6493

#### Notes to the Reviewer

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Tests updated
