### PR TITLE
loki.write: fix duplicate metrics collector registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Bugfixes
+
+- Fix an issue where changing the configuration of `loki.write` would cause a panic. (@rfratto)
+
 v0.40.0-rc.1 (2024-02-23)
 -------------------------
 
@@ -27,7 +31,7 @@ v0.40.0-rc.1 (2024-02-23)
 
 ### Features
 
-- Modules have been redesigned to split the import logic from the instantiation. 
+- Modules have been redesigned to split the import logic from the instantiation.
   You can now define custom components via the `declare` config block and import modules via `import.git`, `import.http`, `import.string`, `import.file`. (@wildum)
 
 - A new `discovery.process` component for discovering Linux OS processes on the current host. (@korniltsev)
@@ -40,7 +44,7 @@ v0.40.0-rc.1 (2024-02-23)
 - Expose track_timestamps_staleness on Prometheus scraping, to fix the issue where container metrics live for 5 minutes after the container disappears. (@ptodev)
 
 - Introduce the `remotecfg` service that enables loading configuration from a
-  remote endpoint. (@tpaschalis) 
+  remote endpoint. (@tpaschalis)
 
 - Add `otelcol.connector.host_info` component to gather usage metrics for cloud users. (@rlankfo, @jcreixell)
 
@@ -102,7 +106,7 @@ v0.40.0-rc.1 (2024-02-23)
 - Fix an issue where agent logs are emitted before the logging format
   is correctly determined. (@hainenber)
 
-- Fix divide-by-zero issue when sharding targets. (@hainenber) 
+- Fix divide-by-zero issue when sharding targets. (@hainenber)
 
 - Fix bug where custom headers were not actually being set in loki client. (@captncraig)
 

--- a/component/common/loki/client/internal/metrics.go
+++ b/component/common/loki/client/internal/metrics.go
@@ -1,6 +1,9 @@
 package internal
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/grafana/agent/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 type MarkerMetrics struct {
 	lastMarkedSegment *prometheus.GaugeVec
@@ -19,7 +22,7 @@ func NewMarkerMetrics(reg prometheus.Registerer) *MarkerMetrics {
 		),
 	}
 	if reg != nil {
-		reg.MustRegister(m.lastMarkedSegment)
+		m.lastMarkedSegment = util.MustRegisterOrGet(reg, m.lastMarkedSegment).(*prometheus.GaugeVec)
 	}
 	return m
 }


### PR DESCRIPTION
Fix an issue where re-creating a write client led to a duplicate metrics collector registration panic.

Fixes #6510.