### PR TITLE
[release-v0.37] Replace docs/reference shortcode with ref URIs

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -13,27 +13,27 @@ cascade:
 refs:
   static-mode-kubernetes-operator:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/operator/
+      destination: /docs/agent/<AGENT_VERSION>/operator/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/operator/
   flow-mode:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
   ui:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
   variants:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/about/
+      destination: /docs/agent/<AGENT_VERSION>/about/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/about/
   static-mode:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/
+      destination: /docs/agent/<AGENT_VERSION>/static/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/static/
 ---

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -10,6 +10,32 @@ weight: 350
 cascade:
   AGENT_RELEASE: v0.37.4
   OTEL_VERSION: v0.87.0
+refs:
+  static-mode-kubernetes-operator:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/operator/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/operator/
+  flow-mode:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/
+  ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+  variants:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/about/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/about/
+  static-mode:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/
 ---
 
 # Grafana Agent
@@ -54,17 +80,17 @@ Grafana Agent can collect, transform, and send data to:
 * **Battle-tested**: Grafana Agent extends the existing battle-tested code from
   the Prometheus and OpenTelemetry Collector projects.
 * **Powerful**: Write programmable pipelines with ease, and debug them using a
-  [built-in UI][UI].
+  [built-in UI](ref:ui).
 * **Batteries included**: Integrate with systems like MySQL, Kubernetes, and
   Apache to get telemetry that's immediately useful.
 
 ## Getting started
 
-* Choose a [variant][variants] of Grafana Agent to run.
+* Choose a [variant](ref:variants) of Grafana Agent to run.
 * Refer to the documentation for the variant to use:
-  * [Static mode][]
-  * [Static mode Kubernetes operator][]
-  * [Flow mode][]
+  * [Static mode](ref:static-mode)
+  * [Static mode Kubernetes operator](ref:static-mode-kubernetes-operator)
+  * [Flow mode](ref:flow-mode)
 
 ## Supported platforms
 
@@ -102,19 +128,3 @@ Patch and security releases may be created at any time.
 
 [Milestones]: https://github.com/grafana/agent/milestones
 
-{{% docs/reference %}}
-[variants]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/about"
-[variants]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/about"
-
-[Static mode]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static"
-[Static mode]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static"
-
-[Static mode Kubernetes operator]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/operator"
-[Static mode Kubernetes operator]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/operator"
-
-[Flow mode]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow"
-[Flow mode]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow"
-
-[UI]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-[UI]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-{{% /docs/reference %}}

--- a/docs/sources/_index.md.t
+++ b/docs/sources/_index.md.t
@@ -13,29 +13,29 @@ cascade:
 refs:
   variants:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/about/
+      destination: /docs/agent/<AGENT_VERSION>/about/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/about/
   static-mode:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/
+      destination: /docs/agent/<AGENT_VERSION>/static/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/static/
   flow-mode:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
   static-mode-kubernetes-operator:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/operator/
+      destination: /docs/agent/<AGENT_VERSION>/operator/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/operator/
   ui:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
 ---
 
 # Grafana Agent

--- a/docs/sources/_index.md.t
+++ b/docs/sources/_index.md.t
@@ -10,6 +10,32 @@ weight: 350
 cascade:
   AGENT_RELEASE: $AGENT_VERSION
   OTEL_VERSION: v0.87.0
+refs:
+  variants:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/about/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/about/
+  static-mode:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/
+  flow-mode:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/
+  static-mode-kubernetes-operator:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/operator/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/operator/
+  ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
 ---
 
 # Grafana Agent
@@ -54,17 +80,17 @@ Grafana Agent can collect, transform, and send data to:
 * **Battle-tested**: Grafana Agent extends the existing battle-tested code from
   the Prometheus and OpenTelemetry Collector projects.
 * **Powerful**: Write programmable pipelines with ease, and debug them using a
-  [built-in UI][UI].
+  [built-in UI](ref:ui).
 * **Batteries included**: Integrate with systems like MySQL, Kubernetes, and
   Apache to get telemetry that's immediately useful.
 
 ## Getting started
 
-* Choose a [variant][variants] of Grafana Agent to run.
+* Choose a [variant](ref:variants) of Grafana Agent to run.
 * Refer to the documentation for the variant to use:
-  * [Static mode][]
-  * [Static mode Kubernetes operator][]
-  * [Flow mode][]
+  * [Static mode](ref:static-mode)
+  * [Static mode Kubernetes operator](ref:static-mode-kubernetes-operator)
+  * [Flow mode](ref:flow-mode)
 
 ## Supported platforms
 
@@ -102,19 +128,3 @@ Patch and security releases may be created at any time.
 
 [Milestones]: https://github.com/grafana/agent/milestones
 
-{{% docs/reference %}}
-[variants]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/about"
-[variants]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/about"
-
-[Static mode]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static"
-[Static mode]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static"
-
-[Static mode Kubernetes operator]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/operator"
-[Static mode Kubernetes operator]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/operator"
-
-[Flow mode]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow"
-[Flow mode]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow"
-
-[UI]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-[UI]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-{{% /docs/reference %}}

--- a/docs/sources/about.md
+++ b/docs/sources/about.md
@@ -9,6 +9,62 @@ menuTitle: Introduction
 title: Introduction to Grafana Agent
 description: Grafana Agent is a flexible, performant, vendor-neutral, telemetry collector
 weight: 100
+refs:
+  prometheus:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-prometheus-metrics/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-prometheus-metrics/
+  clustering:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/clustering//
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/clustering//
+  static-mode:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/
+  integrations:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/configuration/integrations/
+  otel:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-opentelemetry-data/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-opentelemetry-data/
+  vault:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/remote.vault/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/remote.vault/
+  rules:
+    - pattern: /docs/agent/
+      destination: /docs/agent/latest/flow/reference/components/mimir.rules.kubernetes/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/latest/flow/reference/components/mimir.rules.kubernetes/
+  loki:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/migrating-from-promtail/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/migrating-from-promtail/
+  flow-mode:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/reference/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/reference/components/
+  static-mode-kubernetes-operator:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/operator/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/operator/
 ---
 
 # Introduction to Grafana Agent
@@ -17,30 +73,10 @@ Grafana Agent is a flexible, high performance, vendor-neutral telemetry collecto
 
 Grafana Agent is available in three different variants:
 
-- [Static mode][]: The original Grafana Agent.
-- [Static mode Kubernetes operator][]: The Kubernetes operator for Static mode.
-- [Flow mode][]: The new, component-based Grafana Agent.
+- [Static mode](ref:static-mode): The original Grafana Agent.
+- [Static mode Kubernetes operator](ref:static-mode-kubernetes-operator): The Kubernetes operator for Static mode.
+- [Flow mode](ref:flow-mode): The new, component-based Grafana Agent.
 
-{{% docs/reference %}}
-[Static mode]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static"
-[Static mode]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static"
-[Static mode Kubernetes operator]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/operator"
-[Static mode Kubernetes operator]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/operator"
-[Flow mode]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow"
-[Flow mode]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow"
-[Prometheus]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-prometheus-metrics.md"
-[Prometheus]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-prometheus-metrics.md"
-[OTel]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-opentelemetry-data.md"
-[OTel]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-opentelemetry-data.md"
-[Loki]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/migrating-from-promtail.md"
-[Loki]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/migrating-from-promtail.md"
-[clustering]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/clustering/_index.md"
-[clustering]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/clustering/_index.md"
-[rules]: "/docs/agent/ -> /docs/agent/latest/flow/reference/components/mimir.rules.kubernetes.md"
-[rules]: "/docs/grafana-cloud/ -> /docs/agent/latest/flow/reference/components/mimir.rules.kubernetes.md"
-[vault]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/remote.vault.md"
-[vault]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/remote.vault.md"
-{{% /docs/reference %}}
 
 [Pyroscope]: https://grafana.com/docs/pyroscope/latest/configure-client/grafana-agent/go_pull
 [helm chart]: https://grafana.com/docs/grafana-cloud/monitor-infrastructure/kubernetes-monitoring/configuration/config-k8s-helmchart
@@ -68,9 +104,9 @@ Each variant of Grafana Agent provides a different level of functionality. The f
 
 |              | Grafana Agent Flow mode  | Grafana Agent Static mode | Grafana Agent Operator | OpenTelemetry Collector | Prometheus Agent mode |
 |--------------|--------------------------|---------------------------|------------------------|-------------------------|-----------------------|
-| **Metrics**  | [Prometheus][], [OTel][] | Prometheus                | Prometheus             | OTel                    | Prometheus            |
-| **Logs**     | [Loki][], [OTel][]       | Loki                      | Loki                   | OTel                    | No                    |
-| **Traces**   | [OTel][]                 | OTel                      | OTel                   | OTel                    | No                    |
+| **Metrics**  | [Prometheus](ref:prometheus), [OTel](ref:otel) | Prometheus                | Prometheus             | OTel                    | Prometheus            |
+| **Logs**     | [Loki](ref:loki), [OTel](ref:otel)       | Loki                      | Loki                   | OTel                    | No                    |
+| **Traces**   | [OTel](ref:otel)                 | OTel                      | OTel                   | OTel                    | No                    |
 | **Profiles** | [Pyroscope][]            | No                        | No                     | Planned                 | No                    |
 
 #### **OSS features**
@@ -78,9 +114,9 @@ Each variant of Grafana Agent provides a different level of functionality. The f
 |                          | Grafana Agent Flow mode | Grafana Agent Static mode | Grafana Agent Operator | OpenTelemetry Collector | Prometheus Agent mode |
 |--------------------------|-------------------------|---------------------------|------------------------|-------------------------|-----------------------|
 | **Kubernetes native**    | [Yes][helm chart]       | No                        | Yes                    | Yes                     | No                    |
-| **Clustering**           | [Yes][clustering]       | No                        | No                     | No                      | No                    |
-| **Prometheus rules**     | [Yes][rules]            | No                        | No                     | No                      | No                    |
-| **Native Vault support** | [Yes][vault]            | No                        | No                     | No                      | No                    |
+| **Clustering**           | [Yes](ref:clustering)       | No                        | No                     | No                      | No                    |
+| **Prometheus rules**     | [Yes](ref:rules)            | No                        | No                     | No                      | No                    |
+| **Native Vault support** | [Yes](ref:vault)            | No                        | No                     | No                      | No                    |
 
 #### Grafana Cloud solutions
 
@@ -93,7 +129,7 @@ Each variant of Grafana Agent provides a different level of functionality. The f
 
 ### Static mode
 
-[Static mode][] is the original variant of Grafana Agent, introduced on March 3, 2020.
+[Static mode](ref:static-mode) is the original variant of Grafana Agent, introduced on March 3, 2020.
 Static mode is the most mature variant of Grafana Agent.
 
 You should run Static mode when:
@@ -109,7 +145,7 @@ Grafana Agent version 0.37 and newer provides Prometheus Operator compatibility 
 You should use Grafana Agent Flow mode for all new Grafana Agent deployments.
 {{% /admonition %}}
 
-The [Static mode Kubernetes operator][] is a variant of Grafana Agent introduced on June 17, 2021. It's currently in beta.
+The [Static mode Kubernetes operator](ref:static-mode-kubernetes-operator) is a variant of Grafana Agent introduced on June 17, 2021. It's currently in beta.
 
 The Static mode Kubernetes operator provides compatibility with Prometheus Operator,
 allowing static mode to support resources from Prometheus Operator, such as ServiceMonitors, PodMonitors, and Probes.
@@ -122,7 +158,7 @@ You should run the Static mode Kubernetes operator when:
 
 ### Flow mode
 
-[Flow mode][] is a stable variant of Grafana Agent, introduced on September 29, 2022.
+[Flow mode](ref:flow-mode) is a stable variant of Grafana Agent, introduced on September 29, 2022.
 
 Grafana Agent Flow mode focuses on vendor neutrality, ease-of-use,
 improved debugging, and ability to adapt to the needs of power users by adopting a configuration-as-code model.
@@ -146,10 +182,3 @@ You should run Flow mode when:
 [BoringCrypto](https://pkg.go.dev/crypto/internal/boring) is an **EXPERIMENTAL** feature for building Grafana Agent
 binaries and images with BoringCrypto enabled. Builds and Docker images for Linux arm64/amd64 are made available.
 
-{{% docs/reference %}}
-[integrations]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/integrations"
-[integrations]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static/configuration/integrations"
-
-[components]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/reference/components"
-[components]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/reference/components"
-{{% /docs/reference %}}

--- a/docs/sources/about.md
+++ b/docs/sources/about.md
@@ -22,12 +22,12 @@ refs:
       destination: /docs/agent/<AGENT_VERSION>/flow/concepts/clustering//
   static-mode:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/
+      destination: /docs/agent/<AGENT_VERSION>/static/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/static/
   integrations:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/integrations/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/static/configuration/integrations/
   otel:
@@ -52,17 +52,17 @@ refs:
       destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/migrating-from-promtail/
   flow-mode:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
   components:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/reference/components/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/reference/components/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/
   static-mode-kubernetes-operator:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/operator/
+      destination: /docs/agent/<AGENT_VERSION>/operator/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/operator/
 ---

--- a/docs/sources/data-collection.md
+++ b/docs/sources/data-collection.md
@@ -9,6 +9,25 @@ menuTitle: Data collection
 title: Grafana Agent data collection
 description: Grafana Agent data collection
 weight: 500
+refs:
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+  command-line-flag:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+  static:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/
+  flow:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
 ---
 
 # Data collection
@@ -26,23 +45,13 @@ The usage information includes the following details:
 * Version of running Grafana Agent.
 * Operating system Grafana Agent is running on.
 * System architecture Grafana Agent is running on.
-* List of enabled feature flags ([Static] mode only).
-* List of enabled integrations ([Static] mode only).
-* List of enabled [components][] ([Flow] mode only).
+* List of enabled feature flags [Static](ref:static) mode only).
+* List of enabled integrations [Static](ref:static) mode only).
+* List of enabled [components](ref:components) [Flow](ref:flow) mode only).
 
 This list may change over time. All newly reported data is documented in the CHANGELOG.
 
 ## Opt-out of data collection
 
-You can use the `-disable-reporting` [command line flag][] to disable the reporting and opt-out of the data collection.
+You can use the `-disable-reporting` [command line flag](ref:command-line-flag) to disable the reporting and opt-out of the data collection.
 
-{{% docs/reference %}}
-[command line flag]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[command line flag]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
-[components]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[Static]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static"
-[Static]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static
-[Flow]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow"
-[Flow]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT_VERSION>/flow"
-{{% /docs/reference %}}

--- a/docs/sources/data-collection.md
+++ b/docs/sources/data-collection.md
@@ -45,9 +45,9 @@ The usage information includes the following details:
 * Version of running Grafana Agent.
 * Operating system Grafana Agent is running on.
 * System architecture Grafana Agent is running on.
-* List of enabled feature flags [Static](ref:static) mode only).
-* List of enabled integrations [Static](ref:static) mode only).
-* List of enabled [components](ref:components) [Flow](ref:flow) mode only).
+* List of enabled feature flags ([Static](ref:static) mode only).
+* List of enabled integrations ([Static](ref:static) mode only).
+* List of enabled [components](ref:components) ([Flow](ref:flow) mode only).
 
 This list may change over time. All newly reported data is documented in the CHANGELOG.
 

--- a/docs/sources/flow/concepts/clustering.md
+++ b/docs/sources/flow/concepts/clustering.md
@@ -10,6 +10,42 @@ menuTitle: Clustering
 title: Clustering (beta)
 description: Learn about Grafana Agent clustering concepts
 weight: 500
+refs:
+  prometheus.operator.podmonitors:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.operator.podmonitors/#clustering-beta
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.operator.podmonitors/#clustering-beta
+  run:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/#clustering-beta
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/run/#clustering-beta
+  clustering-page:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#clustering-page
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#clustering-page
+  pyroscope.scrape:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/pyroscope.scrape/#clustering-beta
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/pyroscope.scrape/#clustering-beta
+  debugging:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#debugging-clustering-issues
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#debugging-clustering-issues
+  prometheus.scrape:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape/#clustering-beta
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.scrape/#clustering-beta
+  prometheus.operator.servicemonitors:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.operator.servicemonitors/#clustering-beta
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.operator.servicemonitors/#clustering-beta
 ---
 
 # Clustering (beta)
@@ -25,7 +61,7 @@ same configuration file.
 The behavior of a standalone, non-clustered agent is the same as if it was a
 single-node cluster.
 
-You configure clustering by passing `cluster` command-line flags to the [run][]
+You configure clustering by passing `cluster` command-line flags to the [run](ref:run)
 command.
 
 ## Use cases
@@ -64,30 +100,14 @@ targets, meaning that, on average, only ~1/N of the targets are redistributed.
 Refer to component reference documentation to discover whether it supports
 clustering, such as:
 
-- [prometheus.scrape][]
-- [pyroscope.scrape][]
-- [prometheus.operator.podmonitors][]
-- [prometheus.operator.servicemonitors][]
+- [prometheus.scrape](ref:prometheus.scrape)
+- [pyroscope.scrape](ref:pyroscope.scrape)
+- [prometheus.operator.podmonitors](ref:prometheus.operator.podmonitors)
+- [prometheus.operator.servicemonitors](ref:prometheus.operator.servicemonitors)
 
 ## Cluster monitoring and troubleshooting
 
-To monitor your cluster status, you can check the Flow UI [clustering page][].
-The [debugging][] topic contains some clues to help pin down probable
+To monitor your cluster status, you can check the Flow UI [clustering page](ref:clustering-page).
+The [debugging](ref:debugging) topic contains some clues to help pin down probable
 clustering issues.
 
-{{% docs/reference %}}
-[run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md#clustering-beta"
-[run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md#clustering-beta"
-[prometheus.scrape]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape.md#clustering-beta"
-[prometheus.scrape]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.scrape.md#clustering-beta"
-[pyroscope.scrape]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/pyroscope.scrape.md#clustering-beta"
-[pyroscope.scrape]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/pyroscope.scrape.md#clustering-beta"
-[prometheus.operator.podmonitors]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.operator.podmonitors.md#clustering-beta"
-[prometheus.operator.podmonitors]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.operator.podmonitors.md#clustering-beta"
-[prometheus.operator.servicemonitors]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.operator.servicemonitors.md#clustering-beta"
-[prometheus.operator.servicemonitors]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.operator.servicemonitors.md#clustering-beta"
-[clustering page]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md#clustering-page"
-[clustering page]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md#clustering-page"
-[debugging]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md#debugging-clustering-issues"
-[debugging]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md#debugging-clustering-issues"
-{{% /docs/reference %}}

--- a/docs/sources/flow/concepts/component_controller.md
+++ b/docs/sources/flow/concepts/component_controller.md
@@ -8,6 +8,22 @@ canonical: https://grafana.com/docs/agent/latest/flow/concepts/component_control
 title: Component controller
 description: Learn about the component controller
 weight: 200
+refs:
+  run:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/run/
+  prometheus.exporter.unix:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.exporter.unix/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.exporter.unix/
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/components/
 ---
 
 # Component controller
@@ -24,7 +40,7 @@ The component controller is responsible for:
 
 ## Component graph
 
-As discussed in [Components][], a relationship between components is created
+As discussed in [Components](ref:components), a relationship between components is created
 when an expression is used to set the argument of one component to an exported
 field of another component.
 
@@ -65,7 +81,7 @@ components can be evaluated at any time during the evaluation process.
 
 ## Component reevaluation
 
-As mentioned in [Components][], a component is dynamic: a component can update
+As mentioned in [Components](ref:components), a component is dynamic: a component can update
 its exports any number of times throughout its lifetime.
 
 When a component updates its exports, a _controller reevaluation_ is triggered:
@@ -113,7 +129,7 @@ valid API key until the component returns to a healthy state.
 
 ## In-memory traffic
 
-Components which expose HTTP endpoints, such as [prometheus.exporter.unix][],
+Components which expose HTTP endpoints, such as [prometheus.exporter.unix](ref:prometheus.exporter.unix),
 can expose an internal address which will completely bypass the network and
 communicate in-memory. This allows components within the same process to
 communicate with one another without needing to be aware of any network-level
@@ -121,7 +137,7 @@ protections such as authentication or mutual TLS.
 
 The internal address defaults to `agent.internal:12345`. If this address
 collides with a real target on your network, change it to something unique
-using the `--server.http.memory-addr` flag in the [run][] command.
+using the `--server.http.memory-addr` flag in the [run](ref:run) command.
 
 Components must opt-in to using in-memory traffic. See the individual
 documentation for components to learn if in-memory traffic is supported.
@@ -138,11 +154,3 @@ reloading.
 
 [DAG]: https://en.wikipedia.org/wiki/Directed_acyclic_graph
 
-{{% docs/reference %}}
-[prometheus.exporter.unix]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.exporter.unix.md"
-[prometheus.exporter.unix]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.exporter.unix.md"
-[run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md"
-[Components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
-[Components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/components.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/concepts/configuration_language.md
+++ b/docs/sources/flow/concepts/configuration_language.md
@@ -8,6 +8,12 @@ canonical: https://grafana.com/docs/agent/latest/flow/concepts/configuration_lan
 title: Configuration language concepts
 description: Learn about configuration language concepts
 weight: 400
+refs:
+  config-docs:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/config-language/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/config-language/
 ---
 
 # Configuration language concepts
@@ -97,10 +103,6 @@ This file has two blocks:
 
 ## More information
 
-River is documented in detail in [Configuration language][config-docs] section
+River is documented in detail in [Configuration language](ref:config-docs) section
 of the Grafana Agent Flow docs.
 
-{{% docs/reference %}}
-[config-docs]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/config-language"
-[config-docs]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/config-language"
-{{% /docs/reference %}}

--- a/docs/sources/flow/concepts/modules.md
+++ b/docs/sources/flow/concepts/modules.md
@@ -8,6 +8,27 @@ canonical: https://grafana.com/docs/agent/latest/flow/concepts/modules/
 title: Modules
 description: Learn about modules
 weight: 300
+refs:
+  component-controller:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/component_controller/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/component_controller/
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/
+  export-block:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/config-blocks/export/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/export/
+  argument-block:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/config-blocks/argument/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/argument/
 ---
 
 # Modules
@@ -25,7 +46,7 @@ Modules are Grafana Agent Flow configurations which have:
 Modules are loaded into Grafana Agent Flow by using a [Module
 loader](#module-loaders).
 
-Refer to the documentation for the [argument block][] and [export block][] to
+Refer to the documentation for the [argument block](ref:argument-block) and [export block](ref:export-block) to
 learn how to define arguments and exports for a module.
 
 ## Module loaders
@@ -36,13 +57,13 @@ and runs the components defined inside of it.
 Module loader components are responsible for:
 
 * Retrieving the module source to run.
-* Creating a [Component controller][] for the module to run in.
+* Creating a [Component controller](ref:component-controller) for the module to run in.
 * Passing arguments to the loaded module.
 * Exposing exports from the loaded module.
 
 Module loaders typically are called `module.LOADER_NAME`. The list of module
 loader components can be found in the list of Grafana Agent Flow
-[Components][].
+[Components](ref:components).
 
 Some module loaders may not support running modules with arguments or exports.
 Refer to the documentation for the module loader you are using for more
@@ -140,13 +161,3 @@ loki.write "default" {
 }
 ```
 
-{{% docs/reference %}}
-[argument block]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/config-blocks/argument.md"
-[argument block]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/argument.md"
-[export block]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/config-blocks/export.md"
-[export block]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/export.md"
-[Component controller]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/component_controller.md"
-[Component controller]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/component_controller.md"
-[Components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components"
-[Components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components"
-{{% /docs/reference %}}

--- a/docs/sources/flow/getting-started/collect-opentelemetry-data.md
+++ b/docs/sources/flow/getting-started/collect-opentelemetry-data.md
@@ -7,6 +7,37 @@ canonical: https://grafana.com/docs/agent/latest/flow/getting-started/collect-op
 title: Collect OpenTelemetry data
 description: Learn how to collect OpenTelemetry data
 weight: 300
+refs:
+  otelcol.exporter.otlphttp:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.otlphttp/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.exporter.otlphttp/
+  otelcol.auth.basic:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.auth.basic/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.auth.basic/
+  otelcol.exporter.otlp:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.otlp/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.exporter.otlp/
+  otelcol.processor.batch:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.processor.batch/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.processor.batch/
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/components/
+  otelcol.receiver.otlp:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.receiver.otlp/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.receiver.otlp/
 ---
 
 # Collect OpenTelemetry data
@@ -22,11 +53,11 @@ This topic describes how to:
 
 ## Components used in this topic
 
-* [otelcol.auth.basic][]
-* [otelcol.exporter.otlp][]
-* [otelcol.exporter.otlphttp][]
-* [otelcol.processor.batch][]
-* [otelcol.receiver.otlp][]
+* [otelcol.auth.basic](ref:otelcol.auth.basic)
+* [otelcol.exporter.otlp](ref:otelcol.exporter.otlp)
+* [otelcol.exporter.otlphttp](ref:otelcol.exporter.otlphttp)
+* [otelcol.processor.batch](ref:otelcol.processor.batch)
+* [otelcol.receiver.otlp](ref:otelcol.receiver.otlp)
 
 ## Before you begin
 
@@ -35,7 +66,7 @@ This topic describes how to:
 * Have a set of OpenTelemetry applications ready to push telemetry data to
   Grafana Agent Flow.
 * Identify where Grafana Agent Flow will write received telemetry data.
-* Be familiar with the concept of [Components][] in Grafana Agent Flow.
+* Be familiar with the concept of [Components](ref:components) in Grafana Agent Flow.
 
 ## Configure an OpenTelemetry Protocol exporter
 
@@ -44,12 +75,12 @@ responsible for exporting the OpenTelemetry data. An OpenTelemetry _exporter
 component_ is responsible for writing (that is, exporting) OpenTelemetry data
 to an external system.
 
-In this task, we will use the [otelcol.exporter.otlp][] component to send
+In this task, we will use the [otelcol.exporter.otlp](ref:otelcol.exporter.otlp) component to send
 OpenTelemetry data to a server using the OpenTelemetry Protocol (OTLP). Once an
 exporter component is defined, other Grafana Agent Flow components can be used
 to forward data to it.
 
-> Refer to the list of available [Components][] for the full list of
+> Refer to the list of available [Components](ref:components) for the full list of
 > `otelcol.exporter` components that can be used to export OpenTelemetry data.
 
 To configure an `otelcol.exporter.otlp` component for exporting OpenTelemetry
@@ -110,7 +141,7 @@ data using OTLP, complete the following steps:
 
 > `otelcol.exporter.otlp` sends data using OTLP over gRPC (HTTP/2). To send to
 > a server using HTTP/1.1, follow the steps above but use the
-> [otelcol.exporter.otlphttp component][otelcol.exporter.otlphttp] instead.
+> [otelcol.exporter.otlphttp component](ref:otelcol.exporter.otlphttp) instead.
 
 The following example demonstrates configuring `otelcol.exporter.otlp` with
 authentication and a component which forwards data to it:
@@ -148,7 +179,7 @@ otelcol.receiver.otlp "example" {
 ```
 
 For more information on writing OpenTelemetry data using the OpenTelemetry
-Protocol, refer to [otelcol.exporter.otlp][].
+Protocol, refer to [otelcol.exporter.otlp](ref:otelcol.exporter.otlp).
 
 ## Configure batching
 
@@ -161,10 +192,10 @@ Ensuring data is batched is a production-readiness step to improve the
 compression of data and reduce the number of outgoing network requests to
 external systems.
 
-In this task, we will configure an [otelcol.processor.batch][] component to
+In this task, we will configure an [otelcol.processor.batch](ref:otelcol.processor.batch) component to
 batch data before sending it to our exporter.
 
-> Refer to the list of available [Components][] for the full list of
+> Refer to the list of available [Components](ref:components) for the full list of
 > `otelcol.processor` components that can be used to process OpenTelemetry
 > data. You can chain processors by having one processor send data to another
 > processor.
@@ -233,7 +264,7 @@ otelcol.exporter.otlp "default" {
 ```
 
 For more information on configuring OpenTelemetry data batching, refer to
-[otelcol.processor.batch][].
+[otelcol.processor.batch](ref:otelcol.processor.batch).
 
 ## Configure an OpenTelemetry Protocol receiver
 
@@ -241,12 +272,12 @@ Grafana Agent Flow can be configured to receive OpenTelemetry metrics, logs,
 and traces. An OpenTelemetry _receiver_ component is responsible for receiving
 OpenTelemetry data from an external system.
 
-In this task, we will use the [otelcol.receiver.otlp][] component to receive
+In this task, we will use the [otelcol.receiver.otlp](ref:otelcol.receiver.otlp) component to receive
 OpenTelemetry data over the network using the OpenTelemetry Protocol (OTLP). A
 receiver component can be configured to forward received data to other Grafana
 Agent Flow components.
 
-> Refer to the list of available [Components][] for the full list of
+> Refer to the list of available [Components](ref:components) for the full list of
 > `otelcol.receiver` components that can be used to receive
 > OpenTelemetry-compatible data.
 
@@ -351,21 +382,7 @@ otelcol.exporter.otlp "default" {
 ```
 
 For more information on receiving OpenTelemetry data using the OpenTelemetry
-Protocol, refer to [otelcol.receiver.otlp][].
+Protocol, refer to [otelcol.receiver.otlp](ref:otelcol.receiver.otlp).
 
 [OpenTelemetry]: https://opentelemetry.io
 
-{{% docs/reference %}}
-[otelcol.auth.basic]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.auth.basic.md"
-[otelcol.auth.basic]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.auth.basic.md"
-[otelcol.exporter.otlp]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.otlp.md"
-[otelcol.exporter.otlp]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.exporter.otlp.md"
-[otelcol.exporter.otlphttp]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.otlphttp.md"
-[otelcol.exporter.otlphttp]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.exporter.otlphttp.md"
-[otelcol.processor.batch]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.processor.batch.md"
-[otelcol.processor.batch]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.processor.batch.md"
-[otelcol.receiver.otlp]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.receiver.otlp.md"
-[otelcol.receiver.otlp]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.receiver.otlp.md"
-[Components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
-[Components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/components.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/getting-started/collect-prometheus-metrics.md
+++ b/docs/sources/flow/getting-started/collect-prometheus-metrics.md
@@ -7,6 +7,32 @@ canonical: https://grafana.com/docs/agent/latest/flow/getting-started/collect-pr
 title: Collect and forward Prometheus metrics
 description: Learn how to collect and forward Prometheus metrics
 weight: 200
+refs:
+  objects:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/config-language/expressions/types_and_values/#objects
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/config-language/expressions/types_and_values/#objects
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/components/
+  prometheus.remote_write:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.remote_write/
+  discovery.kubernetes:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/discovery.kubernetes/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/discovery.kubernetes/
+  prometheus.scrape:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.scrape/
 ---
 
 # Collect and forward Prometheus metrics
@@ -21,9 +47,9 @@ This topic describes how to:
 
 ## Components used in this topic
 
-* [discovery.kubernetes][]
-* [prometheus.remote_write][]
-* [prometheus.scrape][]
+* [discovery.kubernetes](ref:discovery.kubernetes)
+* [prometheus.remote_write](ref:prometheus.remote_write)
+* [prometheus.scrape](ref:prometheus.scrape)
 
 ## Before you begin
 
@@ -34,14 +60,14 @@ This topic describes how to:
 * Identify where you will write collected metrics. Metrics may be written to
   Prometheus or Prometheus-compatible endpoints such as Grafana Mimir, Grafana
   Cloud, or Grafana Enterprise Metrics.
-* Be familiar with the concept of [Components][] in Grafana Agent Flow.
+* Be familiar with the concept of [Components](ref:components) in Grafana Agent Flow.
 
 ## Configure metrics delivery
 
 Before components can collect Prometheus metrics, you must have a component
 responsible for writing those metrics somewhere.
 
-The [prometheus.remote_write][] component is responsible for delivering
+The [prometheus.remote_write](ref:prometheus.remote_write) component is responsible for delivering
 Prometheus metrics to one or Prometheus-compatible endpoints. Once a
 `prometheus.remote_write` component is defined, other Grafana Agent Flow
 components can be used to forward metrics to it.
@@ -117,7 +143,7 @@ prometheus.scrape "example" {
 ```
 
 For more information on configuring metrics delivery, refer to
-[prometheus.remote_write][].
+[prometheus.remote_write](ref:prometheus.remote_write).
 
 ## Collect metrics from Kubernetes Pods
 
@@ -257,7 +283,7 @@ prometheus.remote_write "default" {
 ```
 
 For more information on configuring Kubernetes service delivery and collecting
-metrics, refer to [discovery.kubernetes][] and [prometheus.scrape][].
+metrics, refer to [discovery.kubernetes](ref:discovery.kubernetes) and [prometheus.scrape](ref:prometheus.scrape).
 
 ## Collect metrics from Kubernetes Services
 
@@ -397,7 +423,7 @@ prometheus.remote_write "default" {
 ```
 
 For more information on configuring Kubernetes service delivery and collecting
-metrics, refer to [discovery.kubernetes][] and [prometheus.scrape][].
+metrics, refer to [discovery.kubernetes](ref:discovery.kubernetes) and [prometheus.scrape](ref:prometheus.scrape).
 
 ## Collect metrics from custom targets
 
@@ -422,7 +448,7 @@ To collect metrics from a custom set of targets, complete the following steps:
         `custom_targets`. The label chosen must be unique across all
         `prometheus.scrape` components in the same configuration file.
 
-     2. Replace `TARGET_LIST` with a comma-delimited list of [Objects][]
+     2. Replace `TARGET_LIST` with a comma-delimited list of [Objects](ref:objects)
         denoting the Prometheus target. Each object must conform to the
         following rules:
 
@@ -487,15 +513,3 @@ prometheus.remote_write "default" {
 [Field Selectors]: https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/
 [Labels and Selectors]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement
 
-{{% docs/reference %}}
-[discovery.kubernetes]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/discovery.kubernetes.md"
-[discovery.kubernetes]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/discovery.kubernetes.md"
-[prometheus.remote_write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write.md"
-[prometheus.remote_write]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.remote_write.md"
-[prometheus.scrape]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape.md"
-[prometheus.scrape]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.scrape.md"
-[Components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
-[Components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/components.md"
-[Objects]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/config-language/expressions/types_and_values.md#objects"
-[Objects]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/config-language/expressions/types_and_values.md#objects"
-{{% /docs/reference %}}

--- a/docs/sources/flow/getting-started/configure-agent-clustering.md
+++ b/docs/sources/flow/getting-started/configure-agent-clustering.md
@@ -8,16 +8,37 @@ menuTitle: Configure Grafana Agent clustering
 title: Configure Grafana Agent clustering in an existing installation
 description: Learn how to configure Grafana Agent clustering in an existing installation
 weight: 400
+refs:
+  ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#component-detail-page
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#component-detail-page
+  beta:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/stability/#beta
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/stability/#beta
+  clustering:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/clustering/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/clustering/
+  install-helm:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/install/kubernetes/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/install/kubernetes/
 ---
 
 # Configure Grafana Agent clustering in an existing installation
 
-You can configure Grafana Agent to run with [clustering][] so that
+You can configure Grafana Agent to run with [clustering](ref:clustering) so that
 individual agents can work together for workload distribution and high
 availability.
 
 
-> **Note:** Clustering is a [beta][] feature. Beta features are subject to breaking changes and may be
+> **Note:** Clustering is a [beta](ref:beta) feature. Beta features are subject to breaking changes and may be
 > replaced with equivalent functionality that covers the same use case.
 
 This topic describes how to add clustering to an existing installation.
@@ -25,7 +46,7 @@ This topic describes how to add clustering to an existing installation.
 ## Configure Grafana Agent clustering with Helm Chart
 
 This section guides you through enabling clustering when Grafana Agent is
-installed on Kubernetes using the [Grafana Agent Helm chart][install-helm].
+installed on Kubernetes using the [Grafana Agent Helm chart](ref:install-helm).
 
 ### Before you begin
 
@@ -54,19 +75,9 @@ To configure clustering:
    Replace `RELEASE_NAME` with the name of the installation you chose when you
    installed the Helm chart.
 
-1. Use the [Grafana Agent UI][UI] to verify the cluster status:
+1. Use the [Grafana Agent UI](ref:ui) to verify the cluster status:
 
    1. Click **Clustering** in the navigation bar.
 
    2. Ensure that all expected nodes appear in the resulting table.
 
-{{% docs/reference %}}
-[clustering]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/clustering.md"
-[clustering]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/clustering.md"
-[beta]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/stability.md#beta"
-[beta]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/stability.md#beta"
-[install-helm]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/install/kubernetes.md"
-[install-helm]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/install/kubernetes.md"
-[UI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md#component-detail-page"
-[UI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md#component-detail-page"
-{{% /docs/reference %}}

--- a/docs/sources/flow/getting-started/distribute-prometheus-scrape-load.md
+++ b/docs/sources/flow/getting-started/distribute-prometheus-scrape-load.md
@@ -8,23 +8,54 @@ menuTitle: Distribute Prometheus metrics scrape load
 title: Distribute Prometheus metrics scrape load
 description: Learn how to distribute your Prometheus metrics scrape load
 weight: 500
+refs:
+  clustering:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/clustering/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/clustering/
+  configure-grafana-agent:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/configure/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/configure/
+  configure-prometheus-metrics-collection:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-prometheus-metrics/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/getting-started/collect-prometheus-metrics/
+  beta:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/stability/#beta
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/stability/#beta
+  configure-clustering:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/configure-agent-clustering/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/getting-started/configure-agent-clustering/
+  ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#component-detail-page
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#component-detail-page
 ---
 
 # Distribute Prometheus metrics scrape load
 
 A good predictor for the size of an agent deployment is the number of
-Prometheus targets each agent scrapes. [Clustering][] with target
+Prometheus targets each agent scrapes. [Clustering](ref:clustering) with target
 auto-distribution allows a fleet of agents to work together to dynamically
 distribute their scrape load, providing high-availability.
 
-> **Note:** Clustering is a [beta][] feature. Beta features are subject to breaking
+> **Note:** Clustering is a [beta](ref:beta) feature. Beta features are subject to breaking
 > changes and may be replaced with equivalent functionality that covers the same use case.
 
 ## Before you begin
 
-- Familiarize yourself with how to [configure existing Grafana Agent installations][configure-grafana-agent].
-- [Configure Prometheus metrics collection][].
-- [Configure clustering][] of agents.
+- Familiarize yourself with how to [configure existing Grafana Agent installations](ref:configure-grafana-agent).
+- [Configure Prometheus metrics collection](ref:configure-prometheus-metrics-collection).
+- [Configure clustering](ref:configure-clustering) of agents.
 - Ensure that all of your clustered agents have the same configuration file.
 
 ## Steps
@@ -44,23 +75,9 @@ To distribute Prometheus metrics scrape load with clustering:
 
 3. Validate that auto-distribution is functioning:
 
-   1. Using the [Grafana Agent UI][UI] on each agent, navigate to the details page for one of
+   1. Using the [Grafana Agent UI](ref:ui) on each agent, navigate to the details page for one of
       the `prometheus.scrape` components you modified.
 
    2. Compare the Debug Info sections between two different agents to ensure
       that they're not scraping the same sets of targets.
 
-{{% docs/reference %}}
-[Clustering]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/clustering.md"
-[Clustering]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/clustering.md"
-[beta]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/stability.md#beta"
-[beta]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/stability.md#beta"
-[configure-grafana-agent]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/configure"
-[configure-grafana-agent]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/configure"
-[Configure Prometheus metrics collection]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-prometheus-metrics.md"
-[Configure Prometheus metrics collection]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/getting-started/collect-prometheus-metrics.md"
-[Configure clustering]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/configure-agent-clustering.md"
-[Configure clustering]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/getting-started/configure-agent-clustering.md"
-[UI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md#component-detail-page"
-[UI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md#component-detail-page"
-{{% /docs/reference %}}

--- a/docs/sources/flow/getting-started/migrating-from-prometheus.md
+++ b/docs/sources/flow/getting-started/migrating-from-prometheus.md
@@ -8,6 +8,52 @@ menuTitle: Migrate from Prometheus
 title: Migrate from Prometheus to Grafana Agent Flow
 description: Learn how to migrate from Prometheus to Grafana Agent Flow
 weight: 320
+refs:
+  convert:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/convert/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/convert/
+  prometheus.remote_write:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.remote_write/
+  river:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/config-language//
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/config-language//
+  run:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/run/
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/components/
+  flow-debugging:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/
+  start-the-agent:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/start-agent/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/start-agent/
+  prometheus.scrape:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.scrape/
+  grafana-agent-flow-ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#grafana-agent-flow-ui
 ---
 
 # Migrate from Prometheus to Grafana Agent Flow
@@ -21,23 +67,23 @@ This topic describes how to:
 
 ## Components used in this topic
 
-* [prometheus.scrape][]
-* [prometheus.remote_write][]
+* [prometheus.scrape](ref:prometheus.scrape)
+* [prometheus.remote_write](ref:prometheus.remote_write)
 
 ## Before you begin
 
 * You must have an existing Prometheus configuration.
 * You must have a set of Prometheus applications ready to push telemetry data to Grafana Agent.
-* You must be familiar with the concept of [Components][] in Grafana Agent flow mode.
+* You must be familiar with the concept of [Components](ref:components) in Grafana Agent flow mode.
 
 ## Convert a Prometheus configuration
 
-To fully migrate your configuration from [Prometheus] to Grafana Agent
+To fully migrate your configuration from[Prometheus][] to Grafana Agent
 in flow mode, you must convert your Prometheus configuration into a Grafana Agent flow
 mode configuration. This conversion will enable you to take full advantage of the many
 additional features available in Grafana Agent flow mode.
 
-> In this task, we will use the [convert][] CLI command to output a flow
+> In this task, we will use the [convert](ref:convert) CLI command to output a flow
 > configuration from a Prometheus configuration.
 
 1. Open a terminal window and run the following command:
@@ -58,7 +104,7 @@ additional features available in Grafana Agent flow mode.
       * `INPUT_CONFIG_PATH`: The full path to the Prometheus configuration.
       * `OUTPUT_CONFIG_PATH`: The full path to output the flow configuration.
 
-1. [Start the agent][] in flow mode using the new flow configuration from `OUTPUT_CONFIG_PATH`:
+1. [Start the agent](ref:start-the-agent) in flow mode using the new flow configuration from `OUTPUT_CONFIG_PATH`:
 
 ### Debugging
 
@@ -115,10 +161,10 @@ If you’re not ready to completely switch to a flow configuration, you can run 
 The `--config.format=prometheus` flag tells Grafana Agent to convert your Prometheus configuration to flow mode and load it directly without saving the new configuration.
 This allows you to try flow mode without modifying your existing Prometheus configuration infrastructure.
 
-> In this task, we will use the [run][] CLI command to run Grafana Agent in flow
+> In this task, we will use the [run](ref:run) CLI command to run Grafana Agent in flow
 > mode using a Prometheus configuration.
 
-[Start the agent][] in flow mode and include the command line flag
+[Start the agent](ref:start-the-agent) in flow mode and include the command line flag
    `--config.format=prometheus`. Your configuration file must be a valid
    Prometheus configuration file rather than a flow mode configuration file.
 
@@ -127,7 +173,7 @@ This allows you to try flow mode without modifying your existing Prometheus conf
 1. You can follow the convert CLI command [debugging][] instructions to
    generate a diagnostic report.
 
-1. Refer to the Grafana Agent [Flow Debugging][] for more information about a running Grafana
+1. Refer to the Grafana Agent [Flow Debugging](ref:flow-debugging) for more information about a running Grafana
    Agent in flow mode.
 
 1. If your Prometheus configuration cannot be converted and
@@ -165,7 +211,7 @@ remote_write:
       password: PASSWORD
 ```
 
-The convert command takes the YAML file as input and outputs a [River][] file.
+The convert command takes the YAML file as input and outputs a [River](ref:river) file.
 
 {{< code >}}
 
@@ -235,28 +281,8 @@ Furthermore, we recommend that you review the following checklist:
   the new metric names, for example, in your alerts and dashboards queries.
 * The logs produced by Grafana Agent will differ from those
   produced by Prometheus.
-* Grafana Agent exposes the [Grafana Agent Flow UI][].
+* Grafana Agent exposes the [Grafana Agent Flow UI](ref:grafana-agent-flow-ui).
 
 [Prometheus]: https://prometheus.io/docs/prometheus/latest/configuration/configuration/
 [debugging]: #debugging
 
-{{% docs/reference %}}
-[prometheus.scrape]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape.md"
-[prometheus.scrape]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.scrape.md"
-[prometheus.remote_write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write.md"
-[prometheus.remote_write]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.remote_write.md"
-[Components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
-[Components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/components.md"
-[convert]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/convert.md"
-[convert]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/convert.md"
-[run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md"
-[Start the agent]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/start-agent.md"
-[Start the agent]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/start-agent.md"
-[Flow Debugging]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md"
-[Flow Debugging]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md"
-[River]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/config-language/_index.md"
-[River]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/config-language/_index.md"
-[Grafana Agent Flow UI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging#grafana-agent-flow-ui"
-[Grafana Agent Flow UI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging#grafana-agent-flow-ui"
-{{% /docs/reference %}}

--- a/docs/sources/flow/getting-started/migrating-from-promtail.md
+++ b/docs/sources/flow/getting-started/migrating-from-promtail.md
@@ -8,6 +8,57 @@ menuTitle: Migrate from Promtail
 title: Migrate from Promtail to Grafana Agent Flow
 description: Learn how to migrate from Promtail to Grafana Agent Flow
 weight: 330
+refs:
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/components/
+  river:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/config-language//
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/config-language//
+  run:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/run/
+  convert:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/convert/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/convert/
+  loki.source.file:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.source.file/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.source.file/
+  local.file_match:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/local.file_match/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/local.file_match/
+  loki.write:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.write/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.write/
+  start-the-agent:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/start-agent/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/start-agent/
+  grafana-agent-flow-ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#grafana-agent-flow-ui
+  flow-debugging:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/
 ---
 
 # Migrate from Promtail to Grafana Agent Flow
@@ -22,23 +73,23 @@ This topic describes how to:
 
 ## Components used in this topic
 
-* [local.file_match][]
-* [loki.source.file][]
-* [loki.write][]
+* [local.file_match](ref:local.file_match)
+* [loki.source.file](ref:loki.source.file)
+* [loki.write](ref:loki.write)
 
 ## Before you begin
 
 * You must have an existing Promtail configuration.
-* You must be familiar with the concept of [Components][] in Grafana Agent Flow mode.
+* You must be familiar with the concept of [Components](ref:components) in Grafana Agent Flow mode.
 
 ## Convert a Promtail configuration
 
-To fully migrate from [Promtail] to Grafana Agent Flow Mode, you must convert
+To fully migrate from[Promtail][] to Grafana Agent Flow Mode, you must convert
 your Promtail configuration into a Grafana Agent Flow Mode configuration. This
 conversion will enable you to take full advantage of the many additional
 features available in Grafana Agent Flow Mode.
 
-> In this task, we will use the [convert][] CLI command to output a flow
+> In this task, we will use the [convert](ref:convert) CLI command to output a flow
 > configuration from a Promtail configuration.
 
 1. Open a terminal window and run the following command:
@@ -120,7 +171,7 @@ configuration to Flow Mode and load it directly without saving the new
 configuration. This allows you to try Flow Mode without modifying your existing
 Promtail configuration infrastructure.
 
-> In this task, we will use the [run][] CLI command to run Grafana Agent in Flow
+> In this task, we will use the [run](ref:run) CLI command to run Grafana Agent in Flow
 > mode using a Promtail configuration.
 
 [Start the Agent][] in Flow mode and include the command line flag
@@ -132,7 +183,7 @@ configuration file rather than a Flow mode configuration file.
 1. You can follow the convert CLI command [debugging][] instructions to generate
    a diagnostic report.
 
-1. Refer to the Grafana Agent [Flow Debugging][] for more information about
+1. Refer to the Grafana Agent [Flow Debugging](ref:flow-debugging) for more information about
    running Grafana Agent in Flow mode.
 
 1. If your Promtail configuration can't be converted and loaded directly into
@@ -165,7 +216,7 @@ scrape_configs:
           __path__: /var/log/*.log
 ```
 
-The convert command takes the YAML file as input and outputs a [River][] file.
+The convert command takes the YAML file as input and outputs a [River](ref:river) file.
 
 {{< code >}}
 
@@ -219,7 +270,7 @@ Furthermore, we recommend that you review the following checklist:
   whether [expanded in the config file][] itself or consumed directly by
   Promtail, such as `JAEGER_AGENT_HOST`.
 * In Flow Mode, the positions file is saved at a different location.
-  Refer to the [loki.source.file][] documentation for more details. Check if you have any existing
+  Refer to the [loki.source.file](ref:loki.source.file) documentation for more details. Check if you have any existing
   setup, for example, a Kubernetes Persistent Volume, that you must update to use the new
   positions file path.
 * Metamonitoring metrics exposed by the Flow Mode usually match Promtail
@@ -227,32 +278,10 @@ Furthermore, we recommend that you review the following checklist:
   use the new metric names, for example, in your alerts and dashboards queries.
 * Note that the logs produced by the Agent will differ from those
   produced by Promtail.
-* Note that the Agent exposes the [Grafana Agent Flow UI][], which differs
+* Note that the Agent exposes the [Grafana Agent Flow UI](ref:grafana-agent-flow-ui), which differs
   from Promtail's Web UI.
 
 [Promtail]: https://www.grafana.com/docs/loki/<LOKI_VERSION>/clients/promtail/
 [debugging]: #debugging
 [expanded in the config file]: https://www.grafana.com/docs/loki/<LOKI_VERSION>/clients/promtail/configuration/#use-environment-variables-in-the-configuration
 
-{{% docs/reference %}}
-[local.file_match]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/local.file_match.md"
-[local.file_match]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/local.file_match.md"
-[loki.source.file]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.source.file.md"
-[loki.source.file]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.source.file.md"
-[loki.write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.write.md"
-[loki.write]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.write.md"
-[Components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
-[Components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/components.md"
-[convert]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/convert.md"
-[convert]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/convert.md"
-[run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md"
-[Start the agent]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/start-agent.md"
-[Start the agent]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/start-agent.md"
-[Flow Debugging]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md"
-[Flow Debugging]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md"
-[River]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/config-language/_index.md"
-[River]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/config-language/_index.md"
-[Grafana Agent Flow UI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging#grafana-agent-flow-ui"
-[Grafana Agent Flow UI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging#grafana-agent-flow-ui"
-{{% /docs/reference %}}

--- a/docs/sources/flow/getting-started/migrating-from-static.md
+++ b/docs/sources/flow/getting-started/migrating-from-static.md
@@ -8,11 +8,120 @@ description: Learn how to migrate your configuration from Grafana Agent Static m
 menuTitle: Migrate from Static mode to Flow mode
 title: Migrate Grafana Agent from Static mode to Flow mode
 weight: 340
+refs:
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/components/
+  env:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/stdlib/env/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/stdlib/env/
+  river:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/config-language/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/config-language/
+  promtail-limitations:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/migrating-from-promtail/#limitations
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/getting-started/migrating-from-promtail/#limitations
+  prometheus.remote_write:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.remote_write/
+  traces:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/traces-config/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/configuration/traces-config/
+  run:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/run/
+  convert:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/convert/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/convert/
+  loki.source.file:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.source.file/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.source.file/
+  loki.process:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.process/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.process/
+  metrics:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/metrics-config/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/configuration/metrics-config/
+  integrations-next:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/integrations/integrations-next//
+  start-the-agent:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/start-agent/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/start-agent/
+  prometheus.scrape:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.scrape/
+  local.file_match:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/local.file_match/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/local.file_match/
+  loki.write:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.write/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.write/
+  grafana-agent-flow-ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#grafana-agent-flow-ui
+  prometheus-limitations:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/migrating-from-prometheus/#limitations
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/getting-started/migrating-from-prometheus/#limitations
+  static:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/
+  agent-management:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/agent-management/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/configuration/agent-management/
+  logs:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/logs-config/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/logs-config/
+  flow-debugging:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/
 ---
 
 # Migrate Grafana Agent from Static mode to Flow mode
 
-The built-in Grafana Agent convert command can migrate your [Static][] mode
+The built-in Grafana Agent convert command can migrate your [Static](ref:static) mode
 configuration to a Flow mode configuration.
 
 This topic describes how to:
@@ -22,26 +131,26 @@ This topic describes how to:
 
 ## Components used in this topic
 
-* [prometheus.scrape][]
-* [prometheus.remote_write][]
-* [local.file_match][]
-* [loki.process][]
-* [loki.source.file][]
-* [loki.write][]
+* [prometheus.scrape](ref:prometheus.scrape)
+* [prometheus.remote_write](ref:prometheus.remote_write)
+* [local.file_match](ref:local.file_match)
+* [loki.process](ref:loki.process)
+* [loki.source.file](ref:loki.source.file)
+* [loki.write](ref:loki.write)
 
 ## Before you begin
 
 * You must have an existing Grafana Agent Static mode configuration.
-* You must be familiar with the [Components][] concept in Grafana Agent Flow mode.
+* You must be familiar with the [Components](ref:components) concept in Grafana Agent Flow mode.
 
 ## Convert a Static mode configuration
 
-To fully migrate Grafana Agent from [Static][] mode to Flow mode, you must convert
+To fully migrate Grafana Agent from [Static](ref:static) mode to Flow mode, you must convert
 your Static mode configuration into a Flow mode configuration.
 This conversion will enable you to take full advantage of the many additional
 features available in Grafana Agent Flow mode.
 
-> In this task, we will use the [convert][] CLI command to output a Flow mode
+> In this task, we will use the [convert](ref:convert) CLI command to output a Flow mode
 > configuration from a Static mode configuration.
 
 1. Open a terminal window and run the following command:
@@ -59,7 +168,7 @@ features available in Grafana Agent Flow mode.
    {{< /code >}}
 
    Replace the following:
-    * `INPUT_CONFIG_PATH`: The full path to the [Static][] configuration.
+    * `INPUT_CONFIG_PATH`: The full path to the [Static](ref:static) configuration.
     * `OUTPUT_CONFIG_PATH`: The full path to output the flow configuration.
 
 1. [Start the Agent][] in Flow mode using the new Flow mode configuration
@@ -67,12 +176,12 @@ features available in Grafana Agent Flow mode.
 
 ### Debugging
 
-1. If the convert command cannot convert a [Static] mode configuration, diagnostic
+1. If the convert command cannot convert a[Static](ref:static) mode configuration, diagnostic
    information is sent to `stderr`. You can use the `--bypass-errors` flag to 
    bypass any non-critical issues and output the Flow mode configuration 
    using a best-effort conversion.
 
-   {{% admonition type="caution" %}}If you bypass the errors, the behavior of the converted configuration may not match the original [Static] mode configuration. Make sure you fully test the converted configuration before using it in a production environment.{{% /admonition %}}
+   {{% admonition type="caution" %}}If you bypass the errors, the behavior of the converted configuration may not match the original[Static](ref:static) mode configuration. Make sure you fully test the converted configuration before using it in a production environment.{{% /admonition %}}
 
    {{< code >}}
 
@@ -113,16 +222,16 @@ features available in Grafana Agent Flow mode.
 
 If you’re not ready to completely switch to a Flow mode configuration, you can run
 Grafana Agent using your existing Grafana Agent Static mode configuration.
-The `--config.format=static` flag tells Grafana Agent to convert your [Static] mode
+The `--config.format=static` flag tells Grafana Agent to convert your[Static](ref:static) mode
 configuration to Flow mode and load it directly without saving the new
 configuration. This allows you to try Flow mode without modifying your existing
 Grafana Agent Static mode configuration infrastructure.
 
-> In this task, we will use the [run][] CLI command to run Grafana Agent in Flow
+> In this task, we will use the [run](ref:run) CLI command to run Grafana Agent in Flow
 > mode using a Static mode configuration.
 
 [Start the Agent][] in Flow mode and include the command line flag
-`--config.format=static`. Your configuration file must be a valid [Static]
+`--config.format=static`. Your configuration file must be a valid[Static](ref:static)
 mode configuration file.
 
 ### Debugging
@@ -130,10 +239,10 @@ mode configuration file.
 1. You can follow the convert CLI command [debugging][] instructions to generate
    a diagnostic report.
 
-1. Refer to the Grafana Agent [Flow Debugging][] for more information about
+1. Refer to the Grafana Agent [Flow Debugging](ref:flow-debugging) for more information about
    running Grafana Agent in Flow mode.
 
-1. If your [Static] mode configuration can't be converted and loaded directly into
+1. If your[Static](ref:static) mode configuration can't be converted and loaded directly into
     Grafana Agent, diagnostic information is sent to `stderr`. You can use the `
     --config.bypass-conversion-errors` flag with `--config.format=static` to bypass any
     non-critical issues and start the Agent.
@@ -142,9 +251,9 @@ mode configuration file.
 
 ## Example
 
-This example demonstrates converting a [Static] mode configuration file to a Flow mode configuration file.
+This example demonstrates converting a[Static](ref:static) mode configuration file to a Flow mode configuration file.
 
-The following [Static] mode configuration file provides the input for the conversion:
+The following[Static](ref:static) mode configuration file provides the input for the conversion:
 
 ```yaml
 server:
@@ -200,7 +309,7 @@ logs:
         - url: https://USER_ID:API_KEY@logs-prod3.grafana.net/loki/api/v1/push
 ```
 
-The convert command takes the YAML file as input and outputs a [River][] file.
+The convert command takes the YAML file as input and outputs a [River](ref:river) file.
 
 {{< code >}}
 
@@ -303,68 +412,22 @@ before starting to use it in a production environment.
 Furthermore, we recommend that you review the following checklist:
 
 * The following configuration options are not available for conversion to Flow
-  mode: [Integrations next][], [Traces][], and [Agent Management][]. Any
+  mode: [Integrations next](ref:integrations-next), [Traces](ref:traces), and [Agent Management](ref:agent-management). Any
   additional unsupported features are returned as errors during conversion.
 * There is no gRPC server to configure for Flow mode, so any non-default config
   will show as unsupported during the conversion.
 * Check if you are using any extra command line arguments with Static mode that
   are not present in your configuration file. For example, `-server.http.address`.
-* Check if you are using any environment variables in your [Static] mode configuration.
+* Check if you are using any environment variables in your[Static](ref:static) mode configuration.
   These will be evaluated during conversion and you may want to replace them
-  with the Flow Standard library [env] function after conversion.
-* Review additional [Prometheus Limitations] for limitations specific to your
-  [Metrics] config.
-* Review additional [Promtail Limitations] for limitations specific to your
-  [Logs] config.
+  with the Flow Standard library[env](ref:env) function after conversion.
+* Review additional[Prometheus Limitations](ref:prometheus-limitations) for limitations specific to your
+ [Metrics](ref:metrics) config.
+* Review additional[Promtail Limitations](ref:promtail-limitations) for limitations specific to your
+ [Logs](ref:logs) config.
 * The logs produced by Grafana Agent Flow mode will differ from those
   produced by Static mode.
-* Grafana Agent exposes the [Grafana Agent Flow UI][].
+* Grafana Agent exposes the [Grafana Agent Flow UI](ref:grafana-agent-flow-ui).
 
 [debugging]: #debugging
 
-{{% docs/reference %}}
-[Static]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static"
-[Static]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static"
-[prometheus.scrape]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape.md"
-[prometheus.scrape]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.scrape.md"
-[prometheus.remote_write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write.md"
-[prometheus.remote_write]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.remote_write.md"
-[local.file_match]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/local.file_match.md"
-[local.file_match]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/local.file_match.md"
-[loki.process]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.process.md"
-[loki.process]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.process.md"
-[loki.source.file]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.source.file.md"
-[loki.source.file]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.source.file.md"
-[loki.write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.write.md"
-[loki.write]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.write.md"
-[Components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
-[Components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/components.md"
-[convert]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/convert.md"
-[convert]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/convert.md"
-[run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md"
-[Start the agent]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/start-agent.md"
-[Start the agent]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/start-agent.md"
-[Flow Debugging]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md"
-[Flow Debugging]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md"
-[River]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/config-language/"
-[River]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/config-language/"
-[Integrations next]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static/configuration/integrations/integrations-next/_index.md"
-[Integrations next]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static/configuration/traces-config.md
-[Traces]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static/configuration/traces-config.md"
-[Traces]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static/configuration/traces-config.md"
-[Agent Management]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static/configuration/agent-management.md"
-[Agent Management]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static/configuration/agent-management.md"
-[env]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/stdlib/env.md"
-[env]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/stdlib/env.md"
-[Prometheus Limitations]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/migrating-from-prometheus.md#limitations"
-[Prometheus Limitations]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/getting-started/migrating-from-prometheus.md#limitations"
-[Promtail Limitations]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/migrating-from-promtail.md#limitations"
-[Promtail Limitations]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/getting-started/migrating-from-promtail.md#limitations"
-[Metrics]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static/configuration/metrics-config.md"
-[Metrics]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static/configuration/metrics-config.md"
-[Logs]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static/configuration/logs-config.md"
-[Logs]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static/logs-config.md"
-[Grafana Agent Flow UI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging#grafana-agent-flow-ui"
-[Grafana Agent Flow UI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging#grafana-agent-flow-ui"
-{{% /docs/reference %}}

--- a/docs/sources/flow/getting-started/opentelemetry-to-lgtm-stack.md
+++ b/docs/sources/flow/getting-started/opentelemetry-to-lgtm-stack.md
@@ -7,6 +7,57 @@ canonical: https://grafana.com/docs/agent/latest/flow/getting-started/openteleme
 title: OpenTelemetry to Grafana stack
 description: Learn how to collect OpenTelemetry data and forward it to the Grafana stack
 weight: 350
+refs:
+  prometheus.remote_write:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.remote_write/
+  otelcol.processor.batch:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.processor.batch/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.processor.batch/
+  collect-open-telemetry-data:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-opentelemetry-data/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/getting-started/collect-opentelemetry-data/
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/components/
+  otelcol.exporter.otlp:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.otlp/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.exporter.otlp/
+  otelcol.auth.basic:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.auth.basic/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.auth.basic/
+  otelcol.receiver.otlp:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.receiver.otlp/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.receiver.otlp/
+  loki.write:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.write/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.write/
+  otelcol.exporter.loki:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.loki/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.exporter.loki/
+  otelcol.exporter.prometheus:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.prometheus/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.exporter.prometheus/
 ---
 
 # OpenTelemetry to Grafana stack
@@ -21,14 +72,14 @@ This topic describes how to:
 
 ## Components used in this topic
 
-* [loki.write][]
-* [otelcol.auth.basic][]
-* [otelcol.exporter.loki][]
-* [otelcol.exporter.otlp][]
-* [otelcol.exporter.prometheus][]
-* [otelcol.processor.batch][]
-* [otelcol.receiver.otlp][]
-* [prometheus.remote_write][]
+* [loki.write](ref:loki.write)
+* [otelcol.auth.basic](ref:otelcol.auth.basic)
+* [otelcol.exporter.loki](ref:otelcol.exporter.loki)
+* [otelcol.exporter.otlp](ref:otelcol.exporter.otlp)
+* [otelcol.exporter.prometheus](ref:otelcol.exporter.prometheus)
+* [otelcol.processor.batch](ref:otelcol.processor.batch)
+* [otelcol.receiver.otlp](ref:otelcol.receiver.otlp)
+* [prometheus.remote_write](ref:prometheus.remote_write)
 
 ## Before you begin
 
@@ -37,8 +88,8 @@ This topic describes how to:
 * Have a set of OpenTelemetry applications ready to push telemetry data to
   Grafana Agent Flow.
 * Identify where Grafana Agent Flow will write received telemetry data.
-* Be familiar with the concept of [Components][] in Grafana Agent Flow.
-* Complete the [Collect open telemetry data][] getting started guide. You will pick up from where that guide ended.
+* Be familiar with the concept of [Components](ref:components) in Grafana Agent Flow.
+* Complete the [Collect open telemetry data](ref:collect-open-telemetry-data) getting started guide. You will pick up from where that guide ended.
 
 ## The pipeline
 
@@ -91,7 +142,7 @@ Traces: OTel → batch processor → OTel exporter
 ```
 ## Grafana Loki
 
-[Grafana Loki][] is a horizontally scalable, highly available, multi-tenant log aggregation system inspired by Prometheus. Similar to Prometheus, to send from OTLP to Loki, we will do a passthrough from the [otelcol.exporter.loki] component to [loki.write] component.
+[Grafana Loki][] is a horizontally scalable, highly available, multi-tenant log aggregation system inspired by Prometheus. Similar to Prometheus, to send from OTLP to Loki, we will do a passthrough from the[otelcol.exporter.loki](ref:otelcol.exporter.loki) component to[loki.write](ref:loki.write) component.
 
 ```river
 otelcol.exporter.loki "default" {
@@ -104,7 +155,7 @@ loki.write "default" {
 }
 ```
 
-To use Loki with basic-auth, which is required with Grafana Cloud Loki, you must configure the [loki.write][] component. You can get the Loki configuration from the Loki **Details** page in the [Grafana Cloud Portal][]:
+To use Loki with basic-auth, which is required with Grafana Cloud Loki, you must configure the [loki.write](ref:loki.write) component. You can get the Loki configuration from the Loki **Details** page in the [Grafana Cloud Portal][]:
 
 ![](../../../assets/getting-started/loki-config.png)
 
@@ -137,7 +188,7 @@ otelcol.exporter.otlp "default" {
 }
 ```
 
-To use Tempo with basic-auth, which is required with Grafana Cloud Tempo, you must use the [otelcol.auth.basic][] component. You can get the Tempo configuration from the Tempo **Details** page in the [Grafana Cloud Portal][]:
+To use Tempo with basic-auth, which is required with Grafana Cloud Tempo, you must use the [otelcol.auth.basic](ref:otelcol.auth.basic) component. You can get the Tempo configuration from the Tempo **Details** page in the [Grafana Cloud Portal][]:
 
 ![](../../../assets/getting-started/tempo-config.png)
 
@@ -157,7 +208,7 @@ otelcol.auth.basic "grafana_cloud_tempo" {
 
 ## Grafana Mimir or Prometheus Remote Write
 
-[Prometheus Remote Write][] is a popular metrics transmission protocol supported by most metrics systems, including [Grafana Mimir][] and Grafana Cloud. To send from OTLP to Prometheus, we do a passthrough from the [otelcol.exporter.prometheus][] to the [prometheus.remote_write][] component. The Prometheus remote write component in Agent is a robust protocol implementation, including a Write Ahead Log for resiliency.
+[Prometheus Remote Write][] is a popular metrics transmission protocol supported by most metrics systems, including [Grafana Mimir][] and Grafana Cloud. To send from OTLP to Prometheus, we do a passthrough from the [otelcol.exporter.prometheus](ref:otelcol.exporter.prometheus) to the [prometheus.remote_write](ref:prometheus.remote_write) component. The Prometheus remote write component in Agent is a robust protocol implementation, including a Write Ahead Log for resiliency.
 
 ```river
 otelcol.exporter.prometheus "default" {
@@ -171,7 +222,7 @@ prometheus.remote_write "default" {
 }
 ```
 
-To use Prometheus with basic-auth, which is required with Grafana Cloud Prometheus, you must configure the [prometheus.remote_write][] component. You can get the Prometheus configuration from the Prometheus **Details** page in the [Grafana Cloud Portal][]:
+To use Prometheus with basic-auth, which is required with Grafana Cloud Prometheus, you must configure the [prometheus.remote_write](ref:prometheus.remote_write) component. You can get the Prometheus configuration from the Prometheus **Details** page in the [Grafana Cloud Portal][]:
 
 ![](../../../assets/getting-started/prometheus-config.png)
 
@@ -307,25 +358,3 @@ You can now check the pipeline graphically by visiting http://localhost:12345/gr
 [Prometheus Remote Write]: https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage
 [Grafana Mimir]: https://grafana.com/oss/mimir/
 
-{{% docs/reference %}}
-[Collect open telemetry data]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-opentelemetry-data.md"
-[Collect open telemetry data]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/getting-started/collect-opentelemetry-data.md"
-[Components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
-[Components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/components.md"
-[loki.write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.write.md"
-[loki.write]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.write.md"
-[otelcol.auth.basic]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.auth.basic.md"
-[otelcol.auth.basic]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.auth.basic.md"
-[otelcol.exporter.loki]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.loki.md"
-[otelcol.exporter.loki]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.exporter.loki.md"
-[otelcol.exporter.otlp]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.otlp.md"
-[otelcol.exporter.otlp]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.exporter.otlp.md"
-[otelcol.exporter.prometheus]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.prometheus.md"
-[otelcol.exporter.prometheus]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.exporter.prometheus.md"
-[otelcol.processor.batch]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.processor.batch.md"
-[otelcol.processor.batch]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.processor.batch.md"
-[otelcol.receiver.otlp]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.receiver.otlp.md"
-[otelcol.receiver.otlp]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.receiver.otlp.md"
-[prometheus.remote_write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write.md"
-[prometheus.remote_write]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.remote_write.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/monitoring/component_metrics.md
+++ b/docs/sources/flow/monitoring/component_metrics.md
@@ -8,11 +8,27 @@ canonical: https://grafana.com/docs/agent/latest/flow/monitoring/component_metri
 title: Component metrics
 description: Learn about component metrics
 weight: 200
+refs:
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/components/
+  reference-documentation:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/
+  grafana-agent-run:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/run/
 ---
 
 # Component metrics
 
-Grafana Agent Flow [components][] may optionally expose Prometheus metrics
+Grafana Agent Flow [components](ref:components) may optionally expose Prometheus metrics
 which can be used to investigate the behavior of that component. These
 component-specific metrics are only generated when an instance of that
 component is running.
@@ -33,15 +49,7 @@ component ID generating those metrics. For example, component-specific metrics
 for a `prometheus.remote_write` component labeled `production` will have a
 `component_id` label with the value `prometheus.remote_write.production`.
 
-The [reference documentation][] for each component will describe the list of
+The [reference documentation](ref:reference-documentation) for each component will describe the list of
 component-specific metrics that component exposes. Not all components will
 expose metrics.
 
-{{% docs/reference %}}
-[components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
-[components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/components.md"
-[grafana-agent run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[grafana-agent run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md"
-[reference documentation]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components"
-[reference documentation]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components"
-{{% /docs/reference %}}

--- a/docs/sources/flow/monitoring/controller_metrics.md
+++ b/docs/sources/flow/monitoring/controller_metrics.md
@@ -8,11 +8,22 @@ canonical: https://grafana.com/docs/agent/latest/flow/monitoring/controller_metr
 title: Controller metrics
 description: Learn about controller metrics
 weight: 100
+refs:
+  component-controller:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/component_controller/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/component_controller/
+  grafana-agent-run:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/run/
 ---
 
 # Controller metrics
 
-The Grafana Agent Flow [component controller][] exposes Prometheus metrics
+The Grafana Agent Flow [component controller](ref:component-controller) exposes Prometheus metrics
 which can be used to investigate the controller state.
 
 Metrics for the controller are exposed at the `/metrics` HTTP endpoint of the
@@ -39,9 +50,3 @@ The controller exposes the following metrics:
 * `agent_component_evaluation_queue_size` (Gauge): The current number of
   component evaluations waiting to be performed.
 
-{{% docs/reference %}}
-[component controller]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/component_controller.md"
-[component controller]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/component_controller.md"
-[grafana-agent run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[grafana-agent run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/monitoring/debugging.md
+++ b/docs/sources/flow/monitoring/debugging.md
@@ -7,6 +7,32 @@ canonical: https://grafana.com/docs/agent/latest/flow/monitoring/debugging/
 title: Debugging
 description: Learn about debugging
 weight: 300
+refs:
+  secret:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/config-language/expressions/types_and_values/#secrets.md
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/config-language/expressions/types_and_values/#secrets.md
+  install:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/install/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/install/
+  clustering:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/clustering/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/clustering/
+  grafana-agent-run:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/run/
+  logging:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/config-blocks/logging/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/logging/
 ---
 
 # Debugging
@@ -27,7 +53,7 @@ server, which defaults to listening at `http://localhost:12345`.
 > prevents other machines on the network from being able to view the UI.
 >
 > To expose the UI to other machines on the network on non-containerized
-> platforms, refer to the documentation for how you [installed][install]
+> platforms, refer to the documentation for how you [installed](ref:install)
 > Grafana Agent Flow.
 >
 > If you are running a custom installation of Grafana Agent Flow, refer to the
@@ -66,7 +92,7 @@ The component detail page shows the following information for each component:
 * The current exports for the component.
 * The current debug info for the component (if the component has debug info).
 
-> Values marked as a [secret][] are obfuscated and will display as the text
+> Values marked as a [secret](ref:secret) are obfuscated and will display as the text
 > `(secret)`.
 
 ### Clustering page
@@ -93,16 +119,16 @@ To debug using the UI:
 Logs may also help debug issues with Grafana Agent Flow.
 
 To reduce logging noise, many components hide debugging info behind debug-level
-log lines. It is recommended that you configure the [`logging` block][logging]
+log lines. It is recommended that you configure the [`logging` block](ref:logging)
 to show debug-level log lines when debugging issues with Grafana Agent Flow.
 
 The location of Grafana Agent's logs is different based on how it is deployed.
-Refer to the [`logging` block][logging] page to see how to find logs for your
+Refer to the [`logging` block](ref:logging) page to see how to find logs for your
 system.
 
 ## Debugging clustering issues
 
-To debug issues when using [clustering][], check for the following symptoms.
+To debug issues when using [clustering](ref:clustering), check for the following symptoms.
 
 - **Cluster not converging**: The cluster peers are not converging on the same
   view of their peers' status. This is most likely due to network connectivity
@@ -125,16 +151,4 @@ down and set its state to Terminating, but it has not completely gone away. Chec
 the clustering page to view the state of the peers and verify that the
 terminating Agent has been shut down.
 
-{{% docs/reference %}}
-[logging]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/config-blocks/logging.md"
-[logging]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/logging.md"
-[clustering]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/clustering.md"
-[clustering]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/clustering.md"
-[install]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/install"
-[install]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/install"
-[secret]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/config-language/expressions/types_and_values.md#secrets.md"
-[secret]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/config-language/expressions/types_and_values.md#secrets.md"
-[grafana-agent run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[grafana-agent run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md"
-{{% /docs/reference %}}
 

--- a/docs/sources/flow/setup/configure/configure-linux.md
+++ b/docs/sources/flow/setup/configure/configure-linux.md
@@ -8,6 +8,17 @@ description: Learn how to configure Grafana Agent in flow mode on Linux
 menuTitle: Linux
 title: Configure Grafana Agent in flow mode on Linux
 weight: 300
+refs:
+  run:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/run/
+  ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#grafana-agent-flow-ui
 ---
 
 # Configure Grafana Agent in flow mode on Linux
@@ -40,7 +51,7 @@ To change the configuration file used by the service, perform the following step
 
 ## Pass additional command-line flags
 
-By default, the Grafana Agent service launches with the [run][]
+By default, the Grafana Agent service launches with the [run](ref:run)
 command, passing the following flags:
 
 * `--storage.path=/var/lib/grafana-agent-flow`
@@ -63,13 +74,13 @@ the following steps:
    ```
 
 To see the list of valid command-line flags that can be passed to the service,
-refer to the documentation for the [run][] command.
+refer to the documentation for the [run](ref:run) command.
 
 ## Expose the UI to other machines
 
 By default, Grafana Agent listens on the local network for its HTTP
 server. This prevents other machines on the network from being able to access
-the [UI for debugging][UI].
+the [UI for debugging](ref:ui).
 
 To expose the UI to other machines, complete the following steps:
 
@@ -89,9 +100,3 @@ To expose the UI to other machines, complete the following steps:
 
        To listen on all interfaces, replace `LISTEN_ADDR` with `0.0.0.0`.
 
-{{% docs/reference %}}
-[run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md"
-[UI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-[UI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-{{% /docs/reference %}}

--- a/docs/sources/flow/setup/configure/configure-macos.md
+++ b/docs/sources/flow/setup/configure/configure-macos.md
@@ -8,6 +8,12 @@ description: Learn how to configure Grafana Agent in flow mode on macOS
 menuTitle: macOS
 title: Configure Grafana Agent in flow mode on macOS
 weight: 400
+refs:
+  ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#grafana-agent-flow-ui
 ---
 
 # Configure Grafana Agent in flow mode on macOS
@@ -65,7 +71,7 @@ steps:
 
 By default, Grafana Agent listens on the local network for its HTTP
 server. This prevents other machines on the network from being able to access
-the [UI for debugging][UI].
+the [UI for debugging](ref:ui).
 
 To expose the UI to other machines, complete the following steps:
 
@@ -80,7 +86,3 @@ To expose the UI to other machines, complete the following steps:
 
        To listen on all interfaces, replace `127.0.0.1` with `0.0.0.0`.
 
-{{% docs/reference %}}
-[UI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-[UI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-{{% /docs/reference %}}

--- a/docs/sources/flow/setup/configure/configure-windows.md
+++ b/docs/sources/flow/setup/configure/configure-windows.md
@@ -8,6 +8,12 @@ description: Learn how to configure Grafana Agent in flow mode on Windows
 menuTitle: Windows
 title: Configure Grafana Agent in flow mode on Windows
 weight: 500
+refs:
+  ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#grafana-agent-flow-ui
 ---
 
 # Configure Grafana Agent in flow mode on Windows
@@ -68,7 +74,7 @@ binary, perform the following steps:
 
 By default, Grafana Agent listens on the local network for its HTTP
 server. This prevents other machines on the network from being able to access
-the [UI for debugging][UI].
+the [UI for debugging](ref:ui).
 
 To expose the UI to other machines, complete the following steps:
 
@@ -88,8 +94,4 @@ To expose the UI to other machines, complete the following steps:
 
        To listen on all interfaces, replace `LISTEN_ADDR` with `0.0.0.0`.
 
-{{% docs/reference %}}
-[UI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-[UI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-{{% /docs/reference %}}
 

--- a/docs/sources/flow/setup/install/_index.md
+++ b/docs/sources/flow/setup/install/_index.md
@@ -9,6 +9,12 @@ menuTitle: Install flow mode
 title: Install Grafana Agent in flow mode
 description: Learn how to install Grafana Agent in flow mode
 weight: 50
+refs:
+  data-collection:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/data-collection/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/data-collection/
 ---
 
 # Install Grafana Agent in flow mode
@@ -30,10 +36,6 @@ Installing Grafana Agent on other operating systems is possible, but is not reco
 
 ## Data collection
 
-By default, Grafana Agent sends anonymous usage information to Grafana Labs. Refer to [data collection][] for more information
+By default, Grafana Agent sends anonymous usage information to Grafana Labs. Refer to [data collection](ref:data-collection) for more information
 about what data is collected and how you can opt-out.
 
-{{% docs/reference %}}
-[data collection]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/data-collection.md"
-[data collection]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/data-collection.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/setup/install/binary.md
+++ b/docs/sources/flow/setup/install/binary.md
@@ -9,6 +9,17 @@ description: Learn how to install Grafana Agent in flow mode as a standalone bin
 menuTitle: Standalone
 title: Install Grafana Agent in flow mode as a standalone binary
 weight: 600
+refs:
+  configure-grafana-agent:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/configure/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/configure/
+  start-grafana-agent:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/start-agent/#standalone-binary
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/start-agent/#standalone-binary
 ---
 
 # Install Grafana Agent in flow mode as a standalone binary
@@ -42,12 +53,6 @@ To download Grafana Agent as a standalone binary, perform the following steps.
 
 ## Next steps
 
-* [Start Grafana Agent][]
-* [Configure Grafana Agent][]
+* [Start Grafana Agent](ref:start-grafana-agent)
+* [Configure Grafana Agent](ref:configure-grafana-agent)
 
-{{% docs/reference %}}
-[Start Grafana Agent]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/start-agent.md#standalone-binary"
-[Start Grafana Agent]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/start-agent.md#standalone-binary"
-[Configure Grafana Agent]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/configure"
-[Configure Grafana Agent]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/configure/"
-{{% /docs/reference %}}

--- a/docs/sources/flow/setup/install/docker.md
+++ b/docs/sources/flow/setup/install/docker.md
@@ -9,6 +9,17 @@ description: Learn how to install Grafana Agent in flow mode on Docker
 menuTitle: Docker
 title: Run Grafana Agent in flow mode in a Docker container
 weight: 100
+refs:
+  run:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/run/
+  ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#grafana-agent-flow-ui
 ---
 
 # Run Grafana Agent in flow mode in a Docker container
@@ -46,10 +57,10 @@ docker run \
 Replace `CONFIG_FILE_PATH` with the path of the configuration file on your host system.
 
 You can modify the last line to change the arguments passed to the Grafana Agent binary.
-Refer to the documentation for [run][] for more information about the options available to the `run` command.
+Refer to the documentation for [run](ref:run) for more information about the options available to the `run` command.
 
 > **Note:** Make sure you pass `--server.http.listen-addr=0.0.0.0:12345` as an argument as shown in the example above.
-> If you don't pass this argument, the [debugging UI][UI] won't be available outside of the Docker container.
+> If you don't pass this argument, the [debugging UI](ref:ui) won't be available outside of the Docker container.
 
 
 ## Run a Windows Docker container
@@ -68,23 +79,17 @@ docker run \
 Replace `CONFIG_FILE_PATH` with the path of the configuration file on your host system.
 
 You can modify the last line to change the arguments passed to the Grafana Agent binary.
-Refer to the documentation for [run][] for more information about the options available to the `run` command.
+Refer to the documentation for [run](ref:run) for more information about the options available to the `run` command.
 
 
 > **Note:** Make sure you pass `--server.http.listen-addr=0.0.0.0:12345` as an argument as shown in the example above.
-> If you don't pass this argument, the [debugging UI][UI] won't be available outside of the Docker container.
+> If you don't pass this argument, the [debugging UI](ref:ui) won't be available outside of the Docker container.
 
 ## Verify
 
-To verify that Grafana Agent is running successfully, navigate to <http://localhost:12345> and make sure the [Grafana Agent UI][UI] loads without error.
+To verify that Grafana Agent is running successfully, navigate to <http://localhost:12345> and make sure the [Grafana Agent UI](ref:ui) loads without error.
 
 [Linux containers]: #run-a-linux-docker-container
 [Windows containers]: #run-a-windows-docker-container
 [Docker]: https://docker.io
 
-{{% docs/reference %}}
-[run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md"
-[UI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-[UI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-{{% /docs/reference %}}

--- a/docs/sources/flow/setup/install/kubernetes.md
+++ b/docs/sources/flow/setup/install/kubernetes.md
@@ -9,6 +9,12 @@ description: Learn how to deploy Grafana Agent in flow mode on Kubernetes
 menuTitle: Kubernetes
 title: Deploy Grafana Agent in flow mode on Kubernetes
 weight: 200
+refs:
+  configure-grafana-agent:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/configure/configure-kubernetes/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/configure/configure-kubernetes/
 ---
 
 # Deploy Grafana Agent in flow mode on Kubernetes
@@ -57,11 +63,7 @@ For more information on the Grafana Agent Helm chart, refer to the Helm chart do
 
 ## Next steps
 
-- [Configure Grafana Agent][]
+- [Configure Grafana Agent](ref:configure-grafana-agent)
 
 [Helm]: https://helm.sh
 
-{{% docs/reference %}}
-[Configure Grafana Agent]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/configure/configure-kubernetes.md"
-[Configure Grafana Agent]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/configure/configure-kubernetes.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/setup/install/linux.md
+++ b/docs/sources/flow/setup/install/linux.md
@@ -9,6 +9,17 @@ description: Learn how to install Grafana Agent in flow mode on Linux
 menuTitle: Linux
 title: Install or uninstall Grafana Agent in flow mode on Linux
 weight: 300
+refs:
+  start-grafana-agent:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/start-agent/#linux
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/start-agent/#linux
+  configure-grafana-agent:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/configure/configure-linux/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/configure/configure-linux/
 ---
 
 # Install or uninstall Grafana Agent in flow mode on Linux
@@ -118,12 +129,6 @@ To uninstall Grafana Agent on Linux, run the following commands in a terminal wi
 
 ## Next steps
 
-- [Start Grafana Agent][]
-- [Configure Grafana Agent][]
+- [Start Grafana Agent](ref:start-grafana-agent)
+- [Configure Grafana Agent](ref:configure-grafana-agent)
 
-{{% docs/reference %}}
-[Start Grafana Agent]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/start-agent.md#linux"
-[Start Grafana Agent]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/start-agent.md#linux"
-[Configure Grafana Agent]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/configure/configure-linux.md"
-[Configure Grafana Agent]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/configure/configure-linux.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/setup/install/macos.md
+++ b/docs/sources/flow/setup/install/macos.md
@@ -9,6 +9,17 @@ description: Learn how to install Grafana Agent in flow mode on macOS
 menuTitle: macOS
 title: Install Grafana Agent in flow mode on macOS
 weight: 400
+refs:
+  start-grafana-agent:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/start-agent/#macos
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/start-agent/#macos
+  configure-grafana-agent:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/configure/configure-macos/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/configure/configure-macos/
 ---
 
 # Install Grafana Agent in flow mode on macOS
@@ -65,14 +76,8 @@ brew uninstall grafana-agent-flow
 
 ## Next steps
 
-- [Start Grafana Agent][]
-- [Configure Grafana Agent][]
+- [Start Grafana Agent](ref:start-grafana-agent)
+- [Configure Grafana Agent](ref:configure-grafana-agent)
 
 [Homebrew]: https://brew.sh
 
-{{% docs/reference %}}
-[Start Grafana Agent]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/start-agent.md#macos"
-[Start Grafana Agent]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/start-agent.md#macos"
-[Configure Grafana Agent]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/configure/configure-macos.md"
-[Configure Grafana Agent]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/configure/configure-macos.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/setup/install/windows.md
+++ b/docs/sources/flow/setup/install/windows.md
@@ -9,6 +9,22 @@ description: Learn how to install Grafana Agent in flow mode on Windows
 menuTitle: Windows
 title: Install Grafana Agent in flow mode on Windows
 weight: 500
+refs:
+  configure-grafana-agent:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/configure/configure-windows/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/configure/configure-windows/
+  start-grafana-agent:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/start-agent/#windows
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/start-agent/#windows
+  data-collection:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/data-collection/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/data-collection/
 ---
 
 # Install Grafana Agent in flow mode on Windows
@@ -59,16 +75,8 @@ Grafana Agent can also be silently uninstalled by running `uninstall.exe /S` as 
 
 ## Next steps
 
-- [Start Grafana Agent][]
-- [Configure Grafana Agent][]
+- [Start Grafana Agent](ref:start-grafana-agent)
+- [Configure Grafana Agent](ref:configure-grafana-agent)
 
 [latest]: https://github.com/grafana/agent/releases/latest
 
-{{% docs/reference %}}
-[Start Grafana Agent]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/start-agent.md#windows"
-[Start Grafana Agent]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/start-agent.md#windows"
-[Configure Grafana Agent]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/configure/configure-windows.md"
-[Configure Grafana Agent]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/configure/configure-windows.md"
-[data collection]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/data-collection.md"
-[data collection]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/data-collection.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/setup/start-agent.md
+++ b/docs/sources/flow/setup/start-agent.md
@@ -8,6 +8,12 @@ description: Learn how to start, restart, and stop Grafana Agent after it is ins
 menuTitle: Start flow mode
 title: Start, restart, and stop Grafana Agent in flow mode
 weight: 800
+refs:
+  configure-the-grafana-agent-service:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/configure/configure-macos/#configure-the-grafana-agent-service
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/configure/configure-macos/#configure-the-grafana-agent-service
 ---
 
 # Start, restart, and stop Grafana Agent in flow mode
@@ -107,7 +113,7 @@ brew services stop grafana-agent-flow
 By default, logs are written to `$(brew --prefix)/var/log/grafana-agent-flow.log` and
 `$(brew --prefix)/var/log/grafana-agent-flow.err.log`.
 
-If you followed [Configure the Grafana Agent service][] and changed the path where logs are written,
+If you followed [Configure the Grafana Agent service](ref:configure-the-grafana-agent-service) and changed the path where logs are written,
 refer to your current copy of the Grafana Agent formula to locate your log files.
 
 ## Windows
@@ -250,7 +256,3 @@ These steps assume you have a default systemd and Grafana Agent configuration.
 
 [release]: https://github.com/grafana/agent/releases/latest
 
-{{% docs/reference %}}
-[Configure the Grafana Agent service]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/configure/configure-macos.md#configure-the-grafana-agent-service"
-[Configure the Grafana Agent service]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/configure/configure-macos.md#configure-the-grafana-agent-service"
-{{% /docs/reference %}}

--- a/docs/sources/flow/tutorials/chaining.md
+++ b/docs/sources/flow/tutorials/chaining.md
@@ -9,11 +9,17 @@ description: Learn how to chain Prometheus components
 menuTitle: Chain Prometheus components
 title: Chain Prometheus components
 weight: 400
+refs:
+  filtering-metrics:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/tutorials/filtering-metrics/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/tutorials/filtering-metrics/
 ---
 
 # Chain Prometheus components
 
-This tutorial shows how to use [multiple-inputs.river][] to send data to several different locations. This tutorial uses the same base as [Filtering metrics][].
+This tutorial shows how to use [multiple-inputs.river][] to send data to several different locations. This tutorial uses the same base as [Filtering metrics](ref:filtering-metrics).
 
 A new concept introduced in Flow is chaining components together in a composable pipeline. This promotes the reusability of components while offering flexibility.
 
@@ -85,7 +91,3 @@ In `multiple-input.river` add a new `prometheus.relabel` component that adds a `
 [Grafana]: http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Mimir%22,%7B%22refId%22:%22A%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22agent_build_info%7B%7D%22%7D%5D
 [node_exporter]: http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Mimir%22,%7B%22refId%22:%22A%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22node_cpu_seconds_total%22%7D%5D
 
-{{% docs/reference %}}
-[Filtering metrics]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/tutorials/filtering-metrics.md"
-[Filtering metrics]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/tutorials/filtering-metrics.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
+++ b/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
@@ -9,6 +9,32 @@ description: Learn how to collect Prometheus metrics
 menuTitle: Collect Prometheus metrics
 title: Collect Prometheus metrics
 weight: 200
+refs:
+  prometheus.scrape:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.scrape/
+  argument:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/components/
+  export:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/components/
+  prometheus.remote_write:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.remote_write/
+  attribute:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/configuration_language/#attributes
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/configuration_language/#attributes
 ---
 
 # Collect Prometheus metrics
@@ -50,7 +76,7 @@ Click the nodes to navigate to the associated component page. There, you can vie
 
 ## Scraping component
 
-The [`prometheus.scrape`][prometheus.scrape] component is responsible for scraping the metrics of a particular endpoint and passing them on to another component.
+The [`prometheus.scrape`](ref:prometheus.scrape) component is responsible for scraping the metrics of a particular endpoint and passing them on to another component.
 
 ```river
 // prometheus.scrape is the name of the component and "default" is its label.
@@ -68,13 +94,13 @@ prometheus.scrape "default" {
 
 The `prometheus.scrape "default"` annotation indicates the name of the component, `prometheus.scrape`, and its label, `default`. All components must have a unique combination of name and if applicable label.
 
-The `targets` [attribute][] is an [argument][]. `targets` is a list of labels that specify the target via the special key `__address__`. The scraper is targeting the Agent's `/metrics` endpoint. Both `http` and `/metrics` are implied but can be overridden.
+The `targets` [attribute](ref:attribute) is an [argument](ref:argument). `targets` is a list of labels that specify the target via the special key `__address__`. The scraper is targeting the Agent's `/metrics` endpoint. Both `http` and `/metrics` are implied but can be overridden.
 
-The `forward_to` attribute is an argument that references the [export][] of the `prometheus.remote_write.prom` component. This is where the scraper will send the metrics for further processing.
+The `forward_to` attribute is an argument that references the [export](ref:export) of the `prometheus.remote_write.prom` component. This is where the scraper will send the metrics for further processing.
 
 ## Remote Write component
 
-The [`prometheus.remote_write`][prometheus.remote_write] component is responsible for writing the metrics to a Prometheus-compatible endpoint (Mimir).
+The [`prometheus.remote_write`](ref:prometheus.remote_write) component is responsible for writing the metrics to a Prometheus-compatible endpoint (Mimir).
 
 ```river
 prometheus.remote_write "prom" {
@@ -95,15 +121,3 @@ To try out the Grafana Agent without using Docker:
 [Docker]: https://www.docker.com/products/docker-desktop
 [Grafana]: http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Mimir%22,%7B%22refId%22:%22A%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22agent_build_info%7B%7D%22%7D%5D
 
-{{% docs/reference %}}
-[prometheus.scrape]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape.md"
-[prometheus.scrape]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.scrape.md"
-[attribute]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/configuration_language.md#attributes"
-[attribute]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/configuration_language.md#attributes"
-[argument]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components"
-[argument]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/components"
-[export]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components"
-[export]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/components"
-[prometheus.remote_write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write.md"
-[prometheus.remote_write]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.remote_write.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/tutorials/filtering-metrics.md
+++ b/docs/sources/flow/tutorials/filtering-metrics.md
@@ -9,11 +9,22 @@ description: Learn how to filter Prometheus metrics
 menuTitle: Filter Prometheus metrics
 title: Filter Prometheus metrics
 weight: 300
+refs:
+  collecting-prometheus-metrics:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/tutorials/collecting-prometheus-metrics/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/tutorials/collecting-prometheus-metrics/
+  prometheus.relabel:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.relabel/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.relabel/
 ---
 
 # Filter Prometheus metrics
 
-In this tutorial, you'll add a new component [prometheus.relabel][] using [relabel.river][] to filter metrics. This tutorial uses the same base as [Collecting Prometheus metrics][].
+In this tutorial, you'll add a new component [prometheus.relabel](ref:prometheus.relabel) using [relabel.river][] to filter metrics. This tutorial uses the same base as [Collecting Prometheus metrics](ref:collecting-prometheus-metrics).
 
 ## Prerequisites
 
@@ -57,9 +68,3 @@ Open the `relabel.river` file that was downloaded and change the name of the ser
 [Grafana]: http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Mimir%22,%7B%22refId%22:%22A%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22agent_build_info%7B%7D%22%7D%5D
 [relabel.river]: https://grafana.com/docs/agent/<AGENT_VERSION>/flow/tutorials/assets/flow_configs/relabel.river
 
-{{% docs/reference %}}
-[prometheus.relabel]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.relabel.md"
-[prometheus.relabel]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.relabel.md"
-[Collecting Prometheus metrics]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/tutorials/collecting-prometheus-metrics.md"
-[Collecting Prometheus metrics]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/tutorials/collecting-prometheus-metrics.md"
-{{% /docs/reference %}}

--- a/docs/sources/operator/release-notes.md
+++ b/docs/sources/operator/release-notes.md
@@ -14,12 +14,12 @@ weight: 999
 refs:
   release-notes-flow:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
+      destination: /docs/agent/<AGENT_VERSION>/flow/release-notes/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
+      destination: /docs/agent/<AGENT_VERSION>/flow/release-notes/
   release-notes-static:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/release-notes/
+      destination: /docs/agent/<AGENT_VERSION>/static/release-notes/
     - pattern: /docs/agent/
       destination: /docs/grafana-cloud/send-data/agent/static/release-notes/
 ---

--- a/docs/sources/operator/release-notes.md
+++ b/docs/sources/operator/release-notes.md
@@ -11,6 +11,17 @@ title: Release notes for Grafana Agent Operator
 description: Release notes for Grafana Agent Operator
 
 weight: 999
+refs:
+  release-notes-flow:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
+  release-notes-static:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/release-notes/
+    - pattern: /docs/agent/
+      destination: /docs/grafana-cloud/send-data/agent/static/release-notes/
 ---
 
 # Release notes for Grafana Agent Operator
@@ -22,16 +33,9 @@ For a complete list of changes to Grafana Agent, with links to pull requests and
 > **Note:** These release notes are specific to the Static mode Kubernetes Operator.
 > Other release notes for the different Grafana Agent variants are contained on separate pages:
 >
-> - [Static mode release notes][release-notes-static]
-> - [Flow mode release notes][release-notes-flow]
+> - [Static mode release notes](ref:release-notes-static)
+> - [Flow mode release notes](ref:release-notes-flow)
 
-{{% docs/reference %}}
-[release-notes-static]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/release-notes"
-[release-notes-static]: "/docs/agent/ -> /docs/grafana-cloud/send-data/agent/static/release-notes"
-
-[release-notes-flow]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/release-notes"
-[release-notes-flow]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/release-notes"
-{{% /docs/reference %}}
 
 ## v0.33
 

--- a/docs/sources/static/_index.md
+++ b/docs/sources/static/_index.md
@@ -6,17 +6,17 @@ weight: 200
 refs:
   install:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/install/
     - pattern: /docs/grafana-cloud/
       destination: ./set-up/install/
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/
     - pattern: /docs/grafana-cloud/
       destination: ./configuration/
   set-up:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/
     - pattern: /docs/grafana-cloud/
       destination: ./set-up/
 ---

--- a/docs/sources/static/_index.md
+++ b/docs/sources/static/_index.md
@@ -3,6 +3,22 @@ canonical: https://grafana.com/docs/agent/latest/static/
 title: Static mode
 description: Learn about Grafana Agent in static mode
 weight: 200
+refs:
+  install:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/
+    - pattern: /docs/grafana-cloud/
+      destination: ./set-up/install/
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/
+    - pattern: /docs/grafana-cloud/
+      destination: ./configuration/
+  set-up:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/
+    - pattern: /docs/grafana-cloud/
+      destination: ./set-up/
 ---
 
 # Static mode
@@ -20,7 +36,7 @@ Static mode is composed of different _subsystems_:
   traces and forwarding them to Grafana Tempo or any OpenTelemetry-compatible
   endpoint.
 
-Static mode is [configured][configure] with a YAML file.
+Static mode is [configured](ref:configure) with a YAML file.
 
 Static mode works with:
 
@@ -31,7 +47,7 @@ Static mode works with:
 This topic helps you to think about what you're trying to accomplish and how to
 use Grafana Agent to meet your goals.
 
-You can [set up][] and [configure][] Grafana Agent in static mode manually, or
+You can [set up](ref:set-up) and [configure](ref:configure) Grafana Agent in static mode manually, or
 you can follow the common workflows described in this topic.
 
 ## Topics
@@ -64,7 +80,7 @@ Grafana Cloud integration workflows and the Kubernetes Monitoring solution are t
 
 | Topic | Description |
 |---|---|
-| [Install or uninstall Grafana Agent][install] | Install or uninstall Grafana Agent. |
+| [Install or uninstall Grafana Agent](ref:install) | Install or uninstall Grafana Agent. |
 | [Troubleshoot Cloud Integrations installation on Linux](/docs/grafana-cloud/monitor-infrastructure/integrations/install-troubleshoot-linux/) | Troubleshoot common errors when executing the Grafana Agent installation script on Linux.  |
 | [Troubleshoot Cloud Integrations installation on Mac](/docs/grafana-cloud/monitor-infrastructure/integrations/install-troubleshoot-mac/) | Troubleshoot common errors when executing the Grafana Agent installation script on Mac.  |
 | [Troubleshoot Cloud Integrations installation on Windows](/docs/grafana-cloud/monitor-infrastructure/integrations/install-troubleshooting-windows/) | Troubleshoot common errors when executing the Grafana Agent installation script on Windows.  |
@@ -84,11 +100,3 @@ Logs are included when you [set up a Cloud integration](/docs/grafana-cloud/data
 | [Set up and use tracing](/docs/grafana-cloud/data-configuration/traces/set-up-and-use-tempo/) |  Install Grafana Agent to collect traces for use with Grafana Tempo, included with your [Grafana Cloud account](/docs/grafana-cloud/account-management/cloud-portal/). |
 | [Use Grafana Agent as a tracing pipeline](/docs/tempo/latest/configuration/grafana-agent/) | Grafana Agent can be configured to run a set of tracing pipelines to collect data from your applications and write it to Grafana Tempo. Pipelines are built using OpenTelemetry, and consist of receivers, processors, and exporters. |
 
-{{% docs/reference %}}
-[set up]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up"
-[set up]: "/docs/grafana-cloud/ -> ./set-up"
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration"
-[configure]: "/docs/grafana-cloud/ -> ./configuration"
-[install]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install"
-[install]: "/docs/grafana-cloud/ -> ./set-up/install"
-{{% /docs/reference %}}

--- a/docs/sources/static/api/_index.md
+++ b/docs/sources/static/api/_index.md
@@ -9,15 +9,15 @@ weight: 400
 refs:
   scrape:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/scraping-service/
   integrations:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/integrations-next/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/integrations/integrations-next/
     - pattern: /docs/grafana-cloud/
       destination: ../configuration/integrations/integrations-next/
   metrics:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/metrics-config/
     - pattern: /docs/grafana-cloud/
       destination: ../configuration/metrics-config/
 ---

--- a/docs/sources/static/api/_index.md
+++ b/docs/sources/static/api/_index.md
@@ -6,6 +6,20 @@ title: Static mode APIs (Stable)
 menuTitle: Static mode API
 description: Learn about the Grafana Agent static mode API
 weight: 400
+refs:
+  scrape:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/
+  integrations:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/integrations-next/
+    - pattern: /docs/grafana-cloud/
+      destination: ../configuration/integrations/integrations-next/
+  metrics:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+    - pattern: /docs/grafana-cloud/
+      destination: ../configuration/metrics-config/
 ---
 
 # Static mode APIs (Stable)
@@ -21,7 +35,7 @@ API endpoints are stable unless otherwise noted.
 
 ## Config management API (Beta)
 
-Grafana Agent exposes a configuration management REST API for managing instance configurations when it's running in [scraping service mode][scrape].
+Grafana Agent exposes a configuration management REST API for managing instance configurations when it's running in [scraping service mode](ref:scrape).
 
 {{< admonition type="note" >}}
 The scraping service mode is a requirement for the configuration management
@@ -128,7 +142,7 @@ with the same name already exists, then it will be completely overwritten.
 URL-encoded names are stored in decoded form. e.g., `hello%2Fworld` will
 represent the config named `hello/world`.
 
-The request body passed to this endpoint must match the format of [metrics_instance_config][metrics]
+The request body passed to this endpoint must match the format of [metrics_instance_config](ref:metrics)
 defined in the Configuration Reference. The name field of the configuration is
 ignored and the name in the URL takes precedence. The request body must be
 formatted as YAML.
@@ -415,7 +429,7 @@ A support bundle contains the following data:
 ## Integrations API (Experimental)
 
 > **WARNING**: This API is currently only available when the experimental
-> [integrations revamp][integrations]
+> [integrations revamp](ref:integrations)
 > is enabled. Both the revamp and this API are subject to change while they
 > are still experimental.
 
@@ -527,11 +541,3 @@ Response:
 Agent is Healthy.
 ```
 
-{{% docs/reference %}}
-[scrape]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/scraping-service"
-[scrape]: "/docs/grafana-cloud/ -> ../configuration/scraping-service
-[metrics]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/metrics-config"
-[metrics]: "/docs/grafana-cloud/ -> ../configuration/metrics-config"
-[integrations]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/integrations/integrations-next"
-[integrations]: "/docs/grafana-cloud/ -> ../configuration/integrations/integrations-next"
-{{% /docs/reference %}}

--- a/docs/sources/static/configuration/_index.md
+++ b/docs/sources/static/configuration/_index.md
@@ -5,6 +5,42 @@ canonical: https://grafana.com/docs/agent/latest/static/configuration/
 title: Configure static mode
 description: Learn how to configure Grafana Agent in static mode
 weight: 300
+refs:
+  metrics:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+    - pattern: /docs/grafana-cloud/
+      destination: ./metrics-config/
+  integrations:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/
+    - pattern: /docs/grafana-cloud/
+      destination: ./integrations/
+  api:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/api/#reload-configuration-file-beta
+    - pattern: /docs/grafana-cloud/
+      destination: ../api/#reload-configuration-file-beta
+  flags:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/flags/
+    - pattern: /docs/grafana-cloud/
+      destination: ./flags/
+  server:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/server-config/
+    - pattern: /docs/grafana-cloud/
+      destination: ./server-config/
+  traces:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/traces-config/
+    - pattern: /docs/grafana-cloud/
+      destination: ./traces-config/
+  logs:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/logs-config/
+    - pattern: /docs/grafana-cloud/
+      destination: ./logs-config/
 ---
 
 # Configure static mode
@@ -12,7 +48,7 @@ weight: 300
 The configuration of static mode is split across two places:
 
 * A YAML file
-* [Command-line flags][flags]
+* [Command-line flags](ref:flags)
 
 The YAML file is used to configure settings which are dynamic and can be
 changed at runtime. The command-line flags then configure things which cannot
@@ -20,11 +56,11 @@ change at runtime, such as the listen port for the HTTP server.
 
 This file describes the YAML configuration, which is usually in a file named `config.yaml`.
 
-- [server_config][server]
-- [metrics_config][metrics]
-- [logs_config][logs]
-- [traces_config][traces]
-- [integrations_config][integrations]
+- [server_config](ref:server)
+- [metrics_config](ref:metrics)
+- [logs_config](ref:logs)
+- [traces_config](ref:traces)
+- [integrations_config](ref:integrations)
 
 The configuration of Grafana Agent is "stable," but subject to breaking changes
 as individual features change. Breaking changes to configuration will be
@@ -77,7 +113,7 @@ which may be slightly unexpected.
 
 ## Reloading (beta)
 
-The configuration file can be reloaded at runtime. Read the [API documentation][api] for more information.
+The configuration file can be reloaded at runtime. Read the [API documentation](ref:api) for more information.
 
 This functionality is in beta, and may have issues. Please open GitHub issues
 for any problems you encounter.
@@ -139,19 +175,3 @@ The following flags will configure basic auth for requests made to HTTP/S remote
 This beta feature is subject to change in future releases.
 {{% /admonition %}}
 
-{{% docs/reference %}}
-[flags]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/flags"
-[flags]: "/docs/grafana-cloud/ -> ./flags"
-[server]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/server-config"
-[server]: "/docs/grafana-cloud/ -> ./server-config"
-[metrics]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/metrics-config"
-[metrics]: "/docs/grafana-cloud/ -> ./metrics-config"
-[logs]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/logs-config"
-[logs]: "/docs/grafana-cloud/ -> ./logs-config"
-[traces]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/traces-config"
-[traces]: "/docs/grafana-cloud/ -> ./traces-config"
-[integrations]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/integrations"
-[integrations]: "/docs/grafana-cloud/ -> ./integrations"
-[api]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/api#reload-configuration-file-beta"
-[api]: "/docs/grafana-cloud/ -> ../api#reload-configuration-file-beta"
-{{% /docs/reference %}}

--- a/docs/sources/static/configuration/_index.md
+++ b/docs/sources/static/configuration/_index.md
@@ -8,37 +8,37 @@ weight: 300
 refs:
   metrics:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/metrics-config/
     - pattern: /docs/grafana-cloud/
       destination: ./metrics-config/
   integrations:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/integrations/
     - pattern: /docs/grafana-cloud/
       destination: ./integrations/
   api:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/api/#reload-configuration-file-beta
+      destination: /docs/agent/<AGENT_VERSION>/static/api/#reload-configuration-file-beta
     - pattern: /docs/grafana-cloud/
       destination: ../api/#reload-configuration-file-beta
   flags:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/flags/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/flags/
     - pattern: /docs/grafana-cloud/
       destination: ./flags/
   server:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/server-config/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/server-config/
     - pattern: /docs/grafana-cloud/
       destination: ./server-config/
   traces:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/traces-config/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/traces-config/
     - pattern: /docs/grafana-cloud/
       destination: ./traces-config/
   logs:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/logs-config/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/logs-config/
     - pattern: /docs/grafana-cloud/
       destination: ./logs-config/
 ---

--- a/docs/sources/static/configuration/create-config-file.md
+++ b/docs/sources/static/configuration/create-config-file.md
@@ -9,7 +9,7 @@ weight: 50
 refs:
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/static/configuration/
 ---

--- a/docs/sources/static/configuration/create-config-file.md
+++ b/docs/sources/static/configuration/create-config-file.md
@@ -6,6 +6,12 @@ canonical: https://grafana.com/docs/agent/latest/static/configuration/create-con
 title: Create a configuration file
 description: Learn how to create a configuration file
 weight: 50
+refs:
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/configuration/
 ---
 
 # Create a configuration file
@@ -62,7 +68,7 @@ the Grafana Agent is running on. This label helps to uniquely identify the
 source of metrics if you are running multiple Grafana Agents across multiple
 machines.
 
-Full configuration options can be found in the [configuration reference][configure].
+Full configuration options can be found in the [configuration reference](ref:configure).
 
 ## Prometheus config/migrating from Prometheus
 
@@ -107,7 +113,7 @@ metrics:
 ```
 
 Like with integrations, full configuration options can be found in the
-[configuration][configure].
+[configuration](ref:configure).
 
 ## Loki Config/Migrating from Promtail
 
@@ -184,7 +190,3 @@ integrations:
     enabled: true
 ```
 
-{{% docs/reference %}}
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration"
-[configure]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static/configuration"
-{{% /docs/reference %}}

--- a/docs/sources/static/configuration/flags.md
+++ b/docs/sources/static/configuration/flags.md
@@ -8,17 +8,17 @@ weight: 100
 refs:
   retrieving:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/#remote-configuration-experimental
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/#remote-configuration-experimental
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/static/configuration/#remote-configuration-experimental
   revamp:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/integrations-next/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/integrations/integrations-next/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/static/configuration/integrations/integrations-next/
   management:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/agent-management/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/agent-management/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/static/configuration/agent-management/
 ---

--- a/docs/sources/static/configuration/flags.md
+++ b/docs/sources/static/configuration/flags.md
@@ -5,6 +5,22 @@ canonical: https://grafana.com/docs/agent/latest/static/configuration/flags/
 title: Command-line flags
 description: Learn about command-line flags
 weight: 100
+refs:
+  retrieving:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/#remote-configuration-experimental
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/configuration/#remote-configuration-experimental
+  revamp:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/integrations-next/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/configuration/integrations/integrations-next/
+  management:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/agent-management/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/configuration/agent-management/
 ---
 
 # Command-line flags
@@ -31,10 +47,10 @@ names to enable.
 
 Valid feature names are:
 
-* `remote-configs`: Enable [retrieving][retrieving] config files over HTTP/HTTPS
-* `integrations-next`: Enable [revamp][revamp] of the integrations subsystem
+* `remote-configs`: Enable [retrieving](ref:retrieving) config files over HTTP/HTTPS
+* `integrations-next`: Enable [revamp](ref:revamp) of the integrations subsystem
 * `extra-scrape-metrics`: When enabled, additional time series  are exposed for each metrics instance scrape. See [Extra scrape metrics](https://prometheus.io/docs/prometheus/2.45/feature_flags/#extra-scrape-metrics).
-* `agent-management`: Enable support for [agent management][management].
+* `agent-management`: Enable support for [agent management](ref:management).
 
 ## Report information usage
 
@@ -144,13 +160,3 @@ YAML configuration when the `-server.http.tls-enabled` flag is used.
 
 * `-metrics.wal-directory`: Directory to store the metrics Write-Ahead Log in
 
-{{% docs/reference %}}
-[retrieving]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration#remote-configuration-experimental"
-[retrieving]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static/configuration#remote-configuration-experimental"
-
-[revamp]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/integrations/integrations-next/"
-[revamp]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static/configuration/integrations/integrations-next"
-
-[management]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/agent-management"
-[management]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static/configuration/agent-management"
-{{% /docs/reference %}}

--- a/docs/sources/static/configuration/metrics-config.md
+++ b/docs/sources/static/configuration/metrics-config.md
@@ -9,7 +9,7 @@ weight: 200
 refs:
   scrape:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/scraping-service/
     - pattern: /docs/grafana-cloud/
       destination: ./scraping-service/
 ---
@@ -348,5 +348,5 @@ remote_write:
 
 ## Data retention
 
-{{< docs/shared source="agent" lookup="/wal-data-retention.md" version="<AGENT VERSION>" >}}
+{{< docs/shared source="agent" lookup="/wal-data-retention.md" version="<AGENT_VERSION>" >}}
 

--- a/docs/sources/static/configuration/metrics-config.md
+++ b/docs/sources/static/configuration/metrics-config.md
@@ -6,6 +6,12 @@ canonical: https://grafana.com/docs/agent/latest/static/configuration/metrics-co
 title: metrics_config
 description: Learn about metrics_config
 weight: 200
+refs:
+  scrape:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/
+    - pattern: /docs/grafana-cloud/
+      destination: ./scraping-service/
 ---
 
 # metrics_config
@@ -66,7 +72,7 @@ configs:
 
 ## scraping_service_config
 
-The `scraping_service` block configures the [scraping service][scrape], an operational
+The `scraping_service` block configures the [scraping service](ref:scrape), an operational
 mode where configurations are stored centrally in a KV store and a cluster of
 agents distributes discovery and scrape load between nodes.
 
@@ -344,7 +350,3 @@ remote_write:
 
 {{< docs/shared source="agent" lookup="/wal-data-retention.md" version="<AGENT VERSION>" >}}
 
-{{% docs/reference %}}
-[scrape]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/scraping-service"
-[scrape]: "/docs/grafana-cloud/ -> ./scraping-service"
-{{% /docs/reference %}}

--- a/docs/sources/static/configuration/scraping-service.md
+++ b/docs/sources/static/configuration/scraping-service.md
@@ -7,6 +7,17 @@ title: Scraping service (Beta)
 menuTitle: Scraping service
 description: Learn about the scraping service
 weight: 600
+refs:
+  metrics:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+    - pattern: /docs/grafana-cloud/
+      destination: ./metrics-config/
+  api:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/api/
+    - pattern: /docs/grafana-cloud/
+      destination: ../api/
 ---
 
 # Scraping service (Beta)
@@ -14,7 +25,7 @@ weight: 600
 The Grafana Agent scraping service allows you to cluster a set of Agent processes and distribute the scrape load.
 
 Determining what to scrape is done by writing instance configuration files to an
-[API][api], which then stores the configuration files in a KV store backend.
+[API](ref:api), which then stores the configuration files in a KV store backend.
 All agents in the cluster **must** use the same KV store to see the same set
 of configuration files.
 
@@ -44,7 +55,7 @@ remote_write:
 
 The full set of supported options for an instance configuration file is
 available in the
-[`metrics-config.md` file][metrics].
+[`metrics-config.md` file](ref:metrics).
 
 Multiple instance configuration files are necessary for sharding. Each
 config file is distributed to a particular agent on the cluster based on the
@@ -183,9 +194,3 @@ Information returned by the `/debug/ring` endpoint includes:
    The exact details of the instance ID generation might be specific to the implementation of the Grafana Agent.
 - The time of the "Last Heartbeat" of each instance. The Last Heartbeat is the last time the instance was active in the ring.
 
-{{% docs/reference %}}
-[api]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/api"
-[api]: "/docs/grafana-cloud/ -> ../api"
-[metrics]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/metrics-config"
-[metrics]: "/docs/grafana-cloud/ -> ./metrics-config"
-{{% /docs/reference %}}

--- a/docs/sources/static/configuration/scraping-service.md
+++ b/docs/sources/static/configuration/scraping-service.md
@@ -10,12 +10,12 @@ weight: 600
 refs:
   metrics:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/metrics-config/
     - pattern: /docs/grafana-cloud/
       destination: ./metrics-config/
   api:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/api/
+      destination: /docs/agent/<AGENT_VERSION>/static/api/
     - pattern: /docs/grafana-cloud/
       destination: ../api/
 ---

--- a/docs/sources/static/operation-guide/_index.md
+++ b/docs/sources/static/operation-guide/_index.md
@@ -8,22 +8,22 @@ weight: 700
 refs:
   metrics:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/metrics-config/
     - pattern: /docs/grafana-cloud/
       destination: ../configuration/metrics-config/
   targets:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/#best-practices
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/scraping-service/#best-practices
     - pattern: /docs/grafana-cloud/
       destination: ../configuration/scraping-service/#best-practices
   scrape:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/scraping-service/
     - pattern: /docs/grafana-cloud/
       destination: ../configuration/scraping-service/
   api:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/api/#agent-api
+      destination: /docs/agent/<AGENT_VERSION>/static/api/#agent-api
     - pattern: /docs/grafana-cloud/
       destination: ../api/#agent-api
 ---

--- a/docs/sources/static/operation-guide/_index.md
+++ b/docs/sources/static/operation-guide/_index.md
@@ -5,6 +5,27 @@ canonical: https://grafana.com/docs/agent/latest/static/operation-guide/
 title: Operation guide
 description: Learn how to operate Grafana Agent
 weight: 700
+refs:
+  metrics:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+    - pattern: /docs/grafana-cloud/
+      destination: ../configuration/metrics-config/
+  targets:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/#best-practices
+    - pattern: /docs/grafana-cloud/
+      destination: ../configuration/scraping-service/#best-practices
+  scrape:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/
+    - pattern: /docs/grafana-cloud/
+      destination: ../configuration/scraping-service/
+  api:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/api/#agent-api
+    - pattern: /docs/grafana-cloud/
+      destination: ../api/#agent-api
 ---
 
 # Operation guide
@@ -20,7 +41,7 @@ There are three options to horizontally scale your deployment of Grafana Agents:
   from the machines they run on.
 - [Hashmod sharding](#hashmod-sharding-stable) allows you to roughly shard the
   discovered set of targets by using hashmod/keep relabel rules.
-- The [scraping service][scrape] allows you to cluster Grafana
+- The [scraping service](ref:scrape) allows you to cluster Grafana
   Agents and have them distribute per-tenant configs throughout the cluster.
 
 Each has their own set of tradeoffs:
@@ -55,7 +76,7 @@ Each has their own set of tradeoffs:
     - Smallest load on SD compared to host filtering, as only one Agent is
       responsible for a config.
   - Cons
-    - Centralized configs must discover a [minimal set of targets][targets]
+    - Centralized configs must discover a [minimal set of targets](ref:targets)
       to distribute evenly.
     - Requires running a separate KV store to store the centralized configs.
     - Managing centralized configs adds operational burden over managing a config
@@ -80,7 +101,7 @@ for scraping other targets that are not running on a cluster node, such as the
 Kubernetes control plane API.
 
 If you want to scale your scrape load without host filtering, you can use the
-[scraping service][scrape] instead.
+[scraping service](ref:scrape) instead.
 
 The host name of the Agent is determined by reading `$HOSTNAME`. If `$HOSTNAME`
 isn't defined, the Agent will use Go's [os.Hostname](https://golang.org/pkg/os/#Hostname)
@@ -111,7 +132,7 @@ logic; only `host_filter_relabel_configs` will work.
 
 If the determined hostname matches any of the meta labels, the discovered target
 is allowed. Otherwise, the target is ignored, and will not show up in the
-[targets API][api].
+[targets API](ref:api).
 
 ## Hashmod sharding (Stable)
 
@@ -156,7 +177,7 @@ Instances allow for fine grained control of what data gets scraped and where it
 gets sent. Users can easily define two Instances that scrape different subsets
 of metrics and send them to two completely different remote_write systems.
 
-Instances are especially relevant to the [scraping service mode][scrape],
+Instances are especially relevant to the [scraping service mode](ref:scrape),
 where breaking up your scrape configs into multiple Instances is required for 
 sharding and balancing scrape load across a cluster of Agents.
 
@@ -176,7 +197,7 @@ from that `remote_write` config separated by a `-`.
 
 The shared instances mode is the new default, and the previous behavior is
 deprecated. If you wish to restore the old behavior, set `instance_mode: distinct`
-in the [`metrics_config`][metrics] block of your config file.
+in the [`metrics_config`](ref:metrics) block of your config file.
 
 Shared instances are completely transparent to the user with the exception of
 exposed metrics. With `instance_mode: shared`, metrics for Prometheus components
@@ -188,16 +209,6 @@ individual Instance config. It is recommended to use the default of
 `instance_mode: shared` unless you don't mind the performance hit and really
 need granular metrics.
 
-Users can use the [targets API][api] to see all scraped targets, and the name 
+Users can use the [targets API](ref:api) to see all scraped targets, and the name 
 of the shared instance they were assigned to.
 
-{{% docs/reference %}}
-[scrape]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/scraping-service"
-[scrape]: "/docs/grafana-cloud/ -> ../configuration/scraping-service"
-[targets]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/scraping-service#best-practices"
-[targets]: "/docs/grafana-cloud/ -> ../configuration/scraping-service#best-practices"
-[api]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/api#agent-api"
-[api]: "/docs/grafana-cloud/ -> ../api#agent-api"
-[metrics]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/metrics-config"
-[metrics]: "/docs/grafana-cloud/ -> ../configuration/metrics-config"
-{{% /docs/reference %}}

--- a/docs/sources/static/release-notes.md
+++ b/docs/sources/static/release-notes.md
@@ -7,6 +7,22 @@ aliases:
 - ../upgrade-guide/
 - ./upgrade-guide/
 weight: 999
+refs:
+  release-notes-operator:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/operator/release-notes/
+    - pattern: /docs/grafana-cloud/
+      destination: ../operator/release-notes/
+  modules:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/concepts/modules/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/concepts/modules/
+  release-notes-flow:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
 ---
 
 # Release notes
@@ -18,19 +34,9 @@ For a complete list of changes to Grafana Agent, with links to pull requests and
 > **Note:** These release notes are specific to Grafana Agent static mode. 
 > Other release notes for the different Grafana Agent variants are contained on separate pages:
 >
-> * [Static mode Kubernetes operator release notes][release-notes-operator]
-> * [Flow mode release notes][release-notes-flow]
+> * [Static mode Kubernetes operator release notes](ref:release-notes-operator)
+> * [Flow mode release notes](ref:release-notes-flow)
 
-{{% docs/reference %}}
-[release-notes-operator]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/operator/release-notes"
-[release-notes-operator]: "/docs/grafana-cloud/ -> ../operator/release-notes"
-
-[release-notes-flow]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/release-notes"
-[release-notes-flow]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/release-notes"
-
-[Modules]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/concepts/modules"
-[Modules]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/concepts/modules"
-{{% /docs/reference %}}
 
 ## v0.37
 
@@ -144,7 +150,7 @@ See [Module and Auth Split Migration](https://github.com/prometheus/snmp_exporte
 ### Removal of Dynamic Configuration
 
 The experimental feature Dynamic Configuration has been removed. The use case of dynamic configuration will be replaced
-with [Modules][] in Grafana Agent Flow.
+with [Modules](ref:modules) in Grafana Agent Flow.
 
 ### Breaking change: Removed and renamed tracing metrics
 

--- a/docs/sources/static/release-notes.md
+++ b/docs/sources/static/release-notes.md
@@ -10,19 +10,19 @@ weight: 999
 refs:
   release-notes-operator:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/operator/release-notes/
+      destination: /docs/agent/<AGENT_VERSION>/operator/release-notes/
     - pattern: /docs/grafana-cloud/
       destination: ../operator/release-notes/
   modules:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/concepts/modules/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/modules/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/concepts/modules/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/modules/
   release-notes-flow:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
+      destination: /docs/agent/<AGENT_VERSION>/flow/release-notes/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
+      destination: /docs/agent/<AGENT_VERSION>/flow/release-notes/
 ---
 
 # Release notes

--- a/docs/sources/static/set-up/install/_index.md
+++ b/docs/sources/static/set-up/install/_index.md
@@ -7,6 +7,12 @@ menuTitle: Install static mode
 title: Install Grafana Agent in static mode
 description: Learn how to install GRafana Agent in static mode
 weight: 100
+refs:
+  data-collection:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/data-collection/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/data-collection/
 ---
 
 # Install Grafana Agent in static mode
@@ -36,10 +42,6 @@ Use the Grafana Agent [Kubernetes configuration](/docs/grafana-cloud/monitor-inf
 
 ## Data collection
 
-By default, Grafana Agent sends anonymous usage information to Grafana Labs. Refer to [data collection][] for more information
+By default, Grafana Agent sends anonymous usage information to Grafana Labs. Refer to [data collection](ref:data-collection) for more information
 about what data is collected and how you can opt-out.
 
-{{% docs/reference %}}
-[data collection]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/data-collection.md"
-[data collection]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/data-collection.md"
-{{% /docs/reference %}}

--- a/docs/sources/static/set-up/install/install-agent-binary.md
+++ b/docs/sources/static/set-up/install/install-agent-binary.md
@@ -10,27 +10,27 @@ weight: 700
 refs:
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/
     - pattern: /docs/grafana-cloud/
       destination: ../../configuration/
   windows:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-on-windows/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/install/install-agent-on-windows/
     - pattern: /docs/grafana-cloud/
       destination: ./install-agent-on-windows/
   start:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/#standalone-binary
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/start-agent/#standalone-binary
     - pattern: /docs/grafana-cloud/
       destination: ../start-agent/#standalone-binary
   linux:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-linux/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/install/install-agent-linux/
     - pattern: /docs/grafana-cloud/
       destination: ./install-agent-linux/
   macos:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-macos/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/install/install-agent-macos/
     - pattern: /docs/grafana-cloud/
       destination: ./install-agent-macos/
 ---

--- a/docs/sources/static/set-up/install/install-agent-binary.md
+++ b/docs/sources/static/set-up/install/install-agent-binary.md
@@ -7,6 +7,32 @@ menuTitle: Standalone
 title: Install Grafana Agent in static mode as a standalone binary
 description: Learn how to install Grafana Agent in static mode as a standalone binary
 weight: 700
+refs:
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/
+    - pattern: /docs/grafana-cloud/
+      destination: ../../configuration/
+  windows:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-on-windows/
+    - pattern: /docs/grafana-cloud/
+      destination: ./install-agent-on-windows/
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/#standalone-binary
+    - pattern: /docs/grafana-cloud/
+      destination: ../start-agent/#standalone-binary
+  linux:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-linux/
+    - pattern: /docs/grafana-cloud/
+      destination: ./install-agent-linux/
+  macos:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-macos/
+    - pattern: /docs/grafana-cloud/
+      destination: ./install-agent-macos/
 ---
 
 # Install Grafana Agent in static mode as a standalone binary
@@ -23,9 +49,9 @@ ppc64le builds are considered secondary release targets and do not have the same
 
 The binary executable will run Grafana Agent in standalone mode. If you want to run Grafana Agent as a service, refer to the installation instructions for:
 
-* [Linux][linux]
-* [macOS][macos]
-* [Windows][windows]
+* [Linux](ref:linux)
+* [macOS](ref:macos)
+* [Windows](ref:windows)
 
 ## Download Grafana Agent
 
@@ -47,18 +73,6 @@ To download the Grafana Agent as a standalone binary, perform the following step
 
 ## Next steps
 
-* [Start Grafana Agent][start]
-* [Configure Grafana Agent][configure]
+* [Start Grafana Agent](ref:start)
+* [Configure Grafana Agent](ref:configure)
 
-{{% docs/reference %}}
-[linux]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-linux"
-[linux]: "/docs/grafana-cloud/ -> ./install-agent-linux"
-[macos]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-macos"
-[macos]: "/docs/grafana-cloud/ -> ./install-agent-macos"
-[windows]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-on-windows"
-[windows]: "/docs/grafana-cloud/ -> ./install-agent-on-windows"
-[start]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/start-agent#standalone-binary"
-[start]: "/docs/grafana-cloud/ -> ../start-agent#standalone-binary"
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration"
-[configure]: "/docs/grafana-cloud/ -> ../../configuration"
-{{% /docs/reference %}}

--- a/docs/sources/static/set-up/install/install-agent-docker.md
+++ b/docs/sources/static/set-up/install/install-agent-docker.md
@@ -7,6 +7,17 @@ menuTitle: Docker
 title: Run Grafana Agent in static mode in a Docker container
 description: Learn how to run Grafana Agent in static mode in a Docker container
 weight: 200
+refs:
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+    - pattern: /docs/grafana-cloud/
+      destination: ../../configuration/create-config-file/
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+    - pattern: /docs/grafana-cloud/
+      destination: ../start-agent/
 ---
 
 # Run Grafana Agent in static mode in a Docker container
@@ -22,7 +33,7 @@ Grafana Agent is available as a Docker container image on the following platform
 ## Before you begin
 
 * Install [Docker][] on your computer.
-* Create and save a Grafana Agent YAML [configuration file][configure] on your computer.
+* Create and save a Grafana Agent YAML [configuration file](ref:configure) on your computer.
 
 [Docker]: https://docker.io
 
@@ -65,12 +76,6 @@ For the flags to work correctly, you must expose the paths on your Windows host 
 
 ## Next steps
 
-- [Start Grafana Agent][start]
-- [Configure Grafana Agent][configure]
+- [Start Grafana Agent](ref:start)
+- [Configure Grafana Agent](ref:configure)
 
-{{% docs/reference %}}
-[start]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/start-agent"
-[start]: "/docs/grafana-cloud/ -> ../start-agent"
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/create-config-file"
-[configure]: "/docs/grafana-cloud/ -> ../../configuration/create-config-file"
-{{% /docs/reference %}}

--- a/docs/sources/static/set-up/install/install-agent-docker.md
+++ b/docs/sources/static/set-up/install/install-agent-docker.md
@@ -10,12 +10,12 @@ weight: 200
 refs:
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/create-config-file/
     - pattern: /docs/grafana-cloud/
       destination: ../../configuration/create-config-file/
   start:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/start-agent/
     - pattern: /docs/grafana-cloud/
       destination: ../start-agent/
 ---

--- a/docs/sources/static/set-up/install/install-agent-linux.md
+++ b/docs/sources/static/set-up/install/install-agent-linux.md
@@ -7,6 +7,17 @@ menuTitle: Linux
 title: Install Grafana Agent in static mode on Linux
 description: Learn how to install Grafana Agent in static mode on Linux
 weight: 400
+refs:
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+    - pattern: /docs/grafana-cloud/
+      destination: ../../configuration/create-config-file/
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+    - pattern: /docs/grafana-cloud/
+      destination: ../start-agent/
 ---
 
 # Install Grafana Agent in static mode on Linux
@@ -212,12 +223,6 @@ Logs of Grafana Agent can be found by running the following command in a termina
 
 ## Next steps
 
-- [Start Grafana Agent][start]
-- [Configure Grafana Agent][configure]
+- [Start Grafana Agent](ref:start)
+- [Configure Grafana Agent](ref:configure)
 
-{{% docs/reference %}}
-[start]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/start-agent"
-[start]: "/docs/grafana-cloud/ -> ../start-agent"
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/create-config-file"
-[configure]: "/docs/grafana-cloud/ -> ../../configuration/create-config-file"
-{{% /docs/reference %}}

--- a/docs/sources/static/set-up/install/install-agent-linux.md
+++ b/docs/sources/static/set-up/install/install-agent-linux.md
@@ -10,12 +10,12 @@ weight: 400
 refs:
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/create-config-file/
     - pattern: /docs/grafana-cloud/
       destination: ../../configuration/create-config-file/
   start:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/start-agent/
     - pattern: /docs/grafana-cloud/
       destination: ../start-agent/
 ---

--- a/docs/sources/static/set-up/install/install-agent-macos.md
+++ b/docs/sources/static/set-up/install/install-agent-macos.md
@@ -7,6 +7,17 @@ menuTitle: macOS
 title: Install Grafana Agent in static mode on macOS
 description: Learn how to install Grafana Agent in static mode on macOS
 weight: 500
+refs:
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+    - pattern: /docs/grafana-cloud/
+      destination: ../../configuration/create-config-file/
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+    - pattern: /docs/grafana-cloud/
+      destination: ../start-agent/
 ---
 
 # Install Grafana Agent in static mode on macOS
@@ -72,7 +83,7 @@ brew uninstall grafana-agent
     touch $(brew --prefix)/etc/grafana-agent/config.yml
     ```
 
-1. Edit `$(brew --prefix)/etc/grafana-agent/config.yml` and add the configuration blocks for your specific telemetry needs. Refer to [Configure Grafana Agent][configure] for more information.
+1. Edit `$(brew --prefix)/etc/grafana-agent/config.yml` and add the configuration blocks for your specific telemetry needs. Refer to [Configure Grafana Agent](ref:configure) for more information.
 
 {{% admonition type="note" %}}
 To send your data to Grafana Cloud, set up Grafana Agent using the Grafana Cloud integration. Refer to [how to install an integration](/docs/grafana-cloud/data-configuration/integrations/install-and-manage-integrations/) and [macOS integration](/docs/grafana-cloud/data-configuration/integrations/integration-reference/integration-macos-node/).
@@ -80,12 +91,6 @@ To send your data to Grafana Cloud, set up Grafana Agent using the Grafana Cloud
 
 ## Next steps
 
-- [Start Grafana Agent][start]
-- [Configure Grafana Agent][configure]
+- [Start Grafana Agent](ref:start)
+- [Configure Grafana Agent](ref:configure)
 
-{{% docs/reference %}}
-[start]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/start-agent"
-[start]: "/docs/grafana-cloud/ -> ../start-agent"
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/create-config-file"
-[configure]: "/docs/grafana-cloud/ -> ../../configuration/create-config-file"
-{{% /docs/reference %}}

--- a/docs/sources/static/set-up/install/install-agent-macos.md
+++ b/docs/sources/static/set-up/install/install-agent-macos.md
@@ -10,12 +10,12 @@ weight: 500
 refs:
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/create-config-file/
     - pattern: /docs/grafana-cloud/
       destination: ../../configuration/create-config-file/
   start:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/start-agent/
     - pattern: /docs/grafana-cloud/
       destination: ../start-agent/
 ---

--- a/docs/sources/static/set-up/install/install-agent-on-windows.md
+++ b/docs/sources/static/set-up/install/install-agent-on-windows.md
@@ -10,12 +10,12 @@ weight: 600
 refs:
   start:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/start-agent/
     - pattern: /docs/grafana-cloud/
       destination: ../start-agent/
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/create-config-file/
     - pattern: /docs/grafana-cloud/
       destination: ../../configuration/create-config-file/
 ---

--- a/docs/sources/static/set-up/install/install-agent-on-windows.md
+++ b/docs/sources/static/set-up/install/install-agent-on-windows.md
@@ -7,6 +7,17 @@ menuTitle: Windows
 title: Install Grafana Agent in static mode on Windows
 description: Learn how to install Grafana Agent in static mode on Windows
 weight: 600
+refs:
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+    - pattern: /docs/grafana-cloud/
+      destination: ../start-agent/
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+    - pattern: /docs/grafana-cloud/
+      destination: ../../configuration/create-config-file/
 ---
 
 # Install Grafana Agent in static mode on Windows
@@ -140,12 +151,6 @@ Refer to [windows_events](/docs/loki/latest/clients/promtail/configuration/#wind
 
 ## Next steps
 
-- [Start Grafana Agent][start]
-- [Configure Grafana Agent][configure]
+- [Start Grafana Agent](ref:start)
+- [Configure Grafana Agent](ref:configure)
 
-{{% docs/reference %}}
-[start]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/start-agent"
-[start]: "/docs/grafana-cloud/ -> ../start-agent"
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/create-config-file"
-[configure]: "/docs/grafana-cloud/ -> ../../configuration/create-config-file"
-{{% /docs/reference %}}

--- a/docs/sources/static/set-up/start-agent.md
+++ b/docs/sources/static/set-up/start-agent.md
@@ -8,7 +8,7 @@ weight: 200
 refs:
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-macos/#configure
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/install/install-agent-macos/#configure
     - pattern: /docs/grafana-cloud/
       destination: ./install/install-agent-macos/#configure
 ---

--- a/docs/sources/static/set-up/start-agent.md
+++ b/docs/sources/static/set-up/start-agent.md
@@ -5,6 +5,12 @@ menuTitle: Start static mode
 title: Start, restart, and stop Grafana Agent in static mode
 description: Learn how to start, restart, and stop Grafana Agent in static mode
 weight: 200
+refs:
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-macos/#configure
+    - pattern: /docs/grafana-cloud/
+      destination: ./install/install-agent-macos/#configure
 ---
 
 # Start, restart, and stop Grafana Agent in static mode
@@ -104,7 +110,7 @@ brew services stop grafana-agent
 By default, logs are written to `$(brew --prefix)/var/log/grafana-agent.log` and
 `$(brew --prefix)/var/log/grafana-agent.err.log`.
 
-If you followed [Configure][configure] steps in the macOS install instructions and changed the path where logs are written, refer to your current copy of the Grafana Agent formula to locate your log files.
+If you followed [Configure](ref:configure) steps in the macOS install instructions and changed the path where logs are written, refer to your current copy of the Grafana Agent formula to locate your log files.
 
 ## Windows
 
@@ -154,7 +160,3 @@ Replace the following:
 * `BINARY_PATH`: The path to the Grafana Agent binary file
 * `CONFIG_FILE`: The path to the Grafana Agent configuration file.
 
-{{% docs/reference %}}
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-macos#configure"
-[configure]: "/docs/grafana-cloud/ -> ./install/install-agent-macos/#configure"
-{{% /docs/reference %}}


### PR DESCRIPTION
You can use `ref` URIs in admonitions (or any shortcodes) because they are inline and not subject to the issues noted in the [`admonition` shortcode](https://grafana.com/docs/writers-toolkit/write/shortcodes/#code-shortcode:~:text=to%20core%20understanding.-,WARNING,For%20more%20information%2C%20refer%20to%20Markdown%20Reference%20Links%20in%20Shortcodes.,-Examples).

The `ref` URIs perform the same pattern matching as `docs/reference` but don't require the use of reference-style links and the destinations are ordinary (full) URLs that can include version substitution. Unlike `docs/reference`, the implementation doesn't use `relref` so you don't have to be careful with omitting trailing slashes and the links will follow redirects.

Documentation: https://grafana.com/docs/writers-toolkit/write/links/#link-from-source-content-thats-used-in-multiple-projects

To check the links, refer to the deploy preview in https://github.com/grafana/website/pull/19630.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
