### PR TITLE
Fix stability label in loki kubernetes rules doc

### DIFF
--- a/docs/sources/flow/reference/components/loki.rules.kubernetes.md
+++ b/docs/sources/flow/reference/components/loki.rules.kubernetes.md
@@ -6,7 +6,7 @@ labels:
 
 # loki.rules.kubernetes
 
-{{< docs/shared lookup="flow/stability/experimental.md" source="agent" >}}
+{{< docs/shared lookup="flow/stability/experimental.md" source="agent" version="<AGENT_VERSION>" >}}
 
 `loki.rules.kubernetes` discovers `PrometheusRule` Kubernetes resources and
 loads them into a Loki instance.

--- a/docs/sources/flow/reference/components/loki.rules.kubernetes.md
+++ b/docs/sources/flow/reference/components/loki.rules.kubernetes.md
@@ -6,7 +6,7 @@ labels:
 
 # loki.rules.kubernetes
 
-{{< docs/shared lookup="flow/stability/beta.md" source="agent" >}}
+{{< docs/shared lookup="flow/stability/experimental.md" source="agent" >}}
 
 `loki.rules.kubernetes` discovers `PrometheusRule` Kubernetes resources and
 loads them into a Loki instance.

--- a/docs/sources/flow/reference/components/loki.rules.kubernetes.md
+++ b/docs/sources/flow/reference/components/loki.rules.kubernetes.md
@@ -1,7 +1,7 @@
 ---
 title: loki.rules.kubernetes
 labels:
-  stage: beta
+  stage: experimental
 ---
 
 # loki.rules.kubernetes


### PR DESCRIPTION
The stability label in the doc was different from the one in the code