### PR TITLE
Fix custom component registry access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ Main (unreleased)
   whenever that argument is explicitly configured. This issue only affected a
   small subset of arguments across 15 components. (@erikbaranowski, @rfratto)
 
+- Fix a bug where a panic could occur when reloading custom components. (@wildum)
+
 ### Other changes
 
 - Clustering for Grafana Agent in Flow mode has graduated from beta to stable.


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

There is a small window where the loader is reloading (a new config is being applied) while a custom component is concurrently being re-evaluated.

To get its config, the custom component must check the custom component registry during its evaluation. This registry is re-created every time a config is applied. This means that there is a possibility that the custom component being re-evaluated is looking at a registry that is not fully initialized and might not have yet loaded the config needed. This results in a panic.

The provided fix locks the mutex before the re-evaluation to prevent both evaluations from running concurrently. In other words, the re-evaluation is paused when a new config is applied.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #6795

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated