### PR TITLE
otelcolconvert: support converting oauth2 client auth extension

### DIFF
--- a/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
+++ b/docs/sources/flow/reference/components/otelcol.auth.oauth2.md
@@ -39,14 +39,23 @@ otelcol.auth.oauth2 "LABEL" {
 
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
-`client_id` | `string` | The client identifier issued to the client. | | yes
-`client_secret` | `secret` | The secret string associated with the client identifier. | | yes
+`client_id` | `string` | The client identifier issued to the client. | | no
+`client_id_file` | `string` | The file path to retrieve the client identifier issued to the client. | | no
+`client_secret` | `secret` | The secret string associated with the client identifier. | | no
+`client_secret_file` | `secret` | The file path to retrieve the secret string associated with the client identifier. | | no
 `token_url` | `string` | The server endpoint URL from which to get tokens. | | yes
 `endpoint_params` | `map(list(string))` | Additional parameters that are sent to the token endpoint. | `{}` | no
 `scopes` | `list(string)` | Requested permissions associated for the client. | `[]` | no
 `timeout` | `duration` | The timeout on the client connecting to `token_url`. | `"0s"` | no
 
 The `timeout` argument is used both for requesting initial tokens and for refreshing tokens. `"0s"` implies no timeout.
+
+At least one of the `client_id` and `client_id_file` pair of arguments must be
+set. In case both are set, `client_id_file` takes precedence.
+
+Similarly, at least one of the `client_secret` and `client_secret_file` pair of
+arguments must be set. In case both are set, `client_secret_file` also takes
+precedence.
 
 ## Blocks
 

--- a/internal/component/otelcol/auth/oauth2/oauth2.go
+++ b/internal/component/otelcol/auth/oauth2/oauth2.go
@@ -31,13 +31,15 @@ func init() {
 
 // Arguments configures the otelcol.auth.oauth2 component.
 type Arguments struct {
-	ClientID       string                     `river:"client_id,attr"`
-	ClientSecret   rivertypes.Secret          `river:"client_secret,attr"`
-	TokenURL       string                     `river:"token_url,attr"`
-	EndpointParams url.Values                 `river:"endpoint_params,attr,optional"`
-	Scopes         []string                   `river:"scopes,attr,optional"`
-	TLSSetting     otelcol.TLSClientArguments `river:"tls,block,optional"`
-	Timeout        time.Duration              `river:"timeout,attr,optional"`
+	ClientID         string                     `river:"client_id,attr,optional"`
+	ClientIDFile     string                     `river:"client_id_file,attr,optional"`
+	ClientSecret     rivertypes.Secret          `river:"client_secret,attr,optional"`
+	ClientSecretFile string                     `river:"client_secret_file,attr,optional"`
+	TokenURL         string                     `river:"token_url,attr"`
+	EndpointParams   url.Values                 `river:"endpoint_params,attr,optional"`
+	Scopes           []string                   `river:"scopes,attr,optional"`
+	TLSSetting       otelcol.TLSClientArguments `river:"tls,block,optional"`
+	Timeout          time.Duration              `river:"timeout,attr,optional"`
 }
 
 var _ auth.Arguments = Arguments{}
@@ -45,13 +47,15 @@ var _ auth.Arguments = Arguments{}
 // Convert implements auth.Arguments.
 func (args Arguments) Convert() (otelcomponent.Config, error) {
 	return &oauth2clientauthextension.Config{
-		ClientID:       args.ClientID,
-		ClientSecret:   configopaque.String(args.ClientSecret),
-		TokenURL:       args.TokenURL,
-		EndpointParams: args.EndpointParams,
-		Scopes:         args.Scopes,
-		TLSSetting:     *args.TLSSetting.Convert(),
-		Timeout:        args.Timeout,
+		ClientID:         args.ClientID,
+		ClientIDFile:     args.ClientIDFile,
+		ClientSecret:     configopaque.String(args.ClientSecret),
+		ClientSecretFile: args.ClientSecretFile,
+		TokenURL:         args.TokenURL,
+		EndpointParams:   args.EndpointParams,
+		Scopes:           args.Scopes,
+		TLSSetting:       *args.TLSSetting.Convert(),
+		Timeout:          args.Timeout,
 	}, nil
 }
 

--- a/internal/converter/internal/otelcolconvert/converter_oauth2clientauthextension.go
+++ b/internal/converter/internal/otelcolconvert/converter_oauth2clientauthextension.go
@@ -1,0 +1,53 @@
+package otelcolconvert
+
+import (
+	"fmt"
+
+	"github.com/grafana/agent/internal/component/otelcol/auth/oauth2"
+	"github.com/grafana/agent/internal/converter/diag"
+	"github.com/grafana/agent/internal/converter/internal/common"
+	"github.com/grafana/river/rivertypes"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension"
+	"go.opentelemetry.io/collector/component"
+)
+
+func init() {
+	converters = append(converters, oauth2ClientAuthExtensionConverter{})
+}
+
+type oauth2ClientAuthExtensionConverter struct{}
+
+func (oauth2ClientAuthExtensionConverter) Factory() component.Factory {
+	return oauth2clientauthextension.NewFactory()
+}
+
+func (oauth2ClientAuthExtensionConverter) InputComponentName() string { return "otelcol.auth.oauth2" }
+
+func (oauth2ClientAuthExtensionConverter) ConvertAndAppend(state *state, id component.InstanceID, cfg component.Config) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	label := state.FlowComponentLabel()
+
+	args := toOAuth2ClientAuthExtension(cfg.(*oauth2clientauthextension.Config))
+	block := common.NewBlockWithOverride([]string{"otelcol", "auth", "oauth2"}, label, args)
+
+	diags.Add(
+		diag.SeverityLevelInfo,
+		fmt.Sprintf("Converted %s into %s", stringifyInstanceID(id), stringifyBlock(block)),
+	)
+
+	state.Body().AppendBlock(block)
+	return diags
+}
+
+func toOAuth2ClientAuthExtension(cfg *oauth2clientauthextension.Config) *oauth2.Arguments {
+	return &oauth2.Arguments{
+		ClientID:       cfg.ClientID,
+		ClientSecret:   rivertypes.Secret(cfg.ClientSecret),
+		TokenURL:       cfg.TokenURL,
+		EndpointParams: cfg.EndpointParams,
+		Scopes:         cfg.Scopes,
+		TLSSetting:     toTLSClientArguments(cfg.TLSSetting),
+		Timeout:        cfg.Timeout,
+	}
+}

--- a/internal/converter/internal/otelcolconvert/testdata/oauth2.river
+++ b/internal/converter/internal/otelcolconvert/testdata/oauth2.river
@@ -1,0 +1,44 @@
+otelcol.auth.oauth2 "default" {
+	client_id       = "someclientid"
+	client_secret   = "someclientsecret"
+	token_url       = "https://example.com/oauth2/default/v1/token"
+	endpoint_params = {
+		audience = ["someaudience"],
+	}
+	scopes = ["api.metrics"]
+
+	tls {
+		ca_file   = "/var/lib/mycert.pem"
+		cert_file = "certfile"
+		key_file  = "keyfile"
+		insecure  = true
+	}
+	timeout = "2s"
+}
+
+otelcol.receiver.otlp "default" {
+	grpc { }
+
+	output {
+		metrics = [otelcol.exporter.otlp.default_withauth.input, otelcol.exporter.otlphttp.default_noauth.input]
+		logs    = [otelcol.exporter.otlp.default_withauth.input, otelcol.exporter.otlphttp.default_noauth.input]
+		traces  = [otelcol.exporter.otlp.default_withauth.input, otelcol.exporter.otlphttp.default_noauth.input]
+	}
+}
+
+otelcol.exporter.otlp "default_withauth" {
+	client {
+		endpoint = "database:4317"
+
+		tls {
+			ca_file = "/tmp/certs/ca.pem"
+		}
+		auth = otelcol.auth.oauth2.default.handler
+	}
+}
+
+otelcol.exporter.otlphttp "default_noauth" {
+	client {
+		endpoint = "database:4318"
+	}
+}

--- a/internal/converter/internal/otelcolconvert/testdata/oauth2.yaml
+++ b/internal/converter/internal/otelcolconvert/testdata/oauth2.yaml
@@ -1,0 +1,61 @@
+extensions:
+  oauth2client/noop: # this extension is not defined in services and shouldn't be converted
+    client_id: dummyclientid
+    client_secret: dummyclientsecret
+    token_url: https://example.com/oauth2/default/v1/token
+  oauth2client:
+    client_id: someclientid
+    client_secret: someclientsecret
+    endpoint_params:
+      audience: someaudience
+    token_url: https://example.com/oauth2/default/v1/token
+    scopes: ["api.metrics"]
+    # tls settings for the token client
+    tls:
+      insecure: true
+      ca_file: /var/lib/mycert.pem
+      cert_file: certfile
+      key_file: keyfile
+    # timeout for the token client
+    timeout: 2s
+    
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+exporters:
+  otlphttp/noauth:
+    # Our defaults have drifted from upstream, so we explicitly set our
+    # defaults below for queue_size.
+    endpoint: database:4318
+    sending_queue:
+      queue_size: 5000
+      
+  otlp/withauth:
+    tls:
+      ca_file: /tmp/certs/ca.pem
+    auth:
+      authenticator: oauth2client
+    # Our defaults have drifted from upstream, so we explicitly set our
+    # defaults below (balancer_name and queue_size).
+    endpoint: database:4317
+    balancer_name: pick_first
+    sending_queue:
+      queue_size: 5000
+
+service:
+  extensions: [oauth2client]
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlp/withauth, otlphttp/noauth]
+    logs:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlp/withauth, otlphttp/noauth]
+    traces:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlp/withauth, otlphttp/noauth]


### PR DESCRIPTION
Closes #6420

Please take a second look as a sanity check, since this is supposed to work for both the static mode tracing subsystem _and_ the OTel collector so I'm not sure if there's anything else I haven't considered