### PR TITLE
docs: exempt converters from backwards compatibility guarantees

### DIFF
--- a/docs/rfcs/0008-backwards-compatibility.md
+++ b/docs/rfcs/0008-backwards-compatibility.md
@@ -63,6 +63,8 @@ It's impossible to guarantee that full backwards compatibility is achieved. Ther
 
 - Other telemetry data: metrics, logs, and traces may change between releases. Only telemetry data which is used in official dashboards is protected under backwards compatibility.
 
+- Tagged as exempt: functionality which is explicitly marked as exempt from backwards compatibility guarantees may include breaking changes or removal between minor releases.
+
 ### Avoiding major release burnout 
 
 As a new major release implies a user must put extra effort into upgrading, it is possible to burn out users by releasing breaking changes too frequently. 

--- a/docs/sources/flow/reference/cli/convert.md
+++ b/docs/sources/flow/reference/cli/convert.md
@@ -17,6 +17,10 @@ weight: 100
 
 The `convert` command converts a supported configuration format to {{< param "PRODUCT_NAME" >}} River format.
 
+{{< admonition type="caution" >}}
+This command has no backward compatibility guarantees and may change or be removed between releases.
+{{< /admonition >}}
+
 ## Usage
 
 Usage:


### PR DESCRIPTION
Converter code is not cheap to maintain, and in some cases can bring in many dependencies that are otherwise unused, making project maintainance more difficult.

This change explicitly marks converter code as exempt from backwards compatibility guarntees, allowing its removal between minor versions if a converter is no longer needed and maintainers don't want to wait for the next major release to remove it.

The RFC for backwards compatibility guarantees is also updated to make it clear that some functionality may opt out of backwards compatibility guarantees, which includes the `convert` and `tools` commands.