### PR TITLE
docs: reference Grafana Agent Flow as an OTel Collector distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 <p align="center"><img src="docs/sources/assets/logo_and_name.png" alt="Grafana Agent logo"></p>
 
-Grafana Agent is a vendor-neutral, batteries-included telemetry collector with
-configuration inspired by [Terraform][]. It is designed to be flexible,
-performant, and compatible with multiple ecosystems such as Prometheus and
-OpenTelemetry.
+Grafana Agent is an OpenTelemetry Collector distribution with configuration
+inspired by [Terraform][]. It is designed to be flexible, performant, and
+compatible with multiple ecosystems such as Prometheus and OpenTelemetry.
 
 Grafana Agent is based around **components**. Components are wired together to
 form programmable observability **pipelines** for telemetry collection,

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -15,10 +15,9 @@ cascade:
 
 # Grafana Agent
 
-Grafana Agent is a vendor-neutral, batteries-included telemetry collector with
-configuration inspired by [Terraform][]. It is designed to be flexible,
-performant, and compatible with multiple ecosystems such as Prometheus and
-OpenTelemetry.
+Grafana Agent is an OpenTelemetry Collector distribution with configuration
+inspired by [Terraform][]. It is designed to be flexible, performant, and
+compatible with multiple ecosystems such as Prometheus and OpenTelemetry.
 
 Grafana Agent is based around **components**. Components are wired together to
 form programmable observability **pipelines** for telemetry collection,

--- a/docs/sources/_index.md.t
+++ b/docs/sources/_index.md.t
@@ -15,10 +15,9 @@ cascade:
 
 # Grafana Agent
 
-Grafana Agent is a vendor-neutral, batteries-included telemetry collector with
-configuration inspired by [Terraform][]. It is designed to be flexible,
-performant, and compatible with multiple ecosystems such as Prometheus and
-OpenTelemetry.
+Grafana Agent is an OpenTelemetry Collector distribution with configuration
+inspired by [Terraform][]. It is designed to be flexible, performant, and
+compatible with multiple ecosystems such as Prometheus and OpenTelemetry.
 
 Grafana Agent is based around **components**. Components are wired together to
 form programmable observability **pipelines** for telemetry collection,

--- a/docs/sources/flow/_index.md
+++ b/docs/sources/flow/_index.md
@@ -33,6 +33,17 @@ Components allow for reusability, composability, and focus on a single task.
 * Use expressions to bind components together to build a programmable pipeline.
 * Includes a UI for debugging the state of a pipeline.
 
+{{< param "PRODUCT_NAME" >}} is a [distribution][] of the OpenTelemetry
+Collector by Grafana Labs.
+Each distribution offers a different collection of components and capabilities.
+{{< param "PRODUCT_NAME" >}} is a distribution that includes dozens of
+OpenTelemetry-native [components][] from the OpenTelemetry project and
+introduces new capabilities such as programmable pipelines, clustering support,
+and the capability of sharing pipelines around the world.
+In addition to being an OpenTelemetry Collector distribution,
+{{< param "PRODUCT_NAME" >}} also includes first-class support for the
+Prometheus and Loki ecosystems, enabling pipelines to mix-and-match as needed.
+
 ## Example
 
 ```river
@@ -94,5 +105,8 @@ This feature is experimental, and it doesn't support all River components.
 [Tutorials]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/tutorials/"
 [Tutorials]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/tutorials/
 [Reference]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/"
-[Reference]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/
+[Reference]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/"
+[components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/"
+[components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components"
+[distribution]: "https://opentelemetry.io/ecosystem/distributions/"
 {{% /docs/reference %}}

--- a/docs/sources/flow/_index.md
+++ b/docs/sources/flow/_index.md
@@ -35,11 +35,13 @@ Components allow for reusability, composability, and focus on a single task.
 
 {{< param "PRODUCT_NAME" >}} is a [distribution][] of the OpenTelemetry
 Collector by Grafana Labs.
+
 Each distribution offers a different collection of components and capabilities.
-{{< param "PRODUCT_NAME" >}} is a distribution that includes dozens of
+As a distribution, {{< param "PRODUCT_NAME" >}} includes dozens of
 OpenTelemetry-native [components][] from the OpenTelemetry project and
-introduces new capabilities such as programmable pipelines, clustering support,
-and the capability of sharing pipelines around the world.
+introduces new features such as programmable pipelines, clustering support,
+and the ability to share pipelines around the world.
+
 In addition to being an OpenTelemetry Collector distribution,
 {{< param "PRODUCT_NAME" >}} also includes first-class support for the
 Prometheus and Loki ecosystems, enabling pipelines to mix-and-match as needed.
@@ -95,6 +97,8 @@ This feature is experimental, and it doesn't support all River components.
 * Consult the [Tasks][] instructions to accomplish common objectives with {{< param "PRODUCT_NAME" >}}.
 * Check out the [Reference][] documentation to find specific information you might be looking for.
 
+[distribution]: https://opentelemetry.io/ecosystem/distributions/
+
 {{% docs/reference %}}
 [Install]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/get-started/install/"
 [Install]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/get-started/install/"
@@ -108,5 +112,4 @@ This feature is experimental, and it doesn't support all River components.
 [Reference]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/"
 [components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/"
 [components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components"
-[distribution]: "https://opentelemetry.io/ecosystem/distributions/"
 {{% /docs/reference %}}

--- a/docs/sources/flow/_index.md
+++ b/docs/sources/flow/_index.md
@@ -34,7 +34,7 @@ Components allow for reusability, composability, and focus on a single task.
 * Includes a UI for debugging the state of a pipeline.
 
 {{< param "PRODUCT_NAME" >}} is a [distribution][] of the OpenTelemetry
-Collector by Grafana Labs.
+Collector.
 
 Each distribution offers a different collection of components and capabilities.
 As a distribution, {{< param "PRODUCT_NAME" >}} includes dozens of

--- a/docs/sources/flow/_index.md
+++ b/docs/sources/flow/_index.md
@@ -44,7 +44,7 @@ and the ability to share pipelines around the world.
 
 In addition to being an OpenTelemetry Collector distribution,
 {{< param "PRODUCT_NAME" >}} also includes first-class support for the
-Prometheus and Loki ecosystems, enabling pipelines to mix-and-match as needed.
+Prometheus and Loki ecosystems, allowing you to mix-and-match your pipelines.
 
 ## Example
 


### PR DESCRIPTION
This PR adds documentation references to Grafana Agent Flow's role as an OpenTelemetry collector distribution in the main landing page as well as the root of the Flow mode docs.