### PR TITLE
[Clustering] Filter the label "instance" from the hash computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ Main (unreleased)
   whenever that argument is explicitly configured. This issue only affected a
   small subset of arguments across 15 components. (@erikbaranowski, @rfratto)
 
+- Fix an issue where targets exposed by exporters were not distributed correctly between agents in clustering mode. (@wildum)
+
 ### Other changes
 
 - Clustering for Grafana Agent in Flow mode has graduated from beta to stable.

--- a/internal/component/discovery/discovery_test.go
+++ b/internal/component/discovery/discovery_test.go
@@ -1,0 +1,18 @@
+package discovery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilteredLabels(t *testing.T) {
+	target := Target{
+		"instance":    "instanceTest",
+		"__meta_test": "metaTest",
+		"job":         "jobTest",
+	}
+	labels := target.FilteredLabels()
+	require.Equal(t, labels.Len(), 1)
+	require.True(t, labels.Has("job"))
+}


### PR DESCRIPTION
#### PR Description

In clustering mode, the targets exposed by exporters are distributed amongst the agents.
For an agent to know whether it should scrape the target or not, it will compute a hash based on the labels of the target.

In https://github.com/grafana/support-escalations/issues/9923, we noticed that the agent adds a label "instance" corresponding by default to the host where the agent runs to the targets. This is a problem because if the agents are not running on the same host, they will have a different value for the label "instance". This means that they will compute different hashes and the targets won't be distributed correctly.

#### Notes to the Reviewer

Is there a scenario where a target can only be uniquely identified by the instance label?
If that's the case, then the agent would compute the same hash for different targets which would result in an unbalanced cluster.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Tests updated