### PR TITLE
General cleanup of relref links

### DIFF
--- a/docs/sources/flow/_index.md
+++ b/docs/sources/flow/_index.md
@@ -85,9 +85,15 @@ This feature is experimental, and it doesn't support all River components.
 * Check out our [Reference][] documentation to find specific information you
   might be looking for.
 
-[Install]: {{< relref "./get-started/install/" >}}
-[Concepts]: {{< relref "./concepts/" >}}
-[Tasks]: {{< relref "./tasks/" >}}
-[Tutorials]: {{< relref "./tutorials/ ">}}
-[Reference]: {{< relref "./reference" >}}
-
+{{% docs/reference %}}
+[Install]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/get-started/install/"
+[Install]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/get-started/install/"
+[Concepts]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/"
+[Concepts]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/"
+[Tasks]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/tasks/"
+[Tasks]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/tasks/"
+[Tutorials]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/tutorials/"
+[Tutorials]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/tutorials/
+[Reference]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/"
+[Reference]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/
+{{% /docs/reference %}}

--- a/docs/sources/flow/_index.md
+++ b/docs/sources/flow/_index.md
@@ -70,7 +70,7 @@ prometheus.remote_write "default" {
 
 ## {{% param "PRODUCT_NAME" %}} configuration generator
 
-The {{< param "PRODUCT_NAME" >}} [configuration generator](https://grafana.github.io/agent-configurator/) will help you get a head start on creating flow code.
+The {{< param "PRODUCT_NAME" >}} [configuration generator](https://grafana.github.io/agent-configurator/) helps you get a head start on creating flow code.
 
 {{< admonition type="note" >}}
 This feature is experimental, and it doesn't support all River components.
@@ -80,10 +80,9 @@ This feature is experimental, and it doesn't support all River components.
 
 * [Install][] {{< param "PRODUCT_NAME" >}}.
 * Learn about the core [Concepts][] of {{< param "PRODUCT_NAME" >}}.
-* Follow our [Tutorials][] for hands-on learning of {{< param "PRODUCT_NAME" >}}.
-* Consult our [Tasks][] instructions to accomplish common objectives with {{< param "PRODUCT_NAME" >}}.
-* Check out our [Reference][] documentation to find specific information you
-  might be looking for.
+* Follow the [Tutorials][] for hands-on learning of {{< param "PRODUCT_NAME" >}}.
+* Consult the [Tasks][] instructions to accomplish common objectives with {{< param "PRODUCT_NAME" >}}.
+* Check out the [Reference][] documentation to find specific information you might be looking for.
 
 {{% docs/reference %}}
 [Install]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/get-started/install/"

--- a/docs/sources/flow/reference/config-blocks/argument.md
+++ b/docs/sources/flow/reference/config-blocks/argument.md
@@ -18,7 +18,8 @@ title: argument block
 The `argument` block may only be specified inside the definition of [a `declare` block][declare].
 
 {{< admonition type="note" >}}
-In [classic modules][], the `argument` block is valid as a top-level block in a classic module. Classic modules are deprecated and scheduled to be removed in the release after v0.40.
+In [classic modules][], the `argument` block is valid as a top-level block in a classic module.
+Classic modules are deprecated and scheduled to be removed in the release after v0.40.
 
 [classic modules]: https://grafana.com/docs/agent/<AGENT_VERSION>/flow/concepts/modules/#classic-modules-deprecated
 {{< /admonition >}}

--- a/docs/sources/flow/reference/config-blocks/argument.md
+++ b/docs/sources/flow/reference/config-blocks/argument.md
@@ -20,11 +20,8 @@ The `argument` block may only be specified inside the definition of [a `declare`
 {{< admonition type="note" >}}
 In [classic modules][], the `argument` block is valid as a top-level block in a classic module. Classic modules are deprecated and scheduled to be removed in the release after v0.40.
 
-[classic modules]: {{< relref "../../concepts/modules.md#classic-modules-deprecated" >}}
+[classic modules]: https://grafana.com/docs/agent/<AGENT_VERSION>/flow/concepts/modules/#classic-modules-deprecated
 {{< /admonition >}}
-
-[custom component]: {{< relref "../../concepts/custom_components.md" >}}
-[declare]: {{< relref "./declare.md" >}}
 
 ## Example
 
@@ -34,9 +31,10 @@ argument "ARGUMENT_NAME" {}
 
 ## Arguments
 
-> **NOTE**: For clarity, "argument" in this section refers to arguments which
-> can be given to the argument block. "Module argument" refers to the argument
-> being defined for a module, determined by the label of the argument block.
+{{< admonition type="note" >}}
+For clarity, "argument" in this section refers to arguments which can be given to the argument block.
+"Module argument" refers to the argument being defined for a module, determined by the label of the argument block.
+{{< /admonition >}}
 
 The following arguments are supported:
 
@@ -46,21 +44,20 @@ Name       | Type     | Description                          | Default | Require
 `default`  | `any`    | Default value for the argument.      | `null`  | no
 `optional` | `bool`   | Whether the argument may be omitted. | `false` | no
 
-By default, all module arguments are required. The `optional` argument can be
-used to mark the module argument as optional. When `optional` is `true`, the
-initial value for the module argument is specified by `default`.
+By default, all module arguments are required.
+The `optional` argument can be used to mark the module argument as optional.
+When `optional` is `true`, the initial value for the module argument is specified by `default`.
 
 ## Exported fields
 
 The following fields are exported and can be referenced by other components:
 
-Name | Type | Description
----- | ---- | -----------
+Name    | Type  | Description
+--------|-------|-----------------------------------
 `value` | `any` | The current value of the argument.
 
 If you use a custom component, you are responsible for determining the values for arguments.
-Other expressions within a custom component may use `argument.ARGUMENT_NAME.value` to retrieve the
-value you provide.
+Other expressions within a custom component may use `argument.ARGUMENT_NAME.value` to retrieve the value you provide.
 
 ## Example
 
@@ -82,3 +79,10 @@ declare "self_collect" {
   }
 }
 ```
+
+{{% docs/reference %}}
+[custom component]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/custom_components"
+[custom component]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/custom_components"
+[declare]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/config-blocks/declare"
+[declare]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/declare"
+{{% /docs/reference %}}

--- a/docs/sources/flow/reference/config-blocks/declare.md
+++ b/docs/sources/flow/reference/config-blocks/declare.md
@@ -15,8 +15,6 @@ title: declare block
 `declare` is an optional configuration block used to define a new [custom component][].
 `declare` blocks must be given a label that determines the name of the custom component.
 
-[custom component]: {{< relref "../../concepts/custom_components.md" >}}
-
 ## Example
 
 ```river
@@ -27,8 +25,9 @@ declare "COMPONENT_NAME" {
 
 ## Arguments
 
-The `declare` block has no predefined schema for its arguments; the body of the
-`declare` block is used as the component definition. The body may contain:
+The `declare` block has no predefined schema for its arguments.
+The body of the `declare` block is used as the component definition.
+The body can contain the following:
 
 * [argument][] blocks
 * [export][] blocks
@@ -36,19 +35,12 @@ The `declare` block has no predefined schema for its arguments; the body of the
 * [import][] blocks
 * Component definitions (either built-in or custom components)
 
-The `declare` block may not contain any configuration blocks that are not
-listed above.
-
-[argument]: {{< relref "./argument.md" >}}
-[export]: {{< relref "./export.md" >}}
-[declare]: {{< relref "./declare.md" >}}
-[import]: {{< relref "../../concepts/modules.md#importing-modules" >}}
+The `declare` block may not contain any configuration blocks that aren't listed above.
 
 ## Exported fields
 
-The `declare` block has no predefined schema for its exports; the fields
-exported by the `declare` block are determined by the [export blocks][export]
-found in its definition.
+The `declare` block has no predefined schema for its exports.
+The fields exported by the `declare` block are determined by the [export blocks][export] found in its definition.
 
 ## Example
 
@@ -80,3 +72,14 @@ prometheus.remote_write "example" {
   }
 }
 ```
+
+{{% docs/reference %}}
+[argument]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/config-blocks/argument"
+[argument]:"/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/argument"
+[export]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/config-blocks/export"
+[export]:"/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/export"
+[declare]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/config-blocks/declare"
+[declare]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/declare"
+[import]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/modules#importing-modules"
+[import]:"/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/modules#importing-modules"
+{{% /docs/reference %}}

--- a/docs/sources/flow/reference/config-blocks/export.md
+++ b/docs/sources/flow/reference/config-blocks/export.md
@@ -20,11 +20,8 @@ The `export` block may only be specified inside the definition of [a `declare` b
 {{< admonition type="note" >}}
 In [classic modules][], the `export` block is valid as a top-level block in a classic module. Classic modules are deprecated and scheduled to be removed in the release after v0.40.
 
-[classic modules]: {{< relref "../../concepts/modules.md#classic-modules-deprecated" >}}
+[classic modules]: https://grafana.com/docs/agent/<AGENT_VERSION>/flow/concepts/modules/#classic-modules-deprecated
 {{< /admonition >}}
-
-[custom component]: {{< relref "../../concepts/custom_components.md" >}}
-[declare]: {{< relref "./declare.md" >}}
 
 ## Example
 
@@ -42,7 +39,7 @@ Name    | Type  | Description      | Default | Required
 --------|-------|------------------|---------|---------
 `value` | `any` | Value to export. |         | yes
 
-The `value` argument determines what the value of the export will be.
+The `value` argument determines what the value of the export is.
 To expose an exported field of another component, set `value` to an expression that references that exported value.
 
 ## Exported fields
@@ -71,3 +68,10 @@ declare "pods_and_nodes" {
   }
 }
 ```
+
+{{% docs/reference %}}
+[custom component]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/custom_components"
+[custom component]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/custom_components"
+[declare]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/config-blocks/declare"
+[declare]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/declare"
+{{% /docs/reference %}}

--- a/docs/sources/flow/reference/config-blocks/http.md
+++ b/docs/sources/flow/reference/config-blocks/http.md
@@ -75,17 +75,15 @@ When the `tls` block is specified, arguments for the TLS certificate (using
 `cert_pem` or `cert_file`) and for the TLS key (using `key_pem` or `key_file`)
 are required.
 
-The following pairs of arguments are mutually exclusive, and only one may be
-configured at a time:
+The following pairs of arguments are mutually exclusive, and only one may be configured at a time:
 
 * `cert_pem` and `cert_file`
 * `key_pem` and `key_file`
 * `client_ca_pem` and `client_ca_file`
 
 The `client_auth_type` argument determines whether to validate client certificates.
-The default value, `NoClientCert`, indicates that the client certificate is not
-validated. The `client_ca_pem` and `client_ca_file` arguments may only
-be configured when `client_auth_type` is not `NoClientCert`.
+The default value, `NoClientCert`, indicates that the client certificate is not validated.
+The `client_ca_pem` and `client_ca_file` arguments may only be configured when `client_auth_type` is not `NoClientCert`.
 
 The following values are accepted for `client_auth_type`:
 
@@ -95,13 +93,12 @@ The following values are accepted for `client_auth_type`:
 * `VerifyClientCertIfGiven`: requests clients to send an optional certificate. If a certificate is sent, it must be valid.
 * `RequireAndVerifyClientCert`: requires clients to send a valid certificate.
 
-The `client_ca_pem` or `client_ca_file` arguments may be used to perform client
-certificate validation. These arguments may only be provided when `client_auth_type`
-is not set to `NoClientCert`.
+The `client_ca_pem` or `client_ca_file` arguments may be used to perform client certificate validation.
+These arguments may only be provided when `client_auth_type` is not set to `NoClientCert`.
 
-The `cipher_suites` argument determines what cipher suites to use. If not
-provided, a default list is used. The set of cipher suites specified may be
-from the following:
+The `cipher_suites` argument determines what cipher suites to use.
+If you don't provide cipher suite, a default list is used.
+The set of cipher suites specified may be from the following:
 
 | Cipher                                          | Allowed in `boringcrypto` builds |
 | ----------------------------------------------- | -------------------------------- |
@@ -134,9 +131,8 @@ is used. The set of elliptic curves specified may be from the following:
 | `CurveP521` | yes                              |
 | `X25519`    | no                               |
 
-The `min_version` and `max_version` arguments determine the oldest and newest
-TLS version that is acceptable from clients. If not provided, a default value
-is used.
+The `min_version` and `max_version` arguments determine the oldest and newest TLS version that's acceptable from clients.
+If you don't provide the min and max TLS version, a default value is used.
 
 The following versions are recognized:
 
@@ -148,9 +144,8 @@ The following versions are recognized:
 
 ### windows certificate filter block
 
-The `windows_certificate_filter` block is used to configure retrieving certificates from the built-in Windows
-certificate store. When you use the `windows_certificate_filter` block
-the following TLS settings are overridden and will cause an error if defined.
+The `windows_certificate_filter` block is used to configure retrieving certificates from the built-in Windows certificate store.
+When you use the `windows_certificate_filter` block the following TLS settings are overridden and cause an error if defined.
 
 * `cert_pem`
 * `cert_file`
@@ -162,15 +157,15 @@ the following TLS settings are overridden and will cause an error if defined.
 {{< admonition type="warning" >}}
 This feature is only available on Windows.
 
-TLS min and max may not be compatible with the certificate stored in the Windows certificate store. The `windows_certificate_filter`
-will serve the found certificate even if it isn't compatible with the specified TLS version.
+TLS min and max may not be compatible with the certificate stored in the Windows certificate store.
+The `windows_certificate_filter` serves the certificate even if it isn't compatible with the specified TLS version.
 {{< /admonition >}}
 
 
 ### server block
 
-The `server` block is used to find the certificate to check the signer. If multiple certificates are found the
-`windows_certificate_filter` will choose the certificate with the expiration farthest in the future.
+The `server` block is used to find the certificate to check the signer.
+If multiple certificates are found, the `windows_certificate_filter` chooses the certificate with the expiration farthest in the future.
 
 Name                  | Type           | Description                                                                                          | Default | Required
 ----------------------|----------------|------------------------------------------------------------------------------------------------------|---------|---------

--- a/docs/sources/flow/reference/config-blocks/http.md
+++ b/docs/sources/flow/reference/config-blocks/http.md
@@ -57,19 +57,19 @@ Similarly, if you remove the `tls` block and reload the configuration when {{< p
 To ensure all connections use TLS, configure the `tls` block before you start {{< param "PRODUCT_NAME" >}}.
 {{< /admonition >}}
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`cert_pem` | `string` | PEM data of the server TLS certificate. | `""` | conditionally
-`cert_file` | `string` | Path to the server TLS certificate on disk. | `""` | conditionally
-`key_pem` | `string` | PEM data of the server TLS key. | `""` | conditionally
-`key_file` | `string` | Path to the server TLS key on disk. | `""` | conditionally
-`client_ca_pem` | `string` | PEM data of the client CA to validate requests against. | `""` | no
-`client_ca_file` | `string` | Path to the client CA file on disk to validate requests against. | `""` | no
-`client_auth_type` | `string` | Client authentication to use. | `"NoClientCert"` | no
-`cipher_suites` | `list(string)` | Set of cipher suites to use. | `[]` | no
-`curve_preferences` | `list(string)` | Set of elliptic curves to use in a handshake. | `[]` | no
-`min_version` | `string` | Oldest TLS version to accept from clients. | `""` | no
-`max_version` | `string` | Newest TLS version to accept from clients. | `""` | no
+Name                | Type           | Description                                                      | Default          | Required
+--------------------|----------------|------------------------------------------------------------------|------------------|--------------
+`cert_pem`          | `string`       | PEM data of the server TLS certificate.                          | `""`             | conditionally
+`cert_file`         | `string`       | Path to the server TLS certificate on disk.                      | `""`             | conditionally
+`key_pem`           | `string`       | PEM data of the server TLS key.                                  | `""`             | conditionally
+`key_file`          | `string`       | Path to the server TLS key on disk.                              | `""`             | conditionally
+`client_ca_pem`     | `string`       | PEM data of the client CA to validate requests against.          | `""`             | no
+`client_ca_file`    | `string`       | Path to the client CA file on disk to validate requests against. | `""`             | no
+`client_auth_type`  | `string`       | Client authentication to use.                                    | `"NoClientCert"` | no
+`cipher_suites`     | `list(string)` | Set of cipher suites to use.                                     | `[]`             | no
+`curve_preferences` | `list(string)` | Set of elliptic curves to use in a handshake.                    | `[]`             | no
+`min_version`       | `string`       | Oldest TLS version to accept from clients.                       | `""`             | no
+`max_version`       | `string`       | Newest TLS version to accept from clients.                       | `""`             | no
 
 When the `tls` block is specified, arguments for the TLS certificate (using
 `cert_pem` or `cert_file`) and for the TLS key (using `key_pem` or `key_file`)
@@ -163,7 +163,7 @@ the following TLS settings are overridden and will cause an error if defined.
 This feature is only available on Windows.
 
 TLS min and max may not be compatible with the certificate stored in the Windows certificate store. The `windows_certificate_filter`
-will serve the found certificate even if it is not compatible with the specified TLS version.
+will serve the found certificate even if it isn't compatible with the specified TLS version.
 {{< /admonition >}}
 
 

--- a/docs/sources/flow/reference/config-blocks/import.file.md
+++ b/docs/sources/flow/reference/config-blocks/import.file.md
@@ -18,8 +18,6 @@ title: import.file
 The `import.file` block imports custom components from a file and exposes them to the importer.
 `import.file` blocks must be given a label that determines the namespace where custom components are exposed.
 
-[module]: {{< relref "../../concepts/modules.md" >}}
-
 ## Usage
 
 ```river
@@ -69,3 +67,8 @@ math.add "default" {
 }
 ```
 {{< /collapse >}}
+
+{{% docs/reference %}}
+[module]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/modules"
+[module]:"/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/modules"
+{{% /docs/reference %}}

--- a/docs/sources/flow/reference/config-blocks/import.file.md
+++ b/docs/sources/flow/reference/config-blocks/import.file.md
@@ -32,11 +32,11 @@ import.file "NAMESPACE" {
 
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`filename`       | `string`   | Path of the file on disk to watch. | | yes
+Name             | Type       | Description                                         | Default      | Required
+-----------------|------------|-----------------------------------------------------|--------------|---------
+`filename`       | `string`   | Path of the file on disk to watch.                  |              | yes
 `detector`       | `string`   | Which file change detector to use (fsnotify, poll). | `"fsnotify"` | no
-`poll_frequency` | `duration` | How often to poll for file changes. | `"1m"` | no
+`poll_frequency` | `duration` | How often to poll for file changes.                 | `"1m"`       | no
 
 {{< docs/shared lookup="flow/reference/components/local-file-arguments-text.md" source="agent" version="<AGENT_VERSION>" >}}
 

--- a/docs/sources/flow/reference/config-blocks/import.git.md
+++ b/docs/sources/flow/reference/config-blocks/import.git.md
@@ -18,8 +18,6 @@ title: import.git
 The `import.git` block imports custom components from a Git repository and exposes them to the importer.
 `import.git` blocks must be given a label that determines the namespace where custom components are exposed.
 
-[module]: {{< relref "../../concepts/modules.md" >}}
-
 ## Usage
 
 ```river
@@ -33,12 +31,12 @@ import.git "NAMESPACE" {
 
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`repository` | `string` | The Git repository address to retrieve the module from. | | yes
-`revision` | `string` | The Git revision to retrieve the module from. | `"HEAD"` | no
-`path` | `string` | The path in the repository where the module is stored. | | yes
-`pull_frequency` | `duration` | The frequency to pull the repository for updates. | `"60s"` | no
+Name             | Type       | Description                                             | Default  | Required
+-----------------|------------|---------------------------------------------------------|----------|---------
+`repository`     | `string`   | The Git repository address to retrieve the module from. |          | yes
+`revision`       | `string`   | The Git revision to retrieve the module from.           | `"HEAD"` | no
+`path`           | `string`   | The path in the repository where the module is stored.  |          | yes
+`pull_frequency` | `duration` | The frequency to pull the repository for updates.       | `"60s"`  | no
 
 The `repository` attribute must be set to a repository address that would be
 recognized by Git with a `git clone REPOSITORY_ADDRESS` command, such as
@@ -53,24 +51,21 @@ commit SHA within the repository.
 You must set the `path` attribute to a path accessible from the repository's root,
 such as `FILE_NAME.river` or `FOLDER_NAME/FILE_NAME.river`.
 
-If `pull_frequency` is not `"0s"`, the Git repository is pulled for
-updates at the frequency specified. If it is set to `"0s"`, the Git repository is pulled once on init.
+If `pull_frequency` isn't `"0s"`, the Git repository is pulled for
+updates at the frequency specified. If it's set to `"0s"`, the Git repository is pulled once on init.
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 Pulling hosted Git repositories too often can result in throttling.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Blocks
 
 The following blocks are supported inside the definition of `import.git`:
 
-Hierarchy        | Block      | Description | Required
----------------- | ---------- | ----------- | --------
+Hierarchy  | Block          | Description                                                | Required
+-----------|----------------|------------------------------------------------------------|---------
 basic_auth | [basic_auth][] | Configure basic_auth for authenticating to the repository. | no
-ssh_key | [ssh_key][] | Configure an SSH Key for authenticating to the repository. | no
-
-[basic_auth]: #basic_auth-block
-[ssh_key]: #ssh_key-block
+ssh_key    | [ssh_key][]    | Configure an SSH Key for authenticating to the repository. | no
 
 ### basic_auth block
 
@@ -78,12 +73,12 @@ ssh_key | [ssh_key][] | Configure an SSH Key for authenticating to the repositor
 
 ### ssh_key block
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`username`  | `string` | SSH username. | | yes
-`key`       | `secret` | SSH private key. | | no
-`key_file`  | `string` | SSH private key path. | | no
-`passphrase` | `secret` | Passphrase for SSH key if needed. | | no
+Name         | Type     | Description                       | Default | Required
+-------------|----------|-----------------------------------|---------|---------
+`username`   | `string` | SSH username.                     |         | yes
+`key`        | `secret` | SSH private key.                  |         | no
+`key_file`   | `string` | SSH private key path.             |         | no
+`passphrase` | `secret` | Passphrase for SSH key if needed. |         | no
 
 ## Examples
 
@@ -101,3 +96,11 @@ math.add "default" {
   b = 45
 }
 ```
+
+[basic_auth]: #basic_auth-block
+[ssh_key]: #ssh_key-block
+
+{{% docs/reference %}}
+[module]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/modules"
+[module]:"/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/modules"
+{{% /docs/reference %}}

--- a/docs/sources/flow/reference/config-blocks/import.git.md
+++ b/docs/sources/flow/reference/config-blocks/import.git.md
@@ -51,8 +51,8 @@ commit SHA within the repository.
 You must set the `path` attribute to a path accessible from the repository's root,
 such as `FILE_NAME.river` or `FOLDER_NAME/FILE_NAME.river`.
 
-If `pull_frequency` isn't `"0s"`, the Git repository is pulled for
-updates at the frequency specified. If it's set to `"0s"`, the Git repository is pulled once on init.
+If `pull_frequency` isn't `"0s"`, the Git repository is pulled for updates at the frequency specified.
+If it's set to `"0s"`, the Git repository is pulled once on init.
 
 {{< admonition type="warning" >}}
 Pulling hosted Git repositories too often can result in throttling.

--- a/docs/sources/flow/reference/config-blocks/import.http.md
+++ b/docs/sources/flow/reference/config-blocks/import.http.md
@@ -17,8 +17,6 @@ title: import.http
 
 `import.http` retrieves a module from an HTTP server.
 
-[module]: {{< relref "../../concepts/modules.md" >}}
-
 ## Usage
 
 ```river
@@ -31,13 +29,13 @@ import.http "LABEL" {
 
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`url` | `string` | URL to poll. | | yes
-`method` | `string` | Define the HTTP method for the request. | `"GET"` | no
-`headers` | `map(string)` | Custom headers for the request. | `{}` | no
-`poll_frequency` | `duration` | Frequency to poll the URL. | `"1m"` | no
-`poll_timeout` | `duration` | Timeout when polling the URL. | `"10s"` | no
+Name             | Type          | Description                             | Default | Required
+-----------------|---------------|-----------------------------------------|---------|---------
+`url`            | `string`      | URL to poll.                            |         | yes
+`method`         | `string`      | Define the HTTP method for the request. | `"GET"` | no
+`headers`        | `map(string)` | Custom headers for the request.         | `{}`    | no
+`poll_frequency` | `duration`    | Frequency to poll the URL.              | `"1m"`  | no
+`poll_timeout`   | `duration`    | Timeout when polling the URL.           | `"10s"` | no
 
 ## Example
 

--- a/docs/sources/flow/reference/config-blocks/import.http.md
+++ b/docs/sources/flow/reference/config-blocks/import.http.md
@@ -66,4 +66,3 @@ math.add "default" {
 }
 ```
 {{< /collapse >}}
-

--- a/docs/sources/flow/reference/config-blocks/import.string.md
+++ b/docs/sources/flow/reference/config-blocks/import.string.md
@@ -18,8 +18,6 @@ title: import.string
 The `import.string` block imports custom components from a string and exposes them to the importer.
 `import.string` blocks must be given a label that determines the namespace where custom components are exposed.
 
-[module]: {{< relref "../../concepts/modules.md" >}}
-
 ## Usage
 
 ```river
@@ -32,9 +30,9 @@ import.string "NAMESPACE" {
 
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`content`   | `secret` or `string` | The contents of the module to import as a secret or string. | | yes
+Name      | Type                 | Description                                                 | Default | Required
+----------|----------------------|-------------------------------------------------------------|---------|---------
+`content` | `secret` or `string` | The contents of the module to import as a secret or string. |         | yes
 
 `content` is a string that contains the configuration of the module to import.
 `content` is typically loaded by using the exports of another component. For example,
@@ -61,3 +59,8 @@ math.add "default" {
   b = 45
 }
 ```
+
+{{% docs/reference %}}
+[module]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/modules"
+[module]:"/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/modules"
+{{% /docs/reference %}}

--- a/docs/sources/flow/reference/config-blocks/remotecfg.md
+++ b/docs/sources/flow/reference/config-blocks/remotecfg.md
@@ -14,18 +14,14 @@ title: remotecfg block
 
 `remotecfg` is an optional configuration block that enables {{< param "PRODUCT_NAME" >}}
 to fetch and load the configuration from a remote endpoint.
-`remotecfg` is specified without a label and can only be provided once per
-configuration file.
+`remotecfg` is specified without a label and can only be provided once per configuration file.
 
 The [API definition][] for managing and fetching configuration that the
 `remotecfg` block uses is available under the Apache 2.0 license.
 
-> **BETA**: The `remotecfg` enables beta functionality.
+> **BETA**: The `remotecfg` enables [beta][] functionality.
 > Beta features are subject to breaking changes, and may be replaced with
 > equivalent functionality that cover the same use case.
-
-[API definition]: https://github.com/grafana/agent-remote-config
-[beta]: {{< relref "../../../stability.md#beta" >}}
 
 ## Example
 
@@ -67,22 +63,16 @@ remote endpoint so that the API can decide what configuration to serve.
 
 The following blocks are supported inside the definition of `remotecfg`:
 
-Hierarchy | Block | Description | Required
---------- | ----- | ----------- | --------
-basic_auth | [basic_auth][] | Configure basic_auth for authenticating to the endpoint. | no
-authorization | [authorization][] | Configure generic authorization to the endpoint. | no
-oauth2 | [oauth2][] | Configure OAuth2 for authenticating to the endpoint. | no
-oauth2 > tls_config | [tls_config][] | Configure TLS settings for connecting to the endpoint. | no
-tls_config | [tls_config][] | Configure TLS settings for connecting to the endpoint. | no
+Hierarchy           | Block             | Description                                              | Required
+--------------------|-------------------|----------------------------------------------------------|---------
+basic_auth          | [basic_auth][]    | Configure basic_auth for authenticating to the endpoint. | no
+authorization       | [authorization][] | Configure generic authorization to the endpoint.         | no
+oauth2              | [oauth2][]        | Configure OAuth2 for authenticating to the endpoint.     | no
+oauth2 > tls_config | [tls_config][]    | Configure TLS settings for connecting to the endpoint.   | no
+tls_config          | [tls_config][]    | Configure TLS settings for connecting to the endpoint.   | no
 
-The `>` symbol indicates deeper levels of nesting. For example,
-`oauth2 > tls_config` refers to a `tls_config` block defined inside
-an `oauth2` block.
-
-[basic_auth]: #basic_auth-block
-[authorization]: #authorization-block
-[oauth2]: #oauth2-block
-[tls_config]: #tls_config-block
+The `>` symbol indicates deeper levels of nesting.
+For example, `oauth2 > tls_config` refers to a `tls_config` block defined inside an `oauth2` block.
 
 ### basic_auth block
 
@@ -100,3 +90,9 @@ an `oauth2` block.
 
 {{< docs/shared lookup="flow/reference/components/tls-config-block.md" source="agent" version="<AGENT_VERSION>" >}}
 
+[API definition]: https://github.com/grafana/agent-remote-config
+[beta]: https://grafana.com/docs/agent/<AGENT_VERSION>/stability/#beta
+[basic_auth]: #basic_auth-block
+[authorization]: #authorization-block
+[oauth2]: #oauth2-block
+[tls_config]: #tls_config-block

--- a/docs/sources/flow/reference/config-blocks/remotecfg.md
+++ b/docs/sources/flow/reference/config-blocks/remotecfg.md
@@ -12,12 +12,10 @@ title: remotecfg block
 
 # remotecfg block (beta)
 
-`remotecfg` is an optional configuration block that enables {{< param "PRODUCT_NAME" >}}
-to fetch and load the configuration from a remote endpoint.
+`remotecfg` is an optional configuration block that enables {{< param "PRODUCT_NAME" >}} to fetch and load the configuration from a remote endpoint.
 `remotecfg` is specified without a label and can only be provided once per configuration file.
 
-The [API definition][] for managing and fetching configuration that the
-`remotecfg` block uses is available under the Apache 2.0 license.
+The [API definition][] for managing and fetching configuration that the `remotecfg` block uses is available under the Apache 2.0 license.
 
 > **BETA**: The `remotecfg` enables [beta][] functionality.
 > Beta features are subject to breaking changes, and may be replaced with


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR  cleans up some of the relrefs (focus on `config-blocks`), converting relrefs to qualified URL links, or `doc/reference` links. This is part of the work required to prepare the markdown for future releases and restructuring.

Refer to: https://grafana.com/docs/writers-toolkit/write/shortcodes/#relref 

This PR is not a full edit of the content. The focus is on the relrefs, but some other minor cleanup i included (table formatting, contractions, and some semantic linebreaks).

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated