### PR TITLE
Log dropped delta sum

### DIFF
--- a/internal/component/otelcol/exporter/prometheus/internal/convert/convert.go
+++ b/internal/component/otelcol/exporter/prometheus/internal/convert/convert.go
@@ -425,6 +425,7 @@ func (conv *Converter) consumeSum(app storage.Appender, memResource *memorySerie
 	case m.Sum().AggregationTemporality() == pmetric.AggregationTemporalityCumulative && !m.Sum().IsMonotonic():
 		convType = textparse.MetricTypeGauge
 	case m.Sum().AggregationTemporality() == pmetric.AggregationTemporalityDelta && m.Sum().IsMonotonic():
+		level.Debug(conv.log).Log("msg", "dropped unsupported delta sum")
 		// Drop non-cumulative summaries for now, which is permitted by the spec.
 		//
 		// TODO(rfratto): implement delta-to-cumulative for sums.


### PR DESCRIPTION
#### PR Description
I've recently came across the issue that delta sums or counts were not exported to Prometheus. A simple log line would have saved a few hours investigating.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated