### PR TITLE
Attempt to fix main: separate clean in windows docker images

### DIFF
--- a/cmd/grafana-agent/Dockerfile.windows
+++ b/cmd/grafana-agent/Dockerfile.windows
@@ -10,7 +10,12 @@ SHELL ["cmd", "/S", "/C"]
 # Creating new layers can be really slow on Windows so we clean up any caches
 # we can before moving on to the next step.
 RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} make generate-ui && rm -rf web/ui/node_modules && yarn cache clean --all""
-RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} GO_TAGS='builtinassets' make agent && go clean -cache -modcache""
+
+RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} GO_TAGS='builtinassets' make agent""
+# In this case, we're separating the clean command from make agent to avoid an issue where access to some mod cache
+# files is denied immediately after make agent, for example:
+# "go: remove C:\go\pkg\mod\golang.org\toolchain@v0.0.1-go1.22.1.windows-amd64\bin\go.exe: Access is denied."
+RUN ""C:\Program Files\git\bin\bash.exe" -c "go clean -cache -modcache""
 
 # Use the smallest container possible for the final image
 FROM mcr.microsoft.com/windows/nanoserver:1809

--- a/cmd/grafana-agentctl/Dockerfile.windows
+++ b/cmd/grafana-agentctl/Dockerfile.windows
@@ -7,9 +7,11 @@ WORKDIR /src/agent
 
 SHELL ["cmd", "/S", "/C"]
 
-# Creating new layers can be really slow on Windows so we clean up any caches
-# we can before moving on to the next step.
-RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} make agentctl && go clean -cache -modcache""
+RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} make agentctl""
+# We're separating the clean command from make agent to avoid an issue where access to some mod cache
+# files is denied immediately after make agentctl, for example:
+# "go: remove C:\go\pkg\mod\golang.org\toolchain@v0.0.1-go1.22.1.windows-amd64\bin\go.exe: Access is denied."
+RUN ""C:\Program Files\git\bin\bash.exe" -c "go clean -cache -modcache""
 
 # Use the smallest container possible for the final image
 FROM mcr.microsoft.com/windows/nanoserver:1809


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Attempt to fix `main` issues:

```
go: remove C:\go\pkg\mod\golang.org\toolchain@v0.0.1-go1.22.1.windows-amd64\bin\go.exe: Access is denied.
The command 'cmd /S /C ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} GO_TAGS='builtinassets' make agent && go clean -cache -modcache""' returned a non-zero code: 1
```

https://drone.grafana.net/grafana/agent/17297/7/2

