### PR TITLE
Feature stability gating on a component level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Features
+
+- Added a new CLI flag `--stability.level` which defines the minimum stability
+  level required for the features that the agent is allowed to use. Default is `experimental`. (@thampiotr)
+
 
 v0.40.0-rc.2 (2024-02-26)
 -------------------------

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -52,6 +52,7 @@ func runCommand() *cobra.Command {
 		inMemoryAddr:          "agent.internal:12345",
 		httpListenAddr:        "127.0.0.1:12345",
 		storagePath:           "data-agent/",
+		minStability:          featuregate.StabilityExperimental,
 		uiPrefix:              "/",
 		disableReporting:      false,
 		enablePprof:           true,

--- a/cmd/internal/flowmode/cmd_run.go
+++ b/cmd/internal/flowmode/cmd_run.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/agent/converter"
 	convert_diag "github.com/grafana/agent/converter/diag"
 	"github.com/grafana/agent/internal/agentseed"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/boringcrypto"
 	"github.com/grafana/agent/pkg/config/instrumentation"
 	"github.com/grafana/agent/pkg/flow"
@@ -97,13 +98,15 @@ depending on the nature of the reload error.
 		},
 	}
 
+	// Server flags
 	cmd.Flags().
 		StringVar(&r.httpListenAddr, "server.http.listen-addr", r.httpListenAddr, "Address to listen for HTTP traffic on")
 	cmd.Flags().StringVar(&r.inMemoryAddr, "server.http.memory-addr", r.inMemoryAddr, "Address to listen for in-memory HTTP traffic on. Change if it collides with a real address")
-	cmd.Flags().StringVar(&r.storagePath, "storage.path", r.storagePath, "Base directory where components can store data")
 	cmd.Flags().StringVar(&r.uiPrefix, "server.http.ui-path-prefix", r.uiPrefix, "Prefix to serve the HTTP UI at")
 	cmd.Flags().
 		BoolVar(&r.enablePprof, "server.http.enable-pprof", r.enablePprof, "Enable /debug/pprof profiling endpoints.")
+
+	// Cluster flags
 	cmd.Flags().
 		BoolVar(&r.clusterEnabled, "cluster.enabled", r.clusterEnabled, "Start in clustered mode")
 	cmd.Flags().
@@ -122,11 +125,17 @@ depending on the nature of the reload error.
 		IntVar(&r.ClusterMaxJoinPeers, "cluster.max-join-peers", r.ClusterMaxJoinPeers, "Number of peers to join from the discovered set")
 	cmd.Flags().
 		StringVar(&r.clusterName, "cluster.name", r.clusterName, "The name of the cluster to join")
-	cmd.Flags().
-		BoolVar(&r.disableReporting, "disable-reporting", r.disableReporting, "Disable reporting of enabled components to Grafana.")
+
+	// Config flags
 	cmd.Flags().StringVar(&r.configFormat, "config.format", r.configFormat, fmt.Sprintf("The format of the source file. Supported formats: %s.", supportedFormatsList()))
 	cmd.Flags().BoolVar(&r.configBypassConversionErrors, "config.bypass-conversion-errors", r.configBypassConversionErrors, "Enable bypassing errors when converting")
 	cmd.Flags().StringVar(&r.configExtraArgs, "config.extra-args", r.configExtraArgs, "Extra arguments from the original format used by the converter. Multiple arguments can be passed by separating them with a space.")
+
+	// Misc flags
+	cmd.Flags().
+		BoolVar(&r.disableReporting, "disable-reporting", r.disableReporting, "Disable reporting of enabled components to Grafana.")
+	cmd.Flags().StringVar(&r.storagePath, "storage.path", r.storagePath, "Base directory where components can store data")
+	cmd.Flags().Var(&r.minStability, "stability.level", fmt.Sprintf("Minimum stability level of features to enable. Supported values: %s", strings.Join(featuregate.AllowedValues(), ", ")))
 	return cmd
 }
 
@@ -134,6 +143,7 @@ type flowRun struct {
 	inMemoryAddr                 string
 	httpListenAddr               string
 	storagePath                  string
+	minStability                 featuregate.Stability
 	uiPrefix                     string
 	enablePprof                  bool
 	disableReporting             bool
@@ -265,10 +275,11 @@ func (fr *flowRun) Run(configPath string) error {
 	agentseed.Init(fr.storagePath, l)
 
 	f := flow.New(flow.Options{
-		Logger:   l,
-		Tracer:   t,
-		DataPath: fr.storagePath,
-		Reg:      reg,
+		Logger:       l,
+		Tracer:       t,
+		DataPath:     fr.storagePath,
+		Reg:          reg,
+		MinStability: fr.minStability,
 		Services: []service.Service{
 			httpService,
 			uiService,

--- a/component/common/loki/positions/write_positions_windows.go
+++ b/component/common/loki/positions/write_positions_windows.go
@@ -8,6 +8,7 @@ package positions
 
 import (
 	"bytes"
+
 	"github.com/natefinch/atomic"
 	yaml "gopkg.in/yaml.v2"
 )

--- a/component/discovery/aws/ec2.go
+++ b/component/discovery/aws/ec2.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river/rivertypes"
 	promcfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -17,9 +18,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.ec2",
-		Args:    EC2Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.ec2",
+		Stability: featuregate.StabilityStable,
+		Args:      EC2Arguments{},
+		Exports:   discovery.Exports{},
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return NewEC2(opts, args.(EC2Arguments))
 		},

--- a/component/discovery/aws/lightsail.go
+++ b/component/discovery/aws/lightsail.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river/rivertypes"
 	promcfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -17,9 +18,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.lightsail",
-		Args:    LightsailArguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.lightsail",
+		Stability: featuregate.StabilityStable,
+		Args:      LightsailArguments{},
+		Exports:   discovery.Exports{},
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return NewLightsail(opts, args.(LightsailArguments))
 		},

--- a/component/discovery/azure/azure.go
+++ b/component/discovery/azure/azure.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river/rivertypes"
 	common "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -16,9 +17,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.azure",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.azure",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/consul/consul.go
+++ b/component/discovery/consul/consul.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river/rivertypes"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -15,9 +16,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.consul",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.consul",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/consulagent/consulagent.go
+++ b/component/discovery/consulagent/consulagent.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river/rivertypes"
 	promcfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -14,9 +15,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.consulagent",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.consulagent",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/digitalocean/digitalocean.go
+++ b/component/discovery/digitalocean/digitalocean.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river/rivertypes"
 	"github.com/prometheus/common/model"
 	prom_discovery "github.com/prometheus/prometheus/discovery/digitalocean"
@@ -14,9 +15,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.digitalocean",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.digitalocean",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/dns/dns.go
+++ b/component/discovery/dns/dns.go
@@ -8,15 +8,17 @@ import (
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/dns"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.dns",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.dns",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/docker/docker.go
+++ b/component/discovery/docker/docker.go
@@ -9,15 +9,17 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/moby"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.docker",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.docker",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/dockerswarm/dockerswarm.go
+++ b/component/discovery/dockerswarm/dockerswarm.go
@@ -8,15 +8,17 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/prometheus/common/model"
 	prom_discovery "github.com/prometheus/prometheus/discovery/moby"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.dockerswarm",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.dockerswarm",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/eureka/eureka.go
+++ b/component/discovery/eureka/eureka.go
@@ -8,15 +8,17 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/prometheus/common/model"
 	prom_discovery "github.com/prometheus/prometheus/discovery/eureka"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.eureka",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.eureka",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/file/file.go
+++ b/component/discovery/file/file.go
@@ -5,15 +5,17 @@ import (
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/prometheus/common/model"
 	prom_discovery "github.com/prometheus/prometheus/discovery/file"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.file",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.file",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/gce/gce.go
+++ b/component/discovery/gce/gce.go
@@ -6,15 +6,17 @@ import (
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/gce"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.gce",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.gce",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/hetzner/hetzner.go
+++ b/component/discovery/hetzner/hetzner.go
@@ -7,15 +7,17 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/prometheus/common/model"
 	prom_discovery "github.com/prometheus/prometheus/discovery/hetzner"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.hetzner",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.hetzner",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/http/http.go
+++ b/component/discovery/http/http.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	promcfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/http"
@@ -13,9 +14,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.http",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.http",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))
 		},

--- a/component/discovery/ionos/ionos.go
+++ b/component/discovery/ionos/ionos.go
@@ -7,15 +7,17 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/prometheus/common/model"
 	prom_discovery "github.com/prometheus/prometheus/discovery/ionos"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.ionos",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.ionos",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/kubelet/kubelet.go
+++ b/component/discovery/kubelet/kubelet.go
@@ -61,7 +61,7 @@ var (
 func init() {
 	component.Register(component.Registration{
 		Name:      "discovery.kubelet",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      Arguments{},
 		Exports:   discovery.Exports{},
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {

--- a/component/discovery/kubelet/kubelet.go
+++ b/component/discovery/kubelet/kubelet.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	commonConfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/refresh"
@@ -59,9 +60,10 @@ var (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.kubelet",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.kubelet",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))
 		},

--- a/component/discovery/kubernetes/kubernetes.go
+++ b/component/discovery/kubernetes/kubernetes.go
@@ -5,14 +5,16 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	promk8s "github.com/prometheus/prometheus/discovery/kubernetes"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.kubernetes",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.kubernetes",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/kuma/kuma.go
+++ b/component/discovery/kuma/kuma.go
@@ -7,15 +7,17 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/prometheus/common/model"
 	prom_discovery "github.com/prometheus/prometheus/discovery/xds"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.kuma",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.kuma",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/linode/linode.go
+++ b/component/discovery/linode/linode.go
@@ -7,15 +7,17 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/prometheus/common/model"
 	prom_discovery "github.com/prometheus/prometheus/discovery/linode"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.linode",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.linode",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/marathon/marathon.go
+++ b/component/discovery/marathon/marathon.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river/rivertypes"
 	promcfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -15,9 +16,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.marathon",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.marathon",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/nerve/nerve.go
+++ b/component/discovery/nerve/nerve.go
@@ -6,15 +6,17 @@ import (
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/prometheus/common/model"
 	prom_discovery "github.com/prometheus/prometheus/discovery/zookeeper"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.nerve",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.nerve",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/nomad/nomad.go
+++ b/component/discovery/nomad/nomad.go
@@ -8,15 +8,17 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/prometheus/common/model"
 	prom_discovery "github.com/prometheus/prometheus/discovery/nomad"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.nomad",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.nomad",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/openstack/openstack.go
+++ b/component/discovery/openstack/openstack.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river/rivertypes"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -15,9 +16,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.openstack",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.openstack",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/ovhcloud/ovhcloud.go
+++ b/component/discovery/ovhcloud/ovhcloud.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river/rivertypes"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -14,9 +15,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.ovhcloud",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.ovhcloud",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/process/process.go
+++ b/component/discovery/process/process.go
@@ -9,13 +9,15 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.process",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.process",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/process/process_stub.go
+++ b/component/discovery/process/process_stub.go
@@ -7,14 +7,16 @@ import (
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.process",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.process",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/puppetdb/puppetdb.go
+++ b/component/discovery/puppetdb/puppetdb.go
@@ -8,15 +8,17 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/prometheus/common/model"
 	prom_discovery "github.com/prometheus/prometheus/discovery/puppetdb"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.puppetdb",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.puppetdb",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/relabel/relabel.go
+++ b/component/discovery/relabel/relabel.go
@@ -7,15 +7,17 @@ import (
 	"github.com/grafana/agent/component"
 	flow_relabel "github.com/grafana/agent/component/common/relabel"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.relabel",
-		Args:    Arguments{},
-		Exports: Exports{},
+		Name:      "discovery.relabel",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/scaleway/scaleway.go
+++ b/component/discovery/scaleway/scaleway.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river/rivertypes"
 	prom_config "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -19,9 +20,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.scaleway",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.scaleway",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/serverset/serverset.go
+++ b/component/discovery/serverset/serverset.go
@@ -8,15 +8,17 @@ import (
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/prometheus/common/model"
 	prom_discovery "github.com/prometheus/prometheus/discovery/zookeeper"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.serverset",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.serverset",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/triton/triton.go
+++ b/component/discovery/triton/triton.go
@@ -7,15 +7,17 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/prometheus/common/model"
 	prom_discovery "github.com/prometheus/prometheus/discovery/triton"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.triton",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.triton",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/discovery/uyuni/uyuni.go
+++ b/component/discovery/uyuni/uyuni.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river/rivertypes"
 	promcfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -16,9 +17,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "discovery.uyuni",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "discovery.uyuni",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/faro/receiver/receiver.go
+++ b/component/faro/receiver/receiver.go
@@ -9,13 +9,15 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-sourcemap/sourcemap"
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name: "faro.receiver",
-		Args: Arguments{},
+		Name:      "faro.receiver",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/local/file/file.go
+++ b/component/local/file/file.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/grafana/river/rivertypes"
 )
@@ -24,9 +25,10 @@ const waitReadPeriod time.Duration = 30 * time.Millisecond
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "local.file",
-		Args:    Arguments{},
-		Exports: Exports{},
+		Name:      "local.file",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/local/file_match/file.go
+++ b/component/local/file_match/file.go
@@ -5,17 +5,18 @@ import (
 	"sync"
 	"time"
 
-	"github.com/grafana/agent/component/discovery"
-
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "local.file_match",
-		Args:    Arguments{},
-		Exports: discovery.Exports{},
+		Name:      "local.file_match",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   discovery.Exports{},
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))
 		},

--- a/component/loki/echo/echo.go
+++ b/component/loki/echo/echo.go
@@ -13,7 +13,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "loki.echo",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      Arguments{},
 		Exports:   Exports{},
 

--- a/component/loki/echo/echo.go
+++ b/component/loki/echo/echo.go
@@ -6,14 +6,16 @@ import (
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/loki"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "loki.echo",
-		Args:    Arguments{},
-		Exports: Exports{},
+		Name:      "loki.echo",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/loki/process/process.go
+++ b/component/loki/process/process.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/loki"
 	"github.com/grafana/agent/component/loki/process/stages"
+	"github.com/grafana/agent/internal/featuregate"
 )
 
 // TODO(thampiotr): We should reconsider which parts of this component should be exported and which should
@@ -20,9 +21,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "loki.process",
-		Args:    Arguments{},
-		Exports: Exports{},
+		Name:      "loki.process",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   Exports{},
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))
 		},

--- a/component/loki/relabel/relabel.go
+++ b/component/loki/relabel/relabel.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/loki"
 	flow_relabel "github.com/grafana/agent/component/common/relabel"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/prometheus/common/model"
@@ -17,9 +18,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "loki.relabel",
-		Args:    Arguments{},
-		Exports: Exports{},
+		Name:      "loki.relabel",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   Exports{},
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))
 		},

--- a/component/loki/source/api/api.go
+++ b/component/loki/source/api/api.go
@@ -11,6 +11,7 @@ import (
 	fnet "github.com/grafana/agent/component/common/net"
 	"github.com/grafana/agent/component/common/relabel"
 	"github.com/grafana/agent/component/loki/source/api/internal/lokipush"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -18,8 +19,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "loki.source.api",
-		Args: Arguments{},
+		Name:      "loki.source.api",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))
 		},

--- a/component/loki/source/aws_firehose/component.go
+++ b/component/loki/source/aws_firehose/component.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/gorilla/mux"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/relabel"
 
@@ -22,8 +23,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "loki.source.awsfirehose",
-		Args: Arguments{},
+		Name:      "loki.source.awsfirehose",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/loki/source/azure_event_hubs/azure_event_hubs.go
+++ b/component/loki/source/azure_event_hubs/azure_event_hubs.go
@@ -12,6 +12,7 @@ import (
 	flow_relabel "github.com/grafana/agent/component/common/relabel"
 	"github.com/grafana/agent/component/loki/source/azure_event_hubs/internal/parser"
 	kt "github.com/grafana/agent/component/loki/source/internal/kafkatarget"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/grafana/dskit/flagext"
 
@@ -20,8 +21,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "loki.source.azure_event_hubs",
-		Args: Arguments{},
+		Name:      "loki.source.azure_event_hubs",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/loki/source/cloudflare/cloudflare.go
+++ b/component/loki/source/cloudflare/cloudflare.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/agent/component/common/loki"
 	"github.com/grafana/agent/component/common/loki/positions"
 	cft "github.com/grafana/agent/component/loki/source/cloudflare/internal/cloudflaretarget"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/grafana/river/rivertypes"
 	"github.com/prometheus/common/model"
@@ -24,8 +25,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "loki.source.cloudflare",
-		Args: Arguments{},
+		Name:      "loki.source.cloudflare",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/loki/source/docker/docker.go
+++ b/component/loki/source/docker/docker.go
@@ -22,6 +22,7 @@ import (
 	flow_relabel "github.com/grafana/agent/component/common/relabel"
 	"github.com/grafana/agent/component/discovery"
 	dt "github.com/grafana/agent/component/loki/source/docker/internal/dockertarget"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/internal/useragent"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/prometheus/common/config"
@@ -31,8 +32,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "loki.source.docker",
-		Args: Arguments{},
+		Name:      "loki.source.docker",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/loki/source/file/file.go
+++ b/component/loki/source/file/file.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/agent/component/common/loki"
 	"github.com/grafana/agent/component/common/loki/positions"
 	"github.com/grafana/agent/component/discovery"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/grafana/tail/watch"
 	"github.com/prometheus/common/model"
@@ -20,8 +21,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "loki.source.file",
-		Args: Arguments{},
+		Name:      "loki.source.file",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/loki/source/gcplog/gcplog.go
+++ b/component/loki/source/gcplog/gcplog.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/relabel"
@@ -20,8 +21,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "loki.source.gcplog",
-		Args: Arguments{},
+		Name:      "loki.source.gcplog",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/loki/source/gelf/gelf.go
+++ b/component/loki/source/gelf/gelf.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/agent/component/common/loki"
 	flow_relabel "github.com/grafana/agent/component/common/relabel"
 	"github.com/grafana/agent/component/loki/source/gelf/internal/target"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/relabel"
@@ -15,8 +16,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "loki.source.gelf",
-		Args: Arguments{},
+		Name:      "loki.source.gelf",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/loki/source/heroku/heroku.go
+++ b/component/loki/source/heroku/heroku.go
@@ -10,6 +10,7 @@ import (
 	fnet "github.com/grafana/agent/component/common/net"
 	flow_relabel "github.com/grafana/agent/component/common/relabel"
 	ht "github.com/grafana/agent/component/loki/source/heroku/internal/herokutarget"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/grafana/agent/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
@@ -19,8 +20,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "loki.source.heroku",
-		Args: Arguments{},
+		Name:      "loki.source.heroku",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/loki/source/journal/journal.go
+++ b/component/loki/source/journal/journal.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/agent/component/common/loki/positions"
 	flow_relabel "github.com/grafana/agent/component/common/relabel"
 	"github.com/grafana/agent/component/loki/source/journal/internal/target"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
 	"github.com/prometheus/common/model"
 
@@ -21,8 +22,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "loki.source.journal",
-		Args: Arguments{},
+		Name:      "loki.source.journal",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/loki/source/journal/journal_stub.go
+++ b/component/loki/source/journal/journal_stub.go
@@ -6,13 +6,15 @@ import (
 	"context"
 
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name: "loki.source.journal",
-		Args: Arguments{},
+		Name:      "loki.source.journal",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/loki/source/kafka/kafka.go
+++ b/component/loki/source/kafka/kafka.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/agent/component/common/loki"
 	flow_relabel "github.com/grafana/agent/component/common/relabel"
 	kt "github.com/grafana/agent/component/loki/source/internal/kafkatarget"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/river/rivertypes"
@@ -18,8 +19,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "loki.source.kafka",
-		Args: Arguments{},
+		Name:      "loki.source.kafka",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/loki/source/kubernetes/kubernetes.go
+++ b/component/loki/source/kubernetes/kubernetes.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/agent/component/common/loki/positions"
 	"github.com/grafana/agent/component/discovery"
 	"github.com/grafana/agent/component/loki/source/kubernetes/kubetail"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/grafana/agent/service/cluster"
 	"k8s.io/client-go/kubernetes"
@@ -24,8 +25,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "loki.source.kubernetes",
-		Args: Arguments{},
+		Name:      "loki.source.kubernetes",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/loki/source/kubernetes/kubernetes.go
+++ b/component/loki/source/kubernetes/kubernetes.go
@@ -26,7 +26,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "loki.source.kubernetes",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityExperimental,
 		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {

--- a/component/loki/source/kubernetes_events/kubernetes_events.go
+++ b/component/loki/source/kubernetes_events/kubernetes_events.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/agent/component/common/kubernetes"
 	"github.com/grafana/agent/component/common/loki"
 	"github.com/grafana/agent/component/common/loki/positions"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/grafana/agent/pkg/runner"
 	"github.com/oklog/run"
@@ -27,8 +28,9 @@ const informerSyncTimeout = 10 * time.Second
 
 func init() {
 	component.Register(component.Registration{
-		Name: "loki.source.kubernetes_events",
-		Args: Arguments{},
+		Name:      "loki.source.kubernetes_events",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/loki/source/podlogs/internal/apis/monitoring/v1alpha2/zz_generated.deepcopy.go
+++ b/component/loki/source/podlogs/internal/apis/monitoring/v1alpha2/zz_generated.deepcopy.go
@@ -5,7 +5,7 @@
 package v1alpha2
 
 import (
-	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/component/loki/source/podlogs/internal/apis/monitoring/v1alpha2/zz_generated.deepcopy.go
+++ b/component/loki/source/podlogs/internal/apis/monitoring/v1alpha2/zz_generated.deepcopy.go
@@ -5,7 +5,7 @@
 package v1alpha2
 
 import (
-	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/component/loki/source/podlogs/podlogs.go
+++ b/component/loki/source/podlogs/podlogs.go
@@ -28,7 +28,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "loki.source.podlogs",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityExperimental,
 		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {

--- a/component/loki/source/podlogs/podlogs.go
+++ b/component/loki/source/podlogs/podlogs.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/agent/component/common/loki/positions"
 	"github.com/grafana/agent/component/loki/source/kubernetes"
 	"github.com/grafana/agent/component/loki/source/kubernetes/kubetail"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/grafana/agent/service/cluster"
 	"github.com/oklog/run"
@@ -26,8 +27,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "loki.source.podlogs",
-		Args: Arguments{},
+		Name:      "loki.source.podlogs",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/loki/source/syslog/syslog.go
+++ b/component/loki/source/syslog/syslog.go
@@ -9,14 +9,16 @@ import (
 	"github.com/grafana/agent/component/common/loki"
 	flow_relabel "github.com/grafana/agent/component/common/relabel"
 	st "github.com/grafana/agent/component/loki/source/syslog/internal/syslogtarget"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/prometheus/prometheus/model/relabel"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name: "loki.source.syslog",
-		Args: Arguments{},
+		Name:      "loki.source.syslog",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/loki/source/windowsevent/component_stub.go
+++ b/component/loki/source/windowsevent/component_stub.go
@@ -5,15 +5,16 @@ package windowsevent
 import (
 	"context"
 
-	"github.com/grafana/agent/pkg/flow/logging/level"
-
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/internal/featuregate"
+	"github.com/grafana/agent/pkg/flow/logging/level"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name: "loki.source.windowsevent",
-		Args: Arguments{},
+		Name:      "loki.source.windowsevent",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			level.Info(opts.Logger).Log("msg", "loki.source.windowsevent only works on windows platforms")

--- a/component/loki/source/windowsevent/component_windows.go
+++ b/component/loki/source/windowsevent/component_windows.go
@@ -9,14 +9,16 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/loki"
 	"github.com/grafana/agent/component/common/loki/utils"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/loki/clients/pkg/promtail/api"
 	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name: "loki.source.windowsevent",
-		Args: Arguments{},
+		Name:      "loki.source.windowsevent",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/loki/write/write.go
+++ b/component/loki/write/write.go
@@ -13,13 +13,15 @@ import (
 	"github.com/grafana/agent/component/common/loki/limit"
 	"github.com/grafana/agent/component/common/loki/wal"
 	"github.com/grafana/agent/internal/agentseed"
+	"github.com/grafana/agent/internal/featuregate"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "loki.write",
-		Args:    Arguments{},
-		Exports: Exports{},
+		Name:      "loki.write",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/mimir/rules/kubernetes/rules.go
+++ b/component/mimir/rules/kubernetes/rules.go
@@ -32,7 +32,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "mimir.rules.kubernetes",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      Arguments{},
 		Exports:   nil,
 		Build: func(o component.Options, c component.Arguments) (component.Component, error) {

--- a/component/mimir/rules/kubernetes/rules.go
+++ b/component/mimir/rules/kubernetes/rules.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	mimirClient "github.com/grafana/agent/pkg/mimir/client"
 	"github.com/grafana/dskit/backoff"
@@ -30,9 +31,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "mimir.rules.kubernetes",
-		Args:    Arguments{},
-		Exports: nil,
+		Name:      "mimir.rules.kubernetes",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   nil,
 		Build: func(o component.Options, c component.Arguments) (component.Component, error) {
 			return New(o, c.(Arguments))
 		},

--- a/component/module/file/file.go
+++ b/component/module/file/file.go
@@ -9,14 +9,16 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/local/file"
 	"github.com/grafana/agent/component/module"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river/rivertypes"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "module.file",
-		Args:    Arguments{},
-		Exports: module.Exports{},
+		Name:      "module.file",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   module.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/module/file/file.go
+++ b/component/module/file/file.go
@@ -16,7 +16,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "module.file",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      Arguments{},
 		Exports:   module.Exports{},
 

--- a/component/module/git/git.go
+++ b/component/module/git/git.go
@@ -12,15 +12,17 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/module"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/internal/vcs"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "module.git",
-		Args:    Arguments{},
-		Exports: module.Exports{},
+		Name:      "module.git",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   module.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/module/git/git.go
+++ b/component/module/git/git.go
@@ -20,7 +20,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "module.git",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      Arguments{},
 		Exports:   module.Exports{},
 

--- a/component/module/http/http.go
+++ b/component/module/http/http.go
@@ -9,14 +9,16 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/module"
 	remote_http "github.com/grafana/agent/component/remote/http"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river/rivertypes"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "module.http",
-		Args:    Arguments{},
-		Exports: module.Exports{},
+		Name:      "module.http",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   module.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/module/http/http.go
+++ b/component/module/http/http.go
@@ -16,7 +16,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "module.http",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      Arguments{},
 		Exports:   module.Exports{},
 

--- a/component/module/string/string.go
+++ b/component/module/string/string.go
@@ -12,7 +12,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "module.string",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      Arguments{},
 		Exports:   module.Exports{},
 

--- a/component/module/string/string.go
+++ b/component/module/string/string.go
@@ -5,14 +5,16 @@ import (
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/module"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river/rivertypes"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "module.string",
-		Args:    Arguments{},
-		Exports: module.Exports{},
+		Name:      "module.string",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   module.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/otelcol/auth/basic/basic.go
+++ b/component/otelcol/auth/basic/basic.go
@@ -4,6 +4,7 @@ package basic
 import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol/auth"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river/rivertypes"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension"
 	otelcomponent "go.opentelemetry.io/collector/component"
@@ -13,9 +14,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.auth.basic",
-		Args:    Arguments{},
-		Exports: auth.Exports{},
+		Name:      "otelcol.auth.basic",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   auth.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := basicauthextension.NewFactory()

--- a/component/otelcol/auth/bearer/bearer.go
+++ b/component/otelcol/auth/bearer/bearer.go
@@ -4,6 +4,7 @@ package bearer
 import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol/auth"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river/rivertypes"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension"
 	otelcomponent "go.opentelemetry.io/collector/component"
@@ -13,9 +14,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.auth.bearer",
-		Args:    Arguments{},
-		Exports: auth.Exports{},
+		Name:      "otelcol.auth.bearer",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   auth.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := bearertokenauthextension.NewFactory()

--- a/component/otelcol/auth/headers/headers.go
+++ b/component/otelcol/auth/headers/headers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol/auth"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river"
 	"github.com/grafana/river/rivertypes"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension"
@@ -17,9 +18,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.auth.headers",
-		Args:    Arguments{},
-		Exports: auth.Exports{},
+		Name:      "otelcol.auth.headers",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   auth.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := headerssetterextension.NewFactory()

--- a/component/otelcol/auth/oauth2/oauth2.go
+++ b/component/otelcol/auth/oauth2/oauth2.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/auth"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river/rivertypes"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension"
 	otelcomponent "go.opentelemetry.io/collector/component"
@@ -16,9 +17,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.auth.oauth2",
-		Args:    Arguments{},
-		Exports: auth.Exports{},
+		Name:      "otelcol.auth.oauth2",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   auth.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := oauth2clientauthextension.NewFactory()

--- a/component/otelcol/auth/sigv4/sigv4.go
+++ b/component/otelcol/auth/sigv4/sigv4.go
@@ -3,6 +3,7 @@ package sigv4
 import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol/auth"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension"
 	otelcomponent "go.opentelemetry.io/collector/component"
 	otelextension "go.opentelemetry.io/collector/extension"
@@ -10,9 +11,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.auth.sigv4",
-		Args:    Arguments{},
-		Exports: auth.Exports{},
+		Name:      "otelcol.auth.sigv4",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   auth.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := sigv4authextension.NewFactory()

--- a/component/otelcol/connector/host_info/host_info.go
+++ b/component/otelcol/connector/host_info/host_info.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/connector"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river"
 	otelcomponent "go.opentelemetry.io/collector/component"
 	otelextension "go.opentelemetry.io/collector/extension"
@@ -15,9 +16,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.connector.host_info",
-		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Name:      "otelcol.connector.host_info",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := NewFactory()

--- a/component/otelcol/connector/servicegraph/servicegraph.go
+++ b/component/otelcol/connector/servicegraph/servicegraph.go
@@ -18,7 +18,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "otelcol.connector.servicegraph",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityExperimental,
 		Args:      Arguments{},
 		Exports:   otelcol.ConsumerExports{},
 

--- a/component/otelcol/connector/servicegraph/servicegraph.go
+++ b/component/otelcol/connector/servicegraph/servicegraph.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/connector"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/servicegraphprocessor"
@@ -16,9 +17,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.connector.servicegraph",
-		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Name:      "otelcol.connector.servicegraph",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := servicegraphconnector.NewFactory()

--- a/component/otelcol/connector/spanlogs/spanlogs.go
+++ b/component/otelcol/connector/spanlogs/spanlogs.go
@@ -9,15 +9,17 @@ import (
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/internal/fanoutconsumer"
 	"github.com/grafana/agent/component/otelcol/internal/lazyconsumer"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/grafana/river"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.connector.spanlogs",
-		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Name:      "otelcol.connector.spanlogs",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
 
 		Build: func(o component.Options, a component.Arguments) (component.Component, error) {
 			return New(o, a.(Arguments))

--- a/component/otelcol/connector/spanmetrics/spanmetrics.go
+++ b/component/otelcol/connector/spanmetrics/spanmetrics.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/connector"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector"
 	otelcomponent "go.opentelemetry.io/collector/component"
@@ -16,9 +17,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.connector.spanmetrics",
-		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Name:      "otelcol.connector.spanmetrics",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := spanmetricsconnector.NewFactory()

--- a/component/otelcol/connector/spanmetrics/spanmetrics.go
+++ b/component/otelcol/connector/spanmetrics/spanmetrics.go
@@ -18,7 +18,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "otelcol.connector.spanmetrics",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityExperimental,
 		Args:      Arguments{},
 		Exports:   otelcol.ConsumerExports{},
 

--- a/component/otelcol/exporter/loadbalancing/loadbalancing.go
+++ b/component/otelcol/exporter/loadbalancing/loadbalancing.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/auth"
 	"github.com/grafana/agent/component/otelcol/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
 	otelcomponent "go.opentelemetry.io/collector/component"
@@ -23,9 +24,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.exporter.loadbalancing",
-		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Name:      "otelcol.exporter.loadbalancing",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := loadbalancingexporter.NewFactory()

--- a/component/otelcol/exporter/loadbalancing/loadbalancing.go
+++ b/component/otelcol/exporter/loadbalancing/loadbalancing.go
@@ -25,7 +25,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "otelcol.exporter.loadbalancing",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      Arguments{},
 		Exports:   otelcol.ConsumerExports{},
 

--- a/component/otelcol/exporter/logging/logging.go
+++ b/component/otelcol/exporter/logging/logging.go
@@ -5,6 +5,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	otelcomponent "go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	loggingexporter "go.opentelemetry.io/collector/exporter/loggingexporter"
@@ -13,9 +14,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.exporter.logging",
-		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Name:      "otelcol.exporter.logging",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := loggingexporter.NewFactory()

--- a/component/otelcol/exporter/loki/loki.go
+++ b/component/otelcol/exporter/loki/loki.go
@@ -10,13 +10,15 @@ import (
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/exporter/loki/internal/convert"
 	"github.com/grafana/agent/component/otelcol/internal/lazyconsumer"
+	"github.com/grafana/agent/internal/featuregate"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.exporter.loki",
-		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Name:      "otelcol.exporter.loki",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
 
 		Build: func(o component.Options, a component.Arguments) (component.Component, error) {
 			return New(o, a.(Arguments))

--- a/component/otelcol/exporter/otlp/otlp.go
+++ b/component/otelcol/exporter/otlp/otlp.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	otelcomponent "go.opentelemetry.io/collector/component"
 	otelpexporterhelper "go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
@@ -15,9 +16,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.exporter.otlp",
-		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Name:      "otelcol.exporter.otlp",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := otlpexporter.NewFactory()

--- a/component/otelcol/exporter/otlphttp/otlphttp.go
+++ b/component/otelcol/exporter/otlphttp/otlphttp.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	otelcomponent "go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
 	otelextension "go.opentelemetry.io/collector/extension"
@@ -15,9 +16,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.exporter.otlphttp",
-		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Name:      "otelcol.exporter.otlphttp",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := otlphttpexporter.NewFactory()

--- a/component/otelcol/exporter/prometheus/prometheus.go
+++ b/component/otelcol/exporter/prometheus/prometheus.go
@@ -13,15 +13,17 @@ import (
 	"github.com/grafana/agent/component/otelcol/exporter/prometheus/internal/convert"
 	"github.com/grafana/agent/component/otelcol/internal/lazyconsumer"
 	"github.com/grafana/agent/component/prometheus"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/service/labelstore"
 	"github.com/prometheus/prometheus/storage"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.exporter.prometheus",
-		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Name:      "otelcol.exporter.prometheus",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
 
 		Build: func(o component.Options, a component.Arguments) (component.Component, error) {
 			return New(o, a.(Arguments))

--- a/component/otelcol/extension/jaeger_remote_sampling/jaeger_remote_sampling.go
+++ b/component/otelcol/extension/jaeger_remote_sampling/jaeger_remote_sampling.go
@@ -16,7 +16,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "otelcol.extension.jaeger_remote_sampling",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityExperimental,
 		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {

--- a/component/otelcol/extension/jaeger_remote_sampling/jaeger_remote_sampling.go
+++ b/component/otelcol/extension/jaeger_remote_sampling/jaeger_remote_sampling.go
@@ -8,14 +8,16 @@ import (
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/extension"
 	"github.com/grafana/agent/component/otelcol/extension/jaeger_remote_sampling/internal/jaegerremotesampling"
+	"github.com/grafana/agent/internal/featuregate"
 	otelcomponent "go.opentelemetry.io/collector/component"
 	otelextension "go.opentelemetry.io/collector/extension"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name: "otelcol.extension.jaeger_remote_sampling",
-		Args: Arguments{},
+		Name:      "otelcol.extension.jaeger_remote_sampling",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := jaegerremotesampling.NewFactory()

--- a/component/otelcol/processor/attributes/attributes.go
+++ b/component/otelcol/processor/attributes/attributes.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/processor"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/mitchellh/mapstructure"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor"
 	otelcomponent "go.opentelemetry.io/collector/component"
@@ -15,9 +16,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.processor.attributes",
-		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Name:      "otelcol.processor.attributes",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := attributesprocessor.NewFactory()

--- a/component/otelcol/processor/batch/batch.go
+++ b/component/otelcol/processor/batch/batch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/processor"
+	"github.com/grafana/agent/internal/featuregate"
 	otelcomponent "go.opentelemetry.io/collector/component"
 	otelextension "go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/processor/batchprocessor"
@@ -15,9 +16,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.processor.batch",
-		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Name:      "otelcol.processor.batch",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := batchprocessor.NewFactory()

--- a/component/otelcol/processor/discovery/discovery.go
+++ b/component/otelcol/processor/discovery/discovery.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/internal/fanoutconsumer"
 	"github.com/grafana/agent/component/otelcol/internal/lazyconsumer"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	promsdconsumer "github.com/grafana/agent/pkg/traces/promsdprocessor/consumer"
 	"github.com/grafana/river"
@@ -18,9 +19,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.processor.discovery",
-		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Name:      "otelcol.processor.discovery",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
 
 		Build: func(o component.Options, a component.Arguments) (component.Component, error) {
 			return New(o, a.(Arguments))

--- a/component/otelcol/processor/filter/filter.go
+++ b/component/otelcol/processor/filter/filter.go
@@ -4,6 +4,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/processor"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/mitchellh/mapstructure"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor"
@@ -13,9 +14,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.processor.filter",
-		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Name:      "otelcol.processor.filter",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := filterprocessor.NewFactory()

--- a/component/otelcol/processor/filter/filter.go
+++ b/component/otelcol/processor/filter/filter.go
@@ -15,7 +15,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "otelcol.processor.filter",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityExperimental,
 		Args:      Arguments{},
 		Exports:   otelcol.ConsumerExports{},
 

--- a/component/otelcol/processor/k8sattributes/k8sattributes.go
+++ b/component/otelcol/processor/k8sattributes/k8sattributes.go
@@ -5,6 +5,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/processor"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/mitchellh/mapstructure"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor"
 	otelcomponent "go.opentelemetry.io/collector/component"
@@ -13,9 +14,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.processor.k8sattributes",
-		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Name:      "otelcol.processor.k8sattributes",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := k8sattributesprocessor.NewFactory()

--- a/component/otelcol/processor/memorylimiter/memorylimiter.go
+++ b/component/otelcol/processor/memorylimiter/memorylimiter.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/processor"
+	"github.com/grafana/agent/internal/featuregate"
 	otelcomponent "go.opentelemetry.io/collector/component"
 	otelextension "go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/processor/memorylimiterprocessor"
@@ -16,9 +17,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.processor.memory_limiter",
-		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Name:      "otelcol.processor.memory_limiter",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := memorylimiterprocessor.NewFactory()

--- a/component/otelcol/processor/probabilistic_sampler/probabilistic_sampler.go
+++ b/component/otelcol/processor/probabilistic_sampler/probabilistic_sampler.go
@@ -5,6 +5,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/processor"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor"
 	otelcomponent "go.opentelemetry.io/collector/component"
@@ -13,9 +14,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.processor.probabilistic_sampler",
-		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Name:      "otelcol.processor.probabilistic_sampler",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := probabilisticsamplerprocessor.NewFactory()

--- a/component/otelcol/processor/probabilistic_sampler/probabilistic_sampler.go
+++ b/component/otelcol/processor/probabilistic_sampler/probabilistic_sampler.go
@@ -15,7 +15,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "otelcol.processor.probabilistic_sampler",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityExperimental,
 		Args:      Arguments{},
 		Exports:   otelcol.ConsumerExports{},
 

--- a/component/otelcol/processor/resourcedetection/resourcedetection.go
+++ b/component/otelcol/processor/resourcedetection/resourcedetection.go
@@ -22,6 +22,7 @@ import (
 	kubernetes_node "github.com/grafana/agent/component/otelcol/processor/resourcedetection/internal/k8snode"
 	"github.com/grafana/agent/component/otelcol/processor/resourcedetection/internal/openshift"
 	"github.com/grafana/agent/component/otelcol/processor/resourcedetection/internal/system"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river"
 	"github.com/mitchellh/mapstructure"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor"
@@ -31,9 +32,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.processor.resourcedetection",
-		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Name:      "otelcol.processor.resourcedetection",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := resourcedetectionprocessor.NewFactory()

--- a/component/otelcol/processor/span/span.go
+++ b/component/otelcol/processor/span/span.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/processor"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/mitchellh/mapstructure"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor"
 	otelcomponent "go.opentelemetry.io/collector/component"
@@ -16,9 +17,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.processor.span",
-		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Name:      "otelcol.processor.span",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := spanprocessor.NewFactory()

--- a/component/otelcol/processor/span/span.go
+++ b/component/otelcol/processor/span/span.go
@@ -18,7 +18,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "otelcol.processor.span",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityExperimental,
 		Args:      Arguments{},
 		Exports:   otelcol.ConsumerExports{},
 

--- a/component/otelcol/processor/tail_sampling/tail_sampling.go
+++ b/component/otelcol/processor/tail_sampling/tail_sampling.go
@@ -17,7 +17,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "otelcol.processor.tail_sampling",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      Arguments{},
 		Exports:   otelcol.ConsumerExports{},
 

--- a/component/otelcol/processor/tail_sampling/tail_sampling.go
+++ b/component/otelcol/processor/tail_sampling/tail_sampling.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/processor"
+	"github.com/grafana/agent/internal/featuregate"
 	tsp "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 	otelcomponent "go.opentelemetry.io/collector/component"
 	otelextension "go.opentelemetry.io/collector/extension"
@@ -15,9 +16,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.processor.tail_sampling",
-		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Name:      "otelcol.processor.tail_sampling",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := tsp.NewFactory()

--- a/component/otelcol/processor/transform/transform.go
+++ b/component/otelcol/processor/transform/transform.go
@@ -19,7 +19,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "otelcol.processor.transform",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityExperimental,
 		Args:      Arguments{},
 		Exports:   otelcol.ConsumerExports{},
 

--- a/component/otelcol/processor/transform/transform.go
+++ b/component/otelcol/processor/transform/transform.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/processor"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/mitchellh/mapstructure"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor"
@@ -17,9 +18,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.processor.transform",
-		Args:    Arguments{},
-		Exports: otelcol.ConsumerExports{},
+		Name:      "otelcol.processor.transform",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := transformprocessor.NewFactory()

--- a/component/otelcol/receiver/jaeger/jaeger.go
+++ b/component/otelcol/receiver/jaeger/jaeger.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/receiver"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver"
 	otelcomponent "go.opentelemetry.io/collector/component"
 	otelconfiggrpc "go.opentelemetry.io/collector/config/configgrpc"
@@ -17,8 +18,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "otelcol.receiver.jaeger",
-		Args: Arguments{},
+		Name:      "otelcol.receiver.jaeger",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := jaegerreceiver.NewFactory()

--- a/component/otelcol/receiver/kafka/kafka.go
+++ b/component/otelcol/receiver/kafka/kafka.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/receiver"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river/rivertypes"
 	"github.com/mitchellh/mapstructure"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
@@ -17,8 +18,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "otelcol.receiver.kafka",
-		Args: Arguments{},
+		Name:      "otelcol.receiver.kafka",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := kafkareceiver.NewFactory()

--- a/component/otelcol/receiver/loki/loki.go
+++ b/component/otelcol/receiver/loki/loki.go
@@ -22,7 +22,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "otelcol.receiver.loki",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      Arguments{},
 		Exports:   Exports{},
 

--- a/component/otelcol/receiver/loki/loki.go
+++ b/component/otelcol/receiver/loki/loki.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/agent/component/common/loki"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/internal/fanoutconsumer"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	loki_translator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki"
 	"go.opentelemetry.io/collector/consumer"
@@ -20,9 +21,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.receiver.loki",
-		Args:    Arguments{},
-		Exports: Exports{},
+		Name:      "otelcol.receiver.loki",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   Exports{},
 
 		Build: func(o component.Options, a component.Arguments) (component.Component, error) {
 			return New(o, a.(Arguments))

--- a/component/otelcol/receiver/opencensus/opencensus.go
+++ b/component/otelcol/receiver/opencensus/opencensus.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/receiver"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver"
 	otelcomponent "go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
@@ -13,8 +14,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "otelcol.receiver.opencensus",
-		Args: Arguments{},
+		Name:      "otelcol.receiver.opencensus",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := opencensusreceiver.NewFactory()

--- a/component/otelcol/receiver/otlp/otlp.go
+++ b/component/otelcol/receiver/otlp/otlp.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/receiver"
+	"github.com/grafana/agent/internal/featuregate"
 	otelcomponent "go.opentelemetry.io/collector/component"
 	otelextension "go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
@@ -16,8 +17,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "otelcol.receiver.otlp",
-		Args: Arguments{},
+		Name:      "otelcol.receiver.otlp",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := otlpreceiver.NewFactory()

--- a/component/otelcol/receiver/prometheus/prometheus.go
+++ b/component/otelcol/receiver/prometheus/prometheus.go
@@ -27,7 +27,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "otelcol.receiver.prometheus",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      Arguments{},
 		Exports:   Exports{},
 

--- a/component/otelcol/receiver/prometheus/prometheus.go
+++ b/component/otelcol/receiver/prometheus/prometheus.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/internal/fanoutconsumer"
 	"github.com/grafana/agent/component/otelcol/receiver/prometheus/internal"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/build"
 	"github.com/grafana/agent/pkg/util/zapadapter"
 	"github.com/prometheus/prometheus/model/labels"
@@ -25,9 +26,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "otelcol.receiver.prometheus",
-		Args:    Arguments{},
-		Exports: Exports{},
+		Name:      "otelcol.receiver.prometheus",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   Exports{},
 
 		Build: func(o component.Options, a component.Arguments) (component.Component, error) {
 			return New(o, a.(Arguments))

--- a/component/otelcol/receiver/vcenter/vcenter.go
+++ b/component/otelcol/receiver/vcenter/vcenter.go
@@ -20,7 +20,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "otelcol.receiver.vcenter",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityExperimental,
 		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {

--- a/component/otelcol/receiver/vcenter/vcenter.go
+++ b/component/otelcol/receiver/vcenter/vcenter.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/receiver"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river/rivertypes"
 	"github.com/mitchellh/mapstructure"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver"
@@ -18,8 +19,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "otelcol.receiver.vcenter",
-		Args: Arguments{},
+		Name:      "otelcol.receiver.vcenter",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := vcenterreceiver.NewFactory()

--- a/component/otelcol/receiver/zipkin/zipkin.go
+++ b/component/otelcol/receiver/zipkin/zipkin.go
@@ -5,6 +5,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/receiver"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver"
 	otelcomponent "go.opentelemetry.io/collector/component"
 	otelextension "go.opentelemetry.io/collector/extension"
@@ -12,8 +13,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "otelcol.receiver.zipkin",
-		Args: Arguments{},
+		Name:      "otelcol.receiver.zipkin",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			fact := zipkinreceiver.NewFactory()

--- a/component/prometheus/exporter/apache/apache.go
+++ b/component/prometheus/exporter/apache/apache.go
@@ -3,15 +3,17 @@ package apache
 import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/apache_http"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.apache",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.apache",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "apache"),
 	})

--- a/component/prometheus/exporter/azure/azure.go
+++ b/component/prometheus/exporter/azure/azure.go
@@ -3,15 +3,17 @@ package azure
 import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/azure_exporter"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.azure",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.azure",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "azure"),
 	})

--- a/component/prometheus/exporter/blackbox/blackbox.go
+++ b/component/prometheus/exporter/blackbox/blackbox.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/discovery"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/blackbox_exporter"
 	"github.com/grafana/agent/pkg/util"
@@ -19,9 +20,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.blackbox",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.blackbox",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.NewWithTargetBuilder(createExporter, "blackbox", buildBlackboxTargets),
 	})

--- a/component/prometheus/exporter/cadvisor/cadvisor.go
+++ b/component/prometheus/exporter/cadvisor/cadvisor.go
@@ -5,15 +5,17 @@ import (
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/cadvisor"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.cadvisor",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.cadvisor",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "cadvisor"),
 	})

--- a/component/prometheus/exporter/cloudwatch/cloudwatch.go
+++ b/component/prometheus/exporter/cloudwatch/cloudwatch.go
@@ -5,15 +5,17 @@ import (
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/cloudwatch_exporter"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.cloudwatch",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.cloudwatch",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "cloudwatch"),
 	})

--- a/component/prometheus/exporter/consul/consul.go
+++ b/component/prometheus/exporter/consul/consul.go
@@ -5,15 +5,17 @@ import (
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/consul_exporter"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.consul",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.consul",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "consul"),
 	})

--- a/component/prometheus/exporter/dnsmasq/dnsmasq.go
+++ b/component/prometheus/exporter/dnsmasq/dnsmasq.go
@@ -3,15 +3,17 @@ package dnsmasq
 import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/dnsmasq_exporter"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.dnsmasq",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.dnsmasq",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "dnsmasq"),
 	})

--- a/component/prometheus/exporter/elasticsearch/elasticsearch.go
+++ b/component/prometheus/exporter/elasticsearch/elasticsearch.go
@@ -6,15 +6,17 @@ import (
 	"github.com/grafana/agent/component"
 	commonCfg "github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/elasticsearch_exporter"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.elasticsearch",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.elasticsearch",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "elasticsearch"),
 	})

--- a/component/prometheus/exporter/gcp/gcp.go
+++ b/component/prometheus/exporter/gcp/gcp.go
@@ -5,15 +5,17 @@ import (
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/gcp_exporter"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.gcp",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.gcp",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "gcp"),
 	})

--- a/component/prometheus/exporter/github/github.go
+++ b/component/prometheus/exporter/github/github.go
@@ -3,6 +3,7 @@ package github
 import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/github_exporter"
 	"github.com/grafana/river/rivertypes"
@@ -11,9 +12,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.github",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.github",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "github"),
 	})

--- a/component/prometheus/exporter/kafka/kafka.go
+++ b/component/prometheus/exporter/kafka/kafka.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/discovery"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/kafka_exporter"
 	"github.com/grafana/river/rivertypes"
@@ -51,9 +52,10 @@ type Arguments struct {
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.kafka",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.kafka",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.NewWithTargetBuilder(createExporter, "kafka", customizeTarget),
 	})

--- a/component/prometheus/exporter/memcached/memcached.go
+++ b/component/prometheus/exporter/memcached/memcached.go
@@ -6,15 +6,17 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/memcached_exporter"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.memcached",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.memcached",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "memcached"),
 	})

--- a/component/prometheus/exporter/mongodb/mongodb.go
+++ b/component/prometheus/exporter/mongodb/mongodb.go
@@ -3,6 +3,7 @@ package mongodb
 import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/mongodb_exporter"
 	"github.com/grafana/river/rivertypes"
@@ -11,9 +12,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.mongodb",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.mongodb",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "mongodb"),
 	})

--- a/component/prometheus/exporter/mssql/mssql.go
+++ b/component/prometheus/exporter/mssql/mssql.go
@@ -8,6 +8,7 @@ import (
 	"github.com/burningalchemist/sql_exporter/config"
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/mssql"
 	"github.com/grafana/agent/pkg/util"
@@ -18,9 +19,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.mssql",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.mssql",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "mssql"),
 	})

--- a/component/prometheus/exporter/mysql/mysql.go
+++ b/component/prometheus/exporter/mysql/mysql.go
@@ -4,6 +4,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/mysqld_exporter"
 	"github.com/grafana/river/rivertypes"
@@ -12,9 +13,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.mysql",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.mysql",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "mysql"),
 	})

--- a/component/prometheus/exporter/oracledb/oracledb.go
+++ b/component/prometheus/exporter/oracledb/oracledb.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/oracledb_exporter"
 	"github.com/grafana/river/rivertypes"
@@ -15,9 +16,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.oracledb",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.oracledb",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "oracledb"),
 	})

--- a/component/prometheus/exporter/postgres/postgres.go
+++ b/component/prometheus/exporter/postgres/postgres.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/postgres_exporter"
 	"github.com/grafana/river/rivertypes"
@@ -15,9 +16,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.postgres",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.postgres",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "postgres"),
 	})

--- a/component/prometheus/exporter/process/process.go
+++ b/component/prometheus/exporter/process/process.go
@@ -3,6 +3,7 @@ package process
 import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/process_exporter"
 	exporter_config "github.com/ncabatoff/process-exporter/config"
@@ -10,9 +11,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.process",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.process",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createIntegration, "process"),
 	})

--- a/component/prometheus/exporter/redis/redis.go
+++ b/component/prometheus/exporter/redis/redis.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/redis_exporter"
 	"github.com/grafana/river/rivertypes"
@@ -15,9 +16,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.redis",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.redis",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "redis"),
 	})

--- a/component/prometheus/exporter/self/self.go
+++ b/component/prometheus/exporter/self/self.go
@@ -3,15 +3,17 @@ package self
 import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/agent"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.self",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.self",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "agent"),
 	})

--- a/component/prometheus/exporter/snmp/snmp.go
+++ b/component/prometheus/exporter/snmp/snmp.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/discovery"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/snmp_exporter"
 	"github.com/grafana/river/rivertypes"
@@ -17,9 +18,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.snmp",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.snmp",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.NewWithTargetBuilder(createExporter, "snmp", buildSNMPTargets),
 	})

--- a/component/prometheus/exporter/snowflake/snowflake.go
+++ b/component/prometheus/exporter/snowflake/snowflake.go
@@ -3,6 +3,7 @@ package snowflake
 import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/snowflake_exporter"
 	"github.com/grafana/river/rivertypes"
@@ -11,9 +12,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.snowflake",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.snowflake",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "snowflake"),
 	})

--- a/component/prometheus/exporter/squid/squid.go
+++ b/component/prometheus/exporter/squid/squid.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/squid_exporter"
 	"github.com/grafana/river/rivertypes"
@@ -13,9 +14,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.squid",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.squid",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "squid"),
 	})

--- a/component/prometheus/exporter/statsd/statsd.go
+++ b/component/prometheus/exporter/statsd/statsd.go
@@ -3,14 +3,16 @@ package statsd
 import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.statsd",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.statsd",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "statsd"),
 	})

--- a/component/prometheus/exporter/unix/unix.go
+++ b/component/prometheus/exporter/unix/unix.go
@@ -3,14 +3,16 @@ package unix
 import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.unix",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.unix",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "unix"),
 	})

--- a/component/prometheus/exporter/vsphere/vsphere.go
+++ b/component/prometheus/exporter/vsphere/vsphere.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 	"github.com/grafana/agent/pkg/integrations/vmware_exporter"
 	"github.com/grafana/river/rivertypes"
@@ -13,9 +14,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.vsphere",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.vsphere",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "vsphere"),
 	})

--- a/component/prometheus/exporter/windows/windows.go
+++ b/component/prometheus/exporter/windows/windows.go
@@ -3,14 +3,16 @@ package windows
 import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/exporter"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/integrations"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.exporter.windows",
-		Args:    Arguments{},
-		Exports: exporter.Exports{},
+		Name:      "prometheus.exporter.windows",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   exporter.Exports{},
 
 		Build: exporter.New(createExporter, "windows"),
 	})

--- a/component/prometheus/operator/podmonitors/operator.go
+++ b/component/prometheus/operator/podmonitors/operator.go
@@ -4,12 +4,14 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/operator"
 	"github.com/grafana/agent/component/prometheus/operator/common"
+	"github.com/grafana/agent/internal/featuregate"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name: "prometheus.operator.podmonitors",
-		Args: operator.Arguments{},
+		Name:      "prometheus.operator.podmonitors",
+		Stability: featuregate.StabilityStable,
+		Args:      operator.Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return common.New(opts, args, common.KindPodMonitor)

--- a/component/prometheus/operator/podmonitors/operator.go
+++ b/component/prometheus/operator/podmonitors/operator.go
@@ -10,7 +10,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "prometheus.operator.podmonitors",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      operator.Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {

--- a/component/prometheus/operator/probes/probes.go
+++ b/component/prometheus/operator/probes/probes.go
@@ -10,7 +10,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "prometheus.operator.probes",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      operator.Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {

--- a/component/prometheus/operator/probes/probes.go
+++ b/component/prometheus/operator/probes/probes.go
@@ -4,12 +4,14 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/operator"
 	"github.com/grafana/agent/component/prometheus/operator/common"
+	"github.com/grafana/agent/internal/featuregate"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name: "prometheus.operator.probes",
-		Args: operator.Arguments{},
+		Name:      "prometheus.operator.probes",
+		Stability: featuregate.StabilityStable,
+		Args:      operator.Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return common.New(opts, args, common.KindProbe)

--- a/component/prometheus/operator/servicemonitors/servicemonitors.go
+++ b/component/prometheus/operator/servicemonitors/servicemonitors.go
@@ -4,12 +4,14 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/prometheus/operator"
 	"github.com/grafana/agent/component/prometheus/operator/common"
+	"github.com/grafana/agent/internal/featuregate"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name: "prometheus.operator.servicemonitors",
-		Args: operator.Arguments{},
+		Name:      "prometheus.operator.servicemonitors",
+		Stability: featuregate.StabilityStable,
+		Args:      operator.Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return common.New(opts, args, common.KindServiceMonitor)

--- a/component/prometheus/operator/servicemonitors/servicemonitors.go
+++ b/component/prometheus/operator/servicemonitors/servicemonitors.go
@@ -10,7 +10,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "prometheus.operator.servicemonitors",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      operator.Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {

--- a/component/prometheus/receive_http/receive_http.go
+++ b/component/prometheus/receive_http/receive_http.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/agent/component"
 	fnet "github.com/grafana/agent/component/common/net"
 	agentprom "github.com/grafana/agent/component/prometheus"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/grafana/agent/pkg/util"
 	"github.com/grafana/agent/service/labelstore"
@@ -21,8 +22,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "prometheus.receive_http",
-		Args: Arguments{},
+		Name:      "prometheus.receive_http",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/prometheus/relabel/relabel.go
+++ b/component/prometheus/relabel/relabel.go
@@ -5,13 +5,10 @@ import (
 	"fmt"
 	"sync"
 
-	"go.uber.org/atomic"
-
-	"github.com/prometheus/prometheus/storage"
-
 	"github.com/grafana/agent/component"
 	flow_relabel "github.com/grafana/agent/component/common/relabel"
 	"github.com/grafana/agent/component/prometheus"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/service/labelstore"
 	lru "github.com/hashicorp/golang-lru/v2"
 	prometheus_client "github.com/prometheus/client_golang/prometheus"
@@ -19,16 +16,18 @@ import (
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/metadata"
-
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/prometheus/model/value"
+	"github.com/prometheus/prometheus/storage"
+	"go.uber.org/atomic"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "prometheus.relabel",
-		Args:    Arguments{},
-		Exports: Exports{},
+		Name:      "prometheus.relabel",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/prometheus/remotewrite/remote_write.go
+++ b/component/prometheus/remotewrite/remote_write.go
@@ -9,25 +9,23 @@ import (
 	"sync"
 	"time"
 
-	"go.uber.org/atomic"
-
+	"github.com/go-kit/log"
+	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/component/prometheus"
+	"github.com/grafana/agent/internal/agentseed"
+	"github.com/grafana/agent/internal/featuregate"
+	"github.com/grafana/agent/internal/useragent"
+	"github.com/grafana/agent/pkg/flow/logging/level"
+	"github.com/grafana/agent/pkg/metrics/wal"
+	"github.com/grafana/agent/service/labelstore"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/metadata"
-
-	"github.com/grafana/agent/component/prometheus"
-	"github.com/grafana/agent/service/labelstore"
-
-	"github.com/go-kit/log"
-	"github.com/grafana/agent/component"
-	"github.com/grafana/agent/internal/agentseed"
-	"github.com/grafana/agent/internal/useragent"
-	"github.com/grafana/agent/pkg/flow/logging/level"
-	"github.com/grafana/agent/pkg/metrics/wal"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
+	"go.uber.org/atomic"
 )
 
 // Options.
@@ -39,9 +37,10 @@ func init() {
 	remote.UserAgent = useragent.Get()
 
 	component.Register(component.Registration{
-		Name:    "prometheus.remote_write",
-		Args:    Arguments{},
-		Exports: Exports{},
+		Name:      "prometheus.remote_write",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   Exports{},
 
 		Build: func(o component.Options, c component.Arguments) (component.Component, error) {
 			return New(o, c.(Arguments))

--- a/component/prometheus/scrape/scrape.go
+++ b/component/prometheus/scrape/scrape.go
@@ -12,6 +12,7 @@ import (
 	component_config "github.com/grafana/agent/component/common/config"
 	"github.com/grafana/agent/component/discovery"
 	"github.com/grafana/agent/component/prometheus"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/internal/useragent"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/grafana/agent/service/cluster"
@@ -30,8 +31,9 @@ func init() {
 	scrape.UserAgent = useragent.Get()
 
 	component.Register(component.Registration{
-		Name: "prometheus.scrape",
-		Args: Arguments{},
+		Name:      "prometheus.scrape",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/pyroscope/ebpf/ebpf_linux.go
+++ b/component/pyroscope/ebpf/ebpf_linux.go
@@ -25,7 +25,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "pyroscope.ebpf",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {

--- a/component/pyroscope/ebpf/ebpf_linux.go
+++ b/component/pyroscope/ebpf/ebpf_linux.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/pyroscope"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	ebpfspy "github.com/grafana/pyroscope/ebpf"
 	demangle2 "github.com/grafana/pyroscope/ebpf/cpp/demangle"
@@ -23,8 +24,9 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "pyroscope.ebpf",
-		Args: Arguments{},
+		Name:      "pyroscope.ebpf",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			arguments := args.(Arguments)

--- a/component/pyroscope/ebpf/ebpf_placeholder.go
+++ b/component/pyroscope/ebpf/ebpf_placeholder.go
@@ -6,13 +6,15 @@ import (
 	"context"
 
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name: "pyroscope.ebpf",
-		Args: Arguments{},
+		Name:      "pyroscope.ebpf",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			arguments := args.(Arguments)

--- a/component/pyroscope/ebpf/ebpf_placeholder.go
+++ b/component/pyroscope/ebpf/ebpf_placeholder.go
@@ -13,7 +13,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "pyroscope.ebpf",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {

--- a/component/pyroscope/java/java.go
+++ b/component/pyroscope/java/java.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/pyroscope"
 	"github.com/grafana/agent/component/pyroscope/java/asprof"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 )
 
@@ -21,8 +22,9 @@ const (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "pyroscope.java",
-		Args: Arguments{},
+		Name:      "pyroscope.java",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			if os.Getuid() != 0 {

--- a/component/pyroscope/java/java_stub.go
+++ b/component/pyroscope/java/java_stub.go
@@ -6,13 +6,15 @@ import (
 	"context"
 
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name: "pyroscope.java",
-		Args: Arguments{},
+		Name:      "pyroscope.java",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			_ = level.Warn(opts.Logger).Log("msg", "the pyroscope.java component only works on linux for amd64 and arm64; enabling it otherwise will do nothing")

--- a/component/pyroscope/scrape/scrape.go
+++ b/component/pyroscope/scrape/scrape.go
@@ -35,7 +35,7 @@ const (
 func init() {
 	component.Register(component.Registration{
 		Name:      "pyroscope.scrape",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {

--- a/component/pyroscope/scrape/scrape.go
+++ b/component/pyroscope/scrape/scrape.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/grafana/agent/component/pyroscope"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/grafana/agent/service/cluster"
 	"github.com/prometheus/common/model"
@@ -33,8 +34,9 @@ const (
 
 func init() {
 	component.Register(component.Registration{
-		Name: "pyroscope.scrape",
-		Args: Arguments{},
+		Name:      "pyroscope.scrape",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/component/pyroscope/write/write.go
+++ b/component/pyroscope/write/write.go
@@ -37,7 +37,7 @@ var (
 func init() {
 	component.Register(component.Registration{
 		Name:      "pyroscope.write",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      Arguments{},
 		Exports:   Exports{},
 		Build: func(o component.Options, c component.Arguments) (component.Component, error) {

--- a/component/pyroscope/write/write.go
+++ b/component/pyroscope/write/write.go
@@ -9,6 +9,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/grafana/agent/component/pyroscope"
 	"github.com/grafana/agent/internal/agentseed"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/internal/useragent"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/oklog/run"
@@ -35,9 +36,10 @@ var (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "pyroscope.write",
-		Args:    Arguments{},
-		Exports: Exports{},
+		Name:      "pyroscope.write",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   Exports{},
 		Build: func(o component.Options, c component.Arguments) (component.Component, error) {
 			return New(o, c.(Arguments))
 		},

--- a/component/remote/http/http.go
+++ b/component/remote/http/http.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/agent/component"
 	common_config "github.com/grafana/agent/component/common/config"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/internal/useragent"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/grafana/river/rivertypes"
@@ -23,9 +24,10 @@ var userAgent = useragent.Get()
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "remote.http",
-		Args:    Arguments{},
-		Exports: Exports{},
+		Name:      "remote.http",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   Exports{},
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))
 		},

--- a/component/remote/kubernetes/configmap/configmap.go
+++ b/component/remote/kubernetes/configmap/configmap.go
@@ -3,13 +3,15 @@ package configmap
 import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/remote/kubernetes"
+	"github.com/grafana/agent/internal/featuregate"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "remote.kubernetes.configmap",
-		Args:    kubernetes.Arguments{},
-		Exports: kubernetes.Exports{},
+		Name:      "remote.kubernetes.configmap",
+		Stability: featuregate.StabilityStable,
+		Args:      kubernetes.Arguments{},
+		Exports:   kubernetes.Exports{},
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return kubernetes.New(opts, args.(kubernetes.Arguments), kubernetes.TypeConfigMap)
 		},

--- a/component/remote/kubernetes/secret/secret.go
+++ b/component/remote/kubernetes/secret/secret.go
@@ -3,13 +3,15 @@ package secret
 import (
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/remote/kubernetes"
+	"github.com/grafana/agent/internal/featuregate"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "remote.kubernetes.secret",
-		Args:    kubernetes.Arguments{},
-		Exports: kubernetes.Exports{},
+		Name:      "remote.kubernetes.secret",
+		Stability: featuregate.StabilityStable,
+		Args:      kubernetes.Arguments{},
+		Exports:   kubernetes.Exports{},
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return kubernetes.New(opts, args.(kubernetes.Arguments), kubernetes.TypeSecret)
 		},

--- a/component/remote/s3/s3.go
+++ b/component/remote/s3/s3.go
@@ -1,6 +1,7 @@
 package s3
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
@@ -8,21 +9,21 @@ import (
 	"sync"
 	"time"
 
-	"context"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	aws_config "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/river/rivertypes"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "remote.s3",
-		Args:    Arguments{},
-		Exports: Exports{},
+		Name:      "remote.s3",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   Exports{},
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))
 		},

--- a/component/remote/vault/vault.go
+++ b/component/remote/vault/vault.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/grafana/river/rivertypes"
 	"github.com/oklog/run"
@@ -17,9 +18,10 @@ import (
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "remote.vault",
-		Args:    Arguments{},
-		Exports: Exports{},
+		Name:      "remote.vault",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return New(opts, args.(Arguments))

--- a/converter/internal/test_common/testing.go
+++ b/converter/internal/test_common/testing.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/grafana/agent/converter/diag"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow"
 	"github.com/grafana/agent/pkg/flow/logging"
 	"github.com/grafana/agent/service"
@@ -193,8 +194,9 @@ func attemptLoadingFlowConfig(t *testing.T, river []byte) {
 	require.NoError(t, err)
 
 	f := flow.New(flow.Options{
-		Logger:   logger,
-		DataPath: t.TempDir(),
+		Logger:       logger,
+		DataPath:     t.TempDir(),
+		MinStability: featuregate.StabilityExperimental,
 		Services: []service.Service{
 			// The services here aren't used, but we still need to provide an
 			// implementations so that components which rely on the services load

--- a/go.mod
+++ b/go.mod
@@ -320,7 +320,7 @@ require (
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/danieljoos/wincred v1.2.0 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/dennwc/btrfs v0.0.0-20230312211831-a1f570bd01a1 // indirect
 	github.com/dennwc/ioctl v1.0.0 // indirect
 	github.com/dennwc/varint v1.0.0 // indirect

--- a/internal/featuregate/featuregate.go
+++ b/internal/featuregate/featuregate.go
@@ -15,16 +15,16 @@ type Stability int
 const (
 	// StabilityUndefined is the default value for Stability, which indicates an error and should never be used.
 	StabilityUndefined Stability = iota
-	// StabilityExperimental is the default value for Stability, used to designate experimental features.
+	// StabilityExperimental is used to designate experimental features.
 	StabilityExperimental
-	// StabilityBeta is used to designate alpha features.
+	// StabilityBeta is used to designate beta features.
 	StabilityBeta
-	// StabilityStable is used to designate beta features.
+	// StabilityStable is used to designate stable features.
 	StabilityStable
 )
 
 func CheckAllowed(stability Stability, minStability Stability, featureName string) error {
-	if stability == StabilityUndefined {
+	if stability == StabilityUndefined || minStability == StabilityUndefined {
 		return fmt.Errorf(
 			"stability levels must be defined: got %s as stability of %s and %s as the minimum stability level",
 			stability,

--- a/internal/featuregate/featuregate.go
+++ b/internal/featuregate/featuregate.go
@@ -1,0 +1,89 @@
+// Package featuregate provides a way to gate features in the collector based on different options, such as the
+// feature's stability level and user-defined minimum allowed stability level. This package is used by Flow Mode only.
+package featuregate
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+)
+
+// Stability is used to designate the stability level of a feature or a minimum stability level the collector
+// is allowed to operate with.
+type Stability int
+
+const (
+	// StabilityUndefined is the default value for Stability, which indicates an error and should never be used.
+	StabilityUndefined Stability = iota
+	// StabilityExperimental is the default value for Stability, used to designate experimental features.
+	StabilityExperimental
+	// StabilityBeta is used to designate alpha features.
+	StabilityBeta
+	// StabilityStable is used to designate beta features.
+	StabilityStable
+)
+
+func CheckAllowed(stability Stability, minStability Stability, featureName string) error {
+	if stability == StabilityUndefined || minStability == StabilityUndefined {
+		return fmt.Errorf(
+			"stability levels must be defined: got %s as stability of %s and %s as the minimum stability level",
+			stability,
+			featureName,
+			minStability,
+		)
+	}
+	if stability < minStability {
+		return fmt.Errorf(
+			"%s is at stability level %s, which is below the minimum allowed stability level %s. "+
+				"Use --stability.level command-line flag to enable %s features",
+			featureName,
+			stability,
+			minStability,
+			stability,
+		)
+	}
+	return nil
+}
+
+func AllowedValues() []string {
+	return []string{
+		StabilityStable.String(),
+		StabilityBeta.String(),
+		StabilityExperimental.String(),
+	}
+}
+
+var (
+	// Stability implements the pflag.Value interface for use with Cobra flags.
+	_ pflag.Value = (*Stability)(nil)
+	// stabilityToString defines how to convert a Stability to a string.
+	stabilityToString = map[Stability]string{
+		StabilityExperimental: "experimental",
+		StabilityBeta:         "beta",
+		StabilityStable:       "stable",
+	}
+)
+
+// String implements the pflag.Value interface. The returned strings are "double-quoted" already.
+func (s Stability) String() string {
+	if str, ok := stabilityToString[s]; ok {
+		return fmt.Sprintf("%q", str)
+	}
+	return "<invalid_stability_level>"
+}
+
+// Set implements the pflag.Value interface.
+func (s *Stability) Set(str string) error {
+	for k, v := range stabilityToString {
+		if v == str {
+			*s = k
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid stability level %q", str)
+}
+
+// Type implements the pflag.Value interface. This value is displayed as a placeholder in help messages.
+func (s Stability) Type() string {
+	return "<stability_level>"
+}

--- a/internal/featuregate/featuregate.go
+++ b/internal/featuregate/featuregate.go
@@ -24,7 +24,7 @@ const (
 )
 
 func CheckAllowed(stability Stability, minStability Stability, featureName string) error {
-	if stability == StabilityUndefined || minStability == StabilityUndefined {
+	if stability == StabilityUndefined {
 		return fmt.Errorf(
 			"stability levels must be defined: got %s as stability of %s and %s as the minimum stability level",
 			stability,

--- a/internal/featuregate/featuregate_test.go
+++ b/internal/featuregate/featuregate_test.go
@@ -1,8 +1,9 @@
 package featuregate
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCheckAllowed(t *testing.T) {

--- a/internal/featuregate/featuregate_test.go
+++ b/internal/featuregate/featuregate_test.go
@@ -1,0 +1,64 @@
+package featuregate
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestCheckAllowed(t *testing.T) {
+	type args struct {
+		stability    Stability
+		minStability Stability
+		featureName  string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		errContains string
+	}{
+		{
+			name: "undefined stability",
+			args: args{
+				stability:    StabilityUndefined,
+				minStability: StabilityStable,
+				featureName:  "component do.all.things",
+			},
+			errContains: "stability levels must be defined: got <invalid_stability_level> as stability of component do.all.things",
+		},
+		{
+			name: "too low stability",
+			args: args{
+				stability:    StabilityBeta,
+				minStability: StabilityStable,
+				featureName:  "component do.all.things",
+			},
+			errContains: "component do.all.things is at stability level \"beta\", which is below the minimum allowed stability level \"stable\"",
+		},
+		{
+			name: "equal stability",
+			args: args{
+				stability:    StabilityBeta,
+				minStability: StabilityBeta,
+				featureName:  "component do.all.things",
+			},
+		},
+		{
+			name: "higher stability",
+			args: args{
+				stability:    StabilityStable,
+				minStability: StabilityBeta,
+				featureName:  "component do.all.things",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckAllowed(tt.args.stability, tt.args.minStability, tt.args.featureName)
+			if tt.errContains == "" {
+				require.NoError(t, err)
+			} else {
+				require.Contains(t, err.Error(), tt.errContains)
+			}
+		})
+	}
+}

--- a/pkg/flow/componenttest/testfailmodule.go
+++ b/pkg/flow/componenttest/testfailmodule.go
@@ -6,13 +6,15 @@ import (
 
 	"github.com/grafana/agent/component"
 	mod "github.com/grafana/agent/component/module"
+	"github.com/grafana/agent/internal/featuregate"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "test.fail.module",
-		Args:    TestFailArguments{},
-		Exports: mod.Exports{},
+		Name:      "test.fail.module",
+		Stability: featuregate.StabilityStable,
+		Args:      TestFailArguments{},
+		Exports:   mod.Exports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			m, err := mod.NewModuleComponent(opts)

--- a/pkg/flow/declare_test.go
+++ b/pkg/flow/declare_test.go
@@ -387,7 +387,7 @@ func TestDeclareError(t *testing.T) {
 			ctrl := flow.New(flow.Options{
 				Logger:       s,
 				DataPath:     t.TempDir(),
-				MinStability: featuregate.StabilityStable,
+				MinStability: featuregate.StabilityBeta,
 				Reg:          nil,
 				Services:     []service.Service{},
 			})

--- a/pkg/flow/declare_test.go
+++ b/pkg/flow/declare_test.go
@@ -368,7 +368,7 @@ func TestDeclareError(t *testing.T) {
 			}
 			a "example" {}
 			`,
-			expectedError: regexp.MustCompile(`cannot retrieve the definition of component name "b_1"`),
+			expectedError: regexp.MustCompile(`cannot find the definition of component name "b_1"`),
 		},
 		{
 			name: "ForbiddenDeclareLabel",

--- a/pkg/flow/declare_test.go
+++ b/pkg/flow/declare_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow"
 	"github.com/grafana/agent/pkg/flow/internal/testcomponents"
 	"github.com/grafana/agent/pkg/flow/logging"
@@ -384,10 +385,11 @@ func TestDeclareError(t *testing.T) {
 			s, err := logging.New(os.Stderr, logging.DefaultOptions)
 			require.NoError(t, err)
 			ctrl := flow.New(flow.Options{
-				Logger:   s,
-				DataPath: t.TempDir(),
-				Reg:      nil,
-				Services: []service.Service{},
+				Logger:       s,
+				DataPath:     t.TempDir(),
+				MinStability: featuregate.StabilityStable,
+				Reg:          nil,
+				Services:     []service.Service{},
 			})
 			f, err := flow.ParseSource(t.Name(), []byte(tc.config))
 			require.NoError(t, err)

--- a/pkg/flow/flow.go
+++ b/pkg/flow/flow.go
@@ -51,6 +51,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/internal/controller"
 	"github.com/grafana/agent/pkg/flow/internal/worker"
 	"github.com/grafana/agent/pkg/flow/logging"
@@ -89,6 +90,10 @@ type Options struct {
 
 	// Reg is the prometheus register to use
 	Reg prometheus.Registerer
+
+	// MinStability is the minimum stability level of features that can be used by the collector. It is defined by
+	// the user, for example, via command-line flags.
+	MinStability featuregate.Stability
 
 	// OnExportsChange is called when the exports of the controller change.
 	// Exports are controlled by "export" configuration blocks. If
@@ -186,6 +191,7 @@ func newController(o controllerOptions) *Flow {
 			Logger:        log,
 			TraceProvider: tracer,
 			DataPath:      o.DataPath,
+			MinStability:  o.MinStability,
 			OnBlockNodeUpdate: func(cn controller.BlockNode) {
 				// Changed node should be queued for reevaluation.
 				f.updateQueue.Enqueue(&controller.QueuedNode{Node: cn, LastUpdatedTime: time.Now()})
@@ -201,6 +207,7 @@ func newController(o controllerOptions) *Flow {
 					Tracer:            tracer,
 					Reg:               o.Reg,
 					DataPath:          o.DataPath,
+					MinStability:      o.MinStability,
 					ID:                id,
 					ServiceMap:        serviceMap,
 					WorkerPool:        workerPool,

--- a/pkg/flow/flow_services.go
+++ b/pkg/flow/flow_services.go
@@ -77,6 +77,7 @@ func (f *Flow) NewController(id string) service.Controller {
 				Logger:          f.opts.Logger,
 				Tracer:          f.opts.Tracer,
 				DataPath:        f.opts.DataPath,
+				MinStability:    f.opts.MinStability,
 				Reg:             f.opts.Reg,
 				Services:        f.opts.Services,
 				OnExportsChange: nil, // NOTE(@tpaschalis, @wildum) The isolated controller shouldn't be able to export any values.

--- a/pkg/flow/flow_test.go
+++ b/pkg/flow/flow_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/internal/controller"
 	"github.com/grafana/agent/pkg/flow/internal/dag"
 	"github.com/grafana/agent/pkg/flow/internal/testcomponents"
@@ -70,9 +71,10 @@ func testOptions(t *testing.T) Options {
 	require.NoError(t, err)
 
 	return Options{
-		Logger:   s,
-		DataPath: t.TempDir(),
-		Reg:      nil,
+		Logger:       s,
+		DataPath:     t.TempDir(),
+		MinStability: featuregate.StabilityStable,
+		Reg:          nil,
 	}
 }
 

--- a/pkg/flow/flow_test.go
+++ b/pkg/flow/flow_test.go
@@ -73,7 +73,7 @@ func testOptions(t *testing.T) Options {
 	return Options{
 		Logger:       s,
 		DataPath:     t.TempDir(),
-		MinStability: featuregate.StabilityStable,
+		MinStability: featuregate.StabilityBeta,
 		Reg:          nil,
 	}
 }

--- a/pkg/flow/import_test.go
+++ b/pkg/flow/import_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow"
 	"github.com/grafana/agent/pkg/flow/internal/testcomponents"
 	"github.com/grafana/agent/pkg/flow/logging"
@@ -239,10 +240,11 @@ func setup(t *testing.T, config string) (*flow.Flow, *flow.Source) {
 	s, err := logging.New(os.Stderr, logging.DefaultOptions)
 	require.NoError(t, err)
 	ctrl := flow.New(flow.Options{
-		Logger:   s,
-		DataPath: t.TempDir(),
-		Reg:      nil,
-		Services: []service.Service{},
+		Logger:       s,
+		DataPath:     t.TempDir(),
+		MinStability: featuregate.StabilityStable,
+		Reg:          nil,
+		Services:     []service.Service{},
 	})
 	f, err := flow.ParseSource(t.Name(), []byte(config))
 	require.NoError(t, err)

--- a/pkg/flow/import_test.go
+++ b/pkg/flow/import_test.go
@@ -242,7 +242,7 @@ func setup(t *testing.T, config string) (*flow.Flow, *flow.Source) {
 	ctrl := flow.New(flow.Options{
 		Logger:       s,
 		DataPath:     t.TempDir(),
-		MinStability: featuregate.StabilityStable,
+		MinStability: featuregate.StabilityBeta,
 		Reg:          nil,
 		Services:     []service.Service{},
 	})

--- a/pkg/flow/internal/controller/component_node_manager.go
+++ b/pkg/flow/internal/controller/component_node_manager.go
@@ -32,9 +32,9 @@ func (m *ComponentNodeManager) createComponentNode(componentName string, block *
 	if isCustomComponent(m.customComponentReg, block.Name[0]) {
 		return NewCustomComponentNode(m.globals, block, m.getCustomComponentConfig), nil
 	}
-	registration, exists := m.builtinComponentReg.Get(componentName)
-	if !exists {
-		return nil, fmt.Errorf("cannot retrieve the definition of component name %q", componentName)
+	registration, err := m.builtinComponentReg.Get(componentName)
+	if err != nil {
+		return nil, err
 	}
 	if block.Label == "" {
 		return nil, fmt.Errorf("component %q must have a label", componentName)

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -75,7 +75,7 @@ func NewLoader(opts LoaderOptions) *Loader {
 	)
 
 	if reg == nil {
-		reg = DefaultComponentRegistry{}
+		reg = NewDefaultComponentRegistry(opts.ComponentGlobals.MinStability)
 	}
 
 	l := &Loader{

--- a/pkg/flow/internal/controller/loader_test.go
+++ b/pkg/flow/internal/controller/loader_test.go
@@ -129,7 +129,7 @@ func TestLoader(t *testing.T) {
 		`
 		l := controller.NewLoader(newLoaderOptions())
 		diags := applyFromContent(t, l, []byte(invalidFile), nil)
-		require.ErrorContains(t, diags.ErrorOrNil(), `cannot retrieve the definition of component name "doesnotexist`)
+		require.ErrorContains(t, diags.ErrorOrNil(), `cannot find the definition of component name "doesnotexist`)
 	})
 
 	t.Run("Load with component with empty label", func(t *testing.T) {

--- a/pkg/flow/internal/controller/loader_test.go
+++ b/pkg/flow/internal/controller/loader_test.go
@@ -150,35 +150,20 @@ func TestLoader(t *testing.T) {
 	})
 
 	t.Run("Load with correct stability level", func(t *testing.T) {
-		invalidFile := `
-			testcomponents.tick "test" {
-				frequency = "1s"
-			}
-		`
 		l := controller.NewLoader(newLoaderOptionsWithStability(featuregate.StabilityBeta))
-		diags := applyFromContent(t, l, []byte(invalidFile), nil)
+		diags := applyFromContent(t, l, []byte(testFile), nil)
 		require.NoError(t, diags.ErrorOrNil())
 	})
 
 	t.Run("Load with below minimum stability level", func(t *testing.T) {
-		invalidFile := `
-			testcomponents.tick "test" {
-				frequency = "1s"
-			}
-		`
 		l := controller.NewLoader(newLoaderOptionsWithStability(featuregate.StabilityStable))
-		diags := applyFromContent(t, l, []byte(invalidFile), nil)
+		diags := applyFromContent(t, l, []byte(testFile), nil)
 		require.ErrorContains(t, diags.ErrorOrNil(), "component \"testcomponents.tick\" is at stability level \"beta\", which is below the minimum allowed stability level \"stable\"")
 	})
 
 	t.Run("Load with undefined minimum stability level", func(t *testing.T) {
-		invalidFile := `
-			testcomponents.tick "test" {
-				frequency = "1s"
-			}
-		`
 		l := controller.NewLoader(newLoaderOptionsWithStability(featuregate.StabilityUndefined))
-		diags := applyFromContent(t, l, []byte(invalidFile), nil)
+		diags := applyFromContent(t, l, []byte(testFile), nil)
 		require.ErrorContains(t, diags.ErrorOrNil(), "stability levels must be defined: got \"beta\" as stability of component \"testcomponents.tick\" and <invalid_stability_level> as the minimum stability level")
 	})
 

--- a/pkg/flow/internal/controller/loader_test.go
+++ b/pkg/flow/internal/controller/loader_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/internal/controller"
 	"github.com/grafana/agent/pkg/flow/internal/dag"
 	"github.com/grafana/agent/pkg/flow/logging"
@@ -73,6 +74,7 @@ func TestLoader(t *testing.T) {
 				Logger:            l,
 				TraceProvider:     noop.NewTracerProvider(),
 				DataPath:          t.TempDir(),
+				MinStability:      featuregate.StabilityStable,
 				OnBlockNodeUpdate: func(cn controller.BlockNode) { /* no-op */ },
 				Registerer:        prometheus.NewRegistry(),
 				NewModuleController: func(id string) controller.ModuleController {
@@ -218,6 +220,7 @@ func TestScopeWithFailingComponent(t *testing.T) {
 				Logger:            l,
 				TraceProvider:     noop.NewTracerProvider(),
 				DataPath:          t.TempDir(),
+				MinStability:      featuregate.StabilityStable,
 				OnBlockNodeUpdate: func(cn controller.BlockNode) { /* no-op */ },
 				Registerer:        prometheus.NewRegistry(),
 				NewModuleController: func(id string) controller.ModuleController {

--- a/pkg/flow/internal/controller/node_builtin_component.go
+++ b/pkg/flow/internal/controller/node_builtin_component.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/grafana/agent/pkg/flow/tracing"
@@ -65,6 +66,7 @@ type ComponentGlobals struct {
 	Logger              *logging.Logger                        // Logger shared between all managed components.
 	TraceProvider       trace.TracerProvider                   // Tracer shared between all managed components.
 	DataPath            string                                 // Shared directory where component data may be stored
+	MinStability        featuregate.Stability                  // Minimum allowed stability level for features
 	OnBlockNodeUpdate   func(cn BlockNode)                     // Informs controller that we need to reevaluate
 	OnExportsChange     func(exports map[string]any)           // Invoked when the managed component updated its exports
 	Registerer          prometheus.Registerer                  // Registerer for serving agent and component metrics

--- a/pkg/flow/internal/controller/node_builtin_component_test.go
+++ b/pkg/flow/internal/controller/node_builtin_component_test.go
@@ -11,7 +11,7 @@ import (
 func TestGlobalID(t *testing.T) {
 	mo := getManagedOptions(ComponentGlobals{
 		DataPath:     "/data/",
-		MinStability: featuregate.StabilityStable,
+		MinStability: featuregate.StabilityBeta,
 		ControllerID: "module.file",
 		NewModuleController: func(id string) ModuleController {
 			return nil
@@ -26,7 +26,7 @@ func TestGlobalID(t *testing.T) {
 func TestLocalID(t *testing.T) {
 	mo := getManagedOptions(ComponentGlobals{
 		DataPath:     "/data/",
-		MinStability: featuregate.StabilityStable,
+		MinStability: featuregate.StabilityBeta,
 		ControllerID: "",
 		NewModuleController: func(id string) ModuleController {
 			return nil

--- a/pkg/flow/internal/controller/node_builtin_component_test.go
+++ b/pkg/flow/internal/controller/node_builtin_component_test.go
@@ -4,12 +4,14 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGlobalID(t *testing.T) {
 	mo := getManagedOptions(ComponentGlobals{
 		DataPath:     "/data/",
+		MinStability: featuregate.StabilityStable,
 		ControllerID: "module.file",
 		NewModuleController: func(id string) ModuleController {
 			return nil
@@ -24,6 +26,7 @@ func TestGlobalID(t *testing.T) {
 func TestLocalID(t *testing.T) {
 	mo := getManagedOptions(ComponentGlobals{
 		DataPath:     "/data/",
+		MinStability: featuregate.StabilityStable,
 		ControllerID: "",
 		NewModuleController: func(id string) ModuleController {
 			return nil

--- a/pkg/flow/internal/testcomponents/count.go
+++ b/pkg/flow/internal/testcomponents/count.go
@@ -8,15 +8,17 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"go.uber.org/atomic"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "testcomponents.count",
-		Args:    CountConfig{},
-		Exports: CountExports{},
+		Name:      "testcomponents.count",
+		Stability: featuregate.StabilityStable,
+		Args:      CountConfig{},
+		Exports:   CountExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return NewCount(opts, args.(CountConfig))

--- a/pkg/flow/internal/testcomponents/count.go
+++ b/pkg/flow/internal/testcomponents/count.go
@@ -16,7 +16,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "testcomponents.count",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      CountConfig{},
 		Exports:   CountExports{},
 

--- a/pkg/flow/internal/testcomponents/passthrough.go
+++ b/pkg/flow/internal/testcomponents/passthrough.go
@@ -13,7 +13,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "testcomponents.passthrough",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      PassthroughConfig{},
 		Exports:   PassthroughExports{},
 

--- a/pkg/flow/internal/testcomponents/passthrough.go
+++ b/pkg/flow/internal/testcomponents/passthrough.go
@@ -6,14 +6,16 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "testcomponents.passthrough",
-		Args:    PassthroughConfig{},
-		Exports: PassthroughExports{},
+		Name:      "testcomponents.passthrough",
+		Stability: featuregate.StabilityStable,
+		Args:      PassthroughConfig{},
+		Exports:   PassthroughExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return NewPassthrough(opts, args.(PassthroughConfig))

--- a/pkg/flow/internal/testcomponents/sumation.go
+++ b/pkg/flow/internal/testcomponents/sumation.go
@@ -13,7 +13,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "testcomponents.summation",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      SummationConfig{},
 		Exports:   SummationExports{},
 

--- a/pkg/flow/internal/testcomponents/sumation.go
+++ b/pkg/flow/internal/testcomponents/sumation.go
@@ -5,15 +5,17 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 	"go.uber.org/atomic"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "testcomponents.summation",
-		Args:    SummationConfig{},
-		Exports: SummationExports{},
+		Name:      "testcomponents.summation",
+		Stability: featuregate.StabilityStable,
+		Args:      SummationConfig{},
+		Exports:   SummationExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return NewSummation(opts, args.(SummationConfig))

--- a/pkg/flow/internal/testcomponents/tick.go
+++ b/pkg/flow/internal/testcomponents/tick.go
@@ -8,14 +8,16 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/logging/level"
 )
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "testcomponents.tick",
-		Args:    TickConfig{},
-		Exports: TickExports{},
+		Name:      "testcomponents.tick",
+		Stability: featuregate.StabilityStable,
+		Args:      TickConfig{},
+		Exports:   TickExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return NewTick(opts, args.(TickConfig))

--- a/pkg/flow/internal/testcomponents/tick.go
+++ b/pkg/flow/internal/testcomponents/tick.go
@@ -15,7 +15,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "testcomponents.tick",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      TickConfig{},
 		Exports:   TickExports{},
 

--- a/pkg/flow/module.go
+++ b/pkg/flow/module.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/internal/controller"
 	"github.com/grafana/agent/pkg/flow/internal/worker"
 	"github.com/grafana/agent/pkg/flow/logging"
@@ -140,6 +141,7 @@ func newModule(o *moduleOptions) *module {
 				Reg:          o.Reg,
 				Logger:       o.Logger,
 				DataPath:     o.DataPath,
+				MinStability: o.MinStability,
 				OnExportsChange: func(exports map[string]any) {
 					if o.export != nil {
 						o.export(exports)
@@ -202,6 +204,10 @@ type moduleControllerOptions struct {
 	// The directory may not exist when the component is created; components
 	// should create the directory if needed.
 	DataPath string
+
+	// MinStability is the minimum stability level of features that can be used by the collector. It is defined by
+	// the user, for example, via command-line flags.
+	MinStability featuregate.Stability
 
 	// ID is the attached components full ID.
 	ID string

--- a/pkg/flow/module_eval_test.go
+++ b/pkg/flow/module_eval_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow"
 	"github.com/grafana/agent/pkg/flow/internal/testcomponents"
 	"github.com/grafana/agent/pkg/flow/logging"
@@ -226,9 +227,10 @@ func testOptions(t *testing.T) flow.Options {
 	require.NotNil(t, otelService)
 
 	return flow.Options{
-		Logger:   s,
-		DataPath: t.TempDir(),
-		Reg:      nil,
+		Logger:       s,
+		DataPath:     t.TempDir(),
+		MinStability: featuregate.StabilityBeta,
+		Reg:          nil,
 		Services: []service.Service{
 			http_service.New(http_service.Options{}),
 			clusterService,

--- a/pkg/flow/module_test.go
+++ b/pkg/flow/module_test.go
@@ -266,6 +266,7 @@ func testModuleControllerOptions(t *testing.T) *moduleControllerOptions {
 	return &moduleControllerOptions{
 		Logger:         s,
 		DataPath:       t.TempDir(),
+		MinStability:   featuregate.StabilityStable,
 		Reg:            prometheus.NewRegistry(),
 		ModuleRegistry: newModuleRegistry(),
 		WorkerPool:     worker.NewFixedWorkerPool(1, 100),

--- a/pkg/flow/module_test.go
+++ b/pkg/flow/module_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/grafana/agent/component"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow/internal/controller"
 	"github.com/grafana/agent/pkg/flow/internal/worker"
 	"github.com/grafana/agent/pkg/flow/logging"
@@ -274,9 +275,10 @@ func testModuleControllerOptions(t *testing.T) *moduleControllerOptions {
 
 func init() {
 	component.Register(component.Registration{
-		Name:    "test.module",
-		Args:    TestArguments{},
-		Exports: TestExports{},
+		Name:      "test.module",
+		Stability: featuregate.StabilityStable,
+		Args:      TestArguments{},
+		Exports:   TestExports{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return &testModule{

--- a/pkg/flow/module_test.go
+++ b/pkg/flow/module_test.go
@@ -266,7 +266,7 @@ func testModuleControllerOptions(t *testing.T) *moduleControllerOptions {
 	return &moduleControllerOptions{
 		Logger:         s,
 		DataPath:       t.TempDir(),
-		MinStability:   featuregate.StabilityStable,
+		MinStability:   featuregate.StabilityBeta,
 		Reg:            prometheus.NewRegistry(),
 		ModuleRegistry: newModuleRegistry(),
 		WorkerPool:     worker.NewFixedWorkerPool(1, 100),
@@ -277,7 +277,7 @@ func testModuleControllerOptions(t *testing.T) *moduleControllerOptions {
 func init() {
 	component.Register(component.Registration{
 		Name:      "test.module",
-		Stability: featuregate.StabilityStable,
+		Stability: featuregate.StabilityBeta,
 		Args:      TestArguments{},
 		Exports:   TestExports{},
 

--- a/pkg/flow/testdata/import_error/import_error_1.txtar
+++ b/pkg/flow/testdata/import_error/import_error_1.txtar
@@ -16,4 +16,4 @@ import.string "testImport" {
 testImport.a "cc" {}
 
 -- error --
-cannot retrieve the definition of component name "cantAccessThis"
+cannot find the definition of component name "cantAccessThis"

--- a/service/remotecfg/remotecfg_test.go
+++ b/service/remotecfg/remotecfg_test.go
@@ -12,6 +12,7 @@ import (
 	agentv1 "github.com/grafana/agent-remote-config/api/gen/proto/go/agent/v1"
 	"github.com/grafana/agent/component"
 	_ "github.com/grafana/agent/component/loki/process"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/pkg/flow"
 	"github.com/grafana/agent/pkg/flow/componenttest"
 	"github.com/grafana/agent/pkg/flow/logging"
@@ -166,6 +167,7 @@ func (f fakeHost) NewController(id string) service.Controller {
 		Logger:          logger,
 		Tracer:          nil,
 		DataPath:        "",
+		MinStability:    featuregate.StabilityStable,
 		Reg:             prometheus.NewRegistry(),
 		OnExportsChange: func(map[string]interface{}) {},
 		Services:        []service.Service{},


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

- Adds the CLI flag that allows to set the minimum stability level for the features that the agent must enforce.
- For now this is on an entire component level only, but is possible to extend in the future to finer-grained features.
- The component's stability levels must be provided at registration. If they're not, the tests will fail.
- Default min stability level for now is experimental.
- Users get a nice error when they use wrong stability levels. Errors when loading modules or reloading config are handled the same way as other invalid config errors.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

Fixes #6063 

#### Notes to the Reviewer

How errors look when stability level is not allowed:
<img width="1564" alt="image" src="https://github.com/grafana/agent/assets/17101802/20b8a01b-8057-4dae-9b7b-d85d25e8a358">

How help message looks like:
```
      --server.http.ui-path-prefix string      Prefix to serve the HTTP UI at (default "/")
      --stability.level <stability_level>      Minimum stability level of features to enable. Supported values: "stable", "beta", "experimental" (default "experimental")
      --storage.path string                    Base directory where components can store data (default "data-agent/")
```

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated