### PR TITLE
go.mod: retract accidentally pushed tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,12 @@ module github.com/grafana/agent
 
 go 1.22.1
 
+retract (
+	v1.3.191 // Published accidentally
+	v1.2.99 // Published accidentally
+	v1.2.99-rc1 // Published accidentally
+)
+
 require (
 	cloud.google.com/go/pubsub v1.33.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.0-beta.1


### PR DESCRIPTION
Retracting a couple of accidentally-pushed Git tags when testing a GitHub action 2 years ago 😬 


Closes #6654
