### PR TITLE
agent-static-mixin: include custom 'all' value

### DIFF
--- a/example/docker-compose/grafana/dashboards/agent-logs-pipeline.json
+++ b/example/docker-compose/grafana/dashboards/agent-logs-pipeline.json
@@ -893,7 +893,7 @@
             "type": "datasource"
          },
          {
-            "allValue": null,
+            "allValue": ".+",
             "current": {
                "text": {
                   "selected": true,
@@ -924,7 +924,7 @@
             "useTags": false
          },
          {
-            "allValue": null,
+            "allValue": ".+",
             "current": {
                "text": {
                   "selected": true,
@@ -955,7 +955,7 @@
             "useTags": false
          },
          {
-            "allValue": null,
+            "allValue": ".+",
             "current": {
                "text": {
                   "selected": true,
@@ -986,7 +986,7 @@
             "useTags": false
          },
          {
-            "allValue": null,
+            "allValue": ".+",
             "current": {
                "text": {
                   "selected": true,

--- a/example/docker-compose/grafana/dashboards/agent-remote-write.json
+++ b/example/docker-compose/grafana/dashboards/agent-remote-write.json
@@ -1332,7 +1332,7 @@
             "type": "datasource"
          },
          {
-            "allValue": null,
+            "allValue": ".+",
             "current": {
                "text": {
                   "selected": true,
@@ -1363,7 +1363,7 @@
             "useTags": false
          },
          {
-            "allValue": null,
+            "allValue": ".+",
             "current": {
                "text": {
                   "selected": true,
@@ -1394,7 +1394,7 @@
             "useTags": false
          },
          {
-            "allValue": null,
+            "allValue": ".+",
             "current": {
                "text": {
                   "selected": true,
@@ -1425,7 +1425,7 @@
             "useTags": false
          },
          {
-            "allValue": null,
+            "allValue": ".+",
             "current": {
                "text": {
                   "selected": true,
@@ -1456,7 +1456,7 @@
             "useTags": false
          },
          {
-            "allValue": null,
+            "allValue": ".+",
             "current": { },
             "datasource": "$datasource",
             "hide": 0,

--- a/example/docker-compose/grafana/dashboards/agent-tracing-pipeline.json
+++ b/example/docker-compose/grafana/dashboards/agent-tracing-pipeline.json
@@ -905,7 +905,7 @@
             "type": "datasource"
          },
          {
-            "allValue": null,
+            "allValue": ".+",
             "current": {
                "text": {
                   "selected": true,
@@ -936,7 +936,7 @@
             "useTags": false
          },
          {
-            "allValue": null,
+            "allValue": ".+",
             "current": {
                "text": {
                   "selected": true,
@@ -967,7 +967,7 @@
             "useTags": false
          },
          {
-            "allValue": null,
+            "allValue": ".+",
             "current": {
                "text": {
                   "selected": true,
@@ -998,7 +998,7 @@
             "useTags": false
          },
          {
-            "allValue": null,
+            "allValue": ".+",
             "current": {
                "text": {
                   "selected": true,

--- a/operations/agent-static-mixin/dashboards.libsonnet
+++ b/operations/agent-static-mixin/dashboards.libsonnet
@@ -286,6 +286,7 @@ local template = grafana.template;
             value: '$__all',
           },
           includeAll=true,
+          allValues='.+',
         ),
       )
       .addTemplate(
@@ -300,6 +301,7 @@ local template = grafana.template;
             value: '$__all',
           },
           includeAll=true,
+          allValues='.+',
         ),
       )
       .addTemplate(
@@ -314,6 +316,7 @@ local template = grafana.template;
             value: '$__all',
           },
           includeAll=true,
+          allValues='.+',
         ),
       )
       .addTemplate(
@@ -328,6 +331,7 @@ local template = grafana.template;
             value: '$__all',
           },
           includeAll=true,
+          allValues='.+',
         ),
       )
       .addTemplate(
@@ -337,6 +341,7 @@ local template = grafana.template;
           'label_values(prometheus_remote_storage_shards{cluster=~"$cluster", pod=~"$pod"}, url)',
           refresh='time',
           includeAll=true,
+          allValues='.+',
         )
       )
       .addRow(
@@ -537,6 +542,7 @@ local template = grafana.template;
             value: '$__all',
           },
           includeAll=true,
+          allValues='.+',
         ),
       )
       .addTemplate(
@@ -551,6 +557,7 @@ local template = grafana.template;
             value: '$__all',
           },
           includeAll=true,
+          allValues='.+',
         ),
       )
       .addTemplate(
@@ -565,6 +572,7 @@ local template = grafana.template;
             value: '$__all',
           },
           includeAll=true,
+          allValues='.+',
         ),
       )
       .addTemplate(
@@ -579,6 +587,7 @@ local template = grafana.template;
             value: '$__all',
           },
           includeAll=true,
+          allValues='.+',
         ),
       )
       .addRow(
@@ -715,6 +724,7 @@ local template = grafana.template;
             value: '$__all',
           },
           includeAll=true,
+          allValues='.+',
         ),
       )
       .addTemplate(
@@ -729,6 +739,7 @@ local template = grafana.template;
             value: '$__all',
           },
           includeAll=true,
+          allValues='.+',
         ),
       )
       .addTemplate(
@@ -743,6 +754,7 @@ local template = grafana.template;
             value: '$__all',
           },
           includeAll=true,
+          allValues='.+',
         ),
       )
       .addTemplate(
@@ -757,6 +769,7 @@ local template = grafana.template;
             value: '$__all',
           },
           includeAll=true,
+          allValues='.+',
         ),
       )
       .addTemplate(


### PR DESCRIPTION
This makes it for easier querying on the backend of your choice. I've verified by comparing the resulting dashboards in main and the fix branch
```
mixtool generate dashboards mixin.libsonnet --directory fix1
```

I'm adding the new parameter on the existing helper instead of refactoring to use `addMultiTemplateWithAll`, should be enough for now.