### PR TITLE
agent-flow-mixin: wire in OpenTelemetry alerts

### DIFF
--- a/operations/agent-flow-mixin/alerts.libsonnet
+++ b/operations/agent-flow-mixin/alerts.libsonnet
@@ -3,6 +3,7 @@
     groups+: [
       (import './alerts/clustering.libsonnet'),
       (import './alerts/controller.libsonnet'),
+      (import './alerts/opentelemetry.libsonnet'),
     ],
   },
 }


### PR DESCRIPTION
I saw that the OpenTelemetry alerts weren't wired in alerts.libsonnet meaning they wouldn't be rendered.