### PR TITLE
otelconvert: fix panic for pipelines with no processors

### DIFF
--- a/internal/converter/internal/otelcolconvert/pipeline_group.go
+++ b/internal/converter/internal/otelcolconvert/pipeline_group.go
@@ -180,10 +180,6 @@ func nextInPipeline(pipeline *pipelines.PipelineConfig, fromID component.Instanc
 		// Processors should send to the next processor if one exists or to every
 		// exporter otherwise.
 		processorIndex := slices.Index(pipeline.Processors, fromID.ID)
-		if len(pipeline.Processors) > 0 && processorIndex == -1 {
-			panic("nextInPipeline: received processor ID not in processor list")
-		}
-
 		if processorIndex+1 < len(pipeline.Processors) {
 			// Send to next processor.
 			return []component.InstanceID{{Kind: component.KindProcessor, ID: pipeline.Processors[processorIndex+1]}}

--- a/internal/converter/internal/otelcolconvert/pipeline_group.go
+++ b/internal/converter/internal/otelcolconvert/pipeline_group.go
@@ -180,7 +180,7 @@ func nextInPipeline(pipeline *pipelines.PipelineConfig, fromID component.Instanc
 		// Processors should send to the next processor if one exists or to every
 		// exporter otherwise.
 		processorIndex := slices.Index(pipeline.Processors, fromID.ID)
-		if processorIndex == -1 {
+		if len(pipeline.Processors) > 0 && processorIndex == -1 {
 			panic("nextInPipeline: received processor ID not in processor list")
 		}
 

--- a/internal/converter/internal/otelcolconvert/testdata/inconsistent_processor.river
+++ b/internal/converter/internal/otelcolconvert/testdata/inconsistent_processor.river
@@ -1,0 +1,25 @@
+otelcol.receiver.otlp "default" {
+	grpc { }
+
+	http { }
+
+	output {
+		metrics = [otelcol.exporter.otlp.default.input]
+		logs    = [otelcol.processor.batch.default.input]
+		traces  = [otelcol.exporter.otlp.default.input]
+	}
+}
+
+otelcol.processor.batch "default" {
+	output {
+		metrics = [otelcol.exporter.otlp.default.input]
+		logs    = [otelcol.exporter.otlp.default.input]
+		traces  = [otelcol.exporter.otlp.default.input]
+	}
+}
+
+otelcol.exporter.otlp "default" {
+	client {
+		endpoint = "database:4317"
+	}
+}

--- a/internal/converter/internal/otelcolconvert/testdata/inconsistent_processor.yaml
+++ b/internal/converter/internal/otelcolconvert/testdata/inconsistent_processor.yaml
@@ -1,0 +1,33 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+processors:
+  batch:
+
+exporters:
+  otlp:
+    # Our defaults have drifted from upstream, so we explicitly set our
+    # defaults below (balancer_name and queue_size).
+    endpoint: database:4317
+    balancer_name: pick_first
+    sending_queue:
+      queue_size: 5000
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlp]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp]
+    traces:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlp]
+


### PR DESCRIPTION
#### PR Description
This PR fixes otelconvert to not panic when a processor is not consistently used throughout all signals.

#### Which issue(s) this PR fixes
Fixes #6584

#### Notes to the Reviewer
The testcase added here doesn't really fit in with the others (which were per-component) but I didn't think it made sense to add a new directory or anything.

#### PR Checklist

- [ ] CHANGELOG.md updated (N/A)
- [ ] Documentation added (N/A)
- [x] Tests updated