### PR TITLE
issue #6667 implement support for mimir.rules.kubernetes federated group rules

### DIFF
--- a/internal/component/common/kubernetes/diff.go
+++ b/internal/component/common/kubernetes/diff.go
@@ -3,8 +3,9 @@ package kubernetes
 import (
 	"bytes"
 
-	"github.com/prometheus/prometheus/model/rulefmt"
 	"gopkg.in/yaml.v3" // Used for prometheus rulefmt compatibility instead of gopkg.in/yaml.v2
+
+	mimirClient "github.com/grafana/agent/internal/mimir/client"
 )
 
 type RuleGroupDiffKind string
@@ -17,11 +18,11 @@ const (
 
 type RuleGroupDiff struct {
 	Kind    RuleGroupDiffKind
-	Actual  rulefmt.RuleGroup
-	Desired rulefmt.RuleGroup
+	Actual  mimirClient.RuleGroup
+	Desired mimirClient.RuleGroup
 }
 
-type RuleGroupsByNamespace map[string][]rulefmt.RuleGroup
+type RuleGroupsByNamespace map[string][]mimirClient.RuleGroup
 type RuleGroupDiffsByNamespace map[string][]RuleGroupDiff
 
 func DiffRuleState(desired, actual RuleGroupsByNamespace) RuleGroupDiffsByNamespace {
@@ -55,7 +56,7 @@ func DiffRuleState(desired, actual RuleGroupsByNamespace) RuleGroupDiffsByNamesp
 	return diff
 }
 
-func diffRuleNamespaceState(desired []rulefmt.RuleGroup, actual []rulefmt.RuleGroup) []RuleGroupDiff {
+func diffRuleNamespaceState(desired []mimirClient.RuleGroup, actual []mimirClient.RuleGroup) []RuleGroupDiff {
 	var diff []RuleGroupDiff
 
 	seenGroups := map[string]bool{}
@@ -99,7 +100,7 @@ desiredGroups:
 	return diff
 }
 
-func equalRuleGroups(a, b rulefmt.RuleGroup) bool {
+func equalRuleGroups(a, b mimirClient.RuleGroup) bool {
 	aBuf, err := yaml.Marshal(a)
 	if err != nil {
 		return false

--- a/internal/component/mimir/rules/kubernetes/events.go
+++ b/internal/component/mimir/rules/kubernetes/events.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/agent/internal/component/common/kubernetes"
 	"github.com/grafana/agent/internal/flow/logging/level"
+	mimirClient "github.com/grafana/agent/internal/mimir/client"
 	"github.com/hashicorp/go-multierror"
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus/prometheus/model/rulefmt"
@@ -136,6 +137,16 @@ func (c *Component) loadStateFromK8s() (kubernetes.RuleGroupsByNamespace, error)
 				return nil, fmt.Errorf("failed to convert rule group: %w", err)
 			}
 
+			var sourceTenants []string
+			if pr.ObjectMeta.Annotations[AnnotationsSourceTenants] != "" {
+				sourceTenants = regexp.MustCompile(`\s*,\s*`).
+					Split(pr.ObjectMeta.Annotations[AnnotationsSourceTenants], -1)
+			}
+
+			for i := range groups {
+				groups[i].SourceTenants = sourceTenants
+			}
+
 			desiredState[mimirNs] = groups
 		}
 	}
@@ -143,7 +154,7 @@ func (c *Component) loadStateFromK8s() (kubernetes.RuleGroupsByNamespace, error)
 	return desiredState, nil
 }
 
-func convertCRDRuleGroupToRuleGroup(crd promv1.PrometheusRuleSpec) ([]rulefmt.RuleGroup, error) {
+func convertCRDRuleGroupToRuleGroup(crd promv1.PrometheusRuleSpec) ([]mimirClient.RuleGroup, error) {
 	buf, err := yaml.Marshal(crd)
 	if err != nil {
 		return nil, err
@@ -154,7 +165,14 @@ func convertCRDRuleGroupToRuleGroup(crd promv1.PrometheusRuleSpec) ([]rulefmt.Ru
 		return nil, multierror.Append(nil, errs...)
 	}
 
-	return groups.Groups, nil
+	mimirGroups := make([]mimirClient.RuleGroup, 0)
+	for _, group := range groups.Groups {
+		mimirGroups = append(mimirGroups, mimirClient.RuleGroup{
+			RuleGroup: group,
+		})
+	}
+
+	return mimirGroups, nil
 }
 
 func (c *Component) applyChanges(ctx context.Context, namespace string, diffs []kubernetes.RuleGroupDiff) error {

--- a/internal/component/mimir/rules/kubernetes/types.go
+++ b/internal/component/mimir/rules/kubernetes/types.go
@@ -8,6 +8,8 @@ import (
 	"github.com/grafana/agent/internal/component/common/kubernetes"
 )
 
+const AnnotationsSourceTenants = "monitoring.grafana.com/source_tenants"
+
 type Arguments struct {
 	Address              string                  `river:"address,attr"`
 	TenantID             string                  `river:"tenant_id,attr,optional"`

--- a/internal/loki/client/client.go
+++ b/internal/loki/client/client.go
@@ -13,11 +13,11 @@ import (
 
 	log "github.com/go-kit/log"
 	"github.com/grafana/agent/internal/loki/client/internal"
+	mimirClient "github.com/grafana/agent/internal/mimir/client"
 	"github.com/grafana/dskit/instrument"
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/config"
-	"github.com/prometheus/prometheus/model/rulefmt"
 )
 
 const (
@@ -39,9 +39,9 @@ type Config struct {
 }
 
 type Interface interface {
-	CreateRuleGroup(ctx context.Context, namespace string, rg rulefmt.RuleGroup) error
+	CreateRuleGroup(ctx context.Context, namespace string, rg mimirClient.RuleGroup) error
 	DeleteRuleGroup(ctx context.Context, namespace, groupName string) error
-	ListRules(ctx context.Context, namespace string) (map[string][]rulefmt.RuleGroup, error)
+	ListRules(ctx context.Context, namespace string) (map[string][]mimirClient.RuleGroup, error)
 }
 
 // LokiClient is a client to the Loki API.

--- a/internal/loki/client/rules.go
+++ b/internal/loki/client/rules.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/prometheus/prometheus/model/rulefmt"
+	mimirClient "github.com/grafana/agent/internal/mimir/client"
 	"gopkg.in/yaml.v3"
 )
 
@@ -15,7 +15,7 @@ type RemoteWriteConfig struct {
 }
 
 // CreateRuleGroup creates a new rule group
-func (r *LokiClient) CreateRuleGroup(ctx context.Context, namespace string, rg rulefmt.RuleGroup) error {
+func (r *LokiClient) CreateRuleGroup(ctx context.Context, namespace string, rg mimirClient.RuleGroup) error {
 	payload, err := yaml.Marshal(&rg)
 	if err != nil {
 		return err
@@ -52,7 +52,7 @@ func (r *LokiClient) DeleteRuleGroup(ctx context.Context, namespace, groupName s
 }
 
 // ListRules retrieves a rule group
-func (r *LokiClient) ListRules(ctx context.Context, namespace string) (map[string][]rulefmt.RuleGroup, error) {
+func (r *LokiClient) ListRules(ctx context.Context, namespace string) (map[string][]mimirClient.RuleGroup, error) {
 	path := r.apiPath
 	op := r.apiPath
 	if namespace != "" {
@@ -72,7 +72,7 @@ func (r *LokiClient) ListRules(ctx context.Context, namespace string) (map[strin
 		return nil, err
 	}
 
-	ruleSet := map[string][]rulefmt.RuleGroup{}
+	ruleSet := map[string][]mimirClient.RuleGroup{}
 	err = yaml.Unmarshal(body, &ruleSet)
 	if err != nil {
 		return nil, err

--- a/internal/mimir/client/client.go
+++ b/internal/mimir/client/client.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/config"
-	"github.com/prometheus/prometheus/model/rulefmt"
 )
 
 var (
@@ -35,9 +34,9 @@ type Config struct {
 }
 
 type Interface interface {
-	CreateRuleGroup(ctx context.Context, namespace string, rg rulefmt.RuleGroup) error
+	CreateRuleGroup(ctx context.Context, namespace string, rg RuleGroup) error
 	DeleteRuleGroup(ctx context.Context, namespace, groupName string) error
-	ListRules(ctx context.Context, namespace string) (map[string][]rulefmt.RuleGroup, error)
+	ListRules(ctx context.Context, namespace string) (map[string][]RuleGroup, error)
 }
 
 // MimirClient is a client to the Mimir API.

--- a/internal/mimir/client/rules.go
+++ b/internal/mimir/client/rules.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/prometheus/prometheus/model/rulefmt"
 	"gopkg.in/yaml.v3"
 )
 
@@ -15,7 +14,7 @@ type RemoteWriteConfig struct {
 }
 
 // CreateRuleGroup creates a new rule group
-func (r *MimirClient) CreateRuleGroup(ctx context.Context, namespace string, rg rulefmt.RuleGroup) error {
+func (r *MimirClient) CreateRuleGroup(ctx context.Context, namespace string, rg RuleGroup) error {
 	payload, err := yaml.Marshal(&rg)
 	if err != nil {
 		return err
@@ -53,7 +52,7 @@ func (r *MimirClient) DeleteRuleGroup(ctx context.Context, namespace, groupName 
 }
 
 // ListRules retrieves a rule group
-func (r *MimirClient) ListRules(ctx context.Context, namespace string) (map[string][]rulefmt.RuleGroup, error) {
+func (r *MimirClient) ListRules(ctx context.Context, namespace string) (map[string][]RuleGroup, error) {
 	path := r.apiPath
 	op := r.apiPath
 	if namespace != "" {
@@ -73,7 +72,7 @@ func (r *MimirClient) ListRules(ctx context.Context, namespace string) (map[stri
 		return nil, err
 	}
 
-	ruleSet := map[string][]rulefmt.RuleGroup{}
+	ruleSet := map[string][]RuleGroup{}
 	err = yaml.Unmarshal(body, &ruleSet)
 	if err != nil {
 		return nil, err

--- a/internal/mimir/client/types.go
+++ b/internal/mimir/client/types.go
@@ -1,0 +1,8 @@
+package client
+
+import "github.com/prometheus/prometheus/model/rulefmt"
+
+type RuleGroup struct {
+	rulefmt.RuleGroup `yaml:"embedded,omitempty"`
+	SourceTenants     []string `yaml:"source_tenants,omitempty"`
+}

--- a/internal/mimir/client/types.go
+++ b/internal/mimir/client/types.go
@@ -3,6 +3,6 @@ package client
 import "github.com/prometheus/prometheus/model/rulefmt"
 
 type RuleGroup struct {
-	rulefmt.RuleGroup `yaml:"embedded,omitempty"`
+	rulefmt.RuleGroup `yaml:",inline"`
 	SourceTenants     []string `yaml:"source_tenants,omitempty"`
 }

--- a/internal/mimir/client/types_test.go
+++ b/internal/mimir/client/types_test.go
@@ -1,0 +1,78 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/prometheus/prometheus/model/rulefmt"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestRuleGroup_Marshal(t *testing.T) {
+	type fields struct {
+		RuleGroup     rulefmt.RuleGroup
+		SourceTenants []string
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "serialises a rule group",
+			fields: fields{
+				SourceTenants: []string{"tenant1", "tenant2"},
+				RuleGroup: rulefmt.RuleGroup{
+					Name:     "group",
+					Interval: 0,
+					Limit:    0,
+					Rules: []rulefmt.RuleNode{
+						{
+							Record: yaml.Node{},
+							Alert: yaml.Node{
+								Kind:   8,
+								Tag:    "!!str",
+								Value:  "alert",
+								Line:   4,
+								Column: 12,
+							},
+							Expr: yaml.Node{
+								Kind:   8,
+								Tag:    "!!str",
+								Value:  "expr",
+								Line:   5,
+								Column: 11,
+							},
+						},
+					},
+				},
+			},
+			want: `name: group
+rules:
+    - alert: alert
+      expr: expr
+source_tenants:
+    - tenant1
+    - tenant2
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rg := RuleGroup{
+				RuleGroup:     tt.fields.RuleGroup,
+				SourceTenants: tt.fields.SourceTenants,
+			}
+
+			got, err := yaml.Marshal(rg)
+			require.NoError(t, err)
+
+			if !cmp.Equal(string(got), tt.want) {
+				t.Errorf("yaml.Marshal() = %v", cmp.Diff(string(got), tt.want))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Federated group rules are loaded from the `monitoring.grafana.com/source_tenants` annotation on the prometheusrules crd.
```yaml
apiVersion: monitoring.coreos.com/v1
kind: PrometheusRule
metadata:
  name: tenant1-group1
  annotations:
    monitoring.grafana.com/source_tenants: tenant1,tenant2
spec:
  groups:
  - ...
```

<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes grafana/alloy#216

#### Notes to the Reviewer

The mimir rule group != prometheus rule group due to the `source_tenants` field. I had to use a new type and embedded `rulefmt.RuleGroup` in internal/mimir/client/types.go

This approach seemed the most flexible, given the field will add query load to the other tenants. Either way the type change is necessary to send the field to mimir, happy to discuss alternatives.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated