### PR TITLE
Fix wiring of custom component nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Main (unreleased)
 
 - Fix an issues where the logging config block would trigger an error when trying to send logs to components that were not running. (@wildum)
 
+- Fix an issue where a custom component might be wired to a local declare instead of an import declare when they have the same label. (@wildum)
+
 v0.40.0 (2024-02-27)
 --------------------
 

--- a/pkg/flow/internal/controller/loader.go
+++ b/pkg/flow/internal/controller/loader.go
@@ -589,15 +589,15 @@ func (l *Loader) wireGraphEdges(g *dag.Graph) diag.Diagnostics {
 
 // wireCustomComponentNode wires a custom component to the import/declare nodes that it depends on.
 func (l *Loader) wireCustomComponentNode(g *dag.Graph, cc *CustomComponentNode) {
-	if declare, ok := l.declareNodes[cc.customComponentName]; ok {
+	if importNode, ok := l.importConfigNodes[cc.importNamespace]; ok {
+		// add an edge between the custom component and the corresponding import node.
+		g.AddEdge(dag.Edge{From: cc, To: importNode})
+	} else if declare, ok := l.declareNodes[cc.customComponentName]; ok {
 		refs := l.findCustomComponentReferences(declare.Block())
 		for ref := range refs {
 			// add edges between the custom component and declare/import nodes.
 			g.AddEdge(dag.Edge{From: cc, To: ref})
 		}
-	} else if importNode, ok := l.importConfigNodes[cc.importNamespace]; ok {
-		// add an edge between the custom component and the corresponding import node.
-		g.AddEdge(dag.Edge{From: cc, To: importNode})
 	}
 }
 

--- a/pkg/flow/testdata/import_file/import_file_16.txtar
+++ b/pkg/flow/testdata/import_file/import_file_16.txtar
@@ -1,0 +1,36 @@
+Imported declare and local declare have the same label.
+
+-- main.river --
+testcomponents.count "inc" {
+	frequency = "10ms"
+	max = 10
+}
+
+import.file "certmanager" {
+	filename = "module.river"
+}
+
+certmanager.config "this" { 
+	input = testcomponents.count.inc.count
+}
+
+declare "config" {
+}
+
+testcomponents.summation "sum" {
+	input = certmanager.config.this.output
+}
+
+-- module.river --
+declare "config" {
+	argument "input" {}
+
+	testcomponents.passthrough "pt" {
+		input = argument.input.value
+		lag = "1ms"
+	}
+
+	export "output" {
+		value = testcomponents.passthrough.pt.output
+	}
+}


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

When a local declare and an imported declare had the same label, there was a possibility that the custom component would be linked to the local declare instead of the import node. By checking if the custom component has a namespace that matches an import we ensure that it doesnt match first a local declare.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #6557 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Tests updated