### PR TITLE
add announcement that prometheus.exporter.vsphere was deprecated in v0.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,9 @@ v0.40.0 (2024-02-27)
 
 ### Deprecations
 
-- Module components have been deprecated in favor of import and declare configuration blocks. These deprecated components will be removed in the next release. (@wildum)
+- Module components have been deprecated in favor of import and declare configuration blocks. These deprecated components will be removed in a future release. (@wildum)
+
+- `prometheus.exporter.vsphere` has been deprecated in favor of `otelcol.receiver.vcenter`. This deprecated component will be removed in a future release. (@rfratto)
 
 ### Features
 

--- a/docs/sources/flow/reference/components/prometheus.exporter.vsphere.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.vsphere.md
@@ -9,14 +9,18 @@ title: prometheus.exporter.vsphere
 description: Learn about prometheus.exporter.vsphere
 ---
 
-# prometheus.exporter.vsphere
+# prometheus.exporter.vsphere (deprecated)
 
-The `prometheus.exporter.vsphere` component embeds [`vmware_exporter`](https://github.com/grafana/vmware_exporter) to collect vSphere metrics
+{{< admonition type="caution" >}}
+Starting with release v0.40, `prometheus.exporter.vsphere` is deprecated. Consider using `otelcol.receiver.vcenter` instead.
+`prometheus.exporter.vsphere` will be removed in a future release.
+{{< /admonition >}}
+
+The `prometheus.exporter.vsphere` component embeds [`vmware_exporter`](https://github.com/grafana/vmware_exporter) to collect vSphere metrics.
 
 > **NOTE**: We recommend to use [otelcol.receiver.vcenter][] instead.
 
 [otelcol.receiver.vcenter]: {{< relref "./otelcol.receiver.vcenter.md" >}}
-
 
 ## Usage
 

--- a/docs/sources/flow/release-notes.md
+++ b/docs/sources/flow/release-notes.md
@@ -36,10 +36,6 @@ Other release notes for the different {{< param "PRODUCT_ROOT_NAME" >}} variants
 The default listen port for `otelcol.receiver.opencensus` has changed from 4317 to 55678 to align with the upstream defaults.
 To retain the previous listen port, explicitly set the `endpoint` argument to `0.0.0.0:4317` before upgrading.
 
-### Breaking change: classic modules have been removed
-
-Classic modules (the `module.git`, `module.file`, `module.http`, and `module.string` components) were initially deprecated in v0.40 in favor of the `import` and `declare` configuration blocks, and have been removed as of this release.
-
 ## v0.40
 
 ### Breaking change: Prohibit the configuration of services within modules.
@@ -57,11 +53,17 @@ If you need to see high cardinality metrics containing labels such as IP address
 The name `prometheus.exporter.agent` is potentially ambiguous and can be misinterpreted as an exporter for Prometheus Agent.
 The new name reflects the component's true purpose as an exporter of the process's own metrics.
 
-### Deprecation: classic modules have been deprecated and will be removed in the next release
+### Deprecation: classic modules have been deprecated and will be removed in a future release
 
 Classic modules (the `module.git`, `module.file`, `module.http`, and `module.string` components) have been deprecated in favor of the new `import` and `declare` configuration blocks.
 
-Support for classic modules will be removed in the next release.
+Support for classic modules will be removed in a future release.
+
+### Deprecation: `prometheus.exporter.vsphere` is deprecated and will be removed in a future release
+
+The `prometheus.exporter.vsphere` component has been deprecated in favor of `otelcol.receiver.vcenter`.
+
+Support for `prometheus.exporter.vsphere` will be removed in a future release.
 
 ## v0.39
 


### PR DESCRIPTION
The intent was the prometheus.exporter.vsphere was deprecated in v0.40, but this was mistakenly omitted from the release. This commit adds the deprecation notice.

Note that while the replacement component, otelcol.receiver.vcenter, is still marked as experimental, it wasn't intentional that prometheus.exporter.vsphere received the "stable" label, and it should have similarly been marked experimental. 