### PR TITLE
add FreeBSD/arm64 to packaging targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ Main (unreleased)
 
 - Add ability to convert static mode positions file to `loki.source.file` compatible via `legacy_positions_file` argument. (@mattdurham)
 
+- Add support for FreeBSD/arm64. (@evgeni)
+
 - Added support for `otelcol` configuration conversion in `grafana-agent convert` and `grafana-agent run` commands. (@rfratto, @erikbaranowski, @tpaschalis, @hainenber)
 
 - Added support for `static` configuration conversion of the `traces` subsystem. (@erikbaranowski, @wildum)

--- a/tools/make/packaging.mk
+++ b/tools/make/packaging.mk
@@ -29,6 +29,7 @@ dist-agent-binaries: dist/grafana-agent-linux-amd64                    \
                      dist/grafana-agent-windows-amd64.exe              \
                      dist/grafana-agent-windows-boringcrypto-amd64.exe \
                      dist/grafana-agent-freebsd-amd64                  \
+                     dist/grafana-agent-freebsd-arm64                  \
                      dist/grafana-agent-linux-arm64-boringcrypto
 
 dist/grafana-agent-linux-amd64: GO_TAGS += netgo builtinassets promtail_journal_enabled
@@ -97,6 +98,13 @@ dist/grafana-agent-freebsd-amd64: generate-ui
 	$(PACKAGING_VARS) AGENT_BINARY=$@ "$(MAKE)" -f $(PARENT_MAKEFILE) agent
 
 
+dist/grafana-agent-freebsd-arm64: GO_TAGS += netgo builtinassets
+dist/grafana-agent-freebsd-arm64: GOOS    := freebsd
+dist/grafana-agent-freebsd-arm64: GOARCH  := arm64
+dist/grafana-agent-freebsd-arm64: generate-ui
+	$(PACKAGING_VARS) AGENT_BINARY=$@ "$(MAKE)" -f $(PARENT_MAKEFILE) agent
+
+
 dist/grafana-agent-linux-amd64-boringcrypto: GO_TAGS      += netgo builtinassets promtail_journal_enabled
 dist/grafana-agent-linux-amd64-boringcrypto: GOOS         := linux
 dist/grafana-agent-linux-amd64-boringcrypto: GOARCH       := amd64
@@ -122,7 +130,8 @@ dist-agentctl-binaries: dist/grafana-agentctl-linux-amd64       \
                         dist/grafana-agentctl-darwin-amd64      \
                         dist/grafana-agentctl-darwin-arm64      \
                         dist/grafana-agentctl-windows-amd64.exe \
-                        dist/grafana-agentctl-freebsd-amd64
+                        dist/grafana-agentctl-freebsd-amd64     \
+                        dist/grafana-agentctl-freebsd-arm64
 
 dist/grafana-agentctl-linux-amd64: GO_TAGS += netgo promtail_journal_enabled
 dist/grafana-agentctl-linux-amd64: GOOS    := linux
@@ -169,6 +178,12 @@ dist/grafana-agentctl-freebsd-amd64: GO_TAGS += netgo
 dist/grafana-agentctl-freebsd-amd64: GOOS    := freebsd
 dist/grafana-agentctl-freebsd-amd64: GOARCH  := amd64
 dist/grafana-agentctl-freebsd-amd64:
+	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ "$(MAKE)" -f $(PARENT_MAKEFILE) agentctl
+
+dist/grafana-agentctl-freebsd-arm64: GO_TAGS += netgo
+dist/grafana-agentctl-freebsd-arm64: GOOS    := freebsd
+dist/grafana-agentctl-freebsd-arm64: GOARCH  := arm64
+dist/grafana-agentctl-freebsd-arm64:
 	$(PACKAGING_VARS) AGENTCTL_BINARY=$@ "$(MAKE)" -f $(PARENT_MAKEFILE) agentctl
 
 #


### PR DESCRIPTION
#### PR Description

Add FreeBSD/arm64 to packaging targets

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

It builds fine on my 14.0-RELEASE system:
```
freebsd@generic:~/agent % ./dist/grafana-agent-freebsd-arm64 --version
agent, version freebsd-arm64-396c6ad-WIP (branch: freebsd-arm64, revision: 396c6ad08)
  build user:       freebsd@generic
  build date:       2024-03-22T10:13:27Z
  go version:       go1.22.0
  platform:         freebsd/arm64
  tags:             netgo,builtinassets
```

But I couldn't manage to cross-compile it from amd64. Are the drone builders you use native arm64? Or do they cross-compile?

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
