### PR TITLE
Reduce default sync_interval for mimir.rules.kubernetes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Main (unreleased)
 - The default listen port for `otelcol.receiver.opencensus` has changed from
   4317 to 55678 to align with upstream. (@rfratto)
 
+- The default sync interval for `mimir.rules.kubernetes` has changed from `30s`
+  to `5m` to reduce load on Mimir. (@56quarters)  
+
 ### Enhancements
 
 - Add support for importing folders as single module to `import.file`. (@wildum)

--- a/docs/sources/flow/reference/components/mimir.rules.kubernetes.md
+++ b/docs/sources/flow/reference/components/mimir.rules.kubernetes.md
@@ -53,7 +53,7 @@ Name                     | Type                | Description                    
 `tenant_id`              | `string`            | Mimir tenant ID.                                                |               | no
 `use_legacy_routes`      | `bool`              | Whether to use [deprecated][gem-2_2] ruler API endpoints.       | false         | no
 `prometheus_http_prefix` | `string`            | Path prefix for [Mimir's Prometheus endpoint][gem-path-prefix]. | `/prometheus` | no
-`sync_interval`          | `duration`          | Amount of time between reconciliations with Mimir.              | "30s"         | no
+`sync_interval`          | `duration`          | Amount of time between reconciliations with Mimir.              | "5m"          | no
 `mimir_namespace_prefix` | `string`            | Prefix used to differentiate multiple {{< param "PRODUCT_NAME" >}} deployments. | "agent" | no
 `bearer_token_file`      | `string`            | File containing a bearer token to authenticate with.            |               | no
 `bearer_token`           | `secret`            | Bearer token to authenticate with.                              |               | no
@@ -89,7 +89,7 @@ unique value for each deployment.
 
 If `use_legacy_routes` is set to `true`, `mimir.rules.kubernetes` contacts Mimir on a `/api/v1/rules` endpoint.
 
-If `prometheus_http_prefix` is set to `/mimir`, `mimir.rules.kubernetes` contacts Mimir on a `/mimir/config/v1/rules` endpoint. 
+If `prometheus_http_prefix` is set to `/mimir`, `mimir.rules.kubernetes` contacts Mimir on a `/mimir/config/v1/rules` endpoint.
 This is useful if you configure Mimir to use a different [prefix][gem-path-prefix] for its Prometheus endpoints than the default one.
 
 `prometheus_http_prefix` is ignored if `use_legacy_routes` is set to `true`.

--- a/internal/component/mimir/rules/kubernetes/types.go
+++ b/internal/component/mimir/rules/kubernetes/types.go
@@ -22,7 +22,7 @@ type Arguments struct {
 }
 
 var DefaultArguments = Arguments{
-	SyncInterval:         30 * time.Second,
+	SyncInterval:         5 * time.Minute,
 	MimirNameSpacePrefix: "agent",
 	HTTPClientConfig:     config.DefaultHTTPClientConfig,
 	PrometheusHTTPPrefix: "/prometheus",


### PR DESCRIPTION
#### PR Description

Changes the default interval on which rules are synced from Mimir via `mimir.rules.kubernetes` when there are otherwise no changes to the `PrometheusRule` resources. This reduces load on the Mimir ruler APIs. Changes to `PrometheusRule` resources still result in immediately applying changes and syncing state with Mimir.

#### Which issue(s) this PR fixes

N/A

#### Notes to the Reviewer

N/A

#### PR Checklist

- [X] CHANGELOG.md updated
- [X] Documentation added
