### PR TITLE
service: allow services to have defined stability levels

### DIFF
--- a/internal/component/registry.go
+++ b/internal/component/registry.go
@@ -124,6 +124,7 @@ type Registration struct {
 	// sure the user is not accidentally using a component that is not yet stable - users
 	// need to explicitly enable less-than-stable components via, for example, a command-line flag.
 	// If a component is not stable enough, an attempt to create it via the controller will fail.
+	// This field must be set to a non-zero value.
 	Stability featuregate.Stability
 
 	// An example Arguments value that the registered component expects to

--- a/internal/component/registry.go
+++ b/internal/component/registry.go
@@ -124,7 +124,6 @@ type Registration struct {
 	// sure the user is not accidentally using a component that is not yet stable - users
 	// need to explicitly enable less-than-stable components via, for example, a command-line flag.
 	// If a component is not stable enough, an attempt to create it via the controller will fail.
-	// The default stability level is Experimental.
 	Stability featuregate.Stability
 
 	// An example Arguments value that the registered component expects to

--- a/internal/flow/flow_services_test.go
+++ b/internal/flow/flow_services_test.go
@@ -63,6 +63,7 @@ func TestServices_Configurable(t *testing.T) {
 				return service.Definition{
 					Name:       "fake",
 					ConfigType: ServiceOptions{},
+					Stability:  featuregate.StabilityBeta,
 				}
 			},
 
@@ -117,6 +118,7 @@ func TestServices_Configurable_Optional(t *testing.T) {
 				return service.Definition{
 					Name:       "fake",
 					ConfigType: ServiceOptions{},
+					Stability:  featuregate.StabilityBeta,
 				}
 			},
 

--- a/internal/flow/internal/controller/loader_test.go
+++ b/internal/flow/internal/controller/loader_test.go
@@ -563,7 +563,3 @@ func (fs *fakeService) Data() any {
 	}
 	return nil
 }
-
-type fakeArgumentBlock struct {
-	Name string `river:"name,attr,optional"`
-}

--- a/internal/service/cluster/cluster.go
+++ b/internal/service/cluster/cluster.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/agent/internal/component"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/internal/flow/logging/level"
 	"github.com/grafana/agent/internal/service"
 	http_service "github.com/grafana/agent/internal/service/http"
@@ -162,6 +163,7 @@ func (s *Service) Definition() service.Definition {
 			// Cluster depends on the HTTP service to work properly.
 			http_service.ServiceName,
 		},
+		Stability: featuregate.StabilityBeta,
 	}
 }
 

--- a/internal/service/cluster/cluster.go
+++ b/internal/service/cluster/cluster.go
@@ -163,7 +163,7 @@ func (s *Service) Definition() service.Definition {
 			// Cluster depends on the HTTP service to work properly.
 			http_service.ServiceName,
 		},
-		Stability: featuregate.StabilityBeta,
+		Stability: featuregate.StabilityStable,
 	}
 }
 

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/gorilla/mux"
 	"github.com/grafana/agent/internal/component"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/internal/flow"
 	"github.com/grafana/agent/internal/flow/logging/level"
 	"github.com/grafana/agent/internal/service"
@@ -128,6 +129,7 @@ func (s *Service) Definition() service.Definition {
 		Name:       ServiceName,
 		ConfigType: Arguments{},
 		DependsOn:  nil, // http has no dependencies.
+		Stability:  featuregate.StabilityStable,
 	}
 }
 

--- a/internal/service/labelstore/service.go
+++ b/internal/service/labelstore/service.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/internal/flow/logging/level"
 	agent_service "github.com/grafana/agent/internal/service"
 	flow_service "github.com/grafana/agent/internal/service"
@@ -67,6 +68,7 @@ func (s *service) Definition() agent_service.Definition {
 		Name:       ServiceName,
 		ConfigType: Arguments{},
 		DependsOn:  nil,
+		Stability:  featuregate.StabilityStable,
 	}
 }
 

--- a/internal/service/otel/otel.go
+++ b/internal/service/otel/otel.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/internal/service"
 	"github.com/grafana/agent/internal/util"
 )
@@ -50,6 +51,7 @@ func (*Service) Definition() service.Definition {
 		Name:       ServiceName,
 		ConfigType: nil, // otel does not accept configuration
 		DependsOn:  []string{},
+		Stability:  featuregate.StabilityStable,
 	}
 }
 

--- a/internal/service/remotecfg/remotecfg.go
+++ b/internal/service/remotecfg/remotecfg.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/agent-remote-config/api/gen/proto/go/agent/v1/agentv1connect"
 	"github.com/grafana/agent/internal/agentseed"
 	"github.com/grafana/agent/internal/component/common/config"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/internal/flow/logging/level"
 	"github.com/grafana/agent/internal/service"
 	"github.com/grafana/river"
@@ -128,6 +129,7 @@ func (s *Service) Definition() service.Definition {
 		Name:       ServiceName,
 		ConfigType: Arguments{},
 		DependsOn:  nil, // remotecfg has no dependencies.
+		Stability:  featuregate.StabilityBeta,
 	}
 }
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/agent/internal/component"
+	"github.com/grafana/agent/internal/featuregate"
 )
 
 // Definition describes an individual Flow service. Services have unique names
@@ -35,6 +36,14 @@ type Definition struct {
 	// or a named service doesn't exist), it is treated as a fatal
 	// error and the root Flow module will exit.
 	DependsOn []string
+
+	// Stability is the overall stability level of the service. This is used to
+	// make sure the user is not accidentally configuring a service that is not
+	// yet stable - users need to explicitly enable less-than-stable services
+	// via, for example, a command-line flag. If a service is not stable enough,
+	// an attempt to configure it via the controller will fail.
+	// This field must be set to a non-zero value.
+	Stability featuregate.Stability
 }
 
 // Host is a controller for services and Flow components.

--- a/internal/service/ui/ui.go
+++ b/internal/service/ui/ui.go
@@ -8,6 +8,7 @@ import (
 	"path"
 
 	"github.com/gorilla/mux"
+	"github.com/grafana/agent/internal/featuregate"
 	"github.com/grafana/agent/internal/service"
 	http_service "github.com/grafana/agent/internal/service/http"
 	"github.com/grafana/agent/internal/web/api"
@@ -46,6 +47,7 @@ func (s *Service) Definition() service.Definition {
 		Name:       ServiceName,
 		ConfigType: nil, // ui does not accept configuration
 		DependsOn:  []string{http_service.ServiceName},
+		Stability:  featuregate.StabilityStable,
 	}
 }
 


### PR DESCRIPTION
This commit adds stability levels to services. Every service, with the exception of remotecfg, is then given a stability level of stable. remotecfg is given a stability level of "beta."