### PR TITLE
flow: add native histograms to Flow controller metrics

### DIFF
--- a/internal/flow/internal/controller/metrics.go
+++ b/internal/flow/internal/controller/metrics.go
@@ -36,18 +36,24 @@ func newControllerMetrics(id string) *controllerMetrics {
 
 	cm.componentEvaluationTime = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:        "agent_component_evaluation_seconds",
-			Help:        "Time spent performing component evaluation",
-			ConstLabels: map[string]string{"controller_id": id},
-			Buckets:     evaluationTimesBuckets,
+			Name:                            "agent_component_evaluation_seconds",
+			Help:                            "Time spent performing component evaluation",
+			ConstLabels:                     map[string]string{"controller_id": id},
+			Buckets:                         evaluationTimesBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
 		},
 	)
 	cm.dependenciesWaitTime = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:        "agent_component_dependencies_wait_seconds",
-			Help:        "Time spent by components waiting to be evaluated after their dependency is updated.",
-			ConstLabels: map[string]string{"controller_id": id},
-			Buckets:     evaluationTimesBuckets,
+			Name:                            "agent_component_dependencies_wait_seconds",
+			Help:                            "Time spent by components waiting to be evaluated after their dependency is updated.",
+			ConstLabels:                     map[string]string{"controller_id": id},
+			Buckets:                         evaluationTimesBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
 		},
 	)
 


### PR DESCRIPTION
This commit adds native histogram to Flow controller metrics (component evaluation time and component evaluation wait time).

For the scope of this commit, both classic and native histograms are used for these metrics. A future commit will remove the classic histogram.

The settings I picked came from the [Mimir documentation for native histograms](https://grafana.com/docs/mimir/latest/send/native-histograms/).