### PR TITLE
Update cypher suite support

### DIFF
--- a/docs/sources/flow/reference/config-blocks/http.md
+++ b/docs/sources/flow/reference/config-blocks/http.md
@@ -104,8 +104,8 @@ The set of cipher suites specified may be from the following:
 | ----------------------------------------------- | -------------------------------- |
 | `TLS_RSA_WITH_AES_128_CBC_SHA`                  | no                               |
 | `TLS_RSA_WITH_AES_256_CBC_SHA`                  | no                               |
-| `TLS_RSA_WITH_AES_128_GCM_SHA256`               | yes                              |
-| `TLS_RSA_WITH_AES_256_GCM_SHA384`               | yes                              |
+| `TLS_RSA_WITH_AES_128_GCM_SHA256`               | no                               |
+| `TLS_RSA_WITH_AES_256_GCM_SHA384`               | no                               |
 | `TLS_AES_128_GCM_SHA256`                        | no                               |
 | `TLS_AES_256_GCM_SHA384`                        | no                               |
 | `TLS_CHACHA20_POLY1305_SHA256`                  | no                               |


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Recently, some cipher suites were deprecated in Go 1.22, per https://github.com/golang/go/issues/63413. As a result, certain cipher suites are no longer allowed in recent version of Grafana Agent (0.40.2), including these two:
- TLS_RSA_WITH_AES_256_GCM_SHA384
- TLS_RSA_WITH_AES_128_GCM_SHA256

This PR updates the table to show "no" for these two cipher suites.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes [#9622](https://github.com/grafana/support-escalations/issues/9622)

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated