### PR TITLE
chore(doc): correct cfg for statsd_exporter relay address

### DIFF
--- a/docs/sources/static/configuration/integrations/statsd-exporter-config.md
+++ b/docs/sources/static/configuration/integrations/statsd-exporter-config.md
@@ -121,7 +121,7 @@ Full reference of options:
   # specifies the destination to forward your metrics.
 
   # Note that it must be a UDP endpoint in the format 'host:port'.
-  [relay_address: <string>]
+  [relay_addr: <string>]
 
   # Maximum relay output packet length to avoid fragmentation.
   [relay_packet_length: <int> | default = 1400]


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Correct YAML representation for the config is `relay_addr`, as addressed [here](https://github.com/grafana/agent/blob/main/internal/static/integrations/statsd_exporter/statsd_exporter.go#L74).

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #6601.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added