### PR TITLE
Backport: nest datapath in parents to prevent collision in nested import.git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Main (unreleased)
 - Fix a bug where custom components would not shadow the stdlib. If you have a module whose name conflicts with an stdlib function 
   and if you use this exact function in your config, then you will need to rename your module. (@wildum)
 
+- Fix an issue where nested import.git config blocks could conflict if they had the same labels. (@wildum)
+
 ### Other changes
 
 - Change the Docker base image for Linux containers to `ubuntu:noble`. (@amontalban)

--- a/internal/flow/internal/controller/node_config_import.go
+++ b/internal/flow/internal/controller/node_config_import.go
@@ -286,6 +286,8 @@ func (cn *ImportConfigNode) processImportBlock(stmt *ast.BlockStmt, fullName str
 	childGlobals := cn.globals
 	// Children have a special OnBlockNodeUpdate function which notifies the parent when its content changes.
 	childGlobals.OnBlockNodeUpdate = cn.onChildrenContentUpdate
+	// Children data paths are nested inside their parents to avoid collisions.
+	childGlobals.DataPath = filepath.Join(childGlobals.DataPath, cn.globalID)
 	cn.importConfigNodesChildren[stmt.Label] = NewImportConfigNode(stmt, childGlobals, sourceType)
 	return nil
 }


### PR DESCRIPTION
backport from https://github.com/grafana/alloy/pull/646

The tests are not backported because they require enhancements which were only made in Alloy