### PR TITLE
[release-v0.40] Backport #6709 to release-v0.40

### DIFF
--- a/docs/sources/flow/reference/components/module.file.md
+++ b/docs/sources/flow/reference/components/module.file.md
@@ -11,7 +11,12 @@ labels:
 title: module.file
 ---
 
-# module.file
+# module.file (deprecated)
+
+{{< admonition type="caution" >}}
+Starting with release v0.40, `module.string` is deprecated and is replaced by `import.string`.
+`module.string` will be removed in a future release.
+{{< /admonition >}}
 
 {{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT_VERSION>" >}}
 

--- a/docs/sources/flow/reference/components/module.git.md
+++ b/docs/sources/flow/reference/components/module.git.md
@@ -11,7 +11,12 @@ labels:
 title: module.git
 ---
 
-# module.git
+# module.git (deprecated)
+
+{{< admonition type="caution" >}}
+Starting with release v0.40, `module.git` is deprecated and is replaced by `import.git`.
+`module.git` will be removed in a future release.
+{{< /admonition >}}
 
 {{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT_VERSION>" >}}
 

--- a/docs/sources/flow/reference/components/module.http.md
+++ b/docs/sources/flow/reference/components/module.http.md
@@ -11,7 +11,12 @@ labels:
 title: module.http
 ---
 
-# module.http
+# module.http (deprecated)
+
+{{< admonition type="caution" >}}
+Starting with release v0.40, `module.http` is deprecated and is replaced by `import.http`.
+`module.http` will be removed in a future release.
+{{< /admonition >}}
 
 {{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT_VERSION>" >}}
 

--- a/docs/sources/flow/reference/components/module.string.md
+++ b/docs/sources/flow/reference/components/module.string.md
@@ -11,7 +11,12 @@ labels:
 title: module.string
 ---
 
-# module.string
+# module.string (deprecated)
+
+{{< admonition type="caution" >}}
+Starting with release v0.40, `module.string` is deprecated and is replaced by `import.string`.
+`module.string` will be removed in a future release.
+{{< /admonition >}}
 
 {{< docs/shared lookup="flow/stability/beta.md" source="agent" version="<AGENT_VERSION>" >}}
 

--- a/docs/sources/flow/release-notes.md
+++ b/docs/sources/flow/release-notes.md
@@ -46,18 +46,24 @@ If you need to see high cardinality metrics containing labels such as IP address
 The name `prometheus.exporter.agent` is potentially ambiguous and can be misinterpreted as an exporter for Prometheus Agent.
 The new name reflects the component's true purpose as an exporter of the process's own metrics.
 
+### Deprecation: classic modules have been deprecated and will be removed in the next release
+
+Classic modules (the `module.git`, `module.file`, `module.http`, and `module.string` components) have been deprecated in favor of the new `import` and `declare` configuration blocks.
+
+Support for classic modules will be removed in the next release.
+
 ## v0.39
 
 ### Breaking change: `otelcol.receiver.prometheus` will drop all `otel_scope_info` metrics when converting them to OTLP
 
 * If the `otel_scope_info` metric has the `otel_scope_name` and `otel_scope_version` labels,
-  their values are used to set the OTLP Instrumentation Scope name and  version, respectively. 
-* Labels for `otel_scope_info` metrics other than `otel_scope_name` and `otel_scope_version` 
+  their values are used to set the OTLP Instrumentation Scope name and  version, respectively.
+* Labels for `otel_scope_info` metrics other than `otel_scope_name` and `otel_scope_version`
   are added as scope attributes with the matching name and version.
 
 ### Breaking change: label for `target` block in `prometheus.exporter.blackbox` is removed
 
-Previously in `prometheus.exporter.blackbox`, the `target` block requires a label which is used in job's name. 
+Previously in `prometheus.exporter.blackbox`, the `target` block requires a label which is used in job's name.
 In this version, user needs to be specify `name` attribute instead, which allow less restrictive naming.
 
 Old configuration example:


### PR DESCRIPTION
The deprecation status of classic modules was constrained to the concept page of modules. This commit adds the deprecation notice to each component reference page and mentions it in the release notes.

Co-authored-by: Clayton Cornell <131809008+clayton-cornell@users.noreply.github.com>
(cherry picked from commit 9d65d9f483ea2690f34681431dd32b6356a6026f)