### PR TITLE
agent-flow-mixin: fix visualization for concurrent classic and native histograms

### DIFF
--- a/operations/agent-flow-mixin/dashboards/controller.libsonnet
+++ b/operations/agent-flow-mixin/dashboards/controller.libsonnet
@@ -288,7 +288,7 @@ local filename = 'agent-flow-controller.json';
           panel.newQuery(
             expr=|||
               sum by (le) (increase(agent_component_evaluation_seconds{cluster="$cluster", namespace="$namespace"}[$__rate_interval]))
-              or
+              or ignoring (le)
               sum by (le) (increase(agent_component_evaluation_seconds_bucket{cluster="$cluster", namespace="$namespace"}[$__rate_interval]))
             |||,
             format='heatmap',
@@ -313,7 +313,7 @@ local filename = 'agent-flow-controller.json';
           panel.newQuery(
             expr=|||
               sum by (le) (increase(agent_component_dependencies_wait_seconds{cluster="$cluster", namespace="$namespace"}[$__rate_interval]))
-              or
+              or ignoring (le)
               sum by (le) (increase(agent_component_dependencies_wait_seconds_bucket{cluster="$cluster", namespace="$namespace"}[$__rate_interval]))
             |||,
             format='heatmap',


### PR DESCRIPTION
If both classic and native histograms are visualized concurrently, the old query would not consistently work properly in Grafana, as the `or` operator would return both classic and native histograms.

This would cause Grafana to visualize the histograms inconsistently, sometimes showing nothing for time ranges where native histogram data should be available.