### PR TITLE
docs: make deprecation of classic modules more clear

### DIFF
--- a/docs/sources/flow/reference/components/module.file.md
+++ b/docs/sources/flow/reference/components/module.file.md
@@ -14,7 +14,8 @@ title: module.file
 # module.file (deprecated)
 
 {{< admonition type="caution" >}}
-Modules were redesigned in v0.40 to simplify concepts. `module.file` has been deprecated as of v0.40 in favor of `import.file`, and will be removed in the following release.
+Starting with release v0.40, `module.string` is deprecated and is replaced by `import.string`.
+`module.string` will be removed in a future release.
 {{< /admonition >}}
 
 {{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT_VERSION>" >}}

--- a/docs/sources/flow/reference/components/module.file.md
+++ b/docs/sources/flow/reference/components/module.file.md
@@ -11,7 +11,11 @@ labels:
 title: module.file
 ---
 
-# module.file
+# module.file (deprecated)
+
+{{< admonition type="caution" >}}
+Modules were redesigned in v0.40 to simplify concepts. `module.file` has been deprecated as of v0.40 in favor of `import.file`, and will be removed in the following release.
+{{< /admonition >}}
 
 {{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT_VERSION>" >}}
 

--- a/docs/sources/flow/reference/components/module.git.md
+++ b/docs/sources/flow/reference/components/module.git.md
@@ -14,7 +14,8 @@ title: module.git
 # module.git (deprecated)
 
 {{< admonition type="caution" >}}
-Modules were redesigned in v0.40 to simplify concepts. `module.git` has been deprecated as of v0.40 in favor of `import.git`, and will be removed in the following release.
+Starting with release v0.40, `module.git` is deprecated and is replaced by `import.git`.
+`module.git` will be removed in a future release.
 {{< /admonition >}}
 
 {{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT_VERSION>" >}}

--- a/docs/sources/flow/reference/components/module.git.md
+++ b/docs/sources/flow/reference/components/module.git.md
@@ -11,7 +11,11 @@ labels:
 title: module.git
 ---
 
-# module.git
+# module.git (deprecated)
+
+{{< admonition type="caution" >}}
+Modules were redesigned in v0.40 to simplify concepts. `module.git` has been deprecated as of v0.40 in favor of `import.git`, and will be removed in the following release.
+{{< /admonition >}}
 
 {{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT_VERSION>" >}}
 

--- a/docs/sources/flow/reference/components/module.http.md
+++ b/docs/sources/flow/reference/components/module.http.md
@@ -11,7 +11,11 @@ labels:
 title: module.http
 ---
 
-# module.http
+# module.http (deprecated)
+
+{{< admonition type="caution" >}}
+Modules were redesigned in v0.40 to simplify concepts. `module.http` has been deprecated as of v0.40 in favor of `import.http`, and will be removed in the following release.
+{{< /admonition >}}
 
 {{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT_VERSION>" >}}
 

--- a/docs/sources/flow/reference/components/module.http.md
+++ b/docs/sources/flow/reference/components/module.http.md
@@ -14,7 +14,8 @@ title: module.http
 # module.http (deprecated)
 
 {{< admonition type="caution" >}}
-Modules were redesigned in v0.40 to simplify concepts. `module.http` has been deprecated as of v0.40 in favor of `import.http`, and will be removed in the following release.
+Starting with release v0.40, `module.http` is deprecated and is replaced by `import.http`.
+`module.http` will be removed in a future release.
 {{< /admonition >}}
 
 {{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT_VERSION>" >}}

--- a/docs/sources/flow/reference/components/module.string.md
+++ b/docs/sources/flow/reference/components/module.string.md
@@ -14,7 +14,8 @@ title: module.string
 # module.string (deprecated)
 
 {{< admonition type="caution" >}}
-Modules were redesigned in v0.40 to simplify concepts. `module.string` has been deprecated as of v0.40 in favor of `import.string`, and will be removed in the following release.
+Starting with release v0.40, `module.string` is deprecated and is replaced by `import.string`.
+`module.string` will be removed in a future release.
 {{< /admonition >}}
 
 {{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT_VERSION>" >}}

--- a/docs/sources/flow/reference/components/module.string.md
+++ b/docs/sources/flow/reference/components/module.string.md
@@ -11,7 +11,11 @@ labels:
 title: module.string
 ---
 
-# module.string
+# module.string (deprecated)
+
+{{< admonition type="caution" >}}
+Modules were redesigned in v0.40 to simplify concepts. `module.string` has been deprecated as of v0.40 in favor of `import.string`, and will be removed in the following release.
+{{< /admonition >}}
 
 {{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT_VERSION>" >}}
 

--- a/docs/sources/flow/release-notes.md
+++ b/docs/sources/flow/release-notes.md
@@ -36,6 +36,10 @@ Other release notes for the different {{< param "PRODUCT_ROOT_NAME" >}} variants
 The default listen port for `otelcol.receiver.opencensus` has changed from 4317 to 55678 to align with the upstream defaults.
 To retain the previous listen port, explicitly set the `endpoint` argument to `0.0.0.0:4317` before upgrading.
 
+### Breaking change: classic modules have been removed
+
+Classic modules (the `module.git`, `module.file`, `module.http`, and `module.string` components) were initially deprecated in v0.40 in favor of the `import` and `declare` configuration blocks, and have been removed as of this release.
+
 ## v0.40
 
 ### Breaking change: Prohibit the configuration of services within modules.
@@ -52,6 +56,12 @@ If you need to see high cardinality metrics containing labels such as IP address
 
 The name `prometheus.exporter.agent` is potentially ambiguous and can be misinterpreted as an exporter for Prometheus Agent.
 The new name reflects the component's true purpose as an exporter of the process's own metrics.
+
+### Deprecation: classic modules have been deprecated and will be removed in the next release
+
+Classic modules (the `module.git`, `module.file`, `module.http`, and `module.string` components) have been deprecated in favor of the new `import` and `declare` configuration blocks.
+
+Support for classic modules will be removed in the next release.
 
 ## v0.39
 


### PR DESCRIPTION
The deprecation status of classic modules was constrained to the concept page of modules. This commit adds the deprecation notice to each component reference page and mentions it in the release notes.