### PR TITLE
docs: remove beta labels from import.http, import.git, import.string

### DIFF
--- a/docs/sources/flow/reference/config-blocks/import.git.md
+++ b/docs/sources/flow/reference/config-blocks/import.git.md
@@ -6,14 +6,10 @@ aliases:
 - /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/import.git/
 canonical: https://grafana.com/docs/agent/latest/flow/reference/config-blocks/import.git/
 description: Learn about the import.git configuration block
-labels:
-  stage: beta
 title: import.git
 ---
 
 # import.git
-
-{{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT_VERSION>" >}}
 
 The `import.git` block imports custom components from a Git repository and exposes them to the importer.
 `import.git` blocks must be given a label that determines the namespace where custom components are exposed.

--- a/docs/sources/flow/reference/config-blocks/import.http.md
+++ b/docs/sources/flow/reference/config-blocks/import.http.md
@@ -6,14 +6,10 @@ aliases:
 - /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/import.http/
 canonical: https://grafana.com/docs/agent/latest/flow/reference/config-blocks/import.http/
 description: Learn about the import.http configuration block
-labels:
-  stage: beta
 title: import.http
 ---
 
 # import.http
-
-{{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT_VERSION>" >}}
 
 `import.http` retrieves a module from an HTTP server.
 

--- a/docs/sources/flow/reference/config-blocks/import.string.md
+++ b/docs/sources/flow/reference/config-blocks/import.string.md
@@ -6,14 +6,10 @@ aliases:
 - /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/import.string/
 canonical: https://grafana.com/docs/agent/latest/flow/reference/config-blocks/import.string/
 description: Learn about the import.string configuration block
-labels:
-  stage: beta
 title: import.string
 ---
 
 # import.string
-
-{{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT_VERSION>" >}}
 
 The `import.string` block imports custom components from a string and exposes them to the importer.
 `import.string` blocks must be given a label that determines the namespace where custom components are exposed.


### PR DESCRIPTION
This PR removes the beta label from the import.http and import.string components. The new modules have started picking up use and we don't anticipate breaking changes in the foundational way that these components work.