### PR TITLE
Tweak clustering alerts in the mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Main (unreleased)
 - Improve converter diagnostic output by including a Footer and removing lower
   level diagnostics when a configuration fails to generate. (@erikbaranowski)
 
+- Increased the alert interval and renamed the `ClusterSplitBrain` alert to `ClusterNodeCountMismatch` in the Grafana
+  Agent Mixin to better match the alert conditions. (@thampiotr)
+
 ### Features
 
 - Added a new CLI flag `--stability.level` which defines the minimum stability

--- a/docs/sources/flow/tasks/debug.md
+++ b/docs/sources/flow/tasks/debug.md
@@ -113,6 +113,12 @@ To debug issues when using [clustering][], check for the following symptoms.
 - **Node stuck in terminating state**: The node attempted to gracefully shut down and set its state to Terminating, but it has not completely gone away.
   Check the clustering page to view the state of the peers and verify that the terminating {{< param "PRODUCT_ROOT_NAME" >}} has been shut down.
 
+{{< admonition type="note" >}}
+Some issues that appear to be clustering issues may be symptoms of other issues,
+for example, problems with scraping or service discovery can result in missing
+metrics for an agent that can be interpreted as a node not joining the cluster.
+{{< /admonition >}}
+
 {{% docs/reference %}}
 [logging]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/config-blocks/logging.md"
 [logging]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/logging.md"

--- a/operations/agent-flow-mixin/alerts/clustering.libsonnet
+++ b/operations/agent-flow-mixin/alerts/clustering.libsonnet
@@ -7,23 +7,22 @@ alert.newGroup(
     alert.newRule(
       'ClusterNotConverging',
       'stddev by (cluster, namespace) (sum without (state) (cluster_node_peers)) != 0',
-      'Cluster is not converging.',
+      'Cluster is not converging: nodes report different number of peers in the cluster.',
       '10m',
     ),
 
-    // Cluster has entered a split brain state.
     alert.newRule(
-      'ClusterSplitBrain',
-      // Assert that the set of known peers (regardless of state) for an
-      // agent matches the same number of running agents in the same cluster
-      // and namespace.
+      'ClusterNodeCountMismatch',
+      // Assert that the number of known peers (regardless of state) reported by each
+      // agent matches the number of running agents in the same cluster
+      // and namespace as reported by a count of Prometheus metrics.
       |||
         sum without (state) (cluster_node_peers) !=
         on (cluster, namespace) group_left
         count by (cluster, namespace) (cluster_node_info)
       |||,
-      'Cluster nodes have entered a split brain state.',
-      '10m',
+      'Nodes report different number of peers vs. the count of observed agent metrics. Some agent metrics may be missing or the cluster is in a split brain state.',
+      '15m',
     ),
 
     // Nodes health score is not zero.
@@ -32,7 +31,7 @@ alert.newGroup(
       |||
         cluster_node_gossip_health_score > 0
       |||,
-      'Cluster node is reporting a health score > 0.',
+      'Cluster node is reporting a gossip protocol health score > 0.',
       '10m',
     ),
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

- Rename the ClusterSplitBrain alert to a more descriptive name and improve its description
- Increase the time interval for this alert - to reduce noise during rollouts on large clusters
- Add a short note to docs about the possibility of metrics gaps appearing to look like clustering alerts

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

Fixes #4991 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
