### PR TITLE
flow/logging: check for nil values when writing logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Main (unreleased)
 
 - Fix an issue where a custom component might be wired to a local declare instead of an import declare when they have the same label. (@wildum)
 
+- Fix an issue where flow mode panics if the `logging` config block is given a `null` Loki receiver to write log entries to. (@rfratto)
+
 v0.40.0 (2024-02-27)
 --------------------
 

--- a/pkg/flow/logging/logger.go
+++ b/pkg/flow/logging/logger.go
@@ -164,6 +164,15 @@ type lokiWriter struct {
 
 func (fw *lokiWriter) Write(p []byte) (int, error) {
 	for _, receiver := range fw.f {
+		// We may have been given a nil value in rare circumstances due to
+		// misconfiguration or a component which generates exports after
+		// construction.
+		//
+		// Ignore nil values so we don't panic.
+		if receiver == nil {
+			continue
+		}
+
 		select {
 		case receiver.Chan() <- loki.Entry{
 			Labels: model.LabelSet{"component": "agent"},

--- a/pkg/flow/logging/logger_test.go
+++ b/pkg/flow/logging/logger_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-kit/log"
 	gokitlevel "github.com/go-kit/log/level"
+	"github.com/grafana/agent/component/common/loki"
 	"github.com/grafana/agent/pkg/flow/logging"
 	flowlevel "github.com/grafana/agent/pkg/flow/logging/level"
 	"github.com/stretchr/testify/require"
@@ -163,6 +164,25 @@ func TestLevels(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Test_lokiWriter_nil ensures that writing to a lokiWriter doesn't panic when
+// given a nil receiver.
+func Test_lokiWriter_nil(t *testing.T) {
+	logger, err := logging.New(io.Discard, debugLevel())
+	require.NoError(t, err)
+
+	err = logger.Update(logging.Options{
+		Level:  logging.LevelDebug,
+		Format: logging.FormatLogfmt,
+
+		WriteTo: []loki.LogsReceiver{nil},
+	})
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		_ = logger.Log("msg", "test message")
+	})
 }
 
 func BenchmarkLogging_NoLevel_Prints(b *testing.B) {


### PR DESCRIPTION
There may be situations where the flow mode logger receivers a nil value, potentially due to misconfiguration or a component which exports its values only after being ran.

Closes #6557.

This fixes an issue that can legitimately happen normally, but I'm not convinced it's specifically the problem that #6557 ran into. #6557 seems to indicate a deeper problem where the evaluated graph only contained the `logging` node writing to a `null` River value. With the configuration provided in the bug report, I simply can't see how that would happen. If there is a deeper issue, hopefully we find it later, as it would likely surface in other ways that this PR doesn't address.  
