### PR TITLE
Add support for graceful termination of agent pods when deploying via Helm chart

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -10,6 +10,10 @@ internal API changes are not present.
 Unreleased
 ----------
 
+### Enhancements
+
+- Add support for graceful termination of agent pods using `terminationGracePeriodSeconds` and `lifecycle` hooks on agent container. (@onematchfox)
+
 0.35.0 (2024-02-27)
 -------------------
 
@@ -339,7 +343,6 @@ Unreleased
 - Add PodMonitors, ServiceMonitors, and Probes to the agent ClusterRole. (@captncraig)
 - Add podLabels values. (@therealmanny)
 
-
 0.8.1 (2023-03-06)
 ------------------
 
@@ -371,7 +374,6 @@ Unreleased
 
 - Helm chart: Add support for templates inside of configMap.content (@ts-mini)
 - Add the necessary rbac to support eventhandler integration (@nvanheuverzwijn)
-
 
 0.6.0 (2023-02-13)
 ------------------

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -51,6 +51,7 @@ use the older mode (called "static mode"), set the `agent.mode` value to
 | agent.extraArgs | list | `[]` | Extra args to pass to `agent run`: https://grafana.com/docs/agent/latest/flow/reference/cli/run/ |
 | agent.extraEnv | list | `[]` | Extra environment variables to pass to the agent container. |
 | agent.extraPorts | list | `[]` | Extra ports to expose on the Agent |
+| agent.lifecycle | object | `{}` | Lifecycle for the agent container |
 | agent.listenAddr | string | `"0.0.0.0"` | Address to listen for traffic on. 0.0.0.0 exposes the UI to other containers. |
 | agent.listenPort | int | `80` | Port to listen for traffic on. |
 | agent.listenScheme | string | `"HTTP"` | Scheme is needed for readiness probes. If enabling tls in your configs, set to "HTTPS" |
@@ -95,6 +96,7 @@ use the older mode (called "static mode"), set the `agent.mode` value to
 | controller.podLabels | object | `{}` | Extra pod labels to add. |
 | controller.priorityClassName | string | `""` | priorityClassName to apply to Grafana Agent pods. |
 | controller.replicas | int | `1` | Number of pods to deploy. Ignored when controller.type is 'daemonset'. |
+| controller.terminationGracePeriodSeconds | int | `30` | Grace period to allow the Grafana Agent pods to shutdown before being killed. |
 | controller.tolerations | list | `[]` | Tolerations to apply to Grafana Agent pods. |
 | controller.topologySpreadConstraints | list | `[]` | Topology Spread Constraints to apply to Grafana Agent pods. |
 | controller.type | string | `"daemonset"` | Type of controller to use for deploying Grafana Agent in the cluster. Must be one of 'daemonset', 'deployment', or 'statefulset'. |

--- a/operations/helm/charts/grafana-agent/ci/graceful-shutdown-values.yaml
+++ b/operations/helm/charts/grafana-agent/ci/graceful-shutdown-values.yaml
@@ -1,0 +1,11 @@
+agent:
+  lifecycle:
+    preStop:
+      exec:
+        command:
+          - sleep
+          - "60"
+
+controller:
+  type: deployment
+  terminationGracePeriodSeconds: 300

--- a/operations/helm/charts/grafana-agent/templates/containers/_agent.yaml
+++ b/operations/helm/charts/grafana-agent/templates/containers/_agent.yaml
@@ -40,6 +40,10 @@
   envFrom:
     {{- toYaml .Values.agent.envFrom | nindent 4 }}
   {{- end }}
+  {{- with .Values.agent.lifecycle }}
+  lifecycle:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - containerPort: {{ .Values.agent.listenPort }}
       name: http-metrics

--- a/operations/helm/charts/grafana-agent/templates/controllers/_pod.yaml
+++ b/operations/helm/charts/grafana-agent/templates/controllers/_pod.yaml
@@ -54,6 +54,7 @@ spec:
   nodeSelector:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
   {{- with .Values.controller.tolerations }}
   tolerations:
     {{- toYaml . | nindent 4 }}

--- a/operations/helm/charts/grafana-agent/values.yaml
+++ b/operations/helm/charts/grafana-agent/values.yaml
@@ -96,6 +96,9 @@ agent:
   # -- Resource requests and limits to apply to the Grafana Agent container.
   resources: {}
 
+  # -- Lifecycle for the agent container
+  lifecycle: {}
+
 image:
   # -- Grafana Agent image registry (defaults to docker.io)
   registry: "docker.io"
@@ -178,6 +181,11 @@ controller:
 
   # -- nodeSelector to apply to Grafana Agent pods.
   nodeSelector: {}
+
+  # -- Grace period to allow the Grafana Agent pods to shutdown before being
+  # killed. Useful for ensuring gracefully shutdown flushing/transferring all
+  # data prior to shutdown.
+  terminationGracePeriodSeconds: 30
 
   # -- Tolerations to apply to Grafana Agent pods.
   tolerations: []

--- a/operations/helm/tests/additional-serviceaccount-label/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/additional-serviceaccount-label/grafana-agent/templates/controllers/daemonset.yaml
@@ -70,6 +70,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/clustering/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/clustering/grafana-agent/templates/controllers/statefulset.yaml
@@ -75,6 +75,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/controller-volumes-extra/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/controller-volumes-extra/grafana-agent/templates/controllers/daemonset.yaml
@@ -73,6 +73,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/controllers/daemonset.yaml
@@ -71,6 +71,7 @@ spec:
               memory: 5Mi
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
@@ -70,6 +70,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/create-deployment-autoscaling/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment-autoscaling/grafana-agent/templates/controllers/deployment.yaml
@@ -73,6 +73,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
@@ -71,6 +71,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/create-statefulset-autoscaling/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset-autoscaling/grafana-agent/templates/controllers/statefulset.yaml
@@ -75,6 +75,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
@@ -73,6 +73,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -70,6 +70,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
@@ -70,6 +70,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/enable-servicemonitor-tls/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/enable-servicemonitor-tls/grafana-agent/templates/controllers/daemonset.yaml
@@ -70,6 +70,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/enable-servicemonitor/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/enable-servicemonitor/grafana-agent/templates/controllers/daemonset.yaml
@@ -70,6 +70,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/envFrom/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/envFrom/grafana-agent/templates/controllers/daemonset.yaml
@@ -73,6 +73,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -70,6 +70,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/extra-env/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-env/grafana-agent/templates/controllers/daemonset.yaml
@@ -79,6 +79,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
@@ -73,6 +73,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/faro-ingress/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/faro-ingress/grafana-agent/templates/controllers/daemonset.yaml
@@ -73,6 +73,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/global-image-pullsecrets/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-pullsecrets/grafana-agent/templates/controllers/daemonset.yaml
@@ -75,6 +75,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/global-image-registry/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-registry/grafana-agent/templates/controllers/daemonset.yaml
@@ -70,6 +70,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/graceful-shutdown/grafana-agent/templates/configmap.yaml
+++ b/operations/helm/tests/graceful-shutdown/grafana-agent/templates/configmap.yaml
@@ -1,0 +1,42 @@
+---
+# Source: grafana-agent/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.river: |-
+    logging {
+    	level  = "info"
+    	format = "logfmt"
+    }
+    
+    discovery.kubernetes "pods" {
+    	role = "pod"
+    }
+    
+    discovery.kubernetes "nodes" {
+    	role = "node"
+    }
+    
+    discovery.kubernetes "services" {
+    	role = "service"
+    }
+    
+    discovery.kubernetes "endpoints" {
+    	role = "endpoints"
+    }
+    
+    discovery.kubernetes "endpointslices" {
+    	role = "endpointslice"
+    }
+    
+    discovery.kubernetes "ingresses" {
+    	role = "ingress"
+    }

--- a/operations/helm/tests/graceful-shutdown/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/graceful-shutdown/grafana-agent/templates/controllers/deployment.yaml
@@ -1,7 +1,7 @@
 ---
-# Source: grafana-agent/templates/controllers/daemonset.yaml
+# Source: grafana-agent/templates/controllers/deployment.yaml
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   name: grafana-agent
   labels:
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/version: "vX.Y.Z"
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -27,7 +28,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent@sha256:82575a7be3e4770e53f620298e58bcc4cdb0fd0338e01c4b206cae9e3ca46ebf
+          image: docker.io/grafana/agent:v0.40.1
           imagePullPolicy: IfNotPresent
           args:
             - run
@@ -44,6 +45,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - sleep
+                - "60"
           ports:
             - containerPort: 80
               name: http-metrics
@@ -58,7 +65,7 @@ spec:
             - name: config
               mountPath: /etc/agent
         - name: config-reloader
-          image: docker.io/jimmidyson/configmap-reload@sha256:5af9d3041d12a3e63f115125f89b66d2ba981fe82e64302ac370c5496055059c
+          image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/agent
             - --webhook-url=http://localhost:80/-/reload
@@ -70,7 +77,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 300
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/graceful-shutdown/grafana-agent/templates/rbac.yaml
+++ b/operations/helm/tests/graceful-shutdown/grafana-agent/templates/rbac.yaml
@@ -1,0 +1,117 @@
+---
+# Source: grafana-agent/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  # Rules which allow discovery.kubernetes to function.
+  - apiGroups:
+      - ""
+      - "discovery.k8s.io"
+      - "networking.k8s.io"
+    resources:
+      - endpoints
+      - endpointslices
+      - ingresses
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  # Rules for prometheus.kubernetes.*
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - podmonitors
+      - servicemonitors
+      - probes
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  # needed for remote.kubernetes.*
+  - apiGroups: [""]
+    resources:
+      - "configmaps"
+      - "secrets"
+    verbs:
+      - get
+      - list
+      - watch
+  # needed for otelcol.processor.k8sattributes
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+---
+# Source: grafana-agent/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: grafana-agent
+subjects:
+  - kind: ServiceAccount
+    name: grafana-agent
+    namespace: default

--- a/operations/helm/tests/graceful-shutdown/grafana-agent/templates/service.yaml
+++ b/operations/helm/tests/graceful-shutdown/grafana-agent/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: grafana-agent/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: http-metrics
+      port: 80
+      targetPort: 80
+      protocol: "TCP"

--- a/operations/helm/tests/graceful-shutdown/grafana-agent/templates/serviceaccount.yaml
+++ b/operations/helm/tests/graceful-shutdown/grafana-agent/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: grafana-agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-agent
+  namespace: default
+  labels:
+    helm.sh/chart: grafana-agent
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent
+    app.kubernetes.io/version: "vX.Y.Z"
+    app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/initcontainers/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/initcontainers/grafana-agent/templates/controllers/daemonset.yaml
@@ -91,6 +91,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/local-image-pullsecrets/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/local-image-pullsecrets/grafana-agent/templates/controllers/daemonset.yaml
@@ -72,6 +72,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/local-image-registry/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/local-image-registry/grafana-agent/templates/controllers/daemonset.yaml
@@ -70,6 +70,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/nodeselectors-and-tolerations/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/nodeselectors-and-tolerations/grafana-agent/templates/controllers/daemonset.yaml
@@ -72,6 +72,7 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         key1: value1
+      terminationGracePeriodSeconds: 30
       tolerations:
         - effect: NoSchedule
           key: key1

--- a/operations/helm/tests/pod_annotations/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/pod_annotations/grafana-agent/templates/controllers/daemonset.yaml
@@ -71,6 +71,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/sidecars/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/sidecars/grafana-agent/templates/controllers/daemonset.yaml
@@ -90,6 +90,7 @@ spec:
           - emptyDir: {}
             name: geoip
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
@@ -67,6 +67,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/topologyspreadconstraints/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/topologyspreadconstraints/grafana-agent/templates/controllers/deployment.yaml
@@ -71,6 +71,7 @@ spec:
               cpu: 1m
               memory: 5Mi
       dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       topologySpreadConstraints:
         - labelSelector:
             matchLabels:


### PR DESCRIPTION
#### PR Description

Adds support for setting `terminationGracePeriodSeconds` and `lifecycle` on agent pod/container when deploying via the Helm chart here. This is useful to ensure graceful shutdown of agents, for example, to ensure that traces are not dropped when using tail-based sampling.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated