### PR TITLE
otelcol.receiver.opencensus: sync with upstream defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Breaking changes
+
+- The default listen port for `otelcol.receiver.opencensus` has changed from
+  4317 to 55678 to align with upstream. (@rfratto)
+
 ### Enhancements
 
 - Add support for importing folders as single module to `import.file`. (@wildum)

--- a/docs/sources/flow/reference/components/otelcol.receiver.opencensus.md
+++ b/docs/sources/flow/reference/components/otelcol.receiver.opencensus.md
@@ -43,7 +43,7 @@ otelcol.receiver.opencensus "LABEL" {
 Name | Type | Description | Default | Required
 ---- | ---- | ----------- | ------- | --------
 `cors_allowed_origins` | `list(string)` | A list of allowed Cross-Origin Resource Sharing (CORS) origins. |  | no
-`endpoint` | `string` | `host:port` to listen for traffic on. | `"0.0.0.0:4317"` | no
+`endpoint` | `string` | `host:port` to listen for traffic on. | `"0.0.0.0:55678"` | no
 `transport` | `string` | Transport to use for the gRPC server. | `"tcp"` | no
 `max_recv_msg_size` | `string` | Maximum size of messages the server will accept. 0 disables a limit. | | no
 `max_concurrent_streams` | `number` | Limit the number of concurrent streaming RPC calls. | | no
@@ -59,7 +59,7 @@ The "endpoint" parameter is the same for both gRPC and HTTP/JSON, as the protoco
 
 To write traces with HTTP/JSON, `POST` to `[address]/v1/trace`. The JSON message format parallels the gRPC protobuf format. For details, refer to its [OpenApi specification](https://github.com/census-instrumentation/opencensus-proto/blob/master/gen-openapi/opencensus/proto/agent/trace/v1/trace_service.swagger.json).
 
-Note that `max_recv_msg_size`, `read_buffer_size` and `write_buffer_size` are formatted in a way so that the units are included 
+Note that `max_recv_msg_size`, `read_buffer_size` and `write_buffer_size` are formatted in a way so that the units are included
 in the string, such as "512KiB" or "1024KB".
 
 ## Blocks
@@ -158,56 +158,56 @@ finally sending it to an OTLP-capable endpoint:
 
 ```river
 otelcol.receiver.opencensus "default" {
-	cors_allowed_origins = ["https://*.test.com", "https://test.com"]
+    cors_allowed_origins = ["https://*.test.com", "https://test.com"]
 
-	endpoint  = "0.0.0.0:9090"
-	transport = "tcp"
+    endpoint  = "0.0.0.0:9090"
+    transport = "tcp"
 
-	max_recv_msg_size      = "32KB"
-	max_concurrent_streams = "16"
-	read_buffer_size       = "1024KB"
-	write_buffer_size      = "1024KB"
-	include_metadata       = true
+    max_recv_msg_size      = "32KB"
+    max_concurrent_streams = "16"
+    read_buffer_size       = "1024KB"
+    write_buffer_size      = "1024KB"
+    include_metadata       = true
 
-	tls {
-		cert_file = "test.crt"
-		key_file  = "test.key"
-	}
+    tls {
+        cert_file = "test.crt"
+        key_file  = "test.key"
+    }
 
-	keepalive {
-		server_parameters {
-			max_connection_idle      = "11s"
-			max_connection_age       = "12s"
-			max_connection_age_grace = "13s"
-			time                     = "30s"
-			timeout                  = "5s"
-		}
+    keepalive {
+        server_parameters {
+            max_connection_idle      = "11s"
+            max_connection_age       = "12s"
+            max_connection_age_grace = "13s"
+            time                     = "30s"
+            timeout                  = "5s"
+        }
 
-		enforcement_policy {
-			min_time              = "10s"
-			permit_without_stream = true
-		}
-	}
+        enforcement_policy {
+            min_time              = "10s"
+            permit_without_stream = true
+        }
+    }
 
-	output {
-		metrics = [otelcol.processor.batch.default.input]
-		logs    = [otelcol.processor.batch.default.input]
-		traces  = [otelcol.processor.batch.default.input]
-	}
+    output {
+        metrics = [otelcol.processor.batch.default.input]
+        logs    = [otelcol.processor.batch.default.input]
+        traces  = [otelcol.processor.batch.default.input]
+    }
 }
 
 otelcol.processor.batch "default" {
-	output {
-		metrics = [otelcol.exporter.otlp.default.input]
-		logs    = [otelcol.exporter.otlp.default.input]
-		traces  = [otelcol.exporter.otlp.default.input]
-	}
+    output {
+        metrics = [otelcol.exporter.otlp.default.input]
+        logs    = [otelcol.exporter.otlp.default.input]
+        traces  = [otelcol.exporter.otlp.default.input]
+    }
 }
 
 otelcol.exporter.otlp "default" {
-	client {
-		endpoint = env("OTLP_ENDPOINT")
-	}
+    client {
+        endpoint = env("OTLP_ENDPOINT")
+    }
 }
 ```
 <!-- START GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/release-notes.md
+++ b/docs/sources/flow/release-notes.md
@@ -29,6 +29,13 @@ Other release notes for the different {{< param "PRODUCT_ROOT_NAME" >}} variants
 [release-notes-operator]: {{< relref "../operator/release-notes.md" >}}
 {{< /admonition >}}
 
+## v0.41
+
+### Breaking change: default `otelcol.receiver.opencensus` list port changed
+
+The default listen port for `otelcol.receiver.opencensus` has changed from 4317 to 55678 to align with the upstream defaults.
+To retain the previous listen port, explicitly set the `endpoint` argument to `0.0.0.0:4317` before upgrading.
+
 ## v0.40
 
 ### Breaking change: Prohibit the configuration of services within modules.
@@ -51,13 +58,13 @@ The new name reflects the component's true purpose as an exporter of the process
 ### Breaking change: `otelcol.receiver.prometheus` will drop all `otel_scope_info` metrics when converting them to OTLP
 
 * If the `otel_scope_info` metric has the `otel_scope_name` and `otel_scope_version` labels,
-  their values are used to set the OTLP Instrumentation Scope name and  version, respectively. 
-* Labels for `otel_scope_info` metrics other than `otel_scope_name` and `otel_scope_version` 
+  their values are used to set the OTLP Instrumentation Scope name and  version, respectively.
+* Labels for `otel_scope_info` metrics other than `otel_scope_name` and `otel_scope_version`
   are added as scope attributes with the matching name and version.
 
 ### Breaking change: label for `target` block in `prometheus.exporter.blackbox` is removed
 
-Previously in `prometheus.exporter.blackbox`, the `target` block requires a label which is used in job's name. 
+Previously in `prometheus.exporter.blackbox`, the `target` block requires a label which is used in job's name.
 In this version, user needs to be specify `name` attribute instead, which allow less restrictive naming.
 
 Old configuration example:

--- a/internal/component/otelcol/receiver/opencensus/opencensus.go
+++ b/internal/component/otelcol/receiver/opencensus/opencensus.go
@@ -43,7 +43,7 @@ var _ receiver.Arguments = Arguments{}
 // Default server settings.
 var DefaultArguments = Arguments{
 	GRPC: otelcol.GRPCServerArguments{
-		Endpoint:  "0.0.0.0:4317",
+		Endpoint:  "0.0.0.0:55678",
 		Transport: "tcp",
 
 		ReadBufferSize: 512 * units.Kibibyte,

--- a/internal/converter/internal/otelcolconvert/testdata/opencensus.river
+++ b/internal/converter/internal/otelcolconvert/testdata/opencensus.river
@@ -1,6 +1,4 @@
 otelcol.receiver.opencensus "default" {
-	endpoint = "0.0.0.0:55678"
-
 	output {
 		metrics = [otelcol.exporter.otlp.default.input]
 		traces  = [otelcol.exporter.otlp.default.input]


### PR DESCRIPTION
This commit re-syncs `otelcol.receiver.opencensus` with the upstream defaults, namely changing the default listen port from 4317 to 55678.

This is considered a breaking change; a section has been written in the upgrade guide notifying users to explicitly set the endpoint to the previous port to retain old behavior when upgrading.

Closes #6489.