### PR TITLE
fix(*): prevent  `duplicate metrics collector registration` panic for components with possible surface area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,8 @@ v0.40.0-rc.1 (2024-02-23)
 
 - Fix an issue where the configuration of the `http` and `remotecfg` blocks get ignored after loading a module. (@erikbaranowski)
 
+- Fix duplication metrics registration panic for components with potential error surface. (@hainenber)
+
 ### Other changes
 
 - Removed support for Windows 2012 in line with Microsoft end of life. (@mattdurham)

--- a/component/faro/receiver/exporters.go
+++ b/component/faro/receiver/exporters.go
@@ -54,8 +54,9 @@ func newMetricsExporter(reg prometheus.Registerer) *metricsExporter {
 			Help: "Total number of ingested events",
 		}),
 	}
-
-	reg.MustRegister(exp.totalLogs, exp.totalExceptions, exp.totalMeasurements, exp.totalEvents)
+	if reg != nil {
+		reg.MustRegister(exp.totalLogs, exp.totalExceptions, exp.totalMeasurements, exp.totalEvents)
+	}
 
 	return exp
 }

--- a/component/faro/receiver/handler.go
+++ b/component/faro/receiver/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/agent/component/faro/receiver/internal/payload"
 	"github.com/grafana/agent/pkg/flow/logging/level"
+	"github.com/grafana/agent/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/cors"
 	"golang.org/x/time/rate"
@@ -35,7 +36,10 @@ func newHandler(l log.Logger, reg prometheus.Registerer, exporters []exporter) *
 		Name: "faro_receiver_exporter_errors_total",
 		Help: "Total number of errors produced by a receiver exporter",
 	}, []string{"exporter"})
-	reg.MustRegister(errorsTotal)
+
+	if reg != nil {
+		errorsTotal = util.MustRegisterOrGet(reg, errorsTotal).(*prometheus.CounterVec)
+	}
 
 	return &handler{
 		log:         l,

--- a/component/faro/receiver/server.go
+++ b/component/faro/receiver/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/gorilla/mux"
 	"github.com/grafana/agent/pkg/flow/logging/level"
+	"github.com/grafana/agent/pkg/util"
 	"github.com/grafana/dskit/instrument"
 	"github.com/grafana/dskit/middleware"
 	"github.com/prometheus/client_golang/prometheus"
@@ -46,7 +47,12 @@ func newServerMetrics(reg prometheus.Registerer) *serverMetrics {
 			Help: "Current number of inflight requests.",
 		}, []string{"method", "route"}),
 	}
-	reg.MustRegister(m.requestDuration, m.rxMessageSize, m.txMessageSize, m.inflightRequests)
+	if reg != nil {
+		m.requestDuration = util.MustRegisterOrGet(reg, m.requestDuration).(*prometheus.HistogramVec)
+		m.rxMessageSize = util.MustRegisterOrGet(reg, m.rxMessageSize).(*prometheus.HistogramVec)
+		m.txMessageSize = util.MustRegisterOrGet(reg, m.txMessageSize).(*prometheus.HistogramVec)
+		m.inflightRequests = util.MustRegisterOrGet(reg, m.inflightRequests).(*prometheus.GaugeVec)
+	}
 
 	return m
 }

--- a/component/faro/receiver/sourcemaps.go
+++ b/component/faro/receiver/sourcemaps.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-sourcemap/sourcemap"
 	"github.com/grafana/agent/component/faro/receiver/internal/payload"
 	"github.com/grafana/agent/pkg/flow/logging/level"
+	"github.com/grafana/agent/pkg/util"
 	"github.com/grafana/agent/pkg/util/wildcard"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/vincent-petithory/dataurl"
@@ -68,7 +69,12 @@ func newSourceMapMetrics(reg prometheus.Registerer) *sourceMapMetrics {
 		}, []string{"origin", "status"}),
 	}
 
-	reg.MustRegister(m.cacheSize, m.downloads, m.fileReads)
+	if reg != nil {
+		m.cacheSize = util.MustRegisterOrGet(reg, m.cacheSize).(*prometheus.CounterVec)
+		m.downloads = util.MustRegisterOrGet(reg, m.downloads).(*prometheus.CounterVec)
+		m.fileReads = util.MustRegisterOrGet(reg, m.fileReads).(*prometheus.CounterVec)
+	}
+
 	return m
 }
 

--- a/component/loki/source/aws_firehose/internal/metrics.go
+++ b/component/loki/source/aws_firehose/internal/metrics.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"github.com/grafana/agent/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -34,12 +35,10 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 	}, nil)
 
 	if reg != nil {
-		reg.MustRegister(
-			m.errorsAPIRequest,
-			m.recordsReceived,
-			m.errorsRecord,
-			m.batchSize,
-		)
+		m.errorsAPIRequest = util.MustRegisterOrGet(reg, m.errorsAPIRequest).(*prometheus.CounterVec)
+		m.errorsRecord = util.MustRegisterOrGet(reg, m.errorsRecord).(*prometheus.CounterVec)
+		m.recordsReceived = util.MustRegisterOrGet(reg, m.recordsReceived).(*prometheus.CounterVec)
+		m.batchSize = util.MustRegisterOrGet(reg, m.batchSize).(*prometheus.HistogramVec)
 	}
 
 	return &m

--- a/component/loki/source/file/metrics.go
+++ b/component/loki/source/file/metrics.go
@@ -4,7 +4,10 @@ package file
 // The metrics struct provides a common set of metrics that are reused between all
 // implementations of the reader interface.
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/grafana/agent/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 // metrics hold the set of file-based metrics.
 type metrics struct {
@@ -47,13 +50,11 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 	})
 
 	if reg != nil {
-		reg.MustRegister(
-			m.readBytes,
-			m.totalBytes,
-			m.readLines,
-			m.encodingFailures,
-			m.filesActive,
-		)
+		m.readBytes = util.MustRegisterOrGet(reg, m.readBytes).(*prometheus.GaugeVec)
+		m.totalBytes = util.MustRegisterOrGet(reg, m.totalBytes).(*prometheus.GaugeVec)
+		m.readLines = util.MustRegisterOrGet(reg, m.readLines).(*prometheus.CounterVec)
+		m.encodingFailures = util.MustRegisterOrGet(reg, m.encodingFailures).(*prometheus.CounterVec)
+		reg.MustRegister(m.filesActive)
 	}
 
 	return &m

--- a/component/loki/source/gcplog/internal/gcplogtarget/metrics.go
+++ b/component/loki/source/gcplog/internal/gcplogtarget/metrics.go
@@ -5,7 +5,10 @@ package gcplogtarget
 // logs like bucket logs, load balancer logs, and Kubernetes cluster logs
 // from GCP.
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/grafana/agent/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 // Metrics stores gcplog entry metrics.
 type Metrics struct {
@@ -52,12 +55,13 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		Help: "Number of parsing errors while receiving gcplog messages",
 	}, []string{"reason"})
 
-	reg.MustRegister(
-		m.gcplogEntries,
-		m.gcplogErrors,
-		m.gcplogTargetLastSuccessScrape,
-		m.gcpPushEntries,
-		m.gcpPushErrors,
-	)
+	if reg != nil {
+		m.gcplogEntries = util.MustRegisterOrGet(reg, m.gcplogEntries).(*prometheus.CounterVec)
+		m.gcplogErrors = util.MustRegisterOrGet(reg, m.gcplogErrors).(*prometheus.CounterVec)
+		m.gcplogTargetLastSuccessScrape = util.MustRegisterOrGet(reg, m.gcplogTargetLastSuccessScrape).(*prometheus.GaugeVec)
+		m.gcpPushEntries = util.MustRegisterOrGet(reg, m.gcpPushEntries).(*prometheus.CounterVec)
+		m.gcpPushErrors = util.MustRegisterOrGet(reg, m.gcpPushErrors).(*prometheus.CounterVec)
+	}
+
 	return &m
 }

--- a/component/loki/source/journal/internal/target/metrics.go
+++ b/component/loki/source/journal/internal/target/metrics.go
@@ -4,7 +4,10 @@ package target
 // configure and run the targets that can read journal entries and forward them
 // to other loki components.
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/grafana/agent/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 // Metrics holds a set of journal target metrics.
 type Metrics struct {
@@ -30,10 +33,8 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 	})
 
 	if reg != nil {
-		reg.MustRegister(
-			m.journalErrors,
-			m.journalLines,
-		)
+		m.journalErrors = util.MustRegisterOrGet(reg, m.journalErrors).(*prometheus.CounterVec)
+		reg.MustRegister(m.journalLines)
 	}
 
 	return &m

--- a/component/pyroscope/ebpf/metrics.go
+++ b/component/pyroscope/ebpf/metrics.go
@@ -5,6 +5,7 @@
 package ebpf
 
 import (
+	"github.com/grafana/agent/pkg/util"
 	ebpfmetrics "github.com/grafana/pyroscope/ebpf/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -53,10 +54,10 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			m.targetsActive,
 			m.profilingSessionsTotal,
 			m.profilingSessionsFailingTotal,
-			m.pprofsTotal,
-			m.pprofBytesTotal,
-			m.pprofSamplesTotal,
 		)
+		m.pprofsTotal = util.MustRegisterOrGet(reg, m.pprofsTotal).(*prometheus.CounterVec)
+		m.pprofBytesTotal = util.MustRegisterOrGet(reg, m.pprofBytesTotal).(*prometheus.CounterVec)
+		m.pprofSamplesTotal = util.MustRegisterOrGet(reg, m.pprofSamplesTotal).(*prometheus.CounterVec)
 	}
 
 	return m

--- a/component/pyroscope/write/metrics.go
+++ b/component/pyroscope/write/metrics.go
@@ -1,6 +1,9 @@
 package write
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/grafana/agent/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 type metrics struct {
 	sentBytes       *prometheus.CounterVec
@@ -35,13 +38,11 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 	}
 
 	if reg != nil {
-		reg.MustRegister(
-			m.sentBytes,
-			m.droppedBytes,
-			m.sentProfiles,
-			m.droppedProfiles,
-			m.retries,
-		)
+		m.sentBytes = util.MustRegisterOrGet(reg, m.sentBytes).(*prometheus.CounterVec)
+		m.droppedBytes = util.MustRegisterOrGet(reg, m.droppedBytes).(*prometheus.CounterVec)
+		m.sentProfiles = util.MustRegisterOrGet(reg, m.sentProfiles).(*prometheus.CounterVec)
+		m.droppedProfiles = util.MustRegisterOrGet(reg, m.droppedProfiles).(*prometheus.CounterVec)
+		m.retries = util.MustRegisterOrGet(reg, m.retries).(*prometheus.CounterVec)
 	}
 
 	return m

--- a/pkg/integrations/v2/app_agent_receiver/handler.go
+++ b/pkg/integrations/v2/app_agent_receiver/handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/agent/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/cors"
 	"golang.org/x/time/rate"
@@ -51,7 +52,9 @@ func NewAppAgentReceiverHandler(conf *Config, exporters []AppAgentReceiverExport
 		Help: "Total number of errors produced by a receiver exporter",
 	}, []string{"exporter"})
 
-	reg.MustRegister(exporterErrorsCollector)
+	if reg != nil {
+		exporterErrorsCollector = util.MustRegisterOrGet(reg, exporterErrorsCollector).(*prometheus.CounterVec)
+	}
 
 	return AppAgentReceiverHandler{
 		exporters:               exporters,

--- a/pkg/integrations/v2/app_agent_receiver/sourcemaps.go
+++ b/pkg/integrations/v2/app_agent_receiver/sourcemaps.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/go-sourcemap/sourcemap"
+	"github.com/grafana/agent/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/vincent-petithory/dataurl"
 )
@@ -106,7 +107,12 @@ func NewSourceMapStore(l log.Logger, config SourceMapConfig, reg prometheus.Regi
 			Help: "source map file reads from file system, by origin and status",
 		}, []string{"origin", "status"}),
 	}
-	reg.MustRegister(metrics.cacheSize, metrics.downloads, metrics.fileReads)
+
+	if reg != nil {
+		metrics.cacheSize = util.MustRegisterOrGet(reg, metrics.cacheSize).(*prometheus.CounterVec)
+		metrics.downloads = util.MustRegisterOrGet(reg, metrics.downloads).(*prometheus.CounterVec)
+		metrics.fileReads = util.MustRegisterOrGet(reg, metrics.fileReads).(*prometheus.CounterVec)
+	}
 
 	fileLocations := []*sourcemapFileLocation{}
 


### PR DESCRIPTION

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

I saw many [issues with `duplicate metrics registration` panics](https://github.com/grafana/agent/issues?q=is%3Aissue+%22duplicate+metrics+collector%22+is%3Aclosed) and saw that there are many places in the codebase not having such guardrails. The PR helps fixing that and would hopefully prevent any similar issues from happening.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
N/A

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated