### PR TITLE
Feature/mimir.rules.kubernetes externallabels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ Main (unreleased)
 - Increased the alert interval and renamed the `ClusterSplitBrain` alert to `ClusterNodeCountMismatch` in the Grafana
   Agent Mixin to better match the alert conditions. (@thampiotr)
 
+- `loki.rules.kubernetes` support for add extra labels (@psychomantys)
+
+
 ### Features
 
 - Added a new CLI flag `--stability.level` which defines the minimum stability

--- a/docs/sources/flow/reference/components/mimir.rules.kubernetes.md
+++ b/docs/sources/flow/reference/components/mimir.rules.kubernetes.md
@@ -61,8 +61,9 @@ Name                     | Type                | Description                    
 `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.    | `true`        | no
 `proxy_url`              | `string`            | HTTP proxy to send requests through.                            |               | no
 `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. | | no
-`proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.         | `false` | no
-`proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests. |         | no
+`proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.           | `false` | no
+`proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.   |         | no
+`external_labels`        | `map(string)`       | Labels to add to rules sent over the network.                   |         | no
 
  At most, one of the following can be provided:
  - [`bearer_token` argument](#arguments).

--- a/internal/component/mimir/rules/kubernetes/events.go
+++ b/internal/component/mimir/rules/kubernetes/events.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"context"
 	"fmt"
+	"maps"
 	"regexp"
 	"time"
 
@@ -134,6 +135,15 @@ func (c *Component) loadStateFromK8s() (kubernetes.RuleGroupsByNamespace, error)
 			groups, err := convertCRDRuleGroupToRuleGroup(pr.Spec)
 			if err != nil {
 				return nil, fmt.Errorf("failed to convert rule group: %w", err)
+			}
+
+			for _, rule_group := range groups {
+				for _, rule_node := range rule_group.Rules {
+					if rule_node.Labels == nil {
+						rule_node.Labels = make(map[string]string)
+					}
+					maps.Copy(rule_node.Labels, c.args.ExternalLabels)
+				}
 			}
 
 			desiredState[mimirNs] = groups

--- a/internal/component/mimir/rules/kubernetes/types.go
+++ b/internal/component/mimir/rules/kubernetes/types.go
@@ -11,6 +11,7 @@ import (
 type Arguments struct {
 	Address              string                  `river:"address,attr"`
 	TenantID             string                  `river:"tenant_id,attr,optional"`
+	ExternalLabels       map[string]string       `river:"external_labels,attr,optional"`
 	UseLegacyRoutes      bool                    `river:"use_legacy_routes,attr,optional"`
 	PrometheusHTTPPrefix string                  `river:"prometheus_http_prefix,attr,optional"`
 	HTTPClientConfig     config.HTTPClientConfig `river:",squash"`


### PR DESCRIPTION
#### PR Description

Add support to inject `external_labels` to `mimir.rules.kubernetes`.

#### Which issue(s) this PR fixes

Fixes #5135
Fixes #5983

#### PR Checklist

- [x] CHANGELOG.md updated
- [x] Documentation added
