### PR TITLE
azure_exporter: Fix bug which prevents subscription scope from working with only a single region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Main (unreleased)
 ### Bugfixes
 
 - Fix an issue where JSON string array elements were not parsed correctly in `loki.source.cloudflare`. (@thampiotr)
+- Fix an issue where the azure exporter was not correctly gathering subscription scoped metrics when only one region was configured (@kgeckhart)
 
 - Update gcp_exporter to a newer version with a patch for incorrect delta histograms (@kgeckhart)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Main (unreleased)
 ### Bugfixes
 
 - Fix an issue where JSON string array elements were not parsed correctly in `loki.source.cloudflare`. (@thampiotr)
+
 - Fix an issue where the azure exporter was not correctly gathering subscription scoped metrics when only one region was configured (@kgeckhart)
 
 - Update gcp_exporter to a newer version with a patch for incorrect delta histograms (@kgeckhart)

--- a/internal/static/integrations/azure_exporter/azure_exporter.go
+++ b/internal/static/integrations/azure_exporter/azure_exporter.go
@@ -81,7 +81,7 @@ func (e Exporter) MetricsHandler() (http.Handler, error) {
 		//  "RunOnSubscriptionScope" uses a different API, https://github.com/Azure/azure-rest-api-specs/blob/main/specification/monitor/resource-manager/Microsoft.Insights/stable/2021-05-01/metrics_API.json#L40,
 		//  which can get metric data for all resources in a single API call reducing overhead/likelihood of being rate limited.
 		// Limiting to specific resources requires 1 API call per resource to get metrics which can easily lead to rate limiting
-		if len(settings.Regions) > 1 {
+		if len(settings.Regions) > 0 {
 			prober.RunOnSubscriptionScope()
 		} else {
 			err = prober.ServiceDiscovery.FindResourceGraph(ctx, settings.Subscriptions, settings.ResourceType, settings.Filter)


### PR DESCRIPTION
#### PR Description

Fix logic bug preventing subscription scoped requests from working. Subscription scoped requests take far fewer API calls so are much more valuable for preventing rate limiting.

#### Which issue(s) this PR fixes

None, noticed this bug while tracking down what was going on in, https://github.com/grafana/agent/issues/6637

#### PR Checklist

- [x] CHANGELOG.md updated