### PR TITLE
Remove `ci` directory from packaged chart

### DIFF
--- a/operations/helm/charts/grafana-agent/.helmignore
+++ b/operations/helm/charts/grafana-agent/.helmignore
@@ -27,3 +27,4 @@ README.md.gotmpl
 
 # Don't packages the tests used for CI.
 /tests/
+/ci/

--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -7,6 +7,11 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
+Unreleased
+----------
+
+- Remove `ci` directory from packaged chart. (@aerfio)
+
 0.37.0 (2024-03-14)
 ----------
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Removes useless `ci` directory used for chart tests from the packaged chart

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated