### PR TITLE
Fix logging node buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Main (unreleased)
 
 - A new `loki.rules.kubernetes` component that discovers `PrometheusRule` Kubernetes resources and loads them into a Loki Ruler instance. (@EStork09)
 
+### Bugfixes
+
+- Fix an issues where the logging config block would trigger an error when trying to send logs to components that were not running. (@wildum)
+
 v0.40.0 (2024-02-27)
 --------------------
 

--- a/pkg/flow/logging/logger.go
+++ b/pkg/flow/logging/logger.go
@@ -126,9 +126,9 @@ func (l *Logger) Update(o Options) error {
 
 	// Print out the buffered logs since we determined the log format already
 	for _, bufferedLogChunk := range l.buffer {
-		if err := slogadapter.GoKit(l.handler).Log(bufferedLogChunk...); err != nil {
-			return err
-		}
+		// the buffered logs are currently only sent to the standard output
+		// because the components with the receivers are not running yet
+		slogadapter.GoKit(l.handler).Log(bufferedLogChunk...)
 	}
 	l.buffer = nil
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

During the initial evaluation, the logging node is updated with the correct format and tries to log the data that it had buffered. This works for the standard output but it doesn't for the other receivers because the components that own them are not running yet (they are not ready to receive data from the receiver channel). This results in an error.

This fix ignores the error, which is the same behavior as before the introduction of the buffer via #5992 

This is still not ideal because the first logs won't reach the receivers. The buffer should allow us to only send the logs to the components when they are ready but this requires much more effort.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #6542

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated