### PR TITLE
Update to fetch head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Main (unreleased)
 
 - Fix a bug where structured metadata and parsed field are not passed further in `loki.source.api` (@marchellodev)
 
+- Git operations used `HEAD` which could lead to incorrect pulls since it uses fetch and not pull, it now uses `FETCH_HEAD` by default. (@mattdurham)
+
 ### Other changes
 
 - Clustering for Grafana Agent in Flow mode has graduated from beta to stable.

--- a/docs/sources/flow/reference/components/module.git.md
+++ b/docs/sources/flow/reference/components/module.git.md
@@ -41,12 +41,12 @@ module.git "LABEL" {
 
 The following arguments are supported:
 
-Name | Type | Description | Default | Required
----- | ---- | ----------- | ------- | --------
-`repository` | `string` | The Git repository address to retrieve the module from. | | yes
-`revision` | `string` | The Git revision to retrieve the module from. | `"HEAD"` | no
-`path` | `string` | The path in the repository where the module is stored. | | yes
-`pull_frequency` | `duration` | The frequency to pull the repository for updates. | `"60s"` | no
+Name | Type | Description | Default        | Required
+---- | ---- | ----------- |----------------| --------
+`repository` | `string` | The Git repository address to retrieve the module from. |                | yes
+`revision` | `string` | The Git revision to retrieve the module from. | `"FETCH_HEAD"` | no
+`path` | `string` | The path in the repository where the module is stored. |                | yes
+`pull_frequency` | `duration` | The frequency to pull the repository for updates. | `"60s"`        | no
 
 The `repository` attribute must be set to a repository address that would be
 recognized by Git with a `git clone REPOSITORY_ADDRESS` command, such as

--- a/docs/sources/flow/reference/config-blocks/import.git.md
+++ b/docs/sources/flow/reference/config-blocks/import.git.md
@@ -27,12 +27,12 @@ import.git "NAMESPACE" {
 
 The following arguments are supported:
 
-Name             | Type       | Description                                             | Default  | Required
------------------|------------|---------------------------------------------------------|----------|---------
-`repository`     | `string`   | The Git repository address to retrieve the module from. |          | yes
-`revision`       | `string`   | The Git revision to retrieve the module from.           | `"HEAD"` | no
-`path`           | `string`   | The path in the repository where the module is stored.  |          | yes
-`pull_frequency` | `duration` | The frequency to pull the repository for updates.       | `"60s"`  | no
+Name             | Type       | Description                                             | Default        | Required
+-----------------|------------|---------------------------------------------------------|----------------|---------
+`repository`     | `string`   | The Git repository address to retrieve the module from. |                | yes
+`revision`       | `string`   | The Git revision to retrieve the module from.           | `"FETCH_HEAD"` | no
+`path`           | `string`   | The path in the repository where the module is stored.  |                | yes
+`pull_frequency` | `duration` | The frequency to pull the repository for updates.       | `"60s"`        | no
 
 The `repository` attribute must be set to a repository address that would be
 recognized by Git with a `git clone REPOSITORY_ADDRESS` command, such as

--- a/internal/component/module/git/git.go
+++ b/internal/component/module/git/git.go
@@ -43,7 +43,8 @@ type Arguments struct {
 
 // DefaultArguments holds default settings for Arguments.
 var DefaultArguments = Arguments{
-	Revision:      "HEAD",
+	// Because we are using fetch, it does not update HEAD but instead updates FETCH_HEAD.
+	Revision:      "FETCH_HEAD",
 	PullFrequency: time.Minute,
 }
 

--- a/internal/flow/internal/importsource/import_git.go
+++ b/internal/flow/internal/importsource/import_git.go
@@ -51,7 +51,8 @@ type GitArguments struct {
 }
 
 var DefaultGitArguments = GitArguments{
-	Revision:      "HEAD",
+	// Because we are using fetch, it does not update HEAD but instead updates FETCH_HEAD.
+	Revision:      "FETCH_HEAD",
 	PullFrequency: time.Minute,
 }
 


### PR DESCRIPTION
#### PR Description

Internally for git components/config blocks we are using fetch which updates the FETCH_HEAD and not HEAD. So whatever the most recent pull was gets permanently pinned since HEAD never changes.


#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Documentation added
