### PR TITLE
feat(pyroscope/scrape): add support for configuring CPU profile's duration scraped by `pyroscope.scrape`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ Main (unreleased)
 - Add automatic conversion for `legacy_positions_file` in component `loki.source.file`. (@mattdurham)
 
 - Propagate request metadata for `faro.receiver` to downstream components. (@hainenber)
+  
+- Add support for configuring CPU profile's duration scraped by `pyroscope.scrape`. (@hainenber)
 
 ### Features
 

--- a/docs/sources/flow/reference/components/pyroscope.scrape.md
+++ b/docs/sources/flow/reference/components/pyroscope.scrape.md
@@ -76,6 +76,7 @@ Name                | Type                     | Description                    
 `params`            | `map(list(string))`      | A set of query parameters with which the target is scraped.        |                | no
 `scrape_interval`   | `duration`               | How frequently to scrape the targets of this scrape configuration. | `"15s"`        | no
 `scrape_timeout`    | `duration`               | The timeout for scraping targets of this configuration. Must be larger than `scrape_interval`. | `"18s"`        | no
+`profiling_duration`| `duration`               | The duration for a delta profiling to be scraped. Must be larger than 1 second. | `"14s"`        | no
 `scheme`            | `string`                 | The URL scheme with which to fetch metrics from targets.           | `"http"`       | no
 `bearer_token_file` | `string`                 | File containing a bearer token to authenticate with.               |                | no
 `bearer_token`      | `secret`                 | Bearer token to authenticate with.                                 |                | no
@@ -387,7 +388,8 @@ Name | Type | Description | Default | Required
 `delta` | `boolean` | Whether to scrape the profile as a delta. | `false` | no
 
 When the `delta` argument is `true`, a `seconds` query parameter is
-automatically added to requests. The `seconds` used will be equal to `scrape_interval - 1`.
+automatically added to requests. The `seconds` used will be, by default to `scrape_interval - 1`
+, or `profiling_duration` if specified. 
 
 ### clustering block
 
@@ -421,8 +423,10 @@ When the `delta` argument is `false`, the [pprof][] HTTP query will be instantan
 When the `delta` argument is `true`:
 * The [pprof][] HTTP query will run for a certain amount of time.
 * A `seconds` parameter is automatically added to the HTTP request.
-* The `seconds` used will be equal to `scrape_interval - 1`.
-  For example, if `scrape_interval` is `"15s"`, `seconds` will be 14 seconds.
+* The `seconds` used, by default, will be equal to `scrape_interval - 1`
+  or to `profiling_duration` if specified.
+  For example, if `scrape_interval` is `"15s"`, `seconds` will be 14 seconds
+  If `profiling_duration` is set as `"16s"`, `seconds` will be 16 seconds regardless of `scrape_interval`
   If the HTTP endpoint is `/debug/pprof/profile`, then the HTTP query will become `/debug/pprof/profile?seconds=14`
 
 ## Exported fields

--- a/docs/sources/flow/reference/components/pyroscope.scrape.md
+++ b/docs/sources/flow/reference/components/pyroscope.scrape.md
@@ -423,10 +423,10 @@ When the `delta` argument is `false`, the [pprof][] HTTP query will be instantan
 When the `delta` argument is `true`:
 * The [pprof][] HTTP query will run for a certain amount of time.
 * A `seconds` parameter is automatically added to the HTTP request.
-* The `seconds` used, by default, will be equal to `scrape_interval - 1`
-  or to `profiling_duration` if specified.
-  For example, if `scrape_interval` is `"15s"`, `seconds` will be 14 seconds
-  If `profiling_duration` is set as `"16s"`, `seconds` will be 16 seconds regardless of `scrape_interval`
+* The default value for the `seconds` query parameter is `scrape_interval - 1`.
+   If you set `profiling_duration`, then `seconds` is assigned the same value as `profiling_duration`.
+   For example, if you set `scrape_interval` to `"15s"`, then `seconds` defaults to `14s`.
+   If you set `profiling_duration` to `16s`, then `seconds is set to `16s` regardless of the `scrape_interval` value.
   If the HTTP endpoint is `/debug/pprof/profile`, then the HTTP query will become `/debug/pprof/profile?seconds=14`
 
 ## Exported fields

--- a/internal/component/pyroscope/scrape/scrape_test.go
+++ b/internal/component/pyroscope/scrape/scrape_test.go
@@ -151,6 +151,16 @@ func TestUnmarshalConfig(t *testing.T) {
 			`,
 			expectedErr: "scrape_interval must be at least 2 seconds when using delta profiling",
 		},
+		"invalid cpu profiling_duration": {
+			in: `
+			targets    = []
+			forward_to = null
+			scrape_timeout = "1s"
+			scrape_interval = "10s"
+			profiling_duration = "1s"
+			`,
+			expectedErr: "profiling_duration must be larger then 1 second when using delta profiling",
+		},
 		"allow short scrape_intervals without delta": {
 			in: `
 			targets    = []

--- a/internal/component/pyroscope/scrape/target.go
+++ b/internal/component/pyroscope/scrape/target.go
@@ -406,7 +406,11 @@ func targetsFromGroup(group *targetgroup.Group, cfg Arguments, targetTypes map[s
 				}
 
 				if pcfg, found := targetTypes[profType]; found && pcfg.Delta {
-					params.Add("seconds", strconv.Itoa(int((cfg.ScrapeInterval)/time.Second)-1))
+					seconds := (cfg.ScrapeInterval)/time.Second - 1
+					if cfg.ProfilingDuration != defaultProfilingDuration {
+						seconds = (cfg.ProfilingDuration) / time.Second
+					}
+					params.Add("seconds", strconv.Itoa(int(seconds)))
 				}
 				targets = append(targets, NewTarget(lbls, origLabels, params))
 			}

--- a/internal/component/pyroscope/scrape/target_test.go
+++ b/internal/component/pyroscope/scrape/target_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -230,6 +231,68 @@ func Test_targetsFromGroup(t *testing.T) {
 			}),
 			url.Values{"seconds": []string{"14"}}),
 	}
+	require.NoError(t, err)
+	sort.Sort(Targets(active))
+	sort.Sort(Targets(expected))
+	require.Equal(t, expected, active)
+	require.Empty(t, dropped)
+}
+
+func Test_targetsFromGroup_withSpecifiedProfilingDuration(t *testing.T) {
+	args := NewDefaultArguments()
+	args.ProfilingConfig.Block.Enabled = false
+	args.ProfilingConfig.Goroutine.Enabled = false
+	args.ProfilingConfig.Mutex.Enabled = false
+	args.ProfilingDuration = 20 * time.Second
+
+	active, dropped, err := targetsFromGroup(&targetgroup.Group{
+		Targets: []model.LabelSet{
+			{model.AddressLabel: "localhost:9090"},
+		},
+		Labels: model.LabelSet{
+			"foo": "bar",
+		},
+	}, args, args.ProfilingConfig.AllTargets())
+	expected := []*Target{
+		// unspecified
+		NewTarget(
+			labels.FromMap(map[string]string{
+				model.AddressLabel:    "localhost:9090",
+				serviceNameLabel:      "unspecified",
+				model.MetricNameLabel: pprofMemory,
+				ProfilePath:           "/debug/pprof/allocs",
+				model.SchemeLabel:     "http",
+				"foo":                 "bar",
+				"instance":            "localhost:9090",
+			}),
+			labels.FromMap(map[string]string{
+				model.AddressLabel:    "localhost:9090",
+				model.MetricNameLabel: pprofMemory,
+				ProfilePath:           "/debug/pprof/allocs",
+				model.SchemeLabel:     "http",
+				"foo":                 "bar",
+			}),
+			url.Values{}),
+		NewTarget(
+			labels.FromMap(map[string]string{
+				model.AddressLabel:    "localhost:9090",
+				serviceNameLabel:      "unspecified",
+				model.MetricNameLabel: pprofProcessCPU,
+				ProfilePath:           "/debug/pprof/profile",
+				model.SchemeLabel:     "http",
+				"foo":                 "bar",
+				"instance":            "localhost:9090",
+			}),
+			labels.FromMap(map[string]string{
+				model.AddressLabel:    "localhost:9090",
+				model.MetricNameLabel: pprofProcessCPU,
+				ProfilePath:           "/debug/pprof/profile",
+				model.SchemeLabel:     "http",
+				"foo":                 "bar",
+			}),
+			url.Values{"seconds": []string{"20"}}),
+	}
+
 	require.NoError(t, err)
 	sort.Sort(Targets(active))
 	sort.Sort(Targets(expected))


### PR DESCRIPTION


<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes grafana/alloy#195 

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated