### PR TITLE
fix(static/metrics/instance): fix duplicate metrics registration panic when recreating the instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Main (unreleased)
 
 - Fix an issue where Loki could reject a batch of logs when structured metadata feature is used. (@thampiotr)
 
+- Fix a duplicate metrics registration panic when recreating static
+  mode metric instance's write handler. (@rfratto, @hainenber)
+
 v0.40.1 (2024-02-27)
 --------------------
 

--- a/internal/static/metrics/instance/instance.go
+++ b/internal/static/metrics/instance/instance.go
@@ -409,7 +409,7 @@ func (i *Instance) initialize(ctx context.Context, reg prometheus.Registerer, cf
 		return fmt.Errorf("error creating WAL: %w", err)
 	}
 
-	i.writeHandler = remote.NewWriteHandler(i.logger, i.reg, i.wal)
+	i.writeHandler = remote.NewWriteHandler(i.logger, reg, i.wal)
 
 	i.discovery, err = i.newDiscoveryManager(ctx, cfg)
 	if err != nil {

--- a/internal/static/metrics/instance/instance_test.go
+++ b/internal/static/metrics/instance/instance_test.go
@@ -258,7 +258,8 @@ func TestInstance_Recreate(t *testing.T) {
 	cfg.RemoteFlushDeadline = time.Hour
 
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-	inst, err := New(prometheus.NewRegistry(), cfg, walDir, logger)
+	currentReg := prometheus.NewRegistry()
+	inst, err := New(currentReg, cfg, walDir, logger)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -278,6 +279,7 @@ func TestInstance_Recreate(t *testing.T) {
 
 	// Recreate the instance, no panic should happen.
 	require.NotPanics(t, func() {
+		inst, err := New(currentReg, cfg, walDir, logger)
 		require.NoError(t, err)
 		runInstance(t, inst)
 

--- a/internal/static/metrics/instance/instance_test.go
+++ b/internal/static/metrics/instance/instance_test.go
@@ -278,7 +278,6 @@ func TestInstance_Recreate(t *testing.T) {
 
 	// Recreate the instance, no panic should happen.
 	require.NotPanics(t, func() {
-		inst, err := New(prometheus.NewRegistry(), cfg, walDir, logger)
 		require.NoError(t, err)
 		runInstance(t, inst)
 


### PR DESCRIPTION


<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Props to @rfratto for troubleshooting and guidance, I'm just implementing the idea here :D 

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #6548 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Tests updated