### PR TITLE
docs: remove beta label from clustering

### DIFF
--- a/docs/sources/flow/concepts/clustering.md
+++ b/docs/sources/flow/concepts/clustering.md
@@ -6,14 +6,12 @@ aliases:
 - /docs/grafana-cloud/send-data/agent/flow/concepts/clustering/
 canonical: https://grafana.com/docs/agent/latest/flow/concepts/clustering/
 description: Learn about Grafana Agent clustering concepts
-labels:
-  stage: beta
 menuTitle: Clustering
-title: Clustering (beta)
+title: Clustering
 weight: 500
 ---
 
-# Clustering (beta)
+# Clustering
 
 Clustering enables a fleet of {{< param "PRODUCT_ROOT_NAME" >}}s to work together for workload distribution and high availability.
 It helps create horizontally scalable deployments with minimal resource and operational overhead.
@@ -66,8 +64,8 @@ You can use the {{< param "PRODUCT_NAME" >}} UI [clustering page][] to monitor y
 Refer to [Debugging clustering issues][debugging] for additional troubleshooting information.
 
 {{% docs/reference %}}
-[run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md#clustering-beta"
-[run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md#clustering-beta"
+[run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md#clustering"
+[run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md#clustering"
 [prometheus.scrape]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape.md#clustering-beta"
 [prometheus.scrape]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.scrape.md#clustering-beta"
 [pyroscope.scrape]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/pyroscope.scrape.md#clustering-beta"

--- a/docs/sources/flow/reference/cli/run.md
+++ b/docs/sources/flow/reference/cli/run.md
@@ -87,7 +87,7 @@ reloading.
 
 [component controller]: {{< relref "../../concepts/component_controller.md" >}}
 
-## Clustering (beta)
+## Clustering
 
 The `--cluster.enabled` command-line argument starts {{< param "PRODUCT_ROOT_NAME" >}} in
 [clustering][] mode. The rest of the `--cluster.*` command-line flags can be

--- a/docs/sources/flow/reference/components/prometheus.operator.probes.md
+++ b/docs/sources/flow/reference/components/prometheus.operator.probes.md
@@ -193,7 +193,7 @@ fully consistent like hashmod sharding is).
 If {{< param "PRODUCT_NAME" >}} is _not_ running in clustered mode, then the block is a no-op, and
 `prometheus.operator.probes` scrapes every target it receives in its arguments.
 
-[clustered mode]: {{< relref "../cli/run.md#clustering-beta" >}}
+[clustered mode]: {{< relref "../cli/run.md#clustering" >}}
 
 ## Exported fields
 

--- a/docs/sources/flow/tasks/configure-agent-clustering.md
+++ b/docs/sources/flow/tasks/configure-agent-clustering.md
@@ -21,9 +21,6 @@ weight: 400
 
 You can configure {{< param "PRODUCT_NAME" >}} to run with [clustering][] so that individual {{< param "PRODUCT_ROOT_NAME" >}}s can work together for workload distribution and high availability.
 
-> **Note:** Clustering is a [beta][] feature. Beta features are subject to breaking
-> changes and may be replaced with equivalent functionality that covers the same use case.
-
 This topic describes how to add clustering to an existing installation.
 
 ## Configure {{% param "PRODUCT_NAME" %}} clustering with Helm Chart
@@ -65,8 +62,6 @@ To configure clustering:
 {{% docs/reference %}}
 [clustering]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/clustering.md"
 [clustering]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/clustering.md"
-[beta]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/stability.md#beta"
-[beta]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/stability.md#beta"
 [install-helm]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/get-started/install/kubernetes.md"
 [install-helm]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/get-started/install/kubernetes.md"
 [UI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/tasks/debug.md#component-detail-page"

--- a/docs/sources/flow/tasks/distribute-prometheus-scrape-load.md
+++ b/docs/sources/flow/tasks/distribute-prometheus-scrape-load.md
@@ -22,9 +22,6 @@ weight: 500
 A good predictor for the size of an {{< param "PRODUCT_NAME" >}} deployment is the number of Prometheus targets each {{< param "PRODUCT_ROOT_NAME" >}} scrapes.
 [Clustering][] with target auto-distribution allows a fleet of {{< param "PRODUCT_ROOT_NAME" >}}s to work together to dynamically distribute their scrape load, providing high-availability.
 
-> **Note:** Clustering is a [beta][] feature. Beta features are subject to breaking
-> changes and may be replaced with equivalent functionality that covers the same use case.
-
 ## Before you begin
 
 - Familiarize yourself with how to [configure existing {{< param "PRODUCT_NAME" >}} installations][configure-grafana-agent].
@@ -55,8 +52,6 @@ To distribute Prometheus metrics scrape load with clustering:
 {{% docs/reference %}}
 [Clustering]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/clustering.md"
 [Clustering]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/clustering.md"
-[beta]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/stability.md#beta"
-[beta]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/stability.md#beta"
 [configure-grafana-agent]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/tasks/configure"
 [configure-grafana-agent]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/tasks/configure"
 [Configure Prometheus metrics collection]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/tasks/collect-prometheus-metrics.md"


### PR DESCRIPTION
This backports PR #6629 to the v0.40 release branch.