### PR TITLE
[release-v0.36] Replace docs/reference shortcode with ref URIs

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -9,6 +9,32 @@ description: Grafana Agent is a flexible, performant, vendor-neutral, telemetry 
 weight: 350
 cascade:
   AGENT_RELEASE: v0.36.0
+refs:
+  variants:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/about/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/monitor-infrastructure/agent/about/
+  static-mode:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/monitor-infrastructure/agent/static/
+  flow-mode:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/
+  static-mode-kubernetes-operator:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/operator/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/monitor-infrastructure/agent/operator/
+  ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
 ---
 
 # Grafana Agent
@@ -54,17 +80,17 @@ Grafana Agent can collect, transform, and send data to:
 * **Battle-tested**: Grafana Agent extends the existing battle-tested code from
   the Prometheus and OpenTelemetry Collector projects.
 * **Powerful**: Write programmable pipelines with ease, and debug them using a
-  [built-in UI][UI].
+  [built-in UI](ref:ui).
 * **Batteries included**: Integrate with systems like MySQL, Kubernetes, and
   Apache to get telemetry that's immediately useful.
 
 ## Getting started
 
-* Choose a [variant][variants] of Grafana Agent to run.
+* Choose a [variant](ref:variants) of Grafana Agent to run.
 * Refer to the documentation for the variant to use:
-  * [Static mode][]
-  * [Static mode Kubernetes operator][]
-  * [Flow mode][]
+  * [Static mode](ref:static-mode)
+  * [Static mode Kubernetes operator](ref:static-mode-kubernetes-operator)
+  * [Flow mode](ref:flow-mode)
 
 ## Supported platforms
 
@@ -102,19 +128,3 @@ Patch and security releases may be created at any time.
 
 [Milestones]: https://github.com/grafana/agent/milestones
 
-{{% docs/reference %}}
-[variants]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/about"
-[variants]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/about"
-
-[Static mode]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static"
-[Static mode]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static"
-
-[Static mode Kubernetes operator]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/operator"
-[Static mode Kubernetes operator]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/operator"
-
-[Flow mode]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow"
-[Flow mode]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow"
-
-[UI]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-[UI]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-{{% /docs/reference %}}

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -12,29 +12,29 @@ cascade:
 refs:
   variants:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/about/
+      destination: /docs/agent/<AGENT_VERSION>/about/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/monitor-infrastructure/agent/about/
   static-mode:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/
+      destination: /docs/agent/<AGENT_VERSION>/static/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/monitor-infrastructure/agent/static/
   flow-mode:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
   static-mode-kubernetes-operator:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/operator/
+      destination: /docs/agent/<AGENT_VERSION>/operator/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/monitor-infrastructure/agent/operator/
   ui:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
 ---
 
 # Grafana Agent

--- a/docs/sources/about.md
+++ b/docs/sources/about.md
@@ -9,6 +9,32 @@ menuTitle: Introduction
 title: Introduction to Grafana Agent
 description: Grafana Agent is a flexible, performant, vendor-neutral, telemetry collector
 weight: 100
+refs:
+  flow-mode:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/reference/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/reference/components/
+  static-mode-kubernetes-operator:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/operator/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/monitor-infrastructure/agent/operator/
+  static-mode:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/monitor-infrastructure/agent/static/
+  integrations:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration/integrations/
 ---
 
 # Introduction to Grafana Agent
@@ -19,20 +45,10 @@ such as Prometheus and OpenTelemetry.
 
 Grafana Agent is available in three different variants:
 
-- [Static mode][]: The default, original variant of Grafana Agent.
-- [Static mode Kubernetes operator][]: Variant which manages agents running in Static mode.
-- [Flow mode][]: The newer, more flexible re-imagining variant of Grafana Agent.
+- [Static mode](ref:static-mode): The default, original variant of Grafana Agent.
+- [Static mode Kubernetes operator](ref:static-mode-kubernetes-operator): Variant which manages agents running in Static mode.
+- [Flow mode](ref:flow-mode): The newer, more flexible re-imagining variant of Grafana Agent.
 
-{{% docs/reference %}}
-[Static mode]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static"
-[Static mode]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static"
-
-[Static mode Kubernetes operator]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/operator"
-[Static mode Kubernetes operator]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/operator"
-
-[Flow mode]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow"
-[Flow mode]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow"
-{{% /docs/reference %}}
 
 ## Stability
 
@@ -49,7 +65,7 @@ Grafana Agent is available in three different variants:
 
 ### Static mode
 
-[Static mode][] is the original variant of Grafana Agent, first introduced on
+[Static mode](ref:static-mode) is the original variant of Grafana Agent, first introduced on
 March 3, 2020. Static mode is the most mature variant of Grafana Agent.
 
 You should run Static mode when:
@@ -58,12 +74,12 @@ You should run Static mode when:
 
 * **Grafana Cloud integrations**: You need to use Grafana Agent with Grafana Cloud integrations.
 
-* **Complete list of integrations**: You need to use a Static mode [integration][integrations] which is not yet
-  available as a [component][components] in Flow mode.
+* **Complete list of integrations**: You need to use a Static mode [integration](ref:integrations) which is not yet
+  available as a [component](ref:components) in Flow mode.
 
 ### Static mode Kubernetes operator
 
-The [Static mode Kubernetes operator][] is a variant of Grafana Agent first
+The [Static mode Kubernetes operator](ref:static-mode-kubernetes-operator) is a variant of Grafana Agent first
 introduced on June 17, 2021. It is currently in beta.
 
 The Static mode Kubernetes operator was introduced for compatibility with
@@ -78,7 +94,7 @@ You should run the Static mode Kubernetes operator when:
 
 ### Flow mode
 
-[Flow mode][] is a stable variant of Grafana Agent first introduced on
+[Flow mode](ref:flow-mode) is a stable variant of Grafana Agent first introduced on
 September 29, 2022.
 
 Flow mode was introduced as a re-imagining of Grafana Agent with a focus on
@@ -114,10 +130,3 @@ You should run Flow mode when:
 [BoringCrypto](https://pkg.go.dev/crypto/internal/boring) is an **EXPERIMENTAL** feature for building Grafana Agent
 binaries and images with BoringCrypto enabled. Builds and Docker images for Linux arm64/amd64 are made available.
 
-{{% docs/reference %}}
-[integrations]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/integrations"
-[integrations]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration/integrations"
-
-[components]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/reference/components"
-[components]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/reference/components"
-{{% /docs/reference %}}

--- a/docs/sources/about.md
+++ b/docs/sources/about.md
@@ -12,27 +12,27 @@ weight: 100
 refs:
   flow-mode:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
   components:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/reference/components/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/reference/components/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/
   static-mode-kubernetes-operator:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/operator/
+      destination: /docs/agent/<AGENT_VERSION>/operator/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/monitor-infrastructure/agent/operator/
   static-mode:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/
+      destination: /docs/agent/<AGENT_VERSION>/static/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/monitor-infrastructure/agent/static/
   integrations:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/integrations/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration/integrations/
 ---

--- a/docs/sources/data-collection.md
+++ b/docs/sources/data-collection.md
@@ -9,6 +9,25 @@ menuTitle: Data collection
 title: Grafana Agent data collection
 description: Grafana Agent data collection
 weight: 500
+refs:
+  flow:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
+  static:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/
+  command-line-flag:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
 ---
 
 # Data collection
@@ -26,23 +45,13 @@ The usage information includes the following details:
 * Version of running Grafana Agent.
 * Operating system Grafana Agent is running on.
 * System architecture Grafana Agent is running on.
-* List of enabled feature flags ([Static] mode only).
-* List of enabled integrations ([Static] mode only).
-* List of enabled [components][] ([Flow] mode only).
+* List of enabled feature flags [Static](ref:static) mode only).
+* List of enabled integrations [Static](ref:static) mode only).
+* List of enabled [components](ref:components) [Flow](ref:flow) mode only).
 
 This list may change over time. All newly reported data is documented in the CHANGELOG.
 
 ## Opt-out of data collection
 
-You can use the `-disable-reporting` [command line flag][] to disable the reporting and opt-out of the data collection.
+You can use the `-disable-reporting` [command line flag](ref:command-line-flag) to disable the reporting and opt-out of the data collection.
 
-{{% docs/reference %}}
-[command line flag]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[command line flag]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
-[components]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[Static]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static"
-[Static]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static
-[Flow]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow"
-[Flow]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT_VERSION>/flow"
-{{% /docs/reference %}}

--- a/docs/sources/data-collection.md
+++ b/docs/sources/data-collection.md
@@ -45,9 +45,9 @@ The usage information includes the following details:
 * Version of running Grafana Agent.
 * Operating system Grafana Agent is running on.
 * System architecture Grafana Agent is running on.
-* List of enabled feature flags [Static](ref:static) mode only).
-* List of enabled integrations [Static](ref:static) mode only).
-* List of enabled [components](ref:components) [Flow](ref:flow) mode only).
+* List of enabled feature flags ([Static](ref:static) mode only).
+* List of enabled integrations ([Static](ref:static) mode only).
+* List of enabled [components](ref:components) ([Flow](ref:flow) mode only).
 
 This list may change over time. All newly reported data is documented in the CHANGELOG.
 

--- a/docs/sources/flow/setup/install/_index.md
+++ b/docs/sources/flow/setup/install/_index.md
@@ -9,6 +9,12 @@ menuTitle: Install flow mode
 title: Install Grafana Agent in flow mode
 description: Learn how to install Grafana Agent in flow mode
 weight: 50
+refs:
+  data-collection:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/data-collection/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/monitor-infrastructure/agent/data-collection/
 ---
 
 # Install Grafana Agent in flow mode
@@ -30,10 +36,6 @@ Installing Grafana Agent on other operating systems is possible, but is not reco
 
 ## Data collection
 
-By default, Grafana Agent sends anonymous usage information to Grafana Labs. Refer to [data collection][] for more information
+By default, Grafana Agent sends anonymous usage information to Grafana Labs. Refer to [data collection](ref:data-collection) for more information
 about what data is collected and how you can opt-out.
 
-{{% docs/reference %}}
-[data collection]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/data-collection.md"
-[data collection]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/data-collection.md"
-{{% /docs/reference %}}

--- a/docs/sources/operator/release-notes.md
+++ b/docs/sources/operator/release-notes.md
@@ -11,6 +11,17 @@ title: Release notes for Grafana Agent Operator
 description: Release notes for Grafana Agent Operator
 
 weight: 999
+refs:
+  release-notes-static:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/release-notes/
+    - pattern: /docs/agent/
+      destination: /docs/grafana-cloud/monitor-infrastructure/agent/static/release-notes/
+  release-notes-flow:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
 ---
 
 # Release notes for Grafana Agent Operator
@@ -22,16 +33,9 @@ For a complete list of changes to Grafana Agent, with links to pull requests and
 > **Note:** These release notes are specific to the Static mode Kubernetes Operator.
 > Other release notes for the different Grafana Agent variants are contained on separate pages:
 >
-> - [Static mode release notes][release-notes-static]
-> - [Flow mode release notes][release-notes-flow]
+> - [Static mode release notes](ref:release-notes-static)
+> - [Flow mode release notes](ref:release-notes-flow)
 
-{{% docs/reference %}}
-[release-notes-static]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/release-notes"
-[release-notes-static]: "/docs/agent/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static/release-notes"
-
-[release-notes-flow]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/release-notes"
-[release-notes-flow]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/release-notes"
-{{% /docs/reference %}}
 
 ## v0.33
 

--- a/docs/sources/operator/release-notes.md
+++ b/docs/sources/operator/release-notes.md
@@ -14,14 +14,14 @@ weight: 999
 refs:
   release-notes-static:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/release-notes/
+      destination: /docs/agent/<AGENT_VERSION>/static/release-notes/
     - pattern: /docs/agent/
       destination: /docs/grafana-cloud/monitor-infrastructure/agent/static/release-notes/
   release-notes-flow:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
+      destination: /docs/agent/<AGENT_VERSION>/flow/release-notes/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
+      destination: /docs/agent/<AGENT_VERSION>/flow/release-notes/
 ---
 
 # Release notes for Grafana Agent Operator

--- a/docs/sources/static/_index.md
+++ b/docs/sources/static/_index.md
@@ -3,6 +3,22 @@ canonical: https://grafana.com/docs/agent/latest/static/
 title: Static mode
 description: Learn about Grafana Agent in static mode
 weight: 200
+refs:
+  install:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/
+    - pattern: /docs/grafana-cloud/
+      destination: ./set-up/install/
+  set-up:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/
+    - pattern: /docs/grafana-cloud/
+      destination: ./set-up/
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/
+    - pattern: /docs/grafana-cloud/
+      destination: ./configuration/
 ---
 
 # Static mode
@@ -20,7 +36,7 @@ Static mode is composed of different _subsystems_:
   traces and forwarding them to Grafana Tempo or any OpenTelemetry-compatible
   endpoint.
 
-Static mode is [configured][configure] with a YAML file.
+Static mode is [configured](ref:configure) with a YAML file.
 
 Static mode works with:
 
@@ -31,7 +47,7 @@ Static mode works with:
 This topic helps you to think about what you're trying to accomplish and how to
 use Grafana Agent to meet your goals.
 
-You can [set up][] and [configure][] Grafana Agent in static mode manually, or
+You can [set up](ref:set-up) and [configure](ref:configure) Grafana Agent in static mode manually, or
 you can follow the common workflows described in this topic.
 
 ## Topics
@@ -64,7 +80,7 @@ Grafana Cloud integration workflows and the Kubernetes Monitoring solution are t
 
 | Topic | Description |
 |---|---|
-| [Install or uninstall Grafana Agent][install] | Install or uninstall Grafana Agent. |
+| [Install or uninstall Grafana Agent](ref:install) | Install or uninstall Grafana Agent. |
 | [Troubleshoot Cloud Integrations installation on Linux](/docs/grafana-cloud/monitor-infrastructure/integrations/install-troubleshoot-linux/) | Troubleshoot common errors when executing the Grafana Agent installation script on Linux.  |
 | [Troubleshoot Cloud Integrations installation on Mac](/docs/grafana-cloud/monitor-infrastructure/integrations/install-troubleshoot-mac/) | Troubleshoot common errors when executing the Grafana Agent installation script on Mac.  |
 | [Troubleshoot Cloud Integrations installation on Windows](/docs/grafana-cloud/monitor-infrastructure/integrations/install-troubleshooting-windows/) | Troubleshoot common errors when executing the Grafana Agent installation script on Windows.  |
@@ -84,11 +100,3 @@ Logs are included when you [set up a Cloud integration](/docs/grafana-cloud/data
 | [Set up and use tracing](/docs/grafana-cloud/data-configuration/traces/set-up-and-use-tempo/) |  Install Grafana Agent to collect traces for use with Grafana Tempo, included with your [Grafana Cloud account](/docs/grafana-cloud/account-management/cloud-portal/). |
 | [Use Grafana Agent as a tracing pipeline](/docs/tempo/latest/configuration/grafana-agent/) | Grafana Agent can be configured to run a set of tracing pipelines to collect data from your applications and write it to Grafana Tempo. Pipelines are built using OpenTelemetry, and consist of receivers, processors, and exporters. |
 
-{{% docs/reference %}}
-[set up]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up"
-[set up]: "/docs/grafana-cloud/ -> ./set-up"
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration"
-[configure]: "/docs/grafana-cloud/ -> ./configuration"
-[install]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install"
-[install]: "/docs/grafana-cloud/ -> ./set-up/install"
-{{% /docs/reference %}}

--- a/docs/sources/static/_index.md
+++ b/docs/sources/static/_index.md
@@ -6,17 +6,17 @@ weight: 200
 refs:
   install:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/install/
     - pattern: /docs/grafana-cloud/
       destination: ./set-up/install/
   set-up:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/
     - pattern: /docs/grafana-cloud/
       destination: ./set-up/
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/
     - pattern: /docs/grafana-cloud/
       destination: ./configuration/
 ---

--- a/docs/sources/static/api/_index.md
+++ b/docs/sources/static/api/_index.md
@@ -6,6 +6,20 @@ title: Static mode APIs (Stable)
 menuTitle: Static mode API
 description: Learn about the Grafana Agent static mode API
 weight: 400
+refs:
+  integrations:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/integrations-next/
+    - pattern: /docs/grafana-cloud/
+      destination: ../configuration/integrations/integrations-next/
+  scrape:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/
+  metrics:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+    - pattern: /docs/grafana-cloud/
+      destination: ../configuration/metrics-config/
 ---
 
 # Static mode APIs (Stable)
@@ -21,7 +35,7 @@ API endpoints are stable unless otherwise noted.
 
 ## Config management API (Beta)
 
-Grafana Agent exposes a config management REST API for managing instance configurations when it is running in [scraping service mode][scrape].
+Grafana Agent exposes a config management REST API for managing instance configurations when it is running in [scraping service mode](ref:scrape).
 
 {{% admonition type="note" %}}
 The scraping service mode is a requirement for the config management
@@ -120,7 +134,7 @@ with the same name already exists, then it will be completely overwritten.
 URL-encoded names are stored in decoded form. e.g., `hello%2Fworld` will
 represent the config named `hello/world`.
 
-The request body passed to this endpoint must match the format of [metrics_instance_config][metrics]
+The request body passed to this endpoint must match the format of [metrics_instance_config](ref:metrics)
 defined in the Configuration Reference. The name field of the configuration is
 ignored and the name in the URL takes precedence. The request body must be
 formatted as YAML.
@@ -407,7 +421,7 @@ A support bundle contains the following data:
 ## Integrations API (Experimental)
 
 > **WARNING**: This API is currently only available when the experimental
-> [integrations revamp][integrations]
+> [integrations revamp](ref:integrations)
 > is enabled. Both the revamp and this API are subject to change while they
 > are still experimental.
 
@@ -519,11 +533,3 @@ Response:
 Agent is Healthy.
 ```
 
-{{% docs/reference %}}
-[scrape]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/scraping-service"
-[scrape]: "/docs/grafana-cloud/ -> ../configuration/scraping-service
-[metrics]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/metrics-config"
-[metrics]: "/docs/grafana-cloud/ -> ../configuration/metrics-config"
-[integrations]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/integrations/integrations-next"
-[integrations]: "/docs/grafana-cloud/ -> ../configuration/integrations/integrations-next"
-{{% /docs/reference %}}

--- a/docs/sources/static/api/_index.md
+++ b/docs/sources/static/api/_index.md
@@ -9,15 +9,15 @@ weight: 400
 refs:
   integrations:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/integrations-next/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/integrations/integrations-next/
     - pattern: /docs/grafana-cloud/
       destination: ../configuration/integrations/integrations-next/
   scrape:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/scraping-service/
   metrics:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/metrics-config/
     - pattern: /docs/grafana-cloud/
       destination: ../configuration/metrics-config/
 ---

--- a/docs/sources/static/configuration/_index.md
+++ b/docs/sources/static/configuration/_index.md
@@ -5,6 +5,42 @@ canonical: https://grafana.com/docs/agent/latest/static/configuration/
 title: Configure static mode
 description: Learn how to configure Grafana Agent in static mode
 weight: 300
+refs:
+  traces:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/traces-config/
+    - pattern: /docs/grafana-cloud/
+      destination: ./traces-config/
+  server:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/server-config/
+    - pattern: /docs/grafana-cloud/
+      destination: ./server-config/
+  logs:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/logs-config/
+    - pattern: /docs/grafana-cloud/
+      destination: ./logs-config/
+  api:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/api/#reload-configuration-file-beta
+    - pattern: /docs/grafana-cloud/
+      destination: ../api/#reload-configuration-file-beta
+  integrations:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/
+    - pattern: /docs/grafana-cloud/
+      destination: ./integrations/
+  flags:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/flags/
+    - pattern: /docs/grafana-cloud/
+      destination: ./flags/
+  metrics:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+    - pattern: /docs/grafana-cloud/
+      destination: ./metrics-config/
 ---
 
 # Configure static mode
@@ -12,7 +48,7 @@ weight: 300
 The configuration of static mode is split across two places:
 
 * A YAML file
-* [Command-line flags][flags]
+* [Command-line flags](ref:flags)
 
 The YAML file is used to configure settings which are dynamic and can be
 changed at runtime. The command-line flags then configure things which cannot
@@ -20,11 +56,11 @@ change at runtime, such as the listen port for the HTTP server.
 
 This file describes the YAML configuration, which is usually in a file named `config.yaml`.
 
-- [server_config][server]
-- [metrics_config][metrics]
-- [logs_config][logs]
-- [traces_config][traces]
-- [integrations_config][integrations]
+- [server_config](ref:server)
+- [metrics_config](ref:metrics)
+- [logs_config](ref:logs)
+- [traces_config](ref:traces)
+- [integrations_config](ref:integrations)
 
 The configuration of Grafana Agent is "stable," but subject to breaking changes
 as individual features change. Breaking changes to configuration will be
@@ -77,7 +113,7 @@ which may be slightly unexpected.
 
 ## Reloading (beta)
 
-The configuration file can be reloaded at runtime. Read the [API documentation][api] for more information.
+The configuration file can be reloaded at runtime. Read the [API documentation](ref:api) for more information.
 
 This functionality is in beta, and may have issues. Please open GitHub issues
 for any problems you encounter.
@@ -139,19 +175,3 @@ The following flags will configure basic auth for requests made to HTTP/S remote
 This beta feature is subject to change in future releases.
 {{% /admonition %}}
 
-{{% docs/reference %}}
-[flags]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/flags"
-[flags]: "/docs/grafana-cloud/ -> ./flags"
-[server]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/server-config"
-[server]: "/docs/grafana-cloud/ -> ./server-config"
-[metrics]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/metrics-config"
-[metrics]: "/docs/grafana-cloud/ -> ./metrics-config"
-[logs]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/logs-config"
-[logs]: "/docs/grafana-cloud/ -> ./logs-config"
-[traces]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/traces-config"
-[traces]: "/docs/grafana-cloud/ -> ./traces-config"
-[integrations]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/integrations"
-[integrations]: "/docs/grafana-cloud/ -> ./integrations"
-[api]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/api#reload-configuration-file-beta"
-[api]: "/docs/grafana-cloud/ -> ../api#reload-configuration-file-beta"
-{{% /docs/reference %}}

--- a/docs/sources/static/configuration/_index.md
+++ b/docs/sources/static/configuration/_index.md
@@ -8,37 +8,37 @@ weight: 300
 refs:
   traces:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/traces-config/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/traces-config/
     - pattern: /docs/grafana-cloud/
       destination: ./traces-config/
   server:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/server-config/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/server-config/
     - pattern: /docs/grafana-cloud/
       destination: ./server-config/
   logs:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/logs-config/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/logs-config/
     - pattern: /docs/grafana-cloud/
       destination: ./logs-config/
   api:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/api/#reload-configuration-file-beta
+      destination: /docs/agent/<AGENT_VERSION>/static/api/#reload-configuration-file-beta
     - pattern: /docs/grafana-cloud/
       destination: ../api/#reload-configuration-file-beta
   integrations:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/integrations/
     - pattern: /docs/grafana-cloud/
       destination: ./integrations/
   flags:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/flags/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/flags/
     - pattern: /docs/grafana-cloud/
       destination: ./flags/
   metrics:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/metrics-config/
     - pattern: /docs/grafana-cloud/
       destination: ./metrics-config/
 ---

--- a/docs/sources/static/configuration/create-config-file.md
+++ b/docs/sources/static/configuration/create-config-file.md
@@ -9,7 +9,7 @@ weight: 50
 refs:
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration/
 ---

--- a/docs/sources/static/configuration/create-config-file.md
+++ b/docs/sources/static/configuration/create-config-file.md
@@ -6,6 +6,12 @@ canonical: https://grafana.com/docs/agent/latest/static/configuration/create-con
 title: Create a configuration file
 description: Learn how to create a configuration file
 weight: 50
+refs:
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration/
 ---
 
 # Create a configuration file
@@ -62,7 +68,7 @@ the Grafana Agent is running on. This label helps to uniquely identify the
 source of metrics if you are running multiple Grafana Agents across multiple
 machines.
 
-Full configuration options can be found in the [configuration reference][configure].
+Full configuration options can be found in the [configuration reference](ref:configure).
 
 ## Prometheus config/migrating from Prometheus
 
@@ -107,7 +113,7 @@ metrics:
 ```
 
 Like with integrations, full configuration options can be found in the
-[configuration][configure].
+[configuration](ref:configure).
 
 ## Loki Config/Migrating from Promtail
 
@@ -184,7 +190,3 @@ integrations:
     enabled: true
 ```
 
-{{% docs/reference %}}
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration"
-[configure]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration"
-{{% /docs/reference %}}

--- a/docs/sources/static/configuration/flags.md
+++ b/docs/sources/static/configuration/flags.md
@@ -5,6 +5,22 @@ canonical: https://grafana.com/docs/agent/latest/static/configuration/flags/
 title: Command-line flags
 description: Learn about command-line flags
 weight: 100
+refs:
+  management:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/agent-management/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration/agent-management/
+  revamp:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/integrations-next/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration/integrations/integrations-next/
+  retrieving:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/#remote-configuration-experimental
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration/#remote-configuration-experimental
 ---
 
 # Command-line flags
@@ -31,10 +47,10 @@ names to enable.
 
 Valid feature names are:
 
-* `remote-configs`: Enable [retrieving][retrieving] config files over HTTP/HTTPS
-* `integrations-next`: Enable [revamp][revamp] of the integrations subsystem
+* `remote-configs`: Enable [retrieving](ref:retrieving) config files over HTTP/HTTPS
+* `integrations-next`: Enable [revamp](ref:revamp) of the integrations subsystem
 * `extra-scrape-metrics`: When enabled, additional time series  are exposed for each metrics instance scrape. See [Extra scrape metrics](https://prometheus.io/docs/prometheus/2.45/feature_flags/#extra-scrape-metrics).
-* `agent-management`: Enable support for [agent management][management].
+* `agent-management`: Enable support for [agent management](ref:management).
 
 ## Report information usage
 
@@ -144,13 +160,3 @@ YAML configuration when the `-server.http.tls-enabled` flag is used.
 
 * `-metrics.wal-directory`: Directory to store the metrics Write-Ahead Log in
 
-{{% docs/reference %}}
-[retrieving]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration#remote-configuration-experimental"
-[retrieving]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration#remote-configuration-experimental"
-
-[revamp]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/integrations/integrations-next/"
-[revamp]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration/integrations/integrations-next"
-
-[management]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/agent-management"
-[management]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration/agent-management"
-{{% /docs/reference %}}

--- a/docs/sources/static/configuration/flags.md
+++ b/docs/sources/static/configuration/flags.md
@@ -8,17 +8,17 @@ weight: 100
 refs:
   management:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/agent-management/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/agent-management/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration/agent-management/
   revamp:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/integrations-next/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/integrations/integrations-next/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration/integrations/integrations-next/
   retrieving:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/#remote-configuration-experimental
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/#remote-configuration-experimental
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/monitor-infrastructure/agent/static/configuration/#remote-configuration-experimental
 ---

--- a/docs/sources/static/configuration/metrics-config.md
+++ b/docs/sources/static/configuration/metrics-config.md
@@ -6,6 +6,12 @@ canonical: https://grafana.com/docs/agent/latest/static/configuration/metrics-co
 title: metrics_config
 description: Learn about metrics_config
 weight: 200
+refs:
+  scrape:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/
+    - pattern: /docs/grafana-cloud/
+      destination: ./scraping-service/
 ---
 
 # metrics_config
@@ -66,7 +72,7 @@ configs:
 
 ## scraping_service_config
 
-The `scraping_service` block configures the [scraping service][scrape], an operational
+The `scraping_service` block configures the [scraping service](ref:scrape), an operational
 mode where configurations are stored centrally in a KV store and a cluster of
 agents distributes discovery and scrape load between nodes.
 
@@ -336,7 +342,3 @@ remote_write:
 > * [`scrape_config`](https://prometheus.io/docs/prometheus/2.45/configuration/configuration/#scrape_config)
 > * [`remote_write`](https://prometheus.io/docs/prometheus/2.45/configuration/configuration/#remote_write)
 
-{{% docs/reference %}}
-[scrape]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/scraping-service"
-[scrape]: "/docs/grafana-cloud/ -> ./scraping-service"
-{{% /docs/reference %}}

--- a/docs/sources/static/configuration/metrics-config.md
+++ b/docs/sources/static/configuration/metrics-config.md
@@ -9,7 +9,7 @@ weight: 200
 refs:
   scrape:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/scraping-service/
     - pattern: /docs/grafana-cloud/
       destination: ./scraping-service/
 ---

--- a/docs/sources/static/configuration/scraping-service.md
+++ b/docs/sources/static/configuration/scraping-service.md
@@ -10,12 +10,12 @@ weight: 600
 refs:
   api:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/api/
+      destination: /docs/agent/<AGENT_VERSION>/static/api/
     - pattern: /docs/grafana-cloud/
       destination: ../api/
   metrics:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/metrics-config/
     - pattern: /docs/grafana-cloud/
       destination: ./metrics-config/
 ---

--- a/docs/sources/static/configuration/scraping-service.md
+++ b/docs/sources/static/configuration/scraping-service.md
@@ -7,6 +7,17 @@ title: Scraping service (Beta)
 menuTitle: Scraping service
 description: Learn about the scraping service
 weight: 600
+refs:
+  api:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/api/
+    - pattern: /docs/grafana-cloud/
+      destination: ../api/
+  metrics:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+    - pattern: /docs/grafana-cloud/
+      destination: ./metrics-config/
 ---
 
 # Scraping service (Beta)
@@ -14,7 +25,7 @@ weight: 600
 The Grafana Agent scraping service allows you to cluster a set of Agent processes and distribute the scrape load.
 
 Determining what to scrape is done by writing instance configuration files to an
-[API][api], which then stores the configuration files in a KV store backend.
+[API](ref:api), which then stores the configuration files in a KV store backend.
 All agents in the cluster **must** use the same KV store to see the same set
 of configuration files.
 
@@ -44,7 +55,7 @@ remote_write:
 
 The full set of supported options for an instance configuration file is
 available in the
-[`metrics-config.md` file][metrics].
+[`metrics-config.md` file](ref:metrics).
 
 Multiple instance configuration files are necessary for sharding. Each
 config file is distributed to a particular agent on the cluster based on the
@@ -166,9 +177,3 @@ container with the `grafana/agentctl` image. Tanka configurations that
 utilize `grafana/agentctl` and sync a set of configurations to the API
 are planned for the future.
 
-{{% docs/reference %}}
-[api]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/api"
-[api]: "/docs/grafana-cloud/ -> ../api"
-[metrics]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/metrics-config"
-[metrics]: "/docs/grafana-cloud/ -> ./metrics-config"
-{{% /docs/reference %}}

--- a/docs/sources/static/operation-guide/_index.md
+++ b/docs/sources/static/operation-guide/_index.md
@@ -8,22 +8,22 @@ weight: 700
 refs:
   metrics:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/metrics-config/
     - pattern: /docs/grafana-cloud/
       destination: ../configuration/metrics-config/
   targets:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/#best-practices
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/scraping-service/#best-practices
     - pattern: /docs/grafana-cloud/
       destination: ../configuration/scraping-service/#best-practices
   scrape:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/scraping-service/
     - pattern: /docs/grafana-cloud/
       destination: ../configuration/scraping-service/
   api:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/api/#agent-api
+      destination: /docs/agent/<AGENT_VERSION>/static/api/#agent-api
     - pattern: /docs/grafana-cloud/
       destination: ../api/#agent-api
 ---

--- a/docs/sources/static/operation-guide/_index.md
+++ b/docs/sources/static/operation-guide/_index.md
@@ -5,6 +5,27 @@ canonical: https://grafana.com/docs/agent/latest/static/operation-guide/
 title: Operation guide
 description: Learn how to operate Grafana Agent
 weight: 700
+refs:
+  metrics:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+    - pattern: /docs/grafana-cloud/
+      destination: ../configuration/metrics-config/
+  targets:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/#best-practices
+    - pattern: /docs/grafana-cloud/
+      destination: ../configuration/scraping-service/#best-practices
+  scrape:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/
+    - pattern: /docs/grafana-cloud/
+      destination: ../configuration/scraping-service/
+  api:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/api/#agent-api
+    - pattern: /docs/grafana-cloud/
+      destination: ../api/#agent-api
 ---
 
 # Operation guide
@@ -20,7 +41,7 @@ There are three options to horizontally scale your deployment of Grafana Agents:
   from the machines they run on.
 - [Hashmod sharding](#hashmod-sharding-stable) allows you to roughly shard the
   discovered set of targets by using hashmod/keep relabel rules.
-- The [scraping service][scrape] allows you to cluster Grafana
+- The [scraping service](ref:scrape) allows you to cluster Grafana
   Agents and have them distribute per-tenant configs throughout the cluster.
 
 Each has their own set of tradeoffs:
@@ -55,7 +76,7 @@ Each has their own set of tradeoffs:
     - Smallest load on SD compared to host filtering, as only one Agent is
       responsible for a config.
   - Cons
-    - Centralized configs must discover a [minimal set of targets][targets]
+    - Centralized configs must discover a [minimal set of targets](ref:targets)
       to distribute evenly.
     - Requires running a separate KV store to store the centralized configs.
     - Managing centralized configs adds operational burden over managing a config
@@ -80,7 +101,7 @@ for scraping other targets that are not running on a cluster node, such as the
 Kubernetes control plane API.
 
 If you want to scale your scrape load without host filtering, you can use the
-[scraping service][scrape] instead.
+[scraping service](ref:scrape) instead.
 
 The host name of the Agent is determined by reading `$HOSTNAME`. If `$HOSTNAME`
 isn't defined, the Agent will use Go's [os.Hostname](https://golang.org/pkg/os/#Hostname)
@@ -111,7 +132,7 @@ logic; only `host_filter_relabel_configs` will work.
 
 If the determined hostname matches any of the meta labels, the discovered target
 is allowed. Otherwise, the target is ignored, and will not show up in the
-[targets API][api].
+[targets API](ref:api).
 
 ## Hashmod sharding (Stable)
 
@@ -156,7 +177,7 @@ Instances allow for fine grained control of what data gets scraped and where it
 gets sent. Users can easily define two Instances that scrape different subsets
 of metrics and send them to two completely different remote_write systems.
 
-Instances are especially relevant to the [scraping service mode][scrape],
+Instances are especially relevant to the [scraping service mode](ref:scrape),
 where breaking up your scrape configs into multiple Instances is required for 
 sharding and balancing scrape load across a cluster of Agents.
 
@@ -176,7 +197,7 @@ from that `remote_write` config separated by a `-`.
 
 The shared instances mode is the new default, and the previous behavior is
 deprecated. If you wish to restore the old behavior, set `instance_mode: distinct`
-in the [`metrics_config`][metrics] block of your config file.
+in the [`metrics_config`](ref:metrics) block of your config file.
 
 Shared instances are completely transparent to the user with the exception of
 exposed metrics. With `instance_mode: shared`, metrics for Prometheus components
@@ -188,16 +209,6 @@ individual Instance config. It is recommended to use the default of
 `instance_mode: shared` unless you don't mind the performance hit and really
 need granular metrics.
 
-Users can use the [targets API][api] to see all scraped targets, and the name 
+Users can use the [targets API](ref:api) to see all scraped targets, and the name 
 of the shared instance they were assigned to.
 
-{{% docs/reference %}}
-[scrape]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/scraping-service"
-[scrape]: "/docs/grafana-cloud/ -> ../configuration/scraping-service"
-[targets]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/scraping-service#best-practices"
-[targets]: "/docs/grafana-cloud/ -> ../configuration/scraping-service#best-practices"
-[api]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/api#agent-api"
-[api]: "/docs/grafana-cloud/ -> ../api#agent-api"
-[metrics]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/metrics-config"
-[metrics]: "/docs/grafana-cloud/ -> ../configuration/metrics-config"
-{{% /docs/reference %}}

--- a/docs/sources/static/release-notes.md
+++ b/docs/sources/static/release-notes.md
@@ -7,6 +7,22 @@ aliases:
 - ../upgrade-guide/
 - ./upgrade-guide/
 weight: 999
+refs:
+  release-notes-flow:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
+  release-notes-operator:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/operator/release-notes/
+    - pattern: /docs/grafana-cloud/
+      destination: ../operator/release-notes/
+  modules:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/concepts/modules/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/concepts/modules/
 ---
 
 # Release notes
@@ -18,19 +34,9 @@ For a complete list of changes to Grafana Agent, with links to pull requests and
 > **Note:** These release notes are specific to Grafana Agent static mode. 
 > Other release notes for the different Grafana Agent variants are contained on separate pages:
 >
-> * [Static mode Kubernetes operator release notes][release-notes-operator]
-> * [Flow mode release notes][release-notes-flow]
+> * [Static mode Kubernetes operator release notes](ref:release-notes-operator)
+> * [Flow mode release notes](ref:release-notes-flow)
 
-{{% docs/reference %}}
-[release-notes-operator]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/operator/release-notes"
-[release-notes-operator]: "/docs/grafana-cloud/ -> ../operator/release-notes"
-
-[release-notes-flow]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/release-notes"
-[release-notes-flow]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/release-notes"
-
-[Modules]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/concepts/modules"
-[Modules]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/concepts/modules"
-{{% /docs/reference %}}
 
 ## v0.35
 
@@ -103,7 +109,7 @@ See [Module and Auth Split Migration](https://github.com/prometheus/snmp_exporte
 ### Removal of Dynamic Configuration
 
 The experimental feature Dynamic Configuration has been removed. The use case of dynamic configuration will be replaced
-with [Modules][] in Grafana Agent Flow.
+with [Modules](ref:modules) in Grafana Agent Flow.
 
 ### Breaking change: Removed and renamed tracing metrics
 

--- a/docs/sources/static/release-notes.md
+++ b/docs/sources/static/release-notes.md
@@ -10,19 +10,19 @@ weight: 999
 refs:
   release-notes-flow:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
+      destination: /docs/agent/<AGENT_VERSION>/flow/release-notes/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
+      destination: /docs/agent/<AGENT_VERSION>/flow/release-notes/
   release-notes-operator:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/operator/release-notes/
+      destination: /docs/agent/<AGENT_VERSION>/operator/release-notes/
     - pattern: /docs/grafana-cloud/
       destination: ../operator/release-notes/
   modules:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/concepts/modules/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/modules/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/concepts/modules/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/modules/
 ---
 
 # Release notes

--- a/docs/sources/static/set-up/install/_index.md
+++ b/docs/sources/static/set-up/install/_index.md
@@ -7,6 +7,12 @@ menuTitle: Install static mode
 title: Install Grafana Agent in static mode
 description: Learn how to install GRafana Agent in static mode
 weight: 100
+refs:
+  data-collection:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/data-collection/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/monitor-infrastructure/agent/data-collection/
 ---
 
 # Install Grafana Agent in static mode
@@ -40,10 +46,6 @@ For more information, refer to the [Tanka](https://tanka.dev) configurations in 
 
 ## Data collection
 
-By default, Grafana Agent sends anonymous usage information to Grafana Labs. Refer to [data collection][] for more information
+By default, Grafana Agent sends anonymous usage information to Grafana Labs. Refer to [data collection](ref:data-collection) for more information
 about what data is collected and how you can opt-out.
 
-{{% docs/reference %}}
-[data collection]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/data-collection.md"
-[data collection]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/monitor-infrastructure/agent/data-collection.md"
-{{% /docs/reference %}}

--- a/docs/sources/static/set-up/install/install-agent-binary.md
+++ b/docs/sources/static/set-up/install/install-agent-binary.md
@@ -7,6 +7,32 @@ menuTitle: Standalone
 title: Install Grafana Agent in static mode as a standalone binary
 description: Learn how to install Grafana Agent in static mode as a standalone binary
 weight: 700
+refs:
+  macos:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-macos/
+    - pattern: /docs/grafana-cloud/
+      destination: ./install-agent-macos/
+  linux:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-linux/
+    - pattern: /docs/grafana-cloud/
+      destination: ./install-agent-linux/
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/#standalone-binary
+    - pattern: /docs/grafana-cloud/
+      destination: ../start-agent/#standalone-binary
+  windows:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-on-windows/
+    - pattern: /docs/grafana-cloud/
+      destination: ./install-agent-on-windows/
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/
+    - pattern: /docs/grafana-cloud/
+      destination: ../../configuration/
 ---
 
 # Install Grafana Agent in static mode as a standalone binary
@@ -23,9 +49,9 @@ ppc64le builds are considered secondary release targets and do not have the same
 
 The binary executable will run Grafana Agent in standalone mode. If you want to run Grafana Agent as a service, refer to the installation instructions for:
 
-* [Linux][linux]
-* [macOS][macos]
-* [Windows][windows]
+* [Linux](ref:linux)
+* [macOS](ref:macos)
+* [Windows](ref:windows)
 
 ## Download Grafana Agent
 
@@ -47,18 +73,6 @@ To download the Grafana Agent as a standalone binary, perform the following step
 
 ## Next steps
 
-* [Start Grafana Agent][start]
-* [Configure Grafana Agent][configure]
+* [Start Grafana Agent](ref:start)
+* [Configure Grafana Agent](ref:configure)
 
-{{% docs/reference %}}
-[linux]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-linux"
-[linux]: "/docs/grafana-cloud/ -> ./install-agent-linux"
-[macos]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-macos"
-[macos]: "/docs/grafana-cloud/ -> ./install-agent-macos"
-[windows]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-on-windows"
-[windows]: "/docs/grafana-cloud/ -> ./install-agent-on-windows"
-[start]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/start-agent#standalone-binary"
-[start]: "/docs/grafana-cloud/ -> ../start-agent#standalone-binary"
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration"
-[configure]: "/docs/grafana-cloud/ -> ../../configuration"
-{{% /docs/reference %}}

--- a/docs/sources/static/set-up/install/install-agent-binary.md
+++ b/docs/sources/static/set-up/install/install-agent-binary.md
@@ -10,27 +10,27 @@ weight: 700
 refs:
   macos:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-macos/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/install/install-agent-macos/
     - pattern: /docs/grafana-cloud/
       destination: ./install-agent-macos/
   linux:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-linux/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/install/install-agent-linux/
     - pattern: /docs/grafana-cloud/
       destination: ./install-agent-linux/
   start:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/#standalone-binary
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/start-agent/#standalone-binary
     - pattern: /docs/grafana-cloud/
       destination: ../start-agent/#standalone-binary
   windows:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-on-windows/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/install/install-agent-on-windows/
     - pattern: /docs/grafana-cloud/
       destination: ./install-agent-on-windows/
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/
     - pattern: /docs/grafana-cloud/
       destination: ../../configuration/
 ---

--- a/docs/sources/static/set-up/install/install-agent-docker.md
+++ b/docs/sources/static/set-up/install/install-agent-docker.md
@@ -7,6 +7,17 @@ menuTitle: Docker
 title: Run Grafana Agent in static mode in a Docker container
 description: Learn how to run Grafana Agent in static mode in a Docker container
 weight: 200
+refs:
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+    - pattern: /docs/grafana-cloud/
+      destination: ../start-agent/
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+    - pattern: /docs/grafana-cloud/
+      destination: ../../configuration/create-config-file/
 ---
 
 # Run Grafana Agent in static mode in a Docker container
@@ -22,7 +33,7 @@ Grafana Agent is available as a Docker container image on the following platform
 ## Before you begin
 
 * Install [Docker][] on your computer.
-* Create and save a Grafana Agent YAML [configuration file][configure] on your computer.
+* Create and save a Grafana Agent YAML [configuration file](ref:configure) on your computer.
 
 [Docker]: https://docker.io
 
@@ -65,12 +76,6 @@ For the flags to work correctly, you must expose the paths on your Windows host 
 
 ## Next steps
 
-- [Start Grafana Agent][start]
-- [Configure Grafana Agent][configure]
+- [Start Grafana Agent](ref:start)
+- [Configure Grafana Agent](ref:configure)
 
-{{% docs/reference %}}
-[start]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/start-agent"
-[start]: "/docs/grafana-cloud/ -> ../start-agent"
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/create-config-file"
-[configure]: "/docs/grafana-cloud/ -> ../../configuration/create-config-file"
-{{% /docs/reference %}}

--- a/docs/sources/static/set-up/install/install-agent-docker.md
+++ b/docs/sources/static/set-up/install/install-agent-docker.md
@@ -10,12 +10,12 @@ weight: 200
 refs:
   start:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/start-agent/
     - pattern: /docs/grafana-cloud/
       destination: ../start-agent/
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/create-config-file/
     - pattern: /docs/grafana-cloud/
       destination: ../../configuration/create-config-file/
 ---

--- a/docs/sources/static/set-up/install/install-agent-linux.md
+++ b/docs/sources/static/set-up/install/install-agent-linux.md
@@ -7,6 +7,17 @@ menuTitle: Linux
 title: Install Grafana Agent in static mode on Linux
 description: Learn how to install Grafana Agent in static mode on Linux
 weight: 400
+refs:
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+    - pattern: /docs/grafana-cloud/
+      destination: ../../configuration/create-config-file/
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+    - pattern: /docs/grafana-cloud/
+      destination: ../start-agent/
 ---
 
 # Install Grafana Agent in static mode on Linux
@@ -212,12 +223,6 @@ Logs of Grafana Agent can be found by running the following command in a termina
 
 ## Next steps
 
-- [Start Grafana Agent][start]
-- [Configure Grafana Agent][configure]
+- [Start Grafana Agent](ref:start)
+- [Configure Grafana Agent](ref:configure)
 
-{{% docs/reference %}}
-[start]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/start-agent"
-[start]: "/docs/grafana-cloud/ -> ../start-agent"
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/create-config-file"
-[configure]: "/docs/grafana-cloud/ -> ../../configuration/create-config-file"
-{{% /docs/reference %}}

--- a/docs/sources/static/set-up/install/install-agent-linux.md
+++ b/docs/sources/static/set-up/install/install-agent-linux.md
@@ -10,12 +10,12 @@ weight: 400
 refs:
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/create-config-file/
     - pattern: /docs/grafana-cloud/
       destination: ../../configuration/create-config-file/
   start:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/start-agent/
     - pattern: /docs/grafana-cloud/
       destination: ../start-agent/
 ---

--- a/docs/sources/static/set-up/install/install-agent-macos.md
+++ b/docs/sources/static/set-up/install/install-agent-macos.md
@@ -7,6 +7,17 @@ menuTitle: macOS
 title: Install Grafana Agent in static mode on macOS
 description: Learn how to install Grafana Agent in static mode on macOS
 weight: 500
+refs:
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+    - pattern: /docs/grafana-cloud/
+      destination: ../start-agent/
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+    - pattern: /docs/grafana-cloud/
+      destination: ../../configuration/create-config-file/
 ---
 
 # Install Grafana Agent in static mode on macOS
@@ -72,7 +83,7 @@ brew uninstall grafana-agent
     touch $(brew --prefix)/etc/grafana-agent/config.yml
     ```
 
-1. Edit `$(brew --prefix)/etc/grafana-agent/config.yml` and add the configuration blocks for your specific telemetry needs. Refer to [Configure Grafana Agent][configure] for more information.
+1. Edit `$(brew --prefix)/etc/grafana-agent/config.yml` and add the configuration blocks for your specific telemetry needs. Refer to [Configure Grafana Agent](ref:configure) for more information.
 
 {{% admonition type="note" %}}
 To send your data to Grafana Cloud, set up Grafana Agent using the Grafana Cloud integration. Refer to [how to install an integration](/docs/grafana-cloud/data-configuration/integrations/install-and-manage-integrations/) and [macOS integration](/docs/grafana-cloud/data-configuration/integrations/integration-reference/integration-macos-node/).
@@ -80,12 +91,6 @@ To send your data to Grafana Cloud, set up Grafana Agent using the Grafana Cloud
 
 ## Next steps
 
-- [Start Grafana Agent][start]
-- [Configure Grafana Agent][configure]
+- [Start Grafana Agent](ref:start)
+- [Configure Grafana Agent](ref:configure)
 
-{{% docs/reference %}}
-[start]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/start-agent"
-[start]: "/docs/grafana-cloud/ -> ../start-agent"
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/create-config-file"
-[configure]: "/docs/grafana-cloud/ -> ../../configuration/create-config-file"
-{{% /docs/reference %}}

--- a/docs/sources/static/set-up/install/install-agent-macos.md
+++ b/docs/sources/static/set-up/install/install-agent-macos.md
@@ -10,12 +10,12 @@ weight: 500
 refs:
   start:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/start-agent/
     - pattern: /docs/grafana-cloud/
       destination: ../start-agent/
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/create-config-file/
     - pattern: /docs/grafana-cloud/
       destination: ../../configuration/create-config-file/
 ---

--- a/docs/sources/static/set-up/install/install-agent-on-windows.md
+++ b/docs/sources/static/set-up/install/install-agent-on-windows.md
@@ -10,12 +10,12 @@ weight: 600
 refs:
   start:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/start-agent/
     - pattern: /docs/grafana-cloud/
       destination: ../start-agent/
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/create-config-file/
     - pattern: /docs/grafana-cloud/
       destination: ../../configuration/create-config-file/
 ---

--- a/docs/sources/static/set-up/install/install-agent-on-windows.md
+++ b/docs/sources/static/set-up/install/install-agent-on-windows.md
@@ -7,6 +7,17 @@ menuTitle: Windows
 title: Install Grafana Agent in static mode on Windows
 description: Learn how to install Grafana Agent in static mode on Windows
 weight: 600
+refs:
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+    - pattern: /docs/grafana-cloud/
+      destination: ../start-agent/
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+    - pattern: /docs/grafana-cloud/
+      destination: ../../configuration/create-config-file/
 ---
 
 # Install Grafana Agent in static mode on Windows
@@ -140,12 +151,6 @@ Refer to [windows_events](/docs/loki/latest/clients/promtail/configuration/#wind
 
 ## Next steps
 
-- [Start Grafana Agent][start]
-- [Configure Grafana Agent][configure]
+- [Start Grafana Agent](ref:start)
+- [Configure Grafana Agent](ref:configure)
 
-{{% docs/reference %}}
-[start]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/start-agent"
-[start]: "/docs/grafana-cloud/ -> ../start-agent"
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/create-config-file"
-[configure]: "/docs/grafana-cloud/ -> ../../configuration/create-config-file"
-{{% /docs/reference %}}

--- a/docs/sources/static/set-up/start-agent.md
+++ b/docs/sources/static/set-up/start-agent.md
@@ -8,7 +8,7 @@ weight: 200
 refs:
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-macos/#configure
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/install/install-agent-macos/#configure
     - pattern: /docs/grafana-cloud/
       destination: ./install/install-agent-macos/#configure
 ---

--- a/docs/sources/static/set-up/start-agent.md
+++ b/docs/sources/static/set-up/start-agent.md
@@ -5,6 +5,12 @@ menuTitle: Start static mode
 title: Start, restart, and stop Grafana Agent in static mode
 description: Learn how to start, restart, and stop Grafana Agent in static mode
 weight: 200
+refs:
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-macos/#configure
+    - pattern: /docs/grafana-cloud/
+      destination: ./install/install-agent-macos/#configure
 ---
 
 # Start, restart, and stop Grafana Agent in static mode
@@ -104,7 +110,7 @@ brew services stop grafana-agent
 By default, logs are written to `$(brew --prefix)/var/log/grafana-agent.log` and
 `$(brew --prefix)/var/log/grafana-agent.err.log`.
 
-If you followed [Configure][configure] steps in the macOS install instructions and changed the path where logs are written, refer to your current copy of the Grafana Agent formula to locate your log files.
+If you followed [Configure](ref:configure) steps in the macOS install instructions and changed the path where logs are written, refer to your current copy of the Grafana Agent formula to locate your log files.
 
 ## Windows
 
@@ -154,7 +160,3 @@ Replace the following:
 * `BINARY_PATH`: The path to the Grafana Agent binary file
 * `CONFIG_FILE`: The path to the Grafana Agent configuration file.
 
-{{% docs/reference %}}
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-macos#configure"
-[configure]: "/docs/grafana-cloud/ -> ./install/install-agent-macos/#configure"
-{{% /docs/reference %}}


### PR DESCRIPTION
You can use `ref` URIs in admonitions (or any shortcodes) because they are inline and not subject to the issues noted in the [`admonition` shortcode](https://grafana.com/docs/writers-toolkit/write/shortcodes/#code-shortcode:~:text=to%20core%20understanding.-,WARNING,For%20more%20information%2C%20refer%20to%20Markdown%20Reference%20Links%20in%20Shortcodes.,-Examples).

The `ref` URIs perform the same pattern matching as `docs/reference` but don't require the use of reference-style links and the destinations are ordinary (full) URLs that can include version substitution. Unlike `docs/reference`, the implementation doesn't use `relref` so you don't have to be careful with omitting trailing slashes and the links will follow redirects.

Documentation: https://grafana.com/docs/writers-toolkit/write/links/#link-from-source-content-thats-used-in-multiple-projects

To check the links, refer to the deploy preview in https://github.com/grafana/website/pull/19630.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
