### PR TITLE
feat(otelcol/extension/jaeger_remote_sampling): resync defaults with upstreams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,10 @@ Main (unreleased)
 
 - Clustering for Grafana Agent in Flow mode has graduated from beta to stable.
 
-- Resync defaults for `otelcol.processor.k8sattributes` with upstream. (@hainenber)
-
-- Resync defaults for `otelcol.exporter.otlp` and `otelcol.exporter.otlphttp` with upstream. (@hainenber)
+- Resync defaults to upstream for following OpenTelemetry-based components. (@hainenber)
+    - `otelcol.processor.k8sattributes`
+    - `otelcol.exporter.otlp`
+    - `otelcol.exporter.otlphttp`
 
 v0.40.3 (2024-03-14)
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Main (unreleased)
     - `otelcol.processor.k8sattributes`
     - `otelcol.exporter.otlp`
     - `otelcol.exporter.otlphttp`
+    - `otelcol.extension.jaeger_remote_sampling`
 
 v0.40.3 (2024-03-14)
 --------------------

--- a/internal/component/otelcol/extension/jaeger_remote_sampling/internal/jaegerremotesampling/config_test.go
+++ b/internal/component/otelcol/extension/jaeger_remote_sampling/internal/jaegerremotesampling/config_test.go
@@ -27,9 +27,9 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id: component.NewID(typeStr),
 			expected: &Config{
-				HTTPServerConfig: &confighttp.ServerConfig{Endpoint: ":5778"},
+				HTTPServerConfig: &confighttp.ServerConfig{Endpoint: "localhost:5778"},
 				GRPCServerConfig: &configgrpc.ServerConfig{NetAddr: confignet.AddrConfig{
-					Endpoint:  ":14250",
+					Endpoint:  "localhost:14250",
 					Transport: "tcp",
 				}},
 				Source: Source{
@@ -42,9 +42,9 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id: component.NewIDWithName(typeStr, "1"),
 			expected: &Config{
-				HTTPServerConfig: &confighttp.ServerConfig{Endpoint: ":5778"},
+				HTTPServerConfig: &confighttp.ServerConfig{Endpoint: "localhost:5778"},
 				GRPCServerConfig: &configgrpc.ServerConfig{NetAddr: confignet.AddrConfig{
-					Endpoint:  ":14250",
+					Endpoint:  "localhost:14250",
 					Transport: "tcp",
 				}},
 				Source: Source{

--- a/internal/component/otelcol/extension/jaeger_remote_sampling/internal/jaegerremotesampling/factory.go
+++ b/internal/component/otelcol/extension/jaeger_remote_sampling/internal/jaegerremotesampling/factory.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"sync"
 
-	"go.opentelemetry.io/collector/component"
 	otelcomponent "go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -31,14 +30,14 @@ func NewFactory() extension.Factory {
 	)
 }
 
-func createDefaultConfig() component.Config {
+func createDefaultConfig() otelcomponent.Config {
 	return &Config{
 		HTTPServerConfig: &confighttp.ServerConfig{
-			Endpoint: ":5778",
+			Endpoint: "localhost:5778",
 		},
 		GRPCServerConfig: &configgrpc.ServerConfig{
 			NetAddr: confignet.AddrConfig{
-				Endpoint:  ":14250",
+				Endpoint:  "localhost:14250",
 				Transport: "tcp",
 			},
 		},
@@ -64,7 +63,7 @@ func logDeprecation(logger *zap.Logger) {
 // 	featuregate.WithRegisterToVersion("0.92.0"),
 // )
 
-func createExtension(_ context.Context, set extension.CreateSettings, cfg component.Config) (extension.Extension, error) {
+func createExtension(_ context.Context, set extension.CreateSettings, cfg otelcomponent.Config) (extension.Extension, error) {
 	logDeprecation(set.Logger)
 	return newExtension(cfg.(*Config), set.TelemetrySettings), nil
 }

--- a/internal/component/otelcol/extension/jaeger_remote_sampling/internal/jaegerremotesampling/factory_test.go
+++ b/internal/component/otelcol/extension/jaeger_remote_sampling/internal/jaegerremotesampling/factory_test.go
@@ -18,9 +18,9 @@ import (
 func TestCreateDefaultConfig(t *testing.T) {
 	// prepare and test
 	expected := &Config{
-		HTTPServerConfig: &confighttp.ServerConfig{Endpoint: ":5778"},
+		HTTPServerConfig: &confighttp.ServerConfig{Endpoint: "localhost:5778"},
 		GRPCServerConfig: &configgrpc.ServerConfig{NetAddr: confignet.AddrConfig{
-			Endpoint:  ":14250",
+			Endpoint:  "localhost:14250",
 			Transport: "tcp",
 		}},
 	}


### PR DESCRIPTION


<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
As of writing, the [upstream](https://github.com/open-telemetry/opentelemetry-collector/issues/8510) has agreed upon limiting binding IP address to be `localhost` instead of `0.0.0.0` for security reasons. This PR is to reflect that upstream change.


#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes grafana/alloy#219 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated