### PR TITLE
otelconvert: extend framework for connector components

### DIFF
--- a/internal/component/otelcol/connector/spanmetrics/spanmetrics.go
+++ b/internal/component/otelcol/connector/spanmetrics/spanmetrics.go
@@ -47,7 +47,7 @@ type Arguments struct {
 
 	AggregationTemporality string `river:"aggregation_temporality,attr,optional"`
 
-	Histogram HistogramConfig `river:"histogram,block,optional"`
+	Histogram HistogramConfig `river:"histogram,block"`
 
 	// MetricsEmitInterval is the time period between when metrics are flushed or emitted to the downstream components.
 	MetricsFlushInterval time.Duration `river:"metrics_flush_interval,attr,optional"`

--- a/internal/component/otelcol/connector/spanmetrics/spanmetrics.go
+++ b/internal/component/otelcol/connector/spanmetrics/spanmetrics.go
@@ -47,7 +47,7 @@ type Arguments struct {
 
 	AggregationTemporality string `river:"aggregation_temporality,attr,optional"`
 
-	Histogram HistogramConfig `river:"histogram,block"`
+	Histogram HistogramConfig `river:"histogram,block,optional"`
 
 	// MetricsEmitInterval is the time period between when metrics are flushed or emitted to the downstream components.
 	MetricsFlushInterval time.Duration `river:"metrics_flush_interval,attr,optional"`

--- a/internal/component/otelcol/connector/spanmetrics/spanmetrics.go
+++ b/internal/component/otelcol/connector/spanmetrics/spanmetrics.go
@@ -118,6 +118,17 @@ func convertAggregationTemporality(temporality string) (string, error) {
 	}
 }
 
+func FromOTelAggregationTemporality(temporality string) string {
+	switch temporality {
+	case "AGGREGATION_TEMPORALITY_DELTA":
+		return AggregationTemporalityDelta
+	case "AGGREGATION_TEMPORALITY_CUMULATIVE":
+		return AggregationTemporalityCumulative
+	default:
+		return ""
+	}
+}
+
 // Convert implements connector.Arguments.
 func (args Arguments) Convert() (otelcomponent.Config, error) {
 	dimensions := make([]spanmetricsconnector.Dimension, 0, len(args.Dimensions))

--- a/internal/component/otelcol/connector/spanmetrics/types.go
+++ b/internal/component/otelcol/connector/spanmetrics/types.go
@@ -70,9 +70,7 @@ var (
 var DefaultHistogramConfig = HistogramConfig{
 	Unit:        MetricsUnitMilliseconds,
 	Exponential: nil,
-	Explicit: &ExplicitHistogramConfig{
-		Buckets: []time.Duration{2 * time.Millisecond, 4 * time.Millisecond, 6 * time.Millisecond, 8 * time.Millisecond, 10 * time.Millisecond, 50 * time.Millisecond, 100 * time.Millisecond, 200 * time.Millisecond, 400 * time.Millisecond, 800 * time.Millisecond, 1 * time.Second, 1400 * time.Millisecond, 2 * time.Second, 5 * time.Second, 10 * time.Second, 15 * time.Second},
-	},
+	Explicit:    nil,
 }
 
 func (hc *HistogramConfig) SetToDefault() {

--- a/internal/component/otelcol/connector/spanmetrics/types.go
+++ b/internal/component/otelcol/connector/spanmetrics/types.go
@@ -70,7 +70,9 @@ var (
 var DefaultHistogramConfig = HistogramConfig{
 	Unit:        MetricsUnitMilliseconds,
 	Exponential: nil,
-	Explicit:    nil,
+	Explicit: &ExplicitHistogramConfig{
+		Buckets: []time.Duration{2 * time.Millisecond, 4 * time.Millisecond, 6 * time.Millisecond, 8 * time.Millisecond, 10 * time.Millisecond, 50 * time.Millisecond, 100 * time.Millisecond, 200 * time.Millisecond, 400 * time.Millisecond, 800 * time.Millisecond, 1 * time.Second, 1400 * time.Millisecond, 2 * time.Second, 5 * time.Second, 10 * time.Second, 15 * time.Second},
+	},
 }
 
 func (hc *HistogramConfig) SetToDefault() {

--- a/internal/converter/internal/otelcolconvert/converter_spanmetricsconnector.go
+++ b/internal/converter/internal/otelcolconvert/converter_spanmetricsconnector.go
@@ -2,6 +2,7 @@ package otelcolconvert
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/grafana/agent/internal/component/otelcol"
 	"github.com/grafana/agent/internal/component/otelcol/connector/spanmetrics"
@@ -62,6 +63,12 @@ func toSpanmetricsConnector(state *state, id component.InstanceID, cfg *spanmetr
 		explicit = &spanmetrics.ExplicitHistogramConfig{
 			Buckets: cfg.Histogram.Explicit.Buckets,
 		}
+	}
+
+	// If none have been explicitly set, assign the upstream default.
+	if exponential == nil && explicit == nil {
+		explicit = &spanmetrics.ExplicitHistogramConfig{Buckets: []time.Duration{}}
+		explicit.SetToDefault()
 	}
 
 	var dimensions []spanmetrics.Dimension

--- a/internal/converter/internal/otelcolconvert/converter_spanmetricsconnector.go
+++ b/internal/converter/internal/otelcolconvert/converter_spanmetricsconnector.go
@@ -1,0 +1,96 @@
+package otelcolconvert
+
+import (
+	"fmt"
+
+	"github.com/grafana/agent/internal/component/otelcol"
+	"github.com/grafana/agent/internal/component/otelcol/connector/spanmetrics"
+	"github.com/grafana/agent/internal/converter/diag"
+	"github.com/grafana/agent/internal/converter/internal/common"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector"
+	"go.opentelemetry.io/collector/component"
+)
+
+func init() {
+	converters = append(converters, spanmetricsConnectorConverter{})
+}
+
+type spanmetricsConnectorConverter struct{}
+
+func (spanmetricsConnectorConverter) Factory() component.Factory {
+	return spanmetricsconnector.NewFactory()
+}
+
+func (spanmetricsConnectorConverter) InputComponentName() string {
+	return "otelcol.connector.spanmetrics"
+}
+
+func (spanmetricsConnectorConverter) ConvertAndAppend(state *state, id component.InstanceID, cfg component.Config) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	label := state.FlowComponentLabel()
+
+	args := toSpanmetricsConnector(state, id, cfg.(*spanmetricsconnector.Config))
+	block := common.NewBlockWithOverride([]string{"otelcol", "connector", "spanmetrics"}, label, args)
+
+	diags.Add(
+		diag.SeverityLevelInfo,
+		fmt.Sprintf("Converted %s into %s", stringifyInstanceID(id), stringifyBlock(block)),
+	)
+
+	state.Body().AppendBlock(block)
+	return diags
+}
+
+func toSpanmetricsConnector(state *state, id component.InstanceID, cfg *spanmetricsconnector.Config) *spanmetrics.Arguments {
+	if cfg == nil {
+		return nil
+	}
+	var (
+		nextMetrics = state.Next(id, component.DataTypeMetrics)
+	)
+
+	var exponential *spanmetrics.ExponentialHistogramConfig
+	if cfg.Histogram.Exponential != nil {
+		exponential = &spanmetrics.ExponentialHistogramConfig{
+			MaxSize: cfg.Histogram.Exponential.MaxSize,
+		}
+	}
+
+	var explicit *spanmetrics.ExplicitHistogramConfig
+	if cfg.Histogram.Explicit != nil {
+		explicit = &spanmetrics.ExplicitHistogramConfig{
+			Buckets: cfg.Histogram.Explicit.Buckets,
+		}
+	}
+
+	var dimensions []spanmetrics.Dimension
+	for _, d := range cfg.Dimensions {
+		dimensions = append(dimensions, spanmetrics.Dimension{
+			Name:    d.Name,
+			Default: d.Default,
+		})
+	}
+
+	return &spanmetrics.Arguments{
+		Dimensions:             dimensions,
+		ExcludeDimensions:      cfg.ExcludeDimensions,
+		DimensionsCacheSize:    cfg.DimensionsCacheSize,
+		AggregationTemporality: spanmetrics.FromOTelAggregationTemporality(cfg.AggregationTemporality),
+		Histogram: spanmetrics.HistogramConfig{
+			Disable:     cfg.Histogram.Disable,
+			Unit:        cfg.Histogram.Unit.String(),
+			Exponential: exponential,
+			Explicit:    explicit,
+		},
+		MetricsFlushInterval: cfg.MetricsFlushInterval,
+		Namespace:            cfg.Namespace,
+		Exemplars: spanmetrics.ExemplarsConfig{
+			Enabled: cfg.Exemplars.Enabled,
+		},
+
+		Output: &otelcol.ConsumerArguments{
+			Metrics: toTokenizedConsumers(nextMetrics),
+		},
+	}
+}

--- a/internal/converter/internal/otelcolconvert/pipeline_group.go
+++ b/internal/converter/internal/otelcolconvert/pipeline_group.go
@@ -148,6 +148,24 @@ func mergeIDs(in ...[]component.ID) []component.ID {
 	return res
 }
 
+func filterIDs(in []component.ID, rem []component.ID) []component.ID {
+	var res []component.ID
+
+	for _, set := range in {
+		exists := false
+		for _, id := range rem {
+			if set == id {
+				exists = true
+			}
+		}
+		if !exists {
+			res = append(res, set)
+		}
+	}
+
+	return res
+}
+
 // NextMetrics returns the set of components who should be sent metrics from
 // the given component ID.
 func (group pipelineGroup) NextMetrics(fromID component.InstanceID) []component.InstanceID {
@@ -168,9 +186,9 @@ func (group pipelineGroup) NextTraces(fromID component.InstanceID) []component.I
 
 func nextInPipeline(pipeline *pipelines.PipelineConfig, fromID component.InstanceID) []component.InstanceID {
 	switch fromID.Kind {
-	case component.KindReceiver:
-		// Receivers should either send to the first processor if one exists or to
-		// every exporter otherwise.
+	case component.KindReceiver, component.KindConnector:
+		// Receivers and connectors should either send to the first processor
+		// if one exists or to every exporter otherwise.
 		if len(pipeline.Processors) > 0 {
 			return []component.InstanceID{{Kind: component.KindProcessor, ID: pipeline.Processors[0]}}
 		}

--- a/internal/converter/internal/otelcolconvert/pipeline_group.go
+++ b/internal/converter/internal/otelcolconvert/pipeline_group.go
@@ -148,24 +148,6 @@ func mergeIDs(in ...[]component.ID) []component.ID {
 	return res
 }
 
-func filterIDs(in []component.ID, rem []component.ID) []component.ID {
-	var res []component.ID
-
-	for _, set := range in {
-		exists := false
-		for _, id := range rem {
-			if set == id {
-				exists = true
-			}
-		}
-		if !exists {
-			res = append(res, set)
-		}
-	}
-
-	return res
-}
-
 // NextMetrics returns the set of components who should be sent metrics from
 // the given component ID.
 func (group pipelineGroup) NextMetrics(fromID component.InstanceID) []component.InstanceID {

--- a/internal/converter/internal/otelcolconvert/pipeline_group.go
+++ b/internal/converter/internal/otelcolconvert/pipeline_group.go
@@ -1,6 +1,7 @@
 package otelcolconvert
 
 import (
+	"cmp"
 	"fmt"
 
 	"go.opentelemetry.io/collector/component"
@@ -95,7 +96,12 @@ func createPipelineGroups(cfg pipelines.Config) ([]pipelineGroup, error) {
 		groups[key] = group
 	}
 
-	return maps.Values(groups), nil
+	res := maps.Values(groups)
+	slices.SortStableFunc(res, func(a, b pipelineGroup) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+
+	return res, nil
 }
 
 // Receivers returns a set of unique IDs for receivers across all telemetry

--- a/internal/converter/internal/otelcolconvert/testdata/spanmetrics.river
+++ b/internal/converter/internal/otelcolconvert/testdata/spanmetrics.river
@@ -17,7 +17,9 @@ otelcol.exporter.otlp "default" {
 }
 
 otelcol.connector.spanmetrics "default" {
-	histogram { }
+	histogram {
+		explicit { }
+	}
 
 	output {
 		metrics = [otelcol.exporter.otlp.default.input]

--- a/internal/converter/internal/otelcolconvert/testdata/spanmetrics.river
+++ b/internal/converter/internal/otelcolconvert/testdata/spanmetrics.river
@@ -1,0 +1,25 @@
+otelcol.receiver.otlp "default" {
+	grpc { }
+
+	http { }
+
+	output {
+		metrics = [otelcol.exporter.otlp.default.input]
+		logs    = [otelcol.exporter.otlp.default.input]
+		traces  = [otelcol.connector.spanmetrics.default.input]
+	}
+}
+
+otelcol.exporter.otlp "default" {
+	client {
+		endpoint = "database:4317"
+	}
+}
+
+otelcol.connector.spanmetrics "default" {
+	histogram { }
+
+	output {
+		metrics = [otelcol.exporter.otlp.default.input]
+	}
+}

--- a/internal/converter/internal/otelcolconvert/testdata/spanmetrics.yaml
+++ b/internal/converter/internal/otelcolconvert/testdata/spanmetrics.yaml
@@ -1,0 +1,36 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+exporters:
+  otlp:
+    # Our defaults have drifted from upstream, so we explicitly set our
+    # defaults below (balancer_name and queue_size).
+    endpoint: database:4317
+    balancer_name: pick_first
+    sending_queue:
+      queue_size: 5000
+
+processors:
+  batch:
+
+connectors:
+  spanmetrics:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: []
+      exporters: [spanmetrics]
+    metrics:
+      receivers: [spanmetrics]
+      processors: []
+      exporters: [otlp]
+    logs:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlp]
+

--- a/internal/converter/internal/otelcolconvert/testdata/spanmetrics_full.river
+++ b/internal/converter/internal/otelcolconvert/testdata/spanmetrics_full.river
@@ -1,0 +1,45 @@
+otelcol.receiver.otlp "default_traces" {
+	grpc { }
+
+	http { }
+
+	output {
+		metrics = [otelcol.exporter.otlp.default_metrics_backend.input]
+		logs    = []
+		traces  = [otelcol.exporter.otlp.default_traces_backend.input, otelcol.connector.spanmetrics.default.input]
+	}
+}
+
+otelcol.exporter.otlp "default_metrics_backend" {
+	client {
+		endpoint = "database:44317"
+	}
+}
+
+otelcol.exporter.otlp "default_traces_backend" {
+	client {
+		endpoint = "database:34317"
+	}
+}
+
+otelcol.connector.spanmetrics "default" {
+	histogram { }
+
+	output {
+		metrics = [otelcol.exporter.otlp.default_metrics_backend.input]
+	}
+}
+
+otelcol.exporter.otlp "foo_metrics_backend_two" {
+	client {
+		endpoint = "database:54317"
+	}
+}
+
+otelcol.connector.spanmetrics "foo_default" {
+	histogram { }
+
+	output {
+		metrics = [otelcol.exporter.otlp.foo_metrics_backend_two.input]
+	}
+}

--- a/internal/converter/internal/otelcolconvert/testdata/spanmetrics_full.river
+++ b/internal/converter/internal/otelcolconvert/testdata/spanmetrics_full.river
@@ -23,7 +23,9 @@ otelcol.exporter.otlp "default_traces_backend" {
 }
 
 otelcol.connector.spanmetrics "default" {
-	histogram { }
+	histogram {
+		explicit { }
+	}
 
 	output {
 		metrics = [otelcol.exporter.otlp.default_metrics_backend.input]
@@ -37,7 +39,9 @@ otelcol.exporter.otlp "foo_metrics_backend_two" {
 }
 
 otelcol.connector.spanmetrics "foo_default" {
-	histogram { }
+	histogram {
+		explicit { }
+	}
 
 	output {
 		metrics = [otelcol.exporter.otlp.foo_metrics_backend_two.input]

--- a/internal/converter/internal/otelcolconvert/testdata/spanmetrics_full.yaml
+++ b/internal/converter/internal/otelcolconvert/testdata/spanmetrics_full.yaml
@@ -1,0 +1,48 @@
+receivers:
+  otlp/traces:
+    protocols:
+      grpc:
+      http:
+
+exporters:
+  otlp/traces_backend:
+    # Our defaults have drifted from upstream, so we explicitly set our
+    # defaults below (balancer_name and queue_size).
+    endpoint: database:34317
+    balancer_name: pick_first
+    sending_queue:
+      queue_size: 5000
+
+  otlp/metrics_backend:
+    # Our defaults have drifted from upstream, so we explicitly set our
+    # defaults below (balancer_name and queue_size).
+    endpoint: database:44317
+    balancer_name: pick_first
+    sending_queue:
+      queue_size: 5000
+
+  otlp/metrics_backend_two:
+    # Our defaults have drifted from upstream, so we explicitly set our
+    # defaults below (balancer_name and queue_size).
+    endpoint: database:54317
+    balancer_name: pick_first
+    sending_queue:
+      queue_size: 5000
+
+connectors:
+  spanmetrics:
+    histogram:
+      exponential:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp/traces]
+      exporters: [otlp/traces_backend, spanmetrics]
+    metrics:
+      receivers: [spanmetrics]
+      exporters: [otlp/metrics_backend]
+    metrics/foo:
+      receivers: [spanmetrics]
+      exporters: [otlp/metrics_backend_two]
+


### PR DESCRIPTION
NOTE: This PR can be reviewed commit-by-commit.

This PR extends the current framework for converting OpenTelemetry Collector configs into Flow mode configs to support connectors. It also handles conversion for the spanmetrics connector to verify that it works properly.

Connectors are somewhat weirder since from the context of OTel service pipelines they're just valid definition to receiver and exporter component IDs, but underneath they don't match the same component.Kind.

I still want to go through more [complex configuration examples](https://github.com/open-telemetry/opentelemetry-collector/blob/main/connector/README.md) and verify that this works well for multiple groups and I suspect there might be a better abstraction for filtering out components per their respective Kinds, so I'm only opening this as a draft.