### PR TITLE
agent-flow-mixin: visualize native histograms

### DIFF
--- a/operations/agent-flow-mixin/dashboards/controller.libsonnet
+++ b/operations/agent-flow-mixin/dashboards/controller.libsonnet
@@ -200,6 +200,8 @@ local filename = 'agent-flow-controller.json';
       ),
 
       // Component evaluation time
+      //
+      // This panel supports both native and classic histograms, though it only shows one at a time.
       (
         panel.new(title='Component evaluation time', type='timeseries') +
         panel.withUnit('s') +
@@ -216,17 +218,32 @@ local filename = 'agent-flow-controller.json';
         panel.withPosition({ x: 8, y: 12, w: 8, h: 10 }) +
         panel.withQueries([
           panel.newQuery(
-            expr='histogram_quantile(0.99, sum by (le) (rate(agent_component_evaluation_seconds_bucket{cluster="$cluster",namespace="$namespace"}[$__rate_interval])))',
+            expr=|||
+              histogram_quantile(0.99, sum by (le) (rate(agent_component_evaluation_seconds{cluster="$cluster",namespace="$namespace"}[$__rate_interval])))
+              or
+              histogram_quantile(0.99, sum by (le) (rate(agent_component_evaluation_seconds_bucket{cluster="$cluster",namespace="$namespace"}[$__rate_interval])))
+            |||,
             legendFormat='99th percentile',
           ),
           panel.newQuery(
-            expr='histogram_quantile(0.50, sum by (le) (rate(agent_component_evaluation_seconds_bucket{cluster="$cluster",namespace="$namespace"}[$__rate_interval])))',
+            expr=|||
+              histogram_quantile(0.50, sum by (le) (rate(agent_component_evaluation_seconds{cluster="$cluster",namespace="$namespace"}[$__rate_interval])))
+              or
+              histogram_quantile(0.50, sum by (le) (rate(agent_component_evaluation_seconds_bucket{cluster="$cluster",namespace="$namespace"}[$__rate_interval])))
+            |||,
             legendFormat='50th percentile',
           ),
           panel.newQuery(
             expr=|||
-              sum(rate(agent_component_evaluation_seconds_sum{cluster="$cluster",namespace="$namespace"}[$__rate_interval])) /
-              sum(rate(agent_component_evaluation_seconds_count{cluster="$cluster",namespace="$namespace"}[$__rate_interval]))
+              (
+                histogram_sum(sum(rate(agent_component_evaluation_seconds{cluster="$cluster",namespace="$namespace"}[$__rate_interval]))) /
+                histogram_count(sum(rate(agent_component_evaluation_seconds{cluster="$cluster",namespace="$namespace"}[$__rate_interval])))
+              )
+              or
+              (
+                sum(rate(agent_component_evaluation_seconds_sum{cluster="$cluster",namespace="$namespace"}[$__rate_interval])) /
+                sum(rate(agent_component_evaluation_seconds_count{cluster="$cluster",namespace="$namespace"}[$__rate_interval]))
+              )
             |||,
             legendFormat='Average',
           ),
@@ -256,8 +273,10 @@ local filename = 'agent-flow-controller.json';
       ),
 
       // Component evaluation histogram
+      //
+      // This panel supports both native and classic histograms, though it only shows one at a time.
       (
-        panel.newHeatmap('Component evaluation histogram') +
+        panel.newNativeHistogramHeatmap('Component evaluation histogram') +
         panel.withDescription(|||
           Detailed histogram view of how long component evaluations take.
 
@@ -267,7 +286,11 @@ local filename = 'agent-flow-controller.json';
         panel.withPosition({ x: 0, y: 22, w: 8, h: 10 }) +
         panel.withQueries([
           panel.newQuery(
-            expr='sum by (le) (increase(agent_component_evaluation_seconds_bucket{cluster="$cluster", namespace="$namespace"}[$__rate_interval]))',
+            expr=|||
+              sum by (le) (increase(agent_component_evaluation_seconds{cluster="$cluster", namespace="$namespace"}[$__rate_interval]))
+              or
+              sum by (le) (increase(agent_component_evaluation_seconds_bucket{cluster="$cluster", namespace="$namespace"}[$__rate_interval]))
+            |||,
             format='heatmap',
             legendFormat='{{le}}',
           ),
@@ -275,8 +298,10 @@ local filename = 'agent-flow-controller.json';
       ),
 
       // Component dependency wait time histogram
+      //
+      // This panel supports both native and classic histograms, though it only shows one at a time.
       (
-        panel.newHeatmap('Component dependency wait histogram') +
+        panel.newNativeHistogramHeatmap('Component dependency wait histogram') +
         panel.withDescription(|||
           Detailed histogram of how long components wait to be evaluated after their dependency is updated.
 
@@ -286,7 +311,11 @@ local filename = 'agent-flow-controller.json';
         panel.withPosition({ x: 8, y: 22, w: 8, h: 10 }) +
         panel.withQueries([
           panel.newQuery(
-            expr='sum by (le) (increase(agent_component_dependencies_wait_seconds_bucket{cluster="$cluster", namespace="$namespace"}[$__rate_interval]))',
+            expr=|||
+              sum by (le) (increase(agent_component_dependencies_wait_seconds{cluster="$cluster", namespace="$namespace"}[$__rate_interval]))
+              or
+              sum by (le) (increase(agent_component_dependencies_wait_seconds_bucket{cluster="$cluster", namespace="$namespace"}[$__rate_interval]))
+            |||,
             format='heatmap',
             legendFormat='{{le}}',
           ),

--- a/operations/agent-flow-mixin/dashboards/utils/panel.jsonnet
+++ b/operations/agent-flow-mixin/dashboards/utils/panel.jsonnet
@@ -59,6 +59,18 @@
     pluginVersion: '9.0.6',
   },
 
+  newNativeHistogramHeatmap(title=''):: $.newHeatmap(title) {
+    options+: {
+      cellGap: 0,
+      color: {
+        scheme: 'Spectral',
+      },
+      filterValues: {
+        le: 0.1,
+      },
+    },
+  },
+
   withMultiTooltip():: {
     options+: {
       tooltip+: { mode: 'multi' },
@@ -128,8 +140,8 @@
     }
   ),
 
-  newRow(title='', x=0, y=0, w=24, h=1, collapsed=false):: 
-    $.new(title, 'row') 
-    + $.withPosition({x: x, y: y, w: w, h: h })
-    + {collapsed: collapsed},
+  newRow(title='', x=0, y=0, w=24, h=1, collapsed=false)::
+    $.new(title, 'row')
+    + $.withPosition({ x: x, y: y, w: w, h: h })
+    + { collapsed: collapsed },
 }


### PR DESCRIPTION
This commit adds support for native histograms in controller metrics. For basic backwards compatibility, the panels will show either native histograms or classic histograms, but not both at the same time (due to how the "or" operator works in Prometheus).

<img width="1508" alt="image" src="https://github.com/grafana/agent/assets/630212/313b4049-eaab-4f28-9017-c3ff3364da8e">