### PR TITLE
Replace use of deprecated Kubernetes workqueue method

### DIFF
--- a/internal/component/loki/rules/kubernetes/rules.go
+++ b/internal/component/loki/rules/kubernetes/rules.go
@@ -212,7 +212,8 @@ func (c *Component) Run(ctx context.Context) error {
 
 // startup launches the informers and starts the event loop.
 func (c *Component) startup(ctx context.Context) error {
-	c.queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "loki.rules.kubernetes")
+	cfg := workqueue.RateLimitingQueueConfig{Name: "loki.rules.kubernetes"}
+	c.queue = workqueue.NewRateLimitingQueueWithConfig(workqueue.DefaultControllerRateLimiter(), cfg)
 	c.informerStopChan = make(chan struct{})
 
 	if err := c.startNamespaceInformer(); err != nil {

--- a/internal/component/mimir/rules/kubernetes/rules.go
+++ b/internal/component/mimir/rules/kubernetes/rules.go
@@ -212,7 +212,8 @@ func (c *Component) Run(ctx context.Context) error {
 
 // startup launches the informers and starts the event loop.
 func (c *Component) startup(ctx context.Context) error {
-	c.queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "mimir.rules.kubernetes")
+	cfg := workqueue.RateLimitingQueueConfig{Name: "mimir.rules.kubernetes"}
+	c.queue = workqueue.NewRateLimitingQueueWithConfig(workqueue.DefaultControllerRateLimiter(), cfg)
 	c.informerStopChan = make(chan struct{})
 
 	if err := c.startNamespaceInformer(); err != nil {


### PR DESCRIPTION
#### PR Description

Replaces use of the deprecated method `workqueue.NewNamedRateLimitingQueue` with `workqueue.NewRateLimitingQueueWithConfig`.

#### Which issue(s) this PR fixes

N/A

#### Notes to the Reviewer

N/A

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [na] CHANGELOG.md updated
- [na] Documentation added
- [na] Tests updated
- [na] Config converters updated