### PR TITLE
dockertarget: fix flaky test

### DIFF
--- a/internal/component/loki/source/docker/internal/dockertarget/target_test.go
+++ b/internal/component/loki/source/docker/internal/dockertarget/target_test.go
@@ -95,7 +95,7 @@ func TestDockerTarget(t *testing.T) {
 	}, 5*time.Second, 100*time.Millisecond, "Expected log lines were not found within the time limit.")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.False(t, tgt.Ready())
+		assert.False(c, tgt.Ready())
 	}, 5*time.Second, 20*time.Millisecond, "Expected target to finish processing within the time limit.")
 
 	entryHandler.Clear()


### PR DESCRIPTION
The callback for one of the assert.EventuallyWithT calls incorrectly passed the test-wide *testing.T instance. This causes the assert.EventuallyWithT call to always return on the first tick, regardless of whether the assertion passed.

This means that on slower machines, the first assertion would fail, the assert.EventuallyWithT call would return prematurely, and the rest of the test would fail in turn.