### PR TITLE
introduce an otelcol.exporter.kafka component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ Main (unreleased)
 
 - A new `loki.rules.kubernetes` component that discovers `PrometheusRule` Kubernetes resources and loads them into a Loki Ruler instance. (@EStork09)
 
+- A new `otelcol.exporter.kafka` component that can forward OTLP data to one or
+  more Kafka instances. (@tpaschalis)
+
 ### Bugfixes
 
 - Fix an issue where JSON string array elements were not parsed correctly in `loki.source.cloudflare`. (@thampiotr)

--- a/docs/sources/flow/reference/compatibility/_index.md
+++ b/docs/sources/flow/reference/compatibility/_index.md
@@ -287,6 +287,7 @@ The following components, grouped by namespace, _export_ OpenTelemetry `otelcol.
 - [otelcol.connector.servicegraph](../components/otelcol.connector.servicegraph)
 - [otelcol.connector.spanlogs](../components/otelcol.connector.spanlogs)
 - [otelcol.connector.spanmetrics](../components/otelcol.connector.spanmetrics)
+- [otelcol.exporter.kafka](../components/otelcol.exporter.kafka)
 - [otelcol.exporter.loadbalancing](../components/otelcol.exporter.loadbalancing)
 - [otelcol.exporter.logging](../components/otelcol.exporter.logging)
 - [otelcol.exporter.loki](../components/otelcol.exporter.loki)

--- a/docs/sources/flow/reference/components/otelcol.exporter.kafka.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.kafka.md
@@ -1,0 +1,315 @@
+---
+canonical: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.kafka/
+description: Learn about otelcol.exporter.kafka
+title: otelcol.exporter.kafka
+---
+
+# otelcol.exporter.kafka
+
+`otelcol.exporter.kafka` accepts telemetry data from other `otelcol` components
+and writes them over to a Kafka topic.
+
+> **NOTE**: `otelcol.exporter.kafka` is a wrapper over the upstream
+> OpenTelemetry Collector `kafka` exporter. Bug reports or feature requests will
+> be redirected to the upstream repository, if necessary.
+
+This component uses a synchronous producer that blocks and does not batch
+messages, therefore it should be used with batch and queued retry processors
+prepended to it, for higher throughput and resiliency.
+
+Multiple `otelcol.exporter.kafka` components can be specified by giving them
+different labels.
+
+## Usage
+
+```river
+otelcol.exporter.kafka "LABEL" {
+  protocol_version = "2.0.0"
+}
+```
+
+## Arguments
+
+`otelcol.exporter.kafka` supports the following arguments:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`protocol_version` | `duration` | Kafka protocol version to use. | | yes
+`brokers` | list(string) | Kafka brokers to connect to. | `["localhost:9092"]` | no
+`client_id` | string | The client ID to configure the Sarama Kafka client with for all produce requests. | `"sarama"` | no
+`topic` | string | The name of the Kafka topic to export to. | see below | no
+`encoding` | string | The encoding of data sent to Kafka. | see below | no
+`timeout`  | duration | The timeout to use for sending data. | `"5s"` | no
+`partition_traces_by_id` | bool | Whether to include trace IDs as the message key in messages sent to Kafka. | false | no
+`resolve_canonical_bootstrap_servers_only` | bool | Whether to resolve then reverse-lookup broker IPs during startup. | false | no
+
+The `encoding` argument determines how to export messages to Kafka.
+`encoding` must be one of the following strings:
+
+* `"otlp_proto"`: Encode messages as OTLP protobuf.
+* `"otlp_json"`: Encode messages as OTLP JSON.
+* `"jaeger_proto"`: Encode messages as a single Jaeger protobuf span.
+* `"jaeger_json"`: Encode messages as a single Jaeger JSON span.
+* `"zipkin_proto"`: Encode messages as a list of Zipkin protobuf spans.
+* `"zipkin_json"`: Encode messages as a list of Zipkin JSON spans.
+* `"raw"`: Copy the log message bytes into the body of a log record.
+
+`"otlp_proto"` or `"otlp_json"` must be used to send all telemetry types to
+Kafka; other encodings are signal-specific.
+
+## Blocks
+
+The following blocks are supported inside the definition of
+`otelcol.exporter.otlp`:
+
+Hierarchy | Block | Description | Required
+--------- | ----- | ----------- | --------
+authentication | [authentication][] | Configures authentication for connecting to Kafka brokers. | no
+authentication > plaintext | [plaintext][] | Authenticates against Kafka brokers with plaintext. | no
+authentication > sasl | [sasl][] | Authenticates against Kafka brokers with SASL. | no
+authentication > tls | [tls][] | Configures TLS for connecting to the Kafka brokers. | no
+authentication > kerberos | [kerberos][] | Authenticates against Kafka brokers with Kerberos. | no
+metadata | [metadata][] | Configures how to retrieve metadata from Kafka brokers. | no
+metadata > retry | [retry][] | Configures how to retry metadata retrieval. | no
+sending_queue | [sending_queue][] | Configures batching of data before sending. | no
+retry_on_failure | [retry_on_failure][] | Configures retry mechanism for failed requests. | no
+debug_metrics | [debug_metrics][] | Configures the metrics that this component generates to monitor its state. | no
+
+The `>` symbol indicates deeper levels of nesting. For example, `client > tls`
+refers to a `tls` block defined inside a `client` block.
+
+[authentication]: #authentication-block
+[plaintext]: #plaintext-block
+[sasl]: #sasl-block
+[tls]: #tls-block
+[kerberos]: #kerberos-block
+[metadata]: #metadata-block
+[sending_queue]: #sending_queue-block
+[retry_on_failure]: #retry_on_failure-block
+[debug_metrics]: #debug_metrics-block
+
+### authentication block
+
+The `authentication` block holds the definition of different authentication
+mechanisms to use when connecting to Kafka brokers. It doesn't support any
+arguments and is configured fully through inner blocks.
+
+### plaintext block
+
+The `plaintext` block configures `PLAIN` authentication against Kafka brokers.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`username` | `string` | Username to use for `PLAIN` authentication. | | yes
+`password` | `secret` | Password to use for `PLAIN` authentication. | | yes
+
+### sasl block
+
+The `sasl` block configures SASL authentication against Kafka brokers.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`username` | `string` | Username to use for SASL authentication. | | yes
+`password` | `secret` | Password to use for SASL authentication. | | yes
+`mechanism` | `string` | SASL mechanism to use when authenticating. | | yes
+`version` | `number` | Version of the SASL Protocol to use when authenticating. | `0` | no
+
+The `mechanism` argument can be set to one of the following strings:
+
+* `"PLAIN"`
+* `"AWS_MSK_IAM"`
+* `"SCRAM-SHA-256"`
+* `"SCRAM-SHA-512"`
+
+When `mechanism` is set to `"AWS_MSK_IAM"`, the [`aws_msk` child block][aws_msk] must also be provided.
+
+The `version` argument can be set to either `0` or `1`.
+
+### tls block
+
+The `tls` block configures TLS settings used for connecting to the Kafka
+brokers. If the `tls` block isn't provided, TLS won't be used for
+communication.
+
+{{< docs/shared lookup="flow/reference/components/otelcol-tls-config-block.md" source="agent" version="<AGENT_VERSION>" >}}
+
+### kerberos block
+
+The `kerberos` block configures Kerberos authentication against the Kafka
+broker.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`service_name` | `string` | Kerberos service name. | | no
+`realm` | `string` | Kerberos realm. | | no
+`use_keytab` | `string` | Enables using keytab instead of password. | | no
+`username` | `string` | Kerberos username to authenticate as. | | yes
+`password` | `secret` | Kerberos password to authenticate with. | | no
+`config_file` | `string` | Path to Kerberos location (for example, `/etc/krb5.conf`). | | no
+`keytab_file` | `string` | Path to keytab file (for example, `/etc/security/kafka.keytab`). | | no
+
+When `use_keytab` is `false`, the `password` argument is required. When
+`use_keytab` is `true`, the file pointed to by the `keytab_file` argument is
+used for authentication instead. At most one of `password` or `keytab_file`
+must be provided.
+
+### metadata block
+
+The `metadata` block configures how to retrieve and store metadata from the
+Kafka broker.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`include_all_topics` | `bool` | When true, maintains metadata for all topics. | `true` | no
+
+If the `include_all_topics` argument is `true`, `otelcol.receiver.kafka`
+maintains a full set of metadata for all topics rather than the minimal set
+that has been necessary so far. Including the full set of metadata is more
+convenient for users but can consume a substantial amount of memory if you have
+many topics and partitions.
+
+Retrieving metadata may fail if the Kafka broker is starting up at the same
+time as the `otelcol.receiver.kafka` component. The [`retry` child
+block][retry] can be provided to customize retry behavior.
+
+### retry block
+
+The `retry` block configures how to retry retrieving metadata when retrieval
+fails.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`max_retries` | `number` | How many times to reattempt retrieving metadata. | `3` | no
+`backoff` | `duration` | Time to wait between retries. | `"250ms"` | no
+
+### sending_queue block
+
+The `sending_queue` block configures an in-memory buffer of batches before data is sent
+to the gRPC server.
+
+{{< docs/shared lookup="flow/reference/components/otelcol-queue-block.md" source="agent" version="<AGENT_VERSION>" >}}
+
+### retry_on_failure block
+
+The `retry_on_failure` block configures how failed requests to the gRPC server are
+retried.
+
+{{< docs/shared lookup="flow/reference/components/otelcol-retry-block.md" source="agent" version="<AGENT_VERSION>" >}}
+
+### debug_metrics block
+
+{{< docs/shared lookup="flow/reference/components/otelcol-debug-metrics-block.md" source="agent" version="<AGENT_VERSION>" >}}
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+Name | Type | Description
+---- | ---- | -----------
+`input` | `otelcol.Consumer` | A value that other components can use to send telemetry data to.
+
+`input` accepts `otelcol.Consumer` data for any telemetry signal (metrics,
+logs, or traces).
+
+## Component health
+
+`otelcol.exporter.kafka` is only reported as unhealthy if given an invalid
+configuration.
+
+## Debug information
+
+`otelcol.exporter.kafka` does not expose any component-specific debug
+information.
+
+## Debug metrics
+
+* `exporter_sent_spans_ratio_total` (counter): Number of spans successfully sent to destination.
+* `exporter_send_failed_spans_ratio_total` (counter): Number of spans in failed attempts to send to destination.
+* `exporter_queue_capacity_ratio` (gauge): Fixed capacity of the retry queue (in batches)
+* `exporter_queue_size_ratio` (gauge): Current size of the retry queue (in batches)
+* `rpc_client_duration_milliseconds` (histogram): Measures the duration of inbound RPC.
+* `rpc_client_request_size_bytes` (histogram): Measures size of RPC request messages (uncompressed).
+* `rpc_client_requests_per_rpc` (histogram): Measures the number of messages received per RPC. Should be 1 for all non-streaming RPCs.
+* `rpc_client_response_size_bytes` (histogram): Measures size of RPC response messages (uncompressed).
+* `rpc_client_responses_per_rpc` (histogram): Measures the number of messages received per RPC. Should be 1 for all non-streaming RPCs.
+
+## Examples
+
+The following examples show you how to create an exporter to send data to different destinations.
+
+### Send data to a local Kafka instance
+
+You can create an exporter that sends your data to a local Kafka instance with no authentication:
+
+```river
+otelcol.exporter.kafka "default" {
+  protocol_version = "2.0.0"
+  brokers          = ["localhost:9092"]
+}
+```
+
+### Batch OTLP data and send to a Kafka instance.
+
+You can create forwards received telemetry data through a batch processor
+before finally exporting it to a remote Kafka instance.
+
+```river
+otelcol.receiver.otlp "default" {
+  http {}
+  grpc {}
+
+  output {
+    metrics = [otelcol.processor.batch.default.input]
+    logs    = [otelcol.processor.batch.default.input]
+    traces  = [otelcol.processor.batch.default.input]
+  }
+}
+
+otelcol.processor.batch "default" {
+  output {
+    metrics = [otelcol.exporter.kafka.default.input]
+    logs    = [otelcol.exporter.kafka.default.input]
+    traces  = [otelcol.exporter.kafka.default.input]
+  }
+}
+
+otelcol.exporter.kafka "default" {
+  protocol_version = "2.0.0"
+  brokers = [
+    "test1.foo.bar.kafka.us-east-1.amazonaws.com:9094",
+    "test2.foo.bar.kafka.us-east-1.amazonaws.com:9094",
+  ]
+
+  authentication {
+    plaintext {
+      username = env("KAFKA_USERNAME")
+      password = env("KAFKA_PASSWORD")
+    }
+  }
+}
+```
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.exporter.kafka` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`](../../compatibility/#opentelemetry-otelcolconsumer-consumers)
+
+{{< admonition type="note" >}}
+Connecting some components may not be sensible or components may require further configuration to make the connection work correctly.
+Refer to the linked documentation for more details.
+{{< /admonition >}}
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/flow/reference/components/otelcol.exporter.kafka.md
+++ b/docs/sources/flow/reference/components/otelcol.exporter.kafka.md
@@ -67,6 +67,7 @@ Hierarchy | Block | Description | Required
 authentication | [authentication][] | Configures authentication for connecting to Kafka brokers. | no
 authentication > plaintext | [plaintext][] | Authenticates against Kafka brokers with plaintext. | no
 authentication > sasl | [sasl][] | Authenticates against Kafka brokers with SASL. | no
+authentication > sasl > aws_msk | [aws_msk][] | Additional SASL parameters when using AWS_MSK_IAM. | no
 authentication > tls | [tls][] | Configures TLS for connecting to the Kafka brokers. | no
 authentication > kerberos | [kerberos][] | Authenticates against Kafka brokers with Kerberos. | no
 metadata | [metadata][] | Configures how to retrieve metadata from Kafka brokers. | no
@@ -128,6 +129,18 @@ The `mechanism` argument can be set to one of the following strings:
 When `mechanism` is set to `"AWS_MSK_IAM"`, the [`aws_msk` child block][aws_msk] must also be provided.
 
 The `version` argument can be set to either `0` or `1`.
+
+### aws_msk block
+
+The `aws_msk` block configures extra parameters for SASL authentication when
+using the `AWS_MSK_IAM` mechanism.
+
+The following arguments are supported:
+
+Name | Type | Description | Default | Required
+---- | ---- | ----------- | ------- | --------
+`region` | `string` | AWS region the MSK cluster is based in. | | yes
+`broker_addr` | `string` | MSK address to connect to for authentication. | | yes
 
 ### tls block
 

--- a/internal/component/all/all.go
+++ b/internal/component/all/all.go
@@ -70,6 +70,7 @@ import (
 	_ "github.com/grafana/agent/internal/component/otelcol/connector/servicegraph"           // Import otelcol.connector.servicegraph
 	_ "github.com/grafana/agent/internal/component/otelcol/connector/spanlogs"               // Import otelcol.connector.spanlogs
 	_ "github.com/grafana/agent/internal/component/otelcol/connector/spanmetrics"            // Import otelcol.connector.spanmetrics
+	_ "github.com/grafana/agent/internal/component/otelcol/exporter/kafka"                   // Import otelcol.exporter.kafka
 	_ "github.com/grafana/agent/internal/component/otelcol/exporter/loadbalancing"           // Import otelcol.exporter.loadbalancing
 	_ "github.com/grafana/agent/internal/component/otelcol/exporter/logging"                 // Import otelcol.exporter.logging
 	_ "github.com/grafana/agent/internal/component/otelcol/exporter/loki"                    // Import otelcol.exporter.loki

--- a/internal/component/otelcol/exporter/kafka/kafka.go
+++ b/internal/component/otelcol/exporter/kafka/kafka.go
@@ -1,0 +1,165 @@
+// Package kafka provides an otelcol.exporter.kafka component.
+package kafka
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/grafana/agent/internal/component"
+	"github.com/grafana/agent/internal/component/otelcol"
+	"github.com/grafana/agent/internal/component/otelcol/exporter"
+	"github.com/grafana/agent/internal/component/otelcol/receiver/kafka"
+	"github.com/grafana/agent/internal/featuregate"
+	"github.com/mitchellh/mapstructure"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
+	otelcomponent "go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	otelextension "go.opentelemetry.io/collector/extension"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:      "otelcol.exporter.kafka",
+		Stability: featuregate.StabilityStable,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			fact := kafkaexporter.NewFactory()
+			return exporter.New(opts, fact, args.(Arguments), exporter.TypeAll)
+		},
+	})
+}
+
+// Arguments configures the otelcol.exporter.otlp component.
+type Arguments struct {
+	ProtocolVersion string `river:"protocol_version,attr"`
+
+	Brokers  []string      `river:"brokers,attr,optional"`
+	ClientID string        `river:"client_id,attr,optional"`
+	Topic    string        `river:"topic,attr,optional"`
+	Encoding string        `river:"encoding,attr,optional"`
+	Timeout  time.Duration `river:"timeout,attr,optional"`
+
+	Queue        otelcol.QueueArguments        `river:"sending_queue,block,optional"`
+	Retry        otelcol.RetryArguments        `river:"retry_on_failure,block,optional"`
+	DebugMetrics otelcol.DebugMetricsArguments `river:"debug_metrics,block,optional"`
+
+	Auth     kafka.AuthenticationArguments `river:"authentication,block,optional"`
+	Metadata kafka.MetadataArguments       `river:"metadata,block,optional"`
+	Producer Producer                      `river:"producer,block,optional"`
+
+	ResolveCanonicalBootstrapServersOnly bool `river:"resolve_canonical_bootstrap_servers_only,attr,optional"`
+	PartitionTracesByID                  bool `river:"partition_traces_by_id,attr,optional"`
+}
+
+var _ exporter.Arguments = Arguments{}
+
+// SetToDefault implements river.Defaulter.
+func (args *Arguments) SetToDefault() {
+	*args = Arguments{
+		Brokers:  []string{"localhost:9092"},
+		ClientID: "sarama",
+		Encoding: "otlp_proto",
+		Timeout:  otelcol.DefaultTimeout,
+	}
+
+	args.Queue.SetToDefault()
+	args.Retry.SetToDefault()
+	args.DebugMetrics.SetToDefault()
+	args.Metadata.SetToDefault()
+	args.Producer.SetToDefault()
+}
+
+// Convert implements exporter.Arguments.
+func (args Arguments) Convert() (otelcomponent.Config, error) {
+	input := make(map[string]interface{})
+	input["auth"] = args.Auth.Convert()
+
+	res := &kafkaexporter.Config{}
+	err := mapstructure.Decode(input, res)
+	if err != nil {
+		return nil, err
+	}
+	res.ProtocolVersion = args.ProtocolVersion
+
+	res.Brokers = args.Brokers
+	res.ClientID = args.ClientID
+	res.Topic = args.Topic
+	res.Encoding = args.Encoding
+	res.TimeoutSettings = exporterhelper.TimeoutSettings{
+		Timeout: args.Timeout,
+	}
+
+	res.QueueSettings = *args.Queue.Convert()
+	res.BackOffConfig = *args.Retry.Convert()
+
+	res.Metadata = args.Metadata.Convert()
+	res.Producer = args.Producer.Convert()
+
+	res.ResolveCanonicalBootstrapServersOnly = args.ResolveCanonicalBootstrapServersOnly
+	res.PartitionTracesByID = args.PartitionTracesByID
+
+	return res, nil
+}
+
+// Extensions implements exporter.Arguments.
+func (args Arguments) Extensions() map[otelcomponent.ID]otelextension.Extension {
+	return nil
+}
+
+// Exporters implements exporter.Arguments.
+func (args Arguments) Exporters() map[otelcomponent.DataType]map[otelcomponent.ID]otelcomponent.Component {
+	return nil
+}
+
+// DebugMetricsConfig implements receiver.Arguments.
+func (args Arguments) DebugMetricsConfig() otelcol.DebugMetricsArguments {
+	return args.DebugMetrics
+}
+
+type Producer struct {
+	MaxMessageBytes  int    `river:"max_message_bytes,attr,optional"`
+	RequiredAcks     int    `river:"required_acks,attr,optional"`
+	Compression      string `river:"compression,attr,optional"`
+	FlushMaxMessages int    `river:"flush_max_messages,attr,optional"`
+}
+
+func (p Producer) Convert() kafkaexporter.Producer {
+	return kafkaexporter.Producer{
+		MaxMessageBytes:  p.MaxMessageBytes,
+		RequiredAcks:     sarama.RequiredAcks(p.RequiredAcks),
+		Compression:      p.Compression,
+		FlushMaxMessages: p.FlushMaxMessages,
+	}
+}
+
+func (p *Producer) SetToDefault() {
+	*p = Producer{
+		MaxMessageBytes:  1_000_000,
+		RequiredAcks:     1,
+		Compression:      "none",
+		FlushMaxMessages: 0,
+	}
+}
+
+var validCompressions = map[string]struct{}{
+	"none":   {},
+	"gzip":   {},
+	"snappy": {},
+	"lz4":    {},
+	"zstd":   {},
+}
+
+func (p *Producer) Validate() error {
+	if _, ok := validCompressions[p.Compression]; !ok {
+		return fmt.Errorf("invalid compression value; must be one of 'none', 'gzip', 'snappy', 'lz4', 'zstd'")
+	}
+
+	if p.RequiredAcks < -1 || p.RequiredAcks > 1 {
+		return fmt.Errorf("required_acks has to be between -1 and 1")
+	}
+
+	return nil
+}

--- a/internal/component/otelcol/exporter/kafka/kafka_test.go
+++ b/internal/component/otelcol/exporter/kafka/kafka_test.go
@@ -1,0 +1,139 @@
+package kafka_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/grafana/agent/internal/component/otelcol"
+	"github.com/grafana/agent/internal/component/otelcol/exporter/kafka"
+	"github.com/grafana/agent/internal/flow/componenttest"
+	"github.com/grafana/agent/internal/flow/logging/level"
+	"github.com/grafana/agent/internal/util"
+	"github.com/grafana/dskit/backoff"
+	"github.com/grafana/river"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+)
+
+// Test performs a basic integration test which runs the otelcol.exporter.kafka
+// component and ensures that it can pass data to a mock Kafka broker.
+func Test(t *testing.T) {
+	ch := make(chan string)
+	kafkaBroker := makeKafkaBroker(t, ch)
+
+	ctx := componenttest.TestContext(t)
+	l := util.TestLogger(t)
+
+	ctrl, err := componenttest.NewControllerFromID(l, "otelcol.exporter.kafka")
+	require.NoError(t, err)
+
+	cfg := fmt.Sprintf(`
+		protocol_version = "2.0.0"
+		brokers          = ["%s"]
+		// brokers          = ["localhost:9002"]
+		timeout          = "250ms"
+		metadata {
+			include_all_topics = false
+		}
+
+		debug_metrics {
+			disable_high_cardinality_metrics = true
+		}
+	`, kafkaBroker.Addr())
+	var args kafka.Arguments
+	require.NoError(t, river.Unmarshal([]byte(cfg), &args))
+	require.Equal(t, args.DebugMetricsConfig().DisableHighCardinalityMetrics, true)
+
+	go func() {
+		err := ctrl.Run(ctx, args)
+		require.NoError(t, err)
+	}()
+
+	require.NoError(t, ctrl.WaitRunning(time.Second), "component never started")
+	require.NoError(t, ctrl.WaitExports(time.Second), "component never exported anything")
+
+	// Send traces in the background to our exporter.
+	go func() {
+		exports := ctrl.Exports().(otelcol.ConsumerExports)
+
+		bo := backoff.New(ctx, backoff.Config{
+			MinBackoff: 10 * time.Millisecond,
+			MaxBackoff: 100 * time.Millisecond,
+		})
+		for bo.Ongoing() {
+			err := exports.Input.ConsumeTraces(ctx, createTestTraces())
+			if err != nil {
+				level.Error(l).Log("msg", "failed to send traces", "err", err)
+				bo.Wait()
+				continue
+			}
+
+			return
+		}
+	}()
+
+	// Wait for our exporter to finish and pass data to our HTTP server.
+	select {
+	case <-time.After(time.Second):
+		require.FailNow(t, "failed waiting for traces")
+	case tr := <-ch:
+		require.Equal(t, "&{6 [otlp_spans] true false false}", tr)
+	}
+}
+
+// makeTracesServer returns a host:port which will accept Kafka messages.
+func makeKafkaBroker(t *testing.T, ch chan string) *sarama.MockBroker {
+	t.Helper()
+
+	broker := sarama.NewMockBroker(t, 0)
+	t.Cleanup(broker.Close)
+
+	go func() {
+		for {
+			if len(broker.History()) > 0 {
+				rr := broker.History()[0]
+				ch <- fmt.Sprint(rr.Request)
+				return
+			}
+		}
+	}()
+
+	return broker
+}
+
+type mockTracesReceiver struct {
+	ptraceotlp.UnimplementedGRPCServer
+	ch chan ptrace.Traces
+}
+
+var _ ptraceotlp.GRPCServer = (*mockTracesReceiver)(nil)
+
+func (ms *mockTracesReceiver) Export(_ context.Context, req ptraceotlp.ExportRequest) (ptraceotlp.ExportResponse, error) {
+	ms.ch <- req.Traces()
+	return ptraceotlp.NewExportResponse(), nil
+}
+
+func createTestTraces() ptrace.Traces {
+	// Matches format from the protobuf definition:
+	// https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/trace/v1/trace.proto
+	bb := `{
+		"resource_spans": [{
+			"scope_spans": [{
+				"spans": [{
+					"name": "TestSpan"
+				}]
+			}]
+		}]
+	}`
+
+	decoder := &ptrace.JSONUnmarshaler{}
+	data, err := decoder.UnmarshalTraces([]byte(bb))
+	if err != nil {
+		panic(err)
+	}
+	return data
+}

--- a/internal/converter/internal/otelcolconvert/converter_kafkaexporter.go
+++ b/internal/converter/internal/otelcolconvert/converter_kafkaexporter.go
@@ -1,0 +1,68 @@
+package otelcolconvert
+
+import (
+	"fmt"
+
+	"github.com/grafana/agent/internal/component/otelcol/exporter/kafka"
+	"github.com/grafana/agent/internal/component/otelcol/exporter/otlp"
+	"github.com/grafana/agent/internal/converter/diag"
+	"github.com/grafana/agent/internal/converter/internal/common"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
+	"go.opentelemetry.io/collector/component"
+)
+
+func init() {
+	converters = append(converters, kafkaExporterConverter{})
+}
+
+type kafkaExporterConverter struct{}
+
+func (kafkaExporterConverter) Factory() component.Factory {
+	return kafkaexporter.NewFactory()
+}
+
+func (kafkaExporterConverter) InputComponentName() string { return "otelcol.exporter.kafka" }
+
+func (kafkaExporterConverter) ConvertAndAppend(state *state, id component.InstanceID, cfg component.Config) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	label := state.FlowComponentLabel()
+
+	args := toKafkaExporterConfig(cfg.(*kafkaexporter.Config))
+	block := common.NewBlockWithOverride([]string{"otelcol", "exporter", "kafka"}, label, args)
+
+	diags.Add(
+		diag.SeverityLevelInfo,
+		fmt.Sprintf("Converted %s into %s", stringifyInstanceID(id), stringifyBlock(block)),
+	)
+
+	state.Body().AppendBlock(block)
+	return diags
+}
+
+func toKafkaExporterConfig(cfg *kafkaexporter.Config) *kafka.Arguments {
+	return &kafka.Arguments{
+		ProtocolVersion: cfg.ProtocolVersion,
+
+		Brokers:  cfg.Brokers,
+		ClientID: cfg.ClientID,
+		Topic:    cfg.Topic,
+		Encoding: cfg.Encoding,
+		Timeout:  cfg.Timeout,
+
+		Queue:        toQueueArguments(cfg.QueueSettings),
+		Retry:        toRetryArguments(cfg.BackOffConfig),
+		DebugMetrics: common.DefaultValue[otlp.Arguments]().DebugMetrics,
+
+		Auth:     toKafkaAuthentication(encodeMapstruct(cfg.Authentication)),
+		Metadata: toKafkaMetadata(cfg.Metadata),
+		Producer: kafka.Producer{
+			MaxMessageBytes:  cfg.Producer.MaxMessageBytes,
+			RequiredAcks:     int(cfg.Producer.RequiredAcks),
+			Compression:      cfg.Producer.Compression,
+			FlushMaxMessages: cfg.Producer.FlushMaxMessages,
+		},
+		ResolveCanonicalBootstrapServersOnly: cfg.ResolveCanonicalBootstrapServersOnly,
+		PartitionTracesByID:                  cfg.PartitionTracesByID,
+	}
+}

--- a/internal/converter/internal/otelcolconvert/testdata/kafkaexporter.river
+++ b/internal/converter/internal/otelcolconvert/testdata/kafkaexporter.river
@@ -1,0 +1,15 @@
+otelcol.receiver.otlp "default" {
+	grpc { }
+
+	http { }
+
+	output {
+		metrics = [otelcol.exporter.kafka.default.input]
+		logs    = [otelcol.exporter.kafka.default.input]
+		traces  = [otelcol.exporter.kafka.default.input]
+	}
+}
+
+otelcol.exporter.kafka "default" {
+	protocol_version = "2.0.0"
+}

--- a/internal/converter/internal/otelcolconvert/testdata/kafkaexporter.yaml
+++ b/internal/converter/internal/otelcolconvert/testdata/kafkaexporter.yaml
@@ -1,0 +1,24 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+exporters:
+  kafka:
+    protocol_version: 2.0.0
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: []
+      exporters: [kafka]
+    logs:
+      receivers: [otlp]
+      processors: []
+      exporters: [kafka]
+    traces:
+      receivers: [otlp]
+      processors: []
+      exporters: [kafka]


### PR DESCRIPTION
#### PR Description
This component adds the otelcol.exporter.kafka component so that Grafana Agent can work with Kakfa pipelines end-to-end.

#### Which issue(s) this PR fixes
No issue files

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] CHANGELOG.md updated
- [X] Documentation added
- [X] Tests updated
- [x] Config converters updated