### PR TITLE
packaging: properly unregister Grafana Agent when uninstalling on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,9 @@ Main (unreleased)
 - Fixed an issue where creating a `prometheus.exporter.postgres` component with
   multiple `data_source_names` would result in an error. (@thampiotr)
 
+- Fix an issue on Windows where uninstalling Alloy did not remove it from the
+  Add/Remove programs list. (@rfratto)
+
 ### Other changes
 
 - Clustering for Grafana Agent in Flow mode has graduated from beta to stable.

--- a/packaging/grafana-agent-flow/windows/install_script.nsis
+++ b/packaging/grafana-agent-flow/windows/install_script.nsis
@@ -218,9 +218,10 @@ Section "uninstall"
   RMDir /r "$INSTDIR"                # Install directory.
   RMDir /r "$APPDATA\${APPNAME}"     # Application data.
 
-  # Remove service and uninstaller information from the registry.
+  # Remove service and uninstaller information from the registry. Note that the
+  # service settings are stored in the 64-bit registry (so we use /reg:64),
+  # while the uninstaller information is stored in the 32-bit registry.
   nsExec::ExecToLog 'Reg.exe delete "HKLM\SOFTWARE\Grafana\Grafana Agent Flow"  /reg:64 /f'
   Pop $0
-  nsExec::ExecToLog 'Reg.exe delete "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"  /reg:64 /f'
-  Pop $0
+  DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"
 SectionEnd


### PR DESCRIPTION
Porting over grafana/alloy#166

grafana/agent#6550 fixed an issue where the service settings were not being removed properly, but inadvertedly broke the process of removing the application from the Add/Remove programs list.

Grafana Agent is registered as a program to the 32-bit registry, and so it must be removed from the 32-bit registry and not the 64-bit registry.
